### PR TITLE
[13.x] Add PHP 8 attributes to JsonApiResource

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -4,7 +4,6 @@ namespace Illuminate\Database\Eloquent;
 
 use ArrayAccess;
 use Closure;
-use Exception;
 use Illuminate\Contracts\Broadcasting\HasBroadcastChannel;
 use Illuminate\Contracts\Queue\QueueableCollection;
 use Illuminate\Contracts\Queue\QueueableEntity;
@@ -30,7 +29,8 @@ use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Support\Str;
 use Illuminate\Support\Stringable as SupportStringable;
 use Illuminate\Support\Traits\ForwardsCalls;
-use Illuminate\Support\Traits\ResolvesClassAttributes;use JsonException;
+use Illuminate\Support\Traits\ResolvesClassAttributes;
+use JsonException;
 use JsonSerializable;
 use LogicException;
 use ReflectionClass;

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -30,7 +30,7 @@ use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Support\Str;
 use Illuminate\Support\Stringable as SupportStringable;
 use Illuminate\Support\Traits\ForwardsCalls;
-use JsonException;
+use Illuminate\Support\Traits\ResolvesClassAttributes;use JsonException;
 use JsonSerializable;
 use LogicException;
 use ReflectionClass;
@@ -54,6 +54,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         ForwardsCalls;
     /** @use HasCollection<\Illuminate\Database\Eloquent\Collection<array-key, static & self>> */
     use HasCollection;
+    use ResolvesClassAttributes;
 
     /**
      * The connection name for the model.
@@ -285,13 +286,6 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      * @var array<class-string<self>, bool>
      */
     protected static array $isMassPrunable;
