### PR TITLE
[13.x] Add missing capitalize parameter to Stringable::initials()

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -894,11 +894,12 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     /**
      * Convert the given string to only its initials.
      *
+     * @param  bool  $capitalize
      * @return static
      */
-    public function initials()
+    public function initials($capitalize = false)
     {
-        return new static(Str::initials($this->value));
+        return new static(Str::initials($this->value, $capitalize));
     }
 
     /**

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -1484,6 +1484,9 @@ class SupportStringableTest extends TestCase
     public function testInitials()
     {
         $this->assertSame('TO', $this->stringable('Taylor Otwell')->initials()->value());
+        $this->assertSame('to', $this->stringable('taylor otwell')->initials()->value());
+        $this->assertSame('TO', $this->stringable('taylor otwell')->initials(capitalize: true)->value());
+        $this->assertSame('JB', $this->stringable('james bond')->initials(capitalize: true)->value());
     }
 
     public function testToInteger()


### PR DESCRIPTION
## Summary

`Str::initials()` accepts a `$capitalize` parameter, but the `Stringable::initials()` wrapper does not expose it. This makes it impossible to capitalize initials when using the fluent string API.

### Problem

```php
// Static API — works
Str::initials('james bond', capitalize: true); // "JB"

// Fluent API — no way to capitalize
Str::of('james bond')->initials(); // "jb"
Str::of('james bond')->initials(capitalize: true); // ❌ not supported
```

### Solution

Added the `$capitalize` parameter to `Stringable::initials()` and forward it to `Str::initials()`.

```php
// After this PR
Str::of('james bond')->initials(capitalize: true); // "JB" ✅
```

### Why This Doesn't Break Existing Features

- The new parameter defaults to `false`, matching the current behavior exactly
- All existing calls to `Stringable::initials()` continue to work identically

### Changes

- `src/Illuminate/Support/Stringable.php` — Added `$capitalize` parameter to `initials()` 
- `tests/Support/SupportStringableTest.php` — Added test cases for capitalize behavior

## Test Plan

- [x] Existing `testInitials` assertion still passes
- [x] New assertions verify `capitalize: true` produces uppercase initials
- [x] No breaking changes