### PR TITLE
[13.x] Correctly handle route parameters with defaults and key binding

### DIFF
--- a/src/Illuminate/Routing/RouteUrlGenerator.php
+++ b/src/Illuminate/Routing/RouteUrlGenerator.php
@@ -201,7 +201,7 @@ class RouteUrlGenerator
                 $bindingField = $route->bindingFieldFor($name);
                 $defaultParameterKey = $bindingField ? "$name:$bindingField" : $name;
 
-                if (! isset($this->defaultParameters[$defaultParameterKey]) && ! isset($optionalParameters[$name])) {
+                if (! isset($this->defaultParameters[$defaultParameterKey]) && ! isset($this->defaultParameters[$name]) && ! isset($optionalParameters[$name])) {
                     // No named parameter or default value for a required parameter, try to match to positional parameter below...
                     array_push($requiredRouteParametersWithoutDefaultsOrNamedParameters, $name);
                 }
@@ -284,8 +284,12 @@ class RouteUrlGenerator
             $bindingField = $route->bindingFieldFor($key);
             $defaultParameterKey = $bindingField ? "$key:$bindingField" : $key;
 
-            if ($value === '' && isset($this->defaultParameters[$defaultParameterKey])) {
-                $namedParameters[$key] = $this->defaultParameters[$defaultParameterKey];
+            $defaultParameter = $this->defaultParameters[$defaultParameterKey]
+                ?? $this->defaultParameters[$key]
+                ?? null;
+
+            if ($value === '' && isset($defaultParameter)) {
+                $namedParameters[$key] = $defaultParameter;
             }
         }
 

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -2000,6 +2000,173 @@ class RoutingUrlGeneratorTest extends TestCase
             $url->route('tenantPostUserOptionalMethod', ['concreteTenant', 'concretePost', 'concreteUser', 'concreteMethod']),
         );
     }
