### PR TITLE
[13.x] `schedule:list` display expression in the correct timezone

### DIFF
--- a/src/Illuminate/Console/Scheduling/CronExpressionTimezoneConverter.php
+++ b/src/Illuminate/Console/Scheduling/CronExpressionTimezoneConverter.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace Illuminate\Console\Scheduling;
+
+use DateTimeZone;
+use Illuminate\Support\Carbon;
+
+class CronExpressionTimezoneConverter
+{
+    /**
+     * Convert an event cron expression to the display timezone.
+     *
+     * Returns one or more expressions when values straddle a day boundary.
+     *
+     * @param  \Illuminate\Console\Scheduling\Event  $event
+     * @param  \DateTimeZone  $timezone
+     * @return array<string>
+     */
+    public static function forEvent(Event $event, DateTimeZone $timezone)
+    {
+        $eventTimezone = static::resolveEventTimezone($event, $timezone);
+
+        [$totalOffsetMinutes, $hourOffset, $minuteOffset] = static::offsetComponents(
+            $eventTimezone, $timezone
+        );
+
+        if ($totalOffsetMinutes === 0) {
+            return [$event->expression];
+        }
+
+        $segments = preg_split("/\s+/", $event->expression);
+        $minuteGroups = static::shiftAndGroup($segments[0], $minuteOffset, 60);
+
+        $expressions = [];
+
+        foreach ($minuteGroups as $minuteCarry => $minuteValues) {
+            $hourGroups = static::shiftAndGroup($segments[1], $hourOffset + $minuteCarry, 24);
+
+            foreach ($hourGroups as $hourCarry => $hourValues) {
+                $parts = $segments;
+                $parts[0] = $minuteValues;
+                $parts[1] = $hourValues;
+
+                foreach (static::expressionsForHourCarry($segments, $parts, $hourCarry) as $expression) {
+                    $expressions[] = $expression;
+                }
+            }
+        }
+
+        return $expressions;
+    }
+
+    /**
+     * Resolve the timezone used by the given event.
+     *
+     * @param  \Illuminate\Console\Scheduling\Event  $event
+     * @param  \DateTimeZone  $defaultTimezone
+     * @return \DateTimeZone
+     */
+    protected static function resolveEventTimezone(Event $event, DateTimeZone $defaultTimezone)
+    {
+        return $event->timezone instanceof DateTimeZone
+            ? $event->timezone
+            : new DateTimeZone($event->timezone ?? $defaultTimezone->getName());
+    }
+
+    /**
+     * Get offset components between the event and display timezones.
+     *
+     * @return array{int, int, int}
+     */
+    protected static function offsetComponents(DateTimeZone $eventTimezone, DateTimeZone $displayTimezone)
+    {
+        $now = Carbon::now();
+
+        $totalOffsetMinutes = intdiv(
+            $displayTimezone->getOffset($now) - $eventTimezone->getOffset($now),
+            60
+        );
+
+        return [$totalOffsetMinutes, intdiv($totalOffsetMinutes, 60), $totalOffsetMinutes % 60];
+    }
+
+    /**
+     * Build expressions for the given hour carry direction.
+     *
+     * @param  array<int, string>  $segments
+     * @param  array<int, string>  $parts
+     * @return array<int, string>
+     */
+    protected static function expressionsForHourCarry(array $segments, array $parts, int $hourCarry)
+    {
+        if ($hourCarry === 0) {
+            return [implode(' ', $parts)];
+        }
+
+        $parts[4] = static::shiftField($segments[4], $hourCarry, 7);
+
+        $dayGroups = static::shiftAndGroup($segments[2], $hourCarry, 31, min: 1);
+
+        $expressions = [];
+
+        foreach ($dayGroups as $dayCarry => $dayValues) {
+            $dayParts = $parts;
+            $dayParts[2] = $dayValues;
+
+            if ($dayCarry !== 0) {
+                $dayParts[3] = static::shiftField($segments[3], $dayCarry, 12, min: 1);
+            }
+
+            $expressions[] = implode(' ', $dayParts);
+        }
+
+        return $expressions;
+    }
+
+    /**
+     * Shift values in a cron field and group them by carry direction.
+     *
+     * @param  string  $field
+     * @param  int  $offset
+     * @param  int  $mod
+     * @return array<int, string>
+     */
+    protected static function shiftAndGroup($field, $offset, $mod, $min = 0)
+    {
+        if ($offset === 0 || ! preg_match('/^[\d,]+$/', $field)) {
+            return [0 => $field];
+        }
+
+        $groups = [];
+
+        foreach (explode(',', $field) as $value) {
+            $new = (int) $value + $offset;
+            $carry = 0;
+
+            if ($new >= $mod + $min) {
+                $carry = 1;
+                $new -= $mod;
+            } elseif ($new < $min) {
+                $carry = -1;
+                $new += $mod;
+            }
+
+            $groups[$carry][] = $new;
+        }
+
+        return collect($groups)->map(function ($values) {
+            sort($values);
+
+            return implode(',', $values);
+        })->all();
+    }
+
+    /**
+     * Shift a cron field by the given offset.
+     *
+     * @param  string  $field
+     * @param  int  $offset
+     * @param  int  $mod
+     * @param  int  $min
+     * @return string
+     */
+    protected static function shiftField($field, $offset, $mod, $min = 0)
+    {
+        if ($offset === 0 || ! preg_match('/^[\d,]+$/', $field)) {
+            return $field;
+        }
+
+        $shifted = collect(explode(',', $field))
+            ->map(fn ($v) => (((int) $v + $offset - $min) % $mod + $mod) % $mod + $min)
+            ->sort();
+
+        return $shifted->implode(',');
+    }
+}

