### PR TITLE
[13.x] Fix sub-minute scheduling skips at minute boundaries

### DIFF
--- a/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
@@ -240,7 +240,9 @@ class ScheduleRunCommand extends Command
     {
         $hasEnteredMaintenanceMode = false;
 
-        while (Date::now()->lte($this->startedAt->endOfMinute())) {
+        $endOfMinute = $this->startedAt->copy()->endOfMinute();
+
+        while (Date::now()->lte($endOfMinute)) {
             $paused = $this->isPaused();
 
             foreach ($events as $event) {
@@ -250,6 +252,10 @@ class ScheduleRunCommand extends Command
 
                 if (! $event->shouldRepeatNow()) {
                     continue;
+                }
+
+                if (Date::now()->gt($endOfMinute)) {
+                    return;
                 }
 
                 $hasEnteredMaintenanceMode = $hasEnteredMaintenanceMode || $this->laravel->isDownForMaintenance();

--- a/tests/Integration/Console/Scheduling/ScheduleRunCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleRunCommandTest.php
@@ -9,9 +9,10 @@ use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Console\Scheduling\ScheduleRunCommand;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Support\Carbon;
-use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\Event;
 use Orchestra\Testbench\TestCase;
+use ReflectionMethod;
+use ReflectionProperty;
 
 class ScheduleRunCommandTest extends TestCase
 {
@@ -222,14 +223,14 @@ class ScheduleRunCommandTest extends TestCase
         $command = new ScheduleRunCommand;
         $this->app->instance(ScheduleRunCommand::class, $command);
 
-        $reflection = new \ReflectionProperty($command, 'startedAt');
+        $reflection = new ReflectionProperty($command, 'startedAt');
         $startedAt = $reflection->getValue($command);
 
         $originalTimestamp = $startedAt->timestamp;
         $originalMicro = $startedAt->micro;
 
         // Call repeatEvents with an empty collection so it exits immediately
-        $reflection = new \ReflectionMethod($command, 'repeatEvents');
+        $reflection = new ReflectionMethod($command, 'repeatEvents');
         $command->setLaravel($this->app);
 
         // Set test time past the minute boundary so the while loop exits immediately
@@ -237,7 +238,7 @@ class ScheduleRunCommandTest extends TestCase
         $reflection->invoke($command, collect());
 
         // startedAt should not have been mutated to end of minute
-        $startedAtAfter = (new \ReflectionProperty($command, 'startedAt'))->getValue($command);
+        $startedAtAfter = (new ReflectionProperty($command, 'startedAt'))->getValue($command);
         $this->assertEquals($originalTimestamp, $startedAtAfter->timestamp);
         $this->assertEquals($originalMicro, $startedAtAfter->micro);
     }

--- a/tests/Integration/Console/Scheduling/ScheduleRunCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleRunCommandTest.php
@@ -6,8 +6,10 @@ use Illuminate\Console\Events\ScheduledTaskFailed;
 use Illuminate\Console\Events\ScheduledTaskFinished;
 use Illuminate\Console\Events\ScheduledTaskStarting;
 use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Console\Scheduling\ScheduleRunCommand;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\Event;
 use Orchestra\Testbench\TestCase;
 
@@ -211,5 +213,32 @@ class ScheduleRunCommandTest extends TestCase
         Event::assertDispatched(ScheduledTaskStarting::class);
         Event::assertDispatched(ScheduledTaskFinished::class);
         Event::assertNotDispatched(ScheduledTaskFailed::class);
+    }
+
+    public function test_repeat_events_does_not_mutate_started_at()
+    {
+        Carbon::setTestNow('2026-03-25 12:00:30');
+
+        $command = new ScheduleRunCommand;
+        $this->app->instance(ScheduleRunCommand::class, $command);
+
+        $reflection = new \ReflectionProperty($command, 'startedAt');
+        $startedAt = $reflection->getValue($command);
+
+        $originalTimestamp = $startedAt->timestamp;
+        $originalMicro = $startedAt->micro;
+
+        // Call repeatEvents with an empty collection so it exits immediately
+        $reflection = new \ReflectionMethod($command, 'repeatEvents');
+        $command->setLaravel($this->app);
+
+        // Set test time past the minute boundary so the while loop exits immediately
+        Carbon::setTestNow('2026-03-25 12:01:01');
+        $reflection->invoke($command, collect());
+
+        // startedAt should not have been mutated to end of minute
+        $startedAtAfter = (new \ReflectionProperty($command, 'startedAt'))->getValue($command);
+        $this->assertEquals($originalTimestamp, $startedAtAfter->timestamp);
+        $this->assertEquals($originalMicro, $startedAtAfter->micro);
     }
 }


### PR DESCRIPTION
Fixes #57070

`repeatEvents()` calls `endOfMinute()` directly on `$this->startedAt`, mutating the Carbon instance on each loop iteration. This corrupts the timestamp used for scheduling decisions, causing sub-minute tasks to skip executions at minute boundaries.

Fix uses `copy()->endOfMinute()` to preserve the original timestamp, and adds an early return if the minute boundary is crossed mid-iteration.

Test included that verifies `startedAt` is not mutated — fails on the buggy code, passes with the fix.