### PR TITLE
[13.x] Fix manager breaking when called with static closure

### DIFF
--- a/src/Illuminate/Auth/AuthManager.php
+++ b/src/Illuminate/Auth/AuthManager.php
@@ -5,6 +5,8 @@ namespace Illuminate\Auth;
 use Closure;
 use Illuminate\Contracts\Auth\Factory as FactoryContract;
 use InvalidArgumentException;
+use RuntimeException;
+use Throwable;
 
 /**
  * @mixin \Illuminate\Contracts\Auth\Guard
@@ -271,7 +273,13 @@ class AuthManager implements FactoryContract
      */
     public function extend($driver, Closure $callback)
     {
-        $this->customCreators[$driver] = $callback->bindTo($this, $this);
+        try {
+            $callback = $callback->bindTo($this, static::class) ?? throw new RuntimeException;
+        } catch (Throwable) {
+            $callback = $callback->bindTo(null, static::class);
+        }
+
+        $this->customCreators[$driver] = $callback;
 
         return $this;
     }

--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -504,7 +504,13 @@ class BroadcastManager implements FactoryContract
      */
     public function extend($driver, Closure $callback)
     {
-        $this->customCreators[$driver] = $callback->bindTo($this, $this);
+        try {
+            $callback = $callback->bindTo($this, static::class) ?? throw new RuntimeException;
+        } catch (Throwable) {
+            $callback = $callback->bindTo(null, static::class);
+        }
+
+        $this->customCreators[$driver] = $callback;
 
         return $this;
     }

--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -11,6 +11,8 @@ use Illuminate\Support\Arr;
 use InvalidArgumentException;
 use Mockery;
 use Mockery\LegacyMockInterface;
+use RuntimeException;
+use Throwable;
 
 /**
  * @mixin \Illuminate\Cache\Repository
@@ -528,7 +530,13 @@ class CacheManager implements FactoryContract
      */
     public function extend($driver, Closure $callback)
     {
-        $this->customCreators[$driver] = $callback->bindTo($this, $this);
+        try {
+            $callback = $callback->bindTo($this, static::class) ?? throw new RuntimeException;
+        } catch (Throwable) {
+            $callback = $callback->bindTo(null, static::class);
+        }
+
+        $this->customCreators[$driver] = $callback;
 
         return $this;
     }

--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -21,6 +21,8 @@ use League\Flysystem\ReadOnly\ReadOnlyFilesystemAdapter;
 use League\Flysystem\UnixVisibility\PortableVisibilityConverter;
 use League\Flysystem\Visibility;
 
+use RuntimeException;
+use Throwable;
 use function Illuminate\Support\enum_value;
 
 /**
@@ -439,7 +441,13 @@ class FilesystemManager implements FactoryContract
      */
     public function extend($driver, Closure $callback)
     {
-        $this->customCreators[$driver] = $callback->bindTo($this, $this);
+        try {
+            $callback = $callback->bindTo($this, static::class) ?? throw new RuntimeException;
+        } catch (Throwable) {
+            $callback = $callback->bindTo(null, static::class);
+        }
+
+        $this->customCreators[$driver] = $callback;
 
         return $this;
     }

--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -20,9 +20,9 @@ use League\Flysystem\PhpseclibV3\SftpConnectionProvider;
 use League\Flysystem\ReadOnly\ReadOnlyFilesystemAdapter;
 use League\Flysystem\UnixVisibility\PortableVisibilityConverter;
 use League\Flysystem\Visibility;
-
 use RuntimeException;
 use Throwable;
+
 use function Illuminate\Support\enum_value;
 
 /**

--- a/src/Illuminate/Support/Manager.php
+++ b/src/Illuminate/Support/Manager.php
@@ -5,6 +5,7 @@ namespace Illuminate\Support;
 use Closure;
 use Illuminate\Contracts\Container\Container;
 use InvalidArgumentException;
+use Throwable;
 
 abstract class Manager
 {
@@ -127,7 +128,13 @@ abstract class Manager
      */
     public function extend($driver, Closure $callback)
     {
-        $this->customCreators[$driver] = $callback->bindTo($this, $this);
+        try {
+            $callback = $callback->bindTo($this, static::class) ?? throw new RuntimeException;
+        } catch (Throwable) {
+            $callback = $callback->bindTo(null, static::class);
+        }
+
+        $this->customCreators[$driver] = $callback;
 
         return $this;
     }

--- a/tests/Auth/AuthenticateMiddlewareTest.php
+++ b/tests/Auth/AuthenticateMiddlewareTest.php
@@ -154,6 +154,14 @@ class AuthenticateMiddlewareTest extends TestCase
         $this->assertSame($this->auth, $this->auth->guard(__CLASS__));
     }
 
