### PR TITLE
[12.x] Add strict integer validation to Numeric validation rule

### DIFF
--- a/src/Illuminate/Validation/Rules/Numeric.php
+++ b/src/Illuminate/Validation/Rules/Numeric.php
@@ -106,9 +106,19 @@ class Numeric implements Stringable
      *
      * @return $this
      */
-    public function integer(): Numeric
+    public function integer(bool $strict = false): Numeric
     {
-        return $this->addRule('integer');
+        return $this->addRule($strict ? 'integer:strict' : 'integer');
+    }
+
+    /**
+     * The type of the field under validation must integer.
+     *
+     * @return $this
+     */
+    public function strictInteger(): Numeric
+    {
+        return $this->integer(true);
     }
 
     /**

--- a/src/Illuminate/Validation/Rules/Numeric.php
+++ b/src/Illuminate/Validation/Rules/Numeric.php
@@ -112,16 +112,6 @@ class Numeric implements Stringable
     }
 
     /**
-     * The type of the field under validation must integer.
-     *
-     * @return $this
-     */
-    public function strictInteger(): Numeric
-    {
-        return $this->integer(true);
-    }
-
-    /**
      * The field under validation must be less than the given field.
      *
      * @param  string  $field

--- a/tests/Validation/ValidationNumericRuleTest.php
+++ b/tests/Validation/ValidationNumericRuleTest.php
@@ -72,6 +72,15 @@ class ValidationNumericRuleTest extends TestCase
     {
         $rule = Rule::numeric()->integer();
         $this->assertEquals('numeric|integer', (string) $rule);
+
+        $rule = Rule::numeric()->integer(true);
+        $this->assertEquals('numeric|integer:strict', (string) $rule);
+    }
+
+    public function testStrictIntegerRule()
+    {
+        $rule = Rule::numeric()->strictInteger();
+        $this->assertEquals('numeric|integer:strict', (string) $rule);
     }
 
     public function testLessThanRule()

--- a/tests/Validation/ValidationNumericRuleTest.php
+++ b/tests/Validation/ValidationNumericRuleTest.php
@@ -73,13 +73,7 @@ class ValidationNumericRuleTest extends TestCase
         $rule = Rule::numeric()->integer();
         $this->assertEquals('numeric|integer', (string) $rule);
 
-        $rule = Rule::numeric()->integer(true);
-        $this->assertEquals('numeric|integer:strict', (string) $rule);
-    }
-
-    public function testStrictIntegerRule()
-    {
-        $rule = Rule::numeric()->strictInteger();
+        $rule = Rule::numeric()->integer(strict: true);
         $this->assertEquals('numeric|integer:strict', (string) $rule);
     }
 


### PR DESCRIPTION
This adds strict integer validation to `Illuminate\Validation\Rules\Numeric`.

Before:
```php
[
    'attribute' => ['integer:strict', 'max:15'],
]
```

After:

```php
[
    'attribute' => Rule::numeric()->strictInteger()->max(15),
]
```

Alternatively:

```php
[
    'attribute' => Rule::numeric()->integer(strict: true)->max(15),
]
```