--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -79,7 +79,7 @@ class ScheduleListCommand extends Command
      */
     protected function displayJson(Collection $events, DateTimeZone $timezone)
     {
-        $this->output->writeln($events->map(function ($event) use ($timezone) {
+        $this->output->writeln($events->flatMap(function ($event) use ($timezone) {
             $nextDueDate = $this->getNextDueDateForEvent($event, $timezone);
 
             $command = $event->command ?? '';
@@ -96,8 +96,8 @@ class ScheduleListCommand extends Command
                 }
             }
 
-            return [
-                'expression' => $event->expression,
+            return collect($this->expressionsInTimezone($event, $timezone))->map(fn ($expression) => [
+                'expression' => $expression,
                 'command' => $command,
                 'description' => $event->description ?? null,
                 'next_due_date' => $nextDueDate->format('Y-m-d H:i:s P'),
@@ -106,7 +106,7 @@ class ScheduleListCommand extends Command
                 'has_mutex' => $event->mutex->exists($event),
                 'repeat_seconds' => $event->isRepeatable() ? $event->repeatSeconds : null,
                 'environments' => $event->environments,
-            ];
+            ]);
         })->values()->toJson());
     }
 
@@ -121,12 +121,14 @@ class ScheduleListCommand extends Command
     {
         $terminalWidth = self::getTerminalWidth();
 
-        $expressionSpacing = $this->getCronExpressionSpacing($events);
+        $expressionSpacing = $this->getCronExpressionSpacing($events, $timezone);
 
         $repeatExpressionSpacing = $this->getRepeatExpressionSpacing($events);
 
-        $events = $events->map(function ($event) use ($terminalWidth, $expressionSpacing, $repeatExpressionSpacing, $timezone) {
-            return $this->listEvent($event, $terminalWidth, $expressionSpacing, $repeatExpressionSpacing, $timezone);
+        $events = $events->flatMap(function ($event) use ($terminalWidth, $expressionSpacing, $repeatExpressionSpacing, $timezone) {
+            return collect($this->expressionsInTimezone($event, $timezone))->map(
+                fn ($expression) => $this->listEvent($event, $terminalWidth, $expressionSpacing, $repeatExpressionSpacing, $timezone, $expression)
+            );
         });
 
         $this->line(
@@ -140,9 +142,10 @@ class ScheduleListCommand extends Command
      * @param  \Illuminate\Support\Collection  $events
      * @return array<int, int>
      */
-    private function getCronExpressionSpacing($events)
+    private function getCronExpressionSpacing($events, DateTimeZone $timezone)
     {
-        $rows = $events->map(fn ($event) => array_map(mb_strlen(...), preg_split("/\s+/", $event->expression)));
+        $rows = $events->flatMap(fn ($event) => collect($this->expressionsInTimezone($event, $timezone))
+            ->map(fn ($expression) => array_map(mb_strlen(...), preg_split("/\s+/", $expression))));
 
         return (new Collection($rows[0] ?? []))->keys()->map(fn ($key) => $rows->max($key))->all();
     }
@@ -166,11 +169,12 @@ class ScheduleListCommand extends Command
      * @param  array  $expressionSpacing
      * @param  int  $repeatExpressionSpacing
      * @param  \DateTimeZone  $timezone
+     * @param  string|null  $convertedExpression
      * @return array
      */
-    private function listEvent($event, $terminalWidth, $expressionSpacing, $repeatExpressionSpacing, $timezone)
+    private function listEvent($event, $terminalWidth, $expressionSpacing, $repeatExpressionSpacing, $timezone, $convertedExpression = null)
     {
-        $expression = $this->formatCronExpression($event->expression, $expressionSpacing);
+        $expression = $this->formatCronExpression($convertedExpression ?? $event->expression, $expressionSpacing);
 
         $repeatExpression = str_pad($this->getRepeatExpression($event), $repeatExpressionSpacing);
 
@@ -297,6 +301,131 @@ class ScheduleListCommand extends Command
         return $now
             ->endOfSecond()
             ->ceilSeconds($event->repeatSeconds);
+    }
+
+    /**
+     * Convert a cron expression from the event's timezone to the display timezone.
+     *
+     * Returns one or more expressions when values straddle a day boundary.
+     *
+     * @param  \Illuminate\Console\Scheduling\Event  $event
+     * @param  \DateTimeZone  $timezone
+     * @return array<string>
+     */
+    private function expressionsInTimezone($event, DateTimeZone $timezone)
+    {
+        $eventTimezone = $event->timezone instanceof DateTimeZone
+            ? $event->timezone
+            : new DateTimeZone($event->timezone ?? $timezone->getName());
+
+        $now = Carbon::now();
+        $offset = $timezone->getOffset($now) - $eventTimezone->getOffset($now);
+
+        if ($offset === 0) {
+            return [$event->expression];
+        }
+
+        $segments = preg_split("/\s+/", $event->expression);
+        $offsetMinutes = intdiv($offset, 60);
+        $offsetMins = $offsetMinutes % 60;
+        $offsetHours = intdiv($offsetMinutes, 60);
+
+        $minuteGroups = $this->shiftAndGroup($segments[0], $offsetMins, 60);
+
+        $expressions = [];
+
+        foreach ($minuteGroups as $minuteCarry => $minuteValues) {
+            $hourGroups = $this->shiftAndGroup($segments[1], $offsetHours + $minuteCarry, 24);
+
+            foreach ($hourGroups as $hourCarry => $hourValues) {
+                $parts = $segments;
+                $parts[0] = $minuteValues;
+                $parts[1] = $hourValues;
+
+                if ($hourCarry !== 0) {
+                    $parts[4] = $this->shiftField($segments[4], $hourCarry, 7);
+
+                    $dayGroups = $this->shiftAndGroup($segments[2], $hourCarry, 31, min: 1);
+
+                    foreach ($dayGroups as $dayCarry => $dayValues) {
+                        $dayParts = $parts;
+                        $dayParts[2] = $dayValues;
+
+                        if ($dayCarry !== 0) {
+                            $dayParts[3] = $this->shiftField($segments[3], $dayCarry, 12, min: 1);
+                        }
+
+                        $expressions[] = implode(' ', $dayParts);
+                    }
+
+                    continue;
+                }
+
+                $expressions[] = implode(' ', $parts);
+            }
+        }
+
+        return $expressions;
+    }
+
+    /**
+     * Shift values in a cron field and group them by carry direction.
+     *
+     * @param  string  $field
+     * @param  int  $offset
+     * @param  int  $mod
+     * @return array<int, string>
+     */
+    private function shiftAndGroup($field, $offset, $mod, $min = 0)
+    {
+        if ($offset === 0 || ! preg_match('/^[\d,]+$/', $field)) {
+            return [0 => $field];
+        }
+
+        $groups = [];
+
+        foreach (explode(',', $field) as $value) {
+            $new = (int) $value + $offset;
+            $carry = 0;
+
+            if ($new >= $mod + $min) {
+                $carry = 1;
+                $new -= $mod;
+            } elseif ($new < $min) {
+                $carry = -1;
+                $new += $mod;
+            }
+
+            $groups[$carry][] = $new;
+        }
+
+        return collect($groups)->map(function ($values) {
+            sort($values);
+
+            return implode(',', $values);
+        })->all();
+    }
+
+    /**
+     * Shift a cron field by the given offset.
+     *
+     * @param  string  $field
+     * @param  int  $offset
+     * @param  int  $mod
+     * @param  int  $min
+     * @return string
+     */
+    private function shiftField($field, $offset, $mod, $min = 0)
+    {
+        if ($offset === 0 || ! preg_match('/^[\d,]+$/', $field)) {
+            return $field;
+        }
+
+        $shifted = collect(explode(',', $field))
+            ->map(fn ($v) => (((int) $v + $offset - $min) % $mod + $mod) % $mod + $min)
+            ->sort();
+
+        return $shifted->implode(',');
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -96,7 +96,7 @@ class ScheduleListCommand extends Command
                 }
             }
 
-            return collect($this->expressionsInTimezone($event, $timezone))->map(fn ($expression) => [
+            return collect(CronExpressionTimezoneConverter::forEvent($event, $timezone))->map(fn ($expression) => [
                 'expression' => $expression,
                 'command' => $command,
                 'description' => $event->description ?? null,
@@ -126,7 +126,7 @@ class ScheduleListCommand extends Command
         $repeatExpressionSpacing = $this->getRepeatExpressionSpacing($events);
 
         $events = $events->flatMap(function ($event) use ($terminalWidth, $expressionSpacing, $repeatExpressionSpacing, $timezone) {
-            return collect($this->expressionsInTimezone($event, $timezone))->map(
+            return collect(CronExpressionTimezoneConverter::forEvent($event, $timezone))->map(
                 fn ($expression) => $this->listEvent($event, $terminalWidth, $expressionSpacing, $repeatExpressionSpacing, $timezone, $expression)
             );
         });
@@ -144,7 +144,7 @@ class ScheduleListCommand extends Command
      */
     private function getCronExpressionSpacing($events, DateTimeZone $timezone)
     {
-        $rows = $events->flatMap(fn ($event) => collect($this->expressionsInTimezone($event, $timezone))
+        $rows = $events->flatMap(fn ($event) => collect(CronExpressionTimezoneConverter::forEvent($event, $timezone))
             ->map(fn ($expression) => array_map(mb_strlen(...), preg_split("/\s+/", $expression))));
 
         return (new Collection($rows[0] ?? []))->keys()->map(fn ($key) => $rows->max($key))->all();
@@ -301,131 +301,6 @@ class ScheduleListCommand extends Command
         return $now
             ->endOfSecond()
             ->ceilSeconds($event->repeatSeconds);
-    }
-
-    /**
-     * Convert a cron expression from the event's timezone to the display timezone.
-     *
-     * Returns one or more expressions when values straddle a day boundary.
-     *
-     * @param  \Illuminate\Console\Scheduling\Event  $event
-     * @param  \DateTimeZone  $timezone
-     * @return array<string>
-     */
-    private function expressionsInTimezone($event, DateTimeZone $timezone)
-    {
-        $eventTimezone = $event->timezone instanceof DateTimeZone
-            ? $event->timezone
-            : new DateTimeZone($event->timezone ?? $timezone->getName());
-
-        $now = Carbon::now();
-        $offset = $timezone->getOffset($now) - $eventTimezone->getOffset($now);
-
-        if ($offset === 0) {
-            return [$event->expression];
-        }
-
-        $segments = preg_split("/\s+/", $event->expression);
-        $offsetMinutes = intdiv($offset, 60);
-        $offsetMins = $offsetMinutes % 60;
-        $offsetHours = intdiv($offsetMinutes, 60);
-
-        $minuteGroups = $this->shiftAndGroup($segments[0], $offsetMins, 60);
-
-        $expressions = [];
-
-        foreach ($minuteGroups as $minuteCarry => $minuteValues) {
-            $hourGroups = $this->shiftAndGroup($segments[1], $offsetHours + $minuteCarry, 24);
-
-            foreach ($hourGroups as $hourCarry => $hourValues) {
-                $parts = $segments;
-                $parts[0] = $minuteValues;
-                $parts[1] = $hourValues;
-
-                if ($hourCarry !== 0) {
-                    $parts[4] = $this->shiftField($segments[4], $hourCarry, 7);
-
-                    $dayGroups = $this->shiftAndGroup($segments[2], $hourCarry, 31, min: 1);
-
-                    foreach ($dayGroups as $dayCarry => $dayValues) {
-                        $dayParts = $parts;
-                        $dayParts[2] = $dayValues;
-
-                        if ($dayCarry !== 0) {
-                            $dayParts[3] = $this->shiftField($segments[3], $dayCarry, 12, min: 1);
-                        }
-
-                        $expressions[] = implode(' ', $dayParts);
-                    }
-
-                    continue;
-                }
-
-                $expressions[] = implode(' ', $parts);
-            }
-        }
-
-        return $expressions;
-    }
-
-    /**
-     * Shift values in a cron field and group them by carry direction.
-     *
-     * @param  string  $field
-     * @param  int  $offset
-     * @param  int  $mod
-     * @return array<int, string>
-     */
-    private function shiftAndGroup($field, $offset, $mod, $min = 0)
-    {
-        if ($offset === 0 || ! preg_match('/^[\d,]+$/', $field)) {
-            return [0 => $field];
-        }
-
-        $groups = [];
-
-        foreach (explode(',', $field) as $value) {
-            $new = (int) $value + $offset;
-            $carry = 0;
-
-            if ($new >= $mod + $min) {
-                $carry = 1;
-                $new -= $mod;
-            } elseif ($new < $min) {
-                $carry = -1;
-                $new += $mod;
-            }
-
-            $groups[$carry][] = $new;
-        }
-
-        return collect($groups)->map(function ($values) {
-            sort($values);
-
-            return implode(',', $values);
-        })->all();
-    }
-
-    /**
-     * Shift a cron field by the given offset.
-     *
-     * @param  string  $field
-     * @param  int  $offset
-     * @param  int  $mod
-     * @param  int  $min
-     * @return string
-     */
-    private function shiftField($field, $offset, $mod, $min = 0)
-    {
-        if ($offset === 0 || ! preg_match('/^[\d,]+$/', $field)) {
-            return $field;
-        }
-
-        $shifted = collect(explode(',', $field))
-            ->map(fn ($v) => (((int) $v + $offset - $min) % $mod + $mod) % $mod + $min)
-            ->sort();
-
-        return $shifted->implode(',');
     }
 
     /**

--- a/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
@@ -188,6 +188,122 @@ class ScheduleListCommandTest extends TestCase
         $this->assertSame('php artisan inspire', $data[0]['command']);
     }
 
+    public static function expressionTimezoneConversionProvider()
+    {
+        return [
+            // [cron expression, event timezone, display timezone, expected expressions]
+
+            // No conversion needed — same timezone
+            'same timezone' => ['0 8 * * *', 'UTC', null, ['0 8 * * *']],
+
+            // Wildcards/steps — pass through unchanged
+            'every minute' => ['* * * * *', 'America/New_York', null, ['* * * * *']],
+            'every five minutes' => ['*/5 * * * *', 'Asia/Tokyo', null, ['*/5 * * * *']],
+            'every two hours' => ['0 */2 * * *', 'Asia/Tokyo', null, ['0 */2 * * *']],
+            'every odd hour' => ['0 1-23/2 * * *', 'Asia/Tokyo', null, ['0 1-23/2 * * *']],
+            'quarterly step month' => ['0 0 1 1-12/3 *', 'Asia/Tokyo', null, ['0 15 31 1-12/3 *']],
+            'weekdays range' => ['0 8 * * 1-5', 'Asia/Tokyo', null, ['0 23 * * 1-5']],
+
+            // Simple hour shift (no day boundary)
+            'daily LA to UTC' => ['0 8 * * *', 'America/Los_Angeles', null, ['0 16 * * *']],
+            'daily Tokyo to UTC' => ['0 14 * * *', 'Asia/Tokyo', null, ['0 5 * * *']],
+            '--timezone flag' => ['0 0 * * *', 'UTC', 'Asia/Tokyo', ['0 9 * * *']],
+
+            // Hour wraparound (crosses midnight, no fixed day)
+            'hour wraps forward' => ['0 23 * * *', 'Asia/Tokyo', null, ['0 14 * * *']],
+            'hour wraps backward' => ['0 2 * * *', 'America/Los_Angeles', null, ['0 10 * * *']],
+
+            // Half-hour timezone offset
+            'Kolkata +5:30' => ['0 8 * * *', 'Asia/Kolkata', null, ['30 2 * * *']],
+            'Kathmandu +5:45' => ['0 8 * * *', 'Asia/Kathmandu', null, ['15 2 * * *']],
+
+            // Comma-separated hours — same carry direction
+            'twice daily Tokyo' => ['0 9,17 * * *', 'Asia/Tokyo', null, ['0 0,8 * * *']],
+            'twice daily Tokyo wrapping' => ['0 13,22 * * *', 'Asia/Tokyo', null, ['0 4,13 * * *']],
+
+            // Comma-separated hours — mixed carries (splits into two entries)
+            'twice daily LA mixed carry' => ['0 13,17 * * *', 'America/Los_Angeles', null, ['0 21 * * *', '0 1 * * *']],
+            'twice daily Tokyo mixed carry' => ['0 3,20 * * *', 'Asia/Tokyo', null, ['0 18 * * *', '0 11 * * *']],
+
+            // Day-of-week shifts
+            'weekly Monday night LA' => ['0 22 * * 1', 'America/Los_Angeles', null, ['0 6 * * 2']],
+            'weekly Wednesday morning Tokyo' => ['0 3 * * 3', 'Asia/Tokyo', null, ['0 18 * * 2']],
+            'weekly Sunday night LA' => ['0 22 * * 0', 'America/Los_Angeles', null, ['0 6 * * 1']],
+            'weekly Saturday morning Tokyo' => ['0 3 * * 6', 'Asia/Tokyo', null, ['0 18 * * 5']],
+
+            // Day-of-month shifts
+            'monthly 15th Tokyo (no day wrap)' => ['0 12 15 * *', 'Asia/Tokyo', null, ['0 3 15 * *']],
+            'monthly 15th Tokyo (day wraps back)' => ['0 8 15 * *', 'Asia/Tokyo', null, ['0 23 14 * *']],
+            'monthly 1st Tokyo (day wraps to 31)' => ['0 1 1 * *', 'Asia/Tokyo', null, ['0 16 31 * *']],
+            'monthly 1st LA (day wraps forward)' => ['0 22 1 * *', 'America/Los_Angeles', null, ['0 6 2 * *']],
+
+            // Month shifts (day-of-month carry propagates to month)
+            'yearly Jan 1 Tokyo' => ['0 1 1 1 *', 'Asia/Tokyo', null, ['0 16 31 12 *']],
+            'yearly Jul 1 Tokyo' => ['0 1 1 7 *', 'Asia/Tokyo', null, ['0 16 31 6 *']],
+            'yearly Dec 31 LA' => ['0 22 31 12 *', 'America/Los_Angeles', null, ['0 6 1 1 *']],
+
+            // Comma day-of-month
+            'twice monthly Tokyo (no wrap)' => ['0 12 1,16 * *', 'Asia/Tokyo', null, ['0 3 1,16 * *']],
+            // day 1→31 (carry -1 to month) and 16→15 (no carry) — splits
+            'twice monthly Tokyo (wraps)' => ['0 1 1,16 * *', 'Asia/Tokyo', null, ['0 16 31 * *', '0 16 15 * *']],
+
+            // Comma day-of-week
+            'weekends LA night' => ['0 22 * * 0,6', 'America/Los_Angeles', null, ['0 6 * * 0,1']],
+
+            // Hourly with minute offset (half-hour timezone)
+            'hourly at 30 Kolkata' => ['30 * * * *', 'Asia/Kolkata', null, ['0 * * * *']],
+            'hourly at 0 Kolkata' => ['0 * * * *', 'Asia/Kolkata', null, ['30 * * * *']],
+
+            // Comma minutes with half-hour timezone — mixed minute carries (splits)
+            // 15+(-30)=-15→45 (carry -1) and 45+(-30)=15 (no carry)
+            'comma minutes Kolkata mixed carry' => ['15,45 8 * * *', 'Asia/Kolkata', null, ['45 2 * * *', '15 3 * * *']],
+        ];
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('expressionTimezoneConversionProvider')]
+    public function testExpressionTimezoneConversion($expression, $eventTimezone, $displayTimezone, $expectedExpressions)
+    {
+        $this->schedule->command('inspire')->cron($expression)->timezone($eventTimezone);
+
+        $options = ['--json' => true];
+
+        if ($displayTimezone) {
+            $options['--timezone'] = $displayTimezone;
+        }
+
+        $this->withoutMockingConsoleOutput()->artisan(ScheduleListCommand::class, $options);
+        $output = Artisan::output();
+
+        $data = json_decode($output, true);
+
+        $this->assertCount(count($expectedExpressions), $data);
+
+        foreach ($expectedExpressions as $index => $expected) {
+            $this->assertSame($expected, $data[$index]['expression']);
+        }
+    }
+
+    public function testDisplayScheduleCliSplitsExpressionWhenMixedCarry()
+    {
+        // 13+8=21 (no carry), 17+8=1 (carry +1) — splits into two CLI rows
+        $this->schedule->command('inspire')->twiceDaily(13, 17)->timezone('America/Los_Angeles');
+
+        $this->artisan(ScheduleListCommand::class)
+            ->assertSuccessful()
+            ->expectsOutputToContain('0 21 * * *')
+            ->expectsOutputToContain('0 1  * * *');
+    }
+
+    public function testDisplayScheduleCliConvertsExpression()
+    {
+        // 8:00 AM LA (UTC-8 in January) = 16:00 UTC
+        $this->schedule->command('inspire')->dailyAt('08:00')->timezone('America/Los_Angeles');
+
+        $this->artisan(ScheduleListCommand::class)
+            ->assertSuccessful()
+            ->expectsOutputToContain('0 16 * * *');
+    }
+
     public function testDisplayScheduleAsJsonInVerboseMode()
     {
         $this->schedule->command(FooCommand::class)->quarterly();

--- a/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\ProcessUtils;
 use Orchestra\Testbench\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ScheduleListCommandTest extends TestCase
 {
@@ -260,7 +261,7 @@ class ScheduleListCommandTest extends TestCase
         ];
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('expressionTimezoneConversionProvider')]
+    #[DataProvider('expressionTimezoneConversionProvider')]
     public function testExpressionTimezoneConversion($expression, $eventTimezone, $displayTimezone, $expectedExpressions)
     {
         $this->schedule->command('inspire')->cron($expression)->timezone($eventTimezone);


### PR DESCRIPTION
This PR fixes the `schedule:list` command to convert the cron expression to the display timezone. Currently, when a scheduled event has a different timezone, the `next_due_date` is correctly shown in the display timezone but the cron expression still shows the raw value from the event's timezone. This makes the expression misleading — it doesn't match the time shown in `next_due_date`.

### Example

```php
Schedule::command('inspire')
    ->dailyAt('08:00')
    ->timezone('America/Los_Angeles');
```

### Before

```
$ php artisan schedule:list

  0 8 * * *  php artisan inspire  Next Due: 16 hours from now
```

```json
[
  {
    "expression": "0 8 * * *",
    "next_due_date": "2026-03-19 15:00:00 +00:00",
    "timezone": "UTC"
  }
]
```

The expression says `0 8 * * *` and the timezone says `UTC`, implying the task runs at 8:00 AM UTC. It actually runs at 8:00 AM Los Angeles time (3:00 PM UTC).

### After

```
$ php artisan schedule:list

  0 15 * * *  php artisan inspire  Next Due: 16 hours from now
```

```json
[
  {
    "expression": "0 15 * * *",
    "next_due_date": "2026-03-19 15:00:00 +00:00",
    "timezone": "UTC"
  }
]
```

The expression, `next_due_date`, and `timezone` are now all consistent in the display timezone.

### Some edge-cases

The expression is converted to the display timezone, including half-hour offset timezones like `Asia/Kolkata` (UTC+5:30) and `Asia/Kathmandu` (UTC+5:45). 

In some cases, a single cron expression cannot represent the converted schedule. For example, `twiceDaily(13, 17)` in `America/Los_Angeles` converts to 21:00 UTC (same day) and 01:00 UTC (next day). Since these fall on different days, the event is split into two lines:

```
$ php artisan schedule:list --json

[
  { "expression": "0 21 * * *", "command": "php artisan foo", "timezone": "UTC" },
  { "expression": "0 1 * * *", "command": "php artisan foo", "timezone": "UTC" }
]
```

The `--timezone` option also works — passing `--timezone=America/Chicago` will convert all expressions to Chicago time.

### Tests

Added a bunch of tests to cover all those timezone shifts.