### PR TITLE
[13.x] Use constructor promotion and typed properties in database events

### DIFF
--- a/src/Illuminate/Database/Events/ConnectionEvent.php
+++ b/src/Illuminate/Database/Events/ConnectionEvent.php
@@ -2,30 +2,21 @@
 
 namespace Illuminate\Database\Events;
 
+use Illuminate\Database\Connection;
+
 abstract class ConnectionEvent
 {
     /**
      * The name of the connection.
-     *
-     * @var string
      */
-    public $connectionName;
-
-    /**
-     * The database connection instance.
-     *
-     * @var \Illuminate\Database\Connection
-     */
-    public $connection;
+    public string $connectionName;
 
     /**
      * Create a new event instance.
-     *
-     * @param  \Illuminate\Database\Connection  $connection
      */
-    public function __construct($connection)
-    {
-        $this->connection = $connection;
+    public function __construct(
+        public Connection $connection,
+    ) {
         $this->connectionName = $connection->getName();
     }
 }

--- a/src/Illuminate/Database/Events/MigrationEvent.php
+++ b/src/Illuminate/Database/Events/MigrationEvent.php
@@ -8,28 +8,11 @@ use Illuminate\Database\Migrations\Migration;
 abstract class MigrationEvent implements MigrationEventContract
 {
     /**
-     * A migration instance.
-     *
-     * @var \Illuminate\Database\Migrations\Migration
-     */
-    public $migration;
-
-    /**
-     * The migration method that was called.
-     *
-     * @var string
-     */
-    public $method;
-
-    /**
      * Create a new event instance.
-     *
-     * @param  \Illuminate\Database\Migrations\Migration  $migration
-     * @param  string  $method
      */
-    public function __construct(Migration $migration, $method)
-    {
-        $this->method = $method;
-        $this->migration = $migration;
+    public function __construct(
+        public Migration $migration,
+        public string $method,
+    ) {
     }
 }

--- a/src/Illuminate/Database/Events/MigrationsPruned.php
+++ b/src/Illuminate/Database/Events/MigrationsPruned.php
@@ -7,36 +7,17 @@ use Illuminate\Database\Connection;
 class MigrationsPruned
 {
     /**
-     * The database connection instance.
-     *
-     * @var \Illuminate\Database\Connection
-     */
-    public $connection;
-
-    /**
      * The database connection name.
-     *
-     * @var string|null
      */
-    public $connectionName;
-
-    /**
-     * The path to the directory where migrations were pruned.
-     *
-     * @var string
-     */
-    public $path;
+    public ?string $connectionName;
 
     /**
      * Create a new event instance.
-     *
-     * @param  \Illuminate\Database\Connection  $connection
-     * @param  string  $path
      */
-    public function __construct(Connection $connection, string $path)
-    {
-        $this->connection = $connection;
+    public function __construct(
+        public Connection $connection,
+        public string $path,
+    ) {
         $this->connectionName = $connection->getName();
-        $this->path = $path;
     }
 }

--- a/src/Illuminate/Database/Events/QueryExecuted.php
+++ b/src/Illuminate/Database/Events/QueryExecuted.php
@@ -2,67 +2,28 @@
 
 namespace Illuminate\Database\Events;
 
+use Illuminate\Database\Connection;
+
 class QueryExecuted
 {
     /**
-     * The SQL query that was executed.
-     *
-     * @var string
-     */
-    public $sql;
-
-    /**
-     * The array of query bindings.
-     *
-     * @var array
-     */
-    public $bindings;
-
-    /**
-     * The number of milliseconds it took to execute the query.
-     *
-     * @var float
-     */
-    public $time;
-
-    /**
-     * The database connection instance.
-     *
-     * @var \Illuminate\Database\Connection
-     */
-    public $connection;
-
-    /**
      * The database connection name.
-     *
-     * @var string
      */
-    public $connectionName;
-
-    /**
-     * The PDO read / write type for the executed query.
-     *
-     * @var null|'read'|'write'
-     */
-    public $readWriteType;
+    public string $connectionName;
 
     /**
      * Create a new event instance.
      *
-     * @param  string  $sql
-     * @param  array  $bindings
-     * @param  float|null  $time
-     * @param  \Illuminate\Database\Connection  $connection
      * @param  null|'read'|'write'  $readWriteType
      */
-    public function __construct($sql, $bindings, $time, $connection, $readWriteType = null)
-    {
-        $this->sql = $sql;
-        $this->time = $time;
-        $this->bindings = $bindings;
-        $this->connection = $connection;
+    public function __construct(
+        public string $sql,
+        public array $bindings,
+        public ?float $time,
+        public Connection $connection,
+        public ?string $readWriteType = null,
+    ) {
         $this->connectionName = $connection->getName();
-        $this->readWriteType = $readWriteType;
     }
 
     /**

--- a/src/Illuminate/Database/Events/SchemaDumped.php
+++ b/src/Illuminate/Database/Events/SchemaDumped.php
@@ -2,39 +2,22 @@
 
 namespace Illuminate\Database\Events;
 
+use Illuminate\Database\Connection;
+
 class SchemaDumped
 {
     /**
-     * The database connection instance.
-     *
-     * @var \Illuminate\Database\Connection
-     */
-    public $connection;
-
-    /**
      * The database connection name.
-     *
-     * @var string
      */
-    public $connectionName;
-
-    /**
-     * The path to the schema dump.
-     *
-     * @var string
-     */
-    public $path;
+    public string $connectionName;
 
     /**
      * Create a new event instance.
-     *
-     * @param  \Illuminate\Database\Connection  $connection
-     * @param  string  $path
      */
-    public function __construct($connection, $path)
-    {
-        $this->connection = $connection;
+    public function __construct(
+        public Connection $connection,
+        public string $path,
+    ) {
         $this->connectionName = $connection->getName();
-        $this->path = $path;
     }
 }

--- a/src/Illuminate/Database/Events/SchemaLoaded.php
+++ b/src/Illuminate/Database/Events/SchemaLoaded.php
@@ -2,39 +2,22 @@
 
 namespace Illuminate\Database\Events;
 
+use Illuminate\Database\Connection;
+
 class SchemaLoaded
 {
     /**
-     * The database connection instance.
-     *
-     * @var \Illuminate\Database\Connection
-     */
-    public $connection;
-
-    /**
      * The database connection name.
-     *
-     * @var string
      */
-    public $connectionName;
-
-    /**
-     * The path to the schema dump.
-     *
-     * @var string
-     */
-    public $path;
+    public string $connectionName;
 
     /**
      * Create a new event instance.
-     *
-     * @param  \Illuminate\Database\Connection  $connection
-     * @param  string  $path
      */
-    public function __construct($connection, $path)
-    {
-        $this->connection = $connection;
+    public function __construct(
+        public Connection $connection,
+        public string $path,
+    ) {
         $this->connectionName = $connection->getName();
-        $this->path = $path;
     }
 }


### PR DESCRIPTION
## Description

The newer database events (e.g., `DatabaseBusy`, `DatabaseRefreshed`, `ModelsPruned`) already use constructor promotion and typed properties. However, several older database events still follow the previous pattern with untyped properties, `@var` docblocks, and manual constructor assignment.

This change brings the older events in line with the newer ones by using constructor promotion and typed properties for a consistent style across all database events.

**Files changed:**
- `Illuminate\Database\Events\ConnectionEvent`
- `Illuminate\Database\Events\QueryExecuted`
- `Illuminate\Database\Events\SchemaDumped`
- `Illuminate\Database\Events\SchemaLoaded`
- `Illuminate\Database\Events\MigrationEvent`
- `Illuminate\Database\Events\MigrationsPruned`

No behavior change.