### PR TITLE
[13.x] Ensure parallel testing works for multiple connections sharing the default database

### DIFF
--- a/src/Illuminate/Testing/Concerns/TestDatabases.php
+++ b/src/Illuminate/Testing/Concerns/TestDatabases.php
@@ -190,8 +190,17 @@ trait TestDatabases
                 $database,
             );
 
-            foreach (config('database.connections', []) as $name => $connection) {
-                if ($name !== $default && ($connection['database'] ?? null) === $previousDatabase) {
+            $connections = config('database.connections', []);
+            $defaultConnection = $connections[$default] ?? [];
+
+            foreach ($connections as $name => $connection) {
+                if ($name !== $default
+                    && isset($connection['host'])
+                    && ($connection['database'] ?? null) === $previousDatabase
+                    && ($connection['driver'] ?? null) === ($defaultConnection['driver'] ?? null)
+                    && $connection['host'] === ($defaultConnection['host'] ?? null)
+                    && ($connection['port'] ?? null) === ($defaultConnection['port'] ?? null)
+                ) {
                     config()->set("database.connections.{$name}.database", $database);
                 }
             }

--- a/src/Illuminate/Testing/Concerns/TestDatabases.php
+++ b/src/Illuminate/Testing/Concerns/TestDatabases.php
@@ -183,10 +183,18 @@ trait TestDatabases
                 preg_replace('/^(.*)(\/[\w-]*)(\??.*)$/', "$1/{$database}$3", $url),
             );
         } else {
+            $previousDatabase = config("database.connections.{$default}.database");
+
             config()->set(
                 "database.connections.{$default}.database",
                 $database,
             );
+
+            foreach (config('database.connections', []) as $name => $connection) {
+                if ($name !== $default && ($connection['database'] ?? null) === $previousDatabase) {
+                    config()->set("database.connections.{$name}.database", $database);
+                }
+            }
         }
     }
 

--- a/tests/Testing/Concerns/TestDatabasesTest.php
+++ b/tests/Testing/Concerns/TestDatabasesTest.php
@@ -52,7 +52,7 @@ class TestDatabasesTest extends TestCase
         config()->shouldReceive('get')
             ->once()
             ->with('database.connections', [])
-            ->andReturn(['mysql' => ['driver' => 'mysql', 'database' => 'my_database']]);
+            ->andReturn(['mysql' => ['driver' => 'mysql', 'host' => '127.0.0.1', 'port' => '3306', 'database' => 'my_database']]);
 
         $this->switchToDatabase('my_database_test_1');
     }
@@ -79,10 +79,12 @@ class TestDatabasesTest extends TestCase
             ->once()
             ->with('database.connections', [])
             ->andReturn([
-                'mysql' => ['driver' => 'mysql', 'database' => 'my_database'],
-                'mysql_secondary' => ['driver' => 'mysql', 'database' => 'my_database'],
-                'mysql_tertiary' => ['driver' => 'mysql', 'database' => 'my_database'],
-                'mysql_other' => ['driver' => 'mysql', 'database' => 'other_database'],
+                'mysql' => ['driver' => 'mysql', 'host' => '127.0.0.1', 'port' => '3306', 'database' => 'my_database'],
+                'mysql_secondary' => ['driver' => 'mysql', 'host' => '127.0.0.1', 'port' => '3306', 'database' => 'my_database'],
+                'mysql_tertiary' => ['driver' => 'mysql', 'host' => '127.0.0.1', 'port' => '3306', 'database' => 'my_database'],
+                'mysql_other' => ['driver' => 'mysql', 'host' => '127.0.0.1', 'port' => '3306', 'database' => 'other_database'],
+                'mysql_different_host' => ['driver' => 'mysql', 'host' => 'other-server', 'port' => '3306', 'database' => 'my_database'],
+                'mysql_different_driver' => ['driver' => 'pgsql', 'host' => '127.0.0.1', 'port' => '5432', 'database' => 'my_database'],
             ]);
 
         config()->shouldReceive('set')

