### PR TITLE
[13.x] Add Exception to BatchCanceled event

### DIFF
--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -7,7 +7,6 @@ use Closure;
 use Illuminate\Bus\Events\BatchCanceled;
 use Illuminate\Bus\Events\BatchFinished;
 use Illuminate\Container\Container;
-use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Queue\Factory as QueueFactory;
 use Illuminate\Contracts\Support\Arrayable;
@@ -400,7 +399,7 @@ class Batch implements Arrayable, JsonSerializable
     /**
      * Cancel the batch.
      *
-     * @param Throwable|null $exception
+     * @param  \Throwable|null  $exception
      * @return void
      */
     public function cancel(?Throwable $exception = null)

--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -7,6 +7,7 @@ use Closure;
 use Illuminate\Bus\Events\BatchCanceled;
 use Illuminate\Bus\Events\BatchFinished;
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Queue\Factory as QueueFactory;
 use Illuminate\Contracts\Support\Arrayable;
@@ -336,7 +337,7 @@ class Batch implements Arrayable, JsonSerializable
         $counts = $this->incrementFailedJobs($jobId);
 
         if ($counts->failedJobs === 1 && ! $this->allowsFailures()) {
-            $this->cancel();
+            $this->cancel($e);
         }
 
         if ($this->allowsFailures()) {
@@ -399,16 +400,17 @@ class Batch implements Arrayable, JsonSerializable
     /**
      * Cancel the batch.
      *
+     * @param Throwable|null $exception
      * @return void
      */
-    public function cancel()
+    public function cancel(?Throwable $exception = null)
     {
         $this->repository->cancel($this->id);
 
         $container = Container::getInstance();
 
         if ($container->bound(Dispatcher::class)) {
-            $container->make(Dispatcher::class)->dispatch(new BatchCanceled($this));
+            $container->make(Dispatcher::class)->dispatch(new BatchCanceled($this, $exception));
         }
     }
 

--- a/src/Illuminate/Bus/Events/BatchCanceled.php
+++ b/src/Illuminate/Bus/Events/BatchCanceled.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Bus\Events;
 
 use Illuminate\Bus\Batch;
+use Throwable;
 
 class BatchCanceled
 {
@@ -10,9 +11,11 @@ class BatchCanceled
      * Create a new event instance.
      *
      * @param  \Illuminate\Bus\Batch  $batch  The batch instance.
+     * @param  \Throwable|null  $exception  The exception that caused the cancellation.
      */
     public function __construct(
         public Batch $batch,
+        public ?Throwable $exception = null,
     ) {
     }
 }

--- a/src/Illuminate/Support/Testing/Fakes/BatchFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BatchFake.php
@@ -7,6 +7,7 @@ use Illuminate\Bus\Batch;
 use Illuminate\Bus\UpdatedBatchJobCounts;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
+use Throwable;
 
 class BatchFake extends Batch
 {
@@ -148,7 +149,7 @@ class BatchFake extends Batch
      * @return void
      */
     #[\Override]
-    public function cancel()
+    public function cancel(?Throwable $exception = null)
     {
         $this->cancelledAt = Carbon::now();
     }

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -471,6 +471,24 @@ class BusBatchTest extends TestCase
         $batch->cancel();
     }
 
+    public function test_batch_cancelled_event_contains_exception()
+    {
+        Container::getInstance()->instance(EventDispatcher::class, $events = m::mock(EventDispatcher::class));
+
+        $queue = m::mock(Factory::class);
+        $batch = $this->createTestBatch($queue);
+
+        $exception = new RuntimeException('Something went wrong.');
+
+        $events->shouldReceive('dispatch')->once()->with(m::on(function ($event) use ($batch, $exception) {
+            return $event instanceof BatchCanceled
+                && $event->batch->id === $batch->id
+                && $event->exception === $exception;
+        }));
+
+        $batch->cancel($exception);
+    }
+
     public function test_batch_can_be_deleted()
     {
         $queue = m::mock(Factory::class);

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -464,20 +464,6 @@ class BusBatchTest extends TestCase
         $queue = m::mock(Factory::class);
         $batch = $this->createTestBatch($queue);
 
-        $events->shouldReceive('dispatch')->once()->with(m::on(function ($event) use ($batch) {
-            return $event instanceof BatchCanceled && $event->batch->id === $batch->id;
-        }));
-
-        $batch->cancel();
-    }
-
-    public function test_batch_cancelled_event_contains_exception()
-    {
-        Container::getInstance()->instance(EventDispatcher::class, $events = m::mock(EventDispatcher::class));
-
-        $queue = m::mock(Factory::class);
-        $batch = $this->createTestBatch($queue);
-
         $exception = new RuntimeException('Something went wrong.');
 
         $events->shouldReceive('dispatch')->once()->with(m::on(function ($event) use ($batch, $exception) {


### PR DESCRIPTION
This PR basically means we can see the exception that caused the batch to be canceled.

I went to do this today. realised I couldn't and thought about my life choices.

Being able to access why it canceled is a nice touch, and means I can drop loads of catch() methods.

No B/C, I could of targeted 12.x, but i know 13.x is the next release I think /  happy to wait.

Thanks!