### PR TITLE
[13.x] [bug] Fix closure in chain not dispatched after batch completes

### DIFF
--- a/src/Illuminate/Bus/ChainedBatch.php
+++ b/src/Illuminate/Bus/ChainedBatch.php
@@ -130,9 +130,11 @@ class ChainedBatch implements ShouldQueue
             $next->chainQueue = $this->chainQueue;
             $next->chainCatchCallbacks = $this->chainCatchCallbacks;
 
+            $next = serialize($next);
+
             $batch->finally(function (Batch $batch) use ($next) {
                 if (! $batch->cancelled()) {
-                    Container::getInstance()->make(Dispatcher::class)->dispatch($next);
+                    Container::getInstance()->make(Dispatcher::class)->dispatch(unserialize($next));
                 }
             });
 

--- a/tests/Integration/Queue/JobChainingTest.php
+++ b/tests/Integration/Queue/JobChainingTest.php
@@ -470,6 +470,24 @@ class JobChainingTest extends QueueTestCase
         $this->assertEquals(['c1', 'c2', 'b1', 'b2', 'b3', 'b4', 'c3'], JobRunRecorder::$results);
     }
 
+    public function testClosureAfterBatchInChainIsDispatched()
+    {
+        Bus::chain([
+            new JobChainingNamedTestJob('c1'),
+            Bus::batch([
+                new JobChainingTestBatchedJob('b1'),
+                new JobChainingTestBatchedJob('b2'),
+            ]),
+            function () {
+                JobRunRecorder::record('closure-after-batch');
+            },
+        ])->dispatch();
+
+        $this->runQueueWorkerCommand(['--stop-when-empty' => true]);
+
+        $this->assertContains('closure-after-batch', JobRunRecorder::$results);
+    }
+
     public function testBatchInChainUsesCorrectQueue()
     {
         $otherQueue = $this->getQueueDriver() === 'redis' ? '{other}' : 'other';


### PR DESCRIPTION
## Summary

Fixes a bug where a closure in `Bus::chain` is not dispatched when it follows a `Bus::batch`, throwing `Call to undefined method Closure::getClosure()`.

Relates to laravel/serializable-closure#106

## Root cause

The root cause is in `serializable-closure`'s `Native::__unserialize()`. When deserializing a closure that captures an object with a `SerializableClosure` property, the objects restoration loop unconditionally calls `getClosure()` on all stored objects, including `SerializableClosure` instances that should be preserved as-is. This unwraps them to raw `Closure` objects, breaking any code that later calls `getClosure()` on the property.

PR laravel/serializable-closure#135 fixes this at the library level with an `instanceof` check before calling `getClosure()`.

## This PR (framework-level alternative)

If the serializable-closure fix is not accepted, this PR provides a framework-level workaround specific to `ChainedBatch`. It re-serializes `$next` to a string before capturing it in the `finally` closure, so the serializable-closure library never traverses into the `CallQueuedClosure`'s properties:

```php
$next = serialize($next);

$batch->finally(function (Batch $batch) use ($next) {
    if (! $batch->cancelled()) {
        Container::getInstance()->make(Dispatcher::class)->dispatch(unserialize($next));
    }
});
```

## Reproduction

```php
Bus::chain([
    new SomeJob,
    Bus::batch([new AnotherJob]),
    fn() => doSomething(), // This closure never runs
])->dispatch();
// Call to undefined method Closure::getClosure()
```

## Test plan

- [x] Integration test: `testClosureAfterBatchInChainIsDispatched` in `JobChainingTest.php`