### PR TITLE
[12.x] Add fluent list validation rule builder

### DIFF
--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -17,6 +17,7 @@ use Illuminate\Validation\Rules\Exists;
 use Illuminate\Validation\Rules\File;
 use Illuminate\Validation\Rules\ImageFile;
 use Illuminate\Validation\Rules\In;
+use Illuminate\Validation\Rules\ListRule;
 use Illuminate\Validation\Rules\NotIn;
 use Illuminate\Validation\Rules\Numeric;
 use Illuminate\Validation\Rules\ProhibitedIf;
@@ -244,6 +245,16 @@ class Rule
     public static function dimensions(array $constraints = [])
     {
         return new Dimensions($constraints);
+    }
+
+    /**
+     * Get a list rule builder instance.
+     *
+     * @return \Illuminate\Validation\Rules\ListRule
+     */
+    public static function list()
+    {
+        return new ListRule;
     }
 
     /**

--- a/src/Illuminate/Validation/Rules/ListRule.php
+++ b/src/Illuminate/Validation/Rules/ListRule.php
@@ -231,6 +231,16 @@ class ListRule implements ValidationRule, DataAwareRule, ValidatorAwareRule
         );
 
         $subValidator->addCustomAttributes($this->validator->customAttributes);
+        $subValidator->customValues = $this->validator->customValues;
+        $subValidator->fallbackMessages = $this->validator->fallbackMessages;
+        $subValidator->extensions = $this->validator->extensions;
+        $subValidator->replacers = $this->validator->replacers;
+
+        try {
+            $subValidator->setPresenceVerifier($this->validator->getPresenceVerifier());
+        } catch (\RuntimeException) {
+            //
+        }
 
         $this->validator->messages()->merge($subValidator->messages());
     }

--- a/src/Illuminate/Validation/Rules/ListRule.php
+++ b/src/Illuminate/Validation/Rules/ListRule.php
@@ -1,0 +1,237 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\DataAwareRule;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Contracts\Validation\ValidatorAwareRule;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Traits\Conditionable;
+use Illuminate\Validation\Validator;
+
+class ListRule implements ValidationRule, DataAwareRule, ValidatorAwareRule
+{
+    use Conditionable;
+
+    /**
+     * The rules that each item in the list must pass.
+     */
+    protected array $itemRules = [];
+
+    /**
+     * The minimum number of items in the list.
+     */
+    protected ?int $min = null;
+
+    /**
+     * The maximum number of items in the list.
+     */
+    protected ?int $max = null;
+
+    /**
+     * The exact number of items the list must contain.
+     */
+    protected ?int $size = null;
+
+    /**
+     * The distinct validation mode (null, '', 'strict', or 'ignore_case').
+     */
+    protected ?string $distinctMode = null;
+
+    /**
+     * The data under validation.
+     */
+    protected array $data = [];
+
+    /**
+     * The validator performing the validation.
+     */
+    protected Validator $validator;
+
+    /**
+     * The list must have a number of items between the given min and max (inclusive).
+     *
+     * @param  int  $min
+     * @param  int  $max
+     * @return $this
+     */
+    public function between(int $min, int $max): static
+    {
+        $this->min = $min;
+        $this->max = $max;
+        $this->size = null;
+
+        return $this;
+    }
+
+    /**
+     * The list items must all be distinct.
+     *
+     * @return $this
+     */
+    public function distinct(): static
+    {
+        $this->distinctMode = '';
+
+        return $this;
+    }
+
+    /**
+     * The list items must all be distinct using strict comparison.
+     *
+     * @return $this
+     */
+    public function distinctStrict(): static
+    {
+        $this->distinctMode = 'strict';
+
+        return $this;
+    }
+
+    /**
+     * The list items must all be distinct (case-insensitive).
+     *
+     * @return $this
+     */
+    public function distinctIgnoreCase(): static
+    {
+        $this->distinctMode = 'ignore_case';
+
+        return $this;
+    }
+
+    /**
+     * The list must contain exactly the given number of items.
+     *
+     * @param  int  $value
+     * @return $this
+     */
+    public function size(int $value): static
+    {
+        $this->size = $value;
+        $this->min = null;
+        $this->max = null;
+
+        return $this;
+    }
+
+    /**
+     * The list must not have more than the given number of items.
+     *
+     * @param  int  $value
+     * @return $this
+     */
+    public function max(int $value): static
+    {
+        $this->max = $value;
+        $this->size = null;
+
+        return $this;
+    }
+
+    /**
+     * The list must have at least the given number of items.
+     *
+     * @param  int  $value
+     * @return $this
+     */
+    public function min(int $value): static
+    {
+        $this->min = $value;
+        $this->size = null;
+
+        return $this;
+    }
+
+    /**
+     * Each item in the list must pass the given validation rules.
+     *
+     * @param  array|string  $rules
+     * @return $this
+     */
+    public function of(array|string $rules): static
+    {
+        $this->itemRules = Arr::wrap($rules);
+
+        return $this;
+    }
+
+    /**
+     * Set the data under validation.
+     *
+     * @param  array  $data
+     * @return $this
+     */
+    public function setData(array $data): static
+    {
+        $this->data = $data;
+
+        return $this;
+    }
+
+    /**
+     * Set the current validator.
+     *
+     * @param  \Illuminate\Validation\Validator  $validator
+     * @return $this
+     */
+    public function setValidator(Validator $validator): static
+    {
+        $this->validator = $validator;
+
+        return $this;
+    }
+
+    /**
+     * Run the validation rule.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  \Closure(string, ?string=): \Illuminate\Translation\PotentiallyTranslatedString  $fail
+     * @return void
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (! is_array($value) || ! array_is_list($value)) {
+            $fail('validation.list');
+
+            return;
+        }
+
+        $count = count($value);
+
+        if ($this->size !== null && $count !== $this->size) {
+            $fail('validation.size.array')->translate(['size' => $this->size]);
+        }
+
+        if ($this->min !== null && $count < $this->min) {
+            $fail('validation.min.array')->translate(['min' => $this->min]);
+        }
+
+        if ($this->max !== null && $count > $this->max) {
+            $fail('validation.max.array')->translate(['max' => $this->max]);
+        }
+
+        $itemRules = $this->itemRules;
+
+        if ($this->distinctMode !== null) {
+            $itemRules[] = $this->distinctMode !== '' ? 'distinct:'.$this->distinctMode : 'distinct';
+        }
+
+        if (empty($itemRules)) {
+            return;
+        }
+
+        $subValidator = new Validator(
+            $this->validator->getTranslator(),
+            $this->data,
+            [$attribute.'.*' => $itemRules],
+            $this->validator->customMessages,
+        );
+
+        $subValidator->addCustomAttributes($this->validator->customAttributes);
+
+        $this->validator->messages()->merge($subValidator->messages());
+    }
+}

--- a/tests/Validation/ValidationListRuleTest.php
+++ b/tests/Validation/ValidationListRuleTest.php
@@ -1,0 +1,220 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\Translator;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\ListRule;
+use Illuminate\Validation\Validator;
+use PHPUnit\Framework\TestCase;
+
+class ValidationListRuleTest extends TestCase
+{
+    protected Translator $translator;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->translator = new Translator(new ArrayLoader, 'en');
+    }
+
+    public function testDefaultListRule()
+    {
+        $rule = Rule::list();
+        $this->assertInstanceOf(ListRule::class, $rule);
+    }
+
+    public function testDefaultListPassesSequentialArray()
+    {
+        $this->passes(Rule::list(), [1, 2, 3]);
+        $this->passes(Rule::list(), ['a', 'b', 'c']);
+        $this->passes(Rule::list(), []);
+    }
+
+    public function testDefaultListFailsAssociativeArray()
+    {
+        $this->fails(Rule::list(), ['a' => 1, 'b' => 2]);
+        $this->fails(Rule::list(), 'not-an-array');
+        $this->fails(Rule::list(), 123);
+    }
+
+    public function testOfTypeRule()
+    {
+        $this->passes(Rule::list()->of('integer'), [1, 2, 3]);
+        $this->fails(Rule::list()->of('integer'), ['a', 'b', 'c']);
+        $this->fails(Rule::list()->of('integer'), [1, 'a', 3]);
+
+        $this->passes(Rule::list()->of('string'), ['a', 'b', 'c']);
+        $this->fails(Rule::list()->of('string'), [1, 2, 3]);
+    }
+
+    public function testOfWithArrayRules()
+    {
+        $this->passes(Rule::list()->of(['string', 'min:2']), ['ab', 'cd']);
+        $this->fails(Rule::list()->of(['string', 'min:2']), ['a']);
+        $this->fails(Rule::list()->of(['string', 'min:2']), [1, 2]);
+    }
+
+    public function testMinRule()
+    {
+        $this->passes(Rule::list()->min(2), [1, 2]);
+        $this->passes(Rule::list()->min(2), [1, 2, 3]);
+        $this->fails(Rule::list()->min(2), [1]);
+        $this->fails(Rule::list()->min(2), []);
+    }
+
+    public function testMaxRule()
+    {
+        $this->passes(Rule::list()->max(3), [1, 2, 3]);
+        $this->passes(Rule::list()->max(3), [1, 2]);
+        $this->fails(Rule::list()->max(3), [1, 2, 3, 4]);
+    }
+
+    public function testBetweenRule()
+    {
+        $this->passes(Rule::list()->between(2, 4), [1, 2]);
+        $this->passes(Rule::list()->between(2, 4), [1, 2, 3]);
+        $this->passes(Rule::list()->between(2, 4), [1, 2, 3, 4]);
+        $this->fails(Rule::list()->between(2, 4), [1]);
+        $this->fails(Rule::list()->between(2, 4), [1, 2, 3, 4, 5]);
+    }
+
+    public function testSizeRule()
+    {
+        $this->passes(Rule::list()->size(3), [1, 2, 3]);
+        $this->fails(Rule::list()->size(3), [1, 2]);
+        $this->fails(Rule::list()->size(3), [1, 2, 3, 4]);
+    }
+
+    public function testDistinctRule()
+    {
+        $this->passes(Rule::list()->distinct(), [1, 2, 3]);
+        $this->fails(Rule::list()->distinct(), [1, 2, 2]);
+    }
+
+    public function testDistinctStrictRule()
+    {
+        $this->passes(Rule::list()->distinctStrict(), [1, '1']);
+        $this->fails(Rule::list()->distinctStrict(), [1, 1]);
+    }
+
+    public function testDistinctIgnoreCaseRule()
+    {
+        $this->fails(Rule::list()->distinctIgnoreCase(), ['a', 'A']);
+        $this->passes(Rule::list()->distinct(), ['a', 'A']);
+    }
+
+    public function testChainedRules()
+    {
+        $this->passes(Rule::list()->of('integer')->min(1)->max(5)->distinct(), [1, 2, 3]);
+        $this->fails(Rule::list()->of('integer')->min(1)->max(5)->distinct(), []);
+        $this->fails(Rule::list()->of('integer')->min(1)->max(5)->distinct(), [1, 1, 2]);
+        $this->fails(Rule::list()->of('integer')->min(1)->max(5)->distinct(), ['a', 'b']);
+        $this->fails(Rule::list()->of('integer')->min(1)->max(5)->distinct(), [1, 2, 3, 4, 5, 6]);
+    }
+
+    public function testErrorMessagesAppearOnIndexedKeys()
+    {
+        $validator = new Validator(
+            $this->translator,
+            ['field' => ['a', 'b', 'c']],
+            ['field' => Rule::list()->of('integer')],
+        );
+
+        $this->assertTrue($validator->fails());
+        $this->assertNotEmpty($validator->errors()->get('field.0'));
+        $this->assertNotEmpty($validator->errors()->get('field.1'));
+        $this->assertNotEmpty($validator->errors()->get('field.2'));
+    }
+
+    public function testCustomAttributesArePreserved()
+    {
+        $validator = new Validator(
+            $this->translator,
+            ['field' => ['a', 'b']],
+            ['field' => Rule::list()->of('integer')],
+        );
+
+        $validator->setCustomMessages([
+            'field.*.integer' => 'Custom message for :attribute.',
+        ]);
+
+        $validator->addCustomAttributes([
+            'field.0' => 'first item',
+        ]);
+
+        $this->assertTrue($validator->fails());
+        $this->assertContains('Custom message for first item.', $validator->errors()->get('field.0'));
+        $this->assertContains('Custom message for field.1.', $validator->errors()->get('field.1'));
+    }
+
+    public function testConditionalRules()
+    {
+        $this->passes(Rule::list()->when(true, fn ($rule) => $rule->of('string')), ['a', 'b']);
+        $this->fails(Rule::list()->when(true, fn ($rule) => $rule->of('string')), [1, 2]);
+    }
+
+    public function testNestedListRule()
+    {
+        $this->passes(Rule::list()->of([Rule::list()->of('integer')]), [[1, 2], [3, 4]]);
+        $this->fails(Rule::list()->of([Rule::list()->of('integer')]), [[1, 'a'], [3, 4]]);
+        $this->fails(Rule::list()->of([Rule::list()->of('integer')]), ['not-a-list', [3, 4]]);
+    }
+
+    public function testMinAndMaxCalledSeparately()
+    {
+        $this->passes(Rule::list()->min(2)->max(5), [1, 2]);
+        $this->passes(Rule::list()->min(2)->max(5), [1, 2, 3, 4, 5]);
+        $this->fails(Rule::list()->min(2)->max(5), [1]);
+        $this->fails(Rule::list()->min(2)->max(5), [1, 2, 3, 4, 5, 6]);
+    }
+
+    public function testNullValueFails()
+    {
+        $this->fails(Rule::list(), null);
+        $this->fails(Rule::list()->of('string'), null);
+        $this->fails(Rule::list()->min(1), null);
+    }
+
+    public function testOfWithValidationRuleObject()
+    {
+        $uppercaseRule = new class implements ValidationRule
+        {
+            public function validate(string $attribute, mixed $value, Closure $fail): void
+            {
+                if (strtoupper($value) !== $value) {
+                    $fail('The :attribute must be uppercase.');
+                }
+            }
+        };
+
+        $this->passes(Rule::list()->of([$uppercaseRule]), ['ABC', 'DEF']);
+        $this->fails(Rule::list()->of([$uppercaseRule]), ['abc', 'DEF']);
+    }
+
+    protected function passes($rule, $value)
+    {
+        $validator = new Validator(
+            $this->translator,
+            ['field' => $value],
+            ['field' => $rule],
+        );
+
+        $this->assertTrue($validator->passes(), 'Expected list input to pass.');
+    }
+
+    protected function fails($rule, $value)
+    {
+        $validator = new Validator(
+            $this->translator,
+            ['field' => $value],
+            ['field' => $rule],
+        );
+
+        $this->assertTrue($validator->fails(), 'Expected list input to fail.');
+    }
+}

--- a/tests/Validation/ValidationListRuleTest.php
+++ b/tests/Validation/ValidationListRuleTest.php
@@ -94,6 +94,7 @@ class ValidationListRuleTest extends TestCase
     {
         $this->passes(Rule::list()->distinct(), [1, 2, 3]);
         $this->fails(Rule::list()->distinct(), [1, 2, 2]);
+        $this->fails(Rule::list()->distinct(), [1, '1']);
     }
 
     public function testDistinctStrictRule()


### PR DESCRIPTION
This PR adds a fluent `Rule::list()` validation rule builder for validating sequential arrays (lists).

### Motivation

Laravel has fluent builders for `Rule::numeric()`, `Rule::date()`, and `Rule::string()`, but validating lists currently requires combining multiple string-based rules across `field` and `field.*`. `Rule::list()` provides a single, discoverable API for the most common list validation patterns.

### Example usage

```php
// Before
'tags' => 'list',
'tags.*' => 'string|distinct',

// After
'tags' => Rule::list()->of('string')->distinct()
```

Size constraints, item type validation, and distinct checks can be chained fluently:

```php
Rule::list()->of('integer')->min(1)->max(10)->distinctStrict()

Rule::list()->of(['string', 'min:3'])->between(2, 5)

Rule::list()->of([Rule::list()->of('integer')])->size(3)
```

Supports conditional rule building via `Conditionable`:

```php
Rule::list()
    ->of('string')
    ->when($requireUnique, fn ($rule) => $rule->distinct())
```

### Available methods

`between()`, `distinct()`, `distinctStrict()`, `distinctIgnoreCase()`, `max()`, `min()`, `of()`, `size()`

### Implementation details

Unlike `StringRule` and `Numeric` (which implement `Stringable`), `ListRule` implements `ValidationRule` with `DataAwareRule` and `ValidatorAwareRule`. This is necessary because `of()` and `distinct()` require `field.*` wildcard rules that cannot be expressed as a pipe-delimited string. Item-level validation errors are merged into the parent validator's message bag on their indexed keys (e.g. `field.0`, `field.1`), preserving custom messages and custom attributes from the parent validator.
