### PR TITLE
[13.x] Preserve URI fragment when decoding query string

### DIFF
--- a/src/Illuminate/Support/Uri.php
+++ b/src/Illuminate/Support/Uri.php
@@ -390,7 +390,7 @@ class Uri implements Htmlable, JsonSerializable, Responsable, Stringable
             return $this->value();
         }
 
-        return Str::replace(Str::after($this->value(), '?'), $this->query()->decode(), $this->value());
+        return Str::replace($this->query()->value(), $this->query()->decode(), $this->value());
     }
 
     /**

--- a/tests/Support/SupportUriTest.php
+++ b/tests/Support/SupportUriTest.php
@@ -178,6 +178,13 @@ class SupportUriTest extends TestCase
         $this->assertEquals('https://laravel.com/docs/11.x/installation?tags[0]=first&tags[1]=second', $uri->decode());
     }
 
+    public function test_decoding_the_entire_uri_preserves_the_fragment()
+    {
+        $uri = Uri::of('https://laravel.com/docs/11.x/routing?q=laravel%20docs#route-model-binding');
+
+        $this->assertEquals('https://laravel.com/docs/11.x/routing?q=laravel docs#route-model-binding', $uri->decode());
+    }
+
     public function test_with_query_if_missing()
     {
         // Test adding new parameters while preserving existing ones


### PR DESCRIPTION
This fixes an issue in `Illuminate\Support\Uri::decode()` where decoding a URI with both a query string and a fragment could remove the fragment.

Example:

`https://laravel.com/docs/11.x/routing?q=laravel%20docs#route-model-binding`

Before:
`https://laravel.com/docs/11.x/routing?q=laravel docs`

After:
`https://laravel.com/docs/11.x/routing?q=laravel docs#route-model-binding`

A regression test has been added to cover this case.
