### PR TITLE
[12.x] Skip creating maintenance.php when using cache maintenance driver

### DIFF
--- a/src/Illuminate/Foundation/Console/DownCommand.php
+++ b/src/Illuminate/Foundation/Console/DownCommand.php
@@ -8,6 +8,7 @@ use Exception;
 use Illuminate\Console\Command;
 use Illuminate\Foundation\Events\MaintenanceModeEnabled;
 use Illuminate\Foundation\Exceptions\RegisterErrorViewPaths;
+use Illuminate\Foundation\FileBasedMaintenanceMode;
 use Illuminate\Foundation\Http\Middleware\PreventRequestsDuringMaintenance;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
@@ -51,10 +52,12 @@ class DownCommand extends Command
 
             $this->laravel->maintenanceMode()->activate($downFilePayload);
 
-            file_put_contents(
-                storage_path('framework/maintenance.php'),
-                file_get_contents(__DIR__.'/stubs/maintenance-mode.stub')
-            );
+            if ($this->laravel->maintenanceMode() instanceof FileBasedMaintenanceMode) {
+                file_put_contents(
+                    storage_path('framework/maintenance.php'),
+                    file_get_contents(__DIR__.'/stubs/maintenance-mode.stub')
+                );
+            }
 
             $this->laravel->get('events')->dispatch(new MaintenanceModeEnabled());
 

--- a/tests/Integration/Foundation/MaintenanceModeTest.php
+++ b/tests/Integration/Foundation/MaintenanceModeTest.php
@@ -3,6 +3,8 @@
 namespace Illuminate\Tests\Integration\Foundation;
 
 use DateTimeInterface;
+use Illuminate\Contracts\Foundation\MaintenanceMode as MaintenanceModeContract;
+use Illuminate\Foundation\CacheBasedMaintenanceMode;
 use Illuminate\Foundation\Console\DownCommand;
 use Illuminate\Foundation\Console\UpCommand;
 use Illuminate\Foundation\Events\MaintenanceModeDisabled;
@@ -286,5 +288,21 @@ class MaintenanceModeTest extends TestCase
             '/api/*',
             '/webhooks/*',
         ], $data['except']);
+    }
+
+    public function testDownCommandDoesNotCreateMaintenanceFileWhenUsingCacheDriver()
+    {
+        $this->app->instance(
+            MaintenanceModeContract::class,
+            new CacheBasedMaintenanceMode($this->app['cache'], 'array', 'laravel:maintenance')
+        );
+
+        $maintenanceFile = storage_path('framework/maintenance.php');
+
+        @unlink($maintenanceFile);
+
+        $this->artisan(DownCommand::class);
+
+        $this->assertFileDoesNotExist($maintenanceFile);
     }
 }


### PR DESCRIPTION
## Summary

- The `down` command unconditionally creates `storage/framework/maintenance.php`, even when the maintenance mode driver is cache-based
- This file is only used by the file-based driver. When using the cache driver, the file does nothing (it checks for `framework/down` which the cache driver never creates)
- This causes failures on read-only filesystems and the file is not synced in multi-server environments where the cache driver should handle everything
- Only create the file when using `FileBasedMaintenanceMode`

Fixes #53278

## Test plan

- [x] New test: `down` command with `CacheBasedMaintenanceMode` does not create `maintenance.php`
- [x] All 19 existing `MaintenanceModeTest` tests pass (file-based behavior unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)