### PR TITLE
[13.x] Improve DX for `insertUsing()` with `PendingInsertUsing`

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -4182,12 +4182,17 @@ class Builder implements BuilderContract
     /**
      * Insert new records into the table using a subquery.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<*>|string  $query
+     * @param  array|(callable(\Illuminate\Database\Query\PendingInsertUsing): void)  $columns
+     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<*>|string|null  $query
      * @return int
      */
-    public function insertUsing(array $columns, $query)
+    public function insertUsing($columns, $query = null)
     {
         $this->applyBeforeQueryCallbacks();
+
+        if ($columns instanceof Closure && is_null($query)) {
+            return $this->performInsertUsingWithClause($columns, 'compileInsertUsing');
+        }
 
         [$sql, $bindings] = $this->createSub($query);
 
@@ -4200,17 +4205,53 @@ class Builder implements BuilderContract
     /**
      * Insert new records into the table using a subquery while ignoring errors.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<*>|string  $query
+     * @param  array|(callable(\Illuminate\Database\Query\PendingInsertUsing): void)  $columns
+     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<*>|string|null  $query
      * @return int
      */
-    public function insertOrIgnoreUsing(array $columns, $query)
+    public function insertOrIgnoreUsing($columns, $query = null)
     {
         $this->applyBeforeQueryCallbacks();
+
+        if ($columns instanceof Closure && is_null($query)) {
+            return $this->performInsertUsingWithClause($columns, 'compileInsertOrIgnoreUsing');
+        }
 
         [$sql, $bindings] = $this->createSub($query);
 
         return $this->connection->affectingStatement(
             $this->grammar->compileInsertOrIgnoreUsing($this, $columns, $sql),
+            $this->cleanBindings($bindings)
+        );
+    }
+
+    /**
+     * Execute an insert-using statement via a PendingInsertUsing clause.
+     *
+     * @param  \Closure  $callback
+     * @param  string  $compileMethod
+     * @return int
+     */
+    protected function performInsertUsingWithClause(Closure $callback, string $compileMethod)
+    {
+        $pending = new PendingInsertUsing($this->grammar);
+
+        $callback($pending);
+
+        $query = $pending->getQuery();
+
+        if ($query instanceof Closure) {
+            $queryClosure = $query;
+
+            $queryClosure($query = $this->forSubQuery());
+        }
+
+        $pending->applyToQuery($query);
+
+        [$sql, $bindings] = $this->parseSub($query);
+
+        return $this->connection->affectingStatement(
+            $this->grammar->{$compileMethod}($this, $pending->getColumns(), $sql),
             $this->cleanBindings($bindings)
         );
     }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -4228,9 +4228,9 @@ class Builder implements BuilderContract
     /**
      * Execute an insert-using statement via a PendingInsertUsing clause.
      *
-     * @param  \Closure  $callback
+     * @param  \Closure(\Illuminate\Database\Query\PendingInsertUsing): void  $callback
      * @param  string  $compileMethod
-     * @return int
+     * @return non-negative-int
      */
     protected function performInsertUsingWithClause(Closure $callback, string $compileMethod)
     {

--- a/src/Illuminate/Database/Query/PendingInsertUsing.php
+++ b/src/Illuminate/Database/Query/PendingInsertUsing.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Illuminate\Database\Query;
+
+use Illuminate\Contracts\Database\Query\Expression as ExpressionContract;
+
+class PendingInsertUsing
+{
+    /**
+     * The source query.
+     *
+     * @var \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<*>|\Illuminate\Database\Eloquent\Relations\Relation<*, *, *>|null
+     */
+    protected $query;
+
+    /**
+     * The ordered list of column entries.
+     *
+     * @var array
+     */
+    protected $entries = [];
+
+    /**
+     * Create a new pending insert-using instance.
+     *
+     * @param  \Illuminate\Database\Query\Grammars\Grammar  $grammar  The grammar instance.
+     */
+    public function __construct(protected Grammars\Grammar $grammar)
+    {
+    }
+
+    /**
+     * Set the source query.
+     *
+     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<*>|\Illuminate\Database\Eloquent\Relations\Relation<*, *, *>  $query
+     * @return $this
+     */
+    public function from($query)
+    {
+        $this->query = $query;
+
+        return $this;
+    }
+
+    /**
+     * Map a target column to a source column from the subquery.
+     *
+     * @param  string  $target
+     * @param  string  $source
+     * @return $this
+     */
+    public function column(string $target, string $source)
+    {
+        $this->entries[] = ['type' => 'column', 'target' => $target, 'source' => $source];
+
+        return $this;
+    }
+
+    /**
+     * Map target column(s) to literal value(s).
+     *
+     * @param  string|array  $target
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function value(string|array $target, mixed $value = null)
+    {
+        if (is_array($target)) {
+            foreach ($target as $column => $val) {
+                $this->entries[] = ['type' => 'value', 'target' => $column, 'value' => $val];
+            }
+
+            return $this;
+        }
+
+        $this->entries[] = ['type' => 'value', 'target' => $target, 'value' => $value];
+
+        return $this;
+    }
+
+    /**
+     * Get the source query.
+     *
+     * @return \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<*>|\Illuminate\Database\Eloquent\Relations\Relation<*, *, *>|null
+     */
+    public function getQuery()
+    {
+        return $this->query;
+    }
+
+    /**
+     * Get the target column names in definition order.
+     *
+     * @return array
+     */
+    public function getColumns()
+    {
+        return array_map(fn ($entry) => $entry['target'], $this->entries);
+    }
+
+    /**
+     * Apply the column and value definitions to a query's select list.
+     *
+     * @param  \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<*>  $query
+     * @return void
+     */
+    public function applyToQuery($query)
+    {
+        $selects = [];
+        $bindings = [];
+
+        foreach ($this->entries as $entry) {
+            if ($entry['type'] === 'column') {
+                $selects[] = $entry['source'];
+            } else {
+                $value = $entry['value'];
+
+                if ($value instanceof ExpressionContract) {
+                    $selects[] = new Expression($this->grammar->getValue($value));
+                } else {
+                    $selects[] = new Expression('?');
+                    $bindings[] = $value;
+                }
+            }
+        }
+
+        $query->select($selects);
+
+        if ($bindings) {
+            $query->addBinding($bindings, 'select');
+        }
+    }
+}

--- a/src/Illuminate/Database/Query/PendingInsertUsing.php
+++ b/src/Illuminate/Database/Query/PendingInsertUsing.php
@@ -16,12 +16,12 @@ class PendingInsertUsing
     /**
      * The ordered list of column entries.
      *
-     * @var array
+     * @var list<array{type: "column"|"value", target: string, source: string}>
      */
     protected $entries = [];
 
     /**
-     * Create a new pending insert-using instance.
+     * Create a new PendingInsertUsing instance.
      *
      * @param  \Illuminate\Database\Query\Grammars\Grammar  $grammar  The grammar instance.
      */
@@ -45,13 +45,19 @@ class PendingInsertUsing
     /**
      * Map a target column to a source column from the subquery.
      *
-     * @param  string  $target
-     * @param  string  $source
+     * @param  string|array<string, string>  $target
+     * @param  string|null  $source
      * @return $this
      */
-    public function column(string $target, string $source)
+    public function column(array|string $target, string|null $source = null)
     {
-        $this->entries[] = ['type' => 'column', 'target' => $target, 'source' => $source];
+        if (! is_array($target)) {
+            $target = [$target => $source];
+        }
+
+        foreach ($target as $targetColumn => $sourceColumn) {
+            $this->entries[] = ['type' => 'column', 'target' => $targetColumn, 'source' => $sourceColumn];
+        }
 
         return $this;
     }
@@ -65,15 +71,13 @@ class PendingInsertUsing
      */
     public function value(string|array $target, mixed $value = null)
     {
-        if (is_array($target)) {
-            foreach ($target as $column => $val) {
-                $this->entries[] = ['type' => 'value', 'target' => $column, 'value' => $val];
-            }
-
-            return $this;
+        if (! is_array($target)) {
+            $target = [$target => $value];
         }
 
-        $this->entries[] = ['type' => 'value', 'target' => $target, 'value' => $value];
+        foreach ($target as $column => $val) {
+            $this->entries[] = ['type' => 'value', 'target' => $column, 'value' => $val];
+        }
 
         return $this;
     }
@@ -95,7 +99,7 @@ class PendingInsertUsing
      */
     public function getColumns()
     {
-        return array_map(fn ($entry) => $entry['target'], $this->entries);
+        return array_map(static fn ($entry) => $entry['target'], $this->entries);
     }
 
     /**

--- a/src/Illuminate/Database/Query/PendingInsertUsing.php
+++ b/src/Illuminate/Database/Query/PendingInsertUsing.php
@@ -14,9 +14,9 @@ class PendingInsertUsing
     protected $query;
 
     /**
-     * The ordered list of column entries.
+     * The ordered list of column or value entries.
      *
-     * @var list<array{type: "column"|"value", target: string, source: string}>
+     * @var list<array{type: "column", target: string, source: string}|array{type: "value", target: string, value: mixed}>
      */
     protected $entries = [];
 
@@ -65,7 +65,7 @@ class PendingInsertUsing
     /**
      * Map target column(s) to literal value(s).
      *
-     * @param  string|array  $target
+     * @param  string|array<string, mixed>  $target
      * @param  mixed  $value
      * @return $this
      */

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -4103,6 +4103,47 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(1, $result);
     }
 
+    public function testInsertUsingClauseWithBatchColumns()
+    {
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('affectingStatement')->once()->with(
+            'insert into "table1" ("foo", "baz", "status") select "bar", "qux", ? from "table2"',
+            ['active']
+        )->andReturn(1);
+
+        $result = $builder->from('table1')->insertUsing(function (PendingInsertUsing $insert) {
+            $insert->from(function (Builder $query) {
+                $query->from('table2');
+            })
+            ->column([
+                'foo' => 'bar',
+                'baz' => 'qux',
+            ])
+            ->value('status', 'active');
+        });
+
+        $this->assertEquals(1, $result);
+    }
+
+    public function testInsertUsingClauseWithLimitAndOffset()
+    {
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('affectingStatement')->once()->with(
+            'insert into "table1" ("foo", "status") select "bar", ? from "table2" order by "id" asc limit 10 offset 5',
+            ['active']
+        )->andReturn(1);
+
+        $result = $builder->from('table1')->insertUsing(function (PendingInsertUsing $insert) {
+            $insert->from(function (Builder $query) {
+                $query->from('table2')->orderBy('id')->limit(10)->offset(5);
+            })
+            ->column('foo', 'bar')
+            ->value('status', 'active');
+        });
+
+        $this->assertEquals(1, $result);
+    }
+
     public function testInsertOrIgnoreMethod()
     {
         $this->expectException(RuntimeException::class);

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -18,6 +18,7 @@ use Illuminate\Database\Query\Grammars\PostgresGrammar;
 use Illuminate\Database\Query\Grammars\SQLiteGrammar;
 use Illuminate\Database\Query\Grammars\SqlServerGrammar;
 use Illuminate\Database\Query\JoinClause;
+use Illuminate\Database\Query\PendingInsertUsing;
 use Illuminate\Database\Query\Processors\MySqlProcessor;
 use Illuminate\Database\Query\Processors\PostgresProcessor;
 use Illuminate\Database\Query\Processors\Processor;
@@ -3964,6 +3965,144 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->from('table1')->insertUsing(['foo'], ['bar']);
     }
 
+    public function testInsertUsingWithClause()
+    {
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('affectingStatement')->once()->with(
+            'insert into "table1" ("foo", "status", "reason") select "bar", ?, ? from "table2" where "foreign_id" = ?',
+            ['active', 'created', 5]
+        )->andReturn(1);
+
+        $result = $builder->from('table1')->insertUsing(function (PendingInsertUsing $insert) {
+            $insert->from(function (Builder $query) {
+                $query->from('table2')->where('foreign_id', '=', 5);
+            })
+            ->column('foo', 'bar')
+            ->value('status', 'active')
+            ->value('reason', 'created');
+        });
+
+        $this->assertEquals(1, $result);
+    }
+
+    public function testInsertUsingClausePreservesColumnOrder()
+    {
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('affectingStatement')->once()->with(
+            'insert into "table1" ("payment_id", "status", "changed_at") select "id", ?, "created_at" from "table2"',
+            ['active']
+        )->andReturn(1);
+
+        $result = $builder->from('table1')->insertUsing(function (PendingInsertUsing $insert) {
+            $insert->from(function (Builder $query) {
+                $query->from('table2');
+            })
+            ->column('payment_id', 'id')
+            ->value('status', 'active')
+            ->column('changed_at', 'created_at');
+        });
+
+        $this->assertEquals(1, $result);
+    }
+
+    public function testInsertUsingClauseWithExpression()
+    {
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('affectingStatement')->once()->with(
+            'insert into "table1" ("foo", "created_at") select "bar", NOW() from "table2"',
+            []
+        )->andReturn(1);
+
+        $result = $builder->from('table1')->insertUsing(function (PendingInsertUsing $insert) {
+            $insert->from(function (Builder $query) {
+                $query->from('table2');
+            })
+            ->column('foo', 'bar')
+            ->value('created_at', new Raw('NOW()'));
+        });
+
+        $this->assertEquals(1, $result);
+    }
+
+    public function testInsertUsingClauseWithEnum()
+    {
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('affectingStatement')->once()->with(
+            'insert into "table1" ("foo", "status") select "bar", ? from "table2"',
+            [5]
+        )->andReturn(1);
+
+        $result = $builder->from('table1')->insertUsing(function (PendingInsertUsing $insert) {
+            $insert->from(function (Builder $query) {
+                $query->from('table2');
+            })
+            ->column('foo', 'bar')
+            ->value('status', Bar::FOO);
+        });
+
+        $this->assertEquals(1, $result);
+    }
+
+    public function testInsertUsingClauseWithBuilderInstance()
+    {
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('affectingStatement')->once()->with(
+            'insert into "table1" ("foo", "status") select "bar", ? from "table2" where "foreign_id" = ?',
+            ['active', 5]
+        )->andReturn(1);
+
+        $subquery = $this->getBuilder()->from('table2')->where('foreign_id', '=', 5);
+
+        $result = $builder->from('table1')->insertUsing(function (PendingInsertUsing $insert) use ($subquery) {
+            $insert->from($subquery)
+                ->column('foo', 'bar')
+                ->value('status', 'active');
+        });
+
+        $this->assertEquals(1, $result);
+    }
+
+    public function testInsertUsingClauseWithBatchValues()
+    {
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('affectingStatement')->once()->with(
+            'insert into "table1" ("foo", "status", "reason") select "bar", ?, ? from "table2"',
+            ['active', 'created']
+        )->andReturn(1);
+
+        $result = $builder->from('table1')->insertUsing(function (PendingInsertUsing $insert) {
+            $insert->from(function (Builder $query) {
+                $query->from('table2');
+            })
+            ->column('foo', 'bar')
+            ->value([
+                'status' => 'active',
+                'reason' => 'created',
+            ]);
+        });
+
+        $this->assertEquals(1, $result);
+    }
+
+    public function testInsertUsingClauseWithQualifiedColumnNames()
+    {
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('affectingStatement')->once()->with(
+            'insert into "table1" ("table1"."foo", "status") select "table2"."bar", ? from "table2"',
+            ['active']
+        )->andReturn(1);
+
+        $result = $builder->from('table1')->insertUsing(function (PendingInsertUsing $insert) {
+            $insert->from(function (Builder $query) {
+                $query->from('table2');
+            })
+            ->column('table1.foo', 'table2.bar')
+            ->value('status', 'active');
+        });
+
+        $this->assertEquals(1, $result);
+    }
+
     public function testInsertOrIgnoreMethod()
     {
         $this->expectException(RuntimeException::class);
@@ -4187,6 +4326,26 @@ class DatabaseQueryBuilderTest extends TestCase
                 $query->select(['bar'])->from('table2')->where('foreign_id', '=', 5);
             }
         );
+
+        $this->assertEquals(1, $result);
+    }
+
+    public function testMySqlInsertOrIgnoreUsingWithClause()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->getConnection()->shouldReceive('getDatabaseName');
+        $builder->getConnection()->shouldReceive('affectingStatement')->once()->with(
+            'insert ignore into `table1` (`foo`, `status`) select `bar`, ? from `table2` where `foreign_id` = ?',
+            ['active', 5]
+        )->andReturn(1);
+
+        $result = $builder->from('table1')->insertOrIgnoreUsing(function (PendingInsertUsing $insert) {
+            $insert->from(function (Builder $query) {
+                $query->from('table2')->where('foreign_id', '=', 5);
+            })
+            ->column('foo', 'bar')
+            ->value('status', 'active');
+        });
 
         $this->assertEquals(1, $result);
     }

