### PR TITLE
[13.x] Add `selectSum` to the query builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -521,6 +521,62 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Add a sum aggregate select to the query.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  \Closure|null  $constraints
+     * @param  string|null  $as
+     * @return $this
+     */
+    public function selectSum($column, ?Closure $constraints = null, ?string $as = null)
+    {
+        $as ??= is_string($column) ? $column.'_sum' : throw new InvalidArgumentException('An alias is required when using an expression column.');
+
+        if (is_null($constraints)) {
+            return $this->selectRaw(
+                'sum('.$this->grammar->wrap($column).') as '.$this->grammar->wrap($as)
+            );
+        }
+
+        return $this->selectConditionalAggregate('sum', $column, $constraints, $as, '0');
+    }
+
+    /**
+     * Add a conditional aggregate select to the query.
+     *
+     * @param  string  $function
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  \Closure  $constraints
+     * @param  string  $as
+     * @param  string|null  $else
+     * @return $this
+     */
+    protected function selectConditionalAggregate($function, $column, Closure $constraints, $as, $else = null)
+    {
+        $query = $this->forNestedWhere();
+
+        $constraints($query);
+
+        $conditions = $this->grammar->compileConditions($query);
+
+        $columnSql = $this->grammar->wrap($column);
+
+        if ($conditions === '') {
+            return $this->selectRaw(
+                $function.'('.$columnSql.') as '.$this->grammar->wrap($as)
+            );
+        }
+
+        $elseSql = $else !== null ? ' else '.$else : '';
+
+        $this->addBinding($query->getRawBindings()['where'], 'select');
+
+        return $this->selectRaw(
+            $function.'(case when '.$conditions.' then '.$columnSql.$elseSql.' end) as '.$this->grammar->wrap($as)
+        );
+    }
+
+    /**
      * Force the query to only return distinct results.
      *
      * @return $this

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -270,6 +270,21 @@ class Grammar extends BaseGrammar
     }
 
     /**
+     * Compile the conditions of the given query builder into a single string without a leading conjunction.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @return string
+     */
+    public function compileConditions($query)
+    {
+        if (empty($query->wheres)) {
+            return '';
+        }
+
+        return $this->removeLeadingBoolean(implode(' ', $this->compileWheresToArray($query)));
+    }
+
+    /**
      * Format the where clause statements into one string.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -5892,6 +5892,75 @@ SQL;
         $this->assertSame('select "two", "threee" as "threeee", (select "col" from "tbl") as "four", 1 + 1 from "one"', $builder->toSql());
     }
 
+    public function testSelectSum()
+    {
+        $builder = $this->getBuilder();
+        $builder->from('orders')->selectSum('amount', fn ($q) => $q->where('status', 'paid'), 'paid_total');
+        $this->assertSame('select sum(case when "status" = ? then "amount" else 0 end) as "paid_total" from "orders"', $builder->toSql());
+        $this->assertEquals(['paid'], $builder->getBindings());
+    }
+
+    public function testSelectSumWithoutConstraints()
+    {
+        $builder = $this->getBuilder();
+        $builder->from('orders')->selectSum('amount');
+        $this->assertSame('select sum("amount") as "amount_sum" from "orders"', $builder->toSql());
+        $this->assertEquals([], $builder->getBindings());
+    }
+
+    public function testSelectSumWithoutConstraintsWithCustomAlias()
+    {
+        $builder = $this->getBuilder();
+        $builder->from('orders')->selectSum('amount', as: 'total');
+        $this->assertSame('select sum("amount") as "total" from "orders"', $builder->toSql());
+        $this->assertEquals([], $builder->getBindings());
+    }
+
+    public function testSelectSumWithAutoAlias()
+    {
+        $builder = $this->getBuilder();
+        $builder->from('orders')->selectSum('amount', fn ($q) => $q->where('status', 'paid'));
+        $this->assertSame('select sum(case when "status" = ? then "amount" else 0 end) as "amount_sum" from "orders"', $builder->toSql());
+        $this->assertEquals(['paid'], $builder->getBindings());
+    }
+
+    public function testSelectSumWithEmptyConstraints()
+    {
+        $builder = $this->getBuilder();
+        $builder->from('orders')->selectSum('amount', fn ($q) => $q, 'total');
+        $this->assertSame('select sum("amount") as "total" from "orders"', $builder->toSql());
+        $this->assertEquals([], $builder->getBindings());
+    }
+
+    public function testSelectSumWithMultipleConstraints()
+    {
+        $builder = $this->getBuilder();
+        $builder->from('orders')
+            ->selectSum('amount', fn ($q) => $q->where('status', 'paid')->where('refunded', false), 'net_total');
+        $this->assertSame('select sum(case when "status" = ? and "refunded" = ? then "amount" else 0 end) as "net_total" from "orders"', $builder->toSql());
+        $this->assertEquals(['paid', false], $builder->getBindings());
+    }
+
+    public function testSelectSumWithExistingWhereClause()
+    {
+        $builder = $this->getBuilder();
+        $builder->from('orders')
+            ->selectSum('amount', fn ($q) => $q->where('status', 'paid'), 'paid_total')
+            ->where('shop_id', 5);
+        $this->assertSame('select sum(case when "status" = ? then "amount" else 0 end) as "paid_total" from "orders" where "shop_id" = ?', $builder->toSql());
+        $this->assertEquals(['paid', 5], $builder->getBindings());
+    }
+
+    public function testSelectSumBindingsAreInCorrectOrder()
+    {
+        $builder = $this->getBuilder();
+        $builder->from('orders')
+            ->where('shop_id', 5)
+            ->selectSum('amount', fn ($q) => $q->where('status', 'paid'), 'paid_total');
+        $this->assertSame('select sum(case when "status" = ? then "amount" else 0 end) as "paid_total" from "orders" where "shop_id" = ?', $builder->toSql());
+        $this->assertEquals(['paid', 5], $builder->getBindings());
+    }
+
     public function testSqlServerWhereDate()
     {
         $builder = $this->getSqlServerBuilder();


### PR DESCRIPTION
Adds `selectSum` to the query builder for sum aggregates without `selectRaw`.

### Before

```php
Post::query()
    ->selectRaw('sum("amount") as "amount_sum"')
    ->selectRaw('sum(case when "status" = ? then "amount" else 0 end) as "paid_total"', ['paid'])
    ->get();
```

### After

```php
Post::query()
    ->selectSum('amount') // sum("amount") as "amount_sum"
    ->selectSum('amount', as: 'total') // sum("amount") as "total"
    ->selectSum('amount', fn ($q) => $q->where('status', 'paid'), 'paid_total') // sum(case when "status" = 'paid' then "amount" else 0 end) as "paid_total"
    ->get();
```

The closure receives a query builder, so all existing where methods work (`where`, `whereIn`, `whereNotNull`, `whereColumn`, `orWhere`, etc). The generated SQL works across all supported databases.

The alias defaults to `{column}_sum` when omitted:

```php
->selectSum('amount')  // sum("amount") as "amount_sum"
```

### Why

Conditional aggregates are one of the most common reasons to reach for `selectRaw`. You have to write raw SQL, manage bindings manually, and remember to quote column names. `selectSum` handles all of that.

### No breaking changes

- New method on the query builder, no existing signatures modified
- Adds `compileConditions` as a public method on Grammar (compiles where clauses without the `where`/`on` prefix). No existing methods changed
- A protected `selectConditionalAggregate` method can support future `selectCount`/`selectAvg`/`selectMin`/`selectMax`
