### PR TITLE
[13.x] Respect SQS redrive policy for native dead letter queue routing

### DIFF
--- a/src/Illuminate/Queue/Jobs/SqsJob.php
+++ b/src/Illuminate/Queue/Jobs/SqsJob.php
@@ -23,6 +23,13 @@ class SqsJob extends Job implements JobContract
     protected $job;
 
     /**
+     * The SQS queue's redrive policy.
+     *
+     * @var array|null
+     */
+    protected $redrivePolicy;
+
+    /**
      * Create a new job instance.
      *
      * @param  \Illuminate\Container\Container  $container
@@ -30,14 +37,16 @@ class SqsJob extends Job implements JobContract
      * @param  array  $job
      * @param  string  $connectionName
      * @param  string  $queue
+     * @param  array|null  $redrivePolicy
      */
-    public function __construct(Container $container, SqsClient $sqs, array $job, $connectionName, $queue)
+    public function __construct(Container $container, SqsClient $sqs, array $job, $connectionName, $queue, $redrivePolicy = null)
     {
         $this->sqs = $sqs;
         $this->job = $job;
         $this->queue = $queue;
         $this->container = $container;
         $this->connectionName = $connectionName;
+        $this->redrivePolicy = $redrivePolicy;
     }
 
     /**
@@ -66,9 +75,25 @@ class SqsJob extends Job implements JobContract
     {
         parent::delete();
 
-        $this->sqs->deleteMessage([
-            'QueueUrl' => $this->queue, 'ReceiptHandle' => $this->job['ReceiptHandle'],
-        ]);
+        if (! $this->hasFailed() || is_null($this->redrivePolicy)) {
+            $this->sqs->deleteMessage([
+                'QueueUrl' => $this->queue, 'ReceiptHandle' => $this->job['ReceiptHandle'],
+            ]);
+        }
+    }
+
+    /**
+     * Get the number of times the job may be attempted.
+     *
+     * @return int|null
+     */
+    public function maxTries()
+    {
+        if (! is_null($this->redrivePolicy)) {
+            return (int) $this->redrivePolicy['maxReceiveCount'];
+        }
+
+        return parent::maxTries();
     }
 
     /**

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -39,6 +39,13 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
     protected $suffix;
 
     /**
+     * The cached redrive policies for each queue URL.
+     *
+     * @var array<string, array|null>
+     */
+    protected $redrivePolicies = [];
+
+    /**
      * Create a new Amazon SQS queue instance.
      *
      * @param  \Aws\Sqs\SqsClient  $sqs
@@ -302,9 +309,33 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
         if (! is_null($response['Messages']) && count($response['Messages']) > 0) {
             return new SqsJob(
                 $this->container, $this->sqs, $response['Messages'][0],
-                $this->connectionName, $queue
+                $this->connectionName, $queue, $this->redrivePolicy($queue)
             );
         }
+    }
+
+    /**
+     * Get the redrive policy for the given queue.
+     *
+     * @param  string|null  $queue
+     * @return array|null
+     */
+    public function redrivePolicy($queue = null)
+    {
+        $queueUrl = $this->getQueue($queue);
+
+        if (! array_key_exists($queueUrl, $this->redrivePolicies)) {
+            $response = $this->sqs->getQueueAttributes([
+                'QueueUrl' => $queueUrl,
+                'AttributeNames' => ['RedrivePolicy'],
+            ]);
+
+            $this->redrivePolicies[$queueUrl] = isset($response['Attributes']['RedrivePolicy'])
+                ? json_decode($response['Attributes']['RedrivePolicy'], true)
+                : null;
+        }
+
+        return $this->redrivePolicies[$queueUrl];
     }
 
     /**

--- a/tests/Queue/QueueSqsJobTest.php
+++ b/tests/Queue/QueueSqsJobTest.php
@@ -83,6 +83,44 @@ class QueueSqsJobTest extends TestCase
         $job->delete();
     }
 
+    public function testDeleteRemovesNonFailedJobFromSqsWhenRedriveExists()
+    {
+        $redrivePolicy = ['maxReceiveCount' => 5, 'deadLetterTargetArn' => 'arn:aws:sqs:us-east-1:123456789:dlq'];
+        $job = $this->getJobWithRedrivePolicy($redrivePolicy);
+        $job->getSqs()->shouldReceive('deleteMessage')->once()->with(['QueueUrl' => $this->queueUrl, 'ReceiptHandle' => $this->mockedReceiptHandle]);
+        $job->delete();
+    }
+
+    public function testDeleteSkipsSqsDeletionWhenFailedJobHasRedrivePolicy()
+    {
+        $redrivePolicy = ['maxReceiveCount' => 5, 'deadLetterTargetArn' => 'arn:aws:sqs:us-east-1:123456789:dlq'];
+        $job = $this->getJobWithRedrivePolicy($redrivePolicy);
+        $job->markAsFailed();
+        $job->getSqs()->shouldNotReceive('deleteMessage');
+        $job->delete();
+    }
+
+    public function testDeleteRemovesFailedJobFromSqsWhenNoRedrivePolicy()
+    {
+        $job = $this->getJob();
+        $job->markAsFailed();
+        $job->getSqs()->shouldReceive('deleteMessage')->once()->with(['QueueUrl' => $this->queueUrl, 'ReceiptHandle' => $this->mockedReceiptHandle]);
+        $job->delete();
+    }
+
+    public function testMaxTriesReturnsRedriveMaxReceiveCount()
+    {
+        $redrivePolicy = ['maxReceiveCount' => 3, 'deadLetterTargetArn' => 'arn:aws:sqs:us-east-1:123456789:dlq'];
+        $job = $this->getJobWithRedrivePolicy($redrivePolicy);
+        $this->assertEquals(3, $job->maxTries());
+    }
+
+    public function testMaxTriesFallsBackToPayloadWithoutRedrivePolicy()
+    {
+        $job = $this->getJob();
+        $this->assertNull($job->maxTries());
+    }
+
     public function testReleaseProperlyReleasesTheJobOntoSqs()
     {
         $this->mockedSqsClient = m::mock(SqsClient::class)->makePartial();
@@ -102,6 +140,18 @@ class QueueSqsJobTest extends TestCase
             $this->mockedJobData,
             'connection-name',
             $this->queueUrl
+        );
+    }
+
+    protected function getJobWithRedrivePolicy(array $redrivePolicy)
+    {
+        return new SqsJob(
+            $this->mockedContainer,
+            $this->mockedSqsClient,
+            $this->mockedJobData,
+            'connection-name',
+            $this->queueUrl,
+            $redrivePolicy
         );
     }
 }

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -676,4 +676,60 @@ class QueueSqsQueueTest extends TestCase
 
         Str::createUuidsNormally();
     }
+
+    public function testRedrivePolicyIsFetchedAndCached()
+    {
+        $redrivePolicy = json_encode(['maxReceiveCount' => 5, 'deadLetterTargetArn' => 'arn:aws:sqs:us-east-1:123456789:dlq']);
+
+        $this->sqs->shouldReceive('getQueueAttributes')->once()->with([
+            'QueueUrl' => $this->queueUrl,
+            'AttributeNames' => ['RedrivePolicy'],
+        ])->andReturn(new Result([
+            'Attributes' => ['RedrivePolicy' => $redrivePolicy],
+        ]));
+
+        $queue = new SqsQueue($this->sqs, $this->queueName, $this->prefix);
+
+        $result = $queue->redrivePolicy($this->queueName);
+        $this->assertEquals(['maxReceiveCount' => 5, 'deadLetterTargetArn' => 'arn:aws:sqs:us-east-1:123456789:dlq'], $result);
+
+        // Second call should use cache, not make another API call.
+        $cachedResult = $queue->redrivePolicy($this->queueName);
+        $this->assertEquals($result, $cachedResult);
+    }
+
+    public function testRedrivePolicyReturnsNullWhenNotConfigured()
+    {
+        $this->sqs->shouldReceive('getQueueAttributes')->once()->with([
+            'QueueUrl' => $this->queueUrl,
+            'AttributeNames' => ['RedrivePolicy'],
+        ])->andReturn(new Result([
+            'Attributes' => [],
+        ]));
+
+        $queue = new SqsQueue($this->sqs, $this->queueName, $this->prefix);
+
+        $this->assertNull($queue->redrivePolicy($this->queueName));
+    }
+
+    public function testPopPassesRedrivePolicyToSqsJob()
+    {
+        $redrivePolicy = json_encode(['maxReceiveCount' => 3, 'deadLetterTargetArn' => 'arn:aws:sqs:us-east-1:123456789:dlq']);
+
+        $this->sqs->shouldReceive('receiveMessage')->once()->andReturn($this->mockedReceiveMessageResponseModel);
+        $this->sqs->shouldReceive('getQueueAttributes')->once()->with([
+            'QueueUrl' => $this->queueUrl,
+            'AttributeNames' => ['RedrivePolicy'],
+        ])->andReturn(new Result([
+            'Attributes' => ['RedrivePolicy' => $redrivePolicy],
+        ]));
+
+        $queue = new SqsQueue($this->sqs, $this->queueName, $this->prefix);
+        $queue->setContainer(m::mock(Container::class));
+
+        $job = $queue->pop();
+
+        $this->assertInstanceOf(SqsJob::class, $job);
+        $this->assertEquals(3, $job->maxTries());
+    }
 }


### PR DESCRIPTION
## Summary

When an SQS queue has a [redrive policy](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-dead-letter-queues.html) (dead letter queue) configured, Laravel currently deletes failed jobs from SQS immediately — bypassing SQS's native dead letter queue routing entirely. This PR fixes that by detecting the redrive policy and skipping message deletion on failure, allowing SQS to handle the routing natively.

### The Problem

AWS SQS has built-in support for dead letter queues (DLQ) via redrive policies. When a message exceeds `maxReceiveCount`, SQS automatically moves it to the configured DLQ. However, Laravel's `SqsJob::delete()` always calls `deleteMessage` — even for failed jobs. This means:

1. **Failed jobs are deleted from SQS** before SQS can route them to the DLQ
2. **Developers must manually implement DLQ logic** in Laravel instead of relying on AWS's native, battle-tested mechanism
3. **`maxReceiveCount` is ignored** — Laravel uses its own retry count from the job payload, which can conflict with the SQS-configured value

This is a common pain point for teams running Laravel on AWS infrastructure who want to use SQS's native DLQ features.

### The Solution

**`SqsJob`:**
- On `delete()`: if the job has failed **and** a redrive policy exists, skip the `deleteMessage` API call — let SQS handle routing to the DLQ
- On `maxTries()`: when a redrive policy exists, return `maxReceiveCount` from the policy so Laravel's retry count aligns with SQS's expectation
- Non-failed jobs are always deleted normally (no behavior change)
- Jobs without a redrive policy behave exactly as before (no behavior change)

**`SqsQueue`:**
- New `redrivePolicy()` method fetches and caches the redrive policy per queue URL via `getQueueAttributes` API
- The policy is passed to `SqsJob` on `pop()`
- Caching ensures only one API call per queue URL per worker lifecycle

### Why This Doesn't Break Existing Features

- **Fully backward compatible**: the new `$redrivePolicy` parameter defaults to `null`, and all existing behavior is preserved when no redrive policy is configured
- **No change for queues without DLQ**: if a queue has no redrive policy, `redrivePolicy()` returns `null` and all code paths remain unchanged
- **Non-failed jobs unaffected**: the deletion skip only applies when `hasFailed()` is true AND a redrive policy exists
- **Existing constructor calls work**: the new parameter is optional with a `null` default

### Benefit to End Users

- **Zero-config DLQ support**: developers using SQS with a redrive policy get native DLQ routing without any Laravel-side configuration
- **Eliminates a common workaround**: no more custom failed job handlers or event listeners to prevent message deletion
- **Consistent retry behavior**: `maxTries` automatically aligns with SQS `maxReceiveCount`, preventing confusing mismatches
- **Production-safe**: relies on AWS's native, well-tested DLQ mechanism rather than application-level reimplementation

### Example

```php
// AWS SQS queue configured with:
// - maxReceiveCount: 3
// - deadLetterTargetArn: arn:aws:sqs:us-east-1:123456789:my-dlq

// Before this PR:
// - Job fails → Laravel deletes from SQS → message lost, never reaches DLQ
// - Developers must add custom logic to prevent this

// After this PR:
// - Job fails → Laravel skips deletion → SQS increments receive count
// - After 3 receives, SQS automatically moves message to DLQ
// - maxTries() returns 3 (from redrive policy), keeping Laravel in sync
```

### Changes

- `src/Illuminate/Queue/Jobs/SqsJob.php` — Skip deletion for failed jobs with redrive policy; override `maxTries()` with `maxReceiveCount`
- `src/Illuminate/Queue/SqsQueue.php` — Add `redrivePolicy()` method with per-URL caching; pass policy to `SqsJob` on `pop()`
- `tests/Queue/QueueSqsJobTest.php` — 5 new tests covering deletion behavior and `maxTries` with/without redrive policy
- `tests/Queue/QueueSqsQueueTest.php` — 3 new tests covering policy fetching, caching, and propagation to job

## Test Plan

- [x] `testDeleteRemovesNonFailedJobFromSqsWhenRedriveExists` — non-failed job is still deleted normally
- [x] `testDeleteSkipsSqsDeletionWhenFailedJobHasRedrivePolicy` — failed job is NOT deleted when redrive policy exists
- [x] `testDeleteRemovesFailedJobFromSqsWhenNoRedrivePolicy` — failed job IS deleted when no redrive policy
- [x] `testMaxTriesReturnsRedriveMaxReceiveCount` — maxTries returns redrive maxReceiveCount
- [x] `testMaxTriesFallsBackToPayloadWithoutRedrivePolicy` — maxTries falls back to payload when no redrive policy
- [x] `testRedrivePolicyIsFetchedAndCached` — policy is fetched once and cached on subsequent calls
- [x] `testRedrivePolicyReturnsNullWhenNotConfigured` — returns null when queue has no redrive policy
- [x] `testPopPassesRedrivePolicyToSqsJob` — pop() passes the redrive policy to the SqsJob instance