### PR TITLE
[13.x] Fix Number::pairs() infinite loop when step is zero or negative

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -313,6 +313,8 @@ class Number
      * @param  int|float  $start
      * @param  int|float  $offset
      * @return list<array{int|float, int|float}>
+     *
+     * @phpstan-return ($by is non-positive-int ? array{} : list<array{int|float, int|float}>)
      */
     public static function pairs(int|float $to, int|float $by, int|float $start = 0, int|float $offset = 1)
     {

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -316,6 +316,10 @@ class Number
      */
     public static function pairs(int|float $to, int|float $by, int|float $start = 0, int|float $offset = 1)
     {
+        if ($by <= 0) {
+            return [];
+        }
+
         $output = [];
 
         for ($lower = $start; $lower < $to; $lower += $by) {

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -325,6 +325,12 @@ class SupportNumberTest extends TestCase
         $this->assertSame([[0.5, 2.5], [3.0, 5.0], [5.5, 7.5], [8.0, 10.0]], Number::pairs(10, 2.5, 0.5, 0.5));
     }
 
+    public function testPairsWithZeroStep()
+    {
+        $this->assertSame([], Number::pairs(10, 0));
+        $this->assertSame([], Number::pairs(10, -5));
+    }
+
     public function testTrim()
     {
         $this->assertSame(12, Number::trim(12));


### PR DESCRIPTION
## Summary

`Number::pairs()` enters an infinite loop when the `$by` parameter is 0 or negative, causing memory exhaustion and crashing the PHP process.

### The Bug

```php
Number::pairs(10, 0);
// Fatal error: Allowed memory size exhausted

Number::pairs(10, -5);
// Same - infinite loop
```

The `for` loop increments by `$by` each iteration: `$lower += $by`. When `$by` is 0, `$lower` never changes and the condition `$lower < $to` is always true.

### The Fix

Return an empty array when `$by <= 0`:

```php
Number::pairs(10, 0);  // []
Number::pairs(10, -5); // []
Number::pairs(10, 3);  // [[0,2],[3,5],[6,8],[9,10]] (unchanged)
```

### Changes

- `src/Illuminate/Support/Number.php` — Guard against `$by <= 0`
- `tests/Support/SupportNumberTest.php` — Test for zero and negative step values