### PR TITLE
[13.x] Add whereLike and whereNotLike methods to Collection

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -793,6 +793,42 @@ trait EnumeratesValues
     }
 
     /**
+     * Filter items where the value of the given key matches a "like" pattern.
+     *
+     * @param  string  $key
+     * @param  string  $pattern
+     * @param  bool  $caseSensitive
+     * @return static
+     */
+    public function whereLike($key, $pattern, $caseSensitive = false)
+    {
+        $regex = '/^'.str_replace(
+            ['%', '_'], ['.*', '.'],
+            preg_quote($pattern, '/')
+        ).'$/'.($caseSensitive ? '' : 'i');
+
+        return $this->filter(fn ($item) => preg_match($regex, (string) data_get($item, $key)) === 1);
+    }
+
+    /**
+     * Filter items where the value of the given key does not match a "like" pattern.
+     *
+     * @param  string  $key
+     * @param  string  $pattern
+     * @param  bool  $caseSensitive
+     * @return static
+     */
+    public function whereNotLike($key, $pattern, $caseSensitive = false)
+    {
+        $regex = '/^'.str_replace(
+            ['%', '_'], ['.*', '.'],
+            preg_quote($pattern, '/')
+        ).'$/'.($caseSensitive ? '' : 'i');
+
+        return $this->reject(fn ($item) => preg_match($regex, (string) data_get($item, $key)) === 1);
+    }
+
+    /**
      * Pass the collection to the given callback and return the result.
      *
      * @template TPipeReturnType

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1243,6 +1243,78 @@ class SupportCollectionTest extends TestCase
     }
 
     #[DataProvider('collectionClassProvider')]
+    public function testWhereLike($collection)
+    {
+        $c = new $collection([
+            ['name' => 'Taylor Otwell', 'email' => 'taylor@laravel.com'],
+            ['name' => 'Nuno Maduro', 'email' => 'nuno@laravel.com'],
+            ['name' => 'Dries Vints', 'email' => 'dries@example.com'],
+            ['name' => 'Tim MacDonald', 'email' => 'tim@example.org'],
+        ]);
+
+        // % wildcard - contains
+        $this->assertEquals(
+            ['Taylor Otwell', 'Nuno Maduro'],
+            $c->whereLike('email', '%@laravel.com')->pluck('name')->values()->all()
+        );
+
+        // % wildcard - starts with
+        $this->assertEquals(
+            ['Taylor Otwell', 'Tim MacDonald'],
+            $c->whereLike('name', 'T%')->pluck('name')->values()->all()
+        );
+
+        // _ wildcard - single character
+        $this->assertEquals(
+            ['Tim MacDonald'],
+            $c->whereLike('name', 'T__ MacDonald')->pluck('name')->values()->all()
+        );
+
+        // Case insensitive by default
+        $this->assertEquals(
+            ['Taylor Otwell', 'Tim MacDonald'],
+            $c->whereLike('name', 't%')->pluck('name')->values()->all()
+        );
+
+        // Case sensitive
+        $this->assertEmpty(
+            $c->whereLike('name', 't%', caseSensitive: true)->values()->all()
+        );
+
+        // Exact match (no wildcards)
+        $this->assertEquals(
+            ['Nuno Maduro'],
+            $c->whereLike('name', 'Nuno Maduro')->pluck('name')->values()->all()
+        );
+
+        // Dot in pattern is treated as literal
+        $this->assertEquals(
+            ['Dries Vints'],
+            $c->whereLike('email', '%example.com')->pluck('name')->values()->all()
+        );
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testWhereNotLike($collection)
+    {
+        $c = new $collection([
+            ['name' => 'Taylor Otwell', 'email' => 'taylor@laravel.com'],
+            ['name' => 'Nuno Maduro', 'email' => 'nuno@laravel.com'],
+            ['name' => 'Dries Vints', 'email' => 'dries@example.com'],
+        ]);
+
+        $this->assertEquals(
+            ['Dries Vints'],
+            $c->whereNotLike('email', '%@laravel.com')->pluck('name')->values()->all()
+        );
+
+        $this->assertEquals(
+            ['Nuno Maduro', 'Dries Vints'],
+            $c->whereNotLike('name', 'T%')->pluck('name')->values()->all()
+        );
+    }
+
+    #[DataProvider('collectionClassProvider')]
     public function testValues($collection)
     {
         $c = new $collection([['id' => 1, 'name' => 'Hello'], ['id' => 2, 'name' => 'World']]);


### PR DESCRIPTION
## Summary

- Adds `whereLike()` and `whereNotLike()` methods to the `EnumeratesValues` trait, making them available on both `Collection` and `LazyCollection`
- Mirrors the Query Builder's `whereLike()` / `whereNotLike()` API that has existed since Laravel 11, filling an inconsistency in the Collection API
- Supports `%` (any characters) and `_` (single character) SQL-style wildcards with an optional `caseSensitive` parameter (defaults to `false`)

### Usage

```php
// Filter by pattern — case insensitive by default
$users->whereLike('name', '%taylor%');
$users->whereLike('email', '%@laravel.com');

// Case sensitive
$users->whereLike('name', 'T%', caseSensitive: true);

// Single character wildcard
$users->whereLike('code', 'A_B'); // matches "A1B", "AXB", etc.

// Negation
$users->whereNotLike('email', '%@example.com');
```

## Test plan

- [x] 4 test methods with 18 assertions covering both `Collection` and `LazyCollection`
- [x] Tests cover: `%` wildcard, `_` wildcard, case sensitivity, exact match, literal dots, negation, chaining
- [x] Laravel Pint passes with no style violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)