### PR TITLE
[13.x] Cache getCasts() merged result using WeakMap

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -193,6 +193,13 @@ trait HasAttributes
     protected static $castTypeCache = [];
 
     /**
+     * The cache for merged casts keyed by model instance.
+     *
+     * @var \WeakMap|null
+     */
+    protected static $mergedCastsCache = null;
+
+    /**
      * The encrypter instance that is used to encrypt attributes.
      *
      * @var \Illuminate\Contracts\Encryption\Encrypter|null
@@ -797,6 +804,8 @@ trait HasAttributes
         $casts = $this->ensureCastsAreStringValues($casts);
 
         $this->casts = array_merge($this->casts, $casts);
+
+        unset(static::$mergedCastsCache[$this]);
 
         return $this;
     }
@@ -1713,7 +1722,11 @@ trait HasAttributes
     public function getCasts()
     {
         if ($this->getIncrementing()) {
-            return array_merge([$this->getKeyName() => $this->getKeyType()], $this->casts);
+            $cache = (static::$mergedCastsCache ??= new \WeakMap);
+
+            return $cache[$this] ??= array_merge(
+                [$this->getKeyName() => $this->getKeyType()], $this->casts
+            );
         }
 
         return $this->casts;

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3124,6 +3124,29 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertArrayHasKey('foo', $model->getCasts());
     }
 
+    public function testGetCastsCachesResult()
+    {
+        $model = new EloquentModelStub;
+
+        $casts1 = $model->getCasts();
+        $casts2 = $model->getCasts();
+
+        $this->assertSame($casts1, $casts2);
+    }
+
+    public function testGetCastsCacheIsInvalidatedByMergeCasts()
+    {
+        $model = new EloquentModelStub;
+
+        $castsBefore = $model->getCasts();
+        $this->assertArrayNotHasKey('new_field', $castsBefore);
+
+        $model->mergeCasts(['new_field' => 'integer']);
+
+        $castsAfter = $model->getCasts();
+        $this->assertArrayHasKey('new_field', $castsAfter);
+    }
+
     public function testMergeCastsMergesCastsUsingArrays()
     {
         $model = new EloquentModelCastingStub;


### PR DESCRIPTION
Fixes #59349

> **Note:** This is a resubmission of #59437 which was closed because the instance property approach broke `assertEquals` assertions on model objects. This version uses a `WeakMap` instead, which stores the cache outside the object's property list.

## Summary

`getCasts()` calls `array_merge([$this->getKeyName() => $this->getKeyType()], $this->casts)` on every invocation when the model uses auto-incrementing keys (the default). This method is called from `hasCast()`, `transformModelValue()`, `originalIsEquivalent()`, `addCastAttributesToArray()`, and many other hot paths — resulting in thousands of throwaway array allocations per request on Eloquent-heavy pages.

### Why the previous attempt failed

The first version (#59437) added a `$mergedCastsCache` instance property. This caused existing tests to fail because `assertEquals($modelA, $modelB)` compares all object properties — when one model had called `getCasts()` (cache populated) and the other hadn't (cache `null`), they were no longer equal.

### How this version fixes it

Uses a **static `WeakMap`** keyed by model instance. This approach:
- Stores the cache **outside the object's property list** — invisible to `assertEquals`
- **Auto-cleans** when models are garbage collected (no memory leaks)
- Already used elsewhere in Laravel (`Arr`, `Once`, `PreventsCircularRecursion`)

### Implementation

```php
protected static $mergedCastsCache = null;

public function getCasts()
{
    if ($this->getIncrementing()) {
        $cache = (static::$mergedCastsCache ??= new \WeakMap);

        return $cache[$this] ??= array_merge(
            [$this->getKeyName() => $this->getKeyType()], $this->casts
        );
    }

    return $this->casts;
}
```

`mergeCasts()` invalidates via `unset(static::$mergedCastsCache[$this])`.

### Changes

- `src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php` — WeakMap cache for `getCasts()`, invalidation in `mergeCasts()`
- `tests/Database/DatabaseEloquentModelTest.php` — 2 tests: caching and invalidation

## Test Plan

- [x] `testGetCastsCachesResult` — Same array returned on consecutive calls
- [x] `testGetCastsCacheIsInvalidatedByMergeCasts` — New casts appear after `mergeCasts()`
- [x] All 230 Eloquent model tests pass
- [x] All 6 polymorphic integration tests pass (previously failed in #59437)
- [x] `testUpdateModelAfterSoftDeleting` passes (previously failed in #59437)