### PR TITLE
Improve raw SQL binding substitution performance

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -1621,6 +1621,7 @@ class Grammar extends BaseGrammar
         $bindings = array_map(fn ($value) => $this->escape($value, is_resource($value) || gettype($value) === 'resource (closed)'), $bindings);
 
         $query = '';
+        $bindingIndex = 0;
 
         $isStringLiteral = false;
 
@@ -1638,7 +1639,7 @@ class Grammar extends BaseGrammar
                 $query .= $char;
                 $isStringLiteral = ! $isStringLiteral;
             } elseif ($char === '?' && ! $isStringLiteral) { // Substitutable binding...
-                $query .= array_shift($bindings) ?? '?';
+                $query .= $bindings[$bindingIndex++] ?? '?';
             } else { // Normal character...
                 $query .= $char;
             }


### PR DESCRIPTION
## Summary

This PR improves the performance of `Grammar::substituteBindingsIntoRawSql()` by making it from `O(n²)` to `O(n)` greatly reducing CPU overhead for large binding sets.

Current implementation replaces each placeholder with:

```php
array_shift($bindings) ?? '?'
```

Because array_shift() is `O(n)`, repeated substitution across many placeholders introduces `O(n²)` behavior. For large binding sets (for example bulk inserts/
upserts), this creates avoidable CPU overhead in raw SQL formatting paths.

This change uses a simple index counter:

$bindings[$bindingIndex++] ?? '?'

This preserves behavior while reducing substitution overhead to linear time.


## Motivation

substituteBindingsIntoRawSql() is used by APIs and flows that materialize SQL with embedded bindings, including:

- toRawSql(), dumpRawSql(), ddRawSql()
- query event raw SQL formatting
- raw query log formatting
- exception raw SQL formatting

On large queries, formatting can become disproportionately expensive relative to the actual database operation. This PR addresses that hotspot.


## Benchmark (local)

Median of 5 runs in the same environment:

| Bindings | Before (ms) | After (ms) | Speedup |
|---:|---:|---:|---:|
| 1,000 | 2.96 | 2.70 | 1.1x |
| 4,000 | 16.22 | 11.85 | 1.4x |
| 8,000 | 46.79 | 23.45 | 2.0x |
| 16,000 | 148.22 | 46.67 | 3.2x |
| 28,000 | 403.69 | 83.56 | 4.8x |

The improvement increases with binding count, consistent with removing quadratic behavior.


## Behavioral impact

- No intended functional change.
- Existing string literal / escaped token handling is unchanged.
- Only the internal binding lookup mechanism is modified.


## Validation

Executed relevant existing grammar test suites:

- tests/Database/DatabaseMySqlQueryGrammarTest.php
- tests/Database/DatabasePostgresQueryGrammarTest.php
- tests/Database/DatabaseSQLiteQueryGrammarTest.php
- tests/Database/DatabaseSqlServerQueryGrammarTest.php
- tests/Database/DatabaseMariaDbQueryGrammarTest.php

All passing.
