### PR TITLE
[13.x] Add schedule:pause / resume command

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -290,7 +290,7 @@ class Event
     }
 
     /**
-     * Determine if the event runs when the schedule is paused.
+     * Determine if the event runs when the scheduler is paused.
      *
      * @return bool
      */

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -290,6 +290,16 @@ class Event
     }
 
     /**
+     * Determine if the event runs when the schedule is paused.
+     *
+     * @return bool
+     */
+    public function runsWhenPaused()
+    {
+        return $this->evenWhenPaused;
+    }
+
+    /**
      * Determine if the Cron expression passes.
      *
      * @return bool

--- a/src/Illuminate/Console/Scheduling/ManagesAttributes.php
+++ b/src/Illuminate/Console/Scheduling/ManagesAttributes.php
@@ -49,6 +49,13 @@ trait ManagesAttributes
     public $evenInMaintenanceMode = false;
 
     /**
+     * Indicates if the command should run even when the schedule is paused.
+     *
+     * @var bool
+     */
+    public $evenWhenPaused = false;
+
+    /**
      * Indicates if the command should not overlap itself.
      *
      * @var bool
@@ -131,6 +138,18 @@ trait ManagesAttributes
     public function evenInMaintenanceMode()
     {
         $this->evenInMaintenanceMode = true;
+
+        return $this;
+    }
+
+    /**
+     * State that the command should run even when the schedule is paused.
+     *
+     * @return $this
+     */
+    public function evenWhenPaused()
+    {
+        $this->evenWhenPaused = true;
 
         return $this;
     }

--- a/src/Illuminate/Console/Scheduling/ManagesAttributes.php
+++ b/src/Illuminate/Console/Scheduling/ManagesAttributes.php
@@ -49,7 +49,7 @@ trait ManagesAttributes
     public $evenInMaintenanceMode = false;
 
     /**
-     * Indicates if the command should run even when the schedule is paused.
+     * Indicates if the command should run even when the scheduler is paused.
      *
      * @var bool
      */
@@ -143,7 +143,7 @@ trait ManagesAttributes
     }
 
     /**
-     * State that the command should run even when the schedule is paused.
+     * State that the command should run even when the scheduler is paused.
      *
      * @return $this
      */

--- a/src/Illuminate/Console/Scheduling/PendingEventAttributes.php
+++ b/src/Illuminate/Console/Scheduling/PendingEventAttributes.php
@@ -69,6 +69,10 @@ class PendingEventAttributes
             $event->evenInMaintenanceMode();
         }
 
+        if ($this->evenWhenPaused) {
+            $event->evenWhenPaused();
+        }
+
         if ($this->withoutOverlapping) {
             $event->withoutOverlapping($this->expiresAt);
         }

--- a/src/Illuminate/Console/Scheduling/SchedulePauseCommand.php
+++ b/src/Illuminate/Console/Scheduling/SchedulePauseCommand.php
@@ -14,7 +14,7 @@ class SchedulePauseCommand extends Command
      *
      * @var string
      */
-    protected $description = 'Pause the scheduled tasks';
+    protected $description = 'Pause the schedule';
 
     /**
      * Execute the console command.
@@ -25,7 +25,7 @@ class SchedulePauseCommand extends Command
     {
         $cache->forever('illuminate:schedule:paused', true);
 
-        $this->components->info('Scheduled tasks paused.');
+        $this->components->info('Schedule paused.');
 
         return 0;
     }

--- a/src/Illuminate/Console/Scheduling/SchedulePauseCommand.php
+++ b/src/Illuminate/Console/Scheduling/SchedulePauseCommand.php
@@ -14,7 +14,7 @@ class SchedulePauseCommand extends Command
      *
      * @var string
      */
