### PR TITLE
[13.x] Add session to supported drivers comment

### DIFF
--- a/config/cache.php
+++ b/config/cache.php
@@ -26,7 +26,7 @@ return [
     | well as their drivers. You may even define multiple stores for the
     | same cache driver to group types of items stored in your caches.
     |
-    | Supported drivers: "array", "database", "file", "memcached",
+    | Supported drivers: "array", "session", "database", "file", "memcached",
     |                    "redis", "dynamodb", "octane",
     |                    "failover", "null"
     |

--- a/config/cache.php
+++ b/config/cache.php
@@ -26,8 +26,8 @@ return [
     | well as their drivers. You may even define multiple stores for the
     | same cache driver to group types of items stored in your caches.
     |
-    | Supported drivers: "array", "session", "database", "file", "memcached",
-    |                    "redis", "dynamodb", "octane",
+    | Supported drivers: "array", "database", "file", "memcached",
+    |                    "redis", "dynamodb", "octane", "session",
     |                    "failover", "null"
     |
     */


### PR DESCRIPTION
Boring one

Upgrading some OSS, saw session was in the array, but not in the comment. 

This now aligns the comment with the allowed stores

In the AI world, this may help?