### PR TITLE
[12.x] Add missing *OrFail transaction methods to BelongsToMany

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -188,6 +188,21 @@ trait InteractsWithPivotTable
     }
 
     /**
+     * Sync the intermediate tables with a list of IDs with the given pivot values within a transaction.
+     *
+     * @param  \Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Model|array|int|string  $ids
+     * @param  array  $values
+     * @param  bool  $detaching
+     * @return array{attached: array, detached: array, updated: array}
+     *
+     * @throws \Throwable
+     */
+    public function syncWithPivotValuesOrFail($ids, array $values, bool $detaching = true)
+    {
+        return $this->parent->getConnection()->transaction(fn () => $this->syncWithPivotValues($ids, $values, $detaching));
+    }
+
+    /**
      * Format the sync / toggle record list so that it is keyed by ID.
      *
      * @param  array  $records
@@ -269,6 +284,21 @@ trait InteractsWithPivotTable
         }
 
         return $updated;
+    }
+
+    /**
+     * Update an existing pivot record on the table within a transaction.
+     *
+     * @param  mixed  $id
+     * @param  array  $attributes
+     * @param  bool  $touch
+     * @return int
+     *
+     * @throws \Throwable
+     */
+    public function updateExistingPivotOrFail($id, array $attributes, $touch = true)
+    {
+        return $this->parent->getConnection()->transaction(fn () => $this->updateExistingPivot($id, $attributes, $touch));
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBelongsToManyOrFailTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyOrFailTest.php
@@ -150,6 +150,37 @@ class DatabaseEloquentBelongsToManyOrFailTest extends TestCase
         $this->assertCount(1, $user->roles()->get());
     }
 
+    public function testSyncWithPivotValuesOrFail()
+    {
+        $this->seedData();
+
+        $user = OrFailUser::find(1);
+
+        $result = $user->roles()->syncWithPivotValuesOrFail([1, 2], ['active' => true]);
+
+        $this->assertEquals([1, 2], $result['attached']);
+        $this->assertEmpty($result['detached']);
+        $this->assertEmpty($result['updated']);
+
+        $pivot = DB::table('role_user')->where('user_id', 1)->where('role_id', 1)->first();
+        $this->assertEquals(1, $pivot->active);
+    }
+
+    public function testUpdateExistingPivotOrFail()
+    {
+        $this->seedData();
+
+        $user = OrFailUser::find(1);
+        $user->roles()->attach(1, ['active' => false]);
+
+        $result = $user->roles()->updateExistingPivotOrFail(1, ['active' => true]);
+
+        $this->assertEquals(1, $result);
+
+        $pivot = DB::table('role_user')->where('user_id', 1)->where('role_id', 1)->first();
+        $this->assertEquals(1, $pivot->active);
+    }
+
     /**
      * Get a database connection instance.
      *


### PR DESCRIPTION
Follow-up to #59153.

Two public methods in the `InteractsWithPivotTable` trait that modify the pivot table were not included in the original set of `*OrFail` methods:

| Method                                                | Wraps                  |
|-------------------------------------------------------|------------------------|
| syncWithPivotValuesOrFail($ids, $values, $detaching)  | syncWithPivotValues()  |
| updateExistingPivotOrFail($id, $attributes, $touch)   | updateExistingPivot()  |

`syncWithPivotValues()` delegates to `sync()`, which performs detaches and attaches in sequence — the same multi-query behavior that motivated the original PR. `updateExistingPivotOrFail()` follows the same convention as `attachOrFail()` for API consistency.

### Usage

```php
// Sync roles with pivot data atomically
$user->roles()->syncWithPivotValuesOrFail([1, 2, 3], ['approved' => true]);

// Update a pivot record within a transaction
$user->roles()->updateExistingPivotOrFail($roleId, ['expires_at' => now()->addYear()]);
```

### Test plan

- testSyncWithPivotValuesOrFail — verifies sync returns correct attached/detached/updated arrays and pivot values are set
- testUpdateExistingPivotOrFail — verifies update returns affected count and pivot attributes are updated