### PR TITLE
[12.x] Add Model::withoutRelation() for selective relation unloading   

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -1153,7 +1153,7 @@ trait HasRelationships
     /**
      * Duplicate the instance and unset the given loaded relations.
      *
-     * @param  string|array  $relations
+     * @param  array|string  $relations
      * @return $this
      */
     public function withoutRelation($relations)

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -1151,6 +1151,23 @@ trait HasRelationships
     }
 
     /**
+     * Duplicate the instance and unset the given loaded relations.
+     *
+     * @param  string|array  $relations
+     * @return $this
+     */
+    public function withoutRelation($relations)
+    {
+        $model = clone $this;
+
+        foreach ((array) $relations as $relation) {
+            $model->unsetRelation($relation);
+        }
+
+        return $model;
+    }
+
+    /**
      * Unset all the loaded relations for the instance.
      *
      * @return $this

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -259,6 +259,41 @@ class DatabaseEloquentRelationTest extends TestCase
         $this->assertFalse($model->relationLoaded('foo'));
     }
 
+    public function testWithoutRelation()
+    {
+        $original = new EloquentNoTouchingModelStub;
+
+        $original->setRelation('foo', 'baz');
+        $original->setRelation('bar', 'qux');
+
+        $model = $original->withoutRelation('foo');
+
+        $this->assertInstanceOf(EloquentNoTouchingModelStub::class, $model);
+        $this->assertNotSame($model, $original);
+        $this->assertTrue($original->relationLoaded('foo'));
+        $this->assertTrue($original->relationLoaded('bar'));
+        $this->assertFalse($model->relationLoaded('foo'));
+        $this->assertTrue($model->relationLoaded('bar'));
+    }
+
+    public function testWithoutRelationWithArray()
+    {
+        $original = new EloquentNoTouchingModelStub;
+
+        $original->setRelation('foo', 'baz');
+        $original->setRelation('bar', 'qux');
+        $original->setRelation('bam', 'zap');
+
+        $model = $original->withoutRelation(['foo', 'bar']);
+
+        $this->assertTrue($original->relationLoaded('foo'));
+        $this->assertTrue($original->relationLoaded('bar'));
+        $this->assertTrue($original->relationLoaded('bam'));
+        $this->assertFalse($model->relationLoaded('foo'));
+        $this->assertFalse($model->relationLoaded('bar'));
+        $this->assertTrue($model->relationLoaded('bam'));
+    }
+
     public function testMacroable()
     {
         Relation::macro('foo', function () {


### PR DESCRIPTION
Adds `withoutRelation(string|array $relations)` which clones the model and unsets only the specified relations, leaving the rest intact.                                                                            
                                               
## Motivation

Laravel provides `withoutRelations()` to clone a model without any loaded relations, and `unsetRelation()` to
  mutate a model in place. But there's no non-mutating way to selectively remove specific relations:

  ```php
  // Remove all relations (clone) — exists
  $clean = $model->withoutRelations();

  // Remove one relation (mutates) — exists
  $model->unsetRelation('comments');

  // Remove specific relations without mutating — missing
  $lightweight = $model->withoutRelation('comments');
  ```

This comes up when passing models to contexts where certain relations cause issues: circular references during serialization, unnecessary memory overhead in queued jobs, or Livewire/Inertia payloads where you want to strip heavy relations before sending to the frontend:

  ```php
  $block->setRelation('overview', $this->withoutRelation('blocks'));
  ```

### Test plan

  - Single relation: clones model, removes only the specified relation, original unchanged
  - Array of relations: removes multiple relations selectively, keeps the rest
  - Existing withoutRelations() behavior unchanged
