### PR TITLE
[12.x] Skip request duplication when URI has no trailing slash

### DIFF
--- a/src/Illuminate/Routing/CompiledRouteCollection.php
+++ b/src/Illuminate/Routing/CompiledRouteCollection.php
@@ -151,9 +151,14 @@ class CompiledRouteCollection extends AbstractRouteCollection
      */
     protected function requestWithoutTrailingSlash(Request $request)
     {
-        $trimmedRequest = $request->duplicate();
+        $uri = $request->server->get('REQUEST_URI');
+        $parts = explode('?', $uri, 2);
 
-        $parts = explode('?', $request->server->get('REQUEST_URI'), 2);
+        if ($parts[0] === '/' || ! str_ends_with($parts[0], '/')) {
+            return $request;
+        }
+
+        $trimmedRequest = $request->duplicate();
 
         $trimmedRequest->server->set(
             'REQUEST_URI', rtrim($parts[0], '/').(isset($parts[1]) ? '?'.$parts[1] : '')


### PR DESCRIPTION
  When matching routes with cached routes, `requestWithoutTrailingSlash()` clones the entire Request object via `$request->duplicate()` on every request to strip a potential trailing slash before matching. Since most requests don't have a trailing slash, this duplication is unnecessary work on nearly every request.

This adds an early return when the URI path doesn't end with `/` (or is exactly `/`), skipping the clone entirely in the common case.

`$request->duplicate()` copies all request properties (query, request, attributes, cookies, files, server bags), making it one of the more expensive operations in the route matching hot path, called once per request regardless of whether there's anything to trim.

Edit: 
The performance improvements are made using the autoresearch principle followed by cherry-picking parts of the performance findings into small PRs like this one. 

The test failure will be fixed once #59207 is merged

I am open to targeting these improvements to 13.x as well, if we don't want to release them as part of 12.x