### PR TITLE
[13.x] fix: Align JsonApiResource flushState maxRelationshipDepth with trait default 

### DIFF
--- a/src/Illuminate/Http/Resources/JsonApi/JsonApiResource.php
+++ b/src/Illuminate/Http/Resources/JsonApi/JsonApiResource.php
@@ -250,6 +250,6 @@ class JsonApiResource extends JsonResource
         parent::flushState();
 
         static::$jsonApiInformation = [];
-        static::$maxRelationshipDepth = 3;
+        static::$maxRelationshipDepth = 5;
     }
 }

--- a/tests/Http/Resources/JsonApi/JsonApiResourceTest.php
+++ b/tests/Http/Resources/JsonApi/JsonApiResourceTest.php
@@ -39,4 +39,16 @@ class JsonApiResourceTest extends TestCase
 
         JsonApiResource::withoutWrapping();
     }
+
+    public function testFlushStateResetsMaxRelationshipDepthToDefault()
+    {
+        $this->assertSame(5, JsonApiResource::$maxRelationshipDepth);
+
+        JsonApiResource::maxRelationshipDepth(10);
+        $this->assertSame(10, JsonApiResource::$maxRelationshipDepth);
+
+        JsonApiResource::flushState();
+
+        $this->assertSame(5, JsonApiResource::$maxRelationshipDepth);
+    }
 }


### PR DESCRIPTION
 `ResolvesJsonApiElements` declares `$maxRelationshipDepth` with a default of `5`, but                            
  `JsonApiResource::flushState()` resets it to `3`. Both values were introduced in the same PR (#57571), so it's   
  unclear which was intended.                                                                                      
                                                                                                                
  This PR aligns `flushState()` to reset to `5` to match the property declaration, on the basis that the
  declaration is the canonical default. **If `3` was the intended default, the fix should instead change the
  declaration to `3`**, either way, they should be consistent.

  Without this fix, the first instantiation of a `JsonApiResource` uses a max depth of `5`, but after any
  `flushState()` call (e.g. between tests), subsequent resources silently use a max depth of `3`.

  - Adds a failing test that asserts `flushState()` resets to the declared default
  - Fixes `flushState()` to use `5` instead of `3`
