### PR TITLE
[13.x] Use isset() for O(1) trait lookups on class_uses_recursive()

### DIFF
--- a/src/Illuminate/Bus/PendingBatch.php
+++ b/src/Illuminate/Bus/PendingBatch.php
@@ -104,7 +104,7 @@ class PendingBatch
                 return;
             }
 
-            if (! (static::$batchableClasses[$job::class] ?? false) && ! in_array(Batchable::class, class_uses_recursive($job))) {
+            if (! (static::$batchableClasses[$job::class] ?? false) && ! isset(class_uses_recursive($job)[Batchable::class])) {
                 static::$batchableClasses[$job::class] = false;
 
                 throw new RuntimeException(sprintf('Attempted to batch job [%s], but it does not use the Batchable trait.', $job::class));

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -130,7 +130,7 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
     {
         parent::__construct();
 
-        if (in_array(CreatesMatchingTest::class, class_uses_recursive($this))) {
+        if (isset(class_uses_recursive($this)[CreatesMatchingTest::class])) {
             $this->addTestOptions();
         }
 
@@ -186,7 +186,7 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
 
         $info = $this->type;
 
-        if (in_array(CreatesMatchingTest::class, class_uses_recursive($this))) {
+        if (isset(class_uses_recursive($this)[CreatesMatchingTest::class])) {
             $this->handleTestCreation($path);
         }
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2007,7 +2007,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
 
         $this->load((new BaseCollection($this->relations))->reject(
             fn ($relation) => $relation instanceof Pivot
-                || (is_object($relation) && in_array(AsPivot::class, class_uses_recursive($relation), true))
+                || (is_object($relation) && isset(class_uses_recursive($relation)[AsPivot::class]))
         )->keys()->all());
 
         $this->syncOriginal();
@@ -2477,7 +2477,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public static function isSoftDeletable(): bool
     {
-        return static::$isSoftDeletable[static::class] ??= in_array(SoftDeletes::class, class_uses_recursive(static::class));
+        return static::$isSoftDeletable[static::class] ??= isset(class_uses_recursive(static::class)[SoftDeletes::class]);
     }
 
     /**
@@ -2485,7 +2485,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     protected function isPrunable(): bool
     {
-        return self::$isPrunable[static::class] ??= in_array(Prunable::class, class_uses_recursive(static::class)) || static::isMassPrunable();
+        return self::$isPrunable[static::class] ??= isset(class_uses_recursive(static::class)[Prunable::class]) || static::isMassPrunable();
     }
 
     /**
@@ -2493,7 +2493,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     protected function isMassPrunable(): bool
     {
-        return self::$isMassPrunable[static::class] ??= in_array(MassPrunable::class, class_uses_recursive(static::class));
+        return self::$isMassPrunable[static::class] ??= isset(class_uses_recursive(static::class)[MassPrunable::class]);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -194,7 +194,7 @@ class BelongsToMany extends Relation
             return $table;
         }
 
-        if (in_array(AsPivot::class, class_uses_recursive($model))) {
+        if (isset(class_uses_recursive($model)[AsPivot::class])) {
             $this->using($table);
         }
 

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1062,7 +1062,7 @@ class Blueprint
 
         $modelTraits = class_uses_recursive($model);
 
-        if (in_array(HasUlids::class, $modelTraits, true)) {
+        if (isset($modelTraits[HasUlids::class])) {
             return $this->foreignUlid($column, 26)
                 ->table($model->getTable())
                 ->referencesModelColumn($model->getKeyName());

--- a/src/Illuminate/Database/Seeder.php
+++ b/src/Illuminate/Database/Seeder.php
@@ -184,7 +184,7 @@ abstract class Seeder
             ? $this->container->call([$this, 'run'], $parameters)
             : $this->run(...$parameters);
 
-        $uses = array_flip(class_uses_recursive(static::class));
+        $uses = class_uses_recursive(static::class);
 
         if (isset($uses[WithoutModelEvents::class])) {
             $callback = $this->withoutModelEvents($callback);

--- a/src/Illuminate/Events/CallQueuedListener.php
+++ b/src/Illuminate/Events/CallQueuedListener.php
@@ -198,7 +198,7 @@ class CallQueuedListener implements ShouldQueue
      */
     protected function setJobInstanceIfNecessary(Job $job, $instance)
     {
-        if (in_array(InteractsWithQueue::class, class_uses_recursive($instance))) {
+        if (isset(class_uses_recursive($instance)[InteractsWithQueue::class])) {
             $instance->setJob($job);
         }
 

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
@@ -217,7 +217,7 @@ trait InteractsWithTestCaseLifecycle
      */
     protected function setUpTraits()
     {
-        $uses = $this->traitsUsedByTest ?? array_flip(class_uses_recursive(static::class));
+        $uses = $this->traitsUsedByTest ?? class_uses_recursive(static::class);
 
         if (isset($uses[RefreshDatabase::class])) {
             $this->refreshDatabase();

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -36,7 +36,7 @@ abstract class TestCase extends BaseTestCase
     {
         $app = require Application::inferBasePath().'/bootstrap/app.php';
 
-        $this->traitsUsedByTest = array_flip(class_uses_recursive(static::class));
+        $this->traitsUsedByTest = class_uses_recursive(static::class);
 
         if (isset(CachedState::$cachedConfig) &&
             isset($this->traitsUsedByTest[WithCachedConfig::class])) {

--- a/src/Illuminate/Http/Resources/JsonApi/Concerns/ResolvesJsonApiElements.php
+++ b/src/Illuminate/Http/Resources/JsonApi/Concerns/ResolvesJsonApiElements.php
@@ -280,7 +280,7 @@ trait ResolvesJsonApiElements
 
             return;
         } elseif ($relatedModel instanceof Pivot ||
-            in_array(AsPivot::class, class_uses_recursive($relatedModel), true)) {
+            isset(class_uses_recursive($relatedModel)[AsPivot::class])) {
             yield $relationName => new MissingValue;
 
             return;

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -164,7 +164,7 @@ class CallQueuedHandler
      */
     protected function setJobInstanceIfNecessary(Job $job, $instance)
     {
-        if (in_array(InteractsWithQueue::class, class_uses_recursive($instance))) {
+        if (isset(class_uses_recursive($instance)[InteractsWithQueue::class])) {
             $instance->setJob($job);
         }
 
@@ -194,8 +194,8 @@ class CallQueuedHandler
     {
         $uses = class_uses_recursive($command);
 
-        if (! in_array(Batchable::class, $uses) ||
-            ! in_array(InteractsWithQueue::class, $uses)) {
+        if (! isset($uses[Batchable::class]) ||
+            ! isset($uses[InteractsWithQueue::class])) {
             return;
         }
 
@@ -358,7 +358,7 @@ class CallQueuedHandler
      */
     protected function ensureFailedBatchJobIsRecorded(string $uuid, $command, $e)
     {
-        if (! in_array(Batchable::class, class_uses_recursive($command))) {
+        if (! isset(class_uses_recursive($command)[Batchable::class])) {
             return;
         }
 

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -293,7 +293,7 @@ class CallQueuedHandler
      */
     protected function ensureSuccessfulBatchJobIsRecordedForMissingModel(Job $job, string $class)
     {
-        if (! in_array(Batchable::class, class_uses_recursive($class), true)) {
+        if (! isset(class_uses_recursive($class)[Batchable::class])) {
             return;
         }
 

--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -194,7 +194,7 @@ abstract class Job
         // the proper value. Otherwise, the current transaction will never commit.
         if ($e instanceof TimeoutExceededException &&
             $commandName &&
-            in_array(Batchable::class, class_uses_recursive($commandName))) {
+            isset(class_uses_recursive($commandName)[Batchable::class])) {
             $batchRepository = $this->resolve(BatchRepository::class);
 
             try {

--- a/src/Illuminate/Testing/Concerns/TestDatabases.php
+++ b/src/Illuminate/Testing/Concerns/TestDatabases.php
@@ -44,7 +44,7 @@ trait TestDatabases
         });
 
         ParallelTesting::setUpTestCase(function ($testCase) {
-            $uses = array_flip(class_uses_recursive(get_class($testCase)));
+            $uses = class_uses_recursive(get_class($testCase));
 
             $databaseTraits = [
                 Testing\DatabaseMigrations::class,


### PR DESCRIPTION
Builds on #58453 by @bram-pkg (which targeted 12.x with 19 occurrences). This PR targets 13.x and covers 20 (one additional in `CallQueuedHandler::ensureSuccessfulBatchJobIsRecordedForMissingModel` which was added after #58453).

`class_uses_recursive()` returns an associative array where keys mirror values (`['Trait\Name' => 'Trait\Name']`). This means `isset($array[$key])` is an O(1) hash lookup, while `in_array($key, $array)` is an O(n) linear scan.

The per-request performance difference is honestly negligible for most apps. The real value is correctness: when you have a hash table with the lookup target already in the keys, using a linear value scan is the wrong tool. Static analyzers like Exakat and PHP Inspections flag `in_array()` on keyed arrays as a slow function for this reason. This is the same philosophy behind the other micro-optimizations that have been merged into the framework recently. Individually small, but collectively they signal that the framework cares about doing things correctly.

The framework already acknowledged this in 4 places (`Seeder`, `TestCase`, `InteractsWithTestCaseLifecycle`, `TestDatabases`) where it calls `array_flip()` before `isset()`, working around the problem instead of fixing it. This PR removes those unnecessary flips and applies the correct approach everywhere.

Probably the biggest practical benefit is removing those 4 `array_flip()` calls (3.5x faster). These run in `TestCase::setUpTraits()` on every single test method and in `TestDatabases` on every parallel test case. For a test suite with thousands of tests running locally or in CI, that's thousands of unnecessary array copies eliminated per run.

### Why this is safe

`isset()` and `in_array()` return identical results for `class_uses_recursive()` output because keys === values. The only case where they differ is `null` values, which this function never produces. PHP docs confirm this:

- [`isset()`](https://www.php.net/manual/en/function.isset.php)
- [`in_array()`](https://www.php.net/manual/en/function.in-array.php)
- [PHP Internals Book - HashTable](https://www.phpinternalsbook.com/php5/hashtables/basic_structure.html): explains PHP's O(1) hash table key lookup
- [PHP 7 hashtable implementation](https://www.npopov.com/2014/12/22/PHPs-new-hashtable-implementation.html) (Nikita Popov)

### Changes

20 occurrences across 13 files (16 `in_array` replacements + 4 `array_flip` removals):

- **Production paths:** `Model::isSoftDeletable()`, `CallQueuedHandler::setJobInstanceIfNecessary()`, batch job trait checks, `Job::fail()`
- **Other paths:** `GeneratorCommand`, `BelongsToMany`, `Blueprint`, `Seeder`, `TestCase`, JSON:API resources
- **Removes 4 unnecessary `array_flip()` calls** that were flipping an already-keyed array before using `isset()`

### Benchmarks (PHP 8.4.16, Laravel 13.2.0)

Reproducible benchmarks (includes a real Laravel 13 app benchmark): https://github.com/JoshSalway/laravel-isset-benchmark

**Micro-benchmarks (500k iterations)**

| Scenario | in_array | isset | Speedup |
|---|---|---|---|
| TypicalModel: isSoftDeletable (13 traits) | 17.1 ms | 11.4 ms | **1.5x** |
| Job: InteractsWithQueue + Batchable | 19.0 ms | 14.2 ms | **1.3x** |
| array_flip+isset vs direct isset | 39.8 ms | 11.4 ms | **3.5x** |
| 1M model operations | 28.7 ms | 8.5 ms | **3.4x** |

**Real-world simulations**

| Scenario | in_array | isset | Saved |
|---|---|---|---|
| Single request (50 model queries) | 0.001 ms | 0.0004 ms | ~0.001 ms per request |
| 10k queued jobs | 0.235 ms | 0.124 ms | 0.111 ms |
| 1M model operations | 28.7 ms | 8.5 ms | 20.2 ms |

Per-request impact is microseconds. This is more about correctness than speed, but the benchmarks show why the change is warranted.

### Test coverage

No new tests needed. The existing suite validates all affected code paths: `isSoftDeletable()`, batch job handling, queue trait checks, `GeneratorCommand`, pivot relations, test lifecycle. If `isset()` returned a different result than `in_array()` anywhere, they would fail. All 383 relevant tests pass (905 assertions).
