### PR TITLE
[13.x] Fix Pipeline memory retention in long-lived workers

### DIFF
--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -139,6 +139,9 @@ class Pipeline implements PipelineContract
             if ($this->finally) {
                 ($this->finally)($this->passable);
             }
+
+            $this->passable = null;
+            $this->pipes = [];
         }
     }
 

--- a/tests/Pipeline/PipelineTest.php
+++ b/tests/Pipeline/PipelineTest.php
@@ -392,6 +392,150 @@ class PipelineTest extends TestCase
         $this->assertSame(4, $result->value);
     }
 
+    public function testPipelineClearsReferencesAfterThen()
+    {
+        $pipeline = new Pipeline(new Container);
+
+        $result = $pipeline->send('foo')
+            ->through([PipelineTestPipeOne::class])
+            ->then(function ($piped) {
+                return $piped;
+            });
+
+        $this->assertSame('foo', $result);
+
+        $ref = new \ReflectionClass($pipeline);
+
+        $passable = $ref->getProperty('passable');
+
+        $this->assertNull($passable->getValue($pipeline));
+
+        $pipes = $ref->getProperty('pipes');
+
+        $this->assertEmpty($pipes->getValue($pipeline));
+
+        unset($_SERVER['__test.pipe.one']);
+    }
+
+    public function testPipelineClearsReferencesAfterThenReturn()
+    {
+        $pipeline = new Pipeline(new Container);
+
+        $result = $pipeline->send('foo')
+            ->through([PipelineTestPipeOne::class])
+            ->thenReturn();
+
+        $this->assertSame('foo', $result);
+
+        $ref = new \ReflectionClass($pipeline);
+
+        $passable = $ref->getProperty('passable');
+
+        $this->assertNull($passable->getValue($pipeline));
+
+        $pipes = $ref->getProperty('pipes');
+
+        $this->assertEmpty($pipes->getValue($pipeline));
+
+        unset($_SERVER['__test.pipe.one']);
+    }
+
+    public function testPipelineClearsReferencesAfterException()
+    {
+        $pipeline = new Pipeline(new Container);
+
+        try {
+            $pipeline->send('foo')
+                ->through([function ($passable, $next) {
+                    throw new Exception('fail');
+                }])
+                ->then(function ($piped) {
+                    return $piped;
+                });
+        } catch (Exception $e) {
+            // expected
+        }
+
+        $ref = new \ReflectionClass($pipeline);
+
+        $passable = $ref->getProperty('passable');
+
+        $this->assertNull($passable->getValue($pipeline));
+
+        $pipes = $ref->getProperty('pipes');
+
+        $this->assertEmpty($pipes->getValue($pipeline));
+    }
+
+    public function testPipelineFinallyReceivesPassableBeforeCleanup()
+    {
+        $finallyValue = null;
+        $pipeline = new Pipeline(new Container);
+
+        $pipeline->send('foo')
+            ->through([])
+            ->finally(function ($passable) use (&$finallyValue) {
+                $finallyValue = $passable;
+            })
+            ->then(function ($piped) {
+                return $piped;
+            });
+
+        $this->assertSame('foo', $finallyValue);
+
+        $ref = new \ReflectionClass($pipeline);
+
+        $passable = $ref->getProperty('passable');
+
+        $this->assertNull($passable->getValue($pipeline));
+    }
+
+    public function testPipelineAllowsGarbageCollectionAfterThen()
+    {
+        $object = new stdClass;
+        $object->data = str_repeat('x', 1024);
+        $weakRef = \WeakReference::create($object);
+
+        $pipeline = new Pipeline(new Container);
+        $pipeline->send($object)
+            ->through([function ($passable, $next) {
+                return $next($passable);
+            }])
+            ->then(function ($piped) {
+                return $piped;
+            });
+
+        unset($object);
+        gc_collect_cycles();
+
+        $this->assertNull($weakRef->get());
+    }
+
+    public function testPipelineWorksCorrectlyWhenReused()
+    {
+        $pipeline = new Pipeline(new Container);
+
+        $result1 = $pipeline->send('first')
+            ->through([function ($passable, $next) {
+                return $next($passable.'-piped');
+            }])
+            ->then(function ($piped) {
+                return $piped.'-done';
+            });
+
+        $this->assertSame('first-piped-done', $result1);
+
+        $result2 = $pipeline->send('second')
+            ->through([function ($passable, $next) {
+                return $next($passable.'-piped');
+            }])
+            ->then(function ($piped) {
+                return $piped.'-done';
+            });
+
+        $this->assertSame('second-piped-done', $result2);
+    }
+
     public function testPipelineFinallyWhenExceptionOccurs()
     {
         $std = new stdClass();


### PR DESCRIPTION
## Summary

Fixes 🟢 #56395. Related to 🔴 #16783, 🔴 #25999.

Pipeline retains references to `$passable` and `$pipes` after `then()` completes. In long-lived processes (Octane, queue workers, `dispatchSync`/`dispatchNow`), this prevents garbage collection of potentially large objects until the Pipeline instance itself is collected.

### Changes

Adds cleanup in the `finally` block of `Pipeline::then()`:

```php
$this->passable = null;
$this->pipes = [];
```

This runs after the finally callback (which still receives `$passable`), so existing behavior is preserved. No breaking changes — `passable` and `pipes` are only used during pipeline execution. After `then()` returns, they serve no purpose.

### Benchmarks (PHP 8.5.1)

Tested with common job types. Pipeline instance is kept alive after each job completes (simulating Octane/queue workers). Measured with `memory_get_usage(true)`.

**Without fix:**

| Use case | Before | During | After | Freed |
|----------|--------|--------|-------|-------|
| Email notification | 4 MiB | 4 MiB | 4 MiB | - |
| PDF report (large, embedded images) | 4 MiB | 28 MiB | 28 MiB | - |
| Image processing (thumbnail) | 4 MiB | 24 MiB | 24 MiB | - |
| API sync (10K records) | 4 MiB | 28 MiB | 28 MiB | - |

**With fix:**

| Use case | Before | During | After | Freed |
|----------|--------|--------|-------|-------|
| Email notification | 4 MiB | 4 MiB | 4 MiB | - |
| PDF report (large, embedded images) | 4 MiB | 28 MiB | 4 MiB | 24 MiB |
| Image processing (thumbnail) | 4 MiB | 24 MiB | 4 MiB | 20 MiB |
| API sync (10K records) | 4 MiB | 28 MiB | 28 MiB | - |

> Without the fix, "After" matches "During" because Pipeline retains `$passable` and `$pipes` after `then()` completes. With the fix, memory drops back to baseline as references are released in the `finally` block.
>
> API sync (structured arrays) settles at 28 MiB rather than 4 MiB baseline due to PHP's page allocator retaining freed pages for reuse. The data itself is fully released — this is not a cumulative leak.

---

**Simulated sequential heavy jobs** (single reused Pipeline, like a queue worker):

CSV import (100K rows, ~80 MiB), PDF report (50 pages, ~24 MiB), CSV import (80K rows, ~60 MiB).

**Without fix:**

| Job | Before start | Peak | After complete | Freed | Result |
|-----|-------------|------|---------------|-------|--------|
| CSV import (100K rows) | 4 MiB | 86 MiB | 86 MiB | 0 MiB | Memory retained |
| PDF report (50 pages) | 86 MiB | 28 MiB | 28 MiB | 0 MiB | Memory released¹ |
| CSV import (80K rows) | 28 MiB | 66 MiB | 66 MiB | 0 MiB | Memory retained |

**With fix:**

| Job | Before start | Peak | After complete | Freed | Result |
|-----|-------------|------|---------------|-------|--------|
| CSV import (100K rows) | 4 MiB | 86 MiB | 4 MiB | 82 MiB | Memory released |
| PDF report (50 pages) | 4 MiB | 28 MiB | 4 MiB | 24 MiB | Memory released |
| CSV import (80K rows) | 4 MiB | 66 MiB | 4 MiB | 62 MiB | Memory released |

> ¹ Without the fix, the PDF report "releases" memory only because the previous CSV job's larger payload was overwritten by the smaller PDF payload — memory drops from 86 → 28 MiB but that's just the new passable replacing the old one. The 28 MiB is still retained.

### Impact

- **HTTP requests:** Every request creates two Pipeline instances (global middleware in `Kernel` and route middleware in `Router`). Without cleanup, the request object and all middleware instances are retained until the next request overwrites them. With cleanup, they're eligible for GC immediately after the response is sent. This matters most in long-lived processes like Octane where the process persists between requests.
- **Bus Dispatcher:** `dispatchSync`/`dispatchNow` route through a single Pipeline instance stored in the `Dispatcher` constructor — it's reused across every dispatch. Without cleanup, the previous command's data is retained until the next dispatch overwrites it.
- **Queue workers:** `CallQueuedHandler` creates a new Pipeline per job, then dispatches through the Bus Dispatcher's reused Pipeline via `dispatchNow()`. Without cleanup, ghost memory from previous jobs can push workers over `memory_limit`.
- **No breaking changes:** `passable` and `pipes` are only used during pipeline execution. After `then()` returns, they serve no purpose.

### Test plan

**6 tests added to `PipelineTest.php`:**

- [x] `testPipelineClearsReferencesAfterThen` — passable and pipes are null/empty after then()
- [x] `testPipelineClearsReferencesAfterThenReturn` — same for thenReturn()
- [x] `testPipelineClearsReferencesAfterException` — cleanup happens even when pipeline throws
- [x] `testPipelineFinallyReceivesPassableBeforeCleanup` — finally callback gets passable before it's nulled
- [x] `testPipelineAllowsGarbageCollectionAfterThen` — WeakReference confirms object is GC'd
- [x] `testPipelineWorksCorrectlyWhenReused` — pipeline can be reused after cleanup

**Companion fix:** #59329 handles the other side — when OOM does happen, an optimistic exception counter ensures the job fails gracefully instead of retrying forever.

