### PR TITLE
[13.x] Add fluent HTML test assertions

### DIFF
--- a/phpstan.src.neon.dist
+++ b/phpstan.src.neon.dist
@@ -13,6 +13,6 @@ parameters:
         - "#Caught class [a-zA-Z0-9\\\\_]+ not found.#"
         - "#Class [a-zA-Z0-9\\\\_]+ not found.#"
         - "#unknown class Dom\\\\#"
-        - "#has invalid type#"
+        - "#has invalid (return )?type#"
         - "#Instantiated class [a-zA-Z0-9\\\\_]+ not found.#"
         - "#Unsafe usage of new static#"

--- a/phpstan.src.neon.dist
+++ b/phpstan.src.neon.dist
@@ -12,6 +12,7 @@ parameters:
         - "#Call to an undefined method#"
         - "#Caught class [a-zA-Z0-9\\\\_]+ not found.#"
         - "#Class [a-zA-Z0-9\\\\_]+ not found.#"
+        - "#unknown class Dom\\\\#"
         - "#has invalid type#"
         - "#Instantiated class [a-zA-Z0-9\\\\_]+ not found.#"
         - "#Unsafe usage of new static#"

--- a/src/Illuminate/Testing/Fluent/AssertableHtml.php
+++ b/src/Illuminate/Testing/Fluent/AssertableHtml.php
@@ -3,8 +3,8 @@
 namespace Illuminate\Testing\Fluent;
 
 use Closure;
-use Dom\HTMLDocument;
 use Dom\Element;
+use Dom\HTMLDocument;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Support\Traits\Tappable;
@@ -460,9 +460,7 @@ class AssertableHtml
      */
     public function dd(): never
     {
-        $this->dump();
-
-        exit(1);
+        dd($this->getHtml());
     }
 
     /**

--- a/src/Illuminate/Testing/Fluent/AssertableHtml.php
+++ b/src/Illuminate/Testing/Fluent/AssertableHtml.php
@@ -380,17 +380,73 @@ class AssertableHtml
     }
 
     /**
-     * Scope into the first element matching the selector and invoke the callback.
+     * Scope into the element at the given index matching the selector and optionally invoke the callback.
      *
      * @param  string  $selector
-     * @param  \Closure  $callback
+     * @param  int  $index
+     * @param  \Closure|null  $callback
      * @return $this
      */
