### PR TITLE
[13.x] Allow Backoff Attribute to be variadic

### DIFF
--- a/src/Illuminate/Queue/Attributes/Backoff.php
+++ b/src/Illuminate/Queue/Attributes/Backoff.php
@@ -8,12 +8,19 @@ use Attribute;
 class Backoff
 {
     /**
+     * The backoff values.
+     *
+     * @var array<int>|int
+     */
+    public array|int $backoff;
+
+    /**
      * Create a new attribute instance.
      *
-     * @param  array<int>|int  $backoff
+     * @param  array<int>|int  ...$backoff
      */
-    public function __construct(public array|int $backoff)
+    public function __construct(array|int ...$backoff)
     {
-        //
+        $this->backoff = count($backoff) === 1 ? $backoff[0] : $backoff;
     }
 }


### PR DESCRIPTION
I noticed this was actually shown on a Laravel video, but it doesn't work atm re: https://youtu.be/UnvBFcO3Vww?t=643 :trollface: 

Which, then got the brain stems working.. that it kinda makes sense to just allow it. So welcome to my PR, thought I'd give it a go incase anyones copying that, and it feels nice dx..

This allow us to do:

```php
// Before we could only do...
#[Backoff(1)]                                                                                                                                                                                                                                                                                                                                                                                                      
#[Backoff([1, 2, 3])]
  
// And now in this PR we get...
#[Backoff(1, 2, 3)]       
  ```
  
No test, cause non exists..
  
This is a very minor b/c in terms of named args, but, I dont think anyone would of been using `#[Backoff(backoff: 10)] ` 

Here's an example if you've never seen this variadic stuff  before, for future generations https://3v4l.org/RiDb6#vnull

Cheers.