### PR TITLE
[13.x] Fix missing UnitEnum support in ModelNotFoundException

### DIFF
--- a/src/Illuminate/Database/Eloquent/ModelNotFoundException.php
+++ b/src/Illuminate/Database/Eloquent/ModelNotFoundException.php
@@ -2,9 +2,10 @@
 
 namespace Illuminate\Database\Eloquent;
 
-use BackedEnum;
 use Illuminate\Database\RecordsNotFoundException;
 use Illuminate\Support\Arr;
+
+use function Illuminate\Support\enum_value;
 
 /**
  * @template TModel of \Illuminate\Database\Eloquent\Model
@@ -36,10 +37,7 @@ class ModelNotFoundException extends RecordsNotFoundException
     {
         $this->model = $model;
 
-        $this->ids = array_map(
-            fn ($id) => $id instanceof BackedEnum ? $id->value : $id,
-            Arr::wrap($ids)
-        );
+        $this->ids = array_map(enum_value(...), Arr::wrap($ids));
 
         $this->message = "No query results for model [{$model}]";
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -143,6 +143,24 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->findOrFail('bar', ['column']);
     }
 
+    public function testFindOrFailMethodThrowsModelNotFoundExceptionWithBackedEnum()
+    {
+        $exception = new ModelNotFoundException;
+        $exception->setModel('Foo', EloquentBuilderTestBackedEnum::Bar);
+
+        $this->assertSame('No query results for model [Foo] bar', $exception->getMessage());
+        $this->assertSame(['bar'], $exception->getIds());
+    }
+
+    public function testFindOrFailMethodThrowsModelNotFoundExceptionWithUnitEnum()
+    {
+        $exception = new ModelNotFoundException;
+        $exception->setModel('Foo', EloquentBuilderTestUnitEnum::Baz);
+
+        $this->assertSame('No query results for model [Foo] Baz', $exception->getMessage());
+        $this->assertSame(['Baz'], $exception->getIds());
+    }
+
     public function testFindOrFailMethodWithManyThrowsModelNotFoundException()
     {
         $this->expectException(ModelNotFoundException::class);
@@ -3250,4 +3268,14 @@ class EloquentBuilderTestWhereBelongsToStub extends Model
     {
         return $this->belongsTo(self::class, 'parent_id', 'id', 'parent');
     }
+}
+
+enum EloquentBuilderTestBackedEnum: string
+{
+    case Bar = 'bar';
+}
+
+enum EloquentBuilderTestUnitEnum
+{
+    case Baz;
 }


### PR DESCRIPTION
## Summary

Forward-port of #59423 from 12.x to 13.x.

`ModelNotFoundException::setModel()` uses `instanceof BackedEnum` to extract enum values, which misses `UnitEnum` support. When a `UnitEnum` is passed as an ID (e.g., via `findOrFail()`), the enum object itself is stored instead of its name, producing incorrect error messages.

### Before

```php
enum Status { case Active; }

User::findOrFail(Status::Active);
// Message: "No query results for model [App\Models\User] [object]"
// IDs: [Status::Active] (enum object, not string)
```

### After

```php
User::findOrFail(Status::Active);
// Message: "No query results for model [App\Models\User] Active"
// IDs: ['Active'] (string)
```

### Changes

- `src/Illuminate/Database/Eloquent/ModelNotFoundException.php` — Replace `instanceof BackedEnum` with `enum_value()` helper
- `tests/Database/DatabaseEloquentBuilderTest.php` — 2 tests: BackedEnum and UnitEnum in ModelNotFoundException

## Test Plan

- [x] `testFindOrFailMethodThrowsModelNotFoundExceptionWithBackedEnum` — BackedEnum value extracted correctly
- [x] `testFindOrFailMethodThrowsModelNotFoundExceptionWithUnitEnum` — UnitEnum name extracted correctly
- [x] All tests pass locally