### PR TITLE
[13.x] Add toString to Uri

### DIFF
--- a/src/Illuminate/Support/Uri.php
+++ b/src/Illuminate/Support/Uri.php
@@ -390,7 +390,15 @@ class Uri implements Htmlable, JsonSerializable, Responsable, Stringable
      */
     public function value(): string
     {
-        return (string) $this;
+        return $this->toString();
+    }
+
+    /**
+     * Get the string representation of the URI.
+     */
+    public function toString(): string
+    {
+        return $this->uri->toString();
     }
 
     /**
@@ -445,6 +453,6 @@ class Uri implements Htmlable, JsonSerializable, Responsable, Stringable
      */
     public function __toString(): string
     {
-        return $this->uri->toString();
+        return $this->toString();
     }
 }

--- a/tests/Support/SupportUriTest.php
+++ b/tests/Support/SupportUriTest.php
@@ -88,7 +88,11 @@ class SupportUriTest extends TestCase
             ->withQuery(['version' => 1])
             ->withFragment('hello');
 
-        $this->assertEquals('https://taylor:password@laravel.com:80/docs/installation?version=1#hello', (string) $uri);
+        $expected = 'https://taylor:password@laravel.com:80/docs/installation?version=1#hello';
+
+        $this->assertEquals($expected, (string) $uri);
+        $this->assertEquals($expected, $uri->value());
+        $this->assertEquals($expected, $uri->toString());
     }
 
     public function test_complicated_query_string_manipulation()


### PR DESCRIPTION
When using the `Uri` helper I wanted to get a string an assumed the method was `toString()`, like I would have called on a stringable. I had to go back to the documentation to realise that the method was actually `value`.

Maybe it's just me, but it felt unexpected so I wanted to put a PR forward.