### PR TITLE
Feature/form request strict mode

### DIFF
--- a/config/validation.php
+++ b/config/validation.php
@@ -1,5 +1,0 @@
-<?php
-
-return [
-    'fail_on_unknown_fields' => false,
-];

--- a/config/validation.php
+++ b/config/validation.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'fail_on_unknown_fields' => false,
+];

--- a/src/Illuminate/Foundation/Http/Attributes/FailOnUnknownFields.php
+++ b/src/Illuminate/Foundation/Http/Attributes/FailOnUnknownFields.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Foundation\Http\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class FailOnUnknownFields
+{
+    public function __construct(public bool $value = true)
+    {
+    }
+}

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -14,6 +14,7 @@ use Illuminate\Foundation\Http\Attributes\RedirectToRoute;
 use Illuminate\Foundation\Http\Attributes\StopOnFirstFailure;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Redirector;
+use Illuminate\Support\Arr;
 use Illuminate\Validation\ValidatesWhenResolvedTrait;
 use ReflectionClass;
 
@@ -71,11 +72,41 @@ class FormRequest extends Request implements ValidatesWhenResolved
     protected $stopOnFirstFailure = false;
 
     /**
+     * Per-class override for rejecting fields not defined in rules().
+     *
+     * Null falls through to the global flag or the config value.
+     *
+     * @var bool|null
+     */
+    protected ?bool $failOnUnknownFields = null;
+
+    /**
+     * Global flag set via FormRequest::failOnUnknownFields().
+     *
+     * @var bool
+     */
+    protected static bool $globalFailOnUnknownFields = false;
+
+    /**
      * The validator instance.
      *
      * @var \Illuminate\Contracts\Validation\Validator
      */
     protected $validator;
