### PR TITLE
[13.x] Include columns and index in UniqueConstraintViolationException

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -834,11 +834,13 @@ class Connection implements ConnectionInterface
         // message to include the bindings with SQL, which will make this exception a
         // lot more helpful to the developer instead of just the database's errors.
         catch (Exception $e) {
-            $exceptionType = $this->isUniqueConstraintError($e)
+            $isUniqueConstraintError = $this->isUniqueConstraintError($e);
+
+            $exceptionType = $isUniqueConstraintError
                 ? UniqueConstraintViolationException::class
                 : QueryException::class;
 
-            throw new $exceptionType(
+            $exception = new $exceptionType(
                 $this->getNameWithReadWriteType(),
                 $query,
                 $this->prepareBindings($bindings),
@@ -846,6 +848,13 @@ class Connection implements ConnectionInterface
                 $this->getConnectionDetails(),
                 $this->latestReadWriteTypeUsed(),
             );
+
+            if ($isUniqueConstraintError) {
+                ['index' => $index, 'columns' => $columns] = $this->parseUniqueConstraintViolation($e);
+                $exception->setIndex($index)->setColumns($columns);
+            }
+
+            throw $exception;
         }
     }
 
@@ -858,6 +867,17 @@ class Connection implements ConnectionInterface
     protected function isUniqueConstraintError(Exception $exception)
     {
         return false;
+    }
+
+    /**
+     * Extract the index and columns that caused a unique constraint violation.
+     *
+     * @param  Exception  $exception
+     * @return array{index: string|null, columns: list<string>}
+     */
+    protected function parseUniqueConstraintViolation(Exception $exception): array
+    {
+        return ['index' => null, 'columns' => []];
     }
 
     /**

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -834,9 +834,7 @@ class Connection implements ConnectionInterface
         // message to include the bindings with SQL, which will make this exception a
         // lot more helpful to the developer instead of just the database's errors.
         catch (Exception $e) {
-            $isUniqueConstraintError = $this->isUniqueConstraintError($e);
-
-            $exceptionType = $isUniqueConstraintError
+            $exceptionType = ($isUniqueConstraintError = $this->isUniqueConstraintError($e))
                 ? UniqueConstraintViolationException::class
                 : QueryException::class;
 
@@ -851,6 +849,7 @@ class Connection implements ConnectionInterface
 
             if ($isUniqueConstraintError) {
                 ['index' => $index, 'columns' => $columns] = $this->parseUniqueConstraintViolation($e);
+
                 $exception->setIndex($index)->setColumns($columns);
             }
 

--- a/src/Illuminate/Database/MySqlConnection.php
+++ b/src/Illuminate/Database/MySqlConnection.php
@@ -82,6 +82,12 @@ class MySqlConnection extends Connection
         return (bool) preg_match('#Integrity constraint violation: 1062#i', $exception->getMessage());
     }
 
+    /**
+     * Extract the index that caused a unique constraint violation.
+     *
+     * @param  Exception  $exception
+     * @return array{index: string|null, columns: list<string>}
+     */
     protected function parseUniqueConstraintViolation(Exception $exception): array
     {
         preg_match(

--- a/src/Illuminate/Database/MySqlConnection.php
+++ b/src/Illuminate/Database/MySqlConnection.php
@@ -82,6 +82,17 @@ class MySqlConnection extends Connection
         return (bool) preg_match('#Integrity constraint violation: 1062#i', $exception->getMessage());
     }
 
+    protected function parseUniqueConstraintViolation(Exception $exception): array
+    {
+        preg_match(
+            '#Duplicate entry \'.*?\' for key \'(?:.*?\.)?(.+?)\'#i',
+            $exception->getMessage(),
+            $matches
+        );
+
+        return ['columns' => [], 'index' => $matches[1] ?? null];
+    }
+
     /**
      * Get the connection's last insert ID.
      *

--- a/src/Illuminate/Database/PostgresConnection.php
+++ b/src/Illuminate/Database/PostgresConnection.php
@@ -55,6 +55,12 @@ class PostgresConnection extends Connection
         return '23505' === $exception->getCode();
     }
 
+    /**
+     * Extract the index and columns that caused a unique constraint violation.
+     *
+     * @param  Exception  $exception
+     * @return array{index: string|null, columns: list<string>}
+     */
     protected function parseUniqueConstraintViolation(Exception $exception): array
     {
         $index = null;
@@ -67,7 +73,7 @@ class PostgresConnection extends Connection
         }
 
         if (preg_match('#Key \(([^)]+)\)=#i', $message, $matches)) {
-            $columns = array_map('trim', explode(',', $matches[1]));
+            $columns = array_map(trim(...), explode(',', $matches[1]));
         }
 
         return ['columns' => $columns, 'index' => $index];

--- a/src/Illuminate/Database/PostgresConnection.php
+++ b/src/Illuminate/Database/PostgresConnection.php
@@ -55,6 +55,24 @@ class PostgresConnection extends Connection
         return '23505' === $exception->getCode();
     }
 
