### PR TITLE
[12.x] Skip placeholder replacements when message does not contain them

### DIFF
--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -422,6 +422,11 @@ trait FormatsMessages
      */
     protected function replaceIndexOrPositionPlaceholder($message, $attribute, $placeholder, ?Closure $modifier = null)
     {
+        if (! str_contains(strtolower($message), ':'.$placeholder) &&
+            ! str_contains(strtolower($message), '-'.$placeholder)) {
+            return $message;
+        }
+
         $segments = explode('.', $attribute);
 
         $modifier ??= fn ($value) => $value;
@@ -478,6 +483,10 @@ trait FormatsMessages
      */
     protected function replaceInputPlaceholder($message, $attribute)
     {
+        if (! str_contains($message, ':input')) {
+            return $message;
+        }
+
         $actualValue = $this->getValue($attribute);
 
         if (is_scalar($actualValue) || is_null($actualValue)) {


### PR DESCRIPTION
When generating validation error messages, `replaceIndexOrPositionPlaceholder` and `replaceInputPlaceholder` run on every message even when the message does not contain :index, `:position`, `:ordinal-position`, or `:input` placeholders.

The ordinal-position replacement is particularly expensive as it calls `Number::ordinal()` via the `intl` extension for every numeric segment in the attribute name.

For large array validation with many errors (e.g. 500 items failing validation), this adds significant overhead since these placeholders are rarely used in standard validation messages.

Adding a `str_contains` check before doing the work skips the unnecessary processing entirely.

Before: 259ms for 2500 validation errors
After:  104ms for 2500 validation errors (-60%)

Reduces overhead introduced by #47744 for large arrays

Edit: 
This PR is part of a series of PRs with the focus on improving validation performance. One of the repositories I work on does big exports/imports of which 75%+ of the time is spent validating despite doing 100s of insert queries. 

The performance improvements are made using the autoresearch principle followed by cherry-picking parts of the performance findings into small PRs like this one. 

The test failure will be fixed once #59207 is merged

I am open to targeting these improvements to 13.x as well, if we don't want to release them as part of 12.x
