### PR TITLE
[13.x] Clear resolved collection classes in clearBootedModels()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -487,6 +487,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         static::$bootedCallbacks = [];
         static::$classAttributes = [];
         static::$globalScopes = [];
+        static::$resolvedCollectionClasses = [];
     }
 
     /**


### PR DESCRIPTION
## Summary

The `HasCollection` trait (updated in #59419) caches resolved `#[CollectedBy]` attribute values in a static `$resolvedCollectionClasses` array. However, `Model::clearBootedModels()` does not reset this cache.

### The Problem

`clearBootedModels()` resets all other static caches:

```php
public static function clearBootedModels()
{
    static::$booted = [];
    static::$bootedCallbacks = [];
    static::$classAttributes = [];
    static::$globalScopes = [];
    // $resolvedCollectionClasses is NOT cleared
}
```

This means `#[CollectedBy]` resolution persists across:
- Test cases (when `clearBootedModels()` is called in `setUp`)
- Service provider re-boots
- `DatabaseServiceProvider::boot()` which calls `clearBootedModels()`

### The Fix

Add `static::$resolvedCollectionClasses = [];` to `clearBootedModels()`, consistent with how all other static caches are cleared.

### Changes

- `src/Illuminate/Database/Eloquent/Model.php` — 1 line added to `clearBootedModels()`