### PR TITLE
[12.x] Add schedule:why-not command for debugging scheduler failures

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -294,7 +294,7 @@ class Event
      *
      * @return bool
      */
-    protected function expressionPasses()
+    public function expressionPasses()
     {
         $date = Date::now();
 

--- a/src/Illuminate/Console/Scheduling/ScheduleFailureLogger.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleFailureLogger.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Illuminate\Console\Scheduling;
+
+use Illuminate\Console\Events\ScheduledTaskFailed;
+use Illuminate\Console\Events\ScheduledTaskSkipped;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Facades\Date;
+
+class ScheduleFailureLogger
+{
+    /**
+     * Create a new failure logger instance.
+     *
+     * @param  \Illuminate\Filesystem\Filesystem  $files
+     * @param  int  $maxEntries
+     */
+    public function __construct(
+        protected Filesystem $files,
+        protected int $maxEntries = 1000,
+    ) {
+    }
+
+    /**
+     * Handle a scheduled task failure event.
+     *
+     * @param  \Illuminate\Console\Events\ScheduledTaskFailed  $event
+     * @return void
+     */
+    public function handleTaskFailed(ScheduledTaskFailed $event)
+    {
+        $this->writeEntry([
+            'timestamp' => Date::now()->toIso8601String(),
+            'command' => $event->task->command ?? $event->task->getSummaryForDisplay(),
+            'description' => $event->task->description ?? '',
+            'type' => 'failed',
+            'exit_code' => $event->task->exitCode,
+            'exception' => $event->exception::class.': '.$event->exception->getMessage(),
+            'mutex' => $event->task->mutexName(),
+        ]);
+    }
+
+    /**
+     * Handle a scheduled task skipped event.
+     *
+     * @param  \Illuminate\Console\Events\ScheduledTaskSkipped  $event
+     * @return void
+     */
+    public function handleTaskSkipped(ScheduledTaskSkipped $event)
+    {
+        $this->writeEntry([
+            'timestamp' => Date::now()->toIso8601String(),
+            'command' => $event->task->command ?? $event->task->getSummaryForDisplay(),
+            'description' => $event->task->description ?? '',
+            'type' => 'skipped',
+            'mutex' => $event->task->mutexName(),
+        ]);
+    }
+
+    /**
+     * Write an entry to the failure log.
+     *
+     * @param  array  $entry
+     * @return void
+     */
+    protected function writeEntry(array $entry)
+    {
+        $path = static::logPath();
+
+        $this->files->ensureDirectoryExists(dirname($path));
+
+        $this->files->append($path, json_encode($entry)."\n");
+
+        $this->rotateIfNeeded($path);
+    }
+
+    /**
+     * Rotate the log file if it exceeds the max entries.
+     *
+     * @param  string  $path
+     * @return void
+     */
+    protected function rotateIfNeeded(string $path)
+    {
+        if (! $this->files->exists($path)) {
+            return;
+        }
+
+        $lines = array_filter(explode("\n", $this->files->get($path)));
+
+        if (count($lines) > $this->maxEntries) {
+            $lines = array_slice($lines, -$this->maxEntries);
+
+            $this->files->put($path, implode("\n", $lines)."\n");
+        }
+    }
+
+    /**
+     * Get the path to the failure log file.
+     *
+     * @return string
+     */
+    public static function logPath()
+    {
+        return storage_path('logs/schedule-failures.json');
+    }
+}

--- a/src/Illuminate/Console/Scheduling/ScheduleFailureLogger.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleFailureLogger.php
@@ -13,7 +13,7 @@ class ScheduleFailureLogger
      * Create a new failure logger instance.
      *
      * @param  \Illuminate\Filesystem\Filesystem  $files
-     * @param  int  $maxEntries
+     * @param  non-negative-int  $maxEntries
      */
     public function __construct(
         protected Filesystem $files,
@@ -60,7 +60,15 @@ class ScheduleFailureLogger
     /**
      * Write an entry to the failure log.
      *
-     * @param  array  $entry
+     * @param  array{
+     *     timestamp: string,
+     *     command: string,
+     *     description: string,
+     *     type: 'failed'|'skipped',
+     *     exit_code?: int|null,
+     *     exception?: string,
+     *     mutex: string,
+     * }  $entry
      * @return void
      */
     protected function writeEntry(array $entry)

--- a/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
@@ -12,6 +12,7 @@ use Illuminate\Console\Events\ScheduledTaskStarting;
 use Illuminate\Contracts\Cache\Repository as Cache;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Sleep;
@@ -110,6 +111,8 @@ class ScheduleRunCommand extends Command
         $this->cache = $cache;
         $this->handler = $handler;
         $this->phpBinary = Application::phpBinary();
+
+        $this->registerFailureLogger();
 
         $events = $this->schedule->dueEvents($this->laravel);
 
@@ -285,5 +288,27 @@ class ScheduleRunCommand extends Command
     protected function clearInterruptSignal()
     {
         $this->cache->forget('illuminate:schedule:interrupt');
+    }
+
+    /**
+     * Register the schedule failure logger listeners.
+     *
+     * @return void
+     */
+    protected function registerFailureLogger()
+    {
+        $logger = new ScheduleFailureLogger(
+            $this->laravel->make(Filesystem::class)
+        );
+
+        $this->dispatcher->listen(
+            ScheduledTaskFailed::class,
+            [$logger, 'handleTaskFailed']
+        );
+
+        $this->dispatcher->listen(
+            ScheduledTaskSkipped::class,
+            [$logger, 'handleTaskSkipped']
+        );
     }
 }

--- a/src/Illuminate/Console/Scheduling/ScheduleWhyNotCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleWhyNotCommand.php
@@ -78,8 +78,21 @@ class ScheduleWhyNotCommand extends Command
      * Build a row of diagnostic data for the given event.
      *
      * @param  \Illuminate\Console\Scheduling\Event  $event
-     * @param  \Illuminate\Support\Collection  $failures
-     * @return array
+     * @param  \Illuminate\Support\Collection<int, array{
+     *     mutex?: string,
+     *     command?: string,
+     *     type?: string,
+     *     exception?: string,
+     *     reason?: string,
+     *     timestamp?: string,
+     * }>  $failures
+     * @return array{
+     *     command: string,
+     *     status: 'OK'|'FAILED'|'SKIPPED',
+     *     diagnostics: string,
+     *     last_failure: string,
+     *     last_failed_at: string,
+     * }
      */
     protected function buildRow(Event $event, Collection $failures)
     {
@@ -285,6 +298,6 @@ class ScheduleWhyNotCommand extends Command
             return $value;
         }
 
-        return mb_substr($value, 0, $length - 3).'...';
+        return mb_substr($value, 0, $length - 1).'…';
     }
 }

