### PR TITLE
[12.x] Cache parsed string rules in `ValidationRuleParser`

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
@@ -37,6 +37,7 @@ use Illuminate\Support\Facades\ParallelTesting;
 use Illuminate\Support\Once;
 use Illuminate\Support\Sleep;
 use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationRuleParser;
 use Illuminate\Validation\Validator;
 use Illuminate\View\Component;
 use Mockery;
@@ -197,6 +198,7 @@ trait InteractsWithTestCaseLifecycle
         TrustHosts::flushState();
         ValidateCsrfToken::flushState();
         Validator::flushState();
+        ValidationRuleParser::flushState();
         WorkCommand::flushState();
 
         if ($this->callbackException) {

--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -231,6 +231,13 @@ class ValidationRuleParser
     }
 
     /**
+     * Cache for parsed string rules.
+     *
+     * @var array
+     */
+    protected static $parseCache = [];
+
+    /**
      * Extract the rule name and parameters from a rule.
      *
      * @param  array|string  $rule
@@ -238,19 +245,37 @@ class ValidationRuleParser
      */
     public static function parse($rule)
     {
+        if (is_string($rule) && isset(static::$parseCache[$rule])) {
+            return static::$parseCache[$rule];
+        }
+
         if ($rule instanceof RuleContract || $rule instanceof CompilableRules) {
             return [$rule, []];
         }
 
         if (is_array($rule)) {
-            $rule = static::parseArrayRule($rule);
+            $parsed = static::parseArrayRule($rule);
         } else {
-            $rule = static::parseStringRule($rule);
+            $parsed = static::parseStringRule($rule);
         }
 
-        $rule[0] = static::normalizeRule($rule[0]);
+        $parsed[0] = static::normalizeRule($parsed[0]);
 
-        return $rule;
+        if (is_string($rule)) {
+            static::$parseCache[$rule] = $parsed;
+        }
+
+        return $parsed;
+    }
+
+    /**
+     * Flush the parse cache.
+     *
+     * @return void
+     */
+    public static function flushState()
+    {
+        static::$parseCache = [];
     }
 
     /**


### PR DESCRIPTION
`ValidationRuleParser::parse()` is called for every rule on every attribute during validation. For large array validation with wildcard rules (e.g. 500 items × 4 rules each), the same rule strings like `'required'`, `'string'`, `'max:255'` are parsed thousands of times. Each parse call does `Str::studly()`, `explode()`, `trim()`, and `normalizeRule()`.

Adding a static cache keyed by the rule string avoids this redundant work. Non-string rules (objects, arrays) bypass the cache. The cache is flushed via `flushState()` during test teardown.

Before: 432ms for 500 items with 14 wildcard rules
After:  338ms for the same (-22%)

Reduces per-rule overhead from #49375

Edit: 
This PR is part of a series of PRs with the focus on improving validation performance. One of the repositories I work on does big exports/imports of which 75%+ of the time is spent validating despite doing 100s of insert queries. 

The performance improvements are made using the autoresearch principle followed by cherry-picking parts of the performance findings into small PRs like this one. 

The test failure will be fixed once #59207 is merged

I am open to targeting these improvements to 13.x as well, if we don't want to release them as part of 12.x
