### PR TITLE
[13.x] Add missing Illuminate/Queue dependency to Illuminate/Events

### DIFF
--- a/src/Illuminate/Events/composer.json
+++ b/src/Illuminate/Events/composer.json
@@ -20,6 +20,7 @@
         "illuminate/container": "^13.0",
         "illuminate/contracts": "^13.0",
         "illuminate/macroable": "^13.0",
+        "illuminate/queue": "^13.0",
         "illuminate/support": "^13.0"
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
As of v13, `Illuminate/Events` now references classes and traits from `Illuminate/Queue`, but does not require that package in its `composer.json`.

Specifically:

- `Illuminate\Events\Dispatcher` imports queue attribute classes and uses the `ReadsQueueAttributes` trait
- `Illuminate\Events\CallQueuedListener` uses `InteractsWithQueue`

This PR updates the package's `composer.json` so it matches its actual runtime dependencies.

Note: I considered using `suggest` instead of `require`, similar to `Illuminate/Bus`, but the references in `Illuminate/Events` (and `Bus` for that matter) appear to be unconditional, which makes this seem more like a hard dependency. I suspect `Illuminate\Bus` should have this same update.