--- a/src/Illuminate/Console/Scheduling/ScheduleWhyNotCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleWhyNotCommand.php
@@ -1,0 +1,290 @@
+<?php
+
+namespace Illuminate\Console\Scheduling;
+
+use Closure;
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Collection;
+use ReflectionClass;
+use ReflectionFunction;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(name: 'schedule:why-not')]
+class ScheduleWhyNotCommand extends Command
+{
+    /**
+     * The console command signature.
+     *
+     * @var string
+     */
+    protected $signature = 'schedule:why-not
+        {--json : Output the results as JSON}
+        {--event= : Filter to a specific command or description}
+        {--limit=1 : Number of failure entries to show per event}
+    ';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Diagnose why scheduled tasks are failing or not running';
+
+    /**
+     * Execute the console command.
+     *
+     * @param  \Illuminate\Console\Scheduling\Schedule  $schedule
+     * @param  \Illuminate\Filesystem\Filesystem  $files
+     * @return void
+     */
+    public function handle(Schedule $schedule, Filesystem $files)
+    {
+        $events = new Collection($schedule->events());
+
+        if ($events->isEmpty()) {
+            if ($this->option('json')) {
+                $this->output->writeln('[]');
+            } else {
+                $this->components->info('No scheduled tasks have been defined.');
+            }
+
+            return;
+        }
+
+        $filter = $this->option('event');
+
+        if ($filter) {
+            $events = $events->filter(function ($event) use ($filter) {
+                $command = $this->getCommandName($event);
+
+                return str_contains($command, $filter)
+                    || str_contains($event->description ?? '', $filter);
+            });
+        }
+
+        $failures = $this->readFailureLog($files);
+
+        $rows = $events->map(function ($event) use ($failures) {
+            return $this->buildRow($event, $failures);
+        });
+
+        $this->option('json')
+            ? $this->displayJson($rows)
+            : $this->displayTable($rows);
+    }
+
+    /**
+     * Build a row of diagnostic data for the given event.
+     *
+     * @param  \Illuminate\Console\Scheduling\Event  $event
+     * @param  \Illuminate\Support\Collection  $failures
+     * @return array
+     */
+    protected function buildRow(Event $event, Collection $failures)
+    {
+        $command = $this->getCommandName($event);
+        $mutexName = $event->mutexName();
+        $diagnostics = $this->getDiagnostics($event);
+
+        $limit = (int) $this->option('limit');
+
+        $eventFailures = $failures->filter(function ($entry) use ($mutexName, $command) {
+            return ($entry['mutex'] ?? '') === $mutexName
+                || str_contains($entry['command'] ?? '', $command);
+        })->take(-$limit)->values();
+
+        $lastFailure = $eventFailures->last();
+
+        $status = 'OK';
+        if ($lastFailure) {
+            $status = strtoupper($lastFailure['type'] ?? 'failed');
+        }
+
+        return [
+            'command' => $command,
+            'status' => $status,
+            'diagnostics' => $diagnostics,
+            'last_failure' => $lastFailure['exception'] ?? $lastFailure['reason'] ?? '—',
+            'last_failed_at' => $lastFailure['timestamp'] ?? '—',
+        ];
+    }
+
+    /**
+     * Get the real-time diagnostics for an event.
+     *
+     * @param  \Illuminate\Console\Scheduling\Event  $event
+     * @return string
+     */
+    protected function getDiagnostics(Event $event)
+    {
+        $issues = [];
+
+        if (! $event->runsInEnvironment($this->laravel->environment())) {
+            $issues[] = 'Wrong environment';
+        }
+
+        if (! $event->runsInMaintenanceMode() && $this->laravel->isDownForMaintenance()) {
+            $issues[] = 'In maintenance';
+        }
+
+        if (! $event->filtersPass($this->laravel)) {
+            $issues[] = 'Filters failing';
+        }
+
+        if (! $event->expressionPasses()) {
+            $issues[] = 'Not due';
+        } else {
+            $issues[] = 'Due';
+        }
+
+        if ($event->mutex->exists($event)) {
+            $issues[] = 'Mutex active';
+        } else {
+            $issues[] = 'No mutex';
+        }
+
+        return implode(', ', $issues);
+    }
+
+    /**
+     * Get the display name for the command.
+     *
+     * @param  \Illuminate\Console\Scheduling\Event  $event
+     * @return string
+     */
+    protected function getCommandName(Event $event)
+    {
+        if ($event instanceof CallbackEvent) {
+            $summary = $event->getSummaryForDisplay();
+
+            if (in_array($summary, ['Closure', 'Callback'])) {
+                return 'Closure at: '.$this->getClosureLocation($event);
+            }
+
+            return $summary;
+        }
+
+        return $event->normalizeCommand($event->command ?? '');
+    }
+
+    /**
+     * Get the file and line number for the event closure.
+     *
+     * @param  \Illuminate\Console\Scheduling\CallbackEvent  $event
+     * @return string
+     */
+    private function getClosureLocation(CallbackEvent $event)
+    {
+        $callback = (new ReflectionClass($event))->getProperty('callback')->getValue($event);
+
+        if ($callback instanceof Closure) {
+            $function = new ReflectionFunction($callback);
+
+            return sprintf(
+                '%s:%s',
+                str_replace($this->laravel->basePath().DIRECTORY_SEPARATOR, '', $function->getFileName() ?: ''),
+                $function->getStartLine()
+            );
+        }
+
+        if (is_string($callback)) {
+            return $callback;
+        }
+
+        if (is_array($callback)) {
+            $className = is_string($callback[0]) ? $callback[0] : $callback[0]::class;
+
+            return sprintf('%s::%s', $className, $callback[1]);
+        }
+
+        return sprintf('%s::__invoke', $callback::class);
+    }
+
+    /**
+     * Read and parse the failure log.
+     *
+     * @param  \Illuminate\Filesystem\Filesystem  $files
+     * @return \Illuminate\Support\Collection
+     */
+    protected function readFailureLog(Filesystem $files)
+    {
+        $path = ScheduleFailureLogger::logPath();
+
+        if (! $files->exists($path)) {
+            return new Collection;
+        }
+
+        $lines = array_filter(explode("\n", $files->get($path)));
+
+        return (new Collection($lines))
+            ->map(fn ($line) => json_decode($line, true))
+            ->filter()
+            ->values();
+    }
+
+    /**
+     * Display the results as a table.
+     *
+     * @param  \Illuminate\Support\Collection  $rows
+     * @return void
+     */
+    protected function displayTable(Collection $rows)
+    {
+        $this->table(
+            ['Command', 'Status', 'Diagnostics', 'Last Failure', 'Last Failed At'],
+            $rows->map(function ($row) {
+                return [
+                    $row['command'],
+                    $this->formatStatus($row['status']),
+                    $row['diagnostics'],
+                    $this->truncate($row['last_failure'], 50),
+                    $row['last_failed_at'],
+                ];
+            })->all()
+        );
+    }
+
+    /**
+     * Display the results as JSON.
+     *
+     * @param  \Illuminate\Support\Collection  $rows
+     * @return void
+     */
+    protected function displayJson(Collection $rows)
+    {
+        $this->output->writeln($rows->values()->toJson(JSON_PRETTY_PRINT));
+    }
+
+    /**
+     * Format the status for display.
+     *
+     * @param  string  $status
+     * @return string
+     */
+    protected function formatStatus(string $status)
+    {
+        return match ($status) {
+            'OK' => '<fg=green>OK</>',
+            'FAILED' => '<fg=red>FAILED</>',
+            'SKIPPED' => '<fg=yellow>SKIPPED</>',
+            default => $status,
+        };
+    }
+
+    /**
+     * Truncate a string.
+     *
+     * @param  string  $value
+     * @param  int  $length
+     * @return string
+     */
+    protected function truncate(string $value, int $length)
+    {
+        if (mb_strlen($value) <= $length) {
+            return $value;
+        }
+
+        return mb_substr($value, 0, $length - 3).'...';
+    }
+}

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -14,6 +14,7 @@ use Illuminate\Console\Scheduling\ScheduleInterruptCommand;
 use Illuminate\Console\Scheduling\ScheduleListCommand;
 use Illuminate\Console\Scheduling\ScheduleRunCommand;
 use Illuminate\Console\Scheduling\ScheduleTestCommand;
