### PR TITLE
[12.x] Include request context in HTTP client Response::dump()

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -481,11 +481,11 @@ class Response implements ArrayAccess, Stringable
             $content = $json;
         }
 
-        if (! is_null($key)) {
-            dump(data_get($content, $key));
-        } else {
-            dump($content);
+        if ($request = $this->transferStats?->getRequest()) {
+            dump($request->getMethod().' '.$request->getUri().' | '.$this->status());
         }
+
+        dump(is_null($key) ? $content : data_get($content, $key));
 
         return $this;
     }

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -482,7 +482,7 @@ class Response implements ArrayAccess, Stringable
         }
 
         if ($request = $this->transferStats?->getRequest()) {
-            dump($request->getMethod().' '.$request->getUri().' | '.$this->status());
+            dump('"'.$request->getMethod().' '.$request->getUri().'" '.$this->status());
         }
 
         dump(is_null($key) ? $content : data_get($content, $key));

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -1866,7 +1866,7 @@ class HttpClientTest extends TestCase
 
         $this->factory->get('http://200.com')->dump();
 
-        $this->assertSame('GET http://200.com | 200', $dumped[0]);
+        $this->assertSame('"GET http://200.com" 200', $dumped[0]);
         $this->assertSame('hello', $dumped[1]);
 
         VarDumper::setHandler(null);
@@ -1886,7 +1886,7 @@ class HttpClientTest extends TestCase
 
         $this->factory->get('http://200.com')->dump('hello');
 
-        $this->assertSame('GET http://200.com | 200', $dumped[0]);
+        $this->assertSame('"GET http://200.com" 200', $dumped[0]);
         $this->assertSame('world', $dumped[1]);
 
         VarDumper::setHandler(null);

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -1866,7 +1866,8 @@ class HttpClientTest extends TestCase
 
         $this->factory->get('http://200.com')->dump();
 
-        $this->assertSame('hello', $dumped[0]);
+        $this->assertSame('GET http://200.com | 200', $dumped[0]);
+        $this->assertSame('hello', $dumped[1]);
 
         VarDumper::setHandler(null);
     }
@@ -1885,7 +1886,8 @@ class HttpClientTest extends TestCase
 
         $this->factory->get('http://200.com')->dump('hello');
 
-        $this->assertSame('world', $dumped[0]);
+        $this->assertSame('GET http://200.com | 200', $dumped[0]);
+        $this->assertSame('world', $dumped[1]);
 
         VarDumper::setHandler(null);
     }


### PR DESCRIPTION
- `Response::dump()` now includes the request method, URL, and status code before the response body, giving immediate context about which request produced the output.                                                       
                                                                                                                   
## Motivation                                                                                            
                                               
When debugging HTTP client calls, `dump()` currently outputs just the response body with no context. If you're making multiple HTTP calls, you end up staring at a JSON blob with no idea which request produced it:

  ```php
  Http::post('https://api.stripe.com/v1/charges', $data)->dump();
  Http::get('https://api.github.com/repos/laravel/framework')->dump();

  Before:
  {"error": {"message": "Invalid card"}}

  After:
  "POST https://api.stripe.com/v1/charges | 422"
  {"error": {"message": "Invalid card"}}
```

The context line only appears when transfer stats are available (which is always the case for requests made through the HTTP client). Manually constructed Response objects without transfer stats continue to dump just the body.

### Test plan
  - `dump()` includes request method, URL, and status code
  - `dump($key)` still filters the body portion correctly
  - `dumpHeaders()` is unchanged
  - Existing tests updated to verify new output format
