### PR TITLE
[13.x] Add withoutFragment() method to Uri class

### DIFF
--- a/src/Illuminate/Support/Uri.php
+++ b/src/Illuminate/Support/Uri.php
@@ -335,6 +335,14 @@ class Uri implements Htmlable, JsonSerializable, Responsable, Stringable
     }
 
     /**
+     * Remove the fragment from the URI.
+     */
+    public function withoutFragment(): static
+    {
+        return new static($this->uri->withFragment(''));
+    }
+
+    /**
      * Create a redirect HTTP response for the given URI.
      */
     public function redirect(int $status = 302, array $headers = []): RedirectResponse

--- a/tests/Support/SupportUriTest.php
+++ b/tests/Support/SupportUriTest.php
@@ -95,6 +95,31 @@ class SupportUriTest extends TestCase
         $this->assertEquals($expected, $uri->toString());
     }
 
+    public function test_without_fragment()
+    {
+        $uri = Uri::of('https://laravel.com/docs/installation#introduction');
+
+        $this->assertEquals('introduction', $uri->fragment());
+
+        $withoutFragment = $uri->withoutFragment();
+
+        $this->assertNull($withoutFragment->fragment());
+        $this->assertEquals('https://laravel.com/docs/installation', $withoutFragment->value());
+
+        // Original URI should be unchanged (immutability).
+        $this->assertEquals('introduction', $uri->fragment());
+    }
+
+    public function test_without_fragment_on_uri_without_fragment()
+    {
+        $uri = Uri::of('https://laravel.com/docs');
+
+        $withoutFragment = $uri->withoutFragment();
+
+        $this->assertNull($withoutFragment->fragment());
+        $this->assertEquals('https://laravel.com/docs', $withoutFragment->value());
+    }
+
     public function test_complicated_query_string_manipulation()
     {
         $uri = Uri::of('https://laravel.com');


### PR DESCRIPTION
## Summary

Adds a `withoutFragment()` method to the `Uri` class — the missing counterpart to the existing `withFragment()` method, consistent with the `withoutQuery()` / `withQuery()` pattern already in the class.

### Problem

The `Uri` class currently provides:
- `withQuery()` ↔ `withoutQuery()` ✅
- `withFragment()` ↔ ❌ **no `withoutFragment()`**

When working with URIs that contain fragments (e.g., anchor links, SPA routes), developers need a clean way to strip the fragment. Currently the only way is `$uri->withFragment('')`, which is not as expressive or discoverable.

### Solution

Added `withoutFragment()` method that removes the fragment component from the URI while keeping all other parts intact.

### Example

```php
$uri = Uri::of('https://laravel.com/docs/routing#parameters');

// Before: only way to remove fragment
$clean = $uri->withFragment('');

// After: expressive and consistent with withoutQuery()
$clean = $uri->withoutFragment();
// https://laravel.com/docs/routing
```

### Why This Doesn't Break Existing Features

- Purely additive — no existing methods are modified
- Follows the immutable pattern already used by all `with*` / `without*` methods
- Delegates to `withFragment('')` internally, using the same League\Uri mechanism

### Changes

- `src/Illuminate/Support/Uri.php` — Added `withoutFragment()` method
- `tests/Support/SupportUriTest.php` — Added 2 test cases

## Test Plan

- [x] `test_without_fragment` — Removes fragment from URI, verifies original is unchanged (immutability)
- [x] `test_without_fragment_on_uri_without_fragment` — No-op when URI has no fragment
- [x] Existing tests pass