### PR TITLE
[13.x] Use #[Delay] attribute in Bus Dispatcher

### DIFF
--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -10,6 +10,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\PendingChain;
 use Illuminate\Pipeline\Pipeline;
 use Illuminate\Queue\Attributes\Connection;
+use Illuminate\Queue\Attributes\Delay;
 use Illuminate\Queue\Attributes\Queue as QueueAttribute;
 use Illuminate\Queue\Attributes\ReadsQueueAttributes;
 use Illuminate\Queue\InteractsWithQueue;
@@ -251,8 +252,10 @@ class Dispatcher implements QueueingDispatcher
             ?? $this->resolveQueueFromQueueRoute($command)
             ?? null;
 
-        if (isset($command->delay)) {
-            return $queue->later($command->delay, $command, queue: $queueName);
+        $delay = $this->getAttributeValue($command, Delay::class, 'delay');
+
+        if (isset($delay)) {
+            return $queue->later($delay, $command, queue: $queueName);
         }
 
         return $queue->push($command, queue: $queueName);


### PR DESCRIPTION
## Summary

PR #59504 added the `#[Delay]` attribute and wired it into the Event Dispatcher. The Bus Dispatcher's `pushCommandToQueue()` was not updated — it reads `$command->delay` directly, meaning `#[Delay(30)]` on job classes has no effect.

### Before

```php
#[Delay(30)]
class ProcessInvoice implements ShouldQueue
{
    use Dispatchable, Queueable;
}

ProcessInvoice::dispatch();
// #[Delay(30)] ignored — job runs immediately
```

### After

```php
ProcessInvoice::dispatch();
// Job delayed by 30 seconds ✅
```

### Consistency

The queue name already uses `getAttributeValue()` on the same method (line 250). Delay should follow the same pattern:

```php
// Line 250 — queue uses getAttributeValue ✅
$queueName = $this->getAttributeValue($command, QueueAttribute::class, 'queue');

// Line 254 — delay was reading property directly ❌
if (isset($command->delay)) {

// Now uses getAttributeValue ✅
$delay = $this->getAttributeValue($command, Delay::class, 'delay');
```

### Where `#[Delay]` is now supported

| Dispatcher | `#[Delay]` support |
|---|---|
| Event Dispatcher | ✅ (#59504) |
| Notification Sender | ✅ (#59513) |
| **Bus Dispatcher** | **❌ → ✅ (this PR)** |

### Changes

- `src/Illuminate/Bus/Dispatcher.php` — Use `getAttributeValue()` with `Delay::class`