### PR TITLE
Add support for deleteWhenMissingModels to queued listeners

### DIFF
--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -12,6 +12,7 @@ use Illuminate\Contracts\Encryption\Encrypter;
 use Illuminate\Contracts\Queue\ShouldBeEncrypted;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueueAfterCommit;
+use Illuminate\Events\CallQueuedListener;
 use Illuminate\Queue\Events\JobQueued;
 use Illuminate\Queue\Events\JobQueueing;
 use Illuminate\Support\Collection;
@@ -191,10 +192,23 @@ abstract class Queue
 
         return array_merge($payload, [
             'data' => array_merge($payload['data'], [
-                'commandName' => get_class($job),
+                'commandName' => $this->getCommandName($job),
                 'command' => $command,
             ]),
         ]);
+    }
+
+    /**
+     * Get the command name for the given job.
+     *
+     * @param  object  $job
+     * @return string
+     */
+    protected function getCommandName($job)
+    {
+        return $job instanceof CallQueuedListener
+            ? $job->class
+            : get_class($job);
     }
 
     /**

--- a/tests/Integration/Queue/CallQueuedHandlerTest.php
+++ b/tests/Integration/Queue/CallQueuedHandlerTest.php
@@ -9,6 +9,7 @@ use Illuminate\Bus\Dispatcher;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\Job;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Events\CallQueuedListener;
 use Illuminate\Queue\Attributes\DeleteWhenMissingModels;
 use Illuminate\Queue\CallQueuedHandler;
 use Illuminate\Queue\Events\JobFailed;
@@ -178,6 +179,56 @@ class CallQueuedHandlerTest extends TestCase
 
         Event::assertNotDispatched(JobFailed::class);
     }
+
+    public function testQueuedListenerIsDeletedIfListenerHasDeleteProperty()
+    {
+        Event::fake();
+
+        $instance = new CallQueuedHandler(new Dispatcher($this->app), $this->app);
+
+        $job = m::mock(Job::class);
+        $job->shouldReceive('getConnectionName')->andReturn('connection');
+        $job->shouldReceive('resolveQueuedJobClass')->andReturn(CallQueuedHandlerListenerExceptionThrower::class);
+        $job->shouldReceive('markAsFailed')->never();
+        $job->shouldReceive('isDeleted')->andReturn(false);
+        $job->shouldReceive('delete')->once();
+        $job->shouldReceive('failed')->never();
+
+        $instance->call($job, [
+            'command' => serialize(new CallQueuedListener(
+                CallQueuedHandlerListenerExceptionThrower::class,
+                'handle',
+                [new CallQueuedHandlerMissingModelEvent]
+            )),
+        ]);
+
+        Event::assertNotDispatched(JobFailed::class);
+    }
+
+    public function testQueuedListenerIsDeletedIfListenerHasDeleteAttribute()
+    {
+        Event::fake();
+
+        $instance = new CallQueuedHandler(new Dispatcher($this->app), $this->app);
+
+        $job = m::mock(Job::class);
+        $job->shouldReceive('getConnectionName')->andReturn('connection');
+        $job->shouldReceive('resolveQueuedJobClass')->andReturn(CallQueuedHandlerAttributeListenerExceptionThrower::class);
+        $job->shouldReceive('markAsFailed')->never();
+        $job->shouldReceive('isDeleted')->andReturn(false);
+        $job->shouldReceive('delete')->once();
+        $job->shouldReceive('failed')->never();
+
+        $instance->call($job, [
+            'command' => serialize(new CallQueuedListener(
+                CallQueuedHandlerAttributeListenerExceptionThrower::class,
+                'handle',
+                [new CallQueuedHandlerMissingModelEvent]
+            )),
+        ]);
+
+        Event::assertNotDispatched(JobFailed::class);
+    }
 }
 
 class CallQueuedHandlerTestJob
@@ -263,13 +314,38 @@ class CallQueuedHandlerBatchableExceptionThrower
     {
         //
     }
-
     public function __wakeup()
     {
         throw new ModelNotFoundException('Foo');
     }
 }
 
+class CallQueuedHandlerMissingModelEvent
+{
+    public function __wakeup()
+    {
+        throw new ModelNotFoundException('Foo');
+    }
+}
+
+class CallQueuedHandlerListenerExceptionThrower
+{
+    public $deleteWhenMissingModels = true;
+
+    public function handle(CallQueuedHandlerMissingModelEvent $event)
+    {
+        //
+    }
+}
+
+#[DeleteWhenMissingModels]
+class CallQueuedHandlerAttributeListenerExceptionThrower
+{
+    public function handle(CallQueuedHandlerMissingModelEvent $event)
+    {
+        //
+    }
+}
 class TestJobMiddleware
 {
     public function handle($command, $next)

--- a/tests/Queue/QueueSyncQueueTest.php
+++ b/tests/Queue/QueueSyncQueueTest.php
@@ -10,6 +10,7 @@ use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Contracts\Queue\ShouldQueueAfterCommit;
 use Illuminate\Database\DatabaseTransactionsManager;
+use Illuminate\Events\CallQueuedListener;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\Jobs\SyncJob;
 use Illuminate\Queue\SyncQueue;
@@ -101,6 +102,20 @@ class QueueSyncQueueTest extends TestCase
         } catch (LogicException $e) {
             $this->assertSame('extraValue', $e->getMessage());
         }
+    }
+
+    public function testQueuedListenerPayloadUsesListenerClassAsCommandName()
+    {
+        $queue = new SyncQueuePayloadTestQueue;
+        $queue->setContainer(new Container);
+
+        $payload = $queue->createPayloadForTest(new CallQueuedListener(
+            SyncQueuePayloadTestListener::class,
+            'handle',
+            []
+        ));
+
+        $this->assertSame(SyncQueuePayloadTestListener::class, $payload['data']['commandName']);
     }
 
     public function testItAddsATransactionCallbackForAfterCommitJobs()
@@ -268,6 +283,21 @@ class SyncQueueAfterCommitInterfaceUniqueJob implements ShouldBeUnique, ShouldQu
 {
     use InteractsWithQueue;
 
+    public function handle()
+    {
+    }
+}
+
+class SyncQueuePayloadTestQueue extends SyncQueue
+{
+    public function createPayloadForTest($job)
+    {
+        return json_decode($this->createPayload($job, 'default'), true);
+    }
+}
+
+class SyncQueuePayloadTestListener implements ShouldQueue
+{
     public function handle()
     {
     }


### PR DESCRIPTION
Queued jobs support `$deleteWhenMissingModels` and `#[DeleteWhenMissingModels]`, but queued listeners do not behave the same way. Is there a reason why queued listeners doesn't do it in the first place?

The problem is that queued listeners are wrapped in `Illuminate\Events\QueuedListener`, and when a missing model causes unserialization to fail, Laravel checks the wrapper class instead of the actual listener class. Because of that, a listener’s own missing-model setting is ignored.

The use case is a queued listener that receives an event containing an Eloquent model. If that model no longer exists by the time the listener runs, the listener should be deleted cleanly when it has opted into missing-model deletion, just like a queued job.

This change fixes that by storing the underlying listener class as the queued `commandName` for `CallQueuedListener`. That lets the existing missing-model handling logic evaluate the real listener class, so queued listeners can honor both `$deleteWhenMissingModels = true` and `#[DeleteWhenMissingModels]`.

Tests were added to cover:
- queued listener payload metadata
- queued listeners with `$deleteWhenMissingModels = true`
- queued listeners with `#[DeleteWhenMissingModels]`