### PR TITLE
[12.x] Improved html test helpers

### DIFF
--- a/src/Illuminate/Testing/TestComponent.php
+++ b/src/Illuminate/Testing/TestComponent.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Testing;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Testing\Assert as PHPUnit;
 use Illuminate\Testing\Constraints\SeeInOrder;
@@ -41,19 +42,34 @@ class TestComponent implements Stringable
     }
 
     /**
-     * Assert that the given string is contained within the rendered component.
+     * Assert that the given string or array of strings are contained within the rendered component.
      *
-     * @param  string  $value
+     * @param  string|list<string>  $value
      * @param  bool  $escape
      * @return $this
      */
     public function assertSee($value, $escape = true)
     {
-        $value = $escape ? e($value) : $value;
+        $value = Arr::wrap($value);
 
-        PHPUnit::assertStringContainsString((string) $value, $this->rendered);
+        $values = $escape ? array_map(e(...), $value) : $value;
+
+        foreach ($values as $value) {
+            PHPUnit::assertStringContainsString((string) $value, $this->rendered);
+        }
 
         return $this;
+    }
+
+    /**
+     * Assert that the given HTML string or array of HTML strings are contained within the rendered component.
+     *
+     * @param  string|list<string>  $value
+     * @return $this
+     */
+    public function assertSeeHtml($value)
+    {
+        return $this->assertSee($value, false);
     }
 
     /**
@@ -73,17 +89,34 @@ class TestComponent implements Stringable
     }
 
     /**
-     * Assert that the given string is contained within the rendered component text.
+     * Assert that the given HTML strings are contained in order within the rendered component.
      *
-     * @param  string  $value
+     * @param  list<string>  $values
+     * @return $this
+     */
+    public function assertSeeHtmlInOrder(array $values)
+    {
+        return $this->assertSeeInOrder($values, false);
+    }
+
+    /**
+     * Assert that the given string or array of strings are contained within the rendered component text.
+     *
+     * @param  string|list<string>  $value
      * @param  bool  $escape
      * @return $this
      */
     public function assertSeeText($value, $escape = true)
     {
-        $value = $escape ? e($value) : $value;
+        $value = Arr::wrap($value);
 
-        PHPUnit::assertStringContainsString((string) $value, strip_tags($this->rendered));
+        $values = $escape ? array_map(e(...), $value) : $value;
+
+        $rendered = strip_tags($this->rendered);
+
+        foreach ($values as $value) {
+            PHPUnit::assertStringContainsString((string) $value, $rendered);
+        }
 
         return $this;
     }
@@ -91,7 +124,7 @@ class TestComponent implements Stringable
     /**
      * Assert that the given strings are contained in order within the rendered component text.
      *
-     * @param  array  $values
+     * @param  list<string>  $values
      * @param  bool  $escape
      * @return $this
      */
@@ -105,33 +138,54 @@ class TestComponent implements Stringable
     }
 
     /**
-     * Assert that the given string is not contained within the rendered component.
+     * Assert that the given string or array of strings are not contained within the rendered component.
      *
-     * @param  string  $value
+     * @param  string|list<string>  $value
      * @param  bool  $escape
      * @return $this
      */
     public function assertDontSee($value, $escape = true)
     {
-        $value = $escape ? e($value) : $value;
+        $value = Arr::wrap($value);
 
-        PHPUnit::assertStringNotContainsString((string) $value, $this->rendered);
+        $values = $escape ? array_map(e(...), $value) : $value;
+
+        foreach ($values as $value) {
+            PHPUnit::assertStringNotContainsString((string) $value, $this->rendered);
+        }
 
         return $this;
     }
 
     /**
-     * Assert that the given string is not contained within the rendered component text.
+     * Assert that the given HTML string or array of HTML strings are not contained within the rendered component.
      *
-     * @param  string  $value
+     * @param  string|list<string>  $value
+     * @return $this
+     */
+    public function assertDontSeeHtml($value)
+    {
+        return $this->assertDontSee($value, false);
+    }
+
+    /**
+     * Assert that the given string or array of strings are not contained within the rendered component text.
+     *
+     * @param  string|list<string>  $value
      * @param  bool  $escape
      * @return $this
      */
     public function assertDontSeeText($value, $escape = true)
     {
-        $value = $escape ? e($value) : $value;
+        $value = Arr::wrap($value);
 
-        PHPUnit::assertStringNotContainsString((string) $value, strip_tags($this->rendered));
+        $values = $escape ? array_map(e(...), $value) : $value;
+
+        $rendered = strip_tags($this->rendered);
+
+        foreach ($values as $value) {
+            PHPUnit::assertStringNotContainsString((string) $value, $rendered);
+        }
 
         return $this;
     }

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -696,7 +696,7 @@ class TestResponse implements ArrayAccess
     /**
      * Assert that the given string or array of strings are contained within the response.
      *
-     * @param  string|array  $value
+     * @param  string|list<string>  $value
      * @param  bool  $escape
      * @return $this
      */