+    public function testCustomDriverStatic()
+    {
+        $driver = new stdClass;
+
+        $this->auth->extend(__CLASS__, fn () => $driver);
+        $this->assertSame($driver, $this->auth->guard(__CLASS__));
+    }
+
     /**
      * Create a new config repository instance.
      *

--- a/tests/Cache/CacheManagerTest.php
+++ b/tests/Cache/CacheManagerTest.php
@@ -12,6 +12,7 @@ use Illuminate\Events\Dispatcher as Event;
 use InvalidArgumentException;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use stdClass;
 
 class CacheManagerTest extends TestCase
 {
@@ -28,6 +29,24 @@ class CacheManagerTest extends TestCase
         ]));
         $manager->extend(__CLASS__, fn () => $this);
         $this->assertSame($manager, $manager->store(__CLASS__));
+    }
+
+    public function testCustomDriverStaticClosure()
+    {
+        $manager = new CacheManager($this->getApp([
+            'cache' => [
+                'stores' => [
+                    __CLASS__ => [
+                        'driver' => __CLASS__,
+                    ],
+                ],
+            ],
+        ]));
+
+        $driver = new stdClass;
+
+        $manager->extend(__CLASS__, static fn () => $driver);
+        $this->assertSame($driver, $manager->store(__CLASS__));
     }
 
     public function testCustomDriverOverridesInternalDrivers()

--- a/tests/Filesystem/FilesystemManagerTest.php
+++ b/tests/Filesystem/FilesystemManagerTest.php
@@ -10,6 +10,7 @@ use League\Flysystem\PathPrefixing\PathPrefixedAdapter;
 use League\Flysystem\UnableToReadFile;
 use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 use PHPUnit\Framework\TestCase;
+use stdClass;
 
 class FilesystemManagerTest extends TestCase
 {
@@ -228,6 +229,22 @@ class FilesystemManagerTest extends TestCase
         }));
         $manager->extend(__CLASS__, fn () => $this);
         $this->assertSame($manager, $manager->disk(__CLASS__));
+    }
+
+    public function testCustomDriverStaticClosure()
+    {
+        $manager = new FilesystemManager(tap(new Application, static function ($app) {
+            $app['config'] = [
+                'filesystems.disks.'.__CLASS__ => [
+                    'driver' => __CLASS__,
+                ],
+            ];
+        }));
+
+        $driver = new stdClass;
+
+        $manager->extend(__CLASS__, static fn () => $driver);
+        $this->assertSame($driver, $manager->disk(__CLASS__));
     }
 
     // public function testKeepTrackOfAdapterDecoration()

--- a/tests/Integration/Broadcasting/BroadcastManagerTest.php
+++ b/tests/Integration/Broadcasting/BroadcastManagerTest.php
@@ -17,7 +17,9 @@ use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Queue;
 use InvalidArgumentException;
 use Orchestra\Testbench\TestCase;
+use Psr\Log\LoggerInterface;
 use RuntimeException;
+use stdClass;
 
 class BroadcastManagerTest extends TestCase
 {
@@ -156,6 +158,24 @@ class BroadcastManagerTest extends TestCase
         $this->assertSame($manager, $manager->connection(__CLASS__));
     }
 
+    public function testCustomDriverStaticClosure()
+    {
+        $manager = new BroadcastManager($this->getApp([
+            'broadcasting' => [
+                'connections' => [
+                    __CLASS__ => [
+                        'driver' => __CLASS__,
+                    ],
+                ],
+            ],
+        ]));
+
+        $driver = new stdClass;
+
+        $manager->extend(__CLASS__, static fn () => $driver);
+        $this->assertSame($driver, $manager->connection(__CLASS__));
+    }
+
     public function testThrowExceptionWhenDriverCreationFails()
     {
         $userConfig = [
@@ -169,8 +189,8 @@ class BroadcastManagerTest extends TestCase
         ];
 
         $app = $this->getApp($userConfig);
-        $app->singleton(\Psr\Log\LoggerInterface::class, function () {
-            throw new \RuntimeException('Logger service not available');
+        $app->singleton(LoggerInterface::class, function () {
+            throw new RuntimeException('Logger service not available');
         });
 
         $broadcastManager = new BroadcastManager($app);
@@ -181,7 +201,7 @@ class BroadcastManagerTest extends TestCase
         } catch (RuntimeException $e) {
             $this->assertStringContainsString('Failed to create broadcaster for connection "log_connection_1"', $e->getMessage());
             $this->assertStringContainsString('Logger service not available', $e->getMessage());
-            $this->assertInstanceOf(\RuntimeException::class, $e->getPrevious());
+            $this->assertInstanceOf(RuntimeException::class, $e->getPrevious());
         }
     }
 

--- a/tests/Integration/Support/ManagerTest.php
+++ b/tests/Integration/Support/ManagerTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Integration\Support;
 use Illuminate\Tests\Integration\Support\Fixtures\NullableManager;
 use InvalidArgumentException;
 use Orchestra\Testbench\TestCase;
+use stdClass;
 
 class ManagerTest extends TestCase
 {
@@ -20,5 +21,14 @@ class ManagerTest extends TestCase
         $manager = new NullableManager($this->app);
         $manager->extend(__CLASS__, fn () => $this);
         $this->assertSame($manager, $manager->driver(__CLASS__));
+    }
+
+    public function testCustomDriverStaticClosure()
+    {
+        $manager = new NullableManager($this->app);
+        $driver = new stdClass;
+
+        $manager->extend(__CLASS__, static fn () => $driver);
+        $this->assertSame($driver, $manager->driver(__CLASS__));
     }
 }


### PR DESCRIPTION
Fixes a bug introduced by https://github.com/laravel/framework/pull/57173 where PHP will error if `Manager::extend()` is called with a static closure.

This PR mirrors https://github.com/laravel/framework/pull/59414 which fixes a similar issue, from that PR:

> ## Reasoning
>
> Static closures can provide small performance improvements since they skip binding `$this`.[^1][^2][^3]
>
> Some tools (e.g. [PHP CS Fixer](https://cs.symfony.com/doc/rules/function_notation/static_lambda.html) and [Rector](https://getrector.com/rule-detail/static-closure-rector)) automatically mark closures as static when possible, which can currently lead to this error when used with macros.