+    protected function parseUniqueConstraintViolation(Exception $exception): array
+    {
+        $index = null;
+        $columns = [];
+
+        $message = $exception->getMessage();
+
+        if (preg_match('#unique constraint "([^"]+)"#i', $message, $matches)) {
+            $index = $matches[1];
+        }
+
+        if (preg_match('#Key \(([^)]+)\)=#i', $message, $matches)) {
+            $columns = array_map('trim', explode(',', $matches[1]));
+        }
+
+        return ['columns' => $columns, 'index' => $index];
+    }
+
     /**
      * Get the default query grammar instance.
      *

--- a/src/Illuminate/Database/PostgresConnection.php
+++ b/src/Illuminate/Database/PostgresConnection.php
@@ -63,12 +63,9 @@ class PostgresConnection extends Connection
      */
     protected function parseUniqueConstraintViolation(Exception $exception): array
     {
-        $index = null;
-        $columns = [];
+        [$index, $columns] = [null, []];
 
-        $message = $exception->getMessage();
-
-        if (preg_match('#unique constraint "([^"]+)"#i', $message, $matches)) {
+        if (preg_match('#unique constraint "([^"]+)"#i', $message = $exception->getMessage(), $matches)) {
             $index = $matches[1];
         }
 

--- a/src/Illuminate/Database/SQLiteConnection.php
+++ b/src/Illuminate/Database/SQLiteConnection.php
@@ -62,6 +62,22 @@ class SQLiteConnection extends Connection
         return (bool) preg_match('#(column(s)? .* (is|are) not unique|UNIQUE constraint failed: .*)#i', $exception->getMessage());
     }
 
+    protected function parseUniqueConstraintViolation(Exception $exception): array
+    {
+        preg_match('#UNIQUE constraint failed: (.+)#i', $exception->getMessage(), $matches);
+
+        $columns = [];
+
+        if (isset($matches[1])) {
+            $columns = array_map(
+                static fn ($col) => last(explode('.', trim($col))),
+                explode(',', $matches[1])
+            );
+        }
+
+        return ['columns' => $columns, 'index' => null];
+    }
+
     /**
      * Get the default query grammar instance.
      *

--- a/src/Illuminate/Database/SQLiteConnection.php
+++ b/src/Illuminate/Database/SQLiteConnection.php
@@ -62,6 +62,12 @@ class SQLiteConnection extends Connection
         return (bool) preg_match('#(column(s)? .* (is|are) not unique|UNIQUE constraint failed: .*)#i', $exception->getMessage());
     }
 
+    /**
+     * Extract the columns that caused a unique constraint violation.
+     *
+     * @param  Exception  $exception
+     * @return array{index: string|null, columns: list<string>}
+     */
     protected function parseUniqueConstraintViolation(Exception $exception): array
     {
         preg_match('#UNIQUE constraint failed: (.+)#i', $exception->getMessage(), $matches);

--- a/src/Illuminate/Database/SQLiteConnection.php
+++ b/src/Illuminate/Database/SQLiteConnection.php
@@ -66,7 +66,7 @@ class SQLiteConnection extends Connection
      * Extract the columns that caused a unique constraint violation.
      *
      * @param  Exception  $exception
-     * @return array{index: string|null, columns: list<string>}
+     * @return array{index: null, columns: list<string>}
      */
     protected function parseUniqueConstraintViolation(Exception $exception): array
     {

--- a/src/Illuminate/Database/SqlServerConnection.php
+++ b/src/Illuminate/Database/SqlServerConnection.php
@@ -87,6 +87,26 @@ class SqlServerConnection extends Connection
     }
 
     /**
+     * Extract the index that caused a unique constraint violation.
+     *
+     * @param  Exception  $exception
+     * @return array{index: string|null, columns: list<string>}
+     */
+    protected function parseUniqueConstraintViolation(Exception $exception): array
+    {
+        $index = null;
+        $message = $exception->getMessage();
+
+        if (preg_match('#with unique index \'([^\']+)\'#i', $message, $matches)) {
+            $index = $matches[1];
+        } elseif (preg_match('#Violation of [A-Z ]+ constraint \'([^\']+)\'#i', $message, $matches)) {
+            $index = $matches[1];
+        }
+
+        return ['columns' => [], 'index' => $index];
+    }
+
+    /**
      * Get the default query grammar instance.
      *
      * @return \Illuminate\Database\Query\Grammars\SqlServerGrammar

--- a/src/Illuminate/Database/SqlServerConnection.php
+++ b/src/Illuminate/Database/SqlServerConnection.php
@@ -95,9 +95,8 @@ class SqlServerConnection extends Connection
     protected function parseUniqueConstraintViolation(Exception $exception): array
     {
         $index = null;
-        $message = $exception->getMessage();
 
-        if (preg_match('#with unique index \'([^\']+)\'#i', $message, $matches)) {
+        if (preg_match('#with unique index \'([^\']+)\'#i', $message = $exception->getMessage(), $matches)) {
             $index = $matches[1];
         } elseif (preg_match('#Violation of [A-Z ]+ constraint \'([^\']+)\'#i', $message, $matches)) {
             $index = $matches[1];

--- a/src/Illuminate/Database/UniqueConstraintViolationException.php
+++ b/src/Illuminate/Database/UniqueConstraintViolationException.php
@@ -4,10 +4,26 @@ namespace Illuminate\Database;
 
 class UniqueConstraintViolationException extends QueryException
 {
+    /**
+     * The columns which caused the violation.
+     *
+     * @var list<string>
+     */
     public array $columns = [];
 
+    /**
+     * The unique index which prevented the query.
+     *
+     * @var string|null
+     */
     public ?string $index = null;
 
+    /**
+     * Set the columns that caused the violation.
+     *
+     * @param  list<string>  $columns
+     * @return $this
+     */
     public function setColumns(array $columns): self
     {
         $this->columns = $columns;
@@ -15,6 +31,12 @@ class UniqueConstraintViolationException extends QueryException
         return $this;
     }
 
+    /**
+     * Set the unique index which caused the violation.
+     *
+     * @param  string|null  $index
+     * @return $this
+     */
     public function setIndex(?string $index): self
     {
         $this->index = $index;

--- a/src/Illuminate/Database/UniqueConstraintViolationException.php
+++ b/src/Illuminate/Database/UniqueConstraintViolationException.php
@@ -5,13 +5,6 @@ namespace Illuminate\Database;
 class UniqueConstraintViolationException extends QueryException
 {
     /**
-     * The columns which caused the violation.
-     *
-     * @var list<string>
-     */
-    public array $columns = [];
-
-    /**
      * The unique index which prevented the query.
      *
      * @var string|null
@@ -19,17 +12,11 @@ class UniqueConstraintViolationException extends QueryException
     public ?string $index = null;
 
     /**
-     * Set the columns that caused the violation.
+     * The columns which caused the violation.
      *
-     * @param  list<string>  $columns
-     * @return $this
+     * @var list<string>
      */
-    public function setColumns(array $columns): self
-    {
-        $this->columns = $columns;
-
-        return $this;
-    }
+    public array $columns = [];
 
     /**
      * Set the unique index which caused the violation.
@@ -40,6 +27,19 @@ class UniqueConstraintViolationException extends QueryException
     public function setIndex(?string $index): self
     {
         $this->index = $index;
+
+        return $this;
+    }
+
+    /**
+     * Set the columns that caused the violation.
+     *
+     * @param  list<string>  $columns
+     * @return $this
+     */
+    public function setColumns(array $columns): self
+    {
+        $this->columns = $columns;
 
         return $this;
     }

--- a/src/Illuminate/Database/UniqueConstraintViolationException.php
+++ b/src/Illuminate/Database/UniqueConstraintViolationException.php
@@ -4,4 +4,21 @@ namespace Illuminate\Database;
 
 class UniqueConstraintViolationException extends QueryException
 {
+    public array $columns = [];
+
+    public ?string $index = null;
+
+    public function setColumns(array $columns): self
+    {
+        $this->columns = $columns;
+
+        return $this;
+    }
+
+    public function setIndex(?string $index): self
+    {
+        $this->index = $index;
+
+        return $this;
+    }
 }

--- a/tests/Integration/Database/UniqueConstraintViolationTest.php
+++ b/tests/Integration/Database/UniqueConstraintViolationTest.php
@@ -14,7 +14,7 @@ class UniqueConstraintViolationTest extends DatabaseTestCase
     {
         Schema::create('test_unique_constraint', function (Blueprint $table) {
             $table->id();
-            $table->string('name')->unique();
+            $table->string('name')->unique('single_unique_idx');
         });
 
         Schema::create('test_unique_constraint_composite', function (Blueprint $table) {
@@ -22,7 +22,7 @@ class UniqueConstraintViolationTest extends DatabaseTestCase
             $table->string('first_name');
             $table->string('last_name');
 
-            $table->unique(['first_name', 'last_name'], 'unique_idx');
+            $table->unique(['first_name', 'last_name'], 'unique_composite_idx');
         });
     }
 
@@ -68,6 +68,14 @@ class UniqueConstraintViolationTest extends DatabaseTestCase
 
     #[RequiresDatabase('mysql')]
     public function testMysqlUniqueConstraint()
+    {
+        $e = $this->createUniqueModel();
+        $this->assertSame('single_unique_idx', $e->index);
+        $this->assertSame([], $e->columns);
+    }
+
+    #[RequiresDatabase('mysql')]
+    public function testMysqlUniqueCompositeConstraint()
     {
         $e = $this->createUniqueModel();
         $this->assertSame('unique_idx', $e->index);

--- a/tests/Integration/Database/UniqueConstraintViolationTest.php
+++ b/tests/Integration/Database/UniqueConstraintViolationTest.php
@@ -37,7 +37,6 @@ class UniqueConstraintViolationTest extends DatabaseTestCase
         $this->fail('No exception was thrown');
     }
 
-
     private function createCompositeModel(): UniqueConstraintViolationException
     {
         UniqueCompositeModel::query()->create(['first_name' => 'Taylor', 'last_name' => 'Otwell']);

--- a/tests/Integration/Database/UniqueConstraintViolationTest.php
+++ b/tests/Integration/Database/UniqueConstraintViolationTest.php
@@ -78,8 +78,24 @@ class UniqueConstraintViolationTest extends DatabaseTestCase
     public function testMysqlUniqueCompositeConstraint()
     {
         $e = $this->createUniqueModel();
-        $this->assertSame('unique_idx', $e->index);
+        $this->assertSame('unique_composite_idx', $e->index);
         $this->assertSame([], $e->columns);
+    }
+
+    #[RequiresDatabase('pgsql')]
+    public function testPostgresUniqueConstraint()
+    {
+        $e = $this->createUniqueModel();
+        $this->assertSame('single_unique_idx', $e->index);
+        $this->assertSame(['name'], $e->columns);
+    }
+
+    #[RequiresDatabase('pgsql')]
+    public function testPostgresUniqueCompositeConstraint()
+    {
+        $e = $this->createCompositeModel();
+        $this->assertSame('unique_composite_idx', $e->index);
+        $this->assertSame(['first_name', 'last_name'], $e->columns);
     }
 }
 

--- a/tests/Integration/Database/UniqueConstraintViolationTest.php
+++ b/tests/Integration/Database/UniqueConstraintViolationTest.php
@@ -97,6 +97,22 @@ class UniqueConstraintViolationTest extends DatabaseTestCase
         $this->assertSame('unique_composite_idx', $e->index);
         $this->assertSame(['first_name', 'last_name'], $e->columns);
     }
+
+    #[RequiresDatabase('sqlsrv')]
+    public function testSqlServerUniqueConstraint()
+    {
+        $e = $this->createUniqueModel();
+        $this->assertSame('single_unique_idx', $e->index);
+        $this->assertSame([], $e->columns);
+    }
+
+    #[RequiresDatabase('sqlsrv')]
+    public function testSqlServerUniqueCompositeConstraint()
+    {
+        $e = $this->createCompositeModel();
+        $this->assertSame('unique_composite_idx', $e->index);
+        $this->assertSame([], $e->columns);
+    }
 }
 
 class UniqueSingleModel extends Model

--- a/tests/Integration/Database/UniqueConstraintViolationTest.php
+++ b/tests/Integration/Database/UniqueConstraintViolationTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\UniqueConstraintViolationException;
+use Illuminate\Support\Facades\Schema;
+use Orchestra\Testbench\Attributes\RequiresDatabase;
+
+class UniqueConstraintViolationTest extends DatabaseTestCase
+{
+    protected function afterRefreshingDatabase()
+    {
+        Schema::create('test_unique_constraint', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+        });
+
+        Schema::create('test_unique_constraint_composite', function (Blueprint $table) {
+            $table->id();
+            $table->string('first_name');
+            $table->string('last_name');
+
+            $table->unique(['first_name', 'last_name'], 'unique_idx');
+        });
+    }
+
+    private function createUniqueModel(): UniqueConstraintViolationException
+    {
+        UniqueSingleModel::query()->create(['name' => 'test']);
+        try {
+            UniqueSingleModel::query()->create(['name' => 'test']);
+        } catch (UniqueConstraintViolationException $e) {
+            return $e;
+        }
+        $this->fail('No exception was thrown');
+    }
+
+
+    private function createCompositeModel(): UniqueConstraintViolationException
+    {
+        UniqueCompositeModel::query()->create(['first_name' => 'Taylor', 'last_name' => 'Otwell']);
+        try {
+            UniqueCompositeModel::query()->create(['first_name' => 'Taylor', 'last_name' => 'Otwell']);
+        } catch (UniqueConstraintViolationException $e) {
+            return $e;
+        }
+
+        $this->fail('No exception was thrown');
+    }
+
+    #[RequiresDatabase('sqlite')]
+    public function testSqliteUniqueConstraint()
+    {
+        $e = $this->createUniqueModel();
+        $this->assertSame(['name'], $e->columns);
+        $this->assertNull($e->index);
+    }
+
+    #[RequiresDatabase('sqlite')]
+    public function testSqliteUniqueCompositeConstraint()
+    {
+        $e = $this->createCompositeModel();
+        $this->assertSame(['first_name', 'last_name'], $e->columns);
+        $this->assertNull($e->index);
+    }
+
+    #[RequiresDatabase('mysql')]
+    public function testMysqlUniqueConstraint()
+    {
+        $e = $this->createUniqueModel();
+        $this->assertSame('unique_idx', $e->index);
+        $this->assertSame([], $e->columns);
+    }
+}
+
+class UniqueSingleModel extends Model
+{
+    protected $table = 'test_unique_constraint';
+
+    protected $fillable = ['name'];
+
+    public $timestamps = false;
+}
+
+class UniqueCompositeModel extends Model
+{
+    protected $table = 'test_unique_constraint_composite';
+
+    protected $fillable = ['first_name', 'last_name'];
+
+    public $timestamps = false;
+}

--- a/tests/Integration/Database/UniqueConstraintViolationTest.php
+++ b/tests/Integration/Database/UniqueConstraintViolationTest.php
@@ -77,7 +77,7 @@ class UniqueConstraintViolationTest extends DatabaseTestCase
     #[RequiresDatabase('mysql')]
     public function testMysqlUniqueCompositeConstraint()
     {
-        $e = $this->createUniqueModel();
+        $e = $this->createCompositeModel();
         $this->assertSame('unique_composite_idx', $e->index);
         $this->assertSame([], $e->columns);
     }


### PR DESCRIPTION
Two times in two weeks I have had AI generate code to try to determine if we have a unique constraint on a particular column or using a particular index. It seems AI wants it to be in the framework.

Note that depending on the DB, different amounts of data are returned.

| DB | columns | index |
|----- | --------| ------ |
| sqlite | ✅  | ❌  |
| postgres | ✅  | ✅  |
| mysql | ❌   | ✅  |
| sqlsrv | ❌   | ✅  |