### PR TITLE
[13.x] Add releaseOnSignal param to withoutOverlapping

### DIFF
--- a/src/Illuminate/Console/Scheduling/CallbackEvent.php
+++ b/src/Illuminate/Console/Scheduling/CallbackEvent.php
@@ -135,7 +135,7 @@ class CallbackEvent extends Event
      *
      * @throws \LogicException
      */
-    public function withoutOverlapping($expiresAt = 1440, $releaseOnSignal = false)
+    public function withoutOverlapping($expiresAt = 1440, $releaseOnTerminationSignals = true)
     {
         if (! isset($this->description)) {
             throw new LogicException(
@@ -143,7 +143,7 @@ class CallbackEvent extends Event
             );
         }
 
-        return parent::withoutOverlapping($expiresAt, $releaseOnSignal);
+        return parent::withoutOverlapping($expiresAt, $releaseOnTerminationSignals);
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/CallbackEvent.php
+++ b/src/Illuminate/Console/Scheduling/CallbackEvent.php
@@ -135,7 +135,7 @@ class CallbackEvent extends Event
      *
      * @throws \LogicException
      */
-    public function withoutOverlapping($expiresAt = 1440)
+    public function withoutOverlapping($expiresAt = 1440, $releaseOnSignal = false)
     {
         if (! isset($this->description)) {
             throw new LogicException(
@@ -143,7 +143,7 @@ class CallbackEvent extends Event
             );
         }
 
-        return parent::withoutOverlapping($expiresAt);
+        return parent::withoutOverlapping($expiresAt, $releaseOnSignal);
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -850,7 +850,9 @@ class Event
      */
     protected function ensureMutexIsReleasedOnSignal()
     {
-        if (! $this->releaseOnSignal || $this->runInBackground || ! extension_loaded('pcntl')) {
+        if (! $this->releaseOnTerminationSignals ||
+            $this->runInBackground ||
+            ! extension_loaded('pcntl')) {
             return;
         }
 

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -131,6 +131,8 @@ class Event
             return;
         }
 
+        $this->ensureMutexIsReleasedOnSignal();
+
         $exitCode = $this->start($container);
 
         if (! $this->runInBackground) {
@@ -839,6 +841,28 @@ class Event
         $this->mutexNameResolver = is_string($mutexName) ? fn () => $mutexName : $mutexName;
 
         return $this;
+    }
+
+    /**
+     * Ensure the mutex is released if the process receives a termination signal.
+     *
+     * @return void
+     */
+    protected function ensureMutexIsReleasedOnSignal()
+    {
+        if (! $this->releaseOnSignal || $this->runInBackground || ! extension_loaded('pcntl')) {
+            return;
+        }
+
+        pcntl_async_signals(true);
+
+        foreach ([SIGTERM, SIGINT, SIGQUIT] as $signal) {
+            pcntl_signal($signal, function () {
+                $this->removeMutex();
+
+                exit(1);
+            });
+        }
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/ManagesAttributes.php
+++ b/src/Illuminate/Console/Scheduling/ManagesAttributes.php
@@ -166,29 +166,20 @@ trait ManagesAttributes
      * The expiration time of the underlying cache lock may be specified in minutes.
      *
      * @param  int  $expiresAt
+     * @param  bool  $releaseOnSignal
      * @return $this
      */
-    public function withoutOverlapping($expiresAt = 1440)
+    public function withoutOverlapping($expiresAt = 1440, $releaseOnSignal = false)
     {
         $this->withoutOverlapping = true;
 
         $this->expiresAt = $expiresAt;
 
+        $this->releaseOnSignal = $releaseOnSignal;
+
         return $this->skip(function () {
             return $this->mutex->exists($this);
         });
-    }
-
-    /**
-     * Release the mutex if the process receives a termination signal.
-     *
-     * @return $this
-     */
-    public function releaseOnSignal()
-    {
-        $this->releaseOnSignal = true;
-
-        return $this;
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/ManagesAttributes.php
+++ b/src/Illuminate/Console/Scheduling/ManagesAttributes.php
@@ -63,6 +63,13 @@ trait ManagesAttributes
     public $withoutOverlapping = false;
 
     /**
+     * Indicates if the mutex should be released when the process receives a termination signal.
+     *
+     * @var bool
+     */
+    public $releaseOnSignal = false;
+
+    /**
      * Indicates if the command should only be allowed to run on one server for each cron expression.
      *
      * @var bool
@@ -170,6 +177,18 @@ trait ManagesAttributes
         return $this->skip(function () {
             return $this->mutex->exists($this);
         });
+    }
+
+    /**
+     * Release the mutex if the process receives a termination signal.
+     *
+     * @return $this
+     */
+    public function releaseOnSignal()
+    {
+        $this->releaseOnSignal = true;
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/ManagesAttributes.php
+++ b/src/Illuminate/Console/Scheduling/ManagesAttributes.php
@@ -67,7 +67,7 @@ trait ManagesAttributes
      *
      * @var bool
      */
-    public $releaseOnSignal = false;
+    public $releaseOnTerminationSignals = true;
 
     /**
      * Indicates if the command should only be allowed to run on one server for each cron expression.
@@ -163,19 +163,20 @@ trait ManagesAttributes
 
     /**
      * Do not allow the event to overlap each other.
+     *
      * The expiration time of the underlying cache lock may be specified in minutes.
      *
      * @param  int  $expiresAt
-     * @param  bool  $releaseOnSignal
+     * @param  bool  $releaseOnTerminationSignals
      * @return $this
      */
-    public function withoutOverlapping($expiresAt = 1440, $releaseOnSignal = false)
+    public function withoutOverlapping($expiresAt = 1440, $releaseOnTerminationSignals = true)
     {
         $this->withoutOverlapping = true;
 
         $this->expiresAt = $expiresAt;
 
-        $this->releaseOnSignal = $releaseOnSignal;
+        $this->releaseOnTerminationSignals = $releaseOnTerminationSignals;
 
         return $this->skip(function () {
             return $this->mutex->exists($this);


### PR DESCRIPTION
### Why
When you use `withoutOverlapping`, it uses a cache key underneath.

The issue I have often is managed infrastructure CAN kill the scheduler mid task, which leaves the cache key set, which means when it's restarted its never re-ran for 24 hours.   

I don't know how long a particular operation may run, it could be 50 minutes, it could be 3 hours, so I don't set a specific TTL.


### What this PR does
This PR introduces an opt-in `releaseOnSignal` parameter to `withoutOverlapping` that ensures the cache is released if the process receives a  termination signal (SIGTERM, SIGINT, SIGQUIT), allowing the task to run again immediately when the scheduler restarts.                  

This does require the pcntl extension, same asthe Worker etc, so doesn't function without it.. ie just returns

No test cause signals are mental to test afaik.

### Demo

I've got two videos below to show the process (im using Ctrl C for an example): 
They're a bit slow, sorry, blame WSL.
<details>

<summary> Before (or default without specifying releaseOnSignal) </summary>

```php
Artisan::command('inspire', function () {
    $this->comment(Inspiring::quote());
    sleep(10);
})->withoutOverlapping();
```
Run the schedule, let it run and kill the scheduler, when you re-run it, the task won't re run.

https://github.com/user-attachments/assets/fbdcdca4-f98f-406f-8086-1bb7bf78c46f

</details>

<details>

<summary> After (when specifying releaseOnSignal)</summary>


```php
Artisan::command('inspire', function () {
    $this->comment(Inspiring::quote());
    sleep(10);
})->withoutOverlapping(releaseOnSignal: true);
```
Run the schedule, let it run and kill the scheduler, when you re-run it, **it will rerun**.

https://github.com/user-attachments/assets/1ab8b764-a913-46c1-b8e1-f0533e8683a6

</details>

I'm having to currently handle this manually in a trap in a whole bunch of commands, so thought this felt nice to at least try a PR for the rest of the universe.

Any questions, or adjustments let me know! 