### PR TITLE
[13.x] Add json() and collect() methods to ProcessResult

### DIFF
--- a/src/Illuminate/Process/FakeProcessResult.php
+++ b/src/Illuminate/Process/FakeProcessResult.php
@@ -136,6 +136,31 @@ class FakeProcessResult implements ProcessResultContract
     }
 
     /**
+     * Get the JSON decoded output of the process.
+     *
+     * @param  string|null  $key
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public function json($key = null, $default = null)
+    {
+        $data = json_decode(trim($this->output()), true);
+
+        return data_get($data, $key, $default);
+    }
+
+    /**
+     * Get the output as a collection.
+     *
+     * @param  string|null  $key
+     * @return \Illuminate\Support\Collection
+     */
+    public function collect($key = null)
+    {
+        return new Collection($this->json($key));
+    }
+
+    /**
      * Determine if the output contains the given string.
      *
      * @param  string  $output

--- a/src/Illuminate/Process/ProcessResult.php
+++ b/src/Illuminate/Process/ProcessResult.php
@@ -76,6 +76,31 @@ class ProcessResult implements ProcessResultContract
     }
 
     /**
+     * Get the JSON decoded output of the process.
+     *
+     * @param  string|null  $key
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public function json($key = null, $default = null)
+    {
+        $data = json_decode(trim($this->output()), true);
+
+        return data_get($data, $key, $default);
+    }
+
+    /**
+     * Get the output as a collection.
+     *
+     * @param  string|null  $key
+     * @return \Illuminate\Support\Collection
+     */
+    public function collect($key = null)
+    {
+        return new \Illuminate\Support\Collection($this->json($key));
+    }
+
+    /**
      * Determine if the output contains the given string.
      *
      * @param  string  $output

--- a/tests/Process/ProcessTest.php
+++ b/tests/Process/ProcessTest.php
@@ -1097,6 +1097,35 @@ class ProcessTest extends TestCase
         }, 2);
     }
 
+    public function testJsonMethodParsesOutput()
+    {
+        $factory = new Factory;
+
+        $factory->fake(['echo *' => $factory->result('{"name":"Taylor","age":38}')]);
+
+        $result = $factory->run('echo test');
+
+        $this->assertEquals(['name' => 'Taylor', 'age' => 38], $result->json());
+        $this->assertEquals('Taylor', $result->json('name'));
+        $this->assertEquals(38, $result->json('age'));
+        $this->assertNull($result->json('missing'));
+        $this->assertEquals('default', $result->json('missing', 'default'));
+    }
+
+    public function testCollectMethodReturnsCollection()
+    {
+        $factory = new Factory;
+
+        $factory->fake(['echo *' => $factory->result('[1,2,3]')]);
+
+        $result = $factory->run('echo test');
+
+        $collection = $result->collect();
+
+        $this->assertInstanceOf(\Illuminate\Support\Collection::class, $collection);
+        $this->assertEquals([1, 2, 3], $collection->all());
+    }
+
     protected function ls()
     {
         return windows_os() ? 'dir' : 'ls';


### PR DESCRIPTION
## Summary

Adds `json()` and `collect()` methods to `ProcessResult` and `FakeProcessResult`, matching the API pattern already established by the HTTP Client's `Response` class.

### Problem

Many CLI tools output JSON — Docker, Kubernetes, npm, Composer, GitHub CLI, AWS CLI, etc. Currently, parsing their output requires manual decoding:

```php
$result = Process::run('docker inspect my-container');
$data = json_decode($result->output(), true);
$name = $data['Name'] ?? null;
```

The HTTP Client already solved this pattern elegantly:

```php
$data = Http::get('https://api.example.com')->json('name');
```

But the Process component doesn't offer the same convenience.

### After

```php
// Parse JSON output with optional key access
$name = Process::run('docker inspect my-container')->json('Name');

// Get full decoded array
$config = Process::run('composer show --format=json')->json();

// Get output as a Collection
$packages = Process::run('npm ls --json')->collect('dependencies');
```

### API Consistency

| Method | HTTP Response | Process Result |
|---|---|---|
| `body()` / `output()` | ✅ | ✅ |
| `json($key, $default)` | ✅ | ✅ (this PR) |
| `collect($key)` | ✅ | ✅ (this PR) |
| `object()` | ✅ | — |

### Implementation

- Both `ProcessResult` and `FakeProcessResult` get the same methods
- `json()` trims output before decoding (process output typically has trailing newlines)
- `json()` supports dot-notation key access via `data_get()`, matching HTTP Response behavior
- `collect()` delegates to `json()` and wraps in a Collection

### Changes

- `src/Illuminate/Process/ProcessResult.php` — Add `json()` and `collect()`
- `src/Illuminate/Process/FakeProcessResult.php` — Add `json()` and `collect()`
- `tests/Process/ProcessTest.php` — 2 tests with 7 assertions

## Test Plan

- [x] `testJsonMethodParsesOutput` — JSON parsing, key access, default values
- [x] `testCollectMethodReturnsCollection` — Returns Collection with correct data
- [x] All existing Process tests pass