### PR TITLE
[12.x] Support string abstract in mock/partialMock/spy PHPDoc

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
@@ -68,9 +68,9 @@ trait InteractsWithContainer
      *
      * @template TInstance of object
      *
-     * @param  class-string<TInstance>  $abstract
+     * @param  string|class-string<TInstance>  $abstract
      * @param  \Closure|null  $mock
-     * @return TInstance&\Mockery\MockInterface
+     * @return ($abstract is class-string<TInstance> ? TInstance&\Mockery\MockInterface : \Mockery\MockInterface)
      */
     protected function mock($abstract, ?Closure $mock = null)
     {
@@ -82,9 +82,9 @@ trait InteractsWithContainer
      *
      * @template TInstance of object
      *
-     * @param  class-string<TInstance>  $abstract
+     * @param  string|class-string<TInstance>  $abstract
      * @param  \Closure|null  $mock
-     * @return TInstance&\Mockery\MockInterface
+     * @return ($abstract is class-string<TInstance> ? TInstance&\Mockery\MockInterface : \Mockery\MockInterface)
      */
     protected function partialMock($abstract, ?Closure $mock = null)
     {
@@ -96,9 +96,9 @@ trait InteractsWithContainer
      *
      * @template TInstance of object
      *
-     * @param  class-string<TInstance>  $abstract
+     * @param  string|class-string<TInstance>  $abstract
      * @param  \Closure|null  $mock
-     * @return TInstance&\Mockery\MockInterface
+     * @return ($abstract is class-string<TInstance> ? TInstance&\Mockery\MockInterface : \Mockery\MockInterface)
      */
     protected function spy($abstract, ?Closure $mock = null)
     {

--- a/types/Foundation/Testing/InteractsWithContainer.php
+++ b/types/Foundation/Testing/InteractsWithContainer.php
@@ -4,7 +4,6 @@ namespace Illuminate\Types\Foundation\Testing;
 
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithContainer;
-use Mockery\MockInterface;
 use User;
 
 use function PHPStan\Testing\assertType;
@@ -18,13 +17,16 @@ class InteractsWithContainerTestCase
     public function test(): void
     {
         assertType('Mockery\MockInterface&User', $this->mock(User::class));
-        assertType('Mockery\MockInterface&User', $this->mock(User::class, function ($mock) {}));
+        assertType('Mockery\MockInterface&User', $this->mock(User::class, function ($mock) {
+        }));
 
         assertType('Mockery\MockInterface&User', $this->partialMock(User::class));
-        assertType('Mockery\MockInterface&User', $this->partialMock(User::class, function ($mock) {}));
+        assertType('Mockery\MockInterface&User', $this->partialMock(User::class, function ($mock) {
+        }));
 
         assertType('Mockery\MockInterface&User', $this->spy(User::class));
-        assertType('Mockery\MockInterface&User', $this->spy(User::class, function ($mock) {}));
+        assertType('Mockery\MockInterface&User', $this->spy(User::class, function ($mock) {
+        }));
 
         assertType('Mockery\MockInterface', $this->mock('my.service'));
         assertType('Mockery\MockInterface', $this->partialMock('my.service'));

--- a/types/Foundation/Testing/InteractsWithContainer.php
+++ b/types/Foundation/Testing/InteractsWithContainer.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Illuminate\Types\Foundation\Testing;
+
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Foundation\Testing\Concerns\InteractsWithContainer;
+use Mockery\MockInterface;
+use User;
+
+use function PHPStan\Testing\assertType;
+
+class InteractsWithContainerTestCase
+{
+    use InteractsWithContainer;
+
+    protected Application $app;
+
+    public function test(): void
+    {
+        assertType('Mockery\MockInterface&User', $this->mock(User::class));
+        assertType('Mockery\MockInterface&User', $this->mock(User::class, function ($mock) {}));
+
+        assertType('Mockery\MockInterface&User', $this->partialMock(User::class));
+        assertType('Mockery\MockInterface&User', $this->partialMock(User::class, function ($mock) {}));
+
+        assertType('Mockery\MockInterface&User', $this->spy(User::class));
+        assertType('Mockery\MockInterface&User', $this->spy(User::class, function ($mock) {}));
+
+        assertType('Mockery\MockInterface', $this->mock('my.service'));
+        assertType('Mockery\MockInterface', $this->partialMock('my.service'));
+        assertType('Mockery\MockInterface', $this->spy('my.service'));
+    }
+}


### PR DESCRIPTION
This is a follow-up to #59353.

While #59353 improved the return type for `mock()`, `partialMock()`, and `spy()` when using `class-string`, it restricted the `$abstract` parameter to only accept `class-string<TInstance>`, which causes PHPStan errors when passing plain string aliases — a common pattern in Laravel:

```php
$this->app->bind('my.service', fn () => new MyService());

// PHPStan error: Parameter #1 $abstract expects class-string<my.service>, 'my.service' given
$this->mock('my.service', function ($mock) {
    $mock->shouldReceive('doSomething')->andReturn(true);
});
```

This PR updates the `@param` to `string|class-string<TInstance>` and uses conditional return types (consistent with `Container::make()`, `Container::makeWith()`, etc.) so that:

- **`class-string` input** → returns `TInstance & MockInterface` (preserving the DX win from #59353)
- **plain `string` input** → returns `MockInterface` (backward compatible)

Also adds PHPStan type assertion tests to verify both cases.