### PR TITLE
[13.x] fix: QueueRoutes docblocks for getRoute and $routes property 

### DIFF
--- a/src/Illuminate/Queue/QueueRoutes.php
+++ b/src/Illuminate/Queue/QueueRoutes.php
@@ -7,7 +7,7 @@ class QueueRoutes
     /**
      * The mapping of class names to their default routes.
      *
-     * @var array<class-string, string>
+     * @var array<class-string, array|string>
      */
     protected $routes = [];
 
@@ -50,10 +50,10 @@ class QueueRoutes
     }
 
     /**
-     * Get the queue that a given queueable instance should be routed to.
+     * Get the route for a given queueable instance.
      *
      * @param  object  $queueable
-     * @return string|null
+     * @return array|string|null
      */
     public function getRoute($queueable)
     {


### PR DESCRIPTION
 - `getRoute()` had the same description as `getQueue()` ("Get the queue that a given queueable instance should be routed to") despite returning the full route (connection + queue pair)                          
 - `getRoute()` return type listed `string|null` but can also return an array
 - `$routes` property listed `string` values but can also contain arrays