### PR TITLE
[13.x] Allow opting out of worker Job exception reporting

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -107,11 +107,11 @@ class Worker
     public static $memoryExceededExitCode;
 
     /**
-     * Indicates if the worker should report exceptions.
+     * Indicates if the worker should report job exceptions.
      *
      * @var bool
      */
-    public static $reportExceptions = true;
+    public static $reportJobExceptions = true;
 
     /**
      * Indicates if the worker should check for the restart signal in the cache.
@@ -404,9 +404,7 @@ class Worker
                 }
             }
         } catch (Throwable $e) {
-            if (static::$reportExceptions) {
-                $this->exceptions->report($e);
-            }
+            $this->exceptions->report($e);
 
             $this->stopWorkerIfLostConnection($e);
 
@@ -443,7 +441,7 @@ class Worker
         try {
             return $this->process($connectionName, $job, $options);
         } catch (Throwable $e) {
-            if (static::$reportExceptions) {
+            if (static::$reportJobExceptions) {
                 $this->exceptions->report($e);
             }
 

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -107,6 +107,13 @@ class Worker
     public static $memoryExceededExitCode;
 
     /**
+     * Indicates if the worker should report exceptions.
+     *
+     * @var bool
+     */
+    public static $reportExceptions = true;
+
+    /**
      * Indicates if the worker should check for the restart signal in the cache.
      *
      * @var bool
@@ -397,7 +404,9 @@ class Worker
                 }
             }
         } catch (Throwable $e) {
-            $this->exceptions->report($e);
+            if (static::$reportExceptions) {
+                $this->exceptions->report($e);
+            }
 
             $this->stopWorkerIfLostConnection($e);
 
@@ -434,7 +443,9 @@ class Worker
         try {
             return $this->process($connectionName, $job, $options);
         } catch (Throwable $e) {
-            $this->exceptions->report($e);
+            if (static::$reportExceptions) {
+                $this->exceptions->report($e);
+            }
 
             $this->stopWorkerIfLostConnection($e);
         }

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -195,7 +195,7 @@ class QueueWorkerTest extends TestCase
         $this->events->shouldNotHaveReceived('dispatch', [m::type(JobProcessed::class)]);
     }
 
-    public function testExceptionIsNotReportedIfReportExceptionsIsDisabled()
+    public function testExceptionIsNotReportedIfReportJobExceptionsIsDisabled()
     {
         $e = new RuntimeException;
 
@@ -203,7 +203,7 @@ class QueueWorkerTest extends TestCase
             throw $e;
         });
 
-        Worker::$reportExceptions = false;
+        Worker::$reportJobExceptions = false;
 
         try {
             $worker = $this->getWorker('default', ['queue' => [$job]]);
@@ -212,7 +212,7 @@ class QueueWorkerTest extends TestCase
             $this->exceptionHandler->shouldNotHaveReceived('report');
             $this->events->shouldHaveReceived('dispatch')->with(m::type(JobExceptionOccurred::class))->once();
         } finally {
-            Worker::$reportExceptions = true;
+            Worker::$reportJobExceptions = true;
         }
     }
 

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -195,6 +195,27 @@ class QueueWorkerTest extends TestCase
         $this->events->shouldNotHaveReceived('dispatch', [m::type(JobProcessed::class)]);
     }
 
+    public function testExceptionIsNotReportedIfReportExceptionsIsDisabled()
+    {
+        $e = new RuntimeException;
+
+        $job = new WorkerFakeJob(function () use ($e) {
+            throw $e;
+        });
+
+        Worker::$reportExceptions = false;
+
+        try {
+            $worker = $this->getWorker('default', ['queue' => [$job]]);
+            $worker->runNextJob('default', 'queue', $this->workerOptions(['backoff' => 10]));
+
+            $this->exceptionHandler->shouldNotHaveReceived('report');
+            $this->events->shouldHaveReceived('dispatch')->with(m::type(JobExceptionOccurred::class))->once();
+        } finally {
+            Worker::$reportExceptions = true;
+        }
+    }
+
     public function testJobIsNotReleasedIfItHasExceededMaxAttempts()
     {
         $e = new RuntimeException;


### PR DESCRIPTION
A non-breaking (better?) alternative for https://github.com/laravel/framework/pull/59271 

The worker reports every Job exception to the exception handler even when you have queue events wired up. 

A job can throw, retry, succeed  and you've already been paged by Nightwatch/Flare/Sentry for something that has resolved itself. 

We already have events that provide full visibility into this lifecycle (JobExceptionOccurred, JobReleasedAfterException,     
JobFailed), so I'd like to use those and stop the errors coming through.

This adds a static flag to opt out of exception reporting in `runJob()`, `getNextJob()` etc is unaffected.