### PR TITLE
[13.x] Add `rule()` method to fluent validation rule builders

### DIFF
--- a/src/Illuminate/Validation/Rules/ArrayRule.php
+++ b/src/Illuminate/Validation/Rules/ArrayRule.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Validation\Rules;
 
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\Arr;
 use Stringable;
 
 use function Illuminate\Support\enum_value;
@@ -15,6 +16,11 @@ class ArrayRule implements Stringable
      * @var array
      */
     protected $keys;
+
+    /**
+     * The additional constraints for the array rule.
+     */
+    protected array $constraints = [];
 
     /**
      * Create a new array rule instance.
@@ -31,6 +37,17 @@ class ArrayRule implements Stringable
     }
 
     /**
+     * Add a custom validation rule.
+     *
+     * @param  array|string  $rules
+     * @return $this
+     */
+    public function rule(array|string $rules): static
+    {
+        return $this->addRule($rules);
+    }
+
+    /**
      * Convert the rule to a validation string.
      *
      * @return string
@@ -38,14 +55,30 @@ class ArrayRule implements Stringable
     public function __toString()
     {
         if (empty($this->keys)) {
-            return 'array';
+            $base = 'array';
+        } else {
+            $keys = array_map(
+                static fn ($key) => enum_value($key),
+                $this->keys,
+            );
+
+            $base = 'array:'.implode(',', $keys);
         }
 
-        $keys = array_map(
-            static fn ($key) => enum_value($key),
-            $this->keys,
-        );
+        if (empty($this->constraints)) {
+            return $base;
+        }
 
-        return 'array:'.implode(',', $keys);
+        return $base.'|'.implode('|', array_unique($this->constraints));
+    }
+
+    /**
+     * Add custom rules to the validation rules array.
+     */
+    protected function addRule(array|string $rules): static
+    {
+        $this->constraints = array_merge($this->constraints, Arr::wrap($rules));
+
+        return $this;
     }
 }

--- a/src/Illuminate/Validation/Rules/Date.php
+++ b/src/Illuminate/Validation/Rules/Date.php
@@ -145,6 +145,17 @@ class Date implements Stringable
     }
 
     /**
+     * Add a custom validation rule.
+     *
+     * @param  array|string  $rules
+     * @return $this
+     */
+    public function rule(array|string $rules): static
+    {
+        return $this->addRule($rules);
+    }
+
+    /**
      * Add custom rules to the validation rules array.
      */
     protected function addRule(array|string $rules): static

--- a/src/Illuminate/Validation/Rules/Numeric.php
+++ b/src/Illuminate/Validation/Rules/Numeric.php
@@ -211,6 +211,17 @@ class Numeric implements Stringable
     }
 
     /**
+     * Add a custom validation rule.
+     *
+     * @param  array|string  $rules
+     * @return $this
+     */
+    public function rule(array|string $rules): Numeric
+    {
+        return $this->addRule($rules);
+    }
+
+    /**
      * Convert the rule to a validation string.
      */
     public function __toString(): string

--- a/src/Illuminate/Validation/Rules/StringRule.php
+++ b/src/Illuminate/Validation/Rules/StringRule.php
@@ -168,6 +168,17 @@ class StringRule implements Stringable
     }
 
     /**
+     * Add a custom validation rule.
+     *
+     * @param  array|string  $rules
+     * @return $this
+     */
+    public function rule(array|string $rules): static
+    {
+        return $this->addRule($rules);
+    }
+
+    /**
      * Convert the rule to a validation string.
      */
     public function __toString(): string

--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -10,6 +10,7 @@ use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use Illuminate\Validation\Rules\ArrayRule;
 use Illuminate\Validation\Rules\Date;
 use Illuminate\Validation\Rules\Exists;
 use Illuminate\Validation\Rules\Numeric;
