### PR TITLE
[13.x] Make Cache touch() TTL required and remove redundant value fetching 

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -664,23 +664,15 @@ class Repository implements ArrayAccess, CacheContract
     }
 
     /**
-     * Set the expiration of a cached item; null TTL will retain the item forever.
+     * Set the expiration of a cached item.
      *
      * @param  string  $key
-     * @param  \DateTimeInterface|\DateInterval|int|null  $ttl
+     * @param  \DateTimeInterface|\DateInterval|int  $ttl
      * @return bool
      */
-    public function touch($key, $ttl = null)
+    public function touch($key, $ttl)
     {
-        $value = $this->get($key);
-
-        if (is_null($value)) {
-            return false;
-        }
-
-        return is_null($ttl)
-            ? $this->forever($key, $value)
-            : $this->store->touch($this->itemKey($key), $this->getSeconds($ttl));
+        return $this->store->touch($this->itemKey($key), $this->getSeconds($ttl));
     }
 
     /**

--- a/src/Illuminate/Contracts/Cache/Repository.php
+++ b/src/Illuminate/Contracts/Cache/Repository.php
@@ -100,13 +100,13 @@ interface Repository extends CacheInterface
     public function rememberForever($key, Closure $callback);
 
     /**
-     * Set the expiration of a cached item; null TTL will retain the item forever.
+     * Set the expiration of a cached item.
      *
      * @param  \BackedEnum|\UnitEnum|string  $key
-     * @param  \DateTimeInterface|\DateInterval|int|null  $ttl
+     * @param  \DateTimeInterface|\DateInterval|int  $ttl
      * @return bool
      */
-    public function touch($key, $ttl = null);
+    public function touch($key, $ttl);
 
     /**
      * Remove an item from the cache.

--- a/src/Illuminate/Support/Facades/Cache.php
+++ b/src/Illuminate/Support/Facades/Cache.php
@@ -41,7 +41,7 @@ use Mockery;
  * @method static mixed sear(\UnitEnum|string $key, \Closure $callback)
  * @method static mixed rememberForever(\UnitEnum|string $key, \Closure $callback)
  * @method static mixed flexible(\UnitEnum|string $key, array $ttl, callable $callback, array|null $lock = null, bool $alwaysDefer = false)
- * @method static bool touch(string $key, \DateTimeInterface|\DateInterval|int|null $ttl = null)
+ * @method static bool touch(string $key, \DateTimeInterface|\DateInterval|int $ttl)
  * @method static mixed withoutOverlapping(\UnitEnum|string $key, callable $callback, int $lockFor = 0, int $waitFor = 10, string|null $owner = null)
  * @method static bool forget(\UnitEnum|array|string $key)
  * @method static bool delete(\UnitEnum|array|string $key)

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -474,24 +474,12 @@ class CacheRepositoryTest extends TestCase
         $nonFlushableRepo->flushLocks();
     }
 
-    public function testTouchWithNullTTLRemembersItemForever(): void
-    {
-        $key = 'key';
-        $ttl = null;
-
-        $repo = $this->getRepository();
-        $repo->getStore()->shouldReceive('get')->with($key)->andReturn('bar');
-        $repo->getStore()->shouldReceive('forever')->once()->with($key, 'bar')->andReturn(true);
-        $this->assertTrue($repo->touch($key, $ttl));
-    }
-
     public function testTouchWithSecondsTtlCorrectlyProxiesToStore(): void
     {
         $key = 'key';
         $ttl = 60;
 
         $repo = $this->getRepository();
-        $repo->getStore()->shouldReceive('get')->with($key)->andReturn('bar');
         $repo->getStore()->shouldReceive('touch')->once()->with($key, $ttl)->andReturn(true);
         $this->assertTrue($repo->touch($key, $ttl));
     }
@@ -504,7 +492,6 @@ class CacheRepositoryTest extends TestCase
         Carbon::setTestNow($now = Carbon::now());
 
         $repo = $this->getRepository();
-        $repo->getStore()->shouldReceive('get')->with($key)->andReturn('bar');
         $repo->getStore()->shouldReceive('touch')->once()->with($key, $ttl)->andReturn(true);
         $this->assertTrue($repo->touch($key, $now->addSeconds($ttl)));
     }
@@ -515,7 +502,6 @@ class CacheRepositoryTest extends TestCase
         $ttl = 60;
 
         $repo = $this->getRepository();
-        $repo->getStore()->shouldReceive('get')->with($key)->andReturn('bar');
         $repo->getStore()->shouldReceive('touch')->once()->with($key, $ttl)->andReturn(true);
         $this->assertTrue($repo->touch($key, DateInterval::createFromDateString("$ttl seconds")));
     }


### PR DESCRIPTION
 This PR makes two changes to `Cache::touch()` before the 13.x API surface is finalized:

  ### 1. Make `$ttl` a required parameter

  Currently, `Cache::touch($key)` with no TTL silently converts the item to live forever via `$this->forever()`.
  This is surprising behavior for a method whose purpose is TTL *extension*. A developer calling `Cache::touch('session-key')` to "bump" an expiration would not expect to accidentally make the item permanent.

  Unlike `put()`, where `null` TTL meaning "forever" is a convenience shorthand with a clear value being stored, `touch()` is specifically about managing expiration. Having it silently remove expiration contradicts its purpose.

  Making `$ttl` required forces explicit intent: developers who want an item to live forever should call `Cache::forever()` directly.

  ### 2. Remove the redundant `$this->get()` call from the Repository layer

  The current implementation fetches the full cached value at the Repository level before delegating to the store:

  ```php
  public function touch($key, $ttl = null)
  {
      $value = $this->get($key);          // ← fetches full value
      if (is_null($value)) return false;
      // ...
      $this->store->touch($key, $seconds); // ← store doesn't need the value
  }
```

  This is unnecessary because every store implementation already handles the "key doesn't exist" case by returning false:

  - Redis — EXPIRE returns 0 for nonexistent keys
  - Database — UPDATE ... WHERE expiration > now affects 0 rows
  - DynamoDB — ConditionalCheckFailedException caught and returns false
  - Memcached — native touch() returns false
  - File/APC — fetch the value internally and return false if missing

  For the four atomic stores (Redis, Database, DynamoDB, Memcached), the Repository-level get() is pure overhead, it deserializes the entire cached value only to throw it away. For File and APC stores, the value ends up being fetched twice: once at the Repository layer and once inside the store.

  After this change, the Repository simply converts the TTL and delegates:

  ```php
  public function touch($key, $ttl)
  {
      return $this->store->touch($this->itemKey($key), $this->getSeconds($ttl));
  }
```

  ### Change before the new cache touch API goes live

  This is a breaking change to a new cache API introduced in 13.x, so there is no backward-compatibility concern with 11.x or 12.x users. The method signature changes from `touch($key, $ttl = null)` to `touch($key, $ttl)`.

