### PR TITLE
[13.x] Add queue methods to inspect jobs

### DIFF
--- a/src/Illuminate/Queue/BeanstalkdQueue.php
+++ b/src/Illuminate/Queue/BeanstalkdQueue.php
@@ -4,6 +4,7 @@ namespace Illuminate\Queue;
 
 use Illuminate\Contracts\Queue\Queue as QueueContract;
 use Illuminate\Queue\Jobs\BeanstalkdJob;
+use Illuminate\Support\Collection;
 use Pheanstalk\Contract\JobIdInterface;
 use Pheanstalk\Pheanstalk;
 use Pheanstalk\Values\Job;
@@ -109,6 +110,39 @@ class BeanstalkdQueue extends Queue implements QueueContract
     public function reservedSize($queue = null)
     {
         return $this->pheanstalk->statsTube(new TubeName($this->getQueue($queue)))->currentJobsReserved;
+    }
+
+    /**
+     * Get the pending jobs for the given queue.
+     *
+     * @param  string|null  $queue
+     * @return \Illuminate\Support\Collection
+     */
+    public function pendingJobs($queue = null): Collection
+    {
+        return new Collection;
+    }
+
+    /**
+     * Get the delayed jobs for the given queue.
+     *
+     * @param  string|null  $queue
+     * @return \Illuminate\Support\Collection
+     */
+    public function delayedJobs($queue = null): Collection
+    {
+        return new Collection;
+    }
+
+    /**
+     * Get the reserved jobs for the given queue.
+     *
+     * @param  string|null  $queue
+     * @return \Illuminate\Support\Collection
+     */
+    public function reservedJobs($queue = null): Collection
+    {
+        return new Collection;
     }
 
     /**

--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Queue\Queue as QueueContract;
 use Illuminate\Database\Connection;
 use Illuminate\Queue\Jobs\DatabaseJob;
 use Illuminate\Queue\Jobs\DatabaseJobRecord;
+use Illuminate\Queue\Jobs\InspectedJob;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
@@ -129,6 +130,53 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
             ->where('queue', $this->getQueue($queue))
             ->whereNotNull('reserved_at')
             ->count();
+    }
+
+    /**
+     * Get the pending jobs for the given queue.
+     *
+     * @param  string|null  $queue
+     * @return \Illuminate\Support\Collection<int, \Illuminate\Queue\Jobs\InspectedJob>
+     */
+    public function pendingJobs($queue = null): Collection
+    {
+        return $this->database->table($this->table)
+            ->where('queue', $this->getQueue($queue))
+            ->whereNull('reserved_at')
+            ->where('available_at', '<=', $this->currentTime())
+            ->get()
+            ->map(fn ($record) => InspectedJob::fromPayload($record->payload, $record->queue, $record->attempts));
+    }
+
+    /**
+     * Get the delayed jobs for the given queue.
+     *
+     * @param  string|null  $queue
+     * @return \Illuminate\Support\Collection<int, \Illuminate\Queue\Jobs\InspectedJob>
+     */
+    public function delayedJobs($queue = null): Collection
+    {
+        return $this->database->table($this->table)
+            ->where('queue', $this->getQueue($queue))
+            ->whereNull('reserved_at')
+            ->where('available_at', '>', $this->currentTime())
+            ->get()
+            ->map(fn ($record) => InspectedJob::fromPayload($record->payload, $record->queue, $record->attempts));
+    }
+
+    /**
+     * Get the reserved jobs for the given queue.
+     *
+     * @param  string|null  $queue
+     * @return \Illuminate\Support\Collection<int, \Illuminate\Queue\Jobs\InspectedJob>
+     */
+    public function reservedJobs($queue = null): Collection
+    {
+        return $this->database->table($this->table)
+            ->where('queue', $this->getQueue($queue))
+            ->whereNotNull('reserved_at')
+            ->get()
+            ->map(fn ($record) => InspectedJob::fromPayload($record->payload, $record->queue, $record->attempts));
     }
 
     /**

--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -145,7 +145,7 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
             ->whereNull('reserved_at')
             ->where('available_at', '<=', $this->currentTime())
             ->get()
-            ->map(fn ($record) => InspectedJob::fromPayload($record->payload, $record->queue, $record->attempts));
+            ->map(fn ($record) => InspectedJob::fromPayload($record->payload, $record->attempts));
     }
 
     /**
@@ -161,7 +161,7 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
             ->whereNull('reserved_at')
             ->where('available_at', '>', $this->currentTime())
             ->get()
-            ->map(fn ($record) => InspectedJob::fromPayload($record->payload, $record->queue, $record->attempts));
+            ->map(fn ($record) => InspectedJob::fromPayload($record->payload, $record->attempts));
     }
 
     /**
@@ -176,7 +176,7 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
             ->where('queue', $this->getQueue($queue))
             ->whereNotNull('reserved_at')
             ->get()
-            ->map(fn ($record) => InspectedJob::fromPayload($record->payload, $record->queue, $record->attempts));
+            ->map(fn ($record) => InspectedJob::fromPayload($record->payload, $record->attempts));
     }
 
     /**

--- a/src/Illuminate/Queue/FailoverQueue.php
+++ b/src/Illuminate/Queue/FailoverQueue.php
@@ -5,6 +5,7 @@ namespace Illuminate\Queue;
 use Illuminate\Contracts\Events\Dispatcher as EventDispatcher;
 use Illuminate\Contracts\Queue\Queue as QueueContract;
 use Illuminate\Queue\Events\QueueFailedOver;
+use Illuminate\Support\Collection;
 use RuntimeException;
 use Throwable;
 
@@ -69,6 +70,39 @@ class FailoverQueue extends Queue implements QueueContract
     public function reservedSize($queue = null)
     {
         return $this->manager->connection($this->connections[0])->reservedSize($queue);
+    }
+
+    /**
+     * Get the pending jobs for the given queue.
+     *
+     * @param  string|null  $queue
+     * @return \Illuminate\Support\Collection
+     */
+    public function pendingJobs($queue = null): Collection
+    {
+        return $this->manager->connection($this->connections[0])->pendingJobs($queue);
+    }
+
+    /**
+     * Get the delayed jobs for the given queue.
+     *
+     * @param  string|null  $queue
+     * @return \Illuminate\Support\Collection
+     */
+    public function delayedJobs($queue = null): Collection
+    {
+        return $this->manager->connection($this->connections[0])->delayedJobs($queue);
+    }
+
+    /**
+     * Get the reserved jobs for the given queue.
+     *
+     * @param  string|null  $queue
+     * @return \Illuminate\Support\Collection
+     */
+    public function reservedJobs($queue = null): Collection
+    {
+        return $this->manager->connection($this->connections[0])->reservedJobs($queue);
     }
 
     /**

--- a/src/Illuminate/Queue/Jobs/InspectedJob.php
+++ b/src/Illuminate/Queue/Jobs/InspectedJob.php
@@ -10,14 +10,12 @@ class InspectedJob
      * Create a new inspected job instance.
      *
      * @param  string|null  $name  The display name of the job.
-     * @param  string|null  $queue  The name of the queue the job belongs to.
      * @param  int  $attempts  The number of times the job has been attempted.
      * @param  string|null  $uuid  The unique identifier for the job.
      * @param  \Illuminate\Support\Carbon|null  $createdAt  The date and time the job was created.
      */
     public function __construct(
         public readonly ?string $name,
-        public readonly ?string $queue,
         public readonly int $attempts,
         public readonly ?string $uuid,
         public readonly ?Carbon $createdAt,
@@ -28,17 +26,15 @@ class InspectedJob
      * Create a new instance from a raw job payload.
      *
      * @param  string  $payload  The raw JSON job payload.
-     * @param  string  $queue  The name of the queue the job belongs to.
      * @param  int|null  $attempts  The number of times the job has been attempted.
      * @return static
      */
-    public static function fromPayload(string $payload, string $queue, ?int $attempts = null): static
+    public static function fromPayload(string $payload, ?int $attempts = null): static
     {
         $decoded = json_decode($payload, true);
 
         return new static(
             name: $decoded['displayName'] ?? null,
-            queue: $queue,
             attempts: $attempts ?? $decoded['attempts'] ?? 0,
             uuid: $decoded['uuid'] ?? null,
             createdAt: isset($decoded['createdAt']) ? Carbon::createFromTimestamp($decoded['createdAt']) : null,

--- a/src/Illuminate/Queue/Jobs/InspectedJob.php
+++ b/src/Illuminate/Queue/Jobs/InspectedJob.php
@@ -9,15 +9,15 @@ class InspectedJob
     /**
      * Create a new inspected job instance.
      *
+     * @param  string|null  $uuid  The unique identifier for the job.
      * @param  string|null  $name  The display name of the job.
      * @param  int  $attempts  The number of times the job has been attempted.
-     * @param  string|null  $uuid  The unique identifier for the job.
      * @param  \Illuminate\Support\Carbon|null  $createdAt  The date and time the job was created.
      */
     public function __construct(
+        public readonly ?string $uuid,
         public readonly ?string $name,
         public readonly int $attempts,
-        public readonly ?string $uuid,
         public readonly ?Carbon $createdAt,
     ) {
     }
@@ -34,9 +34,9 @@ class InspectedJob
         $decoded = json_decode($payload, true);
 
         return new static(
+            uuid: $decoded['uuid'] ?? null,
             name: $decoded['displayName'] ?? null,
             attempts: $attempts ?? $decoded['attempts'] ?? 0,
-            uuid: $decoded['uuid'] ?? null,
             createdAt: isset($decoded['createdAt']) ? Carbon::createFromTimestamp($decoded['createdAt']) : null,
         );
     }

--- a/src/Illuminate/Queue/Jobs/InspectedJob.php
+++ b/src/Illuminate/Queue/Jobs/InspectedJob.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Illuminate\Queue\Jobs;
+
+use Illuminate\Support\Carbon;
+
+class InspectedJob
+{
+    /**
+     * Create a new inspected job instance.
+     *
+     * @param  string|null  $name  The display name of the job.
+     * @param  string|null  $queue  The name of the queue the job belongs to.
+     * @param  int  $attempts  The number of times the job has been attempted.
+     * @param  string|null  $uuid  The unique identifier for the job.
+     * @param  \Illuminate\Support\Carbon|null  $createdAt  The date and time the job was created.
+     */
+    public function __construct(
+        public readonly ?string $name,
+        public readonly ?string $queue,
+        public readonly int $attempts,
+        public readonly ?string $uuid,
+        public readonly ?Carbon $createdAt,
+    ) {
+    }
+
+    /**
+     * Create a new instance from a raw job payload.
+     *
+     * @param  string  $payload  The raw JSON job payload.
+     * @param  string  $queue  The name of the queue the job belongs to.
+     * @param  int|null  $attempts  The number of times the job has been attempted.
+     * @return static
+     */
+    public static function fromPayload(string $payload, string $queue, ?int $attempts = null): static
+    {
+        $decoded = json_decode($payload, true);
+
+        return new static(
+            name: $decoded['displayName'] ?? null,
+            queue: $queue,
+            attempts: $attempts ?? $decoded['attempts'] ?? 0,
+            uuid: $decoded['uuid'] ?? null,
+            createdAt: isset($decoded['createdAt']) ? Carbon::createFromTimestamp($decoded['createdAt']) : null,
+        );
+    }
+}

--- a/src/Illuminate/Queue/NullQueue.php
+++ b/src/Illuminate/Queue/NullQueue.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Queue;
 
 use Illuminate\Contracts\Queue\Queue as QueueContract;
+use Illuminate\Support\Collection;
 
 class NullQueue extends Queue implements QueueContract
 {
@@ -48,6 +49,39 @@ class NullQueue extends Queue implements QueueContract
     public function reservedSize($queue = null)
     {
         return 0;
+    }
+
+    /**
+     * Get the pending jobs for the given queue.
+     *
+     * @param  string|null  $queue
+     * @return \Illuminate\Support\Collection
+     */
+    public function pendingJobs($queue = null): Collection
+    {
+        return new Collection;
+    }
+
+    /**
+     * Get the delayed jobs for the given queue.
+     *
+     * @param  string|null  $queue
+     * @return \Illuminate\Support\Collection
+     */
+    public function delayedJobs($queue = null): Collection
+    {
+        return new Collection;
+    }
+
+    /**
+     * Get the reserved jobs for the given queue.
+     *
+     * @param  string|null  $queue
+     * @return \Illuminate\Support\Collection
+     */
+    public function reservedJobs($queue = null): Collection
+    {
+        return new Collection;
     }
 
     /**

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -155,7 +155,7 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
         $queue = $this->getQueue($queue);
 
         return (new Collection($this->getConnection()->lrange($queue, 0, -1)))
-            ->map(fn ($payload) => InspectedJob::fromPayload($payload, $queue));
+            ->map(fn ($payload) => InspectedJob::fromPayload($payload));
     }
 
     /**
@@ -169,7 +169,7 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
         $queue = $this->getQueue($queue);
 
         return (new Collection($this->getConnection()->zrange($queue.':delayed', 0, -1)))
-            ->map(fn ($payload) => InspectedJob::fromPayload($payload, $queue));
+            ->map(fn ($payload) => InspectedJob::fromPayload($payload));
     }
 
     /**
@@ -183,7 +183,7 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
         $queue = $this->getQueue($queue);
 
         return (new Collection($this->getConnection()->zrange($queue.':reserved', 0, -1)))
-            ->map(fn ($payload) => InspectedJob::fromPayload($payload, $queue));
+            ->map(fn ($payload) => InspectedJob::fromPayload($payload));
     }
 
     /**

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -5,9 +5,11 @@ namespace Illuminate\Queue;
 use Illuminate\Contracts\Queue\ClearableQueue;
 use Illuminate\Contracts\Queue\Queue as QueueContract;
 use Illuminate\Contracts\Redis\Factory as Redis;
+use Illuminate\Queue\Jobs\InspectedJob;
 use Illuminate\Queue\Jobs\RedisJob;
 use Illuminate\Redis\Connections\PhpRedisClusterConnection;
 use Illuminate\Redis\Connections\PredisClusterConnection;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 
 class RedisQueue extends Queue implements QueueContract, ClearableQueue
@@ -140,6 +142,48 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
     public function reservedSize($queue = null)
     {
         return $this->getConnection()->zcard($this->getQueue($queue).':reserved');
+    }
+
+    /**
+     * Get the pending jobs for the given queue.
+     *
+     * @param  string|null  $queue
+     * @return \Illuminate\Support\Collection<int, \Illuminate\Queue\Jobs\InspectedJob>
+     */
+    public function pendingJobs($queue = null): Collection
+    {
+        $queue = $this->getQueue($queue);
+
+        return (new Collection($this->getConnection()->lrange($queue, 0, -1)))
+            ->map(fn ($payload) => InspectedJob::fromPayload($payload, $queue));
+    }
+
+    /**
+     * Get the delayed jobs for the given queue.
+     *
+     * @param  string|null  $queue
+     * @return \Illuminate\Support\Collection<int, \Illuminate\Queue\Jobs\InspectedJob>
+     */
+    public function delayedJobs($queue = null): Collection
+    {
+        $queue = $this->getQueue($queue);
+
+        return (new Collection($this->getConnection()->zrange($queue.':delayed', 0, -1)))
+            ->map(fn ($payload) => InspectedJob::fromPayload($payload, $queue));
+    }
+
+    /**
+     * Get the reserved jobs for the given queue.
+     *
+     * @param  string|null  $queue
+     * @return \Illuminate\Support\Collection<int, \Illuminate\Queue\Jobs\InspectedJob>
+     */
+    public function reservedJobs($queue = null): Collection
+    {
+        $queue = $this->getQueue($queue);
+
+        return (new Collection($this->getConnection()->zrange($queue.':reserved', 0, -1)))
+            ->map(fn ($payload) => InspectedJob::fromPayload($payload, $queue));
     }
 
     /**

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -6,6 +6,7 @@ use Aws\Sqs\SqsClient;
 use Illuminate\Contracts\Queue\ClearableQueue;
 use Illuminate\Contracts\Queue\Queue as QueueContract;
 use Illuminate\Queue\Jobs\SqsJob;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 
 class SqsQueue extends Queue implements QueueContract, ClearableQueue
@@ -131,6 +132,39 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
         ]);
 
         return (int) $response['Attributes']['ApproximateNumberOfMessagesNotVisible'] ?? 0;
+    }
+
+    /**
+     * Get the pending jobs for the given queue.
+     *
+     * @param  string|null  $queue
+     * @return \Illuminate\Support\Collection
+     */
+    public function pendingJobs($queue = null): Collection
+    {
+        return new Collection;
+    }
+
+    /**
+     * Get the delayed jobs for the given queue.
+     *
+     * @param  string|null  $queue
+     * @return \Illuminate\Support\Collection
+     */
+    public function delayedJobs($queue = null): Collection
+    {
+        return new Collection;
+    }
+
+    /**
+     * Get the reserved jobs for the given queue.
+     *
+     * @param  string|null  $queue
+     * @return \Illuminate\Support\Collection
+     */
+    public function reservedJobs($queue = null): Collection
+    {
+        return new Collection;
     }
 
     /**

--- a/src/Illuminate/Queue/SyncQueue.php
+++ b/src/Illuminate/Queue/SyncQueue.php
@@ -12,6 +12,7 @@ use Illuminate\Queue\Events\JobExceptionOccurred;
 use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Queue\Events\JobProcessing;
 use Illuminate\Queue\Jobs\SyncJob;
+use Illuminate\Support\Collection;
 use Throwable;
 
 class SyncQueue extends Queue implements QueueContract
@@ -68,6 +69,39 @@ class SyncQueue extends Queue implements QueueContract
     public function reservedSize($queue = null)
     {
         return 0;
+    }
+
+    /**
+     * Get the pending jobs for the given queue.
+     *
+     * @param  string|null  $queue
+     * @return \Illuminate\Support\Collection
+     */
+    public function pendingJobs($queue = null): Collection
+    {
+        return new Collection;
+    }
+
+    /**
+     * Get the delayed jobs for the given queue.
+     *
+     * @param  string|null  $queue
+     * @return \Illuminate\Support\Collection
+     */
+    public function delayedJobs($queue = null): Collection
+    {
+        return new Collection;
+    }
+
+    /**
+     * Get the reserved jobs for the given queue.
+     *
+     * @param  string|null  $queue
+     * @return \Illuminate\Support\Collection
+     */
+    public function reservedJobs($queue = null): Collection
+    {
+        return new Collection;
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -472,7 +472,6 @@ class QueueFake extends QueueManager implements Fake, Queue
                 name: is_object($data['job'])
                     ? (method_exists($data['job'], 'displayName') ? $data['job']->displayName() : get_class($data['job']))
                     : $data['job'],
-                queue: $data['queue'],
                 attempts: 0,
                 uuid: null,
                 createdAt: null,

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -10,6 +10,7 @@ use Illuminate\Contracts\Queue\Queue;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Events\CallQueuedListener;
 use Illuminate\Queue\CallQueuedClosure;
+use Illuminate\Queue\Jobs\InspectedJob;
 use Illuminate\Queue\QueueManager;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
@@ -454,6 +455,50 @@ class QueueFake extends QueueManager implements Fake, Queue
     public function reservedSize($queue = null)
     {
         return 0;
+    }
+
+    /**
+     * Get the pending jobs for the given queue.
+     *
+     * @param  string|null  $queue
+     * @return \Illuminate\Support\Collection<int, \Illuminate\Queue\Jobs\InspectedJob>
+     */
+    public function pendingJobs($queue = null): Collection
+    {
+        return (new Collection($this->jobs))
+            ->flatten(1)
+            ->filter(fn ($job) => $job['queue'] === $queue)
+            ->map(fn ($data) => new InspectedJob(
+                name: is_object($data['job'])
+                    ? (method_exists($data['job'], 'displayName') ? $data['job']->displayName() : get_class($data['job']))
+                    : $data['job'],
+                queue: $data['queue'],
+                attempts: 0,
+                uuid: null,
+                createdAt: null,
+            ));
+    }
+
+    /**
+     * Get the delayed jobs for the given queue.
+     *
+     * @param  string|null  $queue
+     * @return \Illuminate\Support\Collection
+     */
+    public function delayedJobs($queue = null): Collection
+    {
+        return new Collection;
+    }
+
+    /**
+     * Get the reserved jobs for the given queue.
+     *
+     * @param  string|null  $queue
+     * @return \Illuminate\Support\Collection
+     */
+    public function reservedJobs($queue = null): Collection
+    {
+        return new Collection;
     }
 
     /**

--- a/tests/Integration/Queue/RedisQueueTest.php
+++ b/tests/Integration/Queue/RedisQueueTest.php
@@ -7,8 +7,10 @@ use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
 use Illuminate\Queue\Events\JobQueued;
 use Illuminate\Queue\Events\JobQueueing;
+use Illuminate\Queue\Jobs\InspectedJob;
 use Illuminate\Queue\Jobs\RedisJob;
 use Illuminate\Queue\RedisQueue;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\InteractsWithTime;
 use Illuminate\Support\Str;
 use Mockery as m;
@@ -592,6 +594,64 @@ class RedisQueueTest extends TestCase
             // Restore original serializer setting
             $client->setOption($optSerializer, $originalSerializer);
         }
+    }
+
+    #[DataProvider('redisDriverProvider')]
+    public function testPendingJobs($driver)
+    {
+        $default = config('queue.connections.redis.queue', 'default');
+        $this->setQueue($driver, $default);
+
+        $job = new RedisQueueIntegrationTestJob(99);
+        $this->queue->push($job);
+
+        $pending = $this->queue->pendingJobs();
+
+        $this->assertCount(1, $pending);
+        $this->assertInstanceOf(InspectedJob::class, $pending->first());
+        $this->assertSame(RedisQueueIntegrationTestJob::class, $pending->first()->name);
+        $this->assertSame(0, $pending->first()->attempts);
+        $this->assertNotNull($pending->first()->uuid);
+        $this->assertInstanceOf(Carbon::class, $pending->first()->createdAt);
+    }
+
+    #[DataProvider('redisDriverProvider')]
+    public function testDelayedJobs($driver)
+    {
+        $default = config('queue.connections.redis.queue', 'default');
+        $this->setQueue($driver, $default);
+
+        $job = new RedisQueueIntegrationTestJob(99);
+        $this->queue->later(60, $job);
+
+        $delayed = $this->queue->delayedJobs();
+
+        $this->assertCount(1, $delayed);
+        $this->assertInstanceOf(InspectedJob::class, $delayed->first());
+        $this->assertSame(RedisQueueIntegrationTestJob::class, $delayed->first()->name);
+        $this->assertSame(0, $delayed->first()->attempts);
+        $this->assertNotNull($delayed->first()->uuid);
+        $this->assertInstanceOf(Carbon::class, $delayed->first()->createdAt);
+    }
+
+    #[DataProvider('redisDriverProvider')]
+    public function testReservedJobs($driver)
+    {
+        $default = config('queue.connections.redis.queue', 'default');
+        $this->setQueue($driver, $default);
+
+        $job = new RedisQueueIntegrationTestJob(99);
+        $this->queue->push($job);
+        $this->queue->pop(); // moves job to reserved sorted set
+
+        $reserved = $this->queue->reservedJobs();
+
+        $this->assertCount(1, $reserved);
+        $this->assertInstanceOf(InspectedJob::class, $reserved->first());
+        $this->assertSame(RedisQueueIntegrationTestJob::class, $reserved->first()->name);
+        $this->assertSame(1, $reserved->first()->attempts);
+        $this->assertNotNull($reserved->first()->uuid);
+        $this->assertInstanceOf(Carbon::class, $reserved->first()->createdAt);
     }
 }
 

--- a/tests/Queue/QueueDatabaseQueueUnitTest.php
+++ b/tests/Queue/QueueDatabaseQueueUnitTest.php
@@ -6,6 +6,7 @@ use Illuminate\Bus\Batchable;
 use Illuminate\Container\Container;
 use Illuminate\Database\Connection;
 use Illuminate\Queue\DatabaseQueue;
+use Illuminate\Queue\Jobs\InspectedJob;
 use Illuminate\Queue\Queue;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
@@ -195,6 +196,77 @@ class QueueDatabaseQueueUnitTest extends TestCase
         $record = $queue->buildDatabaseRecord('queue', 'any_payload', 0);
         $this->assertArrayHasKey('payload', $record);
         $this->assertArrayHasKey('payload', array_slice($record, -1, 1, true));
+    }
+
+    public function testPendingJobs()
+    {
+        $queue = new DatabaseQueue($database = m::mock(Connection::class), 'table', 'default');
+        $queue->setContainer(m::spy(Container::class));
+
+        $payload = json_encode(['uuid' => 'test-uuid', 'displayName' => 'MyTestJob', 'job' => 'foo', 'data' => [], 'createdAt' => 1000000]);
+
+        $database->shouldReceive('table')->with('table')->andReturn($query = m::mock(stdClass::class));
+        $query->shouldReceive('where')->with('queue', 'default')->andReturnSelf();
+        $query->shouldReceive('whereNull')->with('reserved_at')->andReturnSelf();
+        $query->shouldReceive('where')->with('available_at', '<=', m::any())->andReturnSelf();
+        $query->shouldReceive('get')->andReturn(collect([(object) ['id' => 1, 'queue' => 'default', 'payload' => $payload, 'attempts' => 0, 'reserved_at' => null]]));
+
+        $jobs = $queue->pendingJobs();
+
+        $this->assertCount(1, $jobs);
+        $this->assertInstanceOf(InspectedJob::class, $jobs->first());
+        $this->assertSame('MyTestJob', $jobs->first()->name);
+        $this->assertSame('test-uuid', $jobs->first()->uuid);
+        $this->assertSame(0, $jobs->first()->attempts);
+        $this->assertInstanceOf(Carbon::class, $jobs->first()->createdAt);
+        $this->assertSame(1000000, $jobs->first()->createdAt->getTimestamp());
+    }
+
+    public function testDelayedJobs()
+    {
+        $queue = new DatabaseQueue($database = m::mock(Connection::class), 'table', 'default');
+        $queue->setContainer(m::spy(Container::class));
+
+        $payload = json_encode(['uuid' => 'test-uuid', 'displayName' => 'MyDelayedJob', 'job' => 'foo', 'data' => [], 'createdAt' => 1000000]);
+
+        $database->shouldReceive('table')->with('table')->andReturn($query = m::mock(stdClass::class));
+        $query->shouldReceive('where')->with('queue', 'default')->andReturnSelf();
+        $query->shouldReceive('whereNull')->with('reserved_at')->andReturnSelf();
+        $query->shouldReceive('where')->with('available_at', '>', m::any())->andReturnSelf();
+        $query->shouldReceive('get')->andReturn(collect([(object) ['id' => 2, 'queue' => 'default', 'payload' => $payload, 'attempts' => 0, 'reserved_at' => null]]));
+
+        $jobs = $queue->delayedJobs();
+
+        $this->assertCount(1, $jobs);
+        $this->assertInstanceOf(InspectedJob::class, $jobs->first());
+        $this->assertSame('MyDelayedJob', $jobs->first()->name);
+        $this->assertSame('test-uuid', $jobs->first()->uuid);
+        $this->assertSame(0, $jobs->first()->attempts);
+        $this->assertInstanceOf(Carbon::class, $jobs->first()->createdAt);
+        $this->assertSame(1000000, $jobs->first()->createdAt->getTimestamp());
+    }
+
+    public function testReservedJobs()
+    {
+        $queue = new DatabaseQueue($database = m::mock(Connection::class), 'table', 'default');
+        $queue->setContainer(m::spy(Container::class));
+
+        $payload = json_encode(['uuid' => 'test-uuid', 'displayName' => 'MyTestJob', 'job' => 'foo', 'data' => [], 'createdAt' => 1000000]);
+
+        $database->shouldReceive('table')->with('table')->andReturn($query = m::mock(stdClass::class));
+        $query->shouldReceive('where')->with('queue', 'default')->andReturnSelf();
+        $query->shouldReceive('whereNotNull')->with('reserved_at')->andReturnSelf();
+        $query->shouldReceive('get')->andReturn(collect([(object) ['id' => 1, 'queue' => 'default', 'payload' => $payload, 'attempts' => 1, 'reserved_at' => now()->timestamp]]));
+
+        $jobs = $queue->reservedJobs();
+
+        $this->assertCount(1, $jobs);
+        $this->assertInstanceOf(InspectedJob::class, $jobs->first());
+        $this->assertSame('MyTestJob', $jobs->first()->name);
+        $this->assertSame('test-uuid', $jobs->first()->uuid);
+        $this->assertSame(1, $jobs->first()->attempts);
+        $this->assertInstanceOf(Carbon::class, $jobs->first()->createdAt);
+        $this->assertSame(1000000, $jobs->first()->createdAt->getTimestamp());
     }
 
     public function testGetLockForPoppingIsCached()

--- a/tests/Support/SupportTestingQueueFakeTest.php
+++ b/tests/Support/SupportTestingQueueFakeTest.php
@@ -6,6 +6,7 @@ use BadMethodCallException;
 use Illuminate\Bus\Queueable;
 use Illuminate\Foundation\Application;
 use Illuminate\Queue\CallQueuedClosure;
+use Illuminate\Queue\Jobs\InspectedJob;
 use Illuminate\Queue\QueueManager;
 use Illuminate\Support\Testing\Fakes\QueueFake;
 use Mockery as m;
@@ -479,6 +480,20 @@ class SupportTestingQueueFakeTest extends TestCase
         } catch (ExpectationFailedException $e) {
             $this->assertStringContainsString('The job has chained jobs.', $e->getMessage());
         }
+    }
+
+    public function testPendingJobs()
+    {
+        $this->fake->push($this->job, '', 'foo');
+        $this->fake->push(new JobToFakeStub, '', 'bar');
+
+        $pending = $this->fake->pendingJobs('foo');
+
+        $this->assertCount(1, $pending);
+        $this->assertInstanceOf(InspectedJob::class, $pending->first());
+        $this->assertSame(JobStub::class, $pending->first()->name);
+        $this->assertSame('foo', $pending->first()->queue);
+        $this->assertSame(0, $pending->first()->attempts);
     }
 
     public function testGetRawPushes()

--- a/tests/Support/SupportTestingQueueFakeTest.php
+++ b/tests/Support/SupportTestingQueueFakeTest.php
@@ -492,7 +492,6 @@ class SupportTestingQueueFakeTest extends TestCase
         $this->assertCount(1, $pending);
         $this->assertInstanceOf(InspectedJob::class, $pending->first());
         $this->assertSame(JobStub::class, $pending->first()->name);
-        $this->assertSame('foo', $pending->first()->queue);
         $this->assertSame(0, $pending->first()->attempts);
     }
 


### PR DESCRIPTION
In this PR there's 3 new methods which can all be accessed from the queue facade: 

```php
Queue::pendingJobs();
Queue::delayedJobs();
Queue::reservedJobs();
```
( which mirrors the size methods )

Each returns a `Collection` of `InspectedJob`.  which is as a lightweight class to expose uuid, job name, attempts and createdAt of each payload

Which means we can now do cool stuff like:

```php
Queue::reservedJobs('high-priority-queue')->first()->name;
  // => 'App\Jobs\SendEmail'

Queue::pendingJobs()->countBy('name');
  // => ['App\Jobs\SendEmail' => 1842, 'App\Jobs\ProcessOrder' => 43]
```

I use database queues and have logic to ensure certain jobs aren't running during deployment in Laravel Cloud and other infra. IE imagine there's a job that shouldn't be interrupted by a deployment, that's the scenario, if it's running the deployment script waits for it to finish.

This currently means reaching for DB::table, manually decoding the payload, and knowing that the job class is stored under displayName.. we can access size via the queue facade, but there's no clean way to get more job details without understanding the internals hence the PR :) 

I've added the method to each driver, most just being an empty collection as this only works for the Redis and Database drivers. 

No contract changes, no B/C (i dont think), but contracts etc could be tightened in 14.x



This probably needs some love / direction. Happy for you to take over or tell me what to adjust into something more fitting, or throw it into the abyss, but thought I'd give this a idea a try!