### PR TITLE
[12.x] Don't fail database queue jobs on deadlock

### DIFF
--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -5,6 +5,7 @@ namespace Illuminate\Queue;
 use Illuminate\Contracts\Queue\ClearableQueue;
 use Illuminate\Contracts\Queue\Queue as QueueContract;
 use Illuminate\Database\Connection;
+use Illuminate\Database\DetectsConcurrencyErrors;
 use Illuminate\Queue\Jobs\DatabaseJob;
 use Illuminate\Queue\Jobs\DatabaseJobRecord;
 use Illuminate\Support\Carbon;
@@ -16,6 +17,7 @@ use Throwable;
 
 class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
 {
+    use DetectsConcurrencyErrors;
     /**
      * The database connection instance.
      *
@@ -295,8 +297,8 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
                 }
             });
         } catch (Throwable $e) {
-            // Potentially invalid job that we need to fail (#58978)...
-            if ($jobRecord) {
+            if ($jobRecord && ! $this->causedByConcurrencyError($e)) {
+                // Potentially invalid job that we need to fail (#58978)...
                 try {
                     (new DatabaseJob(
                         $this->container, $this, $jobRecord, $this->connectionName, $queue

--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -301,8 +301,8 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
                 return null;
             }
 
+            // Potentially invalid job that we need to fail (#58978)...
             if ($jobRecord) {
-                // Potentially invalid job that we need to fail (#58978)...
                 try {
                     (new DatabaseJob(
                         $this->container, $this, $jobRecord, $this->connectionName, $queue

--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -297,7 +297,11 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
                 }
             });
         } catch (Throwable $e) {
-            if ($jobRecord && ! $this->causedByConcurrencyError($e)) {
+            if ($this->causedByConcurrencyError($e)) {
+                return null;
+            }
+
+            if ($jobRecord) {
                 // Potentially invalid job that we need to fail (#58978)...
                 try {
                     (new DatabaseJob(

--- a/tests/Queue/QueueDatabaseQueueUnitTest.php
+++ b/tests/Queue/QueueDatabaseQueueUnitTest.php
@@ -8,6 +8,7 @@ use Illuminate\Container\Container;
 use Illuminate\Database\Connection;
 use Illuminate\Database\QueryException;
 use Illuminate\Queue\DatabaseQueue;
+use Illuminate\Queue\Jobs\DatabaseJobRecord;
 use Illuminate\Queue\Queue;
 use Illuminate\Support\Str;
 use Mockery as m;
@@ -202,16 +203,20 @@ class QueueDatabaseQueueUnitTest extends TestCase
     public function testPopReturnsNullOnDeadlock()
     {
         $queue = $this->getMockBuilder(DatabaseQueue::class)
-            ->onlyMethods(['deleteReserved'])
+            ->onlyMethods(['getNextAvailableJob', 'marshalJob', 'deleteReserved'])
             ->setConstructorArgs([$database = m::mock(Connection::class), 'table', 'default'])
             ->getMock();
 
         $queue->setContainer(m::mock(Container::class));
-        $queue->expects($this->never())->method('deleteReserved');
-
-        $database->shouldReceive('transaction')->andThrow(
+        $queue->method('getNextAvailableJob')->willReturn(m::mock(DatabaseJobRecord::class));
+        $queue->method('marshalJob')->willThrowException(
             new QueryException('mysql', '', [], new PDOException('SQLSTATE[40001]: Serialization failure: 1213 Deadlock found when trying to get lock; try restarting transaction'))
         );
+        $queue->expects($this->never())->method('deleteReserved');
+
+        $database->shouldReceive('transaction')->andReturnUsing(function ($callback) {
+            return $callback();
+        });
 
         $this->assertNull($queue->pop('default'));
     }

--- a/tests/Queue/QueueDatabaseQueueUnitTest.php
+++ b/tests/Queue/QueueDatabaseQueueUnitTest.php
@@ -6,10 +6,12 @@ use Carbon\Carbon;
 use Illuminate\Bus\Batchable;
 use Illuminate\Container\Container;
 use Illuminate\Database\Connection;
+use Illuminate\Database\QueryException;
 use Illuminate\Queue\DatabaseQueue;
 use Illuminate\Queue\Queue;
 use Illuminate\Support\Str;
 use Mockery as m;
+use PDOException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
@@ -195,6 +197,23 @@ class QueueDatabaseQueueUnitTest extends TestCase
         $record = $queue->buildDatabaseRecord('queue', 'any_payload', 0);
         $this->assertArrayHasKey('payload', $record);
         $this->assertArrayHasKey('payload', array_slice($record, -1, 1, true));
+    }
+
+    public function testPopReturnsNullOnDeadlock()
+    {
+        $queue = $this->getMockBuilder(DatabaseQueue::class)
+            ->onlyMethods(['deleteReserved'])
+            ->setConstructorArgs([$database = m::mock(Connection::class), 'table', 'default'])
+            ->getMock();
+
+        $queue->setContainer(m::mock(Container::class));
+        $queue->expects($this->never())->method('deleteReserved');
+
+        $database->shouldReceive('transaction')->andThrow(
+            new QueryException('mysql', '', [], new PDOException('SQLSTATE[40001]: Serialization failure: 1213 Deadlock found when trying to get lock; try restarting transaction'))
+        );
+
+        $this->assertNull($queue->pop('default'));
     }
 }
 


### PR DESCRIPTION
The index added in https://github.com/laravel/framework/pull/59111 seems to have caused a lot of deadlocks, at least for me, which means I now have a lot of failed jobs, and logs due to concurrency errors,  because I have a lot of workers listening on the same queues, rather than just one. 

Rather than reverting that PR, thought I'd try this as I guess the index is useful still. But up to you 👍🏻 

Currently I have a bunch of jobs in the `failed_jobs` table, where concurrency issues happen during `marshalJob` / `markJobAsReserved`

This PR returns null on concurrency errors so the worker moves on quietly, leaving the job available for the next poll and stops spamming logs.

Added a test for regression too.


<details>
<summary> Images / Trace here </summary>

<img width="535" height="133" alt="image" src="https://github.com/user-attachments/assets/4f8e6554-cea3-4fd8-9633-226c9c6f1622" />

```
1213 Deadlock found when trying to get lock; try restarting transaction (Connection: mysql, Host: xxxx), Port: 3306, Database: zzzz, SQL: update `jobs` set `reserved_at` = 1773439353, `attempts` = 1 where `id` = 112812452)

/srv/app/my-secret-app/x/vendor/laravel/framework/src/Illuminate/Queue/DatabaseQueue.php:422                                                          
/srv/app/my-secret-app/x/vendor/laravel/framework/src/Illuminate/Queue/DatabaseQueue.php:408                                                                                    
/srv/app/my-secret-app/x/vendor/laravel/framework/src/Illuminate/Queue/DatabaseQueue.php:294
```
</details> 