### PR TITLE
[13.x] Fix TypeError in starts_with / ends_with / doesnt_start_with / doesnt_end_with validation rules when value is non-string

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -2636,6 +2636,10 @@ trait ValidatesAttributes
      */
     public function validateStartsWith($attribute, $value, $parameters)
     {
+        if (! is_string($value)) {
+            return false;
+        }
+
         return Str::startsWith($value, $parameters);
     }
 
@@ -2649,6 +2653,10 @@ trait ValidatesAttributes
      */
     public function validateDoesntStartWith($attribute, $value, $parameters)
     {
+        if (! is_string($value)) {
+            return false;
+        }
+
         return ! Str::startsWith($value, $parameters);
     }
 
@@ -2662,6 +2670,10 @@ trait ValidatesAttributes
      */
     public function validateEndsWith($attribute, $value, $parameters)
     {
+        if (! is_string($value)) {
+            return false;
+        }
+
         return Str::endsWith($value, $parameters);
     }
 
@@ -2675,6 +2687,10 @@ trait ValidatesAttributes
      */
     public function validateDoesntEndWith($attribute, $value, $parameters)
     {
+        if (! is_string($value)) {
+            return false;
+        }
+
         return ! Str::endsWith($value, $parameters);
     }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3169,6 +3169,11 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['url' => 'laravel.com'], ['url' => 'ends_with:http,https']);
         $this->assertFalse($v->passes());
         $this->assertSame('The url must end with one of the following values http, https', $v->messages()->first('url'));
+
+        // Array input must fail gracefully without throwing TypeError (issue #59521)
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['x' => ['hello', 'world']], ['x' => 'ends_with:world']);
+        $this->assertFalse($v->passes());
     }
 
     public function testValidateDoesntEndWith()
@@ -3179,6 +3184,11 @@ class ValidationValidatorTest extends TestCase
 
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['x' => 'hello world'], ['x' => 'doesnt_end_with:world']);
+        $this->assertFalse($v->passes());
+
+        // Array input must fail gracefully without throwing TypeError (issue #59521)
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['x' => ['hello', 'world']], ['x' => 'doesnt_end_with:world']);
         $this->assertFalse($v->passes());
     }
 
@@ -3207,6 +3217,11 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['url' => 'laravel.com'], ['url' => 'starts_with:http,https']);
         $this->assertFalse($v->passes());
         $this->assertSame('The url must start with one of the following values http, https', $v->messages()->first('url'));
+
+        // Array input must fail gracefully without throwing TypeError (issue #59521)
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['x' => ['hello', 'world']], ['x' => 'starts_with:hello']);
+        $this->assertFalse($v->passes());
     }
 
     public function testValidateDoesntStartWith()
@@ -3217,6 +3232,11 @@ class ValidationValidatorTest extends TestCase
 
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['x' => 'hello world'], ['x' => 'doesnt_start_with:hello']);
+        $this->assertFalse($v->passes());
+
+        // Array input must fail gracefully without throwing TypeError (issue #59521)
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['x' => ['hello', 'world']], ['x' => 'doesnt_start_with:hello']);
         $this->assertFalse($v->passes());
     }
 


### PR DESCRIPTION
## Description

Fixes #59521

The four validation rules `starts_with`, `ends_with`, `doesnt_start_with`, and `doesnt_end_with` pass `$value` directly to `Str::startsWith()` / `Str::endsWith()` without checking the type first. When a non-string value (e.g. an array from a JSON request) is provided, PHP's native `str_starts_with()` / `str_ends_with()` throw a `TypeError` instead of returning a normal validation failure.

## Root Cause

`Str::startsWith()` and `Str::endsWith()` guard against `null` but not against other non-string types. Since the validator does not abort rule evaluation on the first failure (it collects all errors), adding `string` to the rule chain does **not** prevent the crash.

## Fix

Added an early `is_string()` guard in each of the four affected methods in `ValidatesAttributes`. If the value is not a string, the method returns `false` immediately, producing a standard validation failure instead of an exception.

## Tests

Extended the existing `testValidateStartsWith`, `testValidateEndsWith`, `testValidateDoesntStartWith`, and `testValidateDoesntEndWith` test methods with array-input cases that assert `$v->passes()` returns `false` without throwing.