### PR TITLE
Add depth parameter to Arr::dot()

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -178,25 +178,26 @@ class Arr
      *
      * @param  iterable  $array
      * @param  string  $prepend
+     * @param  int  $depth
      * @return array
      */
-    public static function dot($array, $prepend = '')
+    public static function dot($array, $prepend = '', $depth = INF)
     {
         $results = [];
 
-        $flatten = function ($data, $prefix) use (&$results, &$flatten): void {
+        $flatten = function ($data, $prefix, $currentDepth) use (&$results, &$flatten, $depth): void {
             foreach ($data as $key => $value) {
                 $newKey = $prefix.$key;
 
-                if (is_array($value) && ! empty($value)) {
-                    $flatten($value, $newKey.'.');
+                if (is_array($value) && ! empty($value) && $currentDepth < $depth) {
+                    $flatten($value, $newKey.'.', $currentDepth + 1);
                 } else {
                     $results[$newKey] = $value;
                 }
             }
         };
 
-        $flatten($array, $prepend);
+        $flatten($array, $prepend, 0);
 
         // Destroy self-referencing closure to avoid memory leak...
         $flatten = null;

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1808,11 +1808,12 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Flatten a multi-dimensional associative array with dots.
      *
+     * @param  int  $depth
      * @return static
      */
-    public function dot()
+    public function dot($depth = INF)
     {
-        return new static(Arr::dot($this->all()));
+        return new static(Arr::dot($this->all(), '', $depth));
     }
 
     /**

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1704,11 +1704,12 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     /**
      * Flatten a multi-dimensional associative array with dots.
      *
+     * @param  int  $depth
      * @return static
      */
-    public function dot()
+    public function dot($depth = INF)
     {
-        return $this->passthru(__FUNCTION__, []);
+        return $this->passthru(__FUNCTION__, [$depth]);
     }
 
     /**

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -256,6 +256,43 @@ class SupportArrTest extends TestCase
         ], $array);
     }
 
+    public function testDotWithDepth()
+    {
+        $array = Arr::dot(['user' => ['name' => 'Taylor', 'address' => ['city' => 'Dallas']]], '', 1);
+        $this->assertSame([
+            'user.name' => 'Taylor',
+            'user.address' => ['city' => 'Dallas'],
+        ], $array);
+
+        $array = Arr::dot(['user' => ['address' => ['city' => ['name' => 'Dallas']]]], '', 2);
+        $this->assertSame([
+            'user.address.city' => ['name' => 'Dallas'],
+        ], $array);
+
+        $array = Arr::dot(['user' => ['address' => ['city' => ['name' => 'Dallas']]]], '', INF);
+        $this->assertSame([
+            'user.address.city.name' => 'Dallas',
+        ], $array);
+
+        $array = Arr::dot(['name' => 'taylor', 'languages' => ['php' => true, 'js' => ['react' => true]]], '', 1);
+        $this->assertSame([
+            'name' => 'taylor',
+            'languages.php' => true,
+            'languages.js' => ['react' => true],
+        ], $array);
+
+        $array = Arr::dot(['foo' => ['bar' => []]], '', 1);
+        $this->assertSame(['foo.bar' => []], $array);
+
+        $array = Arr::dot(['user' => ['name' => 'Taylor', 'address' => ['city' => 'Dallas']]], '', 0);
+        $this->assertSame([
+            'user' => ['name' => 'Taylor', 'address' => ['city' => 'Dallas']],
+        ], $array);
+
+        $array = Arr::dot(['user' => ['name' => 'Taylor']], 'prefix.', 1);
+        $this->assertSame(['prefix.user.name' => 'Taylor'], $array);
+    }
+
     public function testUndot()
     {
         $array = Arr::undot([

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -5934,6 +5934,27 @@ class SupportCollectionTest extends TestCase
     }
 
     #[DataProvider('collectionClassProvider')]
+    public function testDotWithDepth($collection)
+    {
+        $data = $collection::make([
+            'name' => 'Taylor',
+            'meta' => [
+                'foo' => 'bar',
+                'bam' => [
+                    'boom' => 'bip',
+                ],
+            ],
+        ])->dot(1);
+        $this->assertSame([
+            'name' => 'Taylor',
+            'meta.foo' => 'bar',
+            'meta.bam' => [
+                'boom' => 'bip',
+            ],
+        ], $data->all());
+    }
+
+    #[DataProvider('collectionClassProvider')]
     public function testEnsureForScalar($collection)
     {
         $data = $collection::make([1, 2, 3]);


### PR DESCRIPTION
`Arr::flatten()` has a `$depth` parameter to control how deep it goes but `Arr::dot()` always flattens everything. this adds the same `$depth` parameter to `Arr::dot()` for consistency.

### Usage

```php
$array = ['user' => ['name' => 'Taylor', 'address' => ['city' => 'Dallas']]];

// current behavior, nothing changes
Arr::dot($array);
// ['user.name' => 'Taylor', 'user.address.city' => 'Dallas']

// only 1 level
Arr::dot($array, '', 1);
// ['user.name' => 'Taylor', 'user.address' => ['city' => 'Dallas']]
```

also works on collections:

```php
collect($array)->dot(1);
```

default value is `INF` so existing usage is not affected.