### PR TITLE
[12.x] Fix TypeError in Http::retry() when callback for non-failed responses

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -1050,8 +1050,10 @@ class PendingRequest
                         return;
                     }
 
+                    $exception = $response->toException();
+
                     try {
-                        $shouldRetry = $this->retryWhenCallback ? call_user_func($this->retryWhenCallback, $response->toException(), $this, $this->request->toPsrRequest()->getMethod()) : true;
+                        $shouldRetry = $this->retryWhenCallback && $exception ? call_user_func($this->retryWhenCallback, $exception, $this, $this->request->toPsrRequest()->getMethod()) : true;
                     } catch (Exception $exception) {
                         $shouldRetry = false;
 
@@ -1237,10 +1239,12 @@ class PendingRequest
             $response = $this->populateResponse($this->newResponse($response->getResponse()));
         }
 
+        $exception = $response instanceof Response ? $response->toException() : $response;
+
         try {
-            $shouldRetry = $this->retryWhenCallback ? call_user_func(
+            $shouldRetry = $this->retryWhenCallback && $exception ? call_user_func(
                 $this->retryWhenCallback,
-                $response instanceof Response ? $response->toException() : $response,
+                $exception,
                 $this
             ) : true;
         } catch (Exception $exception) {

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -2432,6 +2432,34 @@ class HttpClientTest extends TestCase
         $this->factory->assertSentCount(1);
     }
 
+    public function testRetryWhenCallbackWithExceptionTypeHintDoesNotThrowForNonFailedResponses()
+    {
+        $this->factory->fake([
+            '*' => $this->factory->response('', 302),
+        ]);
+
+        $response = $this->factory
+            ->retry(3, 0, fn (Exception $e) => true)
+            ->get('http://foo.com/get');
+
+        $this->assertSame(302, $response->status());
+        $this->factory->assertSentCount(1);
+    }
+
+    public function testRetryWhenCallbackWithThrowableTypeHintDoesNotThrowForNonFailedResponses()
+    {
+        $this->factory->fake([
+            '*' => $this->factory->response('', 302),
+        ]);
+
+        $response = $this->factory
+            ->retry(3, 0, fn (\Throwable $e) => true)
+            ->get('http://foo.com/get');
+
+        $this->assertSame(302, $response->status());
+        $this->factory->assertSentCount(1);
+    }
+
     public function testRequestsWillBeWaitingSleepMillisecondsReceivedBeforeRetry()
     {
         Sleep::fake();


### PR DESCRIPTION
## Summary

- `Http::retry()` throws a `TypeError` when the `when` callback type-hints `Exception` or `Throwable` and the response is a 3xx status code
- `Response::toException()` only returns an exception for 4xx/5xx responses; for 3xx it returns `null`, which cannot be passed to a callback expecting `Exception`
- Skip calling the `when` callback when `toException()` returns null, defaulting to the same behavior as having no `when` callback
- Applied in both the sync (`send()`) and async (`handlePromiseResponse()`) paths

Fixes #59012

## Test plan

- [x] New test: `retry()` with `fn(Exception $e)` callback and 302 response does not throw TypeError
- [x] New test: `retry()` with `fn(Throwable $e)` callback and 302 response does not throw TypeError
- [x] All 18 existing retry tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)