### PR TITLE
[13.x] Use constructor promotion and typed properties in Foundation events

### DIFF
--- a/src/Illuminate/Foundation/Events/LocaleUpdated.php
+++ b/src/Illuminate/Foundation/Events/LocaleUpdated.php
@@ -5,29 +5,11 @@ namespace Illuminate\Foundation\Events;
 class LocaleUpdated
 {
     /**
-     * The new locale.
-     *
-     * @var string
-     */
-    public $locale;
-
-    /**
-     * The previous locale.
-     *
-     * @var ?string
-     */
-    public $previousLocale;
-
-    /**
      * Create a new event instance.
-     *
-     * @param  string  $locale
-     * @param  ?string  $previousLocale
      */
-    public function __construct($locale, $previousLocale = null)
-    {
-        $this->locale = $locale;
-
-        $this->previousLocale = $previousLocale;
+    public function __construct(
+        public string $locale,
+        public ?string $previousLocale = null,
+    ) {
     }
 }

--- a/src/Illuminate/Foundation/Events/PublishingStubs.php
+++ b/src/Illuminate/Foundation/Events/PublishingStubs.php
@@ -7,20 +7,11 @@ class PublishingStubs
     use Dispatchable;
 
     /**
-     * The stubs being published.
-     *
-     * @var array
-     */
-    public $stubs = [];
-
-    /**
      * Create a new event instance.
-     *
-     * @param  array  $stubs
      */
-    public function __construct(array $stubs)
-    {
-        $this->stubs = $stubs;
+    public function __construct(
+        public array $stubs = [],
+    ) {
     }
 
     /**

--- a/src/Illuminate/Foundation/Events/VendorTagPublished.php
+++ b/src/Illuminate/Foundation/Events/VendorTagPublished.php
@@ -5,28 +5,11 @@ namespace Illuminate\Foundation\Events;
 class VendorTagPublished
 {
     /**
-     * The vendor tag that was published.
-     *
-     * @var string
-     */
-    public $tag;
-
-    /**
-     * The publishable paths registered by the tag.
-     *
-     * @var array
-     */
-    public $paths;
-
-    /**
      * Create a new event instance.
-     *
-     * @param  string  $tag
-     * @param  array  $paths
      */
-    public function __construct($tag, $paths)
-    {
-        $this->tag = $tag;
-        $this->paths = $paths;
+    public function __construct(
+        public string $tag,
+        public array $paths,
+    ) {
     }
 }


### PR DESCRIPTION
## Description

The Foundation event classes still use the older pattern with untyped properties, `@var` docblocks, and manual constructor assignment.

This change brings them in line with the modern style used across the framework by using constructor promotion and typed properties.

**Files changed:**
- `Illuminate\Foundation\Events\LocaleUpdated`
- `Illuminate\Foundation\Events\VendorTagPublished`
- `Illuminate\Foundation\Events\PublishingStubs`

No behavior change.