### PR TITLE
Add debug() method to the HTTP client

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -22,6 +22,7 @@ use Illuminate\Http\Client\Promises\FluentPromise;
 use Illuminate\Http\Client\Promises\LazyPromise;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use Illuminate\Support\Stringable;
 use Illuminate\Support\Traits\Conditionable;
@@ -797,6 +798,63 @@ class PendingRequest
     public function throwUnless($condition)
     {
         return $this->throwIf(! $condition);
+    }
+
+    /**
+     * Log the request and response.
+     *
+     * @param  string|null  $channel
+     * @return $this
+     */
+    public function debug(?string $channel = null)
+    {
+        $this->beforeSending(function (Request $request) use ($channel) {
+            $logger = $channel ? Log::channel($channel) : Log::getFacadeRoot();
+
+            $headers = collect($request->headers())
+                ->map(fn ($values, $name) => "$name: ".implode(', ', $values))
+                ->implode("\n  ");
+
+            $body = $request->body();
+            $json = json_decode($body, true);
+
+            if (json_last_error() === JSON_ERROR_NONE) {
+                $body = json_encode($json, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+            }
+
+            $logger->debug(sprintf(
+                "HTTP Request\n── %s %s ──\n  %s%s",
+                $request->method(),
+                $request->url(),
+                $headers,
+                $body !== '' ? "\n\n  Body:\n  ".$body : '',
+            ));
+        });
+
+        return $this->afterResponse(function (Response $response) use ($channel) {
+            $logger = $channel ? Log::channel($channel) : Log::getFacadeRoot();
+
+            $headers = collect($response->headers())
+                ->map(fn ($values, $name) => "$name: ".implode(', ', $values))
+                ->implode("\n  ");
+
+            $body = $response->body();
+            $json = json_decode($body, true);
+
+            if (json_last_error() === JSON_ERROR_NONE) {
+                $body = json_encode($json, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+            }
+
+            $logger->debug(sprintf(
+                "HTTP Response\n── %s %s ──\n  %s\n\n  Body:\n  %s",
+                $response->status(),
+                $response->reason(),
+                $headers,
+                $body,
+            ));
+
+            return $response;
+        });
     }
 
     /**

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -22,6 +22,7 @@ use Illuminate\Http\Client\Promises\FluentPromise;
 use Illuminate\Http\Client\Promises\LazyPromise;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use Illuminate\Support\Stringable;
 use Illuminate\Support\Traits\Conditionable;
@@ -797,6 +798,38 @@ class PendingRequest
     public function throwUnless($condition)
     {
         return $this->throwIf(! $condition);
+    }
+
+    /**
+     * Log the request and response.
+     *
+     * @param  string|null  $channel
+     * @return $this
+     */
+    public function debug(?string $channel = null)
+    {
+        $this->beforeSending(function (Request $request) use ($channel) {
+            $logger = $channel ? Log::channel($channel) : Log::getFacadeRoot();
+
+            $logger->debug('HTTP Request', [
+                'method' => $request->method(),
+                'url' => $request->url(),
+                'headers' => $request->headers(),
+                'body' => $request->body(),
+            ]);
+        });
+
+        return $this->afterResponse(function (Response $response) use ($channel) {
+            $logger = $channel ? Log::channel($channel) : Log::getFacadeRoot();
+
+            $logger->debug('HTTP Response', [
+                'status' => $response->status(),
+                'headers' => $response->headers(),
+                'body' => $response->body(),
+            ]);
+
+            return $response;
+        });
     }
 
     /**

--- a/src/Illuminate/Support/Facades/Http.php
+++ b/src/Illuminate/Support/Facades/Http.php
@@ -71,6 +71,7 @@ use Illuminate\Http\Client\Factory;
  * @method static \Illuminate\Http\Client\PendingRequest throw(callable|null $callback = null)
  * @method static \Illuminate\Http\Client\PendingRequest throwIf(callable|bool $condition)
  * @method static \Illuminate\Http\Client\PendingRequest throwUnless(callable|bool $condition)
+ * @method static \Illuminate\Http\Client\PendingRequest debug(string|null $channel = null)
  * @method static \Illuminate\Http\Client\PendingRequest dump()
  * @method static \Illuminate\Http\Client\PendingRequest dd()
  * @method static \Illuminate\Http\Client\Response|\GuzzleHttp\Promise\PromiseInterface get(string $url, array|string|null $query = null)

--- a/tests/Integration/Http/HttpClientTest.php
+++ b/tests/Integration/Http/HttpClientTest.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Facade;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
 use Orchestra\Testbench\TestCase;
 use RuntimeException;
 
@@ -109,6 +110,58 @@ class HttpClientTest extends TestCase
         $this->assertEquals('second response', $response2->body());
         $this->assertEquals('unnamed', $response3->body());
         $this->assertEquals('unnamed', $response4->body());
+    }
+
+    public function testDebugLogsRequestAndResponse(): void
+    {
+        Http::fake(['*' => Http::response(['name' => 'Taylor'], 200, ['X-Foo' => 'Bar'])]);
+        Log::shouldReceive('debug')
+            ->once()
+            ->withArgs(function ($message) {
+                return str_contains($message, 'HTTP Request')
+                    && str_contains($message, 'POST')
+                    && str_contains($message, 'example.com')
+                    && str_contains($message, 'taylor@laravel.com');
+            });
+
+        Log::shouldReceive('debug')
+            ->once()
+            ->withArgs(function ($message) {
+                return str_contains($message, 'HTTP Response')
+                    && str_contains($message, '200')
+                    && str_contains($message, 'Taylor');
+            });
+
+        Http::debug()->post('http://example.com/login', ['email' => 'taylor@laravel.com']);
+    }
+
+    public function testDebugLogsToSpecificChannel(): void
+    {
+        Http::fake(['*' => Http::response('OK')]);
+
+        $channel = Log::partialMock();
+        Log::shouldReceive('channel')
+            ->with('stderr')
+            ->andReturn($channel);
+
+        $channel->shouldReceive('debug')
+            ->once()
+            ->withArgs(fn ($message) => str_contains($message, 'HTTP Request'));
+        $channel->shouldReceive('debug')
+            ->once()
+            ->withArgs(fn ($message) => str_contains($message, 'HTTP Response'));
+
+        Http::debug('stderr')->get('http://example.com');
+    }
+
+    public function testDebugIsChainable(): void
+    {
+        Http::fake(['*' => Http::response('OK')]);
+        Log::shouldReceive('debug')->twice();
+
+        $response = Http::debug()->withHeaders(['X-Foo' => 'Bar'])->get('http://example.com');
+
+        $this->assertEquals('OK', $response->body());
     }
 
     public function testAsyncCanHandleThrownException()

--- a/tests/Integration/Http/HttpClientTest.php
+++ b/tests/Integration/Http/HttpClientTest.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Facade;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
 use Orchestra\Testbench\TestCase;
 use RuntimeException;
 
@@ -109,6 +110,58 @@ class HttpClientTest extends TestCase
         $this->assertEquals('second response', $response2->body());
         $this->assertEquals('unnamed', $response3->body());
         $this->assertEquals('unnamed', $response4->body());
+    }
+
+    public function testDebugLogsRequestAndResponse(): void
+    {
+        Http::fake(['*' => Http::response(['name' => 'Taylor'], 200, ['X-Foo' => 'Bar'])]);
+        Log::shouldReceive('debug')
+            ->once()
+            ->withArgs(function ($message, $context) {
+                return $message === 'HTTP Request'
+                    && $context['method'] === 'POST'
+                    && str_contains($context['url'], 'example.com')
+                    && $context['body'] === '{"email":"taylor@laravel.com"}';
+            });
+
+        Log::shouldReceive('debug')
+            ->once()
+            ->withArgs(function ($message, $context) {
+                return $message === 'HTTP Response'
+                    && $context['status'] === 200
+                    && str_contains($context['body'], 'Taylor');
+            });
+
+        Http::debug()->post('http://example.com/login', ['email' => 'taylor@laravel.com']);
+    }
+
+    public function testDebugLogsToSpecificChannel(): void
+    {
+        Http::fake(['*' => Http::response('OK')]);
+
+        $channel = Log::partialMock();
+        Log::shouldReceive('channel')
+            ->with('stderr')
+            ->andReturn($channel);
+
+        $channel->shouldReceive('debug')
+            ->once()
+            ->withArgs(fn ($message) => $message === 'HTTP Request');
+        $channel->shouldReceive('debug')
+            ->once()
+            ->withArgs(fn ($message) => $message === 'HTTP Response');
+
+        Http::debug('stderr')->get('http://example.com');
+    }
+
+    public function testDebugIsChainable(): void
+    {
+        Http::fake(['*' => Http::response('OK')]);
+        Log::shouldReceive('debug')->twice();
+
+        $response = Http::debug()->withHeaders(['X-Foo' => 'Bar'])->get('http://example.com');
+
+        $this->assertEquals('OK', $response->body());
     }
 
     public function testAsyncCanHandleThrownException()


### PR DESCRIPTION
## 12.x Add `debug()` method to the HTTP client

I Came across a issue prevusly while debuging a thrid party integration that made me want to log my reqeuset and response for refrences i didn't find a built in method to provide me a full logging for the client

This PR adds a `debug()` method to `PendingRequest` that logs both the HTTP request and response in a human-readable format.

### Usage

```php
// Log to the default channel
Http::debug()->post('https://api.example.com/login', [
    'email' => 'user@example.com',
    'password' => 'secret',
]);
```
### Log output

```
[2026-03-07 04:59:29] local.DEBUG: HTTP Request
── POST https://api.example.com/login ──
  Content-Type: application/json
  User-Agent: GuzzleHttp/7
  Host: api.example.com

  Body:
  {
    "email": "user@example.com",
    "password": "secret"
  }

[2026-03-07 04:59:29] local.DEBUG: HTTP Response
── 200 OK ──
  Content-Type: application/json
  Cache-Control: no-cache

  Body:
  {
    "token": "eyJ..."
  }
```

### No breaking changes

This adds a new method to `PendingRequest`. No existing methods or signatures are modified.
