### PR TITLE
[13.x] Allow #[UnitTest] attribute on classes

### DIFF
--- a/src/Illuminate/Foundation/Testing/Attributes/UnitTest.php
+++ b/src/Illuminate/Foundation/Testing/Attributes/UnitTest.php
@@ -7,7 +7,7 @@ use Attribute;
 /**
  * Run a test without configuring the Laravel framework.
  */
-#[Attribute(Attribute::TARGET_METHOD)]
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD)]
 class UnitTest
 {
 }

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Testing\Attributes\UnitTest;
 use PHPUnit\Framework\TestCase as BaseTestCase;
+use ReflectionClass;
 use ReflectionMethod;
 use Throwable;
 
@@ -106,7 +107,8 @@ abstract class TestCase extends BaseTestCase
     protected function withoutBootingFramework(): bool
     {
         try {
-            return (new ReflectionMethod(static::class, $this->name()))->getAttributes(UnitTest::class) !== [];
+            return (new ReflectionClass(static::class))->getAttributes(UnitTest::class) !== []
+                || (new ReflectionMethod(static::class, $this->name()))->getAttributes(UnitTest::class) !== [];
         } catch (Throwable) {
             return false;
         }


### PR DESCRIPTION
## Summary

The `#[UnitTest]` attribute introduced in #59432 only targets individual test methods. This PR allows it on classes too, so an entire test class can skip framework booting.

### Problem

```php
// Current: must annotate every method individually
class HelperTest extends TestCase
{
    #[UnitTest]
    public function testSlug() { ... }

    #[UnitTest]
    public function testCamel() { ... }

    #[UnitTest]
    public function testSnake() { ... }

    // Easy to forget on a new method
}
```

### After

```php
// Mark the entire class — all methods skip framework booting
#[UnitTest]
class HelperTest extends TestCase
{
    public function testSlug() { ... }
    public function testCamel() { ... }
    public function testSnake() { ... }
}
```

### Implementation

- Updated `#[Attribute]` target to `TARGET_CLASS | TARGET_METHOD`
- `withoutBootingFramework()` checks the class first, then the method — if either has the attribute, framework booting is skipped

### Changes

- `src/Illuminate/Foundation/Testing/Attributes/UnitTest.php` — Allow class target
- `src/Illuminate/Foundation/Testing/TestCase.php` — Check class-level attribute