@@ -716,7 +716,7 @@ class TestResponse implements ArrayAccess
     /**
      * Assert that the given HTML string or array of HTML strings are contained within the response.
      *
-     * @param  array|string  $value
+     * @param  string|list<string>  $value
      * @return $this
      */
     public function assertSeeHtml($value)
@@ -727,7 +727,7 @@ class TestResponse implements ArrayAccess
     /**
      * Assert that the given strings are contained in order within the response.
      *
-     * @param  array  $values
+     * @param  list<string>  $values
      * @param  bool  $escape
      * @return $this
      */
@@ -743,7 +743,7 @@ class TestResponse implements ArrayAccess
     /**
      * Assert that the given HTML strings are contained in order within the response.
      *
-     * @param  array  $values
+     * @param  list<string>  $values
      * @return $this
      */
     public function assertSeeHtmlInOrder(array $values)
@@ -754,7 +754,7 @@ class TestResponse implements ArrayAccess
     /**
      * Assert that the given string or array of strings are contained within the response text.
      *
-     * @param  string|array  $value
+     * @param  string|list<string>  $value
      * @param  bool  $escape
      * @return $this
      */
@@ -776,7 +776,7 @@ class TestResponse implements ArrayAccess
     /**
      * Assert that the given strings are contained in order within the response text.
      *
-     * @param  array  $values
+     * @param  list<string>  $values
      * @param  bool  $escape
      * @return $this
      */
@@ -792,7 +792,7 @@ class TestResponse implements ArrayAccess
     /**
      * Assert that the given string or array of strings are not contained within the response.
      *
-     * @param  string|array  $value
+     * @param  string|list<string>  $value
      * @param  bool  $escape
      * @return $this
      */
@@ -812,7 +812,7 @@ class TestResponse implements ArrayAccess
     /**
      * Assert that the given HTML string or array of HTML strings are not contained within the response.
      *
-     * @param  array|string  $value
+     * @param  string|list<string>  $value
      * @return $this
      */
     public function assertDontSeeHtml($value)
@@ -823,7 +823,7 @@ class TestResponse implements ArrayAccess
     /**
      * Assert that the given string or array of strings are not contained within the response text.
      *
-     * @param  string|array  $value
+     * @param  string|list<string>  $value
      * @param  bool  $escape
      * @return $this
      */

--- a/src/Illuminate/Testing/TestView.php
+++ b/src/Illuminate/Testing/TestView.php
@@ -119,25 +119,40 @@ class TestView implements Stringable
     }
 
     /**
-     * Assert that the given string is contained within the view.
+     * Assert that the given string or array of strings are contained within the view.
      *
-     * @param  string  $value
+     * @param  string|list<string>  $value
      * @param  bool  $escape
      * @return $this
      */
     public function assertSee($value, $escape = true)
     {
-        $value = $escape ? e($value) : $value;
+        $value = Arr::wrap($value);
 
-        PHPUnit::assertStringContainsString((string) $value, $this->rendered);
+        $values = $escape ? array_map(e(...), $value) : $value;
+
+        foreach ($values as $value) {
+            PHPUnit::assertStringContainsString((string) $value, $this->rendered);
+        }
 
         return $this;
     }
 
     /**
+     * Assert that the given HTML string or array of HTML strings are contained within the view.
+     *
+     * @param  string|list<string>  $value
+     * @return $this
+     */
+    public function assertSeeHtml($value)
+    {
+        return $this->assertSee($value, false);
+    }
+
+    /**
      * Assert that the given strings are contained in order within the view.
      *
-     * @param  array  $values
+     * @param  list<string>  $values
      * @param  bool  $escape
      * @return $this
      */
