### PR TITLE
[13.x] Fix MorphTo eager load matching when ownerKey is null and result key is a non-primitive

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -226,7 +226,7 @@ class MorphTo extends BelongsTo
     protected function matchToMorphParents($type, EloquentCollection $results)
     {
         foreach ($results as $result) {
-            $ownerKey = ! is_null($this->ownerKey) ? $this->getDictionaryKey($result->{$this->ownerKey}) : $result->getKey();
+            $ownerKey = $this->getDictionaryKey(! is_null($this->ownerKey) ? $result->{$this->ownerKey} : $result->getKey());
 
             if ($ownerKey !== null && isset($this->dictionary[$type][$ownerKey])) {
                 foreach ($this->dictionary[$type][$ownerKey] as $model) {

--- a/tests/Database/DatabaseEloquentMorphToTest.php
+++ b/tests/Database/DatabaseEloquentMorphToTest.php
@@ -3,8 +3,10 @@
 namespace Illuminate\Tests\Database;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Tests\Database\stubs\TestEnum;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -356,6 +358,38 @@ class DatabaseEloquentMorphToTest extends TestCase
         $this->assertFalse($relation->is($model));
     }
 
+    public function testMatchToMorphParentsNormalizesKeyWhenOwnerKeyIsNullAndResultKeyIsObject()
+    {
+        $uuidObject = new class
+        {
+            public function __toString(): string
+            {
+                return 'uuid-value';
+            }
+        };
+
+        $builder = m::mock(Builder::class);
+        $related = m::mock(Model::class);
+        $builder->shouldReceive('getModel')->andReturn($related);
+
+        $parent = new EloquentMorphToModelStub;
+        $parent->morph_type = 'type_1';
+        $parent->foreign_key = 'uuid-value';
+
+        $relation = Relation::noConstraints(function () use ($builder, $parent) {
+            return new EloquentMorphToAccessibleStub($builder, $parent, 'foreign_key', null, 'morph_type', 'relation');
+        });
+
+        $relation->addEagerConstraints([$parent]);
+
+        $result = m::mock(Model::class);
+        $result->shouldReceive('getKey')->once()->andReturn($uuidObject);
+
+        $relation->callMatchToMorphParents('type_1', new EloquentCollection([$result]));
+
+        $this->assertSame($result, $parent->getRelation('relation'));
+    }
+
     protected function getRelationAssociate($parent)
     {
         $builder = m::mock(Builder::class);
@@ -399,4 +433,12 @@ class EloquentMorphToModelStub extends Model
 class EloquentMorphToRelatedStub extends Model
 {
     public $table = 'eloquent_morph_to_related_stubs';
+}
+
+class EloquentMorphToAccessibleStub extends MorphTo
+{
+    public function callMatchToMorphParents($type, EloquentCollection $results): void
+    {
+        $this->matchToMorphParents($type, $results);
+    }
 }

--- a/tests/Integration/Database/EloquentMorphToEagerLoadTest.php
+++ b/tests/Integration/Database/EloquentMorphToEagerLoadTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentMorphToEagerLoadTest;
+
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+class EloquentMorphToEagerLoadTest extends DatabaseTestCase
+{
+    protected function afterRefreshingDatabase()
+    {
+        Schema::create('posts', function (Blueprint $table) {
+            $table->increments('id');
+        });
+
+        Schema::create('articles', function (Blueprint $table) {
+            $table->string('slug')->primary();
+        });
+
+        Schema::create('videos', function (Blueprint $table) {
+            $table->string('id')->primary();
+        });
+
+        Schema::create('comments', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('commentable_type');
+            $table->string('commentable_id');
+        });
+
+        $post = Post::create();
+        $article = Article::create(['slug' => ArticleSlug::Review->value]);
+        $video = Video::create(['id' => '550e8400-e29b-41d4-a716-446655440000']);
+
+        (new Comment)->commentable()->associate($post)->save();
+        (new Comment)->commentable()->associate($article)->save();
+
+        $comment = new Comment;
+        $comment->commentable_type = Video::class;
+        $comment->commentable_id = (string) $video->id;
+        $comment->save();
+    }
+
+    public function testEagerLoadingResolvesRelationWithPrimitivePrimaryKey(): void
+    {
+        $comments = Comment::with('commentable')
+            ->where('commentable_type', Post::class)
+            ->get();
+
+        $this->assertNotNull($comments[0]->commentable);
+        $this->assertInstanceOf(Post::class, $comments[0]->commentable);
+    }
+
+    public function testEagerLoadingResolvesRelationWithBackedEnumPrimaryKey(): void
+    {
+        $comments = Comment::with('commentable')
+            ->where('commentable_type', Article::class)
+            ->get();
+
+        $this->assertNotNull($comments[0]->commentable);
+        $this->assertInstanceOf(Article::class, $comments[0]->commentable);
+        $this->assertSame(ArticleSlug::Review, $comments[0]->commentable->slug);
+    }
+
+    public function testEagerLoadingResolvesRelationWithUuidValueObjectPrimaryKey(): void
+    {
+        $comments = Comment::with('commentable')
+            ->where('commentable_type', Video::class)
+            ->get();
+
+        $this->assertNotNull($comments[0]->commentable);
+        $this->assertInstanceOf(Video::class, $comments[0]->commentable);
+        $this->assertSame('550e8400-e29b-41d4-a716-446655440000', (string) $comments[0]->commentable->id);
+    }
+}
+
+enum ArticleSlug: string
+{
+    case Review = 'review';
+}
+
+class Post extends Model
+{
+    public $timestamps = false;
+}
+
+class Article extends Model
+{
+    public $timestamps = false;
+
+    protected $primaryKey = 'slug';
+
+    protected $keyType = 'string';
+
+    public $incrementing = false;
+
+    protected $casts = ['slug' => ArticleSlug::class];
+
+    protected $fillable = ['slug'];
+}
+
+class Comment extends Model
+{
+    public $timestamps = false;
+
+    public function commentable()
+    {
+        return $this->morphTo();
+    }
+}
+
+class Uuid
+{
+    public function __construct(private readonly string $value)
+    {
+    }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+}
+
+class UuidCast implements CastsAttributes
+{
+    public function get(Model $model, string $key, mixed $value, array $attributes): mixed
+    {
+        return new Uuid($value);
+    }
+
+    public function set(Model $model, string $key, mixed $value, array $attributes): mixed
+    {
+        return (string) $value;
+    }
+}
+
+class Video extends Model
+{
+    public $timestamps = false;
+
+    public $incrementing = false;
+
+    protected $fillable = ['id'];
+
+    protected $keyType = 'string';
+
+    protected $casts = ['id' => UuidCast::class];
+}


### PR DESCRIPTION
Based on https://github.com/laravel/framework/pull/59380

**The problem**

I am using a value-object as model identifier: string in the database, uuid-object in the code. Custom cast, getKey()-override, etc: works like a charm! Except for loading the morphTo-relation, this fails when the owner-key is not explicitly set.

**Fix MorphTo eager load matching when ownerKey is null and result key is a non-primitive**

When eager loading a morphTo relation, Eloquent builds a dictionary keyed by the parent model's foreign key value. Before matching results back to their parents, each result's key is normalised through getDictionaryKey() — which converts backed enums and objects with __toString() to their string representation. Without this normalisation, non-primitive keys cannot be used as array keys and the lookup silently fails.

This normalisation was already applied when a custom ownerKey is set, but was skipped on the default path (no ownerKey), where getKey() is used instead. See this code:
 
```
// Current — getDictionaryKey() only wraps the ownerKey branch
$ownerKey = ! is_null($this->ownerKey) ? $this->getDictionaryKey($result->{$this->ownerKey}) : $result->getKey();

// After — getDictionaryKey() wraps the full expression
$ownerKey = $this->getDictionaryKey(! is_null($this->ownerKey) ? $result->{$this->ownerKey} : $result->getKey());
```

I wrapped them both within the getDictionaryKey()-method, but I could do it on newline for clarity if you want.

**Who is affected**

Any application that defines a morphTo relation (without a custom ownerKey) where the related model uses a non-primitive primary key — for example, my uuid value-object This is an increasingly common pattern as applications move domain identifiers (slugs, statuses, typed UUIDs) into the primary key. The failure is completely silent: no exception is raised, the relation simply resolves to null.

**Why this does not break existing behaviour**

getDictionaryKey() is a no-op for plain scalars (integers, strings). Models with primitive primary keys are therefore unaffected. The same transformation is already applied when building the dictionary in addEagerConstraints(), so this change makes the matching step symmetric with the building step — it does not introduce a new normalisation, it applies an existing one consistently.

**Tests**

Two integration tests against a real database are included:

- testEagerLoadingResolvesRelationWithPrimitivePrimaryKey — confirms the existing integer-key path is unaffected.
- testEagerLoadingResolvesRelationWithBackedEnumPrimaryKey — covers a model whose primary key is cast to a BackedEnum. Before this fix the relation resolves to null; after it resolves to the correct model instance.
- testEagerLoadingResolvesRelationWithUuidValueObjectPrimaryKey — covers a model whose primary key is cast to a value object (a Uuid class with __toString()). This is the most common real-world trigger: applications that wrap UUID primary keys in a typed value object via a custom cast. Before this fix, getDictionaryKey() is never called on the result key, so the Uuid object cannot be used as an array key and the relation resolves to null. After this fix it resolves to the correct model.  