### PR TITLE
[13.x] Add support for `brick/math` 0.16

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "ext-session": "*",
         "ext-tokenizer": "*",
         "composer-runtime-api": "^2.2",
-        "brick/math": "^0.14.2 || ^0.15",
+        "brick/math": "^0.14.2 || ^0.15 || ^0.16",
         "doctrine/inflector": "^2.0.5",
         "dragonmantank/cron-expression": "^3.4",
         "egulias/email-validator": "^4.0",

--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": "^8.3",
         "ext-pdo": "*",
-        "brick/math": "^0.14.2 || ^0.15",
+        "brick/math": "^0.14.2 || ^0.15 || ^0.16",
         "illuminate/collections": "^13.0",
         "illuminate/container": "^13.0",
         "illuminate/contracts": "^13.0",

--- a/src/Illuminate/Validation/composer.json
+++ b/src/Illuminate/Validation/composer.json
@@ -17,7 +17,7 @@
         "php": "^8.3",
         "ext-filter": "*",
         "ext-mbstring": "*",
-        "brick/math": "^0.14.2 || ^0.15",
+        "brick/math": "^0.14.2 || ^0.15 || ^0.16",
         "egulias/email-validator": "^4.0",
         "illuminate/collections": "^13.0",
         "illuminate/container": "^13.0",


### PR DESCRIPTION
Allows [brick/math 0.16](https://github.com/brick/math/releases/tag/0.16.0)