### PR TITLE
[13.x] Allow for passing enums to attributes

### DIFF
--- a/src/Illuminate/Cache/RedisTaggedCache.php
+++ b/src/Illuminate/Cache/RedisTaggedCache.php
@@ -16,7 +16,7 @@ class RedisTaggedCache extends TaggedCache
     /**
      * Store an item in the cache if the key does not exist.
      *
-     * @param  \BackedEnum|\UnitEnum|string  $key
+     * @param  \UnitEnum|string  $key
      * @param  mixed  $value
      * @param  \DateTimeInterface|\DateInterval|int|null  $ttl
      * @return bool
@@ -44,7 +44,7 @@ class RedisTaggedCache extends TaggedCache
     /**
      * Store an item in the cache.
      *
-     * @param  \BackedEnum|\UnitEnum|string  $key
+     * @param  \UnitEnum|string  $key
      * @param  mixed  $value
      * @param  \DateTimeInterface|\DateInterval|int|null  $ttl
      * @return bool
@@ -72,7 +72,7 @@ class RedisTaggedCache extends TaggedCache
     /**
      * Increment the value of an item in the cache.
      *
-     * @param  \BackedEnum|\UnitEnum|string  $key
+     * @param  \UnitEnum|string  $key
      * @param  mixed  $value
      * @return int|bool
      */
@@ -88,7 +88,7 @@ class RedisTaggedCache extends TaggedCache
     /**
      * Decrement the value of an item in the cache.
      *
-     * @param  \BackedEnum|\UnitEnum|string  $key
+     * @param  \UnitEnum|string  $key
      * @param  mixed  $value
      * @return int|bool
      */
@@ -102,7 +102,7 @@ class RedisTaggedCache extends TaggedCache
     /**
      * Store an item in the cache indefinitely.
      *
-     * @param  \BackedEnum|\UnitEnum|string  $key
+     * @param  \UnitEnum|string  $key
      * @param  mixed  $value
      * @return bool
      */

--- a/src/Illuminate/Cache/TaggedCache.php
+++ b/src/Illuminate/Cache/TaggedCache.php
@@ -53,7 +53,7 @@ class TaggedCache extends Repository
     /**
      * Increment the value of an item in the cache.
      *
-     * @param  \BackedEnum|\UnitEnum|string  $key
+     * @param  \UnitEnum|string  $key
      * @param  mixed  $value
      * @return int|bool
      */
@@ -65,7 +65,7 @@ class TaggedCache extends Repository
     /**
      * Decrement the value of an item in the cache.
      *
-     * @param  \BackedEnum|\UnitEnum|string  $key
+     * @param  \UnitEnum|string  $key
      * @param  mixed  $value
      * @return int|bool
      */

--- a/src/Illuminate/Container/Attributes/Bind.php
+++ b/src/Illuminate/Container/Attributes/Bind.php
@@ -29,7 +29,7 @@ class Bind
      * Create a new attribute instance.
      *
      * @param  class-string  $concrete
-     * @param  non-empty-array<int, \BackedEnum|\UnitEnum|non-empty-string>|non-empty-string|\UnitEnum  $environments
+     * @param  non-empty-array<int, \UnitEnum|non-empty-string>|non-empty-string|\UnitEnum  $environments
      *
      * @throws \InvalidArgumentException
      */

--- a/src/Illuminate/Container/Attributes/Storage.php
+++ b/src/Illuminate/Container/Attributes/Storage.php
@@ -5,6 +5,7 @@ namespace Illuminate\Container\Attributes;
 use Attribute;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Container\ContextualAttribute;
+use UnitEnum;
 
 #[Attribute(Attribute::TARGET_PARAMETER)]
 class Storage implements ContextualAttribute
@@ -12,7 +13,7 @@ class Storage implements ContextualAttribute
     /**
      * Create a new class instance.
      */
-    public function __construct(public ?string $disk = null)
+    public function __construct(public UnitEnum|string|null $disk = null)
     {
     }
 

--- a/src/Illuminate/Contracts/Cache/Repository.php
+++ b/src/Illuminate/Contracts/Cache/Repository.php
@@ -12,7 +12,7 @@ interface Repository extends CacheInterface
      *
      * @template TCacheValue
      *
-     * @param  \BackedEnum|\UnitEnum|array|string  $key
+     * @param  \UnitEnum|array|string  $key
      * @param  TCacheValue|(\Closure(): TCacheValue)  $default
      * @return (TCacheValue is null ? mixed : TCacheValue)
      */
