### PR TITLE
[13.x] Refactor connection and queue retrieval logic for queued notifications

### DIFF
--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -234,7 +234,8 @@ class NotificationSender
                     $notification->locale = $this->locale;
                 }
 
-                $connection = $this->getAttributeValue($notification, Connection::class, 'connection')
+                $connection = $notification->connection
+                    ?? $this->getAttributeValue($notification, Connection::class, 'connection')
                     ?? $this->manager->resolveConnectionFromQueueRoute($notification)
                     ?? null;
 
@@ -242,7 +243,8 @@ class NotificationSender
                     $connection = $notification->viaConnections()[$channel] ?? $connection;
                 }
 
-                $queue = $this->getAttributeValue($notification, QueueAttribute::class, 'queue')
+                $queue = $notification->queue
+                    ?? $this->getAttributeValue($notification, QueueAttribute::class, 'queue')
                     ?? $this->manager->resolveQueueFromQueueRoute($notification)
                     ?? null;
 


### PR DESCRIPTION
Opening this draft PR to start a tought process.

The docs mention the following:
> To speed up your application's response time, let your notification be queued by adding the **ShouldQueue** interface and **Queueable** trait to your class.

The `Queueable` trait includes the `onQueue` method.

12.x and below hence supported two ways for defining the queue of a notification (in order of precedence):
1. the `viaQueues()` method on the notification class itself
2. setting the `$queue` property on the notification class / direct calling of `onQueue()` on a notification object.

https://github.com/laravel/framework/blob/41558b0706228093fbd3c78199eef72aa1f87dbb/src/Illuminate/Notifications/NotificationSender.php#L240-L244

13.x introduced the `#[Queue]` attribute, and things have been shuffled now to:
1. the `viaQueues()` method on the notification class itself
2. the bound queue route defined on a higher level (new in 13.x)
3. the `#[Queue]` attribute (new in 13.x)

https://github.com/laravel/framework/blob/7106836552f7b1186248eee4840b3eeb161497d3/src/Illuminate/Notifications/NotificationSender.php#L245-L251

Even though the docs still refer to the `Queueable` trait, and hence making available the `onQueue` method, it won't do anything anymore as the `$notification->queue` check disappeared. **I think this is actually breaking?**

I have two suggestions:

Bring back support for the `$queue` property, which should be as easy as replacing `null` on L247 by `$notification->queue` in the snippet above.

But while at it, revisit the order of precedence to unlock a powerful side effect: Queues set by the attribute or bound queue route are fixed upon definition. `onQueue` can be called anytime on a notification object, hence in the position to override a class-level configured queue. So I'm aiming here for setting a default queue using for instance the Attribute, and then allow a particular object to override the default by calling `onQueue()`. 

The current state of the PR incorporates both suggestions. Note that I've retained `viaQueues()` to still be able to take precedence over `$notification->queue` as it was before, but I think that can be up for debate as well.
And I've taken the liberty to apply the same principle to the queue connection as well.

Happy to hear your thoughts.