### PR TITLE
[13.x] Fix session cookie name with non-alphanumeric APP_NAME values

### DIFF
--- a/config/session.php
+++ b/config/session.php
@@ -129,7 +129,7 @@ return [
 
     'cookie' => env(
         'SESSION_COOKIE',
-        Str::snake((string) env('APP_NAME', 'laravel')).'_session'
+        Str::slug((string) env('APP_NAME', 'laravel'), '_').'_session'
     ),
 
     /*


### PR DESCRIPTION
Fixes #59344

## Summary

The session cookie name is generated using `Str::snake()` which does not sanitize special characters. When `APP_NAME` contains brackets, symbols, or other non-alphanumeric characters (common in local/staging environments), the resulting cookie name is invalid and breaks session persistence.

### The Bug

```env
APP_NAME="[LOCAL] My Awesome App"
```

```php
// Current (Str::snake) — produces invalid cookie name
Str::snake('[LOCAL] My Awesome App') . '_session'
// → "[_l_o_c_a_l]_my_awesome_app_session"
//    ^^^^^^^^^^^^^^^^ brackets break cookie persistence

// Fixed (Str::slug with _ separator) — produces valid cookie name
Str::slug('[LOCAL] My Awesome App', '_') . '_session'
// → "local_my_awesome_app_session"
```

The invalid cookie name causes sessions to not persist — users log in successfully but are immediately logged out on redirect because the session cookie can't be read back.

### The Fix

Replace `Str::snake()` with `Str::slug($name, '_')` in `config/session.php`. This:
- Strips all non-alphanumeric characters (brackets, symbols, etc.)
- Uses underscores as separator (matching the underscore convention)
- Produces the same output as `Str::snake()` for normal alphabetic app names

### Comparison

| APP_NAME | `Str::snake()` | `Str::slug($name, '_')` |
|---|---|---|
| `Laravel` | `laravel` | `laravel` |
| `My App` | `my_app` | `my_app` |
| `[LOCAL] My App` | `[_l_o_c_a_l]_my_app` | `local_my_app` |
| `(Dev) Test-App` | `(_dev)_test-_app` | `dev_test_app` |

### Context

This regression was introduced in #56172 which changed from `Str::slug()` to `Str::snake()`. The `cache.php` and `database.php` configs still use `Str::slug()` — this PR restores consistency.

### Changes

- `config/session.php` — 1 line: `Str::snake(...)` → `Str::slug(..., '_')`