### PR TITLE
[13.x] Fix null broadcaster deprecation warning in PHP 8.5

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -465,7 +465,7 @@ class BroadcastManager implements FactoryContract
      */
     public function getDefaultDriver()
     {
-        return $this->app['config']['broadcasting.default'];
+        return $this->app['config']['broadcasting.default'] ?? 'null';
     }
 
     /**


### PR DESCRIPTION
This fixes a deprecation warning in PHP 8.5 when `BROADCAST_CONNECTION=null`, like in tests: 
```
Using null as an array offset is deprecated, use an empty string instead
```
Laravel 12 has the same issue.

> [!Note]
> `config('broadcasting.default')` falls back to `'null'` (string) if BROADCAST_CONNECTION is <ins>**not set**</ins>
> If `BROADCAST_CONNECTION=null` (like in phpunit.xml), then `config('broadcasting.default')` returns `null` (not string null)

### Example
Run this test with PHP 8.5 in a fresh Laravel 13 (or 12) project
```php
public function test_null_broadcaster_can_be_resolved(): void
{
    $this->withoutDeprecationHandling();
    $this->expectNotToPerformAssertions();
    \Broadcast::on('foo')->send();
}
```
```
   FAIL  Tests\Feature\ExampleTest
  ⨯ null broadcaster can be resolved                                                                                                                                                  0.32s
  ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   FAILED  Tests\Feature\ExampleTest > null broadcaster can be resolved                                                                                                     ErrorException
  Using null as an array offset is deprecated, use an empty string instead

  at vendor/laravel/framework/src/Illuminate/Broadcasting/BroadcastManager.php:265
    261▕      * @return \Illuminate\Contracts\Broadcasting\Broadcaster
    262▕      */
    263▕     protected function get($name)
    264▕     {
  ➜ 265▕         return $this->drivers[$name] ?? $this->resolve($name);
    266▕     }
    267▕
    268▕     /**
    269▕      * Resolve the given broadcaster.

      +28 vendor frames
  29  tests/Feature/ExampleTest.php:29


  Tests:    1 failed (0 assertions)
  Duration: 0.36s
```

### Alternative solutions
I'm not sure if `BroadcastManager::getDefaultDriver()` is the best place to fix this issue, but it works.
Alternatively the `config/broadcasting.php` could be changed:
```php
'default' => env('BROADCAST_DRIVER') ?? 'null'
```
This would also ensure that the value will never be null, but of course it would not fix the issue in existing projects unless they update/republish their config file..

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