-
-    /**
-     * Cache of resolved class attributes.
-     *
-     * @var array<class-string<self>, array<class-string, mixed>>
-     */
-    protected static array $classAttributes = [];
 
     /**
      * The name of the "created at" column.
@@ -2554,45 +2548,6 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     public function broadcastChannel()
     {
         return str_replace('\\', '.', get_class($this)).'.'.$this->getKey();
-    }
-
-    /**
-     * Resolve a class attribute value from the model.
-     *
-     * @template TAttribute of object
-     *
-     * @param  class-string<TAttribute>  $attributeClass
-     * @param  string|null  $property
-     * @param  string|null  $class
-     * @return mixed
-     */
-    protected static function resolveClassAttribute(string $attributeClass, ?string $property = null, ?string $class = null)
-    {
-        $class = $class ?? static::class;
-
-        $cacheKey = $class.'@'.$attributeClass;
-
-        if (array_key_exists($cacheKey, static::$classAttributes)) {
-            return static::$classAttributes[$cacheKey];
-        }
-
-        try {
-            $reflection = new ReflectionClass($class);
-
-            do {
-                $attributes = $reflection->getAttributes($attributeClass);
-
-                if (count($attributes) > 0) {
-                    $instance = $attributes[0]->newInstance();
-
-                    return static::$classAttributes[$cacheKey] = $property ? $instance->{$property} : $instance;
-                }
-            } while ($reflection = $reflection->getParentClass());
-        } catch (Exception) {
-            //
-        }
-
-        return static::$classAttributes[$cacheKey] = null;
     }
 
     /**

--- a/src/Illuminate/Http/Resources/JsonApi/AnonymousResourceCollection.php
+++ b/src/Illuminate/Http/Resources/JsonApi/AnonymousResourceCollection.php
@@ -6,6 +6,7 @@ use Illuminate\Container\Container;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection as BaseAnonymousResourceCollection;
+use Illuminate\Http\Resources\JsonApi\Attributes\JsonApiInformation;
 use Illuminate\Support\Arr;
 
 class AnonymousResourceCollection extends BaseAnonymousResourceCollection
@@ -21,6 +22,21 @@ class AnonymousResourceCollection extends BaseAnonymousResourceCollection
     #[\Override]
     public function with($request)
     {
+        $implementation = JsonApiResource::$jsonApiInformation;
+
+        if (empty($implementation) && $this->collects) {
+            $info = JsonApiResource::resolveClassAttributeFor($this->collects, JsonApiInformation::class);
+
+            if ($info !== null) {
+                $implementation = array_filter([
+                    'version' => $info->version,
+                    'ext' => $info->ext,
+                    'profile' => $info->profile,
+                    'meta' => $info->meta,
+                ]);
+            }
+        }
+
         return array_filter([
             'included' => $this->collection
                 ->map(fn ($resource) => $resource->resolveIncludedResourceObjects($request))
@@ -29,9 +45,7 @@ class AnonymousResourceCollection extends BaseAnonymousResourceCollection
                 ->map(fn ($included) => Arr::except($included, ['_uniqueKey']))
                 ->values()
                 ->all(),
-            ...($implementation = JsonApiResource::$jsonApiInformation)
-                ? ['jsonapi' => $implementation]
-                : [],
+            ...($implementation ? ['jsonapi' => $implementation] : []),
         ]);
     }
 

--- a/src/Illuminate/Http/Resources/JsonApi/Attributes/Attributes.php
+++ b/src/Illuminate/Http/Resources/JsonApi/Attributes/Attributes.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Http\Resources\JsonApi\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class Attributes
+{
+    public function __construct(public array $attributes = [])
+    {
+    }
+}

--- a/src/Illuminate/Http/Resources/JsonApi/Attributes/JsonApiInformation.php
+++ b/src/Illuminate/Http/Resources/JsonApi/Attributes/JsonApiInformation.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Illuminate\Http\Resources\JsonApi\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class JsonApiInformation
+{
+    public function __construct(
+        public ?string $version = null,
+        public array $ext = [],
+        public array $profile = [],
+        public array $meta = [],
+    ) {
+    }
+}

--- a/src/Illuminate/Http/Resources/JsonApi/Attributes/JsonApiLinks.php
+++ b/src/Illuminate/Http/Resources/JsonApi/Attributes/JsonApiLinks.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Http\Resources\JsonApi\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class JsonApiLinks
+{
+    public function __construct(public array $links = [])
+    {
+    }
+}

--- a/src/Illuminate/Http/Resources/JsonApi/Attributes/JsonApiMeta.php
+++ b/src/Illuminate/Http/Resources/JsonApi/Attributes/JsonApiMeta.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Http\Resources\JsonApi\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class JsonApiMeta
+{
+    public function __construct(public array $meta = [])
+    {
+    }
+}

--- a/src/Illuminate/Http/Resources/JsonApi/Attributes/Relationships.php
+++ b/src/Illuminate/Http/Resources/JsonApi/Attributes/Relationships.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Http\Resources\JsonApi\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class Relationships
+{
+    public function __construct(public array $relationships = [])
+    {
+    }
+}

--- a/src/Illuminate/Http/Resources/JsonApi/Attributes/Wraps.php
+++ b/src/Illuminate/Http/Resources/JsonApi/Attributes/Wraps.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Http\Resources\JsonApi\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class Wraps
+{
+    public function __construct(public string $wrapper = 'data')
+    {
+    }
+}

--- a/src/Illuminate/Http/Resources/JsonApi/JsonApiResource.php
+++ b/src/Illuminate/Http/Resources/JsonApi/JsonApiResource.php
@@ -3,10 +3,18 @@
 namespace Illuminate\Http\Resources\JsonApi;
 
 use BadMethodCallException;
+use Exception;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Http\Resources\JsonApi\Attributes\Attributes;
+use Illuminate\Http\Resources\JsonApi\Attributes\JsonApiInformation;
+use Illuminate\Http\Resources\JsonApi\Attributes\JsonApiLinks;
+use Illuminate\Http\Resources\JsonApi\Attributes\JsonApiMeta;
+use Illuminate\Http\Resources\JsonApi\Attributes\Relationships;
+use Illuminate\Http\Resources\JsonApi\Attributes\Wraps;
 use Illuminate\Support\Arr;
+use ReflectionClass;
 
 class JsonApiResource extends JsonResource
 {
@@ -36,6 +44,67 @@ class JsonApiResource extends JsonResource
      * The resource's "meta" for JSON:API.
      */
     protected array $jsonApiMeta = [];
