### PR TITLE
[13.x] Support attributes and constructor-based queue configuration for listeners

### DIFF
--- a/src/Illuminate/Events/CallQueuedListener.php
+++ b/src/Illuminate/Events/CallQueuedListener.php
@@ -124,7 +124,16 @@ class CallQueuedListener implements ShouldQueue
         $this->class = $class;
         $this->method = $method;
 
-        $this->queue = $this->resolveQueueName($class);
+        $instance = Container::getInstance()->make($class);
+
+        $this->queue = $this->getAttributeValue($instance, \Illuminate\Queue\Attributes\Queue::class, 'queue')
+            ?? (method_exists($instance, 'viaQueue') ? $instance->viaQueue() : null);
+
+        $this->connection = $this->getAttributeValue($instance, \Illuminate\Queue\Attributes\Connection::class, 'connection')
+            ?? ($instance->connection ?? null);
+
+        $this->delay = $this->getAttributeValue($instance, \Illuminate\Queue\Attributes\Delay::class, 'delay')
+            ?? ($instance->delay ?? null);
     }
 
     /**

--- a/src/Illuminate/Events/CallQueuedListener.php
+++ b/src/Illuminate/Events/CallQueuedListener.php
@@ -8,10 +8,11 @@ use Illuminate\Contracts\Cache\Repository as Cache;
 use Illuminate\Contracts\Queue\Job;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Support\Traits\ReadsClassAttributes;
 
 class CallQueuedListener implements ShouldQueue
 {
-    use InteractsWithQueue, Queueable;
+    use InteractsWithQueue, Queueable, ReadsClassAttributes;
 
     /**
      * The listener class name.
@@ -270,10 +271,9 @@ class CallQueuedListener implements ShouldQueue
      */
     protected function resolveQueueName($class)
     {
-        if (property_exists($class, 'queue')) {
-            return (new $class)->queue;
-        }
+        $instance = Container::getInstance()->make($class);
 
-        return null;
+        return $this->getAttributeValue($instance, \Illuminate\Queue\Attributes\Queue::class, 'queue')
+            ?? ($instance->queue ?? null);
     }
 }

--- a/src/Illuminate/Events/CallQueuedListener.php
+++ b/src/Illuminate/Events/CallQueuedListener.php
@@ -274,6 +274,6 @@ class CallQueuedListener implements ShouldQueue
         $instance = Container::getInstance()->make($class);
 
         return $this->getAttributeValue($instance, \Illuminate\Queue\Attributes\Queue::class, 'queue')
-            ?? ($instance->queue ?? null);
+            ?? (method_exists($instance, 'viaQueue') ? $instance->viaQueue() : ($instance->queue ?? null));
     }
 }

--- a/src/Illuminate/Events/CallQueuedListener.php
+++ b/src/Illuminate/Events/CallQueuedListener.php
@@ -273,7 +273,8 @@ class CallQueuedListener implements ShouldQueue
     {
         $instance = Container::getInstance()->make($class);
 
-        return $this->getAttributeValue($instance, \Illuminate\Queue\Attributes\Queue::class, 'queue')
-            ?? (method_exists($instance, 'viaQueue') ? $instance->viaQueue() : ($instance->queue ?? null));
+        $queue = $this->getAttributeValue($instance, \Illuminate\Queue\Attributes\Queue::class, 'queue');
+
+        return $queue ?? (method_exists($instance, 'viaQueue') ? $instance->viaQueue() : null);
     }
 }

--- a/src/Illuminate/Events/CallQueuedListener.php
+++ b/src/Illuminate/Events/CallQueuedListener.php
@@ -122,6 +122,8 @@ class CallQueuedListener implements ShouldQueue
         $this->data = $data;
         $this->class = $class;
         $this->method = $method;
+
+        $this->queue = $this->resolveQueueName($class);
     }
 
     /**
@@ -258,5 +260,20 @@ class CallQueuedListener implements ShouldQueue
         $this->data = array_map(function ($data) {
             return is_object($data) ? clone $data : $data;
         }, $this->data);
+    }
+
+    /**
+     * Resolve the queue name for the listener.
+     *
+     * @param  string  $class
+     * @return string|null
+     */
+    protected function resolveQueueName($class)
+    {
+        if (property_exists($class, 'queue')) {
+            return (new $class)->queue;
+        }
+
+        return null;
     }
 }

