### PR TITLE
[13.x] Add BatchStarted event 

### DIFF
--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -6,6 +6,7 @@ use Carbon\CarbonImmutable;
 use Closure;
 use Illuminate\Bus\Events\BatchCanceled;
 use Illuminate\Bus\Events\BatchFinished;
+use Illuminate\Bus\Events\BatchStarted;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Queue\Factory as QueueFactory;
@@ -237,6 +238,14 @@ class Batch implements Arrayable, JsonSerializable
     {
         $counts = $this->decrementPendingJobs($jobId);
 
+        if ($this->totalJobs - $counts->pendingJobs + $counts->failedJobs === 1) {
+            $container = Container::getInstance();
+
+            if ($container->bound(Dispatcher::class)) {
+                $container->make(Dispatcher::class)->dispatch(new BatchStarted($this));
+            }
+        }
+
         if ($this->hasProgressCallbacks()) {
             $this->invokeCallbacks('progress');
         }
@@ -341,6 +350,14 @@ class Batch implements Arrayable, JsonSerializable
     public function recordFailedJob(string $jobId, $e)
     {
         $counts = $this->incrementFailedJobs($jobId);
+
+        if ($this->totalJobs - $counts->pendingJobs + $counts->failedJobs === 1) {
+            $container = Container::getInstance();
+
+            if ($container->bound(Dispatcher::class)) {
+                $container->make(Dispatcher::class)->dispatch(new BatchStarted($this));
+            }
+        }
 
         if ($counts->failedJobs === 1 && ! $this->allowsFailures()) {
             $this->cancel($e);

--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -220,6 +220,16 @@ class Batch implements Arrayable, JsonSerializable
     }
 
     /**
+     * Determine if this is the first job processed in the batch.
+     *
+     * @return bool
+     */
+    protected function isFirstJobProcessed(UpdatedBatchJobCounts $counts): bool
+    {
+        return $this->totalJobs - $counts->pendingJobs + $counts->failedJobs === 1;
+    }
+
+    /**
      * Get the percentage of jobs that have been processed (between 0-100).
      *
      * @return int<0, 100>
@@ -238,7 +248,7 @@ class Batch implements Arrayable, JsonSerializable
     {
         $counts = $this->decrementPendingJobs($jobId);
 
-        if ($this->totalJobs - $counts->pendingJobs + $counts->failedJobs === 1) {
+        if ($this->isFirstJobProcessed($counts)) {
             $container = Container::getInstance();
 
             if ($container->bound(Dispatcher::class)) {
@@ -351,7 +361,7 @@ class Batch implements Arrayable, JsonSerializable
     {
         $counts = $this->incrementFailedJobs($jobId);
 
-        if ($this->totalJobs - $counts->pendingJobs + $counts->failedJobs === 1) {
+        if ($this->isFirstJobProcessed($counts)) {
             $container = Container::getInstance();
 
             if ($container->bound(Dispatcher::class)) {

--- a/src/Illuminate/Bus/Events/BatchStarted.php
+++ b/src/Illuminate/Bus/Events/BatchStarted.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\Bus\Events;
+
+use Illuminate\Bus\Batch;
+
+class BatchStarted
+{
+    /**
+     * Create a new event instance.
+     *
+     * @param  \Illuminate\Bus\Batch  $batch  The batch instance.
+     */
+    public function __construct(
+        public Batch $batch,
+    ) {
+    }
+}

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -10,6 +10,7 @@ use Illuminate\Bus\DatabaseBatchRepository;
 use Illuminate\Bus\Dispatcher;
 use Illuminate\Bus\Events\BatchCanceled;
 use Illuminate\Bus\Events\BatchFinished;
+use Illuminate\Bus\Events\BatchStarted;
 use Illuminate\Bus\PendingBatch;
 use Illuminate\Bus\Queueable;
 use Illuminate\Container\Container;
@@ -278,10 +279,84 @@ class BusBatchTest extends TestCase
         $batch = $batch->add([$job]);
 
         $events->shouldReceive('dispatch')->once()->with(m::on(function ($event) use ($batch) {
+            return $event instanceof BatchStarted && $event->batch === $batch;
+        }));
+
+        $events->shouldReceive('dispatch')->once()->with(m::on(function ($event) use ($batch) {
             return $event instanceof BatchFinished && $event->batch === $batch;
         }));
 
         $batch->recordSuccessfulJob('test-id');
+    }
+
+    public function test_batch_started_event_is_dispatched()
+    {
+        Container::getInstance()->instance(EventDispatcher::class, $events = m::mock(EventDispatcher::class));
+
+        $queue = m::mock(Factory::class);
+        $batch = $this->createTestBatch($queue);
+
+        $job = new class
+        {
+            use Batchable;
+        };
+
+        $secondJob = new class
+        {
+            use Batchable;
+        };
+
+        $queue->shouldReceive('connection')->once()
+            ->with('test-connection')
+            ->andReturn($connection = m::mock(stdClass::class));
+
+        $connection->shouldReceive('bulk')->once();
+
+        $batch = $batch->add([$job, $secondJob]);
+
+        $events->shouldReceive('dispatch')->once()->with(m::on(function ($event) use ($batch) {
+            return $event instanceof BatchStarted && $event->batch === $batch;
+        }));
+
+        $events->shouldReceive('dispatch')->once()->with(m::on(function ($event) {
+            return $event instanceof BatchFinished;
+        }));
+
+        $batch->recordSuccessfulJob('test-id-1');
+        $batch->recordSuccessfulJob('test-id-2');
+    }
+
+    public function test_batch_started_event_is_dispatched_when_first_job_fails()
+    {
+        Container::getInstance()->instance(EventDispatcher::class, $events = m::mock(EventDispatcher::class));
+
+        $queue = m::mock(Factory::class);
+        $batch = $this->createTestBatch($queue, $allowFailures = true);
+
+        $job = new class
+        {
+            use Batchable;
+        };
+
+        $secondJob = new class
+        {
+            use Batchable;
+        };
+
+        $queue->shouldReceive('connection')->once()
+            ->with('test-connection')
+            ->andReturn($connection = m::mock(stdClass::class));
+
+        $connection->shouldReceive('bulk')->once();
+
+        $batch = $batch->add([$job, $secondJob]);
+
+        $events->shouldReceive('dispatch')->once()->with(m::on(function ($event) use ($batch) {
+            return $event instanceof BatchStarted && $event->batch === $batch;
+        }));
+
+        $batch->recordFailedJob('test-id-1', new RuntimeException('Something went wrong.'));
+        $batch->recordFailedJob('test-id-2', new RuntimeException('Something else went wrong.'));
     }
 
     public function test_failed_jobs_can_be_recorded_while_not_allowing_failures()


### PR DESCRIPTION
This complements the existing `BatchDispatched`, `BatchFinished`, and `BatchCanceled` events, allowing listeners to distinguish between a batch **being queued** and a batch actually **being worked** by a queue worker. Right now there's no way to distinguish a batch that is queued from one that is actively being worked

This is useful for monitoring and UI progress... (ie we could call $batch->progress() once we know its started) etc, etc...

I chose BatchStarted to fit with BatchFinished, but feel free to adjust, or tell me to change it.  Maybe BatchProcessing is better?  

Heres the lifecycle:

  `BatchDispatched`  jobs are IN the queue, no worker has touched them yet (the worker may be busy)                                                                                 
  `BatchStarted`  first job has been processed (succeeded or failed)                                                                    
  `BatchFinished`  all jobs done


![we-shoot](https://github.com/user-attachments/assets/564b0455-0705-469a-8812-ee3114e22bf3)

Added a method to Batch to contain the logic, as I know in a year I'd be looking at it like "huh"

I wanted to add a `started_at` column, but feel like its too much of a potential b/c, will leave in my pocket for a rainy day for 14.x
