### PR TITLE
[13.x] Add array value types to Support module docblocks

### DIFF
--- a/src/Illuminate/Support/Benchmark.php
+++ b/src/Illuminate/Support/Benchmark.php
@@ -12,9 +12,9 @@ class Benchmark
     /**
      * Measure a callable or array of callables over the given number of iterations.
      *
-     * @param  \Closure|array  $benchmarkables
+     * @param  \Closure|array<callable>  $benchmarkables
      * @param  int  $iterations
-     * @return array|float
+     * @return array<float|int|null>|float
      */
     public static function measure(Closure|array $benchmarkables, int $iterations = 1): array|float
     {
@@ -57,7 +57,7 @@ class Benchmark
     /**
      * Measure a callable or array of callables over the given number of iterations, then dump and die.
      *
-     * @param  \Closure|array  $benchmarkables
+     * @param  \Closure|array<callable>  $benchmarkables
      * @param  int  $iterations
      * @return never
      */

--- a/src/Illuminate/Support/BinaryCodec.php
+++ b/src/Illuminate/Support/BinaryCodec.php
@@ -78,7 +78,7 @@ class BinaryCodec
     /**
      * Get all available format names.
      *
-     * @return list<string>
+     * @return array<string>
      */
     public static function formats(): array
     {

--- a/src/Illuminate/Support/Composer.php
+++ b/src/Illuminate/Support/Composer.php
@@ -113,7 +113,7 @@ class Composer
     /**
      * Modify the "composer.json" file contents using the given callback.
      *
-     * @param  callable(array):array  $callback
+     * @param  callable(array<string, mixed>):array<string, mixed>  $callback
      * @return void
      *
      * @throws \RuntimeException
@@ -136,7 +136,7 @@ class Composer
     /**
      * Regenerate the Composer autoloader files.
      *
-     * @param  string|array  $extra
+     * @param  string|array<string>  $extra
      * @param  string|null  $composerBinary
      * @return int
      */
@@ -164,7 +164,7 @@ class Composer
      * Get the Composer binary / command for the environment.
      *
      * @param  string|null  $composerBinary
-     * @return array
+     * @return array<string>
      */
     public function findComposer($composerBinary = null)
     {
@@ -208,8 +208,8 @@ class Composer
     /**
      * Get a new Symfony process instance.
      *
-     * @param  array  $command
-     * @param  array  $env
+     * @param  array<string>  $command
+     * @param  array<string, string>  $env
      * @return \Symfony\Component\Process\Process
      */
     protected function getProcess(array $command, array $env = [])

--- a/src/Illuminate/Support/ConfigurationUrlParser.php
+++ b/src/Illuminate/Support/ConfigurationUrlParser.php
@@ -9,7 +9,7 @@ class ConfigurationUrlParser
     /**
      * The drivers aliases map.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected static $driverAliases = [
         'mssql' => 'sqlsrv',
@@ -24,8 +24,8 @@ class ConfigurationUrlParser
     /**
      * Parse the database configuration, hydrating options using a database configuration URL if possible.
      *
-     * @param  array|string  $config
-     * @return array
+     * @param  array<string, mixed>|string  $config
+     * @return array<string, mixed>
      */
     public function parseConfiguration($config)
     {
@@ -55,8 +55,8 @@ class ConfigurationUrlParser
     /**
      * Get the primary database connection options.
      *
-     * @param  array  $url
-     * @return array
+     * @param  array<string, mixed>  $url
+     * @return array<string, mixed>
      */
     protected function getPrimaryOptions($url)
     {
@@ -73,7 +73,7 @@ class ConfigurationUrlParser
     /**
      * Get the database driver from the URL.
      *
-     * @param  array  $url
+     * @param  array<string, mixed>  $url
      * @return string|null
      */
     protected function getDriver($url)
@@ -90,7 +90,7 @@ class ConfigurationUrlParser
     /**
      * Get the database name from the URL.
      *
-     * @param  array  $url
+     * @param  array<string, mixed>  $url
      * @return string|null
      */
     protected function getDatabase($url)
@@ -103,8 +103,8 @@ class ConfigurationUrlParser
     /**
      * Get all of the additional database options from the query string.
      *
-     * @param  array  $url
-     * @return array
+     * @param  array<string, mixed>  $url
+     * @return array<string, mixed>
      */
     protected function getQueryOptions($url)
     {
@@ -125,7 +125,7 @@ class ConfigurationUrlParser
      * Parse the string URL to an array of components.
      *
      * @param  string  $url
-     * @return array
+     * @return array<string, mixed>
      *
      * @throws \InvalidArgumentException
      */
@@ -170,7 +170,7 @@ class ConfigurationUrlParser
     /**
      * Get all of the current drivers' aliases.
      *
-     * @return array
+     * @return array<string, string>
      */
     public static function getDriverAliases()
     {

--- a/src/Illuminate/Support/DefaultProviders.php
+++ b/src/Illuminate/Support/DefaultProviders.php
@@ -7,12 +7,14 @@ class DefaultProviders
     /**
      * The current providers.
      *
-     * @var array
+     * @var array<class-string>
      */
     protected $providers;
 
     /**
      * Create a new default provider collection.
+     *
+     * @param  array<class-string>|null  $providers
      */
     public function __construct(?array $providers = null)
     {
@@ -46,7 +48,7 @@ class DefaultProviders
     /**
      * Merge the given providers into the provider collection.
      *
-     * @param  array  $providers
+     * @param  array<class-string>  $providers
      * @return static
      */
     public function merge(array $providers)
@@ -59,7 +61,7 @@ class DefaultProviders
     /**
      * Replace the given providers with other providers.
      *
-     * @param  array  $replacements
+     * @param  array<class-string, class-string>  $replacements
      * @return static
      */
     public function replace(array $replacements)
@@ -78,7 +80,7 @@ class DefaultProviders
     /**
      * Disable the given providers.
      *
-     * @param  array  $providers
+     * @param  array<class-string>  $providers
      * @return static
      */
     public function except(array $providers)
@@ -92,7 +94,7 @@ class DefaultProviders
     /**
      * Convert the provider collection to an array.
      *
-     * @return array
+     * @return array<class-string>
      */
     public function toArray()
     {

--- a/src/Illuminate/Support/Env.php
+++ b/src/Illuminate/Support/Env.php
@@ -120,7 +120,7 @@ class Env
     /**
      * Write an array of key-value pairs to the environment file.
      *
-     * @param  array  $variables
+     * @param  array<string, mixed>  $variables
      * @param  string  $pathToFile
      * @param  bool  $overwrite
      * @return void
@@ -178,9 +178,9 @@ class Env
      *
      * @param  string  $key
      * @param  mixed  $value
-     * @param  array  $envLines
+     * @param  array<int, string>  $envLines
      * @param  bool  $overwrite
-     * @return array
+     * @return array<int, string>
      */
     protected static function addVariableToEnvContents(string $key, mixed $value, array $envLines, bool $overwrite): array
     {
@@ -293,7 +293,7 @@ class Env
      * Escape a string using addslashes, excluding the specified characters from being escaped.
      *
      * @param  string  $value
-     * @param  array  $except
+     * @param  array<string>  $except
      * @return string
      */
     protected static function addSlashesExceptFor(string $value, array $except = [])

--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -131,7 +131,7 @@ class Fluent implements Arrayable, ArrayAccess, IteratorAggregate, Jsonable, Jso
      * Get all of the attributes from the fluent instance.
      *
      * @param  mixed  $keys
-     * @return array
+     * @return array<TKey, TValue>
      */
     public function all($keys = null)
     {

--- a/src/Illuminate/Support/Manager.php
+++ b/src/Illuminate/Support/Manager.php
@@ -25,14 +25,14 @@ abstract class Manager
     /**
      * The registered custom driver creators.
      *
-     * @var array
+     * @var array<string, \Closure>
      */
     protected $customCreators = [];
 
     /**
      * The array of created "drivers".
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected $drivers = [];
 
@@ -135,7 +135,7 @@ abstract class Manager
     /**
      * Get all of the created "drivers".
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function getDrivers()
     {
@@ -181,7 +181,7 @@ abstract class Manager
      * Dynamically call the default driver instance.
      *
      * @param  string  $method
-     * @param  array  $parameters
+     * @param  array<string, mixed>  $parameters
      * @return mixed
      */
     public function __call($method, $parameters)

--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -112,7 +112,7 @@ class MessageBag implements Jsonable, JsonSerializable, MessageBagContract, Mess
     /**
      * Determine if messages exist for all of the given keys.
      *
-     * @param  array|string|null  $key
+     * @param  array<string>|string|null  $key
      * @return bool
      */
     public function has($key)
@@ -139,7 +139,7 @@ class MessageBag implements Jsonable, JsonSerializable, MessageBagContract, Mess
     /**
      * Determine if messages exist for any of the given keys.
      *
-     * @param  array|string|null  $keys
+     * @param  array<string>|string|null  $keys
      * @return bool
      */
     public function hasAny($keys = [])
@@ -162,7 +162,7 @@ class MessageBag implements Jsonable, JsonSerializable, MessageBagContract, Mess
     /**
      * Determine if messages don't exist for all of the given keys.
      *
-     * @param  array|string|null  $key
+     * @param  array<string>|string|null  $key
      * @return bool
      */
     public function missing($key)
@@ -253,7 +253,7 @@ class MessageBag implements Jsonable, JsonSerializable, MessageBagContract, Mess
      * Get all of the unique messages for every key in the message bag.
      *
      * @param  string|null  $format
-     * @return array
+     * @return array<string>
      */
     public function unique($format = null)
     {
@@ -403,7 +403,7 @@ class MessageBag implements Jsonable, JsonSerializable, MessageBagContract, Mess
     /**
      * Get the instance as an array.
      *
-     * @return array
+     * @return array<string, array<string>>
      */
     public function toArray()
     {
@@ -413,7 +413,7 @@ class MessageBag implements Jsonable, JsonSerializable, MessageBagContract, Mess
     /**
      * Convert the object into something JSON serializable.
      *
-     * @return array
+     * @return array<string, array<string>>
      */
     public function jsonSerialize(): array
     {

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -261,7 +261,7 @@ class Number
      * @param  int|float  $number
      * @param  int  $precision
      * @param  int|null  $maxPrecision
-     * @param  array  $units
+     * @param  array<int, string>  $units
      * @return string|false
      */
     protected static function summarize(int|float $number, int $precision = 0, ?int $maxPrecision = null, array $units = [])


### PR DESCRIPTION
Adding missing generic array types in Support docblocks to improve IDE experience and PHPStan compliance. Specifies what's inside array parameters and return types so developers get better type hints. No runtime changes, pure documentation improvement across 10 files.