--- a/tests/Integration/Database/QueryBuilderTest.php
+++ b/tests/Integration/Database/QueryBuilderTest.php
@@ -7,6 +7,7 @@ use Illuminate\Database\MultipleRecordsFoundException;
 use Illuminate\Database\RecordsNotFoundException;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Carbon;
+use Illuminate\Database\Query\PendingInsertUsing;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Testing\Assert as PHPUnit;
@@ -685,6 +686,56 @@ class QueryBuilderTest extends DatabaseTestCase
         $this->assertSame('Bar Post', $result[1]->title);
         $this->assertSame('Foo Post', $result2[0]->title);
         $this->assertSame('Bar Post', $result2[1]->title);
+    }
+
+    public function testInsertUsingWithClause()
+    {
+        Schema::create('post_copies', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('title');
+            $table->string('status');
+            $table->timestamp('created_at');
+        });
+
+        DB::table('post_copies')->insertUsing(function (PendingInsertUsing $insert) {
+            $insert->from(DB::table('posts'))
+                ->column('title', 'title')
+                ->value('status', 'archived')
+                ->column('created_at', 'created_at');
+        });
+
+        $copies = DB::table('post_copies')->orderBy('id')->get();
+
+        $this->assertCount(2, $copies);
+        $this->assertSame('Foo Post', $copies[0]->title);
+        $this->assertSame('archived', $copies[0]->status);
+        $this->assertSame('Bar Post', $copies[1]->title);
+        $this->assertSame('archived', $copies[1]->status);
+    }
+
+    public function testInsertUsingClauseWithExpression()
+    {
+        Schema::create('post_copies', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('title');
+            $table->string('status');
+            $table->integer('priority');
+        });
+
+        DB::table('post_copies')->insertUsing(function (PendingInsertUsing $insert) {
+            $insert->from(DB::table('posts'))
+                ->column('title', 'title')
+                ->value('status', 'active')
+                ->value('priority', DB::raw('1 + 1'));
+        });
+
+        $copies = DB::table('post_copies')->orderBy('id')->get();
+
+        $this->assertCount(2, $copies);
+        $this->assertSame('active', $copies[0]->status);
+        $this->assertEquals(2, $copies[0]->priority);
+        $this->assertSame('active', $copies[1]->status);
+        $this->assertEquals(2, $copies[1]->priority);
     }
 
     protected function defineEnvironmentWouldThrowsPDOException($app)

