### PR TITLE
[13.x] insertOrIgnoreReturning with multiple unique keys

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1543,7 +1543,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
             return true;
         }
 
-        $result = $query->toBase()->insertOrIgnoreReturning($attributes, $uniqueBy);
+        $result = $query->toBase()->insertOrIgnoreReturning($attributes, ['*'], $uniqueBy);
 
         if ($result->isEmpty()) {
             return false;

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1315,11 +1315,11 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * Save the model to the database, ignoring specific unique constraint conflicts.
      *
-     * @param  array|string  $uniqueBy
      * @param  array  $options
+     * @param  array|string|null  $uniqueBy
      * @return bool
      */
-    public function saveOrIgnore(array|string $uniqueBy, array $options = [])
+    public function saveOrIgnore(array $options = [], array|string|null $uniqueBy = null)
     {
         if ($this->exists) {
             throw new LogicException('Cannot use saveOrIgnore on an existing model.');
@@ -1520,10 +1520,10 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      * Perform a model insert operation, ignoring specific unique constraint conflicts.
      *
      * @param  \Illuminate\Database\Eloquent\Builder<static>  $query
-     * @param  array|string  $uniqueBy
+     * @param  array|string|null  $uniqueBy
      * @return bool
      */
-    protected function performInsertOrIgnore(Builder $query, array|string $uniqueBy)
+    protected function performInsertOrIgnore(Builder $query, array|string|null $uniqueBy)
     {
         if ($this->usesUniqueIds()) {
             $this->setUniqueIds();

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -4156,13 +4156,13 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Insert new records into the database while ignoring specific conflicts and returning specified columns.
+     * Insert new records into the database and returning specified columns with optional ignoring specific conflicts.
      *
-     * @param  non-empty-string|non-empty-array<non-empty-string>  $uniqueBy
      * @param  non-empty-array<non-empty-string>  $returning
+     * @param non-empty-string|non-empty-array<non-empty-string>|null $uniqueBy
      * @return \Illuminate\Support\Collection
      */
-    public function insertOrIgnoreReturning(array $values, array|string $uniqueBy, array $returning = ['*'])
+    public function insertOrIgnoreReturning(array $values, array $returning = ['*'], array|string|null $uniqueBy = null)
     {
         if (empty($values)) {
             return new Collection;
@@ -4188,7 +4188,7 @@ class Builder implements BuilderContract
 
         $this->applyBeforeQueryCallbacks();
 
-        $sql = $this->grammar->compileInsertOrIgnoreReturning($this, $values, (array) $uniqueBy, $returning);
+        $sql = $this->grammar->compileInsertOrIgnoreReturning($this, $values, $returning, $uniqueBy === null ? null : Arr::wrap($uniqueBy));
 
         $result = new Collection(
             $this->connection->selectFromWriteConnection($sql, $this->cleanBindings(Arr::flatten($values, 1)))

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -4159,7 +4159,7 @@ class Builder implements BuilderContract
      * Insert new records into the database and returning specified columns with optional ignoring specific conflicts.
      *
      * @param  non-empty-array<non-empty-string>  $returning
-     * @param non-empty-string|non-empty-array<non-empty-string>|null $uniqueBy
+     * @param  non-empty-string|non-empty-array<non-empty-string>|null  $uniqueBy
      * @return \Illuminate\Support\Collection
      */
     public function insertOrIgnoreReturning(array $values, array $returning = ['*'], array|string|null $uniqueBy = null)

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -1255,13 +1255,13 @@ class Grammar extends BaseGrammar
      *
      * @param  \Illuminate\Database\Query\Builder  $query
      * @param  array  $values
-     * @param  array  $uniqueBy
      * @param  array  $returning
+     * @param  array|null $uniqueBy
      * @return string
      *
      * @throws \RuntimeException
      */
-    public function compileInsertOrIgnoreReturning(Builder $query, array $values, array $uniqueBy, array $returning)
+    public function compileInsertOrIgnoreReturning(Builder $query, array $values, array $returning, array|null $uniqueBy)
     {
         throw new RuntimeException('This database engine does not support insert or ignore with returning.');
     }

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -1256,12 +1256,12 @@ class Grammar extends BaseGrammar
      * @param  \Illuminate\Database\Query\Builder  $query
      * @param  array  $values
      * @param  array  $returning
-     * @param  array|null $uniqueBy
+     * @param  array|null  $uniqueBy
      * @return string
      *
      * @throws \RuntimeException
      */
-    public function compileInsertOrIgnoreReturning(Builder $query, array $values, array $returning, array|null $uniqueBy)
+    public function compileInsertOrIgnoreReturning(Builder $query, array $values, array $returning, ?array $uniqueBy)
     {
         throw new RuntimeException('This database engine does not support insert or ignore with returning.');
     }

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -378,15 +378,18 @@ class PostgresGrammar extends Grammar
      *
      * @param  \Illuminate\Database\Query\Builder  $query
      * @param  array  $values
-     * @param  array  $uniqueBy
      * @param  array  $returning
+     * @param  array|null $uniqueBy
      * @return string
      */
-    public function compileInsertOrIgnoreReturning(Builder $query, array $values, array $uniqueBy, array $returning)
+    public function compileInsertOrIgnoreReturning(Builder $query, array $values, array $returning, array|null $uniqueBy)
     {
-        return $this->compileInsert($query, $values)
-            .' on conflict ('.$this->columnize($uniqueBy).') do nothing'
-            .' returning '.$this->columnize($returning);
+        $insert = $this->compileInsert($query, $values);
+
+        return match ($uniqueBy) {
+            null => "{$insert} on conflict do nothing returning {$this->columnize($returning)}",
+            default => "{$insert} on conflict ({$this->columnize($uniqueBy)}) do nothing returning {$this->columnize($returning)}",
+        };
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -379,10 +379,10 @@ class PostgresGrammar extends Grammar
      * @param  \Illuminate\Database\Query\Builder  $query
      * @param  array  $values
      * @param  array  $returning
-     * @param  array|null $uniqueBy
+     * @param  array|null  $uniqueBy
      * @return string
      */
-    public function compileInsertOrIgnoreReturning(Builder $query, array $values, array $returning, array|null $uniqueBy)
+    public function compileInsertOrIgnoreReturning(Builder $query, array $values, array $returning, ?array $uniqueBy)
     {
         $insert = $this->compileInsert($query, $values);
 

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -297,7 +297,7 @@ class SQLiteGrammar extends Grammar
      * @param  array|null  $uniqueBy
      * @return string
      */
-    public function compileInsertOrIgnoreReturning(Builder $query, array $values, array $returning, array|null $uniqueBy)
+    public function compileInsertOrIgnoreReturning(Builder $query, array $values, array $returning, ?array $uniqueBy)
     {
         $insert = $this->compileInsert($query, $values);
 

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -293,15 +293,18 @@ class SQLiteGrammar extends Grammar
      *
      * @param  \Illuminate\Database\Query\Builder  $query
      * @param  array  $values
-     * @param  array  $uniqueBy
      * @param  array  $returning
+     * @param  array|null  $uniqueBy
      * @return string
      */
-    public function compileInsertOrIgnoreReturning(Builder $query, array $values, array $uniqueBy, array $returning)
+    public function compileInsertOrIgnoreReturning(Builder $query, array $values, array $returning, array|null $uniqueBy)
     {
-        return $this->compileInsert($query, $values)
-            .' on conflict ('.$this->columnize($uniqueBy).') do nothing'
-            .' returning '.$this->columnize($returning);
+        $insert = $this->compileInsert($query, $values);
+
+        return match ($uniqueBy) {
+            null => "{$insert} on conflict do nothing returning {$this->columnize($returning)}",
+            default => "{$insert} on conflict ({$this->columnize($uniqueBy)}) do nothing returning {$this->columnize($returning)}",
+        };
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1131,7 +1131,7 @@ class DatabaseEloquentModelTest extends TestCase
 
         $model->name = 'taylor';
         $model->exists = false;
-        $this->assertTrue($model->saveOrIgnore(['name']));
+        $this->assertTrue($model->saveOrIgnore());
         $this->assertEquals(1, $model->id);
         $this->assertTrue($model->exists);
         $this->assertTrue($model->wasRecentlyCreated);
@@ -1154,7 +1154,7 @@ class DatabaseEloquentModelTest extends TestCase
 
         $model->name = 'taylor';
         $model->exists = false;
-        $this->assertFalse($model->saveOrIgnore(['name']));
+        $this->assertFalse($model->saveOrIgnore());
         $this->assertFalse($model->exists);
         $this->assertFalse($model->wasRecentlyCreated);
     }
@@ -1179,10 +1179,32 @@ class DatabaseEloquentModelTest extends TestCase
 
         $model->name = 'taylor';
         $model->exists = false;
-        $this->assertTrue($model->saveOrIgnore(['name']));
+        $this->assertTrue($model->saveOrIgnore());
         $this->assertNull($model->id);
         $this->assertTrue($model->exists);
         $this->assertTrue($model->wasRecentlyCreated);
+    }
+
+    public function testInsertOrIgnoreProcessWithNamedUnique()
+    {
+        $model = $this->getMockBuilder(EloquentModelStub::class)->onlyMethods(['newModelQuery', 'updateTimestamps', 'refresh'])->getMock();
+        $query = m::mock(Builder::class);
+        $baseQuery = m::mock(BaseBuilder::class);
+        $query->shouldReceive('toBase')->once()->andReturn($baseQuery);
+        $baseQuery->shouldReceive('insertOrIgnoreReturning')->once()->with(['name' => 'taylor'], ['*'], ['name'])->andReturn(new BaseCollection);
+        $query->shouldReceive('getConnection')->once();
+        $model->expects($this->once())->method('newModelQuery')->willReturn($query);
+        $model->expects($this->once())->method('updateTimestamps');
+
+        $model->setEventDispatcher($events = m::mock(Dispatcher::class));
+        $events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
+        $events->shouldReceive('until')->once()->with('eloquent.creating: '.get_class($model), $model)->andReturn(true);
+
+        $model->name = 'taylor';
+        $model->exists = false;
+        $this->assertFalse($model->saveOrIgnore([], ['name']));
+        $this->assertFalse($model->exists);
+        $this->assertFalse($model->wasRecentlyCreated);
     }
 
     public function testInsertOrIgnoreThrowsOnExistingModel()
@@ -1191,7 +1213,7 @@ class DatabaseEloquentModelTest extends TestCase
 
         $model = new EloquentModelStub;
         $model->exists = true;
-        $model->saveOrIgnore(['name']);
+        $model->saveOrIgnore();
     }
 
     public function testDeleteProperlyDeletesModel()

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1118,7 +1118,7 @@ class DatabaseEloquentModelTest extends TestCase
         $query = m::mock(Builder::class);
         $baseQuery = m::mock(BaseBuilder::class);
         $query->shouldReceive('toBase')->once()->andReturn($baseQuery);
-        $baseQuery->shouldReceive('insertOrIgnoreReturning')->once()->with(['name' => 'taylor'], ['*'])->andReturn(new BaseCollection([(object) ['id' => 1, 'name' => 'taylor']]));
+        $baseQuery->shouldReceive('insertOrIgnoreReturning')->once()->with(['name' => 'taylor'], ['*'], null)->andReturn(new BaseCollection([(object) ['id' => 1, 'name' => 'taylor']]));
         $query->shouldReceive('getConnection')->once();
         $model->expects($this->once())->method('newModelQuery')->willReturn($query);
         $model->expects($this->once())->method('updateTimestamps');
@@ -1143,7 +1143,7 @@ class DatabaseEloquentModelTest extends TestCase
         $query = m::mock(Builder::class);
         $baseQuery = m::mock(BaseBuilder::class);
         $query->shouldReceive('toBase')->once()->andReturn($baseQuery);
-        $baseQuery->shouldReceive('insertOrIgnoreReturning')->once()->with(['name' => 'taylor'], ['*'])->andReturn(new BaseCollection);
+        $baseQuery->shouldReceive('insertOrIgnoreReturning')->once()->with(['name' => 'taylor'], ['*'], null)->andReturn(new BaseCollection);
         $query->shouldReceive('getConnection')->once();
         $model->expects($this->once())->method('newModelQuery')->willReturn($query);
         $model->expects($this->once())->method('updateTimestamps');
@@ -1165,7 +1165,7 @@ class DatabaseEloquentModelTest extends TestCase
         $query = m::mock(Builder::class);
         $baseQuery = m::mock(BaseBuilder::class);
         $query->shouldReceive('toBase')->once()->andReturn($baseQuery);
-        $baseQuery->shouldReceive('insertOrIgnoreReturning')->once()->with(['name' => 'taylor'], ['*'])->andReturn(new BaseCollection([(object) ['name' => 'taylor']]));
+        $baseQuery->shouldReceive('insertOrIgnoreReturning')->once()->with(['name' => 'taylor'], ['*'], null)->andReturn(new BaseCollection([(object) ['name' => 'taylor']]));
         $query->shouldReceive('getConnection')->once();
         $model->expects($this->once())->method('newModelQuery')->willReturn($query);
         $model->expects($this->once())->method('updateTimestamps');

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1118,7 +1118,7 @@ class DatabaseEloquentModelTest extends TestCase
         $query = m::mock(Builder::class);
         $baseQuery = m::mock(BaseBuilder::class);
         $query->shouldReceive('toBase')->once()->andReturn($baseQuery);
-        $baseQuery->shouldReceive('insertOrIgnoreReturning')->once()->with(['name' => 'taylor'], ['*'], ['name'])->andReturn(new BaseCollection([(object) ['id' => 1, 'name' => 'taylor']]));
+        $baseQuery->shouldReceive('insertOrIgnoreReturning')->once()->with(['name' => 'taylor'], ['*'])->andReturn(new BaseCollection([(object) ['id' => 1, 'name' => 'taylor']]));
         $query->shouldReceive('getConnection')->once();
         $model->expects($this->once())->method('newModelQuery')->willReturn($query);
         $model->expects($this->once())->method('updateTimestamps');
@@ -1143,7 +1143,7 @@ class DatabaseEloquentModelTest extends TestCase
         $query = m::mock(Builder::class);
         $baseQuery = m::mock(BaseBuilder::class);
         $query->shouldReceive('toBase')->once()->andReturn($baseQuery);
-        $baseQuery->shouldReceive('insertOrIgnoreReturning')->once()->with(['name' => 'taylor'], ['*'], ['name'])->andReturn(new BaseCollection);
+        $baseQuery->shouldReceive('insertOrIgnoreReturning')->once()->with(['name' => 'taylor'], ['*'])->andReturn(new BaseCollection);
         $query->shouldReceive('getConnection')->once();
         $model->expects($this->once())->method('newModelQuery')->willReturn($query);
         $model->expects($this->once())->method('updateTimestamps');
@@ -1165,7 +1165,7 @@ class DatabaseEloquentModelTest extends TestCase
         $query = m::mock(Builder::class);
         $baseQuery = m::mock(BaseBuilder::class);
         $query->shouldReceive('toBase')->once()->andReturn($baseQuery);
-        $baseQuery->shouldReceive('insertOrIgnoreReturning')->once()->with(['name' => 'taylor'], ['*'], ['name'])->andReturn(new BaseCollection([(object) ['name' => 'taylor']]));
+        $baseQuery->shouldReceive('insertOrIgnoreReturning')->once()->with(['name' => 'taylor'], ['*'])->andReturn(new BaseCollection([(object) ['name' => 'taylor']]));
         $query->shouldReceive('getConnection')->once();
         $model->expects($this->once())->method('newModelQuery')->willReturn($query);
         $model->expects($this->once())->method('updateTimestamps');

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1118,7 +1118,7 @@ class DatabaseEloquentModelTest extends TestCase
         $query = m::mock(Builder::class);
         $baseQuery = m::mock(BaseBuilder::class);
         $query->shouldReceive('toBase')->once()->andReturn($baseQuery);
-        $baseQuery->shouldReceive('insertOrIgnoreReturning')->once()->with(['name' => 'taylor'], ['name'])->andReturn(new BaseCollection([(object) ['id' => 1, 'name' => 'taylor']]));
+        $baseQuery->shouldReceive('insertOrIgnoreReturning')->once()->with(['name' => 'taylor'], ['*'], ['name'])->andReturn(new BaseCollection([(object) ['id' => 1, 'name' => 'taylor']]));
         $query->shouldReceive('getConnection')->once();
         $model->expects($this->once())->method('newModelQuery')->willReturn($query);
         $model->expects($this->once())->method('updateTimestamps');
@@ -1143,7 +1143,7 @@ class DatabaseEloquentModelTest extends TestCase
         $query = m::mock(Builder::class);
         $baseQuery = m::mock(BaseBuilder::class);
         $query->shouldReceive('toBase')->once()->andReturn($baseQuery);
-        $baseQuery->shouldReceive('insertOrIgnoreReturning')->once()->with(['name' => 'taylor'], ['name'])->andReturn(new BaseCollection);
+        $baseQuery->shouldReceive('insertOrIgnoreReturning')->once()->with(['name' => 'taylor'], ['*'], ['name'])->andReturn(new BaseCollection);
         $query->shouldReceive('getConnection')->once();
         $model->expects($this->once())->method('newModelQuery')->willReturn($query);
         $model->expects($this->once())->method('updateTimestamps');
@@ -1165,7 +1165,7 @@ class DatabaseEloquentModelTest extends TestCase
         $query = m::mock(Builder::class);
         $baseQuery = m::mock(BaseBuilder::class);
         $query->shouldReceive('toBase')->once()->andReturn($baseQuery);
-        $baseQuery->shouldReceive('insertOrIgnoreReturning')->once()->with(['name' => 'taylor'], ['name'])->andReturn(new BaseCollection([(object) ['name' => 'taylor']]));
+        $baseQuery->shouldReceive('insertOrIgnoreReturning')->once()->with(['name' => 'taylor'], ['*'], ['name'])->andReturn(new BaseCollection([(object) ['name' => 'taylor']]));
         $query->shouldReceive('getConnection')->once();
         $model->expects($this->once())->method('newModelQuery')->willReturn($query);
         $model->expects($this->once())->method('updateTimestamps');

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -4198,7 +4198,6 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([['id' => 1]], $result->all());
     }
 
-
     public function testSqliteInsertOrIgnoreReturningMethodWithUniqueByColumn()
     {
         $builder = $this->getSQLiteBuilder();

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -4111,13 +4111,13 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('does not support');
         $builder = $this->getBuilder();
-        $builder->from('users')->insertOrIgnoreReturning(['email' => 'foo'], 'email');
+        $builder->from('users')->insertOrIgnoreReturning(['email' => 'foo']);
     }
 
     public function testInsertOrIgnoreReturningMethodWithEmptyValues()
     {
         $builder = $this->getPostgresBuilder();
-        $result = $builder->from('users')->insertOrIgnoreReturning([], 'email');
+        $result = $builder->from('users')->insertOrIgnoreReturning([]);
         $this->assertInstanceOf(Collection::class, $result);
         $this->assertTrue($result->isEmpty());
     }
@@ -4127,7 +4127,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('does not support');
         $builder = $this->getMySqlBuilder();
-        $builder->from('users')->insertOrIgnoreReturning(['email' => 'foo'], 'email');
+        $builder->from('users')->insertOrIgnoreReturning(['email' => 'foo']);
     }
 
     public function testPostgresInsertOrIgnoreReturningMethod()
@@ -4135,15 +4135,28 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getPostgresBuilder();
         $builder->getConnection()->shouldReceive('recordsHaveBeenModified')->once();
         $builder->getConnection()->shouldReceive('selectFromWriteConnection')->once()->with(
-            'insert into "users" ("email") values (?) on conflict ("email") do nothing returning "id"',
+            'insert into "users" ("email") values (?) on conflict do nothing returning "id"',
             ['foo']
         )->andReturn([['id' => 1]]);
-        $result = $builder->from('users')->insertOrIgnoreReturning(['email' => 'foo'], 'email', ['id']);
+        $result = $builder->from('users')->insertOrIgnoreReturning(['email' => 'foo'], ['id']);
         $this->assertInstanceOf(Collection::class, $result);
         $this->assertEquals([['id' => 1]], $result->all());
     }
 
-    public function testPostgresInsertOrIgnoreReturningMethodWithMultipleUniqueByColumns()
+    public function testPostgresInsertOrIgnoreReturningMethodWithUniqueByColumn()
+    {
+        $builder = $this->getPostgresBuilder();
+        $builder->getConnection()->shouldReceive('recordsHaveBeenModified')->once();
+        $builder->getConnection()->shouldReceive('selectFromWriteConnection')->once()->with(
+            'insert into "users" ("email", "name") values (?, ?) on conflict ("email") do nothing returning *',
+            ['foo', 'bar']
+        )->andReturn([['id' => 1, 'email' => 'foo', 'name' => 'bar']]);
+        $result = $builder->from('users')->insertOrIgnoreReturning(['email' => 'foo', 'name' => 'bar'], ['*'], 'email');
+        $this->assertInstanceOf(Collection::class, $result);
+        $this->assertEquals([['id' => 1, 'email' => 'foo', 'name' => 'bar']], $result->all());
+    }
+
+    public function testPostgresInsertOrIgnoreReturningMethodWithUniqueByColumns()
     {
         $builder = $this->getPostgresBuilder();
         $builder->getConnection()->shouldReceive('recordsHaveBeenModified')->once();
@@ -4151,7 +4164,7 @@ class DatabaseQueryBuilderTest extends TestCase
             'insert into "users" ("email", "name") values (?, ?) on conflict ("email", "name") do nothing returning *',
             ['foo', 'bar']
         )->andReturn([['id' => 1, 'email' => 'foo', 'name' => 'bar']]);
-        $result = $builder->from('users')->insertOrIgnoreReturning(['email' => 'foo', 'name' => 'bar'], ['email', 'name']);
+        $result = $builder->from('users')->insertOrIgnoreReturning(['email' => 'foo', 'name' => 'bar'], ['*'], ['email', 'name']);
         $this->assertInstanceOf(Collection::class, $result);
         $this->assertEquals([['id' => 1, 'email' => 'foo', 'name' => 'bar']], $result->all());
     }
@@ -4161,12 +4174,11 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getPostgresBuilder();
         $builder->getConnection()->shouldReceive('recordsHaveBeenModified')->once();
         $builder->getConnection()->shouldReceive('selectFromWriteConnection')->once()->with(
-            'insert into "users" ("email") values (?), (?) on conflict ("email") do nothing returning "id", "email"',
+            'insert into "users" ("email") values (?), (?) on conflict do nothing returning "id", "email"',
             ['foo', 'bar']
         )->andReturn([['id' => 1, 'email' => 'foo']]);
         $result = $builder->from('users')->insertOrIgnoreReturning(
             [['email' => 'foo'], ['email' => 'bar']],
-            'email',
             ['id', 'email']
         );
         $this->assertInstanceOf(Collection::class, $result);
@@ -4178,15 +4190,29 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getSQLiteBuilder();
         $builder->getConnection()->shouldReceive('recordsHaveBeenModified')->once();
         $builder->getConnection()->shouldReceive('selectFromWriteConnection')->once()->with(
-            'insert into "users" ("email") values (?) on conflict ("email") do nothing returning "id"',
+            'insert into "users" ("email") values (?) on conflict do nothing returning "id"',
             ['foo']
         )->andReturn([['id' => 1]]);
-        $result = $builder->from('users')->insertOrIgnoreReturning(['email' => 'foo'], 'email', ['id']);
+        $result = $builder->from('users')->insertOrIgnoreReturning(['email' => 'foo'], ['id']);
         $this->assertInstanceOf(Collection::class, $result);
         $this->assertEquals([['id' => 1]], $result->all());
     }
 
-    public function testSqliteInsertOrIgnoreReturningMethodWithMultipleUniqueByColumns()
+
+    public function testSqliteInsertOrIgnoreReturningMethodWithUniqueByColumn()
+    {
+        $builder = $this->getSQLiteBuilder();
+        $builder->getConnection()->shouldReceive('recordsHaveBeenModified')->once();
+        $builder->getConnection()->shouldReceive('selectFromWriteConnection')->once()->with(
+            'insert into "users" ("email", "name") values (?, ?) on conflict ("email") do nothing returning *',
+            ['foo', 'bar']
+        )->andReturn([['id' => 1, 'email' => 'foo', 'name' => 'bar']]);
+        $result = $builder->from('users')->insertOrIgnoreReturning(['email' => 'foo', 'name' => 'bar'], ['*'], 'email');
+        $this->assertInstanceOf(Collection::class, $result);
+        $this->assertEquals([['id' => 1, 'email' => 'foo', 'name' => 'bar']], $result->all());
+    }
+
+    public function testSqliteInsertOrIgnoreReturningMethodWithUniqueByColumns()
     {
         $builder = $this->getSQLiteBuilder();
         $builder->getConnection()->shouldReceive('recordsHaveBeenModified')->once();
@@ -4194,7 +4220,7 @@ class DatabaseQueryBuilderTest extends TestCase
             'insert into "users" ("email", "name") values (?, ?) on conflict ("email", "name") do nothing returning *',
             ['foo', 'bar']
         )->andReturn([['id' => 1, 'email' => 'foo', 'name' => 'bar']]);
-        $result = $builder->from('users')->insertOrIgnoreReturning(['email' => 'foo', 'name' => 'bar'], ['email', 'name']);
+        $result = $builder->from('users')->insertOrIgnoreReturning(['email' => 'foo', 'name' => 'bar'], ['*'], ['email', 'name']);
         $this->assertInstanceOf(Collection::class, $result);
         $this->assertEquals([['id' => 1, 'email' => 'foo', 'name' => 'bar']], $result->all());
     }
@@ -4204,12 +4230,11 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getSQLiteBuilder();
         $builder->getConnection()->shouldReceive('recordsHaveBeenModified')->once();
         $builder->getConnection()->shouldReceive('selectFromWriteConnection')->once()->with(
-            'insert into "users" ("email") values (?), (?) on conflict ("email") do nothing returning "id", "email"',
+            'insert into "users" ("email") values (?), (?) on conflict do nothing returning "id", "email"',
             ['foo', 'bar']
         )->andReturn([['id' => 1, 'email' => 'foo']]);
         $result = $builder->from('users')->insertOrIgnoreReturning(
             [['email' => 'foo'], ['email' => 'bar']],
-            'email',
             ['id', 'email']
         );
         $this->assertInstanceOf(Collection::class, $result);
@@ -4221,7 +4246,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('does not support');
         $builder = $this->getSqlServerBuilder();
-        $builder->from('users')->insertOrIgnoreReturning(['email' => 'foo'], 'email');
+        $builder->from('users')->insertOrIgnoreReturning(['email' => 'foo']);
     }
 
     public function testInsertOrIgnoreReturningWithEmptyUniqueByArray()
@@ -4229,7 +4254,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The unique columns must not be empty.');
         $builder = $this->getPostgresBuilder();
-        $builder->from('users')->insertOrIgnoreReturning(['email' => 'foo'], []);
+        $builder->from('users')->insertOrIgnoreReturning(['email' => 'foo'], ['*'], []);
     }
 
     public function testInsertOrIgnoreReturningWithEmptyUniqueByString()
@@ -4237,7 +4262,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The unique columns must not be empty.');
         $builder = $this->getPostgresBuilder();
-        $builder->from('users')->insertOrIgnoreReturning(['email' => 'foo'], '');
+        $builder->from('users')->insertOrIgnoreReturning(['email' => 'foo'], ['*'], '');
     }
 
     public function testInsertOrIgnoreReturningWithEmptyReturning()
