### PR TITLE
[13.x] Fix missing `Illuminate\Queue\Attributes\Delay` attribute

### DIFF
--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -20,6 +20,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Contracts\Queue\ShouldQueueAfterCommit;
 use Illuminate\Queue\Attributes\Backoff;
 use Illuminate\Queue\Attributes\Connection;
+use Illuminate\Queue\Attributes\Delay;
 use Illuminate\Queue\Attributes\DeleteWhenMissingModels;
 use Illuminate\Queue\Attributes\FailOnTimeout;
 use Illuminate\Queue\Attributes\MaxExceptions;
@@ -679,7 +680,7 @@ class Dispatcher implements DispatcherContract
 
         $delay = method_exists($listener, 'withDelay')
             ? (isset($arguments[0]) ? $listener->withDelay($arguments[0]) : $listener->withDelay())
-            : $listener->delay ?? null;
+            : $this->getAttributeValue($listener, Delay::class, 'delay');
 
         if (is_null($queue)) {
             $queue = $this->resolveQueueFromQueueRoute($listener) ?? null;

--- a/src/Illuminate/Queue/Attributes/Delay.php
+++ b/src/Illuminate/Queue/Attributes/Delay.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Illuminate\Queue\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class Delay
+{
+    /**
+     * Create a new attribute instance.
+     *
+     * @param  int  $delay
+     */
+    public function __construct(public int $delay)
+    {
+        //
+    }
+}


### PR DESCRIPTION
This PR adds the missing `Delay` attribute for queued event listeners, as referenced in the documentation: https://laravel.com/docs/13.x/events#customizing-the-queue-connection-queue-name.