### PR TITLE
[12.x] Add fluent URL validation rule builder

### DIFF
--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -23,6 +23,7 @@ use Illuminate\Validation\Rules\ProhibitedIf;
 use Illuminate\Validation\Rules\RequiredIf;
 use Illuminate\Validation\Rules\StringRule;
 use Illuminate\Validation\Rules\Unique;
+use Illuminate\Validation\Rules\Url;
 
 class Rule
 {
@@ -254,6 +255,16 @@ class Rule
     public static function string()
     {
         return new StringRule;
+    }
+
+    /**
+     * Get a URL rule builder instance.
+     *
+     * @return \Illuminate\Validation\Rules\Url
+     */
+    public static function url()
+    {
+        return new Url;
     }
 
     /**

--- a/src/Illuminate/Validation/Rules/Url.php
+++ b/src/Illuminate/Validation/Rules/Url.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+use Illuminate\Support\Arr;
+use Illuminate\Support\Traits\Conditionable;
+use Stringable;
+
+class Url implements Stringable
+{
+    use Conditionable;
+
+    /**
+     * The constraints for the URL rule.
+     */
+    protected array $constraints = [];
+
+    /**
+     * The allowed URL schemes.
+     */
+    protected array $schemes = [];
+
+    /**
+     * The field under validation must be an active URL with a valid DNS record.
+     *
+     * @return $this
+     */
+    public function active(): static
+    {
+        return $this->addRule('active_url');
+    }
+
+    /**
+     * The field under validation must be a URL with an https scheme.
+     *
+     * @return $this
+     */
+    public function httpsOnly(): static
+    {
+        $this->schemes = ['https'];
+
+        return $this;
+    }
+
+    /**
+     * The field under validation must be a URL with one of the given schemes.
+     *
+     * @param  array|string  ...$schemes
+     * @return $this
+     */
+    public function schemes(array|string ...$schemes): static
+    {
+        $this->schemes = Arr::flatten($schemes);
+
+        return $this;
+    }
+
+    /**
+     * Convert the rule to a validation string.
+     */
+    public function __toString(): string
+    {
+        $url = empty($this->schemes) ? 'url' : 'url:'.implode(',', $this->schemes);
+
+        return empty($this->constraints)
+            ? $url
+            : $url.'|'.implode('|', array_unique($this->constraints));
+    }
+
+    /**
+     * Add custom rules to the validation rules array.
+     */
+    protected function addRule(array|string $rules): static
+    {
+        $this->constraints = array_merge($this->constraints, Arr::wrap($rules));
+
+        return $this;
+    }
+}

--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -14,6 +14,7 @@ use Illuminate\Validation\Rules\Date;
 use Illuminate\Validation\Rules\Exists;
 use Illuminate\Validation\Rules\Numeric;
 use Illuminate\Validation\Rules\Unique;
