### PR TITLE
[13.x] BusFake assertNothingDispatched should check all dispatches

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -202,9 +202,11 @@ class BusFake implements Fake, QueueingDispatcher
      */
     public function assertNothingDispatched()
     {
-        $commandNames = implode("\n- ", array_keys($this->commands));
+        $dispatchedCommands = $this->commands + $this->commandsSync + $this->commandsAfterResponse;
 
-        PHPUnit::assertEmpty($this->commands, "The following jobs were dispatched unexpectedly:\n\n- $commandNames\n");
+        $commandNames = implode("\n- ", array_keys($dispatchedCommands));
+
+        PHPUnit::assertEmpty($dispatchedCommands, "The following jobs were dispatched unexpectedly:\n\n- $commandNames\n");
     }
 
     /**

--- a/tests/Support/SupportTestingBusFakeTest.php
+++ b/tests/Support/SupportTestingBusFakeTest.php
@@ -478,6 +478,36 @@ class SupportTestingBusFakeTest extends TestCase
         }
     }
 
+    public function testAssertNothingDispatchedWithSyncDispatch()
+    {
+        $this->fake->assertNothingDispatched();
+
+        $this->fake->dispatchSync(new BusJobStub);
+
+        try {
+            $this->fake->assertNothingDispatched();
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringContainsString('The following jobs were dispatched unexpectedly:', $e->getMessage());
+            $this->assertStringContainsString(BusJobStub::class, $e->getMessage());
+        }
+    }
+
+    public function testAssertNothingDispatchedWithAfterResponseDispatch()
+    {
+        $this->fake->assertNothingDispatched();
+
+        $this->fake->dispatchAfterResponse(new BusJobStub);
+
+        try {
+            $this->fake->assertNothingDispatched();
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringContainsString('The following jobs were dispatched unexpectedly:', $e->getMessage());
+            $this->assertStringContainsString(BusJobStub::class, $e->getMessage());
+        }
+    }
+
     public function testAssertChained()
     {
         Container::setInstance($container = new Container);


### PR DESCRIPTION
  `assertDispatched` checks all three dispatch stores:
    
  ```php                                                                                                                                                                                                               
            $this->dispatched($command, $callback)->count() > 0 ||
            $this->dispatchedAfterResponse($command, $callback)->count() > 0 ||
            $this->dispatchedSync($command, $callback)->count() > 0,
```

However, `assertNothingDispatched` was only checking `$this->commands` which ignored sync and after response, which means if you were dispatching sync, it was passing rather than failing in tests.

This PR aligns it to make it the proper inverse. 

Targeted at 13.x as this could technically be considered a breaking change for tests that were relying on the previous behaviour. 

There could be new assertions for the different ways ie `assertNothingDispatchedSync()`, but left it for now as not sure if there's a real need for it. 

Thanks!