--- a/src/Illuminate/Events/CallQueuedListener.php
+++ b/src/Illuminate/Events/CallQueuedListener.php
@@ -271,19 +271,4 @@ class CallQueuedListener implements ShouldQueue
             return is_object($data) ? clone $data : $data;
         }, $this->data);
     }
-
-    /**
-     * Resolve the queue name for the listener.
-     *
-     * @param  string  $class
-     * @return string|null
-     */
-    protected function resolveQueueName($class)
-    {
-        $instance = Container::getInstance()->make($class);
-
-        $queue = $this->getAttributeValue($instance, \Illuminate\Queue\Attributes\Queue::class, 'queue');
-
-        return $queue ?? (method_exists($instance, 'viaQueue') ? $instance->viaQueue() : null);
-    }
 }

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -10,6 +10,9 @@ use Illuminate\Events\CallQueuedListener;
 use Illuminate\Events\Dispatcher;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Queue\Attributes\Connection as ConnectionAttribute;
+use Illuminate\Queue\Attributes\Connection;
+use Illuminate\Queue\Attributes\Delay;
 
 class EventsDispatcherTest extends TestCase
 {
@@ -831,6 +834,17 @@ class EventsDispatcherTest extends TestCase
             return $job->connection === 'attribute-connection' && $job->delay === 60;
         });
     }
+
+    public function testConstructorAssignmentTakesPrecedenceOverAttribute()
+    {
+        $instance = new CallQueuedListener(
+            TestDispatcherPrecedenceConnectionHandler::class,
+            'handle',
+            ['foo']
+        );
+
+        $this->assertEquals('constructor-connection', $instance->connection);
+    }
 }
 
 class TestListenerLean
@@ -1066,13 +1080,26 @@ class TestDispatcherConstructorConnectionAndDelayHandler implements \Illuminate\
     }
 }
 
-use Illuminate\Queue\Attributes\Connection;
-use Illuminate\Queue\Attributes\Delay;
-
 #[Connection('attribute-connection')]
 #[Delay(60)]
 class TestDispatcherAttributeConnectionAndDelayHandler implements ShouldQueue
 {
+    public function handle()
+    {
+        //
+    }
+}
+
+#[ConnectionAttribute('attribute-connection')]
+class TestDispatcherPrecedenceConnectionHandler implements ShouldQueue
+{
+    use \Illuminate\Bus\Queueable;
+
+    public function __construct()
+    {
+        $this->onConnection('constructor-connection');
+    }
+
     public function handle()
     {
         //

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -8,11 +8,11 @@ use Illuminate\Container\Container;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Events\CallQueuedListener;
 use Illuminate\Events\Dispatcher;
+use Illuminate\Queue\Attributes\Connection;
+use Illuminate\Queue\Attributes\Connection as ConnectionAttribute;
+use Illuminate\Queue\Attributes\Delay;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
-use Illuminate\Queue\Attributes\Connection as ConnectionAttribute;
-use Illuminate\Queue\Attributes\Connection;
-use Illuminate\Queue\Attributes\Delay;
 
 class EventsDispatcherTest extends TestCase
 {

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -773,6 +773,34 @@ class EventsDispatcherTest extends TestCase
 
         $fakeQueue->assertPushedOn('attribute-queue', \Illuminate\Events\CallQueuedListener::class);
     }
+
+    public function testItHandlesNullQueueGracefully()
+    {
+        $d = new Dispatcher;
+        $fakeQueue = new \Illuminate\Support\Testing\Fakes\QueueFake(new Container);
+        $d->setQueueResolver(function () use ($fakeQueue) {
+            return $fakeQueue;
+        });
+
+        $d->listen('null.event', TestDispatcherNullQueueHandler::class.'@handle');
+        $d->dispatch('null.event');
+
+        $fakeQueue->assertPushedOn(null, \Illuminate\Events\CallQueuedListener::class);
+    }
+
+    public function testItHandlesEmptyStringQueue()
+    {
+        $d = new Dispatcher;
+        $fakeQueue = new \Illuminate\Support\Testing\Fakes\QueueFake(new Container);
+        $d->setQueueResolver(function () use ($fakeQueue) {
+            return $fakeQueue;
+        });
+
+        $d->listen('empty.event', TestDispatcherEmptyStringQueueHandler::class.'@handle');
+        $d->dispatch('empty.event');
+
+        $fakeQueue->assertPushedOn(null, \Illuminate\Events\CallQueuedListener::class);
+    }
 }
 
 class TestListenerLean
@@ -960,4 +988,18 @@ class TestDispatcherAttributeOnlyQueueHandler implements \Illuminate\Contracts\Q
     {
         //
     }
+}
+
+class TestDispatcherNullQueueHandler implements \Illuminate\Contracts\Queue\ShouldQueue
+{
+    use \Illuminate\Bus\Queueable;
+    public function __construct() { $this->onQueue(null); }
+    public function handle() {}
+}
+
+class TestDispatcherEmptyStringQueueHandler implements \Illuminate\Contracts\Queue\ShouldQueue
+{
+    use \Illuminate\Bus\Queueable;
+    public function __construct() { $this->onQueue(''); }
+    public function handle() {}
 }

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Events;
 use Error;
 use Exception;
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Events\CallQueuedListener;
 use Illuminate\Events\Dispatcher;
 use Mockery as m;