+
+    /**
+     * The cache of resolved class attributes.
+     *
+     * @var array
+     */
+    protected static array $classAttributes = [];
+
+    /**
+     * Resolve a class attribute value from the resource.
+     *
+     * @template TAttribute of object
+     *
+     * @param  class-string<TAttribute>  $attributeClass
+     * @param  string|null  $property
+     * @param  string|null  $class
+     * @return mixed
+     */
+    protected static function resolveClassAttribute(string $attributeClass, ?string $property = null, ?string $class = null)
+    {
+        $class = $class ?? static::class;
+
+        $cacheKey = $class.'@'.$attributeClass;
+
+        if (array_key_exists($cacheKey, static::$classAttributes)) {
+            return static::$classAttributes[$cacheKey];
+        }
+
+        try {
+            $reflection = new ReflectionClass($class);
+
+            do {
+                $attributes = $reflection->getAttributes($attributeClass);
+
+                if (count($attributes) > 0) {
+                    $instance = $attributes[0]->newInstance();
+
+                    return static::$classAttributes[$cacheKey] = $property ? $instance->{$property} : $instance;
+                }
+            } while ($reflection = $reflection->getParentClass());
+        } catch (Exception) {
+            //
+        }
+
+        return static::$classAttributes[$cacheKey] = null;
+    }
+
+    /**
+     * Resolve a class attribute value for a given resource class.
+     *
+     * @template TAttribute of object
+     *
+     * @param  class-string  $resourceClass
+     * @param  class-string<TAttribute>  $attributeClass
+     * @param  string|null  $property
+     * @return mixed
+     */
+    public static function resolveClassAttributeFor(string $resourceClass, string $attributeClass, ?string $property = null)
+    {
+        return static::resolveClassAttribute($attributeClass, $property, $resourceClass);
+    }
 
     /**
      * Set the JSON:API version for the request.
@@ -83,6 +152,8 @@ class JsonApiResource extends JsonResource
     {
         if (property_exists($this, 'attributes')) {
             return $this->attributes;
+        } elseif ($attributes = static::resolveClassAttribute(Attributes::class, 'attributes')) {
+            return $attributes;
         }
 
         return $this->toArray($request);
@@ -98,6 +169,8 @@ class JsonApiResource extends JsonResource
     {
         if (property_exists($this, 'relationships')) {
             return $this->relationships;
+        } elseif ($relationships = static::resolveClassAttribute(Relationships::class, 'relationships')) {
+            return $relationships;
         }
 
         return [];
@@ -110,7 +183,11 @@ class JsonApiResource extends JsonResource
      */
     public function toLinks(Request $request)
     {
-        return $this->jsonApiLinks;
+        if (! empty($this->jsonApiLinks)) {
+            return $this->jsonApiLinks;
+        }
+
+        return static::resolveClassAttribute(JsonApiLinks::class, 'links') ?? [];
     }
 
     /**
@@ -120,7 +197,11 @@ class JsonApiResource extends JsonResource
      */
     public function toMeta(Request $request)
     {
-        return $this->jsonApiMeta;
+        if (! empty($this->jsonApiMeta)) {
+            return $this->jsonApiMeta;
+        }
+
+        return static::resolveClassAttribute(JsonApiMeta::class, 'meta') ?? [];
     }
 
     /**
@@ -132,15 +213,28 @@ class JsonApiResource extends JsonResource
     #[\Override]
     public function with($request)
     {
+        $implementation = static::$jsonApiInformation;
+
+        if (empty($implementation)) {
+            $info = static::resolveClassAttribute(JsonApiInformation::class);
+
+            if ($info !== null) {
+                $implementation = array_filter([
+                    'version' => $info->version,
+                    'ext' => $info->ext,
+                    'profile' => $info->profile,
+                    'meta' => $info->meta,
+                ]);
+            }
+        }
+
         return array_filter([
             'included' => $this->resolveIncludedResourceObjects($request)
                 ->uniqueStrict('_uniqueKey')
                 ->map(fn ($included) => Arr::except($included, ['_uniqueKey']))
                 ->values()
                 ->all(),
-            ...($implementation = static::$jsonApiInformation)
-                ? ['jsonapi' => $implementation]
-                : [],
+            ...($implementation ? ['jsonapi' => $implementation] : []),
         ]);
     }
 
@@ -153,8 +247,16 @@ class JsonApiResource extends JsonResource
     #[\Override]
     public function resolve($request = null)
     {
+        if (static::$wrap === 'data') {
+            $wrapper = static::resolveClassAttribute(Wraps::class, 'wrapper');
+
+            if ($wrapper !== null) {
+                static::$wrap = $wrapper;
+            }
+        }
+
         return [
-            'data' => $this->resolveResourceData($this->resolveJsonApiRequestFrom($request ?? $this->resolveRequestFromContainer())),
+            static::$wrap => $this->resolveResourceData($this->resolveJsonApiRequestFrom($request ?? $this->resolveRequestFromContainer())),
         ];
     }
 
@@ -251,5 +353,6 @@ class JsonApiResource extends JsonResource
 
         static::$jsonApiInformation = [];
         static::$maxRelationshipDepth = 5;
+        static::$classAttributes = [];
     }
 }

--- a/src/Illuminate/Http/Resources/JsonApi/JsonApiResource.php
+++ b/src/Illuminate/Http/Resources/JsonApi/JsonApiResource.php
@@ -14,12 +14,13 @@ use Illuminate\Http\Resources\JsonApi\Attributes\JsonApiMeta;
 use Illuminate\Http\Resources\JsonApi\Attributes\Relationships;
 use Illuminate\Http\Resources\JsonApi\Attributes\Wraps;
 use Illuminate\Support\Arr;
-use ReflectionClass;
+use Illuminate\Support\Traits\ResolvesClassAttributes;use ReflectionClass;
 
 class JsonApiResource extends JsonResource
 {
     use Concerns\ResolvesJsonApiElements,
         Concerns\ResolvesJsonApiRequest;
+    use ResolvesClassAttributes;
 
     /**
      * The "data" wrapper that should be applied.
@@ -44,52 +45,6 @@ class JsonApiResource extends JsonResource
      * The resource's "meta" for JSON:API.
      */
     protected array $jsonApiMeta = [];
