### PR TITLE
[12.x] Apply eager load constraints to oneOfMany inner subquery

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -945,7 +945,36 @@ class Builder implements BuilderContract
 
         $relation->addEagerConstraints($models);
 
+        // For one-of-many relationships, we need to also apply the user's eager
+        // load constraints to the inner subquery that determines which record
+        // is the "latest" / "oldest". We snapshot the outer query's wheres
+        // before and after applying constraints, then copy only the new ones.
+        $subQuery = method_exists($relation, 'getOneOfManySubQuery')
+            ? $relation->getOneOfManySubQuery()
+            : null;
+
+        if ($subQuery) {
+            $whereCountBefore = count($relation->getQuery()->getQuery()->wheres);
+            $bindingCountBefore = count($relation->getQuery()->getQuery()->bindings['where']);
+        }
+
         $constraints($relation);
+
+        if ($subQuery) {
+            $outerWheres = $relation->getQuery()->getQuery()->wheres;
+            $outerBindings = $relation->getQuery()->getQuery()->bindings['where'];
+
+            $newWheres = array_slice($outerWheres, $whereCountBefore);
+            $newBindings = array_slice($outerBindings, $bindingCountBefore);
+
+            foreach ($newWheres as $where) {
+                $subQuery->getQuery()->wheres[] = $where;
+            }
+
+            foreach ($newBindings as $binding) {
+                $subQuery->getQuery()->addBinding($binding, 'where');
+            }
+        }
 
         // Once we have the results, we just match those back up to their parent models
         // using the relationship instance. Then we just return the finished arrays


### PR DESCRIPTION
> **Title:** `[12.x] Apply eager load constraints to oneOfMany inner subquery`
>
> **Compare:** https://github.com/laravel/framework/compare/12.x...sadique-cws:framework:fix/eager-load-one-of-many-subquery-constraints

---

Fixes #59318.

### Problem

When eager loading a [latestOfMany](file:///Users/comestro/framework/src/Illuminate/Database/Eloquent/Relations/Concerns/CanBeOneOfMany.php#145-158) / [ofMany](file:///Users/comestro/framework/src/Illuminate/Database/Eloquent/Relations/Concerns/CanBeOneOfMany.php#60-144) relationship with constraints (e.g. [with(['lastPayment' => fn($q) => $q->where('store_id', 1)])](file:///Users/comestro/framework/src/Illuminate/Database/Eloquent/Builder.php#1725-1744)), the constraints were only being applied to the outer query, not the inner subquery that determines which record is the "latest".

This caused the inner subquery to pick the wrong aggregate row (e.g. the latest payment across *all* stores), and then the outer filter would discard it—silently returning `null`.

### Solution

In `Eloquent\Builder::eagerLoadRelation()`, we now snapshot the outer query's `wheres` and `bindings` before and after the user's constraint closure runs. If the relation is a one-of-many relation, we copy those newly added wheres directly into the inner `oneOfManySubQuery`.

This ensures the inner subquery correctly determines "latest" or "oldest" within the user's filtered dataset, matching the behavior that users expect when adding constraints to eager loads. All existing eloquent relation tests pass.
