### PR TITLE
[13.x] Traverse data directly for wildcard rule expansion

### DIFF
--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -158,35 +158,150 @@ class ValidationRuleParser
      */
     protected function explodeWildcardRules($results, $attribute, $rules)
     {
-        $pattern = str_replace('\*', '[^\.]*', preg_quote($attribute, '/'));
+        $rulesList = (array) $rules;
 
+        // CompilableRules need the flattened data context, so use the original approach.
+        foreach ($rulesList as $rule) {
+            if ($rule instanceof CompilableRules) {
+                return $this->explodeWildcardRulesCompilable($results, $attribute, $rules);
+            }
+        }
+
+        // Fast path: traverse the data structure directly to enumerate matching
+        // keys instead of flattening with Arr::dot() and regex matching.
+        $keys = $this->expandWildcardKeys($attribute, $this->data);
+
+        if (empty($keys)) {
+            return $results;
+        }
+
+        // Pre-explode rules once so we don't re-parse the same rule string
+        // for every expanded key (e.g. 500 items × same rule string).
+        $explodedRules = [];
+
+        foreach ($rulesList as $rule) {
+            if (is_string($rule)) {
+                $explodedRules = array_merge($explodedRules, explode('|', $rule));
+            } else {
+                $explodedRules = array_merge($explodedRules, $this->explodeExplicitRule($rule, $attribute));
+            }
+        }
+
+        foreach ($keys as $key) {
+            // Normalize key to match PHP's array key casting (e.g. '0' → int 0)
+            // so that strict comparisons in implicitAttributes work correctly.
+            $key = ((string) (int) $key === $key) ? (int) $key : $key;
+
+            $this->implicitAttributes[$attribute][] = $key;
+
+            $results[$key] = array_merge($results[$key] ?? [], $explodedRules);
+        }
+
+        return $results;
+    }
+
+    /**
+     * Explode wildcard rules using the original flatten and regex approach.
+     *
+     * Used for CompilableRules which need the flattened data context.
+     *
+     * @param  array  $results
+     * @param  string  $attribute
+     * @param  string|array  $rules
+     * @return array
+     */
+    protected function explodeWildcardRulesCompilable($results, $attribute, $rules)
+    {
+        $keys = $this->expandWildcardKeys($attribute, $this->data);
+
+        if (empty($keys)) {
+            return $results;
+        }
+
+        // Compute flattened data once for CompilableRules that need it.
         $data = ValidationData::initializeAndGatherData($attribute, $this->data);
 
-        foreach ($data as $key => $value) {
-            if (Str::startsWith($key, $attribute) || (bool) preg_match('/^'.$pattern.'\z/', $key)) {
-                foreach ((array) $rules as $rule) {
-                    if ($rule instanceof CompilableRules) {
-                        $context = Arr::get($this->data, Str::beforeLast($key, '.'));
+        foreach ($keys as $key) {
+            $key = ((string) (int) $key === $key) ? (int) $key : $key;
 
-                        $compiled = $rule->compile($key, $value, $data, $context);
+            foreach ((array) $rules as $rule) {
+                if ($rule instanceof CompilableRules) {
+                    $value = Arr::get($this->data, $key);
+                    $context = Arr::get($this->data, Str::beforeLast((string) $key, '.'));
 
-                        $this->implicitAttributes = array_merge_recursive(
-                            $compiled->implicitAttributes,
-                            $this->implicitAttributes,
-                            [$attribute => [$key]]
-                        );
+                    $compiled = $rule->compile($key, $value, $data, $context);
 
-                        $results = $this->mergeRules($results, $compiled->rules);
-                    } else {
-                        $this->implicitAttributes[$attribute][] = $key;
+                    $this->implicitAttributes = array_merge_recursive(
+                        $compiled->implicitAttributes,
+                        $this->implicitAttributes,
+                        [$attribute => [$key]]
+                    );
 
-                        $results = $this->mergeRules($results, $key, $rule);
-                    }
+                    $results = $this->mergeRules($results, $compiled->rules);
+                } else {
+                    $this->implicitAttributes[$attribute][] = $key;
+
+                    $results = $this->mergeRules($results, $key, $rule);
                 }
             }
         }
 
         return $results;
+    }
+
+    /**
+     * Expand a wildcard attribute into all matching concrete keys by
+     * traversing the data structure directly.
+     *
+     * @param  string  $attribute
+     * @param  array  $data
+     * @return array
+     */
+    protected function expandWildcardKeys($attribute, $data)
+    {
+        $segments = explode('.', $attribute);
+        $results = [];
+
+        $this->traverseWildcardSegments($segments, 0, $data, '', $results);
+
+        return $results;
+    }
+
+    /**
+     * Recursively traverse data segments to expand wildcard keys.
+     *
+     * @param  array  $segments
+     * @param  int  $index
+     * @param  mixed  $data
+     * @param  string  $prefix
+     * @param  array  $results
+     * @return void
+     */
+    protected function traverseWildcardSegments($segments, $index, $data, $prefix, &$results)
+    {
+        if ($index >= count($segments)) {
+            $results[] = rtrim($prefix, '.');
+
+            return;
+        }
+
+        $segment = $segments[$index];
+
+        if ($segment === '*') {
+            if (! is_array($data)) {
+                return;
+            }
+
+            foreach ($data as $key => $value) {
+                $this->traverseWildcardSegments($segments, $index + 1, $value, $prefix.$key.'.', $results);
+            }
+
+            return;
+        }
+
+        $nextData = is_array($data) && array_key_exists($segment, $data) ? $data[$segment] : null;
+
+        $this->traverseWildcardSegments($segments, $index + 1, $nextData, $prefix.$segment.'.', $results);
     }
 
     /**

--- a/tests/Validation/ValidationRuleParserTest.php
+++ b/tests/Validation/ValidationRuleParserTest.php
@@ -352,6 +352,87 @@ class ValidationRuleParserTest extends TestCase
         ], $results->implicitAttributes);
     }
 
+    public function testExplodeExpandsWildcardStringRules()
+    {
+        $parser = (new ValidationRuleParser([
+            'items' => [
+                ['name' => 'foo', 'price' => 10],
+                ['name' => 'bar', 'price' => 20],
+            ],
+        ]));
+
+        $results = $parser->explode([
+            'items.*.name' => 'required|string',
+            'items.*.price' => ['required', 'numeric'],
+        ]);
+
+        $this->assertEquals([
+            'items.0.name' => ['required', 'string'],
+            'items.1.name' => ['required', 'string'],
+            'items.0.price' => ['required', 'numeric'],
+            'items.1.price' => ['required', 'numeric'],
+        ], $results->rules);
+
+        $this->assertEquals([
+            'items.*.name' => ['items.0.name', 'items.1.name'],
+            'items.*.price' => ['items.0.price', 'items.1.price'],
+        ], $results->implicitAttributes);
+    }
+
+    public function testExplodeExpandsDeeplyNestedWildcardStringRules()
+    {
+        $parser = (new ValidationRuleParser([
+            'orders' => [
+                ['items' => [['sku' => 'A'], ['sku' => 'B']]],
+                ['items' => [['sku' => 'C']]],
+            ],
+        ]));
+
+        $results = $parser->explode([
+            'orders.*.items.*.sku' => 'required|string',
+        ]);
+
+        $this->assertEquals([
+            'orders.0.items.0.sku' => ['required', 'string'],
+            'orders.0.items.1.sku' => ['required', 'string'],
+            'orders.1.items.0.sku' => ['required', 'string'],
+        ], $results->rules);
+
+        $this->assertEquals([
+            'orders.*.items.*.sku' => [
+                'orders.0.items.0.sku',
+                'orders.0.items.1.sku',
+                'orders.1.items.0.sku',
+            ],
+        ], $results->implicitAttributes);
+    }
+
+    public function testExplodeExpandsWildcardWithStringArrayKeys()
+    {
+        $parser = (new ValidationRuleParser([
+            'settings' => [
+                'theme' => ['color' => 'blue'],
+                'layout' => ['color' => 'red'],
+            ],
+        ]));
+
+        $results = $parser->explode([
+            'settings.*.color' => 'required|string',
+        ]);
+
+        $this->assertEquals([
+            'settings.theme.color' => ['required', 'string'],
+            'settings.layout.color' => ['required', 'string'],
+        ], $results->rules);
+
+        $this->assertEquals([
+            'settings.*.color' => [
+                'settings.theme.color',
+                'settings.layout.color',
+            ],
+        ], $results->implicitAttributes);
+    }
+
     public function testExplodeHandlesStringDateRule()
     {
         $parser = (new ValidationRuleParser([


### PR DESCRIPTION
This PR is the same as #59214 but now with solid benchmarks against `upstream/13.x` using the [laravel-benchmark-app](https://github.com/SanderMuller/laravel-benchmark-app), a Twitter clone. This application probably uses more validation rules than the average application, but I do work on applications that have endpoints where ~75% of the request duration is spent on validating.

All benchmarks run in-process via `php artisan perf:run` (no HTTP overhead).

| Metric | Baseline P50 | PR P50 | Change |
|---|---|---|---|
| **validation-passing** | 447.786ms | 270.085ms | **-39.7%** |
| **validation-failing** | 594.214ms | 397.765ms | **-33.0%** |
| **memory (passing)** | 1.9MB | 1.0MB | **-47.4%** |
| **memory (failing)** | 4.4MB | 3.4MB | **-22.3%** |


When validating rules with wildcards like `'items.*.name'`, the validator flattens the entire data array with `Arr::dot()`, then regex-matches every flattened key to find matches. For 500 items with 10 fields each, this means flattening 5000+ entries and running regex on each — repeated for every wildcard rule pattern (13 times in a typical form).

This change traverses the data structure directly along the wildcard pattern to enumerate matching keys in O(N) time with no flattening or regex. For non-`CompilableRules` (the common case), it also pre-explodes rule strings once instead of re-parsing per expanded key via `mergeRulesForAttribute`.

`CompilableRules` (`Rule::forEach`) still use flattened data since the `compile()` callback expects it, but also benefit from the direct traversal for key enumeration.

Addresses the explodeWildcardRules bottleneck from https://github.com/laravel/framework/issues/49375, complementing https://github.com/laravel/framework/pull/55495