### PR TITLE
[13.x] Fix: Allow runtime property overrides (onQueue) to take precedence over class attributes

### DIFF
--- a/src/Illuminate/Support/Traits/ReadsClassAttributes.php
+++ b/src/Illuminate/Support/Traits/ReadsClassAttributes.php
@@ -13,7 +13,7 @@ trait ReadsClassAttributes
      * @param  object  $target
      * @param  class-string  $attributeClass
      * @param  string|null  $property
-     * @param mixed $default
+     * @param  mixed $default
      */
     protected function getAttributeValue($target, string $attributeClass, ?string $property = null, $default = null)
     {

--- a/src/Illuminate/Support/Traits/ReadsClassAttributes.php
+++ b/src/Illuminate/Support/Traits/ReadsClassAttributes.php
@@ -14,6 +14,7 @@ trait ReadsClassAttributes
      * @param  class-string  $attributeClass
      * @param  string|null  $property
      * @param  mixed  $default
+     * @return mixed
      */
     protected function getAttributeValue($target, string $attributeClass, ?string $property = null, $default = null)
     {

--- a/src/Illuminate/Support/Traits/ReadsClassAttributes.php
+++ b/src/Illuminate/Support/Traits/ReadsClassAttributes.php
@@ -18,6 +18,10 @@ trait ReadsClassAttributes
      */
     protected function getAttributeValue($target, string $attributeClass, ?string $property = null, $default = null)
     {
+        if ($property !== null && isset($target->{$property})) {
+            return $target->{$property};
+        }
+
         try {
             $reflection = new ReflectionClass($target);
 
@@ -32,11 +36,7 @@ trait ReadsClassAttributes
             //
         }
 
-        if ($property !== null) {
-            return $target->{$property} ?? $default;
-        }
-
-        return $default;
+        return $target->{$property} ?? $default;
     }
 
     /**

--- a/src/Illuminate/Support/Traits/ReadsClassAttributes.php
+++ b/src/Illuminate/Support/Traits/ReadsClassAttributes.php
@@ -13,7 +13,7 @@ trait ReadsClassAttributes
      * @param  object  $target
      * @param  class-string  $attributeClass
      * @param  string|null  $property
-     * @param  mixed $default
+     * @param  mixed  $default
      */
     protected function getAttributeValue($target, string $attributeClass, ?string $property = null, $default = null)
     {

--- a/src/Illuminate/Support/Traits/ReadsClassAttributes.php
+++ b/src/Illuminate/Support/Traits/ReadsClassAttributes.php
@@ -24,7 +24,6 @@ trait ReadsClassAttributes
         }
 
         try {
-
             do {
                 $attributes = $reflection->getAttributes($attributeClass);
 

--- a/src/Illuminate/Support/Traits/ReadsClassAttributes.php
+++ b/src/Illuminate/Support/Traits/ReadsClassAttributes.php
@@ -11,8 +11,9 @@ trait ReadsClassAttributes
      * Get a configuration value from an attribute, falling back to a property.
      *
      * @param  object  $target
-     * @param  mixed  $default
-     * @return mixed
+     * @param  class-string  $attributeClass
+     * @param  string|null  $property
+     * @param mixed $default
      */
     protected function getAttributeValue($target, string $attributeClass, ?string $property = null, $default = null)
     {

--- a/src/Illuminate/Support/Traits/ReadsClassAttributes.php
+++ b/src/Illuminate/Support/Traits/ReadsClassAttributes.php
@@ -11,8 +11,6 @@ trait ReadsClassAttributes
      * Get a configuration value from an attribute, falling back to a property.
      *
      * @param  object  $target
-     * @param  string  $attributeClass
-     * @param  string|null  $property
      * @param  mixed  $default
      * @return mixed
      */
@@ -26,7 +24,6 @@ trait ReadsClassAttributes
         }
 
         try {
-            $reflection = new ReflectionClass($target);
 
             do {
                 $attributes = $reflection->getAttributes($attributeClass);

--- a/src/Illuminate/Support/Traits/ReadsClassAttributes.php
+++ b/src/Illuminate/Support/Traits/ReadsClassAttributes.php
@@ -19,6 +19,7 @@ trait ReadsClassAttributes
     protected function getAttributeValue($target, string $attributeClass, ?string $property = null, $default = null)
     {
         $reflection = new ReflectionClass($target);
+
         $defaultProperties = $reflection->getDefaultProperties();
 
         if (isset($target->{$property}) && $target->{$property} !== ($defaultProperties[$property] ?? null)) {

--- a/src/Illuminate/Support/Traits/ReadsClassAttributes.php
+++ b/src/Illuminate/Support/Traits/ReadsClassAttributes.php
@@ -18,7 +18,10 @@ trait ReadsClassAttributes
      */
     protected function getAttributeValue($target, string $attributeClass, ?string $property = null, $default = null)
     {
-        if ($property !== null && isset($target->{$property})) {
+        $reflection = new ReflectionClass($target);
+        $defaultProperties = $reflection->getDefaultProperties();
+
+        if (isset($target->{$property}) && $target->{$property} !== ($defaultProperties[$property] ?? null)) {
             return $target->{$property};
         }
 

--- a/tests/Notifications/NotificationSenderTest.php
+++ b/tests/Notifications/NotificationSenderTest.php
@@ -260,7 +260,7 @@ class NotificationSenderTest extends TestCase
         $sender->sendNow($notifiable, new DummyNotificationWithViaMutation);
     }
 
-    public function test_on_queue_overrides_queue_attribute()
+    public function test_it_queue_overrides_queue_attribute()
     {
         $notification = new #[Queue('attribute-queue')] class extends Notification implements ShouldQueue
         {

--- a/tests/Notifications/NotificationSenderTest.php
+++ b/tests/Notifications/NotificationSenderTest.php
@@ -13,6 +13,7 @@ use Illuminate\Notifications\Events\NotificationSending;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Notifications\Notification;
 use Illuminate\Notifications\NotificationSender;
+use Illuminate\Queue\Attributes\Queue;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Mailer\Exception\HttpTransportException;
@@ -21,7 +22,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class NotificationSenderTest extends TestCase
 {
-    public function testItCanSendQueuedNotificationsWithAStringVia()
+    public function test_it_can_send_queued_notifications_with_a_string_via()
     {
         $notifiable = m::mock(Notifiable::class);
         $manager = m::mock(ChannelManager::class);
@@ -38,7 +39,7 @@ class NotificationSenderTest extends TestCase
         $sender->send($notifiable, new DummyQueuedNotificationWithStringVia);
     }
 
-    public function testItCanSendQueuedNotificationsWithAnArrayVia()
+    public function test_it_can_send_queued_notifications_with_an_array_via()
     {
         $notifiable = m::mock(Notifiable::class);
         $manager = m::mock(ChannelManager::class);
@@ -63,7 +64,7 @@ class NotificationSenderTest extends TestCase
         $sender->send($notifiable, new DummyQueuedNotificationWithArrayVia);
     }
 
-    public function testItCanSendNotificationsWithAnEmptyStringVia()
+    public function test_it_can_send_notifications_with_an_empty_string_via()
     {
         $notifiable = new AnonymousNotifiable;
         $manager = m::mock(ChannelManager::class);
@@ -77,7 +78,7 @@ class NotificationSenderTest extends TestCase
         $sender->sendNow($notifiable, new DummyNotificationWithEmptyStringVia);
     }
 
-    public function testItCannotSendNotificationsViaDatabaseForAnonymousNotifiables()
+    public function test_it_cannot_send_notifications_via_database_for_anonymous_notifiables()
     {
         $notifiable = new AnonymousNotifiable;
         $manager = m::mock(ChannelManager::class);
@@ -92,7 +93,7 @@ class NotificationSenderTest extends TestCase
         $sender->sendNow($notifiable, new DummyNotificationWithDatabaseVia);
     }
 
-    public function testItCanSendQueuedNotificationsThroughMiddleware()
+    public function test_it_can_send_queued_notifications_through_middleware()
     {
         $notifiable = m::mock(Notifiable::class);
         $manager = m::mock(ChannelManager::class);
@@ -112,7 +113,7 @@ class NotificationSenderTest extends TestCase
         $sender->send($notifiable, new DummyNotificationWithMiddleware);
     }
 
-    public function testItCanSendQueuedMultiChannelNotificationsThroughDifferentMiddleware()
+    public function test_it_can_send_queued_multi_channel_notifications_through_different_middleware()
     {
         $notifiable = m::mock(Notifiable::class);
         $manager = m::mock(ChannelManager::class);
@@ -143,7 +144,7 @@ class NotificationSenderTest extends TestCase
         $sender->send($notifiable, new DummyMultiChannelNotificationWithConditionalMiddleware);
     }
 
-    public function testItCanSendQueuedWithViaConnectionsNotifications()
+    public function test_it_can_send_queued_with_via_connections_notifications()
     {
         $notifiable = new AnonymousNotifiable;
         $manager = m::mock(ChannelManager::class);
@@ -168,7 +169,7 @@ class NotificationSenderTest extends TestCase
         $sender->send($notifiable, new DummyNotificationWithViaConnections);
     }
 
-    public function testItCanSendQueuedWithViaQueuesNotifications()
+    public function test_it_can_send_queued_with_via_queues_notifications()
     {
         $notifiable = new AnonymousNotifiable;
         $manager = m::mock(ChannelManager::class);
@@ -193,7 +194,7 @@ class NotificationSenderTest extends TestCase
         $sender->send($notifiable, new DummyNotificationWithViaQueues);
     }
 
-    public function testItCanSendQueuedNotificationsWithQueueRoute()
+    public function test_it_can_send_queued_notifications_with_queue_route()
     {
         $notifiable = new AnonymousNotifiable;
         $manager = m::mock(ChannelManager::class);
@@ -216,11 +217,11 @@ class NotificationSenderTest extends TestCase
         $sender->send($notifiable, new DummyQueuedNotificationWithStringVia);
     }
 
-    public function testNotificationFailedSentWithoutHttpTransportException()
+    public function test_notification_failed_sent_without_http_transport_exception()
     {
         $this->expectException(TransportException::class);
 
-        $notifiable = new AnonymousNotifiable();
+        $notifiable = new AnonymousNotifiable;
         $manager = m::mock(ChannelManager::class);
         $manager->shouldReceive('driver')->andReturn($driver = m::mock());
         $response = m::mock(ResponseInterface::class);
@@ -236,10 +237,10 @@ class NotificationSenderTest extends TestCase
 
         $sender = new NotificationSender($manager, $bus, $events);
 
-        $sender->sendNow($notifiable, new DummyNotificationWithViaConnections(), ['mail']);
+        $sender->sendNow($notifiable, new DummyNotificationWithViaConnections, ['mail']);
     }
 
-    public function testItPreservesNotificationStateMutatedInViaMethod()
+    public function test_it_preserves_notification_state_mutated_in_via_method()
     {
         $notifiable = new AnonymousNotifiable;
         $manager = m::mock(ChannelManager::class);
@@ -257,6 +258,41 @@ class NotificationSenderTest extends TestCase
         $sender = new NotificationSender($manager, $bus, $events);
 
         $sender->sendNow($notifiable, new DummyNotificationWithViaMutation);
+    }
+
+    public function test_on_queue_overrides_queue_attribute()
+    {
+        $notification = new #[Queue('attribute-queue')] class extends Notification implements ShouldQueue
+        {
+            use Queueable;
+
+            public function via($notifiable): string
+            {
+                return 'mail';
+            }
+        };
+
+        $notification->onQueue('manual-queue');
+
+        $notifiable = m::mock(Notifiable::class);
+        $manager = m::mock(ChannelManager::class);
+        $manager->shouldReceive('getContainer')->andReturn(app());
+        $manager->shouldReceive('resolveQueueFromQueueRoute')->andReturn(null);
+        $manager->shouldReceive('resolveConnectionFromQueueRoute')->andReturn(null);
+
+        $events = m::mock(EventDispatcher::class);
+        $events->shouldReceive('listen');
+
+        $bus = m::mock(BusDispatcher::class);
+        $bus->shouldReceive('dispatch')
+            ->once()
+            ->withArgs(function ($job) {
+                return $job->queue === 'manual-queue';
+            });
+
+        $sender = new NotificationSender($manager, $bus, $events);
+
+        $sender->send($notifiable, $notification);
     }
 }
 

--- a/tests/Notifications/NotificationSenderTest.php
+++ b/tests/Notifications/NotificationSenderTest.php
@@ -294,6 +294,77 @@ class NotificationSenderTest extends TestCase
 
         $sender->send($notifiable, $notification);
     }
+
+    public function test_it_queue_attribute_is_used_when_on_queue_is_not_called()
+    {
+        $notification = new #[Queue('attribute-queue')] class extends Notification implements ShouldQueue
+        {
+            use Queueable;
+
+            public function via($notifiable): string
+            {
+                return 'mail';
+            }
+        };
+
+        $notifiable = m::mock(Notifiable::class);
+        $manager = m::mock(ChannelManager::class);
+        $manager->shouldReceive('getContainer')->andReturn(app());
+        $manager->shouldReceive('resolveQueueFromQueueRoute')->andReturn(null);
+        $manager->shouldReceive('resolveConnectionFromQueueRoute')->andReturn(null);
+
+        $events = m::mock(EventDispatcher::class);
+        $events->shouldReceive('listen');
+
+        $bus = m::mock(BusDispatcher::class);
+        $bus->shouldReceive('dispatch')
+            ->once()
+            ->withArgs(function ($job) {
+                return $job->queue === 'attribute-queue';
+            });
+
+        $sender = new NotificationSender($manager, $bus, $events);
+
+        $sender->send($notifiable, $notification);
+    }
+
+    public function test_it_constructor_override_takes_precedence_over_queue_attribute()
+    {
+        $notification = new #[Queue('attribute-queue')] class extends Notification implements ShouldQueue
+        {
+            use Queueable;
+
+            public function __construct()
+            {
+                $this->queue = 'constructor-override-queue';
+            }
+
+            public function via($notifiable): string
+            {
+                return 'mail';
+            }
+        };
+
+        $notifiable = m::mock(Notifiable::class);
+        $manager = m::mock(ChannelManager::class);
+        $manager->shouldReceive('getContainer')->andReturn(app());
+        $manager->shouldReceive('resolveQueueFromQueueRoute')->andReturn(null);
+        $manager->shouldReceive('resolveConnectionFromQueueRoute')->andReturn(null);
+
+        $events = m::mock(EventDispatcher::class);
+        $events->shouldReceive('listen');
+
+        $bus = m::mock(BusDispatcher::class);
+        $bus->shouldReceive('dispatch')
+            ->once()
+            ->withArgs(function ($job) {
+                return $job->queue === 'constructor-override-queue';
+            });
+
+        $sender = new NotificationSender($manager, $bus, $events);
+
+        $sender->send($notifiable, $notification);
+    }
 }
 
 class DummyQueuedNotificationWithStringVia extends Notification implements ShouldQueue


### PR DESCRIPTION
In Laravel 13.x, the introduction of PHP Attributes for queue configuration created a regression where runtime overrides like $notification->onQueue() were completely ignored if a #[Queue] attribute existed on the class.

This PR restores the expected behavior from Laravel 12.x by checking if the property has been explicitly set (non-null) before falling back to the class attribute value. This ensures that:

Attributes still work as the default class-level configuration.

Runtime overrides (like onQueue(), onConnection()) work as they did in previous versions.

Changes:

Modified ReadsClassAttributes::getAttributeValue() to prioritize non-null properties.

Added a regression test in NotificationSenderTest to verify that onQueue() successfully overrides the #[Queue] attribute.

Fixes #59382