### PR TITLE
fix:  Strip gzip-compressed output from concurrent process response

### DIFF
--- a/src/Illuminate/Concurrency/ProcessDriver.php
+++ b/src/Illuminate/Concurrency/ProcessDriver.php
@@ -46,7 +46,13 @@ class ProcessDriver implements Driver
                 throw new Exception('Concurrent process failed with exit code ['.$result->exitCode().']. Message: '.$result->errorOutput());
             }
 
-            $result = json_decode($result->output(), true);
+            $output = $result->output();
+
+            if (($pos = strpos($output, "\x1f\x8b")) !== false) {
+                $output = substr($output, 0, $pos);
+            }
+
+            $result = json_decode($output, true);
 
             if (! $result['successful']) {
                 throw new $result['exception'](


### PR DESCRIPTION
  When `zlib.output_compression` is enabled in PHP, the child process
  appends gzip-compressed binary data (magic bytes \x1f\x8b) to stdout
  after the serialized JSON payload. This corrupts `json_decode`, which
  returns null and triggers an "array offset on null" error on the
  parent side.

  Detect the gzip magic bytes in the child process output and truncate
  before decoding. This is non-intrusive — no configuration changes are
  required from the user, and unaffected environments see zero behavior
  change.

  Fixes #59112

