### PR TITLE
[12.x] Fix TypeError when wildcard custom message is array without ma…

### DIFF
--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -122,8 +122,8 @@ trait FormatsMessages
                     if (preg_match('#^'.$pattern.'\z#u', $key) === 1) {
                         $message = $source[$sourceKey];
 
-                        if (is_array($message) && isset($message[$lowerRule])) {
-                            return $message[$lowerRule];
+                        if (is_array($message)) {
+                            return $message[$lowerRule] ?? null;
                         }
 
                         return $message;


### PR DESCRIPTION

---
> **Title:** `[12.x] Fix TypeError when wildcard custom message is array without matching rule`
>
> **Compare:** https://github.com/laravel/framework/compare/12.x...sadique-cws:framework:fix/validation-wildcard-array-message-type-error

---

Fixes #59316

### Problem

When a custom validation message is defined for a wildcard attribute key (e.g. `students.*.grade`) using a nested array of rule-specific messages:

```php
'custom' => [
    'students.*.grade' => [
        'required' => 'Custom required message.',
        // 'in' is intentionally absent
    ],
],
```

And the failing rule ([in](file:///Users/comestro/framework/src/Illuminate/Database/Eloquent/Factories/Factory.php#473-503)) is **not** in that array, [getFromLocalArray](file:///Users/comestro/framework/src/Illuminate/Validation/Concerns/FormatsMessages.php#92-147) returns the entire array instead of `null`. This array then gets passed to [replaceInputPlaceholder](file:///Users/comestro/framework/src/Illuminate/Validation/Concerns/FormatsMessages.php#477-498) (introduced in v12.55.1), which calls `str_contains($message, ':input')` — crashing with:

```
TypeError: str_contains(): Argument #1 ($haystack) must be of type string, array given
```

### Solution

Make the wildcard branch consistent with the exact-match branch (which already does `$message[$lowerRule] ?? null`):

```diff
- if (is_array($message) && isset($message[$lowerRule])) {
-     return $message[$lowerRule];
- }
+ if (is_array($message)) {
+     return $message[$lowerRule] ?? null;
+ }
```

When the message is an array but doesn't contain the specific failing rule, `null` is returned so Laravel correctly falls back to the default validation message for that rule.

All 717 existing validation tests pass.