### PR TITLE
[13.x] Database cache store `increment()` consistency with other cache drivers

### DIFF
--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -11,6 +11,7 @@ use Illuminate\Database\PostgresConnection;
 use Illuminate\Database\QueryException;
 use Illuminate\Database\SQLiteConnection;
 use Illuminate\Database\SqlServerConnection;
+use Illuminate\Database\UniqueConstraintViolationException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\InteractsWithTime;
@@ -278,11 +279,23 @@ class DatabaseStore implements CanFlushLocks, LockProvider, Store
             $cache = $this->table()->where('key', $prefixed)
                 ->lockForUpdate()->first();
 
-            // If there is no value in the cache, we will return false here. Otherwise the
+            // If there is no value in the cache, we'll set the value to 0. Otherwise, the
             // value will be decrypted and we will proceed with this function to either
             // increment or decrement this value based on the given action callbacks.
             if (is_null($cache)) {
-                return false;
+                $new = $callback(0, $value);
+
+                try {
+                    $this->table()->insert([
+                        'key' => $prefixed,
+                        'value' => $this->serialize($new),
+                        'expiration' => $this->getTime() + 315360000,
+                    ]);
+                } catch (UniqueConstraintViolationException) {
+                    return $this->incrementOrDecrement($key, $value, $callback);
+                }
+
+                return $new;
             }
 
             $cache = is_array($cache) ? (object) $cache : $cache;

--- a/tests/Cache/CacheDatabaseStoreTest.php
+++ b/tests/Cache/CacheDatabaseStoreTest.php
@@ -163,7 +163,7 @@ class CacheDatabaseStoreTest extends TestCase
         $store->getConnection()->shouldReceive('transaction')->once()->with(m::type(Closure::class))->andReturnUsing(function ($closure) {
             return $closure();
         });
-        $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
+        $store->getConnection()->shouldReceive('table')->twice()->with('table')->andReturn($table);
         $table->shouldReceive('where')->once()->with('key', 'prefixfoo')->andReturn($table);
         $table->shouldReceive('lockForUpdate')->once()->andReturn($table);
         $table->shouldReceive('first')->once()->andReturn(null);
@@ -179,11 +179,11 @@ class CacheDatabaseStoreTest extends TestCase
 
         $cache->value = serialize(1);
 
-        $store->getConnection()->shouldReceive('transaction')->once()->with(m::type(Closure::class))->andReturnUsing(function ($closure) {
+        $store->getConnection()->shouldReceive('transaction')->twice()->with(m::type(Closure::class))->andReturnUsing(function ($closure) {
             return $closure();
         });
-        $store->getConnection()->shouldReceive('table')->twice()->with('table')->andReturn($table);
-        $table->shouldReceive('where')->twice()->with('key', 'prefixfoo')->andReturn($table);
+        $store->getConnection()->shouldReceive('table')->times(4)->with('table')->andReturn($table);
+        $table->shouldReceive('where')->times(3)->with('key', 'prefixfoo')->andReturn($table);
         $table->shouldReceive('lockForUpdate')->twice()->andReturn($table);
         $table->shouldReceive('first')->twice()->andReturn(null, $cache);
         $table->shouldReceive('insert')->once()
@@ -220,12 +220,10 @@ class CacheDatabaseStoreTest extends TestCase
         $store->getConnection()->shouldReceive('transaction')->once()->with(m::type(Closure::class))->andReturnUsing(function ($closure) {
             return $closure();
         });
-        $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
-        $table->shouldReceive('where')->once()->with('key', 'prefixfoo')->andReturn($table);
+        $store->getConnection()->shouldReceive('table')->twice()->with('table')->andReturn($table);
+        $table->shouldReceive('where')->twice()->with('key', 'prefixfoo')->andReturn($table);
         $table->shouldReceive('lockForUpdate')->once()->andReturn($table);
         $table->shouldReceive('first')->once()->andReturn($cache);
-        $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
-        $table->shouldReceive('where')->once()->with('key', 'prefixfoo')->andReturn($table);
         $table->shouldReceive('update')->once()->with(['value' => serialize(3)])->andReturn(true);
         $this->assertEquals(3, $store->increment('foo'));
     }
@@ -238,7 +236,7 @@ class CacheDatabaseStoreTest extends TestCase
         $store->getConnection()->shouldReceive('transaction')->once()->with(m::type(Closure::class))->andReturnUsing(function ($closure) {
             return $closure();
         });
-        $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
+        $store->getConnection()->shouldReceive('table')->twice()->with('table')->andReturn($table);
         $table->shouldReceive('where')->once()->with('key', 'prefixfoo')->andReturn($table);
         $table->shouldReceive('lockForUpdate')->once()->andReturn($table);
         $table->shouldReceive('first')->once()->andReturn(null);
@@ -273,12 +271,10 @@ class CacheDatabaseStoreTest extends TestCase
         $store->getConnection()->shouldReceive('transaction')->once()->with(m::type(Closure::class))->andReturnUsing(function ($closure) {
             return $closure();
         });
-        $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
-        $table->shouldReceive('where')->once()->with('key', 'prefixbar')->andReturn($table);
+        $store->getConnection()->shouldReceive('table')->twice()->with('table')->andReturn($table);
+        $table->shouldReceive('where')->twice()->with('key', 'prefixbar')->andReturn($table);
         $table->shouldReceive('lockForUpdate')->once()->andReturn($table);
         $table->shouldReceive('first')->once()->andReturn($cache);
-        $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
-        $table->shouldReceive('where')->once()->with('key', 'prefixbar')->andReturn($table);
         $table->shouldReceive('update')->once()->with(['value' => serialize(2)])->andReturn(true);
         $this->assertEquals(2, $store->decrement('bar'));
     }

