### PR TITLE
[13.x] Auto-recycle model instances provided via for() to prevent dup…

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/BelongsToRelationship.php
+++ b/src/Illuminate/Database/Eloquent/Factories/BelongsToRelationship.php
@@ -93,4 +93,16 @@ class BelongsToRelationship
 
         return $this;
     }
+
+    /**
+     * Get the model class name of the related factory or model.
+     *
+     * @return string
+     */
+    public function getModelName()
+    {
+        return $this->factory instanceof Factory
+            ? $this->factory->modelName()
+            : get_class($this->factory);
+    }
 }

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -746,12 +746,18 @@ abstract class Factory
      */
     public function for($factory, $relationship = null)
     {
-        return $this->newInstance(['for' => $this->for->concat([new BelongsToRelationship(
+        $instance = $this->newInstance(['for' => $this->for->concat([new BelongsToRelationship(
             $factory,
             $relationship ?? Str::camel(class_basename(
                 $factory instanceof Factory ? $factory->modelName() : $factory
             ))
         )])]);
+
+        if ($factory instanceof Model) {
+            $instance = $instance->recycle($factory);
+        }
+
+        return $instance;
     }
 
     /**

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -91,6 +91,14 @@ class DatabaseEloquentFactoryTest extends TestCase
             $table->foreignId('user_id');
             $table->string('admin')->default('N');
         });
+
+        $this->schema()->create('articles', function ($table) {
+            $table->increments('id');
+            $table->foreignId('author_id');
+            $table->foreignId('reviewer_id');
+            $table->string('title');
+            $table->timestamps();
+        });
     }
 
     /**
@@ -1097,6 +1105,36 @@ class DatabaseEloquentFactoryTest extends TestCase
         }
     }
 
+    public function test_for_method_with_model_instance_recycles_for_same_model_type()
+    {
+        $user = FactoryTestUserFactory::new(['name' => 'Taylor Otwell'])->create();
+
+        $article = FactoryTestArticleFactory::new()
+            ->for($user, 'author')
+            ->create();
+
+        // The user passed to for() should be recycled for reviewer_id too
+        $this->assertCount(1, FactoryTestUser::all());
+        $this->assertEquals($user->id, $article->author_id);
+        $this->assertEquals($user->id, $article->reviewer_id);
+    }
+
+    public function test_for_method_with_model_instance_recycles_across_multiple_relationships()
+    {
+        $author = FactoryTestUserFactory::new(['name' => 'Author'])->create();
+        $reviewer = FactoryTestUserFactory::new(['name' => 'Reviewer'])->create();
+
+        $article = FactoryTestArticleFactory::new()
+            ->for($author, 'author')
+            ->for($reviewer, 'reviewer')
+            ->create();
+
+        // Both users are explicitly provided, no duplicates should be created
+        $this->assertCount(2, FactoryTestUser::all());
+        $this->assertEquals($author->id, $article->author_id);
+        $this->assertEquals($reviewer->id, $article->reviewer_id);
+    }
+
     /**
      * Get a database connection instance.
      *
@@ -1361,6 +1399,35 @@ class FactoryTestUserWithCallbacksFactory extends Factory
         })->afterCreating(function ($user) {
             $_SERVER['__test.user.creating'] = $user;
         });
+    }
+}
+
+class FactoryTestArticleFactory extends Factory
+{
+    protected $model = FactoryTestArticle::class;
+
+    public function definition()
+    {
+        return [
+            'author_id' => FactoryTestUserFactory::new(),
+            'reviewer_id' => FactoryTestUserFactory::new(),
+            'title' => $this->faker->sentence(),
+        ];
+    }
+}
+
+class FactoryTestArticle extends Eloquent
+{
+    protected $table = 'articles';
+
+    public function author()
+    {
+        return $this->belongsTo(FactoryTestUser::class, 'author_id');
+    }
+
+    public function reviewer()
+    {
+        return $this->belongsTo(FactoryTestUser::class, 'reviewer_id');
     }
 }
 


### PR DESCRIPTION

## Problem

When a factory's `definition()` has **multiple foreign keys pointing to the same model type**, using `for()` to set one relationship still causes other factory attributes of the same type to create additional, unnecessary models.

### Example Scenario
```php
class ArticleFactory extends Factory {
    public function definition() {
        return [
            'author_id' => User::factory(),    // ← Creates User #1
            'reviewer_id' => User::factory(),  // ← Creates User #2  
            'title' => fake()->sentence(),
        ];
    }
}

$user = User::factory()->create();
Article::factory()->for($user, 'author')->create();

// ❌ BEFORE: User::count() == 2 (the $user + a new one from reviewer_id)
// ✅ AFTER:  User::count() == 1 ($user is reused for both author & reviewer)
```

## Root Cause

The `for()` method correctly overrides the specific foreign key (`author_id`) via `parentResolvers()`, but other Factory instances of the same model type (`reviewer_id => User::factory()`) are independently expanded in `expandAttributes()`, creating new models.

## Fix

### Files Modified

#### 1. `src/Illuminate/Database/Eloquent/Factories/Factory.php`

render_diffs(file:///Users/comestro/framework/src/Illuminate/Database/Eloquent/Factories/Factory.php)

**Change:** Modified the `for()` method to automatically call `recycle()` when a `Model` instance is provided. This adds the model to the recycle pool, so when `expandAttributes()` processes other Factory instances of the same type, `getRandomRecycledModel()` finds and reuses the existing model instead of creating a new one.

#### 2. `src/Illuminate/Database/Eloquent/Factories/BelongsToRelationship.php`

render_diffs(file:///Users/comestro/framework/src/Illuminate/Database/Eloquent/Factories/BelongsToRelationship.php)

**Change:** Added `getModelName()` method to expose the model class name of the relationship's factory/model.

#### 3. `tests/Database/DatabaseEloquentFactoryTest.php`

render_diffs(file:///Users/comestro/framework/tests/Database/DatabaseEloquentFactoryTest.php)

**Change:** Added test schema, model/factory classes, and two new test cases.

## Test Results

```
Tests: 66, Assertions: 203, Warnings: 1.
OK (all passing)
```

> [!NOTE]
> The fix only auto-recycles when `for()` receives a **Model instance** (not a Factory). When a Factory is passed to `for()`, the behavior is unchanged — each Factory instance in the definition creates its own model independently. Use `recycle()` explicitly for those cases.
