### PR TITLE
fix: use enum_value() in ModelNotFoundException to support UnitEnum

### DIFF
--- a/src/Illuminate/Database/Eloquent/ModelNotFoundException.php
+++ b/src/Illuminate/Database/Eloquent/ModelNotFoundException.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Database\Eloquent;
 
-use BackedEnum;
 use Illuminate\Database\RecordsNotFoundException;
 use Illuminate\Support\Arr;
 
@@ -36,10 +35,7 @@ class ModelNotFoundException extends RecordsNotFoundException
     {
         $this->model = $model;
 
-        $this->ids = array_map(
-            fn ($id) => $id instanceof BackedEnum ? $id->value : $id,
-            Arr::wrap($ids)
-        );
+        $this->ids = array_map('enum_value', Arr::wrap($ids));
 
         $this->message = "No query results for model [{$model}]";
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -143,6 +143,24 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->findOrFail('bar', ['column']);
     }
 
+    public function testFindOrFailMethodThrowsModelNotFoundExceptionWithBackedEnum()
+    {
+        $exception = new ModelNotFoundException;
+        $exception->setModel('Foo', EloquentBuilderTestBackedEnum::Bar);
+
+        $this->assertSame('No query results for model [Foo] bar', $exception->getMessage());
+        $this->assertSame(['bar'], $exception->getIds());
+    }
+
+    public function testFindOrFailMethodThrowsModelNotFoundExceptionWithUnitEnum()
+    {
+        $exception = new ModelNotFoundException;
+        $exception->setModel('Foo', EloquentBuilderTestUnitEnum::Baz);
+
+        $this->assertSame('No query results for model [Foo] Baz', $exception->getMessage());
+        $this->assertSame(['Baz'], $exception->getIds());
+    }
+
     public function testFindOrFailMethodWithManyThrowsModelNotFoundException()
     {
         $this->expectException(ModelNotFoundException::class);
@@ -3167,4 +3185,14 @@ class EloquentBuilderTestWhereBelongsToStub extends Model
     {
         return $this->belongsTo(self::class, 'parent_id', 'id', 'parent');
     }
+}
+
+enum EloquentBuilderTestBackedEnum: string
+{
+    case Bar = 'bar';
+}
+
+enum EloquentBuilderTestUnitEnum
+{
+    case Baz;
 }


### PR DESCRIPTION
Follow-up to #59132.

As @jtheuerkauf noted in #55977, the previous fix only handled `BackedEnum` and missed `UnitEnum` cases where the value is `->name`.

Using `enum_value()` — the framework's own helper — resolves both cleanly:

- `BackedEnum`: returns `->value`
- `UnitEnum`: returns `->name`
- Everything else: passes through unchanged

This also removes the now-redundant `use BackedEnum;` import.

**Before:**
```php
$this->ids = array_map(
    fn ($id) => $id instanceof BackedEnum ? $id->value : $id,
    Arr::wrap($ids)
);
```

**After:**
```php
$this->ids = array_map('enum_value', Arr::wrap($ids));
```

Tests added for both `BackedEnum` and `UnitEnum` cases.