-    protected $description = 'Pause the schedule';
+    protected $description = 'Pause the scheduler';
 
     /**
      * Execute the console command.
@@ -25,7 +25,7 @@ class SchedulePauseCommand extends Command
     {
         $cache->forever('illuminate:schedule:paused', true);
 
-        $this->components->info('Schedule paused.');
+        $this->components->info('Scheduler paused.');
 
         return 0;
     }

--- a/src/Illuminate/Console/Scheduling/SchedulePauseCommand.php
+++ b/src/Illuminate/Console/Scheduling/SchedulePauseCommand.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Illuminate\Console\Scheduling;
+
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Cache\Repository as Cache;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(name: 'schedule:pause')]
+class SchedulePauseCommand extends Command
+{
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Pause the scheduled tasks';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle(Cache $cache)
+    {
+        $cache->forever('illuminate:schedule:paused', true);
+
+        $this->components->info('Scheduled tasks paused.');
+
+        return 0;
+    }
+}

--- a/src/Illuminate/Console/Scheduling/SchedulePauseCommand.php
+++ b/src/Illuminate/Console/Scheduling/SchedulePauseCommand.php
@@ -25,7 +25,7 @@ class SchedulePauseCommand extends Command
     {
         $cache->forever('illuminate:schedule:paused', true);
 
-        $this->components->info('Scheduler paused.');
+        $this->components->info('Scheduled task processing has been paused.');
 
         return 0;
     }

--- a/src/Illuminate/Console/Scheduling/ScheduleResumeCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleResumeCommand.php
@@ -6,7 +6,7 @@ use Illuminate\Console\Command;
 use Illuminate\Contracts\Cache\Repository as Cache;
 use Symfony\Component\Console\Attribute\AsCommand;
 
-#[AsCommand(name: 'schedule:resume')]
+#[AsCommand(name: 'schedule:resume', aliases: ['schedule:continue'])]
 class ScheduleResumeCommand extends Command
 {
     /**
@@ -15,6 +15,13 @@ class ScheduleResumeCommand extends Command
      * @var string
      */
     protected $description = 'Resume the schedule';
+
+    /**
+     * The console command name aliases.
+     *
+     * @var list<string>
+     */
+    protected $aliases = ['schedule:continue'];
 
     /**
      * Execute the console command.

--- a/src/Illuminate/Console/Scheduling/ScheduleResumeCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleResumeCommand.php
@@ -14,7 +14,7 @@ class ScheduleResumeCommand extends Command
      *
      * @var string
      */