--- a/tests/Integration/Database/QueryBuilderTest.php
+++ b/tests/Integration/Database/QueryBuilderTest.php
@@ -738,6 +738,52 @@ class QueryBuilderTest extends DatabaseTestCase
         $this->assertEquals(2, $copies[1]->priority);
     }
 
+    public function testInsertUsingClauseWithQualifiedSourceColumnNames()
+    {
+        Schema::create('post_copies', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('title');
+            $table->string('status');
+        });
+
+        DB::table('post_copies')->insertUsing(function (PendingInsertUsing $insert) {
+            $insert->from(DB::table('posts'))
+                ->column('title', 'posts.title')
+                ->value('status', 'archived');
+        });
+
+        $copies = DB::table('post_copies')->orderBy('id')->get();
+
+        $this->assertCount(2, $copies);
+        $this->assertSame('Foo Post', $copies[0]->title);
+        $this->assertSame('archived', $copies[0]->status);
+        $this->assertSame('Bar Post', $copies[1]->title);
+        $this->assertSame('archived', $copies[1]->status);
+    }
+
+    public function testInsertUsingClauseWithLimitAndOffset()
+    {
+        Schema::create('post_copies', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('title');
+            $table->string('status');
+        });
+
+        DB::table('post_copies')->insertUsing(function (PendingInsertUsing $insert) {
+            $insert->from(
+                DB::table('posts')->orderBy('created_at')->limit(1)->offset(1)
+            )
+            ->column('title', 'title')
+            ->value('status', 'archived');
+        });
+
+        $copies = DB::table('post_copies')->get();
+
+        $this->assertCount(1, $copies);
+        $this->assertSame('Bar Post', $copies[0]->title);
+        $this->assertSame('archived', $copies[0]->status);
+    }
+
     protected function defineEnvironmentWouldThrowsPDOException($app)
     {
         $this->afterApplicationCreated(function () {


### PR DESCRIPTION
The `insertUsing()` method felt like a godsend when I found it. The API for it is a little bit cumbersome, especially if I need to add column defaults.

### Current ❌ 
```php
PaymentStatusChange::query()->insertUsing(
    [
        'payment_id',
        'status',
        'reason',
        'changed_by',
        'changed_at',
    ],
    Payment::query()
        ->select([
            'id',
            DB::raw('? as status'),
            DB::raw('? as reason'),
            DB::raw('? as changed_by'),
            'created_at',
        ])
        ->whereIn(
            'user_id',
            UserPaymentAgreement::query()->select('id')->where('agreement_id', $agreement->id)
        )
        ->addBinding(
            [
                PaymentStatusEnum::CREATED,
                PaymentStatusChange::AGREEMENT_CREATED_REASON,
                $user->id,
            ],
            'select'
        )
);
```

### Proposed 👍 

```php
PaymentStatusChange::query()->insertUsing(
    function(PendingInsertUsing $insertUsing) use ($user, $agreement) {
        $insertUsing->from(
            Payment::query()->whereIn('user_id', UserPaymentAgreement::query()->select('id')->where('agreement_id', $agreement->id))
        )
            ->column([
                'payment_id' => 'id',
                'changed_at' => 'created_at',
            ])
            ->value([
                'status' => PaymentStatusEnum::CREATED,
                'reason' => PaymentStatusChange::AGREEMENT_CREATED_REASON,
                'changed_by' => $user->id,
            ]);
    });
```