### PR TITLE
[13.x] Remove useless \Mockery::close()

### DIFF
--- a/tests/Http/Middleware/PreventRequestForgeryTest.php
+++ b/tests/Http/Middleware/PreventRequestForgeryTest.php
@@ -17,8 +17,9 @@ class PreventRequestForgeryTest extends TestCase
 {
     protected function tearDown(): void
     {
-        m::close();
         PreventRequestForgery::flushState();
+
+        parent::tearDown();
     }
 
     public function test_same_origin_header_passes()

--- a/tests/Testing/Concerns/TestViewsTest.php
+++ b/tests/Testing/Concerns/TestViewsTest.php
@@ -44,8 +44,6 @@ class TestViewsTest extends TestCase
 
         unset($_SERVER['LARAVEL_PARALLEL_TESTING']);
 
-        m::close();
-
         parent::tearDown();
     }
 

--- a/tests/View/ClearCommandTest.php
+++ b/tests/View/ClearCommandTest.php
@@ -24,7 +24,7 @@ class ClearCommandTest extends TestCase
     protected function tearDown(): void
     {
         Container::setInstance(null);
-        m::close();
+
         parent::tearDown();
     }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
As this is already done in `AfterEachTestSubscriber`