### PR TITLE
[13.x] Add `ddViewData` to TestResponse

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1809,6 +1809,17 @@ class TestResponse implements ArrayAccess
     }
 
     /**
+     * Dump the view data from the response and end the script.
+     *
+     * @param string|null $key
+     * @return never
+     */
+    public function ddViewData($key = null)
+    {
+        dd($this->viewData($key));
+    }
+
+    /**
      * Dump the session from the response and end the script.
      *
      * @param  string|array  $keys

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1811,7 +1811,7 @@ class TestResponse implements ArrayAccess
     /**
      * Dump the view data from the response and end the script.
      *
-     * @param string|null $key
+     * @param  string|null  $key
      * @return never
      */
     public function ddViewData($key = null)


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR adds a `ddViewData()` method to `Illuminate\Testing\TestResponse`.

Usage:

```php
$response = $this->get('/dashboard');

// Directly inspect view data and terminate
$response->ddViewData();
```