### PR TITLE
[13.x] Use strict base64_decode in Encrypter to reject invalid payloads

### DIFF
--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -156,7 +156,11 @@ class Encrypter implements EncrypterContract, StringEncrypter
     {
         $payload = $this->getJsonPayload($payload);
 
-        $iv = base64_decode($payload['iv']);
+        $iv = base64_decode($payload['iv'], true);
+
+        if ($iv === false) {
+            throw new DecryptException('The payload is invalid.');
+        }
 
         $this->ensureTagIsValid(
             $tag = empty($payload['tag']) ? null : base64_decode($payload['tag'])
@@ -235,7 +239,13 @@ class Encrypter implements EncrypterContract, StringEncrypter
             throw new DecryptException('The payload is invalid.');
         }
 
-        $payload = json_decode(base64_decode($payload), true);
+        $decoded = base64_decode($payload, true);
+
+        if ($decoded === false) {
+            throw new DecryptException('The payload is invalid.');
+        }
+
+        $payload = json_decode($decoded, true);
 
         // If the payload is not valid JSON or does not have the proper keys set we will
         // assume it is invalid and bail out of the routine since we will not be able

--- a/tests/Encryption/EncrypterTest.php
+++ b/tests/Encryption/EncrypterTest.php
@@ -197,6 +197,28 @@ class EncrypterTest extends TestCase
         $e->decrypt($payload);
     }
 
+    public function testExceptionThrownWhenPayloadContainsInvalidBase64Characters()
+    {
+        $this->expectException(DecryptException::class);
+        $this->expectExceptionMessage('The payload is invalid.');
+
+        $e = new Encrypter(str_repeat('a', 16));
+        $e->decrypt('not-valid-base64!@#$%');
+    }
+
+    public function testExceptionThrownWhenIvContainsInvalidBase64()
+    {
+        $this->expectException(DecryptException::class);
+        $this->expectExceptionMessage('The payload is invalid.');
+
+        $e = new Encrypter(str_repeat('a', 16));
+        $payload = $e->encrypt('foo');
+        $decoded = json_decode(base64_decode($payload, true), true);
+        $decoded['iv'] = '!!!invalid-base64!!!';
+        $tampered = base64_encode(json_encode($decoded));
+        $e->decrypt($tampered);
+    }
+
     public function testDecryptionExceptionIsThrownWhenUnexpectedTagIsAdded()
     {
         $this->expectException(DecryptException::class);


### PR DESCRIPTION
Fixes #59364

## Summary

The Encrypter decodes payloads and IVs using `base64_decode()` without the `strict` parameter. Without strict mode, `base64_decode()` silently strips non-base64 characters instead of rejecting them. This means tampered payloads containing invalid characters may still decode to valid-looking data rather than being rejected early.

### Before

```php
base64_decode('valid+base64/with!invalid@chars');
// Returns decoded data — invalid chars silently ignored
```

### After

```php
base64_decode('valid+base64/with!invalid@chars', true);
// Returns false — invalid input rejected
```

### What Changed

**Payload decoding** (`getJsonPayload`):
- Now uses `base64_decode($payload, true)` with explicit `false` check
- Throws `DecryptException` immediately on invalid base64 before attempting JSON decode

**IV decoding** (`decrypt`):
- Now uses `base64_decode($payload['iv'], true)` with explicit `false` check
- Throws `DecryptException` if IV contains invalid base64 characters

**Not changed** (intentionally):
- The `tag` field decoding — as noted in #59364, `ensureTagIsValid()` relies on `is_string()` to detect unexpected tags on non-AEAD ciphers. Strict mode would return `false` instead of a string, which would bypass that validation.
- Line 272 and 341 — these already use `base64_decode($value, true)` with strict mode

### Why This Doesn't Break Existing Features

- Valid base64-encoded payloads decode identically with or without strict mode
- Only malformed/tampered inputs are affected — they now fail fast instead of producing unexpected results
- All 35 existing Encrypter tests pass unchanged

### Changes

- `src/Illuminate/Encryption/Encrypter.php` — Strict `base64_decode` for payload and IV
- `tests/Encryption/EncrypterTest.php` — 2 tests: invalid base64 in payload and in IV

## Test Plan

- [x] `testExceptionThrownWhenPayloadContainsInvalidBase64Characters` — Non-base64 payload is rejected
- [x] `testExceptionThrownWhenIvContainsInvalidBase64` — Tampered IV with invalid base64 is rejected
- [x] All 35 existing Encrypter tests pass