@@ -801,6 +802,35 @@ class EventsDispatcherTest extends TestCase
 
         $fakeQueue->assertPushedOn(null, \Illuminate\Events\CallQueuedListener::class);
     }
+
+    public function testConstructorBasedConnectionAndDelayAssignmentIsRespected()
+    {
+        $instance = new CallQueuedListener(
+            TestDispatcherConstructorConnectionAndDelayHandler::class,
+            'handle',
+            ['foo']
+        );
+
+        $this->assertEquals('constructor-connection', $instance->connection);
+        $this->assertEquals(45, $instance->delay);
+    }
+
+    public function testItRespectsConnectionAndDelayAttributes()
+    {
+        $d = new Dispatcher;
+        $fakeQueue = new \Illuminate\Support\Testing\Fakes\QueueFake(new Container);
+
+        $d->setQueueResolver(function () use ($fakeQueue) {
+            return $fakeQueue;
+        });
+
+        $d->listen('attr.conn.event', TestDispatcherAttributeConnectionAndDelayHandler::class.'@handle');
+        $d->dispatch('attr.conn.event');
+
+        $fakeQueue->assertPushed(CallQueuedListener::class, function ($job) {
+            return $job->connection === 'attribute-connection' && $job->delay === 60;
+        });
+    }
 }
 
 class TestListenerLean
@@ -1014,6 +1044,33 @@ class TestDispatcherEmptyStringQueueHandler implements \Illuminate\Contracts\Que
         $this->onQueue('');
     }
 
+    public function handle()
+    {
+        //
+    }
+}
+
+class TestDispatcherConstructorConnectionAndDelayHandler implements \Illuminate\Contracts\Queue\ShouldQueue
+{
+    use \Illuminate\Bus\Queueable;
+
+    public function __construct() {
+        $this->onConnection('constructor-connection');
+        $this->delay(45);
+    }
+    public function handle()
+    {
+        //
+    }
+}
+
+use Illuminate\Queue\Attributes\Connection;
+use Illuminate\Queue\Attributes\Delay;
+
+#[Connection('attribute-connection')]
+#[Delay(60)]
+class TestDispatcherAttributeConnectionAndDelayHandler implements ShouldQueue
+{
     public function handle()
     {
         //

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Events;
 use Error;
 use Exception;
 use Illuminate\Container\Container;
+use Illuminate\Events\CallQueuedListener;
 use Illuminate\Events\Dispatcher;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -747,6 +748,17 @@ class EventsDispatcherTest extends TestCase
             Container::setInstance($originalContainer);
         }
     }
+
+    public function testConstructorBasedQueueAssignmentIsRespected()
+    {
+        $instance = new CallQueuedListener(
+            TestDispatcherConstructorQueueHandler::class,
+            'handle',
+            ['foo']
+        );
+
+        $this->assertEquals('constructor-queue', $instance->queue);
+    }
 }
 
 class TestListenerLean
@@ -908,4 +920,16 @@ class DispatchableNamedArgumentsEvent
         public string $second,
     ) {
     }
