### PR TITLE
[13.x] Add bail, nullable, required, and sometimes methods to validation rule builders

### DIFF
--- a/src/Illuminate/Validation/Rules/Date.php
+++ b/src/Illuminate/Validation/Rules/Date.php
@@ -23,6 +23,38 @@ class Date implements Stringable
     protected array $constraints = [];
 
     /**
+     * Stop running validation rules for the field after the first failure.
+     */
+    public function bail(): static
+    {
+        return $this->addRule('bail');
+    }
+
+    /**
+     * The field under validation may be null.
+     */
+    public function nullable(): static
+    {
+        return $this->addRule('nullable');
+    }
+
+    /**
+     * The field under validation must be present in the input data and not empty.
+     */
+    public function required(): static
+    {
+        return $this->addRule('required');
+    }
+
+    /**
+     * The field under validation will only be validated if it is present in the input data.
+     */
+    public function sometimes(): static
+    {
+        return $this->addRule('sometimes');
+    }
+
+    /**
      * Ensure the date has the given format.
      */
     public function format(string $format): static
@@ -169,9 +201,9 @@ class Date implements Stringable
      */
     public function __toString(): string
     {
-        return implode('|', [
+        return implode('|', array_unique([
             $this->format === null ? 'date' : 'date_format:'.$this->format,
             ...$this->constraints,
-        ]);
+        ]));
     }
 }