-    public function scope(string $selector, Closure $callback): static
+    public function nth(string $selector, int $index, ?Closure $callback = null): static
     {
-        $callback(new static($this->findOrFail($selector), $this->buildSelector($selector)));
+        $nodes = $this->scope->querySelectorAll($selector);
 
-        return $this;
+        if ($nodes->length === 0) {
+            $this->fail("Failed asserting that element [{$selector}] exists.", $selector);
+        }
+
+        if ($index < 0 || $index >= $nodes->length) {
+            $this->fail(
+                "Failed asserting that [{$selector}] has an element at index [{$index}], found {$nodes->length} element(s).",
+                $selector
+            );
+        }
+
+        $scoped = new static($nodes->item($index), $this->buildSelector($selector));
+
+        if ($callback !== null) {
+            $callback($scoped);
+
+            return $this;
+        }
+
+        return $scoped;
+    }
+
+    /**
+     * Scope into the first element matching the selector and optionally invoke the callback.
+     *
+     * @param  string  $selector
+     * @param  \Closure|null  $callback
+     * @return $this
+     */
+    public function first(string $selector, ?Closure $callback = null): static
+    {
+        return $this->nth($selector, 0, $callback);
+    }
+
+    /**
+     * Scope into the last element matching the selector and optionally invoke the callback.
+     *
+     * @param  string  $selector
+     * @param  \Closure|null  $callback
+     * @return $this
+     */
+    public function last(string $selector, ?Closure $callback = null): static
+    {
+        return $this->nth($selector, $this->scope->querySelectorAll($selector)->length - 1, $callback);
+    }
+
+    /**
+     * Scope into the first element matching the selector and optionally invoke the callback.
+     *
+     * @param  string  $selector
+     * @param  \Closure|null  $callback
+     * @return $this
+     */
+    public function scope(string $selector, ?Closure $callback = null): static
+    {
+        return $this->first($selector, $callback);
     }
 
     /**

--- a/src/Illuminate/Testing/Fluent/AssertableHtml.php
+++ b/src/Illuminate/Testing/Fluent/AssertableHtml.php
@@ -190,7 +190,7 @@ class AssertableHtml
         if ($expected instanceof Closure) {
             if (! $expected($actual)) {
                 $this->fail(
-                    "Failed asserting that [{$selector}] text was accepted by the truth test.",
+                    "Failed asserting that [{$selector}] text was marked as invalid using a closure.",
                     $selector
                 );
             }
@@ -238,7 +238,7 @@ class AssertableHtml
         if ($expected instanceof Closure) {
             if ($expected($actual)) {
                 $this->fail(
-                    "Failed asserting that [{$selector}] text was rejected by the truth test.",
+                    "Failed asserting that [{$selector}] text was marked as invalid using a closure.",
                     $selector
                 );
             }
@@ -271,7 +271,7 @@ class AssertableHtml
         if ($expected instanceof Closure) {
             if (! $expected($actual)) {
                 $this->fail(
-                    "Failed asserting that [{$selector}] attribute [{$attribute}] was accepted by the truth test.",
+                    "Failed asserting that [{$selector}] attribute [{$attribute}] was marked as invalid using a closure.",
                     $selector
                 );
             }

--- a/src/Illuminate/Testing/Fluent/AssertableHtml.php
+++ b/src/Illuminate/Testing/Fluent/AssertableHtml.php
@@ -143,21 +143,6 @@ class AssertableHtml
     }
 
     /**
-     * Assert that each selector's matched element has the expected text content.
-     *
-     * @param  array<string, string|\Closure>  $bindings
-     * @return $this
-     */
-    public function whereAllText(array $bindings): static
-    {
-        foreach ($bindings as $selector => $expected) {
-            $this->whereText($selector, $expected);
-        }
-
-        return $this;
-    }
-
-    /**
      * Assert that the matched element's text content does not equal the given value.
      *
      * @param  string  $selector
@@ -184,6 +169,67 @@ class AssertableHtml
                 "Failed asserting that [{$selector}] text does not equal [{$expected}].",
                 $selector
             );
+        }
+
+        return $this;
+    }
+
+    /**
+     * Assert that each selector's matched element has the expected text content.
+     *
+     * @param  array<string, string|\Closure>  $bindings
+     * @return $this
+     */
+    public function whereAllText(array $bindings): static
+    {
+        foreach ($bindings as $selector => $expected) {
+            $this->whereText($selector, $expected);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Assert that the matched element has all of the given attributes.
+     *
+     * @param  string  $selector
+     * @param  string  ...$attributes
+     * @return $this
+     */
+    public function hasAttributes(string $selector, string ...$attributes): static
+    {
+        $element = $this->findOrFail($selector);
+
+        foreach ($attributes as $attribute) {
+            if (! $element->hasAttribute($attribute)) {
+                $this->fail(
+                    "Failed asserting that [{$selector}] has attribute [{$attribute}].",
+                    $selector
+                );
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * Assert that the matched element does not have any of the given attributes.
+     *
+     * @param  string  $selector
+     * @param  string  ...$attributes
+     * @return $this
+     */
+    public function missingAttributes(string $selector, string ...$attributes): static
+    {
+        $element = $this->findOrFail($selector);
+
+        foreach ($attributes as $attribute) {
+            if ($element->hasAttribute($attribute)) {
+                $this->fail(
+                    "Failed asserting that [{$selector}] does not have attribute [{$attribute}].",
+                    $selector
+                );
+            }
         }
 
         return $this;
@@ -217,29 +263,6 @@ class AssertableHtml
                 "Failed asserting that [{$selector}] attribute [{$attribute}] equals [{$expected}], found [{$actual}].",
                 $selector
             );
-        }
-
-        return $this;
-    }
-
-    /**
-     * Assert that the matched element has all of the given attributes.
-     *
-     * @param  string  $selector
-     * @param  string  ...$attributes
-     * @return $this
-     */
-    public function hasAttributes(string $selector, string ...$attributes): static
-    {
-        $element = $this->findOrFail($selector);
-
-        foreach ($attributes as $attribute) {
-            if (! $element->hasAttribute($attribute)) {
-                $this->fail(
-                    "Failed asserting that [{$selector}] has attribute [{$attribute}].",
-                    $selector
-                );
-            }
         }
 
         return $this;
@@ -295,26 +318,39 @@ class AssertableHtml
     }
 
     /**
-     * Assert that the matched element does not have any of the given attributes.
+     * Scope into the first element matching the selector and optionally invoke the callback.
      *
      * @param  string  $selector
-     * @param  string  ...$attributes
+     * @param  \Closure|null  $callback
      * @return $this
      */
-    public function missingAttributes(string $selector, string ...$attributes): static
+    public function scope(string $selector, ?Closure $callback = null): static
     {
-        $element = $this->findOrFail($selector);
+        return $this->first($selector, $callback);
+    }
 
-        foreach ($attributes as $attribute) {
-            if ($element->hasAttribute($attribute)) {
-                $this->fail(
-                    "Failed asserting that [{$selector}] does not have attribute [{$attribute}].",
-                    $selector
-                );
-            }
-        }
+    /**
+     * Scope into the first element matching the selector and optionally invoke the callback.
+     *
+     * @param  string  $selector
+     * @param  \Closure|null  $callback
+     * @return $this
+     */
+    public function first(string $selector, ?Closure $callback = null): static
+    {
+        return $this->nth($selector, 0, $callback);
+    }
 
-        return $this;
+    /**
+     * Scope into the last element matching the selector and optionally invoke the callback.
+     *
+     * @param  string  $selector
+     * @param  \Closure|null  $callback
+     * @return $this
+     */
+    public function last(string $selector, ?Closure $callback = null): static
+    {
+        return $this->nth($selector, $this->scope->querySelectorAll($selector)->length - 1, $callback);
     }
 
     /**
@@ -349,42 +385,6 @@ class AssertableHtml
         }
 
         return $scoped;
-    }
-
-    /**
-     * Scope into the first element matching the selector and optionally invoke the callback.
-     *
-     * @param  string  $selector
-     * @param  \Closure|null  $callback
-     * @return $this
-     */
-    public function first(string $selector, ?Closure $callback = null): static
-    {
-        return $this->nth($selector, 0, $callback);
-    }
-
-    /**
-     * Scope into the last element matching the selector and optionally invoke the callback.
-     *
-     * @param  string  $selector
-     * @param  \Closure|null  $callback
-     * @return $this
-     */
-    public function last(string $selector, ?Closure $callback = null): static
-    {
-        return $this->nth($selector, $this->scope->querySelectorAll($selector)->length - 1, $callback);
-    }
-
-    /**
-     * Scope into the first element matching the selector and optionally invoke the callback.
-     *
-     * @param  string  $selector
-     * @param  \Closure|null  $callback
-     * @return $this
-     */
-    public function scope(string $selector, ?Closure $callback = null): static
-    {
-        return $this->first($selector, $callback);
     }
 
     /**

--- a/src/Illuminate/Testing/Fluent/AssertableHtml.php
+++ b/src/Illuminate/Testing/Fluent/AssertableHtml.php
@@ -151,7 +151,7 @@ class AssertableHtml
      */
     public function whereText(string $selector, string|Closure $expected): static
     {
-        $actual = trim($this->findOrFail($selector)->textContent);
+        $actual = $this->textContent($selector);
 
         if ($expected instanceof Closure) {
             if (! $expected($actual)) {
@@ -198,7 +198,7 @@ class AssertableHtml
      */
     public function whereNotText(string $selector, string|Closure $expected): static
     {
-        $actual = trim($this->findOrFail($selector)->textContent);
+        $actual = $this->textContent($selector);
 
         if ($expected instanceof Closure) {
             if ($expected($actual)) {
@@ -455,6 +455,17 @@ class AssertableHtml
         $parts[] = $this->getHtml();
 
         PHPUnit::fail(implode("\n\n", $parts));
+    }
+
+    /**
+     * Get the trimmed text content of the first element matching the selector or fail.
+     *
+     * @param  string  $selector
+     * @return string
+     */
+    protected function textContent(string $selector): string
+    {
+        return trim($this->findOrFail($selector)->textContent);
     }
 
     /**

--- a/src/Illuminate/Testing/Fluent/AssertableHtml.php
+++ b/src/Illuminate/Testing/Fluent/AssertableHtml.php
@@ -61,23 +61,11 @@ class AssertableHtml
      * Assert that an element matching the given selector exists.
      *
      * @param  string  $selector
-     * @param  int|\Closure|null  $countOrCallback
-     * @param  \Closure|null  $callback
      * @return $this
      */
-    public function has(string $selector, int|Closure|null $countOrCallback = null, ?Closure $callback = null): static
+    public function has(string $selector): static
     {
-        $element = $this->findOrFail($selector);
-
-        if (is_int($countOrCallback)) {
-            $this->count($selector, $countOrCallback);
-
-            if ($callback !== null) {
-                $callback(new static($element, $this->buildSelector($selector)));
-            }
-        } elseif ($countOrCallback instanceof Closure) {
-            $countOrCallback(new static($element, $this->buildSelector($selector)));
-        }
+        $this->findOrFail($selector);
 
         return $this;
     }

--- a/src/Illuminate/Testing/Fluent/AssertableHtml.php
+++ b/src/Illuminate/Testing/Fluent/AssertableHtml.php
@@ -309,6 +309,55 @@ class AssertableHtml
     }
 
     /**
+     * Assert that the matched element's attribute does not equal the expected value, or does not pass a truth test.
+     *
+     * @param  string  $selector
+     * @param  string  $attribute
+     * @param  string|\Closure  $expected
+     * @return $this
+     */
+    public function whereNotAttr(string $selector, string $attribute, string|Closure $expected): static
+    {
+        $actual = $this->findOrFail($selector)->getAttribute($attribute);
+
+        if ($expected instanceof Closure) {
+            if ($expected($actual)) {
+                $this->fail(
+                    "Failed asserting that [{$selector}] attribute [{$attribute}] was marked as invalid using a closure.",
+                    $selector
+                );
+            }
+
+            return $this;
+        }
+
+        if ($actual === $expected) {
+            $this->fail(
+                "Failed asserting that [{$selector}] attribute [{$attribute}] does not equal [{$expected}].",
+                $selector
+            );
+        }
+
+        return $this;
+    }
+
+    /**
+     * Assert multiple attribute → value (or closure) pairs on the matched element at once.
+     *
+     * @param  string  $selector
+     * @param  array<string, string|\Closure>  $bindings
+     * @return $this
+     */
+    public function whereAttrs(string $selector, array $bindings): static
+    {
+        foreach ($bindings as $attribute => $expected) {
+            $this->whereAttr($selector, $attribute, $expected);
+        }
+
+        return $this;
+    }
+
+    /**
      * Alias for whereAttr().
      *
      * @param  string  $selector
@@ -319,6 +368,31 @@ class AssertableHtml
     public function whereAttribute(string $selector, string $attribute, string|Closure $expected): static
     {
         return $this->whereAttr($selector, $attribute, $expected);
+    }
+
+    /**
+     * Alias for whereNotAttr().
+     *
+     * @param  string  $selector
+     * @param  string  $attribute
+     * @param  string|\Closure  $expected
+     * @return $this
+     */
+    public function whereNotAttribute(string $selector, string $attribute, string|Closure $expected): static
+    {
+        return $this->whereNotAttr($selector, $attribute, $expected);
+    }
+
+    /**
+     * Alias for whereAttrs().
+     *
+     * @param  string  $selector
+     * @param  array<string, string|\Closure>  $bindings
+     * @return $this
+     */
+    public function whereAttributes(string $selector, array $bindings): static
+    {
+        return $this->whereAttrs($selector, $bindings);
     }
 
     /**

--- a/src/Illuminate/Testing/Fluent/AssertableHtml.php
+++ b/src/Illuminate/Testing/Fluent/AssertableHtml.php
@@ -11,6 +11,8 @@ use Illuminate\Support\Traits\Tappable;
 use Illuminate\Testing\TestResponse;
 use PHPUnit\Framework\Assert as PHPUnit;
 use PHPUnit\Framework\AssertionFailedError;
+use Symfony\Component\HttpFoundation\StreamedJsonResponse;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class AssertableHtml
 {
@@ -36,7 +38,12 @@ class AssertableHtml
      */
     public static function fromResponse(TestResponse $response, int $options = LIBXML_NOERROR): static
     {
-        return new static(HTMLDocument::createFromString($response->getContent(), $options));
+        $content = $response->baseResponse instanceof StreamedResponse ||
+            $response->baseResponse instanceof StreamedJsonResponse
+                ? $response->streamedContent()
+                : $response->getContent();
+
+        return new static(HTMLDocument::createFromString($content, $options));
     }
 
     /**

--- a/src/Illuminate/Testing/Fluent/AssertableHtml.php
+++ b/src/Illuminate/Testing/Fluent/AssertableHtml.php
@@ -257,16 +257,27 @@ class AssertableHtml
     }
 
     /**
-     * Assert that the matched element's attribute equals the expected value.
+     * Assert that the matched element's attribute equals the expected value, or passes a truth test.
      *
      * @param  string  $selector
      * @param  string  $attribute
-     * @param  string  $expected
+     * @param  string|\Closure  $expected
      * @return $this
      */
-    public function whereAttr(string $selector, string $attribute, string $expected): static
+    public function whereAttr(string $selector, string $attribute, string|Closure $expected): static
     {
         $actual = $this->findOrFail($selector)->getAttribute($attribute);
+
+        if ($expected instanceof Closure) {
+            if (! $expected($actual)) {
+                $this->fail(
+                    "Failed asserting that [{$selector}] attribute [{$attribute}] was accepted by the truth test.",
+                    $selector
+                );
+            }
+
+            return $this;
+        }
 
         if ($actual !== $expected) {
             $this->fail(
@@ -302,10 +313,10 @@ class AssertableHtml
      *
      * @param  string  $selector
      * @param  string  $attribute
-     * @param  string  $expected
+     * @param  string|\Closure  $expected
      * @return $this
      */
-    public function whereAttribute(string $selector, string $attribute, string $expected): static
+    public function whereAttribute(string $selector, string $attribute, string|Closure $expected): static
     {
         return $this->whereAttr($selector, $attribute, $expected);
     }

--- a/src/Illuminate/Testing/Fluent/AssertableHtml.php
+++ b/src/Illuminate/Testing/Fluent/AssertableHtml.php
@@ -1,0 +1,394 @@
+<?php
+
+namespace Illuminate\Testing\Fluent;
+
+use Closure;
+use Dom\HTMLDocument;
+use Dom\Element;
+use Illuminate\Support\Traits\Conditionable;
+use Illuminate\Support\Traits\Macroable;
+use Illuminate\Support\Traits\Tappable;
+use Illuminate\Testing\TestResponse;
+use PHPUnit\Framework\Assert as PHPUnit;
+use PHPUnit\Framework\AssertionFailedError;
+
+class AssertableHtml
+{
+    use Conditionable, Macroable, Tappable;
+
+    /**
+     * The parsed HTML document.
+     *
+     * @var \Dom\HTMLDocument
+     */
+    protected HTMLDocument $document;
+
+    /**
+     * The current scope (the document root or a scoped element).
+     *
+     * @var \Dom\Element|\Dom\HTMLDocument
+     */
+    protected Element|HTMLDocument $scope;
+
+    /**
+     * Create a new assertable HTML instance.
+     *
+     * @param  \Dom\HTMLDocument  $document
+     * @param  \Dom\Element|\Dom\HTMLDocument|null  $scope
+     */
+    protected function __construct(HTMLDocument $document, Element|HTMLDocument|null $scope = null)
+    {
+        $this->document = $document;
+        $this->scope = $scope ?? $document;
+    }
+
+    /**
+     * Create a new instance from a test response.
+     *
+     * @param  \Illuminate\Testing\TestResponse  $response
+     * @return static
+     */
+    public static function fromResponse(TestResponse $response): static
+    {
+        return static::fromString($response->getContent());
+    }
+
+    /**
+     * Create a new instance from an HTML string.
+     *
+     * @param  string  $html
+     * @param  int  $options
+     * @return static
+     */
+    public static function fromString(string $html, int $options = LIBXML_NOERROR): static
+    {
+        $document = HTMLDocument::createFromString($html, $options);
+
+        return new static($document);
+    }
+
+    /**
+     * Assert that an element matching the selector exists, with optional count and scoped callback.
+     *
+     * @param  string  $selector
+     * @param  int|\Closure|null  $countOrCallback
+     * @param  \Closure|null  $callback
+     * @return $this
+     */
+    public function has(string $selector, int|Closure|null $countOrCallback = null, ?Closure $callback = null): static
+    {
+        $element = $this->scope->querySelector($selector);
+
+        if ($element === null) {
+            $this->fail("Failed asserting that element [{$selector}] exists.", $selector);
+        }
+
+        if (is_int($countOrCallback)) {
+            $actual = $this->scope->querySelectorAll($selector)->length;
+
+            if ($actual !== $countOrCallback) {
+                $this->fail(
+                    "Failed asserting that [{$selector}] matches {$countOrCallback} element(s), found {$actual}.",
+                    $selector
+                );
+            }
+
+            if ($callback !== null) {
+                $callback(new static($this->document, $element));
+            }
+        } elseif ($countOrCallback instanceof Closure) {
+            $countOrCallback(new static($this->document, $element));
+        }
+
+        return $this;
+    }
+
+    /**
+     * Assert that no element matches the selector.
+     *
+     * @param  string  $selector
+     * @return $this
+     */
+    public function missing(string $selector): static
+    {
+        if ($this->scope->querySelector($selector) !== null) {
+            $this->fail("Failed asserting that [{$selector}] is absent.", $selector);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Assert that exactly N elements match the selector.
+     *
+     * @param  string  $selector
+     * @param  int  $expected
+     * @return $this
+     */
+    public function count(string $selector, int $expected): static
+    {
+        $actual = $this->scope->querySelectorAll($selector)->length;
+
+        if ($actual !== $expected) {
+            $this->fail(
+                "Failed asserting that [{$selector}] matches {$expected} element(s), found {$actual}.",
+                $selector
+            );
+        }
+
+        return $this;
+    }
+
+    /**
+     * Assert that the matched element's text equals the expected value.
+     *
+     * @param  string  $selector
+     * @param  string  $expected
+     * @return $this
+     */
+    public function where(string $selector, string $expected): static
+    {
+        $element = $this->scope->querySelector($selector);
+
+        if ($element === null) {
+            $this->fail("Failed asserting that element [{$selector}] exists.", $selector);
+        }
+
+        $actual = trim($element->textContent);
+
+        if ($actual !== $expected) {
+            $this->fail(
+                "Failed asserting that [{$selector}] text equals [{$expected}], found [{$actual}].",
+                $selector
+            );
+        }
+
+        return $this;
+    }
+
+    /**
+     * Assert that the matched element's text contains the expected value.
+     *
+     * @param  string  $selector
+     * @param  string  $expected
+     * @return $this
+     */
+    public function whereContains(string $selector, string $expected): static
+    {
+        $element = $this->scope->querySelector($selector);
+
+        if ($element === null) {
+            $this->fail("Failed asserting that element [{$selector}] exists.", $selector);
+        }
+
+        $actual = trim($element->textContent);
+
+        if (! str_contains($actual, $expected)) {
+            $this->fail(
+                "Failed asserting that [{$selector}] text contains [{$expected}], found [{$actual}].",
+                $selector
+            );
+        }
+
+        return $this;
+    }
+
+    /**
+     * Assert multiple selector → text pairs at once.
+     *
+     * @param  array<string, string>  $bindings
+     * @return $this
+     */
+    public function whereAll(array $bindings): static
+    {
+        foreach ($bindings as $selector => $expected) {
+            $this->where($selector, $expected);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Assert that the matched element's attribute equals the expected value.
+     *
+     * @param  string  $selector
+     * @param  string  $attribute
+     * @param  string  $expected
+     * @return $this
+     */
+    public function whereAttr(string $selector, string $attribute, string $expected): static
+    {
+        $element = $this->scope->querySelector($selector);
+
+        if ($element === null) {
+            $this->fail("Failed asserting that element [{$selector}] exists.", $selector);
+        }
+
+        $actual = $element->getAttribute($attribute);
+
+        if ($actual !== $expected) {
+            $this->fail(
+                "Failed asserting that [{$selector}] attribute [{$attribute}] equals [{$expected}], found [{$actual}].",
+                $selector
+            );
+        }
+
+        return $this;
+    }
+
+    /**
+     * Assert that the matched element has the given attribute.
+     *
+     * @param  string  $selector
+     * @param  string  $attribute
+     * @return $this
+     */
+    public function hasAttr(string $selector, string $attribute): static
+    {
+        $element = $this->scope->querySelector($selector);
+
+        if ($element === null) {
+            $this->fail("Failed asserting that element [{$selector}] exists.", $selector);
+        }
+
+        if (! $element->hasAttribute($attribute)) {
+            $this->fail(
+                "Failed asserting that [{$selector}] has attribute [{$attribute}].",
+                $selector
+            );
+        }
+
+        return $this;
+    }
+
+    /**
+     * Assert that the matched element does not have the given attribute.
+     *
+     * @param  string  $selector
+     * @param  string  $attribute
+     * @return $this
+     */
+    public function missingAttr(string $selector, string $attribute): static
+    {
+        $element = $this->scope->querySelector($selector);
+
+        if ($element === null) {
+            $this->fail("Failed asserting that element [{$selector}] exists.", $selector);
+        }
+
+        if ($element->hasAttribute($attribute)) {
+            $this->fail(
+                "Failed asserting that [{$selector}] does not have attribute [{$attribute}].",
+                $selector
+            );
+        }
+
+        return $this;
+    }
+
+    /**
+     * Scope into the first element matching the selector and invoke the callback.
+     *
+     * @param  string  $selector
+     * @param  \Closure  $callback
+     * @return $this
+     */
+    public function scope(string $selector, Closure $callback): static
+    {
+        $element = $this->scope->querySelector($selector);
+
+        if ($element === null) {
+            $this->fail("Failed to find element matching selector [{$selector}].", $selector);
+        }
+
+        $callback(new static($this->document, $element));
+
+        return $this;
+    }
+
+    /**
+     * Iterate all elements matching the selector, invoking the callback for each.
+     *
+     * @param  string  $selector
+     * @param  \Closure  $callback
+     * @return $this
+     */
+    public function each(string $selector, Closure $callback): static
+    {
+        $nodes = $this->scope->querySelectorAll($selector);
+
+        PHPUnit::assertGreaterThan(
+            0,
+            $nodes->length,
+            "Failed asserting that any elements match [{$selector}]."
+        );
+
+        foreach ($nodes as $index => $node) {
+            try {
+                $callback(new static($this->document, $node), $index);
+            } catch (AssertionFailedError $e) {
+                PHPUnit::fail("Failed assertion on element [{$selector}] at index [{$index}]:\n".$e->getMessage());
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * Dump the current scope's HTML for debugging.
+     *
+     * @return $this
+     */
+    public function dump(): static
+    {
+        dump($this->scopeHtml());
+
+        return $this;
+    }
+
+    /**
+     * Dump the current scope's HTML and stop execution.
+     *
+     * @return never
+     */
+    public function dd(): never
+    {
+        $this->dump();
+
+        exit(1);
+    }
+
+    /**
+     * Fail an assertion with the selector and scope HTML appended to the message.
+     *
+     * @param  string  $message
+     * @param  string|null  $selector
+     * @return never
+     */
+    private function fail(string $message, ?string $selector = null): never
+    {
+        $parts = [$message];
+
+        if ($selector !== null) {
+            $parts[] = "Selector: {$selector}";
+        }
+
+        $parts[] = "Scope HTML:\n".$this->scopeHtml();
+
+        PHPUnit::fail(implode("\n", $parts));
+    }
+
+    /**
+     * Serialize the current scope to an HTML string.
+     *
+     * @return string
+     */
+    private function scopeHtml(): string
+    {
+        if ($this->scope instanceof HTMLDocument) {
+            return $this->document->saveHtml();
+        }
+
+        return $this->document->saveHtml($this->scope);
+    }
+}

--- a/src/Illuminate/Testing/Fluent/AssertableHtml.php
+++ b/src/Illuminate/Testing/Fluent/AssertableHtml.php
@@ -177,32 +177,6 @@ class AssertableHtml
         return $this;
     }
 
-    /**
-     * Assert that the matched element's text contains the expected value.
-     *
-     * @param  string  $selector
-     * @param  string  $expected
-     * @return $this
-     */
-    public function whereContains(string $selector, string $expected): static
-    {
-        $element = $this->scope->querySelector($selector);
-
-        if ($element === null) {
-            $this->fail("Failed asserting that element [{$selector}] exists.", $selector);
-        }
-
-        $actual = trim($element->textContent);
-
-        if (! str_contains($actual, $expected)) {
-            $this->fail(
-                "Failed asserting that [{$selector}] text contains [{$expected}], found [{$actual}].",
-                $selector
-            );
-        }
-
-        return $this;
-    }
 
     /**
      * Assert multiple selector → text (or closure) pairs at once.

--- a/src/Illuminate/Testing/Fluent/AssertableHtml.php
+++ b/src/Illuminate/Testing/Fluent/AssertableHtml.php
@@ -58,43 +58,15 @@ class AssertableHtml
     }
 
     /**
-     * Assert that an element matching the given selector exists.
-     *
-     * @param  string  $selector
-     * @return $this
-     */
-    public function has(string $selector): static
-    {
-        $this->findOrFail($selector);
-
-        return $this;
-    }
-
-    /**
      * Assert that elements matching all of the given selectors exist.
      *
-     * @param  array<int, string>  $selectors
+     * @param  string  ...$selectors
      * @return $this
      */
-    public function hasAll(array $selectors): static
+    public function has(string ...$selectors): static
     {
         foreach ($selectors as $selector) {
-            $this->has($selector);
-        }
-
-        return $this;
-    }
-
-    /**
-     * Assert that no element matches the given selector.
-     *
-     * @param  string  $selector
-     * @return $this
-     */
-    public function missing(string $selector): static
-    {
-        if ($this->scope->querySelector($selector) !== null) {
-            $this->fail("Failed asserting that [{$selector}] is absent.", $selector);
+            $this->findOrFail($selector);
         }
 
         return $this;
@@ -103,13 +75,15 @@ class AssertableHtml
     /**
      * Assert that no elements matching any of the given selectors exist.
      *
-     * @param  array<int, string>  $selectors
+     * @param  string  ...$selectors
      * @return $this
      */
-    public function missingAll(array $selectors): static
+    public function missing(string ...$selectors): static
     {
         foreach ($selectors as $selector) {
-            $this->missing($selector);
+            if ($this->scope->querySelector($selector) !== null) {
+                $this->fail("Failed asserting that [{$selector}] is absent.", $selector);
+            }
         }
 
         return $this;
@@ -249,35 +223,23 @@ class AssertableHtml
     }
 
     /**
-     * Assert that the matched element has the given attribute.
-     *
-     * @param  string  $selector
-     * @param  string  $attribute
-     * @return $this
-     */
-    public function hasAttribute(string $selector, string $attribute): static
-    {
-        if (! $this->findOrFail($selector)->hasAttribute($attribute)) {
-            $this->fail(
-                "Failed asserting that [{$selector}] has attribute [{$attribute}].",
-                $selector
-            );
-        }
-
-        return $this;
-    }
-
-    /**
      * Assert that the matched element has all of the given attributes.
      *
      * @param  string  $selector
-     * @param  array<int, string>  $attributes
+     * @param  string  ...$attributes
      * @return $this
      */
-    public function hasAttributes(string $selector, array $attributes): static
+    public function hasAttributes(string $selector, string ...$attributes): static
     {
+        $element = $this->findOrFail($selector);
+
         foreach ($attributes as $attribute) {
-            $this->hasAttribute($selector, $attribute);
+            if (! $element->hasAttribute($attribute)) {
+                $this->fail(
+                    "Failed asserting that [{$selector}] has attribute [{$attribute}].",
+                    $selector
+                );
+            }
         }
 
         return $this;
@@ -333,35 +295,23 @@ class AssertableHtml
     }
 
     /**
-     * Assert that the matched element does not have the given attribute.
-     *
-     * @param  string  $selector
-     * @param  string  $attribute
-     * @return $this
-     */
-    public function missingAttribute(string $selector, string $attribute): static
-    {
-        if ($this->findOrFail($selector)->hasAttribute($attribute)) {
-            $this->fail(
-                "Failed asserting that [{$selector}] does not have attribute [{$attribute}].",
-                $selector
-            );
-        }
-
-        return $this;
-    }
-
-    /**
      * Assert that the matched element does not have any of the given attributes.
      *
      * @param  string  $selector
-     * @param  array<int, string>  $attributes
+     * @param  string  ...$attributes
      * @return $this
      */
-    public function missingAttributes(string $selector, array $attributes): static
+    public function missingAttributes(string $selector, string ...$attributes): static
     {
+        $element = $this->findOrFail($selector);
+
         foreach ($attributes as $attribute) {
-            $this->missingAttribute($selector, $attribute);
+            if ($element->hasAttribute($attribute)) {
+                $this->fail(
+                    "Failed asserting that [{$selector}] does not have attribute [{$attribute}].",
+                    $selector
+                );
+            }
         }
 
         return $this;

--- a/src/Illuminate/Testing/Fluent/AssertableHtml.php
+++ b/src/Illuminate/Testing/Fluent/AssertableHtml.php
@@ -52,7 +52,7 @@ class AssertableHtml
     }
 
     /**
-     * Assert that an element matching the selector exists, with optional count and scoped callback.
+     * Assert that an element matching the given selector exists.
      *
      * @param  string  $selector
      * @param  int|\Closure|null  $countOrCallback
@@ -92,7 +92,7 @@ class AssertableHtml
     }
 
     /**
-     * Assert that no element matches the selector.
+     * Assert that no element matches the given selector.
      *
      * @param  string  $selector
      * @return $this
@@ -122,7 +122,7 @@ class AssertableHtml
     }
 
     /**
-     * Assert that exactly N elements match the selector.
+     * Assert that the given selector matches the expected number of elements.
      *
      * @param  string  $selector
      * @param  int  $expected
@@ -143,7 +143,7 @@ class AssertableHtml
     }
 
     /**
-     * Assert that the matched element's text content equals the expected value, or passes a truth test.
+     * Assert that the matched element's text content equals the given value.
      *
      * @param  string  $selector
      * @param  string|\Closure  $expected
@@ -175,7 +175,7 @@ class AssertableHtml
     }
 
     /**
-     * Assert multiple selector to text content (or closure) pairs at once.
+     * Assert that each selector's matched element has the expected text content.
      *
      * @param  array<string, string|\Closure>  $bindings
      * @return $this
@@ -190,7 +190,7 @@ class AssertableHtml
     }
 
     /**
-     * Assert that the matched element's text content does not equal the expected value, or does not pass a truth test.
+     * Assert that the matched element's text content does not equal the given value.
      *
      * @param  string  $selector
      * @param  string|\Closure  $expected
@@ -222,7 +222,7 @@ class AssertableHtml
     }
 
     /**
-     * Assert that the matched element's attribute equals the expected value, or passes a truth test.
+     * Assert that the matched element's given attribute equals the given value.
      *
      * @param  string  $selector
      * @param  string  $attribute
@@ -290,7 +290,7 @@ class AssertableHtml
     }
 
     /**
-     * Assert that the matched element's attribute does not equal the expected value, or does not pass a truth test.
+     * Assert that the matched element's given attribute does not equal the given value.
      *
      * @param  string  $selector
      * @param  string  $attribute
@@ -323,7 +323,7 @@ class AssertableHtml
     }
 
     /**
-     * Assert multiple attribute to value (or closure) pairs on the matched element at once.
+     * Assert that the matched element's attributes equal the given values.
      *
      * @param  string  $selector
      * @param  array<string, string|\Closure>  $bindings

--- a/src/Illuminate/Testing/Fluent/AssertableHtml.php
+++ b/src/Illuminate/Testing/Fluent/AssertableHtml.php
@@ -461,12 +461,12 @@ class AssertableHtml
         $path = $this->buildSelector($selector);
 
         if ($path !== null) {
-            $parts[] = "Selector: {$path}";
+            $parts[] = "[{$path}]";
         }
 
-        $parts[] = "Scope HTML:\n".$this->getHtml();
+        $parts[] = $this->getHtml();
 
-        PHPUnit::fail(implode("\n", $parts));
+        PHPUnit::fail(implode("\n\n", $parts));
     }
 
 
@@ -490,6 +490,8 @@ class AssertableHtml
      */
     protected function getHtml(): string
     {
-        return $this->document->saveHtml($this->scope);
+        return $this->scope instanceof HTMLDocument
+            ? $this->document->documentElement->innerHTML
+            : $this->document->saveHtml($this->scope);
     }
 }

--- a/src/Illuminate/Testing/Fluent/AssertableHtml.php
+++ b/src/Illuminate/Testing/Fluent/AssertableHtml.php
@@ -38,10 +38,9 @@ class AssertableHtml
      */
     public static function fromResponse(TestResponse $response, int $options = LIBXML_NOERROR): static
     {
-        $content = $response->baseResponse instanceof StreamedResponse ||
-            $response->baseResponse instanceof StreamedJsonResponse
-                ? $response->streamedContent()
-                : $response->getContent();
+        $content = $response->baseResponse instanceof StreamedResponse
+            ? $response->streamedContent()
+            : $response->getContent();
 
         return new static(HTMLDocument::createFromString($content, $options));
     }

--- a/src/Illuminate/Testing/Fluent/AssertableHtml.php
+++ b/src/Illuminate/Testing/Fluent/AssertableHtml.php
@@ -396,6 +396,10 @@ class AssertableHtml
      */
     public function sequence(string $selector, Closure ...$callbacks): static
     {
+        if (count($callbacks) === 0) {
+            $this->fail("No sequence expectations defined for [{$selector}].", $selector);
+        }
+
         $nodes = $this->scope->querySelectorAll($selector);
 
         if ($nodes->length !== count($callbacks)) {

--- a/src/Illuminate/Testing/Fluent/AssertableHtml.php
+++ b/src/Illuminate/Testing/Fluent/AssertableHtml.php
@@ -31,15 +31,24 @@ class AssertableHtml
     protected Element|HTMLDocument $scope;
 
     /**
+     * The selector path to the current scope.
+     *
+     * @var string|null
+     */
+    protected ?string $selector;
+
+    /**
      * Create a new assertable HTML instance.
      *
      * @param  \Dom\HTMLDocument  $document
      * @param  \Dom\Element|\Dom\HTMLDocument|null  $scope
+     * @param  string|null  $selector
      */
-    protected function __construct(HTMLDocument $document, Element|HTMLDocument|null $scope = null)
+    protected function __construct(HTMLDocument $document, Element|HTMLDocument|null $scope = null, ?string $selector = null)
     {
         $this->document = $document;
         $this->scope = $scope ?? $document;
+        $this->selector = $selector;
     }
 
     /**
@@ -51,7 +60,7 @@ class AssertableHtml
     public static function fromResponse(TestResponse $response, int $options = LIBXML_NOERROR): static
     {
         return new static(
-            HTMLDocument::createFromString($$response->getContent(), $options),
+            HTMLDocument::createFromString($response->getContent(), $options),
         );
     }
 
@@ -96,10 +105,10 @@ class AssertableHtml
             }
 
             if ($callback !== null) {
-                $callback(new static($this->document, $element));
+                $callback(new static($this->document, $element, $this->buildSelector($selector)));
             }
         } elseif ($countOrCallback instanceof Closure) {
-            $countOrCallback(new static($this->document, $element));
+            $countOrCallback(new static($this->document, $element, $this->buildSelector($selector)));
         }
 
         return $this;
@@ -381,7 +390,7 @@ class AssertableHtml
             $this->fail("Failed to find element matching selector [{$selector}].", $selector);
         }
 
-        $callback(new static($this->document, $element));
+        $callback(new static($this->document, $element, $this->buildSelector($selector)));
 
         return $this;
     }
@@ -405,7 +414,7 @@ class AssertableHtml
 
         foreach ($nodes as $index => $node) {
             try {
-                $callback(new static($this->document, $node), $index);
+                $callback(new static($this->document, $node, $this->buildSelector($selector)), $index);
             } catch (AssertionFailedError $e) {
                 PHPUnit::fail("Failed assertion on element [{$selector}] at index [{$index}]:\n".$e->getMessage());
             }
@@ -439,18 +448,20 @@ class AssertableHtml
     }
 
     /**
-     * Fail an assertion with the selector and scope HTML appended to the message.
+     * Fail an assertion with the full selector path and scope HTML appended to the message.
      *
      * @param  string  $message
      * @param  string|null  $selector
      * @return never
      */
-    private function fail(string $message, ?string $selector = null): never
+    protected function fail(string $message, ?string $selector = null): never
     {
         $parts = [$message];
 
-        if ($selector !== null) {
-            $parts[] = "Selector: {$selector}";
+        $path = $this->buildSelector($selector);
+
+        if ($path !== null) {
+            $parts[] = "Selector: {$path}";
         }
 
         $parts[] = "Scope HTML:\n".$this->getHtml();
@@ -459,11 +470,22 @@ class AssertableHtml
     }
 
     /**
+     * Build the full selector path from the current scope to the given selector.
+     *
+     * @param  string|null  $selector
+     * @return string|null
+     */
+    protected function buildSelector(?string $selector = null): ?string
+    {
+        return implode(' > ', array_filter([$this->selector, $selector])) ?: null;
+    }
+
+    /**
      * Serialize the current scope to an HTML string.
      *
      * @return string
      */
-    private function getHtml(): string
+    protected function getHtml(): string
     {
         return $this->document->saveHtml($this->scope);
     }

--- a/src/Illuminate/Testing/Fluent/AssertableHtml.php
+++ b/src/Illuminate/Testing/Fluent/AssertableHtml.php
@@ -388,6 +388,35 @@ class AssertableHtml
     }
 
     /**
+     * Assert that the matched elements satisfy a sequence of callbacks, one per element.
+     *
+     * @param  string  $selector
+     * @param  \Closure  ...$callbacks
+     * @return $this
+     */
+    public function sequence(string $selector, Closure ...$callbacks): static
+    {
+        $nodes = $this->scope->querySelectorAll($selector);
+
+        if ($nodes->length !== count($callbacks)) {
+            $this->fail(
+                "Failed asserting that [{$selector}] matches ".count($callbacks)." element(s), found {$nodes->length}.",
+                $selector
+            );
+        }
+
+        foreach ($callbacks as $index => $callback) {
+            try {
+                $callback(new static($nodes->item($index), $this->buildSelector($selector)));
+            } catch (AssertionFailedError $e) {
+                PHPUnit::fail("Failed assertion on element [{$selector}] at index [{$index}]:\n".$e->getMessage());
+            }
+        }
+
+        return $this;
+    }
+
+    /**
      * Iterate all elements matching the selector, invoking the callback for each.
      *
      * @param  string  $selector

--- a/src/Illuminate/Testing/Fluent/AssertableHtml.php
+++ b/src/Illuminate/Testing/Fluent/AssertableHtml.php
@@ -386,6 +386,22 @@ class AssertableHtml
     }
 
     /**
+     * Assert that the matched element does not have any of the given attributes.
+     *
+     * @param  string  $selector
+     * @param  array<int, string>  $attributes
+     * @return $this
+     */
+    public function missingAttributes(string $selector, array $attributes): static
+    {
+        foreach ($attributes as $attribute) {
+            $this->missingAttribute($selector, $attribute);
+        }
+
+        return $this;
+    }
+
+    /**
      * Scope into the first element matching the selector and invoke the callback.
      *
      * @param  string  $selector

--- a/src/Illuminate/Testing/Fluent/AssertableHtml.php
+++ b/src/Illuminate/Testing/Fluent/AssertableHtml.php
@@ -421,7 +421,7 @@ class AssertableHtml
      */
     public function dump(): static
     {
-        dump($this->scopeHtml());
+        dump($this->getHtml());
 
         return $this;
     }
@@ -453,7 +453,7 @@ class AssertableHtml
             $parts[] = "Selector: {$selector}";
         }
 
-        $parts[] = "Scope HTML:\n".$this->scopeHtml();
+        $parts[] = "Scope HTML:\n".$this->getHtml();
 
         PHPUnit::fail(implode("\n", $parts));
     }
@@ -463,12 +463,8 @@ class AssertableHtml
      *
      * @return string
      */
-    private function scopeHtml(): string
+    private function getHtml(): string
     {
-        if ($this->scope instanceof HTMLDocument) {
-            return $this->document->saveHtml();
-        }
-
         return $this->document->saveHtml($this->scope);
     }
 }

--- a/src/Illuminate/Testing/Fluent/AssertableHtml.php
+++ b/src/Illuminate/Testing/Fluent/AssertableHtml.php
@@ -17,39 +17,15 @@ class AssertableHtml
     use Conditionable, Macroable, Tappable;
 
     /**
-     * The parsed HTML document.
-     *
-     * @var \Dom\HTMLDocument
-     */
-    protected HTMLDocument $document;
-
-    /**
-     * The current scope (the document root or a scoped element).
-     *
-     * @var \Dom\Element|\Dom\HTMLDocument
-     */
-    protected Element|HTMLDocument $scope;
-
-    /**
-     * The selector path to the current scope.
-     *
-     * @var string|null
-     */
-    protected ?string $selector;
-
-    /**
      * Create a new assertable HTML instance.
      *
-     * @param  \Dom\HTMLDocument  $document
-     * @param  \Dom\Element|\Dom\HTMLDocument|null  $scope
+     * @param  \Dom\Element|\Dom\HTMLDocument  $scope
      * @param  string|null  $selector
      */
-    protected function __construct(HTMLDocument $document, Element|HTMLDocument|null $scope = null, ?string $selector = null)
-    {
-        $this->document = $document;
-        $this->scope = $scope ?? $document;
-        $this->selector = $selector;
-    }
+    protected function __construct(
+        protected Element|HTMLDocument $scope,
+        protected ?string $selector = null,
+    ) {}
 
     /**
      * Create a new instance from a test response.
@@ -60,9 +36,7 @@ class AssertableHtml
      */
     public static function fromResponse(TestResponse $response, int $options = LIBXML_NOERROR): static
     {
-        return new static(
-            HTMLDocument::createFromString($response->getContent(), $options),
-        );
+        return new static(HTMLDocument::createFromString($response->getContent(), $options));
     }
 
     /**
@@ -74,9 +48,7 @@ class AssertableHtml
      */
     public static function fromString(string $html, int $options = LIBXML_NOERROR): static
     {
-        return new static(
-            HTMLDocument::createFromString($html, $options),
-        );
+        return new static(HTMLDocument::createFromString($html, $options));
     }
 
     /**
@@ -95,10 +67,10 @@ class AssertableHtml
             $this->count($selector, $countOrCallback);
 
             if ($callback !== null) {
-                $callback(new static($this->document, $element, $this->buildSelector($selector)));
+                $callback(new static($element, $this->buildSelector($selector)));
             }
         } elseif ($countOrCallback instanceof Closure) {
-            $countOrCallback(new static($this->document, $element, $this->buildSelector($selector)));
+            $countOrCallback(new static($element, $this->buildSelector($selector)));
         }
 
         return $this;
@@ -351,7 +323,7 @@ class AssertableHtml
     }
 
     /**
-     * Assert multiple attribute → value (or closure) pairs on the matched element at once.
+     * Assert multiple attribute to value (or closure) pairs on the matched element at once.
      *
      * @param  string  $selector
      * @param  array<string, string|\Closure>  $bindings
@@ -410,7 +382,7 @@ class AssertableHtml
      */
     public function scope(string $selector, Closure $callback): static
     {
-        $callback(new static($this->document, $this->findOrFail($selector), $this->buildSelector($selector)));
+        $callback(new static($this->findOrFail($selector), $this->buildSelector($selector)));
 
         return $this;
     }
@@ -432,7 +404,7 @@ class AssertableHtml
 
         foreach ($nodes as $index => $node) {
             try {
-                $callback(new static($this->document, $node, $this->buildSelector($selector)), $index);
+                $callback(new static($node, $this->buildSelector($selector)), $index);
             } catch (AssertionFailedError $e) {
                 PHPUnit::fail("Failed assertion on element [{$selector}] at index [{$index}]:\n".$e->getMessage());
             }
@@ -511,7 +483,7 @@ class AssertableHtml
     protected function buildSelector(?string $selector = null): ?string
     {
         return $this->selector && $selector
-            ? $this->selector . ' → ' . $selector
+            ? $this->selector.' → '.$selector
             : $this->selector ?? $selector;
     }
 
@@ -523,7 +495,7 @@ class AssertableHtml
     protected function getHtml(): string
     {
         return $this->scope instanceof HTMLDocument
-            ? $this->document->documentElement->innerHTML
-            : $this->document->saveHtml($this->scope);
+            ? $this->scope->documentElement->innerHTML
+            : $this->scope->ownerDocument->saveHtml($this->scope);
     }
 }

--- a/src/Illuminate/Testing/Fluent/AssertableHtml.php
+++ b/src/Illuminate/Testing/Fluent/AssertableHtml.php
@@ -55,6 +55,7 @@ class AssertableHtml
      * Create a new instance from a test response.
      *
      * @param  \Illuminate\Testing\TestResponse  $response
+     * @param  int  $options
      * @return static
      */
     public static function fromResponse(TestResponse $response, int $options = LIBXML_NOERROR): static
@@ -91,14 +92,7 @@ class AssertableHtml
         $element = $this->findOrFail($selector);
 
         if (is_int($countOrCallback)) {
-            $actual = $this->scope->querySelectorAll($selector)->length;
-
-            if ($actual !== $countOrCallback) {
-                $this->fail(
-                    "Failed asserting that [{$selector}] matches {$countOrCallback} element(s), found {$actual}.",
-                    $selector
-                );
-            }
+            $this->count($selector, $countOrCallback);
 
             if ($callback !== null) {
                 $callback(new static($this->document, $element, $this->buildSelector($selector)));
@@ -208,9 +202,8 @@ class AssertableHtml
         return $this;
     }
 
-
     /**
-     * Assert multiple selector → text (or closure) pairs at once.
+     * Assert multiple selector to text (or closure) pairs at once.
      *
      * @param  array<string, string|\Closure>  $bindings
      * @return $this
@@ -477,7 +470,6 @@ class AssertableHtml
 
         PHPUnit::fail(implode("\n\n", $parts));
     }
-
 
     /**
      * Find the first element matching the selector or fail.

--- a/src/Illuminate/Testing/Fluent/AssertableHtml.php
+++ b/src/Illuminate/Testing/Fluent/AssertableHtml.php
@@ -469,6 +469,7 @@ class AssertableHtml
         PHPUnit::fail(implode("\n", $parts));
     }
 
+
     /**
      * Build the full selector path from the current scope to the given selector.
      *
@@ -477,7 +478,9 @@ class AssertableHtml
      */
     protected function buildSelector(?string $selector = null): ?string
     {
-        return implode(' > ', array_filter([$this->selector, $selector])) ?: null;
+        return $this->selector && $selector
+            ? $this->selector . ' → ' . $selector
+            : $this->selector ?? $selector;
     }
 
     /**

--- a/src/Illuminate/Testing/Fluent/AssertableHtml.php
+++ b/src/Illuminate/Testing/Fluent/AssertableHtml.php
@@ -366,11 +366,9 @@ class AssertableHtml
     {
         $nodes = $this->scope->querySelectorAll($selector);
 
-        PHPUnit::assertGreaterThan(
-            0,
-            $nodes->length,
-            "Failed asserting that any elements match [{$selector}]."
-        );
+        if ($nodes->length === 0) {
+            $this->fail("Failed asserting that any elements match [{$selector}].", $selector);
+        }
 
         foreach ($nodes as $index => $node) {
             try {

--- a/src/Illuminate/Testing/Fluent/AssertableHtml.php
+++ b/src/Illuminate/Testing/Fluent/AssertableHtml.php
@@ -309,6 +309,22 @@ class AssertableHtml
     }
 
     /**
+     * Assert that the matched element has all of the given attributes.
+     *
+     * @param  string  $selector
+     * @param  array<int, string>  $attributes
+     * @return $this
+     */
+    public function hasAttributes(string $selector, array $attributes): static
+    {
+        foreach ($attributes as $attribute) {
+            $this->hasAttribute($selector, $attribute);
+        }
+
+        return $this;
+    }
+
+    /**
      * Assert that the matched element's attribute does not equal the expected value, or does not pass a truth test.
      *
      * @param  string  $selector

--- a/src/Illuminate/Testing/Fluent/AssertableHtml.php
+++ b/src/Illuminate/Testing/Fluent/AssertableHtml.php
@@ -143,13 +143,13 @@ class AssertableHtml
     }
 
     /**
-     * Assert that the matched element's text equals the expected value, or passes a truth test.
+     * Assert that the matched element's text content equals the expected value, or passes a truth test.
      *
      * @param  string  $selector
      * @param  string|\Closure  $expected
      * @return $this
      */
-    public function where(string $selector, string|Closure $expected): static
+    public function whereText(string $selector, string|Closure $expected): static
     {
         $actual = trim($this->findOrFail($selector)->textContent);
 
@@ -175,28 +175,28 @@ class AssertableHtml
     }
 
     /**
-     * Assert multiple selector to text (or closure) pairs at once.
+     * Assert multiple selector to text content (or closure) pairs at once.
      *
      * @param  array<string, string|\Closure>  $bindings
      * @return $this
      */
-    public function whereAll(array $bindings): static
+    public function whereAllText(array $bindings): static
     {
         foreach ($bindings as $selector => $expected) {
-            $this->where($selector, $expected);
+            $this->whereText($selector, $expected);
         }
 
         return $this;
     }
 
     /**
-     * Assert that the matched element's text does not equal the expected value, or does not pass a truth test.
+     * Assert that the matched element's text content does not equal the expected value, or does not pass a truth test.
      *
      * @param  string  $selector
      * @param  string|\Closure  $expected
      * @return $this
      */
-    public function whereNot(string $selector, string|Closure $expected): static
+    public function whereNotText(string $selector, string|Closure $expected): static
     {
         $actual = trim($this->findOrFail($selector)->textContent);
 
@@ -494,6 +494,8 @@ class AssertableHtml
      */
     protected function getHtml(): string
     {
+        assert($this->scope instanceof HTMLDocument || $this->scope->ownerDocument !== null);
+
         return $this->scope instanceof HTMLDocument
             ? $this->scope->documentElement->innerHTML
             : $this->scope->ownerDocument->saveHtml($this->scope);

--- a/src/Illuminate/Testing/Fluent/AssertableHtml.php
+++ b/src/Illuminate/Testing/Fluent/AssertableHtml.php
@@ -262,6 +262,31 @@ class AssertableHtml
     }
 
     /**
+     * Alias for whereAttr().
+     *
+     * @param  string  $selector
+     * @param  string  $attribute
+     * @param  string  $expected
+     * @return $this
+     */
+    public function whereAttribute(string $selector, string $attribute, string $expected): static
+    {
+        return $this->whereAttr($selector, $attribute, $expected);
+    }
+
+    /**
+     * Alias for hasAttr().
+     *
+     * @param  string  $selector
+     * @param  string  $attribute
+     * @return $this
+     */
+    public function hasAttribute(string $selector, string $attribute): static
+    {
+        return $this->hasAttr($selector, $attribute);
+    }
+
+    /**
      * Assert that the matched element does not have the given attribute.
      *
      * @param  string  $selector

--- a/src/Illuminate/Testing/Fluent/AssertableHtml.php
+++ b/src/Illuminate/Testing/Fluent/AssertableHtml.php
@@ -140,13 +140,13 @@ class AssertableHtml
     }
 
     /**
-     * Assert that the matched element's text equals the expected value.
+     * Assert that the matched element's text equals the expected value, or passes a truth test.
      *
      * @param  string  $selector
-     * @param  string  $expected
+     * @param  string|\Closure  $expected
      * @return $this
      */
-    public function where(string $selector, string $expected): static
+    public function where(string $selector, string|Closure $expected): static
     {
         $element = $this->scope->querySelector($selector);
 
@@ -155,6 +155,17 @@ class AssertableHtml
         }
 
         $actual = trim($element->textContent);
+
+        if ($expected instanceof Closure) {
+            if (! $expected($actual)) {
+                $this->fail(
+                    "Failed asserting that [{$selector}] text was accepted by the truth test.",
+                    $selector
+                );
+            }
+
+            return $this;
+        }
 
         if ($actual !== $expected) {
             $this->fail(
@@ -194,9 +205,9 @@ class AssertableHtml
     }
 
     /**
-     * Assert multiple selector → text pairs at once.
+     * Assert multiple selector → text (or closure) pairs at once.
      *
-     * @param  array<string, string>  $bindings
+     * @param  array<string, string|\Closure>  $bindings
      * @return $this
      */
     public function whereAll(array $bindings): static

--- a/src/Illuminate/Testing/Fluent/AssertableHtml.php
+++ b/src/Illuminate/Testing/Fluent/AssertableHtml.php
@@ -48,9 +48,11 @@ class AssertableHtml
      * @param  \Illuminate\Testing\TestResponse  $response
      * @return static
      */
-    public static function fromResponse(TestResponse $response): static
+    public static function fromResponse(TestResponse $response, int $options = LIBXML_NOERROR): static
     {
-        return static::fromString($response->getContent());
+        return new static(
+            HTMLDocument::createFromString($$response->getContent(), $options)
+        );
     }
 
     /**
@@ -62,9 +64,9 @@ class AssertableHtml
      */
     public static function fromString(string $html, int $options = LIBXML_NOERROR): static
     {
-        $document = HTMLDocument::createFromString($html, $options);
-
-        return new static($document);
+        return new static(
+            HTMLDocument::createFromString($html, $options),
+        );
     }
 
     /**

--- a/src/Illuminate/Testing/Fluent/AssertableHtml.php
+++ b/src/Illuminate/Testing/Fluent/AssertableHtml.php
@@ -104,6 +104,21 @@ class AssertableHtml
     }
 
     /**
+     * Assert that elements matching all of the given selectors exist.
+     *
+     * @param  array<int, string>  $selectors
+     * @return $this
+     */
+    public function hasAll(array $selectors): static
+    {
+        foreach ($selectors as $selector) {
+            $this->has($selector);
+        }
+
+        return $this;
+    }
+
+    /**
      * Assert that no element matches the selector.
      *
      * @param  string  $selector
@@ -113,6 +128,21 @@ class AssertableHtml
     {
         if ($this->scope->querySelector($selector) !== null) {
             $this->fail("Failed asserting that [{$selector}] is absent.", $selector);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Assert that no elements matching any of the given selectors exist.
+     *
+     * @param  array<int, string>  $selectors
+     * @return $this
+     */
+    public function missingAll(array $selectors): static
+    {
+        foreach ($selectors as $selector) {
+            $this->missing($selector);
         }
 
         return $this;
@@ -188,6 +218,44 @@ class AssertableHtml
     {
         foreach ($bindings as $selector => $expected) {
             $this->where($selector, $expected);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Assert that the matched element's text does not equal the expected value, or does not pass a truth test.
+     *
+     * @param  string  $selector
+     * @param  string|\Closure  $expected
+     * @return $this
+     */
+    public function whereNot(string $selector, string|Closure $expected): static
+    {
+        $element = $this->scope->querySelector($selector);
+
+        if ($element === null) {
+            $this->fail("Failed asserting that element [{$selector}] exists.", $selector);
+        }
+
+        $actual = trim($element->textContent);
+
+        if ($expected instanceof Closure) {
+            if ($expected($actual)) {
+                $this->fail(
+                    "Failed asserting that [{$selector}] text was rejected by the truth test.",
+                    $selector
+                );
+            }
+
+            return $this;
+        }
+
+        if ($actual === $expected) {
+            $this->fail(
+                "Failed asserting that [{$selector}] text does not equal [{$expected}].",
+                $selector
+            );
         }
 
         return $this;

--- a/src/Illuminate/Testing/Fluent/AssertableHtml.php
+++ b/src/Illuminate/Testing/Fluent/AssertableHtml.php
@@ -237,7 +237,7 @@ class AssertableHtml
      */
     public function whereAttribute(string $selector, string $attribute, string|Closure $expected): static
     {
-        $actual = $this->findOrFail($selector)->getAttribute($attribute);
+        $actual = $this->attributeValue($selector, $attribute);
 
         if ($expected instanceof Closure) {
             if (! $expected($actual)) {
@@ -305,7 +305,7 @@ class AssertableHtml
      */
     public function whereNotAttribute(string $selector, string $attribute, string|Closure $expected): static
     {
-        $actual = $this->findOrFail($selector)->getAttribute($attribute);
+        $actual = $this->attributeValue($selector, $attribute);
 
         if ($expected instanceof Closure) {
             if ($expected($actual)) {
@@ -472,6 +472,18 @@ class AssertableHtml
     protected function textContent(string $selector): string
     {
         return trim($this->findOrFail($selector)->textContent);
+    }
+
+    /**
+     * Get the trimmed value of the given attribute on the first element matching the selector or fail.
+     *
+     * @param  string  $selector
+     * @param  string  $attribute
+     * @return string
+     */
+    protected function attributeValue(string $selector, string $attribute): string
+    {
+        return trim($this->findOrFail($selector)->getAttribute($attribute));
     }
 
     /**

--- a/src/Illuminate/Testing/Fluent/AssertableHtml.php
+++ b/src/Illuminate/Testing/Fluent/AssertableHtml.php
@@ -88,11 +88,7 @@ class AssertableHtml
      */
     public function has(string $selector, int|Closure|null $countOrCallback = null, ?Closure $callback = null): static
     {
-        $element = $this->scope->querySelector($selector);
-
-        if ($element === null) {
-            $this->fail("Failed asserting that element [{$selector}] exists.", $selector);
-        }
+        $element = $this->findOrFail($selector);
 
         if (is_int($countOrCallback)) {
             $actual = $this->scope->querySelectorAll($selector)->length;
@@ -189,13 +185,7 @@ class AssertableHtml
      */
     public function where(string $selector, string|Closure $expected): static
     {
-        $element = $this->scope->querySelector($selector);
-
-        if ($element === null) {
-            $this->fail("Failed asserting that element [{$selector}] exists.", $selector);
-        }
-
-        $actual = trim($element->textContent);
+        $actual = trim($this->findOrFail($selector)->textContent);
 
         if ($expected instanceof Closure) {
             if (! $expected($actual)) {
@@ -243,13 +233,7 @@ class AssertableHtml
      */
     public function whereNot(string $selector, string|Closure $expected): static
     {
-        $element = $this->scope->querySelector($selector);
-
-        if ($element === null) {
-            $this->fail("Failed asserting that element [{$selector}] exists.", $selector);
-        }
-
-        $actual = trim($element->textContent);
+        $actual = trim($this->findOrFail($selector)->textContent);
 
         if ($expected instanceof Closure) {
             if ($expected($actual)) {
@@ -282,13 +266,7 @@ class AssertableHtml
      */
     public function whereAttr(string $selector, string $attribute, string $expected): static
     {
-        $element = $this->scope->querySelector($selector);
-
-        if ($element === null) {
-            $this->fail("Failed asserting that element [{$selector}] exists.", $selector);
-        }
-
-        $actual = $element->getAttribute($attribute);
+        $actual = $this->findOrFail($selector)->getAttribute($attribute);
 
         if ($actual !== $expected) {
             $this->fail(
@@ -309,13 +287,7 @@ class AssertableHtml
      */
     public function hasAttr(string $selector, string $attribute): static
     {
-        $element = $this->scope->querySelector($selector);
-
-        if ($element === null) {
-            $this->fail("Failed asserting that element [{$selector}] exists.", $selector);
-        }
-
-        if (! $element->hasAttribute($attribute)) {
+        if (! $this->findOrFail($selector)->hasAttribute($attribute)) {
             $this->fail(
                 "Failed asserting that [{$selector}] has attribute [{$attribute}].",
                 $selector
@@ -359,13 +331,7 @@ class AssertableHtml
      */
     public function missingAttr(string $selector, string $attribute): static
     {
-        $element = $this->scope->querySelector($selector);
-
-        if ($element === null) {
-            $this->fail("Failed asserting that element [{$selector}] exists.", $selector);
-        }
-
-        if ($element->hasAttribute($attribute)) {
+        if ($this->findOrFail($selector)->hasAttribute($attribute)) {
             $this->fail(
                 "Failed asserting that [{$selector}] does not have attribute [{$attribute}].",
                 $selector
@@ -384,13 +350,7 @@ class AssertableHtml
      */
     public function scope(string $selector, Closure $callback): static
     {
-        $element = $this->scope->querySelector($selector);
-
-        if ($element === null) {
-            $this->fail("Failed to find element matching selector [{$selector}].", $selector);
-        }
-
-        $callback(new static($this->document, $element, $this->buildSelector($selector)));
+        $callback(new static($this->document, $this->findOrFail($selector), $this->buildSelector($selector)));
 
         return $this;
     }
@@ -469,6 +429,23 @@ class AssertableHtml
         PHPUnit::fail(implode("\n\n", $parts));
     }
 
+
+    /**
+     * Find the first element matching the selector or fail.
+     *
+     * @param  string  $selector
+     * @return \Dom\Element
+     */
+    protected function findOrFail(string $selector): Element
+    {
+        $element = $this->scope->querySelector($selector);
+
+        if ($element === null) {
+            $this->fail("Failed asserting that element [{$selector}] exists.", $selector);
+        }
+
+        return $element;
+    }
 
     /**
      * Build the full selector path from the current scope to the given selector.

--- a/src/Illuminate/Testing/Fluent/AssertableHtml.php
+++ b/src/Illuminate/Testing/Fluent/AssertableHtml.php
@@ -388,7 +388,9 @@ class AssertableHtml
     }
 
     /**
-     * Assert that the matched elements satisfy a sequence of callbacks, one per element.
+     * Assert that the matched elements satisfy a sequence of callbacks, one per element in order.
+     *
+     * Each callback receives the scoped element and its zero-based index.
      *
      * @param  string  $selector
      * @param  \Closure  ...$callbacks
@@ -407,7 +409,7 @@ class AssertableHtml
 
         foreach ($callbacks as $index => $callback) {
             try {
-                $callback(new static($nodes->item($index), $this->buildSelector($selector)));
+                $callback(new static($nodes->item($index), $this->buildSelector($selector)), $index);
             } catch (AssertionFailedError $e) {
                 PHPUnit::fail("Failed assertion on element [{$selector}] at index [{$index}]:\n".$e->getMessage());
             }

--- a/src/Illuminate/Testing/Fluent/AssertableHtml.php
+++ b/src/Illuminate/Testing/Fluent/AssertableHtml.php
@@ -264,7 +264,7 @@ class AssertableHtml
      * @param  string|\Closure  $expected
      * @return $this
      */
-    public function whereAttr(string $selector, string $attribute, string|Closure $expected): static
+    public function whereAttribute(string $selector, string $attribute, string|Closure $expected): static
     {
         $actual = $this->findOrFail($selector)->getAttribute($attribute);
 
@@ -296,7 +296,7 @@ class AssertableHtml
      * @param  string  $attribute
      * @return $this
      */
-    public function hasAttr(string $selector, string $attribute): static
+    public function hasAttribute(string $selector, string $attribute): static
     {
         if (! $this->findOrFail($selector)->hasAttribute($attribute)) {
             $this->fail(
@@ -316,7 +316,7 @@ class AssertableHtml
      * @param  string|\Closure  $expected
      * @return $this
      */
-    public function whereNotAttr(string $selector, string $attribute, string|Closure $expected): static
+    public function whereNotAttribute(string $selector, string $attribute, string|Closure $expected): static
     {
         $actual = $this->findOrFail($selector)->getAttribute($attribute);
 
@@ -348,63 +348,13 @@ class AssertableHtml
      * @param  array<string, string|\Closure>  $bindings
      * @return $this
      */
-    public function whereAttrs(string $selector, array $bindings): static
+    public function whereAttributes(string $selector, array $bindings): static
     {
         foreach ($bindings as $attribute => $expected) {
-            $this->whereAttr($selector, $attribute, $expected);
+            $this->whereAttribute($selector, $attribute, $expected);
         }
 
         return $this;
-    }
-
-    /**
-     * Alias for whereAttr().
-     *
-     * @param  string  $selector
-     * @param  string  $attribute
-     * @param  string|\Closure  $expected
-     * @return $this
-     */
-    public function whereAttribute(string $selector, string $attribute, string|Closure $expected): static
-    {
-        return $this->whereAttr($selector, $attribute, $expected);
-    }
-
-    /**
-     * Alias for whereNotAttr().
-     *
-     * @param  string  $selector
-     * @param  string  $attribute
-     * @param  string|\Closure  $expected
-     * @return $this
-     */
-    public function whereNotAttribute(string $selector, string $attribute, string|Closure $expected): static
-    {
-        return $this->whereNotAttr($selector, $attribute, $expected);
-    }
-
-    /**
-     * Alias for whereAttrs().
-     *
-     * @param  string  $selector
-     * @param  array<string, string|\Closure>  $bindings
-     * @return $this
-     */
-    public function whereAttributes(string $selector, array $bindings): static
-    {
-        return $this->whereAttrs($selector, $bindings);
-    }
-
-    /**
-     * Alias for hasAttr().
-     *
-     * @param  string  $selector
-     * @param  string  $attribute
-     * @return $this
-     */
-    public function hasAttribute(string $selector, string $attribute): static
-    {
-        return $this->hasAttr($selector, $attribute);
     }
 
     /**
@@ -414,7 +364,7 @@ class AssertableHtml
      * @param  string  $attribute
      * @return $this
      */
-    public function missingAttr(string $selector, string $attribute): static
+    public function missingAttribute(string $selector, string $attribute): static
     {
         if ($this->findOrFail($selector)->hasAttribute($attribute)) {
             $this->fail(

--- a/src/Illuminate/Testing/Fluent/AssertableHtml.php
+++ b/src/Illuminate/Testing/Fluent/AssertableHtml.php
@@ -175,21 +175,6 @@ class AssertableHtml
     }
 
     /**
-     * Assert that each selector's matched element has the expected text content.
-     *
-     * @param  array<string, string|\Closure>  $bindings
-     * @return $this
-     */
-    public function whereAllText(array $bindings): static
-    {
-        foreach ($bindings as $selector => $expected) {
-            $this->whereText($selector, $expected);
-        }
-
-        return $this;
-    }
-
-    /**
      * Assert that the matched element has all of the given attributes.
      *
      * @param  string  $selector

--- a/src/Illuminate/Testing/Fluent/AssertableHtml.php
+++ b/src/Illuminate/Testing/Fluent/AssertableHtml.php
@@ -51,7 +51,7 @@ class AssertableHtml
     public static function fromResponse(TestResponse $response, int $options = LIBXML_NOERROR): static
     {
         return new static(
-            HTMLDocument::createFromString($$response->getContent(), $options)
+            HTMLDocument::createFromString($$response->getContent(), $options),
         );
     }
 

--- a/src/Illuminate/Testing/Fluent/AssertableHtml.php
+++ b/src/Illuminate/Testing/Fluent/AssertableHtml.php
@@ -11,7 +11,6 @@ use Illuminate\Support\Traits\Tappable;
 use Illuminate\Testing\TestResponse;
 use PHPUnit\Framework\Assert as PHPUnit;
 use PHPUnit\Framework\AssertionFailedError;
-use Symfony\Component\HttpFoundation\StreamedJsonResponse;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class AssertableHtml
@@ -27,7 +26,8 @@ class AssertableHtml
     protected function __construct(
         protected Element|HTMLDocument $scope,
         protected ?string $selector = null,
-    ) {}
+    ) {
+    }
 
     /**
      * Create a new instance from a test response.

--- a/src/Illuminate/Testing/Fluent/AssertableHtml.php
+++ b/src/Illuminate/Testing/Fluent/AssertableHtml.php
@@ -318,7 +318,7 @@ class AssertableHtml
     }
 
     /**
-     * Scope into the first element matching the selector and optionally invoke the callback.
+     * Scope into the first element matching the selector, optionally invoking the callback.
      *
      * @param  string  $selector
      * @param  \Closure|null  $callback
@@ -330,7 +330,7 @@ class AssertableHtml
     }
 
     /**
-     * Scope into the first element matching the selector and optionally invoke the callback.
+     * Scope into the first matching element, optionally invoking the callback.
      *
      * @param  string  $selector
      * @param  \Closure|null  $callback
@@ -342,7 +342,7 @@ class AssertableHtml
     }
 
     /**
-     * Scope into the last element matching the selector and optionally invoke the callback.
+     * Scope into the last matching element, optionally invoking the callback.
      *
      * @param  string  $selector
      * @param  \Closure|null  $callback
@@ -354,7 +354,7 @@ class AssertableHtml
     }
 
     /**
-     * Scope into the element at the given index matching the selector and optionally invoke the callback.
+     * Scope into the matching element at the given zero-based index, optionally invoking the callback.
      *
      * @param  string  $selector
      * @param  int  $index
@@ -388,9 +388,7 @@ class AssertableHtml
     }
 
     /**
-     * Assert that the matched elements satisfy a sequence of callbacks, one per element in order.
-     *
-     * Each callback receives the scoped element and its zero-based index.
+     * Assert that the matched elements satisfy a sequence of callbacks, one per element.
      *
      * @param  string  $selector
      * @param  \Closure  ...$callbacks

--- a/src/Illuminate/Testing/TestComponent.php
+++ b/src/Illuminate/Testing/TestComponent.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Traits\Macroable;
 use Illuminate\Testing\Assert as PHPUnit;
 use Illuminate\Testing\Constraints\SeeInOrder;
 use Illuminate\Testing\Fluent\AssertableHtml;
+use RuntimeException;
 use Stringable;
 
 class TestComponent implements Stringable
@@ -202,7 +203,7 @@ class TestComponent implements Stringable
     public function assertHtml(string|Closure $selectorOrCallback, ?Closure $callback = null): static
     {
         if (version_compare(PHP_VERSION, '8.4.0', '<')) {
-            throw new \RuntimeException('assertHtml() requires PHP 8.4.0 or higher.');
+            throw new RuntimeException('assertHtml() requires PHP 8.4.0 or higher.');
         }
 
         if ($selectorOrCallback instanceof Closure) {

--- a/src/Illuminate/Testing/TestComponent.php
+++ b/src/Illuminate/Testing/TestComponent.php
@@ -2,10 +2,12 @@
 
 namespace Illuminate\Testing;
 
+use Closure;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Testing\Assert as PHPUnit;
 use Illuminate\Testing\Constraints\SeeInOrder;
+use Illuminate\Testing\Fluent\AssertableHtml;
 use Stringable;
 
 class TestComponent implements Stringable
@@ -185,6 +187,24 @@ class TestComponent implements Stringable
 
         foreach ($values as $value) {
             PHPUnit::assertStringNotContainsString((string) $value, $rendered);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Assert that the rendered component HTML satisfies a given set of fluent assertions.
+     *
+     * @param  string|\Closure  $selectorOrCallback
+     * @param  \Closure|null  $callback
+     * @return $this
+     */
+    public function assertHtml(string|Closure $selectorOrCallback, ?Closure $callback = null): static
+    {
+        if ($selectorOrCallback instanceof Closure) {
+            $selectorOrCallback(AssertableHtml::fromString($this->rendered));
+        } else {
+            AssertableHtml::fromString($this->rendered)->scope($selectorOrCallback, $callback);
         }
 
         return $this;

--- a/src/Illuminate/Testing/TestComponent.php
+++ b/src/Illuminate/Testing/TestComponent.php
@@ -201,6 +201,10 @@ class TestComponent implements Stringable
      */
     public function assertHtml(string|Closure $selectorOrCallback, ?Closure $callback = null): static
     {
+        if (version_compare(PHP_VERSION, '8.4.0', '<')) {
+            throw new \RuntimeException('assertHtml() requires PHP 8.4.0 or higher.');
+        }
+
         if ($selectorOrCallback instanceof Closure) {
             $selectorOrCallback(AssertableHtml::fromString($this->rendered));
         } else {

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -24,6 +24,7 @@ use Illuminate\Testing\Fluent\AssertableHtml;
 use Illuminate\Testing\Fluent\AssertableJson;
 use Illuminate\Testing\TestResponseAssert as PHPUnit;
 use LogicException;
+use RuntimeException;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\StreamedJsonResponse;
@@ -879,7 +880,7 @@ class TestResponse implements ArrayAccess
     public function assertHtml(string|Closure $selectorOrCallback, ?Closure $callback = null): static
     {
         if (version_compare(PHP_VERSION, '8.4.0', '<')) {
-            throw new \RuntimeException('assertHtml() requires PHP 8.4.0 or higher.');
+            throw new RuntimeException('assertHtml() requires PHP 8.4.0 or higher.');
         }
 
         if ($selectorOrCallback instanceof Closure) {

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -20,6 +20,7 @@ use Illuminate\Support\Traits\Macroable;
 use Illuminate\Support\Traits\Tappable;
 use Illuminate\Support\ViewErrorBag;
 use Illuminate\Testing\Constraints\SeeInOrder;
+use Illuminate\Testing\Fluent\AssertableHtml;
 use Illuminate\Testing\Fluent\AssertableJson;
 use Illuminate\Testing\TestResponseAssert as PHPUnit;
 use LogicException;
@@ -863,6 +864,24 @@ class TestResponse implements ArrayAccess
             if (Arr::isAssoc($assert->toArray())) {
                 $assert->interacted();
             }
+        }
+
+        return $this;
+    }
+
+    /**
+     * Assert that the response HTML satisfies a given set of fluent assertions.
+     *
+     * @param  string|\Closure  $selectorOrCallback
+     * @param  \Closure|null  $callback
+     * @return $this
+     */
+    public function assertHtml(string|Closure $selectorOrCallback, ?Closure $callback = null): static
+    {
+        if ($selectorOrCallback instanceof Closure) {
+            $selectorOrCallback(AssertableHtml::fromResponse($this));
+        } else {
+            AssertableHtml::fromResponse($this)->scope($selectorOrCallback, $callback);
         }
 
         return $this;

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -878,6 +878,10 @@ class TestResponse implements ArrayAccess
      */
     public function assertHtml(string|Closure $selectorOrCallback, ?Closure $callback = null): static
     {
+        if (version_compare(PHP_VERSION, '8.4.0', '<')) {
+            throw new \RuntimeException('assertHtml() requires PHP 8.4.0 or higher.');
+        }
+
         if ($selectorOrCallback instanceof Closure) {
             $selectorOrCallback(AssertableHtml::fromResponse($this));
         } else {

--- a/src/Illuminate/Testing/TestView.php
+++ b/src/Illuminate/Testing/TestView.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Testing\Assert as PHPUnit;
 use Illuminate\Testing\Constraints\SeeInOrder;
+use Illuminate\Testing\Fluent\AssertableHtml;
 use Illuminate\View\View;
 use Stringable;
 
@@ -262,6 +263,24 @@ class TestView implements Stringable
 
         foreach ($values as $value) {
             PHPUnit::assertStringNotContainsString((string) $value, $rendered);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Assert that the rendered view HTML satisfies a given set of fluent assertions.
+     *
+     * @param  string|\Closure  $selectorOrCallback
+     * @param  \Closure|null  $callback
+     * @return $this
+     */
+    public function assertHtml(string|Closure $selectorOrCallback, ?Closure $callback = null): static
+    {
+        if ($selectorOrCallback instanceof Closure) {
+            $selectorOrCallback(AssertableHtml::fromString($this->rendered));
+        } else {
+            AssertableHtml::fromString($this->rendered)->scope($selectorOrCallback, $callback);
         }
 
         return $this;

--- a/src/Illuminate/Testing/TestView.php
+++ b/src/Illuminate/Testing/TestView.php
@@ -11,6 +11,7 @@ use Illuminate\Testing\Assert as PHPUnit;
 use Illuminate\Testing\Constraints\SeeInOrder;
 use Illuminate\Testing\Fluent\AssertableHtml;
 use Illuminate\View\View;
+use RuntimeException;
 use Stringable;
 
 class TestView implements Stringable
@@ -278,7 +279,7 @@ class TestView implements Stringable
     public function assertHtml(string|Closure $selectorOrCallback, ?Closure $callback = null): static
     {
         if (version_compare(PHP_VERSION, '8.4.0', '<')) {
-            throw new \RuntimeException('assertHtml() requires PHP 8.4.0 or higher.');
+            throw new RuntimeException('assertHtml() requires PHP 8.4.0 or higher.');
         }
 
         if ($selectorOrCallback instanceof Closure) {

--- a/src/Illuminate/Testing/TestView.php
+++ b/src/Illuminate/Testing/TestView.php
@@ -277,6 +277,10 @@ class TestView implements Stringable
      */
     public function assertHtml(string|Closure $selectorOrCallback, ?Closure $callback = null): static
     {
+        if (version_compare(PHP_VERSION, '8.4.0', '<')) {
+            throw new \RuntimeException('assertHtml() requires PHP 8.4.0 or higher.');
+        }
+
         if ($selectorOrCallback instanceof Closure) {
             $selectorOrCallback(AssertableHtml::fromString($this->rendered));
         } else {

--- a/tests/Testing/Fluent/AssertableHtmlTest.php
+++ b/tests/Testing/Fluent/AssertableHtmlTest.php
@@ -396,6 +396,14 @@ class AssertableHtmlTest extends TestCase
             });
     }
 
+    public function testScopeWithoutCallback(): void
+    {
+        $this->html('<nav><a href="/home">Home</a></nav><footer><a href="/about">About</a></footer>')
+            ->scope('nav')
+            ->has('a[href="/home"]')
+            ->missing('a[href="/about"]');
+    }
+
     public function testScopeMissingSelector(): void
     {
         $this->expectException(AssertionFailedError::class);
@@ -404,6 +412,80 @@ class AssertableHtmlTest extends TestCase
         $this->html('<nav></nav>')->scope('aside', function (AssertableHtml $el) {
             //
         });
+    }
+
+    public function testNth(): void
+    {
+        $this->html('<ul><li><span>First</span></li><li><span>Second</span></li><li><span>Third</span></li></ul>')
+            ->nth('li', 0, fn (AssertableHtml $li) => $li->whereText('span', 'First'))
+            ->nth('li', 1, fn (AssertableHtml $li) => $li->whereText('span', 'Second'))
+            ->nth('li', 2, fn (AssertableHtml $li) => $li->whereText('span', 'Third'));
+    }
+
+    public function testNthWithoutCallback(): void
+    {
+        $this->html('<ul><li><span>First</span></li><li><span>Second</span></li><li><span>Third</span></li></ul>')
+            ->nth('li', 1)
+            ->whereText('span', 'Second');
+    }
+
+    public function testNthMissingSelector(): void
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Failed asserting that element [li] exists.');
+
+        $this->html('<ul></ul>')->nth('li', 0, fn (AssertableHtml $li) => null);
+    }
+
+    public function testNthOutOfBounds(): void
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Failed asserting that [li] has an element at index [5], found 3 element(s).');
+
+        $this->html('<ul><li>a</li><li>b</li><li>c</li></ul>')
+            ->nth('li', 5, fn (AssertableHtml $li) => null);
+    }
+
+    public function testFirst(): void
+    {
+        $this->html('<ul><li><span>First</span></li><li><span>Second</span></li><li><span>Third</span></li></ul>')
+            ->first('li', fn (AssertableHtml $li) => $li->whereText('span', 'First'));
+    }
+
+    public function testFirstWithoutCallback(): void
+    {
+        $this->html('<ul><li><span>First</span></li><li><span>Second</span></li><li><span>Third</span></li></ul>')
+            ->first('li')
+            ->whereText('span', 'First');
+    }
+
+    public function testFirstMissingSelector(): void
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Failed asserting that element [li] exists.');
+
+        $this->html('<ul></ul>')->first('li', fn (AssertableHtml $li) => null);
+    }
+
+    public function testLast(): void
+    {
+        $this->html('<ul><li><span>First</span></li><li><span>Second</span></li><li><span>Third</span></li></ul>')
+            ->last('li', fn (AssertableHtml $li) => $li->whereText('span', 'Third'));
+    }
+
+    public function testLastWithoutCallback(): void
+    {
+        $this->html('<ul><li><span>First</span></li><li><span>Second</span></li><li><span>Third</span></li></ul>')
+            ->last('li')
+            ->whereText('span', 'Third');
+    }
+
+    public function testLastMissingSelector(): void
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Failed asserting that element [li] exists.');
+
+        $this->html('<ul></ul>')->last('li', fn (AssertableHtml $li) => null);
     }
 
     public function testEach(): void

--- a/tests/Testing/Fluent/AssertableHtmlTest.php
+++ b/tests/Testing/Fluent/AssertableHtmlTest.php
@@ -459,6 +459,40 @@ class AssertableHtmlTest extends TestCase
         $this->html('<ul></ul>')->last('li', fn (AssertableHtml $li) => null);
     }
 
+    public function testSequence(): void
+    {
+        $this->html('<ul><li><span>First</span></li><li><span>Second</span></li><li><span>Third</span></li></ul>')
+            ->sequence('li',
+                fn (AssertableHtml $li) => $li->whereText('span', 'First'),
+                fn (AssertableHtml $li) => $li->whereText('span', 'Second'),
+                fn (AssertableHtml $li) => $li->whereText('span', 'Third'),
+            );
+    }
+
+    public function testSequenceCountMismatch(): void
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Failed asserting that [li] matches 2 element(s), found 3.');
+
+        $this->html('<ul><li>First</li><li>Second</li><li>Third</li></ul>')
+            ->sequence('li',
+                fn (AssertableHtml $li) => null,
+                fn (AssertableHtml $li) => null,
+            );
+    }
+
+    public function testSequenceFailingIndex(): void
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Failed assertion on element [li] at index [1]');
+
+        $this->html('<ul><li><a href="/a">A</a></li><li><span>no link</span></li></ul>')
+            ->sequence('li',
+                fn (AssertableHtml $li) => $li->has('a'),
+                fn (AssertableHtml $li) => $li->has('a'),
+            );
+    }
+
     public function testEach(): void
     {
         $count = 0;

--- a/tests/Testing/Fluent/AssertableHtmlTest.php
+++ b/tests/Testing/Fluent/AssertableHtmlTest.php
@@ -308,7 +308,7 @@ class AssertableHtmlTest extends TestCase
     public function testScopeFailsWhenSelectorMissing(): void
     {
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Failed to find element matching selector [aside].');
+        $this->expectExceptionMessage('Failed asserting that element [aside] exists.');
 
         $this->html('<nav></nav>')->scope('aside', function (AssertableHtml $el) {
             //

--- a/tests/Testing/Fluent/AssertableHtmlTest.php
+++ b/tests/Testing/Fluent/AssertableHtmlTest.php
@@ -162,7 +162,7 @@ class AssertableHtmlTest extends TestCase
     public function testWhereFailsWhenClosureReturnsFalse(): void
     {
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Failed asserting that [p] text was accepted by the truth test.');
+        $this->expectExceptionMessage('Failed asserting that [p] text was marked as invalid using a closure.');
 
         $this->html('<p>Hello World</p>')
             ->where('p', fn ($text) => str_contains($text, 'Goodbye'));
@@ -223,7 +223,7 @@ class AssertableHtmlTest extends TestCase
     public function testWhereNotFailsWhenClosureReturnsTrue(): void
     {
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Failed asserting that [p] text was rejected by the truth test.');
+        $this->expectExceptionMessage('Failed asserting that [p] text was marked as invalid using a closure.');
 
         $this->html('<p>Hello World</p>')
             ->whereNot('p', fn ($text) => str_contains($text, 'Hello'));
@@ -261,7 +261,7 @@ class AssertableHtmlTest extends TestCase
     public function testWhereAttrFailsWhenClosureReturnsFalse(): void
     {
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Failed asserting that [a] attribute [href] was accepted by the truth test.');
+        $this->expectExceptionMessage('Failed asserting that [a] attribute [href] was marked as invalid using a closure.');
 
         $this->html('<a href="/about">About</a>')
             ->whereAttr('a', 'href', fn ($value) => str_starts_with($value, 'http'));

--- a/tests/Testing/Fluent/AssertableHtmlTest.php
+++ b/tests/Testing/Fluent/AssertableHtmlTest.php
@@ -523,6 +523,32 @@ class AssertableHtmlTest extends TestCase
         $this->html('<div></div>')->each('li', fn ($li) => null);
     }
 
+    public function testTap(): void
+    {
+        $assert = $this->html('<nav></nav>');
+
+        $result = $assert->tap(fn (AssertableHtml $html) => $html->has('nav'));
+
+        $this->assertSame($assert, $result);
+    }
+
+    public function testWhen(): void
+    {
+        $this->html('<nav></nav><aside></aside>')
+            ->when(true, fn (AssertableHtml $html) => $html->has('nav'))
+            ->when(false, fn (AssertableHtml $html) => $html->missing('nav'), fn (AssertableHtml $html) => $html->has('aside'));
+    }
+
+    public function testMacro(): void
+    {
+        AssertableHtml::macro('assertHasNav', function () {
+            /** @var AssertableHtml $this */
+            return $this->has('nav');
+        });
+
+        $this->html('<nav></nav>')->assertHasNav();
+    }
+
     public function testChaining(): void
     {
         $assert = $this->html('<nav><a href="/" class="active">Home</a></nav>');

--- a/tests/Testing/Fluent/AssertableHtmlTest.php
+++ b/tests/Testing/Fluent/AssertableHtmlTest.php
@@ -15,19 +15,19 @@ class AssertableHtmlTest extends TestCase
         return AssertableHtml::fromString("<html><body>{$body}</body></html>");
     }
 
-    public function testFromStringParsesValidHtml(): void
+    public function testFromString(): void
     {
         $assert = $this->html('<p>Hello</p>');
 
         $assert->has('p');
     }
 
-    public function testHasPassesWhenSelectorExists(): void
+    public function testHas(): void
     {
         $this->html('<nav><a href="/">Home</a></nav>')->has('nav');
     }
 
-    public function testHasFailsWhenSelectorMissing(): void
+    public function testHasMissingSelector(): void
     {
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Failed asserting that element [nav] exists.');
@@ -35,12 +35,12 @@ class AssertableHtmlTest extends TestCase
         $this->html('<div></div>')->has('nav');
     }
 
-    public function testHasWithCountPassesWhenCountMatches(): void
+    public function testHasWithCount(): void
     {
         $this->html('<ul><li>a</li><li>b</li><li>c</li></ul>')->has('li', 3);
     }
 
-    public function testHasWithCountFailsWhenCountMismatches(): void
+    public function testHasWithCountMismatch(): void
     {
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Failed asserting that [li] matches 2 element(s), found 3.');
@@ -48,7 +48,7 @@ class AssertableHtmlTest extends TestCase
         $this->html('<ul><li>a</li><li>b</li><li>c</li></ul>')->has('li', 2);
     }
 
-    public function testHasWithCallbackScopesIntoElement(): void
+    public function testHasWithCallback(): void
     {
         $this->html('<nav><a href="/about">About</a></nav>')
             ->has('nav', function (AssertableHtml $nav) {
@@ -56,21 +56,21 @@ class AssertableHtmlTest extends TestCase
             });
     }
 
-    public function testHasWithCountAndCallbackScopesIntoFirstMatch(): void
+    public function testHasWithCountAndCallback(): void
     {
         $this->html('<ul><li class="item"><a href="/a">A</a></li><li class="item"><a href="/b">B</a></li></ul>')
             ->has('li.item', 2, function (AssertableHtml $li) {
-                $li->has('a');  // scoped into first li.item
+                $li->has('a');
             });
     }
 
-    public function testHasAllPassesWhenAllSelectorsExist(): void
+    public function testHasAll(): void
     {
         $this->html('<header></header><main></main><footer></footer>')
             ->hasAll(['header', 'main', 'footer']);
     }
 
-    public function testHasAllFailsWhenOneIsMissing(): void
+    public function testHasAllMissingSelector(): void
     {
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Failed asserting that element [footer] exists.');
@@ -79,12 +79,12 @@ class AssertableHtmlTest extends TestCase
             ->hasAll(['header', 'main', 'footer']);
     }
 
-    public function testMissingPassesWhenSelectorAbsent(): void
+    public function testMissing(): void
     {
         $this->html('<div></div>')->missing('nav');
     }
 
-    public function testMissingFailsWhenSelectorPresent(): void
+    public function testMissingPresentSelector(): void
     {
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Failed asserting that [nav] is absent.');
@@ -92,13 +92,13 @@ class AssertableHtmlTest extends TestCase
         $this->html('<nav></nav>')->missing('nav');
     }
 
-    public function testMissingAllPassesWhenAllSelectorsAbsent(): void
+    public function testMissingAll(): void
     {
         $this->html('<div></div>')
             ->missingAll(['.alert', '.error', '.warning']);
     }
 
-    public function testMissingAllFailsWhenOneIsPresent(): void
+    public function testMissingAllPresentSelector(): void
     {
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Failed asserting that [.error] is absent.');
@@ -107,12 +107,12 @@ class AssertableHtmlTest extends TestCase
             ->missingAll(['.alert', '.error', '.warning']);
     }
 
-    public function testCountPassesWhenCountMatches(): void
+    public function testCount(): void
     {
         $this->html('<ul><li>a</li><li>b</li></ul>')->count('li', 2);
     }
 
-    public function testCountFailsWhenCountMismatches(): void
+    public function testCountMismatch(): void
     {
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Failed asserting that [li] matches 3 element(s), found 2.');
@@ -120,12 +120,12 @@ class AssertableHtmlTest extends TestCase
         $this->html('<ul><li>a</li><li>b</li></ul>')->count('li', 3);
     }
 
-    public function testWhereTextPassesWhenTextMatches(): void
+    public function testWhereText(): void
     {
         $this->html('<h1>Hello World</h1>')->whereText('h1', 'Hello World');
     }
 
-    public function testWhereTextFailsWhenTextMismatches(): void
+    public function testWhereTextMismatch(): void
     {
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Failed asserting that [h1] text equals [Goodbye], found [Hello World].');
@@ -133,7 +133,7 @@ class AssertableHtmlTest extends TestCase
         $this->html('<h1>Hello World</h1>')->whereText('h1', 'Goodbye');
     }
 
-    public function testWhereTextFailsWhenSelectorMissing(): void
+    public function testWhereTextMissingSelector(): void
     {
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Failed asserting that element [h2] exists.');
@@ -141,13 +141,13 @@ class AssertableHtmlTest extends TestCase
         $this->html('<h1>Hello</h1>')->whereText('h2', 'Hello');
     }
 
-    public function testWhereTextPassesWithClosureTruthTest(): void
+    public function testWhereTextWithClosure(): void
     {
         $this->html('<p>Hello World</p>')
             ->whereText('p', fn ($text) => str_contains($text, 'World'));
     }
 
-    public function testWhereTextFailsWhenClosureReturnsFalse(): void
+    public function testWhereTextWithClosureFailing(): void
     {
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Failed asserting that [p] text was marked as invalid using a closure.');
@@ -156,7 +156,7 @@ class AssertableHtmlTest extends TestCase
             ->whereText('p', fn ($text) => str_contains($text, 'Goodbye'));
     }
 
-    public function testWhereAllTextPassesForAllSelectors(): void
+    public function testWhereAllText(): void
     {
         $this->html('<p class="a">Foo</p><p class="b">Bar</p>')
             ->whereAllText([
@@ -165,7 +165,7 @@ class AssertableHtmlTest extends TestCase
             ]);
     }
 
-    public function testWhereAllTextFailsOnFirstMismatch(): void
+    public function testWhereAllTextMismatch(): void
     {
         $this->expectException(AssertionFailedError::class);
 
@@ -176,7 +176,7 @@ class AssertableHtmlTest extends TestCase
             ]);
     }
 
-    public function testWhereAllTextPassesWithClosures(): void
+    public function testWhereAllTextWithClosures(): void
     {
         $this->html('<p class="a">Foo</p><p class="b">Bar</p>')
             ->whereAllText([
@@ -185,12 +185,12 @@ class AssertableHtmlTest extends TestCase
             ]);
     }
 
-    public function testWhereNotTextPassesWhenTextDoesNotMatch(): void
+    public function testWhereNotText(): void
     {
         $this->html('<span class="badge">Paid</span>')->whereNotText('.badge', 'Overdue');
     }
 
-    public function testWhereNotTextFailsWhenTextMatches(): void
+    public function testWhereNotTextMismatch(): void
     {
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Failed asserting that [.badge] text does not equal [Paid].');
@@ -198,13 +198,13 @@ class AssertableHtmlTest extends TestCase
         $this->html('<span class="badge">Paid</span>')->whereNotText('.badge', 'Paid');
     }
 
-    public function testWhereNotTextPassesWhenClosureReturnsFalse(): void
+    public function testWhereNotTextWithClosure(): void
     {
         $this->html('<p>Hello World</p>')
             ->whereNotText('p', fn ($text) => str_contains($text, 'Goodbye'));
     }
 
-    public function testWhereNotTextFailsWhenClosureReturnsTrue(): void
+    public function testWhereNotTextWithClosureFailing(): void
     {
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Failed asserting that [p] text was marked as invalid using a closure.');
@@ -213,7 +213,7 @@ class AssertableHtmlTest extends TestCase
             ->whereNotText('p', fn ($text) => str_contains($text, 'Hello'));
     }
 
-    public function testWhereNotTextFailsWhenSelectorMissing(): void
+    public function testWhereNotTextMissingSelector(): void
     {
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Failed asserting that element [h2] exists.');
@@ -221,12 +221,12 @@ class AssertableHtmlTest extends TestCase
         $this->html('<h1>Hello</h1>')->whereNotText('h2', 'Hello');
     }
 
-    public function testWhereAttributePassesWhenAttributeMatches(): void
+    public function testWhereAttribute(): void
     {
         $this->html('<a href="/about">About</a>')->whereAttribute('a', 'href', '/about');
     }
 
-    public function testWhereAttributeFailsWhenAttributeMismatches(): void
+    public function testWhereAttributeMismatch(): void
     {
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Failed asserting that [a] attribute [href] equals [/contact], found [/about].');
@@ -234,13 +234,13 @@ class AssertableHtmlTest extends TestCase
         $this->html('<a href="/about">About</a>')->whereAttribute('a', 'href', '/contact');
     }
 
-    public function testWhereAttributePassesWithClosureTruthTest(): void
+    public function testWhereAttributeWithClosure(): void
     {
         $this->html('<a href="/about">About</a>')
             ->whereAttribute('a', 'href', fn ($value) => str_starts_with($value, '/'));
     }
 
-    public function testWhereAttributeFailsWhenClosureReturnsFalse(): void
+    public function testWhereAttributeWithClosureFailing(): void
     {
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Failed asserting that [a] attribute [href] was marked as invalid using a closure.');
@@ -249,12 +249,12 @@ class AssertableHtmlTest extends TestCase
             ->whereAttribute('a', 'href', fn ($value) => str_starts_with($value, 'http'));
     }
 
-    public function testHasAttributePassesWhenAttributePresent(): void
+    public function testHasAttribute(): void
     {
         $this->html('<input type="email" required>')->hasAttribute('input', 'required');
     }
 
-    public function testHasAttributeFailsWhenAttributeAbsent(): void
+    public function testHasAttributeMissing(): void
     {
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Failed asserting that [input] has attribute [disabled].');
@@ -262,12 +262,12 @@ class AssertableHtmlTest extends TestCase
         $this->html('<input type="email">')->hasAttribute('input', 'disabled');
     }
 
-    public function testHasAttributesPassesWhenAllAttributesPresent(): void
+    public function testHasAttributes(): void
     {
         $this->html('<input type="email" required disabled>')->hasAttributes('input', ['required', 'disabled']);
     }
 
-    public function testHasAttributesFailsWhenOneAttributeAbsent(): void
+    public function testHasAttributesMissing(): void
     {
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Failed asserting that [input] has attribute [disabled].');
@@ -275,12 +275,12 @@ class AssertableHtmlTest extends TestCase
         $this->html('<input type="email" required>')->hasAttributes('input', ['required', 'disabled']);
     }
 
-    public function testWhereNotAttributePassesWhenAttributeDoesNotMatch(): void
+    public function testWhereNotAttribute(): void
     {
         $this->html('<a href="/about">About</a>')->whereNotAttribute('a', 'href', '/contact');
     }
 
-    public function testWhereNotAttributeFailsWhenAttributeMatches(): void
+    public function testWhereNotAttributeMismatch(): void
     {
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Failed asserting that [a] attribute [href] does not equal [/about].');
@@ -288,13 +288,13 @@ class AssertableHtmlTest extends TestCase
         $this->html('<a href="/about">About</a>')->whereNotAttribute('a', 'href', '/about');
     }
 
-    public function testWhereNotAttributePassesWhenClosureReturnsFalse(): void
+    public function testWhereNotAttributeWithClosure(): void
     {
         $this->html('<a href="/about">About</a>')
             ->whereNotAttribute('a', 'href', fn ($v) => str_starts_with($v, 'http'));
     }
 
-    public function testWhereNotAttributeFailsWhenClosureReturnsTrue(): void
+    public function testWhereNotAttributeWithClosureFailing(): void
     {
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Failed asserting that [a] attribute [href] was marked as invalid using a closure.');
@@ -303,7 +303,7 @@ class AssertableHtmlTest extends TestCase
             ->whereNotAttribute('a', 'href', fn ($v) => str_starts_with($v, '/'));
     }
 
-    public function testWhereAttributesPassesForAllAttributes(): void
+    public function testWhereAttributes(): void
     {
         $this->html('<a href="/about" class="nav-link">About</a>')
             ->whereAttributes('a', [
@@ -312,7 +312,7 @@ class AssertableHtmlTest extends TestCase
             ]);
     }
 
-    public function testWhereAttributesPassesWithClosures(): void
+    public function testWhereAttributesWithClosures(): void
     {
         $this->html('<a href="/about" class="nav-link">About</a>')
             ->whereAttributes('a', [
@@ -321,7 +321,7 @@ class AssertableHtmlTest extends TestCase
             ]);
     }
 
-    public function testWhereAttributesFailsOnFirstMismatch(): void
+    public function testWhereAttributesMismatch(): void
     {
         $this->expectException(AssertionFailedError::class);
 
@@ -332,12 +332,12 @@ class AssertableHtmlTest extends TestCase
             ]);
     }
 
-    public function testMissingAttributePassesWhenAttributeAbsent(): void
+    public function testMissingAttribute(): void
     {
         $this->html('<input type="email">')->missingAttribute('input', 'disabled');
     }
 
-    public function testMissingAttributeFailsWhenAttributePresent(): void
+    public function testMissingAttributePresent(): void
     {
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Failed asserting that [input] does not have attribute [required].');
@@ -345,12 +345,12 @@ class AssertableHtmlTest extends TestCase
         $this->html('<input type="email" required>')->missingAttribute('input', 'required');
     }
 
-    public function testMissingAttributesPassesWhenAllAttributesAbsent(): void
+    public function testMissingAttributes(): void
     {
         $this->html('<input type="email">')->missingAttributes('input', ['required', 'disabled']);
     }
 
-    public function testMissingAttributesFailsWhenOneAttributePresent(): void
+    public function testMissingAttributesPresent(): void
     {
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Failed asserting that [input] does not have attribute [required].');
@@ -358,7 +358,7 @@ class AssertableHtmlTest extends TestCase
         $this->html('<input type="email" required>')->missingAttributes('input', ['required', 'disabled']);
     }
 
-    public function testScopeNarrowsAssertionsToMatchedElement(): void
+    public function testScope(): void
     {
         $this->html('<nav><a href="/home">Home</a></nav><footer><a href="/about">About</a></footer>')
             ->scope('nav', function (AssertableHtml $nav) {
@@ -367,7 +367,7 @@ class AssertableHtmlTest extends TestCase
             });
     }
 
-    public function testScopeFailsWhenSelectorMissing(): void
+    public function testScopeMissingSelector(): void
     {
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Failed asserting that element [aside] exists.');
@@ -377,7 +377,7 @@ class AssertableHtmlTest extends TestCase
         });
     }
 
-    public function testEachIteratesAllMatchingElements(): void
+    public function testEach(): void
     {
         $count = 0;
 
@@ -389,7 +389,7 @@ class AssertableHtmlTest extends TestCase
         $this->assertSame(3, $count);
     }
 
-    public function testEachReportsFailingIndex(): void
+    public function testEachFailingIndex(): void
     {
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Failed assertion on element [li] at index [1]');
@@ -400,14 +400,14 @@ class AssertableHtmlTest extends TestCase
             });
     }
 
-    public function testEachFailsWhenNoElementsMatch(): void
+    public function testEachNoMatches(): void
     {
         $this->expectException(AssertionFailedError::class);
 
         $this->html('<div></div>')->each('li', fn ($li) => null);
     }
 
-    public function testMethodsReturnStaticForChaining(): void
+    public function testChaining(): void
     {
         $assert = $this->html('<nav><a href="/" class="active">Home</a></nav>');
 
@@ -424,7 +424,7 @@ class AssertableHtmlTest extends TestCase
         $this->assertSame($assert, $result);
     }
 
-    public function testFailureMessageIncludesScopeHtml(): void
+    public function testFailureOutputIncludesHtml(): void
     {
         try {
             $this->html('<nav><a href="/">Home</a></nav>')->has('footer');
@@ -437,7 +437,7 @@ class AssertableHtmlTest extends TestCase
         $this->fail('Expected an AssertionFailedError.');
     }
 
-    public function testScopedFailureMessageIncludesScopedElementHtml(): void
+    public function testScopedFailureOutputIncludesScopedHtml(): void
     {
         try {
             $this->html('<nav><a href="/">Home</a></nav>')
@@ -446,7 +446,6 @@ class AssertableHtmlTest extends TestCase
                 });
         } catch (AssertionFailedError $e) {
             $this->assertStringContainsString('<nav>', $e->getMessage());
-            // Should not include the full document
             $this->assertStringNotContainsString('<html>', $e->getMessage());
 
             return;

--- a/tests/Testing/Fluent/AssertableHtmlTest.php
+++ b/tests/Testing/Fluent/AssertableHtmlTest.php
@@ -54,35 +54,6 @@ class AssertableHtmlTest extends TestCase
         $this->html('<div></div>')->has('nav');
     }
 
-    public function testHasWithCount(): void
-    {
-        $this->html('<ul><li>a</li><li>b</li><li>c</li></ul>')->has('li', 3);
-    }
-
-    public function testHasWithCountMismatch(): void
-    {
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Failed asserting that [li] matches 2 element(s), found 3.');
-
-        $this->html('<ul><li>a</li><li>b</li><li>c</li></ul>')->has('li', 2);
-    }
-
-    public function testHasWithCallback(): void
-    {
-        $this->html('<nav><a href="/about">About</a></nav>')
-            ->has('nav', function (AssertableHtml $nav) {
-                $nav->has('a[href="/about"]');
-            });
-    }
-
-    public function testHasWithCountAndCallback(): void
-    {
-        $this->html('<ul><li class="item"><a href="/a">A</a></li><li class="item"><a href="/b">B</a></li></ul>')
-            ->has('li.item', 2, function (AssertableHtml $li) {
-                $li->has('a');
-            });
-    }
-
     public function testHasAll(): void
     {
         $this->html('<header></header><main></main><footer></footer>')

--- a/tests/Testing/Fluent/AssertableHtmlTest.php
+++ b/tests/Testing/Fluent/AssertableHtmlTest.php
@@ -286,7 +286,7 @@ class AssertableHtmlTest extends TestCase
             ->missing('aside')
             ->count('a', 1)
             ->where('a', 'Home')
-            ->whereContains('nav', 'Home')
+            ->where('nav', fn ($text) => str_contains($text, 'Home'))
             ->whereAttr('a', 'href', '/')
             ->hasAttr('a', 'class')
             ->missingAttr('a', 'disabled');

--- a/tests/Testing/Fluent/AssertableHtmlTest.php
+++ b/tests/Testing/Fluent/AssertableHtmlTest.php
@@ -373,7 +373,6 @@ class AssertableHtmlTest extends TestCase
         try {
             $this->html('<nav><a href="/">Home</a></nav>')->has('footer');
         } catch (AssertionFailedError $e) {
-            $this->assertStringContainsString('Scope HTML:', $e->getMessage());
             $this->assertStringContainsString('<nav>', $e->getMessage());
 
             return;
@@ -390,7 +389,6 @@ class AssertableHtmlTest extends TestCase
                     $nav->has('button');
                 });
         } catch (AssertionFailedError $e) {
-            $this->assertStringContainsString('Scope HTML:', $e->getMessage());
             $this->assertStringContainsString('<nav>', $e->getMessage());
             // Should not include the full document
             $this->assertStringNotContainsString('<html>', $e->getMessage());

--- a/tests/Testing/Fluent/AssertableHtmlTest.php
+++ b/tests/Testing/Fluent/AssertableHtmlTest.php
@@ -472,4 +472,32 @@ class AssertableHtmlTest extends TestCase
 
         $this->fail('Expected an AssertionFailedError.');
     }
+
+    public function testFailureOutputIncludesFullSelectorPath(): void
+    {
+        try {
+            $this->html('<nav><ul><li>Item</li></ul></nav>')
+                ->scope('nav', function (AssertableHtml $nav) {
+                    $nav->scope('ul', function (AssertableHtml $ul) {
+                        $ul->has('a');
+                    });
+                });
+        } catch (AssertionFailedError $e) {
+            $this->assertStringContainsString('nav → ul → a', $e->getMessage());
+
+            return;
+        }
+
+        $this->fail('Expected an AssertionFailedError.');
+    }
+
+    public function testWhereAttributeWithWhitespace(): void
+    {
+        $this->html('<a href="  /about  ">About</a>')->whereAttribute('a', 'href', '/about');
+    }
+
+    public function testWhereNotAttributeWithWhitespace(): void
+    {
+        $this->html('<a href="  /about  ">About</a>')->whereNotAttribute('a', 'href', '/contact');
+    }
 }

--- a/tests/Testing/Fluent/AssertableHtmlTest.php
+++ b/tests/Testing/Fluent/AssertableHtmlTest.php
@@ -461,11 +461,11 @@ class AssertableHtmlTest extends TestCase
 
     public function testSequence(): void
     {
-        $this->html('<ul><li><span>First</span></li><li><span>Second</span></li><li><span>Third</span></li></ul>')
+        $this->html('<ul><li><span class="even">First</span></li><li><span class="odd">Second</span></li><li><span class="even">Third</span></li></ul>')
             ->sequence('li',
-                fn (AssertableHtml $li) => $li->whereText('span', 'First'),
-                fn (AssertableHtml $li) => $li->whereText('span', 'Second'),
-                fn (AssertableHtml $li) => $li->whereText('span', 'Third'),
+                fn (AssertableHtml $li, int $i) => $li->whereText('span', 'First')->whereAttribute('span', 'class', $i % 2 === 0 ? 'even' : 'odd'),
+                fn (AssertableHtml $li, int $i) => $li->whereText('span', 'Second')->whereAttribute('span', 'class', $i % 2 === 0 ? 'even' : 'odd'),
+                fn (AssertableHtml $li, int $i) => $li->whereText('span', 'Third')->whereAttribute('span', 'class', $i % 2 === 0 ? 'even' : 'odd'),
             );
     }
 

--- a/tests/Testing/Fluent/AssertableHtmlTest.php
+++ b/tests/Testing/Fluent/AssertableHtmlTest.php
@@ -156,35 +156,6 @@ class AssertableHtmlTest extends TestCase
             ->whereText('p', fn ($text) => str_contains($text, 'Goodbye'));
     }
 
-    public function testWhereAllText(): void
-    {
-        $this->html('<p class="a">Foo</p><p class="b">Bar</p>')
-            ->whereAllText([
-                'p.a' => 'Foo',
-                'p.b' => 'Bar',
-            ]);
-    }
-
-    public function testWhereAllTextMismatch(): void
-    {
-        $this->expectException(AssertionFailedError::class);
-
-        $this->html('<p class="a">Foo</p><p class="b">Bar</p>')
-            ->whereAllText([
-                'p.a' => 'Foo',
-                'p.b' => 'Wrong',
-            ]);
-    }
-
-    public function testWhereAllTextWithClosures(): void
-    {
-        $this->html('<p class="a">Foo</p><p class="b">Bar</p>')
-            ->whereAllText([
-                'p.a' => fn ($text) => str_starts_with($text, 'F'),
-                'p.b' => 'Bar',
-            ]);
-    }
-
     public function testWhereNotText(): void
     {
         $this->html('<span class="badge">Paid</span>')->whereNotText('.badge', 'Overdue');

--- a/tests/Testing/Fluent/AssertableHtmlTest.php
+++ b/tests/Testing/Fluent/AssertableHtmlTest.php
@@ -282,6 +282,67 @@ class AssertableHtmlTest extends TestCase
         $this->html('<input type="email">')->hasAttr('input', 'disabled');
     }
 
+    // --- whereNotAttr ---
+
+    public function testWhereNotAttrPassesWhenAttributeDoesNotMatch(): void
+    {
+        $this->html('<a href="/about">About</a>')->whereNotAttr('a', 'href', '/contact');
+    }
+
+    public function testWhereNotAttrFailsWhenAttributeMatches(): void
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Failed asserting that [a] attribute [href] does not equal [/about].');
+
+        $this->html('<a href="/about">About</a>')->whereNotAttr('a', 'href', '/about');
+    }
+
+    public function testWhereNotAttrPassesWhenClosureReturnsFalse(): void
+    {
+        $this->html('<a href="/about">About</a>')
+            ->whereNotAttr('a', 'href', fn ($v) => str_starts_with($v, 'http'));
+    }
+
+    public function testWhereNotAttrFailsWhenClosureReturnsTrue(): void
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Failed asserting that [a] attribute [href] was marked as invalid using a closure.');
+
+        $this->html('<a href="/about">About</a>')
+            ->whereNotAttr('a', 'href', fn ($v) => str_starts_with($v, '/'));
+    }
+
+    // --- whereAttrs ---
+
+    public function testWhereAttrsPassesForAllAttributes(): void
+    {
+        $this->html('<a href="/about" class="nav-link">About</a>')
+            ->whereAttrs('a', [
+                'href'  => '/about',
+                'class' => 'nav-link',
+            ]);
+    }
+
+    public function testWhereAttrsPassesWithClosures(): void
+    {
+        $this->html('<a href="/about" class="nav-link">About</a>')
+            ->whereAttrs('a', [
+                'href'  => fn ($v) => str_starts_with($v, '/'),
+                'class' => 'nav-link',
+            ]);
+    }
+
+    public function testWhereAttrsFailsOnFirstMismatch(): void
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $this->html('<a href="/about" class="nav-link">About</a>')
+            ->whereAttrs('a', [
+                'href'  => '/about',
+                'class' => 'btn',
+            ]);
+    }
+
     // --- whereAttribute / hasAttribute aliases ---
 
     public function testWhereAttributeIsAliasForWhereAttr(): void

--- a/tests/Testing/Fluent/AssertableHtmlTest.php
+++ b/tests/Testing/Fluent/AssertableHtmlTest.php
@@ -4,8 +4,10 @@ namespace Illuminate\Tests\Testing\Fluent;
 
 use Illuminate\Testing\Fluent\AssertableHtml;
 use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Attributes\RequiresPhp;
 use PHPUnit\Framework\TestCase;
 
+#[RequiresPhp('>= 8.4.0')]
 class AssertableHtmlTest extends TestCase
 {
     private function html(string $body = ''): AssertableHtml

--- a/tests/Testing/Fluent/AssertableHtmlTest.php
+++ b/tests/Testing/Fluent/AssertableHtmlTest.php
@@ -343,6 +343,19 @@ class AssertableHtmlTest extends TestCase
         $this->html('<input type="email" required>')->missingAttribute('input', 'required');
     }
 
+    public function testMissingAttributesPassesWhenAllAttributesAbsent(): void
+    {
+        $this->html('<input type="email">')->missingAttributes('input', ['required', 'disabled']);
+    }
+
+    public function testMissingAttributesFailsWhenOneAttributePresent(): void
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Failed asserting that [input] does not have attribute [required].');
+
+        $this->html('<input type="email" required>')->missingAttributes('input', ['required', 'disabled']);
+    }
+
     public function testScopeNarrowsAssertionsToMatchedElement(): void
     {
         $this->html('<nav><a href="/home">Home</a></nav><footer><a href="/about">About</a></footer>')

--- a/tests/Testing/Fluent/AssertableHtmlTest.php
+++ b/tests/Testing/Fluent/AssertableHtmlTest.php
@@ -66,6 +66,23 @@ class AssertableHtmlTest extends TestCase
             });
     }
 
+    // --- hasAll ---
+
+    public function testHasAllPassesWhenAllSelectorsExist(): void
+    {
+        $this->html('<header></header><main></main><footer></footer>')
+            ->hasAll(['header', 'main', 'footer']);
+    }
+
+    public function testHasAllFailsWhenOneIsMissing(): void
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Failed asserting that element [footer] exists.');
+
+        $this->html('<header></header><main></main>')
+            ->hasAll(['header', 'main', 'footer']);
+    }
+
     // --- missing ---
 
     public function testMissingPassesWhenSelectorAbsent(): void
@@ -79,6 +96,23 @@ class AssertableHtmlTest extends TestCase
         $this->expectExceptionMessage('Failed asserting that [nav] is absent.');
 
         $this->html('<nav></nav>')->missing('nav');
+    }
+
+    // --- missingAll ---
+
+    public function testMissingAllPassesWhenAllSelectorsAbsent(): void
+    {
+        $this->html('<div></div>')
+            ->missingAll(['.alert', '.error', '.warning']);
+    }
+
+    public function testMissingAllFailsWhenOneIsPresent(): void
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Failed asserting that [.error] is absent.');
+
+        $this->html('<div class="error"></div>')
+            ->missingAll(['.alert', '.error', '.warning']);
     }
 
     // --- count ---
@@ -163,6 +197,44 @@ class AssertableHtmlTest extends TestCase
                 'p.a' => fn ($text) => str_starts_with($text, 'F'),
                 'p.b' => 'Bar',
             ]);
+    }
+
+    // --- whereNot ---
+
+    public function testWhereNotPassesWhenTextDoesNotMatch(): void
+    {
+        $this->html('<span class="badge">Paid</span>')->whereNot('.badge', 'Overdue');
+    }
+
+    public function testWhereNotFailsWhenTextMatches(): void
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Failed asserting that [.badge] text does not equal [Paid].');
+
+        $this->html('<span class="badge">Paid</span>')->whereNot('.badge', 'Paid');
+    }
+
+    public function testWhereNotPassesWhenClosureReturnsFalse(): void
+    {
+        $this->html('<p>Hello World</p>')
+            ->whereNot('p', fn ($text) => str_contains($text, 'Goodbye'));
+    }
+
+    public function testWhereNotFailsWhenClosureReturnsTrue(): void
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Failed asserting that [p] text was rejected by the truth test.');
+
+        $this->html('<p>Hello World</p>')
+            ->whereNot('p', fn ($text) => str_contains($text, 'Hello'));
+    }
+
+    public function testWhereNotFailsWhenSelectorMissing(): void
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Failed asserting that element [h2] exists.');
+
+        $this->html('<h1>Hello</h1>')->whereNot('h2', 'Hello');
     }
 
     // --- whereAttr ---

--- a/tests/Testing/Fluent/AssertableHtmlTest.php
+++ b/tests/Testing/Fluent/AssertableHtmlTest.php
@@ -237,137 +237,125 @@ class AssertableHtmlTest extends TestCase
         $this->html('<h1>Hello</h1>')->whereNot('h2', 'Hello');
     }
 
-    // --- whereAttr ---
+    // --- whereAttribute ---
 
-    public function testWhereAttrPassesWhenAttributeMatches(): void
+    public function testWhereAttributePassesWhenAttributeMatches(): void
     {
-        $this->html('<a href="/about">About</a>')->whereAttr('a', 'href', '/about');
+        $this->html('<a href="/about">About</a>')->whereAttribute('a', 'href', '/about');
     }
 
-    public function testWhereAttrFailsWhenAttributeMismatches(): void
+    public function testWhereAttributeFailsWhenAttributeMismatches(): void
     {
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Failed asserting that [a] attribute [href] equals [/contact], found [/about].');
 
-        $this->html('<a href="/about">About</a>')->whereAttr('a', 'href', '/contact');
+        $this->html('<a href="/about">About</a>')->whereAttribute('a', 'href', '/contact');
     }
 
-    public function testWhereAttrPassesWithClosureTruthTest(): void
+    public function testWhereAttributePassesWithClosureTruthTest(): void
     {
         $this->html('<a href="/about">About</a>')
-            ->whereAttr('a', 'href', fn ($value) => str_starts_with($value, '/'));
+            ->whereAttribute('a', 'href', fn ($value) => str_starts_with($value, '/'));
     }
 
-    public function testWhereAttrFailsWhenClosureReturnsFalse(): void
+    public function testWhereAttributeFailsWhenClosureReturnsFalse(): void
     {
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Failed asserting that [a] attribute [href] was marked as invalid using a closure.');
 
         $this->html('<a href="/about">About</a>')
-            ->whereAttr('a', 'href', fn ($value) => str_starts_with($value, 'http'));
+            ->whereAttribute('a', 'href', fn ($value) => str_starts_with($value, 'http'));
     }
 
-    // --- hasAttr ---
+    // --- hasAttribute ---
 
-    public function testHasAttrPassesWhenAttributePresent(): void
+    public function testHasAttributePassesWhenAttributePresent(): void
     {
-        $this->html('<input type="email" required>')->hasAttr('input', 'required');
+        $this->html('<input type="email" required>')->hasAttribute('input', 'required');
     }
 
-    public function testHasAttrFailsWhenAttributeAbsent(): void
+    public function testHasAttributeFailsWhenAttributeAbsent(): void
     {
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Failed asserting that [input] has attribute [disabled].');
 
-        $this->html('<input type="email">')->hasAttr('input', 'disabled');
+        $this->html('<input type="email">')->hasAttribute('input', 'disabled');
     }
 
-    // --- whereNotAttr ---
+    // --- whereNotAttribute ---
 
-    public function testWhereNotAttrPassesWhenAttributeDoesNotMatch(): void
+    public function testWhereNotAttributePassesWhenAttributeDoesNotMatch(): void
     {
-        $this->html('<a href="/about">About</a>')->whereNotAttr('a', 'href', '/contact');
+        $this->html('<a href="/about">About</a>')->whereNotAttribute('a', 'href', '/contact');
     }
 
-    public function testWhereNotAttrFailsWhenAttributeMatches(): void
+    public function testWhereNotAttributeFailsWhenAttributeMatches(): void
     {
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Failed asserting that [a] attribute [href] does not equal [/about].');
 
-        $this->html('<a href="/about">About</a>')->whereNotAttr('a', 'href', '/about');
+        $this->html('<a href="/about">About</a>')->whereNotAttribute('a', 'href', '/about');
     }
 
-    public function testWhereNotAttrPassesWhenClosureReturnsFalse(): void
+    public function testWhereNotAttributePassesWhenClosureReturnsFalse(): void
     {
         $this->html('<a href="/about">About</a>')
-            ->whereNotAttr('a', 'href', fn ($v) => str_starts_with($v, 'http'));
+            ->whereNotAttribute('a', 'href', fn ($v) => str_starts_with($v, 'http'));
     }
 
-    public function testWhereNotAttrFailsWhenClosureReturnsTrue(): void
+    public function testWhereNotAttributeFailsWhenClosureReturnsTrue(): void
     {
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Failed asserting that [a] attribute [href] was marked as invalid using a closure.');
 
         $this->html('<a href="/about">About</a>')
-            ->whereNotAttr('a', 'href', fn ($v) => str_starts_with($v, '/'));
+            ->whereNotAttribute('a', 'href', fn ($v) => str_starts_with($v, '/'));
     }
 
-    // --- whereAttrs ---
+    // --- whereAttributes ---
 
-    public function testWhereAttrsPassesForAllAttributes(): void
+    public function testWhereAttributesPassesForAllAttributes(): void
     {
         $this->html('<a href="/about" class="nav-link">About</a>')
-            ->whereAttrs('a', [
+            ->whereAttributes('a', [
                 'href'  => '/about',
                 'class' => 'nav-link',
             ]);
     }
 
-    public function testWhereAttrsPassesWithClosures(): void
+    public function testWhereAttributesPassesWithClosures(): void
     {
         $this->html('<a href="/about" class="nav-link">About</a>')
-            ->whereAttrs('a', [
+            ->whereAttributes('a', [
                 'href'  => fn ($v) => str_starts_with($v, '/'),
                 'class' => 'nav-link',
             ]);
     }
 
-    public function testWhereAttrsFailsOnFirstMismatch(): void
+    public function testWhereAttributesFailsOnFirstMismatch(): void
     {
         $this->expectException(AssertionFailedError::class);
 
         $this->html('<a href="/about" class="nav-link">About</a>')
-            ->whereAttrs('a', [
+            ->whereAttributes('a', [
                 'href'  => '/about',
                 'class' => 'btn',
             ]);
     }
 
-    // --- whereAttribute / hasAttribute aliases ---
+    // --- missingAttribute ---
 
-    public function testWhereAttributeIsAliasForWhereAttr(): void
+    public function testMissingAttributePassesWhenAttributeAbsent(): void
     {
-        $this->html('<a href="/about">About</a>')->whereAttribute('a', 'href', '/about');
+        $this->html('<input type="email">')->missingAttribute('input', 'disabled');
     }
 
-    public function testHasAttributeIsAliasForHasAttr(): void
-    {
-        $this->html('<input type="email" required>')->hasAttribute('input', 'required');
-    }
-
-    // --- missingAttr ---
-
-    public function testMissingAttrPassesWhenAttributeAbsent(): void
-    {
-        $this->html('<input type="email">')->missingAttr('input', 'disabled');
-    }
-
-    public function testMissingAttrFailsWhenAttributePresent(): void
+    public function testMissingAttributeFailsWhenAttributePresent(): void
     {
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Failed asserting that [input] does not have attribute [required].');
 
-        $this->html('<input type="email" required>')->missingAttr('input', 'required');
+        $this->html('<input type="email" required>')->missingAttribute('input', 'required');
     }
 
     // --- scope ---
@@ -435,9 +423,9 @@ class AssertableHtmlTest extends TestCase
             ->count('a', 1)
             ->where('a', 'Home')
             ->where('nav', fn ($text) => str_contains($text, 'Home'))
-            ->whereAttr('a', 'href', '/')
-            ->hasAttr('a', 'class')
-            ->missingAttr('a', 'disabled');
+            ->whereAttribute('a', 'href', '/')
+            ->hasAttribute('a', 'class')
+            ->missingAttribute('a', 'disabled');
 
         $this->assertSame($assert, $result);
     }

--- a/tests/Testing/Fluent/AssertableHtmlTest.php
+++ b/tests/Testing/Fluent/AssertableHtmlTest.php
@@ -252,6 +252,21 @@ class AssertableHtmlTest extends TestCase
         $this->html('<a href="/about">About</a>')->whereAttr('a', 'href', '/contact');
     }
 
+    public function testWhereAttrPassesWithClosureTruthTest(): void
+    {
+        $this->html('<a href="/about">About</a>')
+            ->whereAttr('a', 'href', fn ($value) => str_starts_with($value, '/'));
+    }
+
+    public function testWhereAttrFailsWhenClosureReturnsFalse(): void
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Failed asserting that [a] attribute [href] was accepted by the truth test.');
+
+        $this->html('<a href="/about">About</a>')
+            ->whereAttr('a', 'href', fn ($value) => str_starts_with($value, 'http'));
+    }
+
     // --- hasAttr ---
 
     public function testHasAttrPassesWhenAttributePresent(): void

--- a/tests/Testing/Fluent/AssertableHtmlTest.php
+++ b/tests/Testing/Fluent/AssertableHtmlTest.php
@@ -160,6 +160,16 @@ class AssertableHtmlTest extends TestCase
         $this->html('<h1>Hello</h1>')->whereText('h2', 'Hello');
     }
 
+    public function testWhereTextWithWhitespace(): void
+    {
+        $this->html('<p>  Hello World  </p>')->whereText('p', 'Hello World');
+    }
+
+    public function testWhereNotTextWithWhitespace(): void
+    {
+        $this->html('<p>  Hello World  </p>')->whereNotText('p', 'Goodbye');
+    }
+
     public function testWhereTextWithClosure(): void
     {
         $this->html('<p>Hello World</p>')

--- a/tests/Testing/Fluent/AssertableHtmlTest.php
+++ b/tests/Testing/Fluent/AssertableHtmlTest.php
@@ -119,19 +119,19 @@ class AssertableHtmlTest extends TestCase
         $this->html('<h1>Hello</h1>')->where('h2', 'Hello');
     }
 
-    // --- whereContains ---
-
-    public function testWhereContainsPassesWhenTextContainsExpected(): void
+    public function testWherePassesWithClosureTruthTest(): void
     {
-        $this->html('<p>Hello World</p>')->whereContains('p', 'World');
+        $this->html('<p>Hello World</p>')
+            ->where('p', fn ($text) => str_contains($text, 'World'));
     }
 
-    public function testWhereContainsFailsWhenTextDoesNotContainExpected(): void
+    public function testWhereFailsWhenClosureReturnsFalse(): void
     {
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Failed asserting that [p] text contains [Goodbye], found [Hello World].');
+        $this->expectExceptionMessage('Failed asserting that [p] text was accepted by the truth test.');
 
-        $this->html('<p>Hello World</p>')->whereContains('p', 'Goodbye');
+        $this->html('<p>Hello World</p>')
+            ->where('p', fn ($text) => str_contains($text, 'Goodbye'));
     }
 
     // --- whereAll ---
@@ -153,6 +153,15 @@ class AssertableHtmlTest extends TestCase
             ->whereAll([
                 'p.a' => 'Foo',
                 'p.b' => 'Wrong',
+            ]);
+    }
+
+    public function testWhereAllPassesWithClosures(): void
+    {
+        $this->html('<p class="a">Foo</p><p class="b">Bar</p>')
+            ->whereAll([
+                'p.a' => fn ($text) => str_starts_with($text, 'F'),
+                'p.b' => 'Bar',
             ]);
     }
 

--- a/tests/Testing/Fluent/AssertableHtmlTest.php
+++ b/tests/Testing/Fluent/AssertableHtmlTest.php
@@ -282,6 +282,21 @@ class AssertableHtmlTest extends TestCase
         $this->html('<input type="email">')->hasAttribute('input', 'disabled');
     }
 
+    // --- hasAttributes ---
+
+    public function testHasAttributesPassesWhenAllAttributesPresent(): void
+    {
+        $this->html('<input type="email" required disabled>')->hasAttributes('input', ['required', 'disabled']);
+    }
+
+    public function testHasAttributesFailsWhenOneAttributeAbsent(): void
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Failed asserting that [input] has attribute [disabled].');
+
+        $this->html('<input type="email" required>')->hasAttributes('input', ['required', 'disabled']);
+    }
+
     // --- whereNotAttribute ---
 
     public function testWhereNotAttributePassesWhenAttributeDoesNotMatch(): void

--- a/tests/Testing/Fluent/AssertableHtmlTest.php
+++ b/tests/Testing/Fluent/AssertableHtmlTest.php
@@ -54,19 +54,19 @@ class AssertableHtmlTest extends TestCase
         $this->html('<div></div>')->has('nav');
     }
 
-    public function testHasAll(): void
+    public function testHasMultiple(): void
     {
         $this->html('<header></header><main></main><footer></footer>')
-            ->hasAll(['header', 'main', 'footer']);
+            ->has('header', 'main', 'footer');
     }
 
-    public function testHasAllMissingSelector(): void
+    public function testHasMultipleMissingSelector(): void
     {
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Failed asserting that element [footer] exists.');
 
         $this->html('<header></header><main></main>')
-            ->hasAll(['header', 'main', 'footer']);
+            ->has('header', 'main', 'footer');
     }
 
     public function testMissing(): void
@@ -82,19 +82,19 @@ class AssertableHtmlTest extends TestCase
         $this->html('<nav></nav>')->missing('nav');
     }
 
-    public function testMissingAll(): void
+    public function testMissingMultiple(): void
     {
         $this->html('<div></div>')
-            ->missingAll(['.alert', '.error', '.warning']);
+            ->missing('.alert', '.error', '.warning');
     }
 
-    public function testMissingAllPresentSelector(): void
+    public function testMissingMultiplePresentSelector(): void
     {
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Failed asserting that [.error] is absent.');
 
         $this->html('<div class="error"></div>')
-            ->missingAll(['.alert', '.error', '.warning']);
+            ->missing('.alert', '.error', '.warning');
     }
 
     public function testCount(): void
@@ -249,22 +249,9 @@ class AssertableHtmlTest extends TestCase
             ->whereAttribute('a', 'href', fn ($value) => str_starts_with($value, 'http'));
     }
 
-    public function testHasAttribute(): void
-    {
-        $this->html('<input type="email" required>')->hasAttribute('input', 'required');
-    }
-
-    public function testHasAttributeMissing(): void
-    {
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Failed asserting that [input] has attribute [disabled].');
-
-        $this->html('<input type="email">')->hasAttribute('input', 'disabled');
-    }
-
     public function testHasAttributes(): void
     {
-        $this->html('<input type="email" required disabled>')->hasAttributes('input', ['required', 'disabled']);
+        $this->html('<input type="email" required>')->hasAttributes('input', 'required');
     }
 
     public function testHasAttributesMissing(): void
@@ -272,7 +259,20 @@ class AssertableHtmlTest extends TestCase
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Failed asserting that [input] has attribute [disabled].');
 
-        $this->html('<input type="email" required>')->hasAttributes('input', ['required', 'disabled']);
+        $this->html('<input type="email">')->hasAttributes('input', 'disabled');
+    }
+
+    public function testHasAttributesMultiple(): void
+    {
+        $this->html('<input type="email" required disabled>')->hasAttributes('input', 'required', 'disabled');
+    }
+
+    public function testHasAttributesMultipleMissing(): void
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Failed asserting that [input] has attribute [disabled].');
+
+        $this->html('<input type="email" required>')->hasAttributes('input', 'required', 'disabled');
     }
 
     public function testWhereNotAttribute(): void
@@ -332,22 +332,9 @@ class AssertableHtmlTest extends TestCase
             ]);
     }
 
-    public function testMissingAttribute(): void
-    {
-        $this->html('<input type="email">')->missingAttribute('input', 'disabled');
-    }
-
-    public function testMissingAttributePresent(): void
-    {
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Failed asserting that [input] does not have attribute [required].');
-
-        $this->html('<input type="email" required>')->missingAttribute('input', 'required');
-    }
-
     public function testMissingAttributes(): void
     {
-        $this->html('<input type="email">')->missingAttributes('input', ['required', 'disabled']);
+        $this->html('<input type="email">')->missingAttributes('input', 'disabled');
     }
 
     public function testMissingAttributesPresent(): void
@@ -355,7 +342,20 @@ class AssertableHtmlTest extends TestCase
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Failed asserting that [input] does not have attribute [required].');
 
-        $this->html('<input type="email" required>')->missingAttributes('input', ['required', 'disabled']);
+        $this->html('<input type="email" required>')->missingAttributes('input', 'required');
+    }
+
+    public function testMissingAttributesMultiple(): void
+    {
+        $this->html('<input type="email">')->missingAttributes('input', 'required', 'disabled');
+    }
+
+    public function testMissingAttributesMultiplePresent(): void
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Failed asserting that [input] does not have attribute [required].');
+
+        $this->html('<input type="email" required>')->missingAttributes('input', 'required', 'disabled');
     }
 
     public function testScope(): void
@@ -500,8 +500,8 @@ class AssertableHtmlTest extends TestCase
             ->whereText('a', 'Home')
             ->whereText('nav', fn ($text) => str_contains($text, 'Home'))
             ->whereAttribute('a', 'href', '/')
-            ->hasAttribute('a', 'class')
-            ->missingAttribute('a', 'disabled');
+            ->hasAttributes('a', 'class')
+            ->missingAttributes('a', 'disabled', 'hidden');
 
         $this->assertSame($assert, $result);
     }

--- a/tests/Testing/Fluent/AssertableHtmlTest.php
+++ b/tests/Testing/Fluent/AssertableHtmlTest.php
@@ -118,105 +118,105 @@ class AssertableHtmlTest extends TestCase
         $this->html('<ul><li>a</li><li>b</li></ul>')->count('li', 3);
     }
 
-    public function testWherePassesWhenTextMatches(): void
+    public function testWhereTextPassesWhenTextMatches(): void
     {
-        $this->html('<h1>Hello World</h1>')->where('h1', 'Hello World');
+        $this->html('<h1>Hello World</h1>')->whereText('h1', 'Hello World');
     }
 
-    public function testWhereFailsWhenTextMismatches(): void
+    public function testWhereTextFailsWhenTextMismatches(): void
     {
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Failed asserting that [h1] text equals [Goodbye], found [Hello World].');
 
-        $this->html('<h1>Hello World</h1>')->where('h1', 'Goodbye');
+        $this->html('<h1>Hello World</h1>')->whereText('h1', 'Goodbye');
     }
 
-    public function testWhereFailsWhenSelectorMissing(): void
+    public function testWhereTextFailsWhenSelectorMissing(): void
     {
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Failed asserting that element [h2] exists.');
 
-        $this->html('<h1>Hello</h1>')->where('h2', 'Hello');
+        $this->html('<h1>Hello</h1>')->whereText('h2', 'Hello');
     }
 
-    public function testWherePassesWithClosureTruthTest(): void
+    public function testWhereTextPassesWithClosureTruthTest(): void
     {
         $this->html('<p>Hello World</p>')
-            ->where('p', fn ($text) => str_contains($text, 'World'));
+            ->whereText('p', fn ($text) => str_contains($text, 'World'));
     }
 
-    public function testWhereFailsWhenClosureReturnsFalse(): void
+    public function testWhereTextFailsWhenClosureReturnsFalse(): void
     {
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Failed asserting that [p] text was marked as invalid using a closure.');
 
         $this->html('<p>Hello World</p>')
-            ->where('p', fn ($text) => str_contains($text, 'Goodbye'));
+            ->whereText('p', fn ($text) => str_contains($text, 'Goodbye'));
     }
 
-    public function testWhereAllPassesForAllSelectors(): void
+    public function testWhereAllTextPassesForAllSelectors(): void
     {
         $this->html('<p class="a">Foo</p><p class="b">Bar</p>')
-            ->whereAll([
+            ->whereAllText([
                 'p.a' => 'Foo',
                 'p.b' => 'Bar',
             ]);
     }
 
-    public function testWhereAllFailsOnFirstMismatch(): void
+    public function testWhereAllTextFailsOnFirstMismatch(): void
     {
         $this->expectException(AssertionFailedError::class);
 
         $this->html('<p class="a">Foo</p><p class="b">Bar</p>')
-            ->whereAll([
+            ->whereAllText([
                 'p.a' => 'Foo',
                 'p.b' => 'Wrong',
             ]);
     }
 
-    public function testWhereAllPassesWithClosures(): void
+    public function testWhereAllTextPassesWithClosures(): void
     {
         $this->html('<p class="a">Foo</p><p class="b">Bar</p>')
-            ->whereAll([
+            ->whereAllText([
                 'p.a' => fn ($text) => str_starts_with($text, 'F'),
                 'p.b' => 'Bar',
             ]);
     }
 
-    public function testWhereNotPassesWhenTextDoesNotMatch(): void
+    public function testWhereNotTextPassesWhenTextDoesNotMatch(): void
     {
-        $this->html('<span class="badge">Paid</span>')->whereNot('.badge', 'Overdue');
+        $this->html('<span class="badge">Paid</span>')->whereNotText('.badge', 'Overdue');
     }
 
-    public function testWhereNotFailsWhenTextMatches(): void
+    public function testWhereNotTextFailsWhenTextMatches(): void
     {
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Failed asserting that [.badge] text does not equal [Paid].');
 
-        $this->html('<span class="badge">Paid</span>')->whereNot('.badge', 'Paid');
+        $this->html('<span class="badge">Paid</span>')->whereNotText('.badge', 'Paid');
     }
 
-    public function testWhereNotPassesWhenClosureReturnsFalse(): void
+    public function testWhereNotTextPassesWhenClosureReturnsFalse(): void
     {
         $this->html('<p>Hello World</p>')
-            ->whereNot('p', fn ($text) => str_contains($text, 'Goodbye'));
+            ->whereNotText('p', fn ($text) => str_contains($text, 'Goodbye'));
     }
 
-    public function testWhereNotFailsWhenClosureReturnsTrue(): void
+    public function testWhereNotTextFailsWhenClosureReturnsTrue(): void
     {
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Failed asserting that [p] text was marked as invalid using a closure.');
 
         $this->html('<p>Hello World</p>')
-            ->whereNot('p', fn ($text) => str_contains($text, 'Hello'));
+            ->whereNotText('p', fn ($text) => str_contains($text, 'Hello'));
     }
 
-    public function testWhereNotFailsWhenSelectorMissing(): void
+    public function testWhereNotTextFailsWhenSelectorMissing(): void
     {
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Failed asserting that element [h2] exists.');
 
-        $this->html('<h1>Hello</h1>')->whereNot('h2', 'Hello');
+        $this->html('<h1>Hello</h1>')->whereNotText('h2', 'Hello');
     }
 
     public function testWhereAttributePassesWhenAttributeMatches(): void
@@ -413,8 +413,8 @@ class AssertableHtmlTest extends TestCase
             ->has('nav')
             ->missing('aside')
             ->count('a', 1)
-            ->where('a', 'Home')
-            ->where('nav', fn ($text) => str_contains($text, 'Home'))
+            ->whereText('a', 'Home')
+            ->whereText('nav', fn ($text) => str_contains($text, 'Home'))
             ->whereAttribute('a', 'href', '/')
             ->hasAttribute('a', 'class')
             ->missingAttribute('a', 'disabled');

--- a/tests/Testing/Fluent/AssertableHtmlTest.php
+++ b/tests/Testing/Fluent/AssertableHtmlTest.php
@@ -13,16 +13,12 @@ class AssertableHtmlTest extends TestCase
         return AssertableHtml::fromString("<html><body>{$body}</body></html>");
     }
 
-    // --- fromString ---
-
     public function testFromStringParsesValidHtml(): void
     {
         $assert = $this->html('<p>Hello</p>');
 
         $assert->has('p');
     }
-
-    // --- has ---
 
     public function testHasPassesWhenSelectorExists(): void
     {
@@ -66,8 +62,6 @@ class AssertableHtmlTest extends TestCase
             });
     }
 
-    // --- hasAll ---
-
     public function testHasAllPassesWhenAllSelectorsExist(): void
     {
         $this->html('<header></header><main></main><footer></footer>')
@@ -83,8 +77,6 @@ class AssertableHtmlTest extends TestCase
             ->hasAll(['header', 'main', 'footer']);
     }
 
-    // --- missing ---
-
     public function testMissingPassesWhenSelectorAbsent(): void
     {
         $this->html('<div></div>')->missing('nav');
@@ -97,8 +89,6 @@ class AssertableHtmlTest extends TestCase
 
         $this->html('<nav></nav>')->missing('nav');
     }
-
-    // --- missingAll ---
 
     public function testMissingAllPassesWhenAllSelectorsAbsent(): void
     {
@@ -115,8 +105,6 @@ class AssertableHtmlTest extends TestCase
             ->missingAll(['.alert', '.error', '.warning']);
     }
 
-    // --- count ---
-
     public function testCountPassesWhenCountMatches(): void
     {
         $this->html('<ul><li>a</li><li>b</li></ul>')->count('li', 2);
@@ -129,8 +117,6 @@ class AssertableHtmlTest extends TestCase
 
         $this->html('<ul><li>a</li><li>b</li></ul>')->count('li', 3);
     }
-
-    // --- where ---
 
     public function testWherePassesWhenTextMatches(): void
     {
@@ -168,8 +154,6 @@ class AssertableHtmlTest extends TestCase
             ->where('p', fn ($text) => str_contains($text, 'Goodbye'));
     }
 
-    // --- whereAll ---
-
     public function testWhereAllPassesForAllSelectors(): void
     {
         $this->html('<p class="a">Foo</p><p class="b">Bar</p>')
@@ -198,8 +182,6 @@ class AssertableHtmlTest extends TestCase
                 'p.b' => 'Bar',
             ]);
     }
-
-    // --- whereNot ---
 
     public function testWhereNotPassesWhenTextDoesNotMatch(): void
     {
@@ -237,8 +219,6 @@ class AssertableHtmlTest extends TestCase
         $this->html('<h1>Hello</h1>')->whereNot('h2', 'Hello');
     }
 
-    // --- whereAttribute ---
-
     public function testWhereAttributePassesWhenAttributeMatches(): void
     {
         $this->html('<a href="/about">About</a>')->whereAttribute('a', 'href', '/about');
@@ -267,8 +247,6 @@ class AssertableHtmlTest extends TestCase
             ->whereAttribute('a', 'href', fn ($value) => str_starts_with($value, 'http'));
     }
 
-    // --- hasAttribute ---
-
     public function testHasAttributePassesWhenAttributePresent(): void
     {
         $this->html('<input type="email" required>')->hasAttribute('input', 'required');
@@ -282,8 +260,6 @@ class AssertableHtmlTest extends TestCase
         $this->html('<input type="email">')->hasAttribute('input', 'disabled');
     }
 
-    // --- hasAttributes ---
-
     public function testHasAttributesPassesWhenAllAttributesPresent(): void
     {
         $this->html('<input type="email" required disabled>')->hasAttributes('input', ['required', 'disabled']);
@@ -296,8 +272,6 @@ class AssertableHtmlTest extends TestCase
 
         $this->html('<input type="email" required>')->hasAttributes('input', ['required', 'disabled']);
     }
-
-    // --- whereNotAttribute ---
 
     public function testWhereNotAttributePassesWhenAttributeDoesNotMatch(): void
     {
@@ -326,8 +300,6 @@ class AssertableHtmlTest extends TestCase
         $this->html('<a href="/about">About</a>')
             ->whereNotAttribute('a', 'href', fn ($v) => str_starts_with($v, '/'));
     }
-
-    // --- whereAttributes ---
 
     public function testWhereAttributesPassesForAllAttributes(): void
     {
@@ -358,8 +330,6 @@ class AssertableHtmlTest extends TestCase
             ]);
     }
 
-    // --- missingAttribute ---
-
     public function testMissingAttributePassesWhenAttributeAbsent(): void
     {
         $this->html('<input type="email">')->missingAttribute('input', 'disabled');
@@ -372,8 +342,6 @@ class AssertableHtmlTest extends TestCase
 
         $this->html('<input type="email" required>')->missingAttribute('input', 'required');
     }
-
-    // --- scope ---
 
     public function testScopeNarrowsAssertionsToMatchedElement(): void
     {
@@ -393,8 +361,6 @@ class AssertableHtmlTest extends TestCase
             //
         });
     }
-
-    // --- each ---
 
     public function testEachIteratesAllMatchingElements(): void
     {
@@ -426,8 +392,6 @@ class AssertableHtmlTest extends TestCase
         $this->html('<div></div>')->each('li', fn ($li) => null);
     }
 
-    // --- chaining ---
-
     public function testMethodsReturnStaticForChaining(): void
     {
         $assert = $this->html('<nav><a href="/" class="active">Home</a></nav>');
@@ -444,8 +408,6 @@ class AssertableHtmlTest extends TestCase
 
         $this->assertSame($assert, $result);
     }
-
-    // --- failure output includes scope HTML ---
 
     public function testFailureMessageIncludesScopeHtml(): void
     {

--- a/tests/Testing/Fluent/AssertableHtmlTest.php
+++ b/tests/Testing/Fluent/AssertableHtmlTest.php
@@ -3,9 +3,12 @@
 namespace Illuminate\Tests\Testing\Fluent;
 
 use Illuminate\Testing\Fluent\AssertableHtml;
+use Illuminate\Testing\TestResponse;
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\Attributes\RequiresPhp;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 #[RequiresPhp('>= 8.4.0')]
 class AssertableHtmlTest extends TestCase
@@ -20,6 +23,22 @@ class AssertableHtmlTest extends TestCase
         $assert = $this->html('<p>Hello</p>');
 
         $assert->has('p');
+    }
+
+    public function testFromResponse(): void
+    {
+        $response = TestResponse::fromBaseResponse(new Response('<html><body><p>Hello</p></body></html>'));
+
+        AssertableHtml::fromResponse($response)->has('p');
+    }
+
+    public function testFromStreamedResponse(): void
+    {
+        $response = TestResponse::fromBaseResponse(new StreamedResponse(function () {
+            echo '<html><body><p>Hello</p></body></html>';
+        }));
+
+        AssertableHtml::fromResponse($response)->has('p');
     }
 
     public function testHas(): void

--- a/tests/Testing/Fluent/AssertableHtmlTest.php
+++ b/tests/Testing/Fluent/AssertableHtmlTest.php
@@ -326,7 +326,7 @@ class AssertableHtmlTest extends TestCase
     {
         $this->html('<a href="/about" class="nav-link">About</a>')
             ->whereAttributes('a', [
-                'href'  => '/about',
+                'href' => '/about',
                 'class' => 'nav-link',
             ]);
     }
@@ -335,7 +335,7 @@ class AssertableHtmlTest extends TestCase
     {
         $this->html('<a href="/about" class="nav-link">About</a>')
             ->whereAttributes('a', [
-                'href'  => fn ($v) => str_starts_with($v, '/'),
+                'href' => fn ($v) => str_starts_with($v, '/'),
                 'class' => 'nav-link',
             ]);
     }
@@ -346,7 +346,7 @@ class AssertableHtmlTest extends TestCase
 
         $this->html('<a href="/about" class="nav-link">About</a>')
             ->whereAttributes('a', [
-                'href'  => '/about',
+                'href' => '/about',
                 'class' => 'btn',
             ]);
     }

--- a/tests/Testing/Fluent/AssertableHtmlTest.php
+++ b/tests/Testing/Fluent/AssertableHtmlTest.php
@@ -1,0 +1,310 @@
+<?php
+
+namespace Illuminate\Tests\Testing\Fluent;
+
+use Illuminate\Testing\Fluent\AssertableHtml;
+use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\TestCase;
+
+class AssertableHtmlTest extends TestCase
+{
+    private function html(string $body = ''): AssertableHtml
+    {
+        return AssertableHtml::fromString("<html><body>{$body}</body></html>");
+    }
+
+    // --- fromString ---
+
+    public function testFromStringParsesValidHtml(): void
+    {
+        $assert = $this->html('<p>Hello</p>');
+
+        $assert->has('p');
+    }
+
+    // --- has ---
+
+    public function testHasPassesWhenSelectorExists(): void
+    {
+        $this->html('<nav><a href="/">Home</a></nav>')->has('nav');
+    }
+
+    public function testHasFailsWhenSelectorMissing(): void
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Failed asserting that element [nav] exists.');
+
+        $this->html('<div></div>')->has('nav');
+    }
+
+    public function testHasWithCountPassesWhenCountMatches(): void
+    {
+        $this->html('<ul><li>a</li><li>b</li><li>c</li></ul>')->has('li', 3);
+    }
+
+    public function testHasWithCountFailsWhenCountMismatches(): void
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Failed asserting that [li] matches 2 element(s), found 3.');
+
+        $this->html('<ul><li>a</li><li>b</li><li>c</li></ul>')->has('li', 2);
+    }
+
+    public function testHasWithCallbackScopesIntoElement(): void
+    {
+        $this->html('<nav><a href="/about">About</a></nav>')
+            ->has('nav', function (AssertableHtml $nav) {
+                $nav->has('a[href="/about"]');
+            });
+    }
+
+    public function testHasWithCountAndCallbackScopesIntoFirstMatch(): void
+    {
+        $this->html('<ul><li class="item"><a href="/a">A</a></li><li class="item"><a href="/b">B</a></li></ul>')
+            ->has('li.item', 2, function (AssertableHtml $li) {
+                $li->has('a');  // scoped into first li.item
+            });
+    }
+
+    // --- missing ---
+
+    public function testMissingPassesWhenSelectorAbsent(): void
+    {
+        $this->html('<div></div>')->missing('nav');
+    }
+
+    public function testMissingFailsWhenSelectorPresent(): void
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Failed asserting that [nav] is absent.');
+
+        $this->html('<nav></nav>')->missing('nav');
+    }
+
+    // --- count ---
+
+    public function testCountPassesWhenCountMatches(): void
+    {
+        $this->html('<ul><li>a</li><li>b</li></ul>')->count('li', 2);
+    }
+
+    public function testCountFailsWhenCountMismatches(): void
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Failed asserting that [li] matches 3 element(s), found 2.');
+
+        $this->html('<ul><li>a</li><li>b</li></ul>')->count('li', 3);
+    }
+
+    // --- where ---
+
+    public function testWherePassesWhenTextMatches(): void
+    {
+        $this->html('<h1>Hello World</h1>')->where('h1', 'Hello World');
+    }
+
+    public function testWhereFailsWhenTextMismatches(): void
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Failed asserting that [h1] text equals [Goodbye], found [Hello World].');
+
+        $this->html('<h1>Hello World</h1>')->where('h1', 'Goodbye');
+    }
+
+    public function testWhereFailsWhenSelectorMissing(): void
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Failed asserting that element [h2] exists.');
+
+        $this->html('<h1>Hello</h1>')->where('h2', 'Hello');
+    }
+
+    // --- whereContains ---
+
+    public function testWhereContainsPassesWhenTextContainsExpected(): void
+    {
+        $this->html('<p>Hello World</p>')->whereContains('p', 'World');
+    }
+
+    public function testWhereContainsFailsWhenTextDoesNotContainExpected(): void
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Failed asserting that [p] text contains [Goodbye], found [Hello World].');
+
+        $this->html('<p>Hello World</p>')->whereContains('p', 'Goodbye');
+    }
+
+    // --- whereAll ---
+
+    public function testWhereAllPassesForAllSelectors(): void
+    {
+        $this->html('<p class="a">Foo</p><p class="b">Bar</p>')
+            ->whereAll([
+                'p.a' => 'Foo',
+                'p.b' => 'Bar',
+            ]);
+    }
+
+    public function testWhereAllFailsOnFirstMismatch(): void
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $this->html('<p class="a">Foo</p><p class="b">Bar</p>')
+            ->whereAll([
+                'p.a' => 'Foo',
+                'p.b' => 'Wrong',
+            ]);
+    }
+
+    // --- whereAttr ---
+
+    public function testWhereAttrPassesWhenAttributeMatches(): void
+    {
+        $this->html('<a href="/about">About</a>')->whereAttr('a', 'href', '/about');
+    }
+
+    public function testWhereAttrFailsWhenAttributeMismatches(): void
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Failed asserting that [a] attribute [href] equals [/contact], found [/about].');
+
+        $this->html('<a href="/about">About</a>')->whereAttr('a', 'href', '/contact');
+    }
+
+    // --- hasAttr ---
+
+    public function testHasAttrPassesWhenAttributePresent(): void
+    {
+        $this->html('<input type="email" required>')->hasAttr('input', 'required');
+    }
+
+    public function testHasAttrFailsWhenAttributeAbsent(): void
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Failed asserting that [input] has attribute [disabled].');
+
+        $this->html('<input type="email">')->hasAttr('input', 'disabled');
+    }
+
+    // --- missingAttr ---
+
+    public function testMissingAttrPassesWhenAttributeAbsent(): void
+    {
+        $this->html('<input type="email">')->missingAttr('input', 'disabled');
+    }
+
+    public function testMissingAttrFailsWhenAttributePresent(): void
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Failed asserting that [input] does not have attribute [required].');
+
+        $this->html('<input type="email" required>')->missingAttr('input', 'required');
+    }
+
+    // --- scope ---
+
+    public function testScopeNarrowsAssertionsToMatchedElement(): void
+    {
+        $this->html('<nav><a href="/home">Home</a></nav><footer><a href="/about">About</a></footer>')
+            ->scope('nav', function (AssertableHtml $nav) {
+                $nav->has('a[href="/home"]');
+                $nav->missing('a[href="/about"]');
+            });
+    }
+
+    public function testScopeFailsWhenSelectorMissing(): void
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Failed to find element matching selector [aside].');
+
+        $this->html('<nav></nav>')->scope('aside', function (AssertableHtml $el) {
+            //
+        });
+    }
+
+    // --- each ---
+
+    public function testEachIteratesAllMatchingElements(): void
+    {
+        $count = 0;
+
+        $this->html('<ul><li>a</li><li>b</li><li>c</li></ul>')
+            ->each('li', function (AssertableHtml $li, int $index) use (&$count) {
+                $count++;
+            });
+
+        $this->assertSame(3, $count);
+    }
+
+    public function testEachReportsFailingIndex(): void
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Failed assertion on element [li] at index [1]');
+
+        $this->html('<ul><li><a href="/a">A</a></li><li><span>no link</span></li></ul>')
+            ->each('li', function (AssertableHtml $li) {
+                $li->has('a');
+            });
+    }
+
+    public function testEachFailsWhenNoElementsMatch(): void
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $this->html('<div></div>')->each('li', fn ($li) => null);
+    }
+
+    // --- chaining ---
+
+    public function testMethodsReturnStaticForChaining(): void
+    {
+        $assert = $this->html('<nav><a href="/" class="active">Home</a></nav>');
+
+        $result = $assert
+            ->has('nav')
+            ->missing('aside')
+            ->count('a', 1)
+            ->where('a', 'Home')
+            ->whereContains('nav', 'Home')
+            ->whereAttr('a', 'href', '/')
+            ->hasAttr('a', 'class')
+            ->missingAttr('a', 'disabled');
+
+        $this->assertSame($assert, $result);
+    }
+
+    // --- failure output includes scope HTML ---
+
+    public function testFailureMessageIncludesScopeHtml(): void
+    {
+        try {
+            $this->html('<nav><a href="/">Home</a></nav>')->has('footer');
+        } catch (AssertionFailedError $e) {
+            $this->assertStringContainsString('Scope HTML:', $e->getMessage());
+            $this->assertStringContainsString('<nav>', $e->getMessage());
+
+            return;
+        }
+
+        $this->fail('Expected an AssertionFailedError.');
+    }
+
+    public function testScopedFailureMessageIncludesScopedElementHtml(): void
+    {
+        try {
+            $this->html('<nav><a href="/">Home</a></nav>')
+                ->scope('nav', function (AssertableHtml $nav) {
+                    $nav->has('button');
+                });
+        } catch (AssertionFailedError $e) {
+            $this->assertStringContainsString('Scope HTML:', $e->getMessage());
+            $this->assertStringContainsString('<nav>', $e->getMessage());
+            // Should not include the full document
+            $this->assertStringNotContainsString('<html>', $e->getMessage());
+
+            return;
+        }
+
+        $this->fail('Expected an AssertionFailedError.');
+    }
+}

--- a/tests/Testing/Fluent/AssertableHtmlTest.php
+++ b/tests/Testing/Fluent/AssertableHtmlTest.php
@@ -186,6 +186,18 @@ class AssertableHtmlTest extends TestCase
         $this->html('<input type="email">')->hasAttr('input', 'disabled');
     }
 
+    // --- whereAttribute / hasAttribute aliases ---
+
+    public function testWhereAttributeIsAliasForWhereAttr(): void
+    {
+        $this->html('<a href="/about">About</a>')->whereAttribute('a', 'href', '/about');
+    }
+
+    public function testHasAttributeIsAliasForHasAttr(): void
+    {
+        $this->html('<input type="email" required>')->hasAttribute('input', 'required');
+    }
+
     // --- missingAttr ---
 
     public function testMissingAttrPassesWhenAttributeAbsent(): void

--- a/tests/Testing/Fluent/AssertableHtmlTest.php
+++ b/tests/Testing/Fluent/AssertableHtmlTest.php
@@ -469,6 +469,14 @@ class AssertableHtmlTest extends TestCase
             );
     }
 
