### PR TITLE
[13.x] Add JSON:API error response support with automatic exception handler integration 

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -24,6 +24,7 @@ use Illuminate\Foundation\Exceptions\Renderer\Renderer;
 use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Http\Exceptions\OriginMismatchException;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Resources\JsonApi\JsonApiErrorResponse;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Exceptions\BackedEnumCaseNotFoundException;
 use Illuminate\Routing\Router;
@@ -751,8 +752,24 @@ class Handler implements ExceptionHandlerContract
     protected function unauthenticated($request, AuthenticationException $exception)
     {
         return $this->shouldReturnJson($request, $exception)
-            ? response()->json(['message' => $exception->getMessage()], 401)
+            ? $this->unauthenticatedJson($request, $exception)
             : redirect()->guest($exception->redirectTo($request) ?? route('login'));
+    }
+
+    /**
+     * Convert an authentication exception into a JSON response.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Illuminate\Auth\AuthenticationException  $exception
+     * @return \Illuminate\Http\JsonResponse
+     */
+    protected function unauthenticatedJson($request, AuthenticationException $exception)
+    {
+        if ($request->wantsJsonApi()) {
+            return JsonApiErrorResponse::fromThrowable(new HttpException(401, $exception->getMessage(), $exception), config('app.debug'));
+        }
+
+        return response()->json(['message' => $exception->getMessage()], 401);
     }
 
     /**
@@ -796,6 +813,10 @@ class Handler implements ExceptionHandlerContract
      */
     protected function invalidJson($request, ValidationException $exception)
     {
+        if ($request->wantsJsonApi()) {
+            return JsonApiErrorResponse::fromValidationException($exception);
+        }
+
         return response()->json([
             'message' => $exception->getMessage(),
             'errors' => $exception->errors(),
@@ -1006,6 +1027,10 @@ class Handler implements ExceptionHandlerContract
      */
     protected function prepareJsonResponse($request, Throwable $e)
     {
+        if ($request->wantsJsonApi()) {
+            return JsonApiErrorResponse::fromThrowable($e, config('app.debug'));
+        }
+
         return response()->json(
             $this->convertExceptionToArray($e),
             $this->isHttpException($e) ? $e->getStatusCode() : 500,

--- a/src/Illuminate/Http/Concerns/InteractsWithContentTypes.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithContentTypes.php
@@ -131,6 +131,18 @@ trait InteractsWithContentTypes
     }
 
     /**
+     * Determine if the current request is asking for JSON:API.
+     *
+     * @return bool
+     */
+    public function wantsJsonApi()
+    {
+        $acceptable = $this->getAcceptableContentTypes();
+
+        return isset($acceptable[0]) && Str::contains(strtolower($acceptable[0]), 'vnd.api+json');
+    }
+
+    /**
      * Determines whether a request accepts JSON.
      *
      * @return bool

--- a/src/Illuminate/Http/Resources/JsonApi/AnonymousResourceCollection.php
+++ b/src/Illuminate/Http/Resources/JsonApi/AnonymousResourceCollection.php
@@ -29,9 +29,7 @@ class AnonymousResourceCollection extends BaseAnonymousResourceCollection
                 ->map(fn ($included) => Arr::except($included, ['_uniqueKey']))
                 ->values()
                 ->all(),
-            ...($implementation = JsonApiResource::$jsonApiInformation)
-                ? ['jsonapi' => $implementation]
-                : [],
+            ...JsonApiResource::jsonApiBlock(),
         ]);
     }
 

--- a/src/Illuminate/Http/Resources/JsonApi/JsonApiError.php
+++ b/src/Illuminate/Http/Resources/JsonApi/JsonApiError.php
@@ -1,0 +1,231 @@
+<?php
+
+namespace Illuminate\Http\Resources\JsonApi;
+
+use Illuminate\Contracts\Support\Arrayable;
+use JsonSerializable;
+
+class JsonApiError implements Arrayable, JsonSerializable
+{
+    /**
+     * A unique identifier for this particular occurrence of the problem.
+     */
+    protected ?string $id = null;
+
+    /**
+     * The HTTP status code applicable to this problem, expressed as a string value.
+     */
+    protected ?string $status = null;
+
+    /**
+     * An application-specific error code, expressed as a string value.
+     */
+    protected ?string $code = null;
+
+    /**
+     * A short, human-readable summary of the problem.
+     */
+    protected ?string $title = null;
+
+    /**
+     * A human-readable explanation specific to this occurrence of the problem.
+     */
+    protected ?string $detail = null;
+
+    /**
+     * An object containing references to the primary source of the error.
+     *
+     * @var array{pointer?: string, parameter?: string, header?: string}
+     */
+    protected array $source = [];
+
+    /**
+     * A links object containing an "about" and/or "type" link.
+     *
+     * @var array{about?: string, type?: string}
+     */
+    protected array $links = [];
+
+    /**
+     * A meta object containing non-standard meta-information about the error.
+     */
+    protected array $meta = [];
+
+    /**
+     * Create a new JSON:API error instance.
+     */
+    public function __construct(?string $detail = null, ?string $status = null)
+    {
+        $this->detail = $detail;
+        $this->status = $status;
+    }
+
+    /**
+     * Create a new JSON:API error instance.
+     */
+    public static function make(?string $detail = null, ?string $status = null): static
+    {
+        return new static($detail, $status);
+    }
+
+    /**
+     * Set the unique identifier for this error occurrence.
+     *
+     * @return $this
+     */
+    public function id(string $id): static
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    /**
+     * Set the HTTP status code for this error.
+     *
+     * @return $this
+     */
+    public function status(string $status): static
+    {
+        $this->status = $status;
+
+        return $this;
+    }
+
+    /**
+     * Set the application-specific error code.
+     *
+     * @return $this
+     */
+    public function code(string $code): static
+    {
+        $this->code = $code;
+
+        return $this;
+    }
+
+    /**
+     * Set the short, human-readable summary.
+     *
+     * @return $this
+     */
+    public function title(string $title): static
+    {
+        $this->title = $title;
+
+        return $this;
+    }
+
+    /**
+     * Set the human-readable explanation specific to this occurrence.
+     *
+     * @return $this
+     */
+    public function detail(string $detail): static
+    {
+        $this->detail = $detail;
+
+        return $this;
+    }
+
+    /**
+     * Set a JSON Pointer to the value in the request document that caused the error.
+     *
+     * @return $this
+     */
+    public function pointer(string $pointer): static
+    {
+        $this->source['pointer'] = $pointer;
+
+        return $this;
+    }
+
+    /**
+     * Set the name of the query parameter that caused the error.
+     *
+     * @return $this
+     */
+    public function parameter(string $parameter): static
+    {
+        $this->source['parameter'] = $parameter;
+
+        return $this;
+    }
+
+    /**
+     * Set the name of the request header that caused the error.
+     *
+     * @return $this
+     */
+    public function header(string $header): static
+    {
+        $this->source['header'] = $header;
+
+        return $this;
+    }
+
+    /**
+     * Set the "about" link.
+     *
+     * @return $this
+     */
+    public function about(string $url): static
+    {
+        $this->links['about'] = $url;
+
+        return $this;
+    }
+
+    /**
+     * Set the "type" link.
+     *
+     * @return $this
+     */
+    public function type(string $url): static
+    {
+        $this->links['type'] = $url;
+
+        return $this;
+    }
+
+    /**
+     * Set the meta object.
+     *
+     * @return $this
+     */
+    public function meta(array $meta): static
+    {
+        $this->meta = $meta;
+
+        return $this;
+    }
+
+    /**
+     * Get the instance as an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return array_filter([
+            'id' => $this->id,
+            'status' => $this->status,
+            'code' => $this->code,
+            'title' => $this->title,
+            'detail' => $this->detail,
+            'source' => $this->source ?: null,
+            'links' => $this->links ?: null,
+            'meta' => $this->meta ?: null,
+        ], fn ($value) => ! is_null($value));
+    }
+
+    /**
+     * Specify data which should be serialized to JSON.
+     *
+     * @return array<string, mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+}

--- a/src/Illuminate/Http/Resources/JsonApi/JsonApiErrorResponse.php
+++ b/src/Illuminate/Http/Resources/JsonApi/JsonApiErrorResponse.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Illuminate\Http\Resources\JsonApi;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Validation\ValidationException;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
+use Throwable;
+
+class JsonApiErrorResponse extends JsonResponse
+{
+    /**
+     * Create a new JSON:API error response.
+     *
+     * @param  array<int, \Illuminate\Http\Resources\JsonApi\JsonApiError|array>  $errors
+     */
+    public function __construct(array $errors = [], int $status = 400, array $headers = [])
+    {
+        $data = [
+            'errors' => array_map(
+                fn ($error) => $error instanceof JsonApiError ? $error->toArray() : $error,
+                array_values($errors)
+            ),
+            ...JsonApiResource::jsonApiBlock(),
+        ];
+
+        parent::__construct($data, $status, $headers, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+
+        $this->header('Content-Type', 'application/vnd.api+json');
+    }
+
+    /**
+     * Create a new JSON:API error response.
+     *
+     * @param  array<int, \Illuminate\Http\Resources\JsonApi\JsonApiError|array>  $errors
+     */
+    public static function make(array $errors = [], int $status = 400, array $headers = []): static
+    {
+        return new static($errors, $status, $headers);
+    }
+
+    /**
+     * Create a JSON:API error response from a validation exception.
+     */
+    public static function fromValidationException(ValidationException $exception): static
+    {
+        $errors = [];
+
+        foreach ($exception->errors() as $field => $messages) {
+            foreach ($messages as $message) {
+                $errors[] = JsonApiError::make($message, (string) $exception->status)
+                    ->title('Validation Error')
+                    ->pointer('/data/attributes/'.$field);
+            }
+        }
+
+        return static::make($errors, $exception->status);
+    }
+
+    /**
+     * Create a JSON:API error response from a throwable.
+     */
+    public static function fromThrowable(Throwable $exception, bool $debug = false): static
+    {
+        $isHttpException = $exception instanceof HttpExceptionInterface;
+
+        $status = $isHttpException ? $exception->getStatusCode() : 500;
+        $headers = $isHttpException ? $exception->getHeaders() : [];
+
+        $error = JsonApiError::make(status: (string) $status);
+
+        $message = $isHttpException ? $exception->getMessage() : null;
+
+        $error->title($message ?: 'Server Error');
+
+        if ($debug) {
+            $error->detail($exception->getMessage())
+                ->meta([
+                    'exception' => $exception::class,
+                    'file' => $exception->getFile(),
+                    'line' => $exception->getLine(),
+                ]);
+        }
+
+        return static::make([$error], $status, $headers);
+    }
+}

--- a/src/Illuminate/Http/Resources/JsonApi/JsonApiResource.php
+++ b/src/Illuminate/Http/Resources/JsonApi/JsonApiResource.php
@@ -138,9 +138,7 @@ class JsonApiResource extends JsonResource
                 ->map(fn ($included) => Arr::except($included, ['_uniqueKey']))
                 ->values()
                 ->all(),
-            ...($implementation = static::$jsonApiInformation)
-                ? ['jsonapi' => $implementation]
-                : [],
+            ...static::jsonApiBlock(),
         ]);
     }
 
@@ -212,6 +210,18 @@ class JsonApiResource extends JsonResource
     protected static function newCollection($resource)
     {
         return new AnonymousResourceCollection($resource, static::class);
+    }
+
+    /**
+     * Get the JSON:API implementation block for inclusion in responses.
+     *
+     * @return array
+     */
+    public static function jsonApiBlock(): array
+    {
+        return static::$jsonApiInformation
+            ? ['jsonapi' => static::$jsonApiInformation]
+            : [];
     }
 
     /**

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -62,6 +62,7 @@ class FoundationExceptionsHandlerTest extends TestCase
         $this->viewFactory = m::mock(ViewFactory::class);
 
         $this->request = m::mock(stdClass::class);
+        $this->request->shouldReceive('wantsJsonApi')->andReturn(false);
 
         $this->container = Container::setInstance(new Container);
 

--- a/tests/Integration/Http/Resources/JsonApi/JsonApiErrorTest.php
+++ b/tests/Integration/Http/Resources/JsonApi/JsonApiErrorTest.php
@@ -1,0 +1,315 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http\Resources\JsonApi;
+
+use Illuminate\Http\Resources\JsonApi\JsonApiError;
+use Illuminate\Http\Resources\JsonApi\JsonApiErrorResponse;
+use Illuminate\Http\Resources\JsonApi\JsonApiResource;
+use Illuminate\Validation\ValidationException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+class JsonApiErrorTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        JsonApiResource::flushState();
+    }
+
+    protected function defineRoutes($router)
+    {
+        parent::defineRoutes($router);
+
+        $router->get('errors/validation', function () {
+            $validator = \Illuminate\Support\Facades\Validator::make(
+                ['title' => ''],
+                ['title' => 'required', 'body' => 'required']
+            );
+
+            throw new ValidationException($validator);
+        });
+
+        $router->get('errors/custom', function () {
+            return JsonApiErrorResponse::make([
+                JsonApiError::make('Name is required', '422')
+                    ->title('Validation Error')
+                    ->pointer('/data/attributes/name'),
+            ], 422);
+        });
+
+        $router->get('errors/not-found', function () {
+            throw new NotFoundHttpException('Post not found');
+        });
+
+        $router->get('errors/server-error', function () {
+            throw new \RuntimeException('Something went wrong');
+        });
+
+        $router->get('errors/multiple', function () {
+            return JsonApiErrorResponse::make([
+                JsonApiError::make('Title is required', '422')
+                    ->pointer('/data/attributes/title'),
+                JsonApiError::make('Body must be at least 10 characters', '422')
+                    ->pointer('/data/attributes/body'),
+            ], 422);
+        });
+    }
+
+    public function testJsonApiErrorCanBeConstructedWithFluentApi()
+    {
+        $error = JsonApiError::make()
+            ->id('error-1')
+            ->status('422')
+            ->code('VALIDATION_ERROR')
+            ->title('Invalid Attribute')
+            ->detail('Title must be at least 3 characters.')
+            ->pointer('/data/attributes/title')
+            ->about('https://example.com/docs/errors/validation')
+            ->type('https://example.com/errors/validation')
+            ->meta(['timestamp' => '2024-01-01']);
+
+        $this->assertSame([
+            'id' => 'error-1',
+            'status' => '422',
+            'code' => 'VALIDATION_ERROR',
+            'title' => 'Invalid Attribute',
+            'detail' => 'Title must be at least 3 characters.',
+            'source' => ['pointer' => '/data/attributes/title'],
+            'links' => [
+                'about' => 'https://example.com/docs/errors/validation',
+                'type' => 'https://example.com/errors/validation',
+            ],
+            'meta' => ['timestamp' => '2024-01-01'],
+        ], $error->toArray());
+    }
+
+    public function testJsonApiErrorOmitsNullValues()
+    {
+        $error = JsonApiError::make('Something went wrong', '500');
+
+        $this->assertSame([
+            'status' => '500',
+            'detail' => 'Something went wrong',
+        ], $error->toArray());
+    }
+
+    public function testJsonApiErrorSupportsParameterSource()
+    {
+        $error = JsonApiError::make('Invalid sort field', '400')
+            ->parameter('sort');
+
+        $this->assertSame([
+            'status' => '400',
+            'detail' => 'Invalid sort field',
+            'source' => ['parameter' => 'sort'],
+        ], $error->toArray());
+    }
+
+    public function testJsonApiErrorSupportsHeaderSource()
+    {
+        $error = JsonApiError::make('Unsupported media type', '415')
+            ->header('Content-Type');
+
+        $this->assertSame([
+            'status' => '415',
+            'detail' => 'Unsupported media type',
+            'source' => ['header' => 'Content-Type'],
+        ], $error->toArray());
+    }
+
+    public function testJsonApiErrorSupportsMultipleSourceFields()
+    {
+        $error = JsonApiError::make('Error')
+            ->pointer('/data/attributes/title')
+            ->parameter('include');
+
+        $this->assertSame([
+            'pointer' => '/data/attributes/title',
+            'parameter' => 'include',
+        ], $error->toArray()['source']);
+    }
+
+    public function testJsonApiErrorIsJsonSerializable()
+    {
+        $error = JsonApiError::make('Not found', '404');
+
+        $this->assertSame(
+            '{"status":"404","detail":"Not found"}',
+            json_encode($error)
+        );
+    }
+
+    public function testCustomErrorResponse()
+    {
+        $this->getJson('errors/custom')
+            ->assertStatus(422)
+            ->assertHeader('Content-Type', 'application/vnd.api+json')
+            ->assertExactJson([
+                'errors' => [
+                    [
+                        'status' => '422',
+                        'title' => 'Validation Error',
+                        'detail' => 'Name is required',
+                        'source' => ['pointer' => '/data/attributes/name'],
+                    ],
+                ],
+            ]);
+    }
+
+    public function testMultipleErrors()
+    {
+        $this->getJson('errors/multiple')
+            ->assertStatus(422)
+            ->assertHeader('Content-Type', 'application/vnd.api+json')
+            ->assertJsonCount(2, 'errors')
+            ->assertJsonPath('errors.0.detail', 'Title is required')
+            ->assertJsonPath('errors.0.source.pointer', '/data/attributes/title')
+            ->assertJsonPath('errors.1.detail', 'Body must be at least 10 characters')
+            ->assertJsonPath('errors.1.source.pointer', '/data/attributes/body');
+    }
+
+    public function testFromValidationException()
+    {
+        $validator = \Illuminate\Support\Facades\Validator::make(
+            ['title' => ''],
+            ['title' => 'required', 'body' => 'required']
+        );
+
+        $exception = ValidationException::withMessages($validator->errors()->toArray());
+        $response = JsonApiErrorResponse::fromValidationException($exception);
+
+        $this->assertSame(422, $response->getStatusCode());
+        $this->assertSame('application/vnd.api+json', $response->headers->get('Content-Type'));
+
+        $content = json_decode($response->getContent(), true);
+
+        $this->assertCount(2, $content['errors']);
+        $this->assertSame('Validation Error', $content['errors'][0]['title']);
+        $this->assertSame('422', $content['errors'][0]['status']);
+        $this->assertSame('/data/attributes/title', $content['errors'][0]['source']['pointer']);
+        $this->assertSame('/data/attributes/body', $content['errors'][1]['source']['pointer']);
+    }
+
+    public function testFromThrowableWithHttpException()
+    {
+        $exception = new NotFoundHttpException('Post not found');
+
+        $response = JsonApiErrorResponse::fromThrowable($exception);
+
+        $this->assertSame(404, $response->getStatusCode());
+        $this->assertSame('application/vnd.api+json', $response->headers->get('Content-Type'));
+
+        $content = json_decode($response->getContent(), true);
+
+        $this->assertCount(1, $content['errors']);
+        $this->assertSame('404', $content['errors'][0]['status']);
+        $this->assertSame('Post not found', $content['errors'][0]['title']);
+    }
+
+    public function testFromThrowableWithGenericException()
+    {
+        $exception = new \RuntimeException('Something broke');
+
+        $response = JsonApiErrorResponse::fromThrowable($exception);
+
+        $this->assertSame(500, $response->getStatusCode());
+
+        $content = json_decode($response->getContent(), true);
+
+        $this->assertCount(1, $content['errors']);
+        $this->assertSame('500', $content['errors'][0]['status']);
+        $this->assertSame('Server Error', $content['errors'][0]['title']);
+        $this->assertArrayNotHasKey('detail', $content['errors'][0]);
+    }
+
+    public function testFromThrowableInDebugMode()
+    {
+        $exception = new \RuntimeException('Something broke');
+
+        $response = JsonApiErrorResponse::fromThrowable($exception, debug: true);
+
+        $content = json_decode($response->getContent(), true);
+
+        $this->assertSame('Something broke', $content['errors'][0]['detail']);
+        $this->assertSame('RuntimeException', $content['errors'][0]['meta']['exception']);
+        $this->assertArrayHasKey('file', $content['errors'][0]['meta']);
+        $this->assertArrayHasKey('line', $content['errors'][0]['meta']);
+    }
+
+    public function testErrorResponseIncludesJsonApiInformation()
+    {
+        JsonApiResource::configure(version: '1.1');
+
+        $response = JsonApiErrorResponse::make([
+            JsonApiError::make('Error', '400'),
+        ]);
+
+        $content = json_decode($response->getContent(), true);
+
+        $this->assertArrayHasKey('jsonapi', $content);
+        $this->assertSame('1.1', $content['jsonapi']['version']);
+    }
+
+    public function testErrorResponseDoesNotIncludeDataKey()
+    {
+        $response = JsonApiErrorResponse::make([
+            JsonApiError::make('Error', '400'),
+        ]);
+
+        $content = json_decode($response->getContent(), true);
+
+        $this->assertArrayNotHasKey('data', $content);
+        $this->assertArrayHasKey('errors', $content);
+    }
+
+    public function testValidationExceptionAutoFormatsForJsonApiRequests()
+    {
+        $this->json('GET', 'errors/validation', [], ['Accept' => 'application/vnd.api+json'])
+            ->assertStatus(422)
+            ->assertHeader('Content-Type', 'application/vnd.api+json')
+            ->assertJsonStructure(['errors' => [['status', 'title', 'detail', 'source']]])
+            ->assertJsonPath('errors.0.title', 'Validation Error')
+            ->assertJsonPath('errors.0.source.pointer', '/data/attributes/title')
+            ->assertJsonMissing(['message', 'data']);
+    }
+
+    public function testValidationExceptionUsesStandardFormatForRegularJsonRequests()
+    {
+        $this->getJson('errors/validation')
+            ->assertStatus(422)
+            ->assertJsonStructure(['message', 'errors'])
+            ->assertJsonMissing(['source', 'pointer']);
+    }
+
+    public function testNotFoundExceptionAutoFormatsForJsonApiRequests()
+    {
+        $this->json('GET', 'errors/not-found', [], ['Accept' => 'application/vnd.api+json'])
+            ->assertStatus(404)
+            ->assertHeader('Content-Type', 'application/vnd.api+json')
+            ->assertJsonPath('errors.0.status', '404')
+            ->assertJsonPath('errors.0.title', 'Post not found')
+            ->assertJsonMissing(['data']);
+    }
+
+    public function testServerErrorAutoFormatsForJsonApiRequests()
+    {
+        $this->json('GET', 'errors/server-error', [], ['Accept' => 'application/vnd.api+json'])
+            ->assertStatus(500)
+            ->assertHeader('Content-Type', 'application/vnd.api+json')
+            ->assertJsonPath('errors.0.status', '500')
+            ->assertJsonPath('errors.0.title', 'Server Error');
+    }
+
+    public function testServerErrorIncludesDebugInfoWhenEnabled()
+    {
+        config(['app.debug' => true]);
+
+        $this->json('GET', 'errors/server-error', [], ['Accept' => 'application/vnd.api+json'])
+            ->assertStatus(500)
+            ->assertHeader('Content-Type', 'application/vnd.api+json')
+            ->assertJsonPath('errors.0.status', '500')
+            ->assertJsonPath('errors.0.detail', 'Something went wrong')
+            ->assertJsonPath('errors.0.meta.exception', 'RuntimeException');
+    }
+}


### PR DESCRIPTION
This PR adds spec-compliant JSON:API error responses to the framework, complementing the existing `JsonApiResource` serialization layer. When a request sends `Accept: application/vnd.api+json`, exceptions are automatically formatted as JSON:API error objects and no configuration needed.                           
                                                                                                          
## Motivation                                

The existing `JsonApiResource` implementation handles the response/serialization side well, but when an exception occurs (validation failure, 404, 500, auth error), the framework falls back to Laravel's standard `{"message": "...", "errors": {...}}` format. This breaks JSON:API clients that expect the `{"errors": [...]}` document structure defined in the spec.

Today, developers working with JSON:API must manually override `invalidJson()`, `prepareJsonResponse()`, and `unauthenticated()` in their exception handler to format errors correctly. This PR makes that automatic while still allowing customization.

## New Classes

### `JsonApiError`

A fluent value object representing a single JSON:API error, covering all spec-defined fields:

  ```php
  JsonApiError::make('Title is required', '422')
      ->title('Validation Error')
      ->pointer('/data/attributes/title')
      ->code('VALIDATION_ERROR')
      ->about('https://docs.example.com/errors/validation')
      ->meta(['timestamp' => now()]);
```

### `JsonApiErrorResponse`

A response class extending `JsonResponse` that wraps errors in the spec-compliant `{"errors": [...]}` document structure with the `application/vnd.api+json` content type.

Three factory methods:

  ```php
  // Manual construction
  JsonApiErrorResponse::make([
      JsonApiError::make('Not found', '404'),
  ], 404);

  // From a ValidationException (maps fields to source.pointer)
  JsonApiErrorResponse::fromValidationException($exception);

  // From any Throwable (with optional debug mode)
  JsonApiErrorResponse::fromThrowable($exception, debug: true);
```

  Exception Handler Integration

  Three override points in Handler now automatically detect JSON:API requests via $request->wantsJsonApi()
  and format errors accordingly:

  - invalidJson(): Validation errors return per-field JSON:API error objects with source.pointer values
  - prepareJsonResponse(): General exceptions return JSON:API errors with debug metadata when app.debug is
  true
  - unauthenticatedJson(): New extracted method (previously inline in unauthenticated()) for auth errors,
  now also an override point for all JSON responses

  A validation error for a JSON:API request now returns:
```
  {
      "errors": [
          {
              "status": "422",
              "title": "Validation Error",
              "detail": "The title field is required.",
              "source": {
                  "pointer": "/data/attributes/title"
              }
          }
      ]
  }
```

  Instead of the standard Laravel format:
```
  {
      "message": "The title field is required.",
      "errors": {
          "title": ["The title field is required."]
      }
  }
```

## Additional Changes

  - Request::wantsJsonApi(): New method on InteractsWithContentTypes, following the same pattern as wantsJson(). Returns true when the primary Accept type is application/vnd.api+json.
  - JsonApiResource::jsonApiBlock(): Extracted the jsonapi top-level member logic that was duplicated in JsonApiResource::with(), AnonymousResourceCollection::with(), and now JsonApiErrorResponse. Three call sites consolidated into one method.

## Why This Doesn't Break Existing Features

  - Opt-in via Accept header: The JSON:API error formatting only activates when the client sends Accept:
  application/vnd.api+json. Standard application/json requests are completely unaffected.
  - All override points preserved: invalidJson(), prepareJsonResponse(), and the new unauthenticatedJson()
  are all protected methods. Applications that already override them continue to work unchanged.
  - No behavioral changes for existing JSON:API resources. The JsonApiResource class and its serialization
  behavior are untouched (aside from the jsonApiBlock() extraction, which is a pure refactor).

## Benefit to End Users

  Building a JSON:API compliant API in Laravel currently requires manual exception handler customization to avoid sending non-spec error responses. This PR eliminates that boilerplate, developers using JsonApiResource get spec-compliant error responses for free, while retaining full control through the standard Handler override points.