### PR TITLE
[13.x] Fix Str::password() crash when all character types are disabled

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1050,7 +1050,9 @@ class Str
      * @param  bool  $numbers
      * @param  bool  $symbols
      * @param  bool  $spaces
-     * @return ($letters is false ? ($numbers is true ? ($symbols is false ? ($spaces is false ? numeric-string : string) : string) : string) : string)
+     * @return string
+     *
+     * @phpstan-return ($letters is false ? ($numbers is true ? ($symbols is false ? ($spaces is false ? numeric-string : string) : string) : ($symbols is false ? ($spaces is false ? never : string) : string)) : string)
      */
     public static function password($length = 32, $letters = true, $numbers = true, $symbols = true, $spaces = false)
     {

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1054,6 +1054,10 @@ class Str
      */
     public static function password($length = 32, $letters = true, $numbers = true, $symbols = true, $spaces = false)
     {
+        if (! $letters && ! $numbers && ! $symbols && ! $spaces) {
+            throw new \InvalidArgumentException('At least one character type must be enabled (letters, numbers, symbols, or spaces).');
+        }
+
         $password = new Collection();
 
         $options = (new Collection([

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1847,6 +1847,13 @@ class SupportStrTest extends TestCase
         );
     }
 
+    public function testPasswordWithNoCharacterTypesThrowsException()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        Str::password(16, letters: false, numbers: false, symbols: false, spaces: false);
+    }
+
     public function testToBase64()
     {
         $this->assertSame(base64_encode('foo'), Str::toBase64('foo'));


### PR DESCRIPTION
## Summary

`Str::password()` crashes with a `ValueError` when all character type options are disabled.

### The Bug

```php
Str::password(16, letters: false, numbers: false, symbols: false);
// ValueError: random_int(): Argument #1 ($min) must be less than or equal to argument #2 ($max)
```

After filtering out all disabled character pools, the options collection is empty. The code then calls `random_int(0, $c->count() - 1)` which becomes `random_int(0, -1)` — an invalid range.

### The Fix

Throw a clear `InvalidArgumentException` early when no character types are enabled:

```php
Str::password(16, letters: false, numbers: false, symbols: false);
// InvalidArgumentException: At least one character type must be enabled
```

### Changes

- `src/Illuminate/Support/Str.php` — Guard against empty character pool
- `tests/Support/SupportStrTest.php` — Test verifying exception is thrown