### PR TITLE
[12.x] Use foreach instead of Collection in CompiledRouteCollection::getByAction()

### DIFF
--- a/src/Illuminate/Routing/CompiledRouteCollection.php
+++ b/src/Illuminate/Routing/CompiledRouteCollection.php
@@ -207,16 +207,14 @@ class CompiledRouteCollection extends AbstractRouteCollection
      */
     public function getByAction($action)
     {
-        $attributes = (new Collection($this->attributes))->first(function (array $attributes) use ($action) {
+        foreach ($this->attributes as $attributes) {
             if (isset($attributes['action']['controller'])) {
-                return trim($attributes['action']['controller'], '\\') === $action;
+                if (trim($attributes['action']['controller'], '\\') === $action) {
+                    return $this->newRoute($attributes);
+                }
+            } elseif ($attributes['action']['uses'] === $action) {
+                return $this->newRoute($attributes);
             }
-
-            return $attributes['action']['uses'] === $action;
-        });
-
-        if ($attributes) {
-            return $this->newRoute($attributes);
         }
 
         return $this->routes->getByAction($action);


### PR DESCRIPTION
When resolving a route by its controller action (used by the `action()` URL helper), `getByAction()` wraps the entire compiled attributes array in a new `Collection` just to call `first()` with a `filter` closure. This allocates a `Collection` object and creates a closure on every call, when a plain foreach with early return produces the same result.

This follows the same pattern applied to `matchAgainstRoutes()` in #57871, which replaced `Collection::first()` with foreach for the same reason.

For an app with 200 cached routes, `getByAction()` drops from 6.7μs to 4.9μs per call (-26%).

Edit: 
The performance improvements are made using the autoresearch principle followed by cherry-picking parts of the performance findings into small PRs like this one. 

The test failure will be fixed once #59207 is merged

I am open to targeting these improvements to 13.x as well, if we don't want to release them as part of 12.x