### PR TITLE
Add symmetrical, expressive attributes

### DIFF
--- a/src/Illuminate/Console/Attributes/Aliases.php
+++ b/src/Illuminate/Console/Attributes/Aliases.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Illuminate\Console\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class Aliases
+{
+    /**
+     * Create a new attribute instance.
+     *
+     * @param  string[]  $aliases
+     */
+    public function __construct(public array $aliases)
+    {
+        //
+    }
+}

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Console;
 
+use Illuminate\Console\Attributes\Aliases;
 use Illuminate\Console\Attributes\Description;
 use Illuminate\Console\Attributes\Help;
 use Illuminate\Console\Attributes\Hidden;
@@ -169,6 +170,12 @@ class Command extends SymfonyCommand
 
         if (count($reflection->getAttributes(Hidden::class)) > 0) {
             $this->hidden = true;
+        }
+
+        $aliases = $reflection->getAttributes(Aliases::class);
+
+        if (count($aliases) > 0) {
+            $this->aliases = $aliases[0]->newInstance()->aliases;
         }
     }
 

--- a/src/Illuminate/Database/Eloquent/Attributes/DateFormat.php
+++ b/src/Illuminate/Database/Eloquent/Attributes/DateFormat.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class DateFormat
+{
+    /**
+     * Create a new attribute instance.
+     *
+     * @param  string  $format
+     */
+    public function __construct(public string $format)
+    {
+        //
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Attributes/WithoutIncrementing.php
+++ b/src/Illuminate/Database/Eloquent/Attributes/WithoutIncrementing.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class WithoutIncrementing
+{
+    /**
+     * Create a new attribute instance.
+     */
+    public function __construct()
+    {
+        //
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Attributes/WithoutTimestamps.php
+++ b/src/Illuminate/Database/Eloquent/Attributes/WithoutTimestamps.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class WithoutTimestamps
+{
+    /**
+     * Create a new attribute instance.
+     */
+    public function __construct()
+    {
+        //
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -14,6 +14,7 @@ use Illuminate\Contracts\Database\Eloquent\Castable;
 use Illuminate\Contracts\Database\Eloquent\CastsInboundAttributes;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Attributes\Appends;
+use Illuminate\Database\Eloquent\Attributes\DateFormat;
 use Illuminate\Database\Eloquent\Attributes\Initialize;
 use Illuminate\Database\Eloquent\Attributes\Table;
 use Illuminate\Database\Eloquent\Casts\AsArrayObject;
@@ -209,7 +210,9 @@ trait HasAttributes
             array_merge($this->casts, $this->casts()),
         );
 
-        $this->dateFormat ??= static::resolveClassAttribute(Table::class)->dateFormat ?? null;
+        $this->dateFormat ??= static::resolveClassAttribute(DateFormat::class, 'format')
+            ?? static::resolveClassAttribute(Table::class)->dateFormat
+            ?? null;
 
         if (empty($this->appends)) {
             $this->appends = static::resolveClassAttribute(Appends::class, 'columns') ?? [];

--- a/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
@@ -4,6 +4,7 @@ namespace Illuminate\Database\Eloquent\Concerns;
 
 use Illuminate\Database\Eloquent\Attributes\Initialize;
 use Illuminate\Database\Eloquent\Attributes\Table;
+use Illuminate\Database\Eloquent\Attributes\WithoutTimestamps;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Date;
 
@@ -32,7 +33,9 @@ trait HasTimestamps
     public function initializeHasTimestamps()
     {
         if ($this->timestamps === true) {
-            if (($table = static::resolveClassAttribute(Table::class)) && $table->timestamps !== null) {
+            if (static::resolveClassAttribute(WithoutTimestamps::class) !== null) {
+                $this->timestamps = false;
+            } elseif (($table = static::resolveClassAttribute(Table::class)) && $table->timestamps !== null) {
                 $this->timestamps = $table->timestamps;
             }
         }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -19,6 +19,7 @@ use Illuminate\Database\Eloquent\Attributes\Initialize;
 use Illuminate\Database\Eloquent\Attributes\Scope as LocalScope;
 use Illuminate\Database\Eloquent\Attributes\Table;
 use Illuminate\Database\Eloquent\Attributes\UseEloquentBuilder;
+use Illuminate\Database\Eloquent\Attributes\WithoutIncrementing;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\Concerns\AsPivot;
@@ -445,8 +446,12 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
             $this->keyType = $table->keyType;
         }
 
-        if ($this->incrementing === true && $table && $table->incrementing !== null) {
-            $this->incrementing = $table->incrementing;
+        if ($this->incrementing === true) {
+            if (static::resolveClassAttribute(WithoutIncrementing::class) !== null) {
+                $this->incrementing = false;
+            } elseif ($table && $table->incrementing !== null) {
+                $this->incrementing = $table->incrementing;
+            }
         }
     }
 

--- a/tests/Console/CommandTest.php
+++ b/tests/Console/CommandTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Console;
 
 use Illuminate\Console\Application;
+use Illuminate\Console\Attributes\Aliases;
 use Illuminate\Console\Attributes\Help;
 use Illuminate\Console\Attributes\Hidden;
 use Illuminate\Console\Attributes\Signature;
@@ -223,6 +224,22 @@ class CommandTest extends TestCase
         $this->assertSame(['bar:baz', 'baz:qux'], $command->getAliases());
     }
 
+    public function testAliasesAttributeCanSetAliases()
+    {
+        $command = new AliasesAttributeCommand;
+
+        $this->assertSame('foo:bar', $command->getName());
+        $this->assertSame(['bar:baz', 'baz:qux'], $command->getAliases());
+    }
+
+    public function testAliasesAttributeOverridesSignatureAliases()
+    {
+        $command = new AliasesAttributeOverridesSignatureCommand;
+
+        $this->assertSame('foo:bar', $command->getName());
+        $this->assertSame(['override:alias'], $command->getAliases());
+    }
+
     public function testHiddenAttributeHidesCommand()
     {
         $command = new HiddenCommand;
@@ -275,6 +292,24 @@ class HelpCommand extends Command
 #[Usage('foo:bar 1')]
 #[Usage('foo:bar 1 --force')]
 class UsageCommand extends Command
+{
+    public function handle()
+    {
+    }
+}
+
+#[Signature('foo:bar')]
+#[Aliases(['bar:baz', 'baz:qux'])]
+class AliasesAttributeCommand extends Command
+{
+    public function handle()
+    {
+    }
+}
+
+#[Signature('foo:bar', aliases: ['ignored:alias'])]
+#[Aliases(['override:alias'])]
+class AliasesAttributeOverridesSignatureCommand extends Command
 {
     public function handle()
     {

--- a/tests/Database/DatabaseEloquentModelAttributesTest.php
+++ b/tests/Database/DatabaseEloquentModelAttributesTest.php
@@ -13,6 +13,7 @@ use Illuminate\Database\Eloquent\Attributes\Table;
 use Illuminate\Database\Eloquent\Attributes\Touches;
 use Illuminate\Database\Eloquent\Attributes\Unguarded;
 use Illuminate\Database\Eloquent\Attributes\Visible;
+use Illuminate\Database\Eloquent\Attributes\WithoutIncrementing;
 use Illuminate\Database\Eloquent\Attributes\WithoutTimestamps;
 use Illuminate\Database\Eloquent\Model;
 use PHPUnit\Framework\TestCase;
@@ -89,6 +90,20 @@ class DatabaseEloquentModelAttributesTest extends TestCase
 
         $this->assertSame('uuid', $model->getKeyName());
         $this->assertSame('string', $model->getKeyType());
+        $this->assertFalse($model->getIncrementing());
+    }
+
+    public function test_dedicated_without_incrementing_attribute(): void
+    {
+        $model = new ModelWithDedicatedWithoutIncrementingAttribute;
+
+        $this->assertFalse($model->getIncrementing());
+    }
+
+    public function test_dedicated_without_incrementing_attribute_overrides_table_incrementing(): void
+    {
+        $model = new ModelWithWithoutIncrementingAttributeOverride;
+
         $this->assertFalse($model->getIncrementing());
     }
 
@@ -437,6 +452,19 @@ class ModelWithDedicatedWithoutTimestampsAttribute extends Model
 #[Table(timestamps: true)]
 #[WithoutTimestamps]
 class ModelWithWithoutTimestampsAttributeOverride extends Model
+{
+    //
+}
+
+#[WithoutIncrementing]
+class ModelWithDedicatedWithoutIncrementingAttribute extends Model
+{
+    //
+}
+
+#[Table(incrementing: true)]
+#[WithoutIncrementing]
+class ModelWithWithoutIncrementingAttributeOverride extends Model
 {
     //
 }

--- a/tests/Database/DatabaseEloquentModelAttributesTest.php
+++ b/tests/Database/DatabaseEloquentModelAttributesTest.php
@@ -13,6 +13,7 @@ use Illuminate\Database\Eloquent\Attributes\Table;
 use Illuminate\Database\Eloquent\Attributes\Touches;
 use Illuminate\Database\Eloquent\Attributes\Unguarded;
 use Illuminate\Database\Eloquent\Attributes\Visible;
+use Illuminate\Database\Eloquent\Attributes\WithoutTimestamps;
 use Illuminate\Database\Eloquent\Model;
 use PHPUnit\Framework\TestCase;
 
@@ -138,6 +139,20 @@ class DatabaseEloquentModelAttributesTest extends TestCase
         $model = new ModelWithDateFormatAttributeOverride;
 
         $this->assertSame('Y-m-d', $model->getDateFormat());
+    }
+
+    public function test_dedicated_without_timestamps_attribute(): void
+    {
+        $model = new ModelWithDedicatedWithoutTimestampsAttribute;
+
+        $this->assertFalse($model->usesTimestamps());
+    }
+
+    public function test_dedicated_without_timestamps_attribute_overrides_table_timestamps(): void
+    {
+        $model = new ModelWithWithoutTimestampsAttributeOverride;
+
+        $this->assertFalse($model->usesTimestamps());
     }
 
     public function test_fillable_attribute(): void
@@ -409,6 +424,19 @@ class ModelWithDedicatedDateFormatAttribute extends Model
 #[Table(dateFormat: 'U')]
 #[DateFormat('Y-m-d')]
 class ModelWithDateFormatAttributeOverride extends Model
+{
+    //
+}
+
+#[WithoutTimestamps]
+class ModelWithDedicatedWithoutTimestampsAttribute extends Model
+{
+    //
+}
+
+#[Table(timestamps: true)]
+#[WithoutTimestamps]
+class ModelWithWithoutTimestampsAttributeOverride extends Model
 {
     //
 }

--- a/tests/Database/DatabaseEloquentModelAttributesTest.php
+++ b/tests/Database/DatabaseEloquentModelAttributesTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Database;
 use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Attributes\Appends;
 use Illuminate\Database\Eloquent\Attributes\Connection;
+use Illuminate\Database\Eloquent\Attributes\DateFormat;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Guarded;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
@@ -123,6 +124,20 @@ class DatabaseEloquentModelAttributesTest extends TestCase
         $model = new ModelWithDateFormatAttribute;
 
         $this->assertSame('U', $model->getDateFormat());
+    }
+
+    public function test_dedicated_date_format_attribute(): void
+    {
+        $model = new ModelWithDedicatedDateFormatAttribute;
+
+        $this->assertSame('Y-m-d', $model->getDateFormat());
+    }
+
+    public function test_dedicated_date_format_attribute_overrides_table_date_format(): void
+    {
+        $model = new ModelWithDateFormatAttributeOverride;
+
+        $this->assertSame('Y-m-d', $model->getDateFormat());
     }
 
     public function test_fillable_attribute(): void
@@ -381,6 +396,19 @@ class ModelWithAppendsAttribute extends Model
 
 #[Touches(['post', 'author'])]
 class ModelWithTouchesAttribute extends Model
+{
+    //
+}
+
+#[DateFormat('Y-m-d')]
+class ModelWithDedicatedDateFormatAttribute extends Model
+{
+    //
+}
+
+#[Table(dateFormat: 'U')]
+#[DateFormat('Y-m-d')]
+class ModelWithDateFormatAttributeOverride extends Model
 {
     //
 }


### PR DESCRIPTION
This PR adds (or re-adds) some _symmetrical_ PHP attributes introduced in Laravel 13.

While I'm sure more may present themselves, I feel these specifically serve as simple alternatives to existing attributes with long parameter lists, or compliment the other expressive attributes which exist, such as `#[Unguarded]`.

For example:

**Current:**
```php
#[Table(timestamps: false, dateFormat: 'U')]
class Post extends Model {}
```

**Alternative:**
```php
#[DateFormat('U')]
#[WithoutTimestamps]
class Post extends Model {}
```