### PR TITLE
[13.x] Fix FileStore cache deserialization with sub-10-digit timestamps

### DIFF
--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -91,7 +91,7 @@ class FileStore implements CanFlushLocks, LockProvider, Store
         $this->ensureCacheDirectoryExists($path = $this->path($key));
 
         $result = $this->files->put(
-            $path, $this->expiration($seconds).serialize($value), true
+            $path, sprintf('%010d', $this->expiration($seconds)).serialize($value), true
         );
 
         if ($result !== false && $result > 0) {
@@ -129,7 +129,7 @@ class FileStore implements CanFlushLocks, LockProvider, Store
 
         if (empty($expire) || $this->currentTime() >= $expire) {
             $file->truncate()
-                ->write($this->expiration($seconds).serialize($value))
+                ->write(sprintf('%010d', $this->expiration($seconds)).serialize($value))
                 ->close();
 
             $this->ensurePermissionsAreCorrect($path);
@@ -426,15 +426,13 @@ class FileStore implements CanFlushLocks, LockProvider, Store
      * Get the expiration time based on the given seconds.
      *
      * @param  int  $seconds
-     * @return string
+     * @return int
      */
     protected function expiration($seconds)
     {
         $time = $this->availableAt($seconds);
 
-        return $seconds === 0 || $time > 9999999999
-            ? '9999999999'
-            : str_pad((string) $time, 10, '0', STR_PAD_LEFT);
+        return $seconds === 0 || $time > 9999999999 ? 9999999999 : $time;
     }
 
     /**

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -354,7 +354,9 @@ class FileStore implements CanFlushLocks, LockProvider, Store
                 return $this->emptyPayload();
             }
 
-            $expire = substr($contents, 0, 10);
+            $timestampLength = ctype_digit(substr($contents, 9, 1)) ? 10 : 9;
+
+            $expire = substr($contents, 0, $timestampLength);
         } catch (Exception) {
             return $this->emptyPayload();
         }
@@ -369,7 +371,7 @@ class FileStore implements CanFlushLocks, LockProvider, Store
         }
 
         try {
-            $data = $this->unserialize(substr($contents, 10));
+            $data = $this->unserialize(substr($contents, $timestampLength));
         } catch (Exception) {
             $this->forget($key);
 

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -426,13 +426,15 @@ class FileStore implements CanFlushLocks, LockProvider, Store
      * Get the expiration time based on the given seconds.
      *
      * @param  int  $seconds
-     * @return int
+     * @return string
      */
     protected function expiration($seconds)
     {
         $time = $this->availableAt($seconds);
 
-        return $seconds === 0 || $time > 9999999999 ? 9999999999 : $time;
+        return $seconds === 0 || $time > 9999999999
+            ? '9999999999'
+            : str_pad((string) $time, 10, '0', STR_PAD_LEFT);
     }
 
     /**

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -127,11 +127,9 @@ class FileStore implements CanFlushLocks, LockProvider, Store
 
         $expire = $file->read(10);
 
-        // If the timestamp is only 9 digits (pre-2001), the 10th character is part
-        // of the serialized data, not the timestamp. Trim it for a correct comparison.
-        if ($expire !== '' && ! ctype_digit($expire)) {
-            $expire = substr($expire, 0, 9);
-        }
+        // The timestamp may be fewer than 10 digits for dates before 2001-09-09.
+        // Trim any trailing non-digit characters that are part of the serialized data.
+        $expire = substr($expire, 0, strspn($expire, '0123456789'));
 
         if (empty($expire) || $this->currentTime() >= $expire) {
             $file->truncate()
@@ -360,7 +358,10 @@ class FileStore implements CanFlushLocks, LockProvider, Store
                 return $this->emptyPayload();
             }
 
-            $timestampLength = ctype_digit(substr($contents, 9, 1)) ? 10 : 9;
+            // The timestamp may be fewer than 10 digits for dates before 2001-09-09.
+            // Serialized PHP data always starts with a letter, so we find where
+            // the digits end to split the timestamp from the serialized value.
+            $timestampLength = strspn($contents, '0123456789');
 
             $expire = substr($contents, 0, $timestampLength);
         } catch (Exception) {

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -127,6 +127,12 @@ class FileStore implements CanFlushLocks, LockProvider, Store
 
         $expire = $file->read(10);
 
+        // If the timestamp is only 9 digits (pre-2001), the 10th character is part
+        // of the serialized data, not the timestamp. Trim it for a correct comparison.
+        if ($expire !== '' && ! ctype_digit($expire)) {
+            $expire = substr($expire, 0, 9);
+        }
+
         if (empty($expire) || $this->currentTime() >= $expire) {
             $file->truncate()
                 ->write(sprintf('%010d', $this->expiration($seconds)).serialize($value))

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -125,11 +125,10 @@ class FileStore implements CanFlushLocks, LockProvider, Store
             return false;
         }
 
-        $expire = $file->read(10);
-
         // The timestamp may be fewer than 10 digits for dates before 2001-09-09.
         // Trim any trailing non-digit characters that are part of the serialized data.
-        $expire = substr($expire, 0, strspn($expire, '0123456789'));
+        $raw = $file->read(10);
+        $expire = substr($raw, 0, strspn($raw, '0123456789'));
 
         if (empty($expire) || $this->currentTime() >= $expire) {
             $file->truncate()

--- a/tests/Cache/CacheFileStoreTest.php
+++ b/tests/Cache/CacheFileStoreTest.php
@@ -499,6 +499,54 @@ class CacheFileStoreTest extends TestCase
         $store->forget($key);
     }
 
+    public function testCacheWorksAtExactTenDigitBoundary()
+    {
+        // Timestamp 1000000000 (Sept 9, 2001) is the first 10-digit timestamp.
+        // This should work without any padding.
+        Carbon::setTestNow(Carbon::createFromTimestampUTC(1000000000));
+
+        $store = new FileStore(new Filesystem, __DIR__);
+        $key = Str::random();
+
+        $store->put($key, 'boundary-test', 60);
+        $this->assertSame('boundary-test', $store->get($key));
+
+        Carbon::setTestNow(null);
+        $store->forget($key);
+    }
+
+    public function testCacheForeverProducesTenDigitSentinel()
+    {
+        $store = new FileStore(new Filesystem, __DIR__);
+        $key = Str::random();
+
+        // seconds=0 means "forever", should store 9999999999 (already 10 digits)
+        $store->forever($key, 'forever-value');
+        $this->assertSame('forever-value', $store->get($key));
+
+        // Verify the raw file starts with the 10-digit sentinel
+        $contents = file_get_contents($store->path($key));
+        $this->assertSame('9999999999', substr($contents, 0, 10));
+
+        $store->forget($key);
+    }
+
+    public function testCacheHandlesComplexSerializedValues()
+    {
+        // Verify that zero-padding doesn't interfere with serialized arrays/objects
+        Carbon::setTestNow(Carbon::createFromTimestampUTC(990464400));
+
+        $store = new FileStore(new Filesystem, __DIR__);
+        $key = Str::random();
+
+        $complex = ['nested' => ['key' => 'value'], 'count' => 42];
+        $store->put($key, $complex, 60);
+        $this->assertSame($complex, $store->get($key));
+
+        Carbon::setTestNow(null);
+        $store->forget($key);
+    }
+
     protected function mockFilesystem()
     {
         return $this->createMock(Filesystem::class);

--- a/tests/Cache/CacheFileStoreTest.php
+++ b/tests/Cache/CacheFileStoreTest.php
@@ -499,6 +499,29 @@ class CacheFileStoreTest extends TestCase
         $store->forget($key);
     }
 
+    public function testAddRespectsNineDigitTimestampOnExistingFile()
+    {
+        // The add() method reads 10 bytes to check expiry. If an existing file
+        // has a 9-digit timestamp, add() should detect this and not treat the
+        // 10th byte (part of serialized data) as part of the timestamp.
+        Carbon::setTestNow(Carbon::createFromTimestampUTC(990464400));
+
+        $store = new FileStore(new Filesystem, __DIR__);
+        $key = Str::random();
+
+        // First put creates file with 9-digit timestamp (now padded by write fix)
+        $store->put($key, 'original', 300);
+        $this->assertSame('original', $store->get($key));
+
+        // add() should see the item as not expired and NOT overwrite
+        $result = $store->add($key, 'replaced', 300);
+        $this->assertFalse($result);
+        $this->assertSame('original', $store->get($key));
+
+        Carbon::setTestNow(null);
+        $store->forget($key);
+    }
+
     public function testCacheWorksAtExactTenDigitBoundary()
     {
         // Timestamp 1000000000 (Sept 9, 2001) is the first 10-digit timestamp.

--- a/tests/Cache/CacheFileStoreTest.php
+++ b/tests/Cache/CacheFileStoreTest.php
@@ -499,172 +499,25 @@ class CacheFileStoreTest extends TestCase
         $store->forget($key);
     }
 
-    public function testAddRespectsNineDigitTimestampOnExistingFile()
+    public function testCacheRecoversOldFilesWithShortTimestamps()
     {
-        // The add() method reads 10 bytes to check expiry. If an existing file
-        // has a 9-digit timestamp, add() should detect this and not treat the
-        // 10th byte (part of serialized data) as part of the timestamp.
-        Carbon::setTestNow(Carbon::createFromTimestampUTC(990464400)); // 2001-05-21 — 9-digit timestamp
-
-        $store = new FileStore(new Filesystem, __DIR__);
-        $key = Str::random();
-
-        // First put creates file with 9-digit timestamp (now padded by write fix)
-        $store->put($key, 'original', 300);
-        $this->assertSame('original', $store->get($key));
-
-        // add() should see the item as not expired and NOT overwrite
-        $result = $store->add($key, 'replaced', 300);
-        $this->assertFalse($result);
-        $this->assertSame('original', $store->get($key));
-
-        Carbon::setTestNow(null);
-        $store->forget($key);
-    }
-
-    public function testCacheWorksAtExactTenDigitBoundary()
-    {
-        // Timestamp 1000000000 (Sept 9, 2001) is the first 10-digit timestamp.
-        // This should work without any padding.
-        Carbon::setTestNow(Carbon::createFromTimestampUTC(1000000000));
-
-        $store = new FileStore(new Filesystem, __DIR__);
-        $key = Str::random();
-
-        $store->put($key, 'boundary-test', 60);
-        $this->assertSame('boundary-test', $store->get($key));
-
-        Carbon::setTestNow(null);
-        $store->forget($key);
-    }
-
-    public function testCacheForeverProducesTenDigitSentinel()
-    {
-        $store = new FileStore(new Filesystem, __DIR__);
-        $key = Str::random();
-
-        // seconds=0 means "forever", should store 9999999999 (already 10 digits)
-        $store->forever($key, 'forever-value');
-        $this->assertSame('forever-value', $store->get($key));
-
-        // Verify the raw file starts with the 10-digit sentinel
-        $contents = file_get_contents($store->path($key));
-        $this->assertSame('9999999999', substr($contents, 0, 10));
-
-        $store->forget($key);
-    }
-
-    public function testCacheRecoversOldFilesWithNineDigitTimestamps()
-    {
-        // Old cache files written before the fix have 9-digit timestamps with no
-        // zero-padding. The read side detects the short timestamp and splits correctly.
+        // Old cache files written before this fix have unpadded timestamps.
+        // The read side uses strspn to find the digit/data boundary, recovering them.
         $store = new FileStore(new Filesystem, __DIR__);
         $key = Str::random();
         $path = $store->path($key);
 
         (new Filesystem)->ensureDirectoryExists(dirname($path));
 
-        // 10-digit timestamp starting with 9 — valid, not expired
+        // 10-digit timestamp — not expired, should deserialize
         file_put_contents($path, '9990464403'.serialize('recovered'));
         $this->assertSame('recovered', $store->get($key));
 
-        // Actual 9-digit timestamp — already expired, should return null and clean up
+        // 9-digit timestamp — already expired, should return null
         file_put_contents($path, '990464403'.serialize('old-value'));
         $this->assertNull($store->get($key));
 
         @unlink($path);
-    }
-
-    public function testCacheHandlesComplexSerializedValues()
-    {
-        // Verify that zero-padding doesn't interfere with serialized arrays/objects
-        Carbon::setTestNow(Carbon::createFromTimestampUTC(990464400)); // 2001-05-21 — 9-digit timestamp
-
-        $store = new FileStore(new Filesystem, __DIR__);
-        $key = Str::random();
-
-        $complex = ['nested' => ['key' => 'value'], 'count' => 42];
-        $store->put($key, $complex, 60);
-        $this->assertSame($complex, $store->get($key));
-
-        Carbon::setTestNow(null);
-        $store->forget($key);
-    }
-
-    public function testCacheRecoversOldFilesWithEightDigitTimestamps()
-    {
-        // 8-digit timestamps are pre-March 1973 (max 99999999 = 1973-03-03).
-        // strspn correctly finds the boundary at any digit length.
-        $store = new FileStore(new Filesystem, __DIR__);
-        $key = Str::random();
-        $path = $store->path($key);
-
-        (new Filesystem)->ensureDirectoryExists(dirname($path));
-
-        // 8-digit timestamp, far-future value to avoid expiry check
-        file_put_contents($path, '99999999'.serialize('eight-digits'));
-        // 99999999 = March 1973, already expired — should return null
-        $this->assertNull($store->get($key));
-
-        // Use a fake 8-digit "not expired" by prepending to a valid future timestamp
-        // Actually we can't fake a non-expired 8-digit timestamp since they're all pre-1973.
-        // Just verify it doesn't crash and returns null gracefully.
-        @unlink($path);
-    }
-
-    public function testCacheWritePadsEightDigitTimestamps()
-    {
-        // Time-travel to 1972 (8-digit timestamp era)
-        Carbon::setTestNow(Carbon::createFromTimestampUTC(63072000)); // 1972-01-01 — 8-digit timestamp
-
-        $store = new FileStore(new Filesystem, __DIR__);
-        $key = Str::random();
-
-        $store->put($key, 'seventies', 300);
-
-        // Verify the raw file has a zero-padded 10-digit timestamp
-        $contents = file_get_contents($store->path($key));
-        $this->assertTrue(ctype_digit(substr($contents, 0, 10)));
-        $this->assertSame('0', substr($contents, 0, 1)); // leading zero from padding
-
-        $this->assertSame('seventies', $store->get($key));
-
-        Carbon::setTestNow(null);
-        $store->forget($key);
-    }
-
-    public function testCacheHandlesNegativeTimestampsGracefully()
-    {
-        // Negative timestamps (pre-1970) produce a leading '-' which strspn
-        // won't count as a digit. The entry is treated as empty — no crash.
-        $store = new FileStore(new Filesystem, __DIR__);
-        $key = Str::random();
-        $path = $store->path($key);
-
-        (new Filesystem)->ensureDirectoryExists(dirname($path));
-
-        // Write a file with a negative timestamp (simulating pre-1970 time travel)
-        file_put_contents($path, '-62135596800'.serialize('ancient'));
-        $this->assertNull($store->get($key)); // treated as empty, no crash
-
-        @unlink($path);
-    }
-
-    public function testCacheHandlesElevenDigitTimestampOnRead()
-    {
-        // 11-digit timestamps start at 10000000000 (November 20, 2286).
-        // strspn correctly reads all 11 digits with no hardcoded length.
-        $store = new FileStore(new Filesystem, __DIR__);
-        $key = Str::random();
-        $path = $store->path($key);
-
-        (new Filesystem)->ensureDirectoryExists(dirname($path));
-
-        // Simulate a file with an 11-digit timestamp (far future, not expired)
-        file_put_contents($path, '10000000000'.serialize('future'));
-        $this->assertSame('future', $store->get($key));
-
-        $store->forget($key);
     }
 
     protected function mockFilesystem()

--- a/tests/Cache/CacheFileStoreTest.php
+++ b/tests/Cache/CacheFileStoreTest.php
@@ -484,7 +484,7 @@ class CacheFileStoreTest extends TestCase
     {
         // Timestamps before ~2001 are only 9 digits, which would break
         // deserialization since getPayload() assumes 10-digit timestamps.
-        Carbon::setTestNow(Carbon::createFromTimestampUTC(990464400));
+        Carbon::setTestNow(Carbon::createFromTimestampUTC(990464400)); // 2001-05-21 — 9-digit timestamp
 
         $store = new FileStore(new Filesystem, __DIR__);
         $key = Str::random();
@@ -504,7 +504,7 @@ class CacheFileStoreTest extends TestCase
         // The add() method reads 10 bytes to check expiry. If an existing file
         // has a 9-digit timestamp, add() should detect this and not treat the
         // 10th byte (part of serialized data) as part of the timestamp.
-        Carbon::setTestNow(Carbon::createFromTimestampUTC(990464400));
+        Carbon::setTestNow(Carbon::createFromTimestampUTC(990464400)); // 2001-05-21 — 9-digit timestamp
 
         $store = new FileStore(new Filesystem, __DIR__);
         $key = Str::random();
@@ -578,7 +578,7 @@ class CacheFileStoreTest extends TestCase
     public function testCacheHandlesComplexSerializedValues()
     {
         // Verify that zero-padding doesn't interfere with serialized arrays/objects
-        Carbon::setTestNow(Carbon::createFromTimestampUTC(990464400));
+        Carbon::setTestNow(Carbon::createFromTimestampUTC(990464400)); // 2001-05-21 — 9-digit timestamp
 
         $store = new FileStore(new Filesystem, __DIR__);
         $key = Str::random();

--- a/tests/Cache/CacheFileStoreTest.php
+++ b/tests/Cache/CacheFileStoreTest.php
@@ -480,6 +480,25 @@ class CacheFileStoreTest extends TestCase
         $this->assertFileDoesNotExist($flexiblePath);
     }
 
+    public function testCacheWorksWithTimestampsShorterThanTenDigits()
+    {
+        // Timestamps before ~2001 are only 9 digits, which would break
+        // deserialization since getPayload() assumes 10-digit timestamps.
+        Carbon::setTestNow(Carbon::createFromTimestampUTC(990464400));
+
+        $store = new FileStore(new Filesystem, __DIR__);
+        $key = Str::random();
+
+        $store->put($key, 'value', 3);
+        $this->assertSame('value', $store->get($key));
+
+        // Also verify that the value is still readable after returning to normal time
+        Carbon::setTestNow(null);
+        $this->assertNull($store->get($key)); // Expired since real time > 990464403
+
+        $store->forget($key);
+    }
+
     protected function mockFilesystem()
     {
         return $this->createMock(Filesystem::class);

--- a/tests/Cache/CacheFileStoreTest.php
+++ b/tests/Cache/CacheFileStoreTest.php
@@ -531,6 +531,27 @@ class CacheFileStoreTest extends TestCase
         $store->forget($key);
     }
 
+    public function testCacheRecoversOldFilesWithNineDigitTimestamps()
+    {
+        // Old cache files written before the fix have 9-digit timestamps with no
+        // zero-padding. The read side detects the short timestamp and splits correctly.
+        $store = new FileStore(new Filesystem, __DIR__);
+        $key = Str::random();
+        $path = $store->path($key);
+
+        (new Filesystem)->ensureDirectoryExists(dirname($path));
+
+        // 10-digit timestamp starting with 9 — valid, not expired
+        file_put_contents($path, '9990464403'.serialize('recovered'));
+        $this->assertSame('recovered', $store->get($key));
+
+        // Actual 9-digit timestamp — already expired, should return null and clean up
+        file_put_contents($path, '990464403'.serialize('old-value'));
+        $this->assertNull($store->get($key));
+
+        @unlink($path);
+    }
+
     public function testCacheHandlesComplexSerializedValues()
     {
         // Verify that zero-padding doesn't interfere with serialized arrays/objects

--- a/tests/Cache/CacheFileStoreTest.php
+++ b/tests/Cache/CacheFileStoreTest.php
@@ -591,6 +591,82 @@ class CacheFileStoreTest extends TestCase
         $store->forget($key);
     }
 
+    public function testCacheRecoversOldFilesWithEightDigitTimestamps()
+    {
+        // 8-digit timestamps are pre-March 1973 (max 99999999 = 1973-03-03).
+        // strspn correctly finds the boundary at any digit length.
+        $store = new FileStore(new Filesystem, __DIR__);
+        $key = Str::random();
+        $path = $store->path($key);
+
+        (new Filesystem)->ensureDirectoryExists(dirname($path));
+
+        // 8-digit timestamp, far-future value to avoid expiry check
+        file_put_contents($path, '99999999'.serialize('eight-digits'));
+        // 99999999 = March 1973, already expired — should return null
+        $this->assertNull($store->get($key));
+
+        // Use a fake 8-digit "not expired" by prepending to a valid future timestamp
+        // Actually we can't fake a non-expired 8-digit timestamp since they're all pre-1973.
+        // Just verify it doesn't crash and returns null gracefully.
+        @unlink($path);
+    }
+
+    public function testCacheWritePadsEightDigitTimestamps()
+    {
+        // Time-travel to 1972 (8-digit timestamp era)
+        Carbon::setTestNow(Carbon::createFromTimestampUTC(63072000)); // 1972-01-01 — 8-digit timestamp
+
+        $store = new FileStore(new Filesystem, __DIR__);
+        $key = Str::random();
+
+        $store->put($key, 'seventies', 300);
+
+        // Verify the raw file has a zero-padded 10-digit timestamp
+        $contents = file_get_contents($store->path($key));
+        $this->assertTrue(ctype_digit(substr($contents, 0, 10)));
+        $this->assertSame('0', substr($contents, 0, 1)); // leading zero from padding
+
+        $this->assertSame('seventies', $store->get($key));
+
+        Carbon::setTestNow(null);
+        $store->forget($key);
+    }
+
+    public function testCacheHandlesNegativeTimestampsGracefully()
+    {
+        // Negative timestamps (pre-1970) produce a leading '-' which strspn
+        // won't count as a digit. The entry is treated as empty — no crash.
+        $store = new FileStore(new Filesystem, __DIR__);
+        $key = Str::random();
+        $path = $store->path($key);
+
+        (new Filesystem)->ensureDirectoryExists(dirname($path));
+
+        // Write a file with a negative timestamp (simulating pre-1970 time travel)
+        file_put_contents($path, '-62135596800'.serialize('ancient'));
+        $this->assertNull($store->get($key)); // treated as empty, no crash
+
+        @unlink($path);
+    }
+
+    public function testCacheHandlesElevenDigitTimestampOnRead()
+    {
+        // 11-digit timestamps start at 10000000000 (November 20, 2286).
+        // strspn correctly reads all 11 digits with no hardcoded length.
+        $store = new FileStore(new Filesystem, __DIR__);
+        $key = Str::random();
+        $path = $store->path($key);
+
+        (new Filesystem)->ensureDirectoryExists(dirname($path));
+
+        // Simulate a file with an 11-digit timestamp (far future, not expired)
+        file_put_contents($path, '10000000000'.serialize('future'));
+        $this->assertSame('future', $store->get($key));
+
+        $store->forget($key);
+    }
+
     protected function mockFilesystem()
     {
         return $this->createMock(Filesystem::class);


### PR DESCRIPTION
## Problem

`FileStore::getPayload()` reads cache files by splitting at a hardcoded 10-character boundary:

```php
$expire = substr($contents, 0, 10);
$data   = substr($contents, 10);
```

`expiration()` returns a plain `int`, and timestamps before 2001-09-09 are only 9 digits (e.g. `990464460`). When a 9-digit timestamp is concatenated with the serialized value, the read side grabs 10 characters and eats the first byte of the data.

Fixes #56075.

### Prior discussion

@murrant reported this in #56075. @crynobone noted it would be hard to fix without a breaking change.

This approach avoids a breaking change. `expiration()` is untouched (same signature, same return type, same behavior). The padding is applied at the call sites only.

## How it breaks (before)

Writing a cache entry while time-traveling to May 2001:

```
Carbon::setTestNow('2001-05-21 17:00:00')
Cache::put('key', 'hello', 60)

expiration(60) returns 990464460 (9 digits)

File written: 990464460s:5:"hello";
```

Reading it back:

```
Cache::get('key')

substr($contents, 0, 10) = "990464460s"    <- grabbed 's' from serialized data
substr($contents, 10)    = ":5:\"hello\";" <- missing the 's:', broken

unserialize(":5:\"hello\";") fails silently, returns null
```

The user gets `null`. No error, no exception. The data was written but can never be read.

## How it works (after)

**New files** get padded to 10 digits on write with `sprintf('%010d', ...)`:

```
sprintf('%010d', 990464460) = "0990464460"

File written: 0990464460s:5:"hello";

strspn("0990464460s:5:...", '0123456789') = 10
substr($contents, 0, 10) = "0990464460"    <- clean timestamp
substr($contents, 10)    = "s:5:\"hello\";" <- valid serialized data
```

**Old files** (written before the fix) are recovered. `strspn` detects the short timestamp:

```
File on disk: 990464460s:5:"hello";

strspn("990464460s:5:...", '0123456789') = 9
substr($contents, 0, 9)  = "990464460"     <- correct timestamp
substr($contents, 9)     = "s:5:\"hello\";" <- valid serialized data
```

**Self-healing**: old files get corrected on the next write. No `cache:clear` needed after upgrading.

## The fix

Fixing only the write side would prevent new broken files but leave old ones unreadable. Fixing only the read side would recover old files but keep writing broken ones. Fixing both makes the cache self-healing: any file written before or after this fix is handled correctly.

**Write side** (`put()` and `add()`): wraps `$this->expiration($seconds)` with `sprintf('%010d', ...)` so new cache files always have 10-digit timestamps.

**Read side** (`getPayload()` and `add()`): uses `strspn($contents, '0123456789')` to count leading digits and find the boundary between timestamp and serialized data. Serialized PHP always starts with a type-prefix letter (`s:`, `i:`, `a:`, `b:`, `d:`, `N;`, `O:`, `C:`), so the boundary is unambiguous. Works for any timestamp length.

**When would someone hit this?** `Carbon::setTestNow()` or `Date::withTestNow()` with a date before September 9, 2001. This is the scenario @murrant reported: time-traveling in tests.

## Test plan

Two new tests:
- 9-digit timestamp round-trip: time-travels to 2001-05-21 (exact reproduction from #56075), verifies `put()`/`get()` works and correctly expires
- Old file recovery: manually writes cache files with unpadded timestamps, verifies the read side recovers them

All existing FileStore tests pass.

## Scope and safety

This change is limited to `FileStore.php`, affecting `put()`, `add()`, and `getPayload()` only. No other cache drivers are affected. No method signatures change. The `expiration()` method is untouched.

Existing cache files cannot be corrupted by this change. The read side is backwards-compatible with both old (unpadded) and new (padded) formats. Worst case if anything goes wrong is a cache miss, which is the same failure mode as before.

## Note on timestamp range

`strspn` handles any digit length (8, 9, 10, 11+) and `sprintf('%010d', ...)` pads anything shorter than 10 digits. Timestamps outside the typical range (pre-1973 for 8-digit, post-2286 for 11-digit) work at the serialization level. Edge cases like negative timestamps (pre-1970) are outside the scope of this fix since they involve broader limitations in Unix timestamp representation.