### PR TITLE
[13.x] Add SetCacheHeaders middleware attribute

### DIFF
--- a/src/Illuminate/Routing/Attributes/Controllers/SetCacheHeaders.php
+++ b/src/Illuminate/Routing/Attributes/Controllers/SetCacheHeaders.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Illuminate\Routing\Attributes\Controllers;
+
+use Attribute;
+use Illuminate\Http\Middleware\SetCacheHeaders as SetCacheHeadersMiddleware;
+
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
+class SetCacheHeaders extends Middleware
+{
+    /**
+     * @param  array<mixed>|string  $options
+     * @param  array<string>|null  $only
+     * @param  array<string>|null  $except
+     */
+    public function __construct(
+        public array|string $options,
+        public ?array $only = null,
+        public ?array $except = null,
+    ) {
+        parent::__construct(SetCacheHeadersMiddleware::using($options), $only, $except);
+    }
+}

--- a/tests/Integration/Routing/SetCacheHeadersAttributeTest.php
+++ b/tests/Integration/Routing/SetCacheHeadersAttributeTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Routing;
+
+use Illuminate\Routing\Attributes\Controllers\SetCacheHeaders;
+use Illuminate\Support\Facades\Route;
+use Orchestra\Testbench\TestCase;
+
+class SetCacheHeadersAttributeTest extends TestCase
+{
+    public function test_attribute_middleware_is_respected(): void
+    {
+        $route = Route::get('/', [SetCacheHeadersAttributeController::class, 'public']);
+        $this->assertEquals([
+            'Illuminate\Http\Middleware\SetCacheHeaders:max_age=120;no-transform;s_maxage=60;',
+        ], $route->controllerMiddleware());
+
+        $route = Route::get('/', [SetCacheHeadersAttributeController::class, 'private']);
+        $this->assertEquals([
+            'Illuminate\Http\Middleware\SetCacheHeaders:private;max_age=120;etag',
+        ], $route->controllerMiddleware());
+    }
+}
+
+class SetCacheHeadersAttributeController
+{
+    #[SetCacheHeaders('max_age=120;no-transform;s_maxage=60;')]
+    public function public(): void
+    {
+        // ...
+    }
+
+    #[SetCacheHeaders(['private', 'max_age' => 120, 'etag' => true])]
+    public function private(): void
+    {
+        // ...
+    }
+}


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
In #58578 various attributes were introduced, including the `Middleware` attribute that adds middleware to a controller for some or all of its routes. However due to PHP limitations on expressions that are valid for usage within attributes parameters, namely only constant expressions, it is not possible to provide middleware with parameters leveraging their static `using` function to such attributes.

This PR adds a `SetCacheHeaders` attribute, corresponding to the middleware with same name, that calls the static `using` method in its constructor and as such allows for using this middleware with parameters in a concise manner to be applied.

For what it's worth, similar efforts may be undertaken for all other middlewares that have a static `using` method.

For reference, #59048 contains similar efforts for the Authorize middleware.