### PR TITLE
[13.x] Remove phpstan ignore comments from ComponentTagCompiler

### DIFF
--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -340,9 +340,9 @@ class ComponentTagCompiler
                     : $component;
 
                 if (! is_null($guess = match (true) {
-                    $viewFactory->exists($guess = $path['prefixHash'].$delimiter.$formattedComponent) => $guess, // @phpstan-ignore variable.undefined
-                    $viewFactory->exists($guess = $path['prefixHash'].$delimiter.$formattedComponent.'.index') => $guess, // @phpstan-ignore variable.undefined
-                    $viewFactory->exists($guess = $path['prefixHash'].$delimiter.$formattedComponent.'.'.Str::afterLast($formattedComponent, '.')) => $guess, // @phpstan-ignore variable.undefined
+                    $viewFactory->exists($guess = $path['prefixHash'].$delimiter.$formattedComponent) => $guess,
+                    $viewFactory->exists($guess = $path['prefixHash'].$delimiter.$formattedComponent.'.index') => $guess,
+                    $viewFactory->exists($guess = $path['prefixHash'].$delimiter.$formattedComponent.'.'.Str::afterLast($formattedComponent, '.')) => $guess,
                     default => null,
                 })) {
                     return $guess;


### PR DESCRIPTION
Stan is complaining that these arent needed: 

https://github.com/laravel/framework/actions/runs/23168079715/job/67313121453
https://github.com/laravel/framework/actions/runs/23168149127/job/67313346554


So, this PR drops the comments.

Thanks!