### PR TITLE
[13.x] Add pint.json to export-ignore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -24,5 +24,6 @@ docker-compose.yml export-ignore
 phpstan.src.neon.dist export-ignore
 phpstan.types.neon.dist export-ignore
 phpunit.xml.dist export-ignore
+pint.json export-ignore
 rector.php export-ignore
 RELEASE.md export-ignore


### PR DESCRIPTION
This PR makes it so the pint.json file wont be included in Laravel releases going forward