### PR TITLE
[13.x] Adds fingerprinting utility

### DIFF
--- a/config/hashing.php
+++ b/config/hashing.php
@@ -65,4 +65,17 @@ return [
 
     'rehash_on_login' => true,
 
+    /*
+    |--------------------------------------------------------------------------
+    | Fingerprint
+    |--------------------------------------------------------------------------
+    |
+    | The Fingerprinter tool allows you to create non-secure hashes for data
+    | integrity checks. This value set the default hashing algorithm to use
+    | with the Fingerprinter tool but you may also use another at runtime.
+    |
+    */
+
+    'fingerprint' => 'xxh3',
+
 ];

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1658,6 +1658,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
             'filesystem.cloud' => [\Illuminate\Contracts\Filesystem\Cloud::class],
             'hash' => [\Illuminate\Hashing\HashManager::class],
             'hash.driver' => [\Illuminate\Contracts\Hashing\Hasher::class],
+            'fingerprint' => [\Illuminate\Hashing\Fingerprinter::class],
             'log' => [\Illuminate\Log\LogManager::class, \Psr\Log\LoggerInterface::class],
             'mail.manager' => [\Illuminate\Mail\MailManager::class, \Illuminate\Contracts\Mail\Factory::class],
             'mailer' => [\Illuminate\Mail\Mailer::class, \Illuminate\Contracts\Mail\Mailer::class, \Illuminate\Contracts\Mail\MailQueue::class],

--- a/src/Illuminate/Hashing/Fingerprinter.php
+++ b/src/Illuminate/Hashing/Fingerprinter.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace Illuminate\Hashing;
+
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Support\Jsonable;
+use Illuminate\Support\LazyCollection;
+use JsonSerializable;
+use Stringable;
+use function hash;
+use function json_encode;
+
+class Fingerprinter
+{
+    /**
+     * Create a new Fingerprinter instance.
+     */
+    public function __construct(protected string $algorithm)
+    {
+        //
+    }
+
+    /**
+     * Returns the fingerprint hash encoded in Base64.
+     *
+     * @param  mixed  $target
+     * @param  string|null  $algorithm
+     * @param  array  $options
+     * @return string
+     */
+    public function make($target, $algorithm = null, array $options = [])
+    {
+        return base64_encode($this->generate($target, $algorithm, $options));
+    }
+
+    /**
+     * Returns the fingerprint hash encoded in Base64.
+     *
+     * @param  mixed  $target
+     * @param  string|null  $algorithm
+     * @param  array  $options
+     * @return string
+     */
+    public function base64($target, $algorithm = null, $options = [])
+    {
+        return $this->make($target, $algorithm, $options);
+    }
+
+    /**
+     * Returns the fingerprint hash encoded as Base64 with URL-safe characters.
+     *
+     * @param  mixed  $target
+     * @param  string|null  $algorithm
+     * @param  array  $options
+     * @return string
+     */
+    public function base64Url($target, $algorithm = null, $options = [])
+    {
+        return rtrim(strtr($this->binary($target, $algorithm, $options), ['+' => '-', '/' => '_']), '=');
+    }
+
+    /**
+     * Returns the fingerprint hash as a binary string.
+     *
+     * @param  mixed  $target
+     * @param  string|null  $algorithm
+     * @param  array  $options
+     * @return string
+     */
+    public function binary($target, $algorithm = null, $options = [])
+    {
+        return $this->generate($target, $algorithm, $options);
+    }
+
+    /**
+     * Returns the fingerprint hash as a hexadecimal string.
+     *
+     * @param  mixed  $target
+     * @param  string|null  $algorithm
+     * @param  array  $options
+     * @return string
+     */
+    public function hex($target, $algorithm = null, $options = [])
+    {
+        return bin2hex($this->binary($target, $algorithm, $options));
+    }
+
+    /**
+     * Generates a fingerprint hash as a binary string.
+     *
+     * @param  mixed  $target
+     * @param  string|null  $algorithm
+     * @param  array  $options
+     * @return string
+     */
+    protected function generate($target, $algorithm, $options)
+    {
+        if (!$target) {
+            return '';
+        }
+
+        if (!$algorithm) {
+            $algorithm = $this->algorithm;
+        }
+
+        // When the target can be represented as a string, we can just hash it and return the
+        // result as-is. For other types of objects, we will try to normalize them to avoid
+        // loading the whole buffer into system memory and encode each "part" using JSON.
+        if ($target instanceof JsonSerializable) {
+            return hash($algorithm, json_encode($target), true, $options);
+        } elseif ($target instanceof Jsonable) {
+            return hash($algorithm, $target->toJson(), true, $options);
+        } elseif (is_string($target) || $target instanceof Stringable) {
+            return hash($algorithm, $target, true, $options);
+        } else
+
+        $context = hash_init($algorithm, 0, '', $options);
+
+        foreach ($this->normalizeTarget($target) as $memberOrLine) {
+            hash_update($context, json_encode($memberOrLine, JSON_THROW_ON_ERROR));
+        }
+
+        return hash_final($context, true);
+    }
+
+    /**
+     * Normalize the fingerprintable target into an iterable object for hashing.
+     *
+     * @param  mixed  $target
+     * @return iterable
+     */
+    protected function normalizeTarget($target)
+    {
+        return match (true) {
+            is_resource($target) => new LazyCollection(function () use ($target) {
+                rewind($target);
+
+                while (!feof($target)) {
+                    yield fgets($target);
+                }
+            }),
+            is_iterable($target) => new LazyCollection(function () use ($target) {
+                foreach ($target as $value) {
+                    yield $value;
+                }
+            }),
+            is_array($target) => $target,
+            $target instanceof Arrayable => $target->toArray(),
+            default => [$target],
+        };
+    }
+
+    /**
+     * Determines if this fingerprint hash and the issued hash are the same.
+     *
+     * @param  mixed  $expected
+     * @param  mixed  $string
+     * @return bool
+     */
+    public function is($expected, $string)
+    {
+        return hash_equals($expected, $string);
+    }
+
+    /**
+     * Determines if this fingerprint hash and the issued hash are different.
+     *
+     * @param  mixed  $expected
+     * @param  mixed  $string
+     * @return bool
+     */
+    public function isNot($expected, $string)
+    {
+        return !$this->is($expected, $string);
+    }
+}

