### PR TITLE
[13.x] Fix static closure binding in ClosureCommand

### DIFF
--- a/src/Illuminate/Foundation/Console/ClosureCommand.php
+++ b/src/Illuminate/Foundation/Console/ClosureCommand.php
@@ -66,8 +66,16 @@ class ClosureCommand extends Command
         }
 
         try {
+            $callback = $this->callback;
+
+            try {
+                $callback = $callback->bindTo($this, static::class) ?? throw new \RuntimeException;
+            } catch (\Throwable) {
+                $callback = $callback->bindTo(null, static::class);
+            }
+
             return (int) $this->laravel->call(
-                $this->callback->bindTo($this, $this), $parameters
+                $callback, $parameters
             );
         } catch (ManuallyFailedException $e) {
             $this->components->error($e->getMessage());


### PR DESCRIPTION
## Summary

`ClosureCommand::execute()` uses `bindTo($this, $this)` which breaks when a static closure is passed to `Artisan::command()`. This applies the same fix from #59470 that was applied to all Manager classes.

### The Bug

```php
// This breaks
Artisan::command('greet', static function () {
    $this->info('Hello'); // won't work anyway with static, but the bind itself throws
});
```

`bindTo($this, $this)` returns `null` for static closures and the call fails.

### The Fix

Same pattern as #59470:

```php
try {
    $callback = $callback->bindTo($this, static::class) ?? throw new RuntimeException;
} catch (Throwable) {
    $callback = $callback->bindTo(null, static::class);
}
```

### All `bindTo($this, $this)` locations

| File | Fixed in | Status |
|---|---|---|
| `Manager::extend()` | #59470 | ✅ |
| `AuthManager::extend()` | #59470 | ✅ |
| `BroadcastManager::extend()` | #59470 | ✅ |
| `CacheManager::extend()` | #59470 | ✅ |
| `FilesystemManager::extend()` | #59470 | ✅ |
| `RedisManager::extend()` | #59493 | Pending |
| `LogManager::extend()` | #59493 | Pending |
| `MultipleInstanceManager::extend()` | #59493 | Pending |
| **`ClosureCommand::execute()`** | **This PR** | **Pending** |

### Changes

- `src/Illuminate/Foundation/Console/ClosureCommand.php` — Fix static closure handling in `execute()`