### PR TITLE
[12.x] Align casts property type with casts method return type

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -79,7 +79,7 @@ trait HasAttributes
     /**
      * The attributes that should be cast.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $casts = [];
 


### PR DESCRIPTION
### Summary

This PR updates the PHPDoc type for the `casts` property in the HasAttributes trait so it matches the type used by the trait’s `casts` method.

https://github.com/laravel/framework/blob/affb0bcae202ca2b3ce003d1ddd03e3aacde0007/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php#L1698-L1706