### PR TITLE
[13.x] remove unnecessary `array_flip()` calls

### DIFF
--- a/src/Illuminate/Database/Seeder.php
+++ b/src/Illuminate/Database/Seeder.php
@@ -184,7 +184,7 @@ abstract class Seeder
             ? $this->container->call([$this, 'run'], $parameters)
             : $this->run(...$parameters);
 
-        $uses = array_flip(class_uses_recursive(static::class));
+        $uses = class_uses_recursive(static::class);
 
         if (isset($uses[WithoutModelEvents::class])) {
             $callback = $this->withoutModelEvents($callback);

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
@@ -217,7 +217,7 @@ trait InteractsWithTestCaseLifecycle
      */
     protected function setUpTraits()
     {
-        $uses = $this->traitsUsedByTest ?? array_flip(class_uses_recursive(static::class));
+        $uses = $this->traitsUsedByTest ?? class_uses_recursive(static::class);
 
         if (isset($uses[RefreshDatabase::class])) {
             $this->refreshDatabase();

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -36,7 +36,7 @@ abstract class TestCase extends BaseTestCase
     {
         $app = require Application::inferBasePath().'/bootstrap/app.php';
 
-        $this->traitsUsedByTest = array_flip(class_uses_recursive(static::class));
+        $this->traitsUsedByTest = class_uses_recursive(static::class);
 
         if (isset(CachedState::$cachedConfig) &&
             isset($this->traitsUsedByTest[WithCachedConfig::class])) {

--- a/src/Illuminate/Testing/Concerns/TestDatabases.php
+++ b/src/Illuminate/Testing/Concerns/TestDatabases.php
@@ -44,7 +44,7 @@ trait TestDatabases
         });
 
         ParallelTesting::setUpTestCase(function ($testCase) {
-            $uses = array_flip(class_uses_recursive(get_class($testCase)));
+            $uses = class_uses_recursive(get_class($testCase));
 
             $databaseTraits = [
                 Testing\DatabaseMigrations::class,


### PR DESCRIPTION
the `class_uses_recursive()` function returns an array where both the key and the value are the fully qualified class name, so an `array_flip` returns exactly what it was given.

```php
$results = class_uses_recursive(User::class);

dd($results === array_flip($results));  //true
```

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