@@ -21,7 +21,7 @@ interface Repository extends CacheInterface
     /**
      * Store an item in the cache.
      *
-     * @param  \BackedEnum|\UnitEnum|string  $key
+     * @param  \UnitEnum|string  $key
      * @param  mixed  $value
      * @param  \DateTimeInterface|\DateInterval|int|null  $ttl
      * @return bool
@@ -31,7 +31,7 @@ interface Repository extends CacheInterface
     /**
      * Store an item in the cache if the key does not exist.
      *
-     * @param  \BackedEnum|\UnitEnum|string  $key
+     * @param  \UnitEnum|string  $key
      * @param  mixed  $value
      * @param  \DateTimeInterface|\DateInterval|int|null  $ttl
      * @return bool
@@ -41,7 +41,7 @@ interface Repository extends CacheInterface
     /**
      * Increment the value of an item in the cache.
      *
-     * @param  \BackedEnum|\UnitEnum|string  $key
+     * @param  \UnitEnum|string  $key
      * @param  mixed  $value
      * @return int|bool
      */
@@ -50,7 +50,7 @@ interface Repository extends CacheInterface
     /**
      * Decrement the value of an item in the cache.
      *
-     * @param  \BackedEnum|\UnitEnum|string  $key
+     * @param  \UnitEnum|string  $key
      * @param  mixed  $value
      * @return int|bool
      */
@@ -59,7 +59,7 @@ interface Repository extends CacheInterface
     /**
      * Store an item in the cache indefinitely.
      *
-     * @param  \BackedEnum|\UnitEnum|string  $key
+     * @param  \UnitEnum|string  $key
      * @param  mixed  $value
      * @return bool
      */
@@ -70,7 +70,7 @@ interface Repository extends CacheInterface
      *
      * @template TCacheValue
      *
-     * @param  \BackedEnum|\UnitEnum|string  $key
+     * @param  \UnitEnum|string  $key
      * @param  \DateTimeInterface|\DateInterval|\Closure|int|null  $ttl
      * @param  \Closure(): TCacheValue  $callback
      * @return TCacheValue
@@ -82,7 +82,7 @@ interface Repository extends CacheInterface
      *
      * @template TCacheValue
      *
-     * @param  \BackedEnum|\UnitEnum|string  $key
+     * @param  \UnitEnum|string  $key
      * @param  \Closure(): TCacheValue  $callback
      * @return TCacheValue
      */
@@ -93,7 +93,7 @@ interface Repository extends CacheInterface
      *
      * @template TCacheValue
      *
-     * @param  \BackedEnum|\UnitEnum|string  $key
+     * @param  \UnitEnum|string  $key
      * @param  \Closure(): TCacheValue  $callback
      * @return TCacheValue
      */
@@ -102,7 +102,7 @@ interface Repository extends CacheInterface
     /**
      * Set the expiration of a cached item.
      *
-     * @param  \BackedEnum|\UnitEnum|string  $key
+     * @param  \UnitEnum|string  $key
      * @param  \DateTimeInterface|\DateInterval|int  $ttl
      * @return bool
      */
@@ -111,7 +111,7 @@ interface Repository extends CacheInterface
     /**
      * Remove an item from the cache.
      *
-     * @param  \BackedEnum|\UnitEnum|string  $key
+     * @param  \UnitEnum|string  $key
      * @return bool
      */
     public function forget($key);

--- a/src/Illuminate/Database/Eloquent/Attributes/Connection.php
+++ b/src/Illuminate/Database/Eloquent/Attributes/Connection.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Eloquent\Attributes;
 
 use Attribute;
+use UnitEnum;
 
 #[Attribute(Attribute::TARGET_CLASS)]
 class Connection
@@ -10,9 +11,9 @@ class Connection
     /**
      * Create a new attribute instance.
      *
-     * @param  string  $name
+     * @param  UnitEnum|string  $name
      */
-    public function __construct(public string $name)
+    public function __construct(public UnitEnum|string $name)
     {
     }
 }

--- a/src/Illuminate/Queue/Attributes/Connection.php
+++ b/src/Illuminate/Queue/Attributes/Connection.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Queue\Attributes;
 
 use Attribute;
-use BackedEnum;
+use UnitEnum;
 
 #[Attribute(Attribute::TARGET_CLASS)]
 class Connection
@@ -11,9 +11,9 @@ class Connection
     /**
      * Create a new attribute instance.
      *
-     * @param  string  $connection
+     * @param  UnitEnum|string  $connection
      */
-    public function __construct(public BackedEnum|string $connection)
+    public function __construct(public UnitEnum|string $connection)
     {
         //
     }

--- a/src/Illuminate/Queue/Attributes/Queue.php
+++ b/src/Illuminate/Queue/Attributes/Queue.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Queue\Attributes;
 
 use Attribute;
-use BackedEnum;
+use UnitEnum;
 
 #[Attribute(Attribute::TARGET_CLASS)]
 class Queue
@@ -11,9 +11,9 @@ class Queue
     /**
      * Create a new attribute instance.
      *
-     * @param  string  $queue
+     * @param  UnitEnum|string  $queue
      */
