### PR TITLE
[13.x] Add appendPath() method to Uri class

### DIFF
--- a/src/Illuminate/Support/Uri.php
+++ b/src/Illuminate/Support/Uri.php
@@ -248,6 +248,17 @@ class Uri implements Htmlable, JsonSerializable, Responsable, Stringable
     }
 
     /**
+     * Append the given path to the URI's existing path.
+     */
+    public function appendPath(Stringable|string $path): static
+    {
+        $current = rtrim((string) $this->uri->getPath(), '/');
+        $append = ltrim((string) $path, '/');
+
+        return new static($this->uri->withPath($current.'/'.$append));
+    }
+
+    /**
      * Merge new query parameters into the URI.
      */
     public function withQuery(array $query, bool $merge = true): static

--- a/tests/Support/SupportUriTest.php
+++ b/tests/Support/SupportUriTest.php
@@ -238,6 +238,40 @@ class SupportUriTest extends TestCase
         $this->assertEquals(3, $uri->pathSegments()->count());
     }
 
+    public function test_append_path()
+    {
+        $uri = Uri::of('https://laravel.com/api/v1');
+
+        // Basic append
+        $this->assertEquals('https://laravel.com/api/v1/users', (string) $uri->appendPath('users'));
+
+        // Append with leading slash
+        $this->assertEquals('https://laravel.com/api/v1/users', (string) $uri->appendPath('/users'));
+
+        // Append to trailing slash path
+        $uri = Uri::of('https://laravel.com/api/v1/');
+        $this->assertEquals('https://laravel.com/api/v1/users', (string) $uri->appendPath('users'));
+
+        // Append multi-segment path
+        $uri = Uri::of('https://laravel.com/api');
+        $this->assertEquals('https://laravel.com/api/v1/users', (string) $uri->appendPath('v1/users'));
+
+        // Append preserves query and fragment
+        $uri = Uri::of('https://laravel.com/api?key=123#section');
+        $this->assertEquals('https://laravel.com/api/users?key=123#section', (string) $uri->appendPath('users'));
+
+        // Append to root path
+        $uri = Uri::of('https://laravel.com');
+        $this->assertEquals('https://laravel.com/users', (string) $uri->appendPath('users'));
+
+        // Chaining with other methods
+        $uri = Uri::of('https://laravel.com/api')
+            ->appendPath('v2')
+            ->appendPath('users')
+            ->withQuery(['page' => 1]);
+        $this->assertEquals('https://laravel.com/api/v2/users?page=1', (string) $uri);
+    }
+
     public function test_macroable()
     {
         Uri::macro('myMacro', function () {


### PR DESCRIPTION
This PR adds an `appendPath()` method to the `Uri` class, allowing developers to fluently append path segments to an existing URI without manually handling slashes or reading the current path.

**Before:**
```php
$uri = Uri::of('https://api.example.com/v1');
$uri = $uri->withPath($uri->path().'/users'); // manual slash handling
```

**After:**
```php
$uri = Uri::of('https://api.example.com/v1');
$uri = $uri->appendPath('users');
// https://api.example.com/v1/users
```

The method intelligently normalizes leading and trailing slashes, preserves existing query strings and fragments, and supports chaining:

```php
$uri = Uri::of('https://api.example.com')
    ->appendPath('v2')
    ->appendPath('users')
    ->withQuery(['page' => 1]);

// https://api.example.com/v2/users?page=1
```