### PR TITLE
[12.x] Cache Route instances in CompiledRouteCollection::getByName()

### DIFF
--- a/src/Illuminate/Routing/CompiledRouteCollection.php
+++ b/src/Illuminate/Routing/CompiledRouteCollection.php
@@ -50,6 +50,13 @@ class CompiledRouteCollection extends AbstractRouteCollection
     protected $container;
 
     /**
+     * A cache of resolved Route instances keyed by route name.
+     *
+     * @var array<string, \Illuminate\Routing\Route>
+     */
+    protected $nameCache = [];
+
+    /**
      * Create a new CompiledRouteCollection instance.
      *
      * @param  array  $compiled
@@ -192,8 +199,12 @@ class CompiledRouteCollection extends AbstractRouteCollection
      */
     public function getByName($name)
     {
+        if (isset($this->nameCache[$name])) {
+            return $this->nameCache[$name];
+        }
+
         if (isset($this->attributes[$name])) {
-            return $this->newRoute($this->attributes[$name]);
+            return $this->nameCache[$name] = $this->newRoute($this->attributes[$name]);
         }
 
         return $this->routes->getByName($name);


### PR DESCRIPTION
When using cached routes (`route:cache`), `getByName()` constructs a new Route object from the compiled attributes array on every call. This involves `Router::newRoute()`, `setFallback()`, `setDefaults()`, `setWheres()`, `setBindingFields()`, `block()`, and `withTrashed()`, repeated work for the same route.

This is called on every request during route matching (`match()` calls `getByName()`), and on every `route()` URL generation call in Blade templates. A typical page with 20-50 `route()` calls in the navigation rebuilds the same Route objects repeatedly.

Caching the constructed Route by name eliminates this redundancy:

  `getByName`:  26.3ms → 0.5ms per 10K calls (-98%)
  `route()`:    85.6ms → 50.4ms per 10K calls (-41%)
  `match()`:   176.0ms → 82.8ms per 10K calls (-53%)

Edit: 
The performance improvements are made using the autoresearch principle followed by cherry-picking parts of the performance findings into small PRs like this one. 

The test failure will be fixed once #59207 is merged

I am open to targeting these improvements to 13.x as well, if we don't want to release them as part of 12.x