### PR TITLE
[13.x] Add #[Throttle] attribute for route/controller rate limiting

### DIFF
--- a/src/Illuminate/Routing/Attributes/Controllers/Throttle.php
+++ b/src/Illuminate/Routing/Attributes/Controllers/Throttle.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Illuminate\Routing\Attributes\Controllers;
+
+use Attribute;
+use Illuminate\Routing\Middleware\ThrottleRequests;
+use UnitEnum;
+
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
+class Throttle extends Middleware
+{
+    /**
+     * Create a new throttle attribute.
+     *
+     * When $limiter is a string or enum it is treated as a named rate-limiter
+     * (e.g. 'api') and resolves to `ThrottleRequests::using($limiter)`.
+     *
+     * When $limiter is an integer it is treated as a raw attempt count and
+     * resolves to `ThrottleRequests::with($limiter, $decayMinutes)`.
+     *
+     * @param  int|string|\UnitEnum  $limiter       Named limiter or max attempts per window.
+     * @param  int                   $decayMinutes  Decay window in minutes (only used when $limiter is an int).
+     * @param  array<string>|null    $only          Limit to these controller methods.
+     * @param  array<string>|null    $except        Exclude these controller methods.
+     */
+    public function __construct(
+        int|string|UnitEnum $limiter = 'api',
+        int $decayMinutes = 1,
+        ?array $only = null,
+        ?array $except = null,
+    ) {
+        $middleware = is_int($limiter)
+            ? ThrottleRequests::with($limiter, $decayMinutes)
+            : ThrottleRequests::using($limiter);
+
+        parent::__construct($middleware, $only, $except);
+    }
+}

--- a/tests/Integration/Routing/ThrottleMiddlewareAttributeTest.php
+++ b/tests/Integration/Routing/ThrottleMiddlewareAttributeTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Routing;
+
+use Illuminate\Routing\Attributes\Controllers\Throttle;
+use Illuminate\Routing\Middleware\ThrottleRequests;
+use Illuminate\Support\Facades\Route;
+use Orchestra\Testbench\TestCase;
+
+class ThrottleMiddlewareAttributeTest extends TestCase
+{
+    public function test_named_limiter_attribute_is_resolved(): void
+    {
+        $route = Route::get('/', [ThrottleAttributeController::class, 'index']);
+
+        $this->assertEquals([
+            ThrottleRequests::using('api'),
+            ThrottleRequests::using('uploads'),
+        ], $route->controllerMiddleware());
+    }
+
+    public function test_method_scoped_attribute_is_respected(): void
+    {
+        $route = Route::get('/', [ThrottleAttributeController::class, 'index']);
+        $this->assertContains(ThrottleRequests::using('uploads'), $route->controllerMiddleware());
+
+        $route = Route::get('/', [ThrottleAttributeController::class, 'show']);
+        $this->assertNotContains(ThrottleRequests::using('uploads'), $route->controllerMiddleware());
+    }
+
+    public function test_numeric_limiter_attribute_is_resolved(): void
+    {
+        $route = Route::get('/', [ThrottleAttributeWithNumericLimiterController::class, 'index']);
+
+        $this->assertEquals([
+            ThrottleRequests::with(60, 1),
+        ], $route->controllerMiddleware());
+    }
+
+    public function test_method_level_throttle_attribute(): void
+    {
+        $route = Route::get('/', [ThrottleAttributeController::class, 'show']);
+
+        $this->assertEquals([
+            ThrottleRequests::using('api'),
+            ThrottleRequests::with(10, 1),
+        ], $route->controllerMiddleware());
+    }
+}
+
+#[Throttle('api')]
+#[Throttle('uploads', only: ['index'])]
+class ThrottleAttributeController
+{
+    public function index(): void
+    {
+        // ...
+    }
+
+    #[Throttle(10, 1)]
+    public function show(): void
+    {
+        // ...
+    }
+}
+
+#[Throttle(60, 1)]
+class ThrottleAttributeWithNumericLimiterController
+{
+    public function index(): void
+    {
+        // ...
+    }
+}


### PR DESCRIPTION
Introduces a `#[Throttle]` PHP attribute as a declarative alternative to registering throttle middleware manually, following the same pattern as the existing `#[Authorize]` attribute which extends `#[Middleware]`.

- Accepts a named rate-limiter string/enum: `#[Throttle('api')]`
- Accepts a numeric limit with decay window: `#[Throttle(60, 1)]`
- Supports `only` / `except` for method-scoped application
- Resolves via `ThrottleRequests::using()` or `ThrottleRequests::with()` so it is fully compatible with both named limiters (registered via `RateLimiter::for(...)`) and inline attempt/window pairs
- Picked up automatically by the existing `IS_INSTANCEOF` check on `Middleware` in `Route::attributeProvidedControllerMiddleware()`

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
