### PR TITLE
[13.x] Add schedule resume and pause events

### DIFF
--- a/src/Illuminate/Console/Events/SchedulePaused.php
+++ b/src/Illuminate/Console/Events/SchedulePaused.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Illuminate\Console\Events;
+
+class SchedulePaused
+{
+}

--- a/src/Illuminate/Console/Events/ScheduleResumed.php
+++ b/src/Illuminate/Console/Events/ScheduleResumed.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Illuminate\Console\Events;
+
+class ScheduleResumed
+{
+}

--- a/src/Illuminate/Console/Scheduling/SchedulePauseCommand.php
+++ b/src/Illuminate/Console/Scheduling/SchedulePauseCommand.php
@@ -3,7 +3,9 @@
 namespace Illuminate\Console\Scheduling;
 
 use Illuminate\Console\Command;
+use Illuminate\Console\Events\SchedulePaused;
 use Illuminate\Contracts\Cache\Repository as Cache;
+use Illuminate\Contracts\Events\Dispatcher;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'schedule:pause')]
@@ -21,9 +23,11 @@ class SchedulePauseCommand extends Command
      *
      * @return int
      */
-    public function handle(Cache $cache)
+    public function handle(Cache $cache, Dispatcher $dispatcher)
     {
         $cache->forever('illuminate:schedule:paused', true);
+
+        $dispatcher->dispatch(new SchedulePaused);
 
         $this->components->info('Scheduled task processing has been paused.');
 

--- a/src/Illuminate/Console/Scheduling/ScheduleResumeCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleResumeCommand.php
@@ -3,7 +3,9 @@
 namespace Illuminate\Console\Scheduling;
 
 use Illuminate\Console\Command;
+use Illuminate\Console\Events\ScheduleResumed;
 use Illuminate\Contracts\Cache\Repository as Cache;
+use Illuminate\Contracts\Events\Dispatcher;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'schedule:resume', aliases: ['schedule:continue'])]
@@ -28,9 +30,11 @@ class ScheduleResumeCommand extends Command
      *
      * @return int
      */
-    public function handle(Cache $cache)
+    public function handle(Cache $cache, Dispatcher $dispatcher)
     {
         $cache->forget('illuminate:schedule:paused');
+
+        $dispatcher->dispatch(new ScheduleResumed);
 
         $this->components->info('Scheduled task processing has resumed.');
 

--- a/tests/Integration/Console/Scheduling/SchedulePauseCommandTest.php
+++ b/tests/Integration/Console/Scheduling/SchedulePauseCommandTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Console\Scheduling;
+
+use Illuminate\Console\Events\SchedulePaused;
+use Illuminate\Support\Facades\Event;
+use Orchestra\Testbench\TestCase;
+
+class SchedulePauseCommandTest extends TestCase
+{
+    public function testDispatchesEvent()
+    {
+        Event::fake();
+
+        $this->artisan('schedule:pause');
+
+        Event::assertDispatched(SchedulePaused::class);
+    }
+}

--- a/tests/Integration/Console/Scheduling/ScheduleResumeCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleResumeCommandTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Console\Scheduling;
+
+use Illuminate\Console\Events\ScheduleResumed;
+use Illuminate\Support\Facades\Event;
+use Orchestra\Testbench\TestCase;
+
+class ScheduleResumeCommandTest extends TestCase
+{
+    public function testDispatchesEvent()
+    {
+        Event::fake();
+
+        $this->artisan('schedule:resume');
+
+        Event::assertDispatched(ScheduleResumed::class);
+    }
+}


### PR DESCRIPTION
The last PR went surprisingly well, so because we can now pause and resume the schedule... matching events are nice so we can ping off Slack notifications etc or do whatever logic we want when someone does it. This mirrors the queue pause / resume events.. we love events.

I was going to `this->laravel->make` like the `ScheduleFinishCommand` but just injected it.. felt cleaner.  

Two very boring tests to prevent regression.  

Open to renaming or any feedback.

Thanks!