### PR TITLE
[13.x] Use ::class syntax instead of get_class()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
@@ -246,7 +246,7 @@ trait GuardsAttributes
             return true;
         }
 
-        if (! isset(static::$guardableColumns[get_class($this)])) {
+        if (! isset(static::$guardableColumns[$this::class])) {
             $columns = $this->getConnection()
                 ->getSchemaBuilder()
                 ->getColumnListing($this->getTable());
@@ -255,10 +255,10 @@ trait GuardsAttributes
                 return true;
             }
 
-            static::$guardableColumns[get_class($this)] = $columns;
+            static::$guardableColumns[$this::class] = $columns;
         }
 
-        return in_array($key, static::$guardableColumns[get_class($this)]);
+        return in_array($key, static::$guardableColumns[$this::class]);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -671,17 +671,17 @@ trait HasAttributes
      */
     public function hasAttributeMutator($key)
     {
-        if (isset(static::$attributeMutatorCache[get_class($this)][$key])) {
-            return static::$attributeMutatorCache[get_class($this)][$key];
+        if (isset(static::$attributeMutatorCache[$this::class][$key])) {
+            return static::$attributeMutatorCache[$this::class][$key];
         }
 
         if (! method_exists($this, $method = Str::camel($key))) {
-            return static::$attributeMutatorCache[get_class($this)][$key] = false;
+            return static::$attributeMutatorCache[$this::class][$key] = false;
         }
 
         $returnType = (new ReflectionMethod($this, $method))->getReturnType();
 
-        return static::$attributeMutatorCache[get_class($this)][$key] =
+        return static::$attributeMutatorCache[$this::class][$key] =
                     $returnType instanceof ReflectionNamedType &&
                     $returnType->getName() === Attribute::class;
     }
@@ -694,15 +694,15 @@ trait HasAttributes
      */
     public function hasAttributeGetMutator($key)
     {
-        if (isset(static::$getAttributeMutatorCache[get_class($this)][$key])) {
-            return static::$getAttributeMutatorCache[get_class($this)][$key];
+        if (isset(static::$getAttributeMutatorCache[$this::class][$key])) {
+            return static::$getAttributeMutatorCache[$this::class][$key];
         }
 
         if (! $this->hasAttributeMutator($key)) {
-            return static::$getAttributeMutatorCache[get_class($this)][$key] = false;
+            return static::$getAttributeMutatorCache[$this::class][$key] = false;
         }
 
-        return static::$getAttributeMutatorCache[get_class($this)][$key] = is_callable($this->{Str::camel($key)}()->get);
+        return static::$getAttributeMutatorCache[$this::class][$key] = is_callable($this->{Str::camel($key)}()->get);
     }
 
     /**
@@ -771,8 +771,8 @@ trait HasAttributes
     {
         if ($this->isClassCastable($key)) {
             $value = $this->getClassCastableAttributeValue($key, $value);
-        } elseif (isset(static::$getAttributeMutatorCache[get_class($this)][$key]) &&
-                  static::$getAttributeMutatorCache[get_class($this)][$key] === true) {
+        } elseif (isset(static::$getAttributeMutatorCache[$this::class][$key]) &&
+                  static::$getAttributeMutatorCache[$this::class][$key] === true) {
             $value = $this->mutateAttributeMarkedAttribute($key, $value);
 
             $value = $value instanceof DateTimeInterface
@@ -1151,7 +1151,7 @@ trait HasAttributes
      */
     public function hasAttributeSetMutator($key)
     {
-        $class = get_class($this);
+        $class = $this::class;
 
         if (isset(static::$setAttributeMutatorCache[$class][$key])) {
             return static::$setAttributeMutatorCache[$class][$key];

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -181,7 +181,7 @@ trait HasRelationships
      */
     protected function invokeRelationAutoloadCallbackFor($key, $tuples)
     {
-        $tuples = array_merge([[$key, get_class($this)]], $tuples);
+        $tuples = array_merge([[$key, $this::class]], $tuples);
 
         call_user_func($this->relationAutoloadCallback, $tuples);
     }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasUniqueStringIds.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasUniqueStringIds.php
@@ -103,6 +103,6 @@ trait HasUniqueStringIds
      */
     protected function handleInvalidUniqueId($value, $field)
     {
-        throw (new ModelNotFoundException)->setModel(get_class($this), $value);
+        throw (new ModelNotFoundException)->setModel($this::class, $value);
     }
 }

--- a/src/Illuminate/Database/Eloquent/Concerns/TransformsToResource.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/TransformsToResource.php
@@ -46,7 +46,7 @@ trait TransformsToResource
             }
         }
 
-        throw new LogicException(sprintf('Failed to find resource class for model [%s].', get_class($this)));
+        throw new LogicException(sprintf('Failed to find resource class for model [%s].', $this::class));
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -680,7 +680,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
                 } else {
                     throw new MassAssignmentException(sprintf(
                         'Add [%s] to fillable property to allow mass assignment on [%s].',
-                        $key, get_class($this)
+                        $key, $this::class
                     ));
                 }
             }
@@ -696,7 +696,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
                 throw new MassAssignmentException(sprintf(
                     'Add fillable property [%s] to allow mass assignment on [%s].',
                     implode(', ', $keys),
-                    get_class($this)
+                    $this::class
                 ));
             }
         }
