### PR TITLE
[12.x] Hash displayName() in cache lock keys

### DIFF
--- a/src/Illuminate/Bus/UniqueLock.php
+++ b/src/Illuminate/Bus/UniqueLock.php
@@ -70,7 +70,7 @@ class UniqueLock
             : ($job->uniqueId ?? '');
 
         $jobName = method_exists($job, 'displayName')
-            ? $job->displayName()
+            ? hash('xxh128', $job->displayName())
             : get_class($job);
 
         return 'laravel_unique_job:'.$jobName.':'.$uniqueId;

--- a/src/Illuminate/Queue/Middleware/WithoutOverlapping.php
+++ b/src/Illuminate/Queue/Middleware/WithoutOverlapping.php
@@ -159,7 +159,7 @@ class WithoutOverlapping
         }
 
         $jobName = method_exists($job, 'displayName')
-            ? $job->displayName()
+            ? hash('xxh128', $job->displayName())
             : get_class($job);
 
         return $this->prefix.$jobName.':'.$this->key;

--- a/tests/Events/QueuedEventsTest.php
+++ b/tests/Events/QueuedEventsTest.php
@@ -429,7 +429,7 @@ class QueuedEventsTest extends TestCase
 
         $this->assertSame(TestDispatcherShouldBeUnique::class, $listener->displayName());
         $this->assertSame(
-            'laravel_unique_job:'.TestDispatcherShouldBeUnique::class.':test-id',
+            'laravel_unique_job:'.hash('xxh128', TestDispatcherShouldBeUnique::class).':test-id',
             \Illuminate\Bus\UniqueLock::getKey($listener)
         );
     }
@@ -445,7 +445,7 @@ class QueuedEventsTest extends TestCase
 
         $container->instance(Cache::class, $cache);
 
-        $expectedKey = 'laravel_unique_job:'.TestDispatcherShouldBeUnique::class.':unique-listener-id';
+        $expectedKey = 'laravel_unique_job:'.hash('xxh128', TestDispatcherShouldBeUnique::class).':unique-listener-id';
 
         $cache->shouldReceive('lock')
             ->once()
@@ -479,7 +479,7 @@ class QueuedEventsTest extends TestCase
 
         TestDispatcherShouldBeUniqueWithCustomCache::$cache = $uniqueCache;
 
-        $expectedKey = 'laravel_unique_job:'.TestDispatcherShouldBeUniqueWithCustomCache::class.':unique-listener-id';
+        $expectedKey = 'laravel_unique_job:'.hash('xxh128', TestDispatcherShouldBeUniqueWithCustomCache::class).':unique-listener-id';
 
         $uniqueCache->shouldReceive('lock')
             ->once()
@@ -511,7 +511,7 @@ class QueuedEventsTest extends TestCase
         $listener->uniqueId = 'unique-listener-id';
         $listener->uniqueFor = 60;
 
-        $expectedKey = 'laravel_unique_job:'.TestDispatcherShouldBeUnique::class.':unique-listener-id';
+        $expectedKey = 'laravel_unique_job:'.hash('xxh128', TestDispatcherShouldBeUnique::class).':unique-listener-id';
 
         $cache->shouldReceive('lock')
             ->once()
@@ -541,14 +541,14 @@ class QueuedEventsTest extends TestCase
 
         TestDispatcherShouldBeUniqueUntilProcessing::$lockReleasedBeforeHandling = null;
         TestDispatcherShouldBeUniqueUntilProcessing::$cache = $cache;
-        TestDispatcherShouldBeUniqueUntilProcessing::$expectedLockKey = 'laravel_unique_job:'.TestDispatcherShouldBeUniqueUntilProcessing::class.':until-processing-id';
+        TestDispatcherShouldBeUniqueUntilProcessing::$expectedLockKey = 'laravel_unique_job:'.hash('xxh128', TestDispatcherShouldBeUniqueUntilProcessing::class).':until-processing-id';
 
         $listener = new CallQueuedListener(TestDispatcherShouldBeUniqueUntilProcessing::class, 'handle', ['foo', 'bar']);
         $listener->shouldBeUnique = true;
         $listener->shouldBeUniqueUntilProcessing = true;
         $listener->uniqueId = 'until-processing-id';
 
-        $expectedKey = 'laravel_unique_job:'.TestDispatcherShouldBeUniqueUntilProcessing::class.':until-processing-id';
+        $expectedKey = 'laravel_unique_job:'.hash('xxh128', TestDispatcherShouldBeUniqueUntilProcessing::class).':until-processing-id';
 
         $cache->shouldReceive('lock')
             ->with($expectedKey)

--- a/tests/Integration/Broadcasting/BroadcastManagerTest.php
+++ b/tests/Integration/Broadcasting/BroadcastManagerTest.php
@@ -75,7 +75,7 @@ class BroadcastManagerTest extends TestCase
         Bus::assertNotDispatched(UniqueBroadcastEvent::class);
         Queue::assertPushed(UniqueBroadcastEvent::class);
 
