### PR TITLE
[12.x] Add `base64` validation rule and `Str::isBase64()`

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -565,6 +565,27 @@ class Str
     }
 
     /**
+     * Determine if a given value is a valid base64 encoded string.
+     *
+     * @param  mixed  $value
+     * @return bool
+     */
+    public static function isBase64($value)
+    {
+        if (! is_string($value)) {
+            return false;
+        }
+
+        $decoded = base64_decode($value, true);
+
+        if ($decoded === false) {
+            return false;
+        }
+
+        return base64_encode($decoded) === $value;
+    }
+
+    /**
      * Determine if a given value is valid JSON.
      *
      * @param  mixed  $value

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -382,6 +382,16 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
+     * Determine if the string is valid base64 encoded.
+     *
+     * @return bool
+     */
+    public function isBase64()
+    {
+        return Str::isBase64($this->value);
+    }
+
+    /**
      * Determine if a given string is valid JSON.
      *
      * @return bool

--- a/src/Illuminate/Translation/lang/en/validation.php
+++ b/src/Illuminate/Translation/lang/en/validation.php
@@ -24,6 +24,7 @@ return [
     'any_of' => 'The :attribute field is invalid.',
     'array' => 'The :attribute field must be an array.',
     'ascii' => 'The :attribute field must only contain single-byte alphanumeric characters and symbols.',
+    'base64' => 'The :attribute field must be a valid base64 encoded string.',
     'before' => 'The :attribute field must be a date before :date.',
     'before_or_equal' => 'The :attribute field must be a date before or equal to :date.',
     'between' => [

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -175,6 +175,18 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate that an attribute is a valid base64 encoded string.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function validateBase64($attribute, $value)
+    {
+        return Str::isBase64($value);
+    }
+
+    /**
      * Validate the date is before a given date.
      *
      * @param  string  $attribute

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3258,6 +3258,37 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
+    public function testValidateBase64()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => base64_encode('Hello World')], ['foo' => 'base64']);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => base64_encode('')], ['foo' => 'base64']);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => base64_encode("\x00\x01\x02\xff")], ['foo' => 'base64']);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => 'not-valid-base64!@#$'], ['foo' => 'base64']);
+        $this->assertFalse($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => 'SGVsbG8gV29ybGQ'], ['foo' => 'base64']);
+        $this->assertFalse($v->passes()); // missing padding
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => ['array']], ['foo' => 'base64']);
+        $this->assertFalse($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => null], ['foo' => 'base64']);
+        $this->assertFalse($v->passes());
+    }
+
     public function testValidateBoolean()
     {
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
Adds a `base64` validation rule and `Str::isBase64()` helper for validating base64-encoded strings.

  ```php
  // Validation rule
  $request->validate([
      'file_data' => ['required', 'string', 'base64'],
  ]);

  // Str helper
  Str::isBase64($value);

  // Stringable
  str($value)->isBase64();
```

### Motivation

Validating `base64` input is common when accepting inline file uploads, encoded API payloads, or data URIs.
Currently this requires a custom validation rule in every project. The implementation uses strict mode `base64_decode` with a round-trip `base64_encode` check to reject strings with invalid characters or missing padding.

This follows the existing pattern where format validators delegate to Str::is*() helpers (isJson, isUrl, isUuid, isUlid), making the validation logic reusable outside of the validator context.

### Changes

  - `Str::isBase64()` — round-trip decode/encode validation
  - `Stringable::isBase64()` — fluent wrapper
  - `validateBase64()` — validation rule delegating to Str::isBase64()
  - Validation message in `en/validation.php`
  - Tests covering valid strings, binary data, invalid characters, missing padding, non-string types, and null