+use Illuminate\Validation\Rules\Url;
 
 class ValidationRuleParser
 {
@@ -94,7 +95,7 @@ class ValidationRuleParser
         }
 
         if (is_object($rule)) {
-            if ($rule instanceof Date || $rule instanceof Numeric) {
+            if ($rule instanceof Date || $rule instanceof Numeric || $rule instanceof Url) {
                 return explode('|', (string) $rule);
             }
 
@@ -104,7 +105,7 @@ class ValidationRuleParser
         $rules = [];
 
         foreach ($rule as $value) {
-            if ($value instanceof Date || $value instanceof Numeric) {
+            if ($value instanceof Date || $value instanceof Numeric || $value instanceof Url) {
                 $rules = array_merge($rules, explode('|', (string) $value));
             } else {
                 $rules[] = $this->prepareRule($value, $attribute);

--- a/tests/Validation/ValidationUrlRuleTest.php
+++ b/tests/Validation/ValidationUrlRuleTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\Translator;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\Url;
+use Illuminate\Validation\Validator;
+use PHPUnit\Framework\TestCase;
+
+class ValidationUrlRuleTest extends TestCase
+{
+    public function testDefaultUrlRule()
+    {
+        $rule = Rule::url();
+        $this->assertSame('url', (string) $rule);
+
+        $rule = new Url();
+        $this->assertSame('url', (string) $rule);
+    }
+
+    public function testSchemesRuleWithArray()
+    {
+        $rule = Rule::url()->schemes(['https']);
+        $this->assertSame('url:https', (string) $rule);
+
+        $rule = Rule::url()->schemes(['http', 'https']);
+        $this->assertSame('url:http,https', (string) $rule);
+    }
+
+    public function testSchemesRuleWithVariadic()
+    {
+        $rule = Rule::url()->schemes('https');
+        $this->assertSame('url:https', (string) $rule);
+
+        $rule = Rule::url()->schemes('http', 'https');
+        $this->assertSame('url:http,https', (string) $rule);
+    }
+
+    public function testSchemesReplacesOnSubsequentCalls()
+    {
+        $rule = Rule::url()->schemes(['http', 'https'])->schemes(['https']);
+        $this->assertSame('url:https', (string) $rule);
+    }
+
+    public function testHttpsOnlyRule()
+    {
+        $rule = Rule::url()->httpsOnly();
+        $this->assertSame('url:https', (string) $rule);
+    }
+
+    public function testActiveUrlRule()
+    {
+        $rule = Rule::url()->active();
+        $this->assertSame('url|active_url', (string) $rule);
+    }
+
+    public function testChainedRules()
+    {
+        $rule = Rule::url()
+            ->schemes(['https'])
+            ->active();
+        $this->assertSame('url:https|active_url', (string) $rule);
+    }
+
+    public function testUrlValidation()
+    {
+        $trans = new Translator(new ArrayLoader, 'en');
+
+        $rule = Rule::url();
+
+        $validator = new Validator(
+            $trans,
+            ['field' => 'not-a-url'],
+            ['field' => $rule]
+        );
+
+        $this->assertSame(
+            $trans->get('validation.url'),
+            $validator->errors()->first('field')
+        );
+
+        $validator = new Validator(
+            $trans,
+            ['field' => 'https://example.com'],
+            ['field' => $rule]
+        );
+
+        $this->assertEmpty($validator->errors()->first('field'));
+
+        $rule = Rule::url()->schemes(['https']);
+
+        $validator = new Validator(
+            $trans,
+            ['field' => 'https://example.com'],
+            ['field' => $rule]
+        );
+
+        $this->assertEmpty($validator->errors()->first('field'));
+
+        $rule = Rule::url()->schemes(['https']);
+
+        $validator = new Validator(
+            $trans,
+            ['field' => 'http://example.com'],
+            ['field' => $rule]
+        );
+
+        $this->assertSame(
+            $trans->get('validation.url'),
+            $validator->errors()->first('field')
+        );
+    }
+
+    public function testConditionalRules()
+    {
+        $rule = Rule::url()
+            ->when(true, function ($rule) {
+                $rule->httpsOnly();
+            });
+        $this->assertSame('url:https', (string) $rule);
+    }
+}


### PR DESCRIPTION
This PR adds a fluent `Rule::url()` validation rule builder, following the pattern established by `Rule::numeric()`, `Rule::date()`, and `Rule::string()`.

### Motivation

URL validation with scheme restrictions and active DNS checks currently requires memorizing string syntax (`url:https`, `active_url`). `Rule::url()` makes these options discoverable through IDE autocomplete and provides a readable, chainable API.

### Example usage

```php
// Before
'website' => 'url:https'
'website' => 'url:https|active_url'

// After
'website' => Rule::url()->httpsOnly()
'website' => Rule::url()->httpsOnly()->active()
```

Scheme restrictions can be set explicitly:

```php
Rule::url()->schemes('https', 'ftp')
Rule::url()->schemes(['http', 'https'])
```

Supports conditional rule building via `Conditionable`:

```php
Rule::url()
    ->when($requireSecure, fn ($rule) => $rule->httpsOnly())
```

### Available methods

`active()`, `httpsOnly()`, `schemes()`