-    protected $description = 'Resume the scheduled tasks';
+    protected $description = 'Resume the schedule';
 
     /**
      * Execute the console command.
@@ -25,7 +25,7 @@ class ScheduleResumeCommand extends Command
     {
         $cache->forget('illuminate:schedule:paused');
 
-        $this->components->info('Scheduled tasks resumed.');
+        $this->components->info('Schedule resumed.');
 
         return 0;
     }

--- a/src/Illuminate/Console/Scheduling/ScheduleResumeCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleResumeCommand.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Illuminate\Console\Scheduling;
+
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Cache\Repository as Cache;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(name: 'schedule:resume')]
+class ScheduleResumeCommand extends Command
+{
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Resume the scheduled tasks';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle(Cache $cache)
+    {
+        $cache->forget('illuminate:schedule:paused');
+
+        $this->components->info('Scheduled tasks resumed.');
+
+        return 0;
+    }
+}

--- a/src/Illuminate/Console/Scheduling/ScheduleResumeCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleResumeCommand.php
@@ -32,7 +32,7 @@ class ScheduleResumeCommand extends Command
     {
         $cache->forget('illuminate:schedule:paused');
 
-        $this->components->info('Schedule resumed.');
+        $this->components->info('Scheduled task processing has resumed.');
 
         return 0;
     }

--- a/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
@@ -117,7 +117,15 @@ class ScheduleRunCommand extends Command
             $this->clearInterruptSignal();
         }
 
+        $paused = $this->cache->has('illuminate:schedule:paused');
+
         foreach ($events as $event) {
+            if ($paused && ! $event->runsWhenPaused()) {
+                $this->dispatcher->dispatch(new ScheduledTaskSkipped($event));
+
+                continue;
+            }
+
             if (! $event->filtersPass($this->laravel)) {
                 $this->dispatcher->dispatch(new ScheduledTaskSkipped($event));
 
@@ -233,6 +241,8 @@ class ScheduleRunCommand extends Command
         $hasEnteredMaintenanceMode = false;
 
         while (Date::now()->lte($this->startedAt->endOfMinute())) {
+            $paused = $this->cache->has('illuminate:schedule:paused');
+
             foreach ($events as $event) {
                 if ($this->shouldInterrupt()) {
                     return;
@@ -245,6 +255,12 @@ class ScheduleRunCommand extends Command
                 $hasEnteredMaintenanceMode = $hasEnteredMaintenanceMode || $this->laravel->isDownForMaintenance();
 
                 if ($hasEnteredMaintenanceMode && ! $event->runsInMaintenanceMode()) {
+                    continue;
+                }
+
+                if ($paused && ! $event->runsWhenPaused()) {
+                    $this->dispatcher->dispatch(new ScheduledTaskSkipped($event));
+
                     continue;
                 }
 

--- a/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
@@ -117,7 +117,7 @@ class ScheduleRunCommand extends Command
             $this->clearInterruptSignal();
         }
 
-        $paused = $this->cache->has('illuminate:schedule:paused');
+        $paused = $this->isPaused();
 
         foreach ($events as $event) {
             if ($paused && ! $event->runsWhenPaused()) {
@@ -241,7 +241,7 @@ class ScheduleRunCommand extends Command
         $hasEnteredMaintenanceMode = false;
 
         while (Date::now()->lte($this->startedAt->endOfMinute())) {
-            $paused = $this->cache->has('illuminate:schedule:paused');
+            $paused = $this->isPaused();
 
             foreach ($events as $event) {
                 if ($this->shouldInterrupt()) {
@@ -281,6 +281,16 @@ class ScheduleRunCommand extends Command
 
             Sleep::usleep(100_000);
         }
+    }
+
+    /**
+     * Determine if the schedule is paused.
+     *
+     * @return bool
+     */
+    protected function isPaused()
+    {
+        return $this->cache->get('illuminate:schedule:paused', false);
     }
 
     /**

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -12,6 +12,8 @@ use Illuminate\Console\Scheduling\ScheduleClearCacheCommand;
 use Illuminate\Console\Scheduling\ScheduleFinishCommand;
 use Illuminate\Console\Scheduling\ScheduleInterruptCommand;
 use Illuminate\Console\Scheduling\ScheduleListCommand;
+use Illuminate\Console\Scheduling\SchedulePauseCommand;
+use Illuminate\Console\Scheduling\ScheduleResumeCommand;
 use Illuminate\Console\Scheduling\ScheduleRunCommand;
 use Illuminate\Console\Scheduling\ScheduleTestCommand;
 use Illuminate\Console\Scheduling\ScheduleWorkCommand;
@@ -174,6 +176,8 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'ScheduleTest' => ScheduleTestCommand::class,
         'ScheduleWork' => ScheduleWorkCommand::class,
         'ScheduleInterrupt' => ScheduleInterruptCommand::class,
+        'SchedulePause' => SchedulePauseCommand::class,
+        'ScheduleResume' => ScheduleResumeCommand::class,
         'ShowModel' => ShowModelCommand::class,
         'StorageLink' => StorageLinkCommand::class,
         'StorageUnlink' => StorageUnlinkCommand::class,

--- a/tests/Console/Scheduling/EventTest.php
+++ b/tests/Console/Scheduling/EventTest.php
@@ -109,4 +109,19 @@ class EventTest extends TestCase
         $event->daysOfMonth([1, 10, 20, 30]);
         $this->assertSame('0 0 1,10,20,30 * *', $event->getExpression());
     }
+
+    public function testEventDoesNotRunWhenPausedByDefault()
+    {
+        $event = new Event(m::mock(EventMutex::class), 'php -i');
+
+        $this->assertFalse($event->runsWhenPaused());
+    }
+
+    public function testEventRunsWhenMarkedAsEvenWhenPaused()
+    {
+        $event = new Event(m::mock(EventMutex::class), 'php -i');
+        $event->evenWhenPaused();
+
+        $this->assertTrue($event->runsWhenPaused());
+    }
 }

--- a/tests/Integration/Console/Scheduling/ScheduleGroupTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleGroupTest.php
@@ -117,6 +117,7 @@ class ScheduleGroupTest extends TestCase
             ],
             'runInBackground' => ['runInBackground', true],
             'evenInMaintenanceMode' => ['evenInMaintenanceMode', true],
+            'evenWhenPaused' => ['evenWhenPaused', true],
             'withoutOverlapping' => ['withoutOverlapping', rand(1000, 1400)],
         ];
     }

--- a/tests/Integration/Console/Scheduling/SubMinuteSchedulingTest.php
+++ b/tests/Integration/Console/Scheduling/SubMinuteSchedulingTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Integration\Console\Scheduling;
 
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Sleep;
 use Orchestra\Testbench\TestCase;
@@ -172,6 +173,56 @@ class SubMinuteSchedulingTest extends TestCase
 
         Sleep::assertSleptTimes(600);
         $this->assertEquals(60, $runs);
+    }
+
+    public function test_sub_minute_events_can_be_run_when_schedule_is_paused()
+    {
+        $runs = 0;
+        $this->schedule->call(function () use (&$runs) {
+            $runs++;
+        })->everySecond()->evenWhenPaused();
+
+        Carbon::setTestNow(now()->startOfMinute());
+        $startedAt = now();
+        Sleep::fake();
+        Sleep::whenFakingSleep(function ($duration) use ($startedAt) {
+            Carbon::setTestNow(now()->add($duration));
+
+            if ($startedAt->diffInSeconds() >= 30 && ! Cache::has('illuminate:schedule:paused')) {
+                $this->artisan('schedule:pause');
+            }
+        });
+
+        $this->artisan('schedule:run')
+            ->expectsOutputToContain('Running [Callback]');
+
+        Sleep::assertSleptTimes(600);
+        $this->assertEquals(60, $runs);
+    }
+
+    public function test_sub_minute_events_stop_for_the_rest_of_the_minute_once_schedule_is_paused()
+    {
+        $runs = 0;
+        $this->schedule->call(function () use (&$runs) {
+            $runs++;
+        })->everySecond();
+
+        Carbon::setTestNow(now()->startOfMinute());
+        $startedAt = now();
+        Sleep::fake();
+        Sleep::whenFakingSleep(function ($duration) use ($startedAt) {
+            Carbon::setTestNow(now()->add($duration));
+
+            if ($startedAt->diffInSeconds() >= 30 && ! Cache::has('illuminate:schedule:paused')) {
+                $this->artisan('schedule:pause');
+            }
+        });
+
+        $this->artisan('schedule:run')
+            ->expectsOutputToContain('Running [Callback]');
+
+        Sleep::assertSleptTimes(600);
+        $this->assertEquals(30, $runs);
     }
 
     public function test_sub_minute_scheduling_respects_filters()


### PR DESCRIPTION
Queues are currently pausable, but the scheduler has no equivalent which means during deployment windows, outages, or  incidents we have no _clean way_ to stop the schedule without a hard deployment. 

This PR adds `schedule:pause `and `schedule:resume` commands, which use a cache key to halt scheduled task execution without requiring a code change or taking the application down.

Individual events can opt out of the pause with `evenWhenPaused()`  which mirrors  `evenInMaintenanceMode() ` 

Tests are the same as the maintenance ones pretty much..

I was gonna add events, but left it basic so it can be improved on as didn't want to give you a mega PR to review. 

Happy to let this sit / open to feedback,  this was something I had in my back pocket as an avid schedule user with many windows where we need to do things 👯 
