### PR TITLE
[13.x] Add `->file()` method to `$request->safe()`

### DIFF
--- a/src/Illuminate/Support/ValidatedInput.php
+++ b/src/Illuminate/Support/ValidatedInput.php
@@ -98,6 +98,20 @@ class ValidatedInput implements ValidatedData
     }
 
     /**
+     * Retrieve a file from the validated inputs.
+     *
+     * @param  string  $key
+     * @param  mixed  $default
+     * @return \Illuminate\Http\UploadedFile|null
+     */
+    public function file($key, $default = null)
+    {
+        $value = $this->input($key, $default);
+
+        return $value instanceof \Illuminate\Http\UploadedFile ? $value : $default;
+    }
+
+    /**
      * Dump the items.
      *
      * @param  mixed  ...$keys

--- a/tests/Support/ValidatedInputTest.php
+++ b/tests/Support/ValidatedInputTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Support;
 
+use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Stringable;
@@ -491,6 +492,23 @@ class ValidatedInputTest extends TestCase
         $this->assertEquals([StringBackedEnum::HELLO_WORLD], $input->enums('valid_enum_value', StringBackedEnum::class));
 
         $this->assertEmpty($input->enums('invalid_enum_value', StringBackedEnum::class));
+    }
+
+    public function test_file_method()
+    {
+        $file = UploadedFile::fake()->create('document.pdf');
+
+        $input = new ValidatedInput([
+            'name' => 'Taylor',
+            'avatar' => $file,
+        ]);
+
+        $this->assertInstanceOf(UploadedFile::class, $input->file('avatar'));
+        $this->assertSame($file, $input->file('avatar'));
+        $this->assertNull($input->file('name'));
+        $this->assertNull($input->file('missing'));
+        $this->assertSame('default', $input->file('missing', 'default'));
+        $this->assertSame('default', $input->file('name', 'default'));
     }
 
     public function test_collect_method()


### PR DESCRIPTION
This adds a `file()` method to `ValidatedInput`, so `$request->safe()->file('avatar')` works like `$request->file('avatar')`.

Returns the value only if it's an `UploadedFile` instance, otherwise returns `$default`.