### PR TITLE
[13.x] Cache database queue lock type to avoid repeated PDO version detection

### DIFF
--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -45,6 +45,13 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
     protected $retryAfter = 60;
 
     /**
+     * The cached lock type for popping jobs.
+     *
+     * @var string|bool|null
+     */
+    protected $lockForPopping = null;
+
+    /**
      * Create a new database queue instance.
      *
      * @param  \Illuminate\Database\Connection  $database
@@ -338,6 +345,10 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
      */
     protected function getLockForPopping()
     {
+        if ($this->lockForPopping !== null) {
+            return $this->lockForPopping;
+        }
+
         $databaseEngine = $this->database->getPdo()->getAttribute(PDO::ATTR_DRIVER_NAME);
         $databaseVersion = $this->database->getConfig('version') ?? $this->database->getPdo()->getAttribute(PDO::ATTR_SERVER_VERSION);
 
@@ -354,14 +365,14 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
             ($databaseEngine === 'pgsql' && version_compare($databaseVersion, '9.5', '>=')) ||
             ($databaseEngine === 'vitess' && version_compare($databaseVersion, '19.0', '>='))
         ) {
-            return 'FOR UPDATE SKIP LOCKED';
+            return $this->lockForPopping = 'FOR UPDATE SKIP LOCKED';
         }
 
         if ($databaseEngine === 'sqlsrv') {
-            return 'with(rowlock,updlock,readpast)';
+            return $this->lockForPopping = 'with(rowlock,updlock,readpast)';
         }
 
-        return true;
+        return $this->lockForPopping = true;
     }
 
     /**

--- a/tests/Queue/QueueDatabaseQueueUnitTest.php
+++ b/tests/Queue/QueueDatabaseQueueUnitTest.php
@@ -10,6 +10,7 @@ use Illuminate\Queue\Queue;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
 use Mockery as m;
+use PDO;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
@@ -195,6 +196,31 @@ class QueueDatabaseQueueUnitTest extends TestCase
         $record = $queue->buildDatabaseRecord('queue', 'any_payload', 0);
         $this->assertArrayHasKey('payload', $record);
         $this->assertArrayHasKey('payload', array_slice($record, -1, 1, true));
+    }
+
+    public function testGetLockForPoppingCachesPdoLookup()
+    {
+        $pdo = m::mock(PDO::class);
+        $pdo->shouldReceive('getAttribute')->with(PDO::ATTR_DRIVER_NAME)->once()->andReturn('mysql');
+        $pdo->shouldReceive('getAttribute')->with(PDO::ATTR_SERVER_VERSION)->once()->andReturn('8.0.28');
+
+        $database = m::mock(Connection::class);
+        $database->shouldReceive('getPdo')->once()->andReturn($pdo);
+        $database->shouldReceive('getConfig')->with('version')->once()->andReturnNull();
+
+        $queue = new DatabaseQueue($database, 'table', 'default');
+
+        $method = (new ReflectionClass(DatabaseQueue::class))->getMethod('getLockForPopping');
+
+        $result1 = $method->invoke($queue);
+        $result2 = $method->invoke($queue);
+        $result3 = $method->invoke($queue);
+
+        $this->assertSame('FOR UPDATE SKIP LOCKED', $result1);
+        $this->assertSame($result1, $result2);
+        $this->assertSame($result1, $result3);
+
+        // Mockery's once() constraints verify getPdo/getAttribute were only called once
     }
 }
 

--- a/tests/Queue/QueueDatabaseQueueUnitTest.php
+++ b/tests/Queue/QueueDatabaseQueueUnitTest.php
@@ -18,6 +18,12 @@ use stdClass;
 
 class QueueDatabaseQueueUnitTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        m::close();
+
+        parent::tearDown();
+    }
     #[DataProvider('pushJobsDataProvider')]
     public function testPushProperlyPushesJobOntoDatabase($uuid, $job, $displayNameStartsWith, $jobStartsWith)
     {


### PR DESCRIPTION
Fixes #59350

## Summary

`getLockForPopping()` makes 2 PDO attribute calls, creates Stringable objects, parses version strings, and runs `version_compare()` on every single job pop. The DB engine and version never change during a worker's lifetime, so this work is redundant after the first call.

## Problem

Every call to `DatabaseQueue::pop()` triggers `getLockForPopping()`, which:
1. Calls `PDO::getAttribute(ATTR_DRIVER_NAME)`
2. Calls `PDO::getAttribute(ATTR_SERVER_VERSION)`
3. Creates a `Stringable` instance
4. Runs `version_compare()`

For high-throughput queue workers processing thousands of jobs, this adds up to significant unnecessary overhead.

## Solution

Cache the computed lock type in an instance property after the first call. Subsequent calls return the cached value directly, eliminating repeated PDO calls and string parsing for the lifetime of the worker process.

## Before

Every `pop()` call triggers full PDO version detection and string comparison, regardless of how many times it has already been computed.

## After

PDO version detection runs once on the first `pop()`, then the cached lock type is returned for all subsequent calls.

## Test plan

- Existing database queue test suite passes
- Queue workers correctly detect lock type on first pop
- Verified on MySQL, PostgreSQL, and SQLite drivers