### PR TITLE
Add string helper to get initials from a string

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1463,16 +1463,16 @@ class Str
      * Returns the initials for each word in the provided string, optionally capitalizing.
      *
      * @param  string  $value
-     * @param  bool    $capitalize
+     * @param  bool  $capitalize
      * @return string
      */
     public static function initials($value, $capitalize = false)
     {
         $parts = mb_split("\s+", $value);
 
-        $parts = array_map(fn($part) => mb_substr($part, 0, 1), $parts);
+        $parts = array_map(fn ($part) => mb_substr($part, 0, 1), $parts);
 
-        $initials = implode("", $parts);
+        $initials = implode('', $parts);
 
         return $capitalize ? static::upper($initials) : $initials;
     }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1460,6 +1460,24 @@ class Str
     }
 
     /**
+     * Returns the initials for each word in the provided string, optionally capitalizing.
+     *
+     * @param  string  $value
+     * @param  bool    $capitalize
+     * @return string
+     */
+    public static function initials($value, $capitalize = false)
+    {
+        $parts = mb_split("\s+", $value);
+
+        $parts = array_map(fn($part) => mb_substr($part, 0, 1), $parts);
+
+        $initials = implode("", $parts);
+
+        return $capitalize ? static::upper($initials) : $initials;
+    }
+
+    /**
      * Convert the given string to APA-style title case.
      *
      * See: https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -892,6 +892,16 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
+     * Convert the given string to only its initials.
+     *
+     * @return static
+     */
+    public function initials()
+    {
+        return new static(Str::initials($this->value));
+    }
+
+    /**
      * Convert the given string to APA-style title case.
      *
      * @return static

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -90,6 +90,18 @@ class SupportStrTest extends TestCase
         $this->assertSame('Orwell 1984', Str::headline(' orwell_- 1984 '));
     }
 
+    public function testStringInitials() {
+        $this->assertSame('jb', Str::initials('james bond'));
+        $this->assertSame('jb', Str::initials(' james bond'));
+        $this->assertSame('jb', Str::initials('james  bond'));
+
+        $this->assertSame('JB', Str::initials('James Bond'));
+
+        $this->assertSame('JB', Str::initials('james bond', true));
+
+        $this->assertSame('JBLL', Str::initials('james bond loves laravel', true));
+    }
+
     public function testStringApa()
     {
         $this->assertSame('Tom and Jerry', Str::apa('tom and jerry'));

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -90,7 +90,8 @@ class SupportStrTest extends TestCase
         $this->assertSame('Orwell 1984', Str::headline(' orwell_- 1984 '));
     }
 
-    public function testStringInitials() {
+    public function testStringInitials() 
+    {
         $this->assertSame('jb', Str::initials('james bond'));
         $this->assertSame('jb', Str::initials(' james bond'));
         $this->assertSame('jb', Str::initials('james  bond'));

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -90,7 +90,7 @@ class SupportStrTest extends TestCase
         $this->assertSame('Orwell 1984', Str::headline(' orwell_- 1984 '));
     }
 
-    public function testStringInitials() 
+    public function testStringInitials()
     {
         $this->assertSame('jb', Str::initials('james bond'));
         $this->assertSame('jb', Str::initials(' james bond'));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -1481,6 +1481,11 @@ class SupportStringableTest extends TestCase
         $this->assertFalse($this->stringable('0')->exactly(0));
     }
 
+    public function testInitials()
+    {
+        $this->assertSame('TO', $this->stringable('Taylor Otwell')->initials()->value());
+    }
+
     public function testToInteger()
     {
         $this->assertSame(123, $this->stringable('123')->toInteger());


### PR DESCRIPTION
This PR introduces the support for retrieving the initials from a string, optionally capitalizing the string:

```php
Str::initials('mickey mouse');       // mm
Str::initials('mickey mouse', true); // MM
```

It also introduces fluent API support:
```php
new Stringable('mickey mouse')->initials();          // mm
new Stringable('mickey mouse')->initials()->upper(); // MM
```