-
-    /**
-     * The cache of resolved class attributes.
-     *
-     * @var array
-     */
-    protected static array $classAttributes = [];
-
-    /**
-     * Resolve a class attribute value from the resource.
-     *
-     * @template TAttribute of object
-     *
-     * @param  class-string<TAttribute>  $attributeClass
-     * @param  string|null  $property
-     * @param  string|null  $class
-     * @return mixed
-     */
-    protected static function resolveClassAttribute(string $attributeClass, ?string $property = null, ?string $class = null)
-    {
-        $class = $class ?? static::class;
-
-        $cacheKey = $class.'@'.$attributeClass;
-
-        if (array_key_exists($cacheKey, static::$classAttributes)) {
-            return static::$classAttributes[$cacheKey];
-        }
-
-        try {
-            $reflection = new ReflectionClass($class);
-
-            do {
-                $attributes = $reflection->getAttributes($attributeClass);
-
-                if (count($attributes) > 0) {
-                    $instance = $attributes[0]->newInstance();
-
-                    return static::$classAttributes[$cacheKey] = $property ? $instance->{$property} : $instance;
-                }
-            } while ($reflection = $reflection->getParentClass());
-        } catch (Exception) {
-            //
-        }
-
-        return static::$classAttributes[$cacheKey] = null;
-    }
 
     /**
      * Resolve a class attribute value for a given resource class.

--- a/src/Illuminate/Http/Resources/JsonApi/JsonApiResource.php
+++ b/src/Illuminate/Http/Resources/JsonApi/JsonApiResource.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Http\Resources\JsonApi;
 
 use BadMethodCallException;
-use Exception;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;

--- a/src/Illuminate/Http/Resources/JsonApi/JsonApiResource.php
+++ b/src/Illuminate/Http/Resources/JsonApi/JsonApiResource.php
@@ -14,7 +14,7 @@ use Illuminate\Http\Resources\JsonApi\Attributes\JsonApiMeta;
 use Illuminate\Http\Resources\JsonApi\Attributes\Relationships;
 use Illuminate\Http\Resources\JsonApi\Attributes\Wraps;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Traits\ResolvesClassAttributes;use ReflectionClass;
+use Illuminate\Support\Traits\ResolvesClassAttributes;
 
 class JsonApiResource extends JsonResource
 {

--- a/src/Illuminate/Support/Traits/ResolvesClassAttributes.php
+++ b/src/Illuminate/Support/Traits/ResolvesClassAttributes.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace Illuminate\Support\Traits;
 
-use Exception;use ReflectionClass;trait ResolvesClassAttributes
+use Exception;
+use ReflectionClass;
+
+trait ResolvesClassAttributes
 {
     /**
      * Cache of resolved class attributes.

--- a/src/Illuminate/Support/Traits/ResolvesClassAttributes.php
+++ b/src/Illuminate/Support/Traits/ResolvesClassAttributes.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Support\Traits;
+
+use Exception;use ReflectionClass;trait ResolvesClassAttributes
+{
+    /**
+     * Cache of resolved class attributes.
+     *
+     * @var array<class-string<self>, array<class-string, mixed>>
+     */
+    protected static array $classAttributes = [];
+
+    /**
+     * Resolve a class attribute value from the resource.
+     *
+     * @template TAttribute of object
+     *
+     * @param  class-string<TAttribute>  $attributeClass
+     * @param  string|null  $property
+     * @param  string|null  $class
+     * @return mixed
+     */
+    protected static function resolveClassAttribute(string $attributeClass, ?string $property = null, ?string $class = null)
+    {
+        $class = $class ?? static::class;
+
+        $cacheKey = $class.'@'.$attributeClass;
+
+        if (array_key_exists($cacheKey, static::$classAttributes)) {
+            return static::$classAttributes[$cacheKey];
+        }
+
+        try {
+            $reflection = new ReflectionClass($class);
+
+            do {
+                $attributes = $reflection->getAttributes($attributeClass);
+
+                if (count($attributes) > 0) {
+                    $instance = $attributes[0]->newInstance();
+
+                    return static::$classAttributes[$cacheKey] = $property ? $instance->{$property} : $instance;
+                }
+            } while ($reflection = $reflection->getParentClass());
+        } catch (Exception) {
+            //
+        }
+
+        return static::$classAttributes[$cacheKey] = null;
+    }
+}

