### PR TITLE
[13.x] Fix inconsistent accessor attribute name conversion

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -803,6 +803,10 @@ trait HasAttributes
      */
     protected function normalizeAttributeMutatorKey($key)
     {
+        if (! preg_match('/\d/', $key)) {
+            return $key;
+        }
+
         return lcfirst(static::$snakeAttributes ? Str::snake(Str::camel($key)) : Str::camel($key));
     }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -672,17 +672,19 @@ trait HasAttributes
      */
     public function hasAttributeMutator($key)
     {
-        if (isset(static::$attributeMutatorCache[get_class($this)][$key])) {
-            return static::$attributeMutatorCache[get_class($this)][$key];
+        $normalizedKey = $this->normalizeAttributeMutatorKey($key);
+
+        if (isset(static::$attributeMutatorCache[get_class($this)][$normalizedKey])) {
+            return static::$attributeMutatorCache[get_class($this)][$normalizedKey];
         }
 
         if (! method_exists($this, $method = Str::camel($key))) {
-            return static::$attributeMutatorCache[get_class($this)][$key] = false;
+            return static::$attributeMutatorCache[get_class($this)][$normalizedKey] = false;
         }
 
         $returnType = (new ReflectionMethod($this, $method))->getReturnType();
 
-        return static::$attributeMutatorCache[get_class($this)][$key] =
+        return static::$attributeMutatorCache[get_class($this)][$normalizedKey] =
                     $returnType instanceof ReflectionNamedType &&
                     $returnType->getName() === Attribute::class;
     }
@@ -695,15 +697,17 @@ trait HasAttributes
      */
     public function hasAttributeGetMutator($key)
     {
-        if (isset(static::$getAttributeMutatorCache[get_class($this)][$key])) {
-            return static::$getAttributeMutatorCache[get_class($this)][$key];
+        $normalizedKey = $this->normalizeAttributeMutatorKey($key);
+
+        if (isset(static::$getAttributeMutatorCache[get_class($this)][$normalizedKey])) {
+            return static::$getAttributeMutatorCache[get_class($this)][$normalizedKey];
         }
 
         if (! $this->hasAttributeMutator($key)) {
-            return static::$getAttributeMutatorCache[get_class($this)][$key] = false;
+            return static::$getAttributeMutatorCache[get_class($this)][$normalizedKey] = false;
         }
 
-        return static::$getAttributeMutatorCache[get_class($this)][$key] = is_callable($this->{Str::camel($key)}()->get);
+        return static::$getAttributeMutatorCache[get_class($this)][$normalizedKey] = is_callable($this->{Str::camel($key)}()->get);
     }
 
     /**
@@ -770,10 +774,12 @@ trait HasAttributes
      */
     protected function mutateAttributeForArray($key, $value)
     {
+        $normalizedKey = $this->normalizeAttributeMutatorKey($key);
+
         if ($this->isClassCastable($key)) {
             $value = $this->getClassCastableAttributeValue($key, $value);
-        } elseif (isset(static::$getAttributeMutatorCache[get_class($this)][$key]) &&
-                  static::$getAttributeMutatorCache[get_class($this)][$key] === true) {
+        } elseif (isset(static::$getAttributeMutatorCache[get_class($this)][$normalizedKey]) &&
+                  static::$getAttributeMutatorCache[get_class($this)][$normalizedKey] === true) {
             $value = $this->mutateAttributeMarkedAttribute($key, $value);
 
             $value = $value instanceof DateTimeInterface
@@ -784,6 +790,20 @@ trait HasAttributes
         }
 
         return $value instanceof Arrayable ? $value->toArray() : $value;
+    }
+
+    /**
+     * Normalize an attribute key to match the format used in the mutator cache.
+     *
+     * This handles cases where multiple snake_case forms map to the same camelCase
+     * method (e.g., both "foo_1_bar" and "foo1_bar" map to "foo1Bar").
+     *
+     * @param  string  $key
+     * @return string
+     */
+    protected function normalizeAttributeMutatorKey($key)
+    {
+        return lcfirst(static::$snakeAttributes ? Str::snake(Str::camel($key)) : Str::camel($key));
     }
 
     /**
@@ -1153,18 +1173,19 @@ trait HasAttributes
     public function hasAttributeSetMutator($key)
     {
         $class = get_class($this);
+        $normalizedKey = $this->normalizeAttributeMutatorKey($key);
 
-        if (isset(static::$setAttributeMutatorCache[$class][$key])) {
-            return static::$setAttributeMutatorCache[$class][$key];
+        if (isset(static::$setAttributeMutatorCache[$class][$normalizedKey])) {
+            return static::$setAttributeMutatorCache[$class][$normalizedKey];
         }
 
         if (! method_exists($this, $method = Str::camel($key))) {
-            return static::$setAttributeMutatorCache[$class][$key] = false;
+            return static::$setAttributeMutatorCache[$class][$normalizedKey] = false;
         }
 
         $returnType = (new ReflectionMethod($this, $method))->getReturnType();
 
-        return static::$setAttributeMutatorCache[$class][$key] =
+        return static::$setAttributeMutatorCache[$class][$normalizedKey] =
                     $returnType instanceof ReflectionNamedType &&
                     $returnType->getName() === Attribute::class &&
                     is_callable($this->{$method}()->set);

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3818,6 +3818,26 @@ class DatabaseEloquentModelTest extends TestCase
 
         $this->assertNotInstanceOf(CustomBuilder::class, $eloquentBuilder);
     }
+
+    public function testAccessorAttributeNameConversionWithAlternateSnakeCaseForm()
+    {
+        $model = new EloquentModelWithNumericAccessorStub;
+
+        // Both snake_case forms should resolve to the same camelCase method
+        $this->assertSame('yay', $model->foo1_bar);
+        $this->assertSame('yay', $model->foo_1_bar);
+
+        // Appending via the canonical snake form should work
+        $model->append('foo1_bar');
+        $array = $model->toArray();
+        $this->assertSame('yay', $array['foo1_bar']);
+
+        // Appending via the alternate snake form should also work
+        $model2 = new EloquentModelWithNumericAccessorStub;
+        $model2->append('foo_1_bar');
+        $array2 = $model2->toArray();
+        $this->assertSame('yay', $array2['foo_1_bar']);
+    }
 }
 
 class CustomBuilder extends Builder
@@ -4730,6 +4750,16 @@ class StringableCastBuilder implements NativeStringable
     public function __toString()
     {
         return $this->cast;
+    }
+}
+
+class EloquentModelWithNumericAccessorStub extends Model
+{
+    protected function foo1Bar(): Attribute
+    {
+        return Attribute::make(
+            get: fn () => 'yay',
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes inconsistent behavior when accessing Attribute-style accessors via alternate snake_case forms (e.g., `foo_1_bar` vs `foo1_bar`). Both forms correctly resolve to the same `foo1Bar()` method when getting values, but `append('foo_1_bar')->toArray()` would fail because the mutator cache only stored the canonical form `foo1_bar`.

Normalizes cache keys by round-tripping through camel→snake conversion so that alternate forms resolve to the same entry.

### Performance

Two prior PRs addressing this issue (#54578, #54793) were rejected due to performance concerns -- `Str::camel()` + `Str::snake()` runs on every attribute access, which is a hot path.

This PR includes a **fast-path short-circuit**: the normalization is only needed when the attribute key contains a digit (the only case where `foo_1_bar` vs `foo1_bar` ambiguity exists). For the 99% common case (`first_name`, `email`, `created_at`, etc.), the key is returned unchanged with zero overhead beyond a single `preg_match('/\d/', $key)` check.

## Test plan

- All 222 existing Eloquent model tests pass
- New test verifies both `foo1_bar` and `foo_1_bar` work with `append()` and `toArray()`

Fixes laravel/framework#54570