### PR TITLE
[13.x] Fix static closure binding in remaining manager classes

### DIFF
--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -21,6 +21,7 @@ use Monolog\Logger as Monolog;
 use Monolog\Processor\ProcessorInterface;
 use Monolog\Processor\PsrLogMessageProcessor;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
 use Throwable;
 
 use function Illuminate\Support\enum_value;
@@ -600,7 +601,13 @@ class LogManager implements LoggerInterface
      */
     public function extend($driver, Closure $callback)
     {
-        $this->customCreators[$driver] = $callback->bindTo($this, $this);
+        try {
+            $callback = $callback->bindTo($this, static::class) ?? throw new RuntimeException;
+        } catch (Throwable) {
+            $callback = $callback->bindTo(null, static::class);
+        }
+
+        $this->customCreators[$driver] = $callback;
 
         return $this;
     }

--- a/src/Illuminate/Redis/RedisManager.php
+++ b/src/Illuminate/Redis/RedisManager.php
@@ -10,6 +10,8 @@ use Illuminate\Redis\Connectors\PredisConnector;
 use Illuminate\Support\Arr;
 use Illuminate\Support\ConfigurationUrlParser;
 use InvalidArgumentException;
+use RuntimeException;
+use Throwable;
 
 use function Illuminate\Support\enum_value;
 
@@ -263,7 +265,13 @@ class RedisManager implements Factory
      */
     public function extend($driver, Closure $callback)
     {
-        $this->customCreators[$driver] = $callback->bindTo($this, $this);
+        try {
+            $callback = $callback->bindTo($this, static::class) ?? throw new RuntimeException;
+        } catch (Throwable) {
+            $callback = $callback->bindTo(null, static::class);
+        }
+
+        $this->customCreators[$driver] = $callback;
 
         return $this;
     }

--- a/src/Illuminate/Support/MultipleInstanceManager.php
+++ b/src/Illuminate/Support/MultipleInstanceManager.php
@@ -5,6 +5,7 @@ namespace Illuminate\Support;
 use Closure;
 use InvalidArgumentException;
 use RuntimeException;
+use Throwable;
 
 abstract class MultipleInstanceManager
 {
@@ -198,7 +199,13 @@ abstract class MultipleInstanceManager
      */
     public function extend($name, Closure $callback)
     {
-        $this->customCreators[$name] = $callback->bindTo($this, $this);
+        try {
+            $callback = $callback->bindTo($this, static::class) ?? throw new RuntimeException;
+        } catch (Throwable) {
+            $callback = $callback->bindTo(null, static::class);
+        }
+
+        $this->customCreators[$name] = $callback;
 
         return $this;
     }


### PR DESCRIPTION
## Summary

PR #59470 fixed static closure handling in `extend()` for AuthManager, BroadcastManager, CacheManager, FilesystemManager, and the base Manager class. Three manager classes were missed and still use the old `bindTo($this, $this)` pattern that breaks with static closures.

### Affected Files

| File | Status |
|---|---|
| `AuthManager::extend()` | Fixed in #59470 ✅ |
| `BroadcastManager::extend()` | Fixed in #59470 ✅ |
| `CacheManager::extend()` | Fixed in #59470 ✅ |
| `FilesystemManager::extend()` | Fixed in #59470 ✅ |
| `Manager::extend()` | Fixed in #59470 ✅ |
| **`RedisManager::extend()`** | **Not fixed ❌ → Fixed in this PR** |
| **`LogManager::extend()`** | **Not fixed ❌ → Fixed in this PR** |
| **`MultipleInstanceManager::extend()`** | **Not fixed ❌ → Fixed in this PR** |

### The Bug

```php
// This breaks with the old pattern
Redis::extend('custom', static function () {
    return new CustomConnection;
});

// Error: Cannot bind static closure
```

### The Fix

Same fix as #59470 — try binding to the instance, fall back to binding with null scope for static closures:

```php
try {
    $callback = $callback->bindTo($this, static::class) ?? throw new RuntimeException;
} catch (Throwable) {
    $callback = $callback->bindTo(null, static::class);
}
```

### Changes

- `src/Illuminate/Redis/RedisManager.php` — Fix `extend()` static closure handling
- `src/Illuminate/Log/LogManager.php` — Fix `extend()` static closure handling
- `src/Illuminate/Support/MultipleInstanceManager.php` — Fix `extend()` static closure handling

## Test Plan

- [x] All 104 existing Log and Redis tests pass