### PR TITLE
[12.x] Avoid redundant `Util::getParameterClassName()` call in container resolution

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1232,9 +1232,9 @@ class Container implements ArrayAccess, ContainerContract
             // If the class is null, it means the dependency is a string or some other
             // primitive type which we can not resolve since it is not a class and
             // we will just bomb out with an error since we have no-where to go.
-            $result ??= is_null(Util::getParameterClassName($dependency))
+            $result ??= is_null($className = Util::getParameterClassName($dependency))
                 ? $this->resolvePrimitive($dependency)
-                : $this->resolveClass($dependency);
+                : $this->resolveClass($dependency, $className);
 
             $this->fireAfterResolvingAttributeCallbacks($dependency->getAttributes(), $result);
 
@@ -1317,9 +1317,9 @@ class Container implements ArrayAccess, ContainerContract
      *
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
-    protected function resolveClass(ReflectionParameter $parameter)
+    protected function resolveClass(ReflectionParameter $parameter, ?string $className = null)
     {
-        $className = Util::getParameterClassName($parameter);
+        $className ??= Util::getParameterClassName($parameter);
 
         // First we will check if a default value has been defined for the parameter.
         // If it has, and no explicit binding exists, we should return it to avoid


### PR DESCRIPTION
When resolving class-typed dependencies, `Util::getParameterClassName()` is called in `resolveDependencies()` to determine if the parameter is a class type, then called again inside `resolveClass()` to get the same class name. This performs redundant reflection work (`getType()`, `isBuiltin()`, `getDeclaringClass()`) on every class-typed parameter.

Capture the result in `resolveDependencies()` and pass it to `resolveClass()` to avoid the double call.

For applications that heavily resolve transient services (e.g. request-scoped DTOs, action classes, form requests), this reduces the per-resolution overhead. In a synthetic benchmark resolving a service with a 4-level dependency tree 20K times, the improvement is ~5-7%.

Edit: 
The performance improvements are made using the autoresearch principle followed by cherry-picking parts of the performance findings into small PRs like this one. 

The test failure will be fixed once #59207 is merged

I am open to targeting these improvements to 13.x as well, if we don't want to release them as part of 12.x