+
+    /**
+     * Enable or disable unknown-field rejection globally for all form requests.
+     *
+     * Usage in AppServiceProvider::boot():
+     *   FormRequest::failOnUnknownFields(! app()->isProduction());
+     *
+     * @param  bool  $value
+     * @return void
+     */
+    public static function failOnUnknownFields(bool $value = true): void
+    {
+        static::$globalFailOnUnknownFields = $value;
+    }
 
     /**
      * Get the validator instance for the request.
@@ -107,6 +138,12 @@ class FormRequest extends Request implements ValidatesWhenResolved
                 $this->after(...),
                 ['validator' => $validator]
             ));
+        }
+
+        if ($this->shouldFailOnUnknownFields()) {
+            $validator->after(function (Validator $validator) {
+                $this->validateNoExtraFields($validator);
+            });
         }
 
         $this->setValidator($validator);
@@ -144,6 +181,91 @@ class FormRequest extends Request implements ValidatesWhenResolved
         if (count($errorBag) > 0) {
             $this->errorBag = $errorBag[0]->newInstance()->name;
         }
+    }
+
+    /**
+     * Determine if fields not present in rules() should fail validation.
+     *
+     * Resolution order:
+     *   1. $failOnUnknownFields  → per-class override
+     *   2. $globalFailOnUnknownFields  → FormRequest::failOnUnknownFields() ile set edilen global değer
+     *   3. Config "validation.fail_on_unknown_fields"
+     *
+     * @return bool
+     */
+    protected function shouldFailOnUnknownFields(): bool
+    {
+        if ($this->failOnUnknownFields !== null) {
+            return $this->failOnUnknownFields;
+        }
+
+        if (static::$globalFailOnUnknownFields) {
+            return true;
+        }
+
+        if ($this->container->bound('config')) {
+            return (bool) $this->container->make('config')->get('validation.fail_on_unknown_fields', false);
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  \Illuminate\Contracts\Validation\Validator  $validator
+     * @return void
+     */
+    protected function validateNoExtraFields(Validator $validator): void
+    {
+        $allowedKeys = array_keys($this->container->call([$this, 'rules']));
+
+        $inputKeys = array_keys(Arr::dot($this->all()));
+
+        foreach ($inputKeys as $inputKey) {
+            if (! $this->isAllowedKey($inputKey, $allowedKeys)) {
+                $validator->errors()->add(
+                    $inputKey,
+                    $this->getFailOnUnknownFieldsMessage($inputKey)
+                );
+            }
+        }
+    }
+
+    /**
+     * @param  string  $inputKey  The dot-notation key from the request input.
+     * @param  array  $allowedKeys  The keys defined in rules().
+     * @return bool
+     */
+    protected function isAllowedKey(string $inputKey, array $allowedKeys): bool
+    {
+        foreach ($allowedKeys as $ruleKey) {
+            if ($ruleKey === $inputKey) {
+                return true;
+            }
+
+            if (str_contains($ruleKey, '*')) {
+                $pattern = '/^'.str_replace(
+                        ['\*', '\.'],
+                        ['[^.]+', '\.'],
+                        preg_quote($ruleKey, '/')
+                    ).'$/';
+
+                if (preg_match($pattern, $inputKey)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  string  $field  The name of the unexpected field.
+     * @return string
+     */
+    protected function getFailOnUnknownFieldsMessage(string $field): string
+    {
+        return trans('validation.prohibited', ['attribute' => str_replace('_', ' ', $field)])
+            ?: "The {$field} field is not allowed.";
     }
 
     /**

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -74,7 +74,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
     /**
      * Per-class override for rejecting fields not defined in rules().
      *
-     * Null falls through to the global flag or the config value.
+     * Null falls through to the global flag set via FormRequest::failOnUnknownFields().
      *
      * @var bool|null
      */
@@ -187,9 +187,8 @@ class FormRequest extends Request implements ValidatesWhenResolved
      * Determine if fields not present in rules() should fail validation.
      *
      * Resolution order:
-     *   1. $failOnUnknownFields  → per-class override
-     *   2. $globalFailOnUnknownFields  → FormRequest::failOnUnknownFields() ile set edilen global değer
-     *   3. Config "validation.fail_on_unknown_fields"
+     *   1. $failOnUnknownFields — per-class override
+     *   2. $globalFailOnUnknownFields — set via FormRequest::failOnUnknownFields()
      *
      * @return bool
      */
@@ -199,15 +198,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
             return $this->failOnUnknownFields;
         }
 
-        if (static::$globalFailOnUnknownFields) {
-            return true;
-        }
-
-        if ($this->container->bound('config')) {
-            return (bool) $this->container->make('config')->get('validation.fail_on_unknown_fields', false);
-        }
-
-        return false;
+        return static::$globalFailOnUnknownFields;
     }
 
     /**

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -73,13 +73,6 @@ class FormRequest extends Request implements ValidatesWhenResolved
     protected $stopOnFirstFailure = false;
 
     /**
-     * Global flag set via FormRequest::failOnUnknownFields().
-     *
-     * @var bool
-     */
-    protected static bool $globalFailOnUnknownFields = false;
-
-    /**
      * The validator instance.
      *
      * @var \Illuminate\Contracts\Validation\Validator
@@ -87,15 +80,11 @@ class FormRequest extends Request implements ValidatesWhenResolved
     protected $validator;
 
     /**
-     * Enable or disable unknown-field rejection globally for all form requests.
+     * Indicates if unknown fields should be rejected for all form requests.
      *
-     * @param  bool  $value
-     * @return void
+     * @var bool
      */
-    public static function failOnUnknownFields(bool $value = true): void
-    {
-        static::$globalFailOnUnknownFields = $value;
-    }
+    protected static bool $globalFailOnUnknownFields = false;
 
     /**
      * Get the validator instance for the request.
@@ -131,7 +120,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
 
         if ($this->shouldFailOnUnknownFields()) {
             $validator->after(function (Validator $validator) {
-                $this->validateNoExtraFields($validator);
+                $this->validateNoUnknownFields($validator);
             });
         }
 
@@ -171,66 +160,6 @@ class FormRequest extends Request implements ValidatesWhenResolved
             $this->errorBag = $errorBag[0]->newInstance()->name;
         }
 
-    }
-
-    /**
-     * Determine if fields not present in rules() should fail validation.
-     *
-     * @return bool
-     */
-    protected function shouldFailOnUnknownFields(): bool
-    {
-        $failOnUnknownFields = (new ReflectionClass($this))->getAttributes(FailOnUnknownFields::class);
-
-        if ($failOnUnknownFields !== []) {
-            return $failOnUnknownFields[0]->newInstance()->value;
-        }
-
-        return static::$globalFailOnUnknownFields;
-    }
-
-    /**
-     * @param  \Illuminate\Contracts\Validation\Validator  $validator
-     * @return void
-     */
-    protected function validateNoExtraFields(Validator $validator): void
-    {
-        $allowedKeys = array_keys($this->validationRules());
-
-        $inputKeys = array_keys(Arr::dot($this->all()));
-
-        foreach ($inputKeys as $inputKey) {
-            if (! $this->isAllowedKey($inputKey, $allowedKeys)) {
-                $validator->errors()->add($inputKey, trans('validation.prohibited', [
-                    'attribute' => str_replace('_', ' ', $inputKey),
-                ]));
-            }
-        }
-    }
-
-    /**
-     * @param  string  $inputKey  The dot-notation key from the request input.
-     * @param  array  $allowedKeys  The keys defined in rules().
-     * @return bool
-     */
-    protected function isAllowedKey(string $inputKey, array $allowedKeys): bool
-    {
-        foreach ($allowedKeys as $ruleKey) {
-            if ($ruleKey === $inputKey) {
-                return true;
-            }
-
-            if (str_contains($ruleKey, '*')) {
-                $pattern = '/^'.str_replace('\*', '[^.]+', preg_quote($ruleKey, '/')).'$/';
-
-                if (preg_match($pattern, $inputKey)) {
-                    return true;
-                }
-            }
-
-        }
-
-        return false;
     }
 
     /**
@@ -277,6 +206,66 @@ class FormRequest extends Request implements ValidatesWhenResolved
     protected function validationRules()
     {
         return method_exists($this, 'rules') ? $this->container->call([$this, 'rules']) : [];
+    }
+
+    /**
+     * Determine if fields not present in rules should fail validation.
+     *
+     * @return bool
+     */
+    protected function shouldFailOnUnknownFields(): bool
+    {
+        $failOnUnknownFields = (new ReflectionClass($this))->getAttributes(FailOnUnknownFields::class);
+
+        return $failOnUnknownFields !== []
+            ? $failOnUnknownFields[0]->newInstance()->value
+            : static::$globalFailOnUnknownFields;
+    }
+
+    /**
+     * Validate that no unknown fields were sent as input.
+     *
+     * @param  \Illuminate\Contracts\Validation\Validator  $validator
+     * @return void
+     */
+    protected function validateNoUnknownFields(Validator $validator): void
+    {
+        $allowedKeys = array_keys($this->validationRules());
+
+        foreach (array_keys(Arr::dot($this->all())) as $inputKey) {
+            if (! $this->isKnownField($inputKey, $allowedKeys)) {
+                $validator->errors()->add($inputKey, trans('validation.prohibited', [
+                    'attribute' => str_replace('_', ' ', $inputKey),
+                ]));
+            }
+        }
+    }
+
+    /**
+     * Determine if the given input key is an allowed key based on the validation rules.
+     *
+     * @param  string  $inputKey
+     * @param  array  $allowedKeys
+     * @return bool
+     */
+    protected function isKnownField(string $inputKey, array $allowedKeys): bool
+    {
+        foreach ($allowedKeys as $ruleKey) {
+            if ($ruleKey === $inputKey) {
+                return true;
+            }
+
+            if (str_contains($ruleKey, '*')) {
+                $pattern = '/^'.str_replace('\*', '[^.]+', preg_quote($ruleKey, '/')).'$/';
+
+                if (preg_match($pattern, $inputKey)) {
+                    return true;
+                }
+            }
+
+        }
+
+        return false;
     }
 
     /**
@@ -389,6 +378,17 @@ class FormRequest extends Request implements ValidatesWhenResolved
     public function attributes()
     {
         return [];
+    }
+
+    /**
+     * Enable or disable unknown-field rejection globally for all form requests.
+     *
+     * @param  bool  $value
+     * @return void
+     */
+    public static function failOnUnknownFields(bool $value = true): void
+    {
+        static::$globalFailOnUnknownFields = $value;
     }
 
     /**

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Validation\Factory as ValidationFactory;
 use Illuminate\Contracts\Validation\ValidatesWhenResolved;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Foundation\Http\Attributes\ErrorBag;
+use Illuminate\Foundation\Http\Attributes\FailOnUnknownFields;
 use Illuminate\Foundation\Http\Attributes\RedirectTo;
 use Illuminate\Foundation\Http\Attributes\RedirectToRoute;
 use Illuminate\Foundation\Http\Attributes\StopOnFirstFailure;
@@ -72,15 +73,6 @@ class FormRequest extends Request implements ValidatesWhenResolved
     protected $stopOnFirstFailure = false;
 
     /**
-     * Per-class override for rejecting fields not defined in rules().
-     *
-     * Null falls through to the global flag set via FormRequest::failOnUnknownFields().
-     *
-     * @var bool|null
-     */
-    protected ?bool $failOnUnknownFields = null;
-
-    /**
      * Global flag set via FormRequest::failOnUnknownFields().
      *
      * @var bool
@@ -96,9 +88,6 @@ class FormRequest extends Request implements ValidatesWhenResolved
 
     /**
      * Enable or disable unknown-field rejection globally for all form requests.
-     *
-     * Usage in AppServiceProvider::boot():
-     *   FormRequest::failOnUnknownFields(! app()->isProduction());
      *
      * @param  bool  $value
      * @return void
@@ -181,21 +170,20 @@ class FormRequest extends Request implements ValidatesWhenResolved
         if (count($errorBag) > 0) {
             $this->errorBag = $errorBag[0]->newInstance()->name;
         }
+
     }
 
     /**
      * Determine if fields not present in rules() should fail validation.
      *
-     * Resolution order:
-     *   1. $failOnUnknownFields — per-class override
-     *   2. $globalFailOnUnknownFields — set via FormRequest::failOnUnknownFields()
-     *
      * @return bool
      */
     protected function shouldFailOnUnknownFields(): bool
     {
-        if ($this->failOnUnknownFields !== null) {
-            return $this->failOnUnknownFields;
+        $failOnUnknownFields = (new ReflectionClass($this))->getAttributes(FailOnUnknownFields::class);
+
+        if ($failOnUnknownFields !== []) {
+            return $failOnUnknownFields[0]->newInstance()->value;
         }
 
         return static::$globalFailOnUnknownFields;
@@ -207,16 +195,15 @@ class FormRequest extends Request implements ValidatesWhenResolved
      */
     protected function validateNoExtraFields(Validator $validator): void
     {
-        $allowedKeys = array_keys($this->container->call([$this, 'rules']));
+        $allowedKeys = array_keys($this->validationRules());
 
         $inputKeys = array_keys(Arr::dot($this->all()));
 
         foreach ($inputKeys as $inputKey) {
             if (! $this->isAllowedKey($inputKey, $allowedKeys)) {
-                $validator->errors()->add(
-                    $inputKey,
-                    $this->getFailOnUnknownFieldsMessage($inputKey)
-                );
+                $validator->errors()->add($inputKey, trans('validation.prohibited', [
+                    'attribute' => str_replace('_', ' ', $inputKey),
+                ]));
             }
         }
     }
@@ -234,29 +221,16 @@ class FormRequest extends Request implements ValidatesWhenResolved
             }
 
             if (str_contains($ruleKey, '*')) {
-                $pattern = '/^'.str_replace(
-                    ['\*', '\.'],
-                    ['[^.]+', '\.'],
-                    preg_quote($ruleKey, '/')
-                ).'$/';
+                $pattern = '/^'.str_replace('\*', '[^.]+', preg_quote($ruleKey, '/')).'$/';
 
                 if (preg_match($pattern, $inputKey)) {
                     return true;
                 }
             }
+
         }
 
         return false;
-    }
-
-    /**
-     * @param  string  $field  The name of the unexpected field.
-     * @return string
-     */
-    protected function getFailOnUnknownFieldsMessage(string $field): string
-    {
-        return trans('validation.prohibited', ['attribute' => str_replace('_', ' ', $field)])
-            ?: "The {$field} field is not allowed.";
     }
 
     /**

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -235,10 +235,10 @@ class FormRequest extends Request implements ValidatesWhenResolved
 
             if (str_contains($ruleKey, '*')) {
                 $pattern = '/^'.str_replace(
-                        ['\*', '\.'],
-                        ['[^.]+', '\.'],
-                        preg_quote($ruleKey, '/')
-                    ).'$/';
+                    ['\*', '\.'],
+                    ['[^.]+', '\.'],
+                    preg_quote($ruleKey, '/')
+                ).'$/';
 
                 if (preg_match($pattern, $inputKey)) {
                     return true;

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -28,6 +28,8 @@ class FoundationFormRequestTest extends TestCase
 
     protected function tearDown(): void
     {
+        FormRequest::failOnUnknownFields(false);
+
         Container::setInstance(null);
 
         $this->mocks = [];
@@ -272,16 +274,13 @@ class FoundationFormRequestTest extends TestCase
         $this->assertEquals(['name' => 'Taylor'], $request->validated());
     }
 
-    public function testFailOnUnknownFieldsEnabledViaApplicationConfig()
+    public function testFailOnUnknownFieldsEnabledViaFailOnUnknownFieldsStaticMethod()
     {
+        FormRequest::failOnUnknownFields();
+
         $request = $this->createRequest(
             ['name' => 'Taylor', 'unexpected' => 'value'],
-            FoundationTestFormRequestStub::class,
-            [
-                'validation' => [
-                    'fail_on_unknown_fields' => true,
-                ],
-            ]
+            FoundationTestFormRequestStub::class
         );
 
         $exception = $this->catchException(ValidationException::class, function () use ($request) {
@@ -291,16 +290,13 @@ class FoundationFormRequestTest extends TestCase
         $this->assertTrue($exception->validator->errors()->has('unexpected'));
     }
 
-    public function testFailOnUnknownFieldsPropertyOverridesConfig()
+    public function testFailOnUnknownFieldsPropertyOverridesGlobalStatic()
     {
+        FormRequest::failOnUnknownFields();
+
         $request = $this->createRequest(
             ['name' => 'Taylor', 'with' => 'extras'],
-            FoundationTestFormRequestStrictDisabledStub::class,
-            [
-                'validation' => [
-                    'fail_on_unknown_fields' => true,
-                ],
-            ]
+            FoundationTestFormRequestStrictDisabledStub::class
         );
 
         $request->validateResolved();

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Foundation;
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Auth\Access\Response;
+use Illuminate\Config\Repository;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Translation\Translator;
 use Illuminate\Contracts\Validation\Factory as ValidationFactoryContract;
@@ -14,6 +15,8 @@ use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Routing\Redirector;
 use Illuminate\Routing\UrlGenerator;
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\Translator as TranslatorConcrete;
 use Illuminate\Validation\Factory as ValidationFactory;
 use Illuminate\Validation\ValidationException;
 use Mockery as m;
@@ -25,6 +28,8 @@ class FoundationFormRequestTest extends TestCase
 
     protected function tearDown(): void
     {
+        Container::setInstance(null);
+
         $this->mocks = [];
 
         parent::tearDown();
@@ -241,6 +246,112 @@ class FoundationFormRequestTest extends TestCase
         $request->validateResolved();
     }
 
+    public function testFailOnUnknownFieldsRejectsExtraInputWhenEnabledOnRequest()
+    {
+        $request = $this->createRequest(
+            ['name' => 'Taylor', 'unexpected' => 'value'],
+            FoundationTestFormRequestStrictStub::class
+        );
+
+        $exception = $this->catchException(ValidationException::class, function () use ($request) {
+            $request->validateResolved();
+        });
+
+        $this->assertTrue($exception->validator->errors()->has('unexpected'));
+    }
+
+    public function testFailOnUnknownFieldsAllowsExtraInputWhenExplicitlyDisabledOnRequest()
+    {
+        $request = $this->createRequest(
+            ['name' => 'Taylor', 'with' => 'extras'],
+            FoundationTestFormRequestStrictDisabledStub::class
+        );
+
+        $request->validateResolved();
+
+        $this->assertEquals(['name' => 'Taylor'], $request->validated());
+    }
+
+    public function testFailOnUnknownFieldsEnabledViaApplicationConfig()
+    {
+        $request = $this->createRequest(
+            ['name' => 'Taylor', 'unexpected' => 'value'],
+            FoundationTestFormRequestStub::class,
+            [
+                'validation' => [
+                    'fail_on_unknown_fields' => true,
+                ],
+            ]
+        );
+
+        $exception = $this->catchException(ValidationException::class, function () use ($request) {
+            $request->validateResolved();
+        });
+
+        $this->assertTrue($exception->validator->errors()->has('unexpected'));
+    }
+
+    public function testFailOnUnknownFieldsPropertyOverridesConfig()
+    {
+        $request = $this->createRequest(
+            ['name' => 'Taylor', 'with' => 'extras'],
+            FoundationTestFormRequestStrictDisabledStub::class,
+            [
+                'validation' => [
+                    'fail_on_unknown_fields' => true,
+                ],
+            ]
+        );
+
+        $request->validateResolved();
+
+        $this->assertEquals(['name' => 'Taylor'], $request->validated());
+    }
+
+    public function testFailOnUnknownFieldsAllowsKeysMatchingWildcardRules()
+    {
+        $request = $this->createRequest(
+            [
+                'items' => [
+                    ['id' => 1, 'name' => 'a'],
+                    ['id' => 2, 'name' => 'b'],
+                ],
+            ],
+            FoundationTestFormRequestStrictWildcardStub::class
+        );
+
+        $exception = $this->catchException(ValidationException::class, function () use ($request) {
+            $request->validateResolved();
+        });
+
+        $this->assertTrue($exception->validator->errors()->has('items.0.name'));
+    }
+
+    public function testFailOnUnknownFieldsPassesForInputMatchingWildcardRulesOnly()
+    {
+        $request = $this->createRequest(
+            [
+                'items' => [
+                    ['id' => 1],
+                    ['id' => 2],
+                ],
+            ],
+            FoundationTestFormRequestStrictWildcardStub::class
+        );
+
+        $request->validateResolved();
+
+        $this->assertSame(
+            [
+                'items' => [
+                    ['id' => 1],
+                    ['id' => 2],
+                ],
+            ],
+            $request->validated()
+        );
+    }
+
     /**
      * Catch the given exception thrown from the executor, and return it.
      *
@@ -270,16 +381,29 @@ class FoundationFormRequestTest extends TestCase
      *
      * @param  array  $payload
      * @param  string  $class
+     * @param  array  $config
      * @return \Illuminate\Foundation\Http\FormRequest
      */
-    protected function createRequest($payload = [], $class = FoundationTestFormRequestStub::class)
+    protected function createRequest($payload = [], $class = FoundationTestFormRequestStub::class, array $config = [])
     {
-        $container = tap(new Container, function ($container) {
+        $container = tap(new Container, function ($container) use ($config) {
             $container->instance(
                 ValidationFactoryContract::class,
                 $this->createValidationFactory($container)
             );
+
+            $container->instance('translator', new TranslatorConcrete(new ArrayLoader([
+                'validation' => [
+                    'prohibited' => 'The :attribute field is prohibited.',
+                ],
+            ]), 'en'));
+
+            if ($config !== []) {
+                $container->instance('config', new Repository($config));
+            }
         });
+
+        Container::setInstance($container);
 
         $request = $class::create('/', 'GET', $payload);
 
@@ -296,6 +420,7 @@ class FoundationFormRequestTest extends TestCase
     protected function createValidationFactory($container)
     {
         $translator = m::mock(Translator::class)->shouldReceive('get')
+            ->zeroOrMoreTimes()->andReturn('error')->shouldReceive('choice')
             ->zeroOrMoreTimes()->andReturn('error')->getMock();
 
         return new ValidationFactory($translator, $container);
@@ -540,5 +665,50 @@ class FoundationTestFormRequestWithGetRules extends FormRequest
                 'a' => ['required', 'int', 'min:2'],
             ];
         }
+    }
+}
+
+class FoundationTestFormRequestStrictStub extends FormRequest
+{
+    protected ?bool $failOnUnknownFields = true;
+
+    public function rules()
+    {
+        return ['name' => 'required'];
+    }
+
+    public function authorize()
+    {
+        return true;
+    }
+}
+
+class FoundationTestFormRequestStrictDisabledStub extends FormRequest
+{
+    protected ?bool $failOnUnknownFields = false;
+
+    public function rules()
+    {
+        return ['name' => 'required'];
+    }
+
+    public function authorize()
+    {
+        return true;
+    }
+}
+
+class FoundationTestFormRequestStrictWildcardStub extends FormRequest
+{
+    protected ?bool $failOnUnknownFields = true;
+
+    public function rules()
+    {
+        return ['items.*.id' => 'required'];
+    }
+
+    public function authorize()
+    {
+        return true;
     }
 }

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -382,6 +382,79 @@ class FoundationFormRequestTest extends TestCase
         $this->assertTrue($exception->validator->errors()->has('items.0.name'));
     }
 
+    public function testFailOnUnknownFieldsRejectsMultipleUnknownKeys()
+    {
+        $request = $this->createRequest(
+            [
+                'name' => 'Taylor',
+                'role' => 'admin',
+                'profile' => ['is_admin' => true],
+            ],
+            FoundationTestFormRequestFailOnUnknownFieldsStub::class
+        );
+
+        $exception = $this->catchException(ValidationException::class, function () use ($request) {
+            $request->validateResolved();
+        });
+
+        $this->assertTrue($exception->validator->errors()->has('role'));
+        $this->assertTrue($exception->validator->errors()->has('profile.is_admin'));
+    }
+
+    public function testFailOnUnknownFieldsRejectsUnknownNestedSibling()
+    {
+        $request = $this->createRequest(
+            ['user' => ['name' => 'Taylor', 'role' => 'admin']],
+            FoundationTestFormRequestFailOnUnknownFieldsNestedStub::class
+        );
+
+        $exception = $this->catchException(ValidationException::class, function () use ($request) {
+            $request->validateResolved();
+        });
+
+        $this->assertTrue($exception->validator->errors()->has('user.role'));
+    }
+
+    public function testFailOnUnknownFieldsUsesPreparedInput()
+    {
+        $request = $this->createRequest(
+            ['full_name' => 'Taylor'],
+            FoundationTestFormRequestFailOnUnknownFieldsPrepareForValidationStub::class
+        );
+
+        $request->validateResolved();
+
+        $this->assertSame(['name' => 'Taylor'], $request->validated());
+    }
+
+    public function testFailOnUnknownFieldsChecksRequestPayloadWhenValidationDataIsOverridden()
+    {
+        $request = $this->createRequest(
+            ['name' => 'Taylor', 'unexpected' => 'value'],
+            FoundationTestFormRequestFailOnUnknownFieldsValidationDataOverrideStub::class
+        );
+
+        $exception = $this->catchException(ValidationException::class, function () use ($request) {
+            $request->validateResolved();
+        });
+
+        $this->assertTrue($exception->validator->errors()->has('unexpected'));
+    }
+
+    public function testFailOnUnknownFieldsStillRunsWithStopOnFirstFailureAttribute()
+    {
+        $request = $this->createRequest(
+            ['unexpected' => 'value'],
+            FoundationTestFormRequestFailOnUnknownFieldsStopOnFirstFailureStub::class
+        );
+
+        $exception = $this->catchException(ValidationException::class, function () use ($request) {
+            $request->validateResolved();
+        });
+
+        $this->assertTrue($exception->validator->errors()->has('unexpected'));
+    }
+
     /**
      * Catch the given exception thrown from the executor, and return it.
      *
@@ -741,6 +814,73 @@ class FoundationTestFormRequestFailOnUnknownFieldsSingleSegmentWildcardStub exte
     public function rules()
     {
         return ['items.*' => 'array'];
+    }
+
+    public function authorize()
+    {
+        return true;
+    }
+}
+
+#[FailOnUnknownFields]
+class FoundationTestFormRequestFailOnUnknownFieldsNestedStub extends FormRequest
+{
+    public function rules()
+    {
+        return ['user.name' => 'required'];
+    }
+
+    public function authorize()
+    {
+        return true;
+    }
+}
+
+#[FailOnUnknownFields]
+class FoundationTestFormRequestFailOnUnknownFieldsPrepareForValidationStub extends FormRequest
+{
+    public function rules()
+    {
+        return ['name' => 'required'];
+    }
+
+    public function prepareForValidation()
+    {
+        $this->replace(['name' => $this->input('full_name')]);
+    }
+
+    public function authorize()
+    {
+        return true;
+    }
+}
+
+#[FailOnUnknownFields]
+class FoundationTestFormRequestFailOnUnknownFieldsValidationDataOverrideStub extends FormRequest
+{
+    public function rules()
+    {
+        return ['name' => 'required'];
+    }
+
+    public function validationData()
+    {
+        return ['name' => $this->input('name')];
+    }
+
+    public function authorize()
+    {
+        return true;
+    }
+}
+
+#[StopOnFirstFailure]
+#[FailOnUnknownFields]
+class FoundationTestFormRequestFailOnUnknownFieldsStopOnFirstFailureStub extends FormRequest
+{
+    public function rules()
+    {
+        return ['name' => 'required'];
     }
 
     public function authorize()

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -5,12 +5,12 @@ namespace Illuminate\Tests\Foundation;
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Auth\Access\Response;
-use Illuminate\Config\Repository;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Translation\Translator;
 use Illuminate\Contracts\Validation\Factory as ValidationFactoryContract;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Foundation\Http\Attributes\ErrorBag;
+use Illuminate\Foundation\Http\Attributes\FailOnUnknownFields;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Routing\Redirector;
@@ -252,7 +252,7 @@ class FoundationFormRequestTest extends TestCase
     {
         $request = $this->createRequest(
             ['name' => 'Taylor', 'unexpected' => 'value'],
-            FoundationTestFormRequestStrictStub::class
+            FoundationTestFormRequestFailOnUnknownFieldsStub::class
         );
 
         $exception = $this->catchException(ValidationException::class, function () use ($request) {
@@ -266,7 +266,7 @@ class FoundationFormRequestTest extends TestCase
     {
         $request = $this->createRequest(
             ['name' => 'Taylor', 'with' => 'extras'],
-            FoundationTestFormRequestStrictDisabledStub::class
+            FoundationTestFormRequestSkipUnknownFieldsFailureStub::class
         );
 
         $request->validateResolved();
@@ -290,13 +290,29 @@ class FoundationFormRequestTest extends TestCase
         $this->assertTrue($exception->validator->errors()->has('unexpected'));
     }
 
-    public function testFailOnUnknownFieldsPropertyOverridesGlobalStatic()
+    public function testFailOnUnknownFieldsWorksWhenRequestDoesNotDefineRulesMethod()
+    {
+        FormRequest::failOnUnknownFields();
+
+        $request = $this->createRequest(
+            ['unexpected' => 'value'],
+            FoundationTestFormRequestWithoutRulesMethod::class
+        );
+
+        $exception = $this->catchException(ValidationException::class, function () use ($request) {
+            $request->validateResolved();
+        });
+
+        $this->assertTrue($exception->validator->errors()->has('unexpected'));
+    }
+
+    public function testFailOnUnknownFieldsAttributeOverridesGlobalStatic()
     {
         FormRequest::failOnUnknownFields();
 
         $request = $this->createRequest(
             ['name' => 'Taylor', 'with' => 'extras'],
-            FoundationTestFormRequestStrictDisabledStub::class
+            FoundationTestFormRequestSkipUnknownFieldsFailureStub::class
         );
 
         $request->validateResolved();
@@ -313,7 +329,7 @@ class FoundationFormRequestTest extends TestCase
                     ['id' => 2, 'name' => 'b'],
                 ],
             ],
-            FoundationTestFormRequestStrictWildcardStub::class
+            FoundationTestFormRequestFailOnUnknownFieldsWithWildcardStub::class
         );
 
         $exception = $this->catchException(ValidationException::class, function () use ($request) {
@@ -332,7 +348,7 @@ class FoundationFormRequestTest extends TestCase
                     ['id' => 2],
                 ],
             ],
-            FoundationTestFormRequestStrictWildcardStub::class
+            FoundationTestFormRequestFailOnUnknownFieldsWithWildcardStub::class
         );
 
         $request->validateResolved();
@@ -346,6 +362,24 @@ class FoundationFormRequestTest extends TestCase
             ],
             $request->validated()
         );
+    }
+
+    public function testFailOnUnknownFieldsWildcardMatchesSingleSegmentOnly()
+    {
+        $request = $this->createRequest(
+            [
+                'items' => [
+                    ['name' => 'a'],
+                ],
+            ],
+            FoundationTestFormRequestFailOnUnknownFieldsSingleSegmentWildcardStub::class
+        );
+
+        $exception = $this->catchException(ValidationException::class, function () use ($request) {
+            $request->validateResolved();
+        });
+
+        $this->assertTrue($exception->validator->errors()->has('items.0.name'));
     }
 
     /**
@@ -377,12 +411,11 @@ class FoundationFormRequestTest extends TestCase
      *
      * @param  array  $payload
      * @param  string  $class
-     * @param  array  $config
      * @return \Illuminate\Foundation\Http\FormRequest
      */
-    protected function createRequest($payload = [], $class = FoundationTestFormRequestStub::class, array $config = [])
+    protected function createRequest($payload = [], $class = FoundationTestFormRequestStub::class)
     {
-        $container = tap(new Container, function ($container) use ($config) {
+        $container = tap(new Container, function ($container) {
             $container->instance(
                 ValidationFactoryContract::class,
                 $this->createValidationFactory($container)
@@ -393,10 +426,6 @@ class FoundationFormRequestTest extends TestCase
                     'prohibited' => 'The :attribute field is prohibited.',
                 ],
             ]), 'en'));
-
-            if ($config !== []) {
-                $container->instance('config', new Repository($config));
-            }
         });
 
         Container::setInstance($container);
@@ -664,10 +693,9 @@ class FoundationTestFormRequestWithGetRules extends FormRequest
     }
 }
 
