### PR TITLE
[13.x] Add a driver method to the MailFake class

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -431,6 +431,17 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
     }
 
     /**
+     * Get a mailer driver instance.
+     *
+     * @param  string|null  $driver
+     * @return \Illuminate\Contracts\Mail\Mailer
+     */
+    public function driver($driver = null)
+    {
+        return $this->mailer($driver);
+    }
+
+    /**
      * Begin the process of mailing a mailable class instance.
      *
      * @param  mixed  $users

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -413,7 +413,6 @@ class SupportTestingMailFakeTest extends TestCase
 
     public function testDriverMethod()
     {
-
         $this->fake->driver('ses')->to('taylor@laravel.com')->send($this->mailable);
 
         $this->fake->assertSent(MailableStub::class, function ($mail) {

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -410,6 +410,31 @@ class SupportTestingMailFakeTest extends TestCase
             return $mail->usesMailer('mailjet');
         });
     }
+
+    public function testDriverMethod()
+    {
+
+        $this->fake->driver('ses')->to('taylor@laravel.com')->send($this->mailable);
+
+        $this->fake->assertSent(MailableStub::class, function ($mail) {
+            return $mail->hasTo('taylor@laravel.com') &&
+                $mail->usesMailer('ses');
+        });
+
+        $this->fake->driver('sendgrid')->to('taylor@laravel.com')->queue($this->mailable);
+
+        $this->fake->assertQueued(MailableStub::class, function ($mail) {
+            return $mail->hasTo('taylor@laravel.com') &&
+                $mail->usesMailer('sendgrid');
+        });
+
+        $this->fake->driver('mailjet')->to('taylor@laravel.com')->queue($this->mailable);
+
+        $this->fake->assertQueued(MailableStub::class, function ($mail) {
+            return $mail->hasTo('taylor@laravel.com') &&
+                $mail->usesMailer('mailjet');
+        });
+    }
 }
 
 class MailableStub extends Mailable


### PR DESCRIPTION
We are using different emails services for different purposes: Amazon SES (default) and SendGrid. We have the following code snippets:

```php
use Illuminate\Support\Facades\Mail;
use App\Mails\AprilPromotion;

Mail::mailer('sendgrid')
    ->to($customer->email)
    ->queue(new AprilPromotion($customer));

// The assertion works correctly.
Mail::fake()
// ...
Mail::assertQueued(AprilPromotion::class);
```
That works perfectly. However, if I use the `driver` method instead of `mailer`:

```php
Mail::driver('sendgrid')
    ->to($customer->email)
    ->queue(new AprilPromotion($customer));

// The assertion is gonna fail!
Mail::fake()
// ...
Mail::assertQueued(AprilPromotion::class);
```

Weird. I found out that the `MailFake` class doesn't have a `driver` method like the `Illuminate\Mail\Manager` class. So the method call from the former is forwarded to the latter. And no email objects are captured.

A simple fix is to simply add a similar `driver` method to the `MailFake` class.