### PR TITLE
[13.x] Add withoutFragment() method to Uri class

### DIFF
--- a/src/Illuminate/Support/Uri.php
+++ b/src/Illuminate/Support/Uri.php
@@ -335,6 +335,14 @@ class Uri implements Htmlable, JsonSerializable, Responsable, Stringable
     }
 
     /**
+     * Remove the fragment from the URI.
+     */
+    public function withoutFragment(): static
+    {
+        return new static($this->uri->withFragment(null));
+    }
+
+    /**
      * Create a redirect HTTP response for the given URI.
      */
     public function redirect(int $status = 302, array $headers = []): RedirectResponse

--- a/tests/Support/SupportUriTest.php
+++ b/tests/Support/SupportUriTest.php
@@ -54,6 +54,31 @@ class SupportUriTest extends TestCase
         $this->assertTrue(Uri::of('https://laravel.com')->isNotEmpty());
     }
 
+    public function test_without_fragment()
+    {
+        $uri = Uri::of('https://laravel.com/docs/installation#introduction');
+
+        $this->assertEquals('introduction', $uri->fragment());
+
+        $withoutFragment = $uri->withoutFragment();
+
+        $this->assertNull($withoutFragment->fragment());
+        $this->assertEquals('https://laravel.com/docs/installation', $withoutFragment->value());
+
+        // Original URI should be unchanged (immutability).
+        $this->assertEquals('introduction', $uri->fragment());
+    }
+
+    public function test_without_fragment_on_uri_without_fragment()
+    {
+        $uri = Uri::of('https://laravel.com/docs');
+
+        $withoutFragment = $uri->withoutFragment();
+
+        $this->assertNull($withoutFragment->fragment());
+        $this->assertEquals('https://laravel.com/docs', $withoutFragment->value());
+    }
+
     public function test_complicated_query_string_parsing()
     {
         $uri = Uri::of('https://example.com/users?key_1=value&key_2[sub_field]=value&key_3[]=value&key_4[9]=value&key_5[][][foo][9]=bar&key.6=value&flag_value');


### PR DESCRIPTION
## Summary

Adds a `withoutFragment()` method to the `Uri` class — the missing counterpart to the existing `withFragment()` method, consistent with the `withoutQuery()` / `withQuery()` pattern already in the class.

> **Note:** This is a resubmission of #59392 which was closed due to failing tests. The root cause was using `withFragment('')` which sets the fragment to an empty string (leaving a dangling `#` in the URI), instead of `withFragment(null)` which fully removes the fragment component.

### Root Cause of Previous Test Failure

```php
// withFragment('') → sets fragment to empty string, NOT null
$uri->withFragment('');
$uri->getFragment();   // '' (empty string)
$uri->toString();      // 'https://example.com#' (dangling #)

// withFragment(null) → fully removes the fragment
$uri->withFragment(null);
$uri->getFragment();   // null
$uri->toString();      // 'https://example.com' (clean)
```

The previous implementation used `withFragment('')`, so `fragment()` returned `''` instead of `null`, causing `assertNull()` to fail across all CI environments.

### Fix

Changed to `withFragment(null)` which properly removes the fragment component, making `fragment()` return `null` — consistent with how URIs without fragments behave throughout the class.

### Example

```php
$uri = Uri::of('https://laravel.com/docs/routing#parameters');

$clean = $uri->withoutFragment();
// https://laravel.com/docs/routing

$clean->fragment(); // null (not '' empty string)
```

### Changes

- `src/Illuminate/Support/Uri.php` — Added `withoutFragment()` using `withFragment(null)`
- `tests/Support/SupportUriTest.php` — Added 2 test cases (verified passing locally on PHP 8.3)

## Test Plan

- [x] `test_without_fragment` — Removes fragment, verifies `null` return and clean URL, confirms immutability
- [x] `test_without_fragment_on_uri_without_fragment` — No-op when URI has no fragment
- [x] All 14 URI tests pass locally
- [x] Tests use `assertNull` which matches the actual `fragment()` behavior with `withFragment(null)`