### PR TITLE
[13.x] Fix sum() docblock to include key parameter in callback signature

### DIFF
--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -1115,7 +1115,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Get the sum of the given values.
      *
-     * @param  (callable(TValue): mixed)|string|null  $callback
+     * @param  (callable(TValue, TKey): mixed)|string|null  $callback
      * @return mixed
      */
     public function sum($callback = null);

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -572,7 +572,7 @@ trait EnumeratesValues
      *
      * @template TReturnType
      *
-     * @param  (callable(TValue): TReturnType)|string|null  $callback
+     * @param  (callable(TValue, TKey): TReturnType)|string|null  $callback
      * @return ($callback is callable ? TReturnType : mixed)
      */
     public function sum($callback = null)


### PR DESCRIPTION
## Summary

PR #59322 updated `sum()` to pass both value and key to the callback, but the docblock was not updated to match.

### Before (incorrect)

```php
// Docblock says: callable(TValue): TReturnType
// But implementation passes: callback($item, $key)

collect(['a' => 10, 'b' => 20])->sum(function ($value, $key) {
    // IDE shows: Parameter #2 $key unexpected
    return $value;
});
```

### After (correct)

```php
// Docblock says: callable(TValue, TKey): TReturnType
// Matches the implementation

collect(['a' => 10, 'b' => 20])->sum(function ($value, $key) {
    // IDE autocomplete works correctly
    return $key === 'a' ? $value * 2 : $value;
});
```

### Changes

- `src/Illuminate/Collections/Traits/EnumeratesValues.php` — Fix `@param` callable signature
- `src/Illuminate/Collections/Enumerable.php` — Fix `@param` callable signature on interface