### PR TITLE
[13.x] Fix: respect null redirect in unauthenticated exception handler

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -757,7 +757,7 @@ class Handler implements ExceptionHandlerContract
         $redirectTo = $exception->redirectTo($request);
 
         if (! $redirectTo) {
-            return response()->json(['message' => $exception->getMessage()], 401);
+            return response()->noContent(401);
         }
 
         return redirect()->guest($redirectTo);

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -750,9 +750,17 @@ class Handler implements ExceptionHandlerContract
      */
     protected function unauthenticated($request, AuthenticationException $exception)
     {
-        return $this->shouldReturnJson($request, $exception)
-            ? response()->json(['message' => $exception->getMessage()], 401)
-            : redirect()->guest($exception->redirectTo($request) ?? route('login'));
+        if ($this->shouldReturnJson($request, $exception)) {
+            return response()->json(['message' => $exception->getMessage()], 401);
+        }
+
+        $redirectTo = $exception->redirectTo($request);
+
+        if (! $redirectTo) {
+            return response()->json(['message' => $exception->getMessage()], 401);
+        }
+
+        return redirect()->guest($redirectTo);
     }
 
     /**


### PR DESCRIPTION
## Summary

When `redirectGuestsTo` is configured to return `null` (common for pure API applications), the exception handler's `unauthenticated` method falls back to `route('login')` via the null coalescing operator:

```php
redirect()->guest($exception->redirectTo($request) ?? route('login'));
```

This causes a `RouteNotFoundException` in applications that don't define a `login` route. The `redirectGuestsTo(fn () => null)` configuration is explicitly intended to disable redirects, but the fallback undermines it.

## Change

Instead of falling back to `route('login')` when `redirectTo` returns null, return a 401 response. This is consistent with the JSON branch of the same method and respects the developer's intent when configuring a null redirect.

### Before
```php
return $this->shouldReturnJson($request, $exception)
    ? response()->json(['message' => $exception->getMessage()], 401)
    : redirect()->guest($exception->redirectTo($request) ?? route('login'));
```

### After
```php
if ($this->shouldReturnJson($request, $exception)) {
    return response()->json(['message' => $exception->getMessage()], 401);
}

$redirectTo = $exception->redirectTo($request);

if (! $redirectTo) {
    return response()->noContent(401);
}

return redirect()->guest($redirectTo);
```

## Why this is safe

The default behavior is unchanged for applications that define a login route. `ApplicationBuilder` sets `redirectGuestsTo(fn () => route('login'))` by default, which resolves to a non-null URL string. The `?? route('login')` fallback was only reachable when someone explicitly overrode `redirectGuestsTo` to return null — exactly the case where it should *not* redirect.