### PR TITLE
[13.x] Add isNotEmpty() method to Context Repository

### DIFF
--- a/src/Illuminate/Log/Context/Repository.php
+++ b/src/Illuminate/Log/Context/Repository.php
@@ -578,6 +578,16 @@ class Repository
     }
 
     /**
+     * Determine if the context is not empty.
+     *
+     * @return bool
+     */
+    public function isNotEmpty()
+    {
+        return ! $this->isEmpty();
+    }
+
+    /**
      * Execute the given callback when context is about to be dehydrated.
      *
      * @param  (callable(static): void)  $callback

--- a/src/Illuminate/Support/Facades/Context.php
+++ b/src/Illuminate/Support/Facades/Context.php
@@ -35,6 +35,7 @@ namespace Illuminate\Support\Facades;
  * @method static bool hiddenStackContains(string $key, mixed $value, bool $strict = false)
  * @method static mixed scope(callable $callback, array $data = [], array $hidden = [])
  * @method static bool isEmpty()
+ * @method static bool isNotEmpty()
  * @method static \Illuminate\Log\Context\Repository dehydrating(callable $callback)
  * @method static \Illuminate\Log\Context\Repository hydrated(callable $callback)
  * @method static \Illuminate\Log\Context\Repository handleUnserializeExceptionsUsing(callable|null $callback)

--- a/tests/Log/ContextTest.php
+++ b/tests/Log/ContextTest.php
@@ -699,6 +699,31 @@ class ContextTest extends TestCase
         Context::rememberHidden('foo', $closure);
         $this->assertSame(1, $closureRunCount);
     }
+
+    public function test_is_empty_and_is_not_empty()
+    {
+        $context = app(Repository::class);
+
+        $this->assertTrue($context->isEmpty());
+        $this->assertFalse($context->isNotEmpty());
+
+        $context->add('key', 'value');
+
+        $this->assertFalse($context->isEmpty());
+        $this->assertTrue($context->isNotEmpty());
+    }
+
+    public function test_is_not_empty_with_only_hidden_data()
+    {
+        $context = app(Repository::class);
+
+        $this->assertTrue($context->isEmpty());
+
+        $context->addHidden('secret', 'value');
+
+        $this->assertFalse($context->isEmpty());
+        $this->assertTrue($context->isNotEmpty());
+    }
 }
 
 enum Suit


### PR DESCRIPTION
## Summary

Adds `isNotEmpty()` method to the Context Repository and updates the Context facade docblock.

### Problem

The Context Repository has `isEmpty()` but no `isNotEmpty()`. This is inconsistent with the standard pattern used across the framework:

| Class | `isEmpty()` | `isNotEmpty()` |
|---|---|---|
| `Collection` | ✅ | ✅ |
| `Stringable` | ✅ | ✅ |
| `HtmlString` | ✅ | ✅ |
| `MessageBag` | ✅ | ✅ |
| `Uri` | ✅ | ✅ (merged in #59408) |
| **`Context\Repository`** | ✅ | ❌ |

### Solution

```php
// Before — only negative check available
if (! Context::isEmpty()) {
    // has context data
}

// After — expressive positive check
if (Context::isNotEmpty()) {
    // has context data
}
```

### Changes

- `src/Illuminate/Log/Context/Repository.php` — Added `isNotEmpty()` method
- `src/Illuminate/Support/Facades/Context.php` — Added `@method` docblock entry
- `tests/Log/ContextTest.php` — Added 2 tests (empty/not-empty state, hidden-only data)

## Test Plan

- [x] `test_is_empty_and_is_not_empty` — Verifies both methods with regular context data
- [x] `test_is_not_empty_with_only_hidden_data` — Verifies hidden data also makes context non-empty
- [x] All tests pass locally