### PR TITLE
[13.x] Use standard SQL escaping for column comments in MySqlGrammar

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -1401,7 +1401,7 @@ class MySqlGrammar extends Grammar
     protected function modifyComment(Blueprint $blueprint, Fluent $column)
     {
         if (! is_null($column->comment)) {
-            return " comment '".addslashes($column->comment)."'";
+            return " comment '".str_replace("'", "''", $column->comment)."'";
         }
     }
 

--- a/tests/Database/DatabaseMariaDbSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMariaDbSchemaGrammarTest.php
@@ -1374,7 +1374,7 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
-        $this->assertSame("alter table `users` add `foo` varchar(255) not null comment 'Escape \\' when using words like it\\'s'", $statements[0]);
+        $this->assertSame("alter table `users` add `foo` varchar(255) not null comment 'Escape '' when using words like it''s'", $statements[0]);
     }
 
     public function testCreateDatabase()

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -1379,7 +1379,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
-        $this->assertSame("alter table `users` add `foo` varchar(255) not null comment 'Escape \\' when using words like it\\'s'", $statements[0]);
+        $this->assertSame("alter table `users` add `foo` varchar(255) not null comment 'Escape '' when using words like it''s'", $statements[0]);
     }
 
     public function testAddingVector()


### PR DESCRIPTION
## Summary

Replaces `addslashes()` with `str_replace("'", "''", ...)` for column comment escaping in `MySqlGrammar::modifyComment()`.

## Changes

The `modifyComment()` method at line 1404 used `addslashes()` to escape column comments, while `compileTableComment()` at line 733 in the same file already correctly uses `str_replace("'", "''", ...)`. This change makes column-level comments consistent with table-level comments, using standard SQL single-quote escaping throughout.

`addslashes()` escapes with backslashes (`\'`) which is MySQL-specific and can be vulnerable to multi-byte character bypass. SQL-standard escaping (`''`) is what the rest of the grammar already uses.

## Test plan

- [x] `testAddingComment` passes in both MySqlSchemaGrammarTest and MariaDbSchemaGrammarTest
- [x] Consistent with `compileTableComment()` at line 733 in the same file
- [x] Consistent with PostgresGrammar comment escaping