--- a/src/Illuminate/Hashing/HashServiceProvider.php
+++ b/src/Illuminate/Hashing/HashServiceProvider.php
@@ -21,6 +21,10 @@ class HashServiceProvider extends ServiceProvider implements DeferrableProvider
         $this->app->singleton('hash.driver', function ($app) {
             return $app['hash']->driver();
         });
+
+        $this->app->bind('fingerprint', function ($app) {
+            return new Fingerprinter($app->make('config')->get('hashing.fingerprint', 'xxh3'));
+        });
     }
 
     /**
@@ -30,6 +34,6 @@ class HashServiceProvider extends ServiceProvider implements DeferrableProvider
      */
     public function provides()
     {
-        return ['hash', 'hash.driver'];
+        return ['hash', 'hash.driver', 'fingerprint'];
     }
 }

--- a/src/Illuminate/Support/Facades/Fingerprint.php
+++ b/src/Illuminate/Support/Facades/Fingerprint.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Illuminate\Support\Facades;
+
+/**
+ * @method static string make(mixed $target, string|null $algorithm = null, array $options = [])
+ * @method static string base64(mixed $target, string|null $algorithm = null, array $options = [])
+ * @method static string base64Url(mixed $target, string|null $algorithm = null, array $options = [])
+ * @method static string binary(mixed $target, string|null $algorithm = null, array $options = [])
+ * @method static string hex(mixed $target, string|null $algorithm = null, array $options = [])
+ * @method static bool is(mixed $expected, mixed $string)
+ * @method static bool isNot(mixed $expected, mixed $string)
+ *
+ * @see \Illuminate\Hashing\Fingerprinter
+ */
+class Fingerprint extends Facade
+{
+    /**
+     * Get the registered name of the component.
+     *
+     * @return string
+     */
+    protected static function getFacadeAccessor()
+    {
+        return 'fingerprint';
+    }
+}

