### PR TITLE
[13.x] Add lost connection to WorkerStopReason

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -86,7 +86,7 @@ class Worker
     public $shouldQuit = false;
 
     /**
-     * Indicates if the worker stopped due to a lost connection.
+     * Indicates if the worker lost its connection.
      *
      * @var bool
      */

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -86,6 +86,13 @@ class Worker
     public $shouldQuit = false;
 
     /**
+     * Indicates if the worker stopped due to a lost connection.
+     *
+     * @var bool
+     */
+    public $lostConnection = false;
+
+    /**
      * Indicates if the worker is paused.
      *
      * @var bool
@@ -334,6 +341,7 @@ class Worker
     protected function stopIfNecessary(WorkerOptions $options, $lastRestart, $startTime = 0, $jobsProcessed = 0, $job = null)
     {
         return match (true) {
+            $this->lostConnection => [static::EXIT_SUCCESS, WorkerStopReason::LostConnection],
             $this->shouldQuit => [static::EXIT_SUCCESS, WorkerStopReason::Interrupted],
             $this->memoryExceeded($options->memory) => [static::$memoryExceededExitCode ?? static::EXIT_MEMORY_LIMIT, WorkerStopReason::MaxMemoryExceeded],
             $this->queueShouldRestart($lastRestart) => [static::EXIT_SUCCESS, WorkerStopReason::ReceivedRestartSignal],
@@ -458,7 +466,7 @@ class Worker
     protected function stopWorkerIfLostConnection($e)
     {
         if ($this->causedByLostConnection($e)) {
-            $this->shouldQuit = true;
+            $this->lostConnection = true;
         }
     }
 

--- a/src/Illuminate/Queue/WorkerStopReason.php
+++ b/src/Illuminate/Queue/WorkerStopReason.php
@@ -5,6 +5,7 @@ namespace Illuminate\Queue;
 enum WorkerStopReason: string
 {
     case Interrupted = 'interrupted';
+    case LostConnection = 'lost_connection';
     case MaxJobsExceeded = 'max_jobs';
     case MaxMemoryExceeded = 'memory';
     case MaxTimeExceeded = 'max_time';

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -465,6 +465,29 @@ class QueueWorkerTest extends TestCase
         }));
     }
 
+    public function testWorkerStopsWithLostConnectionReason()
+    {
+        $workerOptions = new WorkerOptions();
+        $workerOptions->stopWhenEmpty = true;
+
+        $worker = $this->getWorker('default', ['queue' => [
+            $job = new WorkerFakeJob(function () {
+                throw new RuntimeException('server has gone away');
+            }),
+        ]]);
+
+        $worker->daemon('default', 'queue', $workerOptions);
+
+        $this->assertTrue($job->fired);
+
+        $this->events->shouldHaveReceived('dispatch')->with(m::on(function ($event) use ($workerOptions) {
+            return $event instanceof WorkerStopping
+                && $event->status === 0
+                && $event->workerOptions === $workerOptions
+                && $event->reason === WorkerStopReason::LostConnection;
+        }));
+    }
+
     public function testJobReleasedEvent()
     {
         $e = new RuntimeException;


### PR DESCRIPTION
I'm back, again... (I live here now) 😄 

I've been staring at queues so long I'm starting to think in SIGTERM.                                                                                            
   
Lost connections currently report as Interrupted when listening to `WorkerStopping` which is confusing. Was it a signal or a lost connection?                                    
                                                                                                                                                                                 
All this PR does is track when a worker stops due to a lost connection so we can report the reason properly which gives clear insight, no false signals (pun intended).                    
                                                            
Minor behavioral change  for the `WorkerStopping` event, lost connections previously reported as Interrupted, so if you're matching on that you'll want to handle LostConnection now. Though, I dont think this warrants waiting for 14.x
                                                                                                                                                                                   
No B/C, same exit code as shouldQuit.

Test added to stop regression.