### PR TITLE
Fix missing UnitEnum support in ModelNotFoundException

### DIFF
--- a/src/Illuminate/Database/Eloquent/ModelNotFoundException.php
+++ b/src/Illuminate/Database/Eloquent/ModelNotFoundException.php
@@ -5,6 +5,8 @@ namespace Illuminate\Database\Eloquent;
 use Illuminate\Database\RecordsNotFoundException;
 use Illuminate\Support\Arr;
 
+use function Illuminate\Support\enum_value;
+
 /**
  * @template TModel of \Illuminate\Database\Eloquent\Model
  */
@@ -35,7 +37,7 @@ class ModelNotFoundException extends RecordsNotFoundException
     {
         $this->model = $model;
 
-        $this->ids = array_map('enum_value', Arr::wrap($ids));
+        $this->ids = array_map(enum_value(...), Arr::wrap($ids));
 
         $this->message = "No query results for model [{$model}]";
 

--- a/src/Illuminate/Database/Eloquent/ModelNotFoundException.php
+++ b/src/Illuminate/Database/Eloquent/ModelNotFoundException.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Database\Eloquent;
 
-use BackedEnum;
 use Illuminate\Database\RecordsNotFoundException;
 use Illuminate\Support\Arr;
 
@@ -36,10 +35,7 @@ class ModelNotFoundException extends RecordsNotFoundException
     {
         $this->model = $model;
 
-        $this->ids = array_map(
-            fn ($id) => $id instanceof BackedEnum ? $id->value : $id,
-            Arr::wrap($ids)
-        );
+        $this->ids = array_map('enum_value', Arr::wrap($ids));
 
         $this->message = "No query results for model [{$model}]";
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -143,6 +143,24 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->findOrFail('bar', ['column']);
     }
 
+    public function testFindOrFailMethodThrowsModelNotFoundExceptionWithBackedEnum()
+    {
+        $exception = new ModelNotFoundException;
+        $exception->setModel('Foo', EloquentBuilderTestBackedEnum::Bar);
+
+        $this->assertSame('No query results for model [Foo] bar', $exception->getMessage());
+        $this->assertSame(['bar'], $exception->getIds());
+    }
+
+    public function testFindOrFailMethodThrowsModelNotFoundExceptionWithUnitEnum()
+    {
+        $exception = new ModelNotFoundException;
+        $exception->setModel('Foo', EloquentBuilderTestUnitEnum::Baz);
+
+        $this->assertSame('No query results for model [Foo] Baz', $exception->getMessage());
+        $this->assertSame(['Baz'], $exception->getIds());
+    }
+
     public function testFindOrFailMethodWithManyThrowsModelNotFoundException()
     {
         $this->expectException(ModelNotFoundException::class);
@@ -3186,4 +3204,14 @@ class EloquentBuilderTestWhereBelongsToStub extends Model
     {
         return $this->belongsTo(self::class, 'parent_id', 'id', 'parent');
     }
+}
+
+enum EloquentBuilderTestBackedEnum: string
+{
+    case Bar = 'bar';
+}
+
+enum EloquentBuilderTestUnitEnum
+{
+    case Baz;
 }


### PR DESCRIPTION
Follow up to #55977 (PR #59132 and #59147) 

This PR follows up on adding Enum support to the stringification of IDs passed to the exception. Initially only BackedEnum support was added. This switches to `enum_value()` to provide full support.

The original bug report points out this exception doesn't accept IDs the same way the rest of Builder logic does, particularly for enums. It's a non-breaking change and improves clean query building when dealing with non-stringable data.