### PR TITLE
[feat] Add dimension parameter to vector similarity queries

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1164,12 +1164,13 @@ class Builder implements BuilderContract
      * @param  \Illuminate\Support\Collection<int, float>|\Illuminate\Contracts\Support\Arrayable|array<int, float>|string  $vector
      * @param  float  $minSimilarity  A value between 0.0 and 1.0, where 1.0 is identical.
      * @param  bool  $order
+     * @param  int|null  $dimensions  The number of dimensions for the vector, if the string needs to be converted to embeddings.
      * @return $this
      */
-    public function whereVectorSimilarTo($column, $vector, $minSimilarity = 0.6, $order = true)
+    public function whereVectorSimilarTo($column, $vector, $minSimilarity = 0.6, $order = true, $dimensions = null)
     {
         if (is_string($vector)) {
-            $vector = Str::of($vector)->toEmbeddings(cache: true);
+            $vector = Str::of($vector)->toEmbeddings(cache: true, dimensions: $dimensions);
         }
 
         $this->whereVectorDistanceLessThan($column, $vector, 1 - $minSimilarity);
@@ -1188,14 +1189,15 @@ class Builder implements BuilderContract
      * @param  \Illuminate\Support\Collection<int, float>|\Illuminate\Contracts\Support\Arrayable|array<int, float>|string  $vector
      * @param  float  $maxDistance
      * @param  string  $boolean
+     * @param  int|null  $dimensions  The number of dimensions for the vector, if the string needs to be converted to embeddings.
      * @return $this
      */
-    public function whereVectorDistanceLessThan($column, $vector, $maxDistance, $boolean = 'and')
+    public function whereVectorDistanceLessThan($column, $vector, $maxDistance, $boolean = 'and', $dimensions = null)
     {
         $this->ensureConnectionSupportsVectors();
 
         if (is_string($vector)) {
-            $vector = Str::of($vector)->toEmbeddings(cache: true);
+            $vector = Str::of($vector)->toEmbeddings(cache: true, dimensions: $dimensions);
         }
 
         return $this->whereRaw(
@@ -1219,11 +1221,12 @@ class Builder implements BuilderContract
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
      * @param  \Illuminate\Support\Collection<int, float>|\Illuminate\Contracts\Support\Arrayable|array<int, float>|string  $vector
      * @param  float  $maxDistance
+     * @param  int|null  $dimensions  The number of dimensions for the vector, if the string needs to be converted to embeddings.
      * @return $this
      */
-    public function orWhereVectorDistanceLessThan($column, $vector, $maxDistance)
+    public function orWhereVectorDistanceLessThan($column, $vector, $maxDistance, $dimensions = null)
     {
-        return $this->whereVectorDistanceLessThan($column, $vector, $maxDistance, 'or');
+        return $this->whereVectorDistanceLessThan($column, $vector, $maxDistance, 'or', $dimensions);
     }
 
     /**


### PR DESCRIPTION
## Description

This PR introduces a `$dimensions` parameter to the vector similarity query methods, allowing users to explicitly specify the vector dimensions when performing similarity searches.

### Changes
1. Add `$dimensions` parameter to `whereVectorSimilarTo` to support vector dimension configuration.
2. Add `$dimensions` parameter to `whereVectorDistanceLessThan` to allow users to specify vector dimensions.
3. Pass `$dimensions` parameter through `orWhereVectorDistanceLessThan` for consistency.

## Benefit to End Users

Different embedding models produce vectors of varying dimensions (e.g. 768, 1024, 1536, 3072). Without the ability to specify dimensions explicitly, users are forced to rely on implicit configuration or workarounds. This change allows users to define the expected vector dimensions directly in the query, making vector similarity searches more flexible and explicit.

## Backwards Compatibility

The `$dimensions` parameter is optional and defaults to `null`, meaning all existing code continues to work without any modification. No breaking changes are introduced.
