### PR TITLE
[13.x] Use null coalescing assignment operator

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -651,9 +651,7 @@ class Container implements ArrayAccess, ContainerContract
         $tags = is_array($tags) ? $tags : array_slice(func_get_args(), 1);
 
         foreach ($tags as $tag) {
-            if (! isset($this->tags[$tag])) {
-                $this->tags[$tag] = [];
-            }
+            $this->tags[$tag] ??= [];
 
             foreach ((array) $abstracts as $abstract) {
                 $this->tags[$tag][] = $abstract;

--- a/src/Illuminate/Cookie/CookieJar.php
+++ b/src/Illuminate/Cookie/CookieJar.php
@@ -146,9 +146,7 @@ class CookieJar implements JarContract
             $cookie = $this->make(...array_values($parameters));
         }
 
-        if (! isset($this->queued[$cookie->getName()])) {
-            $this->queued[$cookie->getName()] = [];
-        }
+        $this->queued[$cookie->getName()] ??= [];
 
         $this->queued[$cookie->getName()][$cookie->getPath()] = $cookie;
     }

--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -38,9 +38,7 @@ trait SoftDeletes
      */
     public function initializeSoftDeletes()
     {
-        if (! isset($this->casts[$this->getDeletedAtColumn()])) {
-            $this->casts[$this->getDeletedAtColumn()] = 'datetime';
-        }
+        $this->casts[$this->getDeletedAtColumn()] ??= 'datetime';
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3774,9 +3774,7 @@ class Builder implements BuilderContract
      */
     public function cursor()
     {
-        if (is_null($this->columns)) {
-            $this->columns = ['*'];
-        }
+        $this->columns ??= ['*'];
 
         return (new LazyCollection(function () {
             yield from $this->connection->cursor(

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -184,7 +184,7 @@ trait InteractsWithInput
     {
         $files = $this->files->all();
 
-        return $this->convertedFiles = $this->convertedFiles ?? $this->convertUploadedFiles($files);
+        return $this->convertedFiles ??= $this->convertUploadedFiles($files);
     }
 
     /**

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -461,9 +461,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      */
     public function json($key = null, $default = null)
     {
-        if (! isset($this->json)) {
-            $this->json = new InputBag((array) json_decode($this->getContent() ?: '[]', true));
-        }
+        $this->json ??= new InputBag((array) json_decode($this->getContent() ?: '[]', true));
 
         if (is_null($key)) {
             return $this->json;

--- a/src/Illuminate/Http/Resources/JsonApi/JsonApiRequest.php
+++ b/src/Illuminate/Http/Resources/JsonApi/JsonApiRequest.php
@@ -23,11 +23,9 @@ class JsonApiRequest extends Request
      */
     public function sparseFields(string $key): array
     {
-        if (is_null($this->cachedSparseFields)) {
-            $this->cachedSparseFields = (new Collection($this->array('fields')))
-                ->transform(fn ($fieldsets) => empty($fieldsets) ? [] : explode(',', $fieldsets))
-                ->all();
-        }
+        $this->cachedSparseFields ??= (new Collection($this->array('fields')))
+            ->transform(fn ($fieldsets) => empty($fieldsets) ? [] : explode(',', $fieldsets))
+            ->all();
 
         return $this->cachedSparseFields[$key] ?? [];
     }

--- a/src/Illuminate/Queue/Events/JobRetryRequested.php
+++ b/src/Illuminate/Queue/Events/JobRetryRequested.php
@@ -28,9 +28,7 @@ class JobRetryRequested
      */
     public function payload()
     {
-        if (is_null($this->payload)) {
-            $this->payload = json_decode($this->job->payload, true);
-        }
+        $this->payload ??= json_decode($this->job->payload, true);
 
         return $this->payload;
     }

--- a/src/Illuminate/Redis/Connections/PhpRedisClusterConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisClusterConnection.php
@@ -72,9 +72,7 @@ class PhpRedisClusterConnection extends PhpRedisConnection
      */
     private function defaultNode()
     {
-        if (! isset($this->defaultNode)) {
-            $this->defaultNode = $this->client->_masters()[0] ?? throw new InvalidArgumentException('Unable to determine default node. No master nodes found in the cluster.');
-        }
+        $this->defaultNode ??= $this->client->_masters()[0] ?? throw new InvalidArgumentException('Unable to determine default node. No master nodes found in the cluster.');
 
         return $this->defaultNode;
     }

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -345,9 +345,7 @@ class UrlGenerator implements UrlGeneratorContract
             return $secure ? 'https://' : 'http://';
         }
 
-        if (is_null($this->cachedScheme)) {
-            $this->cachedScheme = $this->forceScheme ?: $this->request->getScheme().'://';
-        }
+        $this->cachedScheme ??= $this->forceScheme ?: $this->request->getScheme().'://';
 
         return $this->cachedScheme;
     }
@@ -638,9 +636,7 @@ class UrlGenerator implements UrlGeneratorContract
     public function formatRoot($scheme, $root = null)
     {
         if (is_null($root)) {
-            if (is_null($this->cachedRoot)) {
-                $this->cachedRoot = $this->forcedRoot ?: $this->request->root();
-            }
+            $this->cachedRoot ??= $this->forcedRoot ?: $this->request->root();
 
             $root = $this->cachedRoot;
         }

--- a/src/Illuminate/Support/Once.php
+++ b/src/Illuminate/Support/Once.php
@@ -56,9 +56,7 @@ class Once
 
         $hash = $onceable->hash;
 
-        if (! isset($this->values[$object])) {
-            $this->values[$object] = [];
-        }
+        $this->values[$object] ??= [];
 
         if (array_key_exists($hash, $this->values[$object])) {
             return $this->values[$object][$hash];

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -479,9 +479,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      */
     public function getSelector()
     {
-        if (! isset($this->selector)) {
-            $this->selector = new MessageSelector;
-        }
+        $this->selector ??= new MessageSelector;
 
         return $this->selector;
     }

--- a/src/Illuminate/View/Concerns/ManagesStacks.php
+++ b/src/Illuminate/View/Concerns/ManagesStacks.php
@@ -72,9 +72,7 @@ trait ManagesStacks
      */
     protected function extendPush($section, $content)
     {
-        if (! isset($this->pushes[$section])) {
-            $this->pushes[$section] = [];
-        }
+        $this->pushes[$section] ??= [];
 
         if (! isset($this->pushes[$section][$this->renderCount])) {
             $this->pushes[$section][$this->renderCount] = $content;
@@ -128,9 +126,7 @@ trait ManagesStacks
      */
     protected function extendPrepend($section, $content)
     {
-        if (! isset($this->prepends[$section])) {
-            $this->prepends[$section] = [];
-        }
+        $this->prepends[$section] ??= [];
 
         if (! isset($this->prepends[$section][$this->renderCount])) {
             $this->prepends[$section][$this->renderCount] = $content;


### PR DESCRIPTION
## Summary

- Replaces `if (! isset($x)) { $x = val; }` and `if (is_null($x)) { $x = val; }` patterns with the `??=` operator across 13 files (15 occurrences)
- Reduces code by 28 lines with zero behavioral changes
- All replacements are semantically identical — `??=` assigns only when the left-hand side is `null` or undefined, matching the original guard patterns exactly

## Changed Files

| File | Pattern Replaced |
|---|---|
| `Container.php` | `if (!isset) { assign }` → `??=` |
| `CookieJar.php` | `if (!isset) { assign }` → `??=` |
| `SoftDeletes.php` | `if (!isset) { assign }` → `??=` |
| `Builder.php` | `if (is_null) { assign }` → `??=` |
| `InteractsWithInput.php` | `$x = $x ?? val` → `??=` |
| `Request.php` | `if (!isset) { assign }` → `??=` |
| `JsonApiRequest.php` | `if (is_null) { assign }` → `??=` |
| `JobRetryRequested.php` | `if (is_null) { assign }` → `??=` |
| `PhpRedisClusterConnection.php` | `if (!isset) { assign }` → `??=` |
| `UrlGenerator.php` | `if (is_null) { assign }` (×2) → `??=` |
| `Once.php` | `if (!isset) { assign }` → `??=` |
| `Translator.php` | `if (!isset) { assign }` → `??=` |
| `ManagesStacks.php` | `if (!isset) { assign }` (×2) → `??=` |

## Test plan

- [x] Verified all existing tests pass with no regressions (same results before and after changes)
- [x] Laravel Pint passes — no style violations introduced
- [x] Each replacement is a mechanical 1:1 substitution with identical semantics