### PR TITLE
[12.x] Fix TypeError in Http::retry() when callback type-hints Throwable

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -1051,7 +1051,11 @@ class PendingRequest
                     }
 
                     try {
-                        $shouldRetry = $this->retryWhenCallback ? call_user_func($this->retryWhenCallback, $response->toException(), $this, $this->request->toPsrRequest()->getMethod()) : true;
+                        $exception = $response->toException();
+
+                        $shouldRetry = $this->retryWhenCallback
+                            ? ($exception ? call_user_func($this->retryWhenCallback, $exception, $this, $this->request->toPsrRequest()->getMethod()) : true)
+                            : true;
                     } catch (Exception $exception) {
                         $shouldRetry = false;
 
@@ -1238,11 +1242,11 @@ class PendingRequest
         }
 
         try {
-            $shouldRetry = $this->retryWhenCallback ? call_user_func(
-                $this->retryWhenCallback,
-                $response instanceof Response ? $response->toException() : $response,
-                $this
-            ) : true;
+            $exception = $response instanceof Response ? $response->toException() : $response;
+
+            $shouldRetry = $this->retryWhenCallback
+                ? ($exception ? call_user_func($this->retryWhenCallback, $exception, $this) : true)
+                : true;
         } catch (Exception $exception) {
             return $exception;
         }

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -2428,6 +2428,36 @@ class HttpClientTest extends TestCase
         $this->factory->assertSentCount(1);
     }
 
+    public function testRetryWhenCallbackWithExceptionTypeHintDoesNotThrowTypeErrorForNon4xxOr5xxResponses()
+    {
+        $this->factory->fake([
+            '*' => $this->factory->response(['redirect'], 301),
+        ]);
+
+        // Should not throw a TypeError when the when callback type-hints Exception
+        // and the response is a 3xx (where toException() returns null).
+        $response = $this->factory
+            ->retry(2, 0, fn (Exception $exception) => true, false)
+            ->get('http://foo.com/get');
+
+        $this->assertSame(301, $response->status());
+    }
+
+    public function testRetryWhenCallbackWithThrowableTypeHintDoesNotThrowTypeErrorForNon4xxOr5xxResponses()
+    {
+        $this->factory->fake([
+            '*' => $this->factory->response(['redirect'], 301),
+        ]);
+
+        // Should not throw a TypeError when the when callback type-hints Throwable
+        // and the response is a 3xx (where toException() returns null).
+        $response = $this->factory
+            ->retry(2, 0, fn (\Throwable $exception) => true, false)
+            ->get('http://foo.com/get');
+
+        $this->assertSame(301, $response->status());
+    }
+
     public function testRequestsWillBeWaitingSleepMillisecondsReceivedBeforeRetry()
     {
         Sleep::fake();


### PR DESCRIPTION
## Summary

Fixes #59012

`Http::retry()` throws a `TypeError` when the `when` callback type-hints `Exception` or `Throwable` and the response is not a 4xx/5xx (e.g., a 3xx redirect). This happens because `$response->toException()` returns `null` for non-failed responses, and passing `null` to a callback expecting `Exception` causes the `TypeError`.

**Fix:** Extract `$response->toException()` into a variable first. If it's `null`, skip calling the `when` callback and default `$shouldRetry` to `true`. Applied in both `send()` and `handlePromiseResponse()`.

## Changes

| File | Change |
|------|--------|
| `PendingRequest.php` | Guard against null exception before invoking `when` callback in both sync and async paths |
| `HttpClientTest.php` | Add 2 tests for `Exception` and `Throwable` type-hints with non-4xx/5xx responses |

## Test Plan

- [x] `testRetryWhenCallbackWithExceptionTypeHintDoesNotThrowTypeErrorForNon4xxOr5xxResponses`
- [x] `testRetryWhenCallbackWithThrowableTypeHintDoesNotThrowTypeErrorForNon4xxOr5xxResponses`
- [x] All existing retry tests pass