### PR TITLE
[13.x] Forward releaseOnTerminationSignals through schedule groups

### DIFF
--- a/src/Illuminate/Console/Scheduling/PendingEventAttributes.php
+++ b/src/Illuminate/Console/Scheduling/PendingEventAttributes.php
@@ -30,13 +30,16 @@ class PendingEventAttributes
      * The expiration time of the underlying cache lock may be specified in minutes.
      *
      * @param  int  $expiresAt
+     * @param  bool  $releaseOnTerminationSignals
      * @return $this
      */
-    public function withoutOverlapping($expiresAt = 1440)
+    public function withoutOverlapping($expiresAt = 1440, $releaseOnTerminationSignals = true)
     {
         $this->withoutOverlapping = true;
 
         $this->expiresAt = $expiresAt;
+
+        $this->releaseOnTerminationSignals = $releaseOnTerminationSignals;
 
         return $this;
     }
@@ -74,7 +77,7 @@ class PendingEventAttributes
         }
 
         if ($this->withoutOverlapping) {
-            $event->withoutOverlapping($this->expiresAt);
+            $event->withoutOverlapping($this->expiresAt, $this->releaseOnTerminationSignals);
         }
 
         if ($this->onOneServer) {

--- a/tests/Integration/Console/Scheduling/ScheduleGroupTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleGroupTest.php
@@ -217,6 +217,20 @@ class ScheduleGroupTest extends TestCase
         $this->assertSame('0 4 * * 1-5', $events[3]->expression);
     }
 
+    public function testGroupCanOptOutOfReleaseOnTerminationSignals()
+    {
+        $schedule = new ScheduleClass;
+        $schedule->daily()
+            ->withoutOverlapping(1440, releaseOnTerminationSignals: false)
+            ->group(function ($schedule) {
+                $schedule->command('inspire');
+            });
+
+        $events = $schedule->events();
+        $this->assertTrue($events[0]->withoutOverlapping);
+        $this->assertFalse($events[0]->releaseOnTerminationSignals);
+    }
+
     public function testGroupAppliesEventMacrosToAllEvents()
     {
         Event::macro('sentryMonitor', function () {

--- a/tests/Integration/Console/Scheduling/ScheduleGroupTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleGroupTest.php
@@ -102,6 +102,7 @@ class ScheduleGroupTest extends TestCase
         } else {
             $this->assertSame($value, $events[0]->expiresAt);
             $this->assertTrue($events[0]->withoutOverlapping);
+            $this->assertTrue($events[0]->releaseOnTerminationSignals);
         }
     }
 


### PR DESCRIPTION
Me, yet again! I swear I have a life Taylor.

In https://github.com/laravel/framework/pull/59298 we added `releaseOnTerminationSignals` to events. 

But, I forgot to route it through groups, groups basically merge their attributes onto each event.. from reading it so this PR this means you can opt out properly now.

```php
// You could not opt out before...
Schedule::daily()                                                                                                                          
      ->withoutOverlapping(1440, releaseOnTerminationSignals: false)  
      ->group(function (Schedule $schedule) {                                                                                                
          $schedule->command('emails:send');                                                                                                 
          $schedule->command('emails:cleanup');                                                                                              
      });           
``` 