### PR TITLE
Introduces the string helper to get the initials for a given string

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1460,6 +1460,24 @@ class Str
     }
 
     /**
+     * Returns the initials for each word in the provided string, optionally capitalizing.
+     *
+     * @param  string  $value
+     * @param  bool    $capitalize
+     * @return string
+     */
+    public static function initials($value, $capitalize = false)
+    {
+        $parts = mb_split("\s+", $value);
+
+        $parts = array_map(fn($part) => mb_substr($part, 0, 1), $parts);
+
+        $initials = implode("", $parts);
+
+        return $capitalize ? static::upper($initials) : $initials;
+    }
+
+    /**
      * Convert the given string to APA-style title case.
      *
      * See: https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -90,6 +90,18 @@ class SupportStrTest extends TestCase
         $this->assertSame('Orwell 1984', Str::headline(' orwell_- 1984 '));
     }
 
+    public function testStringInitials() {
+        $this->assertSame('jb', Str::initials('james bond'));
+        $this->assertSame('jb', Str::initials(' james bond'));
+        $this->assertSame('jb', Str::initials('james  bond'));
+
+        $this->assertSame('JB', Str::initials('James Bond'));
+
+        $this->assertSame('JB', Str::initials('james bond', true));
+
+        $this->assertSame('JBLL', Str::initials('james bond loves laravel', true));
+    }
+
     public function testStringApa()
     {
         $this->assertSame('Tom and Jerry', Str::apa('tom and jerry'));


### PR DESCRIPTION
This PR introduces a new string helper to easily return the initials from a given string, e.g. to retrieve the initials for a name.
It supports an optional parameter to capitalize immediately (defaulting to false).