### PR TITLE
Fix Table attribute incrementing not working for Pivot models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -446,11 +446,6 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
             $this->keyType = $table->keyType;
         }
 
-        // Allow the Table attribute or the dedicated WithoutIncrementing attribute
-        // to determine whether the model's primary key is incrementing. The
-        // attribute should be able to override the default property value
-        // (for example Pivot models default to false), so we consult the
-        // WithoutIncrementing attribute first, then the Table attribute.
         if (static::resolveClassAttribute(WithoutIncrementing::class) !== null) {
             $this->incrementing = false;
         } elseif ($table && $table->incrementing !== null) {

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -446,12 +446,15 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
             $this->keyType = $table->keyType;
         }
 
-        if ($this->incrementing === true) {
-            if (static::resolveClassAttribute(WithoutIncrementing::class) !== null) {
-                $this->incrementing = false;
-            } elseif ($table && $table->incrementing !== null) {
-                $this->incrementing = $table->incrementing;
-            }
+        // Allow the Table attribute or the dedicated WithoutIncrementing attribute
+        // to determine whether the model's primary key is incrementing. The
+        // attribute should be able to override the default property value
+        // (for example Pivot models default to false), so we consult the
+        // WithoutIncrementing attribute first, then the Table attribute.
+        if (static::resolveClassAttribute(WithoutIncrementing::class) !== null) {
+            $this->incrementing = false;
+        } elseif ($table && $table->incrementing !== null) {
+            $this->incrementing = $table->incrementing;
         }
     }
 

--- a/tests/Database/DatabaseEloquentModelAttributesTest.php
+++ b/tests/Database/DatabaseEloquentModelAttributesTest.php
@@ -107,6 +107,13 @@ class DatabaseEloquentModelAttributesTest extends TestCase
         $this->assertFalse($model->getIncrementing());
     }
 
+    public function test_table_attribute_incrementing_applies_to_pivot_models(): void
+    {
+        $model = new PivotWithIncrementing;
+
+        $this->assertTrue($model->getIncrementing());
+    }
+
     public function test_connection_attribute(): void
     {
         $model = new ModelWithConnectionAttribute;
@@ -501,6 +508,12 @@ class ModelWithDedicatedWithoutIncrementingAttribute extends Model
 #[Table(incrementing: true)]
 #[WithoutIncrementing]
 class ModelWithWithoutIncrementingAttributeOverride extends Model
+{
+    //
+}
+
+#[Table(incrementing: true)]
+class PivotWithIncrementing extends \Illuminate\Database\Eloquent\Relations\Pivot
 {
     //
 }


### PR DESCRIPTION
### Description

Fixes #59335

This PR solves an issue where using the `#[Table]` attribute on a **Pivot model** fails to configure its `incrementing` primary key property correctly. For regular model classes, the `incrementing` argument acts as a drop-in replacement layout over the classic `$incrementing = true;` property styling.

#### 🚨 The core issue
Pivot models default to non-incrementing primary keys:
```php
class Pivot extends Model {
    public $incrementing = false; // <-- Default false for Pivot
}
```

Inside Illuminate\Database\Eloquent\Model::__construct, there exists logic that attempts to sync attributes from #Table classes, but includes an isolated safeguard:

```
php

if ($this->incrementing === true) { // <-- ❌ Blocks override for values that start as false
     $this->incrementing = $tableAttribute->incrementing;
}
```
Because of this specific outer validation barrier, the static $incrementing = false definition explicitly placed inside the parent Pivot class overrides the attribute statement, locking the model fully from applying the toggle config back to true.

💡 Solution
I've updated the logic by removing the outer check. Eliminating the condition lets the #[Table] attribute function correctly as the universal source of truth for both basic model instances and Pivot model instances alike.