### PR TITLE
[13.x] Add enum support to LogManager channel and driver methods

### DIFF
--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -7,6 +7,8 @@ use Illuminate\Contracts\Log\ContextLogProcessor;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
+
+use function Illuminate\Support\enum_value;
 use Monolog\Formatter\LineFormatter;
 use Monolog\Handler\ErrorLogHandler;
 use Monolog\Handler\FingersCrossedHandler;
@@ -106,7 +108,7 @@ class LogManager implements LoggerInterface
     /**
      * Get a log channel instance.
      *
-     * @param  string|null  $channel
+     * @param  \UnitEnum|string|null  $channel
      * @return \Psr\Log\LoggerInterface
      */
     public function channel($channel = null)
@@ -117,12 +119,12 @@ class LogManager implements LoggerInterface
     /**
      * Get a log driver instance.
      *
-     * @param  string|null  $driver
+     * @param  \UnitEnum|string|null  $driver
      * @return \Psr\Log\LoggerInterface
      */
     public function driver($driver = null)
     {
-        return $this->get($this->parseDriver($driver));
+        return $this->get($this->parseDriver(enum_value($driver)));
     }
 
     /**

--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -7,8 +7,6 @@ use Illuminate\Contracts\Log\ContextLogProcessor;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
-
-use function Illuminate\Support\enum_value;
 use Monolog\Formatter\LineFormatter;
 use Monolog\Handler\ErrorLogHandler;
 use Monolog\Handler\FingersCrossedHandler;
@@ -24,6 +22,8 @@ use Monolog\Processor\ProcessorInterface;
 use Monolog\Processor\PsrLogMessageProcessor;
 use Psr\Log\LoggerInterface;
 use Throwable;
+
+use function Illuminate\Support\enum_value;
 
 /**
  * @mixin \Illuminate\Log\Logger

--- a/src/Illuminate/Support/Facades/Log.php
+++ b/src/Illuminate/Support/Facades/Log.php
@@ -5,8 +5,8 @@ namespace Illuminate\Support\Facades;
 /**
  * @method static \Psr\Log\LoggerInterface build(array $config)
  * @method static \Psr\Log\LoggerInterface stack(array $channels, string|null $channel = null)
- * @method static \Psr\Log\LoggerInterface channel(string|null $channel = null)
- * @method static \Psr\Log\LoggerInterface driver(string|null $driver = null)
+ * @method static \Psr\Log\LoggerInterface channel(\UnitEnum|string|null $channel = null)
+ * @method static \Psr\Log\LoggerInterface driver(\UnitEnum|string|null $driver = null)
  * @method static \Illuminate\Log\LogManager shareContext(array $context)
  * @method static array sharedContext()
  * @method static \Illuminate\Log\LogManager withoutContext(string[]|null $keys = null)

--- a/tests/Log/LogManagerTest.php
+++ b/tests/Log/LogManagerTest.php
@@ -764,6 +764,26 @@ class LogManagerTest extends TestCase
         $manager->extend(__CLASS__, fn () => $this);
         $this->assertSame($manager, $manager->channel(__CLASS__)->getLogger());
     }
+
+    public function testLogManagerCanResolveBackedEnumChannel()
+    {
+        $manager = new LogManager($this->app);
+
+        $logger1 = $manager->channel(LogChannelName::Single);
+        $logger2 = $manager->channel('single');
+
+        $this->assertSame($logger1, $logger2);
+    }
+
+    public function testLogManagerCanResolveBackedEnumDriver()
+    {
+        $manager = new LogManager($this->app);
+
+        $logger1 = $manager->driver(LogChannelName::Single);
+        $logger2 = $manager->driver('single');
+
+        $this->assertSame($logger1, $logger2);
+    }
 }
 
 class CustomizeFormatter
@@ -792,4 +812,9 @@ class LoggerSpy implements LoggerInterface
             'context' => $context,
         ];
     }
+}
+
+enum LogChannelName: string
+{
+    case Single = 'single';
 }


### PR DESCRIPTION
## Summary

This PR adds enum support to `LogManager::channel()` and `LogManager::driver()` methods using the `enum_value()` helper, aligning it with other manager classes that already support this pattern.

### Context

Several manager classes already accept enums for connection/driver names:

| Manager | Supports Enums |
|---|---|
| `DatabaseManager::connection()` | ✅ |
| `FilesystemManager::disk()` | ✅ |
| `RedisManager::connection()` | ✅ |
| `QueueManager::connection()` | ✅ (merged in #59389) |
| **`LogManager::channel()`** | ❌ |
| **`LogManager::driver()`** | ❌ |

This inconsistency means developers who define channel/driver names as enums cannot pass them directly to `Log::channel()` like they can with `DB::connection()` or `Queue::connection()`.

### Solution

- Added `enum_value()` call in `LogManager::driver()`
- Updated `@param` docblocks on `channel()` and `driver()` to accept `\UnitEnum|string|null`
- Updated the `Log` facade docblock accordingly

### Example

```php
enum LogChannel: string
{
    case Slack = 'slack';
    case Daily = 'daily';
}

// Before: would not resolve correctly
Log::channel(LogChannel::Slack)->info('Deployed!');

// After: works as expected
Log::channel(LogChannel::Slack)->info('Deployed!');
```

### Why This Doesn't Break Existing Features

- `enum_value()` returns the input unchanged for strings and null — all existing calls behave identically
- The new parameter is a docblock-only change; no signature change required
- Follows the exact same pattern already established in `DatabaseManager`, `FilesystemManager`, `RedisManager`, and `QueueManager`

### Changes

- `src/Illuminate/Log/LogManager.php` — Added `enum_value()` in `driver()`, updated docblocks
- `src/Illuminate/Support/Facades/Log.php` — Updated facade docblock
- `tests/Log/LogManagerTest.php` — Added 2 test cases

## Test Plan

- [x] `testLogManagerCanResolveBackedEnumChannel` — Verifies backed enum resolves to correct log channel
- [x] `testLogManagerCanResolveBackedEnumDriver` — Verifies backed enum resolves to correct log driver
- [x] Existing tests pass (no breaking changes)