### PR TITLE
[13.x] Fix invalid session cookie names generated by APP_NAME characters

### DIFF
--- a/config/session.php
+++ b/config/session.php
@@ -129,7 +129,7 @@ return [
 
     'cookie' => env(
         'SESSION_COOKIE',
-        Str::snake((string) env('APP_NAME', 'laravel')).'_session'
+        Str::slug(Str::snake((string) env('APP_NAME', 'laravel')), '_').'_session'
     ),
 
     /*

--- a/tests/Integration/Session/SessionConfigTest.php
+++ b/tests/Integration/Session/SessionConfigTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Session;
+
+use Orchestra\Testbench\TestCase;
+
+class SessionConfigTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        putenv('SESSION_COOKIE');
+        $this->setAppName('laravel');
+        parent::tearDown();
+    }
+
+    public function testDefaultSessionCookieNameRespectsAppNameAndStripsInvalidCharacters()
+    {
+        $this->setAppName('[LOCAL] My Admin');
+        $config = require __DIR__.'/../../../config/session.php';
+
+        $this->assertSame('l_o_c_a_l_my_admin_session', $config['cookie']);
+    }
+
+    public function testDefaultSessionCookieNameMaintainsSnakeCase()
+    {
+        $this->setAppName('My App');
+        $config = require __DIR__.'/../../../config/session.php';
+
+        $this->assertSame('my_app_session', $config['cookie']);
+    }
+
+    protected function setAppName($name)
+    {
+        $_ENV['APP_NAME'] = $name;
+        $_SERVER['APP_NAME'] = $name;
+        putenv('APP_NAME='.$name);
+    }
+}


### PR DESCRIPTION

This PR fixes a critical bug where using non-alphanumeric punctuation inside `APP_NAME` generates HTTP-invalid session cookie names, completely breaking session persistence in certain app configurations (Fixes Issue #59344).

#### 🚨 The Context & The Bug
In PR #56172, the author attempted to hyphenate all prefixes across the Laravel configuration strings. During the review, @taylorotwell  explicitly stated: *"No need for the cookie name change."* 

To comply, instead of purely reverting the line back to its original code (`Str::slug(..., '_')`), the author forcefully changed it to `Str::snake(...)` to satisfy the underscore requirement.

However, `Str::snake()` does **not** strip symbols, special characters, or whitespace like `slug()` does. When a developer explicitly configures an app name containing common staging prefixes or punctuation—for example `APP_NAME="[LOCAL] My Admin"`—it gets improperly translated:
```php
Str::snake('[LOCAL] My Admin') // generates: [_l_o_c_a_l]_my_admin
```

RFC 6265 strictly prohibits characters like `[`, `]`, ` `, `=`, and `@` inside cookie names. Browsers refuse to set the `[_l_o_c_a_l]_my_admin_session` cookie entirely, silently breaking session writes, CSRF validation, and user authentication on the application.

#### 💡 The Solution
Simply reverting the behavior entirely away from `Str::snake()` back to just `Str::slug()` is dangerous because it would silently rename explicitly valid cookies from `my_app_session` to `myapp_session`, invalidating all active sessions for upgrading Laravel 13 deployers.

Instead, this PR safely wraps the existing `Str::snake()` output in `Str::slug(..., '_')` exclusively to sanitize the resulting cookie hash.

```php
Str::slug(Str::snake((string) env('APP_NAME', 'laravel')), '_')
```

- If `APP_NAME="My App"`, it resolves seamlessly to `my_app_session` (retaining full backward compatibility for users running on PR #56172 without interruptions).
- If `APP_NAME="[LOCAL] My App"`, `snake` returns `[_l_o_c_a_l]_my_app`, which `slug` automatically cleanses into `l_o_c_a_l_my_app_session`, guaranteeing HTTP browser safety regardless of how noisy the provided `APP_NAME` string is. 

### 🤔 Why is this safe?
This perfectly honors Taylor's original request that the cookie prefix formatting stay the same while hard-enforcing HTTP-compliant alphanumeric strings, ensuring that users on noisy staging environments don't face completely broken authentication cookies.

### ✅ Tests Added
I've implemented [tests/Integration/Session/SessionConfigTest.php](file:///Users/comestro/framework/tests/Integration/Session/SessionConfigTest.php) that actively evaluates [config/session.php](file:///Users/comestro/framework/config/session.php) against test-injected `.env` variables to conclusively prove:
`APP_NAME=[LOCAL] My Admin` securely strips unsafe constraints and resolves valid strings while `APP_NAME=My App` identically generates the `my_app_session` default expected in `.env` upgrades.