@@ -2540,7 +2540,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function broadcastChannelRoute()
     {
-        return str_replace('\\', '.', get_class($this)).'.{'.Str::camel(class_basename($this)).'}';
+        return str_replace('\\', '.', $this::class).'.{'.Str::camel(class_basename($this)).'}';
     }
 
     /**
@@ -2550,7 +2550,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function broadcastChannel()
     {
-        return str_replace('\\', '.', get_class($this)).'.'.$this->getKey();
+        return str_replace('\\', '.', $this::class).'.'.$this->getKey();
     }
 
     /**

--- a/src/Illuminate/Database/Seeder.php
+++ b/src/Illuminate/Database/Seeder.php
@@ -177,7 +177,7 @@ abstract class Seeder
     public function __invoke(array $parameters = [])
     {
         if (! method_exists($this, 'run')) {
-            throw new InvalidArgumentException('Method [run] missing from '.get_class($this));
+            throw new InvalidArgumentException('Method [run] missing from '.$this::class);
         }
 
         $callback = fn () => isset($this->container)

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -546,7 +546,7 @@ class Kernel implements KernelContract
      */
     protected function shouldDiscoverCommands()
     {
-        return get_class($this) === __CLASS__;
+        return $this::class === __CLASS__;
     }
 
     /**

--- a/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
@@ -107,7 +107,7 @@ class EventServiceProvider extends ServiceProvider
         if ($this->app->eventsAreCached()) {
             $cache = require $this->app->getCachedEventsPath();
 
-            return $cache[get_class($this)] ?? [];
+            return $cache[$this::class] ?? [];
         } else {
             return array_merge_recursive(
                 $this->discoveredEvents(),
@@ -135,7 +135,7 @@ class EventServiceProvider extends ServiceProvider
      */
     public function shouldDiscoverEvents()
     {
-        return get_class($this) === __CLASS__ && static::$shouldDiscoverEvents === true;
+        return $this::class === __CLASS__ && static::$shouldDiscoverEvents === true;
     }
 
     /**

--- a/src/Illuminate/Http/Resources/CollectsResources.php
+++ b/src/Illuminate/Http/Resources/CollectsResources.php
@@ -72,8 +72,8 @@ trait CollectsResources
         } elseif ($this->collects) {
             $collects = $this->collects;
         } elseif (str_ends_with(class_basename($this), 'Collection') &&
-            (class_exists($class = Str::replaceLast('Collection', '', get_class($this))) ||
-             class_exists($class = Str::replaceLast('Collection', 'Resource', get_class($this))))) {
+            (class_exists($class = Str::replaceLast('Collection', '', $this::class)) ||
+             class_exists($class = Str::replaceLast('Collection', 'Resource', $this::class)))) {
             $collects = $class;
         }
 

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -395,7 +395,7 @@ class Mailable implements MailableContract, Renderable
     protected function additionalMessageData(): array
     {
         return [
-            '__laravel_mailable' => get_class($this),
+            '__laravel_mailable' => $this::class,
         ];
     }
 

--- a/src/Illuminate/Queue/SerializesModels.php
+++ b/src/Illuminate/Queue/SerializesModels.php
@@ -22,7 +22,7 @@ trait SerializesModels
         $reflectionClass = new ReflectionClass($this);
 
         [$class, $properties, $classLevelWithoutRelations] = [
-            get_class($this),
+            $this::class,
             $reflectionClass->getProperties(),
             ! empty($reflectionClass->getAttributes(WithoutRelations::class)),
         ];
@@ -74,7 +74,7 @@ trait SerializesModels
     {
         $properties = (new ReflectionClass($this))->getProperties();
 
-        $class = get_class($this);
+        $class = $this::class;
 
         foreach ($properties as $property) {
             if ($property->isStatic()) {

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -523,7 +523,7 @@ abstract class ServiceProvider
      */
     protected function getProviderKey(?string $key = null): string
     {
-        $key ??= (string) Str::of(get_class($this))
+        $key ??= (string) Str::of($this::class)
             ->classBasename()
             ->before('ServiceProvider')
             ->kebab()
@@ -531,7 +531,7 @@ abstract class ServiceProvider
             ->trim();
 
         if (empty($key)) {
-            $key = class_basename(get_class($this));
+            $key = class_basename($this::class);
         }
 
         return $key;

--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -235,7 +235,7 @@ abstract class Component
      */
     protected function extractPublicProperties()
     {
-        $class = get_class($this);
+        $class = $this::class;
 
         if (! isset(static::$propertyCache[$class])) {
             $reflection = new ReflectionClass($this);
@@ -263,7 +263,7 @@ abstract class Component
      */
     protected function extractPublicMethods()
     {
-        $class = get_class($this);
+        $class = $this::class;
 
         if (! isset(static::$methodCache[$class])) {
             $reflection = new ReflectionClass($this);


### PR DESCRIPTION
This PR replaces `get_class($this)` with the modern `$this::class` syntax available since PHP 8.0, across 14 files.

The `::class` syntax on objects is cleaner, more concise, and consistent with how class names are typically referenced in modern PHP.

### Changes

All replacements are `get_class($this)` → `$this::class` which is guaranteed safe since `$this` is always an object.

**Files modified:** GuardsAttributes, HasAttributes, HasRelationships, HasUniqueStringIds, TransformsToResource, Model, Seeder, Kernel, EventServiceProvider, CollectsResources, Mailable, SerializesModels, ServiceProvider, Component