### PR TITLE
[12.x] Cache `Arr::undot()` result in `Rule::compile()` for repeated calls

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
@@ -37,6 +37,7 @@ use Illuminate\Support\Facades\ParallelTesting;
 use Illuminate\Support\Once;
 use Illuminate\Support\Sleep;
 use Illuminate\Support\Str;
+use Illuminate\Validation\Rule;
 use Illuminate\Validation\Validator;
 use Illuminate\View\Component;
 use Mockery;
@@ -197,6 +198,7 @@ trait InteractsWithTestCaseLifecycle
         TrustHosts::flushState();
         ValidateCsrfToken::flushState();
         Validator::flushState();
+        Rule::flushState();
         WorkCommand::flushState();
 
         if ($this->callbackException) {

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -310,6 +310,20 @@ class Rule
     }
 
     /**
+     * Cached undotted data from the last compile call.
+     *
+     * @var array|null
+     */
+    protected static $lastCompileData = null;
+
+    /**
+     * The undotted result for the cached compile data.
+     *
+     * @var array|null
+     */
+    protected static $lastCompileUndotted = null;
+
+    /**
      * Compile a set of rules for an attribute.
      *
      * @param  string  $attribute
@@ -319,9 +333,19 @@ class Rule
      */
     public static function compile($attribute, $rules, $data = null)
     {
-        $parser = new ValidationRuleParser(
-            Arr::undot(Arr::wrap($data))
-        );
+        // Cache the undotted data since compile() is often called repeatedly
+        // with the same $data (e.g. when using Rule::forEach over many items).
+        if ($data === null) {
+            $undotted = [];
+        } elseif ($data === static::$lastCompileData) {
+            $undotted = static::$lastCompileUndotted;
+        } else {
+            $undotted = Arr::undot(Arr::wrap($data));
+            static::$lastCompileData = $data;
+            static::$lastCompileUndotted = $undotted;
+        }
+
+        $parser = new ValidationRuleParser($undotted);
 
         if (is_array($rules) && ! array_is_list($rules)) {
             $nested = [];
@@ -336,5 +360,16 @@ class Rule
         }
 
         return $parser->explode(ValidationRuleParser::filterConditionalRules($rules, $data));
+    }
+
+    /**
+     * Flush the rule's global state.
+     *
+     * @return void
+     */
+    public static function flushState()
+    {
+        static::$lastCompileData = null;
+        static::$lastCompileUndotted = null;
     }
 }


### PR DESCRIPTION
When using `Rule::forEach` with large arrays, `Rule::compile()` is called once per array item. Each call runs `Arr::undot()` on the same flattened data array, which is O(n) per call. For 500 items with 2000 flattened entries, this produces ~381ms of redundant work.

Cache the undotted result and reuse it when the same data array is passed to consecutive `compile()` calls.

Before: 473ms for 500 items with `Rule::forEach`
After:   59ms for 500 items with `Rule::forEach` (-88%)

This PR addresses a remaining bottleneck from #49375

Edit: 
This PR is part of a series of PRs with the focus on improving validation performance. One of the repositories I work on does big exports/imports of which 75%+ of the time is spent validating despite doing 100s of insert queries. 

The performance improvements are made using the autoresearch principle followed by cherry-picking parts of the performance findings into small PRs like this one. 

The test failure will be fixed once #59207 is merged

I am open to targeting these improvements to 13.x as well, if we don't want to release them as part of 12.x
