### PR TITLE
Improvements for asserting HTML in text

### DIFF
--- a/src/Illuminate/Testing/Constraints/SeeInHtml.php
+++ b/src/Illuminate/Testing/Constraints/SeeInHtml.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Illuminate\Testing\Constraints;
+
+use PHPUnit\Framework\Constraint\Constraint;
+use ReflectionClass;
+
+class SeeInHtml extends Constraint
+{
+    /**
+     * The string under validation.
+     *
+     * @var string
+     */
+    protected $content;
+
+    /**
+     * The last value that failed to pass validation.
+     *
+     * @var string
+     */
+    protected $failedValue;
+
+    /**
+     * Whether to negate the assertion.
+     *
+     * @var bool
+     */
+    protected $negate;
+
+    /**
+     * The values must appear in order.
+     *
+     * @var bool
+     */
+    protected $ordered;
+
+    /**
+     * Create a new constraint instance.
+     *
+     * @param  string  $content
+     */
+    public function __construct($content, $ordered = false, $negate = false)
+    {
+        $this->content = $content;
+        $this->ordered = $ordered;
+        $this->negate = $negate;
+    }
+
+    /**
+     * Determine if the rule passes validation.
+     *
+     * @param  array  $values
+     * @return bool
+     */
+    public function matches($values): bool
+    {
+        $normalizedContent = $this->normalize($this->content);
+
+        $position = 0;
+
+        foreach ($values as $value) {
+            if (empty($value)) {
+                continue;
+            }
+
+            $normalizedValue = $this->normalize($value);
+
+            $valuePosition = mb_strpos($normalizedContent, $normalizedValue, $position);
+
+            if ($this->negate) {
+                if ($valuePosition !== false) {
+                    $this->failedValue = $value;
+
+                    return false;
+                }
+
+                continue;
+            }
+
+            if ($valuePosition === false || $valuePosition < $position) {
+                $this->failedValue = $value;
+
+                return false;
+            }
+
+            if ($this->ordered) {
+                $position = $valuePosition + mb_strlen($normalizedValue);
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Get the description of the failure.
+     *
+     * @param  array  $values
+     * @return string
+     */
+    public function failureDescription($values): string
+    {
+        if ($this->negate) {
+            return sprintf(
+                '\'%s\' does not contain "%s".',
+                $this->content,
+                $this->failedValue
+            );
+        }
+
+        return sprintf(
+            '\'%s\' contains "%s"%s',
+            $this->content,
+            $this->failedValue,
+            $this->ordered ? ' in specified order.' : '.'
+        );
+    }
+
+    /**
+     * Get a string representation of the object.
+     *
+     * @return string
+     */
+    public function toString(): string
+    {
+        return (new ReflectionClass($this))->name;
+    }
+
+    protected function normalize(string $value): ?string
+    {
+        $value = strip_tags($value);
+        $value = html_entity_decode($value, ENT_QUOTES, 'UTF-8');
+        $value = trim($value);
+        $value = preg_replace('/\s+/', ' ', $value);
+
+        return $value;
+    }
+}

--- a/src/Illuminate/Testing/Constraints/SeeInHtml.php
+++ b/src/Illuminate/Testing/Constraints/SeeInHtml.php
@@ -15,25 +15,25 @@ class SeeInHtml extends Constraint
     protected $content;
 
     /**
-     * The last value that failed to pass validation.
+     * Indicates the values must appear in order.
      *
-     * @var string
+     * @var bool
      */
-    protected $failedValue;
+    protected $ordered;
 
     /**
-     * Whether to negate the assertion.
+     * Indicates whether to negate the assertion.
      *
      * @var bool
      */
     protected $negate;
 
     /**
-     * The values must appear in order.
+     * The last value that failed to pass validation.
      *
-     * @var bool
+     * @var string
      */
-    protected $ordered;
+    protected $failedValue;
 
     /**
      * Create a new constraint instance.
@@ -51,7 +51,6 @@ class SeeInHtml extends Constraint
      * Determine if the rule passes validation.
      *
      * @param  array  $values
-     * @return bool
      */
     public function matches($values): bool
     {
@@ -96,7 +95,6 @@ class SeeInHtml extends Constraint
      * Get the description of the failure.
      *
      * @param  array  $values
-     * @return string
      */
     public function failureDescription($values): string
     {
@@ -117,15 +115,8 @@ class SeeInHtml extends Constraint
     }
 
     /**
-     * Get a string representation of the object.
-     *
-     * @return string
+     * Normalize the given value.
      */
-    public function toString(): string
-    {
-        return (new ReflectionClass($this))->name;
-    }
-
     protected function normalize(string $value): ?string
     {
         $value = strip_tags($value);
@@ -134,5 +125,13 @@ class SeeInHtml extends Constraint
         $value = preg_replace('/\s+/', ' ', $value);
 
         return $value;
+    }
+
+    /**
+     * Get a string representation of the object.
+     */
+    public function toString(): string
+    {
+        return (new ReflectionClass($this))->name;
     }
 }

--- a/src/Illuminate/Testing/Constraints/SeeInOrder.php
+++ b/src/Illuminate/Testing/Constraints/SeeInOrder.php
@@ -73,7 +73,7 @@ class SeeInOrder extends Constraint
     public function failureDescription($values): string
     {
         return sprintf(
-            'Failed asserting that \'%s\' contains "%s" in specified order.',
+            '\'%s\' contains "%s" in specified order.',
             $this->content,
             $this->failedValue
         );

--- a/src/Illuminate/Testing/TestComponent.php
+++ b/src/Illuminate/Testing/TestComponent.php
@@ -5,6 +5,7 @@ namespace Illuminate\Testing;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Testing\Assert as PHPUnit;
+use Illuminate\Testing\Constraints\SeeInHtml;
 use Illuminate\Testing\Constraints\SeeInOrder;
 use Stringable;
 
@@ -112,11 +113,7 @@ class TestComponent implements Stringable
 
         $values = $escape ? array_map(e(...), $value) : $value;
 
-        $rendered = strip_tags($this->rendered);
-
-        foreach ($values as $value) {
-            PHPUnit::assertStringContainsString((string) $value, $rendered);
-        }
+        PHPUnit::assertThat($values, new SeeInHtml($this->rendered));
 
         return $this;
     }
@@ -132,7 +129,7 @@ class TestComponent implements Stringable
     {
         $values = $escape ? array_map(e(...), $values) : $values;
 
-        PHPUnit::assertThat($values, new SeeInOrder(strip_tags($this->rendered)));
+        PHPUnit::assertThat($values, new SeeInHtml($this->rendered, true));
 
         return $this;
     }

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -19,6 +19,7 @@ use Illuminate\Support\Traits\Dumpable;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Support\Traits\Tappable;
 use Illuminate\Support\ViewErrorBag;
+use Illuminate\Testing\Constraints\SeeInHtml;
 use Illuminate\Testing\Constraints\SeeInOrder;
 use Illuminate\Testing\Fluent\AssertableJson;
 use Illuminate\Testing\TestResponseAssert as PHPUnit;
@@ -764,11 +765,7 @@ class TestResponse implements ArrayAccess
 
         $values = $escape ? array_map(e(...), $value) : $value;
 
-        $content = strip_tags($this->getContent());
-
-        foreach ($values as $value) {
-            PHPUnit::withResponse($this)->assertStringContainsString((string) $value, $content);
-        }
+        PHPUnit::withResponse($this)->assertThat($values, new SeeInHtml($this->getContent()));
 
         return $this;
     }
@@ -784,7 +781,7 @@ class TestResponse implements ArrayAccess
     {
         $values = $escape ? array_map(e(...), $values) : $values;
 
-        PHPUnit::withResponse($this)->assertThat($values, new SeeInOrder(strip_tags($this->getContent())));
+        PHPUnit::withResponse($this)->assertThat($values, new SeeInHtml($this->getContent(), true));
 
         return $this;
     }
@@ -833,11 +830,7 @@ class TestResponse implements ArrayAccess
 
         $values = $escape ? array_map(e(...), $value) : $value;
 
-        $content = strip_tags($this->getContent());
-
-        foreach ($values as $value) {
-            PHPUnit::withResponse($this)->assertStringNotContainsString((string) $value, $content);
-        }
+        PHPUnit::withResponse($this)->assertThat($values, new SeeInHtml($this->getContent(), negate: true));
 
         return $this;
     }

--- a/src/Illuminate/Testing/TestView.php
+++ b/src/Illuminate/Testing/TestView.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Testing\Assert as PHPUnit;
+use Illuminate\Testing\Constraints\SeeInHtml;
 use Illuminate\Testing\Constraints\SeeInOrder;
 use Illuminate\View\View;
 use Stringable;
@@ -189,11 +190,7 @@ class TestView implements Stringable
 
         $values = $escape ? array_map(e(...), $value) : $value;
 
-        $rendered = strip_tags($this->rendered);
-
-        foreach ($values as $value) {
-            PHPUnit::assertStringContainsString((string) $value, $rendered);
-        }
+        PHPUnit::assertThat($values, new SeeInHtml($this->rendered));
 
         return $this;
     }
