### PR TITLE
[12.x] Add fluent string validation rule builder

### DIFF
--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -21,6 +21,7 @@ use Illuminate\Validation\Rules\NotIn;
 use Illuminate\Validation\Rules\Numeric;
 use Illuminate\Validation\Rules\ProhibitedIf;
 use Illuminate\Validation\Rules\RequiredIf;
+use Illuminate\Validation\Rules\StringRule;
 use Illuminate\Validation\Rules\Unique;
 
 class Rule
@@ -243,6 +244,16 @@ class Rule
     public static function dimensions(array $constraints = [])
     {
         return new Dimensions($constraints);
+    }
+
+    /**
+     * Get a string rule builder instance.
+     *
+     * @return \Illuminate\Validation\Rules\StringRule
+     */
+    public static function string()
+    {
+        return new StringRule;
     }
 
     /**

--- a/src/Illuminate/Validation/Rules/StringRule.php
+++ b/src/Illuminate/Validation/Rules/StringRule.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+use Illuminate\Support\Arr;
+use Illuminate\Support\Traits\Conditionable;
+use Stringable;
+
+class StringRule implements Stringable
+{
+    use Conditionable;
+
+    /**
+     * The constraints for the string rule.
+     */
+    protected array $constraints = ['string'];
+
+    /**
+     * The field under validation must be entirely alphabetic characters.
+     *
+     * @param  bool  $ascii
+     * @return $this
+     */
+    public function alpha(bool $ascii = false): static
+    {
+        return $this->addRule($ascii ? 'alpha:ascii' : 'alpha');
+    }
+
+    /**
+     * The field under validation must be entirely alpha-numeric characters, dashes, and underscores.
+     *
+     * @param  bool  $ascii
+     * @return $this
+     */
+    public function alphaDash(bool $ascii = false): static
+    {
+        return $this->addRule($ascii ? 'alpha_dash:ascii' : 'alpha_dash');
+    }
+
+    /**
+     * The field under validation must be entirely alpha-numeric characters.
+     *
+     * @param  bool  $ascii
+     * @return $this
+     */
+    public function alphaNumeric(bool $ascii = false): static
+    {
+        return $this->addRule($ascii ? 'alpha_num:ascii' : 'alpha_num');
+    }
+
+    /**
+     * The field under validation must be entirely ASCII characters.
+     *
+     * @return $this
+     */
+    public function ascii(): static
+    {
+        return $this->addRule('ascii');
+    }
+
+    /**
+     * The field under validation must have a length between the given min and max (inclusive).
+     *
+     * @param  int  $min
+     * @param  int  $max
+     * @return $this
+     */
+    public function between(int $min, int $max): static
+    {
+        return $this->addRule('between:'.$min.','.$max);
+    }
+
+    /**
+     * The field under validation must not end with any of the given values.
+     *
+     * @param  string  ...$values
+     * @return $this
+     */
+    public function doesntEndWith(string ...$values): static
+    {
+        return $this->addRule('doesnt_end_with:'.implode(',', $values));
+    }
+
+    /**
+     * The field under validation must not start with any of the given values.
+     *
+     * @param  string  ...$values
+     * @return $this
+     */
+    public function doesntStartWith(string ...$values): static
+    {
+        return $this->addRule('doesnt_start_with:'.implode(',', $values));
+    }
+
+    /**
+     * The field under validation must end with one of the given values.
+     *
+     * @param  string  ...$values
+     * @return $this
+     */
+    public function endsWith(string ...$values): static
+    {
+        return $this->addRule('ends_with:'.implode(',', $values));
+    }
+
+    /**
+     * The field under validation must have an exact length.
+     *
+     * @param  int  $value
+     * @return $this
+     */
+    public function exactly(int $value): static
+    {
+        return $this->addRule('size:'.$value);
+    }
+
+    /**
+     * The field under validation must be entirely lowercase.
+     *
+     * @return $this
+     */
+    public function lowercase(): static
+    {
+        return $this->addRule('lowercase');
+    }
+
+    /**
+     * The field under validation must not exceed the given length.
+     *
+     * @param  int  $value
+     * @return $this
+     */
+    public function max(int $value): static
+    {
+        return $this->addRule('max:'.$value);
+    }
+
+    /**
+     * The field under validation must have a minimum length.
+     *
+     * @param  int  $value
+     * @return $this
+     */
+    public function min(int $value): static
+    {
+        return $this->addRule('min:'.$value);
+    }
+
+    /**
+     * The field under validation must start with one of the given values.
+     *
+     * @param  string  ...$values
+     * @return $this
+     */
+    public function startsWith(string ...$values): static
+    {
+        return $this->addRule('starts_with:'.implode(',', $values));
+    }
+
+    /**
+     * The field under validation must be entirely uppercase.
+     *
+     * @return $this
+     */
+    public function uppercase(): static
+    {
+        return $this->addRule('uppercase');
+    }
+
+    /**
+     * Convert the rule to a validation string.
+     */
+    public function __toString(): string
+    {
+        return implode('|', array_unique($this->constraints));
+    }
+
+    /**
+     * Add custom rules to the validation rules array.
+     */
+    protected function addRule(array|string $rules): static
+    {
+        $this->constraints = array_merge($this->constraints, Arr::wrap($rules));
+
+        return $this;
+    }
+}

