### PR TITLE
[12.x] Add per-message log sampling via sample() method

### DIFF
--- a/src/Illuminate/Log/Logger.php
+++ b/src/Illuminate/Log/Logger.php
@@ -37,6 +37,13 @@ class Logger implements LoggerInterface
     protected $context = [];
 
     /**
+     * The sample rate for the next log message.
+     *
+     * @var float|null
+     */
+    protected $sampleRate = null;
+
+    /**
      * Create a new log writer instance.
      *
      * @param  \Psr\Log\LoggerInterface  $logger
@@ -171,6 +178,23 @@ class Logger implements LoggerInterface
     }
 
     /**
+     * Set a sample rate for the next log message.
+     *
+     * @param  float  $rate  A value between 0.0 and 1.0
+     * @return $this
+     */
+    public function sample(float $rate)
+    {
+        if ($rate < 0.0 || $rate > 1.0) {
+            throw new \InvalidArgumentException('Sample rate must be between 0.0 and 1.0.');
+        }
+
+        $this->sampleRate = $rate;
+
+        return $this;
+    }
+
+    /**
      * Write a message to the log.
      *
      * @param  string  $level
@@ -180,6 +204,15 @@ class Logger implements LoggerInterface
      */
     protected function writeLog($level, $message, $context): void
     {
+        if (! is_null($this->sampleRate)) {
+            $rate = $this->sampleRate;
+            $this->sampleRate = null;
+
+            if ($rate === 0.0 || ($rate < 1.0 && (mt_rand() / mt_getrandmax()) > $rate)) {
+                return;
+            }
+        }
+
         if (method_exists($this->logger, 'isHandling') && ! $this->logger->isHandling($level)) {
             return;
         }

--- a/tests/Log/LogSamplingTest.php
+++ b/tests/Log/LogSamplingTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Illuminate\Tests\Log;
+
+use Illuminate\Log\Logger;
+use Monolog\Handler\TestHandler;
+use Monolog\Logger as Monolog;
+use Orchestra\Testbench\TestCase;
+
+class LogSamplingTest extends TestCase
+{
+    private function makeLogger(): array
+    {
+        $handler = new TestHandler;
+        $monolog = new Monolog('test', [$handler]);
+        $logger = new Logger($monolog);
+
+        return [$logger, $handler];
+    }
+
+    public function testSampleAtZeroDropsAllMessages()
+    {
+        [$logger, $handler] = $this->makeLogger();
+
+        for ($i = 0; $i < 100; $i++) {
+            $logger->sample(0.0)->info('test');
+        }
+
+        $this->assertCount(0, $handler->getRecords());
+    }
+
+    public function testSampleAtOnePassesAllMessages()
+    {
+        [$logger, $handler] = $this->makeLogger();
+
+        for ($i = 0; $i < 100; $i++) {
+            $logger->sample(1.0)->info('test');
+        }
+
+        $this->assertCount(100, $handler->getRecords());
+    }
+
+    public function testSampleAtPartialRateSamplesStatistically()
+    {
+        [$logger, $handler] = $this->makeLogger();
+
+        for ($i = 0; $i < 10000; $i++) {
+            $logger->sample(0.5)->info('test');
+        }
+
+        $count = count($handler->getRecords());
+
+        $this->assertGreaterThan(1000, $count);
+        $this->assertLessThan(9000, $count);
+    }
+
+    public function testSampleRateResetsAfterEachMessage()
+    {
+        [$logger, $handler] = $this->makeLogger();
+
+        // Sampled message
+        $logger->sample(0.0)->info('should be dropped');
+        $this->assertCount(0, $handler->getRecords());
+
+        // Next message without sample() should always log
+        $logger->info('should be logged');
+        $this->assertCount(1, $handler->getRecords());
+    }
+
+    public function testSampleThrowsWhenRateAboveOne()
+    {
+        [$logger] = $this->makeLogger();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $logger->sample(1.5);
+    }
+
+    public function testSampleThrowsWhenRateBelowZero()
+    {
+        [$logger] = $this->makeLogger();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $logger->sample(-0.5);
+    }
+
+    public function testSampleWorksWithAllLogLevels()
+    {
+        [$logger, $handler] = $this->makeLogger();
+
+        $logger->sample(1.0)->debug('d');
+        $logger->sample(1.0)->info('i');
+        $logger->sample(1.0)->notice('n');
+        $logger->sample(1.0)->warning('w');
+        $logger->sample(1.0)->error('e');
+        $logger->sample(1.0)->critical('c');
+        $logger->sample(1.0)->alert('a');
+        $logger->sample(1.0)->emergency('em');
+
+        $this->assertCount(8, $handler->getRecords());
+    }
+
+    public function testSampleWorksWithWriteMethod()
+    {
+        [$logger, $handler] = $this->makeLogger();
+
+        $logger->sample(0.0)->write('info', 'should be dropped');
+        $this->assertCount(0, $handler->getRecords());
+
+        $logger->sample(1.0)->write('info', 'should be logged');
+        $this->assertCount(1, $handler->getRecords());
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a fluent `sample(float $rate)` method to `Illuminate\Log\Logger` that allows randomly skipping individual log messages based on a probability rate (0.0 to 1.0)
- The sample rate is consumed on the next log call and automatically resets, so it never leaks into subsequent messages
- Throws `InvalidArgumentException` if rate is outside [0.0, 1.0]

### Usage

```php
// Only log ~10% of these messages
Log::sample(0.1)->info('High-volume event happened');

// Normal logging is unaffected
Log::info('This always logs');
```

## Test plan

- [x] 0.0 rate drops all messages
- [x] 1.0 rate passes all messages
- [x] Partial rate samples statistically
- [x] Sample rate resets after each message
- [x] Throws on invalid rates (> 1.0, < 0.0)
- [x] Works with all log levels and write()