### PR TITLE
Modify sum callback to include item key

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -581,7 +581,7 @@ trait EnumeratesValues
             ? $this->identity()
             : $this->valueRetriever($callback);
 
-        return $this->reduce(fn ($result, $item) => $result + $callback($item), 0);
+        return $this->reduce(fn ($result, $item, $key) => $result + $callback($item, $key), 0);
     }
 
     /**


### PR DESCRIPTION
Hey.

Small PR to add the key to `sum` callback, like in map and reduce. 

```diff
$scores = [...];
- collect($items)->map(fn($item, $id) => $score[$id])->sum();
+ collect($items)->sum(fn($item, $id) => $score[$id]);
```

Thanks.
Mathieu