--- a/tests/Validation/ValidationStringRuleTest.php
+++ b/tests/Validation/ValidationStringRuleTest.php
@@ -1,0 +1,229 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\Translator;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\StringRule;
+use Illuminate\Validation\Validator;
+use PHPUnit\Framework\TestCase;
+
+class ValidationStringRuleTest extends TestCase
+{
+    public function testDefaultStringRule()
+    {
+        $rule = Rule::string();
+        $this->assertSame('string', (string) $rule);
+
+        $rule = new StringRule();
+        $this->assertSame('string', (string) $rule);
+    }
+
+    public function testMinRule()
+    {
+        $rule = Rule::string()->min(3);
+        $this->assertSame('string|min:3', (string) $rule);
+    }
+
+    public function testMaxRule()
+    {
+        $rule = Rule::string()->max(255);
+        $this->assertSame('string|max:255', (string) $rule);
+    }
+
+    public function testBetweenRule()
+    {
+        $rule = Rule::string()->between(3, 255);
+        $this->assertSame('string|between:3,255', (string) $rule);
+    }
+
+    public function testExactlyRule()
+    {
+        $rule = Rule::string()->exactly(10);
+        $this->assertSame('string|size:10', (string) $rule);
+    }
+
+    public function testAlphaRule()
+    {
+        $rule = Rule::string()->alpha();
+        $this->assertSame('string|alpha', (string) $rule);
+
+        $rule = Rule::string()->alpha(ascii: true);
+        $this->assertSame('string|alpha:ascii', (string) $rule);
+    }
+
+    public function testAlphaNumericRule()
+    {
+        $rule = Rule::string()->alphaNumeric();
+        $this->assertSame('string|alpha_num', (string) $rule);
+
+        $rule = Rule::string()->alphaNumeric(ascii: true);
+        $this->assertSame('string|alpha_num:ascii', (string) $rule);
+    }
+
+    public function testAlphaDashRule()
+    {
+        $rule = Rule::string()->alphaDash();
+        $this->assertSame('string|alpha_dash', (string) $rule);
+
+        $rule = Rule::string()->alphaDash(ascii: true);
+        $this->assertSame('string|alpha_dash:ascii', (string) $rule);
+    }
+
+    public function testAsciiRule()
+    {
+        $rule = Rule::string()->ascii();
+        $this->assertSame('string|ascii', (string) $rule);
+    }
+
+    public function testUppercaseRule()
+    {
+        $rule = Rule::string()->uppercase();
+        $this->assertSame('string|uppercase', (string) $rule);
+    }
+
+    public function testLowercaseRule()
+    {
+        $rule = Rule::string()->lowercase();
+        $this->assertSame('string|lowercase', (string) $rule);
+    }
+
+    public function testStartsWithRule()
+    {
+        $rule = Rule::string()->startsWith('foo');
+        $this->assertSame('string|starts_with:foo', (string) $rule);
+
+        $rule = Rule::string()->startsWith('foo', 'bar');
+        $this->assertSame('string|starts_with:foo,bar', (string) $rule);
+    }
+
+    public function testEndsWithRule()
+    {
+        $rule = Rule::string()->endsWith('.com');
+        $this->assertSame('string|ends_with:.com', (string) $rule);
+
+        $rule = Rule::string()->endsWith('.com', '.org');
+        $this->assertSame('string|ends_with:.com,.org', (string) $rule);
+    }
+
+    public function testDoesntStartWithRule()
+    {
+        $rule = Rule::string()->doesntStartWith('foo');
+        $this->assertSame('string|doesnt_start_with:foo', (string) $rule);
+
+        $rule = Rule::string()->doesntStartWith('foo', 'bar');
+        $this->assertSame('string|doesnt_start_with:foo,bar', (string) $rule);
+    }
+
+    public function testDoesntEndWithRule()
+    {
+        $rule = Rule::string()->doesntEndWith('.exe');
+        $this->assertSame('string|doesnt_end_with:.exe', (string) $rule);
+
+        $rule = Rule::string()->doesntEndWith('.exe', '.bat');
+        $this->assertSame('string|doesnt_end_with:.exe,.bat', (string) $rule);
+    }
+
+    public function testChainedRules()
+    {
+        $rule = Rule::string()
+            ->min(3)
+            ->max(255)
+            ->alpha()
+            ->uppercase();
+        $this->assertSame('string|min:3|max:255|alpha|uppercase', (string) $rule);
+
+        $rule = Rule::string()
+            ->between(1, 100)
+            ->when(true, function ($rule) {
+                $rule->startsWith('prefix');
+            })
+            ->unless(true, function ($rule) {
+                $rule->endsWith('suffix');
+            });
+        $this->assertSame('string|between:1,100|starts_with:prefix', (string) $rule);
+    }
+
+    public function testStringValidation()
+    {
+        $trans = new Translator(new ArrayLoader, 'en');
+
+        $rule = Rule::string();
+
+        $validator = new Validator(
+            $trans,
+            ['field' => 123],
+            ['field' => $rule]
+        );
+
+        $this->assertSame(
+            $trans->get('validation.string'),
+            $validator->errors()->first('field')
+        );
+
+        $validator = new Validator(
+            $trans,
+            ['field' => 'hello'],
+            ['field' => $rule]
+        );
+
+        $this->assertEmpty($validator->errors()->first('field'));
+
+        $rule = Rule::string()->min(3)->max(10);
+
+        $validator = new Validator(
+            $trans,
+            ['field' => 'hello'],
+            ['field' => $rule]
+        );
+
+        $this->assertEmpty($validator->errors()->first('field'));
+
+        $rule = Rule::string()->min(3)->max(10);
+
+        $validator = new Validator(
+            $trans,
+            ['field' => 'ab'],
+            ['field' => $rule]
+        );
+
+        $this->assertNotEmpty($validator->errors()->first('field'));
+
+        $rule = Rule::string()->min(3)->max(10);
+
+        $validator = new Validator(
+            $trans,
+            ['field' => 'this string is too long'],
+            ['field' => $rule]
+        );
+
+        $this->assertNotEmpty($validator->errors()->first('field'));
+
+        $rule = Rule::string()->uppercase();
+
+        $validator = new Validator(
+            $trans,
+            ['field' => 'HELLO'],
+            ['field' => $rule]
+        );
+
+        $this->assertEmpty($validator->errors()->first('field'));
+
+        $rule = Rule::string()->uppercase();
+
+        $validator = new Validator(
+            $trans,
+            ['field' => 'hello'],
+            ['field' => $rule]
+        );
+
+        $this->assertNotEmpty($validator->errors()->first('field'));
+    }
+
+    public function testUniquenessOfConstraints()
+    {
+        $rule = Rule::string()->alpha()->alpha();
+        $this->assertSame('string|alpha', (string) $rule);
+    }
+}


