### PR TITLE
Add illuminate/queue dependency to composer.json

### DIFF
--- a/src/Illuminate/Events/composer.json
+++ b/src/Illuminate/Events/composer.json
@@ -20,8 +20,8 @@
         "illuminate/container": "^13.0",
         "illuminate/contracts": "^13.0",
         "illuminate/macroable": "^13.0",
-        "illuminate/support": "^13.0",
-        "illuminate/queue": "^13.0"
+        "illuminate/queue": "^13.0",
+        "illuminate/support": "^13.0"
     },
     "minimum-stability": "dev",
     "autoload": {

--- a/src/Illuminate/Events/composer.json
+++ b/src/Illuminate/Events/composer.json
@@ -20,7 +20,8 @@
         "illuminate/container": "^13.0",
         "illuminate/contracts": "^13.0",
         "illuminate/macroable": "^13.0",
-        "illuminate/support": "^13.0"
+        "illuminate/support": "^13.0",
+        "illuminate/queue": "^13.0"
     },
     "minimum-stability": "dev",
     "autoload": {


### PR DESCRIPTION
If you require `illuminate/events` in a package, it produces an error on v13:
```
PHP Fatal error:  Trait "Illuminate\Queue\Attributes\ReadsQueueAttributes" not found in /vendor/illuminate/events/Dispatcher.php on line 41
```