--- a/tests/Integration/Http/Resources/JsonApi/Fixtures/AttributeBasedPostResource.php
+++ b/tests/Integration/Http/Resources/JsonApi/Fixtures/AttributeBasedPostResource.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures;
+
+use Illuminate\Http\Resources\JsonApi\Attributes\Attributes;
+use Illuminate\Http\Resources\JsonApi\Attributes\Relationships;
+use Illuminate\Http\Resources\JsonApi\JsonApiResource;
+
+#[Attributes(attributes: ['title', 'content'])]
+#[Relationships(relationships: ['author' => AuthorResource::class, 'comments'])]
+class AttributeBasedPostResource extends JsonApiResource
+{
+}

--- a/tests/Integration/Http/Resources/JsonApi/Fixtures/AttributeBasedUserResource.php
+++ b/tests/Integration/Http/Resources/JsonApi/Fixtures/AttributeBasedUserResource.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures;
+
+use Illuminate\Http\Resources\JsonApi\Attributes\Attributes;
+use Illuminate\Http\Resources\JsonApi\Attributes\Relationships;
+use Illuminate\Http\Resources\JsonApi\JsonApiResource;
+
+#[Attributes(attributes: ['name', 'email'])]
+#[Relationships(relationships: ['comments', 'profile', 'posts'])]
+class AttributeBasedUserResource extends JsonApiResource
+{
+}

--- a/tests/Integration/Http/Resources/JsonApi/Fixtures/ConfigureOverridesAttributeResource.php
+++ b/tests/Integration/Http/Resources/JsonApi/Fixtures/ConfigureOverridesAttributeResource.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures;
+
+use Illuminate\Http\Resources\JsonApi\Attributes\Attributes;
+use Illuminate\Http\Resources\JsonApi\Attributes\JsonApiInformation;
+use Illuminate\Http\Resources\JsonApi\JsonApiResource;
+
+#[JsonApiInformation(version: '1.0', ext: ['atomic'], profile: ['https://example.com/profiles/blog'])]
+#[Attributes(attributes: ['name', 'email'])]
+class ConfigureOverridesAttributeResource extends JsonApiResource
+{
+}

--- a/tests/Integration/Http/Resources/JsonApi/Fixtures/MethodOverridesAttributeResource.php
+++ b/tests/Integration/Http/Resources/JsonApi/Fixtures/MethodOverridesAttributeResource.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\JsonApi\Attributes\Attributes;
+use Illuminate\Http\Resources\JsonApi\JsonApiResource;
+
+#[Attributes(attributes: ['name'])]
+class MethodOverridesAttributeResource extends JsonApiResource
+{
+    #[\Override]
+    public function toAttributes(Request $request)
+    {
+        return [
+            'name' => $this->name,
+            'email' => $this->email,
+        ];
+    }
+}

--- a/tests/Integration/Http/Resources/JsonApi/Fixtures/PropertyOverridesAttributeResource.php
+++ b/tests/Integration/Http/Resources/JsonApi/Fixtures/PropertyOverridesAttributeResource.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures;
+
+use Illuminate\Http\Resources\JsonApi\Attributes\Attributes;
+use Illuminate\Http\Resources\JsonApi\JsonApiResource;
+
+#[Attributes(attributes: ['name'])]
+class PropertyOverridesAttributeResource extends JsonApiResource
+{
+    protected array $attributes = [
+        'name',
+        'email',
+    ];
+}

--- a/tests/Integration/Http/Resources/JsonApi/Fixtures/ResourceWithCustomWrap.php
+++ b/tests/Integration/Http/Resources/JsonApi/Fixtures/ResourceWithCustomWrap.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures;
+
+use Illuminate\Http\Resources\JsonApi\Attributes\Attributes;
+use Illuminate\Http\Resources\JsonApi\Attributes\Wraps;
+use Illuminate\Http\Resources\JsonApi\JsonApiResource;
+
+#[Wraps(wrapper: 'result')]
+#[Attributes(attributes: ['name', 'email'])]
+class ResourceWithCustomWrap extends JsonApiResource
+{
+}

