### PR TITLE
fix: make:enum creates Enums directory if none exists

### DIFF
--- a/src/Illuminate/Foundation/Console/EnumMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/EnumMakeCommand.php
@@ -58,7 +58,7 @@ class EnumMakeCommand extends GeneratorCommand
     {
         return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
             ? $customPath
-            : __DIR__.$stub;
+            : __DIR__ . $stub;
     }
 
     /**
@@ -70,9 +70,9 @@ class EnumMakeCommand extends GeneratorCommand
     protected function getDefaultNamespace($rootNamespace)
     {
         return match (true) {
-            is_dir(app_path('Enums')) => $rootNamespace.'\\Enums',
-            is_dir(app_path('Enumerations')) => $rootNamespace.'\\Enumerations',
-            default => $rootNamespace,
+            is_dir(app_path('Enums')) => $rootNamespace . '\\Enums',
+            is_dir(app_path('Enumerations')) => $rootNamespace . '\\Enumerations',
+            default => $rootNamespace . '\\Enums',
         };
     }
 

--- a/tests/Integration/Generators/EnumMakeCommandTest.php
+++ b/tests/Integration/Generators/EnumMakeCommandTest.php
@@ -7,9 +7,9 @@ use Illuminate\Tests\Integration\Generators\TestCase;
 class EnumMakeCommandTest extends TestCase
 {
     protected $files = [
-        'app/IntEnum.php',
-        'app/StatusEnum.php',
-        'app/StringEnum.php',
+        'app/Enums/IntEnum.php',
+        'app/Enums/StatusEnum.php',
+        'app/Enums/StringEnum.php',
         'app/*/OrderStatusEnum.php',
     ];
 
@@ -19,9 +19,9 @@ class EnumMakeCommandTest extends TestCase
             ->assertExitCode(0);
 
         $this->assertFileContains([
-            'namespace App;',
+            'namespace App\Enums;',
             'enum StatusEnum',
-        ], 'app/StatusEnum.php');
+        ], 'app/Enums/StatusEnum.php');
     }
 
     public function testItCanGenerateEnumFileWithString()
@@ -30,9 +30,9 @@ class EnumMakeCommandTest extends TestCase
             ->assertExitCode(0);
 
         $this->assertFileContains([
-            'namespace App;',
+            'namespace App\Enums;',
             'enum StringEnum: string',
-        ], 'app/StringEnum.php');
+        ], 'app/Enums/StringEnum.php');
     }
 
     public function testItCanGenerateEnumFileWithInt()
@@ -41,9 +41,9 @@ class EnumMakeCommandTest extends TestCase
             ->assertExitCode(0);
 
         $this->assertFileContains([
-            'namespace App;',
+            'namespace App\Enums;',
             'enum IntEnum: int',
-        ], 'app/IntEnum.php');
+        ], 'app/Enums/IntEnum.php');
     }
 
     public function testItCanGenerateEnumFileInEnumsFolder()


### PR DESCRIPTION
## What this fixes

When running `make:enum` in a fresh Laravel application (or any app without an existing `Enums` or `Enumerations` directory), the generated enum is dropped directly into `app/` with `namespace App;` instead of the expected `app/Enums/` with `namespace App\Enums;`.

This happens because `getDefaultNamespace()` falls back to the root namespace when neither folder exists, and no directory is created.

## The fix

The `default` case in `getDefaultNamespace()` now returns `$rootNamespace.'\\Enums'` instead of `$rootNamespace`. The existing `makeDirectory()` call in the parent `GeneratorCommand` class handles the actual folder creation — so no additional infrastructure changes are needed.

## Why this doesn't break existing behaviour

- If `app/Enums` already exists → same behaviour as before
- If `app/Enumerations` already exists → same behaviour as before
- If neither exists → previously broken (dumped in `app/`), now correctly creates `app/Enums/` and places the file there

## Benefit to end users

Running `make:enum Status` on a fresh app now works exactly as a developer would expect — consistent with how other `make:*` commands handle their target directories. No manual folder creation needed.

## Tests

Updated three existing tests that were asserting the old broken behaviour (`namespace App;` / `app/*.php`) to reflect the correct output. The two existing directory-specific tests are unchanged.