### PR TITLE
[13.x] Fix `$request->interval()` failing with very small float values 

### DIFF
--- a/src/Illuminate/Support/Traits/InteractsWithData.php
+++ b/src/Illuminate/Support/Traits/InteractsWithData.php
@@ -347,7 +347,7 @@ trait InteractsWithData
 
         $unit = $unit instanceof Unit ? $unit : Unit::fromName($unit);
 
-        return $unit->interval((float) $value);
+        return CarbonInterval::fromString(number_format((float) $value, 10, '.', '').' '.$unit->name);
     }
 
     /**

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -858,6 +858,37 @@ class HttpRequestTest extends TestCase
         $this->assertSame(45, $request->interval('as_minutes', Unit::Second)->seconds);
     }
 
+    public function testIntervalMethodWithScientificNotationFloats()
+    {
+        $request = Request::create('/', 'GET', [
+            'small_float' => '0.000053',
+            'very_small' => '0.000001',
+            'scientific' => '5.3E-5',
+            'normal_float' => '1.5',
+            'integer' => '90',
+        ]);
+
+        // Small floats that PHP would render in scientific notation (e.g. 5.3E-5)
+        $interval = $request->interval('small_float', Unit::Millisecond);
+        $this->assertInstanceOf(CarbonInterval::class, $interval);
+
+        $interval = $request->interval('very_small', Unit::Second);
+        $this->assertInstanceOf(CarbonInterval::class, $interval);
+
+        // Scientific notation string passed directly
+        $interval = $request->interval('scientific', Unit::Millisecond);
+        $this->assertInstanceOf(CarbonInterval::class, $interval);
+
+        // Normal values should still work
+        $interval = $request->interval('normal_float', Unit::Hour);
+        $this->assertInstanceOf(CarbonInterval::class, $interval);
+        $this->assertSame(1, $interval->hours);
+
+        $interval = $request->interval('integer', Unit::Minute);
+        $this->assertInstanceOf(CarbonInterval::class, $interval);
+        $this->assertSame(90, $interval->minutes);
+    }
+
     public function testEnumMethod()
     {
         $request = Request::create('/', 'GET', [


### PR DESCRIPTION
When calling `$request->interval('time', Unit::Millisecond)` with a very small float value (e.g. `0.000053`), `Unit::interval()` internally does:

```php
CarbonInterval::fromString("$value $this->name");
```

PHP's string interpolation renders small floats in scientific notation, producing `"5.3E-5 Millisecond"`, which `CarbonInterval::fromString()` cannot parse, throwing:

```
InvalidArgumentException: Invalid part 5.3E- in definition 5.3E-5 Millisecond
```

### Fix

Use `number_format()` to ensure the float is rendered as a decimal string before passing it to `CarbonInterval::fromString()`:

```php
// Before
return $unit->interval((float) $value);

// After
return CarbonInterval::fromString(number_format((float) $value, 10, '.', '').' '.$unit->name);
```

This also handles cases where the input string is already in scientific notation (e.g. `"5.3E-5"`), since `number_format()` normalizes it to a decimal representation.


### p.s. this also has to be backported to Laravel 12