### PR TITLE
[13.x] Add deliverVia and deliversVia methods to NotificationFake

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -34,6 +34,13 @@ class NotificationFake implements Fake, NotificationDispatcher, NotificationFact
     public $locale;
 
     /**
+     * The default channel used to deliver messages.
+     *
+     * @var string|null
+     */
+    protected $defaultChannel;
+
+    /**
      * Indicates if notifications should be serialized and restored when pushed to the queue.
      *
      * @var bool
@@ -401,5 +408,26 @@ class NotificationFake implements Fake, NotificationDispatcher, NotificationFact
     public function sentNotifications()
     {
         return $this->notifications;
+    }
+
+    /**
+     * Get the default channel driver name.
+     *
+     * @return string
+     */
+    public function deliversVia()
+    {
+        return $this->defaultChannel ?? 'mail';
+    }
+
+    /**
+     * Set the default channel driver name.
+     *
+     * @param  string  $channel
+     * @return void
+     */
+    public function deliverVia($channel)
+    {
+        $this->defaultChannel = $channel;
     }
 }

--- a/tests/Support/SupportTestingNotificationFakeTest.php
+++ b/tests/Support/SupportTestingNotificationFakeTest.php
@@ -233,6 +233,15 @@ class SupportTestingNotificationFakeTest extends TestCase
             return $notification->value === 'hello-serialized-unserialized';
         });
     }
+
+    public function testDeliverViaAndDeliversVia()
+    {
+        $this->assertSame('mail', $this->fake->deliversVia());
+
+        $this->fake->deliverVia('database');
+
+        $this->assertSame('database', $this->fake->deliversVia());
+    }
 }
 
 class NotificationStub extends Notification


### PR DESCRIPTION
## Summary

`ChannelManager` has `deliverVia()` and `deliversVia()` methods for setting and getting the default notification channel. These are documented on the `Notification` facade but missing from `NotificationFake`, causing errors when test code calls these methods after faking.

### The Problem

```php
Notification::fake();

// This throws: method does not exist on NotificationFake
Notification::deliverVia('database');
```

This is the same type of issue that #59448 fixed for `MailFake` — the real manager class has methods that the fake doesn't, breaking tests.

### The Fix

Add both methods to `NotificationFake`:

```php
Notification::fake();

Notification::deliverVia('database'); // now works
Notification::deliversVia();          // returns 'database'
```

### Precedent

PR #59448 merged the same pattern — adding `driver()` to `MailFake` because `MailManager` had it but the fake didn't.

### Changes

- `src/Illuminate/Support/Testing/Fakes/NotificationFake.php` — Add `deliverVia()`, `deliversVia()`, and `$defaultChannel` property
- `tests/Support/SupportTestingNotificationFakeTest.php` — Test both methods

## Test Plan

- [x] `testDeliverViaAndDeliversVia` — Set and get default channel
- [x] All 18 existing NotificationFake tests pass