### PR TITLE
[12.x] Fix File::types() silently discarding chain configuration

### DIFF
--- a/src/Illuminate/Validation/Rules/File.php
+++ b/src/Illuminate/Validation/Rules/File.php
@@ -14,7 +14,46 @@ use InvalidArgumentException;
 
 class File implements Rule, DataAwareRule, ValidatorAwareRule
 {
-    use Conditionable, Macroable;
+    use Conditionable, Macroable {
+        Macroable::__call as macroCall;
+        Macroable::__callStatic as macroCallStatic;
+    }
+
+    /**
+     * Handle dynamic calls to the object.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return mixed
+     *
+     * @throws \BadMethodCallException
+     */
+    public function __call($method, $parameters)
+    {
+        if ($method === 'types') {
+            return $this->setTypes(...$parameters);
+        }
+
+        return $this->macroCall($method, $parameters);
+    }
+
+    /**
+     * Handle dynamic, static calls to the object.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return mixed
+     *
+     * @throws \BadMethodCallException
+     */
+    public static function __callStatic($method, $parameters)
+    {
+        if ($method === 'types') {
+            return (new static())->setTypes(...$parameters);
+        }
+
+        return static::macroCallStatic($method, $parameters);
+    }
 
     /**
      * The MIME types that the given file should match. This array may also contain file extensions.
@@ -137,12 +176,18 @@ class File implements Rule, DataAwareRule, ValidatorAwareRule
     /**
      * Limit the uploaded file to the given MIME types or file extensions.
      *
+     * This method can be called both statically (as a factory) and on an instance.
+     * When called statically, a new File instance is created.
+     * When called on an instance, the current instance is modified and returned.
+     *
      * @param  string|array<int, string>  $mimetypes
-     * @return static
+     * @return $this
      */
-    public static function types($mimetypes)
+    public function setTypes($mimetypes)
     {
-        return tap(new static(), fn ($file) => $file->allowedMimetypes = (array) $mimetypes);
+        $this->allowedMimetypes = (array) $mimetypes;
+
+        return $this;
     }
 
     /**

--- a/tests/Validation/ValidationFileRuleTest.php
+++ b/tests/Validation/ValidationFileRuleTest.php
@@ -135,6 +135,31 @@ class ValidationFileRuleTest extends TestCase
         );
     }
 
+    public function testTypesPreservesChainConfiguration()
+    {
+        // When types() is called on an existing instance, it should preserve
+        // prior configuration like max() instead of creating a new instance.
+        $this->fails(
+            File::image()->max(1)->types(['jpg', 'jpeg']),
+            UploadedFile::fake()->image('photo.jpg', 800, 600),
+            ['validation.max.file'],
+        );
+
+        // When types() is called statically, it should still work as a factory.
+        $this->fails(
+            File::types('text/plain'),
+            UploadedFile::fake()->createWithContent('foo.png', file_get_contents(__DIR__.'/fixtures/image.png')),
+            ['validation.mimetypes'],
+        );
+
+        // When types() is called before max(), the max constraint should also work.
+        $this->fails(
+            File::default()->types(['jpg', 'jpeg'])->max(1),
+            UploadedFile::fake()->image('photo.jpg', 800, 600),
+            ['validation.max.file'],
+        );
+    }
+
     public function testSingleExtension()
     {
         $this->fails(


### PR DESCRIPTION
## Summary

Fixes `File::types()` silently discarding prior chain configuration when called as an instance method (e.g., `File::image()->max(1)->types(['jpg'])` would lose the `max(1)` constraint). The `types()` method was `static`, so calling it on an instance created a new `File` object, dropping all previously configured rules.

Now works correctly both as a static factory (`File::types('png')`) and as a chainable instance method (`File::image()->max(1)->types(['jpg'])`).

## Prior work

#59247 by @AnnoyingTechnology took a similar approach to fix this issue but was closed due to timing (13.x release day). This PR builds on that work.

## Test plan

- Existing 23 File validation tests still pass
- New test verifies `max()` constraint is preserved when `types()` is called after it
- New test verifies static factory usage still works
- New test verifies instance chaining in both orders works

Fixes laravel/framework#59242