### PR TITLE
[13.x] Rename Middleware attribute parameter from $value to $middleware 

### DIFF
--- a/src/Illuminate/Routing/Attributes/Controllers/Middleware.php
+++ b/src/Illuminate/Routing/Attributes/Controllers/Middleware.php
@@ -13,7 +13,7 @@ class Middleware
      * @param  array<string>|null  $except
      */
     public function __construct(
-        public Closure|string $value,
+        public Closure|string $middleware,
         public ?array $only = null,
         public ?array $except = null,
     ) {

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -1193,7 +1193,7 @@ class Route
 
             return static::methodExcludedByOptions(
                 $method, ['only' => $instance->only, 'except' => $instance->except],
-            ) ? null : $instance->value;
+            ) ? null : $instance->middleware;
         })
             ->filter()
             ->values()


### PR DESCRIPTION
Renames the `$value` parameter on the `Middleware` controller attribute to `$middleware` for consistency with the naming convention used across all other framework attributes.

Every other attribute in the framework uses a semantic parameter name that describes what the value represents:

  | Attribute | Parameter |
  |---|---|
  | `Signature` | `$signature` |
  | `Queue\Connection` | `$connection` |
  | `Queue` | `$queue` |
  | `Tries` | `$tries` |
  | `Timeout` | `$timeout` |
  | `Authorize` | `$ability` |
  | `ErrorBag` | `$name` |
  | `RedirectTo` | `$url` |
  | `Middleware` | ~~`$value`~~ → `$middleware` |

The `Middleware` attribute is the only one using a generic `$value` name. Since this attribute is new in 13.x and hasn't shipped in a stable release, this is a free consistency improvement with no backward-compatibility concern.

In practice most developers use positional arguments (`#[Middleware('auth')]`), but the parameter name surfaces in IDE autocomplete, reflection output, and documentation.
