### PR TITLE
[13.x] Add isNotEmpty() method to Uri class

### DIFF
--- a/src/Illuminate/Support/Uri.php
+++ b/src/Illuminate/Support/Uri.php
@@ -410,6 +410,14 @@ class Uri implements Htmlable, JsonSerializable, Responsable, Stringable
     }
 
     /**
+     * Determine if the URI is not an empty string.
+     */
+    public function isNotEmpty(): bool
+    {
+        return ! $this->isEmpty();
+    }
+
+    /**
      * Dump the string representation of the URI.
      *
      * @param  mixed  ...$args

--- a/tests/Support/SupportUriTest.php
+++ b/tests/Support/SupportUriTest.php
@@ -45,6 +45,15 @@ class SupportUriTest extends TestCase
         $this->assertEquals('taylor:password@laravel.com', $uri->authority());
     }
 
+    public function test_is_empty_and_is_not_empty()
+    {
+        $this->assertTrue(Uri::of('')->isEmpty());
+        $this->assertFalse(Uri::of('')->isNotEmpty());
+
+        $this->assertFalse(Uri::of('https://laravel.com')->isEmpty());
+        $this->assertTrue(Uri::of('https://laravel.com')->isNotEmpty());
+    }
+
     public function test_complicated_query_string_parsing()
     {
         $uri = Uri::of('https://example.com/users?key_1=value&key_2[sub_field]=value&key_3[]=value&key_4[9]=value&key_5[][][foo][9]=bar&key.6=value&flag_value');


### PR DESCRIPTION
## Summary

Adds the `isNotEmpty()` method to the `Uri` class — the standard counterpart to the existing `isEmpty()` method.

### Problem

The `Uri` class has `isEmpty()` but no `isNotEmpty()`. This breaks the consistent pattern used across the framework:

| Class | `isEmpty()` | `isNotEmpty()` |
|---|---|---|
| `Stringable` | ✅ | ✅ |
| `HtmlString` | ✅ | ✅ |
| `MessageBag` | ✅ | ✅ |
| `Fluent` | ✅ | ✅ |
| `Collection` | ✅ | ✅ |
| **`Uri`** | ✅ | ❌ |

### Solution

```php
// Now possible
$uri = Uri::of('https://laravel.com');

if ($uri->isNotEmpty()) {
    // process the URI
}
```

### Why This Doesn't Break Existing Features

- Purely additive — no existing methods modified
- Delegates to `isEmpty()` internally

### Changes

- `src/Illuminate/Support/Uri.php` — Added `isNotEmpty()` method
- `tests/Support/SupportUriTest.php` — Added test covering both `isEmpty()` and `isNotEmpty()`

## Test Plan

- [x] `test_is_empty_and_is_not_empty` — Verifies both methods on empty and non-empty URIs
- [x] Existing tests pass