--- a/tests/Hashing/FingerprintTest.php
+++ b/tests/Hashing/FingerprintTest.php
@@ -1,0 +1,196 @@
+<?php
+
+namespace Illuminate\Tests\Hashing;
+
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Support\Jsonable;
+use Illuminate\Foundation\Auth\User;
+use Illuminate\Hashing\Fingerprinter;
+use JsonSerializable;
+use Orchestra\Testbench\TestCase;
+use Stringable;
+
+class FingerprintTest extends TestCase
+{
+    protected function fingerprinter(): Fingerprinter
+    {
+        return $this->app->make('fingerprint');
+    }
+
+    public function test_makes_hash_using_xxh3_by_default(): void
+    {
+        $this->assertSame(hash('xxh3', 'test', true), $this->fingerprinter()->binary('test'));
+    }
+
+    public function test_makes_hash_using_config(): void
+    {
+        $this->app->make('config')->set('hashing.fingerprint', 'sha256');
+
+        $this->assertSame(hash('sha256', 'test', true), $this->fingerprinter()->binary('test'));
+    }
+
+    public function test_makes_hash_using_different_algorithm_at_runtime(): void
+    {
+        $this->assertSame(hash('sha256', 'test', true), $this->fingerprinter()->binary('test', 'sha256'));
+    }
+
+    public function test_hashes_with_option(): void
+    {
+        $hashable = 'test';
+
+        $hash = hash('xxh3', $hashable, true, $options = [
+            'seed' => 'test-seed',
+        ]);
+
+        $this->assertSame($hash, $this->fingerprinter()->binary($hashable, options: $options));
+        $this->assertSame(base64_encode($hash), $this->fingerprinter()->make($hashable, options: $options));
+        $this->assertSame(base64_encode($hash), $this->fingerprinter()->base64($hashable, options: $options));
+        $this->assertSame(rtrim(strtr($hash, ['+' => '-', '/' => '_']), '='), $this->fingerprinter()->base64Url($hashable, options: $options));
+        $this->assertSame(bin2hex($hash), $this->fingerprinter()->hex($hashable, options: $options));
+    }
+
+    public function test_hashes_string(): void
+    {
+        $hashable = 'test';
+
+        $hash = hash('xxh3', $hashable, true);
+
+        $this->assertSame($hash, $this->fingerprinter()->binary($hashable));
+        $this->assertSame(base64_encode($hash), $this->fingerprinter()->make($hashable));
+        $this->assertSame(base64_encode($hash), $this->fingerprinter()->base64($hashable));
+        $this->assertSame(rtrim(strtr($hash, ['+' => '-', '/' => '_']), '='), $this->fingerprinter()->base64Url($hashable));
+        $this->assertSame(bin2hex($hash), $this->fingerprinter()->hex($hashable));
+    }
+
+    public function test_hashes_stringable(): void
+    {
+        $hashable = new class implements Stringable
+        {
+            public function __toString(): string
+            {
+                return 'test';
+            }
+        };
+
+        $hash = hash('xxh3', $hashable, true);
+
+        $this->assertSame($hash, $this->fingerprinter()->binary($hashable));
+        $this->assertSame(base64_encode($hash), $this->fingerprinter()->make($hashable));
+        $this->assertSame(base64_encode($hash), $this->fingerprinter()->base64($hashable));
+        $this->assertSame(rtrim(strtr($hash, ['+' => '-', '/' => '_']), '='), $this->fingerprinter()->base64Url($hashable));
+        $this->assertSame(bin2hex($hash), $this->fingerprinter()->hex($hashable));
+    }
+
+    public function test_hashes_resource(): void
+    {
+        $resource = fopen('php://memory', '+r');
+
+        fwrite($resource, 'test');
+
+        $hash = hash('xxh3', json_encode('test'), true);
+
+        try {
+            $this->assertSame($hash, $this->fingerprinter()->binary($resource));
+            $this->assertSame(base64_encode($hash), $this->fingerprinter()->make($resource));
+            $this->assertSame(base64_encode($hash), $this->fingerprinter()->base64($resource));
+            $this->assertSame(rtrim(strtr($hash, ['+' => '-', '/' => '_']), '='), $this->fingerprinter()->base64Url($resource));
+            $this->assertSame(bin2hex($hash), $this->fingerprinter()->hex($resource));
+        } finally {
+            fclose($resource);
+        }
+    }
+
+    public function test_hashes_iterable(): void
+    {
+        $hashable = ['test'];
+
+        $hash = hash('xxh3', '"test"', true);
+
+        $this->assertSame($hash, $this->fingerprinter()->binary($hashable));
+        $this->assertSame(base64_encode($hash), $this->fingerprinter()->make($hashable));
+        $this->assertSame(base64_encode($hash), $this->fingerprinter()->base64($hashable));
+        $this->assertSame(rtrim(strtr($hash, ['+' => '-', '/' => '_']), '='), $this->fingerprinter()->base64Url($hashable));
+        $this->assertSame(bin2hex($hash), $this->fingerprinter()->hex($hashable));
+    }
+
+    public function test_hashes_arrayable(): void
+    {
+        $hashable = new class implements Arrayable
+        {
+            public function toArray()
+            {
+                return ['test'];
+            }
+        };
+
+        $hash = hash('xxh3', '"test"', true);
+
+        $this->assertSame($hash, $this->fingerprinter()->binary($hashable));
+        $this->assertSame(base64_encode($hash), $this->fingerprinter()->make($hashable));
+        $this->assertSame(base64_encode($hash), $this->fingerprinter()->base64($hashable));
+        $this->assertSame(rtrim(strtr($hash, ['+' => '-', '/' => '_']), '='), $this->fingerprinter()->base64Url($hashable));
+        $this->assertSame(bin2hex($hash), $this->fingerprinter()->hex($hashable));
+    }
+
+    public function test_hashes_jsonable(): void
+    {
+        $hashable = new class implements Jsonable
+        {
+            public function toJson($options = 0)
+            {
+                return '"test"';
+            }
+        };
+
+        $hash = hash('xxh3', '"test"', true);
+
+        $this->assertSame($hash, $this->fingerprinter()->binary($hashable));
+        $this->assertSame(base64_encode($hash), $this->fingerprinter()->make($hashable));
+        $this->assertSame(base64_encode($hash), $this->fingerprinter()->base64($hashable));
+        $this->assertSame(rtrim(strtr($hash, ['+' => '-', '/' => '_']), '='), $this->fingerprinter()->base64Url($hashable));
+        $this->assertSame(bin2hex($hash), $this->fingerprinter()->hex($hashable));
+    }
+
+    public function test_hashes_json_serializable(): void
+    {
+        $hashable = new class implements JsonSerializable
+        {
+            public function jsonSerialize(): string
+            {
+                return 'test';
+            }
+        };
+
+        $hash = hash('xxh3', '"test"', true);
+
+        $this->assertSame($hash, $this->fingerprinter()->binary($hashable));
+        $this->assertSame(base64_encode($hash), $this->fingerprinter()->make($hashable));
+        $this->assertSame(base64_encode($hash), $this->fingerprinter()->base64($hashable));
+        $this->assertSame(rtrim(strtr($hash, ['+' => '-', '/' => '_']), '='), $this->fingerprinter()->base64Url($hashable));
+        $this->assertSame(bin2hex($hash), $this->fingerprinter()->hex($hashable));
+    }
+
+    public function test_hashes_model(): void
+    {
+        $hashable = User::make()->forceFill(['name' => 'test']);
+
+        $hash = hash('xxh3', $hashable->toJson(), true);
+
+        $this->assertSame($hash, $this->fingerprinter()->binary($hashable));
+        $this->assertSame(base64_encode($hash), $this->fingerprinter()->make($hashable));
+        $this->assertSame(base64_encode($hash), $this->fingerprinter()->base64($hashable));
+        $this->assertSame(rtrim(strtr($hash, ['+' => '-', '/' => '_']), '='), $this->fingerprinter()->base64Url($hashable));
+        $this->assertSame(bin2hex($hash), $this->fingerprinter()->hex($hashable));
+    }
+
+    public function test_compares_hashes(): void
+    {
+        $expected = hash('xxh3', 'test', true);
+
+        $this->assertTrue($this->fingerprinter()->is($expected, $expected));
+        $this->assertFalse($this->fingerprinter()->is($expected, 'different'));
+
+        $this->assertFalse($this->fingerprinter()->isNot($expected, $expected));
+        $this->assertTrue($this->fingerprinter()->isNot($expected, 'different'));
+    }
+}


### PR DESCRIPTION
Rework of #56350

Adds the `Fingerprinter` utility mainly to create non-secure hashes from objects, resources, arrays or anything else.

The main purpose on why I'm doing this, it's because **it's a PITA to test with built-in functions** like `hash` and `hash_equals`. When testing, this means you have to set up the whole expectation and hashing. This follows the same mantra for the `File` helper.

```php
use Illuminate\Support\Facades\Fingerprint;

// Make a Base64 encoded hash
Fingerprint::make($hashable);
Fingerprint::base64($hashable);

// This one is for using transmit over the network, like as JSON or URLs.
Fingerprint::base64Url($hashable);

// Make a binary hash.
Fingerprint::binary($hashable);

// Make an hexagonal hash.
Fingerprint::hex($hashable);

// Compare two hashes.
Fingerprint::is($expected, $string);
Fingerprint::isNot($expected, $string);
```