--- a/tests/Integration/Http/Resources/JsonApi/Fixtures/ResourceWithJsonApiInfo.php
+++ b/tests/Integration/Http/Resources/JsonApi/Fixtures/ResourceWithJsonApiInfo.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures;
+
+use Illuminate\Http\Resources\JsonApi\Attributes\Attributes;
+use Illuminate\Http\Resources\JsonApi\Attributes\JsonApiInformation;
+use Illuminate\Http\Resources\JsonApi\JsonApiResource;
+
+#[JsonApiInformation(version: '1.0', ext: ['atomic'], profile: ['https://example.com/profiles/blog'])]
+#[Attributes(attributes: ['name', 'email'])]
+class ResourceWithJsonApiInfo extends JsonApiResource
+{
+}

--- a/tests/Integration/Http/Resources/JsonApi/Fixtures/ResourceWithMetaAndLinks.php
+++ b/tests/Integration/Http/Resources/JsonApi/Fixtures/ResourceWithMetaAndLinks.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures;
+
+use Illuminate\Http\Resources\JsonApi\Attributes\Attributes;
+use Illuminate\Http\Resources\JsonApi\Attributes\JsonApiLinks;
+use Illuminate\Http\Resources\JsonApi\Attributes\JsonApiMeta;
+use Illuminate\Http\Resources\JsonApi\JsonApiResource;
+
+#[JsonApiMeta(meta: ['copyright' => '2024 Laravel'])]
+#[JsonApiLinks(links: ['self' => 'https://example.com/users/1'])]
+#[Attributes(attributes: ['name', 'email'])]
+class ResourceWithMetaAndLinks extends JsonApiResource
+{
+}

--- a/tests/Integration/Http/Resources/JsonApi/JsonApiResourceAttributeTest.php
+++ b/tests/Integration/Http/Resources/JsonApi/JsonApiResourceAttributeTest.php
@@ -8,7 +8,6 @@ use Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures\AttributeBasedU
 use Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures\ConfigureOverridesAttributeResource;
 use Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures\MethodOverridesAttributeResource;
 use Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures\Post;
-use Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures\Profile;
 use Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures\PropertyOverridesAttributeResource;
 use Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures\ResourceWithCustomWrap;
 use Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures\ResourceWithJsonApiInfo;

