### PR TITLE
Add `env:set` Artisan command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "fruitcake/php-cors": "^1.3",
         "guzzlehttp/guzzle": "^7.8.2",
         "guzzlehttp/uri-template": "^1.0",
-        "laravel/prompts": "^0.3.0",
+        "laravel/prompts": "^0.3.15",
         "laravel/serializable-closure": "^2.0.10",
         "league/commonmark": "^2.8.1",
         "league/flysystem": "^3.25.1",

--- a/src/Illuminate/Console/Concerns/ConfiguresPrompts.php
+++ b/src/Illuminate/Console/Concerns/ConfiguresPrompts.php
@@ -88,13 +88,11 @@ trait ConfiguresPrompts
             $prompt->validate
         ));
 
-        if (class_exists(AutoCompletePrompt::class)) {
-            AutoCompletePrompt::fallbackUsing(fn (AutoCompletePrompt $prompt) => $this->promptUntilValid(
-                fn () => $this->components->askWithCompletion($prompt->label, $prompt->options, $prompt->default ?: null) ?? '',
-                $prompt->required,
-                $prompt->validate
-            ));
-        }
+        AutoCompletePrompt::fallbackUsing(fn (AutoCompletePrompt $prompt) => $this->promptUntilValid(
+            fn () => $this->components->askWithCompletion($prompt->label, $prompt->options, $prompt->default ?: null) ?? '',
+            $prompt->required,
+            $prompt->validate
+        ));
 
         SearchPrompt::fallbackUsing(fn (SearchPrompt $prompt) => $this->promptUntilValid(
             function () use ($prompt) {

--- a/src/Illuminate/Console/Concerns/ConfiguresPrompts.php
+++ b/src/Illuminate/Console/Concerns/ConfiguresPrompts.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Console\Concerns;
 
 use Illuminate\Console\PromptValidationException;
+use Laravel\Prompts\AutoCompletePrompt;
 use Laravel\Prompts\ConfirmPrompt;
 use Laravel\Prompts\MultiSearchPrompt;
 use Laravel\Prompts\MultiSelectPrompt;
@@ -82,6 +83,12 @@ trait ConfiguresPrompts
         ));
 
         SuggestPrompt::fallbackUsing(fn (SuggestPrompt $prompt) => $this->promptUntilValid(
+            fn () => $this->components->askWithCompletion($prompt->label, $prompt->options, $prompt->default ?: null) ?? '',
+            $prompt->required,
+            $prompt->validate
+        ));
+
+        AutoCompletePrompt::fallbackUsing(fn (AutoCompletePrompt $prompt) => $this->promptUntilValid(
             fn () => $this->components->askWithCompletion($prompt->label, $prompt->options, $prompt->default ?: null) ?? '',
             $prompt->required,
             $prompt->validate

--- a/src/Illuminate/Console/Concerns/ConfiguresPrompts.php
+++ b/src/Illuminate/Console/Concerns/ConfiguresPrompts.php
@@ -88,11 +88,13 @@ trait ConfiguresPrompts
             $prompt->validate
         ));
 
-        AutoCompletePrompt::fallbackUsing(fn (AutoCompletePrompt $prompt) => $this->promptUntilValid(
-            fn () => $this->components->askWithCompletion($prompt->label, $prompt->options, $prompt->default ?: null) ?? '',
-            $prompt->required,
-            $prompt->validate
-        ));
+        if (class_exists(AutoCompletePrompt::class)) {
+            AutoCompletePrompt::fallbackUsing(fn (AutoCompletePrompt $prompt) => $this->promptUntilValid(
+                fn () => $this->components->askWithCompletion($prompt->label, $prompt->options, $prompt->default ?: null) ?? '',
+                $prompt->required,
+                $prompt->validate
+            ));
+        }
 
         SearchPrompt::fallbackUsing(fn (SearchPrompt $prompt) => $this->promptUntilValid(
             function () use ($prompt) {

--- a/src/Illuminate/Foundation/Console/EnvironmentSetCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentSetCommand.php
@@ -25,7 +25,7 @@ class EnvironmentSetCommand extends Command
      */
     protected $signature = 'env:set
                     {key? : The environment variable name (optionally with =value)}
-                    {--value= : The environment variable value}
+                    {value? : The environment variable value}
                     {--config-key= : Config key in dot notation}
                     {--default= : Default value for the config env() call}
                     {--example : Add to .env.example}
@@ -58,7 +58,11 @@ class EnvironmentSetCommand extends Command
         [$key, $value] = $this->parseKeyAndValue();
 
         if ($value === null) {
-            $value = $this->option('value') ?? password('What is the value?');
+            $value = $this->argument('value') ?? $this->whenInteractive(fn () => password('What is the value?'));
+        }
+
+        if ($value === null && ! $this->input->isInteractive()) {
+            $this->fail('The value argument is required in non-interactive mode.');
         }
 
         $key = strtoupper($key);

--- a/src/Illuminate/Foundation/Console/EnvironmentSetCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentSetCommand.php
@@ -234,6 +234,10 @@ class EnvironmentSetCommand extends Command
             return 'Config key must contain only letters, numbers, underscores, dashes, and dots.';
         }
 
+        if (preg_match('/\\.\\.|^\\.|\\.$/', $value)) {
+            return 'Config key must not contain consecutive dots or leading/trailing dots.';
+        }
+
         return null;
     }
 

--- a/src/Illuminate/Foundation/Console/EnvironmentSetCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentSetCommand.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Command;
+use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\ConfigWriter;
 use Illuminate\Support\Env;
@@ -18,6 +19,7 @@ use function Laravel\Prompts\text;
 #[AsCommand(name: 'env:set')]
 class EnvironmentSetCommand extends Command
 {
+    use ConfirmableTrait;
     /**
      * The name and signature of the console command.
      *
@@ -65,6 +67,10 @@ class EnvironmentSetCommand extends Command
      */
     public function handle()
     {
+        if (! $this->confirmToProceed()) {
+            return Command::FAILURE;
+        }
+
         [$key, $value] = $this->parseKeyAndValue();
 
         if ($value === null) {
@@ -111,7 +117,11 @@ class EnvironmentSetCommand extends Command
                 $this->fail('The key argument is required in non-interactive mode.');
             }
 
-            $key = text('What is the environment variable name?', required: true);
+            $key = text(
+                'What is the environment variable name?',
+                required: true,
+                placeholder: 'E.g. MY_API_KEY',
+            );
         }
 
         if (str_contains($key, '=')) {
@@ -184,11 +194,12 @@ class EnvironmentSetCommand extends Command
         if ($configKey === null && $this->input->isInteractive()) {
             $configKey = autocomplete(
                 label: 'What config key should this be associated with? (Optional)',
-                options: fn (string $value) => $this->getConfigKeySuggestions($value),
+                options: fn(string $value) => $this->getConfigKeySuggestions($value),
                 placeholder: 'E.g. services.stripe.key',
-                validate: fn (string $value) => $value !== '' && ! str_contains($value, '.')
+                validate: fn(string $value) => $value !== '' && ! str_contains($value, '.')
                     ? 'Config key must include at least a file and a key (e.g. services.stripe).'
                     : null,
+                hint: 'Enter an existing or new config key',
             );
         }
 
@@ -286,16 +297,16 @@ class EnvironmentSetCommand extends Command
     {
         $segments = $value !== '' ? explode('.', $value) : [];
         $currentInput = array_pop($segments) ?? '';
-        $prefix = count($segments) ? implode('.', $segments).'.' : '';
+        $prefix = count($segments) ? implode('.', $segments) . '.' : '';
 
         $items = count($segments)
             ? config(implode('.', $segments))
             : array_combine(
                 $keys = array_map(
-                    fn ($file) => basename($file, '.php'),
+                    fn($file) => basename($file, '.php'),
                     glob($this->laravel->configPath('*.php'))
                 ),
-                array_map(fn ($key) => config($key), $keys),
+                array_map(fn($key) => config($key), $keys),
             );
 
         if (! is_array($items)) {
@@ -305,7 +316,7 @@ class EnvironmentSetCommand extends Command
         $suggestions = [];
 
         foreach ($items as $key => $val) {
-            $suggestion = $prefix.$key;
+            $suggestion = $prefix . $key;
 
             if (is_array($val)) {
                 $suggestion .= '.';

--- a/src/Illuminate/Foundation/Console/EnvironmentSetCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentSetCommand.php
@@ -116,7 +116,7 @@ class EnvironmentSetCommand extends Command
 
         $value = $this->unquote($value);
 
-        $this->components->info("Key/value pair detected, extracted value automatically.");
+        $this->components->info('Key/value pair detected, extracted value automatically.');
 
         return [$key, $value];
     }
@@ -224,7 +224,7 @@ class EnvironmentSetCommand extends Command
      * @param  string  $value
      * @return string|null
      */
-    protected function validateConfigKey(string $value): string|null
+    protected function validateConfigKey(string $value): ?string
     {
         if ($value === '') {
             return null;

--- a/src/Illuminate/Foundation/Console/EnvironmentSetCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentSetCommand.php
@@ -26,9 +26,9 @@ class EnvironmentSetCommand extends Command
     protected $signature = 'env:set
                     {key? : The environment variable name (optionally with =value)}
                     {value? : The environment variable value}
-                    {--config-key= : Config key in dot notation}
-                    {--default= : Default value for the config env() call}
-                    {--example : Add to .env.example}
+                    {--config-key= : Configuration key in dot notation}
+                    {--default= : Default value for the configuration env() call}
+                    {--example : Indicates if the value should be added to .env.example}
                     {--force : Overwrite existing values without asking}';
 
     /**
@@ -58,7 +58,8 @@ class EnvironmentSetCommand extends Command
         [$key, $value] = $this->parseKeyAndValue();
 
         if ($value === null) {
-            $value = $this->argument('value') ?? $this->whenInteractive(fn () => password('What is the value?'));
+            $value = $this->argument('value') ??
+                $this->whenInteractive(fn () => password('What is the value?'));
         }
 
         if ($value === null && ! $this->input->isInteractive()) {
@@ -87,8 +88,8 @@ class EnvironmentSetCommand extends Command
 
         $this->components->info("Environment variable [{$key}] set successfully.");
 
-        $this->handleExample($key);
-        $this->handleConfig($key, $value);
+        $this->writeToExampleEnvironmentFile($key);
+        $this->writeToConfigFile($key, $value);
     }
 
     /**
@@ -116,27 +117,15 @@ class EnvironmentSetCommand extends Command
 
         $value = $this->unquote($value);
 
-        $this->components->info('Key/value pair detected, extracted value automatically.');
+        $this->components->info('Key / value pair detected, extracted value automatically.');
 
         return [$key, $value];
     }
 
     /**
-     * Remove surrounding quotes from a value.
+     * Write the value to the .env.example file if applicable.
      */
-    protected function unquote(string $value): string
-    {
-        if (preg_match('/^([\'"])(.*)\1$/', $value, $matches)) {
-            return $matches[2];
-        }
-
-        return $value;
-    }
-
-    /**
-     * Handle adding the variable to .env.example.
-     */
-    protected function handleExample(string $key): void
+    protected function writeToExampleEnvironmentFile(string $key): void
     {
         $examplePath = $this->laravel->environmentPath().'/.env.example';
 
@@ -144,8 +133,9 @@ class EnvironmentSetCommand extends Command
             return;
         }
 
-        $shouldAdd = $this->option('example')
-            || ($this->input->isInteractive() && confirm("Add [{$key}] to .env.example?", default: true));
+        $shouldAdd = $this->option('example') ||
+            ($this->input->isInteractive() &&
+             confirm("Add [{$key}] to .env.example?", default: true));
 
         if ($shouldAdd) {
             Env::writeVariable($key, '', $examplePath);
@@ -155,9 +145,9 @@ class EnvironmentSetCommand extends Command
     }
 
     /**
-     * Handle writing the variable to a config file.
+     * Write the variable to the configuration files if applicable.
      */
-    protected function handleConfig(string $key, string $value): void
+    protected function writeToConfigFile(string $key, string $value): void
     {
         $configKey = $this->option('config-key') ?? $this->whenInteractive(fn () => autocomplete(
             label: 'What config key should this be associated with? (Optional)',
@@ -199,23 +189,11 @@ class EnvironmentSetCommand extends Command
             placeholder: 'E.g. null',
         ));
 
-        $writer = new ConfigWriter($this->files);
-        $writer->write($configPath, $segments, $key, $default ?? '');
+        (new ConfigWriter($this->files))->write(
+            $configPath, $segments, $key, $default ?? ''
+        );
 
         $this->components->info("Config [{$configKey}] set to env('{$key}').");
-    }
-
-    /**
-     * Execute a callback when the input is interactive.
-     *
-     * @template TReturn
-     *
-     * @param  \Closure(): TReturn  $callback
-     * @return TReturn|null
-     */
-    protected function whenInteractive(Closure $callback): mixed
-    {
-        return $this->input->isInteractive() ? $callback() : null;
     }
 
     /**
@@ -243,42 +221,6 @@ class EnvironmentSetCommand extends Command
         }
 
         return null;
-    }
-
-    /**
-     * Check if a variable exists in the given env file.
-     */
-    protected function variableExistsInFile(string $path, string $key): bool
-    {
-        $contents = $this->files->get($path);
-
-        foreach (explode(PHP_EOL, $contents) as $line) {
-            if (str_starts_with($line, $key.'=')) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * Format a config value for display.
-     */
-    protected function formatConfigValue(mixed $value): string
-    {
-        if (is_null($value)) {
-            return 'null';
-        }
-
-        if (is_bool($value)) {
-            return $value ? 'true' : 'false';
-        }
-
-        if (is_array($value)) {
-            return json_encode($value);
-        }
-
-        return (string) $value;
     }
 
     /**
@@ -333,5 +275,59 @@ class EnvironmentSetCommand extends Command
             $keys,
             array_map(fn ($key) => config($key), $keys),
         );
+    }
+
+    /**
+     * Check if a variable exists in the given env file.
+     */
+    protected function variableExistsInFile(string $path, string $key): bool
+    {
+        $contents = $this->files->get($path);
+
+        foreach (explode(PHP_EOL, $contents) as $line) {
+            if (str_starts_with($line, $key.'=')) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Format a config value for display.
+     */
+    protected function formatConfigValue(mixed $value): string
+    {
+        return match (true) {
+            is_null($value) => 'null',
+            is_bool($value) => $value ? 'true' : 'false',
+            is_array($value) => json_encode($value),
+            default => (string) $value,
+        };
+    }
+
+    /**
+     * Remove surrounding quotes from a value.
+     */
+    protected function unquote(string $value): string
+    {
+        if (preg_match('/^([\'"])(.*)\1$/', $value, $matches)) {
+            return $matches[2];
+        }
+
+        return $value;
+    }
+
+    /**
+     * Execute a callback when the input is interactive.
+     *
+     * @template TReturn
+     *
+     * @param  \Closure(): TReturn  $callback
+     * @return TReturn|null
+     */
+    protected function whenInteractive(Closure $callback): mixed
+    {
+        return $this->input->isInteractive() ? $callback() : null;
     }
 }

--- a/src/Illuminate/Foundation/Console/EnvironmentSetCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentSetCommand.php
@@ -42,8 +42,6 @@ class EnvironmentSetCommand extends Command
     public function __construct(protected Filesystem $files)
     {
         parent::__construct();
-
-        $this->files = $files;
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/EnvironmentSetCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentSetCommand.php
@@ -112,7 +112,7 @@ class EnvironmentSetCommand extends Command
 
         $value = $this->unquote($value);
 
-        $this->components->info("Using value from argument: {$value}");
+        $this->components->info("Key/value pair detected, extracted value automatically.");
 
         return [$key, $value];
     }

--- a/src/Illuminate/Foundation/Console/EnvironmentSetCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentSetCommand.php
@@ -1,0 +1,323 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\ConfigWriter;
+use Illuminate\Support\Env;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+use Illuminate\Support\Arr;
+
+use function Laravel\Prompts\confirm;
+use function Laravel\Prompts\autocomplete;
+use function Laravel\Prompts\password;
+use function Laravel\Prompts\text;
+
+#[AsCommand(name: 'env:set')]
+class EnvironmentSetCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'env:set
+                    {key? : The environment variable name (optionally with =value)}
+                    {--value= : The environment variable value}
+                    {--config-key= : Config key in dot notation}
+                    {--default= : Default value for the config env() call}
+                    {--example : Add to .env.example}
+                    {--no-example : Do not add to .env.example}
+                    {--force : Overwrite existing values without asking}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Set an environment variable';
+
+    /**
+     * The filesystem instance.
+     *
+     * @var \Illuminate\Filesystem\Filesystem
+     */
+    protected $files;
+
+    /**
+     * Create a new command instance.
+     *
+     * @param  \Illuminate\Filesystem\Filesystem  $files
+     */
+    public function __construct(Filesystem $files)
+    {
+        parent::__construct();
+
+        $this->files = $files;
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        [$key, $value] = $this->parseKeyAndValue();
+
+        if ($value === null) {
+            $value = $this->option('value') ?? password('What is the value?');
+        }
+
+        $key = strtoupper($key);
+
+        $envPath = $this->laravel->environmentFilePath();
+
+        if (! $this->files->exists($envPath)) {
+            $this->fail('Environment file not found.');
+        }
+
+        if ($this->variableExistsInFile($envPath, $key) && ! $this->option('force')) {
+            if (! $this->input->isInteractive()) {
+                $this->fail("Environment variable [{$key}] already exists. Use --force to overwrite.");
+            }
+
+            if (! confirm("Environment variable [{$key}] already exists. Overwrite?", default: false)) {
+                return;
+            }
+        }
+
+        Env::writeVariable($key, $value, $envPath, overwrite: true);
+
+        $this->components->info("Environment variable [{$key}] set successfully.");
+
+        $this->handleExample($key);
+        $this->handleConfig($key, $value);
+    }
+
+    /**
+     * Parse the key argument, extracting an inline value if present.
+     *
+     * @return array{string, string|null}
+     */
+    protected function parseKeyAndValue(): array
+    {
+        $key = $this->argument('key');
+
+        if ($key === null) {
+            if (! $this->input->isInteractive()) {
+                $this->fail('The key argument is required in non-interactive mode.');
+            }
+
+            $key = text('What is the environment variable name?', required: true);
+        }
+
+        if (str_contains($key, '=')) {
+            [$key, $value] = explode('=', $key, 2);
+
+            $value = $this->unquote($value);
+
+            $this->components->info("Using value from argument: {$value}");
+
+            return [$key, $value];
+        }
+
+        return [$key, null];
+    }
+
+    /**
+     * Remove surrounding quotes from a value.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    protected function unquote(string $value): string
+    {
+        if (preg_match('/^([\'"])(.*)\1$/', $value, $matches)) {
+            return $matches[2];
+        }
+
+        return $value;
+    }
+
+    /**
+     * Handle adding the variable to .env.example.
+     *
+     * @param  string  $key
+     * @return void
+     */
+    protected function handleExample(string $key): void
+    {
+        $examplePath = $this->laravel->environmentPath() . '/.env.example';
+
+        if (! $this->files->exists($examplePath)) {
+            return;
+        }
+
+        if ($this->option('no-example')) {
+            return;
+        }
+
+        $shouldAdd = $this->option('example')
+            || ($this->input->isInteractive() && confirm("Add [{$key}] to .env.example?", default: true));
+
+        if ($shouldAdd) {
+            Env::writeVariable($key, '', $examplePath);
+
+            $this->components->info("Added [{$key}] to .env.example.");
+        }
+    }
+
+    /**
+     * Handle writing the variable to a config file.
+     *
+     * @param  string  $key
+     * @param  string  $value
+     * @return void
+     */
+    protected function handleConfig(string $key, string $value): void
+    {
+        $configKey = $this->option('config-key');
+
+        if ($configKey === null && $this->input->isInteractive()) {
+            $configKey = autocomplete(
+                label: 'What config key should this be associated with? (Optional)',
+                options: fn (string $value) => $this->getConfigKeySuggestions($value),
+                placeholder: 'E.g. services.stripe.key',
+                validate: fn (string $value) => $value !== '' && ! str_contains($value, '.')
+                    ? 'Config key must include at least a file and a key (e.g. services.stripe).'
+                    : null,
+            );
+        }
+
+        if (! $configKey) {
+            return;
+        }
+
+        if (! str_contains($configKey, '.')) {
+            $this->fail('Config key must include at least a file and a key (e.g. services.stripe).');
+        }
+
+        $segments = explode('.', $configKey);
+        $file = array_shift($segments);
+        $configPath = $this->laravel->configPath("{$file}.php");
+
+        if ($this->files->exists($configPath) && config()->has($configKey) && ! $this->option('force')) {
+            $currentValue = config($configKey);
+
+            $this->components->info("Current value of [{$configKey}]: {$this->formatConfigValue($currentValue)}");
+
+            if (! $this->input->isInteractive()) {
+                $this->fail("Config key [{$configKey}] already exists. Use --force to overwrite.");
+            }
+
+            if (! confirm("Config key [{$configKey}] already exists. Overwrite?", default: false)) {
+                return;
+            }
+        }
+
+        $default = $this->option('default');
+
+        if ($default === null && $this->input->isInteractive()) {
+            $default = text(
+                'What is the default value for the env() call? (Optional)',
+                default: '',
+            );
+        }
+
+        $writer = new ConfigWriter($this->files);
+        $writer->write($configPath, $segments, $key, $default ?? '');
+
+        $this->components->info("Config [{$configKey}] set to env('{$key}').");
+    }
+
+    /**
+     * Check if a variable exists in the given env file.
+     *
+     * @param  string  $path
+     * @param  string  $key
+     * @return bool
+     */
+    protected function variableExistsInFile(string $path, string $key): bool
+    {
+        $contents = $this->files->get($path);
+
+        foreach (explode(PHP_EOL, $contents) as $line) {
+            if (str_starts_with($line, $key . '=')) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Format a config value for display.
+     *
+     * @param  mixed  $value
+     * @return string
+     */
+    protected function formatConfigValue(mixed $value): string
+    {
+        if (is_null($value)) {
+            return 'null';
+        }
+
+        if (is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+
+        if (is_array($value)) {
+            return json_encode($value);
+        }
+
+        return (string) $value;
+    }
+
+    /**
+     * Get config key suggestions based on the current input.
+     *
+     * @param  string  $value
+     * @return array
+     */
+    protected function getConfigKeySuggestions(string $value): array
+    {
+        $segments = $value !== '' ? explode('.', $value) : [];
+        $currentInput = array_pop($segments) ?? '';
+        $prefix = count($segments) ? implode('.', $segments).'.' : '';
+
+        $items = count($segments)
+            ? config(implode('.', $segments))
+            : array_combine(
+                $keys = array_map(
+                    fn ($file) => basename($file, '.php'),
+                    glob($this->laravel->configPath('*.php'))
+                ),
+                array_map(fn ($key) => config($key), $keys),
+            );
+
+        if (! is_array($items)) {
+            return [];
+        }
+
+        $suggestions = [];
+
+        foreach ($items as $key => $val) {
+            $suggestion = $prefix.$key;
+
+            if (is_array($val)) {
+                $suggestion .= '.';
+            }
+
+            if ($currentInput === '' || str_starts_with(strtolower((string) $key), strtolower($currentInput))) {
+                $suggestions[] = $suggestion;
+            }
+        }
+
+        sort($suggestions);
+
+        return $suggestions;
+    }
+}

--- a/src/Illuminate/Foundation/Console/EnvironmentSetCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentSetCommand.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Console;
 
+use Closure;
 use Illuminate\Console\Command;
 use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Filesystem\Filesystem;
@@ -9,10 +10,8 @@ use Illuminate\Support\ConfigWriter;
 use Illuminate\Support\Env;
 use Symfony\Component\Console\Attribute\AsCommand;
 
-use Illuminate\Support\Arr;
-
-use function Laravel\Prompts\confirm;
 use function Laravel\Prompts\autocomplete;
+use function Laravel\Prompts\confirm;
 use function Laravel\Prompts\password;
 use function Laravel\Prompts\text;
 
@@ -20,10 +19,9 @@ use function Laravel\Prompts\text;
 class EnvironmentSetCommand extends Command
 {
     use ConfirmableTrait;
+
     /**
      * The name and signature of the console command.
-     *
-     * @var string
      */
     protected $signature = 'env:set
                     {key? : The environment variable name (optionally with =value)}
@@ -31,29 +29,17 @@ class EnvironmentSetCommand extends Command
                     {--config-key= : Config key in dot notation}
                     {--default= : Default value for the config env() call}
                     {--example : Add to .env.example}
-                    {--no-example : Do not add to .env.example}
                     {--force : Overwrite existing values without asking}';
 
     /**
      * The console command description.
-     *
-     * @var string
      */
     protected $description = 'Set an environment variable';
 
     /**
-     * The filesystem instance.
-     *
-     * @var \Illuminate\Filesystem\Filesystem
-     */
-    protected $files;
-
-    /**
      * Create a new command instance.
-     *
-     * @param  \Illuminate\Filesystem\Filesystem  $files
      */
-    public function __construct(Filesystem $files)
+    public function __construct(protected Filesystem $files)
     {
         parent::__construct();
 
@@ -110,38 +96,31 @@ class EnvironmentSetCommand extends Command
      */
     protected function parseKeyAndValue(): array
     {
-        $key = $this->argument('key');
+        $key = $this->argument('key') ?? $this->whenInteractive(fn () => text(
+            'What is the environment variable name?',
+            required: true,
+            placeholder: 'E.g. MY_API_KEY',
+        ));
 
-        if ($key === null) {
-            if (! $this->input->isInteractive()) {
-                $this->fail('The key argument is required in non-interactive mode.');
-            }
-
-            $key = text(
-                'What is the environment variable name?',
-                required: true,
-                placeholder: 'E.g. MY_API_KEY',
-            );
+        if ($key === null && ! $this->input->isInteractive()) {
+            $this->fail('The key argument is required in non-interactive mode.');
         }
 
-        if (str_contains($key, '=')) {
-            [$key, $value] = explode('=', $key, 2);
-
-            $value = $this->unquote($value);
-
-            $this->components->info("Using value from argument: {$value}");
-
-            return [$key, $value];
+        if (! str_contains($key, '=')) {
+            return [$key, null];
         }
 
-        return [$key, null];
+        [$key, $value] = explode('=', $key, 2);
+
+        $value = $this->unquote($value);
+
+        $this->components->info("Using value from argument: {$value}");
+
+        return [$key, $value];
     }
 
     /**
      * Remove surrounding quotes from a value.
-     *
-     * @param  string  $value
-     * @return string
      */
     protected function unquote(string $value): string
     {
@@ -154,19 +133,12 @@ class EnvironmentSetCommand extends Command
 
     /**
      * Handle adding the variable to .env.example.
-     *
-     * @param  string  $key
-     * @return void
      */
     protected function handleExample(string $key): void
     {
-        $examplePath = $this->laravel->environmentPath() . '/.env.example';
+        $examplePath = $this->laravel->environmentPath().'/.env.example';
 
         if (! $this->files->exists($examplePath)) {
-            return;
-        }
-
-        if ($this->option('no-example')) {
             return;
         }
 
@@ -182,33 +154,23 @@ class EnvironmentSetCommand extends Command
 
     /**
      * Handle writing the variable to a config file.
-     *
-     * @param  string  $key
-     * @param  string  $value
-     * @return void
      */
     protected function handleConfig(string $key, string $value): void
     {
-        $configKey = $this->option('config-key');
-
-        if ($configKey === null && $this->input->isInteractive()) {
-            $configKey = autocomplete(
-                label: 'What config key should this be associated with? (Optional)',
-                options: fn(string $value) => $this->getConfigKeySuggestions($value),
-                placeholder: 'E.g. services.stripe.key',
-                validate: fn(string $value) => $value !== '' && ! str_contains($value, '.')
-                    ? 'Config key must include at least a file and a key (e.g. services.stripe).'
-                    : null,
-                hint: 'Enter an existing or new config key',
-            );
-        }
+        $configKey = $this->option('config-key') ?? $this->whenInteractive(fn () => autocomplete(
+            label: 'What config key should this be associated with? (Optional)',
+            options: fn (string $value) => $this->getConfigKeySuggestions($value),
+            placeholder: 'E.g. services.stripe.key',
+            validate: fn ($value) => $this->validateConfigKey($value),
+            hint: 'Enter a new or existing config key',
+        ));
 
         if (! $configKey) {
             return;
         }
 
-        if (! str_contains($configKey, '.')) {
-            $this->fail('Config key must include at least a file and a key (e.g. services.stripe).');
+        if ($failMessage = $this->validateConfigKey($configKey)) {
+            $this->fail($failMessage);
         }
 
         $segments = explode('.', $configKey);
@@ -229,14 +191,11 @@ class EnvironmentSetCommand extends Command
             }
         }
 
-        $default = $this->option('default');
-
-        if ($default === null && $this->input->isInteractive()) {
-            $default = text(
-                'What is the default value for the env() call? (Optional)',
-                default: '',
-            );
-        }
+        $default = $this->option('default') ?? $this->whenInteractive(fn () => password(
+            'What is the default value for the env() call? (Optional)',
+            required: false,
+            placeholder: 'E.g. null',
+        ));
 
         $writer = new ConfigWriter($this->files);
         $writer->write($configPath, $segments, $key, $default ?? '');
@@ -245,18 +204,50 @@ class EnvironmentSetCommand extends Command
     }
 
     /**
-     * Check if a variable exists in the given env file.
+     * Execute a callback when the input is interactive.
      *
-     * @param  string  $path
-     * @param  string  $key
-     * @return bool
+     * @template TReturn
+     *
+     * @param  \Closure(): TReturn  $callback
+     * @return TReturn|null
+     */
+    protected function whenInteractive(Closure $callback): mixed
+    {
+        return $this->input->isInteractive() ? $callback() : null;
+    }
+
+    /**
+     * Validate a config key.
+     *
+     * @param  string  $value
+     * @return string|null
+     */
+    protected function validateConfigKey(string $value): string|null
+    {
+        if ($value === '') {
+            return null;
+        }
+
+        if (! str_contains($value, '.')) {
+            return 'Config key must include at least a file and a key (e.g. services.stripe).';
+        }
+
+        if (preg_match('/[^a-zA-Z0-9_.\\-]/', $value)) {
+            return 'Config key must contain only letters, numbers, underscores, dashes, and dots.';
+        }
+
+        return null;
+    }
+
+    /**
+     * Check if a variable exists in the given env file.
      */
     protected function variableExistsInFile(string $path, string $key): bool
     {
         $contents = $this->files->get($path);
 
         foreach (explode(PHP_EOL, $contents) as $line) {
-            if (str_starts_with($line, $key . '=')) {
+            if (str_starts_with($line, $key.'=')) {
                 return true;
             }
         }
@@ -266,9 +257,6 @@ class EnvironmentSetCommand extends Command
 
     /**
      * Format a config value for display.
-     *
-     * @param  mixed  $value
-     * @return string
      */
     protected function formatConfigValue(mixed $value): string
     {
@@ -289,25 +277,14 @@ class EnvironmentSetCommand extends Command
 
     /**
      * Get config key suggestions based on the current input.
-     *
-     * @param  string  $value
-     * @return array
      */
     protected function getConfigKeySuggestions(string $value): array
     {
         $segments = $value !== '' ? explode('.', $value) : [];
         $currentInput = array_pop($segments) ?? '';
-        $prefix = count($segments) ? implode('.', $segments) . '.' : '';
+        $prefix = count($segments) ? implode('.', $segments).'.' : '';
 
-        $items = count($segments)
-            ? config(implode('.', $segments))
-            : array_combine(
-                $keys = array_map(
-                    fn($file) => basename($file, '.php'),
-                    glob($this->laravel->configPath('*.php'))
-                ),
-                array_map(fn($key) => config($key), $keys),
-            );
+        $items = $this->getConfigItems($segments);
 
         if (! is_array($items)) {
             return [];
@@ -316,7 +293,7 @@ class EnvironmentSetCommand extends Command
         $suggestions = [];
 
         foreach ($items as $key => $val) {
-            $suggestion = $prefix . $key;
+            $suggestion = $prefix.$key;
 
             if (is_array($val)) {
                 $suggestion .= '.';
@@ -330,5 +307,25 @@ class EnvironmentSetCommand extends Command
         sort($suggestions);
 
         return $suggestions;
+    }
+
+    /**
+     * Get the config items.
+     */
+    protected function getConfigItems(array $segments): ?array
+    {
+        if (count($segments)) {
+            return config(implode('.', $segments));
+        }
+
+        $keys = array_map(
+            fn ($file) => basename($file, '.php'),
+            glob($this->laravel->configPath('*.php'))
+        );
+
+        return array_combine(
+            $keys,
+            array_map(fn ($key) => config($key), $keys),
+        );
     }
 }

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -51,6 +51,7 @@ use Illuminate\Foundation\Console\EnumMakeCommand;
 use Illuminate\Foundation\Console\EnvironmentCommand;
 use Illuminate\Foundation\Console\EnvironmentDecryptCommand;
 use Illuminate\Foundation\Console\EnvironmentEncryptCommand;
+use Illuminate\Foundation\Console\EnvironmentSetCommand;
 use Illuminate\Foundation\Console\EventCacheCommand;
 use Illuminate\Foundation\Console\EventClearCommand;
 use Illuminate\Foundation\Console\EventGenerateCommand;
@@ -140,6 +141,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'Environment' => EnvironmentCommand::class,
         'EnvironmentDecrypt' => EnvironmentDecryptCommand::class,
         'EnvironmentEncrypt' => EnvironmentEncryptCommand::class,
+        'EnvironmentSet' => EnvironmentSetCommand::class,
         'EventCache' => EventCacheCommand::class,
         'EventClear' => EventClearCommand::class,
         'EventList' => EventListCommand::class,

--- a/src/Illuminate/Support/ConfigWriter.php
+++ b/src/Illuminate/Support/ConfigWriter.php
@@ -1,0 +1,266 @@
+<?php
+
+namespace Illuminate\Support;
+
+use Illuminate\Filesystem\Filesystem;
+use PhpParser\Comment;
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\ArrayItem;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\CloningVisitor;
+use PhpParser\Parser;
+use PhpParser\ParserFactory;
+use PhpParser\PrettyPrinter\Standard;
+
+class ConfigWriter
+{
+    /**
+     * The filesystem instance.
+     *
+     * @var \Illuminate\Filesystem\Filesystem
+     */
+    protected $files;
+
+    /**
+     * Create a new config writer instance.
+     *
+     * @param  \Illuminate\Filesystem\Filesystem  $files
+     */
+    public function __construct(Filesystem $files)
+    {
+        $this->files = $files;
+    }
+
+    /**
+     * Write an env() call into a PHP config file at the given key path.
+     *
+     * @param  string  $filePath
+     * @param  array  $keySegments
+     * @param  string  $envVariable
+     * @param  string  $default
+     * @return void
+     */
+    public function write(string $filePath, array $keySegments, string $envVariable, string $default = ''): void
+    {
+        if ($this->files->exists($filePath)) {
+            $this->updateExistingFile($filePath, $keySegments, $envVariable, $default);
+        } else {
+            $this->createNewFile($filePath, $keySegments, $envVariable, $default);
+        }
+    }
+
+    /**
+     * Update an existing config file using format-preserving printing.
+     *
+     * @param  string  $filePath
+     * @param  array  $keySegments
+     * @param  string  $envVariable
+     * @param  string  $default
+     * @return void
+     */
+    protected function updateExistingFile(string $filePath, array $keySegments, string $envVariable, string $default): void
+    {
+        $code = $this->files->get($filePath);
+
+        $parser = $this->createParser();
+        $oldStmts = $parser->parse($code);
+        $oldTokens = $parser->getTokens();
+
+        $traverser = new NodeTraverser;
+        $traverser->addVisitor(new CloningVisitor);
+        $newStmts = $traverser->traverse($oldStmts);
+
+        $returnArray = $this->findReturnArray($newStmts);
+
+        if ($returnArray === null) {
+            return;
+        }
+
+        $targetArray = $this->findOrCreateNestedArray($returnArray, array_slice($keySegments, 0, -1));
+        $this->setValueInArray($targetArray, end($keySegments), $this->buildEnvCall($envVariable, $default));
+
+        $printer = new Standard;
+        $newCode = $printer->printFormatPreserving($newStmts, $oldStmts, $oldTokens);
+        $newCode = preg_replace('/^\s*\/\* __CONFIGWRITER__ \*\/\n/m', '', $newCode);
+
+        $this->files->put($filePath, $newCode);
+    }
+
+    /**
+     * Create a new config file with the given key path and env() call.
+     *
+     * @param  string  $filePath
+     * @param  array  $keySegments
+     * @param  string  $envVariable
+     * @param  string  $default
+     * @return void
+     */
+    protected function createNewFile(string $filePath, array $keySegments, string $envVariable, string $default): void
+    {
+        $printer = new Standard(['shortArraySyntax' => true]);
+
+        $envCall = $printer->prettyPrintExpr($this->buildEnvCall($envVariable, $default));
+
+        $code = $this->buildNestedArrayString($keySegments, $envCall);
+
+        $directory = dirname($filePath);
+
+        if (! $this->files->isDirectory($directory)) {
+            $this->files->makeDirectory($directory, 0755, true);
+        }
+
+        $this->files->put($filePath, $code);
+    }
+
+    /**
+     * Build an env() FuncCall node.
+     *
+     * @param  string  $envVariable
+     * @param  string  $default
+     * @return \PhpParser\Node\Expr\FuncCall
+     */
+    protected function buildEnvCall(string $envVariable, string $default): FuncCall
+    {
+        $args = [new Arg(new String_($envVariable))];
+
+        if ($default !== '') {
+            $defaultNode = match (true) {
+                strtolower($default) === 'null' => new Node\Expr\ConstFetch(new Name('null')),
+                strtolower($default) === 'true' => new Node\Expr\ConstFetch(new Name('true')),
+                strtolower($default) === 'false' => new Node\Expr\ConstFetch(new Name('false')),
+                is_numeric($default) => str_contains($default, '.')
+                    ? new Node\Scalar\Float_((float) $default)
+                    : new Node\Scalar\Int_((int) $default),
+                default => new String_($default),
+            };
+
+            $args[] = new Arg($defaultNode);
+        }
+
+        return new FuncCall(new Name('env'), $args);
+    }
+
+    /**
+     * Find the return statement's array in the AST.
+     *
+     * @param  array  $stmts
+     * @return \PhpParser\Node\Expr\Array_|null
+     */
+    protected function findReturnArray(array $stmts): ?Array_
+    {
+        foreach ($stmts as $stmt) {
+            if ($stmt instanceof Node\Stmt\Return_ && $stmt->expr instanceof Array_) {
+                return $stmt->expr;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Navigate or create nested arrays for the given key segments.
+     *
+     * @param  \PhpParser\Node\Expr\Array_  $array
+     * @param  array  $segments
+     * @return \PhpParser\Node\Expr\Array_
+     */
+    protected function findOrCreateNestedArray(Array_ $array, array $segments): Array_
+    {
+        foreach ($segments as $segment) {
+            $found = false;
+
+            foreach ($array->items as $item) {
+                if ($item instanceof ArrayItem
+                    && $item->key instanceof String_
+                    && $item->key->value === $segment
+                ) {
+                    if ($item->value instanceof Array_) {
+                        $array = $item->value;
+                        $found = true;
+                        break;
+                    }
+                }
+            }
+
+            if (! $found) {
+                $newArray = new Array_([], ['kind' => Array_::KIND_SHORT]);
+                $newItem = new ArrayItem($newArray, new String_($segment));
+                $newItem->setAttribute('comments', [new Comment('/* __CONFIGWRITER__ */')]);
+                $array->items[] = $newItem;
+                $array = $newArray;
+            }
+        }
+
+        return $array;
+    }
+
+    /**
+     * Set or replace a value in an Array_ node by key.
+     *
+     * @param  \PhpParser\Node\Expr\Array_  $array
+     * @param  string  $key
+     * @param  \PhpParser\Node\Expr  $value
+     * @return void
+     */
+    protected function setValueInArray(Array_ $array, string $key, Node\Expr $value): void
+    {
+        foreach ($array->items as $item) {
+            if ($item instanceof ArrayItem
+                && $item->key instanceof String_
+                && $item->key->value === $key
+            ) {
+                $item->value = $value;
+
+                return;
+            }
+        }
+
+        $newItem = new ArrayItem($value, new String_($key));
+        $newItem->setAttribute('comments', [new Comment('/* __CONFIGWRITER__ */')]);
+        $array->items[] = $newItem;
+    }
+
+    /**
+     * Build a properly indented nested array string for a new config file.
+     *
+     * @param  array  $keySegments
+     * @param  string  $value
+     * @param  int  $depth
+     * @return string
+     */
+    protected function buildNestedArrayString(array $keySegments, string $value, int $depth = 1): string
+    {
+        $indent = str_repeat('    ', $depth);
+        $closingIndent = str_repeat('    ', $depth - 1);
+        $key = array_shift($keySegments);
+
+        if (empty($keySegments)) {
+            $inner = "{$indent}'{$key}' => {$value},";
+        } else {
+            $inner = "{$indent}'{$key}' => ".$this->buildNestedArrayString($keySegments, $value, $depth + 1).',';
+        }
+
+        $array = "[\n{$inner}\n{$closingIndent}]";
+
+        if ($depth === 1) {
+            return "<?php\n\nreturn {$array};\n";
+        }
+
+        return $array;
+    }
+
+    /**
+     * Create a PHP parser instance.
+     *
+     * @return \PhpParser\Parser
+     */
+    protected function createParser(): Parser
+    {
+        return (new ParserFactory)->createForNewestSupportedVersion();
+    }
+}

--- a/src/Illuminate/Support/ConfigWriter.php
+++ b/src/Illuminate/Support/ConfigWriter.php
@@ -46,28 +46,37 @@ class ConfigWriter
     {
         $code = $this->files->get($filePath);
 
-        $parser = $this->createParser();
-        $oldStmts = $parser->parse($code);
+        $parser = (new ParserFactory)->createForNewestSupportedVersion();
+        $traverser = new NodeTraverser;
+
+        $oldStatements = $parser->parse($code);
         $oldTokens = $parser->getTokens();
 
-        $traverser = new NodeTraverser;
         $traverser->addVisitor(new CloningVisitor);
-        $newStmts = $traverser->traverse($oldStmts);
+        $newStatements = $traverser->traverse($oldStatements);
 
-        $returnArray = $this->findReturnArray($newStmts);
+        $returnArray = $this->findReturnArray($newStatements);
 
         if ($returnArray === null) {
             return;
         }
 
-        $targetArray = $this->findOrCreateNestedArray($returnArray, array_slice($keySegments, 0, -1));
-        $this->setValueInArray($targetArray, end($keySegments), $this->buildEnvCall($envVariable, $default));
+        $targetArray = $this->findOrCreateNestedArray(
+            $returnArray, array_slice($keySegments, 0, -1)
+        );
 
-        $printer = new Standard;
-        $newCode = $printer->printFormatPreserving($newStmts, $oldStmts, $oldTokens);
-        $newCode = preg_replace('/^\s*\/\* __CONFIGWRITER__ \*\/\n/m', '', $newCode);
+        $this->setValueInArray(
+            $targetArray,
+            end($keySegments),
+            $this->buildEnvCall($envVariable, $default)
+        );
 
-        $this->files->put($filePath, $newCode);
+        $newCode = (new Standard)->printFormatPreserving($newStatements, $oldStatements, $oldTokens);
+
+        $this->files->put(
+            $filePath,
+            preg_replace('/^\s*\/\* __CONFIGWRITER__ \*\/\n/m', '', $newCode)
+        );
     }
 
     /**
@@ -117,11 +126,11 @@ class ConfigWriter
     /**
      * Find the return statement's array in the AST.
      */
-    protected function findReturnArray(array $stmts): ?Array_
+    protected function findReturnArray(array $statements): ?Array_
     {
-        foreach ($stmts as $stmt) {
-            if ($stmt instanceof Node\Stmt\Return_ && $stmt->expr instanceof Array_) {
-                return $stmt->expr;
+        foreach ($statements as $statement) {
+            if ($statement instanceof Node\Stmt\Return_ && $statement->expr instanceof Array_) {
+                return $statement->expr;
             }
         }
 

--- a/src/Illuminate/Support/ConfigWriter.php
+++ b/src/Illuminate/Support/ConfigWriter.php
@@ -20,30 +20,15 @@ use PhpParser\PrettyPrinter\Standard;
 class ConfigWriter
 {
     /**
-     * The filesystem instance.
-     *
-     * @var \Illuminate\Filesystem\Filesystem
-     */
-    protected $files;
-
-    /**
      * Create a new config writer instance.
-     *
-     * @param  \Illuminate\Filesystem\Filesystem  $files
      */
-    public function __construct(Filesystem $files)
+    public function __construct(protected Filesystem $files)
     {
-        $this->files = $files;
+        //
     }
 
     /**
      * Write an env() call into a PHP config file at the given key path.
-     *
-     * @param  string  $filePath
-     * @param  array  $keySegments
-     * @param  string  $envVariable
-     * @param  string  $default
-     * @return void
      */
     public function write(string $filePath, array $keySegments, string $envVariable, string $default = ''): void
     {
@@ -56,12 +41,6 @@ class ConfigWriter
 
     /**
      * Update an existing config file using format-preserving printing.
-     *
-     * @param  string  $filePath
-     * @param  array  $keySegments
-     * @param  string  $envVariable
-     * @param  string  $default
-     * @return void
      */
     protected function updateExistingFile(string $filePath, array $keySegments, string $envVariable, string $default): void
     {
@@ -93,12 +72,6 @@ class ConfigWriter
 
     /**
      * Create a new config file with the given key path and env() call.
-     *
-     * @param  string  $filePath
-     * @param  array  $keySegments
-     * @param  string  $envVariable
-     * @param  string  $default
-     * @return void
      */
     protected function createNewFile(string $filePath, array $keySegments, string $envVariable, string $default): void
     {
@@ -119,10 +92,6 @@ class ConfigWriter
 
     /**
      * Build an env() FuncCall node.
-     *
-     * @param  string  $envVariable
-     * @param  string  $default
-     * @return \PhpParser\Node\Expr\FuncCall
      */
     protected function buildEnvCall(string $envVariable, string $default): FuncCall
     {
@@ -147,9 +116,6 @@ class ConfigWriter
 
     /**
      * Find the return statement's array in the AST.
-     *
-     * @param  array  $stmts
-     * @return \PhpParser\Node\Expr\Array_|null
      */
     protected function findReturnArray(array $stmts): ?Array_
     {
@@ -164,10 +130,6 @@ class ConfigWriter
 
     /**
      * Navigate or create nested arrays for the given key segments.
-     *
-     * @param  \PhpParser\Node\Expr\Array_  $array
-     * @param  array  $segments
-     * @return \PhpParser\Node\Expr\Array_
      */
     protected function findOrCreateNestedArray(Array_ $array, array $segments): Array_
     {
@@ -175,7 +137,8 @@ class ConfigWriter
             $found = false;
 
             foreach ($array->items as $item) {
-                if ($item instanceof ArrayItem
+                if (
+                    $item instanceof ArrayItem
                     && $item->key instanceof String_
                     && $item->key->value === $segment
                 ) {
@@ -201,16 +164,12 @@ class ConfigWriter
 
     /**
      * Set or replace a value in an Array_ node by key.
-     *
-     * @param  \PhpParser\Node\Expr\Array_  $array
-     * @param  string  $key
-     * @param  \PhpParser\Node\Expr  $value
-     * @return void
      */
     protected function setValueInArray(Array_ $array, string $key, Node\Expr $value): void
     {
         foreach ($array->items as $item) {
-            if ($item instanceof ArrayItem
+            if (
+                $item instanceof ArrayItem
                 && $item->key instanceof String_
                 && $item->key->value === $key
             ) {
@@ -227,11 +186,6 @@ class ConfigWriter
 
     /**
      * Build a properly indented nested array string for a new config file.
-     *
-     * @param  array  $keySegments
-     * @param  string  $value
-     * @param  int  $depth
-     * @return string
      */
     protected function buildNestedArrayString(array $keySegments, string $value, int $depth = 1): string
     {
@@ -256,8 +210,6 @@ class ConfigWriter
 
     /**
      * Create a PHP parser instance.
-     *
-     * @return \PhpParser\Parser
      */
     protected function createParser(): Parser
     {

--- a/tests/Integration/Console/EnvironmentSetCommandTest.php
+++ b/tests/Integration/Console/EnvironmentSetCommandTest.php
@@ -35,7 +35,7 @@ class EnvironmentSetCommandTest extends TestCase
 
     public function testItSetsANewEnvironmentVariable(): void
     {
-        $this->artisan('env:set', ['key' => 'STRIPE_KEY', '--value' => 'sk_test_123', '-n' => true])
+        $this->artisan('env:set', ['key' => 'STRIPE_KEY', 'value' =>'sk_test_123', '-n' => true])
             ->expectsOutputToContain('Environment variable [STRIPE_KEY] set successfully.')
             ->assertExitCode(0);
 
@@ -74,7 +74,7 @@ class EnvironmentSetCommandTest extends TestCase
     {
         unlink($this->tempDir.'/.env');
 
-        $this->artisan('env:set', ['key' => 'STRIPE_KEY', '--value' => 'sk_test_123'])
+        $this->artisan('env:set', ['key' => 'STRIPE_KEY', 'value' =>'sk_test_123'])
             ->expectsOutputToContain('Environment file not found.')
             ->assertExitCode(1);
     }
@@ -84,7 +84,7 @@ class EnvironmentSetCommandTest extends TestCase
         file_put_contents($this->tempDir.'/.env', 'STRIPE_KEY=old_value');
         file_put_contents($this->tempDir.'/.env.example', '');
 
-        $this->artisan('env:set', ['key' => 'STRIPE_KEY', '--value' => 'new_value'])
+        $this->artisan('env:set', ['key' => 'STRIPE_KEY', 'value' =>'new_value'])
             ->expectsConfirmation('Environment variable [STRIPE_KEY] already exists. Overwrite?', 'yes')
             ->expectsConfirmation('Add [STRIPE_KEY] to .env.example?', 'no')
             ->expectsQuestion('What config key should this be associated with? (Optional)', '')
@@ -98,7 +98,7 @@ class EnvironmentSetCommandTest extends TestCase
     {
         file_put_contents($this->tempDir.'/.env', 'STRIPE_KEY=old_value');
 
-        $this->artisan('env:set', ['key' => 'STRIPE_KEY', '--value' => 'new_value'])
+        $this->artisan('env:set', ['key' => 'STRIPE_KEY', 'value' =>'new_value'])
             ->expectsConfirmation('Environment variable [STRIPE_KEY] already exists. Overwrite?', 'no')
             ->assertExitCode(0);
 
@@ -110,7 +110,7 @@ class EnvironmentSetCommandTest extends TestCase
         file_put_contents($this->tempDir.'/.env', 'STRIPE_KEY=old_value');
         file_put_contents($this->tempDir.'/.env.example', '');
 
-        $this->artisan('env:set', ['key' => 'STRIPE_KEY', '--value' => 'new_value', '--force' => true])
+        $this->artisan('env:set', ['key' => 'STRIPE_KEY', 'value' =>'new_value', '--force' => true])
             ->expectsConfirmation('Add [STRIPE_KEY] to .env.example?', 'no')
             ->expectsQuestion('What config key should this be associated with? (Optional)', '')
             ->expectsOutputToContain('Environment variable [STRIPE_KEY] set successfully.')
@@ -123,7 +123,7 @@ class EnvironmentSetCommandTest extends TestCase
     {
         file_put_contents($this->tempDir.'/.env', 'STRIPE_KEY=old_value');
 
-        $this->artisan('env:set', ['key' => 'STRIPE_KEY', '--value' => 'new_value', '-n' => true])
+        $this->artisan('env:set', ['key' => 'STRIPE_KEY', 'value' =>'new_value', '-n' => true])
             ->expectsOutputToContain('Environment variable [STRIPE_KEY] already exists. Use --force to overwrite.')
             ->assertExitCode(1);
     }
@@ -132,7 +132,7 @@ class EnvironmentSetCommandTest extends TestCase
     {
         file_put_contents($this->tempDir.'/.env.example', '');
 
-        $this->artisan('env:set', ['key' => 'STRIPE_KEY', '--value' => 'sk_test_123', '--example' => true, '-n' => true])
+        $this->artisan('env:set', ['key' => 'STRIPE_KEY', 'value' =>'sk_test_123', '--example' => true, '-n' => true])
             ->expectsOutputToContain('Added [STRIPE_KEY] to .env.example.')
             ->assertExitCode(0);
 
@@ -143,7 +143,7 @@ class EnvironmentSetCommandTest extends TestCase
     {
         file_put_contents($this->tempDir.'/.env.example', '');
 
-        $this->artisan('env:set', ['key' => 'STRIPE_KEY', '--value' => 'sk_test_123', '-n' => true])
+        $this->artisan('env:set', ['key' => 'STRIPE_KEY', 'value' =>'sk_test_123', '-n' => true])
             ->assertExitCode(0);
 
         $this->assertStringNotContainsString('STRIPE_KEY', file_get_contents($this->tempDir.'/.env.example'));
@@ -151,7 +151,7 @@ class EnvironmentSetCommandTest extends TestCase
 
     public function testItSkipsEnvExampleWhenFileDoesNotExist(): void
     {
-        $this->artisan('env:set', ['key' => 'STRIPE_KEY', '--value' => 'sk_test_123', '-n' => true])
+        $this->artisan('env:set', ['key' => 'STRIPE_KEY', 'value' =>'sk_test_123', '-n' => true])
             ->assertExitCode(0);
 
         $this->assertFileDoesNotExist($this->tempDir.'/.env.example');
@@ -161,7 +161,7 @@ class EnvironmentSetCommandTest extends TestCase
     {
         $this->artisan('env:set', [
             'key' => 'STRIPE_KEY',
-            '--value' => 'sk_test_123',
+            'value' =>'sk_test_123',
             '--config-key' => 'services.stripe.key',
             '--default' => 'null',
             '-n' => true,
@@ -194,7 +194,7 @@ PHP);
 
         $this->artisan('env:set', [
             'key' => 'STRIPE_KEY',
-            '--value' => 'sk_test_123',
+            'value' =>'sk_test_123',
             '--config-key' => 'services.stripe.key',
             '--default' => 'null',
             '--force' => true,
@@ -212,7 +212,7 @@ PHP);
     {
         $this->artisan('env:set', [
             'key' => 'APP_TIMEZONE',
-            '--value' => 'America/New_York',
+            'value' =>'America/New_York',
             '--config-key' => 'app.timezone',
             '--default' => 'UTC',
             '-n' => true,
@@ -228,7 +228,7 @@ PHP);
     {
         $this->artisan('env:set', [
             'key' => 'STRIPE_KEY',
-            '--value' => 'sk_test_123',
+            'value' =>'sk_test_123',
             '--config-key' => 'services.stripe.key',
             '--default' => '',
             '-n' => true,
@@ -245,7 +245,7 @@ PHP);
     {
         $this->artisan('env:set', [
             'key' => 'STRIPE_KEY',
-            '--value' => 'sk_test_123',
+            'value' =>'sk_test_123',
             '--config-key' => 'services',
             '-n' => true,
         ])
@@ -257,7 +257,7 @@ PHP);
     {
         $this->artisan('env:set', [
             'key' => 'STRIPE_KEY',
-            '--value' => 'sk_test_123',
+            'value' =>'sk_test_123',
             '--config-key' => 'services..stripe.key',
             '-n' => true,
         ])
@@ -269,7 +269,7 @@ PHP);
     {
         $this->artisan('env:set', [
             'key' => 'STRIPE_KEY',
-            '--value' => 'sk_test_123',
+            'value' =>'sk_test_123',
             '--config-key' => '.services.key',
             '-n' => true,
         ])
@@ -283,7 +283,7 @@ PHP);
 
         $this->artisan('env:set', [
             'key' => 'STRIPE_KEY',
-            '--value' => 'sk_test_123',
+            'value' =>'sk_test_123',
             '--config-key' => 'services.stripe.key',
             '--default' => 'null',
             '--example' => true,
@@ -303,7 +303,7 @@ PHP);
     {
         $this->artisan('env:set', [
             'key' => 'STRIPE_KEY',
-            '--value' => 'sk_test_123',
+            'value' =>'sk_test_123',
             '-n' => true,
         ])
             ->expectsOutputToContain('Environment variable [STRIPE_KEY] set successfully.')
@@ -318,7 +318,7 @@ PHP);
 
         $this->artisan('env:set', [
             'key' => 'STRIPE_KEY',
-            '--value' => 'sk_test_123',
+            'value' =>'sk_test_123',
             '-n' => true,
         ])
             ->assertExitCode(0);
@@ -330,7 +330,7 @@ PHP);
     {
         $this->artisan('env:set', [
             'key' => 'STRIPE_WEBHOOK_SECRET',
-            '--value' => 'whsec_test',
+            'value' =>'whsec_test',
             '--config-key' => 'services.stripe.webhook.secret',
             '--default' => '',
             '-n' => true,
@@ -360,7 +360,7 @@ PHP);
 
         $this->artisan('env:set', [
             'key' => 'STRIPE_KEY',
-            '--value' => 'sk_test_123',
+            'value' =>'sk_test_123',
             '--config-key' => 'services.stripe.key',
             '--default' => 'null',
             '--force' => true,
@@ -377,7 +377,7 @@ PHP);
     {
         $this->artisan('env:set', [
             'key' => 'APP_DEBUG',
-            '--value' => 'true',
+            'value' =>'true',
             '--config-key' => 'app.debug',
             '--default' => 'true',
             '-n' => true,
@@ -393,7 +393,7 @@ PHP);
     {
         $this->artisan('env:set', [
             'key' => 'APP_DEBUG',
-            '--value' => 'false',
+            'value' =>'false',
             '--config-key' => 'app.debug',
             '--default' => 'false',
             '-n' => true,
@@ -411,7 +411,7 @@ PHP);
 
         $this->artisan('env:set', [
             'key' => 'STRIPE_KEY',
-            '--value' => 'sk_test_123',
+            'value' =>'sk_test_123',
             '-n' => true,
         ])
             ->assertExitCode(0);

--- a/tests/Integration/Console/EnvironmentSetCommandTest.php
+++ b/tests/Integration/Console/EnvironmentSetCommandTest.php
@@ -45,7 +45,7 @@ class EnvironmentSetCommandTest extends TestCase
     public function testItSetsVariableWithInlineValue(): void
     {
         $this->artisan('env:set', ['key' => 'STRIPE_KEY=sk_test_123', '-n' => true])
-            ->expectsOutputToContain('Using value from argument: sk_test_123')
+            ->expectsOutputToContain('Key/value pair detected, extracted value automatically.')
             ->expectsOutputToContain('Environment variable [STRIPE_KEY] set successfully.')
             ->assertExitCode(0);
 
@@ -55,7 +55,7 @@ class EnvironmentSetCommandTest extends TestCase
     public function testItSetsVariableWithQuotedInlineValue(): void
     {
         $this->artisan('env:set', ['key' => 'APP_NAME="My App"', '-n' => true])
-            ->expectsOutputToContain('Using value from argument: My App')
+            ->expectsOutputToContain('Key/value pair detected, extracted value automatically.')
             ->assertExitCode(0);
 
         $this->assertStringContainsString('APP_NAME="My App"', file_get_contents($this->tempDir.'/.env'));
@@ -64,7 +64,7 @@ class EnvironmentSetCommandTest extends TestCase
     public function testItSetsVariableWithSingleQuotedInlineValue(): void
     {
         $this->artisan('env:set', ['key' => "APP_NAME='My App'", '-n' => true])
-            ->expectsOutputToContain('Using value from argument: My App')
+            ->expectsOutputToContain('Key/value pair detected, extracted value automatically.')
             ->assertExitCode(0);
 
         $this->assertStringContainsString('APP_NAME="My App"', file_get_contents($this->tempDir.'/.env'));
@@ -250,6 +250,30 @@ PHP);
             '-n' => true,
         ])
             ->expectsOutputToContain('Config key must include at least a file and a key')
+            ->assertExitCode(1);
+    }
+
+    public function testItFailsWithConsecutiveDotsInConfigKey(): void
+    {
+        $this->artisan('env:set', [
+            'key' => 'STRIPE_KEY',
+            '--value' => 'sk_test_123',
+            '--config-key' => 'services..stripe.key',
+            '-n' => true,
+        ])
+            ->expectsOutputToContain('Config key must not contain consecutive dots or leading/trailing dots.')
+            ->assertExitCode(1);
+    }
+
+    public function testItFailsWithLeadingDotInConfigKey(): void
+    {
+        $this->artisan('env:set', [
+            'key' => 'STRIPE_KEY',
+            '--value' => 'sk_test_123',
+            '--config-key' => '.services.key',
+            '-n' => true,
+        ])
+            ->expectsOutputToContain('Config key must not contain consecutive dots or leading/trailing dots.')
             ->assertExitCode(1);
     }
 

--- a/tests/Integration/Console/EnvironmentSetCommandTest.php
+++ b/tests/Integration/Console/EnvironmentSetCommandTest.php
@@ -1,0 +1,405 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Console;
+
+use Illuminate\Filesystem\Filesystem;
+use Orchestra\Testbench\TestCase;
+
+class EnvironmentSetCommandTest extends TestCase
+{
+    protected $tempDir;
+
+    protected $files;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->files = new Filesystem;
+        $this->tempDir = sys_get_temp_dir().'/laravel-env-set-test-'.uniqid();
+        mkdir($this->tempDir);
+        mkdir($this->tempDir.'/config', 0755, true);
+
+        $this->app->useEnvironmentPath($this->tempDir);
+        $this->app->setBasePath($this->tempDir);
+
+        file_put_contents($this->tempDir.'/.env', '');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->files->deleteDirectory($this->tempDir);
+
+        parent::tearDown();
+    }
+
+    public function testItSetsANewEnvironmentVariable(): void
+    {
+        $this->artisan('env:set', ['key' => 'STRIPE_KEY', '--value' => 'sk_test_123', '--no-example' => true])
+            ->expectsQuestion('What config key should this be associated with? (Optional)', '')
+            ->expectsOutputToContain('Environment variable [STRIPE_KEY] set successfully.')
+            ->assertExitCode(0);
+
+        $this->assertStringContainsString('STRIPE_KEY=sk_test_123', file_get_contents($this->tempDir.'/.env'));
+    }
+
+    public function testItSetsVariableWithInlineValue(): void
+    {
+        $this->artisan('env:set', ['key' => 'STRIPE_KEY=sk_test_123', '--no-example' => true])
+            ->expectsOutputToContain('Using value from argument: sk_test_123')
+            ->expectsQuestion('What config key should this be associated with? (Optional)', '')
+            ->expectsOutputToContain('Environment variable [STRIPE_KEY] set successfully.')
+            ->assertExitCode(0);
+
+        $this->assertStringContainsString('STRIPE_KEY=sk_test_123', file_get_contents($this->tempDir.'/.env'));
+    }
+
+    public function testItSetsVariableWithQuotedInlineValue(): void
+    {
+        $this->artisan('env:set', ['key' => 'APP_NAME="My App"', '--no-example' => true])
+            ->expectsOutputToContain('Using value from argument: My App')
+            ->expectsQuestion('What config key should this be associated with? (Optional)', '')
+            ->assertExitCode(0);
+
+        $this->assertStringContainsString('APP_NAME="My App"', file_get_contents($this->tempDir.'/.env'));
+    }
+
+    public function testItSetsVariableWithSingleQuotedInlineValue(): void
+    {
+        $this->artisan('env:set', ['key' => "APP_NAME='My App'", '--no-example' => true])
+            ->expectsOutputToContain('Using value from argument: My App')
+            ->expectsQuestion('What config key should this be associated with? (Optional)', '')
+            ->assertExitCode(0);
+
+        $this->assertStringContainsString('APP_NAME="My App"', file_get_contents($this->tempDir.'/.env'));
+    }
+
+    public function testItFailsWhenEnvFileIsMissing(): void
+    {
+        unlink($this->tempDir.'/.env');
+
+        $this->artisan('env:set', ['key' => 'STRIPE_KEY', '--value' => 'sk_test_123'])
+            ->expectsOutputToContain('Environment file not found.')
+            ->assertExitCode(1);
+    }
+
+    public function testItPromptsForOverwriteWhenVariableExists(): void
+    {
+        file_put_contents($this->tempDir.'/.env', 'STRIPE_KEY=old_value');
+
+        $this->artisan('env:set', ['key' => 'STRIPE_KEY', '--value' => 'new_value', '--no-example' => true])
+            ->expectsConfirmation('Environment variable [STRIPE_KEY] already exists. Overwrite?', 'yes')
+            ->expectsQuestion('What config key should this be associated with? (Optional)', '')
+            ->expectsOutputToContain('Environment variable [STRIPE_KEY] set successfully.')
+            ->assertExitCode(0);
+
+        $this->assertStringContainsString('STRIPE_KEY=new_value', file_get_contents($this->tempDir.'/.env'));
+    }
+
+    public function testItDoesNotOverwriteWhenUserDeclinesConfirmation(): void
+    {
+        file_put_contents($this->tempDir.'/.env', 'STRIPE_KEY=old_value');
+
+        $this->artisan('env:set', ['key' => 'STRIPE_KEY', '--value' => 'new_value'])
+            ->expectsConfirmation('Environment variable [STRIPE_KEY] already exists. Overwrite?', 'no')
+            ->assertExitCode(0);
+
+        $this->assertStringContainsString('STRIPE_KEY=old_value', file_get_contents($this->tempDir.'/.env'));
+    }
+
+    public function testItOverwritesWithForceOption(): void
+    {
+        file_put_contents($this->tempDir.'/.env', 'STRIPE_KEY=old_value');
+
+        $this->artisan('env:set', ['key' => 'STRIPE_KEY', '--value' => 'new_value', '--force' => true, '--no-example' => true])
+            ->expectsQuestion('What config key should this be associated with? (Optional)', '')
+            ->expectsOutputToContain('Environment variable [STRIPE_KEY] set successfully.')
+            ->assertExitCode(0);
+
+        $this->assertStringContainsString('STRIPE_KEY=new_value', file_get_contents($this->tempDir.'/.env'));
+    }
+
+    public function testItFailsInNonInteractiveModeWhenVariableExistsWithoutForce(): void
+    {
+        file_put_contents($this->tempDir.'/.env', 'STRIPE_KEY=old_value');
+
+        $this->artisan('env:set', ['key' => 'STRIPE_KEY', '--value' => 'new_value', '-n' => true])
+            ->expectsOutputToContain('Environment variable [STRIPE_KEY] already exists. Use --force to overwrite.')
+            ->assertExitCode(1);
+    }
+
+    public function testItAddsToEnvExample(): void
+    {
+        file_put_contents($this->tempDir.'/.env.example', '');
+
+        $this->artisan('env:set', ['key' => 'STRIPE_KEY', '--value' => 'sk_test_123', '--example' => true])
+            ->expectsQuestion('What config key should this be associated with? (Optional)', '')
+            ->expectsOutputToContain('Added [STRIPE_KEY] to .env.example.')
+            ->assertExitCode(0);
+
+        $this->assertStringContainsString('STRIPE_KEY=', file_get_contents($this->tempDir.'/.env.example'));
+    }
+
+    public function testItDoesNotAddToEnvExampleWithNoExampleOption(): void
+    {
+        file_put_contents($this->tempDir.'/.env.example', '');
+
+        $this->artisan('env:set', ['key' => 'STRIPE_KEY', '--value' => 'sk_test_123', '--no-example' => true])
+            ->expectsQuestion('What config key should this be associated with? (Optional)', '')
+            ->assertExitCode(0);
+
+        $this->assertStringNotContainsString('STRIPE_KEY', file_get_contents($this->tempDir.'/.env.example'));
+    }
+
+    public function testItSkipsEnvExampleWhenFileDoesNotExist(): void
+    {
+        $this->artisan('env:set', ['key' => 'STRIPE_KEY', '--value' => 'sk_test_123'])
+            ->expectsQuestion('What config key should this be associated with? (Optional)', '')
+            ->assertExitCode(0);
+
+        $this->assertFileDoesNotExist($this->tempDir.'/.env.example');
+    }
+
+    public function testItWritesConfigForNewFile(): void
+    {
+        $this->artisan('env:set', [
+            'key' => 'STRIPE_KEY',
+            '--value' => 'sk_test_123',
+            '--no-example' => true,
+            '--config-key' => 'services.stripe.key',
+            '--default' => 'null',
+        ])
+            ->expectsOutputToContain('Environment variable [STRIPE_KEY] set successfully.')
+            ->expectsOutputToContain("Config [services.stripe.key] set to env('STRIPE_KEY').")
+            ->assertExitCode(0);
+
+        $configFile = $this->tempDir.'/config/services.php';
+        $this->assertFileExists($configFile);
+
+        $contents = file_get_contents($configFile);
+        $this->assertStringContainsString("env('STRIPE_KEY', null)", $contents);
+        $this->assertStringContainsString("'stripe'", $contents);
+        $this->assertStringContainsString("'key'", $contents);
+    }
+
+    public function testItWritesConfigForExistingFile(): void
+    {
+        $configFile = $this->tempDir.'/config/services.php';
+        file_put_contents($configFile, <<<'PHP'
+<?php
+
+return [
+    'mailgun' => [
+        'domain' => env('MAILGUN_DOMAIN'),
+    ],
+];
+PHP);
+
+        $this->artisan('env:set', [
+            'key' => 'STRIPE_KEY',
+            '--value' => 'sk_test_123',
+            '--no-example' => true,
+            '--config-key' => 'services.stripe.key',
+            '--default' => 'null',
+            '--force' => true,
+        ])
+            ->assertExitCode(0);
+
+        $contents = file_get_contents($configFile);
+        $this->assertStringContainsString("env('STRIPE_KEY', null)", $contents);
+        $this->assertStringContainsString("'mailgun'", $contents);
+        $this->assertStringContainsString("env('MAILGUN_DOMAIN')", $contents);
+    }
+
+    public function testItWritesConfigWithStringDefault(): void
+    {
+        $this->artisan('env:set', [
+            'key' => 'APP_TIMEZONE',
+            '--value' => 'America/New_York',
+            '--no-example' => true,
+            '--config-key' => 'app.timezone',
+            '--default' => 'UTC',
+        ])
+            ->assertExitCode(0);
+
+        $configFile = $this->tempDir.'/config/app.php';
+        $contents = file_get_contents($configFile);
+        $this->assertStringContainsString("env('APP_TIMEZONE', 'UTC')", $contents);
+    }
+
+    public function testItWritesConfigWithEmptyDefault(): void
+    {
+        $this->artisan('env:set', [
+            'key' => 'STRIPE_KEY',
+            '--value' => 'sk_test_123',
+            '--no-example' => true,
+            '--config-key' => 'services.stripe.key',
+            '--default' => '',
+        ])
+            ->assertExitCode(0);
+
+        $configFile = $this->tempDir.'/config/services.php';
+        $contents = file_get_contents($configFile);
+        $this->assertStringContainsString("env('STRIPE_KEY')", $contents);
+        $this->assertStringNotContainsString("env('STRIPE_KEY',", $contents);
+    }
+
+    public function testItFailsWithConfigKeyMissingNestedKey(): void
+    {
+        $this->artisan('env:set', [
+            'key' => 'STRIPE_KEY',
+            '--value' => 'sk_test_123',
+            '--no-example' => true,
+            '--config-key' => 'services',
+        ])
+            ->expectsOutputToContain('Config key must include at least a file and a key')
+            ->assertExitCode(1);
+    }
+
+    public function testItHandlesFullNonInteractiveMode(): void
+    {
+        file_put_contents($this->tempDir.'/.env.example', '');
+
+        $this->artisan('env:set', [
+            'key' => 'STRIPE_KEY',
+            '--value' => 'sk_test_123',
+            '--config-key' => 'services.stripe.key',
+            '--default' => 'null',
+            '--example' => true,
+            '--force' => true,
+            '-n' => true,
+        ])
+            ->expectsOutputToContain('Environment variable [STRIPE_KEY] set successfully.')
+            ->expectsOutputToContain("Config [services.stripe.key] set to env('STRIPE_KEY').")
+            ->assertExitCode(0);
+
+        $this->assertStringContainsString('STRIPE_KEY=sk_test_123', file_get_contents($this->tempDir.'/.env'));
+        $this->assertStringContainsString('STRIPE_KEY=', file_get_contents($this->tempDir.'/.env.example'));
+        $this->assertFileExists($this->tempDir.'/config/services.php');
+    }
+
+    public function testItSkipsConfigInNonInteractiveModeWithoutConfigKey(): void
+    {
+        $this->artisan('env:set', [
+            'key' => 'STRIPE_KEY',
+            '--value' => 'sk_test_123',
+            '--no-example' => true,
+            '-n' => true,
+        ])
+            ->expectsOutputToContain('Environment variable [STRIPE_KEY] set successfully.')
+            ->assertExitCode(0);
+
+        $this->assertFileDoesNotExist($this->tempDir.'/config/services.php');
+    }
+
+    public function testItSkipsEnvExampleInNonInteractiveModeWithoutExampleFlag(): void
+    {
+        file_put_contents($this->tempDir.'/.env.example', '');
+
+        $this->artisan('env:set', [
+            'key' => 'STRIPE_KEY',
+            '--value' => 'sk_test_123',
+            '-n' => true,
+        ])
+            ->assertExitCode(0);
+
+        $this->assertStringNotContainsString('STRIPE_KEY', file_get_contents($this->tempDir.'/.env.example'));
+    }
+
+    public function testItHandlesDeeplyNestedConfigKeys(): void
+    {
+        $this->artisan('env:set', [
+            'key' => 'STRIPE_WEBHOOK_SECRET',
+            '--value' => 'whsec_test',
+            '--no-example' => true,
+            '--config-key' => 'services.stripe.webhook.secret',
+            '--default' => '',
+        ])
+            ->assertExitCode(0);
+
+        $configFile = $this->tempDir.'/config/services.php';
+        $contents = file_get_contents($configFile);
+        $this->assertStringContainsString("'stripe'", $contents);
+        $this->assertStringContainsString("'webhook'", $contents);
+        $this->assertStringContainsString("'secret'", $contents);
+        $this->assertStringContainsString("env('STRIPE_WEBHOOK_SECRET')", $contents);
+    }
+
+    public function testItReplacesExistingConfigValue(): void
+    {
+        $configFile = $this->tempDir.'/config/services.php';
+        file_put_contents($configFile, <<<'PHP'
+<?php
+
+return [
+    'stripe' => [
+        'key' => 'hardcoded_value',
+    ],
+];
+PHP);
+
+        $this->artisan('env:set', [
+            'key' => 'STRIPE_KEY',
+            '--value' => 'sk_test_123',
+            '--no-example' => true,
+            '--config-key' => 'services.stripe.key',
+            '--default' => 'null',
+            '--force' => true,
+        ])
+            ->assertExitCode(0);
+
+        $contents = file_get_contents($configFile);
+        $this->assertStringContainsString("env('STRIPE_KEY', null)", $contents);
+        $this->assertStringNotContainsString('hardcoded_value', $contents);
+    }
+
+    public function testItWritesConfigWithBooleanDefault(): void
+    {
+        $this->artisan('env:set', [
+            'key' => 'APP_DEBUG',
+            '--value' => 'true',
+            '--no-example' => true,
+            '--config-key' => 'app.debug',
+            '--default' => 'true',
+        ])
+            ->assertExitCode(0);
+
+        $configFile = $this->tempDir.'/config/app.php';
+        $contents = file_get_contents($configFile);
+        $this->assertStringContainsString("env('APP_DEBUG', true)", $contents);
+    }
+
+    public function testItWritesConfigWithFalseDefault(): void
+    {
+        $this->artisan('env:set', [
+            'key' => 'APP_DEBUG',
+            '--value' => 'false',
+            '--no-example' => true,
+            '--config-key' => 'app.debug',
+            '--default' => 'false',
+        ])
+            ->assertExitCode(0);
+
+        $configFile = $this->tempDir.'/config/app.php';
+        $contents = file_get_contents($configFile);
+        $this->assertStringContainsString("env('APP_DEBUG', false)", $contents);
+    }
+
+    public function testItPreservesExistingEnvVariablesWhenAddingNew(): void
+    {
+        file_put_contents($this->tempDir.'/.env', "APP_NAME=Laravel\nAPP_ENV=local");
+
+        $this->artisan('env:set', [
+            'key' => 'STRIPE_KEY',
+            '--value' => 'sk_test_123',
+            '--no-example' => true,
+            '-n' => true,
+        ])
+            ->assertExitCode(0);
+
+        $contents = file_get_contents($this->tempDir.'/.env');
+        $this->assertStringContainsString('APP_NAME=Laravel', $contents);
+        $this->assertStringContainsString('APP_ENV=local', $contents);
+        $this->assertStringContainsString('STRIPE_KEY=sk_test_123', $contents);
+    }
+}

--- a/tests/Integration/Console/EnvironmentSetCommandTest.php
+++ b/tests/Integration/Console/EnvironmentSetCommandTest.php
@@ -35,8 +35,7 @@ class EnvironmentSetCommandTest extends TestCase
 
     public function testItSetsANewEnvironmentVariable(): void
     {
-        $this->artisan('env:set', ['key' => 'STRIPE_KEY', '--value' => 'sk_test_123', '--no-example' => true])
-            ->expectsQuestion('What config key should this be associated with? (Optional)', '')
+        $this->artisan('env:set', ['key' => 'STRIPE_KEY', '--value' => 'sk_test_123', '-n' => true])
             ->expectsOutputToContain('Environment variable [STRIPE_KEY] set successfully.')
             ->assertExitCode(0);
 
@@ -45,9 +44,8 @@ class EnvironmentSetCommandTest extends TestCase
 
     public function testItSetsVariableWithInlineValue(): void
     {
-        $this->artisan('env:set', ['key' => 'STRIPE_KEY=sk_test_123', '--no-example' => true])
+        $this->artisan('env:set', ['key' => 'STRIPE_KEY=sk_test_123', '-n' => true])
             ->expectsOutputToContain('Using value from argument: sk_test_123')
-            ->expectsQuestion('What config key should this be associated with? (Optional)', '')
             ->expectsOutputToContain('Environment variable [STRIPE_KEY] set successfully.')
             ->assertExitCode(0);
 
@@ -56,9 +54,8 @@ class EnvironmentSetCommandTest extends TestCase
 
     public function testItSetsVariableWithQuotedInlineValue(): void
     {
-        $this->artisan('env:set', ['key' => 'APP_NAME="My App"', '--no-example' => true])
+        $this->artisan('env:set', ['key' => 'APP_NAME="My App"', '-n' => true])
             ->expectsOutputToContain('Using value from argument: My App')
-            ->expectsQuestion('What config key should this be associated with? (Optional)', '')
             ->assertExitCode(0);
 
         $this->assertStringContainsString('APP_NAME="My App"', file_get_contents($this->tempDir.'/.env'));
@@ -66,9 +63,8 @@ class EnvironmentSetCommandTest extends TestCase
 
     public function testItSetsVariableWithSingleQuotedInlineValue(): void
     {
-        $this->artisan('env:set', ['key' => "APP_NAME='My App'", '--no-example' => true])
+        $this->artisan('env:set', ['key' => "APP_NAME='My App'", '-n' => true])
             ->expectsOutputToContain('Using value from argument: My App')
-            ->expectsQuestion('What config key should this be associated with? (Optional)', '')
             ->assertExitCode(0);
 
         $this->assertStringContainsString('APP_NAME="My App"', file_get_contents($this->tempDir.'/.env'));
@@ -86,9 +82,11 @@ class EnvironmentSetCommandTest extends TestCase
     public function testItPromptsForOverwriteWhenVariableExists(): void
     {
         file_put_contents($this->tempDir.'/.env', 'STRIPE_KEY=old_value');
+        file_put_contents($this->tempDir.'/.env.example', '');
 
-        $this->artisan('env:set', ['key' => 'STRIPE_KEY', '--value' => 'new_value', '--no-example' => true])
+        $this->artisan('env:set', ['key' => 'STRIPE_KEY', '--value' => 'new_value'])
             ->expectsConfirmation('Environment variable [STRIPE_KEY] already exists. Overwrite?', 'yes')
+            ->expectsConfirmation('Add [STRIPE_KEY] to .env.example?', 'no')
             ->expectsQuestion('What config key should this be associated with? (Optional)', '')
             ->expectsOutputToContain('Environment variable [STRIPE_KEY] set successfully.')
             ->assertExitCode(0);
@@ -110,8 +108,10 @@ class EnvironmentSetCommandTest extends TestCase
     public function testItOverwritesWithForceOption(): void
     {
         file_put_contents($this->tempDir.'/.env', 'STRIPE_KEY=old_value');
+        file_put_contents($this->tempDir.'/.env.example', '');
 
-        $this->artisan('env:set', ['key' => 'STRIPE_KEY', '--value' => 'new_value', '--force' => true, '--no-example' => true])
+        $this->artisan('env:set', ['key' => 'STRIPE_KEY', '--value' => 'new_value', '--force' => true])
+            ->expectsConfirmation('Add [STRIPE_KEY] to .env.example?', 'no')
             ->expectsQuestion('What config key should this be associated with? (Optional)', '')
             ->expectsOutputToContain('Environment variable [STRIPE_KEY] set successfully.')
             ->assertExitCode(0);
@@ -132,20 +132,18 @@ class EnvironmentSetCommandTest extends TestCase
     {
         file_put_contents($this->tempDir.'/.env.example', '');
 
-        $this->artisan('env:set', ['key' => 'STRIPE_KEY', '--value' => 'sk_test_123', '--example' => true])
-            ->expectsQuestion('What config key should this be associated with? (Optional)', '')
+        $this->artisan('env:set', ['key' => 'STRIPE_KEY', '--value' => 'sk_test_123', '--example' => true, '-n' => true])
             ->expectsOutputToContain('Added [STRIPE_KEY] to .env.example.')
             ->assertExitCode(0);
 
         $this->assertStringContainsString('STRIPE_KEY=', file_get_contents($this->tempDir.'/.env.example'));
     }
 
-    public function testItDoesNotAddToEnvExampleWithNoExampleOption(): void
+    public function testItDoesNotAddToEnvExampleInNonInteractiveModeWithoutFlag(): void
     {
         file_put_contents($this->tempDir.'/.env.example', '');
 
-        $this->artisan('env:set', ['key' => 'STRIPE_KEY', '--value' => 'sk_test_123', '--no-example' => true])
-            ->expectsQuestion('What config key should this be associated with? (Optional)', '')
+        $this->artisan('env:set', ['key' => 'STRIPE_KEY', '--value' => 'sk_test_123', '-n' => true])
             ->assertExitCode(0);
 
         $this->assertStringNotContainsString('STRIPE_KEY', file_get_contents($this->tempDir.'/.env.example'));
@@ -153,8 +151,7 @@ class EnvironmentSetCommandTest extends TestCase
 
     public function testItSkipsEnvExampleWhenFileDoesNotExist(): void
     {
-        $this->artisan('env:set', ['key' => 'STRIPE_KEY', '--value' => 'sk_test_123'])
-            ->expectsQuestion('What config key should this be associated with? (Optional)', '')
+        $this->artisan('env:set', ['key' => 'STRIPE_KEY', '--value' => 'sk_test_123', '-n' => true])
             ->assertExitCode(0);
 
         $this->assertFileDoesNotExist($this->tempDir.'/.env.example');
@@ -165,9 +162,9 @@ class EnvironmentSetCommandTest extends TestCase
         $this->artisan('env:set', [
             'key' => 'STRIPE_KEY',
             '--value' => 'sk_test_123',
-            '--no-example' => true,
             '--config-key' => 'services.stripe.key',
             '--default' => 'null',
+            '-n' => true,
         ])
             ->expectsOutputToContain('Environment variable [STRIPE_KEY] set successfully.')
             ->expectsOutputToContain("Config [services.stripe.key] set to env('STRIPE_KEY').")
@@ -198,10 +195,10 @@ PHP);
         $this->artisan('env:set', [
             'key' => 'STRIPE_KEY',
             '--value' => 'sk_test_123',
-            '--no-example' => true,
             '--config-key' => 'services.stripe.key',
             '--default' => 'null',
             '--force' => true,
+            '-n' => true,
         ])
             ->assertExitCode(0);
 
@@ -216,9 +213,9 @@ PHP);
         $this->artisan('env:set', [
             'key' => 'APP_TIMEZONE',
             '--value' => 'America/New_York',
-            '--no-example' => true,
             '--config-key' => 'app.timezone',
             '--default' => 'UTC',
+            '-n' => true,
         ])
             ->assertExitCode(0);
 
@@ -232,9 +229,9 @@ PHP);
         $this->artisan('env:set', [
             'key' => 'STRIPE_KEY',
             '--value' => 'sk_test_123',
-            '--no-example' => true,
             '--config-key' => 'services.stripe.key',
             '--default' => '',
+            '-n' => true,
         ])
             ->assertExitCode(0);
 
@@ -249,8 +246,8 @@ PHP);
         $this->artisan('env:set', [
             'key' => 'STRIPE_KEY',
             '--value' => 'sk_test_123',
-            '--no-example' => true,
             '--config-key' => 'services',
+            '-n' => true,
         ])
             ->expectsOutputToContain('Config key must include at least a file and a key')
             ->assertExitCode(1);
@@ -283,7 +280,6 @@ PHP);
         $this->artisan('env:set', [
             'key' => 'STRIPE_KEY',
             '--value' => 'sk_test_123',
-            '--no-example' => true,
             '-n' => true,
         ])
             ->expectsOutputToContain('Environment variable [STRIPE_KEY] set successfully.')
@@ -311,9 +307,9 @@ PHP);
         $this->artisan('env:set', [
             'key' => 'STRIPE_WEBHOOK_SECRET',
             '--value' => 'whsec_test',
-            '--no-example' => true,
             '--config-key' => 'services.stripe.webhook.secret',
             '--default' => '',
+            '-n' => true,
         ])
             ->assertExitCode(0);
 
@@ -341,10 +337,10 @@ PHP);
         $this->artisan('env:set', [
             'key' => 'STRIPE_KEY',
             '--value' => 'sk_test_123',
-            '--no-example' => true,
             '--config-key' => 'services.stripe.key',
             '--default' => 'null',
             '--force' => true,
+            '-n' => true,
         ])
             ->assertExitCode(0);
 
@@ -358,9 +354,9 @@ PHP);
         $this->artisan('env:set', [
             'key' => 'APP_DEBUG',
             '--value' => 'true',
-            '--no-example' => true,
             '--config-key' => 'app.debug',
             '--default' => 'true',
+            '-n' => true,
         ])
             ->assertExitCode(0);
 
@@ -374,9 +370,9 @@ PHP);
         $this->artisan('env:set', [
             'key' => 'APP_DEBUG',
             '--value' => 'false',
-            '--no-example' => true,
             '--config-key' => 'app.debug',
             '--default' => 'false',
+            '-n' => true,
         ])
             ->assertExitCode(0);
 
@@ -392,7 +388,6 @@ PHP);
         $this->artisan('env:set', [
             'key' => 'STRIPE_KEY',
             '--value' => 'sk_test_123',
-            '--no-example' => true,
             '-n' => true,
         ])
             ->assertExitCode(0);

--- a/tests/Integration/Console/EnvironmentSetCommandTest.php
+++ b/tests/Integration/Console/EnvironmentSetCommandTest.php
@@ -35,7 +35,7 @@ class EnvironmentSetCommandTest extends TestCase
 
     public function testItSetsANewEnvironmentVariable(): void
     {
-        $this->artisan('env:set', ['key' => 'STRIPE_KEY', 'value' =>'sk_test_123', '-n' => true])
+        $this->artisan('env:set', ['key' => 'STRIPE_KEY', 'value' => 'sk_test_123', '-n' => true])
             ->expectsOutputToContain('Environment variable [STRIPE_KEY] set successfully.')
             ->assertExitCode(0);
 
@@ -74,7 +74,7 @@ class EnvironmentSetCommandTest extends TestCase
     {
         unlink($this->tempDir.'/.env');
 
-        $this->artisan('env:set', ['key' => 'STRIPE_KEY', 'value' =>'sk_test_123'])
+        $this->artisan('env:set', ['key' => 'STRIPE_KEY', 'value' => 'sk_test_123'])
             ->expectsOutputToContain('Environment file not found.')
             ->assertExitCode(1);
     }
@@ -84,7 +84,7 @@ class EnvironmentSetCommandTest extends TestCase
         file_put_contents($this->tempDir.'/.env', 'STRIPE_KEY=old_value');
         file_put_contents($this->tempDir.'/.env.example', '');
 
-        $this->artisan('env:set', ['key' => 'STRIPE_KEY', 'value' =>'new_value'])
+        $this->artisan('env:set', ['key' => 'STRIPE_KEY', 'value' => 'new_value'])
             ->expectsConfirmation('Environment variable [STRIPE_KEY] already exists. Overwrite?', 'yes')
             ->expectsConfirmation('Add [STRIPE_KEY] to .env.example?', 'no')
             ->expectsQuestion('What config key should this be associated with? (Optional)', '')
@@ -98,7 +98,7 @@ class EnvironmentSetCommandTest extends TestCase
     {
         file_put_contents($this->tempDir.'/.env', 'STRIPE_KEY=old_value');
 
-        $this->artisan('env:set', ['key' => 'STRIPE_KEY', 'value' =>'new_value'])
+        $this->artisan('env:set', ['key' => 'STRIPE_KEY', 'value' => 'new_value'])
             ->expectsConfirmation('Environment variable [STRIPE_KEY] already exists. Overwrite?', 'no')
             ->assertExitCode(0);
 
@@ -110,7 +110,7 @@ class EnvironmentSetCommandTest extends TestCase
         file_put_contents($this->tempDir.'/.env', 'STRIPE_KEY=old_value');
         file_put_contents($this->tempDir.'/.env.example', '');
 
-        $this->artisan('env:set', ['key' => 'STRIPE_KEY', 'value' =>'new_value', '--force' => true])
+        $this->artisan('env:set', ['key' => 'STRIPE_KEY', 'value' => 'new_value', '--force' => true])
             ->expectsConfirmation('Add [STRIPE_KEY] to .env.example?', 'no')
             ->expectsQuestion('What config key should this be associated with? (Optional)', '')
             ->expectsOutputToContain('Environment variable [STRIPE_KEY] set successfully.')
@@ -123,7 +123,7 @@ class EnvironmentSetCommandTest extends TestCase
     {
         file_put_contents($this->tempDir.'/.env', 'STRIPE_KEY=old_value');
 
-        $this->artisan('env:set', ['key' => 'STRIPE_KEY', 'value' =>'new_value', '-n' => true])
+        $this->artisan('env:set', ['key' => 'STRIPE_KEY', 'value' => 'new_value', '-n' => true])
             ->expectsOutputToContain('Environment variable [STRIPE_KEY] already exists. Use --force to overwrite.')
             ->assertExitCode(1);
     }
@@ -132,7 +132,7 @@ class EnvironmentSetCommandTest extends TestCase
     {
         file_put_contents($this->tempDir.'/.env.example', '');
 
-        $this->artisan('env:set', ['key' => 'STRIPE_KEY', 'value' =>'sk_test_123', '--example' => true, '-n' => true])
+        $this->artisan('env:set', ['key' => 'STRIPE_KEY', 'value' => 'sk_test_123', '--example' => true, '-n' => true])
             ->expectsOutputToContain('Added [STRIPE_KEY] to .env.example.')
             ->assertExitCode(0);
 
@@ -143,7 +143,7 @@ class EnvironmentSetCommandTest extends TestCase
     {
         file_put_contents($this->tempDir.'/.env.example', '');
 
-        $this->artisan('env:set', ['key' => 'STRIPE_KEY', 'value' =>'sk_test_123', '-n' => true])
+        $this->artisan('env:set', ['key' => 'STRIPE_KEY', 'value' => 'sk_test_123', '-n' => true])
             ->assertExitCode(0);
 
         $this->assertStringNotContainsString('STRIPE_KEY', file_get_contents($this->tempDir.'/.env.example'));
@@ -151,7 +151,7 @@ class EnvironmentSetCommandTest extends TestCase
 
     public function testItSkipsEnvExampleWhenFileDoesNotExist(): void
     {
-        $this->artisan('env:set', ['key' => 'STRIPE_KEY', 'value' =>'sk_test_123', '-n' => true])
+        $this->artisan('env:set', ['key' => 'STRIPE_KEY', 'value' => 'sk_test_123', '-n' => true])
             ->assertExitCode(0);
 
         $this->assertFileDoesNotExist($this->tempDir.'/.env.example');
@@ -161,7 +161,7 @@ class EnvironmentSetCommandTest extends TestCase
     {
         $this->artisan('env:set', [
             'key' => 'STRIPE_KEY',
-            'value' =>'sk_test_123',
+            'value' => 'sk_test_123',
             '--config-key' => 'services.stripe.key',
             '--default' => 'null',
             '-n' => true,
@@ -194,7 +194,7 @@ PHP);
 
         $this->artisan('env:set', [
             'key' => 'STRIPE_KEY',
-            'value' =>'sk_test_123',
+            'value' => 'sk_test_123',
             '--config-key' => 'services.stripe.key',
             '--default' => 'null',
             '--force' => true,
@@ -212,7 +212,7 @@ PHP);
     {
         $this->artisan('env:set', [
             'key' => 'APP_TIMEZONE',
-            'value' =>'America/New_York',
+            'value' => 'America/New_York',
             '--config-key' => 'app.timezone',
             '--default' => 'UTC',
             '-n' => true,
@@ -228,7 +228,7 @@ PHP);
     {
         $this->artisan('env:set', [
             'key' => 'STRIPE_KEY',
-            'value' =>'sk_test_123',
+            'value' => 'sk_test_123',
             '--config-key' => 'services.stripe.key',
             '--default' => '',
             '-n' => true,
@@ -245,7 +245,7 @@ PHP);
     {
         $this->artisan('env:set', [
             'key' => 'STRIPE_KEY',
-            'value' =>'sk_test_123',
+            'value' => 'sk_test_123',
             '--config-key' => 'services',
             '-n' => true,
         ])
@@ -257,7 +257,7 @@ PHP);
     {
         $this->artisan('env:set', [
             'key' => 'STRIPE_KEY',
-            'value' =>'sk_test_123',
+            'value' => 'sk_test_123',
             '--config-key' => 'services..stripe.key',
             '-n' => true,
         ])
@@ -269,7 +269,7 @@ PHP);
     {
         $this->artisan('env:set', [
             'key' => 'STRIPE_KEY',
-            'value' =>'sk_test_123',
+            'value' => 'sk_test_123',
             '--config-key' => '.services.key',
             '-n' => true,
         ])
@@ -283,7 +283,7 @@ PHP);
 
         $this->artisan('env:set', [
             'key' => 'STRIPE_KEY',
-            'value' =>'sk_test_123',
+            'value' => 'sk_test_123',
             '--config-key' => 'services.stripe.key',
             '--default' => 'null',
             '--example' => true,
@@ -303,7 +303,7 @@ PHP);
     {
         $this->artisan('env:set', [
             'key' => 'STRIPE_KEY',
-            'value' =>'sk_test_123',
+            'value' => 'sk_test_123',
             '-n' => true,
         ])
             ->expectsOutputToContain('Environment variable [STRIPE_KEY] set successfully.')
@@ -318,7 +318,7 @@ PHP);
 
         $this->artisan('env:set', [
             'key' => 'STRIPE_KEY',
-            'value' =>'sk_test_123',
+            'value' => 'sk_test_123',
             '-n' => true,
         ])
             ->assertExitCode(0);
@@ -330,7 +330,7 @@ PHP);
     {
         $this->artisan('env:set', [
             'key' => 'STRIPE_WEBHOOK_SECRET',
-            'value' =>'whsec_test',
+            'value' => 'whsec_test',
             '--config-key' => 'services.stripe.webhook.secret',
             '--default' => '',
             '-n' => true,
@@ -360,7 +360,7 @@ PHP);
 
         $this->artisan('env:set', [
             'key' => 'STRIPE_KEY',
-            'value' =>'sk_test_123',
+            'value' => 'sk_test_123',
             '--config-key' => 'services.stripe.key',
             '--default' => 'null',
             '--force' => true,
@@ -377,7 +377,7 @@ PHP);
     {
         $this->artisan('env:set', [
             'key' => 'APP_DEBUG',
-            'value' =>'true',
+            'value' => 'true',
             '--config-key' => 'app.debug',
             '--default' => 'true',
             '-n' => true,
@@ -393,7 +393,7 @@ PHP);
     {
         $this->artisan('env:set', [
             'key' => 'APP_DEBUG',
-            'value' =>'false',
+            'value' => 'false',
             '--config-key' => 'app.debug',
             '--default' => 'false',
             '-n' => true,
@@ -411,7 +411,7 @@ PHP);
 
         $this->artisan('env:set', [
             'key' => 'STRIPE_KEY',
-            'value' =>'sk_test_123',
+            'value' => 'sk_test_123',
             '-n' => true,
         ])
             ->assertExitCode(0);

--- a/tests/Support/ConfigWriterTest.php
+++ b/tests/Support/ConfigWriterTest.php
@@ -56,7 +56,6 @@ class ConfigWriterTest extends TestCase
         $this->assertStringContainsString("'key'", $contents);
         $this->assertStringContainsString("env('STRIPE_KEY', null)", $contents);
         $this->assertValidPhp($contents);
-
     }
 
     public function testItCreatesNewFileWithDeeplyNestedKeys(): void

--- a/tests/Support/ConfigWriterTest.php
+++ b/tests/Support/ConfigWriterTest.php
@@ -1,0 +1,399 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\ConfigWriter;
+use PHPUnit\Framework\TestCase;
+
+class ConfigWriterTest extends TestCase
+{
+    protected $tempDir;
+
+    protected $files;
+
+    protected $writer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->files = new Filesystem;
+        $this->tempDir = sys_get_temp_dir().'/laravel-config-writer-test-'.uniqid();
+        mkdir($this->tempDir, 0755, true);
+
+        $this->writer = new ConfigWriter($this->files);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->files->deleteDirectory($this->tempDir);
+
+        parent::tearDown();
+    }
+
+    public function testItCreatesNewFileWithSingleKey(): void
+    {
+        $path = $this->tempDir.'/services.php';
+
+        $this->writer->write($path, ['key'], 'STRIPE_KEY', 'null');
+
+        $this->assertFileExists($path);
+        $contents = file_get_contents($path);
+        $this->assertStringContainsString("env('STRIPE_KEY', null)", $contents);
+        $this->assertStringContainsString("'key'", $contents);
+        $this->assertValidPhp($contents);
+    }
+
+    public function testItCreatesNewFileWithNestedKeys(): void
+    {
+        $path = $this->tempDir.'/services.php';
+
+        $this->writer->write($path, ['stripe', 'key'], 'STRIPE_KEY', 'null');
+
+        $contents = file_get_contents($path);
+        $this->assertStringContainsString("'stripe'", $contents);
+        $this->assertStringContainsString("'key'", $contents);
+        $this->assertStringContainsString("env('STRIPE_KEY', null)", $contents);
+        $this->assertValidPhp($contents);
+
+    }
+
+    public function testItCreatesNewFileWithDeeplyNestedKeys(): void
+    {
+        $path = $this->tempDir.'/services.php';
+
+        $this->writer->write($path, ['stripe', 'webhook', 'secret'], 'STRIPE_WEBHOOK_SECRET');
+
+        $contents = file_get_contents($path);
+        $this->assertStringContainsString("'stripe'", $contents);
+        $this->assertStringContainsString("'webhook'", $contents);
+        $this->assertStringContainsString("'secret'", $contents);
+        $this->assertStringContainsString("env('STRIPE_WEBHOOK_SECRET')", $contents);
+        $this->assertValidPhp($contents);
+    }
+
+    public function testItCreatesNewFileWithStringDefault(): void
+    {
+        $path = $this->tempDir.'/app.php';
+
+        $this->writer->write($path, ['timezone'], 'APP_TIMEZONE', 'UTC');
+
+        $contents = file_get_contents($path);
+        $this->assertStringContainsString("env('APP_TIMEZONE', 'UTC')", $contents);
+        $this->assertValidPhp($contents);
+    }
+
+    public function testItCreatesNewFileWithNoDefault(): void
+    {
+        $path = $this->tempDir.'/services.php';
+
+        $this->writer->write($path, ['key'], 'STRIPE_KEY');
+
+        $contents = file_get_contents($path);
+        $this->assertStringContainsString("env('STRIPE_KEY')", $contents);
+        $this->assertStringNotContainsString("env('STRIPE_KEY',", $contents);
+        $this->assertValidPhp($contents);
+    }
+
+    public function testItCreatesNewFileWithNullDefault(): void
+    {
+        $path = $this->tempDir.'/services.php';
+
+        $this->writer->write($path, ['key'], 'STRIPE_KEY', 'null');
+
+        $contents = file_get_contents($path);
+        $this->assertStringContainsString("env('STRIPE_KEY', null)", $contents);
+        $this->assertValidPhp($contents);
+    }
+
+    public function testItCreatesNewFileWithTrueDefault(): void
+    {
+        $path = $this->tempDir.'/app.php';
+
+        $this->writer->write($path, ['debug'], 'APP_DEBUG', 'true');
+
+        $contents = file_get_contents($path);
+        $this->assertStringContainsString("env('APP_DEBUG', true)", $contents);
+        $this->assertValidPhp($contents);
+    }
+
+    public function testItCreatesNewFileWithFalseDefault(): void
+    {
+        $path = $this->tempDir.'/app.php';
+
+        $this->writer->write($path, ['debug'], 'APP_DEBUG', 'false');
+
+        $contents = file_get_contents($path);
+        $this->assertStringContainsString("env('APP_DEBUG', false)", $contents);
+        $this->assertValidPhp($contents);
+    }
+
+    public function testItCreatesParentDirectories(): void
+    {
+        $path = $this->tempDir.'/nested/dir/services.php';
+
+        $this->writer->write($path, ['key'], 'STRIPE_KEY');
+
+        $this->assertFileExists($path);
+        $this->assertValidPhp(file_get_contents($path));
+    }
+
+    public function testItAddsKeyToExistingFile(): void
+    {
+        $path = $this->tempDir.'/services.php';
+        file_put_contents($path, <<<'PHP'
+<?php
+
+return [
+    'mailgun' => [
+        'domain' => env('MAILGUN_DOMAIN'),
+    ],
+];
+PHP);
+
+        $this->writer->write($path, ['stripe', 'key'], 'STRIPE_KEY', 'null');
+
+        $contents = file_get_contents($path);
+        $this->assertStringContainsString("env('MAILGUN_DOMAIN')", $contents);
+        $this->assertStringContainsString("env('STRIPE_KEY', null)", $contents);
+        $this->assertStringContainsString("'mailgun'", $contents);
+        $this->assertStringContainsString("'stripe'", $contents);
+        $this->assertValidPhp($contents);
+    }
+
+    public function testItReplacesExistingValue(): void
+    {
+        $path = $this->tempDir.'/services.php';
+        file_put_contents($path, <<<'PHP'
+<?php
+
+return [
+    'stripe' => [
+        'key' => 'hardcoded_value',
+    ],
+];
+PHP);
+
+        $this->writer->write($path, ['stripe', 'key'], 'STRIPE_KEY', 'null');
+
+        $contents = file_get_contents($path);
+        $this->assertStringContainsString("env('STRIPE_KEY', null)", $contents);
+        $this->assertStringNotContainsString('hardcoded_value', $contents);
+        $this->assertValidPhp($contents);
+    }
+
+    public function testItReplacesExistingEnvCall(): void
+    {
+        $path = $this->tempDir.'/services.php';
+        file_put_contents($path, <<<'PHP'
+<?php
+
+return [
+    'stripe' => [
+        'key' => env('OLD_KEY', 'old_default'),
+    ],
+];
+PHP);
+
+        $this->writer->write($path, ['stripe', 'key'], 'NEW_KEY', 'null');
+
+        $contents = file_get_contents($path);
+        $this->assertStringContainsString("env('NEW_KEY', null)", $contents);
+        $this->assertStringNotContainsString('OLD_KEY', $contents);
+        $this->assertValidPhp($contents);
+    }
+
+    public function testItPreservesFormatting(): void
+    {
+        $path = $this->tempDir.'/services.php';
+        $original = <<<'PHP'
+<?php
+
+return [
+    'mailgun' => [
+        'domain' => env('MAILGUN_DOMAIN'),
+        'secret' => env('MAILGUN_SECRET'),
+    ],
+];
+PHP;
+        file_put_contents($path, $original);
+
+        $this->writer->write($path, ['stripe', 'key'], 'STRIPE_KEY', 'null');
+
+        $contents = file_get_contents($path);
+        // The original mailgun section should remain intact
+        $this->assertStringContainsString("'mailgun' => [\n        'domain' => env('MAILGUN_DOMAIN'),\n        'secret' => env('MAILGUN_SECRET'),\n    ]", $contents);
+        $this->assertValidPhp($contents);
+    }
+
+    public function testItAddsToExistingNestedArray(): void
+    {
+        $path = $this->tempDir.'/services.php';
+        file_put_contents($path, <<<'PHP'
+<?php
+
+return [
+    'stripe' => [
+        'key' => env('STRIPE_KEY'),
+    ],
+];
+PHP);
+
+        $this->writer->write($path, ['stripe', 'secret'], 'STRIPE_SECRET', 'null');
+
+        $contents = file_get_contents($path);
+        $this->assertStringContainsString("env('STRIPE_KEY')", $contents);
+        $this->assertStringContainsString("env('STRIPE_SECRET', null)", $contents);
+        $this->assertValidPhp($contents);
+    }
+
+    public function testItCreatesIntermediateArrays(): void
+    {
+        $path = $this->tempDir.'/services.php';
+        file_put_contents($path, <<<'PHP'
+<?php
+
+return [
+    'mailgun' => [
+        'domain' => env('MAILGUN_DOMAIN'),
+    ],
+];
+PHP);
+
+        $this->writer->write($path, ['stripe', 'webhook', 'secret'], 'STRIPE_WEBHOOK_SECRET');
+
+        $contents = file_get_contents($path);
+        $this->assertStringContainsString("'stripe'", $contents);
+        $this->assertStringContainsString("'webhook'", $contents);
+        $this->assertStringContainsString("'secret'", $contents);
+        $this->assertStringContainsString("env('STRIPE_WEBHOOK_SECRET')", $contents);
+        $this->assertStringContainsString("env('MAILGUN_DOMAIN')", $contents);
+        $this->assertValidPhp($contents);
+    }
+
+    public function testItDoesNothingWhenFileHasNoReturnArray(): void
+    {
+        $path = $this->tempDir.'/broken.php';
+        $original = <<<'PHP'
+<?php
+
+echo 'hello';
+PHP;
+        file_put_contents($path, $original);
+
+        $this->writer->write($path, ['key'], 'SOME_KEY');
+
+        $this->assertSame($original, file_get_contents($path));
+    }
+
+    public function testItHandlesEmptyReturnArray(): void
+    {
+        $path = $this->tempDir.'/services.php';
+        file_put_contents($path, <<<'PHP'
+<?php
+
+return [
+];
+PHP);
+
+        $this->writer->write($path, ['stripe', 'key'], 'STRIPE_KEY', 'null');
+
+        $contents = file_get_contents($path);
+        $this->assertStringContainsString("env('STRIPE_KEY', null)", $contents);
+        $this->assertValidPhp($contents);
+    }
+
+    public function testItHandlesFileWithComments(): void
+    {
+        $path = $this->tempDir.'/services.php';
+        file_put_contents($path, <<<'PHP'
+<?php
+
+// Third-party service configuration.
+return [
+    // Mailgun settings
+    'mailgun' => [
+        'domain' => env('MAILGUN_DOMAIN'),
+    ],
+];
+PHP);
+
+        $this->writer->write($path, ['stripe', 'key'], 'STRIPE_KEY', 'null');
+
+        $contents = file_get_contents($path);
+        $this->assertStringContainsString('// Third-party service configuration.', $contents);
+        $this->assertStringContainsString('// Mailgun settings', $contents);
+        $this->assertStringContainsString("env('STRIPE_KEY', null)", $contents);
+        $this->assertValidPhp($contents);
+    }
+
+    public function testItProducesValidPhpForNewFileWithAllDefaultTypes(): void
+    {
+        $cases = [
+            ['null', "env('K', null)"],
+            ['true', "env('K', true)"],
+            ['false', "env('K', false)"],
+            ['some_string', "env('K', 'some_string')"],
+            ['', "env('K')"],
+        ];
+
+        foreach ($cases as $i => [$default, $expected]) {
+            $path = $this->tempDir."/test_{$i}.php";
+            $this->writer->write($path, ['key'], 'K', $default);
+
+            $contents = file_get_contents($path);
+            $this->assertStringContainsString($expected, $contents, "Failed for default: '{$default}'");
+            $this->assertValidPhp($contents);
+        }
+    }
+
+    public function testItHandlesMultipleWritesToSameFile(): void
+    {
+        $path = $this->tempDir.'/services.php';
+        file_put_contents($path, <<<'PHP'
+<?php
+
+return [
+];
+PHP);
+
+        $this->writer->write($path, ['stripe', 'key'], 'STRIPE_KEY', 'null');
+        $this->writer->write($path, ['stripe', 'secret'], 'STRIPE_SECRET', 'null');
+        $this->writer->write($path, ['mailgun', 'domain'], 'MAILGUN_DOMAIN');
+
+        $contents = file_get_contents($path);
+        $this->assertStringContainsString("env('STRIPE_KEY', null)", $contents);
+        $this->assertStringContainsString("env('STRIPE_SECRET', null)", $contents);
+        $this->assertStringContainsString("env('MAILGUN_DOMAIN')", $contents);
+        $this->assertValidPhp($contents);
+    }
+
+    public function testItHandlesOldArraySyntax(): void
+    {
+        $path = $this->tempDir.'/services.php';
+        file_put_contents($path, <<<'PHP'
+<?php
+
+return array(
+    'mailgun' => array(
+        'domain' => env('MAILGUN_DOMAIN'),
+    ),
+);
+PHP);
+
+        $this->writer->write($path, ['stripe', 'key'], 'STRIPE_KEY', 'null');
+
+        $contents = file_get_contents($path);
+        $this->assertStringContainsString("env('STRIPE_KEY', null)", $contents);
+        $this->assertStringContainsString("env('MAILGUN_DOMAIN')", $contents);
+        $this->assertValidPhp($contents);
+    }
+
+    protected function assertValidPhp(string $code): void
+    {
+        $result = exec('echo '.escapeshellarg($code).' | php -l 2>&1', $output, $exitCode);
+
+        $this->assertSame(0, $exitCode, 'PHP syntax check failed: '.implode("\n", $output));
+    }
+}


### PR DESCRIPTION
This PR introduces a new `env:set` Artisan command that provides a guided workflow for adding environment variables to a Laravel application. This is intended for local development, the command requires explicit confirmation (or `--force`) to run in production via `ConfirmableTrait`.

Beyond being a quality-of-life improvement, this command gently enforces best practices that benefit both seasoned developers and newcomers alike:

- **Config-first access**: The command prompts developers to associate each variable with a config key, reinforcing the convention that application code should reference `config()` values rather than calling `env()` directly.
- **Keeps `.env.example` in sync**: Optionally adds new variables to `.env.example`, helping prevent the drift that leads to missing-key errors for teammates and in CI.

### Features

- Set env variables interactively or non-interactively (`--config-key`, `--default`, `--example`, `--force`)
- Inline key=value syntax: `php artisan env:set STRIPE_KEY=sk_test_123`
- Interactive autocomplete for existing config keys with progressive drill-down
- Overwrite protection with confirmation prompts (or `--force`)
- Config key validation to prevent path traversal and malformed keys

### New: `ConfigWriter`

This PR also introduces `Illuminate\Support\ConfigWriter`, a utility that uses `nikic/php-parser` to safely modify config files via AST manipulation rather than string replacement. It can create new config files or surgically update existing ones while preserving formatting and surrounding values.

https://github.com/user-attachments/assets/b6eb03ea-5c69-40c0-a7f0-c480a6e0841d