+use Illuminate\Console\Scheduling\ScheduleWhyNotCommand;
 use Illuminate\Console\Scheduling\ScheduleWorkCommand;
 use Illuminate\Console\Signals;
 use Illuminate\Contracts\Support\DeferrableProvider;
@@ -172,6 +173,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'ScheduleRun' => ScheduleRunCommand::class,
         'ScheduleClearCache' => ScheduleClearCacheCommand::class,
         'ScheduleTest' => ScheduleTestCommand::class,
+        'ScheduleWhyNot' => ScheduleWhyNotCommand::class,
         'ScheduleWork' => ScheduleWorkCommand::class,
         'ScheduleInterrupt' => ScheduleInterruptCommand::class,
         'ShowModel' => ShowModelCommand::class,

--- a/tests/Integration/Console/Scheduling/ScheduleFailureLoggerTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleFailureLoggerTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Console\Scheduling;
+
+use Illuminate\Console\Events\ScheduledTaskFailed;
+use Illuminate\Console\Events\ScheduledTaskSkipped;
+use Illuminate\Console\Scheduling\Event;
+use Illuminate\Console\Scheduling\EventMutex;
+use Illuminate\Console\Scheduling\ScheduleFailureLogger;
+use Illuminate\Filesystem\Filesystem;
+use Mockery as m;
+use Orchestra\Testbench\TestCase;
+use RuntimeException;
+
+class ScheduleFailureLoggerTest extends TestCase
+{
+    protected $logPath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->logPath = storage_path('logs/schedule-failures.json');
+
+        @unlink($this->logPath);
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->logPath);
+
+        parent::tearDown();
+    }
+
+    protected function makeEvent($command = 'artisan inspire')
+    {
+        $mutex = m::mock(EventMutex::class);
+        $mutex->shouldReceive('create')->andReturn(true);
+        $mutex->shouldReceive('exists')->andReturn(false);
+        $mutex->shouldReceive('forget');
+
+        return new Event($mutex, $command);
+    }
+
+    public function testLogsFailedTask()
+    {
+        $logger = new ScheduleFailureLogger(new Filesystem);
+
+        $event = $this->makeEvent();
+        $exception = new RuntimeException('Something went wrong');
+
+        $logger->handleTaskFailed(new ScheduledTaskFailed($event, $exception));
+
+        $this->assertFileExists($this->logPath);
+
+        $lines = array_filter(explode("\n", file_get_contents($this->logPath)));
+        $this->assertCount(1, $lines);
+
+        $entry = json_decode($lines[0], true);
+        $this->assertSame('failed', $entry['type']);
+        $this->assertStringContainsString('Something went wrong', $entry['exception']);
+        $this->assertArrayHasKey('timestamp', $entry);
+        $this->assertArrayHasKey('mutex', $entry);
+    }
+
+    public function testLogsSkippedTask()
+    {
+        $logger = new ScheduleFailureLogger(new Filesystem);
+
+        $event = $this->makeEvent();
+
+        $logger->handleTaskSkipped(new ScheduledTaskSkipped($event));
+
+        $this->assertFileExists($this->logPath);
+
+        $lines = array_filter(explode("\n", file_get_contents($this->logPath)));
+        $this->assertCount(1, $lines);
+
+        $entry = json_decode($lines[0], true);
+        $this->assertSame('skipped', $entry['type']);
+        $this->assertArrayHasKey('timestamp', $entry);
+    }
+
+    public function testLogRotation()
+    {
+        $logger = new ScheduleFailureLogger(new Filesystem, 5);
+
+        $event = $this->makeEvent();
+        $exception = new RuntimeException('fail');
+
+        for ($i = 0; $i < 7; $i++) {
+            $logger->handleTaskFailed(new ScheduledTaskFailed($event, $exception));
+        }
+
+        $lines = array_filter(explode("\n", file_get_contents($this->logPath)));
+        $this->assertCount(5, $lines);
+    }
+}

