### PR TITLE
[12.x] Add `config()->first()` helper for fallback keys

### DIFF
--- a/src/Illuminate/Config/Repository.php
+++ b/src/Illuminate/Config/Repository.php
@@ -58,6 +58,24 @@ class Repository implements ArrayAccess, ConfigContract
     }
 
     /**
+     * Get the first configuration value from the given keys.
+     *
+     * @param  array<int, string>  $keys
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public function first(array $keys, $default = null)
+    {
+        foreach ($keys as $key) {
+            if ($this->has($key)) {
+                return $this->get($key);
+            }
+        }
+
+        return $default;
+    }
+
+    /**
      * Get many configuration values.
      *
      * @param  array<string|int,mixed>  $keys

--- a/tests/Config/RepositoryTest.php
+++ b/tests/Config/RepositoryTest.php
@@ -151,6 +151,15 @@ class RepositoryTest extends TestCase
         $this->assertSame('default', $this->repository->get('not-exist', 'default'));
     }
 
+    public function testFirst()
+    {
+        $this->assertSame('bar', $this->repository->first(['foo', 'bar', 'baz']));
+        $this->assertSame('baz', $this->repository->first(['none', 'bar', 'foo']));
+        $this->assertSame('bat', $this->repository->first(['none1', 'none2', 'baz']));
+        $this->assertSame('default', $this->repository->first(['none1', 'none2'], 'default'));
+        $this->assertNull($this->repository->first(['unknown']));
+    }
+
     public function testSet()
     {
         $this->repository->set('key', 'value');


### PR DESCRIPTION
This PR adds a tiny, expressive `first()` method to the config repository (and thus the `config()` helper) that returns the first existing value from a list of keys, falling back to a default if none exist.

### Motivation

Configuration keys sometimes move between files or get renamed in major releases / packages.  
To maintain backward compatibility, packages and applications frequently do:

```php
$value = config('new.key') ?? config('old.key') ?? 'default';

// or worse:
$value = collect(config()->get(['new.key', 'old.key'], 'default'))->first();
```

The second variant is especially noisy in Blade:

```blade
@extends(collect(config()->get(['layout', 'theme.layout'], 'app'))->first())
```

### Proposed solution

Add `first()` method:

```php
$value = config()->first(['new.key', 'old.key'], 'default');
```

```blade
@extends(config()->first(['layout', 'theme.layout'], 'app'))
```