### PR TITLE
[13.x] Allow passing multiple arrays to has factory method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -1148,6 +1148,10 @@ abstract class Factory
         if (str_starts_with($method, 'for')) {
             return $this->for($factory->state($parameters[0] ?? []), $relationship);
         } elseif (str_starts_with($method, 'has')) {
+            if (count($parameters) > 1 && array_all($parameters, fn ($p) => is_array($p))) {
+                return $this->has($factory->forEachSequence(...$parameters), $relationship);
+            }
+
             return $this->has(
                 $factory
                     ->count(is_numeric($parameters[0] ?? null) ? $parameters[0] : 1)

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -755,6 +755,22 @@ class DatabaseEloquentFactoryTest extends TestCase
         $this->assertCount(2, $post->comments);
     }
 
+    public function test_dynamic_has_methods_with_multiple_arrays()
+    {
+        Factory::guessFactoryNamesUsing(function ($model) {
+            return $model.'Factory';
+        });
+
+        $user = FactoryTestUserFactory::new()
+            ->hasPosts(['title' => 'First Post'], ['title' => 'Second Post'], ['title' => 'Third Post'])
+            ->create();
+
+        $this->assertCount(3, $user->posts);
+        $this->assertSame('First Post', $user->posts[0]->title);
+        $this->assertSame('Second Post', $user->posts[1]->title);
+        $this->assertSame('Third Post', $user->posts[2]->title);
+    }
+
     public function test_can_be_macroable()
     {
         $factory = FactoryTestUserFactory::new();


### PR DESCRIPTION
Currently, creating related models with specific per-model attributes means falling back to the explicit `has()` method  - if you're keeping it in one chunk.      
   
I see quite a lot of stuff like this on the daily and its slowly made me think of a better way... so thought I'd try a PR!

```php
  User::factory()                                           
      ->has(Post::factory()->forEachSequence(
          ['title' => 'First'],
          ['title' => 'Second'],
      ), 'posts')
       ->has(Tag::factory()->forEachSequence(
          ['name' => 'Taylor'],
          ['name' => 'Jack'],
      ), 'tags')
      ->create();
```
This PR allows passing multiple arrays directly 
  
  So it becomes:
```php
  User::factory()
      ->hasPosts(['title' => 'First'], ['title' => 'Second'])
      ->hasTags(['name' => 'Taylor'], ['name' => 'Jack'])
      ->create();
```

All it does is call `forEachSequence` under the hood so nothing painful to maintain but feels like nice DX 

No B/C..