### PR TITLE
[13.x] Add biweekly() and biweeklyOn() scheduling frequency methods

### DIFF
--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -562,6 +562,32 @@ trait ManagesFrequencies
     }
 
     /**
+     * Schedule the event to run biweekly on the 1st and 16th of each month.
+     *
+     * @param  string  $time
+     * @return $this
+     */
+    public function biweekly($time = '0:0')
+    {
+        return $this->biweeklyOn(1, 16, $time);
+    }
+
+    /**
+     * Schedule the event to run biweekly on two given days of the month.
+     *
+     * @param  int<1, 31>  $firstDay
+     * @param  int<1, 31>  $secondDay
+     * @param  string  $time
+     * @return $this
+     */
+    public function biweeklyOn($firstDay = 1, $secondDay = 16, $time = '0:0')
+    {
+        $this->dailyAt($time);
+
+        return $this->spliceIntoPosition(3, $firstDay.','.$secondDay);
+    }
+
+    /**
      * Schedule the event to run on the last day of the month.
      *
      * @param  string  $time

--- a/tests/Console/Scheduling/FrequencyTest.php
+++ b/tests/Console/Scheduling/FrequencyTest.php
@@ -137,6 +137,26 @@ class FrequencyTest extends TestCase
         $this->assertSame('30 1 1,16 * *', $this->event->twiceMonthly(1, 16, '1:30')->getExpression());
     }
 
+    public function testBiweekly()
+    {
+        $this->assertSame('0 0 1,16 * *', $this->event->biweekly()->getExpression());
+    }
+
+    public function testBiweeklyAtTime()
+    {
+        $this->assertSame('30 8 1,16 * *', $this->event->biweekly('8:30')->getExpression());
+    }
+
+    public function testBiweeklyOn()
+    {
+        $this->assertSame('0 0 1,16 * *', $this->event->biweeklyOn(1, 16)->getExpression());
+    }
+
+    public function testBiweeklyOnAtTime()
+    {
+        $this->assertSame('30 8 5,20 * *', $this->event->biweeklyOn(5, 20, '8:30')->getExpression());
+    }
+
     public function testMonthlyOnWithMinutes()
     {
         $this->assertSame('15 15 4 * *', $this->event->monthlyOn(4, '15:15')->getExpression());


### PR DESCRIPTION
I noticed there's no expressive way to schedule a task to run twice a month without knowing about `twiceMonthly()`. Developers coming from payroll, billing, or reporting backgrounds naturally reach for "biweekly" — but there's nothing in the scheduler that matches that vocabulary.

This PR adds `biweekly()` and `biweeklyOn()` as a named pair that delegates directly to the existing cron logic — no new mechanics, just clearer naming.

**`biweekly($time = '0:0')`**
Runs on the 1st and 16th of each month. Delegates to `biweeklyOn()`.

**`biweeklyOn($firstDay = 1, $secondDay = 16, $time = '0:0')`**
Runs on two configurable days of the month at a given time.

```php
// Runs at midnight on the 1st and 16th
$schedule->command('reports:generate')->biweekly();

// Runs at 8:30 AM on the 1st and 16th
$schedule->command('reports:generate')->biweekly('8:30');

// Runs at midnight on the 5th and 20th
$schedule->command('payroll:process')->biweeklyOn(5, 20);