### PR TITLE
Fix type mismatch in polymorphic relationships for PostgreSQL

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
@@ -3,7 +3,9 @@
 namespace Illuminate\Database\Eloquent\Relations;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 
 /**
@@ -55,16 +57,25 @@ abstract class MorphOneOrMany extends HasOneOrMany
     public function addConstraints()
     {
         if (static::$constraints) {
-            $this->getRelationQuery()->where($this->morphType, $this->morphClass);
+            $query = $this->getRelationQuery();
 
-            parent::addConstraints();
+            $query->where($this->morphType, $this->morphClass);
+
+            $query->where($this->foreignKey, '=', $this->castMorphKey($this->getParentKey()));
+
+            $query->whereNotNull($this->foreignKey);
         }
     }
 
     /** @inheritDoc */
     public function addEagerConstraints(array $models)
     {
-        parent::addEagerConstraints($models);
+        $this->whereInEager(
+            'whereIn',
+            $this->foreignKey,
+            $this->castMorphKeys($this->getKeys($models, $this->localKey)),
+            $this->getRelationQuery()
+        );
 
         $this->getRelationQuery()->where($this->morphType, $this->morphClass);
     }
@@ -176,5 +187,91 @@ abstract class MorphOneOrMany extends HasOneOrMany
             Str::beforeLast($this->getMorphType(), '_type'),
             ...parent::getPossibleInverseRelations(),
         ]);
+    }
+
+    /**
+     * Build model dictionary keyed by the relation's foreign key.
+     *
+     * Morph keys are cast to strings to ensure consistent matching
+     * across databases with strict type comparison like PostgreSQL.
+     *
+     * @param  \Illuminate\Database\Eloquent\Collection<int, TRelatedModel>  $results
+     * @return array<array<array-key, TRelatedModel>>
+     */
+    protected function buildDictionary(EloquentCollection $results)
+    {
+        $foreign = $this->getForeignKeyName();
+
+        $dictionary = [];
+
+        $isAssociative = Arr::isAssoc($results->all());
+
+        foreach ($results as $key => $item) {
+            $pairKey = $this->castMorphKey($this->getDictionaryKey($item->{$foreign}));
+
+            if ($pairKey === null) {
+                continue;
+            }
+
+            if ($isAssociative) {
+                $dictionary[$pairKey][$key] = $item;
+            } else {
+                $dictionary[$pairKey][] = $item;
+            }
+        }
+
+        return $dictionary;
+    }
+
+    /**
+     * Match the eagerly loaded results to their parents.
+     *
+     * @param  array<int, TDeclaringModel>  $models
+     * @param  \Illuminate\Database\Eloquent\Collection<int, TRelatedModel>  $results
+     * @param  string  $relation
+     * @param  string  $type
+     * @return array<int, TDeclaringModel>
+     */
+    protected function matchOneOrMany(array $models, EloquentCollection $results, $relation, $type)
+    {
+        $dictionary = $this->buildDictionary($results);
+
+        foreach ($models as $model) {
+            $key = $this->castMorphKey($this->getDictionaryKey($model->getAttribute($this->localKey)));
+
+            if ($key !== null && isset($dictionary[$key])) {
+                $related = $this->getRelationValue($dictionary, $key, $type);
+
+                $model->setRelation($relation, $related);
+
+                $type === 'one'
+                    ? $this->applyInverseRelationToModel($related, $model)
+                    : $this->applyInverseRelationToCollection($related, $model);
+            }
+        }
+
+        return $models;
+    }
+
+    /**
+     * Cast the given morph key to a string.
+     *
+     * @param  string|int|null  $key
+     * @return string|null
+     */
+    protected function castMorphKey($key)
+    {
+        return $key !== null ? (string) $key : null;
+    }
+
+    /**
+     * Cast all morph keys in the given array to strings.
+     *
+     * @param  array  $keys
+     * @return array
+     */
+    protected function castMorphKeys(array $keys)
+    {
+        return array_map(fn ($key) => $this->castMorphKey($key), $keys);
     }
 }

--- a/tests/Database/DatabaseEloquentMorphOneOfManyTest.php
+++ b/tests/Database/DatabaseEloquentMorphOneOfManyTest.php
@@ -60,7 +60,7 @@ class DatabaseEloquentMorphOneOfManyTest extends TestCase
         $product = MorphOneOfManyTestProduct::create();
         $relation = $product->current_state();
         $relation->addEagerConstraints([$product]);
