### PR TITLE
[13.x] Add assertHasNoAttachments() method to Mailable

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -1550,6 +1550,28 @@ class Mailable implements MailableContract, Renderable
      * @param  array  $options
      * @return $this
      */
+    public function assertHasNoAttachments()
+    {
+        $this->renderForAssertions();
+
+        PHPUnit::assertEmpty(
+            $this->attachments,
+            'Expected no attachments, but found ['.count($this->attachments).'] file attachment(s).'
+        );
+
+        PHPUnit::assertEmpty(
+            $this->rawAttachments,
+            'Expected no attachments, but found ['.count($this->rawAttachments).'] raw data attachment(s).'
+        );
+
+        PHPUnit::assertEmpty(
+            $this->diskAttachments,
+            'Expected no attachments, but found ['.count($this->diskAttachments).'] storage attachment(s).'
+        );
+
+        return $this;
+    }
+
     public function assertHasAttachment($file, array $options = [])
     {
         $this->renderForAssertions();

--- a/tests/Mail/MailMailableTest.php
+++ b/tests/Mail/MailMailableTest.php
@@ -1019,6 +1019,36 @@ class MailMailableTest extends TestCase
         $this->assertFalse($mailable->hasAttachmentFromStorageDisk('disk', '/path/to/foo.jpg', 'bar.jpg', ['mime' => 'text/html']));
     }
 
+    public function testAssertHasNoAttachments(): void
+    {
+        $this->stubMailer();
+
+        $mailable = new class() extends Mailable
+        {
+            public function build()
+            {
+                //
+            }
+        };
+
+        $mailable->assertHasNoAttachments();
+
+        $mailableWithAttachment = new class() extends Mailable
+        {
+            public function build()
+            {
+                $this->attach('/path/to/foo.jpg');
+            }
+        };
+
+        try {
+            $mailableWithAttachment->assertHasNoAttachments();
+            $this->fail();
+        } catch (AssertionFailedError $e) {
+            $this->assertStringContainsString('Expected no attachments', $e->getMessage());
+        }
+    }
+
     public function testAssertHasAttachment(): void
     {
         $this->stubMailer();


### PR DESCRIPTION
## Summary

Adds `assertHasNoAttachments()` to the Mailable class — the missing negative assertion for the existing attachment assertion family.

### Problem

The Mailable class has assertions for verifying attachments exist:
- `assertHasAttachment()`
- `assertHasAttachedData()`
- `assertHasAttachmentFromStorage()`
- `assertHasAttachmentFromStorageDisk()`

But there's no way to assert that a mailable has **no** attachments. This is a common testing need — for example, verifying that a welcome email or password reset email doesn't accidentally include attachments.

```php
// Before: no clean way to test this
$mailable = new WelcomeEmail($user);
// ...manually check properties?

// After
$mailable->assertHasNoAttachments();
```

### Implementation

Checks all three attachment types (file attachments, raw data attachments, and storage disk attachments) with specific error messages indicating which type was unexpectedly found:

```php
public function assertHasNoAttachments()
{
    $this->renderForAssertions();

    PHPUnit::assertEmpty($this->attachments, ...);
    PHPUnit::assertEmpty($this->rawAttachments, ...);
    PHPUnit::assertEmpty($this->diskAttachments, ...);

    return $this;
}
```

### Why This Doesn't Break Existing Features

- Purely additive — no existing methods modified
- Follows the existing assertion pattern (render, assert, return `$this`)
- Placed logically before the existing `assertHasAttachment()` method

### Changes

- `src/Illuminate/Mail/Mailable.php` — Added `assertHasNoAttachments()` method
- `tests/Mail/MailMailableTest.php` — 1 test with both pass and fail paths

## Test Plan

- [x] `testAssertHasNoAttachments` — Passes on mailable without attachments, fails on mailable with attachments
- [x] All existing mailable tests pass