### PR TITLE
[13.x] Use constructor promotion and typed properties in middleware classes

### DIFF
--- a/src/Illuminate/Auth/Middleware/RequirePassword.php
+++ b/src/Illuminate/Auth/Middleware/RequirePassword.php
@@ -10,37 +10,18 @@ use Illuminate\Support\Facades\Date;
 class RequirePassword
 {
     /**
-     * The response factory instance.
-     *
-     * @var \Illuminate\Contracts\Routing\ResponseFactory
-     */
-    protected $responseFactory;
-
-    /**
-     * The URL generator instance.
-     *
-     * @var \Illuminate\Contracts\Routing\UrlGenerator
-     */
-    protected $urlGenerator;
-
-    /**
      * The password timeout.
-     *
-     * @var int
      */
-    protected $passwordTimeout;
+    protected int $passwordTimeout;
 
     /**
      * Create a new middleware instance.
-     *
-     * @param  \Illuminate\Contracts\Routing\ResponseFactory  $responseFactory
-     * @param  \Illuminate\Contracts\Routing\UrlGenerator  $urlGenerator
-     * @param  int|null  $passwordTimeout
      */
-    public function __construct(ResponseFactory $responseFactory, UrlGenerator $urlGenerator, $passwordTimeout = null)
-    {
-        $this->responseFactory = $responseFactory;
-        $this->urlGenerator = $urlGenerator;
+    public function __construct(
+        protected ResponseFactory $responseFactory,
+        protected UrlGenerator $urlGenerator,
+        ?int $passwordTimeout = null,
+    ) {
         $this->passwordTimeout = $passwordTimeout ?: 10800;
     }
 

--- a/src/Illuminate/Cookie/Middleware/EncryptCookies.php
+++ b/src/Illuminate/Cookie/Middleware/EncryptCookies.php
@@ -14,13 +14,6 @@ use Symfony\Component\HttpFoundation\Response;
 class EncryptCookies
 {
     /**
-     * The encrypter instance.
-     *
-     * @var \Illuminate\Contracts\Encryption\Encrypter
-     */
-    protected $encrypter;
-
-    /**
      * The names of the cookies that should not be encrypted.
      *
      * @var array<int, string>
@@ -43,12 +36,10 @@ class EncryptCookies
 
     /**
      * Create a new CookieGuard instance.
-     *
-     * @param  \Illuminate\Contracts\Encryption\Encrypter  $encrypter
      */
-    public function __construct(EncrypterContract $encrypter)
-    {
-        $this->encrypter = $encrypter;
+    public function __construct(
+        protected EncrypterContract $encrypter,
+    ) {
     }
 
     /**

--- a/src/Illuminate/Foundation/Http/Middleware/PreventRequestForgery.php
+++ b/src/Illuminate/Foundation/Http/Middleware/PreventRequestForgery.php
@@ -22,20 +22,6 @@ class PreventRequestForgery
         InteractsWithTime;
 
     /**
-     * The application instance.
-     *
-     * @var \Illuminate\Contracts\Foundation\Application
-     */
-    protected $app;
-
-    /**
-     * The encrypter implementation.
-     *
-     * @var \Illuminate\Contracts\Encryption\Encrypter
-     */
-    protected $encrypter;
-
-    /**
      * The URIs that should be excluded.
      *
      * @var array<int, string>
@@ -72,14 +58,11 @@ class PreventRequestForgery
 
     /**
      * Create a new middleware instance.
-     *
-     * @param  \Illuminate\Contracts\Foundation\Application  $app
-     * @param  \Illuminate\Contracts\Encryption\Encrypter  $encrypter
      */
-    public function __construct(Application $app, Encrypter $encrypter)
-    {
-        $this->app = $app;
-        $this->encrypter = $encrypter;
+    public function __construct(
+        protected Application $app,
+        protected Encrypter $encrypter,
+    ) {
     }
 
     /**

--- a/src/Illuminate/Http/Middleware/TrustHosts.php
+++ b/src/Illuminate/Http/Middleware/TrustHosts.php
@@ -8,13 +8,6 @@ use Illuminate\Http\Request;
 class TrustHosts
 {
     /**
-     * The application instance.
-     *
-     * @var \Illuminate\Contracts\Foundation\Application
-     */
-    protected $app;
-
-    /**
      * The trusted hosts that have been configured to always be trusted.
      *
      * @var array<int, string>|(callable(): array<int, string>)|null
@@ -30,12 +23,10 @@ class TrustHosts
 
     /**
      * Create a new middleware instance.
-     *
-     * @param  \Illuminate\Contracts\Foundation\Application  $app
      */
-    public function __construct(Application $app)
-    {
-        $this->app = $app;
+    public function __construct(
+        protected Application $app,
+    ) {
     }
 
     /**

--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -15,29 +15,12 @@ use Symfony\Component\HttpFoundation\Response;
 class StartSession
 {
     /**
-     * The session manager.
-     *
-     * @var \Illuminate\Session\SessionManager
-     */
-    protected $manager;
-
-    /**
-     * The callback that can resolve an instance of the cache factory.
-     *
-     * @var callable|null
-     */
-    protected $cacheFactoryResolver;
-
-    /**
      * Create a new session middleware.
-     *
-     * @param  \Illuminate\Session\SessionManager  $manager
-     * @param  callable|null  $cacheFactoryResolver
      */
-    public function __construct(SessionManager $manager, ?callable $cacheFactoryResolver = null)
-    {
-        $this->manager = $manager;
-        $this->cacheFactoryResolver = $cacheFactoryResolver;
+    public function __construct(
+        protected SessionManager $manager,
+        protected ?callable $cacheFactoryResolver = null,
+    ) {
     }
 
     /**

--- a/src/Illuminate/View/Middleware/ShareErrorsFromSession.php
+++ b/src/Illuminate/View/Middleware/ShareErrorsFromSession.php
@@ -9,20 +9,11 @@ use Illuminate\Support\ViewErrorBag;
 class ShareErrorsFromSession
 {
     /**
-     * The view factory implementation.
-     *
-     * @var \Illuminate\Contracts\View\Factory
-     */
-    protected $view;
-
-    /**
      * Create a new error binder instance.
-     *
-     * @param  \Illuminate\Contracts\View\Factory  $view
      */
-    public function __construct(ViewFactory $view)
-    {
-        $this->view = $view;
+    public function __construct(
+        protected ViewFactory $view,
+    ) {
     }
 
     /**


### PR DESCRIPTION
## Description

Several middleware classes still use the older pattern with untyped properties, `@var` docblocks, and manual constructor assignment.

This change brings them in line with the modern style used across the framework by using constructor promotion and typed properties.

**Files changed:**
- `Illuminate\Auth\Middleware\RequirePassword`
- `Illuminate\Foundation\Http\Middleware\PreventRequestForgery`
- `Illuminate\Http\Middleware\TrustHosts`
- `Illuminate\Cookie\Middleware\EncryptCookies`
- `Illuminate\Session\Middleware\StartSession`
- `Illuminate\View\Middleware\ShareErrorsFromSession`

No behavior change.