### PR TITLE
[13.x] Fix OOM jobs retrying infinitely with maxExceptions

### DIFF
--- a/src/Illuminate/Queue/MaxExceptionsExceededException.php
+++ b/src/Illuminate/Queue/MaxExceptionsExceededException.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Illuminate\Queue;
+
+use RuntimeException;
+
+class MaxExceptionsExceededException extends RuntimeException
+{
+    /**
+     * The job instance.
+     *
+     * @var \Illuminate\Contracts\Queue\Job|null
+     */
+    public $job;
+
+    /**
+     * Create a new instance for the job.
+     *
+     * @param  \Illuminate\Contracts\Queue\Job  $job
+     * @return static
+     */
+    public static function forJob($job)
+    {
+        return tap(new static($job->resolveName().' has exceeded the maximum number of exceptions.'), function ($e) use ($job) {
+            $e->job = $job;
+        });
+    }
+}

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -641,7 +641,7 @@ class Worker
 
         $exceptions = (int) $this->cache->get('job-exceptions:'.$uuid, 0);
 
-        if ($exceptions >= $maxExceptions) {
+        if ($exceptions > 0 && $exceptions >= $maxExceptions) {
             $this->cache->forget('job-exceptions:'.$uuid);
 
             $this->failJob($job, $e = $this->maxExceptionsExceededException($job));
@@ -717,7 +717,11 @@ class Worker
             return;
         }
 
-        $this->cache->decrement('job-exceptions:'.$uuid);
+        $key = 'job-exceptions:'.$uuid;
+
+        if ($this->cache->decrement($key) <= 0) {
+            $this->cache->forget($key);
+        }
     }
 
     /**

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -484,14 +484,27 @@ class Worker
                 $connectionName, $job, (int) $options->maxTries
             );
 
+            $this->markJobAsFailedIfAlreadyExceedsMaxExceptions(
+                $connectionName, $job
+            );
+
             if ($job->isDeleted()) {
                 return $this->raiseAfterJobEvent($connectionName, $job);
             }
+
+            // Optimistically increment the exception counter before processing. If the
+            // worker is killed unexpectedly (e.g. OOM), the counter will already reflect
+            // this attempt. On success, we decrement it back. On caught exceptions, the
+            // handleJobException method will leave the counter as-is since it was already
+            // incremented here.
+            $this->incrementExceptionCount($job);
 
             // Here we will fire off the job and let it process. We will catch any exceptions, so
             // they can be reported to the developer's logs, etc. Once the job is finished the
             // proper events will be fired to let any listeners know this job has completed.
             $job->fire();
+
+            $this->decrementExceptionCount($job);
 
             $this->raiseAfterJobEvent($connectionName, $job);
         } catch (Throwable $e) {
@@ -607,7 +620,42 @@ class Worker
     }
 
     /**
-     * Mark the given job as failed if it has exceeded the maximum allowed attempts.
+     * Mark the given job as failed if it has exceeded the maximum allowed exceptions.
+     *
+     * This is checked before the job fires. If the worker was previously killed
+     * unexpectedly (e.g. OOM), the optimistic exception count increment will
+     * already be reflected, causing this check to catch it on the next attempt.
+     *
+     * @param  string  $connectionName
+     * @param  \Illuminate\Contracts\Queue\Job  $job
+     * @return void
+     *
+     * @throws \Throwable
+     */
+    protected function markJobAsFailedIfAlreadyExceedsMaxExceptions($connectionName, $job)
+    {
+        if (! $this->cache || is_null($uuid = $job->uuid()) ||
+            is_null($maxExceptions = $job->maxExceptions())) {
+            return;
+        }
+
+        $exceptions = (int) $this->cache->get('job-exceptions:'.$uuid, 0);
+
+        if ($exceptions >= $maxExceptions) {
+            $this->cache->forget('job-exceptions:'.$uuid);
+
+            $this->failJob($job, $e = $this->maxExceptionsExceededException($job));
+
+            throw $e;
+        }
+    }
+
+    /**
+     * Mark the given job as failed if it has exceeded the maximum allowed exceptions.
+     *
+     * The exception counter was already incremented optimistically before the job
+     * was fired, so this method only needs to check the current value without
+     * incrementing again.
      *
      * @param  string  $connectionName
      * @param  \Illuminate\Contracts\Queue\Job  $job
@@ -621,15 +669,55 @@ class Worker
             return;
         }
 
-        if (! $this->cache->get('job-exceptions:'.$uuid)) {
-            $this->cache->put('job-exceptions:'.$uuid, 0, Carbon::now()->addDay());
-        }
+        $exceptions = (int) $this->cache->get('job-exceptions:'.$uuid, 0);
 
-        if ($maxExceptions <= $this->cache->increment('job-exceptions:'.$uuid)) {
+        if ($exceptions >= $maxExceptions) {
             $this->cache->forget('job-exceptions:'.$uuid);
 
             $this->failJob($job, $e);
         }
+    }
+
+    /**
+     * Increment the exception count for the given job.
+     *
+     * This is called optimistically before the job fires so that if the worker
+     * is killed unexpectedly (e.g. by OOM), the count is already incremented.
+     *
+     * @param  \Illuminate\Contracts\Queue\Job  $job
+     * @return void
+     */
+    protected function incrementExceptionCount($job)
+    {
+        if (! $this->cache || is_null($uuid = $job->uuid()) ||
+            is_null($job->maxExceptions())) {
+            return;
+        }
+
+        if (! $this->cache->get('job-exceptions:'.$uuid)) {
+            $this->cache->put('job-exceptions:'.$uuid, 0, Carbon::now()->addDay());
+        }
+
+        $this->cache->increment('job-exceptions:'.$uuid);
+    }
+
+    /**
+     * Decrement the exception count for the given job.
+     *
+     * Called after the job successfully completes to reverse the optimistic
+     * increment, since no exception actually occurred.
+     *
+     * @param  \Illuminate\Contracts\Queue\Job  $job
+     * @return void
+     */
+    protected function decrementExceptionCount($job)
+    {
+        if (! $this->cache || is_null($uuid = $job->uuid()) ||
+            is_null($job->maxExceptions())) {
+            return;
+        }
+
+        $this->cache->decrement('job-exceptions:'.$uuid);
     }
 
     /**
@@ -882,6 +970,17 @@ class Worker
     protected function timeoutExceededException($job)
     {
         return TimeoutExceededException::forJob($job);
+    }
+
+    /**
+     * Create an instance of MaxExceptionsExceededException.
+     *
+     * @param  \Illuminate\Contracts\Queue\Job  $job
+     * @return \Illuminate\Queue\MaxExceptionsExceededException
+     */
+    protected function maxExceptionsExceededException($job)
+    {
+        return MaxExceptionsExceededException::forJob($job);
     }
 
     /**

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -327,7 +327,7 @@ class QueueWorkerTest extends TestCase
         $worker->runNextJob('default', 'queue', new WorkerOptions);
 
         $this->assertTrue($job->fired);
-        $this->assertEquals(0, (int) $cache->get('job-exceptions:test-uuid', 0));
+        $this->assertNull($cache->get('job-exceptions:test-uuid'));
     }
 
     public function testMaxExceptionsCounterNotDecrementedOnException()
@@ -428,6 +428,114 @@ class QueueWorkerTest extends TestCase
 
         // The cache key should be cleaned up.
         $this->assertNull($cache->get('job-exceptions:test-uuid'));
+    }
+
+    public function testMaxExceptionsZeroAllowsFirstRunButFailsAfterOom()
+    {
+        $cache = new \Illuminate\Cache\Repository(new \Illuminate\Cache\ArrayStore);
+
+        // First run with maxExceptions=0: job should fire normally.
+        $job = new WorkerFakeJob;
+        $job->uuid = 'test-uuid-zero';
+        $job->maxExceptions = 0;
+
+        $worker = $this->getWorker('default', ['queue' => [$job]]);
+        $worker->setCache($cache);
+        $worker->runNextJob('default', 'queue', new WorkerOptions);
+
+        $this->assertTrue($job->fired);
+        $this->assertFalse($job->failed);
+
+        // After a simulated OOM (counter left at 1), the pre-fire check should catch it.
+        $cache->put('job-exceptions:test-uuid-zero', 1, 3600);
+
+        $job2 = new WorkerFakeJob;
+        $job2->uuid = 'test-uuid-zero';
+        $job2->maxExceptions = 0;
+
+        $worker2 = $this->getWorker('default', ['queue' => [$job2]]);
+        $worker2->setCache($cache);
+        $worker2->runNextJob('default', 'queue', new WorkerOptions);
+
+        $this->assertFalse($job2->fired);
+        $this->assertTrue($job2->failed);
+        $this->assertInstanceOf(MaxExceptionsExceededException::class, $job2->failedWith);
+    }
+
+    public function testMaxExceptionsOneFailsImmediatelyOnFirstException()
+    {
+        $cache = new \Illuminate\Cache\Repository(new \Illuminate\Cache\ArrayStore);
+
+        // With maxExceptions=1, the first thrown exception should immediately
+        // fail the job (optimistic increment brings counter to 1, post-exception
+        // check sees 1 >= 1 and fails).
+        $job = new WorkerFakeJob(function () {
+            throw new RuntimeException('fail');
+        });
+        $job->uuid = 'test-uuid-one';
+        $job->maxExceptions = 1;
+
+        $worker = $this->getWorker('default', ['queue' => [$job]]);
+        $worker->setCache($cache);
+        $worker->runNextJob('default', 'queue', new WorkerOptions);
+
+        $this->assertTrue($job->fired);
+        $this->assertTrue($job->failed);
+        $this->assertNull($cache->get('job-exceptions:test-uuid-one'));
+    }
+
+    public function testMaxExceptionsThreeAllowsRetryUntilThresholdReached()
+    {
+        $cache = new \Illuminate\Cache\Repository(new \Illuminate\Cache\ArrayStore);
+
+        // Simulate 2 previous OOM kills (counter left at 2, post-exception handler never ran).
+        $cache->put('job-exceptions:test-uuid-three', 2, 3600);
+
+        // Pre-fire check: 2 > 0 && 2 >= 3 is false — job is allowed to run.
+        $job = new WorkerFakeJob;
+        $job->uuid = 'test-uuid-three';
+        $job->maxExceptions = 3;
+
+        $worker = $this->getWorker('default', ['queue' => [$job]]);
+        $worker->setCache($cache);
+        $worker->runNextJob('default', 'queue', new WorkerOptions);
+
+        $this->assertTrue($job->fired);
+        $this->assertFalse($job->failed);
+
+        // Simulate a third OOM kill (counter now at 3).
+        $cache->put('job-exceptions:test-uuid-three', 3, 3600);
+
+        // Pre-fire check: 3 > 0 && 3 >= 3 is true — job should fail without firing.
+        $job2 = new WorkerFakeJob;
+        $job2->uuid = 'test-uuid-three';
+        $job2->maxExceptions = 3;
+
+        $worker2 = $this->getWorker('default', ['queue' => [$job2]]);
+        $worker2->setCache($cache);
+        $worker2->runNextJob('default', 'queue', new WorkerOptions);
+
+        $this->assertFalse($job2->fired);
+        $this->assertTrue($job2->failed);
+        $this->assertNull($cache->get('job-exceptions:test-uuid-three'));
+    }
+
+    public function testSuccessfulJobCleansUpCacheKeyCompletely()
+    {
+        $cache = new \Illuminate\Cache\Repository(new \Illuminate\Cache\ArrayStore);
+
+        $job = new WorkerFakeJob;
+        $job->uuid = 'test-uuid-cleanup';
+        $job->maxExceptions = 3;
+
+        $worker = $this->getWorker('default', ['queue' => [$job]]);
+        $worker->setCache($cache);
+        $worker->runNextJob('default', 'queue', new WorkerOptions);
+
+        $this->assertTrue($job->fired);
+        // Key should be fully removed, not left at 0.
+        $this->assertNull($cache->get('job-exceptions:test-uuid-cleanup'));
+        $this->assertFalse($cache->has('job-exceptions:test-uuid-cleanup'));
     }
 
     public function testJobBasedMaxRetries()

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -16,6 +16,7 @@ use Illuminate\Queue\Events\JobReleasedAfterException;
 use Illuminate\Queue\Events\WorkerStarting;
 use Illuminate\Queue\Events\WorkerStopping;
 use Illuminate\Queue\MaxAttemptsExceededException;
+use Illuminate\Queue\MaxExceptionsExceededException;
 use Illuminate\Queue\QueueManager;
 use Illuminate\Queue\Worker;
 use Illuminate\Queue\WorkerOptions;
@@ -313,6 +314,122 @@ class QueueWorkerTest extends TestCase
         $this->events->shouldNotHaveReceived('dispatch', [m::type(JobProcessed::class)]);
     }
 
+    public function testMaxExceptionsCounterIncrementsBeforeFireAndDecrementsOnSuccess()
+    {
+        $cache = new \Illuminate\Cache\Repository(new \Illuminate\Cache\ArrayStore);
+
+        $job = new WorkerFakeJob;
+        $job->uuid = 'test-uuid';
+        $job->maxExceptions = 3;
+
+        $worker = $this->getWorker('default', ['queue' => [$job]]);
+        $worker->setCache($cache);
+        $worker->runNextJob('default', 'queue', new WorkerOptions);
+
+        $this->assertTrue($job->fired);
+        $this->assertEquals(0, (int) $cache->get('job-exceptions:test-uuid', 0));
+    }
+
+    public function testMaxExceptionsCounterNotDecrementedOnException()
+    {
+        $cache = new \Illuminate\Cache\Repository(new \Illuminate\Cache\ArrayStore);
+
+        $job = new WorkerFakeJob(function () {
+            throw new RuntimeException('fail');
+        });
+        $job->uuid = 'test-uuid';
+        $job->maxExceptions = 3;
+
+        $worker = $this->getWorker('default', ['queue' => [$job]]);
+        $worker->setCache($cache);
+        $worker->runNextJob('default', 'queue', new WorkerOptions);
+
+        $this->assertTrue($job->released);
+        $this->assertEquals(1, (int) $cache->get('job-exceptions:test-uuid', 0));
+    }
+
+    public function testJobFailedWhenExceptionCountAlreadyExceedsMaxExceptions()
+    {
+        $cache = new \Illuminate\Cache\Repository(new \Illuminate\Cache\ArrayStore);
+        $cache->put('job-exceptions:test-uuid', 1, 3600);
+
+        $job = new WorkerFakeJob;
+        $job->uuid = 'test-uuid';
+        $job->maxExceptions = 1;
+
+        $worker = $this->getWorker('default', ['queue' => [$job]]);
+        $worker->setCache($cache);
+        $worker->runNextJob('default', 'queue', new WorkerOptions);
+
+        $this->assertTrue($job->failed);
+        $this->assertFalse($job->fired);
+        $this->assertInstanceOf(MaxExceptionsExceededException::class, $job->failedWith);
+    }
+
+    public function testMaxExceptionsSkippedWhenNoCacheAvailable()
+    {
+        $job = new WorkerFakeJob;
+        $job->uuid = 'test-uuid';
+        $job->maxExceptions = 1;
+
+        $worker = $this->getWorker('default', ['queue' => [$job]]);
+        $worker->runNextJob('default', 'queue', new WorkerOptions);
+
+        $this->assertTrue($job->fired);
+        $this->assertFalse($job->failed);
+    }
+
+    public function testMaxExceptionsSkippedWhenJobHasNoUuid()
+    {
+        $cache = new \Illuminate\Cache\Repository(new \Illuminate\Cache\ArrayStore);
+
+        $job = new WorkerFakeJob;
+        $job->uuid = null;
+        $job->maxExceptions = 1;
+
+        $worker = $this->getWorker('default', ['queue' => [$job]]);
+        $worker->setCache($cache);
+        $worker->runNextJob('default', 'queue', new WorkerOptions);
+
+        $this->assertTrue($job->fired);
+    }
+
+    /**
+     * Simulate the OOM scenario described in #58207: a worker is killed during
+     * job execution (e.g. by OOM), leaving the exception counter incremented in
+     * cache but the catch block never reached. On the next attempt, the pre-fire
+     * check should detect the counter and fail the job.
+     *
+     * Verified: fails on stock Laravel 13.x, passes with this fix.
+     */
+    public function testJobFailsAfterSimulatedWorkerKillDuringExecution()
+    {
+        $cache = new \Illuminate\Cache\Repository(new \Illuminate\Cache\ArrayStore);
+
+        // Simulate a previous worker run that was killed mid-execution.
+        // The optimistic increment ran before fire(), but the worker was killed
+        // before the catch block could run. The counter is left at 1 in cache.
+        $cache->put('job-exceptions:test-uuid', 0, 3600);
+        $cache->increment('job-exceptions:test-uuid');
+
+        // Now a new worker picks up the same job.
+        $job = new WorkerFakeJob;
+        $job->uuid = 'test-uuid';
+        $job->maxExceptions = 1;
+
+        $worker = $this->getWorker('default', ['queue' => [$job]]);
+        $worker->setCache($cache);
+        $worker->runNextJob('default', 'queue', new WorkerOptions);
+
+        // The job should be failed without firing — the pre-fire check caught it.
+        $this->assertFalse($job->fired);
+        $this->assertTrue($job->failed);
+        $this->assertInstanceOf(MaxExceptionsExceededException::class, $job->failedWith);
+
+        // The cache key should be cleaned up.
+        $this->assertNull($cache->get('job-exceptions:test-uuid'));
+    }
+
     public function testJobBasedMaxRetries()
     {
         $job = new WorkerFakeJob(function ($job) {
@@ -554,6 +671,11 @@ class WorkerFakeManager extends QueueManager
     public function __construct($name, $connection)
     {
         $this->connections[$name] = $connection;
+    }
+
+    public function isPaused($connection, $queue)
+    {
+        return false;
     }
 
     public function connection($name = null)

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -538,6 +538,29 @@ class QueueWorkerTest extends TestCase
         $this->assertFalse($cache->has('job-exceptions:test-uuid-cleanup'));
     }
 
+    public function testMaxExceptionsNullBypassesAllExceptionTracking()
+    {
+        $cache = new \Illuminate\Cache\Repository(new \Illuminate\Cache\ArrayStore);
+
+        // maxExceptions=null (default) means no limit — exception tracking
+        // should be completely bypassed, even if exceptions are thrown.
+        $job = new WorkerFakeJob(function () {
+            throw new RuntimeException('fail');
+        });
+        $job->uuid = 'test-uuid-null';
+        // maxExceptions is null by default (not set)
+
+        $worker = $this->getWorker('default', ['queue' => [$job]]);
+        $worker->setCache($cache);
+        $worker->runNextJob('default', 'queue', new WorkerOptions);
+
+        $this->assertTrue($job->fired);
+        $this->assertFalse($job->failed);
+        $this->assertTrue($job->released);
+        // No cache key should be created at all.
+        $this->assertFalse($cache->has('job-exceptions:test-uuid-null'));
+    }
+
     public function testJobBasedMaxRetries()
     {
         $job = new WorkerFakeJob(function ($job) {


### PR DESCRIPTION
## Summary

Fixes 🟢 #58207. Also related to 🟢 #56395.

Jobs with `$maxExceptions` retry infinitely when killed by OOM. The exception counter is only incremented inside the catch block, which is never reached when the process is killed by a fatal error. The counter stays at 0 forever, and the job retries on every worker restart.

This affects Redis, database, and Beanstalkd queue drivers. SQS is unaffected (native receive count limits). Horizon benefits automatically as it uses the standard Worker.

### Before

A job processes a large CSV upload and runs out of memory:

```php
class ProcessUpload implements ShouldQueue
{
    public $tries = 0;          // unlimited retries (using maxExceptions instead)
    public $maxExceptions = 3;  // should fail after 3 exceptions
}
```

```
Worker starts → job fires → PHP fatal: Allowed memory size exhausted → worker killed
Worker restarts → same job picked up → exception counter is still 0 → fires again → OOM → killed
Worker restarts → counter still 0 → fires again → OOM → killed
... forever. maxExceptions is never checked because the counter is never incremented.
```

Meanwhile, every worker in the pool gets stuck on this one impossible job. The queue backs up. No error in the logs — the job just keeps appearing and killing workers.

### After

```
Worker starts → counter incremented to 1 → job fires → OOM → worker killed
Worker restarts → pre-fire check: counter (1) < maxExceptions (3) → counter incremented to 2 → fires → OOM
Worker restarts → pre-fire check: counter (2) < maxExceptions (3) → counter incremented to 3 → fires → OOM
Worker restarts → pre-fire check: counter (3) >= maxExceptions (3) → job marked as failed → moved to failed_jobs → done
```

The job fails after exactly 3 attempts, as configured. Workers are freed to process other jobs.

### How it works

Uses an "optimistic increment" pattern:

1. **Before** `$job->fire()`: increment the exception counter in cache
2. **After** successful `$job->fire()`: decrement it back (no exception occurred)
3. **On next attempt**: check if counter already >= maxExceptions before firing

If the worker dies between increment and fire completion, the counter persists in cache. On the next pickup, the pre-fire check catches it.

For normal (non-OOM) exceptions: the counter is incremented before fire, the catch block checks the current value, and the existing `markJobAsFailedIfWillExceedMaxExceptions` fails the job if needed. The counter is NOT decremented (because fire threw), so the count is correct.

For successful jobs: increment then decrement = net zero. No change in behavior.

### Prior work and what this addresses

All prior work assumed the catch block would execute:

- **PR #33521** (merged, 2020) — added `maxExceptions` and the `job-exceptions:{uuid}` cache counter. The counter is incremented inside `markJobAsFailedIfWillExceedMaxExceptions`, which is called from `handleJobException`, which is called from the `catch(Throwable)` block. This works for every exception PHP can catch — timeouts, runtime errors, type errors, everything.

- **PR #37450** (merged, 2021) — added `$failOnTimeouts`. Timeouts are caught because Laravel sends SIGALRM, which the worker handles gracefully inside the catch block. So this also relied on the catch block executing.

**The gap:** OOM is not a catchable exception. It's a PHP fatal error that kills the process. The catch block never runs. `handleJobException` never runs. `markJobAsFailedIfWillExceedMaxExceptions` never runs. The counter is never incremented. The job goes back to the queue with a counter of 0, and the cycle repeats forever.

The `maxExceptions` feature was designed around catchable exceptions — that's what it counts. OOM wasn't considered because it's a process-level kill, not a PHP exception. The feature worked exactly as designed; the design just didn't account for fatal errors.

This fix bridges the gap by moving the increment **before** `fire()` instead of **after** the catch. If the process survives, we decrement (net zero). If it dies, the increment persists. Next time the job is picked up, the pre-fire check sees the counter and fails the job. The catch block is no longer in the critical path.

A middleware-based version of this same pattern was independently developed and validated in the #58207 discussion, confirming the approach works in production.

### Changes

- **`Worker::process()`** — calls `incrementExceptionCount` before `fire()`, `decrementExceptionCount` after success
- **`Worker::markJobAsFailedIfAlreadyExceedsMaxExceptions()`** — new pre-fire check that fails the job if counter already exceeds limit
- **`Worker::markJobAsFailedIfWillExceedMaxExceptions()`** — simplified to only check the current counter value (no longer increments)
- **`Worker::incrementExceptionCount()` / `decrementExceptionCount()`** — new helper methods with guards for missing cache/UUID/maxExceptions
- **`MaxExceptionsExceededException`** — new exception class (mirrors `MaxAttemptsExceededException`)

### Companion fix: #59415 (memory retention)

#59415 fixes the upstream cause. `Pipeline` holds references to completed job data, inflating worker memory between jobs. When a large job runs before a moderately sized one, the retained memory can push the worker over PHP's `memory_limit`, triggering the OOM that this PR handles. Together, #59415 reduces the likelihood of OOM and this PR ensures graceful failure when it does happen.

### Verified

The integration test `testJobFailsAfterSimulatedWorkerKillDuringExecution` was run against stock Laravel 13.x (without this fix) and confirmed the issue: the job fires despite the exception counter being at the limit. With the fix applied, the job is correctly failed without firing.

### Test plan

**11 tests in `QueueWorkerTest.php`:**

**Unit tests** (verify the optimistic counter mechanics):
- [x] `testMaxExceptionsCounterIncrementsBeforeFireAndDecrementsOnSuccess` — counter cleaned up after successful job
- [x] `testMaxExceptionsCounterNotDecrementedOnException` — counter stays at 1 when job throws
- [x] `testJobFailedWhenExceptionCountAlreadyExceedsMaxExceptions` — pre-fire check fails job without firing it
- [x] `testMaxExceptionsSkippedWhenNoCacheAvailable` — graceful no-op without cache
- [x] `testMaxExceptionsSkippedWhenJobHasNoUuid` — graceful no-op for jobs without UUID

**Edge case tests** (maxExceptions threshold coverage):
- [x] `testMaxExceptionsZeroAllowsFirstRunButFailsAfterOom` — maxExceptions=0 allows first run, catches OOM on retry
- [x] `testMaxExceptionsOneFailsImmediatelyOnFirstException` — maxExceptions=1 fails on first thrown exception
- [x] `testMaxExceptionsThreeAllowsRetryUntilThresholdReached` — maxExceptions=3 allows retries until counter hits limit
- [x] `testMaxExceptionsNullBypassesAllExceptionTracking` — null maxExceptions skips all tracking, no cache keys created
- [x] `testSuccessfulJobCleansUpCacheKeyCompletely` — cache key fully removed after success, not left at 0

**Regression test** (proves the fix):
- [x] `testJobFailsAfterSimulatedWorkerKillDuringExecution` — simulates a worker killed by OOM mid-execution, verifies the job is failed on the next attempt instead of retrying forever. Confirmed: fails on stock Laravel 13.x, passes with this fix.




