### PR TITLE
[13.x] Optional strict environment variables

### DIFF
--- a/src/Illuminate/Support/Env.php
+++ b/src/Illuminate/Support/Env.php
@@ -95,13 +95,38 @@ class Env
     /**
      * Get the value of an environment variable.
      *
+     * When $strict is true, the value is cast when present: boolean-like → bool, numeric → int,
+     *
      * @param  string  $key
      * @param  mixed  $default
+     * @param  bool  $strict
      * @return mixed
      */
-    public static function get($key, $default = null)
+    public static function get($key, $default = null, bool $strict = false)
     {
-        return self::getOption($key)->getOrCall(fn () => value($default));
+        $option = self::getOption($key);
+
+        if ($option->isEmpty()) {
+            return value($default);
+        }
+
+        $result = $option->get();
+
+        if ($strict) {
+            if (is_bool($result)) {
+                return $result;
+            }
+
+            if (is_numeric($result)) {
+                return (int) $result;
+            }
+
+            if (in_array($result, ['true', 'false', '1', '0', 'on', 'off', 'yes', 'no'], true)) {
+                return filter_var($result, FILTER_VALIDATE_BOOLEAN);
+            }
+        }
+
+        return $result;
     }
 
     /**

--- a/src/Illuminate/Support/Env.php
+++ b/src/Illuminate/Support/Env.php
@@ -95,7 +95,8 @@ class Env
     /**
      * Get the value of an environment variable.
      *
-     * When $strict is true, the value is cast when present: boolean-like → bool, numeric → int,
+     * When $strict is true, the value is cast when present: numeric with decimal/exponent → float,
+     * other numeric → int, boolean-like → bool.
      *
      * @param  string  $key
      * @param  mixed  $default
@@ -112,12 +113,17 @@ class Env
 
         $result = $option->get();
 
+
         if ($strict) {
             if (is_bool($result)) {
                 return $result;
             }
 
             if (is_numeric($result)) {
+                if (str_contains($result, '.') || str_contains($result, 'e')) {
+                    return (float) $result;
+                }
+
                 return (int) $result;
             }
 

--- a/src/Illuminate/Support/Env.php
+++ b/src/Illuminate/Support/Env.php
@@ -119,14 +119,14 @@ class Env
             }
 
             if (is_numeric($result)) {
-                if (str_contains($result, '.') || str_contains($result, 'e')) {
+                if (str_contains($result, '.') || str_contains(strtolower($result), 'e')) {
                     return (float) $result;
                 }
 
                 return (int) $result;
             }
 
-            if (in_array($result, ['true', 'false', '1', '0', 'on', 'off', 'yes', 'no'], true)) {
+            if (in_array(strtolower($result), ['true', 'false', 'on', 'off', 'yes', 'no'], true)) {
                 return filter_var($result, FILTER_VALIDATE_BOOLEAN);
             }
         }

--- a/src/Illuminate/Support/Env.php
+++ b/src/Illuminate/Support/Env.php
@@ -113,7 +113,6 @@ class Env
 
         $result = $option->get();
 
-
         if ($strict) {
             if (is_bool($result)) {
                 return $result;

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -142,7 +142,8 @@ if (! function_exists('env')) {
     /**
      * Gets the value of an environment variable.
      *
-     * When $strict is true, the value is cast when present: boolean-like → bool, numeric → int,
+     * When $strict is true, the value is cast when present: numeric with . or e → float,
+     * other numeric → int, boolean-like → bool.
      *
      * @param  string  $key
      * @param  mixed  $default

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -142,13 +142,16 @@ if (! function_exists('env')) {
     /**
      * Gets the value of an environment variable.
      *
+     * When $strict is true, the value is cast when present: boolean-like → bool, numeric → int,
+     *
      * @param  string  $key
      * @param  mixed  $default
+     * @param  bool  $strict
      * @return mixed
      */
