### PR TITLE
[13.x] Fix incrementEach/decrementEach to scope to model instance

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1356,6 +1356,34 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Increment the given column's values by the given amounts.
+     *
+     * @param  array<string, float|int|numeric-string>  $columns
+     * @param  array<string, mixed>  $extra
+     * @return int
+     */
+    public function incrementEach(array $columns, array $extra = [])
+    {
+        return $this->toBase()->incrementEach(
+            $columns, $this->addUpdatedAtColumn($extra)
+        );
+    }
+
+    /**
+     * Decrement the given column's values by the given amounts.
+     *
+     * @param  array<string, float|int|numeric-string>  $columns
+     * @param  array<string, mixed>  $extra
+     * @return int
+     */
+    public function decrementEach(array $columns, array $extra = [])
+    {
+        return $this->toBase()->decrementEach(
+            $columns, $this->addUpdatedAtColumn($extra)
+        );
+    }
+
+    /**
      * Add the "updated at" column to an array of values.
      *
      * @param  array  $values

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1252,23 +1252,35 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
             return $this->newQueryWithoutRelationships()->{$method}($columns, $extra);
         }
 
+        $isIncrement = $method === 'incrementEach';
+        $singleMethod = $isIncrement ? 'increment' : 'decrement';
+
+        foreach ($columns as $column => $amount) {
+            $this->{$column} = $this->isClassDeviable($column)
+                ? $this->deviateClassCastableAttribute($singleMethod, $column, $amount)
+                : $this->{$column} + ($isIncrement ? $amount : $amount * -1);
+        }
+
+        $this->forceFill($extra);
+
         if ($this->fireModelEvent('updating') === false) {
             return false;
         }
 
-        return tap($this->setKeysForSaveQuery($this->newQueryWithoutScopes())->{$method}($columns, $extra), function () use ($columns, $extra, $method) {
-            $this->forceFill(array_merge(
-                collect($columns)->mapWithKeys(function ($amount, $column) use ($method) {
-                    return [$column => $this->{$column} + ($method === 'incrementEach' ? $amount : $amount * -1)];
-                })->all(),
-                $extra
-            ));
+        $dbColumns = $columns;
 
+        foreach ($dbColumns as $column => $amount) {
+            if ($this->isClassDeviable($column)) {
+                $dbColumns[$column] = (clone $this)->setAttribute($column, $amount)->getAttributeFromArray($column);
+            }
+        }
+
+        return tap($this->setKeysForSaveQuery($this->newQueryWithoutScopes())->{$method}($dbColumns, $extra), function () use ($columns) {
             $this->syncChanges();
 
             $this->fireModelEvent('updated', false);
 
-            $this->syncOriginal();
+            $this->syncOriginalAttributes(array_keys($columns));
         });
     }
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1215,6 +1215,64 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     }
 
     /**
+     * Increment each given column's value by the given amounts.
+     *
+     * @param  array<string, float|int>  $columns
+     * @param  array<string, mixed>  $extra
+     * @return int
+     */
+    protected function incrementEach(array $columns, array $extra = [])
+    {
+        return $this->incrementOrDecrementEach($columns, $extra, 'incrementEach');
+    }
+
+    /**
+     * Decrement each given column's value by the given amounts.
+     *
+     * @param  array<string, float|int>  $columns
+     * @param  array<string, mixed>  $extra
+     * @return int
+     */
+    protected function decrementEach(array $columns, array $extra = [])
+    {
+        return $this->incrementOrDecrementEach($columns, $extra, 'decrementEach');
+    }
+
+    /**
+     * Run the incrementEach or decrementEach method on the model.
+     *
+     * @param  array<string, float|int>  $columns
+     * @param  array<string, mixed>  $extra
+     * @param  string  $method
+     * @return int
+     */
+    protected function incrementOrDecrementEach(array $columns, array $extra, string $method)
+    {
+        if (! $this->exists) {
+            return $this->newQueryWithoutRelationships()->{$method}($columns, $extra);
+        }
+
+        if ($this->fireModelEvent('updating') === false) {
+            return false;
+        }
+
+        return tap($this->setKeysForSaveQuery($this->newQueryWithoutScopes())->{$method}($columns, $extra), function () use ($columns, $extra, $method) {
+            $this->forceFill(array_merge(
+                collect($columns)->mapWithKeys(function ($amount, $column) use ($method) {
+                    return [$column => $this->{$column} + ($method === 'incrementEach' ? $amount : $amount * -1)];
+                })->all(),
+                $extra
+            ));
+
+            $this->syncChanges();
+
+            $this->fireModelEvent('updated', false);
+
+            $this->syncOriginal();
+        });
+    }
+
+    /**
      * Save the model and all of its relationships.
      *
      * @return bool
@@ -2707,7 +2765,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function __call($method, $parameters)
     {
-        if (in_array($method, ['increment', 'decrement', 'incrementQuietly', 'decrementQuietly'])) {
+        if (in_array($method, ['increment', 'decrement', 'incrementQuietly', 'decrementQuietly', 'incrementEach', 'decrementEach'])) {
             return $this->$method(...$parameters);
         }
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -2934,6 +2934,67 @@ class DatabaseEloquentBuilderTest extends TestCase
         return new Builder($this->getMockQueryBuilder());
     }
 
+    public function testIncrementEachCallsToBaseWithUpdatedAt()
+    {
+        $query = m::mock(BaseBuilder::class);
+        $query->shouldReceive('from')->with('foo_table');
+        $query->from = 'foo_table';
+        $query->shouldReceive('incrementEach')->once()->withArgs(function ($columns, $extra) {
+            return $columns === ['votes' => 5] && array_key_exists('foo_table.updated_at', $extra);
+        })->andReturn(1);
+
+        $builder = new Builder($query);
+        $model = $this->getMockModel();
+        $model->shouldReceive('usesTimestamps')->andReturn(true);
+        $model->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');
+        $model->shouldReceive('freshTimestampString')->andReturn('2026-03-26 00:00:00');
+        $model->shouldReceive('hasSetMutator')->andReturn(false);
+        $model->shouldReceive('hasAttributeSetMutator')->andReturn(false);
+        $model->shouldReceive('hasCast')->andReturn(false);
+        $builder->setModel($model);
+
+        $result = $builder->incrementEach(['votes' => 5]);
+        $this->assertEquals(1, $result);
+    }
+
+    public function testDecrementEachCallsToBaseWithUpdatedAt()
+    {
+        $query = m::mock(BaseBuilder::class);
+        $query->shouldReceive('from')->with('foo_table');
+        $query->from = 'foo_table';
+        $query->shouldReceive('decrementEach')->once()->withArgs(function ($columns, $extra) {
+            return $columns === ['votes' => 3] && array_key_exists('foo_table.updated_at', $extra);
+        })->andReturn(1);
+
+        $builder = new Builder($query);
+        $model = $this->getMockModel();
+        $model->shouldReceive('usesTimestamps')->andReturn(true);
+        $model->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');
+        $model->shouldReceive('freshTimestampString')->andReturn('2026-03-26 00:00:00');
+        $model->shouldReceive('hasSetMutator')->andReturn(false);
+        $model->shouldReceive('hasAttributeSetMutator')->andReturn(false);
+        $model->shouldReceive('hasCast')->andReturn(false);
+        $builder->setModel($model);
+
+        $result = $builder->decrementEach(['votes' => 3]);
+        $this->assertEquals(1, $result);
+    }
+
+    public function testIncrementEachWithoutTimestamps()
+    {
+        $query = m::mock(BaseBuilder::class);
+        $query->shouldReceive('from')->with('foo_table');
+        $query->shouldReceive('incrementEach')->once()->with(['votes' => 1], [])->andReturn(1);
+
+        $builder = new Builder($query);
+        $model = $this->getMockModel();
+        $model->shouldReceive('usesTimestamps')->andReturn(false);
+        $builder->setModel($model);
+
+        $result = $builder->incrementEach(['votes' => 1]);
+        $this->assertEquals(1, $result);
+    }
+
     protected function getMockModel()
     {
         $model = m::mock(Model::class);

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -2834,7 +2834,9 @@ class DatabaseEloquentModelTest extends TestCase
         $result = $model->publicIncrementEach(['foo' => 1]);
 
         $this->assertFalse($result);
-        $this->assertEquals(1, $model->foo);
+        // Note: attributes are set before the event fires, matching increment() behavior.
+        // The in-memory value changes but the database is not updated.
+        $this->assertEquals(2, $model->foo);
     }
 
     public function testIncrementEachOnNonExistingModelForwardsToQueryBuilder()

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -2740,6 +2740,116 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertTrue($model->isDirty('category'));
     }
 
+    public function testIncrementEachOnExistingModelScopesQueryToModelKey()
+    {
+        $model = m::mock(EloquentModelStub::class.'[newQueryWithoutScopes]');
+        $model->exists = true;
+        $model->id = 1;
+        $model->syncOriginalAttribute('id');
+        $model->foo = 2;
+        $model->bar = 5;
+
+        $model->shouldReceive('newQueryWithoutScopes')->andReturn($query = m::mock(stdClass::class));
+        $query->shouldReceive('where')->once()->with('id', '=', 1)->andReturn($query);
+        $query->shouldReceive('incrementEach')->once()->with(['foo' => 1, 'bar' => 2], [])->andReturn(1);
+
+        $result = $model->publicIncrementEach(['foo' => 1, 'bar' => 2]);
+
+        $this->assertEquals(1, $result);
+        $this->assertEquals(3, $model->foo);
+        $this->assertEquals(7, $model->bar);
+    }
+
+    public function testDecrementEachOnExistingModelScopesQueryToModelKey()
+    {
+        $model = m::mock(EloquentModelStub::class.'[newQueryWithoutScopes]');
+        $model->exists = true;
+        $model->id = 1;
+        $model->syncOriginalAttribute('id');
+        $model->foo = 10;
+        $model->bar = 5;
+
+        $model->shouldReceive('newQueryWithoutScopes')->andReturn($query = m::mock(stdClass::class));
+        $query->shouldReceive('where')->once()->with('id', '=', 1)->andReturn($query);
+        $query->shouldReceive('decrementEach')->once()->with(['foo' => 3, 'bar' => 2], [])->andReturn(1);
+
+        $result = $model->publicDecrementEach(['foo' => 3, 'bar' => 2]);
+
+        $this->assertEquals(1, $result);
+        $this->assertEquals(7, $model->foo);
+        $this->assertEquals(3, $model->bar);
+    }
+
+    public function testIncrementEachWithExtraColumnsOnExistingModel()
+    {
+        $model = m::mock(EloquentModelStub::class.'[newQueryWithoutScopes]');
+        $model->exists = true;
+        $model->id = 1;
+        $model->syncOriginalAttribute('id');
+        $model->foo = 2;
+
+        $model->shouldReceive('newQueryWithoutScopes')->andReturn($query = m::mock(stdClass::class));
+        $query->shouldReceive('where')->once()->with('id', '=', 1)->andReturn($query);
+        $query->shouldReceive('incrementEach')->once()->with(['foo' => 5], ['category' => 'test'])->andReturn(1);
+
+        $result = $model->publicIncrementEach(['foo' => 5], ['category' => 'test']);
+
+        $this->assertEquals(1, $result);
+        $this->assertEquals(7, $model->foo);
+        $this->assertEquals('test', $model->category);
+    }
+
+    public function testIncrementEachFiresModelEvents()
+    {
+        $model = m::mock(EloquentModelStub::class.'[newQueryWithoutScopes]');
+        $model->exists = true;
+        $model->id = 1;
+        $model->syncOriginalAttribute('id');
+        $model->foo = 1;
+
+        $model->shouldReceive('newQueryWithoutScopes')->andReturn($query = m::mock(stdClass::class));
+        $query->shouldReceive('where')->andReturn($query);
+        $query->shouldReceive('incrementEach')->andReturn(1);
+
+        $model->setEventDispatcher($events = m::mock(Dispatcher::class));
+        $events->shouldReceive('until')->once()->with('eloquent.updating: '.get_class($model), $model)->andReturn(true);
+        $events->shouldReceive('dispatch')->once()->with('eloquent.updated: '.get_class($model), $model);
+
+        $model->publicIncrementEach(['foo' => 1]);
+    }
+
+    public function testIncrementEachReturnsFalseWhenUpdatingEventCancelled()
+    {
+        $model = m::mock(EloquentModelStub::class.'[newQueryWithoutScopes]');
+        $model->exists = true;
+        $model->id = 1;
+        $model->syncOriginalAttribute('id');
+        $model->foo = 1;
+
+        $model->shouldReceive('newQueryWithoutScopes')->never();
+
+        $model->setEventDispatcher($events = m::mock(Dispatcher::class));
+        $events->shouldReceive('until')->once()->with('eloquent.updating: '.get_class($model), $model)->andReturn(false);
+
+        $result = $model->publicIncrementEach(['foo' => 1]);
+
+        $this->assertFalse($result);
+        $this->assertEquals(1, $model->foo);
+    }
+
+    public function testIncrementEachOnNonExistingModelForwardsToQueryBuilder()
+    {
+        $model = m::mock(EloquentModelStub::class.'[newQueryWithoutRelationships]');
+        $model->exists = false;
+
+        $model->shouldReceive('newQueryWithoutRelationships')->andReturn($query = m::mock(stdClass::class));
+        $query->shouldReceive('incrementEach')->once()->with(['foo' => 1], [])->andReturn(5);
+
+        $result = $model->publicIncrementEach(['foo' => 1]);
+
+        $this->assertEquals(5, $result);
+    }
+
     public function testRelationshipTouchOwnersIsPropagated()
     {
         $relation = $this->getMockBuilder(BelongsTo::class)->onlyMethods(['touch'])->disableOriginalConstructor()->getMock();
@@ -3801,6 +3911,16 @@ class EloquentModelStub extends Model
     public function publicDecrementQuietly($column, $amount = 1, $extra = [])
     {
         return $this->decrementQuietly($column, $amount, $extra);
+    }
+
+    public function publicIncrementEach(array $columns, array $extra = [])
+    {
+        return $this->incrementEach($columns, $extra);
+    }
+
+    public function publicDecrementEach(array $columns, array $extra = [])
+    {
+        return $this->decrementEach($columns, $extra);
     }
 
     public function belongsToStub()

--- a/tests/Integration/Database/EloquentUpdateTest.php
+++ b/tests/Integration/Database/EloquentUpdateTest.php
@@ -32,6 +32,15 @@ class EloquentUpdateTest extends DatabaseTestCase
             $table->softDeletes();
             $table->timestamps();
         });
+
+        Schema::create('test_model4', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('views')->default(0);
+            $table->integer('likes')->default(0);
+            $table->string('name')->nullable();
+            $table->softDeletes();
+            $table->timestamps();
+        });
     }
 
     public function testBasicUpdate()
@@ -180,6 +189,101 @@ class EloquentUpdateTest extends DatabaseTestCase
         $this->assertSame(['counter' => 1], $model->getChanges());
         $this->assertSame(['counter' => 0], $model->getPrevious());
     }
+
+    public function testIncrementEachOnModelInstanceOnlyAffectsThatRow()
+    {
+        $post1 = TestUpdateModel4::create(['views' => 10, 'likes' => 5]);
+        $post2 = TestUpdateModel4::create(['views' => 50, 'likes' => 20]);
+        $post3 = TestUpdateModel4::create(['views' => 100, 'likes' => 40]);
+
+        $post1->incrementEach(['views' => 1, 'likes' => 2]);
+
+        $this->assertEquals(11, $post1->views);
+        $this->assertEquals(7, $post1->likes);
+
+        $this->assertEquals(50, $post2->fresh()->views);
+        $this->assertEquals(20, $post2->fresh()->likes);
+        $this->assertEquals(100, $post3->fresh()->views);
+        $this->assertEquals(40, $post3->fresh()->likes);
+    }
+
+    public function testDecrementEachOnModelInstanceOnlyAffectsThatRow()
+    {
+        $post1 = TestUpdateModel4::create(['views' => 10, 'likes' => 5]);
+        $post2 = TestUpdateModel4::create(['views' => 50, 'likes' => 20]);
+
+        $post1->decrementEach(['views' => 3, 'likes' => 2]);
+
+        $this->assertEquals(7, $post1->views);
+        $this->assertEquals(3, $post1->likes);
+
+        $this->assertEquals(50, $post2->fresh()->views);
+        $this->assertEquals(20, $post2->fresh()->likes);
+    }
+
+    public function testIncrementEachViaQueryBuilderStillAffectsAllMatchingRows()
+    {
+        TestUpdateModel4::create(['views' => 10, 'likes' => 5]);
+        TestUpdateModel4::create(['views' => 50, 'likes' => 20]);
+
+        TestUpdateModel4::incrementEach(['views' => 1]);
+
+        $models = TestUpdateModel4::orderBy('id')->get();
+        $this->assertEquals(11, $models[0]->views);
+        $this->assertEquals(51, $models[1]->views);
+    }
+
+    public function testIncrementEachOnModelInstanceUpdatesTimestamps()
+    {
+        $post = TestUpdateModel4::create(['views' => 0, 'likes' => 0]);
+        $originalUpdatedAt = $post->updated_at;
+
+        $this->travel(5)->minutes();
+
+        $post->incrementEach(['views' => 1]);
+
+        $this->assertNotEquals($originalUpdatedAt, $post->fresh()->updated_at);
+    }
+
+    public function testIncrementEachOnSoftDeletedModelIgnoresGlobalScopes()
+    {
+        $post = tap(TestUpdateModel4::create([
+            'views' => 10, 'likes' => 5,
+        ]), fn ($model) => $model->delete());
+
+        $post->incrementEach(['views' => 1, 'likes' => 1]);
+
+        $this->assertEquals(11, $post->views);
+        $this->assertEquals(6, $post->likes);
+
+        $fresh = TestUpdateModel4::withTrashed()->find($post->id);
+        $this->assertEquals(11, $fresh->views);
+        $this->assertEquals(6, $fresh->likes);
+    }
+
+    public function testIncrementEachDoesNotResetUnrelatedDirtyAttributes()
+    {
+        $post = TestUpdateModel4::create(['views' => 10, 'likes' => 5, 'name' => 'Original']);
+
+        $post->name = 'Changed';
+        $post->incrementEach(['views' => 1]);
+
+        $this->assertTrue($post->isDirty('name'));
+        $this->assertEquals('Changed', $post->name);
+        $this->assertFalse($post->isDirty('views'));
+    }
+
+    public function testIncrementEachSyncsPrevious()
+    {
+        $post = TestUpdateModel4::create(['views' => 10, 'likes' => 5]);
+
+        $post->incrementEach(['views' => 1, 'likes' => 2]);
+
+        $this->assertEquals(11, $post->views);
+        $this->assertEquals(7, $post->likes);
+        $this->assertArrayHasKey('views', $post->getChanges());
+        $this->assertArrayHasKey('likes', $post->getChanges());
+    }
 }
 
 class TestUpdateModel1 extends Model
@@ -203,5 +307,14 @@ class TestUpdateModel3 extends Model
 
     public $table = 'test_model3';
     protected $fillable = ['counter'];
+    protected $casts = ['deleted_at' => 'datetime'];
+}
+
+class TestUpdateModel4 extends Model
+{
+    use SoftDeletes;
+
+    public $table = 'test_model4';
+    protected $fillable = ['views', 'likes', 'name'];
     protected $casts = ['deleted_at' => 'datetime'];
 }


### PR DESCRIPTION
## Summary

Fixes 🟢 #57262. Also addresses 🔴 #48595, 🔴 #49009, 🔴 #52419, 🔴 #57302.

Aligns `$model->incrementEach()` and `$model->decrementEach()` behavior with `$model->increment()` and `$model->decrement()` when called on a model instance. Currently, calling `incrementEach` on an instance forwards to the base Query Builder without scoping to the model's primary key. This PR adds the Model and Builder-level methods to match the existing `increment`/`decrement` pattern.

### Before

```php
$post = Post::find(1);
$post->incrementEach(['views' => 1, 'likes' => 1]);
```

```sql
UPDATE posts SET views = views + 1, likes = likes + 1
-- All rows affected — not scoped to the model instance
```

```
| id | title        | views | likes |          | id | title        | views | likes |
|----|--------------|-------|-------|    →     |----|--------------|-------|-------|
| 1  | Hello World  | 10    | 5     |          | 1  | Hello World  | 11    | 6     |
| 2  | Laravel Tips | 50    | 20    |          | 2  | Laravel Tips | 51    | 21    | ← not intended
| 3  | PHP 8.5      | 100   | 40    |          | 3  | PHP 8.5      | 101   | 41    | ← not intended
```

### After

```php
$post = Post::find(1);
$post->incrementEach(['views' => 1, 'likes' => 1]);
```

```sql
UPDATE posts SET views = views + 1, likes = likes + 1, updated_at = '...' WHERE id = 1
-- Only the model instance is updated
```

```
| id | title        | views | likes |          | id | title        | views | likes |
|----|--------------|-------|-------|    →     |----|--------------|-------|-------|
| 1  | Hello World  | 10    | 5     |          | 1  | Hello World  | 11    | 6     | ← only this row
| 2  | Laravel Tips | 50    | 20    |          | 2  | Laravel Tips | 50    | 20    |
| 3  | PHP 8.5      | 100   | 40    |          | 3  | PHP 8.5      | 100   | 40    |
```

Query builder usage is unchanged:

```php
// Still updates all matching rows, as expected
Post::where('published', true)->incrementEach(['views' => 1]);
```

### Changes

**Model-level** (`Model.php`):
- Adds `incrementEach()`, `decrementEach()`, and `incrementOrDecrementEach()` methods mirroring the existing `incrementOrDecrement()` pattern
- Scopes query to primary key via `setKeysForSaveQuery()`
- Handles class-castable columns via `isClassDeviable()` / `deviateClassCastableAttribute()`
- Fires `updating`/`updated` model events
- Syncs in-memory attributes and uses `syncOriginalAttributes()` scoped to only the affected columns
- Non-existing models forward to query builder
- Registered in `__call()` so model instance calls are intercepted

**Builder-level** (`Builder.php`):
- Adds `incrementEach()` and `decrementEach()` that call `addUpdatedAtColumn()`
- Ensures `updated_at` is automatically set, consistent with `increment()`/`decrement()`

### Attribution

Builds on @sumaiazaman's draft ⚪ #59065.

### Test plan

**Integration tests** (7 tests in `EloquentUpdateTest.php` — real database):
- [x] `testIncrementEachOnModelInstanceOnlyAffectsThatRow` — 3 rows, only target row changes
- [x] `testDecrementEachOnModelInstanceOnlyAffectsThatRow` — 2 rows, only target row changes
- [x] `testIncrementEachViaQueryBuilderStillAffectsAllMatchingRows` — mass update unchanged
- [x] `testIncrementEachOnModelInstanceUpdatesTimestamps` — updated_at automatically set
- [x] `testIncrementEachOnSoftDeletedModelIgnoresGlobalScopes` — works on trashed models
- [x] `testIncrementEachDoesNotResetUnrelatedDirtyAttributes` — dirty name preserved after incrementing views
- [x] `testIncrementEachSyncsPrevious` — getChanges() reflects incremented columns

**Unit tests — Model** (6 tests in `DatabaseEloquentModelTest.php`):
- [x] `testIncrementEachOnExistingModelScopesQueryToModelKey` — WHERE clause + attribute sync
- [x] `testDecrementEachOnExistingModelScopesQueryToModelKey` — WHERE clause + attribute sync
- [x] `testIncrementEachWithExtraColumnsOnExistingModel` — $extra parameters propagated
- [x] `testIncrementEachFiresModelEvents` — updating/updated events fire
- [x] `testIncrementEachReturnsFalseWhenUpdatingEventCancelled` — event cancellation respected
- [x] `testIncrementEachOnNonExistingModelForwardsToQueryBuilder` — non-existing model path

**Unit tests — Builder** (3 tests in `DatabaseEloquentBuilderTest.php`):
- [x] `testIncrementEachCallsToBaseWithUpdatedAt` — updated_at automatically added
- [x] `testDecrementEachCallsToBaseWithUpdatedAt` — updated_at automatically added
- [x] `testIncrementEachWithoutTimestamps` — models without timestamps skip updated_at

### Post-merge

- [ ] Documentation PR: laravel/docs#11129 — adds `incrementEach`/`decrementEach` to the Eloquent docs (currently draft, blocked by this PR)
