### PR TITLE
[13.x] Improve `Arr::whereNotNull()` docs

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -1284,8 +1284,11 @@ class Arr
     /**
      * Filter items where the value is not null.
      *
-     * @param  array  $array
-     * @return array
+     * @template TKey of array-key
+     * @template TValue
+     *
+     * @param  array<TKey, TValue|null>  $array
+     * @return array<TKey, TValue>
      */
     public static function whereNotNull($array)
     {

--- a/types/Support/Arr.php
+++ b/types/Support/Arr.php
@@ -196,3 +196,9 @@ assertType('array<0|string, float>', Arr::wrap($value));
 assertType('array<array<float>>', Arr::wrap($value));
 /** @var stdClass|stdClass[]|null $value */
 assertType('array<stdClass>', Arr::wrap($value));
+
+/** @var array<string, int|null> $arr */
+assertType('array<string, int>', Arr::whereNotNull($arr));
+
+/** @var list<int|null> $arr */
+assertType('array<int<0, max>, int>', Arr::whereNotNull($arr));


### PR DESCRIPTION
Allows tools like PHPStan to understand that after this function call the resulting array will not have `null` values