### PR TITLE
[13.x] Use Carbon::now() instead of now() helper

### DIFF
--- a/src/Illuminate/Cache/Lock.php
+++ b/src/Illuminate/Cache/Lock.php
@@ -4,6 +4,7 @@ namespace Illuminate\Cache;
 
 use Illuminate\Contracts\Cache\Lock as LockContract;
 use Illuminate\Contracts\Cache\LockTimeoutException;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\InteractsWithTime;
 use Illuminate\Support\Sleep;
 use Illuminate\Support\Str;
@@ -111,12 +112,12 @@ abstract class Lock implements LockContract
      */
     public function block($seconds, $callback = null)
     {
-        $starting = ((int) now()->format('Uu')) / 1000;
+        $starting = ((int) Carbon::now()->format('Uu')) / 1000;
 
         $milliseconds = $seconds * 1000;
 
         while (! $this->acquire()) {
-            $now = ((int) now()->format('Uu')) / 1000;
+            $now = ((int) Carbon::now()->format('Uu')) / 1000;
 
             if (($now + $this->sleepMilliseconds - $milliseconds) >= $starting) {
                 throw new LockTimeoutException;

--- a/src/Illuminate/Database/Concerns/BuildsWhereDateClauses.php
+++ b/src/Illuminate/Database/Concerns/BuildsWhereDateClauses.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Database\Concerns;
 
-use Carbon\Carbon;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Carbon;
 
 trait BuildsWhereDateClauses
 {

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -133,7 +133,7 @@ class ServeCommand extends Command
 
         $environmentLastModified = $hasEnvironment
             ? filemtime($environmentFile)
-            : now()->addDays(30)->getTimestamp();
+            : Carbon::now()->addDays(30)->getTimestamp();
 
         $process = $this->startProcess($hasEnvironment);
 

--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -6,6 +6,7 @@ use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Foundation\Events\VendorTagPublished;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
 use League\Flysystem\Filesystem as Flysystem;
@@ -94,7 +95,7 @@ class VendorPublishCommand extends Command
      */
     public function handle()
     {
-        $this->publishedAt = now();
+        $this->publishedAt = Carbon::now();
 
         $this->determineWhatShouldBePublished();
 

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Queue;
 
-use Carbon\Carbon;
 use Closure;
 use DateTimeInterface;
 use Illuminate\Bus\UniqueLock;
@@ -21,6 +20,7 @@ use Illuminate\Queue\Attributes\Timeout;
 use Illuminate\Queue\Attributes\Tries;
 use Illuminate\Queue\Events\JobQueued;
 use Illuminate\Queue\Events\JobQueueing;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\InteractsWithTime;
 use Illuminate\Support\Str;

--- a/src/Illuminate/Support/Testing/Fakes/BatchRepositoryFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BatchRepositoryFake.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Support\Testing\Fakes;
 
+use Carbon\Carbon;
 use Carbon\CarbonImmutable;
 use Closure;
 use Illuminate\Bus\BatchRepository;
@@ -112,7 +113,7 @@ class BatchRepositoryFake implements BatchRepository
     public function markAsFinished(string $batchId)
     {
         if (isset($this->batches[$batchId])) {
-            $this->batches[$batchId]->finishedAt = now();
+            $this->batches[$batchId]->finishedAt = Carbon::now();
         }
     }
 

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -24,6 +24,7 @@ use Illuminate\Database\Query\Builder;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Foundation\Bus\PendingChain;
 use Illuminate\Queue\CallQueuedClosure;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Facade;
 use Illuminate\Support\Facades\Queue;
@@ -495,7 +496,7 @@ class BusBatchTest extends TestCase
         $batch = $this->createTestBatch($queue);
 
         $this->assertFalse($batch->finished());
-        $batch->finishedAt = now();
+        $batch->finishedAt = Carbon::now();
         $this->assertTrue($batch->finished());
 
         $batch->options['progress'] = [];
@@ -522,7 +523,7 @@ class BusBatchTest extends TestCase
         $this->assertTrue($batch->hasCatchCallbacks());
 
         $this->assertFalse($batch->cancelled());
-        $batch->cancelledAt = now();
+        $batch->cancelledAt = Carbon::now();
         $this->assertTrue($batch->cancelled());
 
         $this->assertIsString(json_encode($batch));
@@ -629,7 +630,7 @@ class BusBatchTest extends TestCase
                 'failed_jobs' => '',
                 'failed_job_ids' => '[]',
                 'options' => $serialize,
-                'created_at' => now()->timestamp,
+                'created_at' => Carbon::now()->timestamp,
                 'cancelled_at' => null,
                 'finished_at' => null,
             ]);

--- a/tests/Cache/CacheRateLimiterTest.php
+++ b/tests/Cache/CacheRateLimiterTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Cache;
 use Illuminate\Cache\ArrayStore;
 use Illuminate\Cache\RateLimiter;
 use Illuminate\Contracts\Cache\Repository as Cache;
+use Illuminate\Support\Carbon;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
@@ -107,7 +108,7 @@ class CacheRateLimiterTest extends TestCase
     public function testAvailableInReturnsPositiveValues()
     {
         $cache = m::mock(Cache::class);
-        $cache->shouldReceive('get')->andReturn(now()->subSeconds(60)->getTimestamp(), null);
+        $cache->shouldReceive('get')->andReturn(Carbon::now()->subSeconds(60)->getTimestamp(), null);
         $cache->shouldReceive('getStore')->andReturn(new ArrayStore);
         $rateLimiter = new RateLimiter($cache);
 

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Tests\Database;
 
 use BadMethodCallException;
-use Carbon\Carbon;
 use Faker\Generator;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Foundation\Application;
@@ -17,6 +16,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Factories\Sequence;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
 use Illuminate\Tests\Database\Fixtures\Models\Money\Price;
 use Mockery as m;
@@ -1062,7 +1062,7 @@ class DatabaseEloquentFactoryTest extends TestCase
             ->count(5)
             ->recycle([
                 (new FactoryTestUserFactory())->create(['name' => Name::Taylor]),
-                (new FactoryTestUserFactory())->create(['name' => Name::Shad, 'created_at' => now()]),
+                (new FactoryTestUserFactory())->create(['name' => Name::Shad, 'created_at' => Carbon::now()]),
             ])
             ->state(['title' => 'hello'])
             ->insert();

--- a/tests/Database/DatabaseEloquentHasOneOfManyTest.php
+++ b/tests/Database/DatabaseEloquentHasOneOfManyTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Database;
 use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Carbon;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
@@ -628,7 +629,7 @@ class HasOneOfManyTestUser extends Eloquent
             'published_at' => 'max',
             'id' => 'max',
         ], function ($q) {
-            $q->where('published_at', '<', now());
+            $q->where('published_at', '<', Carbon::now());
         });
     }
 
@@ -648,7 +649,7 @@ class HasOneOfManyTestUser extends Eloquent
             'published_at' => 'max',
             'id' => 'max',
         ], function ($q) {
-            $q->where('published_at', '<', now());
+            $q->where('published_at', '<', Carbon::now());
         });
     }
 

--- a/tests/Database/DatabaseEloquentHasOneThroughOfManyTest.php
+++ b/tests/Database/DatabaseEloquentHasOneThroughOfManyTest.php
@@ -12,6 +12,7 @@ use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\Relations\HasOneThrough;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Schema\Builder;
+use Illuminate\Support\Carbon;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
@@ -634,7 +635,7 @@ class HasOneThroughOfManyTestUser extends Eloquent
             'published_at' => 'max',
             'id' => 'max',
         ], function ($q) {
-            $q->where('published_at', '<', now());
+            $q->where('published_at', '<', Carbon::now());
         });
     }
 
@@ -654,7 +655,7 @@ class HasOneThroughOfManyTestUser extends Eloquent
             'published_at' => 'max',
             'id' => 'max',
         ], function ($q) {
-            $q->where('published_at', '<', now());
+            $q->where('published_at', '<', Carbon::now());
         });
     }
 

--- a/tests/Database/DatabaseEloquentWithCastsTest.php
+++ b/tests/Database/DatabaseEloquentWithCastsTest.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\MissingAttributeException;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Model as Eloquent;
+use Illuminate\Support\Carbon;
 use PHPUnit\Framework\TestCase;
 
 class DatabaseEloquentWithCastsTest extends TestCase
