### PR TITLE
[13.x] Include runs_when_paused in schedule:list JSON output

### DIFF
--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -105,6 +105,7 @@ class ScheduleListCommand extends Command
                 'timezone' => $timezone->getName(),
                 'has_mutex' => $event->mutex->exists($event),
                 'repeat_seconds' => $event->isRepeatable() ? $event->repeatSeconds : null,
+                'runs_when_paused' => $event->runsWhenPaused(),
                 'environments' => $event->environments,
             ]);
         })->values()->toJson());

--- a/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
@@ -106,6 +106,7 @@ class ScheduleListCommandTest extends TestCase
         $this->assertFalse($data[0]['has_mutex']);
         $this->assertIsArray($data[0]['environments']);
         $this->assertEmpty($data[0]['environments']);
+        $this->assertFalse($data[0]['runs_when_paused']);
 
         $this->assertSame('* * * * *', $data[2]['expression']);
         $this->assertSame('php artisan foobar a='.ProcessUtils::escapeArgument('b'), $data[2]['command']);


### PR DESCRIPTION
## Summary

The `schedule:list --json` output includes metadata like `environments`, `has_mutex`, and `repeat_seconds` for each event, but doesn't include whether the event will continue running when the scheduler is paused via `schedule:pause`.

This is useful for monitoring dashboards and automation tools that consume the JSON output to understand which tasks are affected by a scheduler pause.

### Before

```json
{
  "expression": "* * * * *",
  "command": "php artisan emails:send",
  "has_mutex": false,
  "repeat_seconds": null,
  "environments": []
}
```

### After

```json
{
  "expression": "* * * * *",
  "command": "php artisan emails:send",
  "has_mutex": false,
  "repeat_seconds": null,
  "runs_when_paused": false,
  "environments": []
}
```

### Context

The `schedule:pause` / `schedule:resume` commands were added in #59169. The `ScheduleRunCommand` already checks `runsWhenPaused()` to determine which events to skip. This PR exposes the same information in the JSON output so external tools can reason about scheduler behavior.

### Changes

- `src/Illuminate/Console/Scheduling/ScheduleListCommand.php` — Add `runs_when_paused` to JSON output
- `tests/Integration/Console/Scheduling/ScheduleListCommandTest.php` — Assert the field exists