### PR TITLE
[12.x] Display file path and line number for closure routes in `route:list`

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -47,7 +47,7 @@ class RouteListCommand extends Command
      *
      * @var string[]
      */
-    protected $headers = ['Domain', 'Method', 'URI', 'Name', 'Action', 'Middleware'];
+    protected $headers = ['Domain', 'Method', 'URI', 'Name', 'Action', 'Middleware', 'Path'];
 
     /**
      * The terminal width resolver callback.
@@ -146,6 +146,7 @@ class RouteListCommand extends Command
             'name' => $route->getName(),
             'action' => ltrim($route->getActionName(), '\\'),
             'middleware' => $this->getMiddleware($route),
+            'path' => $this->getClosurePath($route),
             'vendor' => $this->isVendorRoute($route),
         ]);
     }
@@ -253,6 +254,25 @@ class RouteListCommand extends Command
             '\Illuminate\Routing\RedirectController',
             '\Illuminate\Routing\ViewController',
         ], true);
+    }
+
+    /**
+     * Get the file path and line number for a closure-based route.
+     *
+     * @param  \Illuminate\Routing\Route  $route
+     * @return string|null
+     */
+    protected function getClosurePath(Route $route)
+    {
+        if (! $route->action['uses'] instanceof Closure) {
+            return null;
+        }
+
+        $reflection = new ReflectionFunction($route->action['uses']);
+
+        return str_replace(
+            '\\', '/', ltrim(Str::after($reflection->getFileName(), base_path()), DIRECTORY_SEPARATOR)
+        ).':'.$reflection->getStartLine();
     }
 
     /**
@@ -424,7 +444,7 @@ class RouteListCommand extends Command
         ['action' => $action, 'name' => $name] = $route;
 
         if ($action === 'Closure' || $action === ViewController::class) {
-            return $name;
+            return $name.($route['path'] ?? null);
         }
 
         $name = $name ? "$name   " : null;

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -444,7 +444,13 @@ class RouteListCommand extends Command
         ['action' => $action, 'name' => $name] = $route;
 
         if ($action === 'Closure' || $action === ViewController::class) {
-            return $name.($route['path'] ?? null);
+            $path = $route['path'] ?? null;
+
+            if ($name && $path) {
+                return $name.'   '.$path;
+            }
+
+            return $name ?? $path;
         }
 
         $name = $name ? "$name   " : null;

--- a/tests/Foundation/Console/RouteListCommandTest.php
+++ b/tests/Foundation/Console/RouteListCommandTest.php
@@ -77,9 +77,17 @@ class RouteListCommandTest extends TestCase
         $this->app->call('route:list', ['--json' => true, '--sort' => 'domain,uri']);
         $output = $this->app->output();
 
-        $expectedOrder = '[{"domain":null,"method":"GET|HEAD","uri":"example","name":null,"action":"Closure","middleware":["exampleMiddleware"]},{"domain":null,"method":"GET|HEAD","uri":"example-group","name":null,"action":"Closure","middleware":["web","auth"]},{"domain":"sub","method":"GET|HEAD","uri":"sub-example","name":null,"action":"Closure","middleware":["exampleMiddleware"]}]';
+        $routes = json_decode($output, true);
 
-        $this->assertJsonStringEqualsJsonString($expectedOrder, $output);
+        $this->assertCount(3, $routes);
+        $this->assertEquals('example', $routes[0]['uri']);
+        $this->assertEquals('example-group', $routes[1]['uri']);
+        $this->assertEquals('sub-example', $routes[2]['uri']);
+
+        foreach ($routes as $route) {
+            $this->assertArrayHasKey('path', $route);
+            $this->assertStringContainsString('RouteListCommandTest.php:', $route['path']);
+        }
     }
 
     public function testSortRouteListDesc()
@@ -87,9 +95,17 @@ class RouteListCommandTest extends TestCase
         $this->app->call('route:list', ['--json' => true, '--sort' => 'domain,uri', '--reverse' => true]);
         $output = $this->app->output();
 
-        $expectedOrder = '[{"domain":"sub","method":"GET|HEAD","uri":"sub-example","name":null,"action":"Closure","middleware":["exampleMiddleware"]},{"domain":null,"method":"GET|HEAD","uri":"example-group","name":null,"action":"Closure","middleware":["web","auth"]},{"domain":null,"method":"GET|HEAD","uri":"example","name":null,"action":"Closure","middleware":["exampleMiddleware"]}]';
+        $routes = json_decode($output, true);
 
-        $this->assertJsonStringEqualsJsonString($expectedOrder, $output);
+        $this->assertCount(3, $routes);
+        $this->assertEquals('sub-example', $routes[0]['uri']);
+        $this->assertEquals('example-group', $routes[1]['uri']);
+        $this->assertEquals('example', $routes[2]['uri']);
+
+        foreach ($routes as $route) {
+            $this->assertArrayHasKey('path', $route);
+            $this->assertStringContainsString('RouteListCommandTest.php:', $route['path']);
+        }
     }
 
     public function testSortRouteListDefault()
@@ -97,9 +113,17 @@ class RouteListCommandTest extends TestCase
         $this->app->call('route:list', ['--json' => true]);
         $output = $this->app->output();
 
-        $expectedOrder = '[{"domain":null,"method":"GET|HEAD","uri":"example","name":null,"action":"Closure","middleware":["exampleMiddleware"]},{"domain":null,"method":"GET|HEAD","uri":"example-group","name":null,"action":"Closure","middleware":["web","auth"]}, {"domain":"sub","method":"GET|HEAD","uri":"sub-example","name":null,"action":"Closure","middleware":["exampleMiddleware"]}]';
+        $routes = json_decode($output, true);
 
-        $this->assertJsonStringEqualsJsonString($expectedOrder, $output);
+        $this->assertCount(3, $routes);
+        $this->assertEquals('example', $routes[0]['uri']);
+        $this->assertEquals('example-group', $routes[1]['uri']);
+        $this->assertEquals('sub-example', $routes[2]['uri']);
+
+        foreach ($routes as $route) {
+            $this->assertArrayHasKey('path', $route);
+            $this->assertStringContainsString('RouteListCommandTest.php:', $route['path']);
+        }
     }
 
     public function testSortRouteListPrecedence()
@@ -107,9 +131,17 @@ class RouteListCommandTest extends TestCase
         $this->app->call('route:list', ['--json' => true, '--sort' => 'definition']);
         $output = $this->app->output();
 
-        $expectedOrder = '[{"domain":null,"method":"GET|HEAD","uri":"example","name":null,"action":"Closure","middleware":["exampleMiddleware"]},{"domain":"sub","method":"GET|HEAD","uri":"sub-example","name":null,"action":"Closure","middleware":["exampleMiddleware"]}, {"domain":null,"method":"GET|HEAD","uri":"example-group","name":null,"action":"Closure","middleware":["web","auth"]}]';
+        $routes = json_decode($output, true);
 
-        $this->assertJsonStringEqualsJsonString($expectedOrder, $output);
+        $this->assertCount(3, $routes);
+        $this->assertEquals('example', $routes[0]['uri']);
+        $this->assertEquals('sub-example', $routes[1]['uri']);
+        $this->assertEquals('example-group', $routes[2]['uri']);
+
+        foreach ($routes as $route) {
+            $this->assertArrayHasKey('path', $route);
+            $this->assertStringContainsString('RouteListCommandTest.php:', $route['path']);
+        }
     }
 
     public function testMiddlewareGroupsAssignmentInCli()
@@ -181,9 +213,15 @@ class RouteListCommandTest extends TestCase
         $this->app->call('route:list', ['--json' => true, '-vv' => true]);
         $output = $this->app->output();
 
-        $expectedOrder = '[{"domain":null,"method":"GET|HEAD","uri":"example","name":null,"action":"Closure","middleware":["exampleMiddleware"]},{"domain":null,"method":"GET|HEAD","uri":"example-group","name":null,"action":"Closure","middleware":["Middleware 5","Middleware 1","Middleware 4","Middleware 2","Middleware 3"]},{"domain":"sub","method":"GET|HEAD","uri":"sub-example","name":null,"action":"Closure","middleware":["exampleMiddleware"]}]';
+        $routes = json_decode($output, true);
 
-        $this->assertJsonStringEqualsJsonString($expectedOrder, $output);
+        $this->assertCount(3, $routes);
+        $this->assertEquals('example', $routes[0]['uri']);
+        $this->assertEquals(['exampleMiddleware'], $routes[0]['middleware']);
+        $this->assertEquals('example-group', $routes[1]['uri']);
+        $this->assertEquals(['Middleware 5', 'Middleware 1', 'Middleware 4', 'Middleware 2', 'Middleware 3'], $routes[1]['middleware']);
+        $this->assertEquals('sub-example', $routes[2]['uri']);
+        $this->assertEquals(['exampleMiddleware'], $routes[2]['middleware']);
     }
 
     public function testFilterByMiddleware()
@@ -191,8 +229,63 @@ class RouteListCommandTest extends TestCase
         $this->app->call('route:list', ['--json' => true, '-v' => true, '--middleware' => 'auth']);
         $output = $this->app->output();
 
-        $expectedOrder = '[{"domain":null,"method":"GET|HEAD","uri":"example-group","name":null,"action":"Closure","middleware":["web","auth"]}]';
+        $routes = json_decode($output, true);
 
-        $this->assertJsonStringEqualsJsonString($expectedOrder, $output);
+        $this->assertCount(1, $routes);
+        $this->assertEquals('example-group', $routes[0]['uri']);
+        $this->assertEquals(['web', 'auth'], $routes[0]['middleware']);
+        $this->assertStringContainsString('RouteListCommandTest.php:', $routes[0]['path']);
+    }
+
+    public function testClosureRouteShowsPathInCli()
+    {
+        RouteListCommand::resolveTerminalWidthUsing(fn () => 200);
+
+        $this->app->call('route:list');
+        $output = $this->app->output();
+
+        $this->assertStringContainsString('RouteListCommandTest.php:', $output);
+
+        RouteListCommand::resolveTerminalWidthUsing(null);
+    }
+
+    public function testControllerRoutePathIsNull()
+    {
+        $laravel = new \Illuminate\Foundation\Application(__DIR__);
+        $router = new Router(m::mock('Illuminate\Events\Dispatcher'));
+
+        $kernel = new class($laravel, $router) extends Kernel
+        {
+            protected $middlewareGroups = [];
+        };
+
+        $laravel->instance(Kernel::class, $kernel);
+
+        $router->get('/controller-route', [RouteListCommandTestController::class, 'index']);
+
+        $command = new RouteListCommand($router);
+        $command->setLaravel($laravel);
+
+        $app = new Application(
+            $laravel,
+            m::mock(Dispatcher::class, ['dispatch' => null, 'fire' => null]),
+            'testing',
+        );
+        $app->addCommands([$command]);
+        $app->call('route:list', ['--json' => true]);
+        $output = $app->output();
+
+        $routes = json_decode($output, true);
+
+        $this->assertCount(1, $routes);
+        $this->assertNull($routes[0]['path']);
+    }
+}
+
+class RouteListCommandTestController
+{
+    public function index()
+    {
+        return 'Hello World';
     }
 }

--- a/tests/Testing/Console/RouteListCommandTest.php
+++ b/tests/Testing/Console/RouteListCommandTest.php
@@ -8,6 +8,7 @@ use Illuminate\Foundation\Console\RouteListCommand;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithDeprecationHandling;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Artisan;
 use Orchestra\Testbench\Attributes\WithConfig;
 use Orchestra\Testbench\TestCase;
 
@@ -39,6 +40,11 @@ class RouteListCommandTest extends TestCase
 
     public function testDisplayRoutesForCli()
     {
+        $this->withoutMockingConsoleOutput();
+
+        RouteListCommand::resolveTerminalWidthUsing(fn () => 200);
+
+        $closureLine = __LINE__ + 1;
         $this->router->get('/', function () {
             //
         });
@@ -59,22 +65,24 @@ class RouteListCommandTest extends TestCase
             })->name('user.show')->middleware('web');
         });
 
-        $this->artisan(RouteListCommand::class)
-            ->assertSuccessful()
-            ->expectsOutput('')
-            ->expectsOutput('  GET|HEAD   / ..................................................... ')
-            ->expectsOutput('  GET|HEAD   {account}.example.com/ ................................ ')
-            ->expectsOutput('  GET|HEAD   closure ............................................... ')
-            ->expectsOutput('  POST       controller-invokable Illuminate\Tests\Testing\Console\…')
-            ->expectsOutput('  GET|HEAD   controller-method/{user} Illuminate\Tests\Testing\Cons…')
-            ->expectsOutput('  GET|HEAD   {account}.example.com/user/{id} ............. user.show')
-            ->expectsOutput('')
-            ->expectsOutput('                                                  Showing [6] routes')
-            ->expectsOutput('');
+        $this->artisan(RouteListCommand::class);
+        $output = Artisan::output();
+
+        $this->assertStringContainsString('GET|HEAD', $output);
+        $this->assertStringContainsString('closure', $output);
+        $this->assertStringContainsString('controller-invokable', $output);
+        $this->assertStringContainsString('controller-method/{user}', $output);
+        $this->assertStringContainsString('RouteListCommandTest.php:'.$closureLine, $output);
+        $this->assertStringContainsString('Showing [6] routes', $output);
     }
 
     public function testDisplayRoutesForCliInVerboseMode()
     {
+        $this->withoutMockingConsoleOutput();
+
+        RouteListCommand::resolveTerminalWidthUsing(fn () => 200);
+
+        $closureLine = __LINE__ + 1;
         $this->router->get('closure', function () {
             return new RedirectResponse($this->urlGenerator->signedRoute('signed-route'));
         });
@@ -87,37 +95,40 @@ class RouteListCommandTest extends TestCase
             })->name('user.show')->middleware('web');
         });
 
-        $this->artisan(RouteListCommand::class, ['-v' => true])
-            ->assertSuccessful()
-            ->expectsOutput('')
-            ->expectsOutput('  GET|HEAD   closure ............................................... ')
-            ->expectsOutput('  POST       controller-invokable Illuminate\\Tests\\Testing\\Console\\FooController')
-            ->expectsOutput('  GET|HEAD   controller-method/{user} Illuminate\\Tests\\Testing\\Console\\FooController@show')
-            ->expectsOutput('  GET|HEAD   {account}.example.com/user/{id} ............. user.show')
-            ->expectsOutput('             ⇂ web')
-            ->expectsOutput('')
-            ->expectsOutput('                                                  Showing [4] routes')
-            ->expectsOutput('');
+        $this->artisan(RouteListCommand::class, ['-v' => true]);
+        $output = Artisan::output();
+
+        $this->assertStringContainsString('closure', $output);
+        $this->assertStringContainsString('RouteListCommandTest.php:'.$closureLine, $output);
+        $this->assertStringContainsString('controller-invokable', $output);
+        $this->assertStringContainsString('FooController@show', $output);
+        $this->assertStringContainsString('user.show', $output);
+        $this->assertStringContainsString('web', $output);
+        $this->assertStringContainsString('Showing [4] routes', $output);
     }
 
     public function testRouteCanBeFilteredByName()
     {
         $this->withoutDeprecationHandling();
+        $this->withoutMockingConsoleOutput();
+
+        RouteListCommand::resolveTerminalWidthUsing(fn () => 200);
 
         $this->router->get('/', function () {
             //
         });
+        $closureLine = __LINE__ + 1;
         $this->router->get('/foo', function () {
             //
         })->name('foo.show');
 
-        $this->artisan(RouteListCommand::class, ['--name' => 'foo'])
-            ->assertSuccessful()
-            ->expectsOutput('')
-            ->expectsOutput('  GET|HEAD       foo ...................................... foo.show')
-            ->expectsOutput('')
-            ->expectsOutput('                                                  Showing [1] routes')
-            ->expectsOutput('');
+        $this->artisan(RouteListCommand::class, ['--name' => 'foo']);
+        $output = Artisan::output();
+
+        $this->assertStringContainsString('foo', $output);
+        $this->assertStringContainsString('foo.show', $output);
+        $this->assertStringContainsString('RouteListCommandTest.php:'.$closureLine, $output);
+        $this->assertStringContainsString('Showing [1] routes', $output);
     }
 
     public function testRouteCanBeFilteredByAction()
@@ -143,6 +154,64 @@ class RouteListCommandTest extends TestCase
                 '                                                              Showing [1] routes'
             )
             ->expectsOutput('');
+    }
+
+    public function testClosurePathIsDisplayedInVerboseMode()
+    {
+        $closureLine = __LINE__ + 1;
+        $this->router->get('closure-path', function () {
+            //
+        });
+
+        $this->router->get('controller-method/{user}', [FooController::class, 'show']);
+
+        $expectedPath = 'tests/Testing/Console/RouteListCommandTest.php:'.$closureLine;
+
+        $this->artisan(RouteListCommand::class, ['-v' => true])
+            ->assertSuccessful()
+            ->expectsOutputToContain($expectedPath);
+    }
+
+    public function testClosurePathIsDisplayedInNonVerboseMode()
+    {
+        RouteListCommand::resolveTerminalWidthUsing(fn () => 200);
+
+        $closureLine = __LINE__ + 1;
+        $this->router->get('closure-path', function () {
+            //
+        });
+
+        $expectedPath = 'tests/Testing/Console/RouteListCommandTest.php:'.$closureLine;
+
+        $this->artisan(RouteListCommand::class)
+            ->assertSuccessful()
+            ->expectsOutputToContain($expectedPath);
+    }
+
+    public function testClosurePathIsIncludedInJsonOutput()
+    {
+        $closureLine = __LINE__ + 1;
+        $this->router->get('closure-path', function () {
+            //
+        });
+
+        $this->router->get('controller-method/{user}', [FooController::class, 'show']);
+
+        $expectedPath = 'tests/Testing/Console/RouteListCommandTest.php:'.$closureLine;
+        $jsonPath = str_replace('/', '\\/', $expectedPath);
+
+        $this->artisan(RouteListCommand::class, ['--json' => true])
+            ->assertSuccessful()
+            ->expectsOutputToContain($jsonPath);
+    }
+
+    public function testControllerRouteHasNullPathInJsonOutput()
+    {
+        $this->router->get('controller-method/{user}', [FooController::class, 'show']);
+
+        $this->artisan(RouteListCommand::class, ['--json' => true])
+            ->assertSuccessful()
+            ->expectsOutputToContain('"path":null');
     }
 
     public function testDisplayRoutesExceptVendor()


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR aims to add file:line location display for closure-based routes in `route:list`, showing where each closure was originally defined in the file. Examples:

**Before:**

<img width="986" height="336" alt="CleanShot 2026-03-16 at 21 19 56" src="https://github.com/user-attachments/assets/30feaeb0-e145-45ee-9f1a-91cb054fcdda" />

**After:**

<img width="984" height="333" alt="CleanShot 2026-03-16 at 21 29 02" src="https://github.com/user-attachments/assets/e01682b6-bd02-462d-bb3b-daf4f9afc359" />

