### PR TITLE
[12.x] fix `throwUnlessStatus` exceptions on successful 2xx responses (partial revert of #58724)

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -410,10 +410,10 @@ class Response implements ArrayAccess, Stringable
     public function throwUnlessStatus($statusCode)
     {
         if (is_callable($statusCode)) {
-            return $statusCode($this->status(), $this) ? $this : throw new RequestException($this, $this->truncateExceptionsAt);
+            return $statusCode($this->status(), $this) ? $this : $this->throw();
         }
 
-        return $this->status() === $statusCode ? $this : throw new RequestException($this, $this->truncateExceptionsAt);
+        return $this->status() === $statusCode ? $this : $this->throw();
     }
 
     /**

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -3576,8 +3576,7 @@ class HttpClientTest extends TestCase
             $exception = $e;
         }
 
-        $this->assertNotNull($exception);
-        $this->assertInstanceOf(RequestException::class, $exception);
+        $this->assertNull($exception);
 
         $exception = null;
 
@@ -3597,8 +3596,7 @@ class HttpClientTest extends TestCase
             $exception = $e;
         }
 
-        $this->assertNotNull($exception);
-        $this->assertInstanceOf(RequestException::class, $exception);
+        $this->assertNull($exception);
     }
 
     public function testRequestExceptionIsThrownIfIsServerError()


### PR DESCRIPTION
fix https://github.com/laravel/framework/issues/59288
partial revert of #58724
