### PR TITLE
[12.x] Add updateWhere method to Collections and Arr

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -1282,6 +1282,45 @@ class Arr
     }
 
     /**
+     * Update items in the array where the given conditions match.
+     *
+     * @param  iterable  $array
+     * @param  array  $where
+     * @param  array  $update
+     * @return array
+     */
+    public static function updateWhere($array, array $where, array $update)
+    {
+        $results = [];
+
+        foreach ($array as $key => $item) {
+            $match = true;
+
+            foreach ($where as $whereKey => $whereValue) {
+                if (data_get($item, $whereKey) !== $whereValue) {
+                    $match = false;
+
+                    break;
+                }
+            }
+
+            if ($match) {
+                if (is_object($item)) {
+                    $item = clone $item;
+                }
+
+                foreach ($update as $updateKey => $updateValue) {
+                    data_set($item, $updateKey, $updateValue);
+                }
+            }
+
+            $results[$key] = $item;
+        }
+
+        return $results;
+    }
+
+    /**
      * Filter items where the value is not null.
      *
      * @param  array  $array

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -688,6 +688,34 @@ trait EnumeratesValues
     }
 
     /**
+     * Update items in the collection where the given conditions match.
+     *
+     * @param  array  $where
+     * @param  array  $update
+     * @return static
+     */
+    public function updateWhere(array $where, array $update)
+    {
+        return $this->map(function ($item) use ($where, $update) {
+            foreach ($where as $whereKey => $whereValue) {
+                if (data_get($item, $whereKey) !== $whereValue) {
+                    return $item;
+                }
+            }
+
+            if (is_object($item)) {
+                $item = clone $item;
+            }
+
+            foreach ($update as $updateKey => $updateValue) {
+                data_set($item, $updateKey, $updateValue);
+            }
+
+            return $item;
+        });
+    }
+
+    /**
      * Filter items by the given key value pair.
      *
      * @param  string  $key

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1937,4 +1937,43 @@ class SupportArrTest extends TestCase
 
         $this->assertEquals([[0 => 'John', 1 => 'Jane'], [2 => 'Greg']], $result);
     }
+
+    public function testUpdateWhere()
+    {
+        $array = [
+            ['id' => 1, 'name' => 'John', 'status' => 'inactive'],
+            ['id' => 2, 'name' => 'Jane', 'status' => 'inactive'],
+            ['id' => 3, 'name' => 'John', 'status' => 'active'],
+        ];
+
+        // Basic update with single condition
+        $updated = Arr::updateWhere($array, ['id' => 1], ['status' => 'active']);
+        $this->assertSame('active', $updated[0]['status']);
+        $this->assertSame('inactive', $array[0]['status']); // Immutability
+
+        // Multiple conditions
+        $updated = Arr::updateWhere($array, ['name' => 'John', 'status' => 'inactive'], ['name' => 'Johnny']);
+        $this->assertSame('Johnny', $updated[0]['name']);
+        $this->assertSame('John', $updated[2]['name']); // Should not match
+
+        // Dot-notation support
+        $array = [
+            ['id' => 1, 'user' => ['name' => 'John', 'meta' => ['role' => 'admin']]],
+            ['id' => 2, 'user' => ['name' => 'Jane', 'meta' => ['role' => 'user']]],
+        ];
+        $updated = Arr::updateWhere($array, ['user.meta.role' => 'admin'], ['user.name' => 'Mario', 'user.meta.level' => 10]);
+        $this->assertSame('Mario', $updated[0]['user']['name']);
+        $this->assertSame(10, $updated[0]['user']['meta']['level']);
+        $this->assertSame('Jane', $updated[1]['user']['name']);
+
+        // Immutability for objects
+        $obj1 = (object) ['id' => 1, 'name' => 'John'];
+        $obj2 = (object) ['id' => 2, 'name' => 'Jane'];
+        $array = [$obj1, $obj2];
+        $updated = Arr::updateWhere($array, ['id' => 1], ['name' => 'Mario']);
+        $this->assertSame('Mario', $updated[0]->name);
+        $this->assertSame('John', $obj1->name);
+        $this->assertNotSame($obj1, $updated[0]);
+        $this->assertSame($obj2, $updated[1]);
+    }
 }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -6052,6 +6052,53 @@ class SupportCollectionTest extends TestCase
         $this->assertNull($collection->percentage(fn ($value) => $value === 1));
     }
 
+    #[DataProvider('collectionClassProvider')]
+    public function testUpdateWhere($collection)
+    {
+        $c = new $collection([
+            ['id' => 1, 'name' => 'John', 'status' => 'inactive'],
+            ['id' => 2, 'name' => 'Jane', 'status' => 'inactive'],
+            ['id' => 3, 'name' => 'John', 'status' => 'active'],
+        ]);
+
+        $updated = $c->updateWhere(['id' => 1], ['status' => 'active']);
+
+        $this->assertInstanceOf($collection, $updated);
+
+        $results = $updated->all();
+        $this->assertSame('active', data_get($results[0], 'status'));
+        $this->assertSame('inactive', data_get($c->first(), 'status')); // Immutability
+
+        // Multiple conditions
+        $updated = $c->updateWhere(['name' => 'John', 'status' => 'inactive'], ['name' => 'Johnny']);
+
+        $results = $updated->all();
+        $this->assertSame('Johnny', data_get($results[0], 'name'));
+        $this->assertSame('John', data_get($results[2], 'name')); // Should not match
+
+        // Dot-notation support
+        $c = new $collection([
+            ['id' => 1, 'user' => ['name' => 'John', 'meta' => ['role' => 'admin']]],
+            ['id' => 2, 'user' => ['name' => 'Jane', 'meta' => ['role' => 'user']]],
+        ]);
+        $updated = $c->updateWhere(['user.meta.role' => 'admin'], ['user.name' => 'Mario', 'user.meta.level' => 10]);
+
+        $results = $updated->all();
+        $this->assertSame('Mario', data_get($results[0], 'user.name'));
+        $this->assertSame(10, data_get($results[0], 'user.meta.level'));
+
+        // Immutability for objects
+        $obj1 = (object) ['id' => 1, 'name' => 'John'];
+        $obj2 = (object) ['id' => 2, 'name' => 'Jane'];
+        $c = new $collection([$obj1, $obj2]);
+        $updated = $c->updateWhere(['id' => 1], ['name' => 'Mario']);
+
+        $results = $updated->all();
+        $this->assertSame('Mario', $results[0]->name);
+        $this->assertSame('John', $obj1->name);
+        $this->assertNotSame($obj1, $results[0]);
+    }
+
     /**
      * Provides each collection class, respectively.
      *

--- a/tests/Support/SupportLazyCollectionTest.php
+++ b/tests/Support/SupportLazyCollectionTest.php
@@ -531,4 +531,20 @@ class SupportLazyCollectionTest extends TestCase
             $this->assertContains($key, ['first', 'second', 'third']);
         }
     }
+
+    public function testUpdateWhere()
+    {
+        $c = LazyCollection::make([
+            ['id' => 1, 'name' => 'John', 'status' => 'inactive'],
+            ['id' => 2, 'name' => 'Jane', 'status' => 'inactive'],
+        ]);
+
+        $updated = $c->updateWhere(['id' => 1], ['status' => 'active']);
+
+        $this->assertInstanceOf(LazyCollection::class, $updated);
+
+        $results = $updated->all();
+        $this->assertSame('active', $results[0]['status']);
+        $this->assertSame('inactive', $c->first()['status']);
+    }
 }


### PR DESCRIPTION
This PR introduces a new `updateWhere` utility method to `Illuminate\Collections\Arr` and the `EnumeratesValues` trait (providing support for both `Collection` and `LazyCollection`).

When working with in-memory arrays of objects or associative arrays, it's a very common requirement to update specific items that match certain conditions (e.g., updating a user's role by their ID). Currently, developers have to write verbose `map` callbacks, manually check conditions, and handle object cloning or array copying to preserve immutability. 

This PR brings an Eloquent-like syntax to in-memory collections and arrays, leveraging `data_get` and `data_set` for powerful dot-notation support.

### Before

```php
$users = collect([
    ['id' => 1, 'name' => 'Maria', 'role' => 'user'],
    ['id' => 2, 'name' => 'Luca', 'role' => 'user']
]);

// Updating the role where id is 1
$updatedUsers = $users->map(function ($user) {
    if (data_get($user, 'id') === 1) {
        $user = is_object($user) ? clone $user : $user;
        data_set($user, 'role', 'admin');
    }
    
    return $user;
});

```

### After

```php
$updatedUsers = $users->updateWhere(
    ['id' => 1], 
    ['role' => 'admin']
);

```
