### PR TITLE
[13.x] Use first-class callable syntax

### DIFF
--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -229,7 +229,7 @@ abstract class Grammar
     public function quoteString($value)
     {
         if (is_array($value)) {
-            return implode(', ', array_map([$this, __FUNCTION__], $value));
+            return implode(', ', array_map($this->quoteString(...), $value));
         }
 
         return "'$value'";

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -1037,7 +1037,7 @@ class SqlServerGrammar extends Grammar
     public function quoteString($value)
     {
         if (is_array($value)) {
-            return implode(', ', array_map([$this, __FUNCTION__], $value));
+            return implode(', ', array_map($this->quoteString(...), $value));
         }
 
         return "N'$value'";

--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -292,7 +292,7 @@ abstract class Component
     {
         return $method->getNumberOfParameters() === 0
             ? $this->createInvokableVariable($method->getName())
-            : Closure::fromCallable([$this, $method->getName()]);
+            : $this->{$method->getName()}(...);
     }
 
     /**


### PR DESCRIPTION
This PR replaces legacy array callable syntax and `Closure::fromCallable()` with PHP 8.1 first-class callable syntax for cleaner, more modern code.

### Changes

- `Database/Grammar.php` - Replace `[$this, __FUNCTION__]` with `$this->quoteString(...)`
- `Database/Schema/Grammars/SqlServerGrammar.php` - Replace `[$this, __FUNCTION__]` with `$this->quoteString(...)`
- `View/Component.php` - Replace `Closure::fromCallable([$this, $method->getName()])` with `$this->{$method->getName()}(...)`