+}
+
+class TestDispatcherConstructorQueueHandler implements \Illuminate\Contracts\Queue\ShouldQueue
+{
+    use \Illuminate\Bus\Queueable;
+
+    public function __construct()
+    {
+        $this->onQueue('constructor-queue');
+    }
+
+    public function handle() { }
 }

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -993,6 +993,7 @@ class TestDispatcherAttributeOnlyQueueHandler implements \Illuminate\Contracts\Q
 class TestDispatcherNullQueueHandler implements \Illuminate\Contracts\Queue\ShouldQueue
 {
     use \Illuminate\Bus\Queueable;
+
     public function __construct()
     {
         $this->onQueue(null);
@@ -1007,10 +1008,12 @@ class TestDispatcherNullQueueHandler implements \Illuminate\Contracts\Queue\Shou
 class TestDispatcherEmptyStringQueueHandler implements \Illuminate\Contracts\Queue\ShouldQueue
 {
     use \Illuminate\Bus\Queueable;
+
     public function __construct()
     {
         $this->onQueue('');
     }
+
     public function handle()
     {
         //

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -993,13 +993,26 @@ class TestDispatcherAttributeOnlyQueueHandler implements \Illuminate\Contracts\Q
 class TestDispatcherNullQueueHandler implements \Illuminate\Contracts\Queue\ShouldQueue
 {
     use \Illuminate\Bus\Queueable;
-    public function __construct() { $this->onQueue(null); }
-    public function handle() {}
+    public function __construct()
+    {
+        $this->onQueue(null);
+    }
+
+    public function handle()
+    {
+        //
+    }
 }
 
 class TestDispatcherEmptyStringQueueHandler implements \Illuminate\Contracts\Queue\ShouldQueue
 {
     use \Illuminate\Bus\Queueable;
-    public function __construct() { $this->onQueue(''); }
-    public function handle() {}
+    public function __construct()
+    {
+        $this->onQueue('');
+    }
+    public function handle()
+    {
+        //
+    }
 }

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -1059,6 +1059,7 @@ class TestDispatcherConstructorConnectionAndDelayHandler implements \Illuminate\
         $this->onConnection('constructor-connection');
         $this->delay(45);
     }
+
     public function handle()
     {
         //

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -759,6 +759,20 @@ class EventsDispatcherTest extends TestCase
 
         $this->assertEquals('constructor-queue', $instance->queue);
     }
+
+    public function testItRespectsQueueAttributeWhenConstructorIsEmpty()
+    {
+        $d = new Dispatcher;
+        $fakeQueue = new \Illuminate\Support\Testing\Fakes\QueueFake(new Container);
+        $d->setQueueResolver(function () use ($fakeQueue) {
+            return $fakeQueue;
+        });
+
+        $d->listen('attribute.event', TestDispatcherAttributeOnlyQueueHandler::class.'@handle');
+        $d->dispatch('attribute.event');
+
+        $fakeQueue->assertPushedOn('attribute-queue', \Illuminate\Events\CallQueuedListener::class);
+    }
 }
 
 class TestListenerLean
@@ -930,6 +944,17 @@ class TestDispatcherConstructorQueueHandler implements \Illuminate\Contracts\Que
     {
         $this->onQueue('constructor-queue');
     }
+
+    public function handle()
+    {
+        //
+    }
+}
+
+#[\Illuminate\Queue\Attributes\Queue('attribute-queue')]
+class TestDispatcherAttributeOnlyQueueHandler implements \Illuminate\Contracts\Queue\ShouldQueue
+{
+    use \Illuminate\Bus\Queueable;
 
     public function handle()
     {

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -1054,7 +1054,8 @@ class TestDispatcherConstructorConnectionAndDelayHandler implements \Illuminate\
 {
     use \Illuminate\Bus\Queueable;
 
-    public function __construct() {
+    public function __construct()
+    {
         $this->onConnection('constructor-connection');
         $this->delay(45);
     }

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -931,5 +931,8 @@ class TestDispatcherConstructorQueueHandler implements \Illuminate\Contracts\Que
         $this->onQueue('constructor-queue');
     }
 
-    public function handle() { }
+    public function handle()
+    {
+        //
+    }
 }


### PR DESCRIPTION
This PR ensures that queue assignments made within a listener's constructor (via $this->onQueue()) are correctly respected when the listener is instantiated.

The Problem:
Previously, the CallQueuedListener did not resolve the queue name from the listener class during its own construction. This caused assignments made in the listener's __construct() method to be ignored, defaulting to the connection's default queue.

The Solution:
I've added a resolveQueueName method to CallQueuedListener that checks if the listener class specifies a queue, and I've called this method within the CallQueuedListener constructor.

This fix has been verified with a regression test.

Fixes a part of the underlying issue described in #59483