### PR DESCRIPTION
This PR adds a fluent `Rule::string()` validation rule builder, following the pattern established by `Rule::numeric()` and `Rule::date()`.

### Motivation

String is the most commonly used validation type, yet it's the only core type without a fluent builder. Developers currently have to memorize string rule names and their syntax (`alpha_dash:ascii`, `doesnt_start_with:foo,bar`), while numeric and date rules are fully discoverable through IDE autocomplete.

`Rule::string()` closes that gap, making string validation rules discoverable, readable, and consistent with the existing fluent API.

### Example usage

```php
// Before
'name' => 'string|min:3|max:255|alpha:ascii'

// After
'name' => Rule::string()->min(3)->max(255)->alpha(ascii: true)
```

Supports conditional rule building via `Conditionable`:

```php
Rule::string()
    ->min(3)
    ->when($requirePrefix, fn ($rule) => $rule->startsWith('prefix_'))
```

### Available methods

`alpha()`, `alphaDash()`, `alphaNumeric()`, `ascii()`, `between()`, `doesntEndWith()`, `doesntStartWith()`, `endsWith()`, `exactly()`, `lowercase()`, `max()`, `min()`, `startsWith()`, `uppercase()`

### Non-breaking

This is a purely additive change: a new `StringRule` class and a `Rule::string()` factory method. No existing functionality is modified. Existing string validation rules (`'string|min:3'`) continue to work as before.