### PR TITLE
[13.x] Add sentence() in Str & Stringable to convert a value to sentence case

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -53,7 +53,7 @@ class Str
     protected static $studlyCache = [];
 
     /**
-     * The cache of sentence-cased words.
+     * The cache of sentence-cased strings.
      *
      * @var array<string, string>
      */

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -53,6 +53,13 @@ class Str
     protected static $studlyCache = [];
 
     /**
+     * The cache of sentence-cased words.
+     *
+     * @var array<string, string>
+     */
+    protected static array $sentenceCache = [];
+
+    /**
      * The callback that should be used to generate UUIDs.
      *
      * @var (callable(): \Ramsey\Uuid\UuidInterface)|null
@@ -1724,6 +1731,22 @@ class Str
         $studlyWords = array_map(fn ($word) => static::ucfirst($word), $words);
 
         return static::$studlyCache[$key] = implode($studlyWords);
+    }
+
+    /**
+     * Convert a value to sentence case.
+     */
+    public static function sentence(string $value): string
+    {
+        if (isset(static::$sentenceCache[$value])) {
+            return static::$sentenceCache[$value];
+        }
+
+        $sentences = preg_split('/([.!?]\s+)/', $value, -1, PREG_SPLIT_DELIM_CAPTURE);
+
+        $formattedSentences = array_map(fn ($sentence) => static::ucfirst($sentence), $sentences);
+
+        return static::$sentenceCache[$value] = implode($formattedSentences);
     }
 
     /**

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -991,6 +991,14 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
+     * Convert a value to sentence case.
+     */
+    public function sentence(): static
+    {
+        return new static(Str::sentence($this->value));
+    }
+
+    /**
      * Convert the string to Pascal case.
      *
      * @return static

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1159,7 +1159,7 @@ class SupportStrTest extends TestCase
     public function testSentence(): void
     {
         $this->assertSame('Foo bar', Str::sentence('foo bar'));
-        $this->assertSame("Foo bar? Foo bar! Foo bar.", Str::sentence('foo bar? foo bar! foo bar.'));
+        $this->assertSame('Foo bar? Foo bar! Foo bar.', Str::sentence('foo bar? foo bar! foo bar.'));
         $this->assertSame('Foo bar', Str::sentence('Foo bar'));
 
         $this->assertSame('', Str::sentence(''));
@@ -1168,7 +1168,7 @@ class SupportStrTest extends TestCase
         $this->assertSame('Foo bar baz', Str::sentence('foo bar baz'));
         $this->assertSame('Foo bar baz', Str::sentence('foo bar baz')); // test cache
 
-        $this->assertSame("Foo bar?foo bar!foo bar.", Str::sentence('foo bar?foo bar!foo bar.'));
+        $this->assertSame('Foo bar?foo bar!foo bar.', Str::sentence('foo bar?foo bar!foo bar.'));
 
         $this->assertSame('Añoranza. Übel.', Str::sentence('añoranza. übel.'));
     }

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1156,6 +1156,23 @@ class SupportStrTest extends TestCase
         $this->assertSame('ÖffentlicheÜberraschungen', Str::studly('öffentliche-überraschungen'));
     }
 
+    public function testSentence(): void
+    {
+        $this->assertSame('Foo bar', Str::sentence('foo bar'));
+        $this->assertSame("Foo bar? Foo bar! Foo bar.", Str::sentence('foo bar? foo bar! foo bar.'));
+        $this->assertSame('Foo bar', Str::sentence('Foo bar'));
+
+        $this->assertSame('', Str::sentence(''));
+        $this->assertSame('Foo   bar.  Baz', Str::sentence('foo   bar.  baz'));
+
+        $this->assertSame('Foo bar baz', Str::sentence('foo bar baz'));
+        $this->assertSame('Foo bar baz', Str::sentence('foo bar baz')); // test cache
+
+        $this->assertSame("Foo bar?foo bar!foo bar.", Str::sentence('foo bar?foo bar!foo bar.'));
+
+        $this->assertSame('Añoranza. Übel.', Str::sentence('añoranza. übel.'));
+    }
+
     public function testPascal()
     {
         $this->assertSame('LaravelPhpFramework', Str::pascal('laravel_php_framework'));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -1175,7 +1175,7 @@ class SupportStringableTest extends TestCase
     public function testSentence(): void
     {
         $this->assertSame('Foo bar', (string) $this->stringable('foo bar')->sentence());
-        $this->assertSame("Foo bar? Foo bar! Foo bar.", (string) $this->stringable('foo bar? foo bar! foo bar.')->sentence());
+        $this->assertSame('Foo bar? Foo bar! Foo bar.', (string) $this->stringable('foo bar? foo bar! foo bar.')->sentence());
         $this->assertSame('Foo bar', (string) $this->stringable('Foo bar')->sentence());
 
         $this->assertSame('', (string) $this->stringable()->sentence());
@@ -1184,7 +1184,7 @@ class SupportStringableTest extends TestCase
         $this->assertSame('Foo bar baz', (string) $this->stringable('foo bar baz')->sentence());
         $this->assertSame('Foo bar baz', (string) $this->stringable('foo bar baz')->sentence()); // test cache
 
-        $this->assertSame("Foo bar?foo bar!foo bar.", (string) $this->stringable('foo bar?foo bar!foo bar.')->sentence());
+        $this->assertSame('Foo bar?foo bar!foo bar.', (string) $this->stringable('foo bar?foo bar!foo bar.')->sentence());
 
         $this->assertSame('Añoranza. Übel.', (string) $this->stringable('añoranza. übel.')->sentence());
     }

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -1172,6 +1172,23 @@ class SupportStringableTest extends TestCase
         $this->assertSame('FooBarBaz', (string) $this->stringable('foo-bar_baz')->studly());
     }
 
+    public function testSentence(): void
+    {
+        $this->assertSame('Foo bar', (string) $this->stringable('foo bar')->sentence());
+        $this->assertSame("Foo bar? Foo bar! Foo bar.", (string) $this->stringable('foo bar? foo bar! foo bar.')->sentence());
+        $this->assertSame('Foo bar', (string) $this->stringable('Foo bar')->sentence());
+
+        $this->assertSame('', (string) $this->stringable()->sentence());
+        $this->assertSame('Foo   bar.  Baz', (string) $this->stringable('foo   bar.  baz')->sentence());
+
+        $this->assertSame('Foo bar baz', (string) $this->stringable('foo bar baz')->sentence());
+        $this->assertSame('Foo bar baz', (string) $this->stringable('foo bar baz')->sentence()); // test cache
+
+        $this->assertSame("Foo bar?foo bar!foo bar.", (string) $this->stringable('foo bar?foo bar!foo bar.')->sentence());
+
+        $this->assertSame('Añoranza. Übel.', (string) $this->stringable('añoranza. übel.')->sentence());
+    }
+
     public function testPascal()
     {
         $this->assertSame('LaravelPHPFramework', (string) $this->stringable('laravel_p_h_p_framework')->pascal());


### PR DESCRIPTION
This PR adds `sentence()` to `Str` and `Stringable` to convert a value to sentence case.

```php
use Illuminate\Support\Str;

Str::sentence('hello world! foo bar? baz qux.');
// "Hello world! Foo bar? Baz qux."

Str::of('hello world!')->sentence();
// "Hello world!"
```