@@ -209,7 +206,7 @@ class TestView implements Stringable
     {
         $values = $escape ? array_map(e(...), $values) : $values;
 
-        PHPUnit::assertThat($values, new SeeInOrder(strip_tags($this->rendered)));
+        PHPUnit::assertThat($values, new SeeInHtml($this->rendered, true));
 
         return $this;
     }
@@ -258,11 +255,7 @@ class TestView implements Stringable
 
         $values = $escape ? array_map(e(...), $value) : $value;
 
-        $rendered = strip_tags($this->rendered);
-
-        foreach ($values as $value) {
-            PHPUnit::assertStringNotContainsString((string) $value, $rendered);
-        }
+        PHPUnit::assertThat($values, new SeeInHtml($this->rendered));
 
         return $this;
     }

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -594,6 +594,7 @@ class TestResponseTest extends TestCase
     public function testAssertSeeTextCanFail(): void
     {
         $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Failed asserting that \'foo<strong>bar</strong>\' contains "bazfoo".');
 
         $response = $this->makeMockResponse([
             'render' => 'foo<strong>bar</strong>',
@@ -611,6 +612,20 @@ class TestResponseTest extends TestCase
 
         $response->assertSeeText('laravel & php');
         $response->assertSeeText(['php & friends', 'laravel & php']);
+    }
+
+    public function testAssertSeeTextWhitespace(): void
+    {
+        $response = $this->makeMockResponse([
+            'render' => <<<'EOT'
+<p>
+    Hello,
+    laravel &amp; php &amp; friends
+</p>,
+EOT
+        ]);
+
+        $response->assertSeeText('Hello, laravel & php & friends');
     }
 
     public function testAssertSeeTextEscapedCanFail(): void
@@ -645,9 +660,24 @@ class TestResponseTest extends TestCase
         $response->assertSeeTextInOrder(['laravel & php', 'phpstorm > sublime']);
     }
 
