### PR TITLE
[12.x] Allow `touch()` to accept multiple columns

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1298,7 +1298,7 @@ class Builder implements BuilderContract
     /**
      * Update the column's update timestamp.
      *
-     * @param  string|null  $column
+     * @param  string|array|null  $column
      * @return int|false
      */
     public function touch($column = null)
@@ -1306,7 +1306,9 @@ class Builder implements BuilderContract
         $time = $this->model->freshTimestamp();
 
         if ($column) {
-            return $this->toBase()->update([$column => $time]);
+            $columns = (new BaseCollection(Arr::wrap($column)))->mapWithKeys(fn ($column) => [$column => $time])->all();
+
+            return $this->toBase()->update($columns);
         }
 
         $column = $this->model->getUpdatedAtColumn();

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1298,7 +1298,7 @@ class Builder implements BuilderContract
     /**
      * Update the column's update timestamp.
      *
-     * @param  string|array|null  $column
+     * @param  array|string|null  $column
      * @return int|false
      */
     public function touch($column = null)

--- a/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Eloquent\Concerns;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Date;
 
 trait HasTimestamps
@@ -23,13 +24,17 @@ trait HasTimestamps
     /**
      * Update the model's update timestamp.
      *
-     * @param  string|null  $attribute
+     * @param  string|array|null  $attribute
      * @return bool
      */
     public function touch($attribute = null)
     {
         if ($attribute) {
-            $this->$attribute = $this->freshTimestamp();
+            $time = $this->freshTimestamp();
+
+            foreach (Arr::wrap($attribute) as $col) {
+                $this->$col = $time;
+            }
 
             return $this->save();
         }
@@ -46,7 +51,7 @@ trait HasTimestamps
     /**
      * Update the model's update timestamp without raising any events.
      *
-     * @param  string|null  $attribute
+     * @param  string|array|null  $attribute
      * @return bool
      */
     public function touchQuietly($attribute = null)

--- a/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
@@ -24,7 +24,7 @@ trait HasTimestamps
     /**
      * Update the model's update timestamp.
      *
-     * @param  string|array|null  $attribute
+     * @param  array|string|null  $attribute
      * @return bool
      */
     public function touch($attribute = null)
@@ -32,8 +32,8 @@ trait HasTimestamps
         if ($attribute) {
             $time = $this->freshTimestamp();
 
-            foreach (Arr::wrap($attribute) as $col) {
-                $this->$col = $time;
+            foreach (Arr::wrap($attribute) as $column) {
+                $this->{$column} = $time;
             }
 
             return $this->save();
@@ -51,7 +51,7 @@ trait HasTimestamps
     /**
      * Update the model's update timestamp without raising any events.
      *
-     * @param  string|array|null  $attribute
+     * @param  array|string|null  $attribute
      * @return bool
      */
     public function touchQuietly($attribute = null)

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -2740,6 +2740,25 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals(2, $result);
     }
 
+    public function testTouchWithMultipleColumns()
+    {
+        Carbon::setTestNow($now = '2017-10-10 10:10:10');
+
+        $query = m::mock(BaseBuilder::class);
+        $query->shouldReceive('from')->with('foo_table')->andReturn('foo_table');
+        $query->from = 'foo_table';
+
+        $builder = new Builder($query);
+        $model = new EloquentBuilderTestStubStringPrimaryKey;
+        $builder->setModel($model);
+
+        $query->shouldReceive('update')->once()->with(['published_at' => $now, 'verified_at' => $now])->andReturn(2);
+
+        $result = $builder->touch(['published_at', 'verified_at']);
+
+        $this->assertEquals(2, $result);
+    }
+
     public function testTouchWithoutUpdatedAtColumn()
     {
         $query = m::mock(BaseBuilder::class);

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3255,6 +3255,20 @@ class DatabaseEloquentModelTest extends TestCase
         });
     }
 
+    public function testTouchMethodWithMultipleAttributes()
+    {
+        Carbon::setTestNow($now = Carbon::now());
+
+        $model = m::mock(EloquentModelStub::class.'[save]');
+        $model->shouldReceive('save')->once()->andReturn(true);
+
+        $result = $model->touch(['published_at', 'verified_at']);
+
+        $this->assertTrue($result);
+        $this->assertEquals($now->toDateTimeString(), $model->published_at->toDateTimeString());
+        $this->assertEquals($now->toDateTimeString(), $model->verified_at->toDateTimeString());
+    }
+
     public function testTouchingModelWithTimestamps()
     {
         $this->assertFalse(


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR extends `Builder::touch()` and `Model::touch()` to accept an array of column names, allowing multiple timestamp columns to be updated in a single query.

### Before

```php
$model->touch('published_at');

$model->touch('verified_at'); // two queries
```

### After

```php
$model->touch(['published_at', 'verified_at']); // single query
```

Both `touch()` and `touchQuietly()` on the model, as well as `Builder::touch()`, now accept `string|array|null`. Full backward compatibility was preserved, ensuring that introducing this feature will not break anything.
