### PR TITLE
[13.x] Add enum support to BroadcastManager connection methods

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -27,6 +27,9 @@ use Psr\Log\LoggerInterface;
 use Pusher\Pusher;
 use RuntimeException;
 use Throwable;
+use UnitEnum;
+
+use function Illuminate\Support\enum_value;
 
 /**
  * @mixin \Illuminate\Contracts\Broadcasting\Broadcaster
@@ -250,10 +253,10 @@ class BroadcastManager implements FactoryContract
     /**
      * Get a driver instance.
      *
-     * @param  string|null  $name
+     * @param  \UnitEnum|string|null  $name
      * @return mixed
      */
-    public function connection($name = null)
+    public function connection(UnitEnum|string|null $name = null)
     {
         return $this->driver($name);
     }
@@ -261,12 +264,12 @@ class BroadcastManager implements FactoryContract
     /**
      * Get a driver instance.
      *
-     * @param  string|null  $name
+     * @param  \UnitEnum|string|null  $name
      * @return mixed
      */
-    public function driver($name = null)
+    public function driver(UnitEnum|string|null $name = null)
     {
-        $name = $name ?: $this->getDefaultDriver();
+        $name = enum_value($name) ?: $this->getDefaultDriver();
 
         return $this->drivers[$name] = $this->get($name);
     }

--- a/src/Illuminate/Contracts/Broadcasting/Factory.php
+++ b/src/Illuminate/Contracts/Broadcasting/Factory.php
@@ -2,13 +2,15 @@
 
 namespace Illuminate\Contracts\Broadcasting;
 
+use UnitEnum;
+
 interface Factory
 {
     /**
      * Get a broadcaster implementation by name.
      *
-     * @param  string|null  $name
+     * @param  \UnitEnum|string|null  $name
      * @return \Illuminate\Contracts\Broadcasting\Broadcaster
      */
-    public function connection($name = null);
+    public function connection(UnitEnum|string|null $name = null);
 }

--- a/tests/Integration/Broadcasting/BroadcastManagerTest.php
+++ b/tests/Integration/Broadcasting/BroadcastManagerTest.php
@@ -185,6 +185,26 @@ class BroadcastManagerTest extends TestCase
         }
     }
 
+    public function testConnectionAcceptsEnum()
+    {
+        $userConfig = [
+            'broadcasting' => [
+                'connections' => [
+                    'log' => [
+                        'driver' => 'log',
+                    ],
+                ],
+            ],
+        ];
+
+        $app = $this->getApp($userConfig);
+        $app->singleton(\Psr\Log\LoggerInterface::class, fn () => new \Psr\Log\NullLogger);
+
+        $broadcastManager = new BroadcastManager($app);
+
+        $this->assertNotNull($broadcastManager->connection(BroadcastConnectionEnum::Log));
+    }
+
     protected function getApp(array $userConfig)
     {
         $app = new Container;
@@ -192,6 +212,11 @@ class BroadcastManagerTest extends TestCase
 
         return $app;
     }
+}
+
+enum BroadcastConnectionEnum: string
+{
+    case Log = 'log';
 }
 
 class TestEvent implements ShouldBroadcast


### PR DESCRIPTION
## [13.x] Add enum support to BroadcastManager connection methods

### Summary

- Add `UnitEnum|string|null` type to `connection()` and `driver()` methods on `BroadcastManager`
- Use `enum_value()` to resolve enum values, consistent with other managers

### Context

This aligns `BroadcastManager` with the enum support already added to:
- `QueueManager` (#59389)
- `LogManager` (#59391)
- `DatabaseManager`, `RedisManager`, `FilesystemManager`

`BroadcastManager` was the remaining manager class without enum support for its `connection()` method.

### Usage

```php
enum BroadcastConnection: string
{
    case Reverb = 'reverb';
    case Log = 'log';
}

Broadcast::connection(BroadcastConnection::Reverb);