--- a/tests/Integration/Http/Resources/JsonApi/JsonApiResourceAttributeTest.php
+++ b/tests/Integration/Http/Resources/JsonApi/JsonApiResourceAttributeTest.php
@@ -1,0 +1,230 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http\Resources\JsonApi;
+
+use Illuminate\Http\Resources\JsonApi\JsonApiResource;
+use Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures\AttributeBasedPostResource;
+use Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures\AttributeBasedUserResource;
+use Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures\ConfigureOverridesAttributeResource;
+use Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures\MethodOverridesAttributeResource;
+use Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures\Post;
+use Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures\Profile;
+use Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures\PropertyOverridesAttributeResource;
+use Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures\ResourceWithCustomWrap;
+use Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures\ResourceWithJsonApiInfo;
+use Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures\ResourceWithMetaAndLinks;
+use Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures\User;
+
+class JsonApiResourceAttributeTest extends TestCase
+{
+    #[\Override]
+    protected function defineRoutes($router)
+    {
+        parent::defineRoutes($router);
+
+        $router->get('attribute-users/{userId}', function ($userId) {
+            return new AttributeBasedUserResource(User::find($userId));
+        });
+
+        $router->get('attribute-posts/{postId}', function ($postId) {
+            return new AttributeBasedPostResource(Post::find($postId));
+        });
+
+        $router->get('meta-links-users/{userId}', function ($userId) {
+            return new ResourceWithMetaAndLinks(User::find($userId));
+        });
+
+        $router->get('jsonapi-info-users/{userId}', function ($userId) {
+            return new ResourceWithJsonApiInfo(User::find($userId));
+        });
+
+        $router->get('custom-wrap-users/{userId}', function ($userId) {
+            return new ResourceWithCustomWrap(User::find($userId));
+        });
+
+        $router->get('property-override-users/{userId}', function ($userId) {
+            return new PropertyOverridesAttributeResource(User::find($userId));
+        });
+
+        $router->get('method-override-users/{userId}', function ($userId) {
+            return new MethodOverridesAttributeResource(User::find($userId));
+        });
+
+        $router->get('configure-override-users/{userId}', function ($userId) {
+            ConfigureOverridesAttributeResource::configure('2.0', ['bulk'], ['https://example.com/profiles/admin']);
+
+            return new ConfigureOverridesAttributeResource(User::find($userId));
+        });
+
+        $router->get('jsonapi-info-users-collection', function () {
+            return ResourceWithJsonApiInfo::collection(User::paginate(5));
+        });
+    }
+
+    public function testAttributeBasedResourceResolvesAttributes()
+    {
+        $user = User::factory()->create();
+
+        $this->getJson("/attribute-users/{$user->getKey()}")
+            ->assertHeader('Content-type', 'application/vnd.api+json')
+            ->assertExactJson([
+                'data' => [
+                    'id' => (string) $user->getKey(),
+                    'type' => 'attribute_based_users',
+                    'attributes' => [
+                        'name' => $user->name,
+                        'email' => $user->email,
+                    ],
+                ],
+            ]);
+    }
+
+    public function testAttributeBasedResourceResolvesRelationships()
+    {
+        $user = User::factory()->create();
+
+        $post = Post::factory()->create([
+            'user_id' => $user->getKey(),
+        ]);
+
+        $this->getJson("/attribute-posts/{$post->getKey()}?".http_build_query(['include' => 'author']))
+            ->assertHeader('Content-type', 'application/vnd.api+json')
+            ->assertJsonPath('data.id', (string) $post->getKey())
+            ->assertJsonPath('data.type', 'attribute_based_posts')
+            ->assertJsonPath('data.attributes.title', $post->title)
+            ->assertJsonPath('data.attributes.content', $post->content)
+            ->assertJsonPath('data.relationships.author.data.id', (string) $user->getKey())
+            ->assertJsonPath('data.relationships.author.data.type', 'authors')
+            ->assertJsonCount(1, 'included');
+    }
+
+    public function testPropertyOverridesPhpAttribute()
+    {
+        $user = User::factory()->create();
+
+        // The PropertyOverridesAttributeResource has both #[Attributes(['name'])] and
+        // protected array $attributes = ['name', 'email']. The property should win.
+        $this->getJson("/property-override-users/{$user->getKey()}")
+            ->assertHeader('Content-type', 'application/vnd.api+json')
+            ->assertExactJson([
+                'data' => [
+                    'id' => (string) $user->getKey(),
+                    'type' => 'property_overrides_attributes',
+                    'attributes' => [
+                        'name' => $user->name,
+                        'email' => $user->email,
+                    ],
+                ],
+            ]);
+    }
+
+    public function testMethodOverrideOverridesPhpAttribute()
+    {
+        $user = User::factory()->create();
+
+        // The MethodOverridesAttributeResource has #[Attributes(['name'])] and
+        // a toAttributes() override returning name + email. The method should win.
+        $this->getJson("/method-override-users/{$user->getKey()}")
+            ->assertHeader('Content-type', 'application/vnd.api+json')
+            ->assertExactJson([
+                'data' => [
+                    'id' => (string) $user->getKey(),
+                    'type' => 'method_overrides_attributes',
+                    'attributes' => [
+                        'name' => $user->name,
+                        'email' => $user->email,
+                    ],
+                ],
+            ]);
+    }
+
+    public function testJsonApiMetaAttribute()
+    {
+        $user = User::factory()->create();
+
+        $this->getJson("/meta-links-users/{$user->getKey()}")
+            ->assertHeader('Content-type', 'application/vnd.api+json')
+            ->assertJsonPath('data.meta.copyright', '2024 Laravel');
+    }
+
+    public function testJsonApiLinksAttribute()
+    {
+        $user = User::factory()->create();
+
+        $this->getJson("/meta-links-users/{$user->getKey()}")
+            ->assertHeader('Content-type', 'application/vnd.api+json')
+            ->assertJsonPath('data.links.self', 'https://example.com/users/1');
+    }
+
+    public function testJsonApiInformationAttribute()
+    {
+        $user = User::factory()->create();
+
+        $this->getJson("/jsonapi-info-users/{$user->getKey()}")
+            ->assertHeader('Content-type', 'application/vnd.api+json')
+            ->assertJsonPath('jsonapi.version', '1.0')
+            ->assertJsonPath('jsonapi.ext', ['atomic'])
+            ->assertJsonPath('jsonapi.profile', ['https://example.com/profiles/blog']);
+    }
+
+    public function testJsonApiInformationAttributeOnCollection()
+    {
+        User::factory()->create();
+
+        $this->getJson('/jsonapi-info-users-collection')
+            ->assertHeader('Content-type', 'application/vnd.api+json')
+            ->assertJsonPath('jsonapi.version', '1.0')
+            ->assertJsonPath('jsonapi.ext', ['atomic'])
+            ->assertJsonPath('jsonapi.profile', ['https://example.com/profiles/blog']);
+    }
+
+    public function testWrapsAttribute()
+    {
+        $user = User::factory()->create();
+
+        $response = $this->getJson("/custom-wrap-users/{$user->getKey()}")
+            ->assertHeader('Content-type', 'application/vnd.api+json');
+
+        $response->assertJsonStructure(['result']);
+        $response->assertJsonMissing(['data' => []]);
+        $response->assertJsonPath('result.id', (string) $user->getKey());
+        $response->assertJsonPath('result.type', 'resource_with_custom_wraps');
+    }
+
+    public function testConfigureOverridesJsonApiInformationAttribute()
+    {
+        $user = User::factory()->create();
+
+        // The route calls configure('2.0', ['bulk'], [...]) before returning the resource.
+        // configure() should win over #[JsonApiInformation(version: '1.0', ...)].
+        $this->getJson("/configure-override-users/{$user->getKey()}")
+            ->assertHeader('Content-type', 'application/vnd.api+json')
+            ->assertJsonPath('jsonapi.version', '2.0')
+            ->assertJsonPath('jsonapi.ext', ['bulk'])
+            ->assertJsonPath('jsonapi.profile', ['https://example.com/profiles/admin']);
+    }
+
+    public function testFlushStateClearsAttributeCache()
+    {
+        $user = User::factory()->create();
+
+        // Trigger attribute resolution to populate cache
+        $this->getJson("/attribute-users/{$user->getKey()}");
+
+        // Flush state should clear the cache
+        JsonApiResource::flushState();
+
+        // Verify we can resolve again (cache was cleared, not stale)
+        $this->getJson("/attribute-users/{$user->getKey()}")
+            ->assertExactJson([
+                'data' => [
+                    'id' => (string) $user->getKey(),
+                    'type' => 'attribute_based_users',
+                    'attributes' => [
+                        'name' => $user->name,
+                        'email' => $user->email,
+                    ],
+                ],
+            ]);
+    }
+}


