### PR TITLE
[13.x] Drop method_exists checks in MonitorCommand  

### DIFF
--- a/src/Illuminate/Queue/Console/MonitorCommand.php
+++ b/src/Illuminate/Queue/Console/MonitorCommand.php
@@ -100,18 +100,10 @@ class MonitorCommand extends Command
                 'connection' => $connection,
                 'queue' => $queue,
                 'size' => $size = $this->manager->connection($connection)->size($queue),
-                'pending' => method_exists($this->manager->connection($connection), 'pendingSize')
-                    ? $this->manager->connection($connection)->pendingSize($queue)
-                    : null,
-                'delayed' => method_exists($this->manager->connection($connection), 'delayedSize')
-                    ? $this->manager->connection($connection)->delayedSize($queue)
-                    : null,
-                'reserved' => method_exists($this->manager->connection($connection), 'reservedSize')
-                    ? $this->manager->connection($connection)->reservedSize($queue)
-                    : null,
-                'oldest_pending' => method_exists($this->manager->connection($connection), 'creationTimeOfOldestPendingJob')
-                    ? $this->manager->connection($connection)->creationTimeOfOldestPendingJob($queue)
-                    : null,
+                'pending' => $this->manager->connection($connection)->pendingSize($queue),
+                'delayed' => $this->manager->connection($connection)->delayedSize($queue),
+                'reserved' => $this->manager->connection($connection)->reservedSize($queue),
+                'oldest_pending' => $this->manager->connection($connection)->creationTimeOfOldestPendingJob($queue),
                 'status' => $size >= $this->option('max') ? '<fg=yellow;options=bold>ALERT</>' : '<fg=green;options=bold>OK</>',
             ];
         });


### PR DESCRIPTION
Left a note on this to come back to once it was caught up.. which it is now

Now that `pendingSize`, `delayedSize`, etc are now defined on the Queue contract, the `method_exists` checks are no longer needed.         

TLDR They're on the interface, so any implementation must have them..  very minor, but saves a check 🤷🏻 

13.x cause thats where the contract changes are! :)