### PR TITLE
[13.x] Use match expressions instead of switch statements

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -1136,20 +1136,18 @@ trait EnumeratesValues
                 return in_array($operator, ['!=', '<>', '!==']);
             }
 
-            switch ($operator) {
-                default:
-                case '=':
-                case '==':  return $retrieved == $value;
-                case '!=':
-                case '<>':  return $retrieved != $value;
-                case '<':   return $retrieved < $value;
-                case '>':   return $retrieved > $value;
-                case '<=':  return $retrieved <= $value;
-                case '>=':  return $retrieved >= $value;
-                case '===': return $retrieved === $value;
-                case '!==': return $retrieved !== $value;
-                case '<=>': return $retrieved <=> $value;
-            }
+            return match ($operator) {
+                '=', '==' => $retrieved == $value,
+                '!=', '<>' => $retrieved != $value,
+                '<' => $retrieved < $value,
+                '>' => $retrieved > $value,
+                '<=' => $retrieved <= $value,
+                '>=' => $retrieved >= $value,
+                '===' => $retrieved === $value,
+                '!==' => $retrieved !== $value,
+                '<=>' => $retrieved <=> $value,
+                default => $retrieved == $value,
+            };
         };
     }
 

--- a/src/Illuminate/Console/QuestionHelper.php
+++ b/src/Illuminate/Console/QuestionHelper.php
@@ -35,28 +35,12 @@ class QuestionHelper extends SymfonyQuestionHelper
                 : '<comment>Ctrl+D</comment>');
         }
 
-        switch (true) {
-            case null === $default:
-                $text = sprintf('<info>%s</info>', $text);
-
-                break;
-
-            case $question instanceof ConfirmationQuestion:
-                $text = sprintf('<info>%s (yes/no)</info> [<comment>%s</comment>]', $text, $default ? 'yes' : 'no');
-
-                break;
-
-            case $question instanceof ChoiceQuestion:
-                $choices = $question->getChoices();
-                $text = sprintf('<info>%s</info> [<comment>%s</comment>]', $text, OutputFormatter::escape($choices[$default] ?? $default));
-
-                break;
-
-            default:
-                $text = sprintf('<info>%s</info> [<comment>%s</comment>]', $text, OutputFormatter::escape($default));
-
-                break;
-        }
+        $text = match (true) {
+            null === $default => sprintf('<info>%s</info>', $text),
+            $question instanceof ConfirmationQuestion => sprintf('<info>%s (yes/no)</info> [<comment>%s</comment>]', $text, $default ? 'yes' : 'no'),
+            $question instanceof ChoiceQuestion => sprintf('<info>%s</info> [<comment>%s</comment>]', $text, OutputFormatter::escape($question->getChoices()[$default] ?? $default)),
+            default => sprintf('<info>%s</info> [<comment>%s</comment>]', $text, OutputFormatter::escape($default)),
+        };
 
         $output->writeln($text);
 

--- a/src/Illuminate/Support/Env.php
+++ b/src/Illuminate/Support/Env.php
@@ -253,26 +253,13 @@ class Env
     {
         return Option::fromValue(static::getRepository()->get($key))
             ->map(function ($value) {
-                switch (strtolower($value)) {
-                    case 'true':
-                    case '(true)':
-                        return true;
-                    case 'false':
-                    case '(false)':
-                        return false;
-                    case 'empty':
-                    case '(empty)':
-                        return '';
-                    case 'null':
-                    case '(null)':
-                        return;
-                }
-
-                if (preg_match('/\A([\'"])(.*)\1\z/', $value, $matches)) {
-                    return $matches[2];
-                }
-
-                return $value;
+                return match (strtolower($value)) {
+                    'true', '(true)' => true,
+                    'false', '(false)' => false,
+                    'empty', '(empty)' => '',
+                    'null', '(null)' => null,
+                    default => preg_match('/\A([\'"])(.*)\1\z/', $value, $matches) ? $matches[2] : $value,
+                };
             });
     }
 


### PR DESCRIPTION
This PR replaces switch statements with PHP 8.0 match expressions where applicable, resulting in cleaner and more concise code.

### Changes

- `Console/QuestionHelper.php` - Convert question type formatting switch to match expression
- `Collections/Traits/EnumeratesValues.php` - Convert operator comparison switch to match expression  
- `Support/Env.php` - Convert environment variable parsing switch to match expression, consolidating the post-switch logic into the default arm