### PR TITLE
[13.x] Fix MorphTo eager load matching when ownerKey is null and result key is a non-primitive

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -226,7 +226,7 @@ class MorphTo extends BelongsTo
     protected function matchToMorphParents($type, EloquentCollection $results)
     {
         foreach ($results as $result) {
-            $ownerKey = ! is_null($this->ownerKey) ? $this->getDictionaryKey($result->{$this->ownerKey}) : $result->getKey();
+            $ownerKey = $this->getDictionaryKey(! is_null($this->ownerKey) ? $result->{$this->ownerKey} : $result->getKey());
 
             if ($ownerKey !== null && isset($this->dictionary[$type][$ownerKey])) {
                 foreach ($this->dictionary[$type][$ownerKey] as $model) {

--- a/tests/Database/DatabaseEloquentMorphToTest.php
+++ b/tests/Database/DatabaseEloquentMorphToTest.php
@@ -3,8 +3,10 @@
 namespace Illuminate\Tests\Database;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Tests\Database\stubs\TestEnum;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -356,6 +358,38 @@ class DatabaseEloquentMorphToTest extends TestCase
         $this->assertFalse($relation->is($model));
     }
 
+    public function testMatchToMorphParentsNormalizesKeyWhenOwnerKeyIsNullAndResultKeyIsObject()
+    {
+        $uuidObject = new class
+        {
+            public function __toString(): string
+            {
+                return 'uuid-value';
+            }
+        };
+
+        $builder = m::mock(Builder::class);
+        $related = m::mock(Model::class);
+        $builder->shouldReceive('getModel')->andReturn($related);
+
+        $parent = new EloquentMorphToModelStub;
+        $parent->morph_type = 'type_1';
+        $parent->foreign_key = 'uuid-value';
+
+        $relation = Relation::noConstraints(function () use ($builder, $parent) {
+            return new EloquentMorphToAccessibleStub($builder, $parent, 'foreign_key', null, 'morph_type', 'relation');
+        });
+
+        $relation->addEagerConstraints([$parent]);
+
+        $result = m::mock(Model::class);
+        $result->shouldReceive('getKey')->once()->andReturn($uuidObject);
+
+        $relation->callMatchToMorphParents('type_1', new EloquentCollection([$result]));
+
+        $this->assertSame($result, $parent->getRelation('relation'));
+    }
+
     protected function getRelationAssociate($parent)
     {
         $builder = m::mock(Builder::class);
@@ -399,4 +433,12 @@ class EloquentMorphToModelStub extends Model
 class EloquentMorphToRelatedStub extends Model
 {
     public $table = 'eloquent_morph_to_related_stubs';
+}
+
+class EloquentMorphToAccessibleStub extends MorphTo
+{
+    public function callMatchToMorphParents($type, EloquentCollection $results): void
+    {
+        $this->matchToMorphParents($type, $results);
+    }
 }


### PR DESCRIPTION
 When eager loading a `morphTo` relation without a custom `ownerKey`, `matchToMorphParents` did not pass the result key through `getDictionaryKey()`. This meant that if `getKey()` returned a non-primitive — such as a cast value object or a backed enum — the dictionary lookup would fail silently and the relation would resolve to `null`.                                                                                                          
                                                                                                                                                                                                                                                                                                                                                                                                                                                            
  This moves `getDictionaryKey()` to wrap the full ternary so normalisation is applied consistently regardless of whether `ownerKey` is set.