### PR TITLE
[13.x] Cache getLockForPopping() result in DatabaseQueue

### DIFF
--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -45,6 +45,13 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
     protected $retryAfter = 60;
 
     /**
+     * The cached lock type for popping jobs.
+     *
+     * @var string|bool|null
+     */
+    protected $lockForPopping = null;
+
+    /**
      * Create a new database queue instance.
      *
      * @param  \Illuminate\Database\Connection  $database
@@ -338,6 +345,10 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
      */
     protected function getLockForPopping()
     {
+        if ($this->lockForPopping !== null) {
+            return $this->lockForPopping;
+        }
+
         $databaseEngine = $this->database->getPdo()->getAttribute(PDO::ATTR_DRIVER_NAME);
         $databaseVersion = $this->database->getConfig('version') ?? $this->database->getPdo()->getAttribute(PDO::ATTR_SERVER_VERSION);
 
@@ -354,14 +365,14 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
             ($databaseEngine === 'pgsql' && version_compare($databaseVersion, '9.5', '>=')) ||
             ($databaseEngine === 'vitess' && version_compare($databaseVersion, '19.0', '>='))
         ) {
-            return 'FOR UPDATE SKIP LOCKED';
+            return $this->lockForPopping = 'FOR UPDATE SKIP LOCKED';
         }
 
         if ($databaseEngine === 'sqlsrv') {
-            return 'with(rowlock,updlock,readpast)';
+            return $this->lockForPopping = 'with(rowlock,updlock,readpast)';
         }
 
-        return true;
+        return $this->lockForPopping = true;
     }
 
     /**

--- a/tests/Queue/QueueDatabaseQueueUnitTest.php
+++ b/tests/Queue/QueueDatabaseQueueUnitTest.php
@@ -196,6 +196,27 @@ class QueueDatabaseQueueUnitTest extends TestCase
         $this->assertArrayHasKey('payload', $record);
         $this->assertArrayHasKey('payload', array_slice($record, -1, 1, true));
     }
+
+    public function testGetLockForPoppingIsCached()
+    {
+        $database = m::mock(Connection::class);
+        $queue = new DatabaseQueue($database, 'table', 'default');
+
+        $pdo = m::mock(\PDO::class);
+        $pdo->shouldReceive('getAttribute')->with(\PDO::ATTR_DRIVER_NAME)->once()->andReturn('mysql');
+        $pdo->shouldReceive('getAttribute')->with(\PDO::ATTR_SERVER_VERSION)->once()->andReturn('8.0.36');
+
+        $database->shouldReceive('getPdo')->andReturn($pdo);
+        $database->shouldReceive('getConfig')->with('version')->andReturn(null);
+
+        $method = new \ReflectionMethod($queue, 'getLockForPopping');
+
+        $result1 = $method->invoke($queue);
+        $result2 = $method->invoke($queue);
+
+        $this->assertSame('FOR UPDATE SKIP LOCKED', $result1);
+        $this->assertSame($result1, $result2);
+    }
 }
 
 class MyTestJob


### PR DESCRIPTION
Fixes #59350

## Summary

`DatabaseQueue::getLockForPopping()` performs expensive database version detection on every single job pop — including 2 PDO attribute lookups, Stringable object allocations, regex parsing via `Str::before()`/`Str::after()`, and `version_compare()` calls. Since the database engine and version never change during a queue worker's process lifetime, this is pure overhead repeated thousands of times per hour per worker.

This PR caches the computed lock type after the first call.

### Before

Every call to `pop()` → `getNextAvailableJob()` → `getLockForPopping()` runs:

```
PDO::getAttribute(ATTR_DRIVER_NAME)          // PDO call
PDO::getAttribute(ATTR_SERVER_VERSION)       // PDO call
new Stringable($version)->contains(...)      // object allocation + string search
Str::before() / Str::after()                 // regex
version_compare()                            // comparison
```

On a worker processing 1000 jobs/hour, that's 2000 unnecessary PDO calls and 1000 throwaway Stringable objects per hour, per worker.

### After

First call computes and caches the result. All subsequent calls return the cached value immediately.

### Implementation

- Added `$lockForPopping` property initialized to `null`
- First call computes the lock type and assigns it to `$this->lockForPopping`
- Subsequent calls return early from the `null` check
- Uses `return $this->lockForPopping = $value` pattern — clean and minimal

### Why This Doesn't Break Existing Features

- The database engine and version cannot change during a PHP process lifetime
- The `DatabaseQueue` instance is tied to a single database connection
- No behavioral change — same lock strings are returned, just cached
- Workers that restart (e.g., after `queue:restart`) create a new `DatabaseQueue` instance with a fresh cache

### Changes

- `src/Illuminate/Queue/DatabaseQueue.php` — Cache `getLockForPopping()` result in instance property
- `tests/Queue/QueueDatabaseQueueUnitTest.php` — Test verifying PDO is queried only once

## Test Plan

- [x] `testGetLockForPoppingIsCached` — Verifies PDO `getAttribute` is called exactly once across multiple invocations
- [x] All 10 existing DatabaseQueue unit tests pass