### PR TITLE
[13.x] Use constructor promotion and typed properties in mail and notification value objects

### DIFF
--- a/src/Illuminate/Mail/Mailables/Address.php
+++ b/src/Illuminate/Mail/Mailables/Address.php
@@ -5,28 +5,11 @@ namespace Illuminate\Mail\Mailables;
 class Address
 {
     /**
-     * The recipient's email address.
-     *
-     * @var string
-     */
-    public $address;
-
-    /**
-     * The recipient's name.
-     *
-     * @var string|null
-     */
-    public $name;
-
-    /**
      * Create a new address instance.
-     *
-     * @param  string  $address
-     * @param  string|null  $name
      */
-    public function __construct(string $address, ?string $name = null)
-    {
-        $this->address = $address;
-        $this->name = $name;
+    public function __construct(
+        public string $address,
+        public ?string $name = null,
+    ) {
     }
 }

--- a/src/Illuminate/Mail/Mailables/Content.php
+++ b/src/Illuminate/Mail/Mailables/Content.php
@@ -9,69 +9,18 @@ class Content
     use Conditionable;
 
     /**
-     * The Blade view that should be rendered for the mailable.
-     *
-     * @var string|null
-     */
-    public $view;
-
-    /**
-     * The Blade view that should be rendered for the mailable.
-     *
-     * Alternative syntax for "view".
-     *
-     * @var string|null
-     */
-    public $html;
-
-    /**
-     * The Blade view that represents the text version of the message.
-     *
-     * @var string|null
-     */
-    public $text;
-
-    /**
-     * The Blade view that represents the Markdown version of the message.
-     *
-     * @var string|null
-     */
-    public $markdown;
-
-    /**
-     * The pre-rendered HTML of the message.
-     *
-     * @var string|null
-     */
-    public $htmlString;
-
-    /**
-     * The message's view data.
-     *
-     * @var array
-     */
-    public $with;
-
-    /**
      * Create a new content definition.
-     *
-     * @param  string|null  $view
-     * @param  string|null  $html
-     * @param  string|null  $text
-     * @param  string|null  $markdown
-     * @param  array  $with
-     * @param  string|null  $htmlString
      *
      * @named-arguments-supported
      */
-    public function __construct(?string $view = null, ?string $html = null, ?string $text = null, $markdown = null, array $with = [], ?string $htmlString = null)
-    {
-        $this->view = $view;
-        $this->html = $html;
-        $this->text = $text;
-        $this->markdown = $markdown;
-        $this->with = $with;
-        $this->htmlString = $htmlString;
+    public function __construct(
+        public ?string $view = null,
+        public ?string $html = null,
+        public ?string $text = null,
+        public ?string $markdown = null,
+        public array $with = [],
+        public ?string $htmlString = null,
+    ) {
     }
 
     /**

--- a/src/Illuminate/Mail/Mailables/Headers.php
+++ b/src/Illuminate/Mail/Mailables/Headers.php
@@ -11,40 +11,15 @@ class Headers
     use Conditionable;
 
     /**
-     * The message's message ID.
-     *
-     * @var string|null
-     */
-    public $messageId;
-
-    /**
-     * The message IDs that are referenced by the message.
-     *
-     * @var array
-     */
-    public $references;
-
-    /**
-     * The message's text headers.
-     *
-     * @var array
-     */
-    public $text;
-
-    /**
      * Create a new instance of headers for a message.
-     *
-     * @param  string|null  $messageId
-     * @param  array  $references
-     * @param  array  $text
      *
      * @named-arguments-supported
      */
-    public function __construct(?string $messageId = null, array $references = [], array $text = [])
-    {
-        $this->messageId = $messageId;
-        $this->references = $references;
-        $this->text = $text;
+    public function __construct(
+        public ?string $messageId = null,
+        public array $references = [],
+        public array $text = [],
+    ) {
     }
 
     /**

--- a/src/Illuminate/Notifications/Action.php
+++ b/src/Illuminate/Notifications/Action.php
@@ -5,28 +5,11 @@ namespace Illuminate\Notifications;
 class Action
 {
     /**
-     * The action text.
-     *
-     * @var string
-     */
-    public $text;
-
-    /**
-     * The action URL.
-     *
-     * @var string
-     */
-    public $url;
-
-    /**
      * Create a new action instance.
-     *
-     * @param  string  $text
-     * @param  string  $url
      */
-    public function __construct($text, $url)
-    {
-        $this->url = $url;
-        $this->text = $text;
+    public function __construct(
+        public string $text,
+        public string $url,
+    ) {
     }
 }

--- a/src/Illuminate/Notifications/Messages/BroadcastMessage.php
+++ b/src/Illuminate/Notifications/Messages/BroadcastMessage.php
@@ -9,20 +9,11 @@ class BroadcastMessage
     use Queueable;
 
     /**
-     * The data for the notification.
-     *
-     * @var array
-     */
-    public $data;
-
-    /**
      * Create a new message instance.
-     *
-     * @param  array  $data
      */
-    public function __construct(array $data)
-    {
-        $this->data = $data;
+    public function __construct(
+        public array $data,
+    ) {
     }
 
     /**

--- a/src/Illuminate/Notifications/Messages/DatabaseMessage.php
+++ b/src/Illuminate/Notifications/Messages/DatabaseMessage.php
@@ -5,19 +5,10 @@ namespace Illuminate\Notifications\Messages;
 class DatabaseMessage
 {
     /**
-     * The data that should be stored with the notification.
-     *
-     * @var array
-     */
-    public $data = [];
-
-    /**
      * Create a new database message.
-     *
-     * @param  array  $data
      */
-    public function __construct(array $data = [])
-    {
-        $this->data = $data;
+    public function __construct(
+        public array $data = [],
+    ) {
     }
 }


### PR DESCRIPTION
## Description

Several mail and notification value object classes still use the older pattern with untyped properties, `@var` docblocks, and manual constructor assignment.

This change brings them in line with the modern style used across the framework by using constructor promotion and typed properties.

**Files changed:**
- `Illuminate\Notifications\Action`
- `Illuminate\Notifications\Messages\BroadcastMessage`
- `Illuminate\Notifications\Messages\DatabaseMessage`
- `Illuminate\Mail\Mailables\Address`
- `Illuminate\Mail\Mailables\Headers`
- `Illuminate\Mail\Mailables\Content`

No behavior change.