--- a/src/Illuminate/Validation/Rules/Numeric.php
+++ b/src/Illuminate/Validation/Rules/Numeric.php
@@ -16,6 +16,46 @@ class Numeric implements Stringable
     protected array $constraints = ['numeric'];
 
     /**
+     * Stop running validation rules for the field after the first failure.
+     *
+     * @return $this
+     */
+    public function bail(): Numeric
+    {
+        return $this->addRule('bail');
+    }
+
+    /**
+     * The field under validation may be null.
+     *
+     * @return $this
+     */
+    public function nullable(): Numeric
+    {
+        return $this->addRule('nullable');
+    }
+
+    /**
+     * The field under validation must be present in the input data and not empty.
+     *
+     * @return $this
+     */
+    public function required(): Numeric
+    {
+        return $this->addRule('required');
+    }
+
+    /**
+     * The field under validation will only be validated if it is present in the input data.
+     *
+     * @return $this
+     */
+    public function sometimes(): Numeric
+    {
+        return $this->addRule('sometimes');
+    }
+
+    /**
      * The field under validation must have a size between the given min and max (inclusive).
      *
      * @param  int|float  $min

--- a/src/Illuminate/Validation/Rules/StringRule.php
+++ b/src/Illuminate/Validation/Rules/StringRule.php
@@ -16,6 +16,46 @@ class StringRule implements Stringable
     protected array $constraints = ['string'];
 
     /**
+     * Stop running validation rules for the field after the first failure.
+     *
+     * @return $this
+     */
+    public function bail(): static
+    {
+        return $this->addRule('bail');
+    }
+
+    /**
+     * The field under validation may be null.
+     *
+     * @return $this
+     */
+    public function nullable(): static
+    {
+        return $this->addRule('nullable');
+    }
+
+    /**
+     * The field under validation must be present in the input data and not empty.
+     *
+     * @return $this
+     */
+    public function required(): static
+    {
+        return $this->addRule('required');
+    }
+
+    /**
+     * The field under validation will only be validated if it is present in the input data.
+     *
+     * @return $this
+     */
+    public function sometimes(): static
+    {
+        return $this->addRule('sometimes');
+    }
+
+    /**
      * The field under validation must be entirely alphabetic characters.
      *
      * @param  bool  $ascii

--- a/tests/Validation/ValidationDateRuleTest.php
+++ b/tests/Validation/ValidationDateRuleTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit\Rules;
+namespace Illuminate\Tests\Validation;
 
 use Illuminate\Support\Carbon;
 use Illuminate\Translation\ArrayLoader;
@@ -94,6 +94,30 @@ class ValidationDateRuleTest extends TestCase
     {
         $rule = Rule::date()->betweenOrEqual('2024-01-01', '2024-02-01');
         $this->assertEquals('date|after_or_equal:2024-01-01|before_or_equal:2024-02-01', (string) $rule);
+    }
+
+    public function testBailRule()
+    {
+        $rule = Rule::date()->bail()->after('today');
+        $this->assertSame('date|bail|after:today', (string) $rule);
+    }
+
+    public function testNullableRule()
+    {
+        $rule = Rule::date()->nullable();
+        $this->assertSame('date|nullable', (string) $rule);
+    }
+
+    public function testRequiredRule()
+    {
+        $rule = Rule::date()->required();
+        $this->assertSame('date|required', (string) $rule);
+    }
+
+    public function testSometimesRule()
+    {
+        $rule = Rule::date()->sometimes();
+        $this->assertSame('date|sometimes', (string) $rule);
     }
 
     public function testChainedRules()

--- a/tests/Validation/ValidationNumericRuleTest.php
+++ b/tests/Validation/ValidationNumericRuleTest.php
@@ -137,6 +137,30 @@ class ValidationNumericRuleTest extends TestCase
         $this->assertEquals('numeric|integer|size:10', (string) $rule);
     }
 
+    public function testBailRule()
+    {
+        $rule = Rule::numeric()->bail()->integer();
+        $this->assertEquals('numeric|bail|integer', (string) $rule);
+    }
+
+    public function testNullableRule()
+    {
+        $rule = Rule::numeric()->nullable();
+        $this->assertEquals('numeric|nullable', (string) $rule);
+    }
+
+    public function testRequiredRule()
+    {
+        $rule = Rule::numeric()->required();
+        $this->assertEquals('numeric|required', (string) $rule);
+    }
+
+    public function testSometimesRule()
+    {
+        $rule = Rule::numeric()->sometimes();
+        $this->assertEquals('numeric|sometimes', (string) $rule);
+    }
+
     public function testChainedRules()
     {
         $rule = Rule::numeric()

--- a/tests/Validation/ValidationStringRuleTest.php
+++ b/tests/Validation/ValidationStringRuleTest.php
@@ -125,6 +125,30 @@ class ValidationStringRuleTest extends TestCase
         $this->assertSame('string|doesnt_end_with:.exe,.bat', (string) $rule);
     }
 
+    public function testBailRule()
+    {
+        $rule = Rule::string()->bail()->max(255);
+        $this->assertSame('string|bail|max:255', (string) $rule);
+    }
+
+    public function testNullableRule()
+    {
+        $rule = Rule::string()->nullable();
+        $this->assertSame('string|nullable', (string) $rule);
+    }
+
+    public function testRequiredRule()
+    {
+        $rule = Rule::string()->required();
+        $this->assertSame('string|required', (string) $rule);
+    }
+
+    public function testSometimesRule()
+    {
+        $rule = Rule::string()->sometimes();
+        $this->assertSame('string|sometimes', (string) $rule);
+    }
+
     public function testChainedRules()
     {
         $rule = Rule::string()


### PR DESCRIPTION
This PR adds `bail()`, `nullable()`, `required()`, and `sometimes()` methods to the fluent validation rule builders: `Rule::string()`, `Rule::numeric()`, and `Rule::date()`.

## Motivation

Currently, when using the fluent rule builders, there is no way to express common field-level modifiers like `nullable` or `required` within the fluent chain. Users are forced to mix array syntax with the fluent API:

### Before

```php

'name' => ['required', Rule::string()->min(3)->max(255)],
'age' => ['nullable', Rule::numeric()->integer()->min(0)],
'birthday' => ['sometimes', Rule::date()->before('today')],
```

### after, fully fluent

```php
'name' => Rule::string()->required()->min(3)->max(255),
'age' => Rule::numeric()->nullable()->integer()->min(0),
'birthday' => Rule::date()->sometimes()->before('today'),
```

The `bail()` method is also included, which reads naturally in the fluent chain:

```php
'email' => Rule::string()->bail()->required()->max(255),
```