### PR TITLE
[13.x] Ensure ScopedBy Attribute works with inheritance

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasGlobalScopes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasGlobalScopes.php
@@ -4,6 +4,7 @@ namespace Illuminate\Database\Eloquent\Concerns;
 
 use Closure;
 use Illuminate\Database\Eloquent\Attributes\ScopedBy;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Scope;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
@@ -38,8 +39,15 @@ trait HasGlobalScopes
             $attributes->push(...$trait->getAttributes(ScopedBy::class, ReflectionAttribute::IS_INSTANCEOF));
         }
 
+        $isEloquentGrandchild = is_subclass_of(static::class, Model::class)
+            && get_parent_class(static::class) !== Model::class;
+
         return $attributes->map(fn ($attribute) => $attribute->getArguments())
             ->flatten()
+            ->when($isEloquentGrandchild, function (Collection $attributes) {
+                return (new Collection(get_parent_class(static::class)::resolveGlobalScopeAttributes()))
+                    ->merge($attributes);
+            })
             ->all();
     }
 

--- a/tests/Database/DatabaseEloquentGlobalScopesTest.php
+++ b/tests/Database/DatabaseEloquentGlobalScopesTest.php
@@ -68,6 +68,14 @@ class DatabaseEloquentGlobalScopesTest extends TestCase
         $this->assertEquals([1], $query->getBindings());
     }
 
+    public function testGlobalScopeInParentClassAttributeIsApplied()
+    {
+        $model = new EloquentGlobalScopeInAttributeChildTestModel;
+        $query = $model->newQuery();
+        $this->assertSame('select * from "table" where "active" = ?', $query->toSql());
+        $this->assertEquals([1], $query->getBindings());
+    }
+
     public function testClosureGlobalScopeIsApplied()
     {
         $model = new EloquentClosureGlobalScopesTestModel;
@@ -324,4 +332,15 @@ class EloquentGlobalScopeInInheritedAttributeTestModel extends Model
     use EloquentGlobalScopeInInheritedAttributeTestTrait;
 
     protected $table = 'table';
+}
+
+#[ScopedBy(ActiveScope::class)]
+class EloquentGlobalScopeInAttributeParentTestModel extends Model
+{
+    protected $table = 'table';
+}
+
+class EloquentGlobalScopeInAttributeChildTestModel extends EloquentGlobalScopeInAttributeParentTestModel
+{
+    //
 }


### PR DESCRIPTION
The `ObservedBy` attribute works with inheritance, but `ScopedBy` doesnt. 

This PR fixes that.

_**This is a B/C**_, but arguably expected behavior IMO, if you did this the booted() way, it would work like this PR.  

The code is pretty much a copy paste of what `ObservedBy` does no lie

Happy to target master, but thought I'd try 13.x first 🫡  Not sure if it needs porting back too

  
Example: 

```php
  class OrgModel extends Model
  {                                                                                                                                                                     
      protected static function booted(): void
      {                                                                                                                                                                 
          static::addGlobalScope(new OrgScope);                                                                                                              
      }
  }
  
  
  class Invoice extends OrgModel { // Has the right scope 
 
```

```php
 #[ScopedBy(OrgScope::class)]
  class OrgModel extends Model {}
                                                                                                                                                                        
  class Invoice extends OrgModel { // Did not have the scope without this PR
  ``` 

  