### PR TITLE
Enhance Relation class with Conditionable trait and add tests for whe…

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -372,7 +372,9 @@ class MorphTo extends BelongsTo
             'parameters' => [true, $callback],
         ];
 
-        return $this->when(true, $callback);
+        $this->query->when(true, $callback);
+
+        return $this;
     }
 
     /**
@@ -389,7 +391,9 @@ class MorphTo extends BelongsTo
             'parameters' => [true, $callback],
         ];
 
-        return $this->when(true, $callback);
+        $this->query->when(true, $callback);
+
+        return $this;
     }
 
     /**
@@ -406,7 +410,9 @@ class MorphTo extends BelongsTo
             'parameters' => [true, $callback],
         ];
 
-        return $this->when(true, $callback);
+        $this->query->when(true, $callback);
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Database\MultipleRecordsFoundException;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Support\Collection as BaseCollection;
+use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\ForwardsCalls;
 use Illuminate\Support\Traits\Macroable;
 
@@ -23,7 +24,7 @@ use Illuminate\Support\Traits\Macroable;
  */
 abstract class Relation implements BuilderContract
 {
-    use ForwardsCalls, Macroable {
+    use Conditionable, ForwardsCalls, Macroable {
         Macroable::__call as macroCall;
     }
 

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -314,6 +314,116 @@ class DatabaseEloquentRelationTest extends TestCase
         $this->assertTrue($model->isRelation('parent'));
         $this->assertFalse($model->isRelation('field'));
     }
+
+    public function testWhenCallbackReceivesRelationInstance()
+    {
+        $builder = m::mock(Builder::class);
+        $builder->shouldReceive('getModel')->andReturn(new EloquentRelationResetModelStub);
+        $parent = new EloquentRelationResetModelStub;
+
+        $relation = new EloquentRelationStub($builder, $parent);
+
+        $relation->when(true, function ($query) {
+            $this->assertInstanceOf(Relation::class, $query);
+            $this->assertInstanceOf(EloquentRelationStub::class, $query);
+        });
+    }
+
+    public function testWhenReturnsSelfWhenCallbackReturnsNull()
+    {
+        $builder = m::mock(Builder::class);
+        $builder->shouldReceive('getModel')->andReturn(new EloquentRelationResetModelStub);
+        $parent = new EloquentRelationResetModelStub;
+
+        $relation = new EloquentRelationStub($builder, $parent);
+
+        $result = $relation->when(true, function ($query) {
+            // return null implicitly
+        });
+
+        $this->assertSame($relation, $result);
+    }
+
+    public function testWhenReturnsSelfWhenConditionIsFalse()
+    {
+        $builder = m::mock(Builder::class);
+        $builder->shouldReceive('getModel')->andReturn(new EloquentRelationResetModelStub);
+        $parent = new EloquentRelationResetModelStub;
+
+        $relation = new EloquentRelationStub($builder, $parent);
+
+        $callbackExecuted = false;
+
+        $result = $relation->when(false, function ($query) use (&$callbackExecuted) {
+            $callbackExecuted = true;
+        });
+
+        $this->assertFalse($callbackExecuted);
+        $this->assertSame($relation, $result);
+    }
+
+    public function testUnlessCallbackReceivesRelationInstance()
+    {
+        $builder = m::mock(Builder::class);
+        $builder->shouldReceive('getModel')->andReturn(new EloquentRelationResetModelStub);
+        $parent = new EloquentRelationResetModelStub;
+
+        $relation = new EloquentRelationStub($builder, $parent);
+
+        $relation->unless(false, function ($query) {
+            $this->assertInstanceOf(Relation::class, $query);
+            $this->assertInstanceOf(EloquentRelationStub::class, $query);
+        });
+    }
+
+    public function testWhenWithDefaultCallbackReceivesRelationInstance()
+    {
+        $builder = m::mock(Builder::class);
+        $builder->shouldReceive('getModel')->andReturn(new EloquentRelationResetModelStub);
+        $parent = new EloquentRelationResetModelStub;
+
+        $relation = new EloquentRelationStub($builder, $parent);
+
+        $relation->when(false, function () {
+            $this->fail('Primary callback should not be called when condition is false.');
+        }, function ($query) {
+            $this->assertInstanceOf(Relation::class, $query);
+            $this->assertInstanceOf(EloquentRelationStub::class, $query);
+        });
+    }
+
+    public function testWhenCallbackCanChainBuilderMethods()
+    {
+        $builder = m::mock(Builder::class);
+        $builder->shouldReceive('getModel')->andReturn(new EloquentRelationResetModelStub);
+        $builder->shouldReceive('where')->andReturnSelf();
+        $builder->shouldReceive('whereNotNull')->andReturnSelf();
+        $parent = m::mock(Model::class);
+        $parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
+
+        $relation = new HasOne($builder, $parent, 'foreign_key', 'id');
+
+        $result = $relation->when(true, function ($query) {
+            $this->assertInstanceOf(HasOne::class, $query);
+
+            return $query->where('active', true);
+        });
+
+        $this->assertInstanceOf(HasOne::class, $result);
+    }
+
+    public function testHigherOrderWhenProxyReturnsRelation()
+    {
+        $builder = m::mock(Builder::class);
+        $builder->shouldReceive('getModel')->andReturn(new EloquentRelationResetModelStub);
+        $parent = new EloquentRelationResetModelStub;
+
+        $relation = new EloquentRelationStub($builder, $parent);
+
+        $proxy = $relation->when(true);
+
+        $this->assertInstanceOf(\Illuminate\Support\HigherOrderWhenProxy::class, $proxy);
+    }
 }
 
 class EloquentRelationResetModelStub extends Model


### PR DESCRIPTION
## Fix `when()` helper returning Builder instead of Relation

Fixes #53292

### Problem

When calling `when()` or `unless()` on a relationship instance, the callback receives an `Eloquent\Builder` instead of the relationship object. This means relation-specific methods like `withPivot()`, `wherePivot()`, `syncWithPivotValues()`, etc. are unavailable inside the callback:

```php
$user->roles()->when($condition, function ($query) {
    $query->withPivot('role'); // ❌ Method not found — $query is Builder, not BelongsToMany
});
```

This happens because `Relation::__call()` forwards `when()` to the underlying Builder via `forwardDecoratedCallTo()`. The `Conditionable::when()` trait method then passes `$this` (the Builder) to the callback, not the Relation.

### Solution

Add the `Conditionable` trait directly to the `Relation` base class. This makes `when()` and `unless()` first-class methods on all relations, so `$this` in the callback is the Relation instance:

```php
$user->roles()->when($condition, function ($query) {
    $query->withPivot('role'); // ✅ $query is BelongsToMany
});
```

The fix is two lines in `Relation.php` — one import and one trait use. Since `Relation` already proxies all Builder methods via `__call`, the callback still has full access to query builder methods while also gaining access to relation-specific methods.

### Why 13.x

A previous PR for this was closed as a breaking change in 11.x. The callback parameter type changes from `Builder` to `Relation`, which is appropriate for a major version.
