### PR TITLE
[13.x] Fix class attribute vs property precedence order

### DIFF
--- a/src/Illuminate/Support/Traits/ReadsClassAttributes.php
+++ b/src/Illuminate/Support/Traits/ReadsClassAttributes.php
@@ -18,6 +18,10 @@ trait ReadsClassAttributes
      */
     protected function getAttributeValue($target, string $attributeClass, ?string $property = null, $default = null)
     {
+        if ($property !== null && ($target->{$property} ?? null) !== null) {
+            return $target->{$property};
+        }
+
         try {
             $reflection = new ReflectionClass($target);
 

--- a/tests/Notifications/NotificationSenderTest.php
+++ b/tests/Notifications/NotificationSenderTest.php
@@ -13,6 +13,7 @@ use Illuminate\Notifications\Events\NotificationSending;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Notifications\Notification;
 use Illuminate\Notifications\NotificationSender;
+use Illuminate\Queue\Attributes\Queue as QueueAttribute;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Mailer\Exception\HttpTransportException;
@@ -214,6 +215,49 @@ class NotificationSenderTest extends TestCase
         $sender = new NotificationSender($manager, $bus, $events);
 
         $sender->send($notifiable, new DummyQueuedNotificationWithStringVia);
+    }
+
+    public function testOnQueueOverridesQueueAttribute()
+    {
+        $notifiable = m::mock(Notifiable::class);
+        $manager = m::mock(ChannelManager::class);
+        $manager->shouldReceive('getContainer')->andReturn(app());
+        $manager->shouldReceive('resolveConnectionFromQueueRoute')->andReturn(null);
+        $bus = m::mock(BusDispatcher::class);
+        $bus->shouldReceive('dispatch')
+            ->once()
+            ->withArgs(function ($job) {
+                return $job->queue === 'ingest-prio';
+            });
+        $events = m::mock(EventDispatcher::class);
+        $events->shouldReceive('listen')->once();
+
+        $sender = new NotificationSender($manager, $bus, $events);
+
+        $notification = new DummyQueuedNotificationWithQueueAttribute;
+        $notification->onQueue('ingest-prio');
+
+        $sender->send($notifiable, $notification);
+    }
+
+    public function testQueueAttributeIsUsedWhenOnQueueNotCalled()
+    {
+        $notifiable = m::mock(Notifiable::class);
+        $manager = m::mock(ChannelManager::class);
+        $manager->shouldReceive('getContainer')->andReturn(app());
+        $manager->shouldReceive('resolveConnectionFromQueueRoute')->andReturn(null);
+        $bus = m::mock(BusDispatcher::class);
+        $bus->shouldReceive('dispatch')
+            ->once()
+            ->withArgs(function ($job) {
+                return $job->queue === 'ingest';
+            });
+        $events = m::mock(EventDispatcher::class);
+        $events->shouldReceive('listen')->once();
+
+        $sender = new NotificationSender($manager, $bus, $events);
+
+        $sender->send($notifiable, new DummyQueuedNotificationWithQueueAttribute);
     }
 
     public function testNotificationFailedSentWithoutHttpTransportException()
@@ -448,6 +492,17 @@ class DummyNotificationWithViaMutation extends Notification
     {
         $this->channelData = $notifiable->routeConfig ?? 'default';
 
+        return 'mail';
+    }
+}
+
+#[QueueAttribute('ingest')]
+class DummyQueuedNotificationWithQueueAttribute extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function via($notifiable)
+    {
         return 'mail';
     }
 }


### PR DESCRIPTION
# [13.x] Fix class attribute vs property precedence order

Fixes #59382

## Problem

When using PHP Attributes to configure queues (e.g., `#[Queue('ingest')]`) on Notifications, Events, or Jobs, runtime override methods like `$notification->onQueue('ingest-prio')` do not work. The `$queue` property gets updated, but the framework completely ignores it, always preferring the class-level Attribute.

For example:
```php
#[Queue('ingest')]
class SomeNotification extends Notification implements ShouldQueue
{
    use Queueable;
}

$notification = new SomeNotification;
$notification->onQueue('ingest-prio');

// Expected: queued to 'ingest-prio' (Laravel 12.x behavior)
// Actual in 13.x: queued to 'ingest'
```

## Root Cause

`Illuminate\Support\Traits\ReadsClassAttributes` provides the [getAttributeValue()](file:///Users/comestro/framework/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php#535-545) method to extract configuration values (like queue, connection, backoff, etc.). In 13.x, it checked for a PHP Attribute **first**, and only fell back to checking the object's property if the Attribute didn't exist.

As a result, an explicitly set object property (`$target->queue`) could never override an existing class attribute (`#[Queue]`).

## Solution

This PR updates the precedence order in `ReadsClassAttributes::getAttributeValue()`. 

The explicitly set property (`$target->{$property}`) is now evaluated first. If it holds a non-null value (meaning it was modified at runtime by `onQueue()` or similar), it is returned immediately. The PHP Attribute acts as a strict class-level default/fallback if the property isn't explicitly initialized.

This restores the expected functionality from Laravel 12.x while seamlessly integrating the new Attribute syntax.

### Tests

Added [testOnQueueOverridesQueueAttribute](file:///Users/comestro/framework/tests/Notifications/NotificationSenderTest.php#220-242) and [testQueueAttributeIsUsedWhenOnQueueNotCalled](file:///Users/comestro/framework/tests/Notifications/NotificationSenderTest.php#243-262) to [NotificationSenderTest.php](file:///Users/comestro/framework/tests/Notifications/NotificationSenderTest.php) to verify that `onQueue()` successfully takes precedence over the `#[Queue]` attribute, while still correctly falling back to the attribute when `onQueue()` is not called.
