### PR TITLE
[13.x] Use #[Delay] attribute in NotificationSender

### DIFF
--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -10,6 +10,7 @@ use Illuminate\Notifications\Events\NotificationFailed;
 use Illuminate\Notifications\Events\NotificationSending;
 use Illuminate\Notifications\Events\NotificationSent;
 use Illuminate\Queue\Attributes\Connection;
+use Illuminate\Queue\Attributes\Delay;
 use Illuminate\Queue\Attributes\Queue as QueueAttribute;
 use Illuminate\Queue\Attributes\ReadsQueueAttributes;
 use Illuminate\Support\Collection;
@@ -250,11 +251,9 @@ class NotificationSender
                     $queue = $notification->viaQueues()[$channel] ?? $queue;
                 }
 
-                $delay = $notification->delay;
-
-                if (method_exists($notification, 'withDelay')) {
-                    $delay = $notification->withDelay($notifiable, $channel) ?? null;
-                }
+                $delay = method_exists($notification, 'withDelay')
+                    ? ($notification->withDelay($notifiable, $channel) ?? null)
+                    : $this->getAttributeValue($notification, Delay::class, 'delay');
 
                 $messageGroup = $notification->messageGroup ?? (method_exists($notification, 'messageGroup') ? $notification->messageGroup() : null);
 


### PR DESCRIPTION
## Summary

PR #59504 added the `#[Delay]` attribute and wired it into the Event Dispatcher via `getAttributeValue()`. The `NotificationSender` was not updated — it still reads `$notification->delay` directly, meaning `#[Delay(30)]` on a notification class has no effect.

### Before

```php
#[Delay(30)]
class InvoicePaid extends Notification implements ShouldQueue
{
    use Queueable;
    // ...
}

// #[Delay(30)] is ignored — notification is sent without delay
```

### After

```php
#[Delay(30)]
class InvoicePaid extends Notification implements ShouldQueue
{
    use Queueable;
    // ...
}

// Notification is delayed by 30 seconds ✅
```

### Consistency

| Class | `#[Connection]` | `#[Queue]` | `#[Delay]` |
|---|---|---|---|
| Event Dispatcher | `getAttributeValue()` ✅ | `getAttributeValue()` ✅ | `getAttributeValue()` ✅ (#59504) |
| NotificationSender | `getAttributeValue()` ✅ | `getAttributeValue()` ✅ | `$notification->delay` ❌ → ✅ (this PR) |

### Changes

- `src/Illuminate/Notifications/NotificationSender.php` — Use `getAttributeValue()` with `Delay::class` instead of reading property directly