### PR TITLE
[12.x] Add Model::collect() method 

### DIFF
--- a/src/Illuminate/Database/Eloquent/HasCollection.php
+++ b/src/Illuminate/Database/Eloquent/HasCollection.php
@@ -18,6 +18,16 @@ trait HasCollection
     protected static array $resolvedCollectionClasses = [];
 
     /**
+     * Wrap the model in its Eloquent Collection.
+     *
+     * @return TCollection
+     */
+    public function collect()
+    {
+        return $this->newCollection([$this]);
+    }
+
+    /**
      * Create a new Eloquent Collection instance.
      *
      * @param  array<array-key, \Illuminate\Database\Eloquent\Model>  $models

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3542,6 +3542,26 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertInstanceOf(CustomEloquentCollection::class, $collection);
     }
 
+    public function testCollect()
+    {
+        $model = new EloquentModelStub;
+        $collection = $model->collect();
+
+        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Collection::class, $collection);
+        $this->assertCount(1, $collection);
+        $this->assertSame($model, $collection->first());
+    }
+
+    public function testCollectRespectsCustomCollection()
+    {
+        $model = new EloquentModelWithCollectedByAttribute;
+        $collection = $model->collect();
+
+        $this->assertInstanceOf(CustomEloquentCollection::class, $collection);
+        $this->assertCount(1, $collection);
+        $this->assertSame($model, $collection->first());
+    }
+
     public function testUseFactoryAttribute()
     {
         $model = new EloquentModelWithUseFactoryAttribute;


### PR DESCRIPTION
 Adds a `collect()` method to Eloquent models that wraps the model in its Eloquent Collection. This provides a clean way to access collection-level methods on a single model instance, without the awkward `$model->newCollection([$model])`.

## Motivation

Several Eloquent Collection methods are useful on single models but only available on the collection, things like `loadMissing()`, `loadCount()`, custom collection methods, or tree-traversal methods on custom collections.

Currently the workaround is:

  ```php
  $model->newCollection([$model])->loadSessionCount($start, $end);
  $model->newCollection([$model])->descendantsAndSelf()->pluck('id');
```

  With this change:

  ```php
  $model->collect()->loadSessionCount($start, $end);
  $model->collect()->descendantsAndSelf()->pluck('id');
```

This is especially valuable when models use custom Eloquent Collections (via newCollection() or #[CollectedBy])
  that define domain-specific methods only available at the collection level.

  The naming follows the existing convention: `collect()` already exists on `Response`, `TestResponse`, `ArrayObject`, and `Enumerable`, always meaning "wrap this in a Collection".

## Changes

  - Added `collect()` to the `HasCollection` trait, returning `$this->newCollection([$this])`
  - Added tests for both the default `EloquentCollection` and custom collections via `#[CollectedBy]`
