### PR TITLE
 [13.x] Display memory usage in verbose queue worker output

### DIFF
--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -256,13 +256,14 @@ class WorkCommand extends Command
         }
 
         $runTime = $this->runTimeForHumans($this->latestStartedAt);
+        $memory = $isVerbose ? round(memory_get_usage(true) / 1024 / 1024, 1).'MB' : '';
 
         $dots = max(terminal()->width() - mb_strlen($job->resolveName()) - (
-            $isVerbose ? mb_strlen($job->getJobId()) + mb_strlen($job->getConnectionName()) + mb_strlen($job->getQueue()) + 2 : 0
+            $isVerbose ? mb_strlen($job->getJobId()) + mb_strlen($job->getConnectionName()) + mb_strlen($job->getQueue()) + mb_strlen($memory) + 3 : 0
         ) - mb_strlen($runTime) - 31, 0);
 
         $this->output->write(' '.str_repeat('<fg=gray>.</>', $dots));
-        $this->output->write(" <fg=gray>$runTime</>");
+        $this->output->write(" <fg=gray>{$runTime}".($memory ? " {$memory}" : '').'</>');
 
         $this->output->writeln(match ($status) {
             'success' => ' <fg=green;options=bold>DONE</>',


### PR DESCRIPTION
I currently have custom logging to get the memory usage out of Jobs, but its noisy, so I had an idea... we should just see this in verbose mode!

It feels like a natural fit when you're using verbose as it's already used for additional debugging insight


This PR adds the ability to see the memory usage, when using verbose the logic is the same as what `memoryExceeded` uses internally so you can easily see if you're close to the --memory limit etc.

Before:
```
2026-03-26 09:45:39 App\Jobs\ProcessFinancialReport 121599597 database reports  110.57ms DONE
```
After:
```
2026-03-26 09:48:33 App\Jobs\ProcessFinancialReport 121647039 database reports  44.58ms 132.5MB DONE
```

Memory is only calculated and displayed when verbose is active, so there is no impact on default output or performance.     


I can't see any tests, etc for verbose mode.. so nothing added as fairly simple PR.                                                                                                                                                                                                                                                                                 