### PR TITLE
[12.x] Add *OrFail transaction methods to `BelongsToMany`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -325,16 +325,16 @@ trait InteractsWithPivotTable
     /**
      * Attach a model to the parent within a transaction.
      *
-     * @param  mixed  $id
+     * @param  mixed  $ids
      * @param  array  $attributes
      * @param  bool  $touch
      * @return void
      *
      * @throws \Throwable
      */
-    public function attachOrFail($id, array $attributes = [], $touch = true)
+    public function attachOrFail($ids, array $attributes = [], $touch = true)
     {
-        $this->parent->getConnection()->transaction(fn () => $this->attach($id, $attributes, $touch));
+        $this->parent->getConnection()->transaction(fn () => $this->attach($ids, $attributes, $touch));
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -64,6 +64,20 @@ trait InteractsWithPivotTable
     }
 
     /**
+     * Toggles a model (or models) from the parent within a transaction.
+     *
+     * @param  mixed  $ids
+     * @param  bool  $touch
+     * @return array
+     *
+     * @throws \Throwable
+     */
+    public function toggleOrFail($ids, $touch = true)
+    {
+        return $this->parent->getConnection()->transaction(fn () => $this->toggle($ids, $touch));
+    }
+
+    /**
      * Sync the intermediate tables with a list of IDs without detaching.
      *
      * @param  \Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Model|array|int|string  $ids
@@ -129,6 +143,33 @@ trait InteractsWithPivotTable
         }
 
         return $changes;
+    }
+
+    /**
+     * Sync the intermediate tables with a list of IDs or collection of models within a transaction.
+     *
+     * @param  \Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Model|array  $ids
+     * @param  bool  $detaching
+     * @return array{attached: array, detached: array, updated: array}
+     *
+     * @throws \Throwable
+     */
+    public function syncOrFail($ids, $detaching = true)
+    {
+        return $this->parent->getConnection()->transaction(fn () => $this->sync($ids, $detaching));
+    }
+
+    /**
+     * Sync the intermediate tables with a list of IDs without detaching within a transaction.
+     *
+     * @param  \Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Model|array  $ids
+     * @return array{attached: array, detached: array, updated: array}
+     *
+     * @throws \Throwable
+     */
+    public function syncWithoutDetachingOrFail($ids)
+    {
+        return $this->syncOrFail($ids, false);
     }
 
     /**
@@ -279,6 +320,21 @@ trait InteractsWithPivotTable
         if ($touch) {
             $this->touchIfTouching();
         }
+    }
+
+    /**
+     * Attach a model to the parent within a transaction.
+     *
+     * @param  mixed  $id
+     * @param  array  $attributes
+     * @param  bool  $touch
+     * @return void
+     *
+     * @throws \Throwable
+     */
+    public function attachOrFail($id, array $attributes = [], $touch = true)
+    {
+        $this->parent->getConnection()->transaction(fn () => $this->attach($id, $attributes, $touch));
     }
 
     /**
@@ -462,6 +518,20 @@ trait InteractsWithPivotTable
         }
 
         return $results;
+    }
+
+    /**
+     * Detach models from the relationship within a transaction.
+     *
+     * @param  mixed  $ids
+     * @param  bool  $touch
+     * @return int
+     *
+     * @throws \Throwable
+     */
+    public function detachOrFail($ids = null, $touch = true)
+    {
+        return $this->parent->getConnection()->transaction(fn () => $this->detach($ids, $touch));
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBelongsToManyOrFailTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyOrFailTest.php
@@ -1,0 +1,191 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Model as Eloquent;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseEloquentBelongsToManyOrFailTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $db = new DB;
+
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+
+        $db->bootEloquent();
+        $db->setAsGlobal();
+
+        $this->createSchema();
+    }
+
+    public function createSchema()
+    {
+        $this->schema()->create('users', function ($table) {
+            $table->increments('id');
+            $table->string('email');
+        });
+
+        $this->schema()->create('roles', function ($table) {
+            $table->increments('id');
+            $table->string('name');
+        });
+
+        $this->schema()->create('role_user', function ($table) {
+            $table->integer('user_id')->unsigned();
+            $table->integer('role_id')->unsigned();
+            $table->boolean('active')->default(false);
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        $this->schema()->drop('users');
+        $this->schema()->drop('roles');
+        $this->schema()->drop('role_user');
+    }
+
+    protected function seedData()
+    {
+        OrFailUser::create(['id' => 1, 'email' => 'taylor@laravel.com']);
+        OrFailRole::insert([
+            ['id' => 1, 'name' => 'Admin'],
+            ['id' => 2, 'name' => 'Editor'],
+            ['id' => 3, 'name' => 'Viewer'],
+        ]);
+    }
+
+    public function testSyncOrFail()
+    {
+        $this->seedData();
+
+        $user = OrFailUser::find(1);
+
+        $result = $user->roles()->syncOrFail([1, 2]);
+
+        $this->assertEquals([1, 2], $result['attached']);
+        $this->assertEmpty($result['detached']);
+        $this->assertEmpty($result['updated']);
+        $this->assertCount(2, $user->roles);
+    }
+
+    public function testSyncWithoutDetachingOrFail()
+    {
+        $this->seedData();
+
+        $user = OrFailUser::find(1);
+        $user->roles()->attach([1]);
+
+        $result = $user->roles()->syncWithoutDetachingOrFail([2, 3]);
+
+        $this->assertEquals([2, 3], $result['attached']);
+        $this->assertEmpty($result['detached']);
+        $this->assertCount(3, $user->roles()->get());
+    }
+
+    public function testAttachOrFail()
+    {
+        $this->seedData();
+
+        $user = OrFailUser::find(1);
+
+        $user->roles()->attachOrFail(1);
+
+        $this->assertCount(1, $user->roles);
+    }
+
+    public function testAttachOrFailWithAttributes()
+    {
+        $this->seedData();
+
+        $user = OrFailUser::find(1);
+        $user->roles()->attachOrFail(1, ['active' => true]);
+
+        $pivot = DB::table('role_user')->where('user_id', 1)->where('role_id', 1)->first();
+        $this->assertEquals(1, $pivot->active);
+    }
+
+    public function testDetachOrFail()
+    {
+        $this->seedData();
+
+        $user = OrFailUser::find(1);
+        $user->roles()->attach([1, 2, 3]);
+
+        $result = $user->roles()->detachOrFail([1, 2]);
+
+        $this->assertEquals(2, $result);
+        $this->assertCount(1, $user->roles()->get());
+    }
+
+    public function testDetachOrFailAll()
+    {
+        $this->seedData();
+
+        $user = OrFailUser::find(1);
+        $user->roles()->attach([1, 2, 3]);
+
+        $result = $user->roles()->detachOrFail();
+
+        $this->assertEquals(3, $result);
+        $this->assertCount(0, $user->roles()->get());
+    }
+
+    public function testToggleOrFail()
+    {
+        $this->seedData();
+
+        $user = OrFailUser::find(1);
+        $user->roles()->attach([1]);
+
+        $result = $user->roles()->toggleOrFail([1, 2]);
+
+        $this->assertEquals([1], $result['detached']);
+        $this->assertEquals([2], $result['attached']);
+        $this->assertCount(1, $user->roles()->get());
+    }
+
+    /**
+     * Get a database connection instance.
+     *
+     * @return \Illuminate\Database\Connection
+     */
+    protected function connection()
+    {
+        return Eloquent::getConnectionResolver()->connection();
+    }
+
+    /**
+     * Get a schema builder instance.
+     *
+     * @return \Illuminate\Database\Schema\Builder
+     */
+    protected function schema()
+    {
+        return $this->connection()->getSchemaBuilder();
+    }
+}
+
+class OrFailUser extends Eloquent
+{
+    protected $table = 'users';
+    protected $guarded = [];
+    public $timestamps = false;
+
+    public function roles(): BelongsToMany
+    {
+        return $this->belongsToMany(OrFailRole::class, 'role_user', 'user_id', 'role_id');
+    }
+}
+
+class OrFailRole extends Eloquent
+{
+    protected $table = 'roles';
+    protected $guarded = [];
+    public $timestamps = false;
+}


### PR DESCRIPTION
Adds `syncOrFail()`, `syncWithoutDetachingOrFail()`, `attachOrFail()`, `detachOrFail()`, and `toggleOrFail()` to the BelongsToMany relationship, wrapping each operation in a database transaction.

This follows the existing `saveOrFail()` / `deleteOrFail()` / `updateOrFail()` convention on Model. While single-query operations like `attach(1)` are already atomic, multi-query operations like `sync()` and `toggle()` perform detaches and attaches in sequence. If one fails partway through, the pivot table is left in a partial state. These methods guarantee all-or-nothing behavior.

### New methods

  | Method                                 | Wraps                  |
  |----------------------------------------|------------------------|
  | syncOrFail($ids, $detaching)           | sync()                 |
  | syncWithoutDetachingOrFail($ids)       | syncWithoutDetaching() |
  | attachOrFail($id, $attributes, $touch) | attach()               |
  | detachOrFail($ids, $touch)             | detach()               |
  | toggleOrFail($ids, $touch)             | toggle()               |

  Each method is placed directly after its base counterpart in the InteractsWithPivotTable trait.

### Usage

```php
  // Sync roles atomically — rolls back if any query fails
  $user->roles()->syncOrFail([1, 2, 3]);

  // Attach within a transaction (useful with custom pivot classes)
  $user->roles()->attachOrFail($roleId, ['expires_at' => now()->addYear()]);
```

### Test plan

  - testSyncOrFail — verifies sync returns correct attached/detached/updated arrays
  - testSyncWithoutDetachingOrFail — verifies existing attachments are preserved
  - testAttachOrFail — verifies basic attach
  - testAttachOrFailWithAttributes — verifies pivot attributes are set
  - testDetachOrFail — verifies partial detach returns correct count
  - testDetachOrFailAll — verifies detach with no args removes all
  - testToggleOrFail — verifies toggle attaches/detaches correctly