### PR TITLE
Add RegistersRouteFiles trait to ServiceProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased](https://github.com/laravel/framework/compare/v12.54.1...12.x)
 
+### Added
+- Added `RegistersRouteFiles` trait to `Illuminate\Support\ServiceProvider` for fluent, cache-compatible route file loading without manual `require` calls or repetitive `Route::group()` boilerplate ([#XXXXX](https://github.com/laravel/framework/pull/XXXXX))
+
 ## [v12.54.1](https://github.com/laravel/framework/compare/v12.54.0...v12.54.1) - 2026-03-10
 
 * [12.x] Makes imports consistent by [@nunomaduro](https://github.com/nunomaduro) in https://github.com/laravel/framework/pull/59149

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased](https://github.com/laravel/framework/compare/v12.54.1...12.x)
 
 ### Added
-- Added `RegistersRouteFiles` trait to `Illuminate\Support\ServiceProvider` for fluent, cache-compatible route file loading without manual `require` calls or repetitive `Route::group()` boilerplate ([#XXXXX](https://github.com/laravel/framework/pull/XXXXX))
+- Added `RegistersRouteFiles` trait to `Illuminate\Support\ServiceProvider` for fluent, cache-compatible route file loading without manual `require` calls or repetitive `Route::group()` boilerplate ([#XXXXX](https://github.com/laravel/framework/pull/59152))
 
 ## [v12.54.1](https://github.com/laravel/framework/compare/v12.54.0...v12.54.1) - 2026-03-10
 

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Foundation\CachesRoutes;
 use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Database\Eloquent\Factory as ModelFactory;
 use Illuminate\View\Compilers\BladeCompiler;
+use Illuminate\Support\Traits\RegistersRouteFiles;
 
 /**
  * @property array<string, string> $bindings All of the container bindings that should be registered.
@@ -16,6 +17,8 @@ use Illuminate\View\Compilers\BladeCompiler;
  */
 abstract class ServiceProvider
 {
+
+    use RegistersRouteFiles; 
     /**
      * The application instance.
      *

--- a/src/Illuminate/Support/Traits/RegistersRouteFiles.php
+++ b/src/Illuminate/Support/Traits/RegistersRouteFiles.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Illuminate\Support\Traits;
+
+use Illuminate\Support\Facades\Route;
+use InvalidArgumentException;
+
+trait RegistersRouteFiles
+{
+    /**
+     * Track resolved absolute paths across all ServiceProviders
+     * to prevent the same file from being loaded more than once.
+     *
+     * @var array<string>
+     */
+    protected static array $registeredRouteFiles = [];
+
+    /**
+     * Load one or more route files into the application.
+     *
+     * Examples:
+     *   $this->registerRouteFiles('api')
+     *   $this->registerRouteFiles(['web', 'api', 'admin'])
+     *   $this->registerRouteFiles('api/v2', [
+     *       'middleware' => ['api', 'auth:sanctum'],
+     *       'prefix'     => 'api/v2',
+     *   ]);
+     *
+     * @param  string|array<string>  $files
+     * @param  array<string, mixed>  $options
+     * @return static
+     *
+     * @throws InvalidArgumentException
+     */
+    public function registerRouteFiles(string|array $files, array $options = []): static
+    {
+        foreach ((array) $files as $file) {
+            $path = $this->resolveRouteFilePath($file);
+
+            if (in_array($path, static::$registeredRouteFiles, true)) {
+                continue;
+            }
+
+            static::$registeredRouteFiles[] = $path;
+
+            Route::group($options, $path);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Resolve a route file path to a confirmed absolute path.
+     *
+     * @param  string  $file
+     * @return string
+     *
+     * @throws InvalidArgumentException
+     */
+    protected function resolveRouteFilePath(string $file): string
+    {
+        $file = str_replace('\\', '/', $file);
+
+        if (! str_ends_with($file, '.php')) {
+            $file .= '.php';
+        }
+
+        if ($this->isAbsolutePath($file) && is_file($file)) {
+            return $file;
+        }
+
+        $relative = ltrim($file, '/');
+
+        $fromRoutes = base_path('routes/' . $relative);
+        if (is_file($fromRoutes)) {
+            return $fromRoutes;
+        }
+
+        $fromBase = base_path($relative);
+        if (is_file($fromBase)) {
+            return $fromBase;
+        }
+
+        throw new InvalidArgumentException(
+            "Route file [{$file}] could not be found. "
+            . "Checked: [routes/{$relative}] and [{$relative}] relative to base_path()."
+        );
+    }
+
+    /**
+     * Determine whether the given path is absolute.
+     * Handles Unix, Windows drive letters, and UNC paths.
+     *
+     * @param  string  $path
+     * @return bool
+     */
+    protected function isAbsolutePath(string $path): bool
+    {
+        return str_starts_with($path, '/')
+            || preg_match('/^[A-Za-z]:[\/\\\\]/', $path) === 1
+            || str_starts_with($path, '\\\\');
+    }
+}

--- a/tests/Support/RegistersRouteFilesTest.php
+++ b/tests/Support/RegistersRouteFilesTest.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Traits\RegistersRouteFiles;
+use InvalidArgumentException;
+use Orchestra\Testbench\TestCase;
+
+// Concrete stub to test the trait
+class RouteFileServiceProviderStub extends ServiceProvider
+{
+    public function boot(): void {}
+    public function register(): void {}
+
+    public static function resetRegistry(): void
+    {
+        static::$registeredRouteFiles = [];
+    }
+}
+
+class RegistersRouteFilesTest extends TestCase
+{
+    protected RouteFileServiceProviderStub $provider;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->provider = new RouteFileServiceProviderStub($this->app);
+
+        RouteFileServiceProviderStub::resetRegistry();
+    }
+
+    /** @test */
+    public function it_throws_for_a_missing_file(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/could not be found/');
+
+        $this->provider->registerRouteFiles('nonexistent');
+    }
+
+    /** @test */
+    public function it_auto_appends_php_extension(): void
+    {
+        $this->withTempRouteFile('api.php', function () {
+            $this->provider->registerRouteFiles('api'); // no .php — should still work
+            $this->assertTrue(true);
+        });
+    }
+
+    /** @test */
+    public function it_does_not_double_append_extension(): void
+    {
+        $this->withTempRouteFile('api.php', function () {
+            $this->provider->registerRouteFiles('api.php');
+            $this->assertTrue(true);
+        });
+    }
+
+    /** @test */
+    public function it_loads_multiple_files_from_array(): void
+    {
+        $this->withTempRouteFile('web.php', function () {
+            $this->withTempRouteFile('api.php', function () {
+                $this->provider->registerRouteFiles(['web', 'api']);
+                $this->assertTrue(true);
+            });
+        });
+    }
+
+    /** @test */
+    public function it_does_not_load_same_file_twice(): void
+    {
+        $loaded = 0;
+
+        $this->withTempRouteFile('web.php', function () use (&$loaded) {
+            $this->provider->registerRouteFiles('web');
+            $this->provider->registerRouteFiles('web'); // second call — ignored
+
+            $loaded = count(RouteFileServiceProviderStub::$registeredRouteFiles);
+        });
+
+        $this->assertSame(1, $loaded);
+    }
+
+    /** @test */
+    public function it_returns_itself_for_fluent_chaining(): void
+    {
+        $this->withTempRouteFile('web.php', function () {
+            $this->withTempRouteFile('api.php', function () {
+                $result = $this->provider
+                    ->registerRouteFiles('web')
+                    ->registerRouteFiles('api');
+
+                $this->assertSame($this->provider, $result);
+            });
+        });
+    }
+
+    /** @test */
+    public function it_resolves_subdirectory_paths(): void
+    {
+        $this->withTempRouteFile('admin/dashboard.php', function () {
+            $this->provider->registerRouteFiles('admin/dashboard');
+            $this->assertTrue(true);
+        });
+    }
+
+    // ── Helper ────────────────────────────────────────────────────────────────
+
+    protected function withTempRouteFile(string $relative, \Closure $callback): void
+    {
+        $base = sys_get_temp_dir() . '/laravel_test_' . uniqid();
+        $dir  = $base . '/routes/' . dirname($relative);
+
+        @mkdir($dir, 0777, true);
+        file_put_contents($base . '/routes/' . $relative, '<?php');
+
+        $this->app->instance('path.base', $base);
+
+        try {
+            $callback();
+        } finally {
+            @unlink($base . '/routes/' . $relative);
+            @rmdir($dir);
+            @rmdir($base . '/routes');
+            @rmdir($base);
+        }
+    }
+}


### PR DESCRIPTION
## What this PR does
Adds a `RegistersRouteFiles` trait to `ServiceProvider` that provides
a fluent, cache-compatible API for loading route files without manual
`require` calls or repetitive `Route::group()` boilerplate.

## Usage
$this->registerRouteFiles('api');
$this->registerRouteFiles(['web', 'api', 'admin']);
$this->registerRouteFiles('api/v2', [
    'middleware' => ['api', 'auth:sanctum'],
    'prefix'     => 'api/v2',
]);

## Why
- No bare `require` — fully compatible with `php artisan route:cache`
- Deduplication across multiple ServiceProviders
- Resolves relative and absolute paths automatically
- Fluent chaining supported