### PR TITLE
[13.x] Wrap retrying job exceptions in JobRetryingException                   

### DIFF
--- a/src/Illuminate/Queue/JobRetryingException.php
+++ b/src/Illuminate/Queue/JobRetryingException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Queue;
+
+use RuntimeException;
+
+class JobRetryingException extends RuntimeException
+{
+    //
+}

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -434,7 +434,9 @@ class Worker
         try {
             return $this->process($connectionName, $job, $options);
         } catch (Throwable $e) {
-            $this->exceptions->report($e);
+            $this->exceptions->report(
+                $job->isReleased() ? new JobRetryingException($e->getMessage(), previous: $e) : $e
+            );
 
             $this->stopWorkerIfLostConnection($e);
         }

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -15,6 +15,7 @@ use Illuminate\Queue\Events\JobProcessing;
 use Illuminate\Queue\Events\JobReleasedAfterException;
 use Illuminate\Queue\Events\WorkerStarting;
 use Illuminate\Queue\Events\WorkerStopping;
+use Illuminate\Queue\JobRetryingException;
 use Illuminate\Queue\MaxAttemptsExceededException;
 use Illuminate\Queue\QueueManager;
 use Illuminate\Queue\Worker;
@@ -190,7 +191,7 @@ class QueueWorkerTest extends TestCase
 
         $this->assertEquals(10, $job->releaseAfter);
         $this->assertFalse($job->deleted);
-        $this->exceptionHandler->shouldHaveReceived('report')->with($e);
+        $this->exceptionHandler->shouldHaveReceived('report')->with(m::type(JobRetryingException::class));
         $this->events->shouldHaveReceived('dispatch')->with(m::type(JobExceptionOccurred::class))->once();
         $this->events->shouldNotHaveReceived('dispatch', [m::type(JobProcessed::class)]);
     }


### PR DESCRIPTION
I regularly see exceptions and think a job has failed, and go to put the job back onto the queue, to realise its not actually failed hard, its just been retried and is already sorted                                                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                                                                                                                                         
This PR wraps exceptions in a JobRetryingException when a job is released back to the queue for retry, allowing exception handlers and us to tell the difference between exceptions that caused failure vs. ones where the job will be retried.

Open to renaming it or something different I'm just one man, but trying to make it more obvious as it's hard to tell if it's something we need to act or or not atm.  

This is very helpful with tracking tools, Sentry, Mezmo etc.

This is the current trace I get where I need to decide if its a real failure that I may need to manually pop back onto the queue or not : 
<details>

```
{
"message": "SQLSTATE[40001]: Serialization failure: 1213 Deadlock found when trying to get lock; try restarting transaction",
"trace": [
"/srv/app/some-app-prd/htdocs/vendor/laravel/framework/src/Illuminate/Database/Connection.php:609",
"/srv/app/some-app-prd/htdocs/vendor/laravel/framework/src/Illuminate/Database/Connection.php:827",
"/srv/app/some-app-prd/htdocs/vendor/laravel/framework/src/Illuminate/Database/Connection.php:794",
"/srv/app/some-app-prd/htdocs/vendor/laravel/framework/src/Illuminate/Database/Connection.php:597",
"/srv/app/some-app-prd/htdocs/vendor/laravel/framework/src/Illuminate/Database/Query/Builder.php:4289",
"/srv/app/some-app-prd/htdocs/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Builder.php:1291",
"/srv/app/some-app-prd/htdocs/vendor/laravel/framework/src/Illuminate/Support/Traits/ForwardsCalls.php:23",
"/srv/app/some-app-prd/htdocs/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php:2540",
"/srv/app/some-app-prd/htdocs/app/Jobs/AJob.php:27",
"/srv/app/some-app-prd/htdocs/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php:36",
"/srv/app/some-app-prd/htdocs/vendor/laravel/framework/src/Illuminate/Container/Util.php:43",
"/srv/app/some-app-prd/htdocs/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php:96",
"/srv/app/some-app-prd/htdocs/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php:35",
"/srv/app/some-app-prd/htdocs/vendor/laravel/framework/src/Illuminate/Container/Container.php:799",
"/srv/app/some-app-prd/htdocs/vendor/laravel/framework/src/Illuminate/Bus/Dispatcher.php:129",
"/srv/app/some-app-prd/htdocs/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php:180",
"/srv/app/some-app-prd/htdocs/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php:137",
"/srv/app/some-app-prd/htdocs/vendor/laravel/framework/src/Illuminate/Bus/Dispatcher.php:133",
"/srv/app/some-app-prd/htdocs/vendor/laravel/framework/src/Illuminate/Queue/CallQueuedHandler.php:136",
"/srv/app/some-app-prd/htdocs/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php:180",
"/srv/app/some-app-prd/htdocs/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php:137",
"/srv/app/some-app-prd/htdocs/vendor/laravel/framework/src/Illuminate/Queue/CallQueuedHandler.php:129",
"/srv/app/some-app-prd/htdocs/vendor/laravel/framework/src/Illuminate/Queue/CallQueuedHandler.php:70",
"/srv/app/some-app-prd/htdocs/vendor/laravel/framework/src/Illuminate/Queue/Jobs/Job.php:102",
"/srv/app/some-app-prd/htdocs/vendor/laravel/framework/src/Illuminate/Queue/Worker.php:485",
"/srv/app/some-app-prd/htdocs/vendor/laravel/framework/src/Illuminate/Queue/Worker.php:435",
"/srv/app/some-app-prd/htdocs/vendor/laravel/framework/src/Illuminate/Queue/Worker.php:201",
"/srv/app/some-app-prd/htdocs/vendor/laravel/framework/src/Illuminate/Queue/Console/WorkCommand.php:148",
"/srv/app/some-app-prd/htdocs/vendor/laravel/framework/src/Illuminate/Queue/Console/WorkCommand.php:131",
"/srv/app/some-app-prd/htdocs/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php:36",
"/srv/app/some-app-prd/htdocs/vendor/laravel/framework/src/Illuminate/Container/Util.php:43",
"/srv/app/some-app-prd/htdocs/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php:96",
"/srv/app/some-app-prd/htdocs/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php:35",
"/srv/app/some-app-prd/htdocs/vendor/laravel/framework/src/Illuminate/Container/Container.php:799",
"/srv/app/some-app-prd/htdocs/vendor/laravel/framework/src/Illuminate/Console/Command.php:211",
"/srv/app/some-app-prd/htdocs/vendor/symfony/console/Command/Command.php:341",
"/srv/app/some-app-prd/htdocs/vendor/laravel/framework/src/Illuminate/Console/Command.php:180",
"/srv/app/some-app-prd/htdocs/vendor/symfony/console/Application.php:1117",
"/srv/app/some-app-prd/htdocs/vendor/symfony/console/Application.php:356",
"/srv/app/some-app-prd/htdocs/vendor/symfony/console/Application.php:195",
"/srv/app/some-app-prd/htdocs/vendor/laravel/framework/src/Illuminate/Foundation/Console/Kernel.php:198",
"/srv/app/some-app-prd/htdocs/vendor/laravel/framework/src/Illuminate/Foundation/Application.php:1235",
"/srv/app/some-app-prd/htdocs/artisan:14"
]
```
</details>