### PR TITLE
[12.x] Add option to hide detailed validation errors in JSON responses

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -46,6 +46,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Hide Validation Errors
+    |--------------------------------------------------------------------------
+    |
+    | When enabled, detailed validation error messages and field names will
+    | not be included in JSON error responses. This prevents attackers from
+    | discovering your API's expected fields by sending empty requests.
+    |
+    */
+
+    'hide_validation_errors' => (bool) env('HIDE_VALIDATION_ERRORS', false),
+
+    /*
+    |--------------------------------------------------------------------------
     | Application URL
     |--------------------------------------------------------------------------
     |

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -793,10 +793,12 @@ class Handler implements ExceptionHandlerContract
      */
     protected function invalidJson($request, ValidationException $exception)
     {
-        return response()->json([
-            'message' => $exception->getMessage(),
-            'errors' => $exception->errors(),
-        ], $exception->status);
+        return response()->json(array_filter([
+            'message' => config('app.hide_validation_errors')
+                ? $exception->validator->getTranslator()->get('The given data was invalid.')
+                : $exception->getMessage(),
+            'errors' => config('app.hide_validation_errors') ? null : $exception->errors(),
+        ]), $exception->status);
     }
 
     /**

--- a/tests/Foundation/Configuration/ExceptionsTest.php
+++ b/tests/Foundation/Configuration/ExceptionsTest.php
@@ -4,10 +4,19 @@ namespace Illuminate\Tests\Foundation\Configuration;
 
 use Exception;
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Routing\ResponseFactory as ResponseFactoryContract;
+use Illuminate\Contracts\View\Factory as ViewFactory;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Exceptions\Handler;
 use Illuminate\Http\Request;
+use Illuminate\Routing\Redirector;
+use Illuminate\Routing\ResponseFactory;
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\Translator;
+use Illuminate\Validation\ValidationException;
+use Illuminate\Validation\Validator;
+use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
@@ -48,5 +57,39 @@ class ExceptionsTest extends TestCase
         $exceptions->shouldRenderJsonWhen(fn () => false);
         $shouldReturnJson = (fn () => $this->shouldReturnJson(new Request, new Exception()))->call($exceptions->handler);
         $this->assertFalse($shouldReturnJson);
+    }
+
+    public function testHideValidationErrors()
+    {
+        $container = Container::setInstance(new Container);
+        $config = new \Illuminate\Config\Repository;
+        $container->instance('config', $config);
+        $container->instance(ViewFactory::class, $viewFactory = m::mock(ViewFactory::class));
+        $container->instance(ResponseFactoryContract::class, new ResponseFactory(
+            $viewFactory,
+            m::mock(Redirector::class)
+        ));
+
+        $handler = new Handler($container);
+
+        $translator = new Translator(new ArrayLoader, 'en');
+        $validator = new Validator($translator, ['name' => ''], ['name' => 'required']);
+        $validator->fails();
+        $validationException = new ValidationException($validator);
+
+        // By default, validation errors are included.
+        $response = (fn () => $this->invalidJson(new Request, $validationException))->call($handler);
+        $data = json_decode($response->getContent(), true);
+        $this->assertArrayHasKey('errors', $data);
+        $this->assertArrayHasKey('name', $data['errors']);
+
+        // When HIDE_VALIDATION_ERRORS is enabled, errors should be omitted.
+        $config->set('app.hide_validation_errors', true);
+        $response = (fn () => $this->invalidJson(new Request, $validationException))->call($handler);
+        $data = json_decode($response->getContent(), true);
+        $this->assertArrayNotHasKey('errors', $data);
+        $this->assertEquals('The given data was invalid.', $data['message']);
+
+        Container::setInstance(null);
     }
 }


### PR DESCRIPTION
## Summary

This is more of a **discussion** than a ready-to-merge PR. I'd love to hear maintainers' thoughts on this.

### The Problem

Laravel's default JSON validation error response exposes exact field names and validation rules. This makes API enumeration trivial for attackers — just send an empty `{}` body to any endpoint:

```bash
curl -X POST https://example.com/api/v1/register \
  -H 'Content-Type: application/json' \
  -d '{}'
```

Response:
```json
{
    "message": "The customer id field is required.",
    "errors": {
        "customer_id": ["The customer id field is required."],
        "device_id": ["The device id field is required."],
        "password": ["The password field is required."]
    }
}
```

Without any authentication or prior knowledge, an attacker now knows the exact schema. I've seen this on production banking APIs.

### The Proposal

Add a `HIDE_VALIDATION_ERRORS` env variable (opt-in, defaults to `false`). When enabled, JSON validation responses become:

```json
{
    "message": "The given data was invalid."
}
```

No field names, no per-field errors, no enumeration.

### Usage

```env
HIDE_VALIDATION_ERRORS=true
```

### What Changed

- `config/app.php` — new `hide_validation_errors` config key reading from env
- `Handler::invalidJson()` — respects the config to omit detailed errors
- Added test covering both behaviors

### Discussion Points

- Is this the right approach, or should this be a method on the exception handler instead?
- Should it be tied to `APP_DEBUG` (hide errors when debug is false)?
- Is this something the framework should handle, or is it better left to individual apps?
- Would a different config key name be preferred?

I understand this is opinionated — just wanted to start the conversation around making this easier out of the box.

## Test Plan

- [x] Existing tests pass
- [x] New test covers both default (errors shown) and opt-in (errors hidden) behavior