-    public function __construct(public BackedEnum|string $queue)
+    public function __construct(public UnitEnum|string $queue)
     {
         //
     }

--- a/tests/Container/ContextualAttributeBindingTest.php
+++ b/tests/Container/ContextualAttributeBindingTest.php
@@ -272,6 +272,8 @@ class ContextualAttributeBindingTest extends TestCase
             $manager = m::mock(FilesystemManager::class);
             $manager->shouldReceive('disk')->with('foo')->andReturn(m::mock(Filesystem::class));
             $manager->shouldReceive('disk')->with('bar')->andReturn(m::mock(Filesystem::class));
+            $manager->shouldReceive('disk')->with(StorageDiskUnitEnum::unit)->andReturn(m::mock(Filesystem::class));
+            $manager->shouldReceive('disk')->with(StorageDiskBackedEnum::Backed)->andReturn(m::mock(Filesystem::class));
 
             return $manager;
         });
@@ -358,6 +360,16 @@ class ContainerTestAttributeThatResolvesContractImpl implements ContextualAttrib
         public readonly string $name
     ) {
     }
+}
+
+enum StorageDiskUnitEnum
+{
+    case unit;
+}
+
+enum StorageDiskBackedEnum: string
+{
+    case Backed = 'backed';
 }
 
 interface ContainerTestContract
@@ -530,9 +542,12 @@ final class RouteParameterTest
 
 final class StorageTest
 {
-    public function __construct(#[Storage('foo')] Filesystem $foo, #[Storage('bar')] Filesystem $bar)
-    {
-    }
+    public function __construct(
+        #[Storage('foo')] Filesystem $foo,
+        #[Storage('bar')] Filesystem $bar,
+        #[Storage(StorageDiskUnitEnum::unit)] Filesystem $unit,
+        #[Storage(StorageDiskBackedEnum::Backed)] Filesystem $backed,
+    ) {}
 }
 
 final class GiveTestSimple

--- a/tests/Database/DatabaseEloquentModelAttributesTest.php
+++ b/tests/Database/DatabaseEloquentModelAttributesTest.php
@@ -97,6 +97,20 @@ class DatabaseEloquentModelAttributesTest extends TestCase
         $this->assertSame('secondary', $model->getConnectionName());
     }
 
+    public function test_connection_attribute_with_unit_enum(): void
+    {
+        $model = new ModelWithUnitEnumConnectionAttribute;
+
+        $this->assertSame('secondary', $model->getConnectionName());
+    }
+
+    public function test_connection_attribute_with_backed_enum(): void
+    {
+        $model = new ModelWithBackedEnumConnectionAttribute;
+
+        $this->assertSame('secondary', $model->getConnectionName());
+    }
+
     public function test_timestamps_attribute(): void
     {
         $model = new ModelWithTimestampsFalseAttribute;
@@ -248,6 +262,16 @@ class DatabaseEloquentModelAttributesTest extends TestCase
     }
 }
 
+enum ConnectionUnitEnum
+{
+    case secondary;
+}
+
+enum ConnectionBackedEnum: string
+{
+    case Secondary = 'secondary';
+}
+
 #[Table('custom_table_name')]
 class ModelWithTableAttribute extends Model
 {
@@ -292,6 +316,18 @@ class ModelWithFullPrimaryKeyAttribute extends Model
 
 #[Connection('secondary')]
 class ModelWithConnectionAttribute extends Model
+{
+    //
+}
+
+#[Connection(ConnectionUnitEnum::secondary)]
+class ModelWithUnitEnumConnectionAttribute extends Model
+{
+    //
+}
+
+#[Connection(ConnectionBackedEnum::Secondary)]
+class ModelWithBackedEnumConnectionAttribute extends Model
 {
     //
 }


### PR DESCRIPTION
## Storage attribute

Before:
```php
public function __construct(
    #[Storage(StorageDisk::S3->value)]
    Filesystem $disk,
) {}
```

After:
```php
public function __construct(
    #[Storage(StorageDisk::S3)]
    Filesystem $disk,
) {}
```

## Database Connection attribute

Before:
```php
#[Connection(Database::Sqlite->value)]
class User extends Model
{
    //
}
```

After:
```php
#[Connection(Database::Sqlite)]
class User extends Model
{
    //
}
```

## Also

### Queue attributes

Follow-up on #59278 to also accept `UnitEnum` for `#[Queue(...)]` and `#[Connection(...)]`

### PhpDoc

Changed some of these occurrences for consistency with most of the framework code. `BackedEnum` extends `UnitEnum`, making it redundant to mention it:

Before:
`@param \BackedEnum|\UnitEnum|string $key`

After:
`@param \UnitEnum|string $key`
