### PR TITLE
[13.x] Include failedJobIds in Batch::toArray()

### DIFF
--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -482,6 +482,7 @@ class Batch implements Arrayable, JsonSerializable
             'processedJobs' => $this->processedJobs(),
             'progress' => $this->progress(),
             'failedJobs' => $this->failedJobs,
+            'failedJobIds' => $this->failedJobIds,
             'options' => $this->options,
             'createdAt' => $this->createdAt,
             'cancelledAt' => $this->cancelledAt,

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -738,6 +738,31 @@ class BusBatchTest extends TestCase
     {
         return $this->connection()->getSchemaBuilder();
     }
+
+    public function testBatchToArrayIncludesFailedJobIds()
+    {
+        $queue = m::mock(Factory::class);
+        $repository = m::mock(\Illuminate\Bus\BatchRepository::class);
+
+        $batch = new Batch(
+            $queue,
+            $repository,
+            'test-id',
+            'test-batch',
+            totalJobs: 3,
+            pendingJobs: 0,
+            failedJobs: 2,
+            failedJobIds: ['job-1', 'job-2'],
+            options: [],
+            createdAt: CarbonImmutable::now(),
+        );
+
+        $array = $batch->toArray();
+
+        $this->assertArrayHasKey('failedJobIds', $array);
+        $this->assertSame(['job-1', 'job-2'], $array['failedJobIds']);
+        $this->assertSame(2, $array['failedJobs']);
+    }
 }
 
 class ChainHeadJob implements ShouldQueue


### PR DESCRIPTION
## Summary

`Batch::toArray()` includes the `failedJobs` count but omits the `failedJobIds` array. This is the only public property set in the constructor that isn't included in the serialized output.

### Problem

```php
$batch = Bus::findBatch($batchId);

// toArray() includes failedJobs count...
$batch->toArray()['failedJobs']; // 2

// ...but not the actual IDs
$batch->toArray()['failedJobIds']; // undefined key

// You have to access the property directly
$batch->failedJobIds; // ['job-uuid-1', 'job-uuid-2']
```

This means `json_encode($batch)` and API responses that serialize batches lose the failed job IDs, which are essential for debugging failed batches and building monitoring dashboards.

### After

```php
$batch->toArray()['failedJobIds']; // ['job-uuid-1', 'job-uuid-2']
```

### All Batch public properties vs toArray()

| Property | In `toArray()` |
|---|---|
| `id` | ✅ |
| `name` | ✅ |
| `totalJobs` | ✅ |
| `pendingJobs` | ✅ |
| `failedJobs` | ✅ |
| **`failedJobIds`** | **❌ → ✅ (this PR)** |
| `options` | ✅ |
| `createdAt` | ✅ |
| `cancelledAt` | ✅ |
| `finishedAt` | ✅ |

### Changes

- `src/Illuminate/Bus/Batch.php` — Add `failedJobIds` to `toArray()`
- `tests/Bus/BusBatchTest.php` — Test verifying the field is present

## Test Plan

- [x] `testBatchToArrayIncludesFailedJobIds` — Verifies failedJobIds appears in toArray() output
- [x] All existing tests pass