-        $lockKey = 'laravel_unique_job:'.TestEventUnique::class.':';
+        $lockKey = 'laravel_unique_job:'.hash('xxh128', TestEventUnique::class).':';
         $this->assertFalse($this->app->get(Cache::class)->lock($lockKey, 10)->get());
     }
 
@@ -89,7 +89,7 @@ class BroadcastManagerTest extends TestCase
         Bus::assertNotDispatched(UniqueBroadcastEvent::class);
         Queue::assertPushed(UniqueBroadcastEvent::class);
 
-        $lockKey = 'laravel_unique_job:'.TestEventUniqueWithIdProperty::class.':unique-id-property';
+        $lockKey = 'laravel_unique_job:'.hash('xxh128', TestEventUniqueWithIdProperty::class).':unique-id-property';
         $this->assertFalse($this->app->get(Cache::class)->lock($lockKey, 10)->get());
     }
 
@@ -103,7 +103,7 @@ class BroadcastManagerTest extends TestCase
         Bus::assertNotDispatched(UniqueBroadcastEvent::class);
         Queue::assertPushed(UniqueBroadcastEvent::class);
 
-        $lockKey = 'laravel_unique_job:'.TestEventUniqueWithIdMethod::class.':unique-id-method';
+        $lockKey = 'laravel_unique_job:'.hash('xxh128', TestEventUniqueWithIdMethod::class).':unique-id-method';
         $this->assertFalse($this->app->get(Cache::class)->lock($lockKey, 10)->get());
     }
 

--- a/tests/Integration/Queue/UniqueJobTest.php
+++ b/tests/Integration/Queue/UniqueJobTest.php
@@ -199,7 +199,7 @@ class UniqueJobTest extends QueueTestCase
     {
         Bus::fake();
 
-        $lockKey = 'laravel_unique_job:App\\Actions\\UniqueTestAction:';
+        $lockKey = 'laravel_unique_job:'.hash('xxh128', 'App\\Actions\\UniqueTestAction').':';
 
         dispatch(new UniqueTestJobWithDisplayName);
         $this->runQueueWorkerCommand(['--once' => true]);
@@ -238,7 +238,7 @@ class UniqueJobTest extends QueueTestCase
     public function testUniqueLockCreatesKeyWithDisplayNameWhenAvailable()
     {
         $this->assertEquals(
-            'laravel_unique_job:App\\Actions\\UniqueTestAction:unique-id-2',
+            'laravel_unique_job:'.hash('xxh128', 'App\\Actions\\UniqueTestAction').':unique-id-2',
             UniqueLock::getKey(new UniqueIdTestJobWithDisplayName)
         );
     }
@@ -246,7 +246,7 @@ class UniqueJobTest extends QueueTestCase
     public function testUniqueLockCreatesKeyWithIdAndDisplayNameWhenAvailable()
     {
         $this->assertEquals(
-            'laravel_unique_job:App\\Actions\\UniqueTestAction:unique-id-2',
+            'laravel_unique_job:'.hash('xxh128', 'App\\Actions\\UniqueTestAction').':unique-id-2',
             UniqueLock::getKey(new UniqueIdTestJobWithDisplayName)
         );
     }

--- a/tests/Integration/Queue/WithoutOverlappingJobsTest.php
+++ b/tests/Integration/Queue/WithoutOverlappingJobsTest.php
@@ -157,7 +157,7 @@ class WithoutOverlappingJobsTest extends QueueTestCase
         $job = new OverlappingTestJobWithDisplayName;
 
         $this->assertSame(
-            'laravel-queue-overlap:App\\Actions\\WithoutOverlappingTestAction:key',
+            'laravel-queue-overlap:'.hash('xxh128', 'App\\Actions\\WithoutOverlappingTestAction').':key',
             (new WithoutOverlapping('key'))->getLockKey($job)
         );
 
@@ -167,7 +167,7 @@ class WithoutOverlappingJobsTest extends QueueTestCase
         );
 
         $this->assertSame(
-            'prefix:App\\Actions\\WithoutOverlappingTestAction:key',
+            'prefix:'.hash('xxh128', 'App\\Actions\\WithoutOverlappingTestAction').':key',
             (new WithoutOverlapping('key'))->withPrefix('prefix:')->getLockKey($job)
         );
 


### PR DESCRIPTION
## Problem

PR #57499 introduced the use of `displayName()` for job identification in cache lock keys. When a job specifies a `displayName()` that includes spaces, the Memcached cache store silently rejects the key.

For `ShouldBeUnique` jobs, `Memcached::add()` returns `false` for invalid keys, which is indistinguishable from an already-held lock. This causes `PendingDispatch` to silently skip dispatching the job with no exception thrown.

## Solution

Hash the `displayName()` value using `xxh128` before using it in cache lock keys. This produces a safe, fixed-length hex string regardless of the display name.