-        $this->assertSame('select MAX("states"."id") as "id_aggregate", "states"."stateful_id", "states"."stateful_type" from "states" where "states"."stateful_type" = ? and "states"."stateful_id" = ? and "states"."stateful_id" is not null and "states"."stateful_id" in (1) and "states"."stateful_type" = ? group by "states"."stateful_id", "states"."stateful_type"', $relation->getOneOfManySubQuery()->toSql());
+        $this->assertSame('select MAX("states"."id") as "id_aggregate", "states"."stateful_id", "states"."stateful_type" from "states" where "states"."stateful_type" = ? and "states"."stateful_id" = ? and "states"."stateful_id" is not null and "states"."stateful_id" in (?) and "states"."stateful_type" = ? group by "states"."stateful_id", "states"."stateful_type"', $relation->getOneOfManySubQuery()->toSql());
     }
 
     public function testReceivingModel()

--- a/tests/Database/DatabaseEloquentMorphTest.php
+++ b/tests/Database/DatabaseEloquentMorphTest.php
@@ -31,9 +31,7 @@ class DatabaseEloquentMorphTest extends TestCase
     public function testMorphOneEagerConstraintsAreProperlyAdded()
     {
         $relation = $this->getOneRelation();
-        $relation->getParent()->shouldReceive('getKeyName')->once()->andReturn('id');
-        $relation->getParent()->shouldReceive('getKeyType')->once()->andReturn('string');
-        $relation->getQuery()->shouldReceive('whereIn')->once()->with('table.morph_id', [1, 2]);
+        $relation->getQuery()->shouldReceive('whereIn')->once()->with('table.morph_id', ['1', '2']);
         $relation->getQuery()->shouldReceive('where')->once()->with('table.morph_type', get_class($relation->getParent()));
 
         $model1 = new EloquentMorphResetModelStub;
@@ -55,9 +53,7 @@ class DatabaseEloquentMorphTest extends TestCase
     public function testMorphManyEagerConstraintsAreProperlyAdded()
     {
         $relation = $this->getManyRelation();
-        $relation->getParent()->shouldReceive('getKeyName')->once()->andReturn('id');
-        $relation->getParent()->shouldReceive('getKeyType')->once()->andReturn('int');
-        $relation->getQuery()->shouldReceive('whereIntegerInRaw')->once()->with('table.morph_id', [1, 2]);
+        $relation->getQuery()->shouldReceive('whereIn')->once()->with('table.morph_id', ['1', '2']);
         $relation->getQuery()->shouldReceive('where')->once()->with('table.morph_type', get_class($relation->getParent()));
 
         $model1 = new EloquentMorphResetModelStub;
@@ -484,7 +480,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $queryBuilder = m::mock(QueryBuilder::class);
         $builder = m::mock(Builder::class, [$queryBuilder]);
         $builder->shouldReceive('whereNotNull')->once()->with('table.morph_id');
-        $builder->shouldReceive('where')->once()->with('table.morph_id', '=', 1);
+        $builder->shouldReceive('where')->once()->with('table.morph_id', '=', '1');
         $related = m::mock(Model::class);
         $builder->shouldReceive('getModel')->andReturn($related);
         $parent = m::mock(Model::class);
@@ -499,7 +495,7 @@ class DatabaseEloquentMorphTest extends TestCase
     {
         $builder = m::mock(Builder::class);
         $builder->shouldReceive('whereNotNull')->once()->with('table.morph_id');
-        $builder->shouldReceive('where')->once()->with('table.morph_id', '=', 1);
+        $builder->shouldReceive('where')->once()->with('table.morph_id', '=', '1');
         $related = m::mock(Model::class);
         $builder->shouldReceive('getModel')->andReturn($related);
         $parent = m::mock(Model::class);
@@ -520,7 +516,7 @@ class DatabaseEloquentMorphTest extends TestCase
 
         $builder = m::mock(Builder::class);
         $builder->shouldReceive('whereNotNull')->once()->with('table.morph_id');
-        $builder->shouldReceive('where')->once()->with('table.morph_id', '=', 1);
+        $builder->shouldReceive('where')->once()->with('table.morph_id', '=', '1');
         $related = m::mock(Model::class);
         $builder->shouldReceive('getModel')->andReturn($related);
         $parent = m::mock(EloquentModelNamespacedStub::class);
@@ -529,6 +525,53 @@ class DatabaseEloquentMorphTest extends TestCase
         $builder->shouldReceive('where')->once()->with('table.morph_type', $alias);
 
         return new MorphOne($builder, $parent, 'table.morph_type', 'table.morph_id', 'id');
+    }
+
+    public function testMorphConstraintsCastParentKeyToString()
+    {
+        $builder = m::mock(Builder::class);
+        $builder->shouldReceive('whereNotNull')->once()->with('table.morph_id');
+        $builder->shouldReceive('where')->once()->with('table.morph_id', '=', '42');
+        $related = m::mock(Model::class);
+        $builder->shouldReceive('getModel')->andReturn($related);
+        $parent = m::mock(Model::class);
+        $parent->shouldReceive('getAttribute')->with('id')->andReturn(42);
+        $parent->shouldReceive('getMorphClass')->andReturn('parent_type');
+        $builder->shouldReceive('where')->once()->with('table.morph_type', 'parent_type');
+
+        new MorphMany($builder, $parent, 'table.morph_type', 'table.morph_id', 'id');
+    }
+
+    public function testMorphEagerConstraintsAlwaysUseWhereInWithStringKeys()
+    {
+        $relation = $this->getManyRelation();
+
+        $relation->getQuery()->shouldReceive('whereIn')->once()->with('table.morph_id', ['10', '20']);
+        $relation->getQuery()->shouldReceive('where')->once()->with('table.morph_type', get_class($relation->getParent()));
+
+        $model1 = new EloquentMorphResetModelStub;
+        $model1->id = 10;
+        $model2 = new EloquentMorphResetModelStub;
+        $model2->id = 20;
+        $relation->addEagerConstraints([$model1, $model2]);
+    }
+
+    public function testMorphDictionaryMatchesIntegerParentKeyWithStringForeignKey()
+    {
+        $relation = $this->getManyRelation();
+
+        $relation->getRelated()->shouldReceive('newCollection')->andReturnUsing(fn ($items = []) => new \Illuminate\Database\Eloquent\Collection($items));
+
+        $result1 = new EloquentMorphResetModelStub;
+        $result1->morph_id = '1';
+
+        $parentModel = new EloquentMorphResetModelStub;
+        $parentModel->id = 1;
+
+        $models = $relation->matchMany([$parentModel], new \Illuminate\Database\Eloquent\Collection([$result1]), 'morphRelation');
+
+        $this->assertTrue($models[0]->relationLoaded('morphRelation'));
+        $this->assertCount(1, $models[0]->getRelation('morphRelation'));
     }
 }
 


### PR DESCRIPTION
## Fix Type Mismatch in Polymorphic Relationships for PostgreSQL

Fixes #54401

### Problem

PostgreSQL's strict type system rejects implicit type casts, causing polymorphic relationships to fail when the `morphable_id` column type (typically `varchar` for UUID/ULID support) differs from the parent model's key type (`integer`):

```sql
-- PostgreSQL rejects this:
SELECT * FROM comments WHERE commentable_type = 'App\Models\Post' AND commentable_id = 1
-- ERROR: operator does not exist: character varying = integer
```

MySQL and SQLite handle this implicitly, but PostgreSQL does not.

### Solution

Cast morph keys to strings **at the PHP level** in `MorphOneOrMany`:

- **`addConstraints()`** — casts the parent key to string before binding (`WHERE morph_id = '1'` instead of `WHERE morph_id = 1`)
- **`addEagerConstraints()`** — uses `whereIn` with string-cast keys instead of `whereIntegerInRaw`, preventing the type mismatch in `IN (...)` clauses
- **`buildDictionary()` / `matchOneOrMany()`** — normalizes dictionary keys to strings, fixing a PHP-level bug where integer parent keys (`1`) fail to match string foreign keys (`"1"`) in array lookups during eager loading

### Why this approach

The previous attempt (PR #57640) was closed because it relied on `SchemaBuilder::$defaultMorphKeyType` — a global static configuration. This approach instead:

1. Casts morph keys to strings at the PHP level — no global config or schema introspection needed
2. Works universally across all database drivers
3. Is semantically correct — morph ID columns are inherently polymorphic (mixed int/uuid/string), so string comparison is the right default
4. Fixes a PHP-level dictionary matching bug that affected all drivers, not just PostgreSQL

String-to-integer comparison works on all databases (`WHERE int_col = '1'`), so the string cast is safe even when the morph column is an integer type.
