### PR TITLE
[13.x] Fix dependency injection of faked queueing dispatcher

### DIFF
--- a/src/Illuminate/Bus/BusServiceProvider.php
+++ b/src/Illuminate/Bus/BusServiceProvider.php
@@ -33,7 +33,7 @@ class BusServiceProvider extends ServiceProvider implements DeferrableProvider
         );
 
         $this->app->alias(
-            Dispatcher::class, QueueingDispatcherContract::class
+            DispatcherContract::class, QueueingDispatcherContract::class
         );
     }
 


### PR DESCRIPTION
This PR aims to fix a bug where even when faked, the `QueueingDispatcher` interface resolves to the real dispatcher:

Before:

```php
Bus::fake();

app('Illuminate\Contracts\Bus\Dispatcher');         // ✅ Illuminate\Support\Testing\Fakes\BusFake
app('Illuminate\Contracts\Bus\QueueingDispatcher'); // ❌ Illuminate\Bus\Dispatcher
```

After:

```php
Bus::fake();

app('Illuminate\Contracts\Bus\Dispatcher');         // ✅ Illuminate\Support\Testing\Fakes\BusFake
app('Illuminate\Contracts\Bus\QueueingDispatcher'); // ✅ Illuminate\Support\Testing\Fakes\BusFake
```

What happens under the hood:

- `Illuminate\Contracts\Bus\Dispatcher` is an alias to `Illuminate\Bus\Dispatcher`
- `Illuminate\Contracts\Bus\QueueingDispatcher` is also an alias to `Illuminate\Bus\Dispatcher`
- The `Bus` facade represents `Illuminate\Contracts\Bus\Dispatcher`, so when its faked only that binding is replaced. This means that `Illuminate\Contracts\Bus\QueueingDispatcher` keeps resolving to the real `Illuminate\Bus\Dispatcher` (which is still bound)