### PR TITLE
[12.x] Specific `withoutRelation()` types

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -1156,7 +1156,7 @@ trait HasRelationships
      * @param  array|string  $relations
      * @return $this
      */
-    public function withoutRelation($relations)
+    public function withoutRelation(array|string $relations): static
     {
         $model = clone $this;
 


### PR DESCRIPTION
Add strict types for  `withoutRelation()` method introduced in #59137.