### PR DESCRIPTION
## TL;DR
 
Adds PHP 8 attribute support to `JsonApiResource`, letting you configure resources declaratively with `#[Attributes]`, `#[Relationships]`, `#[JsonApiMeta]`, `#[JsonApiLinks]`, `#[JsonApiInformation]`, and `#[Wraps]` - as an alternative to class properties or method overrides.
 
## ✨ Motivation
 
Eloquent models already support PHP 8 attributes (`#[Table]`, `#[Fillable]`, etc.) with a `resolveClassAttribute()` caching pattern. This PR brings the same declarative style to `JsonApiResource`, giving developers a concise, self-documenting third way to configure resources.
 
## 🆕 New API
 
### Before (still works)
 
```php
class PostResource extends JsonApiResource
{
    protected array $attributes = ['title', 'content'];
    protected array $relationships = ['author' => AuthorResource::class, 'comments'];
}
```
 
### After
 
```php
#[Attributes(attributes: ['title', 'content'])]
#[Relationships(relationships: ['author' => AuthorResource::class, 'comments'])]
class PostResource extends JsonApiResource
{
}
```
 
### Full attribute set
 
```php
#[Wraps(wrapper: 'result')]
#[JsonApiInformation(version: '1.0', ext: ['atomic'], profile: [...], meta: [...])]
#[JsonApiMeta(meta: ['copyright' => '2024 Laravel'])]
#[JsonApiLinks(links: ['self' => '...'])]
#[Attributes(attributes: ['title', 'content'])]
#[Relationships(relationships: ['author' => AuthorResource::class])]
class PostResource extends JsonApiResource {}
```
 
| Attribute | Alternative to |
|---|---|
| `#[Wraps('result')]` | setting `static $wrap` directly |
| `#[JsonApiInformation(...)]` | calling `static::configure()` |
| `#[JsonApiMeta(meta: [...])]` | setting `$jsonApiMeta` property |
| `#[JsonApiLinks(links: [...])]` | setting `$jsonApiLinks` property |
| `#[Attributes(attributes: [...])]` | declaring `$attributes` property |
| `#[Relationships(relationships: [...])]` | declaring `$relationships` property |
 
## ⚡ Priority order
 
```
method override  >  class property  >  PHP attribute  >  default
```
 
Method overrides win as the most explicit - they contain logic and access `$this`. Class properties win over attributes because `property_exists()` already checks for them. PHP attributes serve as a convenient declarative default, falling back to default behavior last.
 
Mixing styles within a single resource is intentional and supported.
 
## 🔧 How it works
 
- Adds 6 attribute classes in `Illuminate\Http\Resources\JsonApi\Attributes\`
- Adds `resolveClassAttribute()` to `JsonApiResource`, mirroring the existing `Model::resolveClassAttribute()` pattern (reflection + static cache + parent class walking)
- Each existing method gains a new fallback branch that checks for the corresponding PHP attribute - no existing code paths are modified
- `flushState()` clears the attribute cache
- `AnonymousResourceCollection::with()` resolves `#[JsonApiInformation]` from the collected resource class
 