### PR TITLE
[13.x] Fix trait initializer collision with Attribute parsing

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
@@ -45,9 +45,7 @@ trait GuardsAttributes
     #[Initialize]
     public function initializeGuardsAttributes()
     {
-        if (empty($this->fillable)) {
-            $this->fillable = static::resolveClassAttribute(Fillable::class, 'columns') ?? [];
-        }
+        $this->mergeFillable(static::resolveClassAttribute(Fillable::class, 'columns') ?? []);
 
         if ($this->guarded === ['*']) {
             if (static::resolveClassAttribute(Unguarded::class) !== null) {

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -214,9 +214,7 @@ trait HasAttributes
             ?? static::resolveClassAttribute(Table::class)->dateFormat
             ?? null;
 
-        if (empty($this->appends)) {
-            $this->appends = static::resolveClassAttribute(Appends::class, 'columns') ?? [];
-        }
+        $this->mergeAppends(static::resolveClassAttribute(Appends::class, 'columns') ?? []);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HidesAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HidesAttributes.php
@@ -30,13 +30,8 @@ trait HidesAttributes
     #[Initialize]
     public function initializeHidesAttributes()
     {
-        if (empty($this->hidden)) {
-            $this->hidden = static::resolveClassAttribute(Hidden::class, 'columns') ?? [];
-        }
-
-        if (empty($this->visible)) {
-            $this->visible = static::resolveClassAttribute(Visible::class, 'columns') ?? [];
-        }
+        $this->mergeHidden(static::resolveClassAttribute(Hidden::class, 'columns') ?? []);
+        $this->mergeVisible(static::resolveClassAttribute(Visible::class, 'columns') ?? []);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelAttributesTest.php
+++ b/tests/Database/DatabaseEloquentModelAttributesTest.php
@@ -198,11 +198,11 @@ class DatabaseEloquentModelAttributesTest extends TestCase
         $this->assertSame(['name', 'email'], $model->getFillable());
     }
 
-    public function test_fillable_property_takes_precedence(): void
+    public function test_fillable_property_merges_with_attribute(): void
     {
         $model = new ModelWithFillableAttributeAndProperty;
 
-        $this->assertSame(['title'], $model->getFillable());
+        $this->assertEqualsCanonicalizing(['title', 'name', 'email'], $model->getFillable());
     }
 
     public function test_guarded_attribute(): void
@@ -311,6 +311,34 @@ class DatabaseEloquentModelAttributesTest extends TestCase
         $this->assertTrue(ModelWithoutTimestampsAttribute::isIgnoringTouch());
         $this->assertTrue(ModelWithTimestampsFalseAttribute::isIgnoringTouch());
         $this->assertFalse(ModelWithFillableAttribute::isIgnoringTouch());
+    }
+
+    public function test_trait_initializer_merges_appends_with_attribute(): void
+    {
+        $model = new ModelWithAppendsAttributeAndTrait;
+
+        $this->assertEqualsCanonicalizing(['full_name', 'is_admin', 'url'], $model->getAppends());
+    }
+
+    public function test_trait_initializer_merges_hidden_with_attribute(): void
+    {
+        $model = new ModelWithHiddenAttributeAndTrait;
+
+        $this->assertEqualsCanonicalizing(['password', 'secret', 'api_token'], $model->getHidden());
+    }
+
+    public function test_trait_initializer_merges_visible_with_attribute(): void
+    {
+        $model = new ModelWithVisibleAttributeAndTrait;
+
+        $this->assertEqualsCanonicalizing(['id', 'name', 'email'], $model->getVisible());
+    }
+
+    public function test_trait_initializer_merges_fillable_with_attribute(): void
+    {
+        $model = new ModelWithFillableAttributeAndTrait;
+
+        $this->assertEqualsCanonicalizing(['name', 'email', 'phone'], $model->getFillable());
     }
 }
 
@@ -516,4 +544,62 @@ class ModelWithWithoutIncrementingAttributeOverride extends Model
 class PivotWithIncrementing extends \Illuminate\Database\Eloquent\Relations\Pivot
 {
     //
+}
+
+// Traits for testing trait initializer + Attribute collision
+
+trait AddsUrlAppend
+{
+    protected function initializeAddsUrlAppend()
+    {
+        $this->mergeAppends(['url']);
+    }
+}
+
+trait AddsApiTokenHidden
+{
+    protected function initializeAddsApiTokenHidden()
+    {
+        $this->mergeHidden(['api_token']);
+    }
+}
+
+trait AddsEmailVisible
+{
+    protected function initializeAddsEmailVisible()
+    {
+        $this->mergeVisible(['email']);
+    }
+}
+
+trait AddsPhoneFillable
+{
+    protected function initializeAddsPhoneFillable()
+    {
+        $this->mergeFillable(['phone']);
+    }
+}
+
+#[Appends(['full_name', 'is_admin'])]
+class ModelWithAppendsAttributeAndTrait extends Model
+{
+    use AddsUrlAppend;
+}
+
+#[Hidden(['password', 'secret'])]
+class ModelWithHiddenAttributeAndTrait extends Model
+{
+    use AddsApiTokenHidden;
+}
+
+#[Visible(['id', 'name'])]
+class ModelWithVisibleAttributeAndTrait extends Model
+{
+    use AddsEmailVisible;
+}
+
+#[Fillable(['name', 'email'])]
+class ModelWithFillableAttributeAndTrait extends Model
+{
+    use AddsPhoneFillable;
 }


### PR DESCRIPTION
Fixes #59381

## Problem

When a model uses both a **PHP Attribute** (e.g. `#[Appends(['name'])]`) and a **trait that calls `merge*()` in its initializer** (e.g. `$this->mergeAppends(['url'])`), the trait's values get silently dropped. The final result only contains the Attribute values—or worse, only the trait's values—depending on execution order.

```php
#[Appends(['name'])]
class MyModel extends Model
{
    use SomeTrait;
}

trait SomeTrait
{
    protected function initializeSomeTrait()
    {
        $this->mergeAppends(['url']);
    }
}

$model = new MyModel;
$model->getAppends(); // Returns ['url'] — 'name' is missing!
```

## Root Cause

The framework's trait initializers (`initializeHasAttributes`, `initializeHidesAttributes`, `initializeGuardsAttributes`) used `if (empty($this->property))` guards before assigning from PHP Attributes:

```php
if (empty($this->appends)) {
    $this->appends = static::resolveClassAttribute(Appends::class, 'columns') ?? [];
}
```

When a user's trait initializer runs **first** and populates the property via `merge*()`, the `empty()` check sees a non-empty value and skips the Attribute entirely — silently dropping its values.

## Solution

Replace the guarded assignment pattern with the corresponding `merge*()` method:

```php
$this->mergeAppends(static::resolveClassAttribute(Appends::class, 'columns') ?? []);
```

This ensures values from **both sources** are always combined, regardless of initializer execution order.

### Files Changed

| File | Change |
|---|---|
| `HasAttributes.php` | `appends`: guarded assign → `mergeAppends()` |
| `HidesAttributes.php` | `hidden`/`visible`: guarded assign → `mergeHidden()`/`mergeVisible()` |
| `GuardsAttributes.php` | `fillable`: guarded assign → `mergeFillable()` |

> **Note:** The `guarded` property is left unchanged because its `['*']` default sentinel value has special "totally guarded" semantics that require the existing conditional logic.

### Tests

Added 4 new test cases in `DatabaseEloquentModelAttributesTest.php` that verify trait initializer values are correctly merged with PHP Attribute values for `appends`, `hidden`, `visible`, and `fillable`.

Updated 1 existing test (`test_fillable_property_merges_with_attribute`) to reflect that property values and Attribute values are now **merged** rather than the property silently overriding.
