### PR TITLE
feat: add shouldRun to Seeder

### DIFF
--- a/src/Illuminate/Database/Seeder.php
+++ b/src/Illuminate/Database/Seeder.php
@@ -49,6 +49,17 @@ abstract class Seeder
 
             $name = get_class($seeder);
 
+            if (! $seeder->shouldRun()) {
+                if ($silent === false && isset($this->command)) {
+                    (new TwoColumnDetail($this->command->getOutput()))
+                        ->render($name, '<fg=yellow;options=bold>SKIPPED</>');
+
+                    $this->command->getOutput()->writeln('');
+                }
+
+                continue;
+            }
+
             if ($silent === false && isset($this->command)) {
                 (new TwoColumnDetail($this->command->getOutput()))
                     ->render($name, '<fg=yellow;options=bold>RUNNING</>');
@@ -164,6 +175,16 @@ abstract class Seeder
         $this->command = $command;
 
         return $this;
+    }
+
+    /**
+     * Determine if this seeder should run.
+     *
+     * @return bool
+     */
+    public function shouldRun(): bool
+    {
+        return true;
     }
 
     /**

--- a/tests/Database/DatabaseSeederTest.php
+++ b/tests/Database/DatabaseSeederTest.php
@@ -26,6 +26,19 @@ class TestDepsSeeder extends Seeder
     }
 }
 
+class TestSkippedSeeder extends Seeder
+{
+    public function run()
+    {
+        //
+    }
+
+    public function shouldRun(): bool
+    {
+        return false;
+    }
+}
+
 class DatabaseSeederTest extends TestCase
 {
     public function testCallResolveTheClassAndCallsRun()
@@ -40,9 +53,33 @@ class DatabaseSeederTest extends TestCase
         $container->shouldReceive('make')->once()->with('ClassName')->andReturn($child = m::mock(Seeder::class));
         $child->shouldReceive('setContainer')->once()->with($container)->andReturn($child);
         $child->shouldReceive('setCommand')->once()->with($command)->andReturn($child);
+        $child->shouldReceive('shouldRun')->once()->andReturn(true);
         $child->shouldReceive('__invoke')->once();
 
         $seeder->call('ClassName');
+    }
+
+    public function testCallSkipsSeederWhenShouldRunReturnsFalse()
+    {
+        $seeder = new TestSeeder;
+        $seeder->setContainer($container = m::mock(Container::class));
+        $output = m::mock(OutputInterface::class);
+        $output->shouldReceive('writeln')->once();
+        $command = m::mock(Command::class);
+        $command->shouldReceive('getOutput')->once()->andReturn($output);
+        $seeder->setCommand($command);
+        $container->shouldReceive('make')->once()->with(TestSkippedSeeder::class)->andReturn(new TestSkippedSeeder);
+
+        $seeder->call(TestSkippedSeeder::class);
+    }
+
+    public function testCallSkipsSeederSilentlyWhenShouldRunReturnsFalse()
+    {
+        $seeder = new TestSeeder;
+        $seeder->setContainer($container = m::mock(Container::class));
+        $container->shouldReceive('make')->once()->with(TestSkippedSeeder::class)->andReturn(new TestSkippedSeeder);
+
+        $seeder->call(TestSkippedSeeder::class, true);
     }
 
     public function testSetContainer()


### PR DESCRIPTION
Adds a shouldRun() method to the Illuminate\Database\Seeder class, allowing individual seeders to conditionally skip execution.                                     
                                                                                                                                                                          
  Changes:                                                                                                                                                                  
                                                                                                                                                                          
  - Seeder::shouldRun(): bool — New overridable method that returns true by default. Subclasses can override it to return false to skip execution.                          
  - Seeder::call() — Before invoking a seeder, checks shouldRun(). If it returns false, the seeder is skipped and a SKIPPED status is displayed in the console output     
  (unless running silently).                                                                                                                                                
  - Tests — Adds TestSkippedSeeder stub and two test cases: one verifying the SKIPPED output is displayed, and another verifying silent skipping produces no output.      
                                                                                                                                                                            
  Use case: Enables conditional seeding logic (e.g., skip seeders based on environment, feature flags, or database state) without needing to modify the calling seeder or   
  wrap calls in conditionals.        