### PR TITLE
Fix enum handling in ModelNotFoundException error message

### DIFF
--- a/src/Illuminate/Database/Eloquent/ModelNotFoundException.php
+++ b/src/Illuminate/Database/Eloquent/ModelNotFoundException.php
@@ -34,7 +34,10 @@ class ModelNotFoundException extends RecordsNotFoundException
     public function setModel($model, $ids = [])
     {
         $this->model = $model;
-        $this->ids = Arr::wrap($ids);
+        $this->ids = array_map(
+            fn ($id) => $id instanceof \BackedEnum ? $id->value : $id,
+            Arr::wrap($ids)
+        );
 
         $this->message = "No query results for model [{$model}]";
 

--- a/src/Illuminate/Database/Eloquent/ModelNotFoundException.php
+++ b/src/Illuminate/Database/Eloquent/ModelNotFoundException.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Eloquent;
 
+use BackedEnum;
 use Illuminate\Database\RecordsNotFoundException;
 use Illuminate\Support\Arr;
 
@@ -34,8 +35,9 @@ class ModelNotFoundException extends RecordsNotFoundException
     public function setModel($model, $ids = [])
     {
         $this->model = $model;
+
         $this->ids = array_map(
-            fn ($id) => $id instanceof \BackedEnum ? $id->value : $id,
+            fn ($id) => $id instanceof BackedEnum ? $id->value : $id,
             Arr::wrap($ids)
         );
 


### PR DESCRIPTION
Fixes #55977

When you pass a `BackedEnum` to `findOrFail()`, the enum instance gets forwarded to `ModelNotFoundException::setModel()` which calls `implode()` on the IDs array. Since enum instances can't be cast to string, this throws a fatal error instead of the expected `ModelNotFoundException`.

This PR maps any `BackedEnum` instances to their underlying value before storing them in the `$ids` array, so the error message renders correctly (e.g. "No query results for model [Foo] 1" instead of a fatal error).