@@ -4245,18 +4270,18 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The returning columns must not be empty.');
         $builder = $this->getPostgresBuilder();
-        $builder->from('users')->insertOrIgnoreReturning(['email' => 'foo'], 'email', []);
+        $builder->from('users')->insertOrIgnoreReturning(['email' => 'foo'], []);
     }
 
     public function testInsertOrIgnoreReturningDoesNotMarkRecordsModifiedWhenNoRowsWereInserted()
     {
         $builder = $this->getPostgresBuilder();
         $builder->getConnection()->shouldReceive('selectFromWriteConnection')->once()->with(
-            'insert into "users" ("email") values (?) on conflict ("email") do nothing returning *',
+            'insert into "users" ("email") values (?) on conflict do nothing returning *',
             ['foo']
         )->andReturn([]);
         $builder->getConnection()->shouldReceive('recordsHaveBeenModified')->once()->with(false);
-        $result = $builder->from('users')->insertOrIgnoreReturning(['email' => 'foo'], 'email');
+        $result = $builder->from('users')->insertOrIgnoreReturning(['email' => 'foo']);
         $this->assertInstanceOf(Collection::class, $result);
         $this->assertTrue($result->isEmpty());
     }


### PR DESCRIPTION
PR #59025 added the `insertOrIgnoreReturning` method which allows inserting data and ignoring duplicate conflicts with the great PostgreSQL/SQLite feature of, .e.g., `RETURNING *` to get all inserted rows back.

