### PR TITLE
[13.x] Change InteractsWithData::string() to return native string

### DIFF
--- a/src/Illuminate/Support/Traits/InteractsWithData.php
+++ b/src/Illuminate/Support/Traits/InteractsWithData.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Number;
 use Illuminate\Support\Str;
+use InvalidArgumentException;
 use stdClass;
 
 use function Illuminate\Support\enum_value;
@@ -234,19 +235,27 @@ trait InteractsWithData
      */
     public function str($key, $default = null)
     {
-        return $this->string($key, $default);
+        return Str::of($this->data($key, $default));
     }
 
     /**
-     * Retrieve data from the instance as a Stringable instance.
+     * Retrieve data from the instance as a string.
      *
      * @param  string  $key
      * @param  mixed  $default
-     * @return \Illuminate\Support\Stringable
+     * @return string
      */
-    public function string($key, $default = null)
+    public function string($key, $default = null): string
     {
-        return Str::of($this->data($key, $default));
+        $value = $this->data($key, $default);
+
+        if (! is_scalar($value) && ! is_null($value)) {
+            throw new InvalidArgumentException(
+                sprintf('Data value for key [%s] must be a scalar type or null, [%s] given.', $key, get_debug_type($value))
+            );
+        }
+
+        return (string) $value;
     }
 
     /**

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -639,17 +639,17 @@ class HttpRequestTest extends TestCase
             'empty_str' => '',
             'null' => null,
         ]);
-        $this->assertTrue($request->string('int') instanceof Stringable);
-        $this->assertTrue($request->string('unknown_key') instanceof Stringable);
-        $this->assertSame('123', $request->string('int')->value());
-        $this->assertSame('456', $request->string('int_str')->value());
-        $this->assertSame('123.456', $request->string('float')->value());
-        $this->assertSame('123.456', $request->string('float_str')->value());
-        $this->assertSame('0', $request->string('float_zero')->value());
-        $this->assertSame('0.000', $request->string('float_str_zero')->value());
-        $this->assertSame('', $request->string('empty_str')->value());
-        $this->assertSame('', $request->string('null')->value());
-        $this->assertSame('', $request->string('unknown_key')->value());
+        $this->assertIsString($request->string('int'));
+        $this->assertIsString($request->string('unknown_key'));
+        $this->assertSame('123', $request->string('int'));
+        $this->assertSame('456', $request->string('int_str'));
+        $this->assertSame('123.456', $request->string('float'));
+        $this->assertSame('123.456', $request->string('float_str'));
+        $this->assertSame('0', $request->string('float_zero'));
+        $this->assertSame('0.000', $request->string('float_str_zero'));
+        $this->assertSame('', $request->string('empty_str'));
+        $this->assertSame('', $request->string('null'));
+        $this->assertSame('', $request->string('unknown_key'));
     }
 
     public function testBooleanMethod()

--- a/tests/Support/SupportFluentTest.php
+++ b/tests/Support/SupportFluentTest.php
@@ -181,17 +181,17 @@ class SupportFluentTest extends TestCase
             'empty_str' => '',
             'null' => null,
         ]);
-        $this->assertTrue($fluent->string('int') instanceof Stringable);
-        $this->assertTrue($fluent->string('unknown_key') instanceof Stringable);
-        $this->assertSame('123', $fluent->string('int')->value());
-        $this->assertSame('456', $fluent->string('int_str')->value());
-        $this->assertSame('123.456', $fluent->string('float')->value());
-        $this->assertSame('123.456', $fluent->string('float_str')->value());
-        $this->assertSame('0', $fluent->string('float_zero')->value());
-        $this->assertSame('0.000', $fluent->string('float_str_zero')->value());
-        $this->assertSame('', $fluent->string('empty_str')->value());
-        $this->assertSame('', $fluent->string('null')->value());
-        $this->assertSame('', $fluent->string('unknown_key')->value());
+        $this->assertIsString($fluent->string('int'));
+        $this->assertIsString($fluent->string('unknown_key'));
+        $this->assertSame('123', $fluent->string('int'));
+        $this->assertSame('456', $fluent->string('int_str'));
+        $this->assertSame('123.456', $fluent->string('float'));
+        $this->assertSame('123.456', $fluent->string('float_str'));
+        $this->assertSame('0', $fluent->string('float_zero'));
+        $this->assertSame('0.000', $fluent->string('float_str_zero'));
+        $this->assertSame('', $fluent->string('empty_str'));
+        $this->assertSame('', $fluent->string('null'));
+        $this->assertSame('', $fluent->string('unknown_key'));
     }
 
     public function testBooleanMethod()

--- a/tests/Support/ValidatedInputTest.php
+++ b/tests/Support/ValidatedInputTest.php
@@ -352,18 +352,18 @@ class ValidatedInputTest extends TestCase
             'null' => null,
         ]);
 
-        $this->assertTrue($input->string('int') instanceof Stringable);
-        $this->assertTrue($input->string('int') instanceof Stringable);
-        $this->assertTrue($input->string('unknown_key') instanceof Stringable);
-        $this->assertSame('123', $input->string('int')->value());
-        $this->assertSame('456', $input->string('int_str')->value());
-        $this->assertSame('123.456', $input->string('float')->value());
-        $this->assertSame('123.456', $input->string('float_str')->value());
-        $this->assertSame('0', $input->string('float_zero')->value());
-        $this->assertSame('0.000', $input->string('float_str_zero')->value());
-        $this->assertSame('', $input->string('empty_str')->value());
-        $this->assertSame('', $input->string('null')->value());
-        $this->assertSame('', $input->string('unknown_key')->value());
+        $this->assertIsString($input->string('int'));
+        $this->assertIsString($input->string('int'));
+        $this->assertIsString($input->string('unknown_key'));
+        $this->assertSame('123', $input->string('int'));
+        $this->assertSame('456', $input->string('int_str'));
+        $this->assertSame('123.456', $input->string('float'));
+        $this->assertSame('123.456', $input->string('float_str'));
+        $this->assertSame('0', $input->string('float_zero'));
+        $this->assertSame('0.000', $input->string('float_str_zero'));
+        $this->assertSame('', $input->string('empty_str'));
+        $this->assertSame('', $input->string('null'));
+        $this->assertSame('', $input->string('unknown_key'));
     }
 
     public function test_boolean_method()

--- a/tests/View/ViewComponentAttributeBagTest.php
+++ b/tests/View/ViewComponentAttributeBagTest.php
@@ -346,11 +346,11 @@ class ViewComponentAttributeBagTest extends TestCase
             'number' => 123,
         ]);
 
-        $this->assertInstanceOf(\Illuminate\Support\Stringable::class, $bag->string('name'));
-        $this->assertEquals('test', (string) $bag->string('name'));
-        $this->assertEquals('', (string) $bag->string('empty'));
-        $this->assertEquals('123', (string) $bag->string('number'));
-        $this->assertEquals('default', (string) $bag->string('missing', 'default'));
+        $this->assertIsString($bag->string('name'));
+        $this->assertEquals('test', $bag->string('name'));
+        $this->assertEquals('', $bag->string('empty'));
+        $this->assertEquals('123', $bag->string('number'));
+        $this->assertEquals('default', $bag->string('missing', 'default'));
     }
 
     public function testBoolean()


### PR DESCRIPTION
## Summary
- `string()` now returns native PHP `string` instead of `Stringable`
- `str()` retains `Stringable` return type for fluent string operations
- Aligns with `Config\Repository::string()` behavior