### PR TITLE
[13.x] Fix Redis session connection contaminating shared cache store

### DIFF
--- a/src/Illuminate/Session/SessionManager.php
+++ b/src/Illuminate/Session/SessionManager.php
@@ -135,16 +135,20 @@ class SessionManager extends Manager
      */
     protected function createRedisDriver()
     {
-        $handler = $this->createCacheHandler('redis');
-
         $connection = $this->config->get('session.connection');
 
         if ($connection) {
-            $handler->getCache()->setStore(
-                tap(clone $handler->getCache()->getStore(), function ($store) use ($connection) {
-                    $store->setConnection($connection);
-                })
+            $cache = clone $this->container->make('cache')->store(
+                $this->config->get('session.store') ?: 'redis'
             );
+
+            $cache->setStore(
+                tap(clone $cache->getStore(), fn ($store) => $store->setConnection($connection))
+            );
+
+            $handler = new CacheBasedSessionHandler($cache, $this->config->get('session.lifetime'));
+        } else {
+            $handler = $this->createCacheHandler('redis');
         }
 
         return $this->buildSession($handler);

--- a/tests/Session/SessionManagerTest.php
+++ b/tests/Session/SessionManagerTest.php
@@ -57,7 +57,8 @@ class SessionManagerTest extends TestCase
     {
         $app = $this->createApplication('redis', 'session');
 
-        $sharedStore = $app->make('cache')->store('redis')->getStore();
+        $sharedRepository = $app->make('cache')->store('redis');
+        $sharedStore = $sharedRepository->getStore();
         $originalConnection = (new \ReflectionProperty($sharedStore, 'connection'))->getValue($sharedStore);
 
         $manager = new SessionManager($app);
@@ -68,6 +69,13 @@ class SessionManagerTest extends TestCase
         // The shared cache store's connection should not be mutated
         $currentConnection = (new \ReflectionProperty($sharedStore, 'connection'))->getValue($sharedStore);
         $this->assertSame($originalConnection, $currentConnection);
+
+        // The shared cache repository should still reference the original store
+        $this->assertSame($sharedStore, $sharedRepository->getStore());
+
+        // The session handler should use a different repository and store
+        $this->assertNotSame($sharedRepository, $handler->getCache());
+        $this->assertNotSame($sharedStore, $handler->getCache()->getStore());
 
         // The session handler's store should have the session connection
         $sessionStore = $handler->getCache()->getStore();


### PR DESCRIPTION
## Summary

Fixes #59515.

When `session.connection` is configured, `createRedisDriver()` calls `setStore()` on the **shared** cache Repository, replacing its store with one pointing to the session Redis connection (e.g., DB 2). This causes all subsequent `Cache::get()` calls across the application to read from the session database instead of the cache database, returning `null` for all cached values.

### Root Cause

PR #59323 removed the `clone` on the Repository in `createCacheHandler()` to avoid duplicate Redis connections. However, `createRedisDriver()` then calls `$handler->getCache()->setStore(...)` which mutates the now-shared Repository singleton. The `clone` on the Store (line 144) is insufficient — `setStore()` replaces the store on the shared Repository itself.

### Reproduction

```env
CACHE_STORE=redis
SESSION_DRIVER=redis
SESSION_CONNECTION=session
```

```php
// config/database.php redis connections:
// 'cache' => ['database' => 1]
// 'session' => ['database' => 2]

Cache::put('test', 'value', 60);
echo Cache::get('test'); // "value"

// After a web request is handled:
\$kernel->handle(Request::create('/'));
echo Cache::get('test'); // null — cache store now reads from DB 2
```

### Fix

When `session.connection` is set, create a fully independent Repository and Store for the session handler, leaving the shared cache store untouched. When no `session.connection` is set, behavior is unchanged — the handler shares the cache Repository as intended by #59323.

### Tests

Updated `testRedisSessionWithConnectionDoesNotMutateSharedStore` to also verify:
- The shared Repository still references the original Store after session creation
- The session handler uses a different Repository and Store instance