+    public function testSequenceNoCallbacks(): void
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('No sequence expectations defined for [li].');
+
+        $this->html('<ul><li>First</li></ul>')->sequence('li');
+    }
+
     public function testSequenceCountMismatch(): void
     {
         $this->expectException(AssertionFailedError::class);


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR adds fluent HTML assertions using PHP 8.4's new built in HTML5 parser. I built it because testing HTML output from Blade views and components using `assertSee()` or `assertSeeInOrder()` is frustrating and error-prone.

I've kept the API mininmal, and it follows a similar pattern as the existing fluent JSON assertions API.

- Elements - `has()`, `missing()`, `count()`
- Text - `whereText()`, `whereNotText()`
- Attributes- `hasAttributes()`, `missingAttributes()`, `whereAttribute()`, `whereNotAttribute()`, `whereAttributes()`
- Navigation - `scope()`, `first()`, `last()`, `nth()`, `sequence()`, `each()`
- Debugging - `dump()`, `dd()`
- Extensibility - `tap()`, `when()`, `macro()`

It works for responses, views and components. Here's a quick overview.

```php
// Examples...
```

When an assertion fails the failure message includes the full selector path and the scoped HTML to make it easy to pinpoint:

```
Failed asserting that element [td.stock] exists.

[table.basket → tr.order-item → td.stock]

<tr>
    <td class="name">Leather Wallet</td>
    <td class="price">£29.99</td>
</tr>
```

The test coverage shows more examples of what can be done (e.g. passing closures for more control over complex assertions).

Note: I wasn't sure how best to solve the PHPStan complaints, so I stuck them in the baseline - any advice welcome.