### PR TITLE
[13.x] Fix previousPath() for external referrers

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -182,9 +182,17 @@ class UrlGenerator implements UrlGeneratorContract
      */
     public function previousPath($fallback = false)
     {
-        $previousPath = str_replace($this->to('/'), '', rtrim(preg_replace('/\?.*/', '', $this->previous($fallback)), '/'));
+        $previousPath = parse_url($this->previous($fallback), PHP_URL_PATH);
 
-        return $previousPath === '' ? '/' : $previousPath;
+        if (! is_string($previousPath) || $previousPath === '') {
+            return '/';
+        }
+
+        $basePath = parse_url($this->to('/'), PHP_URL_PATH) ?: '';
+
+        $previousPath = $basePath !== '/' ? preg_replace('#^'.preg_quote($basePath, '#').'#', '', $previousPath) : $previousPath;
+
+        return rtrim($previousPath, '/') ?: '/';
     }
 
     /**

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -727,10 +727,38 @@ class RoutingUrlGeneratorTest extends TestCase
         $url->getRequest()->headers->set('referer', 'http://www.foo.com/bar?baz=bah');
         $this->assertSame('/bar', $url->previousPath());
 
+        $url->getRequest()->headers->set('referer', 'http://www.bar.com/foo');
+        $this->assertSame('/foo', $url->previousPath());
+
+        $url->getRequest()->headers->set('referer', 'http://www.bar.com/foo?bar=baz');
+        $this->assertSame('/foo', $url->previousPath());
+
+        $url->getRequest()->headers->set('referer', 'http://www.bar.com');
+        $this->assertSame('/', $url->previousPath());
+
         $url->getRequest()->headers->remove('referer');
         $this->assertSame('/', $url->previousPath());
 
         $this->assertSame('/bar', $url->previousPath('/bar'));
+    }
+
+    public function testPreviousPathWithBaseUrl()
+    {
+        $url = new UrlGenerator(
+            new RouteCollection,
+            Request::create('http://www.foo.com/subdir/current')
+        );
+
+        $url->forceRootUrl('http://www.foo.com/subdir');
+
+        $url->getRequest()->headers->set('referer', 'http://www.foo.com/subdir/dashboard?x=1');
+        $this->assertSame('/dashboard', $url->previousPath());
+
+        $url->getRequest()->headers->set('referer', 'http://www.bar.com/foo');
+        $this->assertSame('/foo', $url->previousPath());
+
+        $url->getRequest()->headers->set('referer', 'http://www.foo.com/subdir');
+        $this->assertSame('/', $url->previousPath());
     }
 
     public function testRouteNotDefinedException()


### PR DESCRIPTION
Fixes #57456

`previousPath()` uses `str_replace` to strip the app URL from the referer. When the referer comes from an external domain, the app URL isn't found in the string and the full URL is returned instead of a path.

```php
// referer: http://external.com/foo
url()->previousPath();
// before: "http://external.com/foo"
// after:  "/foo"
```

Switched to `parse_url()` to extract the path component directly. Also strips the base path for subdirectory deployments (`forceRootUrl`).