### PR TITLE
[13.x] fix: DoesntContain docblock typo

### DIFF
--- a/src/Illuminate/Validation/Rules/DoesntContain.php
+++ b/src/Illuminate/Validation/Rules/DoesntContain.php
@@ -10,7 +10,7 @@ use function Illuminate\Support\enum_value;
 class DoesntContain implements Stringable
 {
     /**
-     * The values that should be contained in the attribute.
+     * The values that should not be contained in the attribute.
      *
      * @var array
      */


### PR DESCRIPTION
The `$values` property docblock on `DoesntContain` was copied from `Contains` and says "values that should be contained in the attribute", the opposite of what the rule does. Fixed to "should not be contained".
