### PR TITLE
[12.x] Fix float to int deprecation in trans_choice() for certain locales

### DIFF
--- a/src/Illuminate/Translation/MessageSelector.php
+++ b/src/Illuminate/Translation/MessageSelector.php
@@ -24,7 +24,7 @@ class MessageSelector
 
         $segments = $this->stripConditions($segments);
 
-        $pluralIndex = $this->getPluralIndex($locale, $number);
+        $pluralIndex = $this->getPluralIndex($locale, (int) $number);
 
         if (count($segments) === 1 || ! isset($segments[$pluralIndex])) {
             return $segments[0];

--- a/tests/Translation/TranslationMessageSelectorTest.php
+++ b/tests/Translation/TranslationMessageSelectorTest.php
@@ -16,6 +16,13 @@ class TranslationMessageSelectorTest extends TestCase
         $this->assertEquals($expected, $selector->choose($id, $number, 'en'));
     }
 
+    public function testChooseWithFloatDoesNotTriggerDeprecation()
+    {
+        $selector = new MessageSelector;
+
+        $this->assertEquals('many', $selector->choose('{0} zero|{1} one|[2,*] many', 2.75, 'pl'));
+    }
+
     public static function chooseTestData()
     {
         return [


### PR DESCRIPTION
Fixes #59166

When a float is passed to `trans_choice()`, the `getPluralIndex()` method performs modulo operations on it for certain locales (e.g. Polish, Russian, Croatian). On PHP 8.4+ this triggers a deprecation warning:

```
Implicit conversion from float 2.75 to int loses precision
```

This casts the number to `int` before passing it to `getPluralIndex()`, since plural index resolution is inherently an integer operation. The float value is still used for inline condition matching (e.g. `{2.3}`), so existing behavior is preserved.