--- a/tests/Testing/Concerns/TestDatabasesTest.php
+++ b/tests/Testing/Concerns/TestDatabasesTest.php
@@ -40,9 +40,58 @@ class TestDatabasesTest extends TestCase
             ->with('database.connections.mysql.url', false)
             ->andReturn(false);
 
+        config()->shouldReceive('get')
+            ->once()
+            ->with('database.connections.mysql.database', null)
+            ->andReturn('my_database');
+
         config()->shouldReceive('set')
             ->once()
             ->with('database.connections.mysql.database', 'my_database_test_1');
+
+        config()->shouldReceive('get')
+            ->once()
+            ->with('database.connections', [])
+            ->andReturn(['mysql' => ['driver' => 'mysql', 'database' => 'my_database']]);
+
+        $this->switchToDatabase('my_database_test_1');
+    }
+
+    public function testSwitchToDatabaseAlsoUpdatesSiblingConnectionsSharingTheSameDatabase()
+    {
+        DB::shouldReceive('purge')->once();
+
+        config()->shouldReceive('get')
+            ->once()
+            ->with('database.connections.mysql.url', false)
+            ->andReturn(false);
+
+        config()->shouldReceive('get')
+            ->once()
+            ->with('database.connections.mysql.database', null)
+            ->andReturn('my_database');
+
+        config()->shouldReceive('set')
+            ->once()
+            ->with('database.connections.mysql.database', 'my_database_test_1');
+
+        config()->shouldReceive('get')
+            ->once()
+            ->with('database.connections', [])
+            ->andReturn([
+                'mysql' => ['driver' => 'mysql', 'database' => 'my_database'],
+                'mysql_secondary' => ['driver' => 'mysql', 'database' => 'my_database'],
+                'mysql_tertiary' => ['driver' => 'mysql', 'database' => 'my_database'],
+                'mysql_other' => ['driver' => 'mysql', 'database' => 'other_database'],
+            ]);
+
+        config()->shouldReceive('set')
+            ->once()
+            ->with('database.connections.mysql_secondary.database', 'my_database_test_1');
+
+        config()->shouldReceive('set')
+            ->once()
+            ->with('database.connections.mysql_tertiary.database', 'my_database_test_1');
 
         $this->switchToDatabase('my_database_test_1');
     }

--- a/tests/Testing/Concerns/TestDatabasesTest.php
+++ b/tests/Testing/Concerns/TestDatabasesTest.php
@@ -57,7 +57,7 @@ class TestDatabasesTest extends TestCase
         $this->switchToDatabase('my_database_test_1');
     }
 
-    public function testSwitchToDatabaseAlsoUpdatesSiblingConnectionsSharingTheSameDatabase()
+    public function testSwitchToDatabaseUpdatesConnectionsWithSameDatabase()
     {
         DB::shouldReceive('purge')->once();
 


### PR DESCRIPTION
When an application configures multiple database connections pointing to the default database, parallel testing throws:
`PDOException: SQLSTATE[42S02]: Base table or view not found: 1051 Unknown table.....`  

This is because the schema doesnt exist on the other connections, only the default.

A common example is a read replica sharing the default database:
```
// config/database.php
'mysql'         => ['database' => env('DB_DATABASE')], // default
'mysql_replica' => ['database' => env('DB_DATABASE')], // Same as default in tests...
```
Various logic in controllers etc, may use `::on('mysql_replica')` etc..

`switchToDatabase` only updates the default connection to the worker's isolated test database. If connections share the same driver, database and host (ie so we know its the same same), it makes sense to switch them too.

This does not address **multiple independent** database connections, only the case where connections share the default database.  As I dont want to open that can of worms for migrations etc.

I've had to dive into this locally, and make overrides, but wanted to try this PR to help anyone in future. 

I don't think it's a B/C but can move it to master if you fancy it, or throw it into the deep caverns and never show this again 🌚 

Open to any feedback