### PR TITLE
[13.x] Add hasFile() method to ValidatedInput

### DIFF
--- a/src/Illuminate/Support/ValidatedInput.php
+++ b/src/Illuminate/Support/ValidatedInput.php
@@ -112,6 +112,17 @@ class ValidatedInput implements ValidatedData
     }
 
     /**
+     * Determine if the validated inputs contain a file.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function hasFile($key)
+    {
+        return $this->file($key) instanceof \Illuminate\Http\UploadedFile;
+    }
+
+    /**
      * Dump the items.
      *
      * @param  mixed  ...$keys

--- a/tests/Support/ValidatedInputTest.php
+++ b/tests/Support/ValidatedInputTest.php
@@ -511,6 +511,20 @@ class ValidatedInputTest extends TestCase
         $this->assertSame('default', $input->file('name', 'default'));
     }
 
+    public function test_has_file_method()
+    {
+        $file = UploadedFile::fake()->create('document.pdf');
+
+        $input = new ValidatedInput([
+            'name' => 'Taylor',
+            'avatar' => $file,
+        ]);
+
+        $this->assertTrue($input->hasFile('avatar'));
+        $this->assertFalse($input->hasFile('name'));
+        $this->assertFalse($input->hasFile('missing'));
+    }
+
     public function test_collect_method()
     {
         $input = new ValidatedInput(['users' => [1, 2, 3]]);


### PR DESCRIPTION
## Summary

PR #59396 added `file()` to `ValidatedInput` for retrieving uploaded files from validated data. This PR adds the companion `hasFile()` method, matching the `Request` API where both `file()` and `hasFile()` are available.

### Use Case

```php
$validated = $request->safe();

// Currently possible (added in #59396)
$avatar = $validated->file('avatar');

// Now also possible
if ($validated->hasFile('avatar')) {
    // handle file upload
}
```

Without `hasFile()`, developers have to write `$validated->file('avatar') instanceof UploadedFile` or use a null check, which is less expressive.

### Changes

- `src/Illuminate/Support/ValidatedInput.php` — Add `hasFile()` method
- `tests/Support/ValidatedInputTest.php` — Test with file, non-file, and missing keys