-    function env($key, $default = null)
+    function env($key, $default = null, bool $strict = false)
     {
-        return Env::get($key, $default);
+        return Env::get($key, $default, $strict);
     }
 }
 

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -142,7 +142,7 @@ if (! function_exists('env')) {
     /**
      * Gets the value of an environment variable.
      *
-     * When $strict is true, the value is cast when present: numeric with . or e → float,
+     * When $strict is true, the value is cast when present: numeric with decimal/exponent → float,
      * other numeric → int, boolean-like → bool.
      *
      * @param  string  $key

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -1284,6 +1284,88 @@ class SupportHelpersTest extends TestCase
         $this->assertSame('x"null"x', env('foo'));
     }
 
+    public function testEnvStrictNumericToInteger(): void
+    {
+        $_SERVER['foo'] = '42';
+        $this->assertSame(42, Env::get('foo', null, true));
+        $this->assertSame(42, env('foo', null, strict: true));
+
+        $_SERVER['foo'] = '0';
+        $this->assertSame(0, Env::get('foo', null, true));
+
+        $_SERVER['foo'] = '-100';
+        $this->assertSame(-100, Env::get('foo', null, true));
+
+        $_SERVER['foo'] = '3.14';
+        $this->assertSame(3, Env::get('foo', null, true));
+
+        $this->assertNull(Env::get('env_strict_missing_int', null, true));
+        $this->assertSame(99, Env::get('env_strict_missing_int', 99, true));
+        $this->assertSame('default', Env::get('env_strict_missing_int', 'default', true));
+    }
+
+    public function testEnvStrictBooleanLikeToBoolean(): void
+    {
+        $_SERVER['foo'] = 'true';
+        $this->assertTrue(Env::get('foo', null, true));
+
+        $_SERVER['foo'] = 'on';
+        $this->assertTrue(Env::get('foo', null, true));
+
+        $_SERVER['foo'] = 'yes';
+        $this->assertTrue(Env::get('foo', null, true));
+
+        $_SERVER['foo'] = 'false';
+        $this->assertFalse(Env::get('foo', null, true));
+
+        $_SERVER['foo'] = 'off';
+        $this->assertFalse(Env::get('foo', null, true));
+
+        $_SERVER['foo'] = 'no';
+        $this->assertFalse(Env::get('foo', null, true));
+
+        $_SERVER['foo'] = '';
+        $this->assertSame('', Env::get('foo', null, true));
+
+        $this->assertNull(Env::get('env_strict_missing_bool', null, true));
+        $this->assertTrue(Env::get('env_strict_missing_bool', true, true));
+        $this->assertFalse(Env::get('env_strict_missing_bool', false, true));
+    }
+
+    public function testEnvStrictPlainStringStaysString(): void
+    {
+        $_SERVER['foo'] = 'hello';
+        $this->assertSame('hello', Env::get('foo', null, true));
+
+        $_SERVER['foo'] = 'some-value';
+        $this->assertSame('some-value', Env::get('foo', null, true));
+
+        $this->assertNull(Env::get('env_strict_missing_str', null, true));
+        $this->assertSame('fallback', Env::get('env_strict_missing_str', 'fallback', true));
+    }
+
+    public function testEnvWithoutStrictReturnsRawValue(): void
+    {
+        $_SERVER['foo'] = '42';
+        $this->assertSame('42', Env::get('foo'));
+        $this->assertSame('42', Env::get('foo', null, false));
+    }
+
+    public function testEnvHelperWithStrictParameter(): void
+    {
+        $_SERVER['foo'] = '123';
+        $this->assertSame(123, env('foo', null, strict: true));
+
+        $_SERVER['foo'] = 'true';
+        $this->assertTrue(env('foo', null, strict: true));
+
+        $_SERVER['foo'] = '42';
+        $this->assertSame(42, env('foo', null, strict: true));
+
+        $_SERVER['foo'] = 'hello';
+        $this->assertSame('hello', env('foo', null, strict: true));
+    }
+
     public function testWriteArrayOfEnvVariablesToFile()
     {
         $filesystem = new Filesystem;

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -1296,12 +1296,30 @@ class SupportHelpersTest extends TestCase
         $_SERVER['foo'] = '-100';
         $this->assertSame(-100, Env::get('foo', null, true));
 
-        $_SERVER['foo'] = '3.14';
-        $this->assertSame(3, Env::get('foo', null, true));
-
         $this->assertNull(Env::get('env_strict_missing_int', null, true));
         $this->assertSame(99, Env::get('env_strict_missing_int', 99, true));
         $this->assertSame('default', Env::get('env_strict_missing_int', 'default', true));
+    }
+
+    public function testEnvStrictNumericToFloat(): void
+    {
+        $_SERVER['foo'] = '3.14';
+        $this->assertSame(3.14, Env::get('foo', null, true));
+
+        $_SERVER['foo'] = '0.0';
+        $this->assertSame(0.0, Env::get('foo', null, true));
+
+        $_SERVER['foo'] = '-2.5';
+        $this->assertSame(-2.5, Env::get('foo', null, true));
+
+        $_SERVER['foo'] = '1e2';
+        $this->assertSame(100.0, Env::get('foo', null, true));
+
+        $_SERVER['foo'] = '2.5e-1';
+        $this->assertSame(0.25, Env::get('foo', null, true));
+
+        $this->assertNull(Env::get('env_strict_missing_float', null, true));
+        $this->assertSame(1.5, Env::get('env_strict_missing_float', 1.5, true));
     }
 
     public function testEnvStrictBooleanLikeToBoolean(): void


### PR DESCRIPTION
## Summary
`env()` and `Env::get()` now accept an optional third argument `$strict` (bool). When `$strict` is `true` and the variable is set, the value is cast automatically:

1. **Numeric string** → `int` (e.g. `"42"`, `"0"`, `"3.14"` → `42`, `0`, `3`);
2. **Plain string** → stays `string`;
3. **Boolean-like string** → `bool` (`true`, `false`, `on`, `off`, `yes`, `no`);

When the variable is missing, the default is returned as-is.

## Why this is useful
The change is most useful when config uses an env variable with a manual cast to `int`. For example, `(int) env('REQUEST_TIMEOUT', null)` returns `0` when the variable is not set (because `(int) null === 0`), which is often not what you want.

## Backward compatibility
If `$strict` is not used (default `false`), behaviour is unchanged: `env($key)` and `env($key, $default)` work exactly as before and return the raw string (or the default). Existing code does not need to be updated.

## Examples

### Integer
```php
// With (int): when the variable is missing, default null is cast to 0
(int) env('REQUEST_TIMEOUT', null);  // → 0 if REQUEST_TIMEOUT is not set

// Without (int): returns the raw string or the default as-is
env('REQUEST_TIMEOUT', null);  // → null if REQUEST_TIMEOUT is not set, and string if REQUEST_TIMEOUT is set

// With strict: variable missing → default as-is (null), variable set and numeric → int
env('REQUEST_TIMEOUT', null, strict: true);  // → null if not set, 30 if REQUEST_TIMEOUT=30
```

### Float
```php
// With (float): when the variable is missing, default null is cast to 0.0
(float) env('DEFAULT_PRICE', null);  // → 0.0 if DEFAULT_PRICE is not set

// Without (float): returns the raw string or the default as-is
env('DEFAULT_PRICE', null);  // → null if DEFAULT_PRICE is not set, and string if DEFAULT_PRICE is set

// With strict: variable missing → default as-is (null), variable set and numeric → float
env('DEFAULT_PRICE', null, strict: true);  // → null if not set, 3.14 if REQUEST_TIMEOUT=3.14
```

### Boolean / feature flag

```php
// With strict: "true", "false", "on", "off", "yes", "no" → bool
env('APP_DEBUG', 'yes', strict: true);  // → true/false

// Without strict: "on", "off", "yes", "no" → string
env('APP_DEBUG', 'yes');  // → 'yes'
```

## API
- **Signature:** `Env::get(string $key, $default = null, bool $strict = false)` and global `env($key, $default = null, bool $strict = false)`.
- **Behaviour when `$strict` is true and variable is set:** numeric string → `int` / `float`, boolean-like string → `bool`, else → `string`. When the variable is missing, `$default` is returned as-is.
