### PR TITLE
[13.x] Ensure connectUsing works with UnitEnum / FileManager drive docblock

### DIFF
--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -12,8 +12,8 @@ use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
 use PDO;
 use RuntimeException;
-
 use UnitEnum;
+
 use function Illuminate\Support\enum_value;
 
 /**

--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -13,6 +13,7 @@ use InvalidArgumentException;
 use PDO;
 use RuntimeException;
 
+use UnitEnum;
 use function Illuminate\Support\enum_value;
 
 /**
@@ -146,10 +147,12 @@ class DatabaseManager implements ConnectionResolverInterface
      *
      * @throws \RuntimeException
      */
-    public function connectUsing(string $name, array $config, bool $force = false)
+    public function connectUsing(UnitEnum|string $name, array $config, bool $force = false)
     {
+        $name = enum_value($name);
+
         if ($force) {
-            $this->purge($name = enum_value($name));
+            $this->purge($name);
         }
 
         if (isset($this->connections[$name])) {

--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -63,7 +63,7 @@ class FilesystemManager implements FactoryContract
     /**
      * Get a filesystem instance.
      *
-     * @param  string|null  $name
+     * @param  \UnitEnum|string|null  $name
      * @return \Illuminate\Contracts\Filesystem\Filesystem
      */
     public function drive($name = null)


### PR DESCRIPTION
`connectUsing` declares a UnitEnum in the docblock, but it wasn't typed and the enum_value usage inside was all squiffy so this PR fixes that.

Also added docblock for drive, as it aliases disk which accepts a unit enum. Buy one get one free.