### PR TITLE
[13.x] Add between() method to Number class

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -293,6 +293,19 @@ class Number
     }
 
     /**
+     * Determine if the given number is between the given minimum and maximum.
+     *
+     * @param  int|float  $number
+     * @param  int|float  $min
+     * @param  int|float  $max
+     * @return bool
+     */
+    public static function between(int|float $number, int|float $min, int|float $max): bool
+    {
+        return $number >= $min && $number <= $max;
+    }
+
+    /**
      * Clamp the given number between the given minimum and maximum.
      *
      * @param  int|float  $number

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -188,6 +188,17 @@ class SupportNumberTest extends TestCase
         $this->assertSame('1,024 YB', Number::fileSize(1024 ** 9));
     }
 
+    public function testBetween()
+    {
+        $this->assertTrue(Number::between(5, 1, 10));
+        $this->assertTrue(Number::between(1, 1, 10));
+        $this->assertTrue(Number::between(10, 1, 10));
+        $this->assertTrue(Number::between(4.5, 1, 10));
+        $this->assertFalse(Number::between(0, 1, 10));
+        $this->assertFalse(Number::between(11, 1, 10));
+        $this->assertFalse(Number::between(-1, 0, 5));
+    }
+
     public function testClamp()
     {
         $this->assertSame(2, Number::clamp(1, 2, 3));


### PR DESCRIPTION
## Summary

Adds a `Number::between()` method — a boolean range check companion to the existing `Number::clamp()` method.

### Problem

The `Number` class has `clamp()` to constrain a value into a range, but no way to simply check if a number falls within one. This is a common need in validation logic, conditionals, and business rules:

```php
// Current workaround
if ($age >= 18 && $age <= 65) { ... }

// Or using clamp (awkward)
if (Number::clamp($age, 18, 65) === $age) { ... }
```

### Solution

```php
Number::between(5, 1, 10);    // true
Number::between(1, 1, 10);    // true (inclusive)
Number::between(10, 1, 10);   // true (inclusive)
Number::between(4.5, 1, 10);  // true (floats)
Number::between(0, 1, 10);    // false
Number::between(11, 1, 10);   // false
```

The check is inclusive on both ends, which is the most common and intuitive behavior.

### Relationship to `clamp()`

| Method | Purpose | Returns |
|---|---|---|
| `clamp($n, $min, $max)` | Constrain value to range | `int\|float` |
| `between($n, $min, $max)` | Check if value is in range | `bool` |

### Why This Doesn't Break Existing Features

- Purely additive — no existing methods modified
- Placed next to `clamp()` for logical grouping

### Changes

- `src/Illuminate/Support/Number.php` — Added `between()` method
- `tests/Support/SupportNumberTest.php` — Added 7 assertions covering in-range, boundaries, out-of-range, and floats

## Test Plan

- [x] `testBetween` — All 7 assertions pass (inclusive bounds, floats, out-of-range)
- [x] All 23 Number tests pass