+    public function testAssertSeeTextInOrderWhitespace(): void
+    {
+        $response = $this->makeMockResponse([
+            'render' => <<<'EOT'
+<p>
+    Hello,
+    laravel &amp; php &amp; friends
+</p>,
+EOT
+        ]);
+
+        $response->assertSeeTextInOrder(['Hello', 'laravel & php', 'friends']);
+    }
+
     public function testAssertSeeTextInOrderCanFail(): void
     {
         $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Failed asserting that \'foo<strong>bar</strong> baz <strong>foo</strong>\' contains "foobar" in specified order.');
 
         $response = $this->makeMockResponse([
             'render' => 'foo<strong>bar</strong> baz <strong>foo</strong>',
@@ -746,6 +776,7 @@ class TestResponseTest extends TestCase
     public function testAssertDontSeeTextCanFail(): void
     {
         $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Failed asserting that \'foo<strong>bar</strong>baz<strong>qux</strong>\' does not contain "foobar".');
 
         $response = $this->makeMockResponse([
             'render' => 'foo<strong>bar</strong>baz<strong>qux</strong>',


### PR DESCRIPTION
This PR resolves some papercuts with `assertSeeText` and similar assertions:

- **It _normalizes_ whitespace.** It's standard for HTML to treat multiple, consecutive whitespace as a single space.
- **It outputs the original response HTML.** Similar to the above, without the full HTML it can be hard to diagnose why these assertions are failing.
- It removes the redundant `Failed asserting that` prefix added to the assertion failures.

A few notes. First, to minimize the footprint, I created a single constraint class (`SeeInHtml`) with multiple parameter flags, rather than multiple, very similar constraint classes (e.g. `SeeInHtml`, `NotSeeInHtml`, `SeeInHtmlInOrder`).

Second, there were some recent changes to these assertions in 12.x which may create a conflict when merging with 13.x.

Finally, while not a breaking change in code per se, I targeted 13.x as it is a change in the behavior/output. Although the developer should not see this since both the expected and actual values are normalized. Meaning if a developer was indeed checking for exact whitespace within their HTML text, their assertion should still pass.