@@ -80,7 +81,7 @@ class DatabaseEloquentWithCastsTest extends TestCase
 
     public function testThrowsExceptionIfCastableAttributeWasNotRetrievedAndPreventMissingAttributesIsEnabled()
     {
-        Time::create(['time' => now()]);
+        Time::create(['time' => Carbon::now()]);
         $originalMode = Model::preventsAccessingMissingAttributes();
         Model::preventAccessingMissingAttributes();
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -3,8 +3,9 @@
 namespace Illuminate\Tests\Database;
 
 use BadMethodCallException;
-use Carbon\Carbon;
 use Closure;
+use DateInterval;
+use DatePeriod;
 use DateTime;
 use Illuminate\Contracts\Database\Query\ConditionExpression;
 use Illuminate\Database\Connection;
@@ -26,10 +27,12 @@ use Illuminate\Pagination\AbstractPaginator as Paginator;
 use Illuminate\Pagination\Cursor;
 use Illuminate\Pagination\CursorPaginator;
 use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Tests\Database\Fixtures\Enums\Bar;
 use InvalidArgumentException;
 use Mockery as m;
+use Mockery\MockInterface;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use stdClass;
@@ -1135,31 +1138,31 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([], $builder->getBindings());
 
         $builder = $this->getBuilder();
-        $period = now()->startOfDay()->toPeriod(now()->addDay()->startOfDay());
+        $period = Carbon::now()->startOfDay()->toPeriod(Carbon::now()->addDay()->startOfDay());
         $builder->select('*')->from('users')->whereBetween('created_at', $period);
         $this->assertSame('select * from "users" where "created_at" between ? and ?', $builder->toSql());
-        $this->assertEquals([now()->startOfDay(), now()->addDay()->startOfDay()], $builder->getBindings());
+        $this->assertEquals([Carbon::now()->startOfDay(), Carbon::now()->addDay()->startOfDay()], $builder->getBindings());
 
         // custom long carbon period date
         $builder = $this->getBuilder();
-        $period = now()->startOfDay()->toPeriod(now()->addMonth()->startOfDay());
+        $period = Carbon::now()->startOfDay()->toPeriod(Carbon::now()->addMonth()->startOfDay());
         $builder->select('*')->from('users')->whereBetween('created_at', $period);
         $this->assertSame('select * from "users" where "created_at" between ? and ?', $builder->toSql());
-        $this->assertEquals([now()->startOfDay(), now()->addMonth()->startOfDay()], $builder->getBindings());
+        $this->assertEquals([Carbon::now()->startOfDay(), Carbon::now()->addMonth()->startOfDay()], $builder->getBindings());
 
         // DatePeriod with end date
         $builder = $this->getBuilder();
-        $period = new \DatePeriod(now()->startOfDay(), new \DateInterval('P1D'), now()->addDays(5)->startOfDay());
+        $period = new DatePeriod(Carbon::now()->startOfDay(), new DateInterval('P1D'), Carbon::now()->addDays(5)->startOfDay());
         $builder->select('*')->from('users')->whereBetween('created_at', $period);
         $this->assertSame('select * from "users" where "created_at" between ? and ?', $builder->toSql());
-        $this->assertEquals([now()->startOfDay(), now()->addDays(5)->startOfDay()], $builder->getBindings());
+        $this->assertEquals([Carbon::now()->startOfDay(), Carbon::now()->addDays(5)->startOfDay()], $builder->getBindings());
 
         // DatePeriod with recurrence count (no end date)
         $builder = $this->getBuilder();
-        $period = new \DatePeriod(now()->startOfDay(), new \DateInterval('P1D'), 5);
+        $period = new DatePeriod(Carbon::now()->startOfDay(), new DateInterval('P1D'), 5);
         $builder->select('*')->from('users')->whereBetween('created_at', $period);
         $this->assertSame('select * from "users" where "created_at" between ? and ?', $builder->toSql());
-        $this->assertEquals([now()->startOfDay(), now()->addDays(5)->startOfDay()], $builder->getBindings());
+        $this->assertEquals([Carbon::now()->startOfDay(), Carbon::now()->addDays(5)->startOfDay()], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereBetween('id', collect([1, 2]));
@@ -6625,7 +6628,7 @@ SQL;
 
     public function testCursorPaginateWithUnionWheres()
     {
-        $ts = now()->toDateTimeString();
+        $ts = Carbon::now()->toDateTimeString();
 
         $perPage = 16;
         $columns = ['test'];
@@ -6643,8 +6646,8 @@ SQL;
         $path = 'http://foo.bar?cursor='.$cursor->encode();
 
         $results = collect([
-            ['id' => 1, 'created_at' => now(), 'type' => 'video'],
-            ['id' => 2, 'created_at' => now(), 'type' => 'news'],
+            ['id' => 1, 'created_at' => Carbon::now(), 'type' => 'video'],
+            ['id' => 2, 'created_at' => Carbon::now(), 'type' => 'news'],
         ]);
 
         $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results, $ts) {
@@ -6672,7 +6675,7 @@ SQL;
 
     public function testCursorPaginateWithMultipleUnionsAndMultipleWheres()
     {
-        $ts = now()->toDateTimeString();
+        $ts = Carbon::now()->toDateTimeString();
 
         $perPage = 16;
         $columns = ['test'];
@@ -6691,9 +6694,9 @@ SQL;
         $path = 'http://foo.bar?cursor='.$cursor->encode();
 
         $results = collect([
-            ['id' => 1, 'created_at' => now(), 'type' => 'video'],
-            ['id' => 2, 'created_at' => now(), 'type' => 'news'],
-            ['id' => 3, 'created_at' => now(), 'type' => 'podcasts'],
+            ['id' => 1, 'created_at' => Carbon::now(), 'type' => 'video'],
+            ['id' => 2, 'created_at' => Carbon::now(), 'type' => 'news'],
+            ['id' => 3, 'created_at' => Carbon::now(), 'type' => 'podcasts'],
         ]);
 
         $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results, $ts) {
@@ -6721,7 +6724,7 @@ SQL;
 
     public function testCursorPaginateWithUnionMultipleWheresMultipleOrders()
     {
-        $ts = now()->toDateTimeString();
+        $ts = Carbon::now()->toDateTimeString();
 
         $perPage = 16;
         $columns = ['id', 'created_at', 'type'];
@@ -6740,10 +6743,10 @@ SQL;
         $path = 'http://foo.bar?cursor='.$cursor->encode();
 
         $results = collect([
-            ['id' => 1, 'created_at' => now()->addDay(), 'type' => 'video'],
-            ['id' => 1, 'created_at' => now(), 'type' => 'news'],
-            ['id' => 1, 'created_at' => now(), 'type' => 'podcast'],
-            ['id' => 2, 'created_at' => now(), 'type' => 'podcast'],
+            ['id' => 1, 'created_at' => Carbon::now()->addDay(), 'type' => 'video'],
+            ['id' => 1, 'created_at' => Carbon::now(), 'type' => 'news'],
+            ['id' => 1, 'created_at' => Carbon::now(), 'type' => 'podcast'],
+            ['id' => 2, 'created_at' => Carbon::now(), 'type' => 'podcast'],
         ]);
 
         $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results, $ts) {
@@ -6771,7 +6774,7 @@ SQL;
 
     public function testCursorPaginateWithUnionWheresWithRawOrderExpression()
     {
-        $ts = now()->toDateTimeString();
+        $ts = Carbon::now()->toDateTimeString();
 
         $perPage = 16;
         $columns = ['test'];
@@ -6789,8 +6792,8 @@ SQL;
         $path = 'http://foo.bar?cursor='.$cursor->encode();
 
         $results = collect([
-            ['id' => 1, 'created_at' => now(), 'type' => 'video', 'is_published' => true],
-            ['id' => 2, 'created_at' => now(), 'type' => 'news', 'is_published' => true],
+            ['id' => 1, 'created_at' => Carbon::now(), 'type' => 'video', 'is_published' => true],
+            ['id' => 2, 'created_at' => Carbon::now(), 'type' => 'news', 'is_published' => true],
         ]);
 
         $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results, $ts) {
@@ -6818,7 +6821,7 @@ SQL;
 
     public function testCursorPaginateWithUnionWheresReverseOrder()
     {
-        $ts = now()->toDateTimeString();
+        $ts = Carbon::now()->toDateTimeString();
 
         $perPage = 16;
         $columns = ['test'];
@@ -6836,8 +6839,8 @@ SQL;
         $path = 'http://foo.bar?cursor='.$cursor->encode();
 
         $results = collect([
-            ['id' => 1, 'created_at' => now(), 'type' => 'video'],
-            ['id' => 2, 'created_at' => now(), 'type' => 'news'],
+            ['id' => 1, 'created_at' => Carbon::now(), 'type' => 'video'],
+            ['id' => 2, 'created_at' => Carbon::now(), 'type' => 'news'],
         ]);
 
         $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results, $ts) {
@@ -6865,7 +6868,7 @@ SQL;
 
     public function testCursorPaginateWithUnionWheresMultipleOrders()
     {
-        $ts = now()->toDateTimeString();
+        $ts = Carbon::now()->toDateTimeString();
 
         $perPage = 16;
         $columns = ['test'];
@@ -6883,8 +6886,8 @@ SQL;
         $path = 'http://foo.bar?cursor='.$cursor->encode();
 
         $results = collect([
-            ['id' => 1, 'created_at' => now(), 'type' => 'video'],
-            ['id' => 2, 'created_at' => now(), 'type' => 'news'],
+            ['id' => 1, 'created_at' => Carbon::now(), 'type' => 'video'],
+            ['id' => 2, 'created_at' => Carbon::now(), 'type' => 'news'],
         ]);
 
         $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results, $ts) {
@@ -6912,7 +6915,7 @@ SQL;
 
     public function testCursorPaginateWithUnionWheresAndAliassedOrderColumns()
     {
-        $ts = now()->toDateTimeString();
+        $ts = Carbon::now()->toDateTimeString();
 
         $perPage = 16;
         $columns = ['test'];
@@ -6931,9 +6934,9 @@ SQL;
         $path = 'http://foo.bar?cursor='.$cursor->encode();
 
         $results = collect([
-            ['id' => 1, 'created_at' => now(), 'type' => 'video'],
-            ['id' => 2, 'created_at' => now(), 'type' => 'news'],
-            ['id' => 3, 'created_at' => now(), 'type' => 'podcast'],
+            ['id' => 1, 'created_at' => Carbon::now(), 'type' => 'video'],
+            ['id' => 2, 'created_at' => Carbon::now(), 'type' => 'news'],
+            ['id' => 3, 'created_at' => Carbon::now(), 'type' => 'podcast'],
         ]);
 
         $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results, $ts) {
@@ -7667,7 +7670,7 @@ SQL;
     }
 
     /**
-     * @return \Mockery\MockInterface|\Illuminate\Database\Query\Builder
+     * @return MockInterface|\Illuminate\Database\Query\Builder
      */
     protected function getMockQueryBuilder()
     {

--- a/tests/Events/QueuedEventsTest.php
+++ b/tests/Events/QueuedEventsTest.php
@@ -17,6 +17,7 @@ use Illuminate\Queue\CallQueuedHandler;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\QueueManager;
 use Illuminate\Queue\QueueRoutes;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Testing\Fakes\QueueFake;
 use Laravel\SerializableClosure\SerializableClosure;
 use Mockery as m;
@@ -668,7 +669,7 @@ class TestDispatcherOptions implements ShouldQueue
 
     public function retryUntil()
     {
-        return now()->addHour(1);
+        return Carbon::now()->addHour(1);
     }
 
     public function tries()

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Tests\Filesystem;
 
-use Carbon\Carbon;
 use GuzzleHttp\Psr7\Stream;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Debug\ExceptionHandler;
@@ -10,6 +9,7 @@ use Illuminate\Filesystem\FilesystemAdapter;
 use Illuminate\Filesystem\FilesystemManager;
 use Illuminate\Foundation\Application;
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Carbon;
 use Illuminate\Testing\Assert;
 use InvalidArgumentException;
 use League\Flysystem\Filesystem;

--- a/tests/Foundation/Testing/WormholeTest.php
+++ b/tests/Foundation/Testing/WormholeTest.php
@@ -20,14 +20,14 @@ class WormholeTest extends TestCase
     public function testCanTravelBackToPresent()
     {
         // Preserve the timelines we want to compare the reality with...
-        $present = now();
-        $future = now()->addDays(10);
+        $present = Date::now();
+        $future = Date::now()->addDays(10);
 
         // Travel in time...
         (new Wormhole(10))->days();
 
         // Assert we are now in the future...
-        $this->assertEquals($future->format('Y-m-d'), now()->format('Y-m-d'));
+        $this->assertEquals($future->format('Y-m-d'), Date::now()->format('Y-m-d'));
 
         // Assert we can go back to the present...
         $this->assertEquals($present->format('Y-m-d'), Wormhole::back()->format('Y-m-d'));
@@ -39,7 +39,7 @@ class WormholeTest extends TestCase
         Date::use(CarbonImmutable::class);
 
         // Record what time it is in 10 days...
-        $present = now();
+        $present = Date::now();
         $future = $present->addDays(10);
 
         // Travel in time...
@@ -49,7 +49,7 @@ class WormholeTest extends TestCase
         $this->assertNotEquals($future->format('Y-m-d'), $present->format('Y-m-d'));
 
         // Assert the time travel was successful...
-        $this->assertEquals($future->format('Y-m-d'), now()->format('Y-m-d'));
+        $this->assertEquals($future->format('Y-m-d'), Date::now()->format('Y-m-d'));
     }
 
     public function testItCanTravelByMicroseconds()

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -3820,13 +3820,13 @@ class HttpClientTest extends TestCase
 
     public function testItCanAddGlobalMiddleware()
     {
-        Carbon::setTestNow(now()->startOfDay());
+        Carbon::setTestNow(Carbon::now()->startOfDay());
         $requests = [];
         $responses = [];
         $this->factory->fake(function ($r) use (&$requests) {
             $requests[] = $r;
 
-            Carbon::setTestNow(now()->addSeconds(6 * count($requests)));
+            Carbon::setTestNow(Carbon::now()->addSeconds(6 * count($requests)));
 
             return $this->factory::response('expected content');
         });
@@ -3843,10 +3843,10 @@ class HttpClientTest extends TestCase
         }))->globalMiddleware(function ($handler) {
             // Test wrapping request in timing function...
             return function ($request, $options) use ($handler) {
-                $startedAt = now();
+                $startedAt = Carbon::now();
 
                 return $handler($request, $options)->then(function (ResponseInterface $response) use ($startedAt) {
-                    return $response->withHeader('X-Duration', "{$startedAt->diffInSeconds(now())} seconds");
+                    return $response->withHeader('X-Duration', "{$startedAt->diffInSeconds(Carbon::now())} seconds");
                 });
             };
         });

--- a/tests/Integration/Cache/RepositoryTest.php
+++ b/tests/Integration/Cache/RepositoryTest.php
@@ -40,7 +40,7 @@ class RepositoryTest extends TestCase
         $this->assertSame(1, $cache->get('foo'));
         $this->assertSame(946684800, $cache->get('illuminate:cache:flexible:created:foo'));
 
-        Carbon::setTestNow(now()->addSeconds(11));
+        Carbon::setTestNow(Carbon::now()->addSeconds(11));
 
         // Cache is now "stale". The stored value should be used and a deferred
         // callback should be registered to refresh the cache.
@@ -80,7 +80,7 @@ class RepositoryTest extends TestCase
         $this->assertSame(946684811, $cache->get('illuminate:cache:flexible:created:foo'));
 
         // Let's now progress time beyond the stale TTL...
-        Carbon::setTestNow(now()->addSeconds(21));
+        Carbon::setTestNow(Carbon::now()->addSeconds(21));
 
         // Now the values should have left the cache. We should refresh.
         $value = $cache->flexible('foo', [10, 20], function () use (&$count) {
@@ -94,7 +94,7 @@ class RepositoryTest extends TestCase
         // Now lets see what happens when another request, job, or command is
         // also trying to refresh the same key at the same time. Will push past
         // the "fresh" TTL and register a deferred callback.
-        Carbon::setTestNow(now()->addSeconds(11));
+        Carbon::setTestNow(Carbon::now()->addSeconds(11));
         $value = $cache->flexible('foo', [10, 20], function () use (&$count) {
             return ++$count;
         });
@@ -127,7 +127,7 @@ class RepositoryTest extends TestCase
         // The last thing is to check that we don't refresh the cache in the
         // deferred callback if another thread has already done the work for us.
         // We will make the cache stale...
-        Carbon::setTestNow(now()->addSeconds(11));
+        Carbon::setTestNow(Carbon::now()->addSeconds(11));
         $value = $cache->flexible('foo', [10, 20], function () use (&$count) {
             return ++$count;
         });
@@ -252,7 +252,7 @@ class RepositoryTest extends TestCase
         // First call to flexible() should not defer
         $this->assertCount(0, defer());
 
-        Carbon::setTestNow(now()->addSeconds(11));
+        Carbon::setTestNow(Carbon::now()->addSeconds(11));
 
         // Second callback should defer with always now true
         $cache->flexible('foo', [10, 20], function () use (&$count) {
@@ -272,7 +272,7 @@ class RepositoryTest extends TestCase
             $events[] = $event;
         });
 
-        $result = $cache->put('foo', 'bar', now()->addSecond());
+        $result = $cache->put('foo', 'bar', Carbon::now()->addSecond());
 
         $this->assertTrue($result);
         $this->assertCount(1, $events);

--- a/tests/Integration/Console/CommandDurationThresholdTest.php
+++ b/tests/Integration/Console/CommandDurationThresholdTest.php
@@ -193,7 +193,7 @@ class CommandDurationThresholdTest extends TestCase
         Carbon::setTestNow(Carbon::now());
         $kernel->handle($input = new StringInput('foo'), new ConsoleOutput);
 
-        Carbon::setTestNow(now()->addMinute());
+        Carbon::setTestNow(Carbon::now()->addMinute());
         $kernel->terminate($input, 21);
 
         $this->assertSame('Australia/Melbourne', $startedAt->timezone->getName());

--- a/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
@@ -257,7 +257,7 @@ class ScheduleListCommandTest extends TestCase
 
         $this->artisan(ScheduleListCommand::class, ['-v' => true])
             ->assertSuccessful()
-            ->expectsOutputToContain('Next Due: '.now()->setMinutes(1)->format('Y-m-d H:i:s P'))
+            ->expectsOutputToContain('Next Due: '.Carbon::now()->setMinutes(1)->format('Y-m-d H:i:s P'))
             ->expectsOutput('             ⇁ This is the description of the command.');
     }
 

--- a/tests/Integration/Console/Scheduling/ScheduleTestCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleTestCommandTest.php
@@ -17,7 +17,7 @@ class ScheduleTestCommandTest extends TestCase
     {
         parent::setUp();
 
-        Carbon::setTestNow(now()->startOfYear());
+        Carbon::setTestNow(Carbon::now()->startOfYear());
 
         $this->schedule = $this->app->make(Schedule::class);
     }

--- a/tests/Integration/Console/Scheduling/SubMinuteSchedulingTest.php
+++ b/tests/Integration/Console/Scheduling/SubMinuteSchedulingTest.php
@@ -23,7 +23,7 @@ class SubMinuteSchedulingTest extends TestCase
 
     public function test_it_doesnt_wait_for_sub_minute_events_when_nothing_is_scheduled()
     {
-        Carbon::setTestNow(now()->startOfMinute());
+        Carbon::setTestNow(Carbon::now()->startOfMinute());
         Sleep::fake();
 
         $this->artisan('schedule:run')
@@ -38,7 +38,7 @@ class SubMinuteSchedulingTest extends TestCase
             ->call(fn () => true)
             ->everyMinute();
 
-        Carbon::setTestNow(now()->startOfMinute());
+        Carbon::setTestNow(Carbon::now()->startOfMinute());
         Sleep::fake();
 
         $this->artisan('schedule:run')
@@ -55,9 +55,9 @@ class SubMinuteSchedulingTest extends TestCase
             $runs++;
         })->{$frequency}();
 
-        Carbon::setTestNow(now()->startOfMinute());
+        Carbon::setTestNow(Carbon::now()->startOfMinute());
         Sleep::fake();
-        Sleep::whenFakingSleep(fn ($duration) => Carbon::setTestNow(now()->add($duration)));
+        Sleep::whenFakingSleep(fn ($duration) => Carbon::setTestNow(Carbon::now()->add($duration)));
 
         $this->artisan('schedule:run')
             ->expectsOutputToContain('Running [Callback]');
@@ -78,9 +78,9 @@ class SubMinuteSchedulingTest extends TestCase
             $everyThirtySecondsRuns++;
         })->everyThirtySeconds();
 
-        Carbon::setTestNow(now()->startOfMinute());
+        Carbon::setTestNow(Carbon::now()->startOfMinute());
         Sleep::fake();
-        Sleep::whenFakingSleep(fn ($duration) => Carbon::setTestNow(now()->add($duration)));
+        Sleep::whenFakingSleep(fn ($duration) => Carbon::setTestNow(Carbon::now()->add($duration)));
 
         $this->artisan('schedule:run')
             ->expectsOutputToContain('Running [Callback]');
@@ -97,11 +97,11 @@ class SubMinuteSchedulingTest extends TestCase
             $runs++;
         })->everySecond();
 
-        Carbon::setTestNow(now()->startOfMinute());
-        $startedAt = now();
+        Carbon::setTestNow(Carbon::now()->startOfMinute());
+        $startedAt = Carbon::now();
         Sleep::fake();
         Sleep::whenFakingSleep(function ($duration) use ($startedAt) {
-            Carbon::setTestNow(now()->add($duration));
+            Carbon::setTestNow(Carbon::now()->add($duration));
 
             if ($startedAt->diffInSeconds() >= 30) {
                 $this->artisan('schedule:interrupt')
@@ -114,7 +114,7 @@ class SubMinuteSchedulingTest extends TestCase
 
         Sleep::assertSleptTimes(300);
         $this->assertEquals(30, $runs);
-        $this->assertEquals(30, $startedAt->diffInSeconds(now()));
+        $this->assertEquals(30, $startedAt->diffInSeconds(Carbon::now()));
     }
 
     public function test_sub_minute_events_stop_for_the_rest_of_the_minute_once_maintenance_mode_is_enabled()
@@ -126,11 +126,11 @@ class SubMinuteSchedulingTest extends TestCase
 
         Config::set('app.maintenance.driver', 'cache');
         Config::set('app.maintenance.store', 'array');
-        Carbon::setTestNow(now()->startOfMinute());
-        $startedAt = now();
+        Carbon::setTestNow(Carbon::now()->startOfMinute());
+        $startedAt = Carbon::now();
         Sleep::fake();
         Sleep::whenFakingSleep(function ($duration) use ($startedAt) {
-            Carbon::setTestNow(now()->add($duration));
+            Carbon::setTestNow(Carbon::now()->add($duration));
 
             if ($startedAt->diffInSeconds() >= 30 && ! $this->app->isDownForMaintenance()) {
                 $this->artisan('down');
@@ -157,13 +157,13 @@ class SubMinuteSchedulingTest extends TestCase
 
         Config::set('app.maintenance.driver', 'cache');
         Config::set('app.maintenance.store', 'array');
-        Carbon::setTestNow(now()->startOfMinute());
-        $startedAt = now();
+        Carbon::setTestNow(Carbon::now()->startOfMinute());
+        $startedAt = Carbon::now();
         Sleep::fake();
         Sleep::whenFakingSleep(function ($duration) use ($startedAt) {
-            Carbon::setTestNow(now()->add($duration));
+            Carbon::setTestNow(Carbon::now()->add($duration));
 
-            if (now()->diffInSeconds($startedAt) >= 30 && ! $this->app->isDownForMaintenance()) {
+            if (Carbon::now()->diffInSeconds($startedAt) >= 30 && ! $this->app->isDownForMaintenance()) {
                 $this->artisan('down');
             }
         });
@@ -182,11 +182,11 @@ class SubMinuteSchedulingTest extends TestCase
             $runs++;
         })->everySecond()->evenWhenPaused();
 
-        Carbon::setTestNow(now()->startOfMinute());
-        $startedAt = now();
+        Carbon::setTestNow(Carbon::now()->startOfMinute());
+        $startedAt = Carbon::now();
         Sleep::fake();
         Sleep::whenFakingSleep(function ($duration) use ($startedAt) {
-            Carbon::setTestNow(now()->add($duration));
+            Carbon::setTestNow(Carbon::now()->add($duration));
 
             if ($startedAt->diffInSeconds() >= 30 && ! Cache::has('illuminate:schedule:paused')) {
                 $this->artisan('schedule:pause');
@@ -207,11 +207,11 @@ class SubMinuteSchedulingTest extends TestCase
             $runs++;
         })->everySecond();
 
-        Carbon::setTestNow(now()->startOfMinute());
-        $startedAt = now();
+        Carbon::setTestNow(Carbon::now()->startOfMinute());
+        $startedAt = Carbon::now();
         Sleep::fake();
         Sleep::whenFakingSleep(function ($duration) use ($startedAt) {
-            Carbon::setTestNow(now()->add($duration));
+            Carbon::setTestNow(Carbon::now()->add($duration));
 
             if ($startedAt->diffInSeconds() >= 30 && ! Cache::has('illuminate:schedule:paused')) {
                 $this->artisan('schedule:pause');
@@ -230,11 +230,11 @@ class SubMinuteSchedulingTest extends TestCase
         $runs = 0;
         $this->schedule->call(function () use (&$runs) {
             $runs++;
-        })->everySecond()->when(fn () => now()->second % 2 === 0);
+        })->everySecond()->when(fn () => Carbon::now()->second % 2 === 0);
 
-        Carbon::setTestNow(now()->startOfMinute());
+        Carbon::setTestNow(Carbon::now()->startOfMinute());
         Sleep::fake();
-        Sleep::whenFakingSleep(fn ($duration) => Carbon::setTestNow(now()->add($duration)));
+        Sleep::whenFakingSleep(fn ($duration) => Carbon::setTestNow(Carbon::now()->add($duration)));
 
         $this->artisan('schedule:run')
             ->expectsOutputToContain('Running [Callback]');
@@ -250,10 +250,10 @@ class SubMinuteSchedulingTest extends TestCase
             $runs++;
         })->everySecond()->name('test')->onOneServer();
 
-        $startedAt = now()->startOfMinute();
+        $startedAt = Carbon::now()->startOfMinute();
         Carbon::setTestNow($startedAt);
         Sleep::fake();
-        Sleep::whenFakingSleep(fn ($duration) => Carbon::setTestNow(now()->add($duration)));
+        Sleep::whenFakingSleep(fn ($duration) => Carbon::setTestNow(Carbon::now()->add($duration)));
 
         $this->app->instance(Schedule::class, clone $this->schedule);
         $this->artisan('schedule:run')

--- a/tests/Integration/Database/DatabaseEloquentModelAttributeCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelAttributeCastingTest.php
@@ -100,7 +100,7 @@ class DatabaseEloquentModelAttributeCastingTest extends DatabaseTestCase
         $this->assertTrue($model->isDirty('options'));
 
         $model = new TestEloquentModelWithAttributeCast;
-        $model->birthday_at = now();
+        $model->birthday_at = Carbon::now();
         $this->assertIsString($model->toArray()['birthday_at']);
     }
 

--- a/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
@@ -101,11 +101,11 @@ class DatabaseEloquentModelCustomCastingTest extends DatabaseTestCase
         $this->assertTrue($model->isDirty('options'));
 
         $model = new TestEloquentModelWithCustomCast;
-        $model->birthday_at = now();
+        $model->birthday_at = Carbon::now();
         $this->assertIsString($model->toArray()['birthday_at']);
 
         $model = new TestEloquentModelWithCustomCast;
-        $now = now()->toImmutable();
+        $now = Carbon::now()->toImmutable();
         $model->anniversary_on_with_object_caching = $now;
         $model->anniversary_on_without_object_caching = $now;
         $this->assertSame($now, $model->anniversary_on_with_object_caching);

--- a/tests/Integration/Database/DatabaseLockTest.php
+++ b/tests/Integration/Database/DatabaseLockTest.php
@@ -6,6 +6,7 @@ use Illuminate\Cache\DatabaseLock;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Database\QueryException;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Mockery as m;
@@ -56,7 +57,7 @@ class DatabaseLockTest extends DatabaseTestCase
     {
         $lock = Cache::driver('database')->lock('foo');
         $this->assertTrue($lock->get());
-        DB::table('cache_locks')->update(['expiration' => now()->subDays(1)->getTimestamp()]);
+        DB::table('cache_locks')->update(['expiration' => Carbon::now()->subDays(1)->getTimestamp()]);
 
         $otherLock = Cache::driver('database')->lock('foo');
         $this->assertTrue($otherLock->get());

--- a/tests/Integration/Database/EloquentHasManyTest.php
+++ b/tests/Integration/Database/EloquentHasManyTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Integration\Database;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
@@ -35,7 +36,7 @@ class EloquentHasManyTest extends DatabaseTestCase
     {
         $user = EloquentHasManyTestUser::create();
 
-        $user->logins()->create(['login_time' => now()]);
+        $user->logins()->create(['login_time' => Carbon::now()]);
 
         $this->assertInstanceOf(HasOne::class, $user->logins()->one());
     }

--- a/tests/Integration/Database/EloquentHasManyThroughTest.php
+++ b/tests/Integration/Database/EloquentHasManyThroughTest.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasOneThrough;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
@@ -389,8 +390,8 @@ class EloquentHasManyThroughTest extends DatabaseTestCase
 
         $user = User::create(['team_id' => $team->id, 'name' => Str::random()]);
 
-        Article::create(['user_id' => $user->id, 'title' => Str::random(), 'created_at' => now()->subDay()]);
-        $latestArticle = Article::create(['user_id' => $user->id, 'title' => Str::random(), 'created_at' => now()]);
+        Article::create(['user_id' => $user->id, 'title' => Str::random(), 'created_at' => Carbon::now()->subDay()]);
+        $latestArticle = Article::create(['user_id' => $user->id, 'title' => Str::random(), 'created_at' => Carbon::now()]);
 
         $this->assertEquals($latestArticle->id, $team->latestArticle->id);
     }

--- a/tests/Integration/Database/EloquentMassPrunableTest.php
+++ b/tests/Integration/Database/EloquentMassPrunableTest.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Events\ModelsPruned;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Schema;
 use LogicException;
 use Mockery as m;
@@ -79,7 +80,7 @@ class EloquentMassPrunableTest extends DatabaseTestCase
             ->with(m::type(ModelsPruned::class));
 
         collect(range(1, 5000))->map(function ($id) {
-            return ['deleted_at' => now()];
+            return ['deleted_at' => Carbon::now()];
         })->chunk(200)->each(function ($chunk) {
             MassPrunableSoftDeleteTestModel::insert($chunk->all());
         });

--- a/tests/Integration/Database/EloquentModelDateCastingTest.php
+++ b/tests/Integration/Database/EloquentModelDateCastingTest.php
@@ -2,10 +2,10 @@
 
 namespace Illuminate\Tests\Integration\Database\EloquentModelDateCastingTest;
 
-use Carbon\Carbon;
 use Carbon\CarbonImmutable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 

--- a/tests/Integration/Database/EloquentMorphEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentMorphEagerLoadingTest.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
@@ -40,7 +41,7 @@ class EloquentMorphEagerLoadingTest extends DatabaseTestCase
         });
 
         $user = User::create();
-        $user2 = User::forceCreate(['deleted_at' => now()]);
+        $user2 = User::forceCreate(['deleted_at' => Carbon::now()]);
 
         $post = tap((new Post)->user()->associate($user))->save();
 
@@ -98,7 +99,7 @@ class EloquentMorphEagerLoadingTest extends DatabaseTestCase
 
     public function testMorphWithTrashedRelationLazyLoading()
     {
-        $deletedUser = User::forceCreate(['deleted_at' => now()]);
+        $deletedUser = User::forceCreate(['deleted_at' => Carbon::now()]);
 
         $action = new Action;
         $action->target()->associate($deletedUser)->save();

--- a/tests/Integration/Database/EloquentPrunableTest.php
+++ b/tests/Integration/Database/EloquentPrunableTest.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Prunable;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Events\ModelsPruned;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Exceptions;
 use Illuminate\Support\Facades\Schema;
@@ -67,7 +68,7 @@ class EloquentPrunableTest extends DatabaseTestCase
         Event::fake();
 
         collect(range(1, 5000))->map(function ($id) {
-            return ['deleted_at' => now()];
+            return ['deleted_at' => Carbon::now()];
         })->chunk(200)->each(function ($chunk) {
             PrunableSoftDeleteTestModel::insert($chunk->all());
         });

--- a/tests/Integration/Database/EloquentTransactionWithAfterCommitTests.php
+++ b/tests/Integration/Database/EloquentTransactionWithAfterCommitTests.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Auth\User;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 use Orchestra\Testbench\Concerns\WithLaravelMigrations;
 use Orchestra\Testbench\Factories\UserFactory;
@@ -225,7 +226,7 @@ class EloquentTransactionWithAfterCommitTestsJob implements ShouldQueue
     {
         DB::transaction(function () {
             DB::table('password_reset_tokens')->insert([
-                ['email' => $this->email, 'token' => sha1($this->email), 'created_at' => now()],
+                ['email' => $this->email, 'token' => sha1($this->email), 'created_at' => Carbon::now()],
             ]);
         });
     }

--- a/tests/Integration/Database/MariaDb/EloquentCastTest.php
+++ b/tests/Integration/Database/MariaDb/EloquentCastTest.php
@@ -36,8 +36,8 @@ class EloquentCastTest extends MariaDbTestCase
 
     public function testItCastTimestampsCreatedByTheBuilderWhenTimeHasNotPassed()
     {
-        Carbon::setTestNow(now());
-        $createdAt = now()->timestamp;
+        Carbon::setTestNow(Carbon::now());
+        $createdAt = Carbon::now()->timestamp;
 
         $castUser = UserWithIntTimestampsViaCasts::create([
             'email' => fake()->unique()->email,
@@ -79,8 +79,8 @@ class EloquentCastTest extends MariaDbTestCase
 
     public function testItCastTimestampsCreatedByTheBuilderWhenTimeHasPassed()
     {
-        Carbon::setTestNow(now());
-        $createdAt = now()->timestamp;
+        Carbon::setTestNow(Carbon::now());
+        $createdAt = Carbon::now()->timestamp;
 
         $castUser = UserWithIntTimestampsViaCasts::create([
             'email' => fake()->unique()->email,
@@ -99,8 +99,8 @@ class EloquentCastTest extends MariaDbTestCase
         $this->assertSame($createdAt, $mutatorUser->created_at->timestamp);
         $this->assertSame($createdAt, $mutatorUser->updated_at->timestamp);
 
-        Carbon::setTestNow(now()->addSecond());
-        $updatedAt = now()->timestamp;
+        Carbon::setTestNow(Carbon::now()->addSecond());
+        $updatedAt = Carbon::now()->timestamp;
 
         $castUser->update([
             'email' => fake()->unique()->email,
@@ -125,7 +125,7 @@ class EloquentCastTest extends MariaDbTestCase
 
     public function testItCastTimestampsUpdatedByAMutator()
     {
-        Carbon::setTestNow(now());
+        Carbon::setTestNow(Carbon::now());
 
         $mutatorUser = UserWithUpdatedAtViaMutator::create([
             'email' => fake()->unique()->email,
@@ -133,8 +133,8 @@ class EloquentCastTest extends MariaDbTestCase
 
         $this->assertNull($mutatorUser->updated_at);
 
-        Carbon::setTestNow(now()->addSecond());
-        $updatedAt = now()->timestamp;
+        Carbon::setTestNow(Carbon::now()->addSecond());
+        $updatedAt = Carbon::now()->timestamp;
 
         $mutatorUser->update([
             'email' => fake()->unique()->email,

--- a/tests/Integration/Database/MySql/EloquentCastTest.php
+++ b/tests/Integration/Database/MySql/EloquentCastTest.php
@@ -36,8 +36,8 @@ class EloquentCastTest extends MySqlTestCase
 
     public function testItCastTimestampsCreatedByTheBuilderWhenTimeHasNotPassed()
     {
-        Carbon::setTestNow(now());
-        $createdAt = now()->timestamp;
+        Carbon::setTestNow(Carbon::now());
+        $createdAt = Carbon::now()->timestamp;
 
         $castUser = UserWithIntTimestampsViaCasts::create([
             'email' => fake()->unique()->email,
@@ -79,8 +79,8 @@ class EloquentCastTest extends MySqlTestCase
 
     public function testItCastTimestampsCreatedByTheBuilderWhenTimeHasPassed()
     {
-        Carbon::setTestNow(now());
-        $createdAt = now()->timestamp;
+        Carbon::setTestNow(Carbon::now());
+        $createdAt = Carbon::now()->timestamp;
 
         $castUser = UserWithIntTimestampsViaCasts::create([
             'email' => fake()->unique()->email,
@@ -99,8 +99,8 @@ class EloquentCastTest extends MySqlTestCase
         $this->assertSame($createdAt, $mutatorUser->created_at->timestamp);
         $this->assertSame($createdAt, $mutatorUser->updated_at->timestamp);
 
-        Carbon::setTestNow(now()->addSecond());
-        $updatedAt = now()->timestamp;
+        Carbon::setTestNow(Carbon::now()->addSecond());
+        $updatedAt = Carbon::now()->timestamp;
 
         $castUser->update([
             'email' => fake()->unique()->email,
@@ -125,7 +125,7 @@ class EloquentCastTest extends MySqlTestCase
 
     public function testItCastTimestampsUpdatedByAMutator()
     {
-        Carbon::setTestNow(now());
+        Carbon::setTestNow(Carbon::now());
 
         $mutatorUser = UserWithUpdatedAtViaMutator::create([
             'email' => fake()->unique()->email,
@@ -133,8 +133,8 @@ class EloquentCastTest extends MySqlTestCase
 
         $this->assertNull($mutatorUser->updated_at);
 
-        Carbon::setTestNow(now()->addSecond());
-        $updatedAt = now()->timestamp;
+        Carbon::setTestNow(Carbon::now()->addSecond());
+        $updatedAt = Carbon::now()->timestamp;
 
         $mutatorUser->update([
             'email' => fake()->unique()->email,

--- a/tests/Integration/Filesystem/ReceiveFileTest.php
+++ b/tests/Integration/Filesystem/ReceiveFileTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Filesystem;
 
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Storage;
 use Orchestra\Testbench\Attributes\WithConfig;
 use Orchestra\Testbench\TestCase;
@@ -20,7 +21,7 @@ class ReceiveFileTest extends TestCase
 
     public function testItCanReceiveAFile()
     {
-        $result = Storage::temporaryUploadUrl('receive-file-test.txt', now()->addMinutes(1));
+        $result = Storage::temporaryUploadUrl('receive-file-test.txt', Carbon::now()->addMinutes(1));
 
         $response = $this->call('PUT', $result['url'], [], [], [], [], 'Hello World');
 
@@ -30,7 +31,7 @@ class ReceiveFileTest extends TestCase
 
     public function testItWill403OnWrongSignature()
     {
-        $result = Storage::temporaryUploadUrl('receive-file-test.txt', now()->addMinutes(1));
+        $result = Storage::temporaryUploadUrl('receive-file-test.txt', Carbon::now()->addMinutes(1));
 
         $url = $result['url'].'c';
 
@@ -42,7 +43,7 @@ class ReceiveFileTest extends TestCase
 
     public function testItWill403OnExpiredUrl()
     {
-        $result = Storage::temporaryUploadUrl('receive-file-test.txt', now()->subMinutes(1));
+        $result = Storage::temporaryUploadUrl('receive-file-test.txt', Carbon::now()->subMinutes(1));
 
         $response = $this->call('PUT', $result['url'], [], [], [], [], 'Hello World');
 
@@ -54,7 +55,7 @@ class ReceiveFileTest extends TestCase
     {
         Storage::put('receive-file-test.txt', 'Original Content');
 
-        $downloadUrl = Storage::temporaryUrl('receive-file-test.txt', now()->addMinutes(1));
+        $downloadUrl = Storage::temporaryUrl('receive-file-test.txt', Carbon::now()->addMinutes(1));
 
         $response = $this->call('PUT', $downloadUrl, [], [], [], [], 'Malicious Content');
 
@@ -66,7 +67,7 @@ class ReceiveFileTest extends TestCase
     {
         Storage::put('receive-file-test.txt', 'Secret Content');
 
-        $uploadUrl = Storage::temporaryUploadUrl('receive-file-test.txt', now()->addMinutes(1));
+        $uploadUrl = Storage::temporaryUploadUrl('receive-file-test.txt', Carbon::now()->addMinutes(1));
 
         $response = $this->get($uploadUrl['url']);
 

--- a/tests/Integration/Filesystem/ServeFileTest.php
+++ b/tests/Integration/Filesystem/ServeFileTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Filesystem;
 
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Storage;
 use Orchestra\Testbench\Attributes\WithConfig;
 use Orchestra\Testbench\TestCase;
@@ -24,7 +25,7 @@ class ServeFileTest extends TestCase
 
     public function testItCanServeAnExistingFile()
     {
-        $url = Storage::temporaryUrl('serve-file-test.txt', now()->addMinutes(1));
+        $url = Storage::temporaryUrl('serve-file-test.txt', Carbon::now()->addMinutes(1));
 
         $response = $this->get($url);
 
@@ -33,7 +34,7 @@ class ServeFileTest extends TestCase
 
     public function testItWill404OnMissingFile()
     {
-        $url = Storage::temporaryUrl('serve-missing-test.txt', now()->addMinutes(1));
+        $url = Storage::temporaryUrl('serve-missing-test.txt', Carbon::now()->addMinutes(1));
 
         $response = $this->get($url);
 
@@ -42,7 +43,7 @@ class ServeFileTest extends TestCase
 
     public function testItWill403OnWrongSignature()
     {
-        $url = Storage::temporaryUrl('serve-file-test.txt', now()->addMinutes(1));
+        $url = Storage::temporaryUrl('serve-file-test.txt', Carbon::now()->addMinutes(1));
 
         $url = $url.'c';
 

--- a/tests/Integration/Foundation/MaintenanceModeTest.php
+++ b/tests/Integration/Foundation/MaintenanceModeTest.php
@@ -168,7 +168,7 @@ class MaintenanceModeTest extends TestCase
         $this->assertTrue(MaintenanceModeBypassCookie::isValid($cookie->getValue(), 'test-key'));
         $this->assertFalse(MaintenanceModeBypassCookie::isValid($cookie->getValue(), 'wrong-key'));
 
-        Carbon::setTestNow(now()->addMonths(6));
+        Carbon::setTestNow(Carbon::now()->addMonths(6));
         $this->assertFalse(MaintenanceModeBypassCookie::isValid($cookie->getValue(), 'test-key'));
     }
 

--- a/tests/Integration/Http/RequestDurationThresholdTest.php
+++ b/tests/Integration/Http/RequestDurationThresholdTest.php
@@ -24,7 +24,7 @@ class RequestDurationThresholdTest extends TestCase
             $called = true;
         });
 
-        Carbon::setTestNow(now());
+        Carbon::setTestNow(Carbon::now());
         $kernel->handle($request);
 
         Carbon::setTestNow(Carbon::now()->addSeconds(1)->addMilliseconds(1));
@@ -44,7 +44,7 @@ class RequestDurationThresholdTest extends TestCase
             $called = true;
         });
 
-        Carbon::setTestNow(now());
+        Carbon::setTestNow(Carbon::now());
         $kernel->handle($request);
 
         Carbon::setTestNow(Carbon::now()->addSeconds(1));
@@ -64,7 +64,7 @@ class RequestDurationThresholdTest extends TestCase
             $url = $request->url();
         });
 
-        Carbon::setTestNow(now());
+        Carbon::setTestNow(Carbon::now());
         $kernel->handle($request);
 
         Carbon::setTestNow(Carbon::now()->addSeconds(2));
@@ -84,9 +84,9 @@ class RequestDurationThresholdTest extends TestCase
         });
 
         Config::set('app.timezone', 'Australia/Melbourne');
-        Carbon::setTestNow(now()->startOfDay());
+        Carbon::setTestNow(Carbon::now()->startOfDay());
         $kernel->handle($request = Request::create('http://localhost/test-route'));
-        Carbon::setTestNow(now()->addMinute());
+        Carbon::setTestNow(Carbon::now()->addMinute());
         $kernel->terminate($request, new Response);
 
         $this->assertSame('Australia/Melbourne', $startedAt->timezone->getName());
@@ -103,7 +103,7 @@ class RequestDurationThresholdTest extends TestCase
             $called = true;
         });
 
-        Carbon::setTestNow(now());
+        Carbon::setTestNow(Carbon::now());
         $kernel->handle($request);
 
         Carbon::setTestNow(Carbon::now()->addSeconds(1)->addMilliseconds(1));
@@ -123,7 +123,7 @@ class RequestDurationThresholdTest extends TestCase
             $called = true;
         });
 
-        Carbon::setTestNow(now());
+        Carbon::setTestNow(Carbon::now());
         $kernel->handle($request);
 
         Carbon::setTestNow(Carbon::now()->addSeconds(1));
@@ -139,11 +139,11 @@ class RequestDurationThresholdTest extends TestCase
         $response = new Response();
         $called = false;
         $kernel = $this->app[Kernel::class];
-        $kernel->whenRequestLifecycleIsLongerThan(now()->addSeconds(1), function () use (&$called) {
+        $kernel->whenRequestLifecycleIsLongerThan(Carbon::now()->addSeconds(1), function () use (&$called) {
             $called = true;
         });
 
-        Carbon::setTestNow(now());
+        Carbon::setTestNow(Carbon::now());
         $kernel->handle($request);
 
         Carbon::setTestNow(Carbon::now()->addSeconds(1)->addMilliseconds(1));
@@ -159,11 +159,11 @@ class RequestDurationThresholdTest extends TestCase
         $response = new Response();
         $called = false;
         $kernel = $this->app[Kernel::class];
-        $kernel->whenRequestLifecycleIsLongerThan(now()->addSeconds(1), function () use (&$called) {
+        $kernel->whenRequestLifecycleIsLongerThan(Carbon::now()->addSeconds(1), function () use (&$called) {
             $called = true;
         });
 
-        Carbon::setTestNow(now());
+        Carbon::setTestNow(Carbon::now());
         $kernel->handle($request);
 
         Carbon::setTestNow(Carbon::now()->addSeconds(1));
@@ -179,7 +179,7 @@ class RequestDurationThresholdTest extends TestCase
         $request = Request::create('http://localhost/test-route');
         $response = new Response();
 
-        Carbon::setTestNow(now());
+        Carbon::setTestNow(Carbon::now());
         $kernel->handle($request);
         $this->assertTrue(Carbon::now()->eq($kernel->requestStartedAt()));
 

--- a/tests/Integration/Http/ThrottleRequestsTest.php
+++ b/tests/Integration/Http/ThrottleRequestsTest.php
@@ -142,9 +142,9 @@ class ThrottleRequestsTest extends TestCase
 
         for ($i = 0; $i < 3; $i++) {
             match ($i) {
-                0 => $this->assertSame('2000-01-01 00:00:00.000', now()->toDateTimeString('m')),
-                1 => $this->assertSame('2000-01-01 00:00:01.000', now()->toDateTimeString('m')),
-                2 => $this->assertSame('2000-01-01 00:00:02.000', now()->toDateTimeString('m')),
+                0 => $this->assertSame('2000-01-01 00:00:00.000', Carbon::now()->toDateTimeString('m')),
+                1 => $this->assertSame('2000-01-01 00:00:01.000', Carbon::now()->toDateTimeString('m')),
+                2 => $this->assertSame('2000-01-01 00:00:02.000', Carbon::now()->toDateTimeString('m')),
             };
 
             $response = $this->get('/');
@@ -153,18 +153,18 @@ class ThrottleRequestsTest extends TestCase
             $response->assertHeader('X-RateLimit-Limit', 3);
             $response->assertHeader('X-RateLimit-Remaining', 3 - ($i + 1));
 
-            Carbon::setTestNow(now()->addSecond());
+            Carbon::setTestNow(Carbon::now()->addSecond());
         }
 
         // It is now 3 seconds past and we will make another request that
         // should be rate limited.
 
-        $this->assertSame('2000-01-01 00:00:03.000', now()->toDateTimeString('m'));
+        $this->assertSame('2000-01-01 00:00:03.000', Carbon::now()->toDateTimeString('m'));
 
         $response = $this->get('/');
         $response->assertStatus(429);
         $response->assertHeader('Retry-After', 57);
-        $response->assertHeader('X-RateLimit-Reset', now()->addSeconds(57)->timestamp);
+        $response->assertHeader('X-RateLimit-Reset', Carbon::now()->addSeconds(57)->timestamp);
         $response->assertHeader('X-RateLimit-Limit', 3);
         $response->assertHeader('X-RateLimit-Remaining', 0);
 
@@ -176,7 +176,7 @@ class ThrottleRequestsTest extends TestCase
         $response = $this->get('/');
         $response->assertStatus(429);
         $response->assertHeader('Retry-After', 1);
-        $response->assertHeader('X-RateLimit-Reset', now()->addSeconds(1)->timestamp);
+        $response->assertHeader('X-RateLimit-Reset', Carbon::now()->addSeconds(1)->timestamp);
         $response->assertHeader('X-RateLimit-Limit', 3);
         $response->assertHeader('X-RateLimit-Remaining', 0);
 
@@ -200,9 +200,9 @@ class ThrottleRequestsTest extends TestCase
 
         for ($i = 0; $i < 3; $i++) {
             match ($i) {
-                0 => $this->assertSame('2000-01-01 00:00:00.000', now()->toDateTimeString('m')),
-                1 => $this->assertSame('2000-01-01 00:00:00.100', now()->toDateTimeString('m')),
-                2 => $this->assertSame('2000-01-01 00:00:00.200', now()->toDateTimeString('m')),
+                0 => $this->assertSame('2000-01-01 00:00:00.000', Carbon::now()->toDateTimeString('m')),
+                1 => $this->assertSame('2000-01-01 00:00:00.100', Carbon::now()->toDateTimeString('m')),
+                2 => $this->assertSame('2000-01-01 00:00:00.200', Carbon::now()->toDateTimeString('m')),
             };
 
             $response = $this->get('/');
@@ -211,18 +211,18 @@ class ThrottleRequestsTest extends TestCase
             $response->assertHeader('X-RateLimit-Limit', 3);
             $response->assertHeader('X-RateLimit-Remaining', 3 - ($i + 1));
 
-            Carbon::setTestNow(now()->addMilliseconds(100));
+            Carbon::setTestNow(Carbon::now()->addMilliseconds(100));
         }
 
         // It is now 300 milliseconds past and we will make another request
         // that should be rate limited.
 
-        $this->assertSame('2000-01-01 00:00:00.300', now()->toDateTimeString('m'));
+        $this->assertSame('2000-01-01 00:00:00.300', Carbon::now()->toDateTimeString('m'));
 
         $response = $this->get('/');
         $response->assertStatus(429);
         $response->assertHeader('Retry-After', 1);
-        $response->assertHeader('X-RateLimit-Reset', now()->addSecond()->timestamp);
+        $response->assertHeader('X-RateLimit-Reset', Carbon::now()->addSecond()->timestamp);
         $response->assertHeader('X-RateLimit-Limit', 3);
         $response->assertHeader('X-RateLimit-Remaining', 0);
 
@@ -233,7 +233,7 @@ class ThrottleRequestsTest extends TestCase
 
         $response = $this->get('/');
         $response->assertHeader('Retry-After', 1);
-        $response->assertHeader('X-RateLimit-Reset', now()->addSecond()->timestamp);
+        $response->assertHeader('X-RateLimit-Reset', Carbon::now()->addSecond()->timestamp);
         $response->assertHeader('X-RateLimit-Limit', 3);
         $response->assertHeader('X-RateLimit-Remaining', 0);
 
@@ -260,27 +260,27 @@ class ThrottleRequestsTest extends TestCase
 
         for ($i = 0; $i < 3; $i++) {
             match ($i) {
-                0 => $this->assertSame('2000-01-01 00:00:00.000', now()->toDateTimeString('m')),
-                1 => $this->assertSame('2000-01-01 00:00:00.100', now()->toDateTimeString('m')),
-                2 => $this->assertSame('2000-01-01 00:00:00.200', now()->toDateTimeString('m')),
+                0 => $this->assertSame('2000-01-01 00:00:00.000', Carbon::now()->toDateTimeString('m')),
+                1 => $this->assertSame('2000-01-01 00:00:00.100', Carbon::now()->toDateTimeString('m')),
+                2 => $this->assertSame('2000-01-01 00:00:00.200', Carbon::now()->toDateTimeString('m')),
             };
 
             $response = $this->get('/');
             $response->assertOk();
             $response->assertContent('ok');
 
-            Carbon::setTestNow(now()->addMilliseconds(100));
+            Carbon::setTestNow(Carbon::now()->addMilliseconds(100));
         }
 
         // It is now 300 milliseconds past and we will make another request
         // that should be rate limited.
 
-        $this->assertSame('2000-01-01 00:00:00.300', now()->toDateTimeString('m'));
+        $this->assertSame('2000-01-01 00:00:00.300', Carbon::now()->toDateTimeString('m'));
 
         $response = $this->get('/');
         $response->assertStatus(429);
         $response->assertHeader('Retry-After', 1);
-        $response->assertHeader('X-RateLimit-Reset', now()->addSecond()->timestamp);
+        $response->assertHeader('X-RateLimit-Reset', Carbon::now()->addSecond()->timestamp);
         $response->assertHeader('X-RateLimit-Limit', 3);
         $response->assertHeader('X-RateLimit-Remaining', 0);
 
@@ -291,7 +291,7 @@ class ThrottleRequestsTest extends TestCase
 
         $response = $this->get('/');
         $response->assertHeader('Retry-After', 1);
-        $response->assertHeader('X-RateLimit-Reset', now()->addSecond()->timestamp);
+        $response->assertHeader('X-RateLimit-Reset', Carbon::now()->addSecond()->timestamp);
         $response->assertHeader('X-RateLimit-Limit', 3);
         $response->assertHeader('X-RateLimit-Remaining', 0);
 
@@ -301,25 +301,25 @@ class ThrottleRequestsTest extends TestCase
 
         for ($i = 0; $i < 2; $i++) {
             match ($i) {
-                0 => $this->assertSame('2000-01-01 00:00:01.000', now()->toDateTimeString('m')),
-                1 => $this->assertSame('2000-01-01 00:00:01.100', now()->toDateTimeString('m')),
+                0 => $this->assertSame('2000-01-01 00:00:01.000', Carbon::now()->toDateTimeString('m')),
+                1 => $this->assertSame('2000-01-01 00:00:01.100', Carbon::now()->toDateTimeString('m')),
             };
 
             $response = $this->get('/');
             $response->assertOk();
             $response->assertContent('ok');
 
-            Carbon::setTestNow(now()->addMilliseconds(100));
+            Carbon::setTestNow(Carbon::now()->addMilliseconds(100));
         }
 
         // The per minute rate limiter should now fail.
 
-        $this->assertSame('2000-01-01 00:00:01.200', now()->toDateTimeString('m'));
+        $this->assertSame('2000-01-01 00:00:01.200', Carbon::now()->toDateTimeString('m'));
 
         $response = $this->get('/');
         $response->assertStatus(429);
         $response->assertHeader('Retry-After', 59);
-        $response->assertHeader('X-RateLimit-Reset', now()->addSeconds(59)->timestamp);
+        $response->assertHeader('X-RateLimit-Reset', Carbon::now()->addSeconds(59)->timestamp);
         $response->assertHeader('X-RateLimit-Limit', 5);
         $response->assertHeader('X-RateLimit-Remaining', 0);
     }
@@ -475,10 +475,10 @@ class ThrottleRequestsTest extends TestCase
         // Make 3 requests, each a second apart, that should all be successful.
         for ($i = 0; $i < 3; $i++) {
             $this->get('/')->assertOk();
-            Carbon::setTestNow(now()->addSecond());
+            Carbon::setTestNow(Carbon::now()->addSecond());
         }
 
-        $this->assertSame('2000-01-01 00:00:03.000', now()->toDateTimeString('m'));
+        $this->assertSame('2000-01-01 00:00:03.000', Carbon::now()->toDateTimeString('m'));
         $this->get('/')->assertStatus(429);
 
         // A fourth request is allowed in the same day but not a fifth.

--- a/tests/Integration/Mail/SendingQueuedMailTest.php
+++ b/tests/Integration/Mail/SendingQueuedMailTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Integration\Mail;
 use Illuminate\Mail\Mailable;
 use Illuminate\Mail\SendQueuedMailable;
 use Illuminate\Queue\Middleware\RateLimited;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Queue;
 use Orchestra\Testbench\TestCase;
@@ -44,7 +45,7 @@ class SendingQueuedMailTest extends TestCase
     {
         Queue::fake();
 
-        $delay = now()->addMinutes(10);
+        $delay = Carbon::now()->addMinutes(10);
 
         Mail::to('test@mail.com')->later($delay, new SendingQueuedMailTestMail);
 

--- a/tests/Integration/Queue/DynamoBatchTest.php
+++ b/tests/Integration/Queue/DynamoBatchTest.php
@@ -8,6 +8,7 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Env;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Str;
@@ -66,7 +67,7 @@ class DynamoBatchTest extends TestCase
         $retrieved = $repo->find($batch->id);
         $this->assertEquals(2, $retrieved->totalJobs);
         $this->assertEquals(0, $retrieved->failedJobs);
-        $this->assertTrue($retrieved->finishedAt->between(now()->subSecond(30), now()));
+        $this->assertTrue($retrieved->finishedAt->between(Carbon::now()->subSecond(30), Carbon::now()));
     }
 
     public function test_retrieve_non_existent_batch()
@@ -113,8 +114,8 @@ class DynamoBatchTest extends TestCase
         $retrieved = $repo->find($batch->id);
         $this->assertEquals(2, $retrieved->totalJobs);
         $this->assertEquals(1, $retrieved->failedJobs);
-        $this->assertTrue($retrieved->finishedAt->between(now()->subSecond(30), now()));
-        $this->assertTrue($retrieved->cancelledAt->between(now()->subSecond(30), now()));
+        $this->assertTrue($retrieved->finishedAt->between(Carbon::now()->subSecond(30), Carbon::now()));
+        $this->assertTrue($retrieved->cancelledAt->between(Carbon::now()->subSecond(30), Carbon::now()));
     }
 
     public function test_get_batches()

--- a/tests/Integration/Queue/JobChainingTest.php
+++ b/tests/Integration/Queue/JobChainingTest.php
@@ -891,7 +891,7 @@ class JobChainAddingExistingJob implements ShouldQueue
 
     public function handle()
     {
-        static::$ranAt = now();
+        static::$ranAt = Carbon::now();
     }
 }
 
@@ -904,7 +904,7 @@ class JobChainAddingAddedJob implements ShouldQueue
 
     public function handle()
     {
-        static::$ranAt = now();
+        static::$ranAt = Carbon::now();
     }
 }
 

--- a/tests/Integration/Queue/RateLimitedTest.php
+++ b/tests/Integration/Queue/RateLimitedTest.php
@@ -266,7 +266,7 @@ class RateLimitedTest extends TestCase
             $this->assertSame($job, $result);
             $this->assertFalse($job->released);
 
-            Carbon::setTestNow(now()->addSeconds(1));
+            Carbon::setTestNow(Carbon::now()->addSeconds(1));
         }
 
         $result = $middleware->handle($job = $jobFactory(), $next);
@@ -310,7 +310,7 @@ class RateLimitedTest extends TestCase
             $this->assertSame($job, $result);
             $this->assertFalse($job->released);
 
-            Carbon::setTestNow(now()->addMilliseconds(100));
+            Carbon::setTestNow(Carbon::now()->addMilliseconds(100));
         }
 
         $result = $middleware->handle($job = $jobFactory(), $next);

--- a/tests/Integration/Queue/ThrottlesExceptionsTest.php
+++ b/tests/Integration/Queue/ThrottlesExceptionsTest.php
@@ -186,7 +186,7 @@ class ThrottlesExceptionsTest extends TestCase
             $this->assertTrue($job->released);
             $this->assertTrue($job->handled);
 
-            Carbon::setTestNow(now()->addSeconds(1));
+            Carbon::setTestNow(Carbon::now()->addSeconds(1));
         }
 
         $result = $middleware->handle($job = $jobFactory(), $next);
@@ -240,7 +240,7 @@ class ThrottlesExceptionsTest extends TestCase
             $this->assertTrue($job->released);
             $this->assertTrue($job->handled);
 
-            Carbon::setTestNow(now()->addMilliseconds(100));
+            Carbon::setTestNow(Carbon::now()->addMilliseconds(100));
         }
 
         $result = $middleware->handle($job = $jobFactory(), $next);
@@ -294,7 +294,7 @@ class ThrottlesExceptionsTest extends TestCase
             $this->assertTrue($job->released);
             $this->assertTrue($job->handled);
 
-            Carbon::setTestNow(now()->addSeconds(1));
+            Carbon::setTestNow(Carbon::now()->addSeconds(1));
         }
 
         $result = $middleware->handle($job = $jobFactory(), $next);

--- a/tests/Integration/Queue/ThrottlesExceptionsWithRedisTest.php
+++ b/tests/Integration/Queue/ThrottlesExceptionsWithRedisTest.php
@@ -29,7 +29,7 @@ class ThrottlesExceptionsWithRedisTest extends TestCase
 
         $this->setUpRedis();
 
-        Carbon::setTestNow(now());
+        Carbon::setTestNow(Carbon::now());
     }
 
     protected function tearDown(): void

--- a/tests/Integration/Routing/UrlSigningTest.php
+++ b/tests/Integration/Routing/UrlSigningTest.php
@@ -60,7 +60,7 @@ class UrlSigningTest extends TestCase
         })->name('foo');
 
         Carbon::setTestNow(Carbon::create(2018, 1, 1));
-        $this->assertIsString($url = URL::temporarySignedRoute('foo', now()->addMinutes(5), ['id' => 1]));
+        $this->assertIsString($url = URL::temporarySignedRoute('foo', Carbon::now()->addMinutes(5), ['id' => 1]));
         $this->assertSame('valid', $this->get($url)->original);
 
         Carbon::setTestNow(Carbon::create(2018, 1, 1)->addMinutes(10));
@@ -76,7 +76,7 @@ class UrlSigningTest extends TestCase
             return $request->hasValidSignature() ? 'valid' : 'invalid';
         })->name('foo');
 
-        URL::temporarySignedRoute('foo', now()->addMinutes(5), ['id' => 1, 'expires' => 253402300799]);
+        URL::temporarySignedRoute('foo', Carbon::now()->addMinutes(5), ['id' => 1, 'expires' => 253402300799]);
     }
 
     public function testSignedUrlWithUrlWithoutSignatureParameter()
@@ -217,7 +217,7 @@ class UrlSigningTest extends TestCase
         })->name('foo')->middleware(ValidateSignature::class);
 
         Carbon::setTestNow(Carbon::create(2018, 1, 1));
-        $this->assertIsString($url = URL::temporarySignedRoute('foo', now()->addMinutes(5), ['id' => 1]));
+        $this->assertIsString($url = URL::temporarySignedRoute('foo', Carbon::now()->addMinutes(5), ['id' => 1]));
         $this->assertSame('valid', $this->get($url)->original);
     }
 
@@ -228,7 +228,7 @@ class UrlSigningTest extends TestCase
         })->name('foo')->middleware(ValidateSignature::class);
 
         Carbon::setTestNow(Carbon::create(2018, 1, 1));
-        $this->assertIsString($url = URL::temporarySignedRoute('foo', now()->addMinutes(5), ['id' => 1]));
+        $this->assertIsString($url = URL::temporarySignedRoute('foo', Carbon::now()->addMinutes(5), ['id' => 1]));
         Carbon::setTestNow(Carbon::create(2018, 1, 1)->addMinutes(10));
 
         $response = $this->get($url);

--- a/tests/Notifications/NotificationDatabaseChannelTest.php
+++ b/tests/Notifications/NotificationDatabaseChannelTest.php
@@ -2,10 +2,10 @@
 
 namespace Illuminate\Tests\Notifications;
 
-use Carbon\Carbon;
 use Illuminate\Notifications\Channels\DatabaseChannel;
 use Illuminate\Notifications\Messages\DatabaseMessage;
 use Illuminate\Notifications\Notification;
+use Illuminate\Support\Carbon;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Queue/FileFailedJobProviderTest.php
+++ b/tests/Queue/FileFailedJobProviderTest.php
@@ -42,7 +42,7 @@ class FileFailedJobProviderTest extends TestCase
     public function testCanRetrieveAllFailedJobs()
     {
         try {
-            Carbon::setTestNow(now());
+            Carbon::setTestNow(Carbon::now());
 
             [$uuidOne, $exceptionOne] = $this->logFailedJob();
             [$uuidTwo, $exceptionTwo] = $this->logFailedJob();
@@ -128,14 +128,14 @@ class FileFailedJobProviderTest extends TestCase
         $this->logFailedJob();
         $this->logFailedJob();
 
-        $this->provider->prune(now()->addDay(1));
+        $this->provider->prune(Carbon::now()->addDay(1));
         $failedJobs = $this->provider->all();
         $this->assertEmpty($failedJobs);
 
         $this->logFailedJob();
         $this->logFailedJob();
 
-        $this->provider->prune(now()->subDay(1));
+        $this->provider->prune(Carbon::now()->subDay(1));
         $failedJobs = $this->provider->all();
         $this->assertCount(2, $failedJobs);
     }
@@ -145,14 +145,14 @@ class FileFailedJobProviderTest extends TestCase
         $this->logFailedJob();
         $this->logFailedJob();
 
-        $this->provider->prune(now()->addHour(1));
+        $this->provider->prune(Carbon::now()->addHour(1));
         $failedJobs = $this->provider->all();
         $this->assertEmpty($failedJobs);
 
         $this->logFailedJob();
         $this->logFailedJob();
 
-        $this->provider->prune(now()->subHour(1));
+        $this->provider->prune(Carbon::now()->subHour(1));
         $failedJobs = $this->provider->all();
         $this->assertCount(2, $failedJobs);
     }

--- a/tests/Queue/QueueBeanstalkdQueueTest.php
+++ b/tests/Queue/QueueBeanstalkdQueueTest.php
@@ -2,10 +2,10 @@
 
 namespace Illuminate\Tests\Queue;
 
-use Carbon\Carbon;
 use Illuminate\Container\Container;
 use Illuminate\Queue\BeanstalkdQueue;
 use Illuminate\Queue\Jobs\BeanstalkdJob;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
 use Mockery as m;
 use Pheanstalk\Contract\JobIdInterface;

--- a/tests/Queue/QueueDatabaseQueueUnitTest.php
+++ b/tests/Queue/QueueDatabaseQueueUnitTest.php
@@ -2,12 +2,12 @@
 
 namespace Illuminate\Tests\Queue;
 
-use Carbon\Carbon;
 use Illuminate\Bus\Batchable;
 use Illuminate\Container\Container;
 use Illuminate\Database\Connection;
 use Illuminate\Queue\DatabaseQueue;
 use Illuminate\Queue\Queue;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
 use Mockery as m;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -229,7 +229,7 @@ class QueueWorkerTest extends TestCase
             throw $e;
         });
 
-        $job->retryUntil = now()->addSeconds(1)->getTimestamp();
+        $job->retryUntil = Carbon::now()->addSeconds(1)->getTimestamp();
 
         $job->attempts = 0;
 

--- a/tests/Support/SleepTest.php
+++ b/tests/Support/SleepTest.php
@@ -232,9 +232,9 @@ class SleepTest extends TestCase
     public function testItCanSleepTillGivenTime()
     {
         Sleep::fake();
-        Carbon::setTestNow(now()->startOfDay());
+        Carbon::setTestNow(Carbon::now()->startOfDay());
 
-        Sleep::until(now()->addMinute());
+        Sleep::until(Carbon::now()->addMinute());
 
         Sleep::assertSequence([
             Sleep::for(60)->seconds(),
@@ -244,9 +244,9 @@ class SleepTest extends TestCase
     public function testItCanSleepTillGivenTimestamp()
     {
         Sleep::fake();
-        Carbon::setTestNow(now()->startOfDay());
+        Carbon::setTestNow(Carbon::now()->startOfDay());
 
-        Sleep::until(now()->addMinute()->timestamp);
+        Sleep::until(Carbon::now()->addMinute()->timestamp);
 
         Sleep::assertSequence([
             Sleep::for(60)->seconds(),
@@ -256,9 +256,9 @@ class SleepTest extends TestCase
     public function testItCanSleepTillGivenTimestampAsString()
     {
         Sleep::fake();
-        Carbon::setTestNow(now()->startOfDay());
+        Carbon::setTestNow(Carbon::now()->startOfDay());
 
-        Sleep::until((string) now()->addMinute()->timestamp);
+        Sleep::until((string) Carbon::now()->addMinute()->timestamp);
 
         Sleep::assertSequence([
             Sleep::for(60)->seconds(),
@@ -282,9 +282,9 @@ class SleepTest extends TestCase
     public function testItSleepsForZeroTimeWithNegativeDateTime()
     {
         Sleep::fake();
-        Carbon::setTestNow(now()->startOfDay());
+        Carbon::setTestNow(Carbon::now()->startOfDay());
 
-        Sleep::until(now()->subMinutes(100));
+        Sleep::until(Carbon::now()->subMinutes(100));
 
         Sleep::assertSequence([
             Sleep::for(0)->seconds(),

--- a/tests/Support/SupportLazyCollectionTest.php
+++ b/tests/Support/SupportLazyCollectionTest.php
@@ -253,7 +253,7 @@ class SupportLazyCollectionTest extends TestCase
     public function testThrottleAccountsForTimePassed()
     {
         Sleep::fake();
-        Carbon::setTestNow(now());
+        Carbon::setTestNow(Carbon::now());
 
         $data = LazyCollection::times(3)
             ->throttle(3)

--- a/types/Cache/Repository.php
+++ b/types/Cache/Repository.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Cache\Repository;
+use Illuminate\Support\Carbon;
 
 use function PHPStan\Testing\assertType;
 
@@ -21,7 +22,7 @@ assertType('mixed', $cache->pull('cache', function (): int {
 assertType('33', $cache->sear('cache', function (): int {
     return 33;
 }));
-assertType('36', $cache->remember('cache', now(), function (): int {
+assertType('36', $cache->remember('cache', Carbon::now(), function (): int {
     return 36;
 }));
 assertType('36', $cache->rememberForever('cache', function (): int {

--- a/types/Contracts/Cache/Repository.php
+++ b/types/Contracts/Cache/Repository.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Contracts\Cache\Repository;
+use Illuminate\Support\Carbon;
 
 use function PHPStan\Testing\assertType;
 
@@ -21,7 +22,7 @@ assertType('30', $cache->pull('cache', function (): int {
 assertType('33', $cache->sear('cache', function (): int {
     return 33;
 }));
-assertType('36', $cache->remember('cache', now(), function (): int {
+assertType('36', $cache->remember('cache', Carbon::now(), function (): int {
     return 36;
 }));
 assertType('36', $cache->rememberForever('cache', function (): int {

--- a/types/Database/Eloquent/Model.php
+++ b/types/Database/Eloquent/Model.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Attributes\CollectedBy;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\HasCollection;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
 use User;
 
 use function PHPStan\Testing\assertType;
@@ -28,7 +29,7 @@ function test(User $user, Post $post, Comment $comment, Article $article): void
     User::addGlobalScope('ancient', function ($builder) {
         assertType('Illuminate\Database\Eloquent\Builder<User>', $builder);
 
-        $builder->where('created_at', '<', now()->subYears(2000));
+        $builder->where('created_at', '<', Carbon::now()->subYears(2000));
     });
 
     assertType('Illuminate\Database\Eloquent\Builder<User>', User::query());

--- a/types/Support/Facades/Cache.php
+++ b/types/Support/Facades/Cache.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
 
 use function PHPStan\Testing\assertType;
@@ -18,7 +19,7 @@ assertType('mixed', Cache::pull('cache', function (): int {
 assertType('mixed', Cache::sear('cache', function (): int {
     return 33;
 }));
-assertType('mixed', Cache::remember('cache', now(), function (): int {
+assertType('mixed', Cache::remember('cache', Carbon::now(), function (): int {
     return 36;
 }));
 assertType('mixed', Cache::rememberForever('cache', function (): int {


### PR DESCRIPTION
## Summary

Replaces usages of the `now()` global helper with explicit calls to `Carbon::now()` (from `Illuminate\Support\Carbon`) across the framework's source files and test suite.

## Motivation

- **Implicit dependency on the helper function**: Framework internals should not rely on globally available helpers when an explicit, namespaced equivalent exists.
- **Consistency with `Illuminate\Support\Carbon`**: The framework's own Carbon wrapper respects any custom date driver set via `Date::use()`. Calling `Carbon::now()` directly ensures that driver is honoured consistently.
- **Import hygiene**: Several files were importing `Carbon\Carbon` instead of `Illuminate\Support\Carbon`. This PR standardises those imports on the framework's own wrapper.

## Notes

This is a **non-breaking, internal refactor** with no change in observable behaviour for end users.