### PR TITLE
[13.x] Add --ignore-scripts to yarn in BroadcastingInstallCommand

### DIFF
--- a/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
@@ -412,7 +412,7 @@ class BroadcastingInstallCommand extends Command
             ];
         } elseif (file_exists(base_path('yarn.lock'))) {
             $commands = [
-                'yarn add --dev laravel-echo pusher-js',
+                'yarn add --dev laravel-echo pusher-js --ignore-scripts',
                 'yarn run build',
             ];
         } elseif (file_exists(base_path('bun.lock')) || file_exists(base_path('bun.lockb'))) {


### PR DESCRIPTION
## Summary

PR #59485 added `--ignore-scripts` to `pnpm` and `npm` install commands in `BroadcastingInstallCommand` to prevent installed packages from executing malicious postinstall scripts. The `yarn` command was missed.

### Before

```
pnpm add --save-dev laravel-echo pusher-js --ignore-scripts  ✅
yarn add --dev laravel-echo pusher-js                         ❌ (no --ignore-scripts)
bun add --dev laravel-echo pusher-js                          ✅ (bun ignores scripts by default)
npm install --save-dev laravel-echo pusher-js --ignore-scripts ✅
```

### After

```
pnpm add --save-dev laravel-echo pusher-js --ignore-scripts  ✅
yarn add --dev laravel-echo pusher-js --ignore-scripts        ✅
bun add --dev laravel-echo pusher-js                          ✅ (bun ignores scripts by default)
npm install --save-dev laravel-echo pusher-js --ignore-scripts ✅
```

Note: `bun` does not need this flag because it doesn't run postinstall scripts by default (requires explicit `--trust` flag).

### Changes

- `src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php` — Add `--ignore-scripts` to yarn command