-class FoundationTestFormRequestStrictStub extends FormRequest
+#[FailOnUnknownFields]
+class FoundationTestFormRequestFailOnUnknownFieldsStub extends FormRequest
 {
-    protected ?bool $failOnUnknownFields = true;
-
     public function rules()
     {
         return ['name' => 'required'];
@@ -679,10 +707,9 @@ class FoundationTestFormRequestStrictStub extends FormRequest
     }
 }
 
-class FoundationTestFormRequestStrictDisabledStub extends FormRequest
+#[FailOnUnknownFields(false)]
+class FoundationTestFormRequestSkipUnknownFieldsFailureStub extends FormRequest
 {
-    protected ?bool $failOnUnknownFields = false;
-
     public function rules()
     {
         return ['name' => 'required'];
@@ -694,13 +721,26 @@ class FoundationTestFormRequestStrictDisabledStub extends FormRequest
     }
 }
 
-class FoundationTestFormRequestStrictWildcardStub extends FormRequest
+#[FailOnUnknownFields]
+class FoundationTestFormRequestFailOnUnknownFieldsWithWildcardStub extends FormRequest
 {
-    protected ?bool $failOnUnknownFields = true;
-
     public function rules()
     {
         return ['items.*.id' => 'required'];
+    }
+
+    public function authorize()
+    {
+        return true;
+    }
+}
+
+#[FailOnUnknownFields]
+class FoundationTestFormRequestFailOnUnknownFieldsSingleSegmentWildcardStub extends FormRequest
+{
+    public function rules()
+    {
+        return ['items.*' => 'array'];
     }
 
     public function authorize()


### PR DESCRIPTION
## Summary

This PR introduces a global strict mode for `FormRequest` that rejects any input field not explicitly declared in the `rules()` method. The behavior can be toggled application-wide from `AppServiceProvider`, just like `Model::shouldBeStrict()` in Eloquent.

## Motivation

Laravel's `FormRequest` validates the *content* of known fields but silently ignores fields that were never declared in `rules()`. In practice this means:

- A client can send arbitrary extra fields (e.g. `is_admin`, `role`, `balance`) alongside a legitimate request, and they will pass validation without a single warning.
- While `$request->validated()` correctly bounds its output to declared fields, raw request access via `$request->all()` or `$request->input()` — common in middleware, service classes, or when the request object is passed directly — allows undeclared fields to flow through silently.
- Mass-assignment style bugs are not limited to Eloquent; the same class of error can occur anywhere validated input is forwarded — to jobs, actions, service classes, or third-party APIs.

## Usage

**Option 1 — Global, via `AppServiceProvider`:**
```diff
<?php

namespace App\Providers;

+use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\ServiceProvider;

class AppServiceProvider extends ServiceProvider
{
    public function register(): void
    {
        //
    }

    public function boot(): void
    {
+        FormRequest::failOnUnknownFields(! app()->isProduction());
    }
}
```

**Option 2 — Per-class override:**
```php
class PublicWebhookRequest extends FormRequest
{
    // Opt this specific request out of the global strict mode
    protected ?bool $failOnUnknownFields = false;

    public function rules(): array { ... }
}
```

## Backward Compatibility

Fully backward compatible. The flag defaults to `false`, meaning no existing behavior changes unless the developer explicitly calls `FormRequest::failOnUnknownFields()` or sets `$failOnUnknownFields` on a specific request class.