### PR TITLE
[13.x] Use json column type for notifications data column

### DIFF
--- a/src/Illuminate/Notifications/Console/stubs/notifications.stub
+++ b/src/Illuminate/Notifications/Console/stubs/notifications.stub
@@ -15,7 +15,7 @@ return new class extends Migration
             $table->uuid('id')->primary();
             $table->string('type');
             $table->morphs('notifiable');
-            $table->text('data');
+            $table->json('data');
             $table->timestamp('read_at')->nullable();
             $table->timestamps();
         });


### PR DESCRIPTION
The notification table stub currently defines the `data` column as `text`, even though Laravel always stores JSON-encoded data in it. The `DatabaseNotification` model casts it as `array`, and the `DatabaseChannel` writes PHP arrays that Eloquent
  automatically JSON-encodes.

  This causes issues on PostgreSQL when querying the column using JSON operators (e.g. `where('data->key', 'value')`), because PostgreSQL does not support the `->>` operator on `text` columns:

  SQLSTATE[42883]: Undefined function: 7 ERROR: operator does not exist: text ->> unknown

  All database versions supported by Laravel (MySQL 5.7+, MariaDB 10.3+, PostgreSQL 10.0+, SQLite 3.26.0+, SQL Server 2017+) have native JSON column support, so there is no compatibility reason to use `text`.

  This is not a breaking change — it only affects **newly generated** migrations via `php artisan make:notifications-table`. Existing applications with a `text` column are unaffected, as the Eloquent `array` cast works identically with both column
  types.

  See also: https://github.com/laravel/framework/discussions/46981