### PR TITLE
[13.x] Add #[Cast] attribute for Eloquent models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Attributes/Cast.php
+++ b/src/Illuminate/Database/Eloquent/Attributes/Cast.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
+class Cast
+{
+    /**
+     * Create a new attribute instance.
+     *
+     * @param  string  $attribute  The model attribute name to cast.
+     * @param  string  $as  The cast type or class-string of a custom cast.
+     */
+    public function __construct(
+        public string $attribute,
+        public string $as,
+    ) {
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -14,6 +14,7 @@ use Illuminate\Contracts\Database\Eloquent\Castable;
 use Illuminate\Contracts\Database\Eloquent\CastsInboundAttributes;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Attributes\Appends;
+use Illuminate\Database\Eloquent\Attributes\Cast;
 use Illuminate\Database\Eloquent\Attributes\Initialize;
 use Illuminate\Database\Eloquent\Attributes\Table;
 use Illuminate\Database\Eloquent\Casts\AsArrayObject;
@@ -206,7 +207,7 @@ trait HasAttributes
     protected function initializeHasAttributes()
     {
         $this->casts = $this->ensureCastsAreStringValues(
-            array_merge($this->casts, $this->casts()),
+            array_merge(static::resolveAttributeCasts(), $this->casts, $this->casts()),
         );
 
         $this->dateFormat ??= static::resolveClassAttribute(Table::class)->dateFormat ?? null;
@@ -1726,6 +1727,28 @@ trait HasAttributes
     protected function casts()
     {
         return [];
+    }
+
+    /**
+     * Get the casts defined via PHP #[Cast] attributes on the model class.
+     *
+     * @return array<string, string>
+     */
+    protected static function resolveAttributeCasts(): array
+    {
+        $cacheKey = static::class.'@'.Cast::class;
+
+        if (array_key_exists($cacheKey, static::$classAttributes)) {
+            return static::$classAttributes[$cacheKey];
+        }
+
+        $casts = [];
+
+        foreach (class_attributes_recursive(static::class, Cast::class) as $instance) {
+            $casts[$instance->attribute] = $instance->as;
+        }
+
+        return static::$classAttributes[$cacheKey] = $casts;
     }
 
     /**

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -113,6 +113,45 @@ if (! function_exists('class_uses_recursive')) {
     }
 }
 
+if (! function_exists('class_attributes_recursive')) {
+    /**
+     * Returns all instances of the given PHP attribute from a class and its parents.
+     *
+     * Walks the hierarchy from the topmost parent down to the concrete class so
+     * that child-class attributes are returned last, allowing callers to apply
+     * child-wins-over-parent precedence naturally.
+     *
+     * @template TAttribute of object
+     *
+     * @param  object|string  $class
+     * @param  class-string<TAttribute>  $attribute
+     * @return list<TAttribute>
+     */
+    function class_attributes_recursive(object|string $class, string $attribute): array
+    {
+        if (is_object($class)) {
+            $class = get_class($class);
+        }
+
+        $classes = [];
+        $reflection = new ReflectionClass($class);
+
+        do {
+            $classes[] = $reflection;
+        } while ($reflection = $reflection->getParentClass());
+
+        $instances = [];
+
+        foreach (array_reverse($classes) as $reflectionClass) {
+            foreach ($reflectionClass->getAttributes($attribute) as $attr) {
+                $instances[] = $attr->newInstance();
+            }
+        }
+
+        return $instances;
+    }
+}
+
 if (! function_exists('e')) {
     /**
      * Encode HTML special characters in a string.

--- a/tests/Database/DatabaseEloquentModelAttributesTest.php
+++ b/tests/Database/DatabaseEloquentModelAttributesTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Database;
 
 use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Attributes\Appends;
+use Illuminate\Database\Eloquent\Attributes\Cast;
 use Illuminate\Database\Eloquent\Attributes\Connection;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Guarded;
@@ -246,6 +247,45 @@ class DatabaseEloquentModelAttributesTest extends TestCase
         $this->assertTrue(ModelWithTimestampsFalseAttribute::isIgnoringTouch());
         $this->assertFalse(ModelWithFillableAttribute::isIgnoringTouch());
     }
+
+    public function test_cast_attribute(): void
+    {
+        $model = new ModelWithCastAttribute;
+
+        $this->assertSame('integer', $model->getCasts()['age']);
+        $this->assertSame('boolean', $model->getCasts()['is_active']);
+    }
+
+    public function test_cast_attribute_property_takes_precedence(): void
+    {
+        $model = new ModelWithCastAttributeAndProperty;
+
+        $this->assertSame('string', $model->getCasts()['age']);
+    }
+
+    public function test_cast_attribute_merges_with_property(): void
+    {
+        $model = new ModelWithCastAttributeAndProperty;
+
+        $this->assertSame('string', $model->getCasts()['age']);
+        $this->assertSame('boolean', $model->getCasts()['is_active']);
+    }
+
+    public function test_cast_attribute_inherited_by_child(): void
+    {
+        $model = new ModelExtendingCastParent;
+
+        $this->assertSame('integer', $model->getCasts()['age']);
+        $this->assertSame('array', $model->getCasts()['meta']);
+    }
+
+    public function test_cast_attribute_child_overrides_parent(): void
+    {
+        $model = new ModelOverridingParentCast;
+
+        $this->assertSame('string', $model->getCasts()['age']);
+        $this->assertSame('array', $model->getCasts()['meta']);
+    }
 }
 
 #[Table('custom_table_name')]
@@ -381,6 +421,38 @@ class ModelWithAppendsAttribute extends Model
 
 #[Touches(['post', 'author'])]
 class ModelWithTouchesAttribute extends Model
+{
+    //
+}
+
+#[Cast('age', 'integer')]
+#[Cast('is_active', 'boolean')]
+class ModelWithCastAttribute extends Model
+{
+    //
+}
+
+#[Cast('age', 'integer')]
+#[Cast('is_active', 'boolean')]
+class ModelWithCastAttributeAndProperty extends Model
+{
+    protected $casts = ['age' => 'string'];
+}
+
+#[Cast('age', 'integer')]
+#[Cast('meta', 'array')]
+class CastParentModel extends Model
+{
+    //
+}
+
+class ModelExtendingCastParent extends CastParentModel
+{
+    //
+}
+
+#[Cast('age', 'string')]
+class ModelOverridingParentCast extends CastParentModel
 {
     //
 }


### PR DESCRIPTION
Introduces a repeatable `#[Cast]` PHP attribute as an alternative to the `$casts` property on Eloquent models, following the same pattern established by `#[Fillable]`, `#[Guarded]`, and `#[Table]`.

## ✅ What’s included
- Adds `Illuminate\Database\Eloquent\Attributes\Cast`.
- Resolves all `#[Cast]` declarations in `HasAttributes::initializeHasAttributes()` via the new static `resolveAttributeCasts()` helper.
- Walks the full class hierarchy so child-class attributes override parent-class declarations, matching property-based precedence rules.
- Keeps `$casts` property and `casts()` method precedence for backward compatibility.

---

## 💡 Examples

### Basic usage
```php
use Illuminate\Database\Eloquent\Attributes\Cast;

#[Cast('age', 'integer')]
#[Cast('options', AsArrayObject::class)]
#[Cast('status', UserStatus::class)]
class User extends Model {}