### PR TITLE
[13.x] Use constructor promotion and typed properties in Redis events

### DIFF
--- a/src/Illuminate/Redis/Events/CommandExecuted.php
+++ b/src/Illuminate/Redis/Events/CommandExecuted.php
@@ -2,57 +2,24 @@
 
 namespace Illuminate\Redis\Events;
 
+use Illuminate\Redis\Connections\Connection;
+
 class CommandExecuted
 {
     /**
-     * The Redis command that was executed.
-     *
-     * @var string
-     */
-    public $command;
-
-    /**
-     * The array of command parameters.
-     *
-     * @var array
-     */
-    public $parameters;
-
-    /**
-     * The number of milliseconds it took to execute the command.
-     *
-     * @var float
-     */
-    public $time;
-
-    /**
-     * The Redis connection instance.
-     *
-     * @var \Illuminate\Redis\Connections\Connection
-     */
-    public $connection;
-
-    /**
      * The Redis connection name.
-     *
-     * @var string
      */
-    public $connectionName;
+    public string $connectionName;
 
     /**
      * Create a new event instance.
-     *
-     * @param  string  $command
-     * @param  array  $parameters
-     * @param  float|null  $time
-     * @param  \Illuminate\Redis\Connections\Connection  $connection
      */
-    public function __construct($command, $parameters, $time, $connection)
-    {
-        $this->time = $time;
-        $this->command = $command;
-        $this->parameters = $parameters;
-        $this->connection = $connection;
+    public function __construct(
+        public string $command,
+        public array $parameters,
+        public ?float $time,
+        public Connection $connection,
+    ) {
         $this->connectionName = $connection->getName();
     }
 }

--- a/src/Illuminate/Redis/Events/CommandFailed.php
+++ b/src/Illuminate/Redis/Events/CommandFailed.php
@@ -2,59 +2,25 @@
 
 namespace Illuminate\Redis\Events;
 
+use Illuminate\Redis\Connections\Connection;
 use Throwable;
 
 class CommandFailed
 {
     /**
-     * The Redis command that failed.
-     *
-     * @var string
-     */
-    public $command;
-
-    /**
-     * The array of command parameters.
-     *
-     * @var array
-     */
-    public $parameters;
-
-    /**
-     * The exception that was thrown.
-     *
-     * @var \Throwable
-     */
-    public $exception;
-
-    /**
-     * The Redis connection instance.
-     *
-     * @var \Illuminate\Redis\Connections\Connection
-     */
-    public $connection;
-
-    /**
      * The Redis connection name.
-     *
-     * @var string
      */
-    public $connectionName;
+    public string $connectionName;
 
     /**
      * Create a new event instance.
-     *
-     * @param  string  $command
-     * @param  array  $parameters
-     * @param  \Throwable  $exception
-     * @param  \Illuminate\Redis\Connections\Connection  $connection
      */
-    public function __construct($command, $parameters, Throwable $exception, $connection)
-    {
-        $this->command = $command;
-        $this->parameters = $parameters;
-        $this->exception = $exception;
-        $this->connection = $connection;
+    public function __construct(
+        public string $command,
+        public array $parameters,
+        public Throwable $exception,
+        public Connection $connection,
+    ) {
         $this->connectionName = $connection->getName();
     }
 }


### PR DESCRIPTION
## Description

The Redis event classes (`CommandExecuted`, `CommandFailed`) still use the older pattern with untyped properties, `@var` docblocks, and manual constructor assignment.

This change brings them in line with the modern style used across the framework by using constructor promotion and typed properties.

**Files changed:**
- `Illuminate\Redis\Events\CommandExecuted`
- `Illuminate\Redis\Events\CommandFailed`

No behavior change.