### PR TITLE
[13.x] Add whereStartsWith, whereEndsWith, and whereContains query shortcuts

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -246,12 +246,39 @@ class Builder implements BuilderContract
      * @var string[]
      */
     public $operators = [
-        '=', '<', '>', '<=', '>=', '<>', '!=', '<=>',
-        'like', 'like binary', 'not like', 'ilike',
-        '&', '|', '^', '<<', '>>', '&~', 'is', 'is not',
-        'rlike', 'not rlike', 'regexp', 'not regexp',
-        '~', '~*', '!~', '!~*', 'similar to',
-        'not similar to', 'not ilike', '~~*', '!~~*',
+        '=',
+        '<',
+        '>',
+        '<=',
+        '>=',
+        '<>',
+        '!=',
+        '<=>',
+        'like',
+        'like binary',
+        'not like',
+        'ilike',
+        '&',
+        '|',
+        '^',
+        '<<',
+        '>>',
+        '&~',
+        'is',
+        'is not',
+        'rlike',
+        'not rlike',
+        'regexp',
+        'not regexp',
+        '~',
+        '~*',
+        '!~',
+        '!~*',
+        'similar to',
+        'not similar to',
+        'not ilike',
+        '~~*',
+        '!~~*',
     ];
 
     /**
@@ -260,7 +287,12 @@ class Builder implements BuilderContract
      * @var string[]
      */
     public $bitwiseOperators = [
-        '&', '|', '^', '<<', '>>', '&~',
+        '&',
+        '|',
+        '^',
+        '<<',
+        '>>',
+        '&~',
     ];
 
     /**
@@ -328,7 +360,8 @@ class Builder implements BuilderContract
         [$query, $bindings] = $this->createSub($query);
 
         return $this->selectRaw(
-            '('.$query.') as '.$this->grammar->wrap($as), $bindings
+            '(' . $query . ') as ' . $this->grammar->wrap($as),
+            $bindings
         );
     }
 
@@ -342,7 +375,7 @@ class Builder implements BuilderContract
     public function selectExpression($expression, $as)
     {
         return $this->selectRaw(
-            '('.$this->grammar->getValue($expression).') as '.$this->grammar->wrap($as)
+            '(' . $this->grammar->getValue($expression) . ') as ' . $this->grammar->wrap($as)
         );
     }
 
@@ -376,7 +409,7 @@ class Builder implements BuilderContract
     {
         [$query, $bindings] = $this->createSub($query);
 
-        return $this->fromRaw('('.$query.') as '.$this->grammar->wrapTable($as), $bindings);
+        return $this->fromRaw('(' . $query . ') as ' . $this->grammar->wrapTable($as), $bindings);
     }
 
     /**
@@ -446,12 +479,14 @@ class Builder implements BuilderContract
      */
     protected function prependDatabaseNameIfCrossDatabaseQuery($query)
     {
-        if ($query->getConnection()->getDatabaseName() !==
-            $this->getConnection()->getDatabaseName()) {
+        if (
+            $query->getConnection()->getDatabaseName() !==
+            $this->getConnection()->getDatabaseName()
+        ) {
             $databaseName = $query->getConnection()->getDatabaseName();
 
-            if (! str_starts_with($query->from, $databaseName) && ! str_contains($query->from, '.')) {
-                $query->from($databaseName.'.'.$query->from);
+            if (!str_starts_with($query->from, $databaseName) && !str_contains($query->from, '.')) {
+                $query->from($databaseName . '.' . $query->from);
             }
         }
 
@@ -471,7 +506,7 @@ class Builder implements BuilderContract
         foreach ($columns as $as => $column) {
             if (is_string($as) && $this->isQueryable($column)) {
                 if (is_null($this->columns)) {
-                    $this->select($this->from.'.*');
+                    $this->select($this->from . '.*');
                 }
 
                 $this->selectSub($column, $as);
@@ -506,14 +541,14 @@ class Builder implements BuilderContract
         $this->addBinding(
             json_encode(
                 $vector instanceof Arrayable
-                    ? $vector->toArray()
-                    : $vector,
+                ? $vector->toArray()
+                : $vector,
                 flags: JSON_THROW_ON_ERROR
             ),
             'select',
         );
 
-        $as = $this->getGrammar()->wrap($as ?? $column.'_distance');
+        $as = $this->getGrammar()->wrap($as ?? $column . '_distance');
 
         return $this->addSelect(
             new Expression("({$this->getGrammar()->wrap($column)} <=> ?) as {$as}")
@@ -668,7 +703,7 @@ class Builder implements BuilderContract
     {
         [$query, $bindings] = $this->createSub($query);
 
-        $expression = '('.$query.') as '.$this->grammar->wrapTable($as);
+        $expression = '(' . $query . ') as ' . $this->grammar->wrapTable($as);
 
         $this->addBinding($bindings, 'join');
 
@@ -685,7 +720,7 @@ class Builder implements BuilderContract
     {
         [$query, $bindings] = $this->createSub($query);
 
-        $expression = '('.$query.') as '.$this->grammar->wrapTable($as);
+        $expression = '(' . $query . ') as ' . $this->grammar->wrapTable($as);
 
         $this->addBinding($bindings, 'join');
 
@@ -822,7 +857,7 @@ class Builder implements BuilderContract
     {
         [$query, $bindings] = $this->createSub($query);
 
-        $expression = '('.$query.') as '.$this->grammar->wrapTable($as);
+        $expression = '(' . $query . ') as ' . $this->grammar->wrapTable($as);
 
         $this->addBinding($bindings, 'join');
 
@@ -946,7 +981,9 @@ class Builder implements BuilderContract
         // passed to the method, we will assume that the operator is an equals sign
         // and keep going. Otherwise, we'll require the operator to be passed in.
         [$value, $operator] = $this->prepareValueAndOperator(
-            $value, $operator, func_num_args() === 2
+            $value,
+            $operator,
+            func_num_args() === 2
         );
 
         // If the column is actually a Closure instance, we will assume the developer
@@ -959,11 +996,11 @@ class Builder implements BuilderContract
         // If the column is a Closure instance and there is an operator value, we will
         // assume the developer wants to run a subquery and then compare the result
         // of that subquery with the given value that was provided to the method.
-        if ($this->isQueryable($column) && ! is_null($operator)) {
+        if ($this->isQueryable($column) && !is_null($operator)) {
             [$sub, $bindings] = $this->createSub($column);
 
             return $this->addBinding($bindings, 'where')
-                ->where(new Expression('('.$sub.')'), $operator, $value, $boolean);
+                ->where(new Expression('(' . $sub . ')'), $operator, $value, $boolean);
         }
 
         // If the given operator is not found in the list of valid operators we will
@@ -984,7 +1021,7 @@ class Builder implements BuilderContract
         // where null clause to the query. So, we will allow a short-cut here to
         // that method for convenience so the developer doesn't have to check.
         if (is_null($value)) {
-            return $this->whereNull($column, $boolean, ! in_array($operator, ['=', '<=>'], true));
+            return $this->whereNull($column, $boolean, !in_array($operator, ['=', '<=>'], true));
         }
 
         $type = 'Basic';
@@ -1016,10 +1053,14 @@ class Builder implements BuilderContract
         // in our array and add the query binding to our array of bindings that
         // will be bound to each SQL statements when it is finally executed.
         $this->wheres[] = compact(
-            'type', 'column', 'operator', 'value', 'boolean'
+            'type',
+            'column',
+            'operator',
+            'value',
+            'boolean'
         );
 
-        if (! $value instanceof ExpressionContract) {
+        if (!$value instanceof ExpressionContract) {
             $this->addBinding($this->flattenValue($value), 'where');
         }
 
@@ -1080,7 +1121,7 @@ class Builder implements BuilderContract
     protected function invalidOperatorAndValue($operator, $value)
     {
         return is_null($value) && in_array($operator, $this->operators) &&
-             ! in_array($operator, ['=', '<=>', '<>', '!=']);
+            !in_array($operator, ['=', '<=>', '<>', '!=']);
     }
 
     /**
@@ -1091,8 +1132,8 @@ class Builder implements BuilderContract
      */
     protected function invalidOperator($operator)
     {
-        return ! is_string($operator) || (! in_array(strtolower($operator), $this->operators, true) &&
-               ! in_array(strtolower($operator), $this->grammar->getOperators(), true));
+        return !is_string($operator) || (!in_array(strtolower($operator), $this->operators, true) &&
+            !in_array(strtolower($operator), $this->grammar->getOperators(), true));
     }
 
     /**
@@ -1104,7 +1145,7 @@ class Builder implements BuilderContract
     protected function isBitwiseOperator($operator)
     {
         return in_array(strtolower($operator), $this->bitwiseOperators, true) ||
-               in_array(strtolower($operator), $this->grammar->getBitwiseOperators(), true);
+            in_array(strtolower($operator), $this->grammar->getBitwiseOperators(), true);
     }
 
     /**
@@ -1118,7 +1159,9 @@ class Builder implements BuilderContract
     public function orWhere($column, $operator = null, $value = null)
     {
         [$value, $operator] = $this->prepareValueAndOperator(
-            $value, $operator, func_num_args() === 2
+            $value,
+            $operator,
+            func_num_args() === 2
         );
 
         return $this->where($column, $operator, $value, 'or');
@@ -1138,10 +1181,10 @@ class Builder implements BuilderContract
         if (is_array($column)) {
             return $this->whereNested(function ($query) use ($column, $operator, $value, $boolean) {
                 $query->where($column, $operator, $value, $boolean);
-            }, $boolean.' not');
+            }, $boolean . ' not');
         }
 
-        return $this->where($column, $operator, $value, $boolean.' not');
+        return $this->where($column, $operator, $value, $boolean . ' not');
     }
 
     /**
@@ -1188,7 +1231,11 @@ class Builder implements BuilderContract
         $type = 'Column';
 
         $this->wheres[] = compact(
-            'type', 'first', 'operator', 'second', 'boolean'
+            'type',
+            'first',
+            'operator',
+            'second',
+            'boolean'
         );
 
         return $this;
@@ -1253,8 +1300,8 @@ class Builder implements BuilderContract
             [
                 json_encode(
                     $vector instanceof Arrayable
-                        ? $vector->toArray()
-                        : $vector,
+                    ? $vector->toArray()
+                    : $vector,
                     flags: JSON_THROW_ON_ERROR
                 ),
                 $maxDistance,
@@ -1371,6 +1418,171 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Add a "where starts with" clause to the query.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  string  $value
+     * @param  bool  $caseSensitive
+     * @param  string  $boolean
+     * @param  bool  $not
+     * @return $this
+     */
+    public function whereStartsWith($column, $value, $caseSensitive = false, $boolean = 'and', $not = false)
+    {
+        return $this->whereLike($column, $value . '%', $caseSensitive, $boolean, $not);
+    }
+
+    /**
+     * Add an "or where starts with" clause to the query.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  string  $value
+     * @param  bool  $caseSensitive
+     * @return $this
+     */
+    public function orWhereStartsWith($column, $value, $caseSensitive = false)
+    {
+        return $this->whereStartsWith($column, $value, $caseSensitive, 'or');
+    }
+
+    /**
+     * Add a "where ends with" clause to the query.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  string  $value
+     * @param  bool  $caseSensitive
+     * @param  string  $boolean
+     * @param  bool  $not
+     * @return $this
+     */
+    public function whereEndsWith($column, $value, $caseSensitive = false, $boolean = 'and', $not = false)
+    {
+        return $this->whereLike($column, '%' . $value, $caseSensitive, $boolean, $not);
+    }
+
+    /**
+     * Add an "or where ends with" clause to the query.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  string  $value
+     * @param  bool  $caseSensitive
+     * @return $this
+     */
+    public function orWhereEndsWith($column, $value, $caseSensitive = false)
+    {
+        return $this->whereEndsWith($column, $value, $caseSensitive, 'or');
+    }
+
+    /**
+     * Add a "where contains" clause to the query.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  string  $value
+     * @param  bool  $caseSensitive
+     * @param  string  $boolean
+     * @param  bool  $not
+     * @return $this
+     */
+    public function whereContains($column, $value, $caseSensitive = false, $boolean = 'and', $not = false)
+    {
+        return $this->whereLike($column, '%' . $value . '%', $caseSensitive, $boolean, $not);
+    }
+
+    /**
+     * Add an "or where contains" clause to the query.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  string  $value
+     * @param  bool  $caseSensitive
+     * @return $this
+     */
+    public function orWhereContains($column, $value, $caseSensitive = false)
+    {
+        return $this->whereContains($column, $value, $caseSensitive, 'or');
+    }
+
+    /**
+     * Add a "where not starts with" clause to the query.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  string  $value
+     * @param  bool  $caseSensitive
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereNotStartsWith($column, $value, $caseSensitive = false, $boolean = 'and')
+    {
+        return $this->whereStartsWith($column, $value, $caseSensitive, $boolean, true);
+    }
+
+    /**
+     * Add an "or where not starts with" clause to the query.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  string  $value
+     * @param  bool  $caseSensitive
+     * @return $this
+     */
+    public function orWhereNotStartsWith($column, $value, $caseSensitive = false)
+    {
+        return $this->whereNotStartsWith($column, $value, $caseSensitive, 'or');
+    }
+
+    /**
+     * Add a "where not ends with" clause to the query.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  string  $value
+     * @param  bool  $caseSensitive
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereNotEndsWith($column, $value, $caseSensitive = false, $boolean = 'and')
+    {
+        return $this->whereEndsWith($column, $value, $caseSensitive, $boolean, true);
+    }
+
+    /**
+     * Add an "or where not ends with" clause to the query.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  string  $value
+     * @param  bool  $caseSensitive
+     * @return $this
+     */
+    public function orWhereNotEndsWith($column, $value, $caseSensitive = false)
+    {
+        return $this->whereNotEndsWith($column, $value, $caseSensitive, 'or');
+    }
+
+    /**
+     * Add a "where not contains" clause to the query.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  string  $value
+     * @param  bool  $caseSensitive
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereNotContains($column, $value, $caseSensitive = false, $boolean = 'and')
+    {
+        return $this->whereContains($column, $value, $caseSensitive, $boolean, true);
+    }
+
+    /**
+     * Add an "or where not contains" clause to the query.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  string  $value
+     * @param  bool  $caseSensitive
+     * @return $this
+     */
+    public function orWhereNotContains($column, $value, $caseSensitive = false)
+    {
+        return $this->whereNotContains($column, $value, $caseSensitive, 'or');
+    }
+
+    /**
      * Add a "where null safe equals" clause to the query.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
@@ -1384,7 +1596,7 @@ class Builder implements BuilderContract
 
         $this->wheres[] = compact('type', 'column', 'value', 'boolean');
 
-        if (! $value instanceof ExpressionContract) {
+        if (!$value instanceof ExpressionContract) {
             $this->addBinding($this->flattenValue($value), 'where');
         }
 
@@ -1610,7 +1822,7 @@ class Builder implements BuilderContract
             [$sub, $bindings] = $this->createSub($column);
 
             return $this->addBinding($bindings, 'where')
-                ->whereBetween(new Expression('('.$sub.')'), $values, $boolean, $not);
+                ->whereBetween(new Expression('(' . $sub . ')'), $values, $boolean, $not);
         }
 
         if ($values instanceof DatePeriod) {
@@ -1640,7 +1852,7 @@ class Builder implements BuilderContract
             [$sub, $bindings] = $this->createSub($column);
 
             return $this->addBinding($bindings, 'where')
-                ->whereBetweenColumns(new Expression('('.$sub.')'), $values, $boolean, $not);
+                ->whereBetweenColumns(new Expression('(' . $sub . ')'), $values, $boolean, $not);
         }
 
         $this->wheres[] = compact('type', 'column', 'values', 'boolean', 'not');
@@ -1796,7 +2008,9 @@ class Builder implements BuilderContract
     public function whereDate($column, $operator, $value = null, $boolean = 'and')
     {
         [$value, $operator] = $this->prepareValueAndOperator(
-            $value, $operator, func_num_args() === 2
+            $value,
+            $operator,
+            func_num_args() === 2
         );
 
         // If the given operator is not found in the list of valid operators we will
@@ -1826,7 +2040,9 @@ class Builder implements BuilderContract
     public function orWhereDate($column, $operator, $value = null)
     {
         [$value, $operator] = $this->prepareValueAndOperator(
-            $value, $operator, func_num_args() === 2
+            $value,
+            $operator,
+            func_num_args() === 2
         );
 
         return $this->whereDate($column, $operator, $value, 'or');
@@ -1844,7 +2060,9 @@ class Builder implements BuilderContract
     public function whereTime($column, $operator, $value = null, $boolean = 'and')
     {
         [$value, $operator] = $this->prepareValueAndOperator(
-            $value, $operator, func_num_args() === 2
+            $value,
+            $operator,
+            func_num_args() === 2
         );
 
         // If the given operator is not found in the list of valid operators we will
@@ -1874,7 +2092,9 @@ class Builder implements BuilderContract
     public function orWhereTime($column, $operator, $value = null)
     {
         [$value, $operator] = $this->prepareValueAndOperator(
-            $value, $operator, func_num_args() === 2
+            $value,
+            $operator,
+            func_num_args() === 2
         );
 
         return $this->whereTime($column, $operator, $value, 'or');
@@ -1892,7 +2112,9 @@ class Builder implements BuilderContract
     public function whereDay($column, $operator, $value = null, $boolean = 'and')
     {
         [$value, $operator] = $this->prepareValueAndOperator(
-            $value, $operator, func_num_args() === 2
+            $value,
+            $operator,
+            func_num_args() === 2
         );
 
         // If the given operator is not found in the list of valid operators we will
@@ -1908,7 +2130,7 @@ class Builder implements BuilderContract
             $value = $value->format('d');
         }
 
-        if (! $value instanceof ExpressionContract) {
+        if (!$value instanceof ExpressionContract) {
             $value = sprintf('%02d', $value);
         }
 
@@ -1926,7 +2148,9 @@ class Builder implements BuilderContract
     public function orWhereDay($column, $operator, $value = null)
     {
         [$value, $operator] = $this->prepareValueAndOperator(
-            $value, $operator, func_num_args() === 2
+            $value,
+            $operator,
+            func_num_args() === 2
         );
 
         return $this->whereDay($column, $operator, $value, 'or');
@@ -1944,7 +2168,9 @@ class Builder implements BuilderContract
     public function whereMonth($column, $operator, $value = null, $boolean = 'and')
     {
         [$value, $operator] = $this->prepareValueAndOperator(
-            $value, $operator, func_num_args() === 2
+            $value,
+            $operator,
+            func_num_args() === 2
         );
 
         // If the given operator is not found in the list of valid operators we will
@@ -1960,7 +2186,7 @@ class Builder implements BuilderContract
             $value = $value->format('m');
         }
 
-        if (! $value instanceof ExpressionContract) {
+        if (!$value instanceof ExpressionContract) {
             $value = sprintf('%02d', $value);
         }
 
@@ -1978,7 +2204,9 @@ class Builder implements BuilderContract
     public function orWhereMonth($column, $operator, $value = null)
     {
         [$value, $operator] = $this->prepareValueAndOperator(
-            $value, $operator, func_num_args() === 2
+            $value,
+            $operator,
+            func_num_args() === 2
         );
 
         return $this->whereMonth($column, $operator, $value, 'or');
@@ -1996,7 +2224,9 @@ class Builder implements BuilderContract
     public function whereYear($column, $operator, $value = null, $boolean = 'and')
     {
         [$value, $operator] = $this->prepareValueAndOperator(
-            $value, $operator, func_num_args() === 2
+            $value,
+            $operator,
+            func_num_args() === 2
         );
 
         // If the given operator is not found in the list of valid operators we will
@@ -2026,7 +2256,9 @@ class Builder implements BuilderContract
     public function orWhereYear($column, $operator, $value = null)
     {
         [$value, $operator] = $this->prepareValueAndOperator(
-            $value, $operator, func_num_args() === 2
+            $value,
+            $operator,
+            func_num_args() === 2
         );
 
         return $this->whereYear($column, $operator, $value, 'or');
@@ -2046,7 +2278,7 @@ class Builder implements BuilderContract
     {
         $this->wheres[] = compact('column', 'type', 'boolean', 'operator', 'value');
 
-        if (! $value instanceof ExpressionContract) {
+        if (!$value instanceof ExpressionContract) {
             $this->addBinding($value, 'where');
         }
 
@@ -2119,7 +2351,11 @@ class Builder implements BuilderContract
         }
 
         $this->wheres[] = compact(
-            'type', 'column', 'operator', 'query', 'boolean'
+            'type',
+            'column',
+            'operator',
+            'query',
+            'boolean'
         );
 
         $this->addBinding($query->getBindings(), 'where');
@@ -2258,7 +2494,7 @@ class Builder implements BuilderContract
 
         $this->wheres[] = compact('type', 'column', 'value', 'boolean', 'not');
 
-        if (! $value instanceof ExpressionContract) {
+        if (!$value instanceof ExpressionContract) {
             $this->addBinding($this->grammar->prepareBindingForJsonContains($value));
         }
 
@@ -2317,7 +2553,7 @@ class Builder implements BuilderContract
 
         $this->wheres[] = compact('type', 'column', 'value', 'boolean', 'not');
 
-        if (! $value instanceof ExpressionContract) {
+        if (!$value instanceof ExpressionContract) {
             $this->addBinding($this->grammar->prepareBindingForJsonContains($value));
         }
 
@@ -2426,7 +2662,9 @@ class Builder implements BuilderContract
         $type = 'JsonLength';
 
         [$value, $operator] = $this->prepareValueAndOperator(
-            $value, $operator, func_num_args() === 2
+            $value,
+            $operator,
+            func_num_args() === 2
         );
 
         // If the given operator is not found in the list of valid operators we will
@@ -2438,7 +2676,7 @@ class Builder implements BuilderContract
 
         $this->wheres[] = compact('type', 'column', 'operator', 'value', 'boolean');
 
-        if (! $value instanceof ExpressionContract) {
+        if (!$value instanceof ExpressionContract) {
             $this->addBinding((int) $this->flattenValue($value));
         }
 
@@ -2456,7 +2694,9 @@ class Builder implements BuilderContract
     public function orWhereJsonLength($column, $operator, $value = null)
     {
         [$value, $operator] = $this->prepareValueAndOperator(
-            $value, $operator, func_num_args() === 2
+            $value,
+            $operator,
+            func_num_args() === 2
         );
 
         return $this->whereJsonLength($column, $operator, $value, 'or');
@@ -2474,7 +2714,10 @@ class Builder implements BuilderContract
         $finder = substr($method, 5);
 
         $segments = preg_split(
-            '/(And|Or)(?=[A-Z])/', $finder, -1, PREG_SPLIT_DELIM_CAPTURE
+            '/(And|Or)(?=[A-Z])/',
+            $finder,
+            -1,
+            PREG_SPLIT_DELIM_CAPTURE
         );
 
         // The connector variable will determine which connector will be used for the
@@ -2569,7 +2812,9 @@ class Builder implements BuilderContract
     public function whereAll($columns, $operator = null, $value = null, $boolean = 'and')
     {
         [$value, $operator] = $this->prepareValueAndOperator(
-            $value, $operator, func_num_args() === 2
+            $value,
+            $operator,
+            func_num_args() === 2
         );
 
         $this->whereNested(function ($query) use ($columns, $operator, $value) {
@@ -2606,7 +2851,9 @@ class Builder implements BuilderContract
     public function whereAny($columns, $operator = null, $value = null, $boolean = 'and')
     {
         [$value, $operator] = $this->prepareValueAndOperator(
-            $value, $operator, func_num_args() === 2
+            $value,
+            $operator,
+            func_num_args() === 2
         );
 
         $this->whereNested(function ($query) use ($columns, $operator, $value) {
@@ -2642,7 +2889,7 @@ class Builder implements BuilderContract
      */
     public function whereNone($columns, $operator = null, $value = null, $boolean = 'and')
     {
-        return $this->whereAny($columns, $operator, $value, $boolean.' not');
+        return $this->whereAny($columns, $operator, $value, $boolean . ' not');
     }
 
     /**
@@ -2716,7 +2963,9 @@ class Builder implements BuilderContract
         // passed to the method, we will assume that the operator is an equals sign
         // and keep going. Otherwise, we'll require the operator to be passed in.
         [$value, $operator] = $this->prepareValueAndOperator(
-            $value, $operator, func_num_args() === 2
+            $value,
+            $operator,
+            func_num_args() === 2
         );
 
         if ($column instanceof Closure && is_null($operator)) {
@@ -2736,7 +2985,7 @@ class Builder implements BuilderContract
 
         $this->havings[] = compact('type', 'column', 'operator', 'value', 'boolean');
 
-        if (! $value instanceof ExpressionContract) {
+        if (!$value instanceof ExpressionContract) {
             $this->addBinding($this->flattenValue($value), 'having');
         }
 
@@ -2754,7 +3003,9 @@ class Builder implements BuilderContract
     public function orHaving($column, $operator = null, $value = null)
     {
         [$value, $operator] = $this->prepareValueAndOperator(
-            $value, $operator, func_num_args() === 2
+            $value,
+            $operator,
+            func_num_args() === 2
         );
 
         return $this->having($column, $operator, $value, 'or');
@@ -2972,14 +3223,14 @@ class Builder implements BuilderContract
         if ($this->isQueryable($column)) {
             [$query, $bindings] = $this->createSub($column);
 
-            $column = new Expression('('.$query.')');
+            $column = new Expression('(' . $query . ')');
 
             $this->addBinding($bindings, $this->unions ? 'unionOrder' : 'order');
         }
 
         $direction = strtolower($direction);
 
-        if (! in_array($direction, ['asc', 'desc'], true)) {
+        if (!in_array($direction, ['asc', 'desc'], true)) {
             throw new InvalidArgumentException('Order direction must be "asc" or "desc".');
         }
 
@@ -3042,8 +3293,8 @@ class Builder implements BuilderContract
         $this->addBinding(
             json_encode(
                 $vector instanceof Arrayable
-                    ? $vector->toArray()
-                    : $vector,
+                ? $vector->toArray()
+                : $vector,
                 flags: JSON_THROW_ON_ERROR
             ),
             $this->unions ? 'unionOrder' : 'order'
@@ -3164,7 +3415,7 @@ class Builder implements BuilderContract
         $property = $this->unions ? 'unionLimit' : 'limit';
 
         if ($value >= 0) {
-            $this->$property = ! is_null($value) ? (int) $value : null;
+            $this->$property = !is_null($value) ? (int) $value : null;
         }
 
         return $this;
@@ -3283,7 +3534,7 @@ class Builder implements BuilderContract
     protected function removeExistingOrdersFor($column)
     {
         return (new Collection($this->orders))
-            ->reject(fn ($order) => isset($order['column']) && $order['column'] === $column)
+            ->reject(fn($order) => isset($order['column']) && $order['column'] === $column)
             ->values()
             ->all();
     }
@@ -3329,7 +3580,7 @@ class Builder implements BuilderContract
     {
         $this->lock = $value;
 
-        if (! is_null($this->lock)) {
+        if (!is_null($this->lock)) {
             $this->useWritePdo();
         }
 
@@ -3448,7 +3699,8 @@ class Builder implements BuilderContract
     public function toRawSql()
     {
         return $this->grammar->substituteBindingsIntoRawSql(
-            $this->toSql(), $this->connection->prepareBindings($this->getBindings())
+            $this->toSql(),
+            $this->connection->prepareBindings($this->getBindings())
         );
     }
 
@@ -3482,7 +3734,7 @@ class Builder implements BuilderContract
             $columns = ['*'];
         }
 
-        if (! is_null($data = $this->find($id, $columns))) {
+        if (!is_null($data = $this->find($id, $columns))) {
             return $data;
         }
 
@@ -3560,7 +3812,10 @@ class Builder implements BuilderContract
     protected function runSelect()
     {
         return $this->connection->select(
-            $this->toSql(), $this->getBindings(), ! $this->useWritePdo, $this->fetchUsing
+            $this->toSql(),
+            $this->getBindings(),
+            !$this->useWritePdo,
+            $this->fetchUsing
         );
     }
 
@@ -3577,8 +3832,8 @@ class Builder implements BuilderContract
         if (is_string($this->groupLimit['column'])) {
             $column = last(explode('.', $this->groupLimit['column']));
 
-            $keysToRemove[] = '@laravel_group := '.$this->grammar->wrap($column);
-            $keysToRemove[] = '@laravel_group := '.$this->grammar->wrap('pivot_'.$column);
+            $keysToRemove[] = '@laravel_group := ' . $this->grammar->wrap($column);
+            $keysToRemove[] = '@laravel_group := ' . $this->grammar->wrap('pivot_' . $column);
         }
 
         $items->each(function ($item) use ($keysToRemove) {
@@ -3668,7 +3923,7 @@ class Builder implements BuilderContract
         }
 
         $reverseDirection = function ($order) {
-            if (! isset($order['direction'])) {
+            if (!isset($order['direction'])) {
                 return $order;
             }
 
@@ -3682,10 +3937,10 @@ class Builder implements BuilderContract
             $this->unionOrders = (new Collection($this->unionOrders))->map($reverseDirection)->toArray();
         }
 
-        $orders = ! empty($this->unionOrders) ? $this->unionOrders : $this->orders;
+        $orders = !empty($this->unionOrders) ? $this->unionOrders : $this->orders;
 
         return (new Collection($orders))
-            ->filter(fn ($order) => Arr::has($order, 'direction'))
+            ->filter(fn($order) => Arr::has($order, 'direction'))
             ->values();
     }
 
@@ -3702,7 +3957,7 @@ class Builder implements BuilderContract
         // Once we have run the pagination count query, we will get the resulting count and
         // take into account what type of query it was. When there is a group by we will
         // just return the count of the entire results set since that will be correct.
-        if (! isset($results[0])) {
+        if (!isset($results[0])) {
             return 0;
         } elseif (is_object($results[0])) {
             return (int) $results[0]->aggregate;
@@ -3722,12 +3977,12 @@ class Builder implements BuilderContract
         if ($this->groups || $this->havings) {
             $clone = $this->cloneForPaginationCount();
 
-            if (is_null($clone->columns) && ! empty($this->joins)) {
-                $clone->select($this->from.'.*');
+            if (is_null($clone->columns) && !empty($this->joins)) {
+                $clone->select($this->from . '.*');
             }
 
             return $this->newQuery()
-                ->from(new Expression('('.$clone->toSql().') as '.$this->grammar->wrap('aggregate_table')))
+                ->from(new Expression('(' . $clone->toSql() . ') as ' . $this->grammar->wrap('aggregate_table')))
                 ->mergeBindings($clone)
                 ->setAggregate('count', $this->withoutSelectAliases($columns))
                 ->get()->all();
@@ -3780,11 +4035,14 @@ class Builder implements BuilderContract
 
         return (new LazyCollection(function () {
             yield from $this->connection->cursor(
-                $this->toSql(), $this->getBindings(), ! $this->useWritePdo, $this->fetchUsing
+                $this->toSql(),
+                $this->getBindings(),
+                !$this->useWritePdo,
+                $this->fetchUsing
             );
         }))->map(function ($item) {
             return $this->applyAfterQueryCallbacks(new Collection([$item]))->first();
-        })->reject(fn ($item) => is_null($item));
+        })->reject(fn($item) => is_null($item));
     }
 
     /**
@@ -3836,8 +4094,8 @@ class Builder implements BuilderContract
 
         return $this->applyAfterQueryCallbacks(
             is_array($queryResult[0])
-                ? $this->pluckFromArrayColumn($queryResult, $column, $key)
-                : $this->pluckFromObjectColumn($queryResult, $column, $key)
+            ? $this->pluckFromArrayColumn($queryResult, $column, $key)
+            : $this->pluckFromObjectColumn($queryResult, $column, $key)
         );
     }
 
@@ -3859,7 +4117,7 @@ class Builder implements BuilderContract
 
         $separator = str_contains(strtolower($columnString), ' as ') ? ' as ' : '\.';
 
-        return last(preg_split('~'.$separator.'~i', $columnString));
+        return last(preg_split('~' . $separator . '~i', $columnString));
     }
 
     /**
@@ -3934,7 +4192,9 @@ class Builder implements BuilderContract
         $this->applyBeforeQueryCallbacks();
 
         $results = $this->connection->select(
-            $this->grammar->compileExists($this), $this->getBindings(), ! $this->useWritePdo
+            $this->grammar->compileExists($this),
+            $this->getBindings(),
+            !$this->useWritePdo
         );
 
         // If the results have rows, we will get the row and see if the exists column is a
@@ -3956,7 +4216,7 @@ class Builder implements BuilderContract
      */
     public function doesntExist()
     {
-        return ! $this->exists();
+        return !$this->exists();
     }
 
     /**
@@ -4061,7 +4321,7 @@ class Builder implements BuilderContract
             ->setAggregate($function, $columns)
             ->get($columns);
 
-        if (! $results->isEmpty()) {
+        if (!$results->isEmpty()) {
             return array_change_key_case((array) $results[0])['aggregate'];
         }
     }
@@ -4080,7 +4340,7 @@ class Builder implements BuilderContract
         // If there is no result, we can obviously just return 0 here. Next, we will check
         // if the result is an integer or float. If it is already one of these two data
         // types we can just return the result as-is, otherwise we will convert this.
-        if (! $result) {
+        if (!$result) {
             return 0;
         }
 
@@ -4091,7 +4351,7 @@ class Builder implements BuilderContract
         // If the result doesn't contain a decimal place, we will assume it is an int then
         // cast it to one. When it does we will cast it to a float since it needs to be
         // cast to the expected data type for the developers out of pure convenience.
-        return ! str_contains((string) $result, '.')
+        return !str_contains((string) $result, '.')
             ? (int) $result
             : (float) $result;
     }
@@ -4130,7 +4390,7 @@ class Builder implements BuilderContract
             return true;
         }
 
-        if (! is_array(array_first($values))) {
+        if (!is_array(array_first($values))) {
             $values = [$values];
         }
 
@@ -4167,7 +4427,7 @@ class Builder implements BuilderContract
             return 0;
         }
 
-        if (! is_array(array_first($values))) {
+        if (!is_array(array_first($values))) {
             $values = [$values];
         } else {
             foreach ($values as $key => $value) {
@@ -4206,7 +4466,7 @@ class Builder implements BuilderContract
             throw new InvalidArgumentException('The returning columns must not be empty.');
         }
 
-        if (! is_array(array_first($values))) {
+        if (!is_array(array_first($values))) {
             $values = [$values];
         } else {
             foreach ($values as $key => $value) {
@@ -4292,23 +4552,26 @@ class Builder implements BuilderContract
         $this->applyBeforeQueryCallbacks();
 
         $values = (new Collection($values))->map(function ($value) {
-            if (! $value instanceof self && ! $value instanceof EloquentBuilder && ! $value instanceof Relation) {
-                return ['value' => $value, 'bindings' => match (true) {
-                    $value instanceof Collection => $value->all(),
-                    $value instanceof UnitEnum => enum_value($value),
-                    default => $value,
-                }];
+            if (!$value instanceof self && !$value instanceof EloquentBuilder && !$value instanceof Relation) {
+                return [
+                    'value' => $value,
+                    'bindings' => match (true) {
+                        $value instanceof Collection => $value->all(),
+                        $value instanceof UnitEnum => enum_value($value),
+                        default => $value,
+                    },
+                ];
             }
 
             [$query, $bindings] = $this->parseSub($value);
 
-            return ['value' => new Expression("({$query})"), 'bindings' => fn () => $bindings];
+            return ['value' => new Expression("({$query})"), 'bindings' => fn() => $bindings];
         });
 
-        $sql = $this->grammar->compileUpdate($this, $values->map(fn ($value) => $value['value'])->all());
+        $sql = $this->grammar->compileUpdate($this, $values->map(fn($value) => $value['value'])->all());
 
         return $this->connection->update($sql, $this->cleanBindings(
-            $this->grammar->prepareBindingsForUpdate($this->bindings, $values->map(fn ($value) => $value['bindings'])->all())
+            $this->grammar->prepareBindingsForUpdate($this->bindings, $values->map(fn($value) => $value['bindings'])->all())
         ));
     }
 
@@ -4321,7 +4584,7 @@ class Builder implements BuilderContract
      */
     public function updateFrom(array $values)
     {
-        if (! method_exists($this->grammar, 'compileUpdateFrom')) {
+        if (!method_exists($this->grammar, 'compileUpdateFrom')) {
             throw new LogicException('This database engine does not support the updateFrom method.');
         }
 
@@ -4347,7 +4610,7 @@ class Builder implements BuilderContract
             $values = $values($exists);
         }
 
-        if (! $exists) {
+        if (!$exists) {
             return $this->insert(array_merge($attributes, $values));
         }
 
@@ -4376,7 +4639,7 @@ class Builder implements BuilderContract
             return (int) $this->insert($values);
         }
 
-        if (! is_array(array_first($values))) {
+        if (!is_array(array_first($values))) {
             $values = [$values];
         } else {
             foreach ($values as $key => $value) {
@@ -4395,7 +4658,7 @@ class Builder implements BuilderContract
         $bindings = $this->cleanBindings(array_merge(
             Arr::flatten($values, 1),
             (new Collection($update))
-                ->reject(fn ($value, $key) => is_int($key))
+                ->reject(fn($value, $key) => is_int($key))
                 ->all()
         ));
 
@@ -4416,7 +4679,7 @@ class Builder implements BuilderContract
      */
     public function increment($column, $amount = 1, array $extra = [])
     {
-        if (! is_numeric($amount)) {
+        if (!is_numeric($amount)) {
             throw new InvalidArgumentException('Non-numeric value passed to increment method.');
         }
 
@@ -4435,9 +4698,9 @@ class Builder implements BuilderContract
     public function incrementEach(array $columns, array $extra = [])
     {
         foreach ($columns as $column => $amount) {
-            if (! is_numeric($amount)) {
+            if (!is_numeric($amount)) {
                 throw new InvalidArgumentException("Non-numeric value passed as increment amount for column: '$column'.");
-            } elseif (! is_string($column)) {
+            } elseif (!is_string($column)) {
                 throw new InvalidArgumentException('Non-associative array passed to incrementEach method.');
             }
 
@@ -4458,7 +4721,7 @@ class Builder implements BuilderContract
      */
     public function decrement($column, $amount = 1, array $extra = [])
     {
-        if (! is_numeric($amount)) {
+        if (!is_numeric($amount)) {
             throw new InvalidArgumentException('Non-numeric value passed to decrement method.');
         }
 
@@ -4477,9 +4740,9 @@ class Builder implements BuilderContract
     public function decrementEach(array $columns, array $extra = [])
     {
         foreach ($columns as $column => $amount) {
-            if (! is_numeric($amount)) {
+            if (!is_numeric($amount)) {
                 throw new InvalidArgumentException("Non-numeric value passed as decrement amount for column: '$column'.");
-            } elseif (! is_string($column)) {
+            } elseif (!is_string($column)) {
                 throw new InvalidArgumentException('Non-associative array passed to decrementEach method.');
             }
 
@@ -4500,14 +4763,15 @@ class Builder implements BuilderContract
         // If an ID is passed to the method, we will set the where clause to check the
         // ID to let developers to simply and quickly remove a single row from this
         // database without manually specifying the "where" clauses on the query.
-        if (! is_null($id)) {
-            $this->where($this->from.'.id', '=', $id);
+        if (!is_null($id)) {
+            $this->where($this->from . '.id', '=', $id);
         }
 
         $this->applyBeforeQueryCallbacks();
 
         return $this->connection->delete(
-            $this->grammar->compileDelete($this), $this->cleanBindings(
+            $this->grammar->compileDelete($this),
+            $this->cleanBindings(
                 $this->grammar->prepareBindingsForDelete($this->bindings)
             )
         );
@@ -4554,8 +4818,8 @@ class Builder implements BuilderContract
      */
     public function getColumns()
     {
-        return ! is_null($this->columns)
-            ? array_map(fn ($column) => $this->grammar->getValue($column), $this->columns)
+        return !is_null($this->columns)
+            ? array_map(fn($column) => $this->grammar->getValue($column), $this->columns)
             : [];
     }
 
@@ -4591,7 +4855,7 @@ class Builder implements BuilderContract
     {
         $value = $this->unions ? $this->unionLimit : $this->limit;
 
-        return ! is_null($value) ? (int) $value : null;
+        return !is_null($value) ? (int) $value : null;
     }
 
     /**
@@ -4603,7 +4867,7 @@ class Builder implements BuilderContract
     {
         $value = $this->unions ? $this->unionOffset : $this->offset;
 
-        return ! is_null($value) ? (int) $value : null;
+        return !is_null($value) ? (int) $value : null;
     }
 
     /**
@@ -4647,7 +4911,7 @@ class Builder implements BuilderContract
      */
     public function setBindings(array $bindings, $type = 'where')
     {
-        if (! array_key_exists($type, $this->bindings)) {
+        if (!array_key_exists($type, $this->bindings)) {
             throw new InvalidArgumentException("Invalid binding type: {$type}.");
         }
 
@@ -4667,7 +4931,7 @@ class Builder implements BuilderContract
      */
     public function addBinding($value, $type = 'where')
     {
-        if (! array_key_exists($type, $this->bindings)) {
+        if (!array_key_exists($type, $this->bindings)) {
             throw new InvalidArgumentException("Invalid binding type: {$type}.");
         }
 
@@ -4764,7 +5028,7 @@ class Builder implements BuilderContract
      */
     protected function ensureConnectionSupportsVectors()
     {
-        if (! $this->connection instanceof PostgresConnection) {
+        if (!$this->connection instanceof PostgresConnection) {
             throw new RuntimeException('Vector distance queries are only supported by Postgres.');
         }
     }
@@ -4823,9 +5087,9 @@ class Builder implements BuilderContract
     protected function isQueryable($value)
     {
         return $value instanceof self ||
-               $value instanceof EloquentBuilder ||
-               $value instanceof Relation ||
-               $value instanceof Closure;
+            $value instanceof EloquentBuilder ||
+            $value instanceof Relation ||
+            $value instanceof Closure;
     }
 
     /**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -304,10 +304,10 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $query = $this->getBuilder();
 
-        $result = $query->pipe(fn (Builder $query) => 5);
+        $result = $query->pipe(fn(Builder $query) => 5);
         $this->assertSame(5, $result);
 
-        $result = $query->pipe(fn (Builder $query) => null);
+        $result = $query->pipe(fn(Builder $query) => null);
         $this->assertSame($query, $result);
 
         $result = $query->pipe(function (Builder $query) {
@@ -316,7 +316,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertSame($query, $result);
 
         $this->assertCount(0, $query->wheres);
-        $result = $query->pipe(fn (Builder $query) => $query->where('foo', 'bar'));
+        $result = $query->pipe(fn(Builder $query) => $query->where('foo', 'bar'));
         $this->assertSame($query, $result);
         $this->assertCount(1, $query->wheres);
     }
@@ -934,6 +934,44 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => '1'], $builder->getBindings());
     }
 
+    public function testWhereStringShortcuts()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereStartsWith('name', 'john');
+        $this->assertSame('select * from `users` where `name` like ?', $builder->toSql());
+        $this->assertEquals([0 => 'john%'], $builder->getBindings());
+
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereEndsWith('name', 'doe');
+        $this->assertSame('select * from `users` where `name` like ?', $builder->toSql());
+        $this->assertEquals([0 => '%doe'], $builder->getBindings());
+
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereContains('name', 'middle');
+        $this->assertSame('select * from `users` where `name` like ?', $builder->toSql());
+        $this->assertEquals([0 => '%middle%'], $builder->getBindings());
+
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereNotStartsWith('name', 'jane');
+        $this->assertSame('select * from `users` where `name` not like ?', $builder->toSql());
+        $this->assertEquals([0 => 'jane%'], $builder->getBindings());
+
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereNotEndsWith('name', 'smith');
+        $this->assertSame('select * from `users` where `name` not like ?', $builder->toSql());
+        $this->assertEquals([0 => '%smith'], $builder->getBindings());
+
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereNotContains('name', 'secret');
+        $this->assertSame('select * from `users` where `name` not like ?', $builder->toSql());
+        $this->assertEquals([0 => '%secret%'], $builder->getBindings());
+
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereStartsWith('name', 'john')->orWhereContains('email', 'gmail');
+        $this->assertSame('select * from `users` where `name` like ? or `email` like ?', $builder->toSql());
+        $this->assertEquals([0 => 'john%', 1 => '%gmail%'], $builder->getBindings());
+    }
+
     public function testWhereDateSqlite()
     {
         $builder = $this->getSQLiteBuilder();
@@ -1526,7 +1564,9 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereIntegerInRaw('id', [
-            '1a', 2, Bar::FOO,
+            '1a',
+            2,
+            Bar::FOO,
         ]);
         $this->assertSame('select * from "users" where "id" in (1, 2, 5)', $builder->toSql());
         $this->assertEquals([], $builder->getBindings());
@@ -1713,8 +1753,8 @@ class DatabaseQueryBuilderTest extends TestCase
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereAll([
-            fn (Builder $query) => $query->where('last_name', 'like', '%Otwell%'),
-            fn (Builder $query) => $query->where('email', 'like', '%Otwell%'),
+            fn(Builder $query) => $query->where('last_name', 'like', '%Otwell%'),
+            fn(Builder $query) => $query->where('email', 'like', '%Otwell%'),
         ]);
         $this->assertSame('select * from "users" where (("last_name" like ?) and ("email" like ?))', $builder->toSql());
         $this->assertEquals(['%Otwell%', '%Otwell%'], $builder->getBindings());
@@ -1739,8 +1779,8 @@ class DatabaseQueryBuilderTest extends TestCase
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('first_name', 'like', '%Taylor%')->orWhereAll([
-            fn (Builder $query) => $query->where('last_name', 'like', '%Otwell%'),
-            fn (Builder $query) => $query->where('email', 'like', '%Otwell%'),
+            fn(Builder $query) => $query->where('last_name', 'like', '%Otwell%'),
+            fn(Builder $query) => $query->where('email', 'like', '%Otwell%'),
         ]);
         $this->assertSame('select * from "users" where "first_name" like ? or (("last_name" like ?) and ("email" like ?))', $builder->toSql());
         $this->assertEquals(['%Taylor%', '%Otwell%', '%Otwell%'], $builder->getBindings());
@@ -1760,8 +1800,8 @@ class DatabaseQueryBuilderTest extends TestCase
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereAny([
-            fn (Builder $query) => $query->where('last_name', 'like', '%Otwell%'),
-            fn (Builder $query) => $query->where('email', 'like', '%Otwell%'),
+            fn(Builder $query) => $query->where('last_name', 'like', '%Otwell%'),
+            fn(Builder $query) => $query->where('email', 'like', '%Otwell%'),
         ]);
         $this->assertSame('select * from "users" where (("last_name" like ?) or ("email" like ?))', $builder->toSql());
         $this->assertEquals(['%Otwell%', '%Otwell%'], $builder->getBindings());
@@ -1786,8 +1826,8 @@ class DatabaseQueryBuilderTest extends TestCase
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('first_name', 'like', '%Taylor%')->orWhereAny([
-            fn (Builder $query) => $query->where('last_name', 'like', '%Otwell%'),
-            fn (Builder $query) => $query->where('email', 'like', '%Otwell%'),
+            fn(Builder $query) => $query->where('last_name', 'like', '%Otwell%'),
+            fn(Builder $query) => $query->where('email', 'like', '%Otwell%'),
         ]);
         $this->assertSame('select * from "users" where "first_name" like ? or (("last_name" like ?) or ("email" like ?))', $builder->toSql());
         $this->assertEquals(['%Taylor%', '%Otwell%', '%Otwell%'], $builder->getBindings());
@@ -1812,8 +1852,8 @@ class DatabaseQueryBuilderTest extends TestCase
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereNone([
-            fn (Builder $query) => $query->where('last_name', 'like', '%Otwell%'),
-            fn (Builder $query) => $query->where('email', 'like', '%Otwell%'),
+            fn(Builder $query) => $query->where('last_name', 'like', '%Otwell%'),
+            fn(Builder $query) => $query->where('email', 'like', '%Otwell%'),
         ]);
         $this->assertSame('select * from "users" where not (("last_name" like ?) or ("email" like ?))', $builder->toSql());
         $this->assertEquals(['%Otwell%', '%Otwell%'], $builder->getBindings());
@@ -1838,8 +1878,8 @@ class DatabaseQueryBuilderTest extends TestCase
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('first_name', 'like', '%Taylor%')->orWhereNone([
-            fn (Builder $query) => $query->where('last_name', 'like', '%Otwell%'),
-            fn (Builder $query) => $query->where('email', 'like', '%Otwell%'),
+            fn(Builder $query) => $query->where('last_name', 'like', '%Otwell%'),
+            fn(Builder $query) => $query->where('email', 'like', '%Otwell%'),
         ]);
         $this->assertSame('select * from "users" where "first_name" like ? or not (("last_name" like ?) or ("email" like ?))', $builder->toSql());
         $this->assertEquals(['%Taylor%', '%Otwell%', '%Otwell%'], $builder->getBindings());
@@ -2583,12 +2623,11 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->having(
-            new class() implements ConditionExpression
+            new class () implements ConditionExpression {
+            public function getValue(\Illuminate\Database\Grammar $grammar)
             {
-                public function getValue(\Illuminate\Database\Grammar $grammar)
-                {
-                    return '1 = 1';
-                }
+                return '1 = 1';
+            }
             }
         );
         $this->assertSame('select * from "users" having 1 = 1', $builder->toSql());
@@ -3804,9 +3843,9 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->shouldReceive('first')->with(['column'])->andReturn($data)->once();
         $builder->shouldReceive('first')->andReturn(null)->once();
 
-        $this->assertSame($data, $builder->findOr(1, fn () => 'callback result'));
-        $this->assertSame($data, $builder->findOr(1, ['column'], fn () => 'callback result'));
-        $this->assertSame('callback result', $builder->findOr(1, fn () => 'callback result'));
+        $this->assertSame($data, $builder->findOr(1, fn() => 'callback result'));
+        $this->assertSame($data, $builder->findOr(1, ['column'], fn() => 'callback result'));
+        $this->assertSame('callback result', $builder->findOr(1, fn() => 'callback result'));
     }
 
     public function testFirstMethodReturnsFirstResult()
@@ -4811,7 +4850,7 @@ class DatabaseQueryBuilderTest extends TestCase
 
     public function testUpdateOrInsertMethod()
     {
-        $builder = m::mock(Builder::class.'[where,exists,insert]', [
+        $builder = m::mock(Builder::class . '[where,exists,insert]', [
             $connection = m::mock(Connection::class),
             new Grammar($connection),
             m::mock(Processor::class),
@@ -4823,7 +4862,7 @@ class DatabaseQueryBuilderTest extends TestCase
 
         $this->assertTrue($builder->updateOrInsert(['email' => 'foo'], ['name' => 'bar']));
 
-        $builder = m::mock(Builder::class.'[where,exists,update]', [
+        $builder = m::mock(Builder::class . '[where,exists,update]', [
             $connection = m::mock(Connection::class),
             new Grammar($connection),
             m::mock(Processor::class),
@@ -4839,7 +4878,7 @@ class DatabaseQueryBuilderTest extends TestCase
 
     public function testUpdateOrInsertMethodWorksWithEmptyUpdateValues()
     {
-        $builder = m::spy(Builder::class.'[where,exists,update]', [
+        $builder = m::spy(Builder::class . '[where,exists,update]', [
             $connection = m::mock(Connection::class),
             new Grammar($connection),
             m::mock(Processor::class),
@@ -6292,14 +6331,15 @@ SQL;
             return new Builder($builder->connection, $builder->grammar, $builder->processor);
         });
 
-        $path = 'http://foo.bar?cursor='.$cursor->encode();
+        $path = 'http://foo.bar?cursor=' . $cursor->encode();
 
         $results = collect([['test' => 'foo'], ['test' => 'bar']]);
 
         $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results) {
             $this->assertEquals(
                 'select * from "foobar" where ("test" > ?) order by "test" asc limit 17',
-                $builder->toSql());
+                $builder->toSql()
+            );
             $this->assertEquals(['bar'], $builder->bindings['where']);
 
             return $results;
@@ -6330,7 +6370,7 @@ SQL;
             return new Builder($builder->connection, $builder->grammar, $builder->processor);
         });
 
-        $path = 'http://foo.bar?cursor='.$cursor->encode();
+        $path = 'http://foo.bar?cursor=' . $cursor->encode();
 
         $results = collect([['test' => 'foo', 'another' => 1], ['test' => 'bar', 'another' => 2]]);
 
@@ -6368,14 +6408,15 @@ SQL;
             return new Builder($builder->connection, $builder->grammar, $builder->processor);
         });
 
-        $path = 'http://foo.bar?cursor='.$cursor->encode();
+        $path = 'http://foo.bar?cursor=' . $cursor->encode();
 
         $results = collect([['test' => 'foo'], ['test' => 'bar']]);
 
         $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results) {
             $this->assertEquals(
                 'select * from "foobar" where ("test" > ?) order by "test" asc limit 16',
-                $builder->toSql());
+                $builder->toSql()
+            );
             $this->assertEquals(['bar'], $builder->bindings['where']);
 
             return $results;
@@ -6445,7 +6486,8 @@ SQL;
         $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results) {
             $this->assertEquals(
                 'select * from "foobar" where ("id" > ?) order by "id" asc limit 17',
-                $builder->toSql());
+                $builder->toSql()
+            );
             $this->assertEquals([2], $builder->bindings['where']);
 
             return $results;
@@ -6476,7 +6518,7 @@ SQL;
             return new Builder($builder->connection, $builder->grammar, $builder->processor);
         });
 
-        $path = 'http://foo.bar?cursor='.$cursor->encode();
+        $path = 'http://foo.bar?cursor=' . $cursor->encode();
 
         $results = collect([['foo' => 1, 'bar' => 2, 'baz' => 4], ['foo' => 1, 'bar' => 1, 'baz' => 1]]);
 
@@ -6514,14 +6556,15 @@ SQL;
             return new Builder($builder->connection, $builder->grammar, $builder->processor);
         });
 
-        $path = 'http://foo.bar?cursor='.$cursor->encode();
+        $path = 'http://foo.bar?cursor=' . $cursor->encode();
 
         $results = collect([['test' => 'foo'], ['test' => 'bar']]);
 
         $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results) {
             $this->assertEquals(
                 'select *, (CONCAT(firstname, \' \', lastname)) as test from "foobar" where ((CONCAT(firstname, \' \', lastname)) > ?) order by "test" asc limit 16',
-                $builder->toSql());
+                $builder->toSql()
+            );
             $this->assertEquals(['bar'], $builder->bindings['where']);
 
             return $results;
@@ -6555,14 +6598,15 @@ SQL;
             return new Builder($builder->connection, $builder->grammar, $builder->processor);
         });
 
-        $path = 'http://foo.bar?cursor='.$cursor->encode();
+        $path = 'http://foo.bar?cursor=' . $cursor->encode();
 
         $results = collect([['test' => 'foo'], ['test' => 'bar']]);
 
         $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results) {
             $this->assertEquals(
                 'select *, (CAST(CONCAT(firstname, \' \', lastname) as VARCHAR)) as test from "foobar" where ((CAST(CONCAT(firstname, \' \', lastname) as VARCHAR)) > ?) order by "test" asc limit 16',
-                $builder->toSql());
+                $builder->toSql()
+            );
             $this->assertEquals(['bar'], $builder->bindings['where']);
 
             return $results;
@@ -6596,14 +6640,15 @@ SQL;
             return new Builder($builder->connection, $builder->grammar, $builder->processor);
         });
 
-        $path = 'http://foo.bar?cursor='.$cursor->encode();
+        $path = 'http://foo.bar?cursor=' . $cursor->encode();
 
         $results = collect([['test' => 'foo'], ['test' => 'bar']]);
 
         $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results) {
             $this->assertEquals(
                 'select *, (CONCAT(firstname, \' \', lastname)) as "test" from "foobar" where ((CONCAT(firstname, \' \', lastname)) > ?) order by "test" asc limit 16',
-                $builder->toSql());
+                $builder->toSql()
+            );
             $this->assertEquals(['bar'], $builder->bindings['where']);
 
             return $results;
@@ -6643,7 +6688,7 @@ SQL;
             return new Builder($builder->connection, $builder->grammar, $builder->processor);
         });
 
-        $path = 'http://foo.bar?cursor='.$cursor->encode();
+        $path = 'http://foo.bar?cursor=' . $cursor->encode();
 
         $results = collect([
             ['id' => 1, 'created_at' => Carbon::now(), 'type' => 'video'],
@@ -6653,7 +6698,8 @@ SQL;
         $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results, $ts) {
             $this->assertEquals(
                 '(select "id", "start_time" as "created_at", \'video\' as type from "videos" where ("start_time" > ?)) union (select "id", "created_at", \'news\' as type from "news" where ("created_at" > ?)) order by "created_at" asc limit 17',
-                $builder->toSql());
+                $builder->toSql()
+            );
             $this->assertEquals([$ts], $builder->bindings['where']);
             $this->assertEquals([$ts], $builder->bindings['union']);
 
@@ -6691,7 +6737,7 @@ SQL;
             return new Builder($builder->connection, $builder->grammar, $builder->processor);
         });
 
-        $path = 'http://foo.bar?cursor='.$cursor->encode();
+        $path = 'http://foo.bar?cursor=' . $cursor->encode();
 
         $results = collect([
             ['id' => 1, 'created_at' => Carbon::now(), 'type' => 'video'],
@@ -6702,7 +6748,8 @@ SQL;
         $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results, $ts) {
             $this->assertEquals(
                 '(select "id", "start_time" as "created_at", \'video\' as type from "videos" where ("start_time" > ?)) union (select "id", "created_at", \'news\' as type from "news" where "extra" = ? and ("created_at" > ?)) union (select "id", "created_at", \'podcast\' as type from "podcasts" where "extra" = ? and ("created_at" > ?)) order by "created_at" asc limit 17',
-                $builder->toSql());
+                $builder->toSql()
+            );
             $this->assertEquals([$ts], $builder->bindings['where']);
             $this->assertEquals(['first', $ts, 'second', $ts], $builder->bindings['union']);
 
@@ -6740,7 +6787,7 @@ SQL;
             return new Builder($builder->connection, $builder->grammar, $builder->processor);
         });
 
-        $path = 'http://foo.bar?cursor='.$cursor->encode();
+        $path = 'http://foo.bar?cursor=' . $cursor->encode();
 
         $results = collect([
             ['id' => 1, 'created_at' => Carbon::now()->addDay(), 'type' => 'video'],
@@ -6752,7 +6799,8 @@ SQL;
         $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results, $ts) {
             $this->assertEquals(
                 '(select "id", "start_time" as "created_at", "type" from "videos" where "extra" = ? and ("id" > ? or ("id" = ? and ("start_time" < ? or ("start_time" = ? and ("type" > ?)))))) union (select "id", "created_at", "type" from "news" where "extra" = ? and ("id" > ? or ("id" = ? and ("start_time" < ? or ("start_time" = ? and ("type" > ?)))))) union (select "id", "created_at", "type" from "podcasts" where "extra" = ? and ("id" > ? or ("id" = ? and ("start_time" < ? or ("start_time" = ? and ("type" > ?)))))) order by "id" asc, "created_at" desc, "type" asc limit 17',
-                $builder->toSql());
+                $builder->toSql()
+            );
             $this->assertEquals(['first', 1, 1, $ts, $ts, 'news'], $builder->bindings['where']);
             $this->assertEquals(['second', 1, 1, $ts, $ts, 'news', 'third', 1, 1, $ts, $ts, 'news'], $builder->bindings['union']);
 
@@ -6789,7 +6837,7 @@ SQL;
             return new Builder($builder->connection, $builder->grammar, $builder->processor);
         });
 
-        $path = 'http://foo.bar?cursor='.$cursor->encode();
+        $path = 'http://foo.bar?cursor=' . $cursor->encode();
 
         $results = collect([
             ['id' => 1, 'created_at' => Carbon::now(), 'type' => 'video', 'is_published' => true],
@@ -6799,7 +6847,8 @@ SQL;
         $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results, $ts) {
             $this->assertEquals(
                 '(select "id", "is_published", "start_time" as "created_at", \'video\' as type from "videos" where "is_published" = ? and ("start_time" > ?)) union (select "id", "is_published", "created_at", \'news\' as type from "news" where "is_published" = ? and ("created_at" > ?)) order by case when (id = 3 and type="news" then 0 else 1 end), "created_at" asc limit 17',
-                $builder->toSql());
+                $builder->toSql()
+            );
             $this->assertEquals([true, $ts], $builder->bindings['where']);
             $this->assertEquals([true, $ts], $builder->bindings['union']);
 
@@ -6836,7 +6885,7 @@ SQL;
             return new Builder($builder->connection, $builder->grammar, $builder->processor);
         });
 
-        $path = 'http://foo.bar?cursor='.$cursor->encode();
+        $path = 'http://foo.bar?cursor=' . $cursor->encode();
 
         $results = collect([
             ['id' => 1, 'created_at' => Carbon::now(), 'type' => 'video'],
@@ -6846,7 +6895,8 @@ SQL;
         $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results, $ts) {
             $this->assertEquals(
                 '(select "id", "start_time" as "created_at", \'video\' as type from "videos" where ("start_time" < ?)) union (select "id", "created_at", \'news\' as type from "news" where ("created_at" < ?)) order by "created_at" desc limit 17',
-                $builder->toSql());
+                $builder->toSql()
+            );
             $this->assertEquals([$ts], $builder->bindings['where']);
             $this->assertEquals([$ts], $builder->bindings['union']);
 
@@ -6883,7 +6933,7 @@ SQL;
             return new Builder($builder->connection, $builder->grammar, $builder->processor);
         });
 
-        $path = 'http://foo.bar?cursor='.$cursor->encode();
+        $path = 'http://foo.bar?cursor=' . $cursor->encode();
 
         $results = collect([
             ['id' => 1, 'created_at' => Carbon::now(), 'type' => 'video'],
@@ -6893,7 +6943,8 @@ SQL;
         $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results, $ts) {
             $this->assertEquals(
                 '(select "id", "start_time" as "created_at", \'video\' as type from "videos" where ("start_time" < ? or ("start_time" = ? and ("id" > ?)))) union (select "id", "created_at", \'news\' as type from "news" where ("created_at" < ? or ("created_at" = ? and ("id" > ?)))) order by "created_at" desc, "id" asc limit 17',
-                $builder->toSql());
+                $builder->toSql()
+            );
             $this->assertEquals([$ts, $ts, 1], $builder->bindings['where']);
             $this->assertEquals([$ts, $ts, 1], $builder->bindings['union']);
 
@@ -6931,7 +6982,7 @@ SQL;
             return new Builder($builder->connection, $builder->grammar, $builder->processor);
         });
 
-        $path = 'http://foo.bar?cursor='.$cursor->encode();
+        $path = 'http://foo.bar?cursor=' . $cursor->encode();
 
         $results = collect([
             ['id' => 1, 'created_at' => Carbon::now(), 'type' => 'video'],
@@ -6942,7 +6993,8 @@ SQL;
         $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results, $ts) {
             $this->assertEquals(
                 '(select "id", "start_time" as "created_at", \'video\' as type from "videos" where ("start_time" > ?)) union (select "id", "created_at", \'news\' as type from "news" where ("created_at" > ?)) union (select "id", "init_at" as "created_at", \'podcast\' as type from "podcasts" where ("init_at" > ?)) order by "created_at" asc limit 17',
-                $builder->toSql());
+                $builder->toSql()
+            );
             $this->assertEquals([$ts], $builder->bindings['where']);
             $this->assertEquals([$ts, $ts], $builder->bindings['union']);
 
@@ -6966,12 +7018,11 @@ SQL;
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('orders')->where(
-            new class() implements ConditionExpression
+            new class () implements ConditionExpression {
+            public function getValue(\Illuminate\Database\Grammar $grammar)
             {
-                public function getValue(\Illuminate\Database\Grammar $grammar)
-                {
-                    return '1 = 1';
-                }
+                return '1 = 1';
+            }
             }
         );
         $this->assertSame('select * from "orders" where 1 = 1', $builder->toSql());


### PR DESCRIPTION
This PR adds several expressive "shortcut" methods to the Database Query Builder to simplify string-based searching. These methods mirror the existing `Str::startsWith`, `Str::endsWith`, and `Str::contains` APIs, providing a more consistent experience for developers.

Currently, performing a "starts with" search requires manual string manipulation:
```php
DB::table('users')->where('name', 'LIKE', $value.'%');
```
**With this PR:**
```php
DB::table('users')->whereStartsWith('name', $value);
DB::table('users')->whereEndsWith('name', $value);
DB::table('users')->whereContains('name', $value);
```
**Key Points:**
**Consistency:** Follows the naming conventions of Illuminate\Support\Str.
**Expressiveness:** Reduces boilerplate and cognitive load by abstracting the wildcard (%) logic.
**Full API:** Includes orWhere, whereNot, and orWhereNot variants for a complete experience.
**Zero Breaking Changes:** These are additive methods that wrap the existing whereLike logic.

This is a logical next step following the recent addition of whereLike(), providing high-level abstractions for the most common string-search patterns.

**Tests:** Included comprehensive tests in tests/Database/DatabaseQueryBuilderTest.php with 14 assertions covering all variants.