### PR TITLE
[12.x] Fix validation wildcard array message type error

### DIFF
--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -122,8 +122,8 @@ trait FormatsMessages
                     if (preg_match('#^'.$pattern.'\z#u', $key) === 1) {
                         $message = $source[$sourceKey];
 
-                        if (is_array($message) && isset($message[$lowerRule])) {
-                            return $message[$lowerRule];
+                        if (is_array($message)) {
+                            return $message[$lowerRule] ?? null;
                         }
 
                         return $message;

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -105,6 +105,27 @@ class ValidationValidatorTest extends TestCase
         $this->assertSame('post name is required', $v->errors()->all()[0]);
     }
 
+    public function testWildcardArrayCustomMessagesHandleMissingRulesGracefullyWhenAnotherRuleFails()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, [
+            'users' => [
+                [
+                    'name' => 'Taylor',
+                ],
+            ],
+        ], [
+            'users.*.name' => ['required', 'in:Otwell'],
+        ], [
+            'users.*.name' => [
+                'required' => 'user name is required',
+            ],
+        ]);
+
+        $this->assertFalse($v->passes());
+        $this->assertSame('validation.in', $v->errors()->all()[0]);
+    }
+
     public function testSometimesWorksOnNestedArrays()
     {
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION

### Description

This PR resolves a fatal `TypeError` crash in the validator logic when developers define custom property-based array messages using wildcards, and a separate unregistered rule fails on an index of that array (Issue #59316).

#### 🚨 The Bug
When defining custom messages for nested properties, developers often use the array wildcard approach:
```php
$messages = [
    'fields.*' => [
        'required' => 'This specific field is required'
    ]
];
```
If an input like `fields.0` fails validation for a completely different rule missing in that custom array (for example, [in](file:///Users/comestro/framework/src/Illuminate/Database/Eloquent/Builder.php#555-570)), the app crashes with a fatal `TypeError`:

```
TypeError: Illuminate\Validation\Concerns\ReplacesAttributes::replacePlaceholders(): Argument #1 ($message) must be of type string, array given
```

This happens because the system correctly extracts the array containing the custom message, attempts to match an absent array-key, silently returns the array structure instead of a translation string, and funnels the entire un-stringified array directly into `replacePlaceholders(...)`.

#### 💡 The Solution
During [getFromLocalArray()](file:///Users/comestro/framework/src/Illuminate/Validation/Concerns/FormatsMessages.php#92-147) resolution in [FormatsMessages.php](file:///Users/comestro/framework/src/Illuminate/Validation/Concerns/FormatsMessages.php), we added a safe verification boundary: `if (is_array($source))` check handles the edge case of array-format validation configurations securely. If a given wildcard local custom array match holds an entire array mapping and not specifically a string value, we elegantly `return null`.

This gracefully delegates the missing validation failure to standard laravel language lines instead of attempting to parse an array object through string replace methods. It inherently mirrors the exact behavior standard non-wildcard error paths use to fallback to default language files.

### 🤔 Why is this safe? Does it break anything?
This is completely safe and backwards compatible. 

This condition strictly guards an explicit `is_array` variable type where `string` was absolutely mandated to be passed into a method argument. Returning `null` gracefully defers the unmatched `fields.*` validation line up the delegation chain to the standard validation lines precisely how standard Eloquent mappings fallback!

### 👩‍💻 How does it make building web applications easier?
When building heavy, dynamic form builders (especially SPAs and heavily-iterated Livewire components), developers lean extensively into array wildcards to define custom nested messages. A single validation misconfiguration resulting in a crash instead of a 422 JSON validation error is massively disruptive in production environments. Providing graceful language delegation keeps API consumption safe and predictable.

### ✅ Tests Added
I've implemented a concrete, specific test within [ValidationValidatorTest](file:///Users/comestro/framework/tests/Validation/ValidationValidatorTest.php#43-10128) called [testWildcardArrayCustomMessagesHandleMissingRulesGracefullyWhenAnotherRuleFails](file:///Users/comestro/framework/tests/Validation/ValidationValidatorTest.php#108-128). 

It builds a nested Validator with array-based message configuration and validates an unmatched rule constraint (`in:X`) which definitively proves the regression is resolved and translates the result successfully rather than dumping an application-crashing TypeError.
