### PR TITLE
[13.x] Fix CollectedBy attribute not resolving through abstract parent classes

### DIFF
--- a/src/Illuminate/Database/Eloquent/HasCollection.php
+++ b/src/Illuminate/Database/Eloquent/HasCollection.php
@@ -43,19 +43,16 @@ trait HasCollection
      */
     public function resolveCollectionFromAttribute()
     {
-        $reflectionClass = new ReflectionClass(static::class);
+        $reflection = new ReflectionClass(static::class);
 
-        $isEloquentGrandchild = is_subclass_of(static::class, Model::class)
-            && get_parent_class(static::class) !== Model::class;
+        do {
+            $attributes = $reflection->getAttributes(CollectedBy::class);
 
-        $attributes = $reflectionClass->getAttributes(CollectedBy::class);
+            if (isset($attributes[0], $attributes[0]->getArguments()[0])) {
+                return $attributes[0]->getArguments()[0];
+            }
+        } while ($reflection = $reflection->getParentClass());
 
-        if (! isset($attributes[0]) || ! isset($attributes[0]->getArguments()[0])) {
-            return $isEloquentGrandchild
-                ? (new (get_parent_class(static::class)))->resolveCollectionFromAttribute()
-                : null;
-        }
-
-        return $attributes[0]->getArguments()[0];
+        return null;
     }
 }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3780,6 +3780,14 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertInstanceOf(CustomEloquentCollection::class, $collection);
     }
 
+    public function testCollectedByAttributeIsInheritedThroughAbstractParent()
+    {
+        $model = new EloquentConcreteChildOfAbstractModel;
+        $collection = $model->newCollection([$model]);
+
+        $this->assertInstanceOf(CustomEloquentCollection::class, $collection);
+    }
+
     public function testUseFactoryAttribute()
     {
         $model = new EloquentModelWithUseFactoryAttribute;
@@ -4687,6 +4695,14 @@ class EloquentModelWithCollectedByAttribute extends Model
 }
 
 class EloquentChildModelWithCollectedByAttribute extends EloquentModelWithCollectedByAttribute
+{
+}
+
+abstract class EloquentAbstractModel extends EloquentModelWithCollectedByAttribute
+{
+}
+
+class EloquentConcreteChildOfAbstractModel extends EloquentAbstractModel
 {
 }
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3788,6 +3788,14 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertInstanceOf(CustomEloquentCollection::class, $collection);
     }
 
+    public function testNewCollectionWorksForConcreteModelExtendingAbstractModel()
+    {
+        $model = new EloquentConcreteChildModel;
+        $collection = $model->newCollection([$model]);
+
+        $this->assertInstanceOf(Collection::class, $collection);
+    }
+
     public function testUseFactoryAttribute()
     {
         $model = new EloquentModelWithUseFactoryAttribute;
@@ -4703,6 +4711,14 @@ abstract class EloquentAbstractModel extends EloquentModelWithCollectedByAttribu
 }
 
 class EloquentConcreteChildOfAbstractModel extends EloquentAbstractModel
+{
+}
+
+abstract class EloquentAbstractParentModel extends Model
+{
+}
+
+class EloquentConcreteChildModel extends EloquentAbstractParentModel
 {
 }
 


### PR DESCRIPTION
This was reported via https://github.com/laravel/framework/pull/59419#discussion_r3023681792

And closes https://github.com/laravel/framework/issues/59489

This replaces the instantiation approach with a do/while loop, the exact same as how `Model::resolveClassAttribute()`  works

This isnt needed elsewhere, just for CollectedBy cause the method is not static.... 

I did not consider this, so the previous pr was a b/c so once this is merged, we could do with a new version release... sorry!

Added 2x regression tests, one for the attribute, one for the plain concrete / abstract so it never happens again.