### PR TITLE
[12.x] Suppress chmod errors in Filesystem::replace() for non-POSIX filesystems

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -223,9 +223,9 @@ class Filesystem
 
         // Fix permissions of tempPath because `tempnam()` creates it with permissions set to 0600...
         if (! is_null($mode)) {
-            chmod($tempPath, $mode);
+            @chmod($tempPath, $mode);
         } else {
-            chmod($tempPath, 0777 - umask());
+            @chmod($tempPath, 0777 - umask());
         }
 
         file_put_contents($tempPath, $content);

--- a/src/Illuminate/Foundation/AliasLoader.php
+++ b/src/Illuminate/Foundation/AliasLoader.php
@@ -111,7 +111,7 @@ class AliasLoader
         $tempPath = tempnam(dirname($path), 'facade-');
 
         // Fix permissions of tempPath because `tempnam()` creates it with permissions set to 0600...
-        chmod($tempPath, 0777 - umask());
+        @chmod($tempPath, 0777 - umask());
 
         file_put_contents($tempPath, $stub);
 


### PR DESCRIPTION
Fixes #59076

After #58812 changed `BladeCompiler::compile()` from `put()` to `replace()`,
applications on non-POSIX filesystems (Azure File shares mounted via SMB/CIFS)
get `chmod(): Operation not permitted` errors during Blade compilation.

`Filesystem::replace()` and `AliasLoader::ensureFacadeExists()` both call
`chmod()` to correct the 0600 permissions that `tempnam()` creates by default.
On filesystems without POSIX permission support, the call fails and Laravel's
error handler promotes it to an `ErrorException`.

The fix adds `@` error suppression to the `chmod()` calls in both locations.
`@` is already used for `@unlink`, `@mkdir`, `@rename`, and `@rmdir` in
`Filesystem.php`. On POSIX filesystems, `chmod()` still runs and succeeds
as before.