### PR TITLE
[12.x] Only catch UniqueConstraintViolationException in database session insert

### DIFF
--- a/src/Illuminate/Session/DatabaseSessionHandler.php
+++ b/src/Illuminate/Session/DatabaseSessionHandler.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\QueryException;
+use Illuminate\Database\UniqueConstraintViolationException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\InteractsWithTime;
@@ -155,7 +156,7 @@ class DatabaseSessionHandler implements ExistenceAwareInterface, SessionHandlerI
     {
         try {
             return $this->getQuery()->insert(Arr::set($payload, 'id', $sessionId));
-        } catch (QueryException) {
+        } catch (UniqueConstraintViolationException) {
             $this->performUpdate($sessionId, $payload);
         }
     }

--- a/tests/Integration/Session/DatabaseSessionHandlerTest.php
+++ b/tests/Integration/Session/DatabaseSessionHandlerTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Session;
 
+use Illuminate\Database\QueryException;
 use Illuminate\Session\DatabaseSessionHandler;
 use Illuminate\Support\Carbon;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
@@ -94,6 +95,19 @@ class DatabaseSessionHandlerTest extends DatabaseTestCase
         $this->assertEquals(true, $handler2->destroy('id_1'));
         // only one row is deleted:
         $this->assertEquals(1, $connection->table('sessions')->where('id', 'id_2')->count());
+    }
+
+    public function test_insert_rethrows_non_unique_constraint_query_exceptions()
+    {
+        $connection = $this->app['db']->connection();
+        $handler = new DatabaseSessionHandler($connection, 'sessions', 1);
+
+        // Drop the sessions table to cause a non-unique-constraint QueryException on insert
+        $connection->getSchemaBuilder()->drop('sessions');
+
+        $this->expectException(QueryException::class);
+
+        $handler->write('session_id', 'some data');
     }
 
     public function test_it_can_work_without_container()


### PR DESCRIPTION
## Summary

- `DatabaseSessionHandler::performInsert()` catches all `QueryException` and silently falls back to an update, which suppresses real database errors (missing columns, schema mismatches, permission issues)
- This makes it impossible to diagnose why sessions silently fail to persist, as reported in #57961 (CSRF validation fails with no errors in logs)
- Narrow the catch to `UniqueConstraintViolationException`, which is the only expected failure case (race condition where two requests try to insert the same session ID simultaneously)
- All other `QueryException` types now propagate normally

Fixes #57961

## Test plan

- [x] New test: dropping the sessions table causes a `QueryException` to be thrown (previously suppressed)
- [x] All 5 existing `DatabaseSessionHandlerTest` tests pass (including concurrent insert fallback via `setExists(false)`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)