### PR TITLE
[12.x] Use `array_push` with spread operator in `MessageBag::all()`

### DIFF
--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -243,7 +243,7 @@ class MessageBag implements Jsonable, JsonSerializable, MessageBagContract, Mess
         $all = [];
 
         foreach ($this->messages as $key => $messages) {
-            $all = array_merge($all, $this->transform($messages, $format, $key));
+            array_push($all, ...$this->transform($messages, $format, $key));
         }
 
         return $all;


### PR DESCRIPTION
Replace `array_merge()` in a loop with `array_push(...$items)`, reducing the complexity of `MessageBag::all()` from O(n²) to O(n).

The current implementation copies the entire accumulated array on every iteration via `array_merge()`. For large validation error sets this compounds quickly:

  500 fields (1000 messages): 0.43ms → 0.05ms (-89%)
  200 fields (400 messages):  0.08ms → 0.02ms (-77%)
  100 fields (200 messages):  0.03ms → 0.01ms (-63%)

No change at small sizes (1-10 fields): 0.0002ms → 0.0002ms.

A previous attempt at this optimization (PR #57406) was rejected due to a benchmark showing regression at small field counts. That benchmark was measuring noise at the microsecond level, on current PHP versions, all approaches are identical at small sizes.

The test failure will be fixed once #59207 is merged