### PR TITLE
[13.x] Add enum support to QueueManager connection methods

### DIFF
--- a/src/Illuminate/Contracts/Queue/Factory.php
+++ b/src/Illuminate/Contracts/Queue/Factory.php
@@ -7,7 +7,7 @@ interface Factory
     /**
      * Resolve a queue connection instance.
      *
-     * @param  string|null  $name
+     * @param  \UnitEnum|string|null  $name
      * @return \Illuminate\Contracts\Queue\Queue
      */
     public function connection($name = null);

--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -8,6 +8,8 @@ use Illuminate\Contracts\Queue\Monitor as MonitorContract;
 use Illuminate\Support\Queue\Concerns\ResolvesQueueRoutes;
 use InvalidArgumentException;
 
+use function Illuminate\Support\enum_value;
+
 /**
  * @mixin \Illuminate\Contracts\Queue\Queue
  */
@@ -139,23 +141,23 @@ class QueueManager implements FactoryContract, MonitorContract
     /**
      * Determine if the driver is connected.
      *
-     * @param  string|null  $name
+     * @param  \UnitEnum|string|null  $name
      * @return bool
      */
     public function connected($name = null)
     {
-        return isset($this->connections[$name ?: $this->getDefaultDriver()]);
+        return isset($this->connections[enum_value($name) ?: $this->getDefaultDriver()]);
     }
 
     /**
      * Resolve a queue connection instance.
      *
-     * @param  string|null  $name
+     * @param  \UnitEnum|string|null  $name
      * @return \Illuminate\Contracts\Queue\Queue
      */
     public function connection($name = null)
     {
-        $name = $name ?: $this->getDefaultDriver();
+        $name = enum_value($name) ?: $this->getDefaultDriver();
 
         // If the connection has not been resolved yet we will resolve it now as all
         // of the connections are resolved when they are actually needed so we do

--- a/tests/Queue/QueueManagerTest.php
+++ b/tests/Queue/QueueManagerTest.php
@@ -77,4 +77,57 @@ class QueueManagerTest extends TestCase
 
         $this->assertSame($queue, $manager->connection('null'));
     }
+
+    public function testEnumConnectionCanBeResolved()
+    {
+        $app = [
+            'config' => [
+                'queue.default' => 'sync',
+                'queue.connections.sync' => ['driver' => 'sync'],
+            ],
+            'encrypter' => $encrypter = m::mock(Encrypter::class),
+        ];
+
+        $manager = new QueueManager($app);
+        $connector = m::mock(stdClass::class);
+        $queue = m::mock(stdClass::class);
+        $queue->shouldReceive('setConnectionName')->once()->with('sync')->andReturnSelf();
+        $connector->shouldReceive('connect')->once()->with(['driver' => 'sync'])->andReturn($queue);
+        $manager->addConnector('sync', function () use ($connector) {
+            return $connector;
+        });
+        $queue->shouldReceive('setContainer')->once()->with($app);
+
+        $this->assertSame($queue, $manager->connection(QueueConnectionName::Sync));
+    }
+
+    public function testEnumConnectionCanBeChecked()
+    {
+        $app = [
+            'config' => [
+                'queue.default' => 'sync',
+                'queue.connections.sync' => ['driver' => 'sync'],
+            ],
+            'encrypter' => $encrypter = m::mock(Encrypter::class),
+        ];
+
+        $manager = new QueueManager($app);
+        $connector = m::mock(stdClass::class);
+        $queue = m::mock(stdClass::class);
+        $queue->shouldReceive('setConnectionName')->once()->with('sync')->andReturnSelf();
+        $connector->shouldReceive('connect')->once()->with(['driver' => 'sync'])->andReturn($queue);
+        $manager->addConnector('sync', function () use ($connector) {
+            return $connector;
+        });
+        $queue->shouldReceive('setContainer')->once()->with($app);
+
+        $this->assertFalse($manager->connected(QueueConnectionName::Sync));
+        $manager->connection(QueueConnectionName::Sync);
+        $this->assertTrue($manager->connected(QueueConnectionName::Sync));
+    }
+}
+
+enum QueueConnectionName: string
+{
+    case Sync = 'sync';
 }


### PR DESCRIPTION
## Summary

This PR adds enum support to `QueueManager::connection()` and `QueueManager::connected()` methods using the `enum_value()` helper, aligning it with other manager classes that already support this pattern.

### Problem

Several manager classes in the framework already accept enums for connection/driver names:

| Manager | Supports Enums |
|---|---|
| `DatabaseManager::connection()` | ✅ Yes |
| `FilesystemManager::disk()` | ✅ Yes |
| `RedisManager::connection()` | ✅ Yes |
| **`QueueManager::connection()`** | ❌ **No** |

This inconsistency means users who define connection names as enums (a common pattern for type safety) cannot pass them directly to `Queue::connection()` like they can with `DB::connection()` or `Storage::disk()`.

### Solution

- Added `enum_value()` call in `QueueManager::connection()` and `QueueManager::connected()`
- Updated `@param` docblocks to accept `\UnitEnum|string|null`
- Updated the `Illuminate\Contracts\Queue\Factory` contract docblock accordingly

### Example

```php
enum QueueConnection: string
{
    case Redis = 'redis';
    case Sqs = 'sqs';
}

// Before: TypeError
Queue::connection(QueueConnection::Redis);

// After: Works as expected
Queue::connection(QueueConnection::Redis); // resolves to 'redis'
```

### Changes

- `src/Illuminate/Queue/QueueManager.php` — Added `enum_value()` to `connection()` and `connected()`
- `src/Illuminate/Contracts/Queue/Factory.php` — Updated docblock
- `tests/Queue/QueueManagerTest.php` — Added 2 test cases

## Test Plan

- [x] `testEnumConnectionCanBeResolved` — Verifies enum resolves to correct queue connection
- [x] `testEnumConnectionCanBeChecked` — Verifies `connected()` works with enum before and after resolution
- [x] Existing tests still pass (no breaking changes)