### PR TITLE
[11.x] Deduplicate paths in view:cache

### DIFF
--- a/src/Illuminate/Foundation/Console/ViewCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewCacheCommand.php
@@ -6,6 +6,7 @@ use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
 
@@ -101,8 +102,14 @@ class ViewCacheCommand extends Command
     {
         $finder = $this->laravel['view']->getFinder();
 
-        return (new Collection($finder->getPaths()))->merge(
+        $paths = (new Collection($finder->getPaths()))->merge(
             (new Collection($finder->getHints()))->flatten()
-        );
+        )->unique();
+
+        return $paths->reject(function ($path) use ($paths) {
+            return $paths->contains(function ($existing) use ($path) {
+                return $existing !== $path && Path::isBasePath($existing, $path);
+            });
+        })->values();
     }
 }

--- a/src/Illuminate/Foundation/Console/ViewCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewCacheCommand.php
@@ -6,7 +6,6 @@ use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
 
@@ -107,7 +106,7 @@ class ViewCacheCommand extends Command
         )->unique();
 
         return $paths->reject(fn ($path) => $paths->contains(function ($existing) use ($path) {
-            return $existing !== $path && Path::isBasePath($existing, $path);
+            return $existing !== $path && str_starts_with(realpath($path) ?: $path, realpath($existing) ?: $existing);
         }))->values();
     }
 }

--- a/src/Illuminate/Foundation/Console/ViewCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewCacheCommand.php
@@ -106,10 +106,8 @@ class ViewCacheCommand extends Command
             (new Collection($finder->getHints()))->flatten()
         )->unique();
 
-        return $paths->reject(function ($path) use ($paths) {
-            return $paths->contains(function ($existing) use ($path) {
-                return $existing !== $path && Path::isBasePath($existing, $path);
-            });
-        })->values();
+        return $paths->reject(fn ($path) => $paths->contains(function ($existing) use ($path) {
+            return $existing !== $path && Path::isBasePath($existing, $path);
+        }))->values();
     }
 }

--- a/tests/Integration/View/BladeTest.php
+++ b/tests/Integration/View/BladeTest.php
@@ -12,6 +12,7 @@ use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
 
+use function Illuminate\Filesystem\join_paths;
 use function Orchestra\Testbench\artisan;
 use function Orchestra\Testbench\phpunit_version_compare;
 
@@ -221,8 +222,8 @@ class BladeTest extends TestCase
 
     public function test_view_cache_command_deduplicates_paths_before_compiling()
     {
-        View::addNamespace('templates', __DIR__.'/templates');
-        View::addNamespace('components', __DIR__.'/templates/components');
+        View::addNamespace('templates', join_paths(__DIR__, 'templates'));
+        View::addNamespace('components', join_paths(__DIR__, 'templates', 'components'));
 
         $compiler = Mockery::mock(app('blade.compiler'))->makePartial();
         $compiler->shouldReceive('compile')->with(realpath(__DIR__.'/templates/components/panel.blade.php'))->once();

--- a/tests/Integration/View/BladeTest.php
+++ b/tests/Integration/View/BladeTest.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\View;
 use Illuminate\View\Component;
+use Mockery;
 use Orchestra\Testbench\TestCase;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use Symfony\Component\Finder\Finder;
@@ -216,6 +217,19 @@ class BladeTest extends TestCase
         $found = collect($compiledFiles)
             ->contains(fn (SplFileInfo $file) => str_contains($file->getContents(), 'echo "<?php echo e($scriptMessage); ?>" > output.log'));
         $this->assertTrue($found);
+    }
+
+    public function test_view_cache_command_deduplicates_paths_before_compiling()
+    {
+        View::addNamespace('templates', __DIR__.'/templates');
+        View::addNamespace('components', __DIR__.'/templates/components');
+
+        $compiler = Mockery::mock(app('blade.compiler'))->makePartial();
+        $compiler->shouldReceive('compile')->with(realpath(__DIR__.'/templates/components/panel.blade.php'))->once();
+
+        $this->instance('blade.compiler', $compiler);
+
+        $this->artisan('view:cache');
     }
 
     /** {@inheritdoc} */


### PR DESCRIPTION
Backport of #59145

CI failures seem unrelated