### PR TITLE
[13.x] MariaDbSchemaState uses mysql --version for client detection instead of mariadb --version

### DIFF
--- a/src/Illuminate/Database/Schema/MariaDbSchemaState.php
+++ b/src/Illuminate/Database/Schema/MariaDbSchemaState.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Database\Schema;
 
+use Symfony\Component\Process\Exception\ProcessFailedException;
+
 class MariaDbSchemaState extends MySqlSchemaState
 {
     /**
@@ -35,5 +37,31 @@ class MariaDbSchemaState extends MySqlSchemaState
         $command = 'mariadb-dump '.$this->connectionString($versionInfo).' --no-tablespaces --skip-add-locks --skip-comments --skip-set-charset --tz-utc';
 
         return $command.' "${:LARAVEL_LOAD_DATABASE}"';
+    }
+
+    /**
+     * Detect the MariaDB client version.
+     *
+     * @return array{version: string, isMariaDb: bool}
+     */
+    protected function detectClientVersion(): array
+    {
+        // Minimum version of MariaDB that supports the mariadb command
+        $version = '10.4.6';
+
+        try {
+            $versionOutput = $this->makeProcess('mariadb --version')->mustRun()->getOutput();
+
+            if (preg_match('/(\d+\.\d+\.\d+)/', $versionOutput, $matches)) {
+                $version = $matches[1];
+            }
+        } catch (ProcessFailedException) {
+        }
+
+
+        return [
+            'isMariaDb' => true,
+            'version' => $version,
+        ];
     }
 }

--- a/src/Illuminate/Database/Schema/MariaDbSchemaState.php
+++ b/src/Illuminate/Database/Schema/MariaDbSchemaState.php
@@ -46,7 +46,7 @@ class MariaDbSchemaState extends MySqlSchemaState
      */
     protected function detectClientVersion(): array
     {
-        // Minimum version of MariaDB that supports the mariadb command
+        // Minimum version of MariaDB that supports the mariadb command...
         $version = '10.5.2';
 
         try {

--- a/src/Illuminate/Database/Schema/MariaDbSchemaState.php
+++ b/src/Illuminate/Database/Schema/MariaDbSchemaState.php
@@ -58,7 +58,6 @@ class MariaDbSchemaState extends MySqlSchemaState
         } catch (ProcessFailedException) {
         }
 
-
         return [
             'isMariaDb' => true,
             'version' => $version,

--- a/src/Illuminate/Database/Schema/MariaDbSchemaState.php
+++ b/src/Illuminate/Database/Schema/MariaDbSchemaState.php
@@ -47,7 +47,7 @@ class MariaDbSchemaState extends MySqlSchemaState
     protected function detectClientVersion(): array
     {
         // Minimum version of MariaDB that supports the mariadb command
-        $version = '10.4.6';
+        $version = '10.5.2';
 
         try {
             $versionOutput = $this->makeProcess('mariadb --version')->mustRun()->getOutput();


### PR DESCRIPTION
# What does this change do?

Customizes the client version detection for MariaDB to use the `mariadb` command directly.

> [!NOTE]
> The `mariadb` and `mariadb-dump` command is used in the `MariaDbSchemaState` file already however these commands were only [introduced in Maria 10.5](https://mariadb.com/docs/release-notes/community-server/old-releases/10.5/10.5.2#binaries) but the [docs in Laravel](https://laravel.com/docs/13.x/database) talk about the minimum requirement being Maria 10.3. This might need an update as well?

# Why is it needed?

On 13.x (and 12.x where we noticed it) before this change, the command resolves mysql to the actual MySQL client binary, not MariaDB, because both are in the PATH and MySQL takes precedence. This returns the wrong client version. However, when only MariaDB is installed, Homebrew symlinks mysql → mariadb, so mysql resolves correctly by accident. This is why the bug only surfaces when both are installed side by side. 

When you tie this into trying to run a migration that includes a schema dump AND turn off SSL this results in the schema checker trying to output `--ssl-mode=DISABLED` which fails in Maria as it should instead output `--ssl=off`.

# How do I test this?

No automated tests added due to the edge-i-ness of this and the requirements. These reqs are:

- You must have both mariadb and mysql in your path
- You must have a sql schema dump
- You must have SSL turned off

Install both Maria and Mysql in your system so they're both in your path (with Homebrew). Create a schema output file. Turn off SSL in your config/database connection options (`PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => false`) and then run `migrate:fresh`. This will properly run your migrations. 

If you do this off of the existing 13.x branch (or 12.x, or 11.x, etc) it will error with: `mariadb: unknown variable 'ssl-mode=DISABLED'`



Resolves #59359 