### PR TITLE
[13.x] Add UnitEnum to Connection Attribute

### DIFF
--- a/src/Illuminate/Database/Eloquent/Attributes/Connection.php
+++ b/src/Illuminate/Database/Eloquent/Attributes/Connection.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Eloquent\Attributes;
 
 use Attribute;
+use UnitEnum;
 
 #[Attribute(Attribute::TARGET_CLASS)]
 class Connection
@@ -10,9 +11,9 @@ class Connection
     /**
      * Create a new attribute instance.
      *
-     * @param  string  $name
+     * @param  \UnitEnum|string  $name
      */
-    public function __construct(public string $name)
+    public function __construct(public UnitEnum|string $name)
     {
     }
 }

--- a/tests/Database/DatabaseEloquentModelAttributesTest.php
+++ b/tests/Database/DatabaseEloquentModelAttributesTest.php
@@ -310,7 +310,7 @@ class ModelWithConnectionAttribute extends Model
     //
 }
 
-#[Connection(ConnectionEnum::Secondary)]
+#[Connection(ConnectionBackedEnum::Secondary)]
 class ModelWithBackedEnumConnectionAttribute extends Model
 {
     //
@@ -411,7 +411,7 @@ class ModelWithTouchesAttribute extends Model
     //
 }
 
-enum ConnectionEnum: string
+enum ConnectionBackedEnum: string
 {
     case Secondary = 'secondary';
 }

--- a/tests/Database/DatabaseEloquentModelAttributesTest.php
+++ b/tests/Database/DatabaseEloquentModelAttributesTest.php
@@ -97,6 +97,20 @@ class DatabaseEloquentModelAttributesTest extends TestCase
         $this->assertSame('secondary', $model->getConnectionName());
     }
 
+    public function test_connection_attribute_with_backed_enum(): void
+    {
+        $model = new ModelWithBackedConnectionAttribute;
+
+        $this->assertSame('secondary', $model->getConnectionName());
+    }
+
+    public function test_connection_attribute_with_unit_enum(): void
+    {
+        $model = new ModelWithUnitConnectionAttribute;
+
+        $this->assertSame('Secondary', $model->getConnectionName());
+    }
+
     public function test_timestamps_attribute(): void
     {
         $model = new ModelWithTimestampsFalseAttribute;
@@ -296,6 +310,18 @@ class ModelWithConnectionAttribute extends Model
     //
 }
 
+#[Connection(ConnectionEnum::Secondary)]
+class ModelWithBackedConnectionAttribute extends Model
+{
+    //
+}
+
+#[Connection(ConnectionUnitEnum::Secondary)]
+class ModelWithUnitConnectionAttribute extends Model
+{
+    //
+}
+
 #[Table(timestamps: false)]
 class ModelWithTimestampsFalseAttribute extends Model
 {
@@ -359,6 +385,16 @@ class ModelExtendingGuardedParent extends GuardedBaseModel
 class ModelWithUnguardedAttribute extends Model
 {
     //
+}
+
+enum ConnectionEnum: string
+{
+    case Secondary = 'secondary';
+}
+
+enum ConnectionUnitEnum
+{
+    case Secondary;
 }
 
 #[Hidden(['password', 'secret'])]

--- a/tests/Database/DatabaseEloquentModelAttributesTest.php
+++ b/tests/Database/DatabaseEloquentModelAttributesTest.php
@@ -99,14 +99,14 @@ class DatabaseEloquentModelAttributesTest extends TestCase
 
     public function test_connection_attribute_with_backed_enum(): void
     {
-        $model = new ModelWithBackedConnectionAttribute;
+        $model = new ModelWithBackedEnumConnectionAttribute;
 
         $this->assertSame('secondary', $model->getConnectionName());
     }
 
     public function test_connection_attribute_with_unit_enum(): void
     {
-        $model = new ModelWithUnitConnectionAttribute;
+        $model = new ModelWithUnitEnumConnectionAttribute;
 
         $this->assertSame('Secondary', $model->getConnectionName());
     }
@@ -311,13 +311,13 @@ class ModelWithConnectionAttribute extends Model
 }
 
 #[Connection(ConnectionEnum::Secondary)]
-class ModelWithBackedConnectionAttribute extends Model
+class ModelWithBackedEnumConnectionAttribute extends Model
 {
     //
 }
 
 #[Connection(ConnectionUnitEnum::Secondary)]
-class ModelWithUnitConnectionAttribute extends Model
+class ModelWithUnitEnumConnectionAttribute extends Model
 {
     //
 }
@@ -385,16 +385,6 @@ class ModelExtendingGuardedParent extends GuardedBaseModel
 class ModelWithUnguardedAttribute extends Model
 {
     //
-}
-
-enum ConnectionEnum: string
-{
-    case Secondary = 'secondary';
-}
-
-enum ConnectionUnitEnum
-{
-    case Secondary;
 }
 
 #[Hidden(['password', 'secret'])]

--- a/tests/Database/DatabaseEloquentModelAttributesTest.php
+++ b/tests/Database/DatabaseEloquentModelAttributesTest.php
@@ -410,3 +410,13 @@ class ModelWithTouchesAttribute extends Model
 {
     //
 }
+
+enum ConnectionEnum: string
+{
+    case Secondary = 'secondary';
+}
+
+enum ConnectionUnitEnum
+{
+    case Secondary;
+}


### PR DESCRIPTION
[The connection property supports UnitEnum](https://github.com/laravel/framework/blob/e4223623a04f8c7ffd1ecc82af430fe7292ef007/src/Illuminate/Database/Eloquent/Model.php#L60), but the Attribute does not. 

This aligns the two... also added tests to prevent regression.

This means we can do
```php
  #[Connection(Database::Secondary)]
  class User extends Model {
  //
  } 
  ```