@@ -95,7 +96,7 @@ class ValidationRuleParser
         }
 
         if (is_object($rule)) {
-            if ($rule instanceof Date || $rule instanceof Numeric || $rule instanceof StringRule) {
+            if ($rule instanceof ArrayRule || $rule instanceof Date || $rule instanceof Numeric || $rule instanceof StringRule) {
                 return explode('|', (string) $rule);
             }
 
@@ -105,7 +106,7 @@ class ValidationRuleParser
         $rules = [];
 
         foreach ($rule as $value) {
-            if ($value instanceof Date || $value instanceof Numeric || $value instanceof StringRule) {
+            if ($value instanceof ArrayRule || $value instanceof Date || $value instanceof Numeric || $value instanceof StringRule) {
                 $rules = array_merge($rules, explode('|', (string) $value));
             } else {
                 $rules[] = $this->prepareRule($value, $attribute);

--- a/tests/Validation/ValidationRuleBuilderTest.php
+++ b/tests/Validation/ValidationRuleBuilderTest.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\Translator;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Validator;
+use PHPUnit\Framework\TestCase;
+
+class ValidationRuleBuilderTest extends TestCase
+{
+    public function testStringRuleMethod()
+    {
+        $rule = Rule::string()->rule('required')->rule('email')->max(255);
+        $this->assertSame('string|required|email|max:255', (string) $rule);
+    }
+
+    public function testStringRuleMethodWithArray()
+    {
+        $rule = Rule::string()->rule(['required', 'email'])->max(255);
+        $this->assertSame('string|required|email|max:255', (string) $rule);
+    }
+
+    public function testNumericRuleMethod()
+    {
+        $rule = Rule::numeric()->rule('required')->rule('integer')->min(0);
+        $this->assertSame('numeric|required|integer|min:0', (string) $rule);
+    }
+
+    public function testDateRuleMethod()
+    {
+        $rule = Rule::date()->rule('required')->after('today');
+        $this->assertSame('date|required|after:today', (string) $rule);
+    }
+
+    public function testArrayRuleMethod()
+    {
+        $rule = Rule::array()->rule('required')->rule('min:1');
+        $this->assertSame('array|required|min:1', (string) $rule);
+    }
+
+    public function testArrayRuleMethodWithKeys()
+    {
+        $rule = Rule::array(['name', 'email'])->rule('required');
+        $this->assertSame('array:name,email|required', (string) $rule);
+    }
+
+    public function testArrayRuleMethodBackwardsCompat()
+    {
+        $this->assertSame('array', (string) Rule::array());
+        $this->assertSame('array:name,email', (string) Rule::array(['name', 'email']));
+    }
+
+    public function testStringRuleMethodValidation()
+    {
+        $trans = new Translator(new ArrayLoader, 'en');
+
+        $validator = new Validator(
+            $trans,
+            ['name' => 'John'],
+            ['name' => Rule::string()->rule('required')->min(2)->max(255)]
+        );
+
+        $this->assertTrue($validator->passes());
+    }
+
+    public function testStringRuleMethodValidationFails()
+    {
+        $trans = new Translator(new ArrayLoader, 'en');
+
+        $validator = new Validator(
+            $trans,
+            ['name' => 'J'],
+            ['name' => Rule::string()->rule('required')->rule('min:2')]
+        );
+
+        $this->assertFalse($validator->passes());
+    }
+
+    public function testNumericRuleMethodValidation()
+    {
+        $trans = new Translator(new ArrayLoader, 'en');
+
+        $validator = new Validator(
+            $trans,
+            ['age' => 25],
+            ['age' => Rule::numeric()->rule('required')->rule('integer')->min(0)]
+        );
+
+        $this->assertTrue($validator->passes());
+    }
+
+    public function testChainedWithConditionable()
+    {
+        $isAdmin = true;
+
+        $rule = Rule::string()
+            ->rule('required')
+            ->when($isAdmin, fn ($rule) => $rule->min(12))
+            ->max(255);
+
+        $this->assertSame('string|required|min:12|max:255', (string) $rule);
+    }
+
+    public function testChainedWithConditionableFalse()
+    {
+        $isAdmin = false;
+
+        $rule = Rule::string()
+            ->rule('required')
+            ->when($isAdmin, fn ($rule) => $rule->min(12))
+            ->max(255);
+
+        $this->assertSame('string|required|max:255', (string) $rule);
+    }
+
+    public function testNestedInArrayOfRules()
+    {
+        $trans = new Translator(new ArrayLoader, 'en');
+
+        $validator = new Validator(
+            $trans,
+            ['name' => 'John'],
+            ['name' => ['sometimes', Rule::string()->min(2)]]
+        );
+
+        $this->assertTrue($validator->passes());
+    }
+
+    public function testArrayValidationPasses()
+    {
+        $trans = new Translator(new ArrayLoader, 'en');
+
+        $validator = new Validator(
+            $trans,
+            ['tags' => ['php', 'laravel']],
+            ['tags' => Rule::array()->rule('required')->rule('min:1')]
+        );
+
+        $this->assertTrue($validator->passes());
+    }
+
+    public function testArrayValidationFails()
+    {
+        $trans = new Translator(new ArrayLoader, 'en');
+
+        $validator = new Validator(
+            $trans,
+            ['tags' => []],
+            ['tags' => Rule::array()->rule('required')->rule('min:1')]
+        );
+
+        $this->assertFalse($validator->passes());
+    }
+
+    public function testDateValidation()
+    {
+        $trans = new Translator(new ArrayLoader, 'en');
+
+        $validator = new Validator(
+            $trans,
+            ['date' => '2099-01-01'],
+            ['date' => Rule::date()->rule('required')->after('today')]
+        );
+
+        $this->assertTrue($validator->passes());
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds a `rule()` method to `Rule::string()`, `Rule::numeric()`, `Rule::date()`, and `Rule::array()`, allowing any validation rule to be chained directly onto the fluent builder without falling back to array syntax.

## Before

When using fluent rule builders, adding rules that don't have a dedicated method (like `required`, `email`, `nullable`) requires mixing array syntax with the builder:

```php
'name'  => ['required', Rule::string()->min(2)->max(255)],
'email' => ['required', 'email', Rule::string()->max(255)],
'age'   => ['nullable', Rule::numeric()->integer()->min(0)],
'tags'  => ['required', 'min:1', Rule::array()],
```

## After

```php
'name'  => Rule::string()->rule('required')->min(2)->max(255),
'email' => Rule::string()->rule('required')->rule('email')->max(255),
'age'   => Rule::numeric()->rule('nullable')->rule('integer')->min(0),
'tags'  => Rule::array()->rule('required')->rule('min:1'),
```

Rules can also be passed as arrays:

```php
'name' => Rule::string()->rule(['required', 'email'])->max(255),
```

## Benefit to end users

- **Eliminates the most common reason to fall back to array syntax** when using fluent rule builders. Users can now express their entire validation rule set within a single fluent chain.
- **No new concepts to learn.** The `rule()` method accepts the same string rules developers already know (`'required'`, `'email'`, `'nullable'`, etc.).
- **Works with all existing rules.** Any string-based validation rule can be passed to `rule()`.
