### PR TITLE
[13.x] Update rector with a configured rule for collect.

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Illuminate\Support\Collection;
 use Rector\CodingStyle\Rector\ArrowFunction\ArrowFunctionDelegatingCallToFirstClassCallableRector;
 use Rector\CodingStyle\Rector\Closure\ClosureDelegatingCallToFirstClassCallableRector;
 use Rector\CodingStyle\Rector\FuncCall\ClosureFromCallableToFirstClassCallableRector;
@@ -35,6 +36,7 @@ use Rector\Php82\Rector\Class_\ReadOnlyClassRector;
 use Rector\Php83\Rector\ClassConst\AddTypeToConstRector;
 use Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector;
 use Rector\Php83\Rector\FuncCall\DynamicClassConstFetchRector;
+use Rector\Transform\Rector\FuncCall\FuncCallToNewRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnNeverTypeRector;
 
 return RectorConfig::configure()
@@ -44,6 +46,9 @@ return RectorConfig::configure()
         __DIR__.'/src',
         __DIR__.'/tests',
         __DIR__.'/types',
+    ])
+    ->withConfiguredRule(FuncCallToNewRector::class, [
+        'collect' => Collection::class,
     ])
     ->withSkip([
         AddOverrideAttributeToOverriddenMethodsRector::class,

--- a/tests/Broadcasting/BroadcastEventTest.php
+++ b/tests/Broadcasting/BroadcastEventTest.php
@@ -7,6 +7,7 @@ use Illuminate\Broadcasting\BroadcastEvent;
 use Illuminate\Broadcasting\InteractsWithBroadcasting;
 use Illuminate\Contracts\Broadcasting\Broadcaster;
 use Illuminate\Contracts\Broadcasting\Factory as BroadcastingFactory;
+use Illuminate\Support\Collection;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Throwable;
@@ -127,7 +128,7 @@ class TestBroadcastEvent
 
     public function __construct()
     {
-        $this->collection = collect(['foo' => 'bar']);
+        $this->collection = new Collection(['foo' => 'bar']);
     }
 
     public function broadcastOn()

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -25,6 +25,7 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Foundation\Bus\PendingChain;
 use Illuminate\Queue\CallQueuedClosure;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Facade;
 use Illuminate\Support\Facades\Queue;
@@ -165,7 +166,7 @@ class BusBatchTest extends TestCase
 
     public function test_jobs_can_be_added_to_pending_batch()
     {
-        $batch = new PendingBatch(new Container, collect());
+        $batch = new PendingBatch(new Container, new Collection);
         $this->assertCount(0, $batch->jobs);
 
         $job = new class
@@ -187,7 +188,7 @@ class BusBatchTest extends TestCase
 
     public function test_jobs_can_be_added_to_the_pending_batch_from_iterable()
     {
-        $batch = new PendingBatch(new Container, collect());
+        $batch = new PendingBatch(new Container, new Collection);
         $this->assertCount(0, $batch->jobs);
 
         $count = 3;
@@ -379,7 +380,7 @@ class BusBatchTest extends TestCase
             use Batchable;
         };
 
-        $jobsWithNulls = collect([$job, null, $secondJob, [], 0, '', false]);
+        $jobsWithNulls = new Collection([$job, null, $secondJob, [], 0, '', false]);
 
         $batch = new PendingBatch(new Container, $jobsWithNulls);
 
@@ -394,7 +395,7 @@ class BusBatchTest extends TestCase
 
         $repository = new DatabaseBatchRepository(new BatchFactory($queue), DB::connection(), 'job_batches');
 
-        $pendingBatch = (new PendingBatch(new Container, collect()))
+        $pendingBatch = (new PendingBatch(new Container, new Collection))
             ->allowFailures([
                 static fn (Batch $batch, $e): true => $_SERVER['__failure1.invoked'] = true,
                 function (Batch $batch, $e) {
@@ -572,7 +573,7 @@ class BusBatchTest extends TestCase
         $repository = new DatabaseBatchRepository(new BatchFactory($queue), DB::connection(), 'job_batches');
 
         // Create a batch WITHOUT onQueue — this is the key difference
-        $pendingBatch = (new PendingBatch(new Container, collect()))
+        $pendingBatch = (new PendingBatch(new Container, new Collection))
             ->onConnection('test-connection');
 
         $batch = $repository->store($pendingBatch);
@@ -624,7 +625,7 @@ class BusBatchTest extends TestCase
 
     public function test_options_serialization_on_postgres()
     {
-        $pendingBatch = (new PendingBatch(new Container, collect()))
+        $pendingBatch = (new PendingBatch(new Container, new Collection))
             ->onQueue('test-queue');
 
         $connection = m::spy(PostgresConnection::class);
@@ -694,7 +695,7 @@ class BusBatchTest extends TestCase
     {
         $repository = new DatabaseBatchRepository(new BatchFactory($queue), DB::connection(), 'job_batches');
 
-        $pendingBatch = (new PendingBatch(new Container, collect()))
+        $pendingBatch = (new PendingBatch(new Container, new Collection))
             ->progress(function (Batch $batch) {
                 $_SERVER['__progress.batch'] = $batch;
                 $_SERVER['__progress.count']++;

--- a/tests/Cache/CacheDatabaseStoreTest.php
+++ b/tests/Cache/CacheDatabaseStoreTest.php
@@ -7,6 +7,7 @@ use Illuminate\Cache\DatabaseStore;
 use Illuminate\Database\Connection;
 use Illuminate\Database\PostgresConnection;
 use Illuminate\Database\SQLiteConnection;
+use Illuminate\Support\Collection;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use stdClass;
@@ -19,7 +20,7 @@ class CacheDatabaseStoreTest extends TestCase
         $table = m::mock(stdClass::class);
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
         $table->shouldReceive('whereIn')->once()->with('key', ['prefixfoo'])->andReturn($table);
-        $table->shouldReceive('get')->once()->andReturn(collect([]));
+        $table->shouldReceive('get')->once()->andReturn(new Collection);
 
         $this->assertNull($store->get('foo'));
     }
@@ -30,7 +31,7 @@ class CacheDatabaseStoreTest extends TestCase
 
         $getQuery = m::mock(stdClass::class);
         $getQuery->shouldReceive('whereIn')->once()->with('key', ['prefixfoo'])->andReturn($getQuery);
-        $getQuery->shouldReceive('get')->once()->andReturn(collect([(object) ['key' => 'prefixfoo', 'expiration' => 1]]));
+        $getQuery->shouldReceive('get')->once()->andReturn(new Collection([(object) ['key' => 'prefixfoo', 'expiration' => 1]]));
 
         $deleteQuery = m::mock(stdClass::class);
         $deleteQuery->shouldReceive('whereIn')->once()->with('key', ['prefixfoo', 'prefixilluminate:cache:flexible:created:foo'])->andReturn($deleteQuery);
@@ -48,7 +49,7 @@ class CacheDatabaseStoreTest extends TestCase
         $table = m::mock(stdClass::class);
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
         $table->shouldReceive('whereIn')->once()->with('key', ['prefixfoo'])->andReturn($table);
-        $table->shouldReceive('get')->once()->andReturn(collect([(object) ['key' => 'prefixfoo', 'value' => serialize('bar'), 'expiration' => 999999999999999]]));
+        $table->shouldReceive('get')->once()->andReturn(new Collection([(object) ['key' => 'prefixfoo', 'value' => serialize('bar'), 'expiration' => 999999999999999]]));
 
         $this->assertSame('bar', $store->get('foo'));
     }
@@ -59,7 +60,7 @@ class CacheDatabaseStoreTest extends TestCase
         $table = m::mock(stdClass::class);
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
         $table->shouldReceive('whereIn')->once()->with('key', ['prefixfoo'])->andReturn($table);
-        $table->shouldReceive('get')->once()->andReturn(collect([(object) ['key' => 'prefixfoo', 'value' => base64_encode(serialize('bar')), 'expiration' => 999999999999999]]));
+        $table->shouldReceive('get')->once()->andReturn(new Collection([(object) ['key' => 'prefixfoo', 'value' => base64_encode(serialize('bar')), 'expiration' => 999999999999999]]));
 
         $this->assertSame('bar', $store->get('foo'));
     }
@@ -70,7 +71,7 @@ class CacheDatabaseStoreTest extends TestCase
         $table = m::mock(stdClass::class);
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
         $table->shouldReceive('whereIn')->once()->with('key', ['prefixfoo'])->andReturn($table);
-        $table->shouldReceive('get')->once()->andReturn(collect([(object) ['key' => 'prefixfoo', 'value' => base64_encode(serialize("\0bar\0")), 'expiration' => 999999999999999]]));
+        $table->shouldReceive('get')->once()->andReturn(new Collection([(object) ['key' => 'prefixfoo', 'value' => base64_encode(serialize("\0bar\0")), 'expiration' => 999999999999999]]));
 
         $this->assertSame("\0bar\0", $store->get('foo'));
     }

--- a/tests/Console/ConsoleApplicationTest.php
+++ b/tests/Console/ConsoleApplicationTest.php
@@ -11,6 +11,7 @@ use Illuminate\Events\Dispatcher as EventsDispatcher;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Foundation\Application as FoundationApplication;
 use Illuminate\Foundation\Console\Kernel;
+use Illuminate\Support\Collection;
 use Illuminate\Tests\Console\Fixtures\FakeCommandWithArrayInputPrompting;
 use Illuminate\Tests\Console\Fixtures\FakeCommandWithInputPrompting;
 use Mockery as m;
@@ -349,6 +350,6 @@ class TestKernel extends Kernel
 
     public function getRegisteredCommands(): array
     {
-        return collect($this->getArtisan()->all())->values()->transform(fn ($command) => $command::class)->all();
+        return (new Collection($this->getArtisan()->all()))->values()->transform(fn ($command) => $command::class)->all();
     }
 }

--- a/tests/Database/DatabaseEloquentBelongsToManySyncReturnValueTypeTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManySyncReturnValueTypeTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Database;
 
 use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Model as Eloquent;
+use Illuminate\Support\Collection;
 use PHPUnit\Framework\TestCase;
 
 class DatabaseEloquentBelongsToManySyncReturnValueTypeTest extends TestCase
@@ -87,7 +88,7 @@ class DatabaseEloquentBelongsToManySyncReturnValueTypeTest extends TestCase
 
         $changes = $user->articles()->sync($articleIDs);
 
-        collect($changes['attached'])->map(function ($id) {
+        (new Collection($changes['attached']))->map(function ($id) {
             $this->assertSame(gettype($id), (new BelongsToManySyncTestTestArticle)->getKeyType());
         });
 
@@ -105,7 +106,7 @@ class DatabaseEloquentBelongsToManySyncReturnValueTypeTest extends TestCase
 
         $changes = $user->articles()->syncWithPivotValues($articleIDs, ['visible' => true]);
 
-        collect($changes['attached'])->each(function ($id) {
+        (new Collection($changes['attached']))->each(function ($id) {
             $this->assertSame(gettype($id), (new BelongsToManySyncTestTestArticle)->getKeyType());
         });
 

--- a/tests/Database/DatabaseEloquentBelongsToManySyncTouchesParentTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManySyncTouchesParentTest.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 use Illuminate\Database\Eloquent\Relations\Pivot as EloquentPivot;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
 use PHPUnit\Framework\TestCase;
 
 class DatabaseEloquentBelongsToManySyncTouchesParentTest extends TestCase
@@ -90,8 +91,8 @@ class DatabaseEloquentBelongsToManySyncTouchesParentTest extends TestCase
 
         Carbon::setTestNow('2021-07-20 19:13:14');
         $result = $article->users()->sync([1, 2]);
-        $this->assertCount(1, collect($result['detached']));
-        $this->assertSame('3', (string) collect($result['detached'])->first());
+        $this->assertCount(1, new Collection($result['detached']));
+        $this->assertSame('3', (string) (new Collection($result['detached']))->first());
 
         $article->refresh();
         $this->assertSame('2021-07-20 19:13:14', $article->updated_at->format('Y-m-d H:i:s'));

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -93,7 +93,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->getQuery()->shouldNotReceive('whereIn');
         $builder->shouldNotReceive('get');
 
-        $result = $builder->findMany(collect(), ['column']);
+        $result = $builder->findMany(new BaseCollection(), ['column']);
         $this->assertSame('emptycollection', $result);
     }
 
@@ -271,7 +271,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testFindWithManyUsingCollection()
     {
-        $ids = collect([1, 2]);
+        $ids = new BaseCollection([1, 2]);
         $builder = m::mock(Builder::class.'[get]', [$this->getMockQueryBuilder()]);
         $model = $this->getMockModel();
         $model->shouldReceive('getKeyType')->andReturn('int');

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -227,8 +227,8 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertCount(1, $c->find([2]));
         $this->assertEquals(2, $c->find([2])->first()->id);
         $this->assertCount(2, $c->find([2, 3, 4]));
-        $this->assertCount(2, $c->find(collect([2, 3, 4])));
-        $this->assertEquals([2, 3], $c->find(collect([2, 3, 4]))->pluck('id')->all());
+        $this->assertCount(2, $c->find(new BaseCollection([2, 3, 4])));
+        $this->assertEquals([2, 3], $c->find(new BaseCollection([2, 3, 4]))->pluck('id')->all());
         $this->assertEquals([2, 3], $c->find([2, 3, 4])->pluck('id')->all());
     }
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3520,7 +3520,7 @@ class DatabaseEloquentModelTest extends TestCase
         $array = [
             'foo' => 'bar',
         ];
-        $collection = collect($array);
+        $collection = new BaseCollection($array);
         $model->arrayAttribute = $array;
         $model->jsonAttribute = $array;
         $model->jsonAttributeWithUnicode = $array;
@@ -3543,7 +3543,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model->jsonAttributeWithUnicode = [
             'foo' => 'bar2',
         ];
-        $model->collectionAttribute = collect([
+        $model->collectionAttribute = new BaseCollection([
             'foo' => 'bar2',
         ]);
 

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -12,6 +12,7 @@ use Illuminate\Database\Query\Builder;
 use Illuminate\Pagination\CursorPaginator;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
 use Mockery as m;
 use Mockery\MockInterface;
 use PHPUnit\Framework\TestCase;
@@ -286,7 +287,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
     public function testForceDestroyDeletesRecordsFromCollection()
     {
         $this->createUsers();
-        $deleted = SoftDeletesTestUser::forceDestroy(collect([1, 2]));
+        $deleted = SoftDeletesTestUser::forceDestroy(new Collection([1, 2]));
 
         $this->assertSame(2, $deleted);
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1165,14 +1165,14 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([Carbon::now()->startOfDay(), Carbon::now()->addDays(5)->startOfDay()], $builder->getBindings());
 
         $builder = $this->getBuilder();
-        $builder->select('*')->from('users')->whereBetween('id', collect([1, 2]));
+        $builder->select('*')->from('users')->whereBetween('id', new Collection([1, 2]));
         $this->assertSame('select * from "users" where "id" between ? and ?', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 2], $builder->getBindings());
 
         $subqueryBuilder = $this->getBuilder();
         $subqueryBuilder->select('id')->from('posts')->where('status', 'published')->orderByDesc('created_at')->limit(1);
         $builder = $this->getBuilder();
-        $builder->select('*')->from('users')->whereBetween($subqueryBuilder, collect([1, 2]));
+        $builder->select('*')->from('users')->whereBetween($subqueryBuilder, new Collection([1, 2]));
         $this->assertSame('select * from "users" where (select "id" from "posts" where "status" = ? order by "created_at" desc limit 1) between ? and ?', $builder->toSql());
         $this->assertEquals([0 => 'published', 1 => 1, 2 => 2], $builder->getBindings());
     }
@@ -1200,7 +1200,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1, 1 => 4, 2 => 6], $builder->getBindings());
 
         $builder = $this->getBuilder();
-        $builder->select('*')->from('users')->where('id', '=', 1)->orWhereBetween('id', collect([3, 4]));
+        $builder->select('*')->from('users')->where('id', '=', 1)->orWhereBetween('id', new Collection([3, 4]));
         $this->assertSame('select * from "users" where "id" = ? or "id" between ? and ?', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 3, 2 => 4], $builder->getBindings());
 
@@ -1233,7 +1233,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1, 1 => 4, 2 => 6], $builder->getBindings());
 
         $builder = $this->getBuilder();
-        $builder->select('*')->from('users')->where('id', '=', 1)->orWhereNotBetween('id', collect([3, 4]));
+        $builder->select('*')->from('users')->where('id', '=', 1)->orWhereNotBetween('id', new Collection([3, 4]));
         $this->assertSame('select * from "users" where "id" = ? or "id" not between ? and ?', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 3, 2 => 4], $builder->getBindings());
 
@@ -5937,9 +5937,9 @@ SQL;
         $builder = $this->getMockQueryBuilder();
         $builder->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
 
-        $chunk1 = collect(['foo1', 'foo2']);
-        $chunk2 = collect(['foo3', 'foo4']);
-        $chunk3 = collect([]);
+        $chunk1 = new Collection(['foo1', 'foo2']);
+        $chunk2 = new Collection(['foo3', 'foo4']);
+        $chunk3 = new Collection;
 
         $builder->shouldReceive('getOffset')->once()->andReturnNull();
         $builder->shouldReceive('getLimit')->once()->andReturnNull();
@@ -5964,8 +5964,8 @@ SQL;
         $builder = $this->getMockQueryBuilder();
         $builder->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
 
-        $chunk1 = collect(['foo1', 'foo2']);
-        $chunk2 = collect(['foo3']);
+        $chunk1 = new Collection(['foo1', 'foo2']);
+        $chunk2 = new Collection(['foo3']);
 
         $builder->shouldReceive('getOffset')->once()->andReturnNull();
         $builder->shouldReceive('getLimit')->once()->andReturnNull();
@@ -5988,8 +5988,8 @@ SQL;
         $builder = $this->getMockQueryBuilder();
         $builder->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
 
-        $chunk1 = collect(['foo1', 'foo2']);
-        $chunk2 = collect(['foo3']);
+        $chunk1 = new Collection(['foo1', 'foo2']);
+        $chunk2 = new Collection(['foo3']);
         $builder->shouldReceive('getOffset')->once()->andReturnNull();
         $builder->shouldReceive('getLimit')->once()->andReturnNull();
         $builder->shouldReceive('offset')->once()->with(0)->andReturnSelf();
@@ -6028,9 +6028,9 @@ SQL;
         $builder = $this->getMockQueryBuilder();
         $builder->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
 
-        $chunk1 = collect([['someIdField' => 1], ['someIdField' => 2]]);
-        $chunk2 = collect([['someIdField' => 10], ['someIdField' => 11]]);
-        $chunk3 = collect([]);
+        $chunk1 = new Collection([['someIdField' => 1], ['someIdField' => 2]]);
+        $chunk2 = new Collection([['someIdField' => 10], ['someIdField' => 11]]);
+        $chunk3 = new Collection;
         $builder->shouldReceive('forPageAfterId')->once()->with(2, 0, 'someIdField')->andReturnSelf();
         $builder->shouldReceive('forPageAfterId')->once()->with(2, 2, 'someIdField')->andReturnSelf();
         $builder->shouldReceive('forPageAfterId')->once()->with(2, 11, 'someIdField')->andReturnSelf();
@@ -6051,9 +6051,9 @@ SQL;
         $builder = $this->getMockQueryBuilder();
         $builder->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
 
-        $chunk1 = collect([(object) ['someIdField' => 1], (object) ['someIdField' => 2]]);
-        $chunk2 = collect([(object) ['someIdField' => 10], (object) ['someIdField' => 11]]);
-        $chunk3 = collect([]);
+        $chunk1 = new Collection([(object) ['someIdField' => 1], (object) ['someIdField' => 2]]);
+        $chunk2 = new Collection([(object) ['someIdField' => 10], (object) ['someIdField' => 11]]);
+        $chunk3 = new Collection;
         $builder->shouldReceive('forPageAfterId')->once()->with(2, 0, 'someIdField')->andReturnSelf();
         $builder->shouldReceive('forPageAfterId')->once()->with(2, 2, 'someIdField')->andReturnSelf();
         $builder->shouldReceive('forPageAfterId')->once()->with(2, 11, 'someIdField')->andReturnSelf();
@@ -6074,8 +6074,8 @@ SQL;
         $builder = $this->getMockQueryBuilder();
         $builder->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
 
-        $chunk1 = collect([(object) ['someIdField' => 1], (object) ['someIdField' => 2]]);
-        $chunk2 = collect([(object) ['someIdField' => 10]]);
+        $chunk1 = new Collection([(object) ['someIdField' => 1], (object) ['someIdField' => 2]]);
+        $chunk2 = new Collection([(object) ['someIdField' => 10]]);
         $builder->shouldReceive('forPageAfterId')->once()->with(2, 0, 'someIdField')->andReturnSelf();
         $builder->shouldReceive('forPageAfterId')->once()->with(2, 2, 'someIdField')->andReturnSelf();
         $builder->shouldReceive('get')->times(2)->andReturn($chunk1, $chunk2);
@@ -6107,8 +6107,8 @@ SQL;
         $builder = $this->getMockQueryBuilder();
         $builder->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
 
-        $chunk1 = collect([(object) ['table_id' => 1], (object) ['table_id' => 10]]);
-        $chunk2 = collect([]);
+        $chunk1 = new Collection([(object) ['table_id' => 1], (object) ['table_id' => 10]]);
+        $chunk2 = new Collection;
         $builder->shouldReceive('forPageAfterId')->once()->with(2, 0, 'table.id')->andReturnSelf();
         $builder->shouldReceive('forPageAfterId')->once()->with(2, 10, 'table.id')->andReturnSelf();
         $builder->shouldReceive('get')->times(2)->andReturn($chunk1, $chunk2);
@@ -6127,8 +6127,8 @@ SQL;
         $builder = $this->getMockQueryBuilder();
         $builder->orders[] = ['column' => 'foobar', 'direction' => 'desc'];
 
-        $chunk1 = collect([(object) ['someIdField' => 10], (object) ['someIdField' => 1]]);
-        $chunk2 = collect([]);
+        $chunk1 = new Collection([(object) ['someIdField' => 10], (object) ['someIdField' => 1]]);
+        $chunk2 = new Collection;
         $builder->shouldReceive('forPageBeforeId')->once()->with(2, 0, 'someIdField')->andReturnSelf();
         $builder->shouldReceive('forPageBeforeId')->once()->with(2, 1, 'someIdField')->andReturnSelf();
         $builder->shouldReceive('get')->times(2)->andReturn($chunk1, $chunk2);
@@ -6151,7 +6151,7 @@ SQL;
         $builder = $this->getMockQueryBuilder();
         $path = 'http://foo.bar?page=3';
 
-        $results = collect([['test' => 'foo'], ['test' => 'bar']]);
+        $results = new Collection([['test' => 'foo'], ['test' => 'bar']]);
 
         $builder->shouldReceive('getCountForPagination')->once()->andReturn(2);
         $builder->shouldReceive('forPage')->once()->with($page, $perPage)->andReturnSelf();
@@ -6177,7 +6177,7 @@ SQL;
         $builder = $this->getMockQueryBuilder();
         $path = 'http://foo.bar?page=3';
 
-        $results = collect([['test' => 'foo'], ['test' => 'bar']]);
+        $results = new Collection([['test' => 'foo'], ['test' => 'bar']]);
 
         $builder->shouldReceive('getCountForPagination')->once()->andReturn(2);
         $builder->shouldReceive('forPage')->once()->with($page, $perPage)->andReturnSelf();
@@ -6238,7 +6238,7 @@ SQL;
         $builder = $this->getMockQueryBuilder();
         $path = 'http://foo.bar?page=3';
 
-        $results = collect([['id' => 3, 'name' => 'Taylor'], ['id' => 5, 'name' => 'Mohamed']]);
+        $results = new Collection([['id' => 3, 'name' => 'Taylor'], ['id' => 5, 'name' => 'Mohamed']]);
 
         $builder->shouldReceive('getCountForPagination')->once()->andReturn(2);
         $builder->shouldReceive('forPage')->once()->with($page, $perPage)->andReturnSelf();
@@ -6265,7 +6265,7 @@ SQL;
         $builder = $this->getMockQueryBuilder();
         $path = 'http://foo.bar?page=3';
 
-        $results = collect([['id' => 3, 'name' => 'Taylor'], ['id' => 5, 'name' => 'Mohamed']]);
+        $results = new Collection([['id' => 3, 'name' => 'Taylor'], ['id' => 5, 'name' => 'Mohamed']]);
 
         $builder->shouldReceive('getCountForPagination')->never();
         $builder->shouldReceive('forPage')->once()->with($page, $perPage)->andReturnSelf();
@@ -6294,7 +6294,7 @@ SQL;
 
         $path = 'http://foo.bar?cursor='.$cursor->encode();
 
-        $results = collect([['test' => 'foo'], ['test' => 'bar']]);
+        $results = new Collection([['test' => 'foo'], ['test' => 'bar']]);
 
         $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results) {
             $this->assertEquals(
@@ -6332,7 +6332,7 @@ SQL;
 
         $path = 'http://foo.bar?cursor='.$cursor->encode();
 
-        $results = collect([['test' => 'foo', 'another' => 1], ['test' => 'bar', 'another' => 2]]);
+        $results = new Collection([['test' => 'foo', 'another' => 1], ['test' => 'bar', 'another' => 2]]);
 
         $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results) {
             $this->assertEquals(
@@ -6370,7 +6370,7 @@ SQL;
 
         $path = 'http://foo.bar?cursor='.$cursor->encode();
 
-        $results = collect([['test' => 'foo'], ['test' => 'bar']]);
+        $results = new Collection([['test' => 'foo'], ['test' => 'bar']]);
 
         $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results) {
             $this->assertEquals(
@@ -6440,7 +6440,7 @@ SQL;
 
         $path = 'http://foo.bar?cursor=3';
 
-        $results = collect([['id' => 3, 'name' => 'Taylor'], ['id' => 5, 'name' => 'Mohamed']]);
+        $results = new Collection([['id' => 3, 'name' => 'Taylor'], ['id' => 5, 'name' => 'Mohamed']]);
 
         $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results) {
             $this->assertEquals(
@@ -6478,7 +6478,7 @@ SQL;
 
         $path = 'http://foo.bar?cursor='.$cursor->encode();
 
-        $results = collect([['foo' => 1, 'bar' => 2, 'baz' => 4], ['foo' => 1, 'bar' => 1, 'baz' => 1]]);
+        $results = new Collection([['foo' => 1, 'bar' => 2, 'baz' => 4], ['foo' => 1, 'bar' => 1, 'baz' => 1]]);
 
         $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results) {
             $this->assertEquals(
@@ -6516,7 +6516,7 @@ SQL;
 
         $path = 'http://foo.bar?cursor='.$cursor->encode();
 
-        $results = collect([['test' => 'foo'], ['test' => 'bar']]);
+        $results = new Collection([['test' => 'foo'], ['test' => 'bar']]);
 
         $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results) {
             $this->assertEquals(
@@ -6557,7 +6557,7 @@ SQL;
 
         $path = 'http://foo.bar?cursor='.$cursor->encode();
 
-        $results = collect([['test' => 'foo'], ['test' => 'bar']]);
+        $results = new Collection([['test' => 'foo'], ['test' => 'bar']]);
 
         $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results) {
             $this->assertEquals(
@@ -6598,7 +6598,7 @@ SQL;
 
         $path = 'http://foo.bar?cursor='.$cursor->encode();
 
-        $results = collect([['test' => 'foo'], ['test' => 'bar']]);
+        $results = new Collection([['test' => 'foo'], ['test' => 'bar']]);
 
         $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results) {
             $this->assertEquals(
@@ -6645,7 +6645,7 @@ SQL;
 
         $path = 'http://foo.bar?cursor='.$cursor->encode();
 
-        $results = collect([
+        $results = new Collection([
             ['id' => 1, 'created_at' => Carbon::now(), 'type' => 'video'],
             ['id' => 2, 'created_at' => Carbon::now(), 'type' => 'news'],
         ]);
@@ -6693,7 +6693,7 @@ SQL;
 
         $path = 'http://foo.bar?cursor='.$cursor->encode();
 
-        $results = collect([
+        $results = new Collection([
             ['id' => 1, 'created_at' => Carbon::now(), 'type' => 'video'],
             ['id' => 2, 'created_at' => Carbon::now(), 'type' => 'news'],
             ['id' => 3, 'created_at' => Carbon::now(), 'type' => 'podcasts'],
@@ -6742,7 +6742,7 @@ SQL;
 
         $path = 'http://foo.bar?cursor='.$cursor->encode();
 
-        $results = collect([
+        $results = new Collection([
             ['id' => 1, 'created_at' => Carbon::now()->addDay(), 'type' => 'video'],
             ['id' => 1, 'created_at' => Carbon::now(), 'type' => 'news'],
             ['id' => 1, 'created_at' => Carbon::now(), 'type' => 'podcast'],
@@ -6791,7 +6791,7 @@ SQL;
 
         $path = 'http://foo.bar?cursor='.$cursor->encode();
 
-        $results = collect([
+        $results = new Collection([
             ['id' => 1, 'created_at' => Carbon::now(), 'type' => 'video', 'is_published' => true],
             ['id' => 2, 'created_at' => Carbon::now(), 'type' => 'news', 'is_published' => true],
         ]);
@@ -6838,7 +6838,7 @@ SQL;
 
         $path = 'http://foo.bar?cursor='.$cursor->encode();
 
-        $results = collect([
+        $results = new Collection([
             ['id' => 1, 'created_at' => Carbon::now(), 'type' => 'video'],
             ['id' => 2, 'created_at' => Carbon::now(), 'type' => 'news'],
         ]);
@@ -6885,7 +6885,7 @@ SQL;
 
         $path = 'http://foo.bar?cursor='.$cursor->encode();
 
-        $results = collect([
+        $results = new Collection([
             ['id' => 1, 'created_at' => Carbon::now(), 'type' => 'video'],
             ['id' => 2, 'created_at' => Carbon::now(), 'type' => 'news'],
         ]);
@@ -6933,7 +6933,7 @@ SQL;
 
         $path = 'http://foo.bar?cursor='.$cursor->encode();
 
-        $results = collect([
+        $results = new Collection([
             ['id' => 1, 'created_at' => Carbon::now(), 'type' => 'video'],
             ['id' => 2, 'created_at' => Carbon::now(), 'type' => 'news'],
             ['id' => 3, 'created_at' => Carbon::now(), 'type' => 'podcast'],

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\ForeignIdColumnDefinition;
 use Illuminate\Database\Schema\Grammars\SQLiteGrammar;
 use Illuminate\Database\Schema\SQLiteBuilder;
+use Illuminate\Support\Collection;
 use Illuminate\Tests\Database\Fixtures\Enums\Foo;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -182,7 +183,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         });
 
         $this->assertFalse($schema->hasIndex('users', 'index1'));
-        $this->assertTrue(collect($schema->getIndexes('users'))->contains(
+        $this->assertTrue((new Collection($schema->getIndexes('users')))->contains(
             fn ($index) => $index['name'] === 'index2' && $index['columns'] === ['name', 'email']
         ));
     }

--- a/tests/Foundation/Bootstrap/LoadConfigurationTest.php
+++ b/tests/Foundation/Bootstrap/LoadConfigurationTest.php
@@ -6,6 +6,7 @@ use Closure;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Bootstrap\LoadConfiguration;
+use Illuminate\Support\Collection;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
@@ -66,10 +67,10 @@ class LoadConfigurationTest extends TestCase
 
         $this->assertEqualsCanonicalizing(
             array_keys($app['config']->all()),
-            collect((new Filesystem)->files([
+            (new Collection((new Filesystem)->files([
                 $baseConfigPath,
                 $customConfigPath,
-            ]))->map(fn ($file) => $file->getBaseName('.php'))->unique()->values()->toArray()
+            ])))->map(fn ($file) => $file->getBaseName('.php'))->unique()->values()->toArray()
         );
     }
 }

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -22,6 +22,7 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Redirector;
 use Illuminate\Routing\ResponseFactory;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Lottery;
 use Illuminate\Support\MessageBag;
 use Illuminate\Testing\Assert;
@@ -748,7 +749,7 @@ class FoundationExceptionsHandlerTest extends TestCase
             $handler->report(new RuntimeException("RuntimeException {$i}"));
         }
 
-        [$runtimeExceptions, $baseExceptions] = collect($reported)->partition(fn ($e) => $e instanceof RuntimeException);
+        [$runtimeExceptions, $baseExceptions] = (new Collection($reported))->partition(fn ($e) => $e instanceof RuntimeException);
         $this->assertCount(10, $baseExceptions);
         $this->assertCount(2, $runtimeExceptions);
     }

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Query\Builder;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithDatabase;
 use Illuminate\Foundation\Testing\TestCase as TestingTestCase;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Mockery as m;
 use Orchestra\Testbench\Concerns\CreatesApplication;
@@ -68,7 +69,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
 
         $builder = $this->mockCountBuilder(false);
 
-        $builder->shouldReceive('get')->andReturn(collect());
+        $builder->shouldReceive('get')->andReturn(new Collection);
 
         $this->assertDatabaseHas($this->table, $this->data);
     }
@@ -82,7 +83,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $builder = $this->mockCountBuilder(false);
 
         $builder->shouldReceive('limit')->andReturnSelf();
-        $builder->shouldReceive('get')->andReturn(collect([['title' => 'Forge']]));
+        $builder->shouldReceive('get')->andReturn(new Collection([['title' => 'Forge']]));
 
         $this->assertDatabaseHas($this->table, $this->data);
     }
@@ -97,7 +98,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
 
         $builder->shouldReceive('limit')->andReturnSelf();
         $builder->shouldReceive('get')->andReturn(
-            collect(array_fill(0, 3, 'data'))
+            new Collection(array_fill(0, 3, 'data'))
         );
 
         $this->assertDatabaseHas($this->table, $this->data);
@@ -138,7 +139,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $builder = $this->mockCountBuilder(true);
 
         $builder->shouldReceive('limit')->andReturnSelf();
-        $builder->shouldReceive('get')->andReturn(collect([$this->data]));
+        $builder->shouldReceive('get')->andReturn(new Collection([$this->data]));
 
         $this->assertDatabaseMissing($this->table, $this->data);
     }
@@ -188,7 +189,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
 
         $builder = $this->mockCountBuilder(true);
 
-        $builder->shouldReceive('get')->andReturn(collect([$this->data]));
+        $builder->shouldReceive('get')->andReturn(new Collection([$this->data]));
 
         $this->assertDatabaseMissing($this->table, $this->data);
     }
@@ -199,7 +200,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
 
         $builder = $this->mockCountBuilder(false);
 
-        $builder->shouldReceive('get')->andReturn(collect());
+        $builder->shouldReceive('get')->andReturn(new Collection);
 
         $this->assertModelMissing(new ProductStub($this->data));
     }
@@ -225,7 +226,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
 
         $builder = $this->mockCountBuilder(false);
 
-        $builder->shouldReceive('get')->andReturn(collect());
+        $builder->shouldReceive('get')->andReturn(new Collection);
 
         $this->assertSoftDeleted($this->table, $this->data);
     }
@@ -239,7 +240,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
 
         $builder = $this->mockCountBuilder(false);
 
-        $builder->shouldReceive('get')->andReturn(collect());
+        $builder->shouldReceive('get')->andReturn(new Collection);
 
         $this->assertSoftDeleted(new ProductStub($this->data));
     }
@@ -254,7 +255,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
 
         $builder = $this->mockCountBuilder(false, 'trashed_at');
 
-        $builder->shouldReceive('get')->andReturn(collect());
+        $builder->shouldReceive('get')->andReturn(new Collection);
 
         $this->assertSoftDeleted($model, ['name' => 'Tailwind']);
     }
@@ -269,7 +270,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
 
         $builder = $this->mockCountBuilder(false, 'trashed_at');
 
-        $builder->shouldReceive('get')->andReturn(collect());
+        $builder->shouldReceive('get')->andReturn(new Collection);
 
         $this->assertSoftDeleted(CustomProductStub::class, ['id' => $model->id]);
     }
@@ -295,7 +296,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
 
         $builder = $this->mockCountBuilder(false);
 
-        $builder->shouldReceive('get')->andReturn(collect(), collect(1));
+        $builder->shouldReceive('get')->andReturn(new Collection, new Collection(1));
 
         $this->assertNotSoftDeleted(ProductStub::class, $this->data);
     }
@@ -307,7 +308,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
 
         $builder = $this->mockCountBuilder(false);
 
-        $builder->shouldReceive('get')->andReturn(collect());
+        $builder->shouldReceive('get')->andReturn(new Collection);
 
         $this->assertNotSoftDeleted($this->table, $this->data);
     }
@@ -321,7 +322,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
 
         $builder = $this->mockCountBuilder(false);
 
-        $builder->shouldReceive('get')->andReturn(collect());
+        $builder->shouldReceive('get')->andReturn(new Collection);
 
         $this->assertNotSoftDeleted(new ProductStub($this->data));
     }
@@ -336,7 +337,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
 
         $builder = $this->mockCountBuilder(false, 'trashed_at');
 
-        $builder->shouldReceive('get')->andReturn(collect());
+        $builder->shouldReceive('get')->andReturn(new Collection);
 
         $this->assertNotSoftDeleted($model, ['name' => 'Tailwind']);
     }
@@ -351,7 +352,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
 
         $builder = $this->mockCountBuilder(false, 'trashed_at');
 
-        $builder->shouldReceive('get')->andReturn(collect());
+        $builder->shouldReceive('get')->andReturn(new Collection);
 
         $this->assertNotSoftDeleted(CustomProductStub::class, ['id' => $model->id]);
     }
@@ -362,7 +363,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
 
         $builder = $this->mockCountBuilder(true);
 
-        $builder->shouldReceive('get')->andReturn(collect($this->data));
+        $builder->shouldReceive('get')->andReturn(new Collection($this->data));
 
         $this->assertModelExists(new ProductStub($this->data));
     }

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -454,10 +454,10 @@ class HttpClientTest extends TestCase
         $response = $this->factory->get('http://foo.com/api');
 
         $this->assertInstanceOf(Collection::class, $response->collect());
-        $this->assertEquals(collect(['result' => ['foo' => 'bar']]), $response->collect());
-        $this->assertEquals(collect(['foo' => 'bar']), $response->collect('result'));
-        $this->assertEquals(collect(['bar']), $response->collect('result.foo'));
-        $this->assertEquals(collect(), $response->collect('missing_key'));
+        $this->assertEquals(new Collection(['result' => ['foo' => 'bar']]), $response->collect());
+        $this->assertEquals(new Collection(['foo' => 'bar']), $response->collect('result'));
+        $this->assertEquals(new Collection(['bar']), $response->collect('result.foo'));
+        $this->assertEquals(new Collection, $response->collect('missing_key'));
     }
 
     public function testResponseCanBeReturnedAsFluent()
@@ -2484,7 +2484,7 @@ class HttpClientTest extends TestCase
             '*' => $this->factory->response(['error'], 500),
         ]);
 
-        $whenAttempts = collect();
+        $whenAttempts = new Collection;
 
         [$exception] = $this->factory->pool(fn ($pool) => [
             $pool->retry(2, 1000, function ($exception) use ($whenAttempts) {
@@ -2525,7 +2525,7 @@ class HttpClientTest extends TestCase
             '*' => $this->factory->response(['error'], 500),
         ]);
 
-        $whenAttempts = collect();
+        $whenAttempts = new Collection;
 
         [$response] = $this->factory->pool(fn ($pool) => [
             $pool->retry(2, 1000, function ($exception) use ($whenAttempts) {
@@ -3168,7 +3168,7 @@ class HttpClientTest extends TestCase
             '*' => $this->factory->response(['error'], 403),
         ]);
 
-        $hitThrowCallback = collect();
+        $hitThrowCallback = new Collection;
 
         [$exception] = $this->factory->pool(fn ($pool) => [
             $pool->throwIf(function ($response) {
@@ -3197,7 +3197,7 @@ class HttpClientTest extends TestCase
             '*' => $this->factory->response(['error'], 403),
         ]);
 
-        $hitThrowCallback = collect();
+        $hitThrowCallback = new Collection;
 
         [$response] = $this->factory->pool(fn ($pool) => [
             $pool->throwIf(function ($response) {
@@ -3220,7 +3220,7 @@ class HttpClientTest extends TestCase
             '*' => $this->factory->response(['error'], 403),
         ]);
 
-        $flag = collect();
+        $flag = new Collection;
 
         [$exception] = $this->factory->pool(fn ($pool) => [
             $pool->throw(function ($exception) use (&$flag) {

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -764,7 +764,7 @@ class HttpRequestTest extends TestCase
         $this->assertTrue($request->collect(['roles'])->isNotEmpty());
         $this->assertEquals(['roles' => [4, 5, 6]], $request->collect(['roles'])->all());
         $this->assertEquals(['users' => [1, 2, 3], 'email' => 'test@example.com'], $request->collect(['users', 'email'])->all());
-        $this->assertEquals(collect(['roles' => [4, 5, 6], 'foo' => ['bar', 'baz']]), $request->collect(['roles', 'foo']));
+        $this->assertEquals(new Collection(['roles' => [4, 5, 6], 'foo' => ['bar', 'baz']]), $request->collect(['roles', 'foo']));
         $this->assertEquals(['users' => [1, 2, 3], 'roles' => [4, 5, 6], 'foo' => ['bar', 'baz'], 'email' => 'test@example.com'], $request->collect()->all());
     }
 

--- a/tests/Integration/Console/PromptsAssertionTest.php
+++ b/tests/Integration/Console/PromptsAssertionTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Integration\Console;
 
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Support\Collection;
 use Orchestra\Testbench\TestCase;
 
 use function Laravel\Prompts\confirm;
@@ -307,7 +308,7 @@ class PromptsAssertionTest extends TestCase
 
                 public function handle()
                 {
-                    $options = collect(['John', 'Jane', 'Sally', 'Jack']);
+                    $options = new Collection(['John', 'Jane', 'Sally', 'Jack']);
 
                     $name = search(
                         label: 'What is your name?',
@@ -336,7 +337,7 @@ class PromptsAssertionTest extends TestCase
 
                 public function handle()
                 {
-                    $options = collect(['John', 'Jane', 'Sally', 'Jack']);
+                    $options = new Collection(['John', 'Jane', 'Sally', 'Jack']);
 
                     $names = multisearch(
                         label: 'Which names do you like?',
@@ -379,7 +380,7 @@ class PromptsAssertionTest extends TestCase
                         options: ['John', 'Jane']
                     );
 
-                    $titles = collect(['Mr', 'Mrs', 'Ms', 'Dr']);
+                    $titles = new Collection(['Mr', 'Mrs', 'Ms', 'Dr']);
                     $title = multisearch(
                         label: 'What is your title?',
                         options: fn (string $value) => strlen($value) > 0

--- a/tests/Integration/Console/Scheduling/ScheduleRunCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleRunCommandTest.php
@@ -9,6 +9,7 @@ use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Console\Scheduling\ScheduleRunCommand;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Event;
 use Orchestra\Testbench\TestCase;
 use ReflectionMethod;
@@ -235,7 +236,7 @@ class ScheduleRunCommandTest extends TestCase
 
         // Set test time past the minute boundary so the while loop exits immediately
         Carbon::setTestNow('2026-03-25 12:01:01');
-        $reflection->invoke($command, collect());
+        $reflection->invoke($command, new Collection);
 
         // startedAt should not have been mutated to end of minute
         $startedAtAfter = (new ReflectionProperty($command, 'startedAt'))->getValue($command);

--- a/tests/Integration/Database/AfterQueryTest.php
+++ b/tests/Integration/Database/AfterQueryTest.php
@@ -38,7 +38,7 @@ class AfterQueryTest extends DatabaseTestCase
         AfterQueryUser::create();
         AfterQueryUser::create();
 
-        $afterQueryIds = collect();
+        $afterQueryIds = new Collection;
 
         $users = AfterQueryUser::query()
             ->afterQuery(function (Collection $users) use ($afterQueryIds) {
@@ -59,7 +59,7 @@ class AfterQueryTest extends DatabaseTestCase
         AfterQueryUser::create();
         AfterQueryUser::create();
 
-        $afterQueryIds = collect();
+        $afterQueryIds = new Collection;
 
         $users = AfterQueryUser::query()
             ->toBase()
@@ -81,7 +81,7 @@ class AfterQueryTest extends DatabaseTestCase
         AfterQueryUser::create();
         AfterQueryUser::create();
 
-        $afterQueryIds = collect();
+        $afterQueryIds = new Collection;
 
         $users = AfterQueryUser::query()
             ->afterQuery(function (Collection $users) use ($afterQueryIds) {
@@ -102,7 +102,7 @@ class AfterQueryTest extends DatabaseTestCase
         AfterQueryUser::create();
         AfterQueryUser::create();
 
-        $afterQueryIds = collect();
+        $afterQueryIds = new Collection;
 
         $users = AfterQueryUser::query()
             ->toBase()
@@ -124,7 +124,7 @@ class AfterQueryTest extends DatabaseTestCase
         AfterQueryUser::create();
         AfterQueryUser::create();
 
-        $afterQueryIds = collect();
+        $afterQueryIds = new Collection;
 
         $userIds = AfterQueryUser::query()
             ->afterQuery(function (Collection $userIds) use ($afterQueryIds) {
@@ -145,7 +145,7 @@ class AfterQueryTest extends DatabaseTestCase
         AfterQueryUser::create();
         AfterQueryUser::create();
 
-        $afterQueryIds = collect();
+        $afterQueryIds = new Collection;
 
         $userIds = AfterQueryUser::query()
             ->toBase()
@@ -171,7 +171,7 @@ class AfterQueryTest extends DatabaseTestCase
         $user->posts()->attach($firstPost);
         $user->posts()->attach($secondPost);
 
-        $afterQueryIds = collect();
+        $afterQueryIds = new Collection;
 
         $posts = $user->posts()
             ->afterQuery(function (Collection $posts) use ($afterQueryIds) {
@@ -209,7 +209,7 @@ class AfterQueryTest extends DatabaseTestCase
         AfterQueryUser::create(['team_id' => $team->id]);
         AfterQueryUser::create(['team_id' => $team->id]);
 
-        $afterQueryIds = collect();
+        $afterQueryIds = new Collection;
 
         $teamMates = $user->teamMates()
             ->afterQuery(function (Collection $teamMates) use ($afterQueryIds) {
@@ -232,27 +232,27 @@ class AfterQueryTest extends DatabaseTestCase
 
         $users = AfterQueryUser::query()
             ->afterQuery(function () {
-                return collect(['foo', 'bar']);
+                return new Collection(['foo', 'bar']);
             })
             ->get();
 
-        $this->assertEquals(collect(['foo', 'bar']), $users);
+        $this->assertEquals(new Collection(['foo', 'bar']), $users);
 
         $users = AfterQueryUser::query()
             ->afterQuery(function () {
-                return collect(['foo', 'bar']);
+                return new Collection(['foo', 'bar']);
             })
             ->pluck('id');
 
-        $this->assertEquals(collect(['foo', 'bar']), $users);
+        $this->assertEquals(new Collection(['foo', 'bar']), $users);
 
         $users = AfterQueryUser::query()
             ->afterQuery(function ($users) use ($firstUser) {
-                return $users->first()->is($firstUser) ? collect(['foo', 'bar']) : collect(['bar', 'foo']);
+                return $users->first()->is($firstUser) ? new Collection(['foo', 'bar']) : new Collection(['bar', 'foo']);
             })
             ->cursor();
 
-        $this->assertEquals(collect(['foo', 'bar']), $users->collect());
+        $this->assertEquals(new Collection(['foo', 'bar']), $users->collect());
 
         $users = AfterQueryUser::query()
             ->afterQuery(function ($users) use ($firstUser) {
@@ -270,11 +270,11 @@ class AfterQueryTest extends DatabaseTestCase
 
         $posts = $firstUser->posts()
             ->afterQuery(function () {
-                return collect(['foo', 'bar']);
+                return new Collection(['foo', 'bar']);
             })
             ->get();
 
-        $this->assertEquals(collect(['foo', 'bar']), $posts);
+        $this->assertEquals(new Collection(['foo', 'bar']), $posts);
 
         $user = AfterQueryUser::create();
         $team = AfterQueryTeam::create(['owner_id' => $user->id]);
@@ -284,11 +284,11 @@ class AfterQueryTest extends DatabaseTestCase
 
         $teamMates = $user->teamMates()
             ->afterQuery(function () {
-                return collect(['foo', 'bar']);
+                return new Collection(['foo', 'bar']);
             })
             ->get();
 
-        $this->assertEquals(collect(['foo', 'bar']), $teamMates);
+        $this->assertEquals(new Collection(['foo', 'bar']), $teamMates);
     }
 
     public function testAfterQueryOnBaseBuilderCanAlterReturnedResult()
@@ -299,29 +299,29 @@ class AfterQueryTest extends DatabaseTestCase
         $users = AfterQueryUser::query()
             ->toBase()
             ->afterQuery(function () {
-                return collect(['foo', 'bar']);
+                return new Collection(['foo', 'bar']);
             })
             ->get();
 
-        $this->assertEquals(collect(['foo', 'bar']), $users);
+        $this->assertEquals(new Collection(['foo', 'bar']), $users);
 
         $users = AfterQueryUser::query()
             ->toBase()
             ->afterQuery(function () {
-                return collect(['foo', 'bar']);
+                return new Collection(['foo', 'bar']);
             })
             ->pluck('id');
 
-        $this->assertEquals(collect(['foo', 'bar']), $users);
+        $this->assertEquals(new Collection(['foo', 'bar']), $users);
 
         $users = AfterQueryUser::query()
             ->toBase()
             ->afterQuery(function ($users) use ($firstUser) {
-                return ((int) $users->first()->id) === $firstUser->id ? collect(['foo', 'bar']) : collect(['bar', 'foo']);
+                return ((int) $users->first()->id) === $firstUser->id ? new Collection(['foo', 'bar']) : new Collection(['bar', 'foo']);
             })
             ->cursor();
 
-        $this->assertEquals(collect(['foo', 'bar']), $users->collect());
+        $this->assertEquals(new Collection(['foo', 'bar']), $users->collect());
 
         $users = AfterQueryUser::query()
             ->toBase()
@@ -341,11 +341,11 @@ class AfterQueryTest extends DatabaseTestCase
         $posts = $firstUser->posts()
             ->toBase()
             ->afterQuery(function () {
-                return collect(['foo', 'bar']);
+                return new Collection(['foo', 'bar']);
             })
             ->get();
 
-        $this->assertEquals(collect(['foo', 'bar']), $posts);
+        $this->assertEquals(new Collection(['foo', 'bar']), $posts);
 
         $user = AfterQueryUser::create();
         $team = AfterQueryTeam::create(['owner_id' => $user->id]);
@@ -356,11 +356,11 @@ class AfterQueryTest extends DatabaseTestCase
         $teamMates = $user->teamMates()
             ->toBase()
             ->afterQuery(function () {
-                return collect(['foo', 'bar']);
+                return new Collection(['foo', 'bar']);
             })
             ->get();
 
-        $this->assertEquals(collect(['foo', 'bar']), $teamMates);
+        $this->assertEquals(new Collection(['foo', 'bar']), $teamMates);
     }
 }
 

--- a/tests/Integration/Database/DatabaseConnectionsTest.php
+++ b/tests/Integration/Database/DatabaseConnectionsTest.php
@@ -10,6 +10,7 @@ use Illuminate\Database\QueryException;
 use Illuminate\Database\SQLiteConnection;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\DB;
 use InvalidArgumentException;
@@ -191,7 +192,7 @@ class DatabaseConnectionsTest extends DatabaseTestCase
                 'database' => $writePath,
             ],
         ]);
-        $events = collect();
+        $events = new Collection;
         DB::listen($events->push(...));
 
         try {
@@ -242,7 +243,7 @@ class DatabaseConnectionsTest extends DatabaseTestCase
             'driver' => 'sqlite',
             'database' => $writePath,
         ]);
-        $events = collect();
+        $events = new Collection;
         DB::listen($events->push(...));
 
         try {
@@ -331,7 +332,7 @@ class DatabaseConnectionsTest extends DatabaseTestCase
                 'database' => $writePath,
             ],
         ]);
-        $events = collect();
+        $events = new Collection;
         DB::listen($events->push(...));
 
         try {

--- a/tests/Integration/Database/DatabaseCustomCastsTest.php
+++ b/tests/Integration/Database/DatabaseCustomCastsTest.php
@@ -43,7 +43,7 @@ class DatabaseCustomCastsTest extends DatabaseTestCase
 
         $model->array_object = ['name' => 'Taylor'];
         $model->array_object_json = ['name' => 'Taylor'];
-        $model->collection = collect(['name' => 'Taylor']);
+        $model->collection = new Collection(['name' => 'Taylor']);
         $model->stringable = new Stringable('Taylor');
         $model->password = Hash::make('secret');
 
@@ -91,7 +91,7 @@ class DatabaseCustomCastsTest extends DatabaseTestCase
         $model = TestEloquentModelWithCustomCasts::create([
             'array_object' => ['name' => 'Taylor'],
             'array_object_json' => ['name' => 'Taylor'],
-            'collection' => collect(['name' => 'Taylor']),
+            'collection' => new Collection(['name' => 'Taylor']),
             'stringable' => new Stringable('Taylor'),
             'password' => Hash::make('secret'),
         ]);
@@ -113,7 +113,7 @@ class DatabaseCustomCastsTest extends DatabaseTestCase
 
         $model->array_object = null;
         $model->array_object_json = null;
-        $model->collection = collect();
+        $model->collection = new Collection;
         $model->stringable = null;
 
         $model->save();

--- a/tests/Integration/Database/DatabaseEloquentModelAttributeCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelAttributeCastingTest.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
@@ -416,7 +417,7 @@ class TestEloquentModelWithAttributeCast extends Model
     {
         return new Attribute(
             function () {
-                return collect();
+                return new Collection;
             }
         );
     }

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Database\RecordsNotFoundException;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
@@ -867,7 +868,7 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         );
 
         // Test syncing with a BaseCollection of models
-        $tagCollection = collect([$tag3, $tag4]);
+        $tagCollection = new BaseCollection([$tag3, $tag4]);
 
         $post->tags()->sync($tagCollection);
 
@@ -915,7 +916,7 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
 
         DB::enableQueryLog();
 
-        foreach ([collect(), [], null] as $value) {
+        foreach ([new BaseCollection(), [], null] as $value) {
             $result = $post->tags()->sync($value, false);
 
             $this->assertEquals([

--- a/tests/Integration/Database/EloquentMassPrunableTest.php
+++ b/tests/Integration/Database/EloquentMassPrunableTest.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Events\ModelsPruned;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Schema;
 use LogicException;
 use Mockery as m;
@@ -28,11 +29,11 @@ class EloquentMassPrunableTest extends DatabaseTestCase
 
     protected function afterRefreshingDatabase()
     {
-        collect([
+        (new Collection([
             'mass_prunable_test_models',
             'mass_prunable_soft_delete_test_models',
             'mass_prunable_test_model_missing_prunable_methods',
-        ])->each(function ($table) {
+        ]))->each(function ($table) {
             Schema::create($table, function (Blueprint $table) {
                 $table->increments('id');
                 $table->string('name')->nullable();
@@ -60,7 +61,7 @@ class EloquentMassPrunableTest extends DatabaseTestCase
             ->times(2)
             ->with(m::type(ModelsPruned::class));
 
-        collect(range(1, 5000))->map(function ($id) {
+        (new Collection(range(1, 5000)))->map(function ($id) {
             return ['name' => 'foo'];
         })->chunk(200)->each(function ($chunk) {
             MassPrunableTestModel::insert($chunk->all());
@@ -79,7 +80,7 @@ class EloquentMassPrunableTest extends DatabaseTestCase
             ->times(3)
             ->with(m::type(ModelsPruned::class));
 
-        collect(range(1, 5000))->map(function ($id) {
+        (new Collection(range(1, 5000)))->map(function ($id) {
             return ['deleted_at' => Carbon::now()];
         })->chunk(200)->each(function ($chunk) {
             MassPrunableSoftDeleteTestModel::insert($chunk->all());

--- a/tests/Integration/Database/EloquentModelEnumCastingTest.php
+++ b/tests/Integration/Database/EloquentModelEnumCastingTest.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Casts\AsEnumArrayObject;
 use Illuminate\Database\Eloquent\Casts\AsEnumCollection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use ValueError;
@@ -152,7 +153,7 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
             'integer_status_collection' => json_encode([1, 2]),
             'integer_status_array' => json_encode([1, 2]),
             'arrayable_status' => 'pending',
-        ], collect(DB::table('enum_casts')->where('id', $model->id)->first())->map(function ($value) {
+        ], (new Collection(DB::table('enum_casts')->where('id', $model->id)->first()))->map(function ($value) {
             return str_replace(', ', ',', $value);
         })->all());
     }
@@ -180,7 +181,7 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
             'integer_status_collection' => json_encode([1, 2]),
             'integer_status_array' => json_encode([1, 2]),
             'arrayable_status' => 'pending',
-        ], collect(DB::table('enum_casts')->where('id', $model->id)->first())->map(function ($value) {
+        ], (new Collection(DB::table('enum_casts')->where('id', $model->id)->first()))->map(function ($value) {
             return str_replace(', ', ',', $value);
         })->all());
     }

--- a/tests/Integration/Database/EloquentPrunableTest.php
+++ b/tests/Integration/Database/EloquentPrunableTest.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Events\ModelsPruned;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Exceptions;
 use Illuminate\Support\Facades\Schema;
@@ -18,13 +19,13 @@ class EloquentPrunableTest extends DatabaseTestCase
 {
     protected function afterRefreshingDatabase()
     {
-        collect([
+        (new Collection([
             'prunable_test_models',
             'prunable_soft_delete_test_models',
             'prunable_test_model_missing_prunable_methods',
             'prunable_with_custom_prune_method_test_models',
             'prunable_with_exceptions',
-        ])->each(function ($table) {
+        ]))->each(function ($table) {
             Schema::create($table, function (Blueprint $table) {
                 $table->increments('id');
                 $table->string('name')->nullable();
@@ -49,7 +50,7 @@ class EloquentPrunableTest extends DatabaseTestCase
     {
         Event::fake();
 
-        collect(range(1, 5000))->map(function ($id) {
+        (new Collection(range(1, 5000)))->map(function ($id) {
             return ['name' => 'foo'];
         })->chunk(200)->each(function ($chunk) {
             PrunableTestModel::insert($chunk->all());
@@ -67,7 +68,7 @@ class EloquentPrunableTest extends DatabaseTestCase
     {
         Event::fake();
 
-        collect(range(1, 5000))->map(function ($id) {
+        (new Collection(range(1, 5000)))->map(function ($id) {
             return ['deleted_at' => Carbon::now()];
         })->chunk(200)->each(function ($chunk) {
             PrunableSoftDeleteTestModel::insert($chunk->all());
@@ -86,7 +87,7 @@ class EloquentPrunableTest extends DatabaseTestCase
     {
         Event::fake();
 
-        collect(range(1, 5000))->map(function ($id) {
+        (new Collection(range(1, 5000)))->map(function ($id) {
             return ['name' => 'foo'];
         })->chunk(200)->each(function ($chunk) {
             PrunableWithCustomPruneMethodTestModel::insert($chunk->all());
@@ -107,7 +108,7 @@ class EloquentPrunableTest extends DatabaseTestCase
         Event::fake();
         Exceptions::fake();
 
-        collect(range(1, 5000))->map(function ($id) {
+        (new Collection(range(1, 5000)))->map(function ($id) {
             return ['name' => 'foo'];
         })->chunk(200)->each(function ($chunk) {
             PrunableWithException::insert($chunk->all());

--- a/tests/Integration/Database/MySql/DatabaseMySqlSchemaBuilderTest.php
+++ b/tests/Integration/Database/MySql/DatabaseMySqlSchemaBuilderTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Integration\Database\MySql;
 
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Orchestra\Testbench\Attributes\RequiresDatabase;
@@ -42,6 +43,6 @@ class DatabaseMySqlSchemaBuilderTest extends MySqlTestCase
 
         $indexes = Schema::getIndexes('table');
 
-        $this->assertSame([], collect($indexes)->firstWhere('name', 'table_raw_index')['columns']);
+        $this->assertSame([], (new Collection($indexes))->firstWhere('name', 'table_raw_index')['columns']);
     }
 }

--- a/tests/Integration/Database/Postgres/PostgresSchemaBuilderTest.php
+++ b/tests/Integration/Database/Postgres/PostgresSchemaBuilderTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Integration\Database\Postgres;
 
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Orchestra\Testbench\Attributes\RequiresDatabase;
@@ -203,7 +204,7 @@ class PostgresSchemaBuilderTest extends PostgresTestCase
 
         $indexes = Schema::getIndexes('public.table');
 
-        $this->assertSame([], collect($indexes)->firstWhere('name', 'table_raw_index')['columns']);
+        $this->assertSame([], (new Collection($indexes))->firstWhere('name', 'table_raw_index')['columns']);
     }
 
     public function testCreateIndexesOnline()
@@ -221,7 +222,7 @@ class PostgresSchemaBuilderTest extends PostgresTestCase
         });
 
         $indexes = Schema::getIndexes('public.table');
-        $indexNames = collect($indexes)->pluck('name');
+        $indexNames = (new Collection($indexes))->pluck('name');
 
         $this->assertContains('public_table_title_unique', $indexNames);
         $this->assertContains('public_table_created_at_index', $indexNames);

--- a/tests/Integration/Database/QueryBuilderUpdateTest.php
+++ b/tests/Integration/Database/QueryBuilderUpdateTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Integration\Database;
 
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Orchestra\Testbench\Attributes\RequiresDatabase;
@@ -94,7 +95,7 @@ class QueryBuilderUpdateTest extends DatabaseTestCase
     public static function jsonValuesDataProvider()
     {
         yield ['payload', ['Laravel', 'Founder'], ['Laravel', 'Founder']];
-        yield ['payload', collect(['Laravel', 'Founder']), ['Laravel', 'Founder']];
+        yield ['payload', new Collection(['Laravel', 'Founder']), ['Laravel', 'Founder']];
         yield ['status', StringStatus::draft, 'draft'];
     }
 }

--- a/tests/Integration/Database/SchemaBuilderSchemaNameTest.php
+++ b/tests/Integration/Database/SchemaBuilderSchemaNameTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Integration\Database;
 
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Orchestra\Testbench\Attributes\RequiresDatabase;
@@ -67,7 +68,7 @@ class SchemaBuilderSchemaNameTest extends DatabaseTestCase
 
         $schemas = $schema->getSchemas();
 
-        $this->assertSame($schema->getCurrentSchemaName(), collect($schemas)->firstWhere('default')['name']);
+        $this->assertSame($schema->getCurrentSchemaName(), (new Collection($schemas))->firstWhere('default')['name']);
         $this->assertEqualsCanonicalizing(
             match ($this->driver) {
                 'mysql', 'mariadb' => ['laravel', 'my_schema'],
@@ -215,10 +216,10 @@ class SchemaBuilderSchemaNameTest extends DatabaseTestCase
 
         $this->assertEquals(['id', 'title', 'name', 'count'], $schema->getColumnListing('my_schema.table'));
         $this->assertEquals(['id', 'name', 'count', 'title'], $schema->getColumnListing('my_table'));
-        $this->assertStringContainsString('default schema name', collect($schema->getColumns('my_schema.table'))->firstWhere('name', 'name')['default']);
-        $this->assertStringContainsString('default schema title', collect($schema->getColumns('my_schema.table'))->firstWhere('name', 'title')['default']);
-        $this->assertStringContainsString('default name', collect($schema->getColumns('my_table'))->firstWhere('name', 'name')['default']);
-        $this->assertStringContainsString('default title', collect($schema->getColumns('my_table'))->firstWhere('name', 'title')['default']);
+        $this->assertStringContainsString('default schema name', (new Collection($schema->getColumns('my_schema.table')))->firstWhere('name', 'name')['default']);
+        $this->assertStringContainsString('default schema title', (new Collection($schema->getColumns('my_schema.table')))->firstWhere('name', 'title')['default']);
+        $this->assertStringContainsString('default name', (new Collection($schema->getColumns('my_table')))->firstWhere('name', 'name')['default']);
+        $this->assertStringContainsString('default title', (new Collection($schema->getColumns('my_table')))->firstWhere('name', 'title')['default']);
     }
 
     #[DataProvider('connectionProvider')]
@@ -249,8 +250,8 @@ class SchemaBuilderSchemaNameTest extends DatabaseTestCase
         $this->assertTrue($schema->hasColumn('my_schema.table', 'new_title'));
         $this->assertFalse($schema->hasColumn('table', 'name'));
         $this->assertTrue($schema->hasColumn('table', 'new_name'));
-        $this->assertStringContainsString('default schema title', collect($schema->getColumns('my_schema.table'))->firstWhere('name', 'new_title')['default']);
-        $this->assertStringContainsString('default name', collect($schema->getColumns('table'))->firstWhere('name', 'new_name')['default']);
+        $this->assertStringContainsString('default schema title', (new Collection($schema->getColumns('my_schema.table')))->firstWhere('name', 'new_title')['default']);
+        $this->assertStringContainsString('default name', (new Collection($schema->getColumns('table')))->firstWhere('name', 'new_name')['default']);
     }
 
     #[DataProvider('connectionProvider')]
@@ -278,8 +279,8 @@ class SchemaBuilderSchemaNameTest extends DatabaseTestCase
             $table->bigInteger('count')->change();
         });
 
-        $this->assertStringContainsString('default schema name', collect($schema->getColumns('my_schema.table'))->firstWhere('name', 'name')['default']);
-        $this->assertStringContainsString('default title', collect($schema->getColumns('my_table'))->firstWhere('name', 'title')['default']);
+        $this->assertStringContainsString('default schema name', (new Collection($schema->getColumns('my_schema.table')))->firstWhere('name', 'name')['default']);
+        $this->assertStringContainsString('default title', (new Collection($schema->getColumns('my_table')))->firstWhere('name', 'title')['default']);
         $this->assertEquals($this->driver === 'sqlsrv' ? 'nvarchar' : 'varchar', $schema->getColumnType('my_schema.table', 'name'));
         $this->assertEquals($this->driver === 'sqlsrv' ? 'nvarchar' : 'varchar', $schema->getColumnType('my_table', 'title'));
         $this->assertEquals(match ($this->driver) {
@@ -324,8 +325,8 @@ class SchemaBuilderSchemaNameTest extends DatabaseTestCase
         $this->assertTrue($schema->hasColumns('table', ['id', 'count']));
         $this->assertFalse($schema->hasColumn('table', 'name'));
         $this->assertFalse($schema->hasColumn('table', 'title'));
-        $this->assertStringContainsString('default schema title', collect($schema->getColumns('my_schema.table'))->firstWhere('name', 'title')['default']);
-        $this->assertStringContainsString('10', collect($schema->getColumns('table'))->firstWhere('name', 'count')['default']);
+        $this->assertStringContainsString('default schema title', (new Collection($schema->getColumns('my_schema.table')))->firstWhere('name', 'title')['default']);
+        $this->assertStringContainsString('10', (new Collection($schema->getColumns('table')))->firstWhere('name', 'count')['default']);
     }
 
     #[DataProvider('connectionProvider')]
@@ -412,13 +413,13 @@ class SchemaBuilderSchemaNameTest extends DatabaseTestCase
             default => 'laravel',
         };
 
-        $this->assertTrue(collect($schema->getForeignKeys('my_schema.table'))->contains(
+        $this->assertTrue((new Collection($schema->getForeignKeys('my_schema.table')))->contains(
             fn ($foreign) => $foreign['columns'] === ['my_table_id']
                 && $foreign['foreign_table'] === $tableName && $foreign['foreign_schema'] === $defaultSchemaName
                 && $foreign['foreign_columns'] === ['id']
         ));
 
-        $this->assertTrue(collect($schema->getForeignKeys('table'))->contains(
+        $this->assertTrue((new Collection($schema->getForeignKeys('table')))->contains(
             fn ($foreign) => $foreign['columns'] === ['table_id']
                 && $foreign['foreign_table'] === $schemaTableName && $foreign['foreign_schema'] === 'my_schema'
                 && $foreign['foreign_columns'] === ['id']
@@ -456,13 +457,13 @@ class SchemaBuilderSchemaNameTest extends DatabaseTestCase
         $myTableName = $connection === 'with-prefix' ? 'example_my_tables' : 'my_tables';
         $tableName = $connection === 'with-prefix' ? 'example_table' : 'table';
 
-        $this->assertTrue(collect($schema->getForeignKeys('my_schema.table'))->contains(
+        $this->assertTrue((new Collection($schema->getForeignKeys('my_schema.table')))->contains(
             fn ($foreign) => $foreign['columns'] === ['my_table_id']
                 && $foreign['foreign_table'] === $myTableName && $foreign['foreign_schema'] === 'my_schema'
                 && $foreign['foreign_columns'] === ['id']
         ));
 
-        $this->assertTrue(collect($schema->getForeignKeys('my_schema.second_table'))->contains(
+        $this->assertTrue((new Collection($schema->getForeignKeys('my_schema.second_table')))->contains(
             fn ($foreign) => $foreign['columns'] === ['table_id']
                 && $foreign['foreign_table'] === $tableName && $foreign['foreign_schema'] === 'my_schema'
                 && $foreign['foreign_columns'] === ['id']
@@ -522,7 +523,7 @@ class SchemaBuilderSchemaNameTest extends DatabaseTestCase
             $table->string('name')->comment('comment on column');
         });
 
-        $tables = collect($schema->getTables());
+        $tables = new Collection($schema->getTables());
         $tableName = $connection === 'with-prefix' ? 'example_table' : 'table';
         $defaultSchema = $this->driver === 'pgsql' ? 'public' : 'laravel';
 
@@ -533,10 +534,10 @@ class SchemaBuilderSchemaNameTest extends DatabaseTestCase
             $tables->first(fn ($table) => $table['name'] === $tableName && $table['schema'] === $defaultSchema)['comment']
         );
         $this->assertEquals('comment on schema column',
-            collect($schema->getColumns('my_schema.table'))->firstWhere('name', 'name')['comment']
+            (new Collection($schema->getColumns('my_schema.table')))->firstWhere('name', 'name')['comment']
         );
         $this->assertEquals('comment on column',
-            collect($schema->getColumns('table'))->firstWhere('name', 'name')['comment']
+            (new Collection($schema->getColumns('table')))->firstWhere('name', 'name')['comment']
         );
     }
 

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Integration\Database;
 
 use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Orchestra\Testbench\Attributes\RequiresDatabase;
@@ -135,7 +136,7 @@ class SchemaBuilderTest extends DatabaseTestCase
             $table->string('nullable_column_to_not_null')->nullable();
         });
 
-        $columns = collect(Schema::getColumns('test'));
+        $columns = new Collection(Schema::getColumns('test'));
 
         $this->assertFalse($columns->firstWhere('name', 'not_null_column_to_not_null')['nullable']);
         $this->assertFalse($columns->firstWhere('name', 'not_null_column_to_nullable')['nullable']);
@@ -149,7 +150,7 @@ class SchemaBuilderTest extends DatabaseTestCase
             $table->text('nullable_column_to_not_null')->change();
         });
 
-        $columns = collect(Schema::getColumns('test'));
+        $columns = new Collection(Schema::getColumns('test'));
 
         $this->assertFalse($columns->firstWhere('name', 'not_null_column_to_not_null')['nullable']);
         $this->assertTrue($columns->firstWhere('name', 'not_null_column_to_nullable')['nullable']);
@@ -165,16 +166,16 @@ class SchemaBuilderTest extends DatabaseTestCase
         });
 
         $columns = Schema::getColumns('test');
-        $defaultFoo = collect($columns)->firstWhere('name', 'foo')['default'];
-        $defaultBar = collect($columns)->firstWhere('name', 'bar')['default'];
+        $defaultFoo = (new Collection($columns))->firstWhere('name', 'foo')['default'];
+        $defaultBar = (new Collection($columns))->firstWhere('name', 'bar')['default'];
 
         Schema::table('test', static function (Blueprint $table) {
             $table->renameColumn('foo', 'new_foo');
             $table->renameColumn('bar', 'new_bar');
         });
 
-        $this->assertEquals(collect(Schema::getColumns('test'))->firstWhere('name', 'new_foo')['default'], $defaultFoo);
-        $this->assertEquals(collect(Schema::getColumns('test'))->firstWhere('name', 'new_bar')['default'], $defaultBar);
+        $this->assertEquals((new Collection(Schema::getColumns('test')))->firstWhere('name', 'new_foo')['default'], $defaultFoo);
+        $this->assertEquals((new Collection(Schema::getColumns('test')))->firstWhere('name', 'new_bar')['default'], $defaultBar);
     }
 
     #[RequiresDatabase('sqlite')]
@@ -189,7 +190,7 @@ class SchemaBuilderTest extends DatabaseTestCase
             $table->smallInteger('column_to_change')->default(new Expression('0'))->change();
         });
 
-        $columns = collect(Schema::getColumns('test'));
+        $columns = new Collection(Schema::getColumns('test'));
 
         $this->assertSame('0', $columns->firstWhere('name', 'column_default_zero')['default']);
         $this->assertSame('0', $columns->firstWhere('name', 'column_to_change')['default']);
@@ -208,7 +209,7 @@ class SchemaBuilderTest extends DatabaseTestCase
             $table->primary(['id', 'uuid']);
         });
 
-        $this->assertTrue(collect(Schema::getColumns('test'))->firstWhere('name', 'id')['auto_increment']);
+        $this->assertTrue((new Collection(Schema::getColumns('test')))->firstWhere('name', 'id')['auto_increment']);
         $this->assertTrue(Schema::hasIndex('test', ['id', 'uuid'], 'primary'));
     }
 
@@ -222,14 +223,14 @@ class SchemaBuilderTest extends DatabaseTestCase
             $table->increments('id');
         });
 
-        $this->assertTrue(collect(Schema::getColumns('test'))->firstWhere('name', 'id')['auto_increment']);
+        $this->assertTrue((new Collection(Schema::getColumns('test')))->firstWhere('name', 'id')['auto_increment']);
         $this->assertTrue(Schema::hasIndex('test', ['id'], 'primary'));
 
         Schema::table('test', function (Blueprint $table) {
             $table->bigIncrements('id')->change();
         });
 
-        $this->assertTrue(collect(Schema::getColumns('test'))->firstWhere('name', 'id')['auto_increment']);
+        $this->assertTrue((new Collection(Schema::getColumns('test')))->firstWhere('name', 'id')['auto_increment']);
         $this->assertTrue(Schema::hasIndex('test', ['id'], 'primary'));
     }
 
@@ -243,14 +244,14 @@ class SchemaBuilderTest extends DatabaseTestCase
             $table->unsignedBigInteger('id');
         });
 
-        $this->assertFalse(collect(Schema::getColumns('test'))->firstWhere('name', 'id')['auto_increment']);
+        $this->assertFalse((new Collection(Schema::getColumns('test')))->firstWhere('name', 'id')['auto_increment']);
         $this->assertFalse(Schema::hasIndex('test', ['id'], 'primary'));
 
         Schema::table('test', function (Blueprint $table) {
             $table->bigIncrements('id')->primary()->change();
         });
 
-        $this->assertTrue(collect(Schema::getColumns('test'))->firstWhere('name', 'id')['auto_increment']);
+        $this->assertTrue((new Collection(Schema::getColumns('test')))->firstWhere('name', 'id')['auto_increment']);
         $this->assertTrue(Schema::hasIndex('test', ['id'], 'primary'));
     }
 
@@ -268,7 +269,7 @@ class SchemaBuilderTest extends DatabaseTestCase
             $table->bigIncrements('id');
         });
 
-        $this->assertTrue(collect(Schema::getColumns('test'))->firstWhere('name', 'id')['auto_increment']);
+        $this->assertTrue((new Collection(Schema::getColumns('test')))->firstWhere('name', 'id')['auto_increment']);
         $this->assertTrue(Schema::hasIndex('test', ['id'], 'primary'));
     }
 
@@ -337,12 +338,12 @@ class SchemaBuilderTest extends DatabaseTestCase
             $this->assertCount(13, $types);
         }
 
-        $this->assertTrue(collect($types)->contains(fn ($type) => $type['name'] === 'pseudo_foo' && $type['type'] === 'pseudo' && ! $type['implicit']));
-        $this->assertTrue(collect($types)->contains(fn ($type) => $type['name'] === 'comp_foo' && $type['type'] === 'composite' && ! $type['implicit']));
-        $this->assertTrue(collect($types)->contains(fn ($type) => $type['name'] === 'enum_foo' && $type['type'] === 'enum' && ! $type['implicit']));
-        $this->assertTrue(collect($types)->contains(fn ($type) => $type['name'] === 'range_foo' && $type['type'] === 'range' && ! $type['implicit']));
-        $this->assertTrue(collect($types)->contains(fn ($type) => $type['name'] === 'domain_foo' && $type['type'] === 'domain' && ! $type['implicit']));
-        $this->assertTrue(collect($types)->contains(fn ($type) => $type['name'] === 'base_foo' && $type['type'] === 'base' && ! $type['implicit']));
+        $this->assertTrue((new Collection($types))->contains(fn ($type) => $type['name'] === 'pseudo_foo' && $type['type'] === 'pseudo' && ! $type['implicit']));
+        $this->assertTrue((new Collection($types))->contains(fn ($type) => $type['name'] === 'comp_foo' && $type['type'] === 'composite' && ! $type['implicit']));
+        $this->assertTrue((new Collection($types))->contains(fn ($type) => $type['name'] === 'enum_foo' && $type['type'] === 'enum' && ! $type['implicit']));
+        $this->assertTrue((new Collection($types))->contains(fn ($type) => $type['name'] === 'range_foo' && $type['type'] === 'range' && ! $type['implicit']));
+        $this->assertTrue((new Collection($types))->contains(fn ($type) => $type['name'] === 'domain_foo' && $type['type'] === 'domain' && ! $type['implicit']));
+        $this->assertTrue((new Collection($types))->contains(fn ($type) => $type['name'] === 'base_foo' && $type['type'] === 'base' && ! $type['implicit']));
 
         Schema::dropAllTypes();
         $types = Schema::getTypes();
@@ -361,13 +362,13 @@ class SchemaBuilderTest extends DatabaseTestCase
         $columns = Schema::getColumns('foo');
 
         $this->assertCount(3, $columns);
-        $this->assertTrue(collect($columns)->contains(
+        $this->assertTrue((new Collection($columns))->contains(
             fn ($column) => $column['name'] === 'id' && $column['auto_increment'] && ! $column['nullable']
         ));
-        $this->assertTrue(collect($columns)->contains(
+        $this->assertTrue((new Collection($columns))->contains(
             fn ($column) => $column['name'] === 'bar' && $column['nullable']
         ));
-        $this->assertTrue(collect($columns)->contains(
+        $this->assertTrue((new Collection($columns))->contains(
             fn ($column) => $column['name'] === 'baz' && ! $column['nullable'] && str_contains($column['default'], 'test')
         ));
     }
@@ -416,10 +417,10 @@ class SchemaBuilderTest extends DatabaseTestCase
         $indexes = Schema::getIndexes('foo');
 
         $this->assertCount(2, $indexes);
-        $this->assertTrue(collect($indexes)->contains(
+        $this->assertTrue((new Collection($indexes))->contains(
             fn ($index) => $index['columns'] === ['id'] && $index['primary']
         ));
-        $this->assertTrue(collect($indexes)->contains(
+        $this->assertTrue((new Collection($indexes))->contains(
             fn ($index) => $index['name'] === 'foo_baz_bar_unique' && $index['columns'] === ['baz', 'bar'] && $index['unique']
         ));
         $this->assertTrue(Schema::hasIndex('foo', 'foo_baz_bar_unique'));
@@ -442,10 +443,10 @@ class SchemaBuilderTest extends DatabaseTestCase
         $indexes = Schema::getIndexes('foo');
 
         $this->assertCount(2, $indexes);
-        $this->assertTrue(collect($indexes)->contains(
+        $this->assertTrue((new Collection($indexes))->contains(
             fn ($index) => $index['columns'] === ['baz', 'key'] && $index['primary']
         ));
-        $this->assertTrue(collect($indexes)->contains(
+        $this->assertTrue((new Collection($indexes))->contains(
             fn ($index) => $index['name'] === 'foo_bar_unique' && $index['columns'] === ['bar'] && $index['unique']
         ));
     }
@@ -464,8 +465,8 @@ class SchemaBuilderTest extends DatabaseTestCase
         $indexes = Schema::getIndexes('articles');
 
         $this->assertCount(2, $indexes);
-        $this->assertTrue(collect($indexes)->contains(fn ($index) => $index['columns'] === ['id'] && $index['primary']));
-        $this->assertTrue(collect($indexes)->contains('name', 'articles_body_title_fulltext'));
+        $this->assertTrue((new Collection($indexes))->contains(fn ($index) => $index['columns'] === ['id'] && $index['primary']));
+        $this->assertTrue((new Collection($indexes))->contains('name', 'articles_body_title_fulltext'));
     }
 
     public function testHasIndexOrder()
@@ -501,7 +502,7 @@ class SchemaBuilderTest extends DatabaseTestCase
         $foreignKeys = Schema::getForeignKeys('posts');
 
         $this->assertCount(1, $foreignKeys);
-        $this->assertTrue(collect($foreignKeys)->contains(
+        $this->assertTrue((new Collection($foreignKeys))->contains(
             fn ($foreign) => $foreign['columns'] === ['user_id']
                 && $foreign['foreign_table'] === 'users' && $foreign['foreign_columns'] === ['id']
                 && $foreign['on_update'] === 'cascade' && $foreign['on_delete'] === 'set null'
@@ -528,7 +529,7 @@ class SchemaBuilderTest extends DatabaseTestCase
         $foreignKeys = Schema::getForeignKeys('child');
 
         $this->assertCount(1, $foreignKeys);
-        $this->assertTrue(collect($foreignKeys)->contains(
+        $this->assertTrue((new Collection($foreignKeys))->contains(
             fn ($foreign) => $foreign['columns'] === ['d', 'c']
                 && $foreign['foreign_table'] === 'parent'
                 && $foreign['foreign_columns'] === ['b', 'a']
@@ -558,7 +559,7 @@ class SchemaBuilderTest extends DatabaseTestCase
         $foreignKeys = Schema::getForeignKeys('children');
 
         $this->assertCount(1, $foreignKeys);
-        $this->assertTrue(collect($foreignKeys)->contains(
+        $this->assertTrue((new Collection($foreignKeys))->contains(
             fn ($foreign) => $foreign['columns'] === ['parent_id']
                 && $foreign['foreign_table'] === 'parents' && $foreign['foreign_columns'] === ['id']
         ));
@@ -618,19 +619,19 @@ class SchemaBuilderTest extends DatabaseTestCase
 
         $columns = Schema::getColumns('test');
 
-        $this->assertTrue(collect($columns)->contains(
+        $this->assertTrue((new Collection($columns))->contains(
             fn ($column) => $column['name'] === 'virtual_price' && $column['generation']['type'] === 'virtual'
                 && $column['generation']['expression'] === 'price - 2'
         ));
-        $this->assertTrue(collect($columns)->contains(
+        $this->assertTrue((new Collection($columns))->contains(
             fn ($column) => $column['name'] === 'stored_price' && $column['generation']['type'] === 'stored'
                 && $column['generation']['expression'] === 'price - 4'
         ));
-        $this->assertTrue(collect($columns)->contains(
+        $this->assertTrue((new Collection($columns))->contains(
             fn ($column) => $column['name'] === 'virtual_price_changed' && $column['generation']['type'] === 'virtual'
                 && $column['generation']['expression'] === 'price - 5'
         ));
-        $this->assertTrue(collect($columns)->contains(
+        $this->assertTrue((new Collection($columns))->contains(
             fn ($column) => $column['name'] === 'stored_price_changed' && $column['generation']['type'] === 'stored'
                 && $column['generation']['expression'] === 'price - 7'
         ));
@@ -653,10 +654,10 @@ class SchemaBuilderTest extends DatabaseTestCase
 
         $columns = Schema::getColumns('test');
 
-        $this->assertTrue(collect($columns)->contains(
+        $this->assertTrue((new Collection($columns))->contains(
             fn ($column) => $column['name'] === 'price' && is_null($column['generation'])
         ));
-        $this->assertTrue(collect($columns)->contains(
+        $this->assertTrue((new Collection($columns))->contains(
             fn ($column) => $column['name'] === 'virtual_price'
                 && $column['generation']['type'] === 'virtual'
                 && match ($this->driver) {
@@ -667,7 +668,7 @@ class SchemaBuilderTest extends DatabaseTestCase
                     default => $column['generation']['expression'] === 'price - 5',
                 }
         ));
-        $this->assertTrue(collect($columns)->contains(
+        $this->assertTrue((new Collection($columns))->contains(
             fn ($column) => $column['name'] === 'stored_price'
                 && $column['generation']['type'] === 'stored'
                 && match ($this->driver) {
@@ -700,8 +701,8 @@ class SchemaBuilderTest extends DatabaseTestCase
 
         $foreignKeys = Schema::getForeignKeys('posts');
         $this->assertCount(2, $foreignKeys);
-        $this->assertTrue(collect($foreignKeys)->contains(fn ($foreign) => $foreign['columns'] === ['user_id'] && $foreign['foreign_table'] === 'users' && $foreign['foreign_columns'] === ['id']));
-        $this->assertTrue(collect($foreignKeys)->contains(fn ($foreign) => $foreign['columns'] === ['user_name'] && $foreign['foreign_table'] === 'users' && $foreign['foreign_columns'] === ['name']));
+        $this->assertTrue((new Collection($foreignKeys))->contains(fn ($foreign) => $foreign['columns'] === ['user_id'] && $foreign['foreign_table'] === 'users' && $foreign['foreign_columns'] === ['id']));
+        $this->assertTrue((new Collection($foreignKeys))->contains(fn ($foreign) => $foreign['columns'] === ['user_name'] && $foreign['foreign_table'] === 'users' && $foreign['foreign_columns'] === ['name']));
         $this->assertTrue(Schema::hasColumns('posts', ['title', 'user_id', 'user_name']));
         $this->assertTrue(Schema::hasIndex('posts', ['user_id']));
         $this->assertTrue(Schema::hasIndex('posts', ['title'], 'unique'));
@@ -724,8 +725,8 @@ class SchemaBuilderTest extends DatabaseTestCase
 
         $foreignKeys = Schema::getForeignKeys('posts');
         $this->assertCount(2, $foreignKeys);
-        $this->assertTrue(collect($foreignKeys)->contains(fn ($foreign) => $foreign['columns'] === ['user_id'] && $foreign['foreign_table'] === 'users' && $foreign['foreign_columns'] === ['id']));
-        $this->assertTrue(collect($foreignKeys)->contains(fn ($foreign) => $foreign['columns'] === ['user_name'] && $foreign['foreign_table'] === 'users' && $foreign['foreign_columns'] === ['name']));
+        $this->assertTrue((new Collection($foreignKeys))->contains(fn ($foreign) => $foreign['columns'] === ['user_id'] && $foreign['foreign_table'] === 'users' && $foreign['foreign_columns'] === ['id']));
+        $this->assertTrue((new Collection($foreignKeys))->contains(fn ($foreign) => $foreign['columns'] === ['user_name'] && $foreign['foreign_table'] === 'users' && $foreign['foreign_columns'] === ['name']));
         $this->assertTrue(Schema::hasIndex('posts', ['id'], 'primary'));
 
         Schema::table('posts', function (Blueprint $table) {
@@ -737,7 +738,7 @@ class SchemaBuilderTest extends DatabaseTestCase
 
         $foreignKeys = Schema::getForeignKeys('posts');
         $this->assertCount(1, $foreignKeys);
-        $this->assertTrue(collect($foreignKeys)->contains(fn ($foreign) => $foreign['columns'] === ['user_name'] && $foreign['foreign_table'] === 'users' && $foreign['foreign_columns'] === ['name']));
+        $this->assertTrue((new Collection($foreignKeys))->contains(fn ($foreign) => $foreign['columns'] === ['user_name'] && $foreign['foreign_table'] === 'users' && $foreign['foreign_columns'] === ['name']));
         $this->assertTrue(Schema::hasColumns('posts', ['user_name', 'title']));
         $this->assertTrue(Schema::hasIndex('posts', ['id'], 'primary'));
         $this->assertTrue(Schema::hasIndex('posts', ['title'], 'unique'));
@@ -769,7 +770,7 @@ class SchemaBuilderTest extends DatabaseTestCase
 
         $foreignKeys = Schema::getForeignKeys('posts');
         $this->assertCount(1, $foreignKeys);
-        $this->assertTrue(collect($foreignKeys)->contains(fn ($foreign) => $foreign['columns'] === ['user_name'] && $foreign['foreign_table'] === 'users' && $foreign['foreign_columns'] === ['name']));
+        $this->assertTrue((new Collection($foreignKeys))->contains(fn ($foreign) => $foreign['columns'] === ['user_name'] && $foreign['foreign_table'] === 'users' && $foreign['foreign_columns'] === ['name']));
         $this->assertTrue(Schema::hasColumns('posts', ['user_name', 'title']));
         $this->assertTrue(Schema::hasIndex('posts', ['title'], 'primary'));
         $this->assertTrue(Schema::hasIndex('posts', ['user_name'], 'unique'));
@@ -783,7 +784,7 @@ class SchemaBuilderTest extends DatabaseTestCase
 
         $foreignKeys = Schema::getForeignKeys('posts');
         $this->assertCount(1, $foreignKeys);
-        $this->assertTrue(collect($foreignKeys)->contains(fn ($foreign) => $foreign['columns'] === ['user_name'] && $foreign['foreign_table'] === 'users' && $foreign['foreign_columns'] === ['name']));
+        $this->assertTrue((new Collection($foreignKeys))->contains(fn ($foreign) => $foreign['columns'] === ['user_name'] && $foreign['foreign_table'] === 'users' && $foreign['foreign_columns'] === ['name']));
         $this->assertTrue(Schema::hasColumns('posts', ['user_name', 'title', 'votes']));
         $this->assertFalse(Schema::hasIndex('posts', ['title'], 'primary'));
         $this->assertTrue(Schema::hasIndex('posts', ['user_name'], 'unique'));
@@ -796,9 +797,9 @@ class SchemaBuilderTest extends DatabaseTestCase
         $this->assertEquals('foo', Schema::foo());
 
         Schema::macro('hasForeignKeyForColumn', function (string $column, string $table, string $foreignTable) {
-            return collect(Schema::getForeignKeys($table))
+            return (new Collection(Schema::getForeignKeys($table)))
                 ->contains(function (array $foreignKey) use ($column, $foreignTable) {
-                    return collect($foreignKey['columns'])->contains($column)
+                    return (new Collection($foreignKey['columns']))->contains($column)
                         && $foreignKey['foreign_table'] == $foreignTable;
                 });
         });

--- a/tests/Integration/Database/SqlServer/DatabaseSqlServerSchemaBuilderTest.php
+++ b/tests/Integration/Database/SqlServer/DatabaseSqlServerSchemaBuilderTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Integration\Database\SqlServer;
 
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
@@ -33,15 +34,15 @@ class DatabaseSqlServerSchemaBuilderTest extends SqlServerTestCase
 
         $this->assertGreaterThanOrEqual(2, count($rows));
         $this->assertTrue(
-            collect($rows)->contains('name', 'migrations'),
+            (new Collection($rows))->contains('name', 'migrations'),
             'Failed asserting that table "migrations" was returned.'
         );
         $this->assertTrue(
-            collect($rows)->contains('name', 'users'),
+            (new Collection($rows))->contains('name', 'users'),
             'Failed asserting that table "users" was returned.'
         );
         $this->assertFalse(
-            collect($rows)->contains('name', 'users_view'),
+            (new Collection($rows))->contains('name', 'users_view'),
             'Failed asserting that view "users_view" was not returned.'
         );
     }
@@ -86,7 +87,7 @@ class DatabaseSqlServerSchemaBuilderTest extends SqlServerTestCase
         });
 
         $indexes = Schema::getIndexes('table');
-        $indexNames = collect($indexes)->pluck('name');
+        $indexNames = (new Collection($indexes))->pluck('name');
 
         $this->assertContains('table_title_unique', $indexNames);
         $this->assertContains('table_created_at_index', $indexNames);

--- a/tests/Integration/Database/Sqlite/DatabaseSchemaBuilderTest.php
+++ b/tests/Integration/Database/Sqlite/DatabaseSchemaBuilderTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Integration\Database\Sqlite;
 
 use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Orchestra\Testbench\Attributes\RequiresDatabase;
@@ -97,7 +98,7 @@ class DatabaseSchemaBuilderTest extends TestCase
             $table->foreignId('moderator_id')->constrained('table1');
         });
 
-        $foreignKeys = collect($schema->getForeignKeys('table2'));
+        $foreignKeys = new Collection($schema->getForeignKeys('table2'));
 
         $this->assertTrue($foreignKeys->contains(
             fn ($fk) => $fk['foreign_table'] === 'example_table1' &&
@@ -123,7 +124,7 @@ class DatabaseSchemaBuilderTest extends TestCase
             $table->foreignId('item_id')->nullable()->constrained('items');
         });
 
-        $this->assertTrue(collect(Schema::getForeignKeys('items'))->contains(
+        $this->assertTrue((new Collection(Schema::getForeignKeys('items')))->contains(
             fn ($fk) => $fk['foreign_table'] === 'items' &&
                 $fk['foreign_columns'] === ['id'] &&
                 $fk['columns'] === ['item_id']
@@ -131,10 +132,10 @@ class DatabaseSchemaBuilderTest extends TestCase
 
         $columns = Schema::getColumns('items');
 
-        $this->assertTrue(collect($columns)->contains(
+        $this->assertTrue((new Collection($columns))->contains(
             fn ($column) => $column['name'] === 'flags' && $column['default'] === 'JSON_ARRAY()'
         ));
 
-        $this->assertTrue(collect($columns)->contains(fn ($column) => $column['name'] === 'item_id' && $column['nullable']));
+        $this->assertTrue((new Collection($columns))->contains(fn ($column) => $column['name'] === 'item_id' && $column['nullable']));
     }
 }

--- a/tests/Integration/Database/Sqlite/DatabaseSqliteSchemaBuilderTest.php
+++ b/tests/Integration/Database/Sqlite/DatabaseSqliteSchemaBuilderTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Integration\Database\Sqlite;
 
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
@@ -91,6 +92,6 @@ SQL);
 
         $indexes = Schema::getIndexes('table');
 
-        $this->assertSame([], collect($indexes)->firstWhere('name', 'table_raw_index')['columns']);
+        $this->assertSame([], (new Collection($indexes))->firstWhere('name', 'table_raw_index')['columns']);
     }
 }

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -916,7 +916,7 @@ class ResourceTest extends TestCase
     public function testCollectionResourcesMayCustomizeJsonOptions()
     {
         Route::get('/', function () {
-            return PostResourceWithJsonOptions::collection(collect([
+            return PostResourceWithJsonOptions::collection(new Collection([
                 new Post(['id' => 5, 'title' => 'Test Title', 'reading_time' => 3.0]),
             ]));
         });
@@ -935,7 +935,7 @@ class ResourceTest extends TestCase
     {
         Route::get('/', function () {
             $paginator = new LengthAwarePaginator(
-                collect([new Post(['id' => 5, 'title' => 'Test Title', 'reading_time' => 3.0])]),
+                new Collection([new Post(['id' => 5, 'title' => 'Test Title', 'reading_time' => 3.0])]),
                 10, 15, 1
             );
 
@@ -1012,7 +1012,7 @@ class ResourceTest extends TestCase
     public function testCollectionsAreNotDoubledWrapped()
     {
         Route::get('/', function () {
-            return new PostCollectionResource(collect([new Post([
+            return new PostCollectionResource(new Collection([new Post([
                 'id' => 5,
                 'title' => 'Test Title',
             ])]));
@@ -1038,7 +1038,7 @@ class ResourceTest extends TestCase
     {
         Route::get('/', function () {
             $paginator = new LengthAwarePaginator(
-                collect([new Post(['id' => 5, 'title' => 'Test Title'])]),
+                new Collection([new Post(['id' => 5, 'title' => 'Test Title'])]),
                 10, 15, 1
             );
 
@@ -1079,7 +1079,7 @@ class ResourceTest extends TestCase
     public function testPaginatorResourceCanPreserveQueryParameters()
     {
         Route::get('/', function () {
-            $collection = collect([new Post(['id' => 2, 'title' => 'Laravel Nova'])]);
+            $collection = new Collection([new Post(['id' => 2, 'title' => 'Laravel Nova'])]);
             $paginator = new LengthAwarePaginator(
                 $collection, 3, 1, 2
             );
@@ -1121,7 +1121,7 @@ class ResourceTest extends TestCase
     public function testPaginatorResourceCanReceiveQueryParameters()
     {
         Route::get('/', function () {
-            $collection = collect([new Post(['id' => 2, 'title' => 'Laravel Nova'])]);
+            $collection = new Collection([new Post(['id' => 2, 'title' => 'Laravel Nova'])]);
             $paginator = new LengthAwarePaginator(
                 $collection, 3, 1, 2
             );
@@ -1164,7 +1164,7 @@ class ResourceTest extends TestCase
     {
         Route::get('/', function () {
             $paginator = new CursorPaginator(
-                collect([new Post(['id' => 5, 'title' => 'Test Title']), new Post(['id' => 6, 'title' => 'Hello'])]),
+                new Collection([new Post(['id' => 5, 'title' => 'Test Title']), new Post(['id' => 6, 'title' => 'Hello'])]),
                 1, null, ['parameters' => ['id']]
             );
 
@@ -1202,7 +1202,7 @@ class ResourceTest extends TestCase
     public function testCursorPaginatorResourceCanPreserveQueryParameters()
     {
         Route::get('/', function () {
-            $collection = collect([new Post(['id' => 5, 'title' => 'Test Title']), new Post(['id' => 6, 'title' => 'Hello'])]);
+            $collection = new Collection([new Post(['id' => 5, 'title' => 'Test Title']), new Post(['id' => 6, 'title' => 'Hello'])]);
             $paginator = new CursorPaginator(
                 $collection, 1, null, ['parameters' => ['id']]
             );
@@ -1239,7 +1239,7 @@ class ResourceTest extends TestCase
     public function testCursorPaginatorResourceCanReceiveQueryParameters()
     {
         Route::get('/', function () {
-            $collection = collect([new Post(['id' => 5, 'title' => 'Test Title']), new Post(['id' => 6, 'title' => 'Hello'])]);
+            $collection = new Collection([new Post(['id' => 5, 'title' => 'Test Title']), new Post(['id' => 6, 'title' => 'Hello'])]);
             $paginator = new CursorPaginator(
                 $collection, 1, null, ['parameters' => ['id']]
             );
@@ -1277,7 +1277,7 @@ class ResourceTest extends TestCase
     {
         Route::get('/', function () {
             return new EmptyPostCollectionResource(new LengthAwarePaginator(
-                collect([new Post(['id' => 5, 'title' => 'Test Title'])]),
+                new Collection([new Post(['id' => 5, 'title' => 'Test Title'])]),
                 10, 15, 1
             ));
         });
@@ -1351,7 +1351,7 @@ class ResourceTest extends TestCase
 
     public function testOriginalOnResponseIsCollectionOfModelWhenCollectionResource()
     {
-        $createdPosts = collect([
+        $createdPosts = new Collection([
             new Post(['id' => 5, 'title' => 'Test Title']),
             new Post(['id' => 6, 'title' => 'Test Title 2']),
         ]);
@@ -1368,7 +1368,7 @@ class ResourceTest extends TestCase
 
     public function testCollectionResourceWithPaginationInformation()
     {
-        $posts = collect([
+        $posts = new Collection([
             new Post(['id' => 5, 'title' => 'Test Title']),
         ]);
 
@@ -1399,7 +1399,7 @@ class ResourceTest extends TestCase
 
     public function testResourceWithPaginationInformation()
     {
-        $posts = collect([
+        $posts = new Collection([
             new Post(['id' => 5, 'title' => 'Test Title']),
         ]);
 
@@ -1430,7 +1430,7 @@ class ResourceTest extends TestCase
 
     public function testCollectionResourcesAreCountable()
     {
-        $posts = collect([
+        $posts = new Collection([
             new Post(['id' => 1, 'title' => 'Test title']),
             new Post(['id' => 2, 'title' => 'Test title 2']),
         ]);
@@ -1443,7 +1443,7 @@ class ResourceTest extends TestCase
 
     public function testCollectionResourcesMustCollectResources()
     {
-        $posts = collect([
+        $posts = new Collection([
             new Post(['id' => 1, 'title' => 'Test title']),
             new Post(['id' => 2, 'title' => 'Test title 2']),
         ]);
@@ -1723,7 +1723,7 @@ class ResourceTest extends TestCase
 
             public function work()
             {
-                $posts = collect([
+                $posts = new Collection([
                     new Post(['id' => 1, 'title' => 'Test title 1']),
                     new Post(['id' => 2, 'title' => 'Test title 2']),
                 ]);
@@ -1902,7 +1902,7 @@ class ResourceTest extends TestCase
         try {
             Route::get('/', function () {
                 $paginator = new LengthAwarePaginator(
-                    collect([new Post(['id' => 5, 'title' => 'Test Title', 'reading_time' => 3.0])]),
+                    new Collection([new Post(['id' => 5, 'title' => 'Test Title', 'reading_time' => 3.0])]),
                     10, 15, 1
                 );
 

--- a/tests/Integration/Support/PluralizerPortugueseTest.php
+++ b/tests/Integration/Support/PluralizerPortugueseTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Support;
 
+use Illuminate\Support\Collection;
 use Illuminate\Support\Pluralizer;
 use Illuminate\Support\Str;
 use Orchestra\Testbench\TestCase;
@@ -79,9 +80,9 @@ class PluralizerPortugueseTest extends TestCase
 
     public function testPluralSupportsCollections()
     {
-        $this->assertSame('usuários', Str::plural('usuário', collect()));
-        $this->assertSame('usuário', Str::plural('usuário', collect(['um'])));
-        $this->assertSame('usuários', Str::plural('usuário', collect(['um', 'dois'])));
+        $this->assertSame('usuários', Str::plural('usuário', new Collection));
+        $this->assertSame('usuário', Str::plural('usuário', new Collection(['um'])));
+        $this->assertSame('usuários', Str::plural('usuário', new Collection(['um', 'dois'])));
     }
 
     public function testPluralStudlySupportsArrays()
@@ -93,9 +94,9 @@ class PluralizerPortugueseTest extends TestCase
 
     public function testPluralStudlySupportsCollections()
     {
-        $this->assertPluralStudly('AlgumUsuários', 'AlgumUsuário', collect());
-        $this->assertPluralStudly('AlgumUsuário', 'AlgumUsuário', collect(['um']));
-        $this->assertPluralStudly('AlgumUsuários', 'AlgumUsuário', collect(['um', 'dois']));
+        $this->assertPluralStudly('AlgumUsuários', 'AlgumUsuário', new Collection);
+        $this->assertPluralStudly('AlgumUsuário', 'AlgumUsuário', new Collection(['um']));
+        $this->assertPluralStudly('AlgumUsuários', 'AlgumUsuário', new Collection(['um', 'dois']));
     }
 
     private function assertPluralStudly($expected, $value, $count = 2)

--- a/tests/Integration/View/BladeTest.php
+++ b/tests/Integration/View/BladeTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\View;
 
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\View;
@@ -222,7 +223,7 @@ class BladeTest extends TestCase
         $this->artisan('view:cache');
 
         $compiledFiles = Finder::create()->in(Config::get('view.compiled'))->files();
-        $found = collect($compiledFiles)
+        $found = (new Collection($compiledFiles))
             ->contains(fn (SplFileInfo $file) => str_contains($file->getContents(), 'echo "<?php echo e($scriptMessage); ?>" > output.log'));
         $this->assertTrue($found);
     }

--- a/tests/Mail/MailMailableTest.php
+++ b/tests/Mail/MailMailableTest.php
@@ -11,6 +11,7 @@ use Illuminate\Mail\Mailables\Envelope;
 use Illuminate\Mail\Mailables\Headers;
 use Illuminate\Mail\Mailer;
 use Illuminate\Mail\Transport\ArrayTransport;
+use Illuminate\Support\Collection;
 use Mockery as m;
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\TestCase;
@@ -68,14 +69,14 @@ class MailMailableTest extends TestCase
         $mailable->assertHasTo('taylor@laravel.com');
 
         $mailable = new WelcomeMailableStub;
-        $mailable->to(collect([new MailableTestUserStub]));
+        $mailable->to(new Collection([new MailableTestUserStub]));
         $this->assertEquals([['name' => 'Taylor Otwell', 'address' => 'taylor@laravel.com']], $mailable->to);
         $this->assertTrue($mailable->hasTo(new MailableTestUserStub));
         $this->assertTrue($mailable->hasTo('taylor@laravel.com'));
         $mailable->assertHasTo('taylor@laravel.com');
 
         $mailable = new WelcomeMailableStub;
-        $mailable->to(collect([new MailableTestUserStub, new MailableTestUserStub, new MailableTestUserStub2]));
+        $mailable->to(new Collection([new MailableTestUserStub, new MailableTestUserStub, new MailableTestUserStub2]));
         $this->assertEquals([
             ['name' => 'Taylor Otwell', 'address' => 'taylor@laravel.com'],
             ['name' => 'Laravel Framework', 'address' => 'contact@laravel.com'],
@@ -148,14 +149,14 @@ class MailMailableTest extends TestCase
         $mailable->assertHasCc('taylor@laravel.com');
 
         $mailable = new WelcomeMailableStub;
-        $mailable->cc(collect([new MailableTestUserStub]));
+        $mailable->cc(new Collection([new MailableTestUserStub]));
         $this->assertEquals([['name' => 'Taylor Otwell', 'address' => 'taylor@laravel.com']], $mailable->cc);
         $this->assertTrue($mailable->hasCc(new MailableTestUserStub));
         $this->assertTrue($mailable->hasCc('taylor@laravel.com'));
         $mailable->assertHasCc('taylor@laravel.com');
 
         $mailable = new WelcomeMailableStub;
-        $mailable->cc(collect([new MailableTestUserStub, new MailableTestUserStub, new MailableTestUserStub2]));
+        $mailable->cc(new Collection([new MailableTestUserStub, new MailableTestUserStub, new MailableTestUserStub2]));
         $this->assertEquals([
             ['name' => 'Taylor Otwell', 'address' => 'taylor@laravel.com'],
             ['name' => 'Laravel Framework', 'address' => 'contact@laravel.com'],
@@ -239,14 +240,14 @@ class MailMailableTest extends TestCase
         $mailable->assertHasBcc('taylor@laravel.com');
 
         $mailable = new WelcomeMailableStub;
-        $mailable->bcc(collect([new MailableTestUserStub]));
+        $mailable->bcc(new Collection([new MailableTestUserStub]));
         $this->assertEquals([['name' => 'Taylor Otwell', 'address' => 'taylor@laravel.com']], $mailable->bcc);
         $this->assertTrue($mailable->hasBcc(new MailableTestUserStub));
         $this->assertTrue($mailable->hasBcc('taylor@laravel.com'));
         $mailable->assertHasBcc('taylor@laravel.com');
 
         $mailable = new WelcomeMailableStub;
-        $mailable->bcc(collect([new MailableTestUserStub, new MailableTestUserStub, new MailableTestUserStub2]));
+        $mailable->bcc(new Collection([new MailableTestUserStub, new MailableTestUserStub, new MailableTestUserStub2]));
         $this->assertEquals([
             ['name' => 'Taylor Otwell', 'address' => 'taylor@laravel.com'],
             ['name' => 'Laravel Framework', 'address' => 'contact@laravel.com'],
@@ -330,14 +331,14 @@ class MailMailableTest extends TestCase
         $mailable->assertHasReplyTo('taylor@laravel.com');
 
         $mailable = new WelcomeMailableStub;
-        $mailable->replyTo(collect([new MailableTestUserStub]));
+        $mailable->replyTo(new Collection([new MailableTestUserStub]));
         $this->assertEquals([['name' => 'Taylor Otwell', 'address' => 'taylor@laravel.com']], $mailable->replyTo);
         $this->assertTrue($mailable->hasReplyTo(new MailableTestUserStub));
         $this->assertTrue($mailable->hasReplyTo('taylor@laravel.com'));
         $mailable->assertHasReplyTo('taylor@laravel.com');
 
         $mailable = new WelcomeMailableStub;
-        $mailable->replyTo(collect([new MailableTestUserStub, new MailableTestUserStub, new MailableTestUserStub2]));
+        $mailable->replyTo(new Collection([new MailableTestUserStub, new MailableTestUserStub, new MailableTestUserStub2]));
         $this->assertEquals([
             ['name' => 'Taylor Otwell', 'address' => 'taylor@laravel.com'],
             ['name' => 'Laravel Framework', 'address' => 'contact@laravel.com'],
@@ -410,14 +411,14 @@ class MailMailableTest extends TestCase
         $mailable->assertFrom('taylor@laravel.com');
 
         $mailable = new WelcomeMailableStub;
-        $mailable->from(collect([new MailableTestUserStub]));
+        $mailable->from(new Collection([new MailableTestUserStub]));
         $this->assertEquals([['name' => 'Taylor Otwell', 'address' => 'taylor@laravel.com']], $mailable->from);
         $this->assertTrue($mailable->hasFrom(new MailableTestUserStub));
         $this->assertTrue($mailable->hasFrom('taylor@laravel.com'));
         $mailable->assertFrom('taylor@laravel.com');
 
         $mailable = new WelcomeMailableStub;
-        $mailable->from(collect([new MailableTestUserStub, new MailableTestUserStub, new MailableTestUserStub2]));
+        $mailable->from(new Collection([new MailableTestUserStub, new MailableTestUserStub, new MailableTestUserStub2]));
         $this->assertEquals([
             ['name' => 'Taylor Otwell', 'address' => 'taylor@laravel.com'],
             ['name' => 'Laravel Framework', 'address' => 'contact@laravel.com'],

--- a/tests/Mail/MailMailerTest.php
+++ b/tests/Mail/MailMailerTest.php
@@ -9,6 +9,7 @@ use Illuminate\Mail\Events\MessageSent;
 use Illuminate\Mail\Mailer;
 use Illuminate\Mail\Message;
 use Illuminate\Mail\Transport\ArrayTransport;
+use Illuminate\Support\Collection;
 use Illuminate\Support\HtmlString;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -52,7 +53,7 @@ class MailMailerTest extends TestCase
                 ->from('hello@laravel.com');
         });
 
-        $recipients = collect($sentMessage->getEnvelope()->getRecipients())->map(function ($recipient) {
+        $recipients = (new Collection($sentMessage->getEnvelope()->getRecipients()))->map(function ($recipient) {
             return $recipient->getAddress();
         });
 
@@ -251,7 +252,7 @@ class MailMailerTest extends TestCase
             $message->bcc('james@laravel.com');
         });
 
-        $recipients = collect($sentMessage->getEnvelope()->getRecipients())->map(function ($recipient) {
+        $recipients = (new Collection($sentMessage->getEnvelope()->getRecipients()))->map(function ($recipient) {
             return $recipient->getAddress();
         });
 

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -115,7 +115,7 @@ class SupportArrTest extends TestCase
         $this->assertEquals([1, 2, 'foo', 'bar'], Arr::collapse($mixedArray));
 
         // Case including collections and arrays
-        $collection = collect(['baz', 'boom']);
+        $collection = new Collection(['baz', 'boom']);
         $mixedArray = [[1], [2], [3], ['foo', 'bar'], $collection];
         $this->assertEquals([1, 2, 3, 'foo', 'bar', 'baz', 'boom'], Arr::collapse($mixedArray));
     }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -422,7 +422,7 @@ class SupportCollectionTest extends TestCase
         $data = new Collection(['foo', 'bar', 'baz']);
 
         $this->assertEquals(new Collection([]), $data->shift(0));
-        $this->assertEquals(collect(['foo', 'bar', 'baz']), $data);
+        $this->assertEquals(new Collection(['foo', 'bar', 'baz']), $data);
 
         $this->expectException('InvalidArgumentException');
         (new Collection(['foo', 'bar', 'baz']))->shift(-1);
@@ -438,7 +438,7 @@ class SupportCollectionTest extends TestCase
         $itemBar = new \stdClass();
         $itemBar->text = 'x';
 
-        $items = collect([$itemFoo, $itemBar]);
+        $items = new Collection([$itemFoo, $itemBar]);
 
         $foo = $items->shift();
         $bar = $items->shift();
@@ -864,13 +864,13 @@ class SupportCollectionTest extends TestCase
     public function testForgetCollectionOfKeys()
     {
         $c = new Collection(['foo', 'bar', 'baz']);
-        $c = $c->forget(collect([0, 2]))->all();
+        $c = $c->forget(new Collection([0, 2]))->all();
         $this->assertFalse(isset($c[0]));
         $this->assertFalse(isset($c[2]));
         $this->assertTrue(isset($c[1]));
 
         $c = new Collection(['name' => 'taylor', 'foo' => 'bar', 'baz' => 'qux']);
-        $c = $c->forget(collect(['foo', 'baz']))->all();
+        $c = $c->forget(new Collection(['foo', 'baz']))->all();
         $this->assertFalse(isset($c['foo']));
         $this->assertFalse(isset($c['baz']));
         $this->assertTrue(isset($c['name']));
@@ -951,9 +951,9 @@ class SupportCollectionTest extends TestCase
         $this->assertTrue((new $collection([1]))->containsOneItem());
         $this->assertFalse((new $collection([1, 2]))->containsOneItem());
 
-        $this->assertFalse(collect([1, 2, 2])->containsOneItem(fn ($number) => $number === 2));
-        $this->assertTrue(collect(['ant', 'bear', 'cat'])->containsOneItem(fn ($word) => strlen($word) === 4));
-        $this->assertFalse(collect(['ant', 'bear', 'cat'])->containsOneItem(fn ($word) => strlen($word) > 4));
+        $this->assertFalse((new Collection([1, 2, 2]))->containsOneItem(fn ($number) => $number === 2));
+        $this->assertTrue((new Collection(['ant', 'bear', 'cat']))->containsOneItem(fn ($word) => strlen($word) === 4));
+        $this->assertFalse((new Collection(['ant', 'bear', 'cat']))->containsOneItem(fn ($word) => strlen($word) > 4));
     }
 
     #[DataProvider('collectionClassProvider')]
@@ -964,10 +964,10 @@ class SupportCollectionTest extends TestCase
         $this->assertTrue((new $collection([1, 2]))->containsManyItems());
         $this->assertTrue((new $collection([1, 2, 3]))->containsManyItems());
 
-        $this->assertTrue(collect([1, 2, 2])->containsManyItems(fn ($number) => $number === 2));
-        $this->assertFalse(collect(['ant', 'bear', 'cat'])->containsManyItems(fn ($word) => strlen($word) === 4));
-        $this->assertFalse(collect(['ant', 'bear', 'cat'])->containsManyItems(fn ($word) => strlen($word) > 4));
-        $this->assertTrue(collect(['ant', 'bear', 'cat'])->containsManyItems(fn ($word) => strlen($word) === 3));
+        $this->assertTrue((new Collection([1, 2, 2]))->containsManyItems(fn ($number) => $number === 2));
+        $this->assertFalse((new Collection(['ant', 'bear', 'cat']))->containsManyItems(fn ($word) => strlen($word) === 4));
+        $this->assertFalse((new Collection(['ant', 'bear', 'cat']))->containsManyItems(fn ($word) => strlen($word) > 4));
+        $this->assertTrue((new Collection(['ant', 'bear', 'cat']))->containsManyItems(fn ($word) => strlen($word) === 3));
     }
 
     public function testIterable()
@@ -2440,11 +2440,11 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals($data->all(), $data->except(null)->all());
         $this->assertEquals(['first' => 'Taylor'], $data->except(['last', 'email', 'missing'])->all());
         $this->assertEquals(['first' => 'Taylor'], $data->except('last', 'email', 'missing')->all());
-        $this->assertEquals(['first' => 'Taylor'], $data->except(collect(['last', 'email', 'missing']))->all());
+        $this->assertEquals(['first' => 'Taylor'], $data->except(new Collection(['last', 'email', 'missing']))->all());
 
         $this->assertEquals(['first' => 'Taylor', 'email' => 'taylorotwell@gmail.com'], $data->except(['last'])->all());
         $this->assertEquals(['first' => 'Taylor', 'email' => 'taylorotwell@gmail.com'], $data->except('last')->all());
-        $this->assertEquals(['first' => 'Taylor', 'email' => 'taylorotwell@gmail.com'], $data->except(collect(['last']))->all());
+        $this->assertEquals(['first' => 'Taylor', 'email' => 'taylorotwell@gmail.com'], $data->except(new Collection(['last']))->all());
     }
 
     #[DataProvider('collectionClassProvider')]
@@ -4439,7 +4439,7 @@ class SupportCollectionTest extends TestCase
         $data = new Collection([4, 5, 6]);
         $data->push('Jonny', 'from', 'Laroe');
         $data->push(...[11 => 'Jonny', 12 => 'from', 13 => 'Laroe']);
-        $data->push(...collect(['a', 'b', 'c']));
+        $data->push(...new Collection(['a', 'b', 'c']));
         $actual = $data->push(...[])->toArray();
 
         $this->assertSame($expected, $actual);
@@ -4484,7 +4484,7 @@ class SupportCollectionTest extends TestCase
         $data = new Collection([4, 5, 6]);
         $data->unshift('Jonny', 'from', 'Laroe');
         $data->unshift(...[11 => 'Jonny', 12 => 'from', 13 => 'Laroe']);
-        $data->unshift(...collect(['a', 'b', 'c']));
+        $data->unshift(...new Collection(['a', 'b', 'c']));
         $actual = $data->unshift(...[])->toArray();
 
         $this->assertSame($expected, $actual);
@@ -4599,11 +4599,11 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals($data->all(), $data->only(null)->all());
         $this->assertEquals(['first' => 'Taylor'], $data->only(['first', 'missing'])->all());
         $this->assertEquals(['first' => 'Taylor'], $data->only('first', 'missing')->all());
-        $this->assertEquals(['first' => 'Taylor'], $data->only(collect(['first', 'missing']))->all());
+        $this->assertEquals(['first' => 'Taylor'], $data->only(new Collection(['first', 'missing']))->all());
 
         $this->assertEquals(['first' => 'Taylor', 'email' => 'taylorotwell@gmail.com'], $data->only(['first', 'email'])->all());
         $this->assertEquals(['first' => 'Taylor', 'email' => 'taylorotwell@gmail.com'], $data->only('first', 'email')->all());
-        $this->assertEquals(['first' => 'Taylor', 'email' => 'taylorotwell@gmail.com'], $data->only(collect(['first', 'email']))->all());
+        $this->assertEquals(['first' => 'Taylor', 'email' => 'taylorotwell@gmail.com'], $data->only(new Collection(['first', 'email']))->all());
     }
 
     #[DataProvider('collectionClassProvider')]
@@ -4617,7 +4617,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals($data->all(), $data->select(null)->all());
         $this->assertEquals([['first' => 'Taylor'], ['first' => 'Jess']], $data->select(['first', 'missing'])->all());
         $this->assertEquals([['first' => 'Taylor'], ['first' => 'Jess']], $data->select('first', 'missing')->all());
-        $this->assertEquals([['first' => 'Taylor'], ['first' => 'Jess']], $data->select(collect(['first', 'missing']))->all());
+        $this->assertEquals([['first' => 'Taylor'], ['first' => 'Jess']], $data->select(new Collection(['first', 'missing']))->all());
 
         $this->assertEquals([
             ['first' => 'Taylor', 'email' => 'taylorotwell@gmail.com'],
@@ -4632,7 +4632,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([
             ['first' => 'Taylor', 'email' => 'taylorotwell@gmail.com'],
             ['first' => 'Jess', 'email' => 'jessarcher@gmail.com'],
-        ], $data->select(collect(['first', 'email']))->all());
+        ], $data->select(new Collection(['first', 'email']))->all());
     }
 
     #[DataProvider('collectionClassProvider')]
@@ -4646,7 +4646,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals($data->all(), $data->select(null)->all());
         $this->assertEquals([['first' => 'Taylor'], ['first' => 'Jess']], $data->select(['first', 'missing'])->all());
         $this->assertEquals([['first' => 'Taylor'], ['first' => 'Jess']], $data->select('first', 'missing')->all());
-        $this->assertEquals([['first' => 'Taylor'], ['first' => 'Jess']], $data->select(collect(['first', 'missing']))->all());
+        $this->assertEquals([['first' => 'Taylor'], ['first' => 'Jess']], $data->select(new Collection(['first', 'missing']))->all());
 
         $this->assertEquals([
             ['first' => 'Taylor', 'email' => 'taylorotwell@gmail.com'],
@@ -4661,7 +4661,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([
             ['first' => 'Taylor', 'email' => 'taylorotwell@gmail.com'],
             ['first' => 'Jess', 'email' => 'jessarcher@gmail.com'],
-        ], $data->select(collect(['first', 'email']))->all());
+        ], $data->select(new Collection(['first', 'email']))->all());
     }
 
     #[DataProvider('collectionClassProvider')]
@@ -4675,7 +4675,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals($data->all(), $data->select(null)->all());
         $this->assertEquals([['first' => 'Taylor'], ['first' => 'Jess']], $data->select(['first', 'missing'])->all());
         $this->assertEquals([['first' => 'Taylor'], ['first' => 'Jess']], $data->select('first', 'missing')->all());
-        $this->assertEquals([['first' => 'Taylor'], ['first' => 'Jess']], $data->select(collect(['first', 'missing']))->all());
+        $this->assertEquals([['first' => 'Taylor'], ['first' => 'Jess']], $data->select(new Collection(['first', 'missing']))->all());
 
         $this->assertEquals([
             ['first' => 'Taylor', 'email' => 'taylorotwell@gmail.com'],
@@ -4690,7 +4690,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([
             ['first' => 'Taylor', 'email' => 'taylorotwell@gmail.com'],
             ['first' => 'Jess', 'email' => 'jessarcher@gmail.com'],
-        ], $data->select(collect(['first', 'email']))->all());
+        ], $data->select(new Collection(['first', 'email']))->all());
     }
 
     #[DataProvider('collectionClassProvider')]

--- a/tests/Support/SupportEnumValueFunctionTest.php
+++ b/tests/Support/SupportEnumValueFunctionTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Support;
 
+use Illuminate\Support\Collection;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
@@ -43,6 +44,6 @@ class SupportEnumValueFunctionTest extends TestCase
         yield [true, true];
         yield [1337, 1337];
         yield [1.0, 1.0];
-        yield [$collect = collect(), $collect];
+        yield [$collect = new Collection, $collect];
     }
 }

--- a/tests/Support/SupportFluentTest.php
+++ b/tests/Support/SupportFluentTest.php
@@ -308,7 +308,7 @@ class SupportFluentTest extends TestCase
         $this->assertTrue($fluent->collect(['roles'])->isNotEmpty());
         $this->assertEquals(['roles' => [4, 5, 6]], $fluent->collect(['roles'])->all());
         $this->assertEquals(['users' => [1, 2, 3], 'email' => 'test@example.com'], $fluent->collect(['users', 'email'])->all());
-        $this->assertEquals(collect(['roles' => [4, 5, 6], 'foo' => ['bar', 'baz']]), $fluent->collect(['roles', 'foo']));
+        $this->assertEquals(new Collection(['roles' => [4, 5, 6], 'foo' => ['bar', 'baz']]), $fluent->collect(['roles', 'foo']));
         $this->assertEquals(['users' => [1, 2, 3], 'roles' => [4, 5, 6], 'foo' => ['bar', 'baz'], 'email' => 'test@example.com'], $fluent->collect()->all());
     }
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -10,6 +10,7 @@ use Error;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Env;
 use Illuminate\Support\Optional;
 use Illuminate\Support\Sleep;
@@ -465,7 +466,7 @@ class SupportHelpersTest extends TestCase
         $data = ['foo' => 'bar'];
         $this->assertEquals(['bar'], data_get($data, '*'));
 
-        $data = collect(['foo' => 'bar']);
+        $data = new Collection(['foo' => 'bar']);
         $this->assertEquals(['bar'], data_get($data, '*'));
     }
 

--- a/tests/Support/SupportJsTest.php
+++ b/tests/Support/SupportJsTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Support;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Contracts\Support\Jsonable;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Js;
 use Illuminate\Tests\Support\Fixtures\IntBackedEnum;
 use Illuminate\Tests\Support\Fixtures\StringBackedEnum;
@@ -20,7 +21,7 @@ class SupportJsTest extends TestCase
         $this->assertSame('1', (string) Js::from(1));
         $this->assertSame('1.1', (string) Js::from(1.1));
         $this->assertSame('[]', (string) Js::from([]));
-        $this->assertSame('[]', (string) Js::from(collect()));
+        $this->assertSame('[]', (string) Js::from(new Collection));
         $this->assertSame('null', (string) Js::from(null));
         $this->assertSame("'Hello world'", (string) Js::from('Hello world'));
         $this->assertSame("'Hèlló world'", (string) Js::from('Hèlló world'));

--- a/tests/Support/SupportPluralizerTest.php
+++ b/tests/Support/SupportPluralizerTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Support;
 
+use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use PHPUnit\Framework\TestCase;
 
@@ -94,9 +95,9 @@ class SupportPluralizerTest extends TestCase
 
     public function testPluralSupportsCollections()
     {
-        $this->assertSame('users', Str::plural('user', collect()));
-        $this->assertSame('user', Str::plural('user', collect(['one'])));
-        $this->assertSame('users', Str::plural('user', collect(['one', 'two'])));
+        $this->assertSame('users', Str::plural('user', new Collection));
+        $this->assertSame('user', Str::plural('user', new Collection(['one'])));
+        $this->assertSame('users', Str::plural('user', new Collection(['one', 'two'])));
     }
 
     public function testPluralStudlySupportsArrays()
@@ -108,9 +109,9 @@ class SupportPluralizerTest extends TestCase
 
     public function testPluralStudlySupportsCollections()
     {
-        $this->assertPluralStudly('SomeUsers', 'SomeUser', collect());
-        $this->assertPluralStudly('SomeUser', 'SomeUser', collect(['one']));
-        $this->assertPluralStudly('SomeUsers', 'SomeUser', collect(['one', 'two']));
+        $this->assertPluralStudly('SomeUsers', 'SomeUser', new Collection);
+        $this->assertPluralStudly('SomeUser', 'SomeUser', new Collection(['one']));
+        $this->assertPluralStudly('SomeUsers', 'SomeUser', new Collection(['one', 'two']));
     }
 
     private function assertPluralStudly($expected, $value, $count = 2)

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Support;
 
 use Exception;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Illuminate\Tests\Support\Fixtures\StringableObjectStub;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -178,7 +179,7 @@ class SupportStrTest extends TestCase
         $this->assertTrue(Str::startsWith('jason', 'jason'));
         $this->assertTrue(Str::startsWith('jason', ['jas']));
         $this->assertTrue(Str::startsWith('jason', ['day', 'jas']));
-        $this->assertTrue(Str::startsWith('jason', collect(['day', 'jas'])));
+        $this->assertTrue(Str::startsWith('jason', new Collection(['day', 'jas'])));
         $this->assertFalse(Str::startsWith('jason', 'day'));
         $this->assertFalse(Str::startsWith('jason', ['day']));
         $this->assertFalse(Str::startsWith('jason', null));
@@ -213,7 +214,7 @@ class SupportStrTest extends TestCase
         $this->assertFalse(Str::doesntStartWith('jason', 'jason'));
         $this->assertFalse(Str::doesntStartWith('jason', ['jas']));
         $this->assertFalse(Str::doesntStartWith('jason', ['day', 'jas']));
-        $this->assertFalse(Str::doesntStartWith('jason', collect(['day', 'jas'])));
+        $this->assertFalse(Str::doesntStartWith('jason', new Collection(['day', 'jas'])));
         $this->assertTrue(Str::doesntStartWith('jason', 'day'));
         $this->assertTrue(Str::doesntStartWith('jason', ['day']));
         $this->assertTrue(Str::doesntStartWith('jason', null));
@@ -248,7 +249,7 @@ class SupportStrTest extends TestCase
         $this->assertTrue(Str::endsWith('jason', 'jason'));
         $this->assertTrue(Str::endsWith('jason', ['on']));
         $this->assertTrue(Str::endsWith('jason', ['no', 'on']));
-        $this->assertTrue(Str::endsWith('jason', collect(['no', 'on'])));
+        $this->assertTrue(Str::endsWith('jason', new Collection(['no', 'on'])));
         $this->assertFalse(Str::endsWith('jason', 'no'));
         $this->assertFalse(Str::endsWith('jason', ['no']));
         $this->assertFalse(Str::endsWith('jason', ''));
@@ -281,7 +282,7 @@ class SupportStrTest extends TestCase
         $this->assertFalse(Str::doesntEndWith('jason', 'jason'));
         $this->assertFalse(Str::doesntEndWith('jason', ['on']));
         $this->assertFalse(Str::doesntEndWith('jason', ['no', 'on']));
-        $this->assertFalse(Str::doesntEndWith('jason', collect(['no', 'on'])));
+        $this->assertFalse(Str::doesntEndWith('jason', new Collection(['no', 'on'])));
         $this->assertTrue(Str::doesntEndWith('jason', 'no'));
         $this->assertTrue(Str::doesntEndWith('jason', ['no']));
         $this->assertTrue(Str::doesntEndWith('jason', ''));
@@ -904,7 +905,7 @@ class SupportStrTest extends TestCase
         $this->assertSame('foo bar baz 8.x', Str::replace('x', '8.x', 'foo bar baz X', false));
         $this->assertSame('foo/bar/baz', Str::replace(' ', '/', 'foo bar baz'));
         $this->assertSame('foo bar baz', Str::replace(['?1', '?2', '?3'], ['foo', 'bar', 'baz'], '?1 ?2 ?3'));
-        $this->assertSame(['foo', 'bar', 'baz'], Str::replace(collect(['?1', '?2', '?3']), collect(['foo', 'bar', 'baz']), collect(['?1', '?2', '?3'])));
+        $this->assertSame(['foo', 'bar', 'baz'], Str::replace(new Collection(['?1', '?2', '?3']), new Collection(['foo', 'bar', 'baz']), new Collection(['?1', '?2', '?3'])));
     }
 
     public function testReplaceArray()
@@ -1542,7 +1543,7 @@ class SupportStrTest extends TestCase
             ['Taylor', ['ylo'], true, true],
             ['Taylor', ['ylo'], true, false],
             ['Taylor', ['xxx', 'ylo'], true, true],
-            ['Taylor', collect(['xxx', 'ylo']), true, true],
+            ['Taylor', new Collection(['xxx', 'ylo']), true, true],
             ['Taylor', ['xxx', 'ylo'], true, false],
             ['Taylor', 'xxx', false],
             ['Taylor', ['xxx'], false],

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -642,7 +642,7 @@ class SupportStringableTest extends TestCase
         $this->assertTrue($this->stringable('jason')->startsWith('jason'));
         $this->assertTrue($this->stringable('jason')->startsWith(['jas']));
         $this->assertTrue($this->stringable('jason')->startsWith(['day', 'jas']));
-        $this->assertTrue($this->stringable('jason')->startsWith(collect(['day', 'jas'])));
+        $this->assertTrue($this->stringable('jason')->startsWith(new Collection(['day', 'jas'])));
         $this->assertFalse($this->stringable('jason')->startsWith('day'));
         $this->assertFalse($this->stringable('jason')->startsWith(['day']));
         $this->assertFalse($this->stringable('jason')->startsWith(null));
@@ -672,7 +672,7 @@ class SupportStringableTest extends TestCase
         $this->assertFalse($this->stringable('jason')->doesntStartWith('jason'));
         $this->assertFalse($this->stringable('jason')->doesntStartWith(['jas']));
         $this->assertFalse($this->stringable('jason')->doesntStartWith(['day', 'jas']));
-        $this->assertFalse($this->stringable('jason')->doesntStartWith(collect(['day', 'jas'])));
+        $this->assertFalse($this->stringable('jason')->doesntStartWith(new Collection(['day', 'jas'])));
         $this->assertTrue($this->stringable('jason')->doesntStartWith('day'));
         $this->assertTrue($this->stringable('jason')->doesntStartWith(['day']));
         $this->assertTrue($this->stringable('jason')->doesntStartWith(null));
@@ -702,7 +702,7 @@ class SupportStringableTest extends TestCase
         $this->assertTrue($this->stringable('jason')->endsWith('jason'));
         $this->assertTrue($this->stringable('jason')->endsWith(['on']));
         $this->assertTrue($this->stringable('jason')->endsWith(['no', 'on']));
-        $this->assertTrue($this->stringable('jason')->endsWith(collect(['no', 'on'])));
+        $this->assertTrue($this->stringable('jason')->endsWith(new Collection(['no', 'on'])));
         $this->assertFalse($this->stringable('jason')->endsWith('no'));
         $this->assertFalse($this->stringable('jason')->endsWith(['no']));
         $this->assertFalse($this->stringable('jason')->endsWith(''));
@@ -730,7 +730,7 @@ class SupportStringableTest extends TestCase
         $this->assertFalse($this->stringable('jason')->doesntEndWith('jason'));
         $this->assertFalse($this->stringable('jason')->doesntEndWith(['on']));
         $this->assertFalse($this->stringable('jason')->doesntEndWith(['no', 'on']));
-        $this->assertFalse($this->stringable('jason')->doesntEndWith(collect(['no', 'on'])));
+        $this->assertFalse($this->stringable('jason')->doesntEndWith(new Collection(['no', 'on'])));
         $this->assertTrue($this->stringable('jason')->doesntEndWith('no'));
         $this->assertTrue($this->stringable('jason')->doesntEndWith(['no']));
         $this->assertTrue($this->stringable('jason')->doesntEndWith(''));
@@ -844,7 +844,7 @@ class SupportStringableTest extends TestCase
         $this->assertTrue($this->stringable('taylor')->contains('taylor'));
         $this->assertTrue($this->stringable('taylor')->contains(['ylo']));
         $this->assertTrue($this->stringable('taylor')->contains(['xxx', 'ylo']));
-        $this->assertTrue($this->stringable('taylor')->contains(collect(['xxx', 'ylo'])));
+        $this->assertTrue($this->stringable('taylor')->contains(new Collection(['xxx', 'ylo'])));
         $this->assertTrue($this->stringable('taylor')->contains(['LOR'], true));
         $this->assertFalse($this->stringable('taylor')->contains('xxx'));
         $this->assertFalse($this->stringable('taylor')->contains(['xxx']));
@@ -855,7 +855,7 @@ class SupportStringableTest extends TestCase
     {
         $this->assertTrue($this->stringable('taylor otwell')->containsAll(['taylor', 'otwell']));
         $this->assertTrue($this->stringable('taylor otwell')->containsAll(['TAYLOR', 'OTWELL'], true));
-        $this->assertTrue($this->stringable('taylor otwell')->containsAll(collect(['taylor', 'otwell'])));
+        $this->assertTrue($this->stringable('taylor otwell')->containsAll(new Collection(['taylor', 'otwell'])));
         $this->assertTrue($this->stringable('taylor otwell')->containsAll(['taylor']));
         $this->assertFalse($this->stringable('taylor otwell')->containsAll(['taylor', 'xxx']));
     }
@@ -865,7 +865,7 @@ class SupportStringableTest extends TestCase
         $this->assertTrue($this->stringable('taylor')->doesntContain('xxx'));
         $this->assertTrue($this->stringable('taylor')->doesntContain(['xxx']));
         $this->assertTrue($this->stringable('taylor')->doesntContain(['xxx', 'yyy']));
-        $this->assertTrue($this->stringable('taylor')->doesntContain(collect(['xxx', 'yyy'])));
+        $this->assertTrue($this->stringable('taylor')->doesntContain(new Collection(['xxx', 'yyy'])));
         $this->assertTrue($this->stringable('taylor')->doesntContain(''));
         $this->assertFalse($this->stringable('taylor')->doesntContain('ylo'));
         $this->assertFalse($this->stringable('taylor')->doesntContain('taylor'));
@@ -1051,7 +1051,7 @@ class SupportStringableTest extends TestCase
         $this->assertSame('?/?/?', (string) $this->stringable('? ? ?')->replace(' ', '/'));
         $this->assertSame('foo/bar/baz/bam', (string) $this->stringable('?1/?2/?3/?4')->replace(['?1', '?2', '?3', '?4'], ['foo', 'bar', 'baz', 'bam']));
         $this->assertSame('?1/?2/?3/?4', (string) $this->stringable('foo/bar/baz/bam')->replace(['Foo', 'BaR', 'BAZ', 'bAm'], ['?1', '?2', '?3', '?4'], false));
-        $this->assertSame('foo/bar/baz/bam', (string) $this->stringable('?1/?2/?3/?4')->replace(collect(['?1', '?2', '?3', '?4']), collect(['foo', 'bar', 'baz', 'bam'])));
+        $this->assertSame('foo/bar/baz/bam', (string) $this->stringable('?1/?2/?3/?4')->replace(new Collection(['?1', '?2', '?3', '?4']), new Collection(['foo', 'bar', 'baz', 'bam'])));
     }
 
     public function testReplaceArray()
@@ -1063,7 +1063,7 @@ class SupportStringableTest extends TestCase
         $this->assertSame('foo?/bar/baz', (string) $this->stringable('?/?/?')->replaceArray('?', ['foo?', 'bar', 'baz']));
         $this->assertSame('foo/bar', (string) $this->stringable('?/?')->replaceArray('?', [1 => 'foo', 2 => 'bar']));
         $this->assertSame('foo/bar', (string) $this->stringable('?/?')->replaceArray('?', ['x' => 'foo', 'y' => 'bar']));
-        $this->assertSame('foo/bar', (string) $this->stringable('?/?')->replaceArray('?', collect(['x' => 'foo', 'y' => 'bar'])));
+        $this->assertSame('foo/bar', (string) $this->stringable('?/?')->replaceArray('?', new Collection(['x' => 'foo', 'y' => 'bar'])));
     }
 
     public function testReplaceFirst()
@@ -1126,7 +1126,7 @@ class SupportStringableTest extends TestCase
         $this->assertSame('oobar', (string) $this->stringable('Foobar')->remove('f', false));
 
         $this->assertSame('Fbr', (string) $this->stringable('Foobar')->remove(['o', 'a']));
-        $this->assertSame('Fbr', (string) $this->stringable('Foobar')->remove(collect(['o', 'a'])));
+        $this->assertSame('Fbr', (string) $this->stringable('Foobar')->remove(new Collection(['o', 'a'])));
         $this->assertSame('Fooar', (string) $this->stringable('Foobar')->remove(['f', 'b']));
         $this->assertSame('ooar', (string) $this->stringable('Foobar')->remove(['f', 'b'], false));
         $this->assertSame('Foobar', (string) $this->stringable('Foo|bar')->remove(['f', '|']));

--- a/tests/Support/ValidatedInputTest.php
+++ b/tests/Support/ValidatedInputTest.php
@@ -536,7 +536,7 @@ class ValidatedInputTest extends TestCase
         $this->assertTrue($input->collect(['roles'])->isNotEmpty());
         $this->assertEquals(['roles' => [4, 5, 6]], $input->collect(['roles'])->all());
         $this->assertEquals(['users' => [1, 2, 3], 'email' => 'test@example.com'], $input->collect(['users', 'email'])->all());
-        $this->assertEquals(collect(['roles' => [4, 5, 6], 'foo' => ['bar', 'baz']]), $input->collect(['roles', 'foo']));
+        $this->assertEquals(new Collection(['roles' => [4, 5, 6], 'foo' => ['bar', 'baz']]), $input->collect(['roles', 'foo']));
         $this->assertEquals(['users' => [1, 2, 3], 'roles' => [4, 5, 6], 'foo' => ['bar', 'baz'], 'email' => 'test@example.com'], $input->collect()->all());
     }
 

--- a/tests/Testing/Concerns/InteractsWithDatabaseTest.php
+++ b/tests/Testing/Concerns/InteractsWithDatabaseTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Testing\Concerns;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithDatabase;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Facade;
 use Mockery as m;
@@ -31,7 +32,7 @@ class InteractsWithDatabaseTest extends TestCase
         $this->assertEquals(<<<'TEXT'
         '["foo","bar"]'
         TEXT,
-            $this->castAsJson(collect(['foo', 'bar']), $grammar)
+            $this->castAsJson(new Collection(['foo', 'bar']), $grammar)
         );
 
         $this->assertEquals(<<<'TEXT'
@@ -54,7 +55,7 @@ class InteractsWithDatabaseTest extends TestCase
         $this->assertEquals(<<<'TEXT'
         '["foo","bar"]'
         TEXT,
-            $this->castAsJson(collect(['foo', 'bar']), $grammar)
+            $this->castAsJson(new Collection(['foo', 'bar']), $grammar)
         );
 
         $this->assertEquals(<<<'TEXT'
@@ -77,7 +78,7 @@ class InteractsWithDatabaseTest extends TestCase
         $this->assertEquals(<<<'TEXT'
         json_query('["foo","bar"]')
         TEXT,
-            $this->castAsJson(collect(['foo', 'bar']), $grammar)
+            $this->castAsJson(new Collection(['foo', 'bar']), $grammar)
         );
 
         $this->assertEquals(<<<'TEXT'
@@ -100,7 +101,7 @@ class InteractsWithDatabaseTest extends TestCase
         $this->assertEquals(<<<'TEXT'
         cast('["foo","bar"]' as json)
         TEXT,
-            $this->castAsJson(collect(['foo', 'bar']), $grammar)
+            $this->castAsJson(new Collection(['foo', 'bar']), $grammar)
         );
 
         $this->assertEquals(<<<'TEXT'
@@ -123,7 +124,7 @@ class InteractsWithDatabaseTest extends TestCase
         $this->assertEquals(<<<'TEXT'
         json_query('["foo","bar"]', '$')
         TEXT,
-            $this->castAsJson(collect(['foo', 'bar']), $grammar)
+            $this->castAsJson(new Collection(['foo', 'bar']), $grammar)
         );
 
         $this->assertEquals(<<<'TEXT'

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -2614,7 +2614,7 @@ EOT
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableMixedResourcesStub));
 
         $this->assertInstanceOf(Collection::class, $response->collect());
-        $this->assertEquals(collect([
+        $this->assertEquals(new Collection([
             'foo' => 'bar',
             'foobar' => [
                 'foobar_foo' => 'foo',
@@ -2641,9 +2641,9 @@ EOT
                 4 => ['bar' => 'foo 2', 'foo' => 'bar 2'],
             ],
         ]), $response->collect());
-        $this->assertEquals(collect(['foobar_foo' => 'foo', 'foobar_bar' => 'bar']), $response->collect('foobar'));
-        $this->assertEquals(collect(['bar']), $response->collect('foobar.foobar_bar'));
-        $this->assertEquals(collect(), $response->collect('missing_key'));
+        $this->assertEquals(new Collection(['foobar_foo' => 'foo', 'foobar_bar' => 'bar']), $response->collect('foobar'));
+        $this->assertEquals(new Collection(['bar']), $response->collect('foobar.foobar_bar'));
+        $this->assertEquals(new Collection, $response->collect('missing_key'));
     }
 
     public function testItCanBeTapped(): void
@@ -3110,7 +3110,7 @@ EOT
     public function testHandledExceptionIsIncludedInAssertionFailure(): void
     {
         $response = TestResponse::fromBaseResponse(new Response('', 500))
-            ->withExceptions(collect([new Exception('Unexpected exception.')]));
+            ->withExceptions(new Collection([new Exception('Unexpected exception.')]));
 
         $this->expectException(ExpectationFailedException::class);
         $this->expectExceptionMessageMatches('/Expected response status code \[200\] but received 500.*Exception: Unexpected exception/s');

--- a/tests/Validation/ValidationArrayRuleTest.php
+++ b/tests/Validation/ValidationArrayRuleTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Validation;
 
+use Illuminate\Support\Collection;
 use Illuminate\Translation\ArrayLoader;
 use Illuminate\Translation\Translator;
 use Illuminate\Validation\Rule;
@@ -29,7 +30,7 @@ class ValidationArrayRuleTest extends TestCase
 
         $this->assertSame('array:key_1,key_2,key_3', (string) $rule);
 
-        $rule = Rule::array(collect(['key_1', 'key_2', 'key_3']));
+        $rule = Rule::array(new Collection(['key_1', 'key_2', 'key_3']));
 
         $this->assertSame('array:key_1,key_2,key_3', (string) $rule);
 

--- a/tests/Validation/ValidationInRuleTest.php
+++ b/tests/Validation/ValidationInRuleTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Validation;
 
+use Illuminate\Support\Collection;
 use Illuminate\Tests\Validation\fixtures\Values;
 use Illuminate\Translation\ArrayLoader;
 use Illuminate\Translation\Translator;
@@ -20,7 +21,7 @@ class ValidationInRuleTest extends TestCase
 
         $this->assertSame('in:"Laravel","Framework","PHP"', (string) $rule);
 
-        $rule = new In(collect(['Taylor', 'Michael', 'Tim']));
+        $rule = new In(new Collection(['Taylor', 'Michael', 'Tim']));
 
         $this->assertSame('in:"Taylor","Michael","Tim"', (string) $rule);
 
@@ -28,11 +29,11 @@ class ValidationInRuleTest extends TestCase
 
         $this->assertSame('in:"Life, the Universe and Everything","this is a ""quote"""', (string) $rule);
 
-        $rule = Rule::in(collect([1, 2, 3, 4]));
+        $rule = Rule::in(new Collection([1, 2, 3, 4]));
 
         $this->assertSame('in:"1","2","3","4"', (string) $rule);
 
-        $rule = Rule::in(collect([1, 2, 3, 4]));
+        $rule = Rule::in(new Collection([1, 2, 3, 4]));
 
         $this->assertSame('in:"1","2","3","4"', (string) $rule);
 
@@ -44,7 +45,7 @@ class ValidationInRuleTest extends TestCase
 
         $this->assertSame('in:"1","2","3","4"', (string) $rule);
 
-        $rule = Rule::in(collect([1, 2, 3, 4]));
+        $rule = Rule::in(new Collection([1, 2, 3, 4]));
 
         $this->assertSame('in:"1","2","3","4"', (string) $rule);
 

--- a/tests/Validation/ValidationNotInRuleTest.php
+++ b/tests/Validation/ValidationNotInRuleTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Validation;
 
+use Illuminate\Support\Collection;
 use Illuminate\Tests\Validation\fixtures\Values;
 use Illuminate\Translation\ArrayLoader;
 use Illuminate\Translation\Translator;
@@ -20,15 +21,15 @@ class ValidationNotInRuleTest extends TestCase
 
         $this->assertSame('not_in:"Laravel","Framework","PHP"', (string) $rule);
 
-        $rule = new NotIn(collect(['Taylor', 'Michael', 'Tim']));
+        $rule = new NotIn(new Collection(['Taylor', 'Michael', 'Tim']));
 
         $this->assertSame('not_in:"Taylor","Michael","Tim"', (string) $rule);
 
-        $rule = Rule::notIn(collect([1, 2, 3, 4]));
+        $rule = Rule::notIn(new Collection([1, 2, 3, 4]));
 
         $this->assertSame('not_in:"1","2","3","4"', (string) $rule);
 
-        $rule = Rule::notIn(collect([1, 2, 3, 4]));
+        $rule = Rule::notIn(new Collection([1, 2, 3, 4]));
 
         $this->assertSame('not_in:"1","2","3","4"', (string) $rule);
 
@@ -36,7 +37,7 @@ class ValidationNotInRuleTest extends TestCase
 
         $this->assertSame('not_in:"1","2","3","4"', (string) $rule);
 
-        $rule = Rule::notIn(collect([1, 2, 3, 4]));
+        $rule = Rule::notIn(new Collection([1, 2, 3, 4]));
 
         $this->assertSame('not_in:"1","2","3","4"', (string) $rule);
 

--- a/tests/Validation/ValidationRuleContainsTest.php
+++ b/tests/Validation/ValidationRuleContainsTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Validation;
 
+use Illuminate\Support\Collection;
 use Illuminate\Translation\ArrayLoader;
 use Illuminate\Translation\Translator;
 use Illuminate\Validation\Rule;
@@ -23,7 +24,7 @@ class ValidationRuleContainsTest extends TestCase
         $rule = Rule::contains(['Taylor', 'Abigail']);
         $this->assertSame('contains:"Taylor","Abigail"', (string) $rule);
 
-        $rule = Rule::contains(collect(['Taylor', 'Abigail']));
+        $rule = Rule::contains(new Collection(['Taylor', 'Abigail']));
         $this->assertSame('contains:"Taylor","Abigail"', (string) $rule);
 
         $rule = Rule::contains([ArrayKeys::key_1, ArrayKeys::key_2]);

--- a/tests/Validation/ValidationRuleDoesntContainTest.php
+++ b/tests/Validation/ValidationRuleDoesntContainTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Validation;
 
+use Illuminate\Support\Collection;
 use Illuminate\Translation\ArrayLoader;
 use Illuminate\Translation\Translator;
 use Illuminate\Validation\Rule;
@@ -23,7 +24,7 @@ class ValidationRuleDoesntContainTest extends TestCase
         $rule = Rule::doesntContain(['Taylor', 'Abigail']);
         $this->assertSame('doesnt_contain:"Taylor","Abigail"', (string) $rule);
 
-        $rule = Rule::doesntContain(collect(['Taylor', 'Abigail']));
+        $rule = Rule::doesntContain(new Collection(['Taylor', 'Abigail']));
         $this->assertSame('doesnt_contain:"Taylor","Abigail"', (string) $rule);
 
         $rule = Rule::doesntContain([ArrayKeys::key_1, ArrayKeys::key_2]);

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -14,14 +14,14 @@ class Users implements Arrayable
     }
 }
 
-$collection = collect([new User]);
+$collection = new Collection([new User]);
 $arrayable = new Users;
 /** @var iterable<int, int> $iterable */
 $iterable = [1];
 /** @var Traversable<int, string> $traversable */
 $traversable = new ArrayIterator(['string']);
 
-$associativeCollection = collect(['John' => new User]);
+$associativeCollection = new Collection(['John' => new User]);
 
 class Invokable
 {
@@ -34,13 +34,13 @@ $invokable = new Invokable;
 
 assertType('Illuminate\Support\Collection<int, User>', $collection);
 
-assertType('Illuminate\Support\Collection<int, string>', collect(['string']));
-assertType('Illuminate\Support\Collection<string, User>', collect(['string' => new User]));
-assertType('Illuminate\Support\Collection<int, User>', collect($arrayable));
-assertType('Illuminate\Support\Collection<int, User>', collect($collection));
-assertType('Illuminate\Support\Collection<int, User>', collect($collection));
-assertType('Illuminate\Support\Collection<int, int>', collect($iterable));
-assertType('Illuminate\Support\Collection<int, string>', collect($traversable));
+assertType("Illuminate\Support\Collection<int, 'string'>", new Collection(['string']));
+assertType('Illuminate\Support\Collection<string, User>', new Collection(['string' => new User]));
+assertType('Illuminate\Support\Collection<int, User>', new Collection($arrayable));
+assertType('Illuminate\Support\Collection<int, User>', new Collection($collection));
+assertType('Illuminate\Support\Collection<int, User>', new Collection($collection));
+assertType('Illuminate\Support\Collection<int, int>', new Collection($iterable));
+assertType('Illuminate\Support\Collection<int, string>', new Collection($traversable));
 
 assertType('Illuminate\Support\Collection<int, string>', $collection::make(['string']));
 assertType('Illuminate\Support\Collection<string, User>', $collection::make(['string' => new User]));
@@ -916,10 +916,10 @@ assertType('Illuminate\Support\Collection<int, User>', $collection->tap(function
     assertType('Illuminate\Support\Collection<int, User>', $collection);
 }));
 
-assertType('Illuminate\Support\Collection<int, int>', $collection->pipe(function ($collection) {
+assertType('Illuminate\Support\Collection<int, 1>', $collection->pipe(function ($collection) {
     assertType('Illuminate\Support\Collection<int, User>', $collection);
 
-    return collect([1]);
+    return new Collection([1]);
 }));
 assertType('1', $collection->make([1])->pipe(function ($collection) {
     assertType('Illuminate\Support\Collection<int, int>', $collection);
@@ -1107,8 +1107,8 @@ $collection->offsetUnset(0);
 unset($collection[0]);
 
 assertType('array<int, mixed>', $collection->toArray());
-assertType('array<string, mixed>', collect(['string' => 'string'])->toArray());
-assertType('array<int, mixed>', collect([1, 2])->toArray());
+assertType('array<string, mixed>', new Collection(['string' => 'string'])->toArray());
+assertType('array<int, mixed>', new Collection([1, 2])->toArray());
 
 assertType('ArrayIterator<int, User>', $collection->getIterator());
 foreach ($collection as $int => $user) {
@@ -1138,7 +1138,7 @@ class Zoo
 
     public function __construct()
     {
-        $this->animals = collect([
+        $this->animals = new Collection([
             new Tiger,
             new Lion,
             new Zebra,

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -1107,8 +1107,8 @@ $collection->offsetUnset(0);
 unset($collection[0]);
 
 assertType('array<int, mixed>', $collection->toArray());
-assertType('array<string, mixed>', new Collection(['string' => 'string'])->toArray());
-assertType('array<int, mixed>', new Collection([1, 2])->toArray());
+assertType('array<string, mixed>', (new Collection(['string' => 'string']))->toArray());
+assertType('array<int, mixed>', (new Collection([1, 2]))->toArray());
 
 assertType('ArrayIterator<int, User>', $collection->getIterator());
 foreach ($collection as $int => $user) {

--- a/types/Support/LazyCollection.php
+++ b/types/Support/LazyCollection.php
@@ -935,7 +935,7 @@ class LazyZoo
 
     public function __construct()
     {
-        $this->animals = collect([
+        $this->animals = new Collection([
             new LazyTiger,
             new LazyLion,
             new LazyZebra,


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Follows up on #59453 from @browner12  by adding a `FuncCallToNewRector` configured rule to `rector.php`, mapping `collect()` to `new Collection()`.

This automates the transformation so it stays enforced going forward, and applies it to the remaining occurrences across tests and type stubs.
