### PR TITLE
[13.x] Pass request to afterResponse callback

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -168,7 +168,7 @@ class PendingRequest
     /**
      * The callbacks that should execute after the Laravel Response is built.
      *
-     * @var \Illuminate\Support\Collection<int, (callable(\Illuminate\Http\Client\Response): \Illuminate\Http\Client\Response|null)>
+     * @var \Illuminate\Support\Collection<int, (callable(\Illuminate\Http\Client\Response, \Illuminate\Http\Client\Request): \Illuminate\Http\Client\Response|null)>
      */
     protected $afterResponseCallbacks;
 
@@ -750,7 +750,7 @@ class PendingRequest
     /**
      * Add a new callback to execute after the response is built.
      *
-     * @param  (callable(\Illuminate\Http\Client\Response): \Illuminate\Http\Client\Response|null)  $callback
+     * @param  (callable(\Illuminate\Http\Client\Response, \Illuminate\Http\Client\Request): \Illuminate\Http\Client\Response|null)  $callback
      * @return $this
      */
     public function afterResponse(callable $callback)
@@ -1629,7 +1629,7 @@ class PendingRequest
     protected function runAfterResponseCallbacks(Response $response)
     {
         foreach ($this->afterResponseCallbacks as $callback) {
-            $returnedResponse = $callback($response);
+            $returnedResponse = $callback($response, $this->request);
 
             if ($returnedResponse instanceof Response) {
                 $response = $returnedResponse;

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -4361,8 +4361,8 @@ class HttpClientTest extends TestCase
         $response = $this->factory
             ->afterResponse(fn (Response $response): TestResponse => new TestResponse($response->toPsrResponse()))
             ->afterResponse(fn () => 'abc')
-            ->afterResponse(function ($r, $request) {
-                $this->assertInstanceOf(TestResponse::class, $r);
+            ->afterResponse(function ($response, $request) {
+                $this->assertInstanceOf(TestResponse::class, $response);
                 $this->assertInstanceOf(Request::class, $request);
                 $this->assertSame('http://200.com', (string) $request->url());
             })

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -4361,8 +4361,10 @@ class HttpClientTest extends TestCase
         $response = $this->factory
             ->afterResponse(fn (Response $response): TestResponse => new TestResponse($response->toPsrResponse()))
             ->afterResponse(fn () => 'abc')
-            ->afterResponse(function ($r) {
+            ->afterResponse(function ($r, $request) {
                 $this->assertInstanceOf(TestResponse::class, $r);
+                $this->assertInstanceOf(Request::class, $request);
+                $this->assertSame('http://200.com', (string) $request->url());
             })
             ->afterResponse(fn (Response $r) => new Response($r->toPsrResponse()->withBody(Utils::streamFor(strtolower($r->body())))))
             ->get('http://200.com');
@@ -4393,13 +4395,21 @@ class HttpClientTest extends TestCase
             'http://401.com*' => $this->factory::response('Unauthorized.', 401),
         ]);
 
-        $o = $this->factory->pool(function (Pool $pool): void {
-            $pool->as('200')->afterResponse(fn (Response $response) => new TestResponse($response->toPsrResponse()))->get('http://200.com');
+        $requestReceived = null;
+
+        $o = $this->factory->pool(function (Pool $pool) use (&$requestReceived): void {
+            $pool->as('200')->afterResponse(function (Response $response, Request $request) use (&$requestReceived) {
+                $requestReceived = $request;
+
+                return new TestResponse($response->toPsrResponse());
+            })->get('http://200.com');
             $pool->as('401-throwing')->throw()->afterResponse(fn (Response $response) => new TestResponse($response->toPsrResponse()))->get('http://401.com');
             $pool->as('401-response')->afterResponse(fn (Response $response) => new TestResponse($response->toPsrResponse()->withBody(Utils::streamFor('different'))))->get('http://401.com');
         }, 0);
 
         $this->assertInstanceOf(TestResponse::class, $o['200']);
+        $this->assertInstanceOf(Request::class, $requestReceived);
+        $this->assertSame('http://200.com', (string) $requestReceived->url());
         $this->assertInstanceOf(TestResponse::class, $o['401-response']);
         $this->assertEquals('different', $o['401-response']->body());
         $this->assertInstanceOf(RequestException::class, $o['401-throwing']);


### PR DESCRIPTION
## Summary

Passes the `Request` object as the second argument to the HTTP client `afterResponse` callbacks, enabling inline logging and request inspection without needing event listeners.

With this change, logging that would normally require using event listeners can now be done directly using the `afterResponse` callback, since the callback now has access to the request and — more importantly — the attributes that might have been added to the request and potentially needed to perform the logging.

### Logging via event listener (current approach)

```php
use Illuminate\Http\Client\Events\ConnectionFailed;
use Illuminate\Http\Client\Events\ResponseReceived;
use Illuminate\Support\Facades\Event;
use Illuminate\Support\Facades\Http;
use Illuminate\Http\Client\Response;
use Illuminate\Support\Facades\Log;

Event::listen(function (ResponseReceived $event) {
    Log::info('Logged via listener for ResponseReceived', [
        'method' => strtoupper($event->request->method()),
        'url' => $event->request->url(),
        'status' => $event->response->status(),
        'post_id' => $event->request->attributes()['post_id'],
        'time' => $event->response->transferStats()?->getTransferTime(),
    ]);
});

Http::withAttributes(['post_id' => 123])
    ->get('http://laravel.com/', ['post' => 123]);
```

### Logging via afterResponse callback (made possible by this PR)

```php
use Illuminate\Http\Client\Request;
use Illuminate\Http\Client\Response;
use Illuminate\Support\Facades\Http;
use Illuminate\Support\Facades\Log;

Http::withAttributes(['post_id' => 123])
    ->afterResponse(function (Response $response, Request $request): void {
        Log::info('Logged via after response callback', [
            'method' => strtoupper($request->method()),
            'url' => $request->url(),
            'status' => $response->status(),
            'post_id' => $request->attributes()['post_id'],
            'time' => $response->transferStats()?->getTransferTime(),
        ]);
    })
    ->get('http://laravel.com/', ['post' => 123]);
```

This is fully backwards compatible — existing callbacks that only accept `$response` continue to work since PHP silently ignores extra arguments.

## Test plan

- [x] Updated `testAfterResponse` to assert the `Request` instance and URL are passed to the callback
- [x] Updated `testAfterResponseWithAsync` to verify `Request` is passed in async/pool contexts
- [x] Existing `testAfterResponseWithThrows` and integration tests pass without changes (backwards compat)