--- a/tests/Cache/CacheDatabaseStoreTest.php
+++ b/tests/Cache/CacheDatabaseStoreTest.php
@@ -7,6 +7,7 @@ use Illuminate\Cache\DatabaseStore;
 use Illuminate\Database\Connection;
 use Illuminate\Database\PostgresConnection;
 use Illuminate\Database\SQLiteConnection;
+use Illuminate\Database\UniqueConstraintViolationException;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use stdClass;
@@ -154,11 +155,10 @@ class CacheDatabaseStoreTest extends TestCase
         $this->assertTrue($result);
     }
 
-    public function testIncrementReturnsCorrectValues()
+    public function testIncrementUnsetValue()
     {
         $store = $this->getStore();
         $table = m::mock(stdClass::class);
-        $cache = m::mock(stdClass::class);
 
         $store->getConnection()->shouldReceive('transaction')->once()->with(m::type(Closure::class))->andReturnUsing(function ($closure) {
             return $closure();
@@ -167,7 +167,37 @@ class CacheDatabaseStoreTest extends TestCase
         $table->shouldReceive('where')->once()->with('key', 'prefixfoo')->andReturn($table);
         $table->shouldReceive('lockForUpdate')->once()->andReturn($table);
         $table->shouldReceive('first')->once()->andReturn(null);
-        $this->assertFalse($store->increment('foo'));
+        $table->shouldReceive('insert')->once()->withArgs(fn (array $args) => $args['value'] === serialize(1))->andReturn(true);
+        $this->assertEquals(1, $store->increment('foo'));
+    }
+
+    public function testIncrementUnsetValueWithSimulatedRaceCondition()
+    {
+        $store = $this->getStore();
+        $table = m::mock(stdClass::class);
+        $cache = m::mock(stdClass::class);
+
+        $cache->value = serialize(1);
+
+        $store->getConnection()->shouldReceive('transaction')->once()->with(m::type(Closure::class))->andReturnUsing(function ($closure) {
+            return $closure();
+        });
+        $store->getConnection()->shouldReceive('table')->twice()->with('table')->andReturn($table);
+        $table->shouldReceive('where')->twice()->with('key', 'prefixfoo')->andReturn($table);
+        $table->shouldReceive('lockForUpdate')->twice()->andReturn($table);
+        $table->shouldReceive('first')->twice()->andReturn(null, $cache);
+        $table->shouldReceive('insert')->once()
+            ->withArgs(fn (array $args) => $args['value'] === serialize(1))
+            ->andThrow(new UniqueConstraintViolationException('test', 'test', [], new \Exception()));
+        $table->shouldReceive('update')->once()->with(['value' => serialize(2)])->andReturn(true);
+        $this->assertEquals(2, $store->increment('foo'));
+    }
+
+    public function testIncrementWithNonNumericValue()
+    {
+        $store = $this->getStore();
+        $table = m::mock(stdClass::class);
+        $cache = m::mock(stdClass::class);
 
         $cache->value = serialize('bar');
         $store->getConnection()->shouldReceive('transaction')->once()->with(m::type(Closure::class))->andReturnUsing(function ($closure) {
@@ -178,6 +208,13 @@ class CacheDatabaseStoreTest extends TestCase
         $table->shouldReceive('lockForUpdate')->once()->andReturn($table);
         $table->shouldReceive('first')->once()->andReturn($cache);
         $this->assertFalse($store->increment('foo'));
+    }
+
+    public function testIncrementExistingValue()
+    {
+        $store = $this->getStore();
+        $table = m::mock(stdClass::class);
+        $cache = m::mock(stdClass::class);
 
         $cache->value = serialize(2);
         $store->getConnection()->shouldReceive('transaction')->once()->with(m::type(Closure::class))->andReturnUsing(function ($closure) {
@@ -189,15 +226,14 @@ class CacheDatabaseStoreTest extends TestCase
         $table->shouldReceive('first')->once()->andReturn($cache);
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
         $table->shouldReceive('where')->once()->with('key', 'prefixfoo')->andReturn($table);
-        $table->shouldReceive('update')->once()->with(['value' => serialize(3)]);
+        $table->shouldReceive('update')->once()->with(['value' => serialize(3)])->andReturn(true);
         $this->assertEquals(3, $store->increment('foo'));
     }
 
-    public function testDecrementReturnsCorrectValues()
+    public function testDecrementUnsetValue()
     {
         $store = $this->getStore();
         $table = m::mock(stdClass::class);
-        $cache = m::mock(stdClass::class);
 
         $store->getConnection()->shouldReceive('transaction')->once()->with(m::type(Closure::class))->andReturnUsing(function ($closure) {
             return $closure();
@@ -206,7 +242,15 @@ class CacheDatabaseStoreTest extends TestCase
         $table->shouldReceive('where')->once()->with('key', 'prefixfoo')->andReturn($table);
         $table->shouldReceive('lockForUpdate')->once()->andReturn($table);
         $table->shouldReceive('first')->once()->andReturn(null);
-        $this->assertFalse($store->decrement('foo'));
+        $table->shouldReceive('insert')->withArgs(fn (array $args) => $args['value'] === serialize(1))->andReturn(true);
+        $this->assertEquals(1, $store->increment('foo'));
+    }
+
+    public function testDecrementWithNonNumericValue()
+    {
+        $store = $this->getStore();
+        $table = m::mock(stdClass::class);
+        $cache = m::mock(stdClass::class);
 
         $cache->value = serialize('bar');
         $store->getConnection()->shouldReceive('transaction')->once()->with(m::type(Closure::class))->andReturnUsing(function ($closure) {
@@ -217,6 +261,13 @@ class CacheDatabaseStoreTest extends TestCase
         $table->shouldReceive('lockForUpdate')->once()->andReturn($table);
         $table->shouldReceive('first')->once()->andReturn($cache);
         $this->assertFalse($store->decrement('foo'));
+    }
+
+    public function testDecrementReturnsCorrectValues()
+    {
+        $store = $this->getStore();
+        $table = m::mock(stdClass::class);
+        $cache = m::mock(stdClass::class);
 
         $cache->value = serialize(3);
         $store->getConnection()->shouldReceive('transaction')->once()->with(m::type(Closure::class))->andReturnUsing(function ($closure) {
@@ -228,7 +279,7 @@ class CacheDatabaseStoreTest extends TestCase
         $table->shouldReceive('first')->once()->andReturn($cache);
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
         $table->shouldReceive('where')->once()->with('key', 'prefixbar')->andReturn($table);
-        $table->shouldReceive('update')->once()->with(['value' => serialize(2)]);
+        $table->shouldReceive('update')->once()->with(['value' => serialize(2)])->andReturn(true);
         $this->assertEquals(2, $store->decrement('bar'));
     }
 

--- a/tests/Integration/Database/DatabaseCacheStoreTest.php
+++ b/tests/Integration/Database/DatabaseCacheStoreTest.php
@@ -124,6 +124,24 @@ class DatabaseCacheStoreTest extends DatabaseTestCase
         $this->assertSame('new-bar', $store->get('foo'));
     }
 
+    public function testIncrementOperationCanStoreInitialValue()
+    {
+        $store = $this->getStore();
+
+        $this->assertSame(1, $store->increment('foo'));
+
+        $this->assertSame(1, $store->get('foo'));
+    }
+
+    public function testDecrementOperationCanStoreInitialValue()
+    {
+        $store = $this->getStore();
+
+        $this->assertSame(-1, $store->decrement('foo'));
+
+        $this->assertSame(-1, $store->get('foo'));
+    }
+
     public function testGetOperationReturnNullIfExpired()
     {
         $store = $this->getStore();


### PR DESCRIPTION
**Problem:**

The database cache store seems to be one of the odd ones out among cache drivers where an `increment()`/`decrement()` operation on non-existent cache value results in a no-op. Most cache drivers use an initial value of 0. This is particularly problematic when using the `array` cache driver in tests (as in [out-of-the-box Laravel installs](https://github.com/laravel/laravel/blob/77da0b9a8db30e3858f626d4980224936c37b960/phpunit.xml#L25)), as it can mask an issue on production environments.

Current behaviour:

```php
> cache()->driver('array')->increment('foo')
1

> cache()->driver('redis')->increment('foo')
1

> cache()->driver('database')->increment('foo')
false
```

**Proposal:**

Set the initial value to 0 when calling `increment()`/`decrement()` on an unset cache value.

**Considerations:**

A potential race condition where multiple `increment()`/`decrement()` operations on the same unset key are performed at the same time. The solution used is to catch a `UniqueConstraintViolationException`, and attempt the increment/decrement operation again. See `testIncrementUnsetValueWithSimulatedRaceCondition`.

**12.x or 13.x?**

There's a case to be made to call this a bug fix, but it does break backward compatibility, so my initial thought was to target `master` for inclusion in the next major version.

**Prior issues / discussion:**

- https://github.com/laravel/framework/issues/20643 (note that here it was mentioned that the memcached driver returns `null` too, but I believe that behavior was since patched)
- https://github.com/laravel/framework/issues/20641#issuecomment-323800786