### PR TITLE
[12.x] Lazily evaluate value for constraints in `HasOneOrManyThrough`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrManyThrough.php
@@ -102,7 +102,9 @@ abstract class HasOneOrManyThrough extends Relation
         $this->performJoin($query);
 
         if (static::$constraints) {
-            $query->where($this->getQualifiedFirstKeyName(), '=', $this->farParent[$this->localKey]);
+            $localValue = $this->farParent[$this->localKey];
+
+            $query->where($this->getQualifiedFirstKeyName(), '=', $localValue);
         }
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrManyThrough.php
@@ -99,12 +99,10 @@ abstract class HasOneOrManyThrough extends Relation
     {
         $query = $this->getRelationQuery();
 
-        $localValue = $this->farParent[$this->localKey];
-
         $this->performJoin($query);
 
         if (static::$constraints) {
-            $query->where($this->getQualifiedFirstKeyName(), '=', $localValue);
+            $query->where($this->getQualifiedFirstKeyName(), '=', $this->farParent[$this->localKey]);
         }
     }
 


### PR DESCRIPTION
In a scenario, where:
1. Primary keys are casted, in our case we're using value objects representing an `integer` with a value `>= 1` called `PositiveInteger`
2. Using a relation that extends `HasOneOrManyThrough` results in an exception

The reason is, that at the moment of calling `addConstraints` in the context of constructor of either `HasOneThrough` or `HasManyThrough`, the `$farParent` is empty.
This means our cast, which is highly strict, results in an exception.

When debugging I've noticed that, unlike any other relation's `addContraints` method, this is for some (unknown) reason evaluated even if the `static::$constraints` is set to `false` which, coincidentally, breaks our application.

This PR changes the behaviour in `\Illuminate\Database\Eloquent\Relations\HasOneOrManyThrough::addConstraints` to resolve the value for constraint in the `if` statement, therefore fixing this inconsistency (and our bug).