### PR TITLE
[13.x] Add server error status code helpers to HTTP client response

### DIFF
--- a/src/Illuminate/Http/Client/Concerns/DeterminesStatusCode.php
+++ b/src/Illuminate/Http/Client/Concerns/DeterminesStatusCode.php
@@ -174,4 +174,44 @@ trait DeterminesStatusCode
     {
         return $this->status() === 429;
     }
+
+    /**
+     * Determine if the response was a 500 "Internal Server Error" response.
+     *
+     * @return bool
+     */
+    public function internalServerError()
+    {
+        return $this->status() === 500;
+    }
+
+    /**
+     * Determine if the response was a 502 "Bad Gateway" response.
+     *
+     * @return bool
+     */
+    public function badGateway()
+    {
+        return $this->status() === 502;
+    }
+
+    /**
+     * Determine if the response was a 503 "Service Unavailable" response.
+     *
+     * @return bool
+     */
+    public function serviceUnavailable()
+    {
+        return $this->status() === 503;
+    }
+
+    /**
+     * Determine if the response was a 504 "Gateway Timeout" response.
+     *
+     * @return bool
+     */
+    public function gatewayTimeout()
+    {
+        return $this->status() === 504;
+    }
 }

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -311,6 +311,46 @@ class HttpClientTest extends TestCase
         $this->assertFalse($response->tooManyRequests());
     }
 
+    public function testInternalServerErrorResponse()
+    {
+        $this->factory->fake([
+            'laravel.com' => $this->factory::response('', 500),
+        ]);
+
+        $response = $this->factory->post('http://laravel.com');
+        $this->assertTrue($response->internalServerError());
+    }
+
+    public function testBadGatewayResponse()
+    {
+        $this->factory->fake([
+            'laravel.com' => $this->factory::response('', 502),
+        ]);
+
+        $response = $this->factory->post('http://laravel.com');
+        $this->assertTrue($response->badGateway());
+    }
+
+    public function testServiceUnavailableResponse()
+    {
+        $this->factory->fake([
+            'laravel.com' => $this->factory::response('', 503),
+        ]);
+
+        $response = $this->factory->post('http://laravel.com');
+        $this->assertTrue($response->serviceUnavailable());
+    }
+
+    public function testGatewayTimeoutResponse()
+    {
+        $this->factory->fake([
+            'laravel.com' => $this->factory::response('', 504),
+        ]);
+
+        $response = $this->factory->post('http://laravel.com');
+        $this->assertTrue($response->gatewayTimeout());
+    }
+
     public function testUnauthorizedRequest()
     {
         $this->factory->fake([


### PR DESCRIPTION
## Summary

Adds `internalServerError()`, `badGateway()`, `serviceUnavailable()`, and `gatewayTimeout()` methods to the `DeterminesStatusCode` trait, covering the most common 5xx server error status codes.

### Problem

The `DeterminesStatusCode` trait has helpers for common client-side status codes (400, 401, 402, 403, 404, 408, 409, 422, 429) but no specific helpers for server-side errors. The only server-related check is the broad `serverError()` which matches any 5xx.

```php
$response = Http::get('https://api.example.com/data');

// Currently — can only check the broad range
$response->serverError(); // true for any 5xx

// No way to check specific server errors
$response->status() === 503; // manual comparison required
```

### Solution

| Method | Status Code | Common Use Case |
|---|---|---|
| `internalServerError()` | 500 | Unexpected server failures |
| `badGateway()` | 502 | Proxy/load balancer issues |
| `serviceUnavailable()` | 503 | Maintenance mode, overloaded services |
| `gatewayTimeout()` | 504 | Upstream service timeouts |

```php
$response = Http::get('https://api.example.com/data');

if ($response->serviceUnavailable()) {
    // retry later — service is in maintenance
}

if ($response->gatewayTimeout()) {
    // upstream took too long
}
```

These are the most commonly encountered server errors when building applications that consume external APIs, and developers frequently need to handle them differently (e.g., retry on 503, alert on 500, adjust timeout on 504).

### Why This Doesn't Break Existing Features

- Purely additive — no existing methods modified
- Follows the exact same pattern as existing methods like `notFound()`, `unauthorized()`, `tooManyRequests()`
- The broad `serverError()` method continues to work for catching any 5xx

### Changes

- `src/Illuminate/Http/Client/Concerns/DeterminesStatusCode.php` — Added 4 methods
- `tests/Http/HttpClientTest.php` — Added 4 test cases

## Test Plan

- [x] `testInternalServerErrorResponse` — 500 status returns true
- [x] `testBadGatewayResponse` — 502 status returns true
- [x] `testServiceUnavailableResponse` — 503 status returns true
- [x] `testGatewayTimeoutResponse` — 504 status returns true
- [x] All tests pass locally