### PR TITLE
[13.x] Use constructor promotion and typed properties in exception classes

### DIFF
--- a/src/Illuminate/Auth/AuthenticationException.php
+++ b/src/Illuminate/Auth/AuthenticationException.php
@@ -8,20 +8,6 @@ use Illuminate\Http\Request;
 class AuthenticationException extends Exception
 {
     /**
-     * All of the guards that were checked.
-     *
-     * @var array
-     */
-    protected $guards;
-
-    /**
-     * The path the user should be redirected to.
-     *
-     * @var string|null
-     */
-    protected $redirectTo;
-
-    /**
      * The callback that should be used to generate the authentication redirect path.
      *
      * @var callable
@@ -30,17 +16,13 @@ class AuthenticationException extends Exception
 
     /**
      * Create a new authentication exception.
-     *
-     * @param  string  $message
-     * @param  array  $guards
-     * @param  string|null  $redirectTo
      */
-    public function __construct($message = 'Unauthenticated.', array $guards = [], $redirectTo = null)
-    {
+    public function __construct(
+        string $message = 'Unauthenticated.',
+        protected array $guards = [],
+        protected ?string $redirectTo = null,
+    ) {
         parent::__construct($message);
-
-        $this->guards = $guards;
-        $this->redirectTo = $redirectTo;
     }
 
     /**

--- a/src/Illuminate/Database/MultipleRecordsFoundException.php
+++ b/src/Illuminate/Database/MultipleRecordsFoundException.php
@@ -7,23 +7,13 @@ use RuntimeException;
 class MultipleRecordsFoundException extends RuntimeException
 {
     /**
-     * The number of records found.
-     *
-     * @var int
-     */
-    public $count;
-
-    /**
      * Create a new exception instance.
-     *
-     * @param  int  $count
-     * @param  int  $code
-     * @param  \Throwable|null  $previous
      */
-    public function __construct($count, $code = 0, $previous = null)
-    {
-        $this->count = $count;
-
+    public function __construct(
+        public int $count,
+        int $code = 0,
+        ?\Throwable $previous = null,
+    ) {
         parent::__construct("$count records were found.", $code, $previous);
     }
 

--- a/src/Illuminate/Database/QueryException.php
+++ b/src/Illuminate/Database/QueryException.php
@@ -10,59 +10,20 @@ use Throwable;
 class QueryException extends PDOException
 {
     /**
-     * The database connection name.
-     *
-     * @var string
-     */
-    public $connectionName;
-
-    /**
-     * The SQL for the query.
-     *
-     * @var string
-     */
-    protected $sql;
-
-    /**
-     * The bindings for the query.
-     *
-     * @var array
-     */
-    protected $bindings;
-
-    /**
-     * The PDO read / write type for the executed query.
-     *
-     * @var null|'read'|'write'
-     */
-    public $readWriteType;
-
-    /**
-     * The connection details for the query (host, port, database, etc.).
-     *
-     * @var array
-     */
-    protected $connectionDetails = [];
-
-    /**
      * Create a new query exception instance.
      *
-     * @param  string  $connectionName
-     * @param  string  $sql
-     * @param  array  $bindings
-     * @param  \Throwable  $previous
      * @param  null|'read'|'write'  $readWriteType
-     * @param  array  $connectionDetails
      */
-    public function __construct($connectionName, $sql, array $bindings, Throwable $previous, array $connectionDetails = [], $readWriteType = null)
-    {
+    public function __construct(
+        public string $connectionName,
+        protected string $sql,
+        protected array $bindings,
+        Throwable $previous,
+        protected array $connectionDetails = [],
+        public ?string $readWriteType = null,
+    ) {
         parent::__construct('', 0, $previous);
 
-        $this->connectionName = $connectionName;
-        $this->sql = $sql;
-        $this->bindings = $bindings;
-        $this->connectionDetails = $connectionDetails;
-        $this->readWriteType = $readWriteType;
         $this->code = $previous->getCode();
         $this->message = $this->formatMessage($connectionName, $sql, $bindings, $previous);
 


### PR DESCRIPTION
This PR modernizes exception classes by using PHP constructor promotion and typed properties, reducing boilerplate code.

### Changes

- `AuthenticationException` - Promote `$guards` and `$redirectTo` with type declarations
- `MultipleRecordsFoundException` - Promote `$count` with type declaration
- `QueryException` - Promote `$connectionName`, `$sql`, `$bindings`, `$connectionDetails`, and `$readWriteType` with type declarations