### PR TITLE
[12.x] Add `interval()` method to `InteractsWithData`

### DIFF
--- a/src/Illuminate/Support/Traits/InteractsWithData.php
+++ b/src/Illuminate/Support/Traits/InteractsWithData.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Support\Traits;
 
+use Carbon\CarbonInterval;
+use Carbon\Unit;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Date;
@@ -322,6 +324,30 @@ trait InteractsWithData
         }
 
         return Date::createFromFormat($format, $this->data($key), $tz);
+    }
+
+    /**
+     * Retrieve data from the instance as a CarbonInterval instance.
+     *
+     * @param  string  $key
+     * @param  \Carbon\Unit|string|null  $unit
+     * @return \Carbon\CarbonInterval|null
+     */
+    public function interval($key, $unit = null)
+    {
+        if ($this->isNotFilled($key)) {
+            return null;
+        }
+
+        $value = $this->data($key);
+
+        if (is_null($unit)) {
+            return CarbonInterval::make($value);
+        }
+
+        $unit = $unit instanceof Unit ? $unit : Unit::fromName($unit);
+
+        return $unit->interval((float) $value);
     }
 
     /**

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Tests\Http;
 
+use Carbon\CarbonInterval;
+use Carbon\Unit;
 use Illuminate\Http\Request;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Routing\Route;
@@ -813,6 +815,47 @@ class HttpRequestTest extends TestCase
         ]);
 
         $request->date('date', 'invalid_format');
+    }
+
+    public function testIntervalMethod()
+    {
+        $request = Request::create('/', 'GET', [
+            'as_null' => null,
+            'as_empty' => '',
+            'as_iso' => 'P1Y2M3DT4H5M6S',
+            'as_human' => '2 hours 30 minutes',
+            'as_seconds' => '90',
+            'as_minutes' => '45',
+        ]);
+
+        $this->assertNull($request->interval('as_null'));
+        $this->assertNull($request->interval('as_empty'));
+        $this->assertNull($request->interval('doesnt_exist'));
+
+        $interval = $request->interval('as_iso');
+        $this->assertInstanceOf(CarbonInterval::class, $interval);
+        $this->assertSame(1, $interval->years);
+        $this->assertSame(2, $interval->months);
+        $this->assertSame(3, $interval->dayz);
+        $this->assertSame(4, $interval->hours);
+        $this->assertSame(5, $interval->minutes);
+        $this->assertSame(6, $interval->seconds);
+
+        $interval = $request->interval('as_human');
+        $this->assertInstanceOf(CarbonInterval::class, $interval);
+        $this->assertSame(2, $interval->hours);
+        $this->assertSame(30, $interval->minutes);
+
+        $interval = $request->interval('as_seconds', 'second');
+        $this->assertInstanceOf(CarbonInterval::class, $interval);
+        $this->assertSame(90, $interval->seconds);
+
+        $this->assertSame(90, $request->interval('as_seconds', 'minute')->minutes);
+        $this->assertSame(90, $request->interval('as_seconds', 'hour')->hours);
+        $this->assertSame(90, $request->interval('as_seconds', 'day')->dayz);
+
+        $this->assertSame(45, $request->interval('as_minutes', Unit::Minute)->minutes);
+        $this->assertSame(45, $request->interval('as_minutes', Unit::Second)->seconds);
     }
 
     public function testEnumMethod()


### PR DESCRIPTION
## Add `interval()` method to `InteractsWithData`

The `InteractsWithData` trait provides type-conversion helpers for common types: `string()`, `boolean()`, `integer()`, `float()`, `date()`, `enum()`, and `collect()`. This PR adds an `interval()` method that converts request data into a `CarbonInterval` instance, completing the set of time-related helpers alongside `date()`.

### Usage

```php
// Parse an ISO 8601 duration or human-readable interval string
$request->interval('duration');          // "P1DT2H" → 1 day, 2 hours
$request->interval('duration');          // "2 hours 30 minutes" → 2h 30m

// Parse a numeric value with a specific unit (string)
$request->interval('timeout', 'second'); // "90" → 90 seconds
$request->interval('cooldown', 'day');   // "7" → 7 days

// Parse a numeric value with a Carbon\Unit enum
$request->interval('delay', Unit::Minute); // "45" → 45 minutes
```

Returns `null` when the key is not filled or missing, consistent with `date()`.

### Why this is useful

Duration and timeout fields are common in web applications: scheduling intervals, session timeouts, cooldown periods, cache TTLs, subscription billing cycles, etc. Today, developers handle this manually:

```php
// Before
$interval = CarbonInterval::minutes($request->integer('duration'));

// After
$interval = $request->interval('duration', 'minute');
```

The `unit` parameter is what makes this more than a trivial wrapper. Just as `date()` accepts a `$format` parameter to interpret ambiguous date strings, `interval()` accepts a `$unit` parameter to interpret numeric values, which is the most common form of duration input from HTML forms (e.g., a number input for "minutes").

The method accepts both string unit names (`'second'`, `'minute'`, `'hour'`, `'day'`, etc.) and the `Carbon\Unit` enum for type-safe usage.

### No breaking changes

This adds a new method to the `InteractsWithData` trait. No existing methods or signatures are modified. The method follows the same patterns established by `date()`:

- Returns `null` for unfilled/missing keys via `isNotFilled()`
- Branches behavior based on the optional second parameter
- Delegates to Carbon for all parsing logic
