### PR TITLE
[13.x] Use FQCN for Str in exception renderer blade templates

### DIFF
--- a/src/Illuminate/Foundation/resources/exceptions/renderer/components/previous-exceptions.blade.php
+++ b/src/Illuminate/Foundation/resources/exceptions/renderer/components/previous-exceptions.blade.php
@@ -5,7 +5,7 @@
         <div class="bg-white dark:bg-neutral-800 border border-neutral-200 dark:border-white/5 rounded-md w-6 h-6 flex items-center justify-center p-1">
             <x-laravel-exceptions-renderer::icons.alert class="w-2.5 h-2.5 text-blue-500 dark:text-emerald-500" />
         </div>
-        <h3 class="text-base font-semibold text-neutral-900 dark:text-white">Previous {{ Str::plural('exception', $exception->previousExceptions()->count()) }}</h3>
+        <h3 class="text-base font-semibold text-neutral-900 dark:text-white">Previous {{ \Illuminate\Support\Str::plural('exception', $exception->previousExceptions()->count()) }}</h3>
     </div>
 
     <div class="flex flex-col">

--- a/src/Illuminate/Foundation/resources/exceptions/renderer/components/trace.blade.php
+++ b/src/Illuminate/Foundation/resources/exceptions/renderer/components/trace.blade.php
@@ -8,7 +8,7 @@
         <h3 class="text-base font-semibold text-neutral-900 dark:text-white">Exception trace</h3>
         @if ($exception->previousExceptions()->isNotEmpty())
             <a href="#previous-exceptions" class="ml-auto text-sm text-neutral-500 dark:text-neutral-400 hover:text-blue-500 dark:hover:text-emerald-500 transition-colors">
-                {{ $exception->previousExceptions()->count() }} previous {{ Str::plural('exception', $exception->previousExceptions()->count()) }}
+                {{ $exception->previousExceptions()->count() }} previous {{ \Illuminate\Support\Str::plural('exception', $exception->previousExceptions()->count()) }}
             </a>
         @endif
     </div>

--- a/src/Illuminate/Foundation/resources/exceptions/renderer/markdown.blade.php
+++ b/src/Illuminate/Foundation/resources/exceptions/renderer/markdown.blade.php
@@ -13,7 +13,7 @@ Laravel {{ app()->version() }}
 @endforeach
 
 @if ($exception->previousExceptions()->isNotEmpty())
-## Previous {{ Str::plural('exception', $exception->previousExceptions()->count()) }}
+## Previous {{ \Illuminate\Support\Str::plural('exception', $exception->previousExceptions()->count()) }}
 @foreach ($exception->previousExceptions() as $index => $previous)
 
 ### {{ $index + 1 }}. {{ $previous->class() }}


### PR DESCRIPTION
Replace unqualified  calls with  in exception renderer blade templates to prevent errors when class aliases are not registered.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