--- a/tests/Integration/Console/Scheduling/ScheduleWhyNotCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleWhyNotCommandTest.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Console\Scheduling;
+
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Console\Scheduling\ScheduleWhyNotCommand;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Carbon;
+use Orchestra\Testbench\TestCase;
+
+class ScheduleWhyNotCommandTest extends TestCase
+{
+    protected $schedule;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Carbon::setTestNow('2023-01-01 00:00:00');
+
+        $this->schedule = $this->app->make(Schedule::class);
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink(storage_path('logs/schedule-failures.json'));
+
+        parent::tearDown();
+    }
+
+    public function testDisplaysEmptySchedule()
+    {
+        $this->withoutMockingConsoleOutput();
+        $this->artisan(ScheduleWhyNotCommand::class);
+        $output = \Illuminate\Support\Facades\Artisan::output();
+        $this->assertStringContainsString('No scheduled tasks have been defined.', $output);
+    }
+
+    public function testDisplaysScheduleWithNoFailures()
+    {
+        $this->schedule->command('inspire')->everyMinute();
+
+        $this->withoutMockingConsoleOutput();
+        $this->artisan(ScheduleWhyNotCommand::class);
+        $output = \Illuminate\Support\Facades\Artisan::output();
+        $this->assertStringContainsString('inspire', $output);
+        $this->assertStringContainsString('OK', $output);
+    }
+
+    public function testDisplaysFailureFromLog()
+    {
+        $this->schedule->command('inspire')->everyMinute();
+
+        $entry = json_encode([
+            'timestamp' => '2023-01-01T00:00:00+00:00',
+            'command' => 'php artisan inspire',
+            'description' => '',
+            'type' => 'failed',
+            'exit_code' => 1,
+            'exception' => 'RuntimeException: Something broke',
+            'mutex' => 'framework/schedule-'.sha1('* * * * *'.'php artisan inspire'),
+        ]);
+
+        $files = new Filesystem;
+        $files->ensureDirectoryExists(storage_path('logs'));
+        $files->put(storage_path('logs/schedule-failures.json'), $entry."\n");
+
+        $this->withoutMockingConsoleOutput();
+        $this->artisan(ScheduleWhyNotCommand::class);
+        $output = \Illuminate\Support\Facades\Artisan::output();
+        $this->assertStringContainsString('FAILED', $output);
+        $this->assertStringContainsString('RuntimeException: Something broke', $output);
+    }
+
+    public function testDisplaysSkippedFromLog()
+    {
+        $this->schedule->command('inspire')->everyMinute();
+
+        $entry = json_encode([
+            'timestamp' => '2023-01-01T00:00:00+00:00',
+            'command' => 'php artisan inspire',
+            'description' => '',
+            'type' => 'skipped',
+            'mutex' => 'framework/schedule-'.sha1('* * * * *'.'php artisan inspire'),
+        ]);
+
+        $files = new Filesystem;
+        $files->ensureDirectoryExists(storage_path('logs'));
+        $files->put(storage_path('logs/schedule-failures.json'), $entry."\n");
+
+        $this->withoutMockingConsoleOutput();
+        $this->artisan(ScheduleWhyNotCommand::class);
+        $output = \Illuminate\Support\Facades\Artisan::output();
+        $this->assertStringContainsString('SKIPPED', $output);
+    }
+
+    public function testJsonOutput()
+    {
+        $this->schedule->command('inspire')->everyMinute();
+
+        $this->withoutMockingConsoleOutput();
+        $this->artisan(ScheduleWhyNotCommand::class, ['--json' => true]);
+        $output = \Illuminate\Support\Facades\Artisan::output();
+
+        $this->assertJson($output);
+        $data = json_decode($output, true);
+        $this->assertIsArray($data);
+        $this->assertCount(1, $data);
+        $this->assertArrayHasKey('command', $data[0]);
+        $this->assertArrayHasKey('status', $data[0]);
+        $this->assertArrayHasKey('diagnostics', $data[0]);
+    }
+
+    public function testEventFilter()
+    {
+        $this->schedule->command('inspire')->everyMinute();
+        $this->schedule->command('migrate')->daily();
+
+        $this->withoutMockingConsoleOutput();
+        $this->artisan(ScheduleWhyNotCommand::class, ['--event' => 'inspire']);
+        $output = \Illuminate\Support\Facades\Artisan::output();
+        $this->assertStringContainsString('inspire', $output);
+        $this->assertStringNotContainsString('migrate', $output);
+    }
+
+    public function testLimitOption()
+    {
+        $this->schedule->command('inspire')->everyMinute();
+
+        $files = new Filesystem;
+        $files->ensureDirectoryExists(storage_path('logs'));
+
+        $entries = '';
+        for ($i = 1; $i <= 3; $i++) {
+            $entries .= json_encode([
+                'timestamp' => '2023-01-01T00:00:0'.$i.'+00:00',
+                'command' => 'php artisan inspire',
+                'description' => '',
+                'type' => 'failed',
+                'exit_code' => 1,
+                'exception' => 'RuntimeException: Failure '.$i,
+                'mutex' => 'framework/schedule-'.sha1('* * * * *'.'php artisan inspire'),
+            ])."\n";
+        }
+        $files->put(storage_path('logs/schedule-failures.json'), $entries);
+
+        $this->withoutMockingConsoleOutput();
+        $this->artisan(ScheduleWhyNotCommand::class, ['--json' => true, '--limit' => 2]);
+        $output = \Illuminate\Support\Facades\Artisan::output();
+
+        $this->assertJson($output);
+        $data = json_decode($output, true);
+        $this->assertCount(1, $data);
+        $this->assertSame('FAILED', $data[0]['status']);
+        // With --limit=2, only the last 2 entries are taken, so the last failure message should be "Failure 3"
+        $this->assertStringContainsString('Failure 3', $data[0]['last_failure']);
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds a new `php artisan schedule:why-not` Artisan command that helps developers diagnose why their scheduled tasks are failing or not running. It addresses a common pain point: when a scheduled task silently fails or gets skipped, there's currently no built-in way to understand what went wrong.

The command combines **two sources of information**:

1. **Failure history** — A `ScheduleFailureLogger` listens to `ScheduledTaskFailed` and `ScheduledTaskSkipped` events during `schedule:run` and writes JSON line entries to `storage/logs/schedule-failures.json`. The log auto-rotates at 1,000 entries.

2. **Real-time diagnostics** — For each registered scheduled event, the command checks:
   - Whether the cron expression currently matches (due / not due)
   - Whether a mutex is active (overlapping prevention)
   - Whether the event's environment restriction matches the current environment
   - Whether the application is in maintenance mode
   - Whether the event's filter/reject callbacks pass

### Example output

```
$ php artisan schedule:why-not

+------------------------------------------+---------+--------------------------------------+-----------------------------------------------+---------------------------+
| Command                                  | Status  | Diagnostics                          | Last Failure                                  | Last Failed At            |
+------------------------------------------+---------+--------------------------------------+-----------------------------------------------+---------------------------+
| php artisan inspire                      | FAILED  | Due, No mutex                        | RuntimeException: Connection to database lost | 2026-03-08T10:30:00+00:00 |
| php artisan migrate:status               | SKIPPED | Not due, No mutex                    | —                                             | 2026-03-08T09:00:00+00:00 |
| php artisan queue:work --stop-when-empty | OK      | Wrong environment, Not due, No mutex | —                                             | —                         |
+------------------------------------------+---------+--------------------------------------+-----------------------------------------------+---------------------------+
```

### Command options

| Option | Description |
|--------|-------------|
| `--json` | Output results as JSON for programmatic use |
| `--event=<name>` | Filter to a specific command or description |
| `--limit=N` | Number of failure log entries to consider per event (default: 1) |

## New files

- **`src/Illuminate/Console/Scheduling/ScheduleFailureLogger.php`** — Event listener that writes failure/skip entries to the JSON log with automatic rotation
- **`src/Illuminate/Console/Scheduling/ScheduleWhyNotCommand.php`** — The Artisan command that reads the log and runs real-time diagnostics
- **`tests/Integration/Console/Scheduling/ScheduleFailureLoggerTest.php`** — 3 tests covering failure logging, skip logging, and log rotation
- **`tests/Integration/Console/Scheduling/ScheduleWhyNotCommandTest.php`** — 7 tests covering empty schedule, no-failure display, failure display, skip display, JSON output, event filtering, and the limit option

## Modified files

- **`Event.php`** — Made `expressionPasses()` public (was `protected`) so the diagnostic command can check if a task's cron expression currently matches
- **`ScheduleRunCommand.php`** — Added `registerFailureLogger()` method that wires up the `ScheduleFailureLogger` as a listener for `ScheduledTaskFailed` and `ScheduledTaskSkipped` events during `schedule:run`
- **`ArtisanServiceProvider.php`** — Registered the new `ScheduleWhyNotCommand` in the `$commands` array

## Design decisions

- **JSON lines format** for the failure log — one JSON object per line, easy to append and parse without loading the entire file as a JSON document
- **Log rotation at 1,000 entries** — prevents unbounded growth while keeping enough history for debugging
- **Listener registered in `ScheduleRunCommand::handle()`** rather than globally — the logger only needs to be active during scheduler execution, keeping it scoped and avoiding boot overhead for non-scheduler requests
- **No database dependency** — uses a simple log file so the command works immediately without migrations

## Test plan

- [x] `ScheduleFailureLoggerTest` — 3 tests, all passing
- [x] `ScheduleWhyNotCommandTest` — 7 tests, all passing
- [x] Full scheduling test suite — 138 tests, all passing (2 pre-existing skips)
- [x] Manually tested in a Laravel application referencing the framework via path repository