### PR TITLE
Prevents installed package from executing malicious code via `postinstall` in `install:broadcasting` command

### DIFF
--- a/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
@@ -407,7 +407,7 @@ class BroadcastingInstallCommand extends Command
 
         if (file_exists(base_path('pnpm-lock.yaml'))) {
             $commands = [
-                'pnpm add --save-dev laravel-echo pusher-js',
+                'pnpm add --save-dev laravel-echo pusher-js --ignore-scripts',
                 'pnpm run build',
             ];
         } elseif (file_exists(base_path('yarn.lock'))) {
@@ -422,7 +422,7 @@ class BroadcastingInstallCommand extends Command
             ];
         } else {
             $commands = [
-                'npm install --save-dev laravel-echo pusher-js',
+                'npm install --save-dev laravel-echo pusher-js --ignore-scripts',
                 'npm run build',
             ];
         }


### PR DESCRIPTION
Similar to https://github.com/laravel/laravel/pull/6777, but for the `npm install` and `pnpm add` commands inside the `install:broadcasting` command.

I haven't changed the Yarn or Bun commands here:
- `yarn add` doesn't support an `--ignore-scripts` flag; Yarn handles this differently via `--mode=skip-build / enableScripts`
- Bun doesn’t support `--ignore-scripts` on `bun add`, and it already [blocks](https://pnpm.io/supply-chain-security#block-risky-postinstall-scripts) arbitrary dependency lifecycle scripts unless explicitly trusted
