### PR TITLE
[13.x] CollectedBy Attribute should follow inheritence

### DIFF
--- a/src/Illuminate/Database/Eloquent/HasCollection.php
+++ b/src/Illuminate/Database/Eloquent/HasCollection.php
@@ -45,10 +45,15 @@ trait HasCollection
     {
         $reflectionClass = new ReflectionClass(static::class);
 
+        $isEloquentGrandchild = is_subclass_of(static::class, Model::class)
+            && get_parent_class(static::class) !== Model::class;
+
         $attributes = $reflectionClass->getAttributes(CollectedBy::class);
 
         if (! isset($attributes[0]) || ! isset($attributes[0]->getArguments()[0])) {
-            return;
+            return $isEloquentGrandchild
+                ? (new (get_parent_class(static::class)))->resolveCollectionFromAttribute()
+                : null;
         }
 
         return $attributes[0]->getArguments()[0];

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3772,6 +3772,14 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertInstanceOf(CustomEloquentCollection::class, $collection);
     }
 
+    public function testCollectedByAttributeIsInheritedByChildModels()
+    {
+        $model = new EloquentChildModelWithCollectedByAttribute;
+        $collection = $model->newCollection([$model]);
+
+        $this->assertInstanceOf(CustomEloquentCollection::class, $collection);
+    }
+
     public function testUseFactoryAttribute()
     {
         $model = new EloquentModelWithUseFactoryAttribute;
@@ -4675,6 +4683,10 @@ class EloquentModelWithMutators extends Model
 
 #[CollectedBy(CustomEloquentCollection::class)]
 class EloquentModelWithCollectedByAttribute extends Model
+{
+}
+
+class EloquentChildModelWithCollectedByAttribute extends EloquentModelWithCollectedByAttribute
 {
 }
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3772,7 +3772,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertInstanceOf(CustomEloquentCollection::class, $collection);
     }
 
-    public function testCollectedByAttributeIsInheritedByChildModels()
+    public function testCollectedByAttributeIsInherited()
     {
         $model = new EloquentChildModelWithCollectedByAttribute;
         $collection = $model->newCollection([$model]);


### PR DESCRIPTION
Happy Friday! 

13.x is hot on Attributes, so now all the homies wanna use `#[CollectedBy]` 😎

Anyway, I noticed it doesn't work for inheritance, so this now copies the same as ObservedBy and ScopedBy.


This makes sure the behavior is inline with the `$collectionClass` and `newCollection()`  way.  So... Multiple options now all working the same.

**This is a B/C, but arguably what should be expected**, but feel free to close if it's risky, I can reopen for master or just never open this again 🌚  


I leave you with this....


<img src="https://github.com/user-attachments/assets/e3a52455-2259-46a7-b8f2-fcb415e16446" width="300" height="300">
