### PR TITLE
[12.x] Short-circuit validation checks when outcome is predetermined

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -484,7 +484,7 @@ class Validator implements ValidatorContract
                     break;
                 }
 
-                if ($this->shouldStopValidating($attribute)) {
+                if ($this->messages->isNotEmpty() && $this->shouldStopValidating($attribute)) {
                     break;
                 }
             }
@@ -838,6 +838,12 @@ class Validator implements ValidatorContract
     {
         if (is_string($value) && trim($value) === '') {
             return $this->isImplicit($rule);
+        }
+
+        // Non-null values are definitely present, so we can skip the
+        // Arr::has traversal that validatePresent would perform.
+        if ($value !== null) {
+            return true;
         }
 
         return $this->validatePresent($attribute, $value) ||


### PR DESCRIPTION
Two small optimizations to the validation loop:

1. Skip `shouldStopValidating()` when no messages exist. This method checks for `bail` rules, uploaded file failures, and implicit rule failures, none of which can apply when validation has produced no error messages yet. For passing validation of large arrays, this eliminates thousands of unnecessary method calls.

2. Short-circuit `presentOrRuleIsImplicit()` for non-null values. When the value is not `null`, the attribute is definitely present, so we can skip the `Arr::has()` traversal that `validatePresent()` performs. This avoids redundant data traversal since `getValue()` already retrieved the value.

Before: 432ms for 500 items with 14 wildcard rules
After:  358ms for the same (-17%)

Reduces per-attribute overhead from #49375

Edit: 
This PR is part of a series of PRs with the focus on improving validation performance. One of the repositories I work on does big exports/imports of which 75%+ of the time is spent validating despite doing 100s of insert queries. 

The performance improvements are made using the autoresearch principle followed by cherry-picking parts of the performance findings into small PRs like this one. 

The test failure will be fixed once #59207 is merged

I am open to targeting these improvements to 13.x as well, if we don't want to release them as part of 12.x