@@ -151,17 +166,34 @@ class TestView implements Stringable
     }
 
     /**
-     * Assert that the given string is contained within the view text.
+     * Assert that the given HTML strings are contained in order within the view.
      *
-     * @param  string  $value
+     * @param  list<string>  $values
+     * @return $this
+     */
+    public function assertSeeHtmlInOrder(array $values)
+    {
+        return $this->assertSeeInOrder($values, false);
+    }
+
+    /**
+     * Assert that the given string or array of strings are contained within the view text.
+     *
+     * @param  string|list<string>  $value
      * @param  bool  $escape
      * @return $this
      */
     public function assertSeeText($value, $escape = true)
     {
-        $value = $escape ? e($value) : $value;
+        $value = Arr::wrap($value);
 
-        PHPUnit::assertStringContainsString((string) $value, strip_tags($this->rendered));
+        $values = $escape ? array_map(e(...), $value) : $value;
+
+        $rendered = strip_tags($this->rendered);
+
+        foreach ($values as $value) {
+            PHPUnit::assertStringContainsString((string) $value, $rendered);
+        }
 
         return $this;
     }
@@ -169,7 +201,7 @@ class TestView implements Stringable
     /**
      * Assert that the given strings are contained in order within the view text.
      *
-     * @param  array  $values
+     * @param  list<string>  $values
      * @param  bool  $escape
      * @return $this
      */
@@ -183,33 +215,54 @@ class TestView implements Stringable
     }
 
     /**
-     * Assert that the given string is not contained within the view.
+     * Assert that the given string or array of strings are not contained within the view.
      *
-     * @param  string  $value
+     * @param  string|list<string>  $value
      * @param  bool  $escape
      * @return $this
      */
     public function assertDontSee($value, $escape = true)
     {
-        $value = $escape ? e($value) : $value;
+        $value = Arr::wrap($value);
 
-        PHPUnit::assertStringNotContainsString((string) $value, $this->rendered);
+        $values = $escape ? array_map(e(...), $value) : $value;
+
+        foreach ($values as $value) {
+            PHPUnit::assertStringNotContainsString((string) $value, $this->rendered);
+        }
 
         return $this;
     }
 
     /**
-     * Assert that the given string is not contained within the view text.
+     * Assert that the given HTML string or array of HTML strings are not contained within the view.
      *
-     * @param  string  $value
+     * @param  string|list<string>  $value
+     * @return $this
+     */
+    public function assertDontSeeHtml($value)
+    {
+        return $this->assertDontSee($value, false);
+    }
+
+    /**
+     * Assert that the given string or array of strings are not contained within the view text.
+     *
+     * @param  string|list<string>  $value
      * @param  bool  $escape
      * @return $this
      */
     public function assertDontSeeText($value, $escape = true)
     {
-        $value = $escape ? e($value) : $value;
+        $value = Arr::wrap($value);
 
-        PHPUnit::assertStringNotContainsString((string) $value, strip_tags($this->rendered));
+        $values = $escape ? array_map(e(...), $value) : $value;
+
+        $rendered = strip_tags($this->rendered);
+
+        foreach ($values as $value) {
+            PHPUnit::assertStringNotContainsString((string) $value, $rendered);
+        }
 
         return $this;
     }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
When trying to use the `assertSeeHtml` helper on a view, I ran into issues due to the method only existing on the `TestResponse` object. This PR aims to make this method available in similar manner for views and components. Moreover, it also reworks the helpers there to accept an array of strings in various methods similar to the response counterpart. Finally a somewhat stricter static type for the `array` is introduced.

For those interested in following up on this:
- the current code is heavily duplicated: creating an interface (say `HasAssertableHtml`) that contains a `getAssertableHtmlMethod` and a trait (say `AssertsHtml`) implementing all the shared methods for any class implementing `HasAssertableHtml` can be a nice improvement
- currently only `TestResponse` seems to have tests; adding those for the `TestView` and `TestComponent` might be useful

Note that #52285 seems to mention adding these methods analogous to Livewire components, but I could not find the source of that to have ever existed...