But that PR introduced a new concept, namely the `$uniqueBy` param. The idea was, that you can limit the duplicate ignoring to specific unique columns/keys. But the problem is, you can only limit this logic to __one__ unique key and you __must__ use this feature. So the `insertOrIgnoreReturning` method behaves differently compared to `insertOrIgnore`:
* You can't use the new method if you have more than one unique key
* The method will throw duplicate key exceptions when a table has duplicate key errors and the key ignored by `$uniqueBy` is not the one triggering the error.

So after all, while `insertOrIgnoreReturning` is a great new feature, the new behaviour made switching from `insertOrIgnore` quite complicated - or impossible. I've discussed with @antonkomarev (the creator of PR #59025) on how to solve these issues by retaining the new `$uniqueBy` feature but making it optional for anyone as it is a niche feature.

The method signature has been changed that it can be used absolutely identical to `insertOrIgnore` and users are able to opt-in gradually to more features:
* use `$returning` to limit the columns returned
* use `$uniqueBy` to limit the duplicate detection to a specific unique key (or columns of a specific unique key)

```php
// old
public function insertOrIgnoreReturning(
    array $values, 
    array|string $uniqueBy, 
    array $returning = ['*']
): Collection;

// new
public function insertOrIgnoreReturning(
    array $values, 
    array $returning = ['*']
    array|string|null $uniqueBy = null, 
): Collection;

// API of insertOrIgnore without Returning
public function insertOrIgnore(
    array $values
);
```