### PR TITLE
[13.x] Fix runtime property override being ignored when class attribute exists

### DIFF
--- a/src/Illuminate/Support/Traits/ReadsClassAttributes.php
+++ b/src/Illuminate/Support/Traits/ReadsClassAttributes.php
@@ -18,6 +18,10 @@ trait ReadsClassAttributes
      */
     protected function getAttributeValue($target, string $attributeClass, ?string $property = null, $default = null)
     {
+        if ($property !== null && $target->{$property} !== null) {
+            return $target->{$property};
+        }
+
         try {
             $reflection = new ReflectionClass($target);
 
@@ -30,10 +34,6 @@ trait ReadsClassAttributes
             } while ($reflection = $reflection->getParentClass());
         } catch (Exception) {
             //
-        }
-
-        if ($property !== null) {
-            return $target->{$property} ?? $default;
         }
 
         return $default;

--- a/src/Illuminate/Support/Traits/ReadsClassAttributes.php
+++ b/src/Illuminate/Support/Traits/ReadsClassAttributes.php
@@ -18,7 +18,7 @@ trait ReadsClassAttributes
      */
     protected function getAttributeValue($target, string $attributeClass, ?string $property = null, $default = null)
     {
-        if ($property !== null && $target->{$property} !== null) {
+        if ($property !== null && isset($target->{$property})) {
             return $target->{$property};
         }
 

--- a/tests/Notifications/NotificationSenderTest.php
+++ b/tests/Notifications/NotificationSenderTest.php
@@ -13,6 +13,7 @@ use Illuminate\Notifications\Events\NotificationSending;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Notifications\Notification;
 use Illuminate\Notifications\NotificationSender;
+use Illuminate\Queue\Attributes\Queue;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Mailer\Exception\HttpTransportException;
@@ -257,6 +258,41 @@ class NotificationSenderTest extends TestCase
         $sender = new NotificationSender($manager, $bus, $events);
 
         $sender->sendNow($notifiable, new DummyNotificationWithViaMutation);
+    }
+
+    public function testOnQueueOverridesQueueAttribute()
+    {
+        $notifiable = m::mock(Notifiable::class);
+        $manager = m::mock(ChannelManager::class);
+        $manager->shouldReceive('getContainer')->andReturn(app());
+        $manager->shouldReceive('resolveQueueFromQueueRoute')->andReturn(null);
+        $manager->shouldReceive('resolveConnectionFromQueueRoute')->andReturn(null);
+        $bus = m::mock(BusDispatcher::class);
+        $bus->shouldReceive('dispatch')->once()->withArgs(function ($job) {
+            return $job->queue === 'override-queue';
+        });
+        $events = m::mock(EventDispatcher::class);
+        $events->shouldReceive('until')->andReturn(true);
+        $events->shouldReceive('dispatch');
+        $events->shouldReceive('listen');
+
+        $sender = new NotificationSender($manager, $bus, $events);
+
+        $notification = new DummyQueuedNotificationWithQueueAttribute;
+        $notification->onQueue('override-queue');
+
+        $sender->send($notifiable, $notification);
+    }
+}
+
+#[Queue('default-queue')]
+class DummyQueuedNotificationWithQueueAttribute extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function via($notifiable)
+    {
+        return ['mail'];
     }
 }
 


### PR DESCRIPTION
Fixes #59382

## Summary

When a notification (or job/event) has a `#[Queue]` class attribute, calling `onQueue()` at runtime has no effect. The attribute always takes precedence over the property, making runtime overrides impossible.

This is a **13.x regression** — in 12.x, `onQueue()` always worked because the property was read directly.

### The Bug

```php
#[Queue('ingest')]
class SomeNotification extends Notification implements ShouldQueue
{
    use Queueable;
}

$notification = new SomeNotification;
$notification->onQueue('ingest-prio');

// Expected: queued to 'ingest-prio'
// Actual in 13.x: queued to 'ingest' (attribute wins, onQueue() ignored)
```

### Root Cause

`ReadsClassAttributes::getAttributeValue()` checks the class attribute **first**. If an attribute exists, it returns immediately without ever checking the property:

```php
// Before: attribute checked first — property never reached
do {
    $attributes = $reflection->getAttributes($attributeClass);
    if (count($attributes) > 0) {
        return $this->extractAttributeValue($attributes[0]->newInstance()); // returns here
    }
} while ($reflection = $reflection->getParentClass());

// Property only checked if NO attribute found
return $target->{$property} ?? $default;
```

### The Fix

Check the **property first** — if it has been explicitly set (non-null, meaning `onQueue()` was called), use it. The attribute acts as the default when no runtime override is set:

```php
// After: property checked first — attribute is the fallback
if ($property !== null && $target->{$property} !== null) {
    return $target->{$property};
}

// Then check attribute as default
```

This restores the 12.x behavior where runtime overrides like `onQueue()`, `onConnection()` always work, while attributes serve as class-level defaults.

### Affected Areas

This fix applies to all uses of `ReadsClassAttributes::getAttributeValue()`:
- Notification queue/connection (`NotificationSender`)
- Job queue/connection (`CallQueuedHandler`)
- Event queue/connection (`Dispatcher`)

### Changes

- `src/Illuminate/Support/Traits/ReadsClassAttributes.php` — Property-first precedence
- `tests/Notifications/NotificationSenderTest.php` — Test verifying `onQueue()` overrides `#[Queue]`

## Test Plan

- [x] `testOnQueueOverridesQueueAttribute` — Runtime `onQueue()` value takes precedence over `#[Queue]` attribute
- [x] All 12 existing NotificationSender tests pass