### PR TITLE
[12.x] Detect lost connections using locale-independent MySQL error codes

### DIFF
--- a/src/Illuminate/Database/LostConnectionDetector.php
+++ b/src/Illuminate/Database/LostConnectionDetector.php
@@ -4,6 +4,7 @@ namespace Illuminate\Database;
 
 use Illuminate\Contracts\Database\LostConnectionDetector as LostConnectionDetectorContract;
 use Illuminate\Support\Str;
+use PDOException;
 use Throwable;
 
 class LostConnectionDetector implements LostConnectionDetectorContract
@@ -16,6 +17,10 @@ class LostConnectionDetector implements LostConnectionDetectorContract
      */
     public function causedByLostConnection(Throwable $e): bool
     {
+        if ($this->hasLostConnectionErrorCode($e)) {
+            return true;
+        }
+
         $message = $e->getMessage();
 
         return Str::contains($message, [
@@ -101,6 +106,29 @@ class LostConnectionDetector implements LostConnectionDetectorContract
             'failed to send startup message',
             'failed to read startup message',
             'canceling statement due to conflict with recovery',
+        ]);
+    }
+
+    /**
+     * Determine if the exception has a locale-independent error code indicating a lost connection.
+     *
+     * @param  \Throwable  $e
+     * @return bool
+     */
+    protected function hasLostConnectionErrorCode(Throwable $e): bool
+    {
+        $previous = $e->getPrevious();
+
+        $pdo = $e instanceof PDOException ? $e : ($previous instanceof PDOException ? $previous : null);
+
+        if ($pdo === null || ! isset($pdo->errorInfo[1])) {
+            return false;
+        }
+
+        return in_array($pdo->errorInfo[1], [
+            2002, // CR_CONNECTION_ERROR
+            2006, // CR_SERVER_GONE_ERROR
+            2013, // CR_SERVER_LOST
         ]);
     }
 }

--- a/tests/Database/DatabaseLostConnectionDetectorTest.php
+++ b/tests/Database/DatabaseLostConnectionDetectorTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\LostConnectionDetector;
+use Illuminate\Database\QueryException;
+use PDOException;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseLostConnectionDetectorTest extends TestCase
+{
+    public function testDetectsLostConnectionFromEnglishMessage()
+    {
+        $detector = new LostConnectionDetector;
+
+        $e = new QueryException('mysql', 'SELECT 1', [], new \Exception('server has gone away'));
+
+        $this->assertTrue($detector->causedByLostConnection($e));
+    }
+
+    public function testDetectsLostConnectionFromMysqlErrorCode2002()
+    {
+        $detector = new LostConnectionDetector;
+
+        $pdo = new PDOException('SQLSTATE[HY000] [2002] Connexion terminée par expiration du délai d\'attente');
+        $pdo->errorInfo = ['HY000', 2002, 'Connexion terminée par expiration du délai d\'attente'];
+
+        $e = new QueryException('mysql', 'SELECT 1', [], $pdo);
+
+        $this->assertTrue($detector->causedByLostConnection($e));
+    }
+
+    public function testDetectsLostConnectionFromMysqlErrorCode2006()
+    {
+        $detector = new LostConnectionDetector;
+
+        $pdo = new PDOException('SQLSTATE[HY000] [2006] Le serveur MySQL a disparu');
+        $pdo->errorInfo = ['HY000', 2006, 'Le serveur MySQL a disparu'];
+
+        $e = new QueryException('mysql', 'SELECT 1', [], $pdo);
+
+        $this->assertTrue($detector->causedByLostConnection($e));
+    }
+
+    public function testDetectsLostConnectionFromMysqlErrorCode2013()
+    {
+        $detector = new LostConnectionDetector;
+
+        $pdo = new PDOException('SQLSTATE[HY000] [2013] Connexion perdue');
+        $pdo->errorInfo = ['HY000', 2013, 'Connexion perdue'];
+
+        $e = new QueryException('mysql', 'SELECT 1', [], $pdo);
+
+        $this->assertTrue($detector->causedByLostConnection($e));
+    }
+
+    public function testDoesNotDetectLostConnectionForUnrelatedErrorCode()
+    {
+        $detector = new LostConnectionDetector;
+
+        $pdo = new PDOException('SQLSTATE[42S02] [1146] Table does not exist');
+        $pdo->errorInfo = ['42S02', 1146, 'Table does not exist'];
+
+        $e = new QueryException('mysql', 'SELECT 1', [], $pdo);
+
+        $this->assertFalse($detector->causedByLostConnection($e));
+    }
+
+    public function testDoesNotDetectLostConnectionForGenericException()
+    {
+        $detector = new LostConnectionDetector;
+
+        $e = new \RuntimeException('Something unrelated');
+
+        $this->assertFalse($detector->causedByLostConnection($e));
+    }
+}


### PR DESCRIPTION
## Summary

- `LostConnectionDetector` relies on English error message string matching, which fails on non-English MySQL/MariaDB servers where error messages are localized
- A French server returning `SQLSTATE[HY000] [2002] Connexion terminée par expiration du délai d'attente` is not detected as a lost connection, so automatic retry never triggers
- Add a check for PDOException `errorInfo` codes before the existing message fallback. MySQL client error codes 2002 (`CR_CONNECTION_ERROR`), 2006 (`CR_SERVER_GONE_ERROR`), and 2013 (`CR_SERVER_LOST`) are numeric and locale-independent
- The existing string-based fallback is preserved for non-PDO exceptions and for error patterns that don't have a specific error code

Fixes #59024

## Test plan

- [x] New test: French `SQLSTATE[HY000] [2002]` message detected via error code
- [x] New test: French `SQLSTATE[HY000] [2006]` message detected via error code
- [x] New test: French `SQLSTATE[HY000] [2013]` message detected via error code
- [x] New test: unrelated error code (1146) is not falsely detected
- [x] New test: non-PDO exception with unrelated message is not detected
- [x] New test: English message still works via existing string matching

🤖 Generated with [Claude Code](https://claude.com/claude-code)