### PR TITLE
[12.x] Cache merged casts array in `getCasts()`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -191,9 +191,9 @@ trait HasAttributes
     /**
      * Cached result of getCasts() when incrementing is enabled.
      *
-     * @var array|null
+     * @var \WeakMap|null
      */
-    protected $mergedCastsCache = null;
+    protected static $mergedCastsCache;
 
     /**
      * The encrypter instance that is used to encrypt attributes.
@@ -791,7 +791,9 @@ trait HasAttributes
 
         $this->casts = array_merge($this->casts, $casts);
 
-        $this->mergedCastsCache = null;
+        if (static::$mergedCastsCache !== null) {
+            unset(static::$mergedCastsCache[$this]);
+        }
 
         return $this;
     }
@@ -1698,7 +1700,9 @@ trait HasAttributes
     public function getCasts()
     {
         if ($this->getIncrementing()) {
-            return $this->mergedCastsCache ??= array_merge([$this->getKeyName() => $this->getKeyType()], $this->casts);
+            $cache = (static::$mergedCastsCache ??= new \WeakMap);
+
+            return $cache[$this] ??= array_merge([$this->getKeyName() => $this->getKeyType()], $this->casts);
         }
 
         return $this->casts;

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -189,6 +189,13 @@ trait HasAttributes
     protected static $castTypeCache = [];
 
     /**
+     * Cached result of getCasts() when incrementing is enabled.
+     *
+     * @var array|null
+     */
+    protected $mergedCastsCache = null;
+
+    /**
      * The encrypter instance that is used to encrypt attributes.
      *
      * @var \Illuminate\Contracts\Encryption\Encrypter|null
@@ -783,6 +790,8 @@ trait HasAttributes
         $casts = $this->ensureCastsAreStringValues($casts);
 
         $this->casts = array_merge($this->casts, $casts);
+
+        $this->mergedCastsCache = null;
 
         return $this;
     }
@@ -1689,7 +1698,7 @@ trait HasAttributes
     public function getCasts()
     {
         if ($this->getIncrementing()) {
-            return array_merge([$this->getKeyName() => $this->getKeyType()], $this->casts);
+            return $this->mergedCastsCache ??= array_merge([$this->getKeyName() => $this->getKeyType()], $this->casts);
         }
 
         return $this->casts;


### PR DESCRIPTION
When a model uses incrementing keys (the default), `getCasts()` calls `array_merge()` to prepend the key cast on every invocation. Since `getCasts()` is called internally by `hasCast()`, `getCastType()`, `isEncryptedCastable()`, `isDateCastable()`, `isClassCastable()`, and other methods, this `array_merge` runs hundreds of times per model in typical attribute access patterns.

Caching the merged result with `??=` eliminates the redundant merges. The cache is invalidated in `mergeCasts()` which is the only method that modifies `$this->casts` after construction.

Impact on methods that call `getCasts()` internally (×200K calls):
  getCasts:            56.7ms → 15.0ms (-74%)
  getCastType:         52.8ms → 28.0ms (-47%)
  hasCast:             47.9ms → 24.6ms (-49%)
  isEncryptedCastable: 116ms  → 80ms   (-31%)

Relates to #57045 which profiled `getCastType` being called 25.7M times in a single job, consuming 12.8s of 53s total runtime.