### PR TITLE
[13.x] Respect SQS redrive policy for native dead letter queue routing

### DIFF
--- a/src/Illuminate/Queue/Jobs/SqsJob.php
+++ b/src/Illuminate/Queue/Jobs/SqsJob.php
@@ -23,6 +23,13 @@ class SqsJob extends Job implements JobContract
     protected $job;
 
     /**
+     * The SQS queue's redrive policy.
+     *
+     * @var array|null
+     */
+    protected $redrivePolicy;
+
+    /**
      * Create a new job instance.
      *
      * @param  \Illuminate\Container\Container  $container
@@ -30,14 +37,16 @@ class SqsJob extends Job implements JobContract
      * @param  array  $job
      * @param  string  $connectionName
      * @param  string  $queue
+     * @param  array|null  $redrivePolicy
      */
-    public function __construct(Container $container, SqsClient $sqs, array $job, $connectionName, $queue)
+    public function __construct(Container $container, SqsClient $sqs, array $job, $connectionName, $queue, $redrivePolicy = null)
     {
         $this->sqs = $sqs;
         $this->job = $job;
         $this->queue = $queue;
         $this->container = $container;
         $this->connectionName = $connectionName;
+        $this->redrivePolicy = $redrivePolicy;
     }
 
     /**
@@ -66,9 +75,39 @@ class SqsJob extends Job implements JobContract
     {
         parent::delete();
 
-        $this->sqs->deleteMessage([
-            'QueueUrl' => $this->queue, 'ReceiptHandle' => $this->job['ReceiptHandle'],
-        ]);
+        if ($this->shouldDeleteFromSqs()) {
+            $this->sqs->deleteMessage([
+                'QueueUrl' => $this->queue, 'ReceiptHandle' => $this->job['ReceiptHandle'],
+            ]);
+        }
+    }
+
+    /**
+     * Determine if the job should be deleted from SQS.
+     *
+     * @return bool
+     */
+    protected function shouldDeleteFromSqs()
+    {
+        if ($this->hasFailed() && ! is_null($this->redrivePolicy)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Get the number of times the job may be attempted.
+     *
+     * @return int|null
+     */
+    public function maxTries()
+    {
+        if (! is_null($this->redrivePolicy)) {
+            return (int) $this->redrivePolicy['maxReceiveCount'];
+        }
+
+        return parent::maxTries();
     }
 
     /**

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -39,6 +39,13 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
     protected $suffix;
 
     /**
+     * The cached redrive policies for each queue URL.
+     *
+     * @var array<string, array|null>
+     */
+    protected $redrivePolicy = [];
+
+    /**
      * Create a new Amazon SQS queue instance.
      *
      * @param  \Aws\Sqs\SqsClient  $sqs
@@ -302,9 +309,33 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
         if (! is_null($response['Messages']) && count($response['Messages']) > 0) {
             return new SqsJob(
                 $this->container, $this->sqs, $response['Messages'][0],
-                $this->connectionName, $queue
+                $this->connectionName, $queue, $this->redrivePolicy($queue)
             );
         }
+    }
+
+    /**
+     * Get the redrive policy for the given queue.
+     *
+     * @param  string|null  $queue
+     * @return array|null
+     */
+    public function redrivePolicy($queue = null)
+    {
+        $queueUrl = $this->getQueue($queue);
+
+        if (! array_key_exists($queueUrl, $this->redrivePolicy)) {
+            $response = $this->sqs->getQueueAttributes([
+                'QueueUrl' => $queueUrl,
+                'AttributeNames' => ['RedrivePolicy'],
+            ]);
+
+            $this->redrivePolicy[$queueUrl] = isset($response['Attributes']['RedrivePolicy'])
+                ? json_decode($response['Attributes']['RedrivePolicy'], true)
+                : null;
+        }
+
+        return $this->redrivePolicy[$queueUrl];
     }
 
     /**


### PR DESCRIPTION
## Summary
- Detect SQS redrive policy and skip message deletion on failure
- Align Laravel retry count with SQS maxReceiveCount
- Cache redrive policy per queue URL