### PR TITLE
[13.x] Add hours() and hour() methods to Sleep class

### DIFF
--- a/src/Illuminate/Support/Sleep.php
+++ b/src/Illuminate/Support/Sleep.php
@@ -161,6 +161,28 @@ class Sleep
     }
 
     /**
+     * Sleep for the given number of hours.
+     *
+     * @return $this
+     */
+    public function hours()
+    {
+        $this->duration->add('hours', $this->pullPending());
+
+        return $this;
+    }
+
+    /**
+     * Sleep for one hour.
+     *
+     * @return $this
+     */
+    public function hour()
+    {
+        return $this->hours();
+    }
+
+    /**
      * Sleep for the given number of minutes.
      *
      * @return $this

--- a/tests/Support/SleepTest.php
+++ b/tests/Support/SleepTest.php
@@ -74,6 +74,24 @@ class SleepTest extends TestCase
         $this->assertEqualsWithDelta(0, $end - $start, 0.03);
     }
 
+    public function testItCanSpecifyHours()
+    {
+        Sleep::fake();
+
+        $sleep = Sleep::for(1.5)->hours();
+
+        $this->assertSame((float) $sleep->duration->totalMicroseconds, 5_400_000_000.0);
+    }
+
+    public function testItCanSpecifyHour()
+    {
+        Sleep::fake();
+
+        $sleep = Sleep::for(1)->hour();
+
+        $this->assertSame((float) $sleep->duration->totalMicroseconds, 3_600_000_000.0);
+    }
+
     public function testItCanSpecifyMinutes()
     {
         Sleep::fake();


### PR DESCRIPTION
## Summary

Adds `hours()` and `hour()` methods to the `Sleep` class, filling the gap in the time unit chain.

### Problem

The `Sleep` class supports every common time unit except hours:

| Unit | Plural | Singular |
|---|---|---|
| Hours | ❌ | ❌ |
| Minutes | `minutes()` ✅ | `minute()` ✅ |
| Seconds | `seconds()` ✅ | `second()` ✅ |
| Milliseconds | `milliseconds()` ✅ | `millisecond()` ✅ |
| Microseconds | `microseconds()` ✅ | `microsecond()` ✅ |

This means there's no way to express hour-based sleep durations fluently:

```php
// Not possible before this PR
Sleep::for(2)->hours();

// Workaround required
Sleep::for(120)->minutes();
```

### Solution

Added `hours()` and `hour()` following the exact same pattern as the existing duration methods.

```php
// After this PR
Sleep::for(2)->hours();
Sleep::for(1)->hour();
Sleep::for(1)->hour()->and(30)->minutes();
```

### Why This Doesn't Break Existing Features

- Purely additive — no existing methods modified
- Follows the identical implementation pattern as `minutes()` / `minute()`

### Changes

- `src/Illuminate/Support/Sleep.php` — Added `hours()` and `hour()` methods
- `tests/Support/SleepTest.php` — Added 2 test cases

## Test Plan

- [x] `testItCanSpecifyHours` — 1.5 hours = 5,400,000,000 microseconds
- [x] `testItCanSpecifyHour` — 1 hour = 3,600,000,000 microseconds
- [x] All existing Sleep tests pass