### PR TITLE
[13.x] Patch Commonmark to 2.8.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "guzzlehttp/uri-template": "^1.0",
         "laravel/prompts": "^0.3.0",
         "laravel/serializable-closure": "^2.0.10",
-        "league/commonmark": "^2.8.1",
+        "league/commonmark": "^2.8.2",
         "league/flysystem": "^3.25.1",
         "league/flysystem-local": "^3.25.1",
         "league/uri": "^7.5.1",

--- a/src/Illuminate/Mail/composer.json
+++ b/src/Illuminate/Mail/composer.json
@@ -20,7 +20,7 @@
         "illuminate/contracts": "^13.0",
         "illuminate/macroable": "^13.0",
         "illuminate/support": "^13.0",
-        "league/commonmark": "^2.7",
+        "league/commonmark": "^2.8.2",
         "psr/log": "^1.0 || ^2.0 || ^3.0",
         "symfony/mailer": "^7.4.0 || ^8.0.0",
         "tijsverkoyen/css-to-inline-styles": "^2.2.5"

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -37,7 +37,7 @@
     "suggest": {
         "illuminate/filesystem": "Required to use the Composer class (^13.0).",
         "laravel/serializable-closure": "Required to use the once function (^2.0.10).",
-        "league/commonmark": "Required to use Str::markdown() and Stringable::markdown() (^2.7).",
+        "league/commonmark": "Required to use Str::markdown() and Stringable::markdown() (^2.8.2).",
         "league/uri": "Required to use the Uri class (^7.5.1).",
         "ramsey/uuid": "Required to use Str::uuid() (^4.7).",
         "symfony/process": "Required to use the Composer class (^7.4 || ^8.0).",


### PR DESCRIPTION
This PR updates `league/commonmark` to v2.8.2 so [this security advisory](https://github.com/thephpleague/commonmark/security/advisories/GHSA-hh8v-hgvp-g3f5) is patched.
