### PR TITLE
Handle exceptions in eventStream to prevent fatal error

### DIFF
--- a/src/Illuminate/Routing/ResponseFactory.php
+++ b/src/Illuminate/Routing/ResponseFactory.php
@@ -179,16 +179,6 @@ class ResponseFactory implements FactoryContract
                 }
             } catch (Throwable $e) {
                 report($e);
-
-                echo "event: error\n";
-                echo 'data: '.$e->getMessage();
-                echo "\n\n";
-
-                if (ob_get_level() > 0) {
-                    ob_flush();
-                }
-
-                flush();
             }
         }, 200, array_merge($headers, [
             'Content-Type' => 'text/event-stream',

--- a/src/Illuminate/Routing/ResponseFactory.php
+++ b/src/Illuminate/Routing/ResponseFactory.php
@@ -131,43 +131,57 @@ class ResponseFactory implements FactoryContract
     public function eventStream(Closure $callback, array $headers = [], StreamedEvent|string|null $endStreamWith = '</stream>')
     {
         return $this->stream(function () use ($callback, $endStreamWith) {
-            foreach ($callback() as $message) {
-                if (connection_aborted()) {
-                    break;
+            try {
+                foreach ($callback() as $message) {
+                    if (connection_aborted()) {
+                        break;
+                    }
+
+                    $event = 'update';
+
+                    if ($message instanceof StreamedEvent) {
+                        $event = $message->event;
+                        $message = $message->data;
+                    }
+
+                    if (! is_string($message) && ! is_numeric($message)) {
+                        $message = Js::encode($message);
+                    }
+
+                    echo "event: $event\n";
+                    echo 'data: '.$message;
+                    echo "\n\n";
+
+                    if (ob_get_level() > 0) {
+                        ob_flush();
+                    }
+
+                    flush();
                 }
 
-                $event = 'update';
+                if (filled($endStreamWith)) {
+                    $endEvent = 'update';
 
-                if ($message instanceof StreamedEvent) {
-                    $event = $message->event;
-                    $message = $message->data;
+                    if ($endStreamWith instanceof StreamedEvent) {
+                        $endEvent = $endStreamWith->event;
+                        $endStreamWith = $endStreamWith->data;
+                    }
+
+                    echo "event: $endEvent\n";
+                    echo 'data: '.$endStreamWith;
+                    echo "\n\n";
+
+                    if (ob_get_level() > 0) {
+                        ob_flush();
+                    }
+
+                    flush();
                 }
+            } catch (Throwable $e) {
+                report($e);
 
-                if (! is_string($message) && ! is_numeric($message)) {
-                    $message = Js::encode($message);
-                }
-
-                echo "event: $event\n";
-                echo 'data: '.$message;
-                echo "\n\n";
-
-                if (ob_get_level() > 0) {
-                    ob_flush();
-                }
-
-                flush();
-            }
-
-            if (filled($endStreamWith)) {
-                $endEvent = 'update';
-
-                if ($endStreamWith instanceof StreamedEvent) {
-                    $endEvent = $endStreamWith->event;
-                    $endStreamWith = $endStreamWith->data;
-                }
-
-                echo "event: $endEvent\n";
-                echo 'data: '.$endStreamWith;
+                echo "event: error\n";
+                echo 'data: '.$e->getMessage();
                 echo "\n\n";
 
                 if (ob_get_level() > 0) {

--- a/tests/Integration/Http/EventStreamResponseTest.php
+++ b/tests/Integration/Http/EventStreamResponseTest.php
@@ -40,7 +40,7 @@ class EventStreamResponseTest extends TestCase
         $this->assertStringContainsString('data: </stream>', $content);
     }
 
-    public function testEventStreamExceptionEmitsErrorEventOnStream()
+    public function testEventStreamExceptionDoesNotLeakToClient()
     {
         Route::get('/stream', function () {
             return response()->eventStream(function () {
@@ -62,8 +62,8 @@ class EventStreamResponseTest extends TestCase
 
         $this->assertStringContainsString("event: update\n", $content);
         $this->assertStringContainsString('data: {"message":"hello"}', $content);
-        $this->assertStringContainsString("event: error\n", $content);
-        $this->assertStringContainsString('data: Something went wrong during streaming', $content);
+        $this->assertStringNotContainsString('Something went wrong during streaming', $content);
+        $this->assertStringNotContainsString("event: error\n", $content);
         $this->assertStringNotContainsString('data: </stream>', $content);
     }
 

--- a/tests/Integration/Http/EventStreamResponseTest.php
+++ b/tests/Integration/Http/EventStreamResponseTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http;
+
+use Exception;
+use Illuminate\Http\StreamedEvent;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Route;
+use Orchestra\Testbench\TestCase;
+
+class EventStreamResponseTest extends TestCase
+{
+    public function testEventStreamResponse()
+    {
+        Route::get('/stream', function () {
+            return response()->eventStream(function () {
+                yield new StreamedEvent(
+                    event: 'update',
+                    data: ['message' => 'hello'],
+                );
+
+                yield new StreamedEvent(
+                    event: 'update',
+                    data: ['message' => 'world'],
+                );
+            });
+        });
+
+        $response = $this->get('/stream');
+
+        $response->assertOk();
+        $response->assertHeader('Content-Type', 'text/event-stream; charset=utf-8');
+        $response->assertHeader('X-Accel-Buffering', 'no');
+
+        $content = $response->streamedContent();
+
+        $this->assertStringContainsString("event: update\n", $content);
+        $this->assertStringContainsString('data: {"message":"hello"}', $content);
+        $this->assertStringContainsString('data: {"message":"world"}', $content);
+        $this->assertStringContainsString('data: </stream>', $content);
+    }
+
+    public function testEventStreamExceptionEmitsErrorEventOnStream()
+    {
+        Route::get('/stream', function () {
+            return response()->eventStream(function () {
+                yield new StreamedEvent(
+                    event: 'update',
+                    data: ['message' => 'hello'],
+                );
+
+                throw new Exception('Something went wrong during streaming');
+            });
+        });
+
+        Log::shouldReceive('error')
+            ->once()
+            ->with('Something went wrong during streaming', \Mockery::type('array'));
+
+        $response = $this->get('/stream');
+        $content = $response->streamedContent();
+
+        $this->assertStringContainsString("event: update\n", $content);
+        $this->assertStringContainsString('data: {"message":"hello"}', $content);
+        $this->assertStringContainsString("event: error\n", $content);
+        $this->assertStringContainsString('data: Something went wrong during streaming', $content);
+        $this->assertStringNotContainsString('data: </stream>', $content);
+    }
+
+    public function testEventStreamExceptionIsReportedToExceptionHandler()
+    {
+        Route::get('/stream', function () {
+            return response()->eventStream(function () {
+                throw new Exception('Test exception reporting');
+            });
+        });
+
+        Log::shouldReceive('error')
+            ->once()
+            ->with('Test exception reporting', \Mockery::type('array'));
+
+        $response = $this->get('/stream');
+        $response->streamedContent();
+    }
+}


### PR DESCRIPTION
When an exception is thrown mid-stream in an `eventStream` response, headers have already been sent. The global exception handler then attempts to send a new error response, which triggers a fatal "Cannot modify header information" error — crashing the process entirely.

Fixes #59291

### Approach

- Wrap the generator iteration inside `eventStream()` in a try/catch
- Report the exception through the normal exception handler so it still gets logged
- Emit an SSE `event: error` with the exception message so the client can detect and handle the failure
- Terminate the stream cleanly without attempting to send new HTTP headers