### PR TITLE
[13.x] Setup rector

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -24,4 +24,5 @@ docker-compose.yml export-ignore
 phpstan.src.neon.dist export-ignore
 phpstan.types.neon.dist export-ignore
 phpunit.xml.dist export-ignore
+rector.php export-ignore
 RELEASE.md export-ignore

--- a/composer.json
+++ b/composer.json
@@ -85,6 +85,7 @@
         "phpstan/phpstan": "^2.0",
         "phpunit/phpunit": "^11.5.50 || ^12.5.8 || ^13.0.3",
         "predis/predis": "^2.3 || ^3.0",
+        "rector/rector": "^2.3",
         "resend/resend-php": "^1.0",
         "symfony/cache": "^7.4.0 || ^8.0.0",
         "symfony/http-client": "^7.4.0 || ^8.0.0",

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CodingStyle\Rector\ArrowFunction\ArrowFunctionDelegatingCallToFirstClassCallableRector;
+use Rector\CodingStyle\Rector\Closure\ClosureDelegatingCallToFirstClassCallableRector;
+use Rector\CodingStyle\Rector\FuncCall\ClosureFromCallableToFirstClassCallableRector;
+use Rector\CodingStyle\Rector\FuncCall\ConsistentImplodeRector;
+use Rector\CodingStyle\Rector\FuncCall\FunctionFirstClassCallableRector;
+use Rector\Config\RectorConfig;
+use Rector\Php55\Rector\Class_\ClassConstantToSelfClassRector;
+use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
+use Rector\Php56\Rector\FuncCall\PowToExpRector;
+use Rector\Php70\Rector\FuncCall\RandomFunctionRector;
+use Rector\Php70\Rector\If_\IfToSpaceshipRector;
+use Rector\Php70\Rector\MethodCall\ThisCallOnStaticMethodToStaticCallRector;
+use Rector\Php70\Rector\StaticCall\StaticCallOnNonStaticToInstanceCallRector;
+use Rector\Php70\Rector\StmtsAwareInterface\IfIssetToCoalescingRector;
+use Rector\Php70\Rector\Ternary\TernaryToNullCoalescingRector;
+use Rector\Php71\Rector\BinaryOp\BinaryOpBetweenNumberAndStringRector;
+use Rector\Php71\Rector\FuncCall\RemoveExtraParametersRector;
+use Rector\Php74\Rector\Assign\NullCoalescingOperatorRector;
+use Rector\Php74\Rector\Closure\ClosureToArrowFunctionRector;
+use Rector\Php80\Rector\Catch_\RemoveUnusedVariableInCatchRector;
+use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
+use Rector\Php80\Rector\Class_\StringableForToStringRector;
+use Rector\Php80\Rector\ClassConstFetch\ClassOnThisVariableObjectRector;
+use Rector\Php80\Rector\FuncCall\ClassOnObjectRector;
+use Rector\Php80\Rector\Switch_\ChangeSwitchToMatchRector;
+use Rector\Php80\Rector\Ternary\GetDebugTypeRector;
+use Rector\Php81\Rector\Array_\ArrayToFirstClassCallableRector;
+use Rector\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector;
+use Rector\Php81\Rector\Property\ReadOnlyPropertyRector;
+use Rector\Php82\Rector\Class_\ReadOnlyClassRector;
+use Rector\Php83\Rector\ClassConst\AddTypeToConstRector;
+use Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector;
+use Rector\Php83\Rector\FuncCall\DynamicClassConstFetchRector;
+use Rector\TypeDeclaration\Rector\ClassMethod\ReturnNeverTypeRector;
+
+return RectorConfig::configure()
+    ->withRootFiles()
+    ->withPaths([
+        __DIR__.'/config',
+        __DIR__.'/src',
+        __DIR__.'/tests',
+        __DIR__.'/types',
+    ])
+    ->withSkip([
+        AddOverrideAttributeToOverriddenMethodsRector::class,
+        AddTypeToConstRector::class,
+        ArrayToFirstClassCallableRector::class,
+        ArrowFunctionDelegatingCallToFirstClassCallableRector::class,
+        BinaryOpBetweenNumberAndStringRector::class,
+        ChangeSwitchToMatchRector::class,
+        ClassConstantToSelfClassRector::class,
+        ClassOnObjectRector::class,
+        ClassOnThisVariableObjectRector::class,
+        ClassPropertyAssignToConstructorPromotionRector::class,
+        ClosureDelegatingCallToFirstClassCallableRector::class,
+        ClosureFromCallableToFirstClassCallableRector::class,
+        ClosureToArrowFunctionRector::class,
+        ConsistentImplodeRector::class,
+        DynamicClassConstFetchRector::class,
+        FunctionFirstClassCallableRector::class,
+        GetDebugTypeRector::class,
+        IfIssetToCoalescingRector::class,
+        IfToSpaceshipRector::class,
+        NullCoalescingOperatorRector::class,
+        NullToStrictStringFuncCallArgRector::class,
+        PowToExpRector::class,
+        RandomFunctionRector::class,
+        ReadOnlyClassRector::class,
+        ReadOnlyPropertyRector::class,
+        RemoveExtraParametersRector::class,
+        RemoveUnusedVariableInCatchRector::class,
+        ReturnNeverTypeRector::class,
+        StaticCallOnNonStaticToInstanceCallRector::class,
+        StringClassNameToClassConstantRector::class,
+        StringableForToStringRector::class,
+        TernaryToNullCoalescingRector::class,
+        ThisCallOnStaticMethodToStaticCallRector::class,
+        'tests/Foundation/fixtures/bad-syntax-strategy.php',
+    ])
+    ->withPreparedSets(
+        deadCode: false,
+        codeQuality: false,
+        codingStyle: false,
+        typeDeclarations: false,
+        typeDeclarationDocblocks: false,
+        privatization: false,
+        naming: false,
+        instanceOf: false,
+        earlyReturn: false,
+    )
+    ->withPhpSets(php83: true);


### PR DESCRIPTION
This PR sets up [Rector](https://getrector.com/) for the `laravel/framework` codebase, similar to what was done in [`laravel/mcp`](https://github.com/laravel/mcp).

By default, running `vendor/bin/rector` will **not** change any file — as many rules which are part of the level presets have been put in the `skip` array.

Maintainers can enable them one by one by removing rules from `skip` or toggling `withPreparedSets()`, making it easy to modernize the codebase step by step before a major release.

This also addresses the discussion in #59252: instead of doing replacements like `now()` → `Carbon::now()` manually, Rector can now handle this automatically. 

As @browner12 noted, avoiding helpers at the framework level brings minor performance gains, a shallower call stack, and better IDE support — and with this setup, applying such changes becomes a deliberate, repeatable process.

For instance, replacing `collect` with `new Collection` can be simply achieved using [FuncCallToNewRector](https://getrector.com/rule-detail/func-call-to-new-rector).
This allows to keep a consistant codebase with minimal effort.

Having this rector configuration at disposal allows to skip many PR which are solely focused on keeping the codebase consistant.

---

Once merged, a good example would be to remove `IfToSpaceshipRector::class,` from the skip array, run `vendor/bin/rector` et voilà 