### PR TITLE
[12.x] Update ValidationRuleParser to handle StringRule objects

### DIFF
--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -13,6 +13,7 @@ use Illuminate\Support\Str;
 use Illuminate\Validation\Rules\Date;
 use Illuminate\Validation\Rules\Exists;
 use Illuminate\Validation\Rules\Numeric;
+use Illuminate\Validation\Rules\StringRule;
 use Illuminate\Validation\Rules\Unique;
 
 class ValidationRuleParser
@@ -94,7 +95,7 @@ class ValidationRuleParser
         }
 
         if (is_object($rule)) {
-            if ($rule instanceof Date || $rule instanceof Numeric) {
+            if ($rule instanceof Date || $rule instanceof Numeric || $rule instanceof StringRule) {
                 return explode('|', (string) $rule);
             }
 
@@ -104,7 +105,7 @@ class ValidationRuleParser
         $rules = [];
 
         foreach ($rule as $value) {
-            if ($value instanceof Date || $value instanceof Numeric) {
+            if ($value instanceof Date || $value instanceof Numeric || $value instanceof StringRule) {
                 $rules = array_merge($rules, explode('|', (string) $value));
             } else {
                 $rules[] = $this->prepareRule($value, $attribute);


### PR DESCRIPTION
Tests be failing :

https://github.com/laravel/framework/actions/runs/23092672722/job/67079864853#step:7:246
https://github.com/laravel/framework/actions/runs/23092248664

StringRule was added, but it needs to handle chained rules like `|min`as per ValidationStringRuleTest. 

This PR makes sure everything passes as expected.


Could be worth adding a shared interface so less likely to be missed in future, but leaving it for now.