### PR TITLE
feat(queue): support enums in `#[Queue]` and `#[Connection]`

### DIFF
--- a/src/Illuminate/Queue/Attributes/Connection.php
+++ b/src/Illuminate/Queue/Attributes/Connection.php
@@ -13,7 +13,7 @@ class Connection
      *
      * @param  string  $connection
      */
-    public function __construct(public string|BackedEnum $connection)
+    public function __construct(public BackedEnum|string $connection)
     {
         //
     }

--- a/src/Illuminate/Queue/Attributes/Connection.php
+++ b/src/Illuminate/Queue/Attributes/Connection.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Queue\Attributes;
 
 use Attribute;
+use BackedEnum;
 
 #[Attribute(Attribute::TARGET_CLASS)]
 class Connection
@@ -12,7 +13,7 @@ class Connection
      *
      * @param  string  $connection
      */
-    public function __construct(public string $connection)
+    public function __construct(public string|BackedEnum $connection)
     {
         //
     }

--- a/src/Illuminate/Queue/Attributes/Queue.php
+++ b/src/Illuminate/Queue/Attributes/Queue.php
@@ -13,7 +13,7 @@ class Queue
      *
      * @param  string  $queue
      */
-    public function __construct(public string|BackedEnum $queue)
+    public function __construct(public BackedEnum|string $queue)
     {
         //
     }

--- a/src/Illuminate/Queue/Attributes/Queue.php
+++ b/src/Illuminate/Queue/Attributes/Queue.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Queue\Attributes;
 
 use Attribute;
+use BackedEnum;
 
 #[Attribute(Attribute::TARGET_CLASS)]
 class Queue
@@ -12,7 +13,7 @@ class Queue
      *
      * @param  string  $queue
      */
-    public function __construct(public string $queue)
+    public function __construct(public string|BackedEnum $queue)
     {
         //
     }


### PR DESCRIPTION
This pull request adds backed enum support to the newly-released `#[Queue]` and `#[Connection]` attributes.

We use enums to define our queues for easy refactoring—this was already supported through the property, so I'm just updating the type of the args of the enum to accept `BackedEnum`.

```diff
- #[Queue(Queues::LOGS_INGESTION->value)]
+ #[Queue(Queues::LOGS_INGESTION)] 
final class IngestAuditLog implements ShouldQueue {}
```