### PR TITLE
[13.x] Convert File::types() from static to instance method

### DIFF
--- a/src/Illuminate/Validation/Rules/File.php
+++ b/src/Illuminate/Validation/Rules/File.php
@@ -138,11 +138,13 @@ class File implements Rule, DataAwareRule, ValidatorAwareRule
      * Limit the uploaded file to the given MIME types or file extensions.
      *
      * @param  string|array<int, string>  $mimetypes
-     * @return static
+     * @return $this
      */
-    public static function types($mimetypes)
+    public function types($mimetypes)
     {
-        return tap(new static(), fn ($file) => $file->allowedMimetypes = (array) $mimetypes);
+        $this->allowedMimetypes = (array) $mimetypes;
+
+        return $this;
     }
 
     /**

--- a/tests/Integration/Translation/TranslatorTest.php
+++ b/tests/Integration/Translation/TranslatorTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Integration\Translation;
 
 use Illuminate\Http\UploadedFile;
+use Illuminate\Validation\Rule;
 use Illuminate\Validation\Rules\File;
 use Orchestra\Testbench\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -111,7 +112,7 @@ class TranslatorTest extends TestCase
 
         $validator = $this->app['validator']->make(
             ['file' => UploadedFile::fake()->create('file.pdf')],
-            ['file' => [File::types(['txt'])]]
+            ['file' => [Rule::file()->types(['txt'])]]
         );
 
         $validator->fails();

--- a/tests/Integration/Translation/TranslatorTest.php
+++ b/tests/Integration/Translation/TranslatorTest.php
@@ -4,7 +4,6 @@ namespace Illuminate\Tests\Integration\Translation;
 
 use Illuminate\Http\UploadedFile;
 use Illuminate\Validation\Rule;
-use Illuminate\Validation\Rules\File;
 use Orchestra\Testbench\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 

--- a/tests/Integration/Validation/Rules/FileValidationTest.php
+++ b/tests/Integration/Validation/Rules/FileValidationTest.php
@@ -24,7 +24,7 @@ class FileValidationTest extends TestCase
                 $attribute => $file,
             ],
         ], [
-            'files.*' => ['required', File::types(['image/png', 'image/jpeg'])],
+            'files.*' => ['required', Rule::file()->types(['image/png', 'image/jpeg'])],
         ]);
 
         $this->assertTrue($validator->passes());
@@ -43,7 +43,7 @@ class FileValidationTest extends TestCase
                 $attribute => $file,
             ],
         ], [
-            'files.*' => ['required', File::types($mimes = ['image/png', 'image/jpeg'])],
+            'files.*' => ['required', Rule::file()->types($mimes = ['image/png', 'image/jpeg'])],
         ]);
 
         $this->assertFalse($validator->passes());
@@ -83,7 +83,7 @@ class FileValidationTest extends TestCase
     {
         $validator = Validator::make(
             ['document' => UploadedFile::fake()->create('file.pdf')],
-            ['document' => [File::types(['jpg', 'png'])]],
+            ['document' => [Rule::file()->types(['jpg', 'png'])]],
             ['document.mimes' => 'Wrong file type']
         );
 
@@ -95,7 +95,7 @@ class FileValidationTest extends TestCase
     {
         $validator = Validator::make(
             ['upload' => UploadedFile::fake()->create('small.pdf', 50)],
-            ['upload' => [File::types(['pdf'])->min(100)]],
+            ['upload' => [Rule::file()->types(['pdf'])->min(100)]],
             ['upload.min' => 'File too small']
         );
 
@@ -107,7 +107,7 @@ class FileValidationTest extends TestCase
     {
         $validator = Validator::make(
             ['upload' => UploadedFile::fake()->create('large.pdf', 2000)],
-            ['upload' => [File::types(['pdf'])->max(1024)]],
+            ['upload' => [Rule::file()->types(['pdf'])->max(1024)]],
             ['upload.max' => 'File exceeds limit']
         );
 
@@ -127,11 +127,23 @@ class FileValidationTest extends TestCase
         $this->assertSame(['Invalid dimensions'], $validator->messages()->all());
     }
 
+    public function test_types_preserves_max_when_chained_after_it()
+    {
+        $validator = Validator::make(
+            ['file' => UploadedFile::fake()->image('photo.jpg', 800, 600)->size(8)],
+            ['file' => [File::image()->max(1)->types(['jpg', 'jpeg'])]],
+            ['file.max' => 'File too large']
+        );
+
+        $this->assertTrue($validator->fails());
+        $this->assertSame(['File too large'], $validator->messages()->all());
+    }
+
     public function test_file_between_custom_validation_messages()
     {
         $validator = Validator::make(
             ['file' => UploadedFile::fake()->create('foo.pdf', 10)],
-            ['file' => [File::types(['pdf'])->between(100, 1000)]],
+            ['file' => [Rule::file()->types(['pdf'])->between(100, 1000)]],
             ['file.between' => 'Size out of range']
         );
 
@@ -155,7 +167,7 @@ class FileValidationTest extends TestCase
     {
         $validator = Validator::make(
             ['photo' => UploadedFile::fake()->create('foo.pdf', 5000)],
-            ['photo' => [File::types(['jpg', 'png'])->max(1024)]],
+            ['photo' => [Rule::file()->types(['jpg', 'png'])->max(1024)]],
             [
                 'photo.mimes' => 'Invalid type',
                 'photo.max' => 'Too large',
@@ -174,7 +186,7 @@ class FileValidationTest extends TestCase
     {
         $validator = Validator::make(
             ['file' => UploadedFile::fake()->create('doc.pdf', 500)],
-            ['file' => [File::types(['pdf'])->size(100)]],
+            ['file' => [Rule::file()->types(['pdf'])->size(100)]],
             ['file.size' => 'File must be exactly 100KB']
         );
 
@@ -198,7 +210,7 @@ class FileValidationTest extends TestCase
     {
         $validator = Validator::make(
             ['file' => UploadedFile::fake()->createWithContent('foo.txt', "\xf0\x28\x8c\x28")],
-            ['file' => [File::types(['txt'])->encoding('UTF-8')]],
+            ['file' => [Rule::file()->types(['txt'])->encoding('UTF-8')]],
             ['file.encoding' => 'Invalid file encoding']
         );
 

--- a/tests/Validation/ValidationFileRuleTest.php
+++ b/tests/Validation/ValidationFileRuleTest.php
@@ -65,13 +65,13 @@ class ValidationFileRuleTest extends TestCase
     public function testSingleMimetype()
     {
         $this->fails(
-            File::types('text/plain'),
+            Rule::file()->types('text/plain'),
             UploadedFile::fake()->createWithContent('foo.png', file_get_contents(__DIR__.'/fixtures/image.png')),
             ['validation.mimetypes']
         );
 
         $this->passes(
-            File::types('image/png'),
+            Rule::file()->types('image/png'),
             UploadedFile::fake()->createWithContent('foo.png', file_get_contents(__DIR__.'/fixtures/image.png')),
         );
     }
@@ -79,13 +79,13 @@ class ValidationFileRuleTest extends TestCase
     public function testMultipleMimeTypes()
     {
         $this->fails(
-            File::types(['text/plain', 'image/jpeg']),
+            Rule::file()->types(['text/plain', 'image/jpeg']),
             UploadedFile::fake()->createWithContent('foo.png', file_get_contents(__DIR__.'/fixtures/image.png')),
             ['validation.mimetypes']
         );
 
         $this->passes(
-            File::types(['text/plain', 'image/png']),
+            Rule::file()->types(['text/plain', 'image/png']),
             UploadedFile::fake()->createWithContent('foo.png', file_get_contents(__DIR__.'/fixtures/image.png')),
         );
     }
@@ -93,13 +93,13 @@ class ValidationFileRuleTest extends TestCase
     public function testSingleMime()
     {
         $this->fails(
-            File::types('txt'),
+            Rule::file()->types('txt'),
             UploadedFile::fake()->createWithContent('foo.png', file_get_contents(__DIR__.'/fixtures/image.png')),
             ['validation.mimes']
         );
 
         $this->passes(
-            File::types('png'),
+            Rule::file()->types('png'),
             UploadedFile::fake()->createWithContent('foo.png', file_get_contents(__DIR__.'/fixtures/image.png')),
         );
     }
@@ -107,13 +107,13 @@ class ValidationFileRuleTest extends TestCase
     public function testMultipleMimes()
     {
         $this->fails(
-            File::types(['png', 'jpg', 'jpeg', 'svg']),
+            Rule::file()->types(['png', 'jpg', 'jpeg', 'svg']),
             UploadedFile::fake()->createWithContent('foo.txt', 'Hello World!'),
             ['validation.mimes']
         );
 
         $this->passes(
-            File::types(['png', 'jpg', 'jpeg', 'svg']),
+            Rule::file()->types(['png', 'jpg', 'jpeg', 'svg']),
             [
                 UploadedFile::fake()->createWithContent('foo.png', file_get_contents(__DIR__.'/fixtures/image.png')),
                 UploadedFile::fake()->createWithContent('foo.svg', file_get_contents(__DIR__.'/fixtures/image.svg')),
@@ -124,14 +124,23 @@ class ValidationFileRuleTest extends TestCase
     public function testMixOfMimetypesAndMimes()
     {
         $this->fails(
-            File::types(['png', 'image/png']),
+            Rule::file()->types(['png', 'image/png']),
             UploadedFile::fake()->createWithContent('foo.txt', 'Hello World!'),
             ['validation.mimetypes', 'validation.mimes']
         );
 
         $this->passes(
-            File::types(['png', 'image/png']),
+            Rule::file()->types(['png', 'image/png']),
             UploadedFile::fake()->createWithContent('foo.png', file_get_contents(__DIR__.'/fixtures/image.png')),
+        );
+    }
+
+    public function testTypesCanBeChainedAfterOtherFileConstraints()
+    {
+        $this->fails(
+            Rule::file()->max(1)->types(['png']),
+            UploadedFile::fake()->create('foo.png', 8, 'image/png'),
+            ['validation.max.file']
         );
     }
 
@@ -441,7 +450,7 @@ class ValidationFileRuleTest extends TestCase
         $this->assertInstanceOf(File::class, File::default());
 
         File::defaults(function () {
-            return File::types('txt')->max(12 * 1024);
+            return Rule::file()->types('txt')->max(12 * 1024);
         });
 
         $this->fails(

--- a/tests/Validation/ValidationImageFileRuleTest.php
+++ b/tests/Validation/ValidationImageFileRuleTest.php
@@ -100,6 +100,28 @@ class ValidationImageFileRuleTest extends TestCase
         );
     }
 
+    public function testTypesCanBeChainedAfterImageConfiguration()
+    {
+        $this->passes(
+            File::image(allowSvg: true)->types(['svg']),
+            UploadedFile::fake()->createWithContent('foo.svg', file_get_contents(__DIR__.'/fixtures/image.svg')),
+        );
+    }
+
+    public function testTypesPreservesDimensionsWhenChainedAfterThem()
+    {
+        $this->fails(
+            File::image()->dimensions(Rule::dimensions()->maxWidth(50))->types(['png']),
+            UploadedFile::fake()->image('foo.png', 100, 100),
+            ['validation.dimensions'],
+        );
+
+        $this->passes(
+            File::image()->dimensions(Rule::dimensions()->maxWidth(50))->types(['png']),
+            UploadedFile::fake()->image('foo.png', 50, 50),
+        );
+    }
+
     protected function fails($rule, $values, $messages)
     {
         $this->assertValidationRules($rule, $values, false, $messages);


### PR DESCRIPTION
`File::types()` is a static factory that returns `new static()`. When called in a fluent chain                                                                               
(`File::image()->max(1)->types(['jpg'])`), PHP invokes the static method and returns a fresh
object, silently discarding all prior configuration.

This makes `types()` an instance method returning `$this`, consistent with `extensions()` and the
rest of the fluent builder API.

**Breaking change:** `File::types([...])` as a static entry point no longer works. Replace with
`Rule::file()->types([...])`

Fixes https://github.com/laravel/framework/issues/59242 
Fixes #59242 