### PR TITLE
[12.x] Fix closure in chain not dispatched after batch completes

### DIFF
--- a/src/Illuminate/Bus/ChainedBatch.php
+++ b/src/Illuminate/Bus/ChainedBatch.php
@@ -130,9 +130,11 @@ class ChainedBatch implements ShouldQueue
             $next->chainQueue = $this->chainQueue;
             $next->chainCatchCallbacks = $this->chainCatchCallbacks;
 
+            $next = serialize($next);
+
             $batch->finally(function (Batch $batch) use ($next) {
                 if (! $batch->cancelled()) {
-                    Container::getInstance()->make(Dispatcher::class)->dispatch($next);
+                    Container::getInstance()->make(Dispatcher::class)->dispatch(unserialize($next));
                 }
             });
 

--- a/tests/Integration/Queue/JobChainingTest.php
+++ b/tests/Integration/Queue/JobChainingTest.php
@@ -470,6 +470,24 @@ class JobChainingTest extends QueueTestCase
         $this->assertEquals(['c1', 'c2', 'b1', 'b2', 'b3', 'b4', 'c3'], JobRunRecorder::$results);
     }
 
+    public function testClosureAfterBatchInChainIsDispatched()
+    {
+        Bus::chain([
+            new JobChainingNamedTestJob('c1'),
+            Bus::batch([
+                new JobChainingTestBatchedJob('b1'),
+                new JobChainingTestBatchedJob('b2'),
+            ]),
+            function () {
+                JobRunRecorder::record('closure-after-batch');
+            },
+        ])->dispatch();
+
+        $this->runQueueWorkerCommand(['--stop-when-empty' => true]);
+
+        $this->assertContains('closure-after-batch', JobRunRecorder::$results);
+    }
+
     public function testBatchInChainUsesCorrectQueue()
     {
         $otherQueue = $this->getQueueDriver() === 'redis' ? '{other}' : 'other';


### PR DESCRIPTION
## Summary

Backport of #59491 to 12.x. Fixes a bug where a closure in `Bus::chain` is not dispatched when it follows a `Bus::batch`, throwing `Call to undefined method Closure::getClosure()`.

Relates to laravel/serializable-closure#106

## Problem

`ChainedBatch::attachRemainderOfChainToEndOfBatch()` captures the next chain item directly in the batch's `finally` callback. When the batch serializes this callback, the nested `SerializableClosure` inside `$next->closure` gets unwrapped to a raw `Closure` during the round-trip.

## Solution

Re-serialize `$next` to a string before capturing it in the `finally` closure. The string is deserialized at dispatch time.

## Test plan

- [x] Integration test: `testClosureAfterBatchInChainIsDispatched` in `JobChainingTest.php`