### PR TITLE
[13.x] Add TimedOut worker stop reason

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -255,7 +255,7 @@ class Worker
                 ));
             }
 
-            $this->kill(static::EXIT_ERROR, $options);
+            $this->kill(static::EXIT_ERROR, $options, WorkerStopReason::TimedOut);
         }, true);
 
         pcntl_alarm(
@@ -839,11 +839,12 @@ class Worker
      *
      * @param  int  $status
      * @param  \Illuminate\Queue\WorkerOptions|null  $options
+     * @param  \Illuminate\Queue\WorkerStopReason|null  $reason
      * @return never
      */
-    public function kill($status = 0, $options = null)
+    public function kill($status = 0, $options = null, $reason = null)
     {
-        $this->events->dispatch(new WorkerStopping($status, $options));
+        $this->events->dispatch(new WorkerStopping($status, $options, $reason));
 
         if (extension_loaded('posix')) {
             posix_kill(getmypid(), SIGKILL);

--- a/src/Illuminate/Queue/WorkerStopReason.php
+++ b/src/Illuminate/Queue/WorkerStopReason.php
@@ -10,4 +10,5 @@ enum WorkerStopReason: string
     case MaxTimeExceeded = 'max_time';
     case QueueEmpty = 'empty';
     case ReceivedRestartSignal = 'restart_signal';
+    case TimedOut = 'timed_out';
 }


### PR DESCRIPTION
I noticed this cause I spend 50% of my life in Worker code, and the  other half is general framework bits :trollface: 

Workers have a `--timeout` option, when the worker does timeout we were missing the reason in the WorkerStopping event this PR ensures theres a reason.

No test cause cant see any for signals, so an official "trust me bro" -  I've done it so no b/c if people were for some reason calling kill?

Thanks Big T 🙇🏻 