### PR TITLE
[13.x] Use constructor promotion and typed properties in event classes

### DIFF
--- a/src/Illuminate/Auth/Access/Events/GateEvaluated.php
+++ b/src/Illuminate/Auth/Access/Events/GateEvaluated.php
@@ -2,49 +2,18 @@
 
 namespace Illuminate\Auth\Access\Events;
 
+use Illuminate\Contracts\Auth\Authenticatable;
+
 class GateEvaluated
 {
     /**
-     * The authenticatable model.
-     *
-     * @var \Illuminate\Contracts\Auth\Authenticatable|null
-     */
-    public $user;
-
-    /**
-     * The ability being evaluated.
-     *
-     * @var string
-     */
-    public $ability;
-
-    /**
-     * The result of the evaluation.
-     *
-     * @var bool|null
-     */
-    public $result;
-
-    /**
-     * The arguments given during evaluation.
-     *
-     * @var array
-     */
-    public $arguments;
-
-    /**
      * Create a new event instance.
-     *
-     * @param  \Illuminate\Contracts\Auth\Authenticatable|null  $user
-     * @param  string  $ability
-     * @param  bool|null  $result
-     * @param  array  $arguments
      */
-    public function __construct($user, $ability, $result, $arguments)
-    {
-        $this->user = $user;
-        $this->ability = $ability;
-        $this->result = $result;
-        $this->arguments = $arguments;
+    public function __construct(
+        public ?Authenticatable $user,
+        public string $ability,
+        public ?bool $result,
+        public array $arguments,
+    ) {
     }
 }

--- a/src/Illuminate/Auth/Events/Lockout.php
+++ b/src/Illuminate/Auth/Events/Lockout.php
@@ -7,19 +7,10 @@ use Illuminate\Http\Request;
 class Lockout
 {
     /**
-     * The throttled request.
-     *
-     * @var \Illuminate\Http\Request
-     */
-    public $request;
-
-    /**
      * Create a new event instance.
-     *
-     * @param  \Illuminate\Http\Request  $request
      */
-    public function __construct(Request $request)
-    {
-        $this->request = $request;
+    public function __construct(
+        public Request $request,
+    ) {
     }
 }

--- a/src/Illuminate/Cache/Events/CacheEvent.php
+++ b/src/Illuminate/Cache/Events/CacheEvent.php
@@ -5,38 +5,13 @@ namespace Illuminate\Cache\Events;
 abstract class CacheEvent
 {
     /**
-     * The name of the cache store.
-     *
-     * @var string|null
-     */
-    public $storeName;
-
-    /**
-     * The key of the event.
-     *
-     * @var string
-     */
-    public $key;
-
-    /**
-     * The tags that were assigned to the key.
-     *
-     * @var array
-     */
-    public $tags;
-
-    /**
      * Create a new event instance.
-     *
-     * @param  string|null  $storeName
-     * @param  string  $key
-     * @param  array  $tags
      */
-    public function __construct($storeName, $key, array $tags = [])
-    {
-        $this->storeName = $storeName;
-        $this->key = $key;
-        $this->tags = $tags;
+    public function __construct(
+        public ?string $storeName,
+        public string $key,
+        public array $tags = [],
+    ) {
     }
 
     /**
@@ -45,7 +20,7 @@ abstract class CacheEvent
      * @param  array  $tags
      * @return $this
      */
-    public function setTags($tags)
+    public function setTags(array $tags)
     {
         $this->tags = $tags;
 

--- a/src/Illuminate/Cache/Events/CacheHit.php
+++ b/src/Illuminate/Cache/Events/CacheHit.php
@@ -13,13 +13,8 @@ class CacheHit extends CacheEvent
 
     /**
      * Create a new event instance.
-     *
-     * @param  string|null  $storeName
-     * @param  string  $key
-     * @param  mixed  $value
-     * @param  array  $tags
      */
-    public function __construct($storeName, $key, $value, array $tags = [])
+    public function __construct(?string $storeName, string $key, mixed $value, array $tags = [])
     {
         parent::__construct($storeName, $key, $tags);
 

--- a/src/Illuminate/Cache/Events/KeyWriteFailed.php
+++ b/src/Illuminate/Cache/Events/KeyWriteFailed.php
@@ -5,33 +5,15 @@ namespace Illuminate\Cache\Events;
 class KeyWriteFailed extends CacheEvent
 {
     /**
-     * The value that would have been written.
-     *
-     * @var mixed
-     */
-    public $value;
-
-    /**
-     * The number of seconds the key should have been valid.
-     *
-     * @var int|null
-     */
-    public $seconds;
-
-    /**
      * Create a new event instance.
-     *
-     * @param  string|null  $storeName
-     * @param  string  $key
-     * @param  mixed  $value
-     * @param  int|null  $seconds
-     * @param  array  $tags
      */
-    public function __construct($storeName, $key, $value, $seconds = null, $tags = [])
-    {
+    public function __construct(
+        ?string $storeName,
+        string $key,
+        public mixed $value,
+        public ?int $seconds = null,
+        array $tags = [],
+    ) {
         parent::__construct($storeName, $key, $tags);
-
-        $this->value = $value;
-        $this->seconds = $seconds;
     }
 }

--- a/src/Illuminate/Cache/Events/KeyWritten.php
+++ b/src/Illuminate/Cache/Events/KeyWritten.php
@@ -5,33 +5,15 @@ namespace Illuminate\Cache\Events;
 class KeyWritten extends CacheEvent
 {
     /**
-     * The value that was written.
-     *
-     * @var mixed
-     */
-    public $value;
-
-    /**
-     * The number of seconds the key should be valid.
-     *
-     * @var int|null
-     */
-    public $seconds;
-
-    /**
      * Create a new event instance.
-     *
-     * @param  string|null  $storeName
-     * @param  string  $key
-     * @param  mixed  $value
-     * @param  int|null  $seconds
-     * @param  array  $tags
      */
-    public function __construct($storeName, $key, $value, $seconds = null, $tags = [])
-    {
+    public function __construct(
+        ?string $storeName,
+        string $key,
+        public mixed $value,
+        public ?int $seconds = null,
+        array $tags = [],
+    ) {
         parent::__construct($storeName, $key, $tags);
-
-        $this->value = $value;
-        $this->seconds = $seconds;
     }
 }

--- a/src/Illuminate/Cache/Events/RetrievingManyKeys.php
+++ b/src/Illuminate/Cache/Events/RetrievingManyKeys.php
@@ -5,23 +5,13 @@ namespace Illuminate\Cache\Events;
 class RetrievingManyKeys extends CacheEvent
 {
     /**
-     * The keys that are being retrieved.
-     *
-     * @var array
-     */
-    public $keys;
-
-    /**
      * Create a new event instance.
-     *
-     * @param  string|null  $storeName
-     * @param  array  $keys
-     * @param  array  $tags
      */
-    public function __construct($storeName, $keys, array $tags = [])
-    {
+    public function __construct(
+        ?string $storeName,
+        public array $keys,
+        array $tags = [],
+    ) {
         parent::__construct($storeName, $keys[0] ?? '', $tags);
-
-        $this->keys = $keys;
     }
 }

--- a/src/Illuminate/Cache/Events/WritingKey.php
+++ b/src/Illuminate/Cache/Events/WritingKey.php
@@ -5,33 +5,15 @@ namespace Illuminate\Cache\Events;
 class WritingKey extends CacheEvent
 {
     /**
-     * The value that will be written.
-     *
-     * @var mixed
-     */
-    public $value;
-
-    /**
-     * The number of seconds the key should be valid.
-     *
-     * @var int|null
-     */
-    public $seconds;
-
-    /**
      * Create a new event instance.
-     *
-     * @param  string|null  $storeName
-     * @param  string  $key
-     * @param  mixed  $value
-     * @param  int|null  $seconds
-     * @param  array  $tags
      */
-    public function __construct($storeName, $key, $value, $seconds = null, $tags = [])
-    {
+    public function __construct(
+        ?string $storeName,
+        string $key,
+        public mixed $value,
+        public ?int $seconds = null,
+        array $tags = [],
+    ) {
         parent::__construct($storeName, $key, $tags);
-
-        $this->value = $value;
-        $this->seconds = $seconds;
     }
 }

--- a/src/Illuminate/Cache/Events/WritingManyKeys.php
+++ b/src/Illuminate/Cache/Events/WritingManyKeys.php
@@ -5,41 +5,15 @@ namespace Illuminate\Cache\Events;
 class WritingManyKeys extends CacheEvent
 {
     /**
-     * The keys that are being written.
-     *
-     * @var mixed
-     */
-    public $keys;
-
-    /**
-     * The value that is being written.
-     *
-     * @var mixed
-     */
-    public $values;
-
-    /**
-     * The number of seconds the keys should be valid.
-     *
-     * @var int|null
-     */
-    public $seconds;
-
-    /**
      * Create a new event instance.
-     *
-     * @param  string|null  $storeName
-     * @param  array  $keys
-     * @param  array  $values
-     * @param  int|null  $seconds
-     * @param  array  $tags
      */
-    public function __construct($storeName, $keys, $values, $seconds = null, $tags = [])
-    {
+    public function __construct(
+        ?string $storeName,
+        public array $keys,
+        public mixed $values,
+        public ?int $seconds = null,
+        array $tags = [],
+    ) {
         parent::__construct($storeName, $keys[0], $tags);
-
-        $this->keys = $keys;
-        $this->values = $values;
-        $this->seconds = $seconds;
     }
 }

--- a/src/Illuminate/Database/Events/ConnectionEvent.php
+++ b/src/Illuminate/Database/Events/ConnectionEvent.php
@@ -2,30 +2,21 @@
 
 namespace Illuminate\Database\Events;
 
+use Illuminate\Database\Connection;
+
 abstract class ConnectionEvent
 {
     /**
      * The name of the connection.
-     *
-     * @var string
      */
-    public $connectionName;
-
-    /**
-     * The database connection instance.
-     *
-     * @var \Illuminate\Database\Connection
-     */
-    public $connection;
+    public string $connectionName;
 
     /**
      * Create a new event instance.
-     *
-     * @param  \Illuminate\Database\Connection  $connection
      */
-    public function __construct($connection)
-    {
-        $this->connection = $connection;
+    public function __construct(
+        public Connection $connection,
+    ) {
         $this->connectionName = $connection->getName();
     }
 }

--- a/src/Illuminate/Database/Events/MigrationEvent.php
+++ b/src/Illuminate/Database/Events/MigrationEvent.php
@@ -8,28 +8,11 @@ use Illuminate\Database\Migrations\Migration;
 abstract class MigrationEvent implements MigrationEventContract
 {
     /**
-     * A migration instance.
-     *
-     * @var \Illuminate\Database\Migrations\Migration
-     */
-    public $migration;
-
-    /**
-     * The migration method that was called.
-     *
-     * @var string
-     */
-    public $method;
-
-    /**
      * Create a new event instance.
-     *
-     * @param  \Illuminate\Database\Migrations\Migration  $migration
-     * @param  string  $method
      */
-    public function __construct(Migration $migration, $method)
-    {
-        $this->method = $method;
-        $this->migration = $migration;
+    public function __construct(
+        public Migration $migration,
+        public string $method,
+    ) {
     }
 }

--- a/src/Illuminate/Database/Events/MigrationsPruned.php
+++ b/src/Illuminate/Database/Events/MigrationsPruned.php
@@ -7,36 +7,17 @@ use Illuminate\Database\Connection;
 class MigrationsPruned
 {
     /**
-     * The database connection instance.
-     *
-     * @var \Illuminate\Database\Connection
-     */
-    public $connection;
-
-    /**
      * The database connection name.
-     *
-     * @var string|null
      */
-    public $connectionName;
-
-    /**
-     * The path to the directory where migrations were pruned.
-     *
-     * @var string
-     */
-    public $path;
+    public ?string $connectionName;
 
     /**
      * Create a new event instance.
-     *
-     * @param  \Illuminate\Database\Connection  $connection
-     * @param  string  $path
      */
-    public function __construct(Connection $connection, string $path)
-    {
-        $this->connection = $connection;
+    public function __construct(
+        public Connection $connection,
+        public string $path,
+    ) {
         $this->connectionName = $connection->getName();
-        $this->path = $path;
     }
 }

--- a/src/Illuminate/Database/Events/QueryExecuted.php
+++ b/src/Illuminate/Database/Events/QueryExecuted.php
@@ -2,67 +2,28 @@
 
 namespace Illuminate\Database\Events;
 
+use Illuminate\Database\Connection;
+
 class QueryExecuted
 {
     /**
-     * The SQL query that was executed.
-     *
-     * @var string
-     */
-    public $sql;
-
-    /**
-     * The array of query bindings.
-     *
-     * @var array
-     */
-    public $bindings;
-
-    /**
-     * The number of milliseconds it took to execute the query.
-     *
-     * @var float
-     */
-    public $time;
-
-    /**
-     * The database connection instance.
-     *
-     * @var \Illuminate\Database\Connection
-     */
-    public $connection;
-
-    /**
      * The database connection name.
-     *
-     * @var string
      */
-    public $connectionName;
-
-    /**
-     * The PDO read / write type for the executed query.
-     *
-     * @var null|'read'|'write'
-     */
-    public $readWriteType;
+    public string $connectionName;
 
     /**
      * Create a new event instance.
      *
-     * @param  string  $sql
-     * @param  array  $bindings
-     * @param  float|null  $time
-     * @param  \Illuminate\Database\Connection  $connection
      * @param  null|'read'|'write'  $readWriteType
      */
-    public function __construct($sql, $bindings, $time, $connection, $readWriteType = null)
-    {
-        $this->sql = $sql;
-        $this->time = $time;
-        $this->bindings = $bindings;
-        $this->connection = $connection;
+    public function __construct(
+        public string $sql,
+        public array $bindings,
+        public ?float $time,
+        public Connection $connection,
+        public ?string $readWriteType = null,
+    ) {
         $this->connectionName = $connection->getName();
-        $this->readWriteType = $readWriteType;
     }
 
     /**

--- a/src/Illuminate/Database/Events/SchemaDumped.php
+++ b/src/Illuminate/Database/Events/SchemaDumped.php
@@ -2,39 +2,22 @@
 
 namespace Illuminate\Database\Events;
 
+use Illuminate\Database\Connection;
+
 class SchemaDumped
 {
     /**
-     * The database connection instance.
-     *
-     * @var \Illuminate\Database\Connection
-     */
-    public $connection;
-
-    /**
      * The database connection name.
-     *
-     * @var string
      */
-    public $connectionName;
-
-    /**
-     * The path to the schema dump.
-     *
-     * @var string
-     */
-    public $path;
+    public string $connectionName;
 
     /**
      * Create a new event instance.
-     *
-     * @param  \Illuminate\Database\Connection  $connection
-     * @param  string  $path
      */
-    public function __construct($connection, $path)
-    {
-        $this->connection = $connection;
+    public function __construct(
+        public Connection $connection,
+        public string $path,
+    ) {
         $this->connectionName = $connection->getName();
-        $this->path = $path;
     }
 }

--- a/src/Illuminate/Database/Events/SchemaLoaded.php
+++ b/src/Illuminate/Database/Events/SchemaLoaded.php
@@ -2,39 +2,22 @@
 
 namespace Illuminate\Database\Events;
 
+use Illuminate\Database\Connection;
+
 class SchemaLoaded
 {
     /**
-     * The database connection instance.
-     *
-     * @var \Illuminate\Database\Connection
-     */
-    public $connection;
-
-    /**
      * The database connection name.
-     *
-     * @var string
      */
-    public $connectionName;
-
-    /**
-     * The path to the schema dump.
-     *
-     * @var string
-     */
-    public $path;
+    public string $connectionName;
 
     /**
      * Create a new event instance.
-     *
-     * @param  \Illuminate\Database\Connection  $connection
-     * @param  string  $path
      */
-    public function __construct($connection, $path)
-    {
-        $this->connection = $connection;
+    public function __construct(
+        public Connection $connection,
+        public string $path,
+    ) {
         $this->connectionName = $connection->getName();
-        $this->path = $path;
     }
 }

--- a/src/Illuminate/Foundation/Events/LocaleUpdated.php
+++ b/src/Illuminate/Foundation/Events/LocaleUpdated.php
@@ -5,29 +5,11 @@ namespace Illuminate\Foundation\Events;
 class LocaleUpdated
 {
     /**
-     * The new locale.
-     *
-     * @var string
-     */
-    public $locale;
-
-    /**
-     * The previous locale.
-     *
-     * @var ?string
-     */
-    public $previousLocale;
-
-    /**
      * Create a new event instance.
-     *
-     * @param  string  $locale
-     * @param  ?string  $previousLocale
      */
-    public function __construct($locale, $previousLocale = null)
-    {
-        $this->locale = $locale;
-
-        $this->previousLocale = $previousLocale;
+    public function __construct(
+        public string $locale,
+        public ?string $previousLocale = null,
+    ) {
     }
 }

--- a/src/Illuminate/Foundation/Events/PublishingStubs.php
+++ b/src/Illuminate/Foundation/Events/PublishingStubs.php
@@ -7,20 +7,11 @@ class PublishingStubs
     use Dispatchable;
 
     /**
-     * The stubs being published.
-     *
-     * @var array
-     */
-    public $stubs = [];
-
-    /**
      * Create a new event instance.
-     *
-     * @param  array  $stubs
      */
-    public function __construct(array $stubs)
-    {
-        $this->stubs = $stubs;
+    public function __construct(
+        public array $stubs = [],
+    ) {
     }
 
     /**

--- a/src/Illuminate/Foundation/Events/VendorTagPublished.php
+++ b/src/Illuminate/Foundation/Events/VendorTagPublished.php
@@ -5,28 +5,11 @@ namespace Illuminate\Foundation\Events;
 class VendorTagPublished
 {
     /**
-     * The vendor tag that was published.
-     *
-     * @var string
-     */
-    public $tag;
-
-    /**
-     * The publishable paths registered by the tag.
-     *
-     * @var array
-     */
-    public $paths;
-
-    /**
      * Create a new event instance.
-     *
-     * @param  string  $tag
-     * @param  array  $paths
      */
-    public function __construct($tag, $paths)
-    {
-        $this->tag = $tag;
-        $this->paths = $paths;
+    public function __construct(
+        public string $tag,
+        public array $paths,
+    ) {
     }
 }

--- a/src/Illuminate/Foundation/Http/Events/RequestHandled.php
+++ b/src/Illuminate/Foundation/Http/Events/RequestHandled.php
@@ -2,31 +2,17 @@
 
 namespace Illuminate\Foundation\Http\Events;
 
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
 class RequestHandled
 {
     /**
-     * The request instance.
-     *
-     * @var \Illuminate\Http\Request
-     */
-    public $request;
-
-    /**
-     * The response instance.
-     *
-     * @var \Illuminate\Http\Response
-     */
-    public $response;
-
-    /**
      * Create a new event instance.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \Illuminate\Http\Response  $response
      */
-    public function __construct($request, $response)
-    {
-        $this->request = $request;
-        $this->response = $response;
+    public function __construct(
+        public Request $request,
+        public Response $response,
+    ) {
     }
 }

--- a/src/Illuminate/Http/Client/Events/ConnectionFailed.php
+++ b/src/Illuminate/Http/Client/Events/ConnectionFailed.php
@@ -8,28 +8,11 @@ use Illuminate\Http\Client\Request;
 class ConnectionFailed
 {
     /**
-     * The request instance.
-     *
-     * @var \Illuminate\Http\Client\Request
-     */
-    public $request;
-
-    /**
-     * The exception instance.
-     *
-     * @var \Illuminate\Http\Client\ConnectionException
-     */
-    public $exception;
-
-    /**
      * Create a new event instance.
-     *
-     * @param  \Illuminate\Http\Client\Request  $request
-     * @param  \Illuminate\Http\Client\ConnectionException  $exception
      */
-    public function __construct(Request $request, ConnectionException $exception)
-    {
-        $this->request = $request;
-        $this->exception = $exception;
+    public function __construct(
+        public Request $request,
+        public ConnectionException $exception,
+    ) {
     }
 }

--- a/src/Illuminate/Http/Client/Events/RequestSending.php
+++ b/src/Illuminate/Http/Client/Events/RequestSending.php
@@ -7,19 +7,10 @@ use Illuminate\Http\Client\Request;
 class RequestSending
 {
     /**
-     * The request instance.
-     *
-     * @var \Illuminate\Http\Client\Request
-     */
-    public $request;
-
-    /**
      * Create a new event instance.
-     *
-     * @param  \Illuminate\Http\Client\Request  $request
      */
-    public function __construct(Request $request)
-    {
-        $this->request = $request;
+    public function __construct(
+        public Request $request,
+    ) {
     }
 }

--- a/src/Illuminate/Http/Client/Events/ResponseReceived.php
+++ b/src/Illuminate/Http/Client/Events/ResponseReceived.php
@@ -8,28 +8,11 @@ use Illuminate\Http\Client\Response;
 class ResponseReceived
 {
     /**
-     * The request instance.
-     *
-     * @var \Illuminate\Http\Client\Request
-     */
-    public $request;
-
-    /**
-     * The response instance.
-     *
-     * @var \Illuminate\Http\Client\Response
-     */
-    public $response;
-
-    /**
      * Create a new event instance.
-     *
-     * @param  \Illuminate\Http\Client\Request  $request
-     * @param  \Illuminate\Http\Client\Response  $response
      */
-    public function __construct(Request $request, Response $response)
-    {
-        $this->request = $request;
-        $this->response = $response;
+    public function __construct(
+        public Request $request,
+        public Response $response,
+    ) {
     }
 }

--- a/src/Illuminate/Log/Context/Events/ContextDehydrating.php
+++ b/src/Illuminate/Log/Context/Events/ContextDehydrating.php
@@ -2,22 +2,15 @@
 
 namespace Illuminate\Log\Context\Events;
 
+use Illuminate\Log\Context\Repository;
+
 class ContextDehydrating
 {
     /**
-     * The context instance.
-     *
-     * @var \Illuminate\Log\Context\Repository
-     */
-    public $context;
-
-    /**
      * Create a new event instance.
-     *
-     * @param  \Illuminate\Log\Context\Repository  $context
      */
-    public function __construct($context)
-    {
-        $this->context = $context;
+    public function __construct(
+        public Repository $context,
+    ) {
     }
 }

--- a/src/Illuminate/Log/Context/Events/ContextHydrated.php
+++ b/src/Illuminate/Log/Context/Events/ContextHydrated.php
@@ -2,22 +2,15 @@
 
 namespace Illuminate\Log\Context\Events;
 
+use Illuminate\Log\Context\Repository;
+
 class ContextHydrated
 {
     /**
-     * The context instance.
-     *
-     * @var \Illuminate\Log\Context\Repository
-     */
-    public $context;
-
-    /**
      * Create a new event instance.
-     *
-     * @param  \Illuminate\Log\Context\Repository  $context
      */
-    public function __construct($context)
-    {
-        $this->context = $context;
+    public function __construct(
+        public Repository $context,
+    ) {
     }
 }

--- a/src/Illuminate/Redis/Events/CommandExecuted.php
+++ b/src/Illuminate/Redis/Events/CommandExecuted.php
@@ -2,57 +2,24 @@
 
 namespace Illuminate\Redis\Events;
 
+use Illuminate\Redis\Connections\Connection;
+
 class CommandExecuted
 {
     /**
-     * The Redis command that was executed.
-     *
-     * @var string
-     */
-    public $command;
-
-    /**
-     * The array of command parameters.
-     *
-     * @var array
-     */
-    public $parameters;
-
-    /**
-     * The number of milliseconds it took to execute the command.
-     *
-     * @var float
-     */
-    public $time;
-
-    /**
-     * The Redis connection instance.
-     *
-     * @var \Illuminate\Redis\Connections\Connection
-     */
-    public $connection;
-
-    /**
      * The Redis connection name.
-     *
-     * @var string
      */
-    public $connectionName;
+    public string $connectionName;
 
     /**
      * Create a new event instance.
-     *
-     * @param  string  $command
-     * @param  array  $parameters
-     * @param  float|null  $time
-     * @param  \Illuminate\Redis\Connections\Connection  $connection
      */
-    public function __construct($command, $parameters, $time, $connection)
-    {
-        $this->time = $time;
-        $this->command = $command;
-        $this->parameters = $parameters;
-        $this->connection = $connection;
+    public function __construct(
+        public string $command,
+        public array $parameters,
+        public ?float $time,
+        public Connection $connection,
+    ) {
         $this->connectionName = $connection->getName();
     }
 }

--- a/src/Illuminate/Redis/Events/CommandFailed.php
+++ b/src/Illuminate/Redis/Events/CommandFailed.php
@@ -2,59 +2,25 @@
 
 namespace Illuminate\Redis\Events;
 
+use Illuminate\Redis\Connections\Connection;
 use Throwable;
 
 class CommandFailed
 {
     /**
-     * The Redis command that failed.
-     *
-     * @var string
-     */
-    public $command;
-
-    /**
-     * The array of command parameters.
-     *
-     * @var array
-     */
-    public $parameters;
-
-    /**
-     * The exception that was thrown.
-     *
-     * @var \Throwable
-     */
-    public $exception;
-
-    /**
-     * The Redis connection instance.
-     *
-     * @var \Illuminate\Redis\Connections\Connection
-     */
-    public $connection;
-
-    /**
      * The Redis connection name.
-     *
-     * @var string
      */
-    public $connectionName;
+    public string $connectionName;
 
     /**
      * Create a new event instance.
-     *
-     * @param  string  $command
-     * @param  array  $parameters
-     * @param  \Throwable  $exception
-     * @param  \Illuminate\Redis\Connections\Connection  $connection
      */
-    public function __construct($command, $parameters, Throwable $exception, $connection)
-    {
-        $this->command = $command;
-        $this->parameters = $parameters;
-        $this->exception = $exception;
-        $this->connection = $connection;
+    public function __construct(
+        public string $command,
+        public array $parameters,
+        public Throwable $exception,
+        public Connection $connection,
+    ) {
         $this->connectionName = $connection->getName();
     }
 }


### PR DESCRIPTION
## Description

Many event classes across the framework still use the older pattern with untyped properties, `@var` docblocks, and manual constructor assignment. The newer event classes (e.g., `DatabaseBusy`, `DatabaseRefreshed`, `CacheFailedOver`) already use constructor promotion and typed properties.

This change brings all remaining event classes in line with the modern style for a consistent codebase.

**Components updated (26 files):**
- **Auth:** `GateEvaluated`, `Lockout`
- **Cache:** `CacheEvent`, `CacheHit`, `KeyWritten`, `KeyWriteFailed`, `WritingKey`, `WritingManyKeys`, `RetrievingManyKeys`
- **Database:** `ConnectionEvent`, `QueryExecuted`, `SchemaDumped`, `SchemaLoaded`, `MigrationEvent`, `MigrationsPruned`
- **Foundation:** `LocaleUpdated`, `VendorTagPublished`, `PublishingStubs`, `RequestHandled`
- **HTTP Client:** `ResponseReceived`, `ConnectionFailed`, `RequestSending`
- **Log:** `ContextDehydrating`, `ContextHydrated`
- **Redis:** `CommandExecuted`, `CommandFailed`

No behavior change.