### PR TITLE
[13.x] Show paused warning in schedule:list command

### DIFF
--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -6,6 +6,7 @@ use Closure;
 use Cron\CronExpression;
 use DateTimeZone;
 use Illuminate\Console\Command;
+use Illuminate\Contracts\Cache\Repository as Cache;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use ReflectionClass;
@@ -49,7 +50,7 @@ class ScheduleListCommand extends Command
      *
      * @throws \Exception
      */
-    public function handle(Schedule $schedule)
+    public function handle(Schedule $schedule, Cache $cache)
     {
         $events = new Collection($schedule->events());
 
@@ -61,6 +62,11 @@ class ScheduleListCommand extends Command
             }
 
             return;
+        }
+
+        if (! $this->option('json') && $cache->get('illuminate:schedule:paused', false)) {
+            $this->components->warn('The scheduler is currently paused.');
+            $this->newLine();
         }
 
         $timezone = new DateTimeZone($this->option('timezone') ?? config('app.timezone'));

--- a/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
@@ -8,6 +8,7 @@ use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Console\Scheduling\ScheduleListCommand;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\ProcessUtils;
 use Orchestra\Testbench\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -421,6 +422,28 @@ class ScheduleListCommandTest extends TestCase
             ->expectsOutput('  * *   * * * 15s  php artisan five ............ Next Due: 15 seconds from now')
             ->expectsOutput('  0 *   * * * 20s  php artisan six ............. Next Due: 20 seconds from now')
             ->expectsOutput('  * */3 * * * 1s   php artisan six ............... Next Due: 1 second from now');
+    }
+
+    public function testDisplaysPausedWarningWhenSchedulerIsPaused()
+    {
+        $this->schedule->call(fn () => '')->daily();
+
+        Cache::forever('illuminate:schedule:paused', true);
+
+        $this->artisan(ScheduleListCommand::class)
+            ->assertSuccessful()
+            ->expectsOutputToContain('The scheduler is currently paused.');
+
+        Cache::forget('illuminate:schedule:paused');
+    }
+
+    public function testDoesNotDisplayPausedWarningWhenSchedulerIsRunning()
+    {
+        $this->schedule->call(fn () => '')->daily();
+
+        $this->artisan(ScheduleListCommand::class)
+            ->assertSuccessful()
+            ->doesntExpectOutputToContain('paused');
     }
 
     protected function tearDown(): void


### PR DESCRIPTION
## Summary

When the scheduler is paused via `schedule:pause`, running `schedule:list` shows all tasks normally with no indication they won't execute. This can lead to confusion when debugging why scheduled tasks aren't running.

### Problem

```bash
$ php artisan schedule:pause
Scheduled task processing has been paused.

$ php artisan schedule:list
  0 0 * * *  php artisan emails:send .... Next Due: 5 hours from now
  */5 * * * * php artisan queue:monitor .. Next Due: 2 minutes from now

# No indication the scheduler is paused — tasks appear normal
# Developer wonders why nothing is running
```

### After

```bash
$ php artisan schedule:list
  WARN  The scheduler is currently paused.

  0 0 * * *  php artisan emails:send .... Next Due: 5 hours from now
  */5 * * * * php artisan queue:monitor .. Next Due: 2 minutes from now
```

The warning uses the same cache key (`illuminate:schedule:paused`) that `schedule:pause` and `schedule:run` use, ensuring consistency.

### Implementation

- Inject `Cache` into the `handle()` method (same pattern used by `SchedulePauseCommand` and `ScheduleResumeCommand`)
- Check the `illuminate:schedule:paused` cache key before displaying tasks
- Only show warning in CLI mode (skip for `--json` output to avoid breaking JSON consumers)

### Why This Doesn't Break Existing Features

- The warning is only displayed when the scheduler is actually paused
- JSON output is unaffected
- The method signature change (adding `Cache $cache`) uses Laravel's method injection — fully backward compatible

### Changes

- `src/Illuminate/Console/Scheduling/ScheduleListCommand.php` — Add paused state warning
- `tests/Integration/Console/Scheduling/ScheduleListCommandTest.php` — 2 tests: warning shown when paused, no warning when running

## Test Plan

- [x] `testDisplaysPausedWarningWhenSchedulerIsPaused` — Warning displayed when cache key is set
- [x] `testDoesNotDisplayPausedWarningWhenSchedulerIsRunning` — No warning in normal state