### PR TITLE
[13.x] Fix macros with static closures

### DIFF
--- a/src/Illuminate/Macroable/Traits/Macroable.php
+++ b/src/Illuminate/Macroable/Traits/Macroable.php
@@ -6,6 +6,8 @@ use BadMethodCallException;
 use Closure;
 use ReflectionClass;
 use ReflectionMethod;
+use RuntimeException;
+use Throwable;
 
 trait Macroable
 {
@@ -120,7 +122,11 @@ trait Macroable
         $macro = static::$macros[$method];
 
         if ($macro instanceof Closure) {
-            $macro = $macro->bindTo($this, static::class);
+            try {
+                $macro = $macro->bindTo($this, static::class) ?? throw new RuntimeException;
+            } catch (Throwable) {
+                $macro = $macro->bindTo(null, static::class);
+            }
         }
 
         return $macro(...$parameters);

--- a/tests/Support/SupportMacroableTest.php
+++ b/tests/Support/SupportMacroableTest.php
@@ -159,6 +159,42 @@ class SupportMacroableTest extends TestCase
 
         $this->assertSame('newMethod', $this->macroable::existingMethod());
     }
+
+    public function testStaticCallOfNonStaticClosure()
+    {
+        $this->macroable::macro('nonStaticClosure', function () {
+            return 'Taylor';
+        });
+
+        $this->assertSame('Taylor', $this->macroable::nonStaticClosure());
+    }
+
+    public function testNonStaticCallOfNonStaticClosure()
+    {
+        $this->macroable::macro('nonStaticClosure', function () {
+            return 'Taylor';
+        });
+
+        $this->assertSame('Taylor', $this->macroable->nonStaticClosure());
+    }
+
+    public function testStaticCallOfStaticClosure()
+    {
+        $this->macroable::macro('staticClosure', static function () {
+            return 'Taylor';
+        });
+
+        $this->assertSame('Taylor', $this->macroable::staticClosure());
+    }
+
+    public function testNonStaticCallOfStaticClosure()
+    {
+        $this->macroable::macro('staticClosure', static function () {
+            return 'Taylor';
+        });
+
+        $this->assertSame('Taylor', $this->macroable->staticClosure());
+    }
 }
 
 class EmptyMacroable


### PR DESCRIPTION
## Description

This PR fixes an issue where using static closures in combination with macros can trigger the following error:

```md
Cannot bind an instance to a static closure
```

## Example
```php
SessionGuard::macro('previousUser', static fn (): ?User => session()->get('prev_user'));

auth()->previousUser(); // throws error
```

## Solution

Catch potential errors when rebinding the closure fails, and retry binding it to `null` instead of `$this`.

## Reasoning

Static closures can provide small performance improvements since they skip binding `$this`.[^1][^2][^3]

Some tools (e.g. [PHP CS Fixer](https://cs.symfony.com/doc/rules/function_notation/static_lambda.html) and [Rector](https://getrector.com/rule-detail/static-closure-rector)) automatically mark closures as static when possible, which can currently lead to this error when used with macros.

[^1]: https://dev.to/jszutkowski/static-vs-non-static-closures-in-php-a-surprising-benchmark-4ief
[^2]: https://f2r.github.io/en/static-closures
[^3]: https://github.com/php/php-src/pull/19941
