### PR TITLE
[13.x] Remove unnecessary clone in SessionManager to prevent duplicate Redis connections

### DIFF
--- a/src/Illuminate/Session/SessionManager.php
+++ b/src/Illuminate/Session/SessionManager.php
@@ -137,9 +137,15 @@ class SessionManager extends Manager
     {
         $handler = $this->createCacheHandler('redis');
 
-        $handler->getCache()->getStore()->setConnection(
-            $this->config->get('session.connection')
-        );
+        $connection = $this->config->get('session.connection');
+
+        if ($connection) {
+            $handler->getCache()->setStore(
+                tap(clone $handler->getCache()->getStore(), function ($store) use ($connection) {
+                    $store->setConnection($connection);
+                })
+            );
+        }
 
         return $this->buildSession($handler);
     }
@@ -176,7 +182,7 @@ class SessionManager extends Manager
         $store = $this->config->get('session.store') ?: $driver;
 
         return new CacheBasedSessionHandler(
-            clone $this->container->make('cache')->store($store),
+            $this->container->make('cache')->store($store),
             $this->config->get('session.lifetime')
         );
     }

--- a/tests/Session/SessionManagerTest.php
+++ b/tests/Session/SessionManagerTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Illuminate\Tests\Session;
+
+use Illuminate\Config\Repository;
+use Illuminate\Container\Container;
+use Illuminate\Session\CacheBasedSessionHandler;
+use Illuminate\Session\SessionManager;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class SessionManagerTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+        Container::setInstance(null);
+    }
+
+    public function testCacheBasedSessionHandlerSharesCacheRepository()
+    {
+        $app = $this->createApplication('memcached');
+
+        $manager = new SessionManager($app);
+        $session = $manager->driver('memcached');
+
+        $handler = $session->getHandler();
+
+        $this->assertInstanceOf(CacheBasedSessionHandler::class, $handler);
+
+        // The handler should use the same Repository instance, not a clone
+        $this->assertSame(
+            $app->make('cache')->store('memcached'),
+            $handler->getCache()
+        );
+    }
+
+    public function testRedisSessionWithoutConnectionSharesCacheRepository()
+    {
+        $app = $this->createApplication('redis');
+
+        $manager = new SessionManager($app);
+        $session = $manager->driver('redis');
+
+        $handler = $session->getHandler();
+
+        $this->assertInstanceOf(CacheBasedSessionHandler::class, $handler);
+
+        // Without session.connection, the handler should share the cache Repository
+        $this->assertSame(
+            $app->make('cache')->store('redis'),
+            $handler->getCache()
+        );
+    }
+
+    public function testRedisSessionWithConnectionDoesNotMutateSharedStore()
+    {
+        $app = $this->createApplication('redis', 'session');
+
+        $sharedStore = $app->make('cache')->store('redis')->getStore();
+        $originalConnection = (new \ReflectionProperty($sharedStore, 'connection'))->getValue($sharedStore);
+
+        $manager = new SessionManager($app);
+        $session = $manager->driver('redis');
+
+        $handler = $session->getHandler();
+
+        // The shared cache store's connection should not be mutated
+        $currentConnection = (new \ReflectionProperty($sharedStore, 'connection'))->getValue($sharedStore);
+        $this->assertSame($originalConnection, $currentConnection);
+
+        // The session handler's store should have the session connection
+        $sessionStore = $handler->getCache()->getStore();
+        $sessionConnection = (new \ReflectionProperty($sessionStore, 'connection'))->getValue($sessionStore);
+        $this->assertSame('session', $sessionConnection);
+    }
+
+    protected function createApplication(string $driver, ?string $sessionConnection = null): Container
+    {
+        $app = new Container;
+        Container::setInstance($app);
+
+        $config = new Repository([
+            'session' => [
+                'driver' => $driver,
+                'lifetime' => 120,
+                'connection' => $sessionConnection,
+                'store' => null,
+            ],
+            'cache' => [
+                'default' => $driver,
+                'stores' => [
+                    'memcached' => ['driver' => 'array'],
+                    'redis' => ['driver' => 'redis', 'connection' => 'default'],
+                ],
+                'prefix' => 'test',
+            ],
+        ]);
+
+        $app->instance('config', $config);
+        $app->singleton('cache', function ($app) {
+            return new \Illuminate\Cache\CacheManager($app);
+        });
+
+        $app->singleton('redis', function () {
+            $redis = m::mock(\Illuminate\Contracts\Redis\Factory::class);
+            $redis->shouldReceive('connection')->andReturn(
+                m::mock(\Illuminate\Redis\Connections\Connection::class)
+            );
+
+            return $redis;
+        });
+
+        return $app;
+    }
+}


### PR DESCRIPTION
## Summary

Fixes 🟢 #58377.

`SessionManager::createCacheHandler()` clones the cache Repository for all cache-based session drivers. This clone is unnecessary because `CacheBasedSessionHandler` never mutates the Repository — it only calls `get`, `put`, and `forget`. Other session drivers (database, file) share their dependencies without cloning. 

The clone triggers `Repository::__clone()` which deep-clones the underlying store, creating a duplicate store object on every request. For Redis with persistent connections (phpredis pconnect), this results in a second TCP connection to the same host, which breaks environments with strict connection limits and wastes resources everywhere else.

The `clone` was originally added to prevent `createRedisDriver()` from mutating the shared store via `setConnection()`. This fix removes the clone and only clones the lightweight Store when `session.connection` is explicitly configured.

### Before

```php
// createCacheHandler — called for ALL cache-based sessions
clone $this->container->make('cache')->store($store)  // unnecessary clone on every request
```

### After

```php
// createCacheHandler — no clone
$this->container->make('cache')->store($store)

// createRedisDriver — only clones store when session.connection is set
if ($connection) {
    $handler->getCache()->setStore(
        tap(clone $handler->getCache()->getStore(), fn ($store) => $store->setConnection($connection))
    );
}
```

### Impact

- **Common case** (no `session.connection` set): zero clones, shared Repository. No behavior change.
- **Edge case** (`session.connection` explicitly configured): clones only the Store (not the Repository), sets connection on the clone. Shared cache store is untouched.

### Prior fix attempt

PR #58476 by @TheLevti was closed. Taylor said "I probably won't change this on a patch release." This PR targets 13.x (major release).

### Test plan

- [x] All 96 session tests pass (93 existing + 3 new)
- [x] `testCacheBasedSessionHandlerSharesCacheRepository` — handler uses same Repository, not a clone
- [x] `testRedisSessionWithoutConnectionSharesCacheRepository` — Redis session without session.connection shares the cache Repository
- [x] `testRedisSessionWithConnectionDoesNotMutateSharedStore` — shared cache store connection unchanged when session.connection is set
- [x] Pint passes