+
+    /**
+     * Test the fix for route parameter resolution with URL::defaults() and model key binding fields.
+     */
+    public function testRouteParameterResolutionWithDefaultsAndBindingFields(): void
+    {
+        $url = new UrlGenerator(
+            $routes = new RouteCollection,
+            Request::create('https://www.foo.com/')
+        );
+
+        /**
+         * Test case 1: Route with optional parameter with binding field.
+         */
+        $url->defaults([
+            'team' => 'example-team',
+        ]);
+
+        $route = new Route(['GET'], '{team:slug?}/posts/{post}', ['as' => 'posts.show', fn () => '']);
+        $routes->add($route);
+
+        // Test with positional parameters
+        $this->assertSame(
+            'https://www.foo.com/example-team/posts/123',
+            $url->route('posts.show', [123]),
+        );
+
+        // Test with named parameter
+        $this->assertSame(
+            'https://www.foo.com/example-team/posts/123',
+            $url->route('posts.show', ['post' => 123]),
+        );
+
+        // Test with explicit team parameter
+        $this->assertSame(
+            'https://www.foo.com/another-team/posts/123',
+            $url->route('posts.show', ['team' => 'another-team', 'post' => 123]),
+        );
+
+        /**
+         * Test case 2: Route with required parameter with binding field.
+         */
+        $route = new Route(['GET'], '{team:slug}/posts/{post}', ['as' => 'posts.show.required', fn () => '']);
+        $routes->add($route);
+
+        // Test with positional parameters
+        $this->assertSame(
+            'https://www.foo.com/example-team/posts/123',
+            $url->route('posts.show.required', [123]),
+        );
+
+        // Test with named parameters
+        $this->assertSame(
+            'https://www.foo.com/example-team/posts/123',
+            $url->route('posts.show.required', ['post' => 123]),
+        );
+
+        /**
+         * Test case 3: Route with multiple parameters with binding fields.
+         */
+        $url->defaults([
+            'team' => 'example-team',
+            'team:slug' => 'example-team',
+            'post' => '123',
+        ]);
+
+        $route = new Route(['GET'], '{team:slug?}/posts/{post:id}/comments/{comment}', ['as' => 'posts.show.multi', fn () => '']);
+        $routes->add($route);
+
+        // Test with positional parameter
+        $this->assertSame(
+            'https://www.foo.com/example-team/posts/123/comments/456',
+            $url->route('posts.show.multi', [456]),
+        );
+
+        // Test with named parameter
+        $this->assertSame(
+            'https://www.foo.com/example-team/posts/123/comments/456',
+            $url->route('posts.show.multi', ['comment' => 456]),
+        );
+
+        /**
+         * Test case 4: Route with mixed parameter types (some with defaults, some without).
+         */
+        $route = new Route(['GET'], '{team:slug?}/posts/{post}/comments/{comment}', ['as' => 'comments.show', fn () => '']);
+        $routes->add($route);
+
+        // Test with positional parameters
+        $this->assertSame(
+            'https://www.foo.com/example-team/posts/123/comments/456',
+            $url->route('comments.show', [123, 456]),
+        );
+
+        // Test with named parameters
+        $this->assertSame(
+            'https://www.foo.com/example-team/posts/123/comments/456',
+            $url->route('comments.show', ['post' => 123, 'comment' => 456]),
+        );
+
+        /**
+         * Test case 5: Route with only binding field default (no regular parameter default).
+         */
+        $url->defaults([
+            'team:slug' => 'example-team',
+        ]);
+
+        $route = new Route(['GET'], '{team:slug?}/posts/{post}', ['as' => 'posts.show.binding-only', fn () => '']);
+        $routes->add($route);
+
+        // Test with positional parameter
+        $this->assertSame(
+            'https://www.foo.com/example-team/posts/123',
+            $url->route('posts.show.binding-only', [123]),
+        );
+
+        // Test with named parameter
+        $this->assertSame(
+            'https://www.foo.com/example-team/posts/123',
+            $url->route('posts.show.binding-only', ['post' => 123]),
+        );
+
+        /**
+         * Test case 6: Route with only regular parameter default (no binding field default).
+         */
+        $url->defaults([
+            'team' => 'example-team',
+        ]);
+
+        $route = new Route(['GET'], '{team:slug?}/posts/{post}', ['as' => 'posts.show.regular-only', fn () => '']);
+        $routes->add($route);
+
+        // Test with positional parameter
+        $this->assertSame(
+            'https://www.foo.com/example-team/posts/123',
+            $url->route('posts.show.regular-only', [123]),
+        );
+
+        // Test with named parameter
+        $this->assertSame(
+            'https://www.foo.com/example-team/posts/123',
+            $url->route('posts.show.regular-only', ['post' => 123]),
+        );
+
+        /**
+         * Test case 7: Route without any defaults to ensure existing functionality works.
+         */
+        $route = new Route(['GET'], '{team:slug}/posts/{post}', ['as' => 'posts.show.no-defaults', fn () => '']);
+        $routes->add($route);
+
+        // Test with positional parameters
+        $this->assertSame(
+            'https://www.foo.com/another-team/posts/123',
+            $url->route('posts.show.no-defaults', ['another-team', 123]),
+        );
+
+        // Test with named parameters
+        $this->assertSame(
+            'https://www.foo.com/another-team/posts/123',
+            $url->route('posts.show.no-defaults', ['team' => 'another-team', 'post' => 123]),
+        );
+
+        // Test with mixed parameters
+        $this->assertSame(
+            'https://www.foo.com/another-team/posts/123',
+            $url->route('posts.show.no-defaults', ['team' => 'another-team', 123]),
+        );
+    }
 }
 
 class RoutableInterfaceStub implements UrlRoutable


### PR DESCRIPTION
**Note**
This PR is a follow-up to the [previous discussion](https://github.com/laravel/framework/issues/57488#issuecomment-3654413304) where @crynobone suggested that the change should be submitted against the `master` branch instead of the 12.x patch branch.

---

**Description:**
This PR fixes an issue where `URL::defaults()` combined with route parameters (including model key binding fields) causes positional parameter misalignment when generating URLs with `route()` call.

**Problem:**
When a route defines a parameter with a key binding (e.g., `{team:slug}`) and a default is set using only the parameter name (e.g., `URL::defaults(['team' => 'example-team']);`), the default does not correctly align with the bound field (slug).
As a result, calling `route()` with positional or named parameters can incorrectly assign values, producing an empty query string like `<URL>?team=` instead of the expected URL.


**Reference:** [#57488](https://github.com/laravel/framework/issues/57488)

**Solution:**
Added a check for both named parameters and key binding fields to correctly align route parameters when generating URLs.

**Example:**
1. Define route with model key binding:

```php
Route::get('{team:slug}/projects/{project}', [ProjectController::class, 'show'])
    ->name('projects.show');
```

2. Sets default route params from middleware:

```php
URL::defaults(['team' => 'example-team']);
```

3. Route Call:

```php
// Case 1: Positional parameter
route('projects.show', 123);

// ❌ Before:
// Exceptions: Missing required parameter for [Route: projects.show] [URI: {team}/projects/{project}] [Missing parameter: project].

// ✅ After:
// http://laravel.test/example-team/projects/123


// Case 2: Named parameters
route('projects.show', ['project' => 123]);

// ❌ Before:
// http://laravel.test/example-team/projects/123?team=

// ✅ After:
// http://laravel.test/example-team/projects/123
```