### PR TITLE
[12.x] Add missing conditional validation rule builders

### DIFF
--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -13,6 +13,7 @@ use Illuminate\Validation\Rules\Dimensions;
 use Illuminate\Validation\Rules\Email;
 use Illuminate\Validation\Rules\Enum;
 use Illuminate\Validation\Rules\ExcludeIf;
+use Illuminate\Validation\Rules\ExcludeUnless;
 use Illuminate\Validation\Rules\Exists;
 use Illuminate\Validation\Rules\File;
 use Illuminate\Validation\Rules\ImageFile;
@@ -20,7 +21,9 @@ use Illuminate\Validation\Rules\In;
 use Illuminate\Validation\Rules\NotIn;
 use Illuminate\Validation\Rules\Numeric;
 use Illuminate\Validation\Rules\ProhibitedIf;
+use Illuminate\Validation\Rules\ProhibitedUnless;
 use Illuminate\Validation\Rules\RequiredIf;
+use Illuminate\Validation\Rules\RequiredUnless;
 use Illuminate\Validation\Rules\StringRule;
 use Illuminate\Validation\Rules\Unique;
 
@@ -154,6 +157,17 @@ class Rule
     }
 
     /**
+     * Get a required_unless rule builder instance.
+     *
+     * @param  (\Closure(): bool)|bool  $callback
+     * @return \Illuminate\Validation\Rules\RequiredUnless
+     */
+    public static function requiredUnless($callback)
+    {
+        return new RequiredUnless($callback);
+    }
+
+    /**
      * Get a exclude_if rule builder instance.
      *
      * @param  (\Closure(): bool)|bool  $callback
@@ -165,6 +179,17 @@ class Rule
     }
 
     /**
+     * Get a exclude_unless rule builder instance.
+     *
+     * @param  (\Closure(): bool)|bool  $callback
+     * @return \Illuminate\Validation\Rules\ExcludeUnless
+     */
+    public static function excludeUnless($callback)
+    {
+        return new ExcludeUnless($callback);
+    }
+
+    /**
      * Get a prohibited_if rule builder instance.
      *
      * @param  (\Closure(): bool)|bool  $callback
@@ -173,6 +198,17 @@ class Rule
     public static function prohibitedIf($callback)
     {
         return new ProhibitedIf($callback);
+    }
+
+    /**
+     * Get a prohibited_unless rule builder instance.
+     *
+     * @param  (\Closure(): bool)|bool  $callback
+     * @return \Illuminate\Validation\Rules\ProhibitedUnless
+     */
+    public static function prohibitedUnless($callback)
+    {
+        return new ProhibitedUnless($callback);
     }
 
     /**

--- a/src/Illuminate/Validation/Rules/ExcludeUnless.php
+++ b/src/Illuminate/Validation/Rules/ExcludeUnless.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+use Closure;
+use InvalidArgumentException;
+use Stringable;
+
+class ExcludeUnless implements Stringable
+{
+    /**
+     * The condition that validates the attribute.
+     *
+     * @var (\Closure(): bool)|bool
+     */
+    public $condition;
+
+    /**
+     * Create a new exclude validation rule based on a condition.
+     *
+     * @param  (\Closure(): bool)|bool  $condition
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function __construct($condition)
+    {
+        if ($condition instanceof Closure || is_bool($condition)) {
+            $this->condition = $condition;
+        } else {
+            throw new InvalidArgumentException('The provided condition must be a callable or boolean.');
+        }
+    }
+
+    /**
+     * Convert the rule to a validation string.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        if (is_callable($this->condition)) {
+            return call_user_func($this->condition) ? '' : 'exclude';
+        }
+
+        return $this->condition ? '' : 'exclude';
+    }
+}

--- a/src/Illuminate/Validation/Rules/ProhibitedUnless.php
+++ b/src/Illuminate/Validation/Rules/ProhibitedUnless.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+use Closure;
+use InvalidArgumentException;
+use Stringable;
+
+class ProhibitedUnless implements Stringable
+{
+    /**
+     * The condition that validates the attribute.
+     *
+     * @var (\Closure(): bool)|bool
+     */
+    public $condition;
+
+    /**
+     * Create a new prohibited validation rule based on a condition.
+     *
+     * @param  (\Closure(): bool)|bool  $condition
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function __construct($condition)
+    {
+        if ($condition instanceof Closure || is_bool($condition)) {
+            $this->condition = $condition;
+        } else {
+            throw new InvalidArgumentException('The provided condition must be a callable or boolean.');
+        }
+    }
+
+    /**
+     * Convert the rule to a validation string.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        if (is_callable($this->condition)) {
+            return call_user_func($this->condition) ? '' : 'prohibited';
+        }
+
+        return $this->condition ? '' : 'prohibited';
+    }
+}

--- a/src/Illuminate/Validation/Rules/RequiredUnless.php
+++ b/src/Illuminate/Validation/Rules/RequiredUnless.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+use Closure;
+use InvalidArgumentException;
+use Stringable;
+
+class RequiredUnless implements Stringable
+{
+    /**
+     * The condition that validates the attribute.
+     *
+     * @var (\Closure(): bool)|bool
+     */
+    public $condition;
+
+    /**
+     * Create a new required validation rule based on a condition.
+     *
+     * @param  (\Closure(): bool)|bool  $condition
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function __construct($condition)
+    {
+        if ($condition instanceof Closure || is_bool($condition)) {
+            $this->condition = $condition;
+        } else {
+            throw new InvalidArgumentException('The provided condition must be a callable or boolean.');
+        }
+    }
+
+    /**
+     * Convert the rule to a validation string.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        if (is_callable($this->condition)) {
+            return call_user_func($this->condition) ? '' : 'required';
+        }
+
+        return $this->condition ? '' : 'required';
+    }
+}

--- a/tests/Validation/ValidationExcludeUnlessRuleTest.php
+++ b/tests/Validation/ValidationExcludeUnlessRuleTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\Translator;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\ExcludeUnless;
+use Illuminate\Validation\Validator;
+use PHPUnit\Framework\TestCase;
+
+class ValidationExcludeUnlessRuleTest extends TestCase
+{
+    protected Translator $translator;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->translator = new Translator(new ArrayLoader, 'en');
+    }
+
+    public function testInstanceOf()
+    {
+        $this->assertInstanceOf(ExcludeUnless::class, Rule::excludeUnless(true));
+    }
+
+    public function testBooleanConditionTrue()
+    {
+        $rule = Rule::excludeUnless(true);
+        $this->assertSame('', (string) $rule);
+    }
+
+    public function testBooleanConditionFalse()
+    {
+        $rule = Rule::excludeUnless(false);
+        $this->assertSame('exclude', (string) $rule);
+    }
+
+    public function testClosureConditionTrue()
+    {
+        $rule = Rule::excludeUnless(fn () => true);
+        $this->assertSame('', (string) $rule);
+    }
+
+    public function testClosureConditionFalse()
+    {
+        $rule = Rule::excludeUnless(fn () => false);
+        $this->assertSame('exclude', (string) $rule);
+    }
+
+    public function testFieldIsExcludedWhenConditionFalse()
+    {
+        $validator = new Validator(
+            $this->translator,
+            ['name' => 'Taylor', 'extra' => 'value'],
+            [
+                'name' => 'required|string',
+                'extra' => [Rule::excludeUnless(false), 'string'],
+            ],
+        );
+
+        $this->assertTrue($validator->passes());
+        $this->assertArrayNotHasKey('extra', $validator->validated());
+    }
+
+    public function testFieldIsKeptWhenConditionTrue()
+    {
+        $validator = new Validator(
+            $this->translator,
+            ['name' => 'Taylor', 'extra' => 'value'],
+            [
+                'name' => 'required|string',
+                'extra' => [Rule::excludeUnless(true), 'string'],
+            ],
+        );
+
+        $this->assertTrue($validator->passes());
+        $this->assertArrayHasKey('extra', $validator->validated());
+    }
+
+    public function testInvalidConditionThrows()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        Rule::excludeUnless('invalid');
+    }
+}

--- a/tests/Validation/ValidationProhibitedUnlessRuleTest.php
+++ b/tests/Validation/ValidationProhibitedUnlessRuleTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\Translator;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\ProhibitedUnless;
+use Illuminate\Validation\Validator;
+use PHPUnit\Framework\TestCase;
+
+class ValidationProhibitedUnlessRuleTest extends TestCase
+{
+    protected Translator $translator;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->translator = new Translator(new ArrayLoader, 'en');
+    }
+
+    public function testInstanceOf()
+    {
+        $this->assertInstanceOf(ProhibitedUnless::class, Rule::prohibitedUnless(true));
+    }
+
+    public function testBooleanConditionTrue()
+    {
+        $rule = Rule::prohibitedUnless(true);
+        $this->assertSame('', (string) $rule);
+    }
+
+    public function testBooleanConditionFalse()
+    {
+        $rule = Rule::prohibitedUnless(false);
+        $this->assertSame('prohibited', (string) $rule);
+    }
+
+    public function testClosureConditionTrue()
+    {
+        $rule = Rule::prohibitedUnless(fn () => true);
+        $this->assertSame('', (string) $rule);
+    }
+
+    public function testClosureConditionFalse()
+    {
+        $rule = Rule::prohibitedUnless(fn () => false);
+        $this->assertSame('prohibited', (string) $rule);
+    }
+
+    public function testFieldIsProhibitedWhenConditionFalse()
+    {
+        $validator = new Validator(
+            $this->translator,
+            ['name' => 'Taylor', 'secret' => 'value'],
+            [
+                'name' => 'required|string',
+                'secret' => [Rule::prohibitedUnless(false)],
+            ],
+        );
+
+        $this->assertTrue($validator->fails());
+    }
+
+    public function testFieldIsAllowedWhenConditionTrue()
+    {
+        $validator = new Validator(
+            $this->translator,
+            ['name' => 'Taylor', 'secret' => 'value'],
+            [
+                'name' => 'required|string',
+                'secret' => [Rule::prohibitedUnless(true)],
+            ],
+        );
+
+        $this->assertTrue($validator->passes());
+    }
+
+    public function testInvalidConditionThrows()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        Rule::prohibitedUnless('invalid');
+    }
+}

--- a/tests/Validation/ValidationRequiredUnlessRuleTest.php
+++ b/tests/Validation/ValidationRequiredUnlessRuleTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\Translator;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\RequiredUnless;
+use Illuminate\Validation\Validator;
+use PHPUnit\Framework\TestCase;
+
+class ValidationRequiredUnlessRuleTest extends TestCase
+{
+    protected Translator $translator;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->translator = new Translator(new ArrayLoader, 'en');
+    }
+
+    public function testInstanceOf()
+    {
+        $this->assertInstanceOf(RequiredUnless::class, Rule::requiredUnless(true));
+    }
+
+    public function testBooleanConditionTrue()
+    {
+        $rule = Rule::requiredUnless(true);
+        $this->assertSame('', (string) $rule);
+    }
+
+    public function testBooleanConditionFalse()
+    {
+        $rule = Rule::requiredUnless(false);
+        $this->assertSame('required', (string) $rule);
+    }
+
+    public function testClosureConditionTrue()
+    {
+        $rule = Rule::requiredUnless(fn () => true);
+        $this->assertSame('', (string) $rule);
+    }
+
+    public function testClosureConditionFalse()
+    {
+        $rule = Rule::requiredUnless(fn () => false);
+        $this->assertSame('required', (string) $rule);
+    }
+
+    public function testFieldIsRequiredWhenConditionFalse()
+    {
+        $validator = new Validator(
+            $this->translator,
+            ['name' => 'Taylor'],
+            [
+                'name' => 'required|string',
+                'age' => [Rule::requiredUnless(false), 'integer'],
+            ],
+        );
+
+        $this->assertTrue($validator->fails());
+    }
+
+    public function testFieldIsOptionalWhenConditionTrue()
+    {
+        $validator = new Validator(
+            $this->translator,
+            ['name' => 'Taylor'],
+            [
+                'name' => 'required|string',
+                'age' => [Rule::requiredUnless(true), 'integer'],
+            ],
+        );
+
+        $this->assertTrue($validator->passes());
+    }
+
+    public function testInvalidConditionThrows()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        Rule::requiredUnless('invalid');
+    }
+}


### PR DESCRIPTION
This PR adds the missing `unless` counterparts to the existing conditional validation rule builders (`Rule::requiredIf()`, `Rule::excludeIf()`, `Rule::prohibitedIf()`).

### Motivation

Laravel provides `Rule::requiredIf()`, `Rule::excludeIf()`, and `Rule::prohibitedIf()` for closure/boolean-based conditional validation. However, the `unless` variants are missing. While you can negate the condition (`Rule::requiredIf(! $isFree)`), the `unless` form reads more naturally in many contexts and matches the naming convention users expect when they see the `If` variants exist.

### Example usage

```php
// Before: negate the condition manually
'coupon' => [Rule::excludeIf(! $hasSubscription), 'string']
'terms' => [Rule::requiredIf(! $isAdmin), 'accepted']
'legacy_field' => [Rule::prohibitedIf(! $allowLegacy)]

// After: express intent directly
'coupon' => [Rule::excludeUnless($hasSubscription), 'string']
'terms' => [Rule::requiredUnless($isAdmin), 'accepted']
'legacy_field' => [Rule::prohibitedUnless($allowLegacy)]
```

Works with closures too:

```php
Rule::requiredUnless(fn () => $this->user()->isAdmin())
Rule::excludeUnless(fn () => $this->hasActiveSubscription())
```

### Added

- `Rule::excludeUnless($callback)` - excludes the field when condition is false
- `Rule::requiredUnless($callback)` - requires the field when condition is false
- `Rule::prohibitedUnless($callback)` - prohibits the field when condition is false
