### PR TITLE
[12.x] Add Str::sanitize() for HTML sanitization

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,7 @@
         "symfony/console": "^7.2.0",
         "symfony/error-handler": "^7.2.0",
         "symfony/finder": "^7.2.0",
+        "symfony/html-sanitizer": "^7.2.0",
         "symfony/http-foundation": "^7.2.0",
         "symfony/http-kernel": "^7.2.0",
         "symfony/mailer": "^7.2.0",

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -15,6 +15,8 @@ use Ramsey\Uuid\Generator\CombGenerator;
 use Ramsey\Uuid\Rfc4122\FieldsInterface;
 use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidFactory;
+use Symfony\Component\HtmlSanitizer\HtmlSanitizer;
+use Symfony\Component\HtmlSanitizer\HtmlSanitizerConfig;
 use Symfony\Component\Uid\Ulid;
 use Throwable;
 use Traversable;
@@ -1520,6 +1522,36 @@ class Str
     public static function singular($value)
     {
         return Pluralizer::singular($value);
+    }
+
+    /**
+     * Sanitize the given HTML string.
+     *
+     * @param  string  $html
+     * @param  array|(\Closure(\Symfony\Component\HtmlSanitizer\HtmlSanitizerConfig): \Symfony\Component\HtmlSanitizer\HtmlSanitizerConfig)  $config
+     * @return string
+     */
+    public static function sanitize(string $html, array|Closure $config = [])
+    {
+        if ($config instanceof Closure) {
+            return (new HtmlSanitizer($config(new HtmlSanitizerConfig())))->sanitize($html);
+        }
+
+        $sanitizerConfig = new HtmlSanitizerConfig();
+
+        if (empty($config)) {
+            $sanitizerConfig = $sanitizerConfig->allowSafeElements();
+        } else {
+            foreach ($config as $key => $value) {
+                if (is_int($key)) {
+                    $sanitizerConfig = $sanitizerConfig->allowElement($value);
+                } else {
+                    $sanitizerConfig = $sanitizerConfig->allowElement($key, $value);
+                }
+            }
+        }
+
+        return (new HtmlSanitizer($sanitizerConfig))->sanitize($html);
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1528,30 +1528,28 @@ class Str
      * Sanitize the given HTML string.
      *
      * @param  string  $html
-     * @param  array|(\Closure(\Symfony\Component\HtmlSanitizer\HtmlSanitizerConfig): \Symfony\Component\HtmlSanitizer\HtmlSanitizerConfig)  $config
+     * @param  array|(\Closure(\Symfony\Component\HtmlSanitizer\HtmlSanitizerConfig): \Symfony\Component\HtmlSanitizer\HtmlSanitizerConfig)  $allow
      * @return string
      */
-    public static function sanitize(string $html, array|Closure $config = [])
+    public static function sanitize(string $html, array|Closure $allow = [])
     {
-        if ($config instanceof Closure) {
-            return (new HtmlSanitizer($config(new HtmlSanitizerConfig())))->sanitize($html);
-        }
-
-        $sanitizerConfig = new HtmlSanitizerConfig();
-
-        if (empty($config)) {
-            $sanitizerConfig = $sanitizerConfig->allowSafeElements();
+        if ($allow instanceof Closure) {
+            $config = $allow(new HtmlSanitizerConfig());
         } else {
-            foreach ($config as $key => $value) {
-                if (is_int($key)) {
-                    $sanitizerConfig = $sanitizerConfig->allowElement($value);
-                } else {
-                    $sanitizerConfig = $sanitizerConfig->allowElement($key, $value);
-                }
+            $config = new HtmlSanitizerConfig();
+
+            if (empty($allow)) {
+                $config = $config->allowSafeElements();
+            }
+
+            foreach ($allow as $key => $value) {
+                $config = is_int($key)
+                    ? $config->allowElement($value)
+                    : $config->allowElement($key, $value);
             }
         }
 
-        return (new HtmlSanitizer($sanitizerConfig))->sanitize($html);
+        return (new HtmlSanitizer($config))->sanitize($html);
     }
 
     /**

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -819,6 +819,17 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
+     * Sanitize the HTML string.
+     *
+     * @param  array|(\Closure(\Symfony\Component\HtmlSanitizer\HtmlSanitizerConfig): \Symfony\Component\HtmlSanitizer\HtmlSanitizerConfig)  $config
+     * @return static
+     */
+    public function sanitize(array|Closure $config = [])
+    {
+        return new static(Str::sanitize($this->value, $config));
+    }
+
+    /**
      * Parse input from a string to a collection, according to a format.
      *
      * @param  string  $format

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -821,12 +821,12 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     /**
      * Sanitize the HTML string.
      *
-     * @param  array|(\Closure(\Symfony\Component\HtmlSanitizer\HtmlSanitizerConfig): \Symfony\Component\HtmlSanitizer\HtmlSanitizerConfig)  $config
+     * @param  array|(\Closure(\Symfony\Component\HtmlSanitizer\HtmlSanitizerConfig): \Symfony\Component\HtmlSanitizer\HtmlSanitizerConfig)  $allow
      * @return static
      */
-    public function sanitize(array|Closure $config = [])
+    public function sanitize(array|Closure $allow = [])
     {
-        return new static(Str::sanitize($this->value, $config));
+        return new static(Str::sanitize($this->value, $allow));
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -8,8 +8,8 @@ use Illuminate\Tests\Support\Fixtures\StringableObjectStub;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\UuidInterface;
-use Symfony\Component\HtmlSanitizer\HtmlSanitizerConfig;
 use ReflectionClass;
+use Symfony\Component\HtmlSanitizer\HtmlSanitizerConfig;
 use ValueError;
 
 class SupportStrTest extends TestCase

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -8,6 +8,7 @@ use Illuminate\Tests\Support\Fixtures\StringableObjectStub;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\UuidInterface;
+use Symfony\Component\HtmlSanitizer\HtmlSanitizerConfig;
 use ReflectionClass;
 use ValueError;
 
@@ -507,6 +508,32 @@ class SupportStrTest extends TestCase
         $this->assertEquals(["Class@anonymous\0/laravel/382.php:8$2ec", 'method'], Str::parseCallback("Class@anonymous\0/laravel/382.php:8$2ec@method", 'foo'));
         $this->assertEquals(["Class@anonymous\0/laravel/382.php:8$2ec", 'foo'], Str::parseCallback("Class@anonymous\0/laravel/382.php:8$2ec", 'foo'));
         $this->assertEquals(["Class@anonymous\0/laravel/382.php:8$2ec", null], Str::parseCallback("Class@anonymous\0/laravel/382.php:8$2ec"));
+    }
+
+    public function testSanitize()
+    {
+        $this->assertSame('', Str::sanitize(''));
+        $this->assertSame('hello world', Str::sanitize('hello world'));
+        $this->assertSame('<p>Hello </p>', Str::sanitize('<p>Hello <script>alert("xss")</script></p>'));
+        $this->assertSame('<p><strong>Bold</strong></p>', Str::sanitize('<p><strong>Bold</strong></p>'));
+        $this->assertSame('', Str::sanitize('<script>alert(1)</script>'));
+    }
+
+    public function testSanitizeWithAllowedElements()
+    {
+        $this->assertSame('<p><strong>Bold</strong> </p>', Str::sanitize('<p><strong>Bold</strong> <em>italic</em></p>', ['p', 'strong']));
+        $this->assertSame('<a href="https://laravel.com">Laravel</a>', Str::sanitize('<a href="https://laravel.com" onclick="evil()">Laravel</a>', ['a' => ['href']]));
+        $this->assertSame('<p><a href="https://laravel.com">link</a><em>hi</em></p>', Str::sanitize('<p><a href="https://laravel.com" onclick="x">link</a><em>hi</em></p>', ['p', 'a' => ['href'], 'em']));
+    }
+
+    public function testSanitizeWithClosure()
+    {
+        $result = Str::sanitize(
+            '<a href="http://example.com">Link</a>',
+            fn (HtmlSanitizerConfig $config) => $config->allowElement('a', ['href'])->forceHttpsUrls()
+        );
+
+        $this->assertSame('<a href="https://example.com">Link</a>', $result);
     }
 
     public function testSlug()

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -13,6 +13,7 @@ use Illuminate\Tests\Support\Fixtures\StringableObjectStub;
 use League\CommonMark\Environment\EnvironmentBuilderInterface;
 use League\CommonMark\Extension\ExtensionInterface;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HtmlSanitizer\HtmlSanitizerConfig;
 
 class SupportStringableTest extends TestCase
 {
@@ -878,6 +879,13 @@ class SupportStringableTest extends TestCase
         $this->assertEquals(['Class', 'method'], $this->stringable('Class@method')->parseCallback('foo'));
         $this->assertEquals(['Class', 'foo'], $this->stringable('Class')->parseCallback('foo'));
         $this->assertEquals(['Class', null], $this->stringable('Class')->parseCallback());
+    }
+
+    public function testSanitize()
+    {
+        $this->assertSame('<p>Hello </p>', (string) $this->stringable('<p>Hello <script>alert("xss")</script></p>')->sanitize());
+        $this->assertSame('<p><strong>Bold</strong> </p>', (string) $this->stringable('<p><strong>Bold</strong> <em>italic</em></p>')->sanitize(['p', 'strong']));
+        $this->assertSame('<a href="https://example.com">Link</a>', (string) $this->stringable('<a href="http://example.com">Link</a>')->sanitize(fn (HtmlSanitizerConfig $config) => $config->allowElement('a', ['href'])->forceHttpsUrls()));
     }
 
     public function testSlug()


### PR DESCRIPTION
## Summary

Adds `Str::sanitize()` and `Stringable::sanitize()` methods that wrap Symfony's `html-sanitizer` component, providing a clean API for HTML sanitization, following the same pattern as `Str::markdown()`.

### Usage

```php
// Safe defaults: allows Symfony's curated safe element list (no script, style, iframe, etc.)
Str::sanitize('<p>Hello <script>alert("xss")</script></p>');
// '<p>Hello </p>'

// Allow specific elements
Str::sanitize($html, ['p', 'a', 'strong', 'em']);

// Allow elements with specific attributes
Str::sanitize($html, ['a' => ['href', 'title'], 'img' => ['src', 'alt']]);

// Full control via closure for advanced configuration
Str::sanitize($html, fn (HtmlSanitizerConfig $config) => $config
    ->allowSafeElements()
    ->forceHttpsUrls()
    ->allowRelativeLinks()
);

// Fluent
Str::of($userInput)->sanitize()->toString();
```

## Motivation

Laravel has `e()` for escaping and `Str::markdown()` for rendering Markdown, but no built-in way to sanitize HTML, allowing safe elements through while stripping dangerous ones. This is a common need when accepting rich text input (WYSIWYG editors, user-submitted content, etc.). The current options are `strip_tags()` (too aggressive, removes everything) or pulling in a package.

This follows the same approach as `Str::markdown()`: a static method on `Str` that wraps a well-maintained library (`symfony/html-sanitizer`, same ecosystem as the 10+ Symfony packages Laravel already depends on) with a simple, expressive API.
