### PR TITLE
[12.x] Fix docblock for RateLimiter `for()` method

### DIFF
--- a/src/Illuminate/Cache/RateLimiter.php
+++ b/src/Illuminate/Cache/RateLimiter.php
@@ -39,7 +39,7 @@ class RateLimiter
     }
 
     /**
-     * Register a named limiter configuration.
+     * Register a named rate limiter configuration.
      *
      * @param  \UnitEnum|string  $name
      * @param  \Closure  $callback


### PR DESCRIPTION
Adds the missing word "rate" to the docblock. The missing word is inconsistent with the rest of the class. For example, the `limiter()` method is described as *"Get the given named rate limiter"*.
