### PR TITLE
Fix: Batch::add() wipes queue assignment on first job in array chains

### DIFF
--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -161,10 +161,17 @@ class Batch implements Arrayable, JsonSerializable
 
                 $chain = $this->prepareBatchedChain($job);
 
-                return $chain->first()
-                    ->allOnQueue($this->options['queue'] ?? null)
-                    ->allOnConnection($this->options['connection'] ?? null)
-                    ->chain($chain->slice(1)->values()->all());
+                $first = $chain->first();
+
+                if (isset($this->options['queue'])) {
+                    $first->allOnQueue($this->options['queue']);
+                }
+
+                if (isset($this->options['connection'])) {
+                    $first->allOnConnection($this->options['connection']);
+                }
+
+                return $first->chain($chain->slice(1)->values()->all());
             } else {
                 $job->withBatchId($this->id);
 

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -564,6 +564,40 @@ class BusBatchTest extends TestCase
         $this->assertInstanceOf(CarbonImmutable::class, $batch->createdAt);
     }
 
+    public function test_chained_jobs_in_batch_preserve_their_queue_when_batch_has_no_queue()
+    {
+        $queue = m::mock(Factory::class);
+
+        $repository = new DatabaseBatchRepository(new BatchFactory($queue), DB::connection(), 'job_batches');
+
+        // Create a batch WITHOUT onQueue — this is the key difference
+        $pendingBatch = (new PendingBatch(new Container, collect()))
+            ->onConnection('test-connection');
+
+        $batch = $repository->store($pendingBatch);
+
+        $firstJob = (new ChainHeadJob)->onQueue('custom-queue');
+        $secondJob = (new SecondTestJob)->onQueue('custom-queue');
+
+        $queue->shouldReceive('connection')->once()
+            ->with('test-connection')
+            ->andReturn($connection = m::mock(stdClass::class));
+
+        $connection->shouldReceive('bulk')->once()->with(m::on(function ($args) {
+            return true;
+        }), '', null);
+
+        $batch->add([
+            [$firstJob, $secondJob],
+        ]);
+
+        // Both jobs had ->onQueue('custom-queue') set before batching.
+        // The second job retains its queue, but the first job's queue
+        // is wiped to null by Batch::add() calling allOnQueue(null).
+        $this->assertSame('custom-queue', $secondJob->queue);
+        $this->assertSame('custom-queue', $firstJob->queue);
+    }
+
     public function test_chained_closure_after_multiple_batches_is_properly_dispatched()
     {
         Queue::fake();


### PR DESCRIPTION
## Problem

When jobs with explicit `->onQueue('custom-queue')` are placed in an array chain inside a `Bus::batch()`, the first job in each chain loses its queue assignment. The second and subsequent jobs retain theirs.

```php
Bus::batch([
    [
        (new MyJob('first'))->onQueue('custom-queue'),
        (new MyJob('second'))->onQueue('custom-queue'),
    ],
])->dispatch();

// 'first' dispatches to default queue (bug)
// 'second' dispatches to 'custom-queue' (correct)
```

## Reproduction Steps

In any Laravel application with a simple job class:

```php
class JobOnCustomQueue implements ShouldQueue
{
    use Batchable, Dispatchable, InteractsWithQueue, Queueable, SerializesModels;

    public function __construct(public string $name) {}
    public function handle(): void {}
}
```

**Test 1** — Single job in a batched chain loses its queue:

```php
it('dispatches the first job in a batched chain to the correct queue', function () {
    Queue::fake();

    Bus::batch([
        [(new JobOnCustomQueue('first'))->onQueue('custom-queue')],
    ])->dispatch();

    Queue::assertPushed(JobOnCustomQueue::class, function ($job) {
        expect($job->queue)->toBe('custom-queue'); // FAILS: queue is null
        return true;
    });
});
```

**Test 2** — First and second jobs in the same chain get different queues despite identical `onQueue()` calls:

```php
it('applies different queues to first and second job despite identical onQueue calls', function () {
    Queue::fake();

    Bus::batch([
        [
            (new JobOnCustomQueue('first'))->onQueue('custom-queue'),
            (new JobOnCustomQueue('second'))->onQueue('custom-queue'),
        ],
    ])->dispatch();

    Queue::assertPushed(JobOnCustomQueue::class, function ($job) {
        if ($job->name !== 'first') return false;

        $firstJobQueue = $job->queue;
        $secondJob = unserialize($job->chained[0]);
        $secondJobQueue = $secondJob->queue;

        // Both had ->onQueue('custom-queue'), but after batching:
        // $secondJobQueue === 'custom-queue' (correct)
        // $firstJobQueue === null (bug)
        expect($firstJobQueue)->toBe($secondJobQueue); // FAILS

        return true;
    });
});
```

## Root Cause

In `Illuminate\Bus\Batch::add()`, when processing array chains:

```php
return $chain->first()
    ->allOnQueue($this->options['queue'] ?? null)
    ->allOnConnection($this->options['connection'] ?? null)
    ->chain($chain->slice(1)->values()->all());
```

When the batch has no explicit queue set (`$this->options['queue']` is not set), the `?? null` fallback passes `null` to `allOnQueue()`, which overwrites the job's own queue assignment.

## Fix

Only call `allOnQueue()` / `allOnConnection()` when the batch has explicitly set those options:

```php
$first = $chain->first();

if (isset($this->options['queue'])) {
    $first->allOnQueue($this->options['queue']);
}

if (isset($this->options['connection'])) {
    $first->allOnConnection($this->options['connection']);
}

return $first->chain($chain->slice(1)->values()->all());
```

This preserves the existing behavior where a batch's queue overrides individual jobs when explicitly set, but no longer wipes job queues when the batch doesn't specify one.

## Test

Added `test_chained_jobs_in_batch_preserve_their_queue_when_batch_has_no_queue` which creates a batch without `onQueue()`, adds a chain of two jobs that both have `->onQueue('custom-queue')`, and asserts both retain their queue assignment.

The first commit contains only the failing test. The second commit will contain the fix.