### PR TITLE
[13.x] Allow null to be passed directly to redirectGuestsTo()

### DIFF
--- a/src/Illuminate/Foundation/Configuration/Middleware.php
+++ b/src/Illuminate/Foundation/Configuration/Middleware.php
@@ -533,10 +533,10 @@ class Middleware
     /**
      * Configure where guests are redirected by the "auth" middleware.
      *
-     * @param  callable|string  $redirect
+     * @param  callable|string|null  $redirect
      * @return $this
      */
-    public function redirectGuestsTo(callable|string $redirect)
+    public function redirectGuestsTo(callable|string|null $redirect)
     {
         return $this->redirectTo(guests: $redirect);
     }
@@ -561,7 +561,7 @@ class Middleware
      */
     public function redirectTo(callable|string|null $guests = null, callable|string|null $users = null)
     {
-        $guests = is_string($guests) ? fn () => $guests : $guests;
+        $guests = is_string($guests) || is_null($guests) ? fn () => $guests : $guests;
         $users = is_string($users) ? fn () => $users : $users;
 
         if ($guests) {


### PR DESCRIPTION
Following #59505, which updated the exception handler to respect a `null` redirect and return a `401` response instead of forcing a redirect to `route('login')`, the `redirectGuestsTo()` method still does not accept `null` in its type signature.

This means API-only apps that want to disable the redirect must use:

```php
$middleware->redirectGuestsTo(fn () => null);
```

With this change, you can now pass `null` directly:

```php
$middleware->redirectGuestsTo(null);
```

### Changes

- Updated `redirectGuestsTo()` type signature from `callable|string` to `callable|string|null`
- Updated `redirectTo()` to wrap `null` in a closure (same as it already does for strings), so it properly propagates through `redirectUsing()`

### Backward Compatibility

This is fully backward compatible. Existing calls with `callable` or `string` arguments are unaffected. The only new behavior is that `null` is now a valid argument.
