### PR TITLE
[12.x] Update composer.json to enforce commonmark version without DisallowedRawHtmlRenderer exploit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "guzzlehttp/uri-template": "^1.0",
         "laravel/prompts": "^0.3.0",
         "laravel/serializable-closure": "^1.3|^2.0",
-        "league/commonmark": "^2.7",
+        "league/commonmark": "^2.8.1",
         "league/flysystem": "^3.25.1",
         "league/flysystem-local": "^3.25.1",
         "league/uri": "^7.5.1",


### PR DESCRIPTION
For reference:
```
Found 1 security vulnerability advisory affecting 1 package:
+-------------------+----------------------------------------------------------------------------------+
| Package           | league/commonmark                                                                |
| Severity          | medium                                                                           |
| Advisory ID       | PKSA-2cx9-ynrq-qdk3                                                              |
| CVE               | CVE-2026-30838                                                                   |
| Title             | CommonMark has DisallowedRawHtml extension bypass via whitespace in HTML tag     |
|                   | names                                                                            |
| URL               | https://github.com/advisories/GHSA-4v6x-c7xx-hw9f                                |
| Affected versions | <=2.8.0                                                                          |
| Reported at       | 2026-03-06T23:27:03+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
```
https://github.com/thephpleague/commonmark/releases/tag/2.8.1

Update commonmark version to avoid html parsing bypass

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
