### PR TITLE
[13.x] add cross_slot_safe Redis option to prevent CROSSSLOT errors

### DIFF
--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -104,7 +104,7 @@ class RedisStore extends TaggableStore implements CanFlushLocks, LockProvider
 
         $connection = $this->connection();
 
-        // Cluster connections do not support reading multiple values if the keys hash differently...
+        // Predis cluster and cross-slot safe connections do not support reading multiple values if the keys hash differently...
         if ($connection instanceof PredisClusterConnection ||
             (! $connection instanceof PhpRedisClusterConnection && $connection->isCrossSlotSafe())) {
             return $this->manyAlias($keys);

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -106,7 +106,8 @@ class RedisStore extends TaggableStore implements CanFlushLocks, LockProvider
 
         // Cluster connections do not support reading multiple values if the keys hash differently...
         if ($connection instanceof PhpRedisClusterConnection ||
-            $connection instanceof PredisClusterConnection) {
+            $connection instanceof PredisClusterConnection ||
+            $connection->hashTagsEnabled()) {
             return $this->manyAlias($keys);
         }
 
@@ -151,7 +152,8 @@ class RedisStore extends TaggableStore implements CanFlushLocks, LockProvider
 
         // Cluster connections do not support writing multiple values if the keys hash differently...
         if ($connection instanceof PhpRedisClusterConnection ||
-            $connection instanceof PredisClusterConnection) {
+            $connection instanceof PredisClusterConnection ||
+            $connection->hashTagsEnabled()) {
             return $this->putManyAlias($values, $seconds);
         }
 

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -104,9 +104,10 @@ class RedisStore extends TaggableStore implements CanFlushLocks, LockProvider
 
         $connection = $this->connection();
 
-        // Predis cluster and cross-slot safe connections do not support reading multiple values if the keys hash differently...
+        // Cluster and cross-slot safe connections do not support reading multiple values
+        // if the keys hash differently. PhpRedisClusterConnection is excluded as it handles mget natively...
         if ($connection instanceof PredisClusterConnection ||
-            (! $connection instanceof PhpRedisClusterConnection && $connection->isCrossSlotSafe())) {
+            ($connection->isCrossSlotSafe() && ! $connection instanceof PhpRedisClusterConnection)) {
             return $this->manyAlias($keys);
         }
 
@@ -149,9 +150,9 @@ class RedisStore extends TaggableStore implements CanFlushLocks, LockProvider
     {
         $connection = $this->connection();
 
-        // Cluster connections do not support writing multiple values if the keys hash differently...
-        if ($connection instanceof PhpRedisClusterConnection ||
-            $connection instanceof PredisClusterConnection ||
+        // Cluster and cross-slot safe connections do not support writing multiple values if the keys hash differently...
+        if ($connection instanceof PredisClusterConnection ||
+            $connection instanceof PhpRedisClusterConnection ||
             $connection->isCrossSlotSafe()) {
             return $this->putManyAlias($values, $seconds);
         }

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -150,7 +150,9 @@ class RedisStore extends TaggableStore implements CanFlushLocks, LockProvider
     {
         $connection = $this->connection();
 
-        // Cluster and cross-slot safe connections do not support writing multiple values if the keys hash differently...
+        // Cluster and cross-slot safe connections do not support writing multiple values if the keys hash differently.
+        // Unlike many() where PhpRedisClusterConnection handles mget natively across slots, putMany() uses
+        // MULTI/EXEC which cannot span cluster slots, so PhpRedisClusterConnection is always included here...
         if ($connection instanceof PredisClusterConnection ||
             $connection instanceof PhpRedisClusterConnection ||
             $connection->isCrossSlotSafe()) {

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -104,8 +104,9 @@ class RedisStore extends TaggableStore implements CanFlushLocks, LockProvider
 
         $connection = $this->connection();
 
-        // PredisClusterConnection does not support reading multiple values if the keys hash differently...
-        if ($connection instanceof PredisClusterConnection) {
+        // Cluster connections do not support reading multiple values if the keys hash differently...
+        if ($connection instanceof PhpRedisClusterConnection ||
+            $connection instanceof PredisClusterConnection) {
             return $this->manyAlias($keys);
         }
 

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -105,9 +105,8 @@ class RedisStore extends TaggableStore implements CanFlushLocks, LockProvider
         $connection = $this->connection();
 
         // Cluster connections do not support reading multiple values if the keys hash differently...
-        if ($connection instanceof PhpRedisClusterConnection ||
-            $connection instanceof PredisClusterConnection ||
-            $connection->isCrossSlotSafe()) {
+        if ($connection instanceof PredisClusterConnection ||
+            (! $connection instanceof PhpRedisClusterConnection && $connection->isCrossSlotSafe())) {
             return $this->manyAlias($keys);
         }
 

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -107,7 +107,7 @@ class RedisStore extends TaggableStore implements CanFlushLocks, LockProvider
         // Cluster connections do not support reading multiple values if the keys hash differently...
         if ($connection instanceof PhpRedisClusterConnection ||
             $connection instanceof PredisClusterConnection ||
-            $connection->hashTagsEnabled()) {
+            $connection->isCrossSlotSafe()) {
             return $this->manyAlias($keys);
         }
 
@@ -153,7 +153,7 @@ class RedisStore extends TaggableStore implements CanFlushLocks, LockProvider
         // Cluster connections do not support writing multiple values if the keys hash differently...
         if ($connection instanceof PhpRedisClusterConnection ||
             $connection instanceof PredisClusterConnection ||
-            $connection->hashTagsEnabled()) {
+            $connection->isCrossSlotSafe()) {
             return $this->putManyAlias($values, $seconds);
         }
 

--- a/src/Illuminate/Cache/RedisTaggedCache.php
+++ b/src/Illuminate/Cache/RedisTaggedCache.php
@@ -212,6 +212,10 @@ class RedisTaggedCache extends TaggedCache
                         $connection->del($cacheKey);
                     }
                 });
+            } elseif ($connection instanceof PhpRedisClusterConnection) {
+                foreach ($cacheKeys as $cacheKey) {
+                    $connection->del($cacheKey);
+                }
             } else {
                 $connection->del(...$cacheKeys);
             }

--- a/src/Illuminate/Cache/RedisTaggedCache.php
+++ b/src/Illuminate/Cache/RedisTaggedCache.php
@@ -213,7 +213,7 @@ class RedisTaggedCache extends TaggedCache
                         $connection->del($cacheKey);
                     }
                 });
-            } elseif (! $connection instanceof PhpRedisClusterConnection && $connection->isCrossSlotSafe()) {
+            } elseif ($connection->isCrossSlotSafe() && ! $connection instanceof PhpRedisClusterConnection) {
                 foreach ($cacheKeys as $cacheKey) {
                     $connection->del($cacheKey);
                 }

--- a/src/Illuminate/Cache/RedisTaggedCache.php
+++ b/src/Illuminate/Cache/RedisTaggedCache.php
@@ -212,7 +212,8 @@ class RedisTaggedCache extends TaggedCache
                         $connection->del($cacheKey);
                     }
                 });
-            } elseif ($connection instanceof PhpRedisClusterConnection) {
+            } elseif ($connection instanceof PhpRedisClusterConnection ||
+                $connection->hashTagsEnabled()) {
                 foreach ($cacheKeys as $cacheKey) {
                     $connection->del($cacheKey);
                 }

--- a/src/Illuminate/Cache/RedisTaggedCache.php
+++ b/src/Illuminate/Cache/RedisTaggedCache.php
@@ -213,8 +213,7 @@ class RedisTaggedCache extends TaggedCache
                         $connection->del($cacheKey);
                     }
                 });
-            } elseif ($connection instanceof PhpRedisClusterConnection ||
-                $connection->isCrossSlotSafe()) {
+            } elseif (! $connection instanceof PhpRedisClusterConnection && $connection->isCrossSlotSafe()) {
                 foreach ($cacheKeys as $cacheKey) {
                     $connection->del($cacheKey);
                 }

--- a/src/Illuminate/Cache/RedisTaggedCache.php
+++ b/src/Illuminate/Cache/RedisTaggedCache.php
@@ -213,7 +213,7 @@ class RedisTaggedCache extends TaggedCache
                     }
                 });
             } elseif ($connection instanceof PhpRedisClusterConnection ||
-                $connection->hashTagsEnabled()) {
+                $connection->isCrossSlotSafe()) {
                 foreach ($cacheKeys as $cacheKey) {
                     $connection->del($cacheKey);
                 }

--- a/src/Illuminate/Cache/RedisTaggedCache.php
+++ b/src/Illuminate/Cache/RedisTaggedCache.php
@@ -125,7 +125,8 @@ class RedisTaggedCache extends TaggedCache
         $connection = $this->store->connection();
 
         if ($connection instanceof PredisClusterConnection ||
-            $connection instanceof PhpRedisClusterConnection) {
+            $connection instanceof PhpRedisClusterConnection ||
+            $connection->isCrossSlotSafe()) {
             return $this->flushClusteredConnection();
         }
 

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -441,7 +441,7 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
     {
         $queue = $queue ?: $this->default;
 
-        if ($this->getConnection()->hashTagsEnabled()) {
+        if ($this->getConnection()->isCrossSlotSafe()) {
             return 'queues:{'.$queue.'}';
         }
 

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -441,10 +441,7 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
     {
         $queue = $queue ?: $this->default;
 
-        $connection = $this->getConnection();
-
-        if ($connection instanceof PhpRedisClusterConnection ||
-            $connection instanceof PredisClusterConnection) {
+        if ($this->getConnection()->hashTagsEnabled()) {
             return 'queues:{'.$queue.'}';
         }
 

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -439,7 +439,16 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
      */
     public function getQueue($queue)
     {
-        return 'queues:'.($queue ?: $this->default);
+        $queue = $queue ?: $this->default;
+
+        $connection = $this->getConnection();
+
+        if ($connection instanceof PhpRedisClusterConnection ||
+            $connection instanceof PredisClusterConnection) {
+            return 'queues:{'.$queue.'}';
+        }
+
+        return 'queues:'.$queue;
     }
 
     /**

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -57,6 +57,13 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
     protected $migrationBatchSize = -1;
 
     /**
+     * Indicates if the connection is cross-slot safe.
+     *
+     * @var bool|null
+     */
+    protected $crossSlotSafe;
+
+    /**
      * Indicates if a secondary queue had a job available between checks of the primary queue.
      *
      * Only applicable when monitoring multiple named queues with a single instance.
@@ -441,7 +448,7 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
     {
         $queue = $queue ?: $this->default;
 
-        if ($this->getConnection()->isCrossSlotSafe()) {
+        if ($this->crossSlotSafe ??= $this->getConnection()->isCrossSlotSafe()) {
             return 'queues:{'.$queue.'}';
         }
 

--- a/src/Illuminate/Redis/Connections/Connection.php
+++ b/src/Illuminate/Redis/Connections/Connection.php
@@ -39,6 +39,13 @@ abstract class Connection
     protected $events;
 
     /**
+     * Indicates if hash tags should be used for key slot routing.
+     *
+     * @var bool
+     */
+    protected $hashTags = false;
+
+    /**
      * Subscribe to a set of given channels for messages.
      *
      * @param  array|string  $channels
@@ -203,6 +210,28 @@ abstract class Connection
         $this->name = $name;
 
         return $this;
+    }
+
+    /**
+     * Enable hash tags for key slot routing.
+     *
+     * @return $this
+     */
+    public function enableHashTags()
+    {
+        $this->hashTags = true;
+
+        return $this;
+    }
+
+    /**
+     * Determine if hash tags are enabled for key slot routing.
+     *
+     * @return bool
+     */
+    public function hashTagsEnabled()
+    {
+        return $this->hashTags;
     }
 
     /**

--- a/src/Illuminate/Redis/Connections/Connection.php
+++ b/src/Illuminate/Redis/Connections/Connection.php
@@ -39,11 +39,11 @@ abstract class Connection
     protected $events;
 
     /**
-     * Indicates if hash tags should be used for key slot routing.
+     * Indicates if the connection should avoid cross-slot operations.
      *
      * @var bool
      */
-    protected $hashTags = false;
+    protected $crossSlotSafe = false;
 
     /**
      * Subscribe to a set of given channels for messages.
@@ -213,25 +213,25 @@ abstract class Connection
     }
 
     /**
-     * Enable hash tags for key slot routing.
+     * Enable cross-slot safe mode for the connection.
      *
      * @return $this
      */
-    public function enableHashTags()
+    public function enableCrossSlotSafe()
     {
-        $this->hashTags = true;
+        $this->crossSlotSafe = true;
 
         return $this;
     }
 
     /**
-     * Determine if hash tags are enabled for key slot routing.
+     * Determine if the connection is operating in cross-slot safe mode.
      *
      * @return bool
      */
-    public function hashTagsEnabled()
+    public function isCrossSlotSafe()
     {
-        return $this->hashTags;
+        return $this->crossSlotSafe;
     }
 
     /**

--- a/src/Illuminate/Redis/Limiters/ConcurrencyLimiter.php
+++ b/src/Illuminate/Redis/Limiters/ConcurrencyLimiter.php
@@ -3,8 +3,6 @@
 namespace Illuminate\Redis\Limiters;
 
 use Illuminate\Contracts\Redis\LimiterTimeoutException;
-use Illuminate\Redis\Connections\PhpRedisClusterConnection;
-use Illuminate\Redis\Connections\PredisClusterConnection;
 use Illuminate\Support\Sleep;
 use Illuminate\Support\Str;
 use Throwable;
@@ -103,11 +101,10 @@ class ConcurrencyLimiter
      */
     protected function acquire($id)
     {
-        $isCluster = $this->redis instanceof PhpRedisClusterConnection
-            || $this->redis instanceof PredisClusterConnection;
+        $hashTags = $this->redis->hashTagsEnabled();
 
-        $slots = array_map(function ($i) use ($isCluster) {
-            return $isCluster ? '{'.$this->name.'}'.$i : $this->name.$i;
+        $slots = array_map(function ($i) use ($hashTags) {
+            return $hashTags ? '{'.$this->name.'}'.$i : $this->name.$i;
         }, range(1, $this->maxLocks));
 
         return $this->redis->eval(...array_merge(

--- a/src/Illuminate/Redis/Limiters/ConcurrencyLimiter.php
+++ b/src/Illuminate/Redis/Limiters/ConcurrencyLimiter.php
@@ -101,7 +101,7 @@ class ConcurrencyLimiter
      */
     protected function acquire($id)
     {
-        $hashTags = $this->redis->hashTagsEnabled();
+        $hashTags = $this->redis->isCrossSlotSafe();
 
         $slots = array_map(function ($i) use ($hashTags) {
             return $hashTags ? '{'.$this->name.'}'.$i : $this->name.$i;

--- a/src/Illuminate/Redis/Limiters/ConcurrencyLimiter.php
+++ b/src/Illuminate/Redis/Limiters/ConcurrencyLimiter.php
@@ -107,9 +107,11 @@ class ConcurrencyLimiter
             return $crossSlotSafe ? '{'.$this->name.'}'.$i : $this->name.$i;
         }, range(1, $this->maxLocks));
 
+        $nameArg = $crossSlotSafe ? '{'.$this->name.'}' : $this->name;
+
         return $this->redis->eval(...array_merge(
             [$this->lockScript(), count($slots)],
-            array_merge($slots, [$this->name, $this->releaseAfter, $id])
+            array_merge($slots, [$nameArg, $this->releaseAfter, $id])
         ));
     }
 

--- a/src/Illuminate/Redis/Limiters/ConcurrencyLimiter.php
+++ b/src/Illuminate/Redis/Limiters/ConcurrencyLimiter.php
@@ -101,10 +101,10 @@ class ConcurrencyLimiter
      */
     protected function acquire($id)
     {
-        $hashTags = $this->redis->isCrossSlotSafe();
+        $crossSlotSafe = $this->redis->isCrossSlotSafe();
 
-        $slots = array_map(function ($i) use ($hashTags) {
-            return $hashTags ? '{'.$this->name.'}'.$i : $this->name.$i;
+        $slots = array_map(function ($i) use ($crossSlotSafe) {
+            return $crossSlotSafe ? '{'.$this->name.'}'.$i : $this->name.$i;
         }, range(1, $this->maxLocks));
 
         return $this->redis->eval(...array_merge(

--- a/src/Illuminate/Redis/Limiters/ConcurrencyLimiter.php
+++ b/src/Illuminate/Redis/Limiters/ConcurrencyLimiter.php
@@ -3,6 +3,8 @@
 namespace Illuminate\Redis\Limiters;
 
 use Illuminate\Contracts\Redis\LimiterTimeoutException;
+use Illuminate\Redis\Connections\PhpRedisClusterConnection;
+use Illuminate\Redis\Connections\PredisClusterConnection;
 use Illuminate\Support\Sleep;
 use Illuminate\Support\Str;
 use Throwable;
@@ -101,8 +103,11 @@ class ConcurrencyLimiter
      */
     protected function acquire($id)
     {
-        $slots = array_map(function ($i) {
-            return $this->name.$i;
+        $isCluster = $this->redis instanceof PhpRedisClusterConnection
+            || $this->redis instanceof PredisClusterConnection;
+
+        $slots = array_map(function ($i) use ($isCluster) {
+            return $isCluster ? '{'.$this->name.'}'.$i : $this->name.$i;
         }, range(1, $this->maxLocks));
 
         return $this->redis->eval(...array_merge(

--- a/src/Illuminate/Redis/Limiters/DurationLimiter.php
+++ b/src/Illuminate/Redis/Limiters/DurationLimiter.php
@@ -95,6 +95,16 @@ class DurationLimiter
     }
 
     /**
+     * Get the properly formatted key for this limiter.
+     *
+     * @return string
+     */
+    protected function key()
+    {
+        return $this->redis->isCrossSlotSafe() ? '{'.$this->name.'}' : $this->name;
+    }
+
+    /**
      * Attempt to acquire the lock.
      *
      * @return bool
@@ -102,7 +112,7 @@ class DurationLimiter
     public function acquire()
     {
         $results = $this->redis->eval(
-            $this->luaScript(), 1, $this->name, microtime(true), time(), $this->decay, $this->maxLocks
+            $this->luaScript(), 1, $this->key(), microtime(true), time(), $this->decay, $this->maxLocks
         );
 
         $this->decaysAt = $results[1];
@@ -120,7 +130,7 @@ class DurationLimiter
     public function tooManyAttempts()
     {
         [$this->decaysAt, $this->remaining] = $this->redis->eval(
-            $this->tooManyAttemptsLuaScript(), 1, $this->name, microtime(true), time(), $this->decay, $this->maxLocks
+            $this->tooManyAttemptsLuaScript(), 1, $this->key(), microtime(true), time(), $this->decay, $this->maxLocks
         );
 
         return $this->remaining <= 0;
@@ -133,7 +143,7 @@ class DurationLimiter
      */
     public function clear()
     {
-        $this->redis->del($this->name);
+        $this->redis->del($this->key());
     }
 
     /**

--- a/src/Illuminate/Redis/RedisManager.php
+++ b/src/Illuminate/Redis/RedisManager.php
@@ -157,8 +157,8 @@ class RedisManager implements Factory
 
         $config = $this->config[$name] ?? $this->config['clusters'][$name] ?? [];
 
-        if (! empty($config['hash_tags']) || ! empty($this->config['options']['hash_tags'] ?? false)) {
-            $connection->enableHashTags();
+        if (! empty($config['cross_slot_safe']) || ! empty($this->config['options']['cross_slot_safe'] ?? false)) {
+            $connection->enableCrossSlotSafe();
         }
 
         return $connection;

--- a/src/Illuminate/Redis/RedisManager.php
+++ b/src/Illuminate/Redis/RedisManager.php
@@ -155,6 +155,8 @@ class RedisManager implements Factory
             $connection->setEventDispatcher($this->app->make('events'));
         }
 
+        // For cluster connections, per-connection config lives in 'clusters.options'
+        // or global 'options', not in the cluster node definitions array...
         $config = $this->config[$name] ?? [];
         $clusterOptions = $this->config['clusters']['options'] ?? [];
 

--- a/src/Illuminate/Redis/RedisManager.php
+++ b/src/Illuminate/Redis/RedisManager.php
@@ -155,6 +155,12 @@ class RedisManager implements Factory
             $connection->setEventDispatcher($this->app->make('events'));
         }
 
+        $config = $this->config[$name] ?? $this->config['clusters'][$name] ?? [];
+
+        if (! empty($config['hash_tags']) || ! empty($this->config['options']['hash_tags'] ?? false)) {
+            $connection->enableHashTags();
+        }
+
         return $connection;
     }
 

--- a/src/Illuminate/Redis/RedisManager.php
+++ b/src/Illuminate/Redis/RedisManager.php
@@ -155,9 +155,10 @@ class RedisManager implements Factory
             $connection->setEventDispatcher($this->app->make('events'));
         }
 
-        $config = $this->config[$name] ?? $this->config['clusters'][$name] ?? [];
+        $config = $this->config[$name] ?? [];
+        $clusterOptions = $this->config['clusters']['options'] ?? [];
 
-        if (! empty($config['cross_slot_safe']) || ! empty($this->config['options']['cross_slot_safe'] ?? false)) {
+        if (! empty($config['cross_slot_safe']) || ! empty($clusterOptions['cross_slot_safe']) || ! empty($this->config['options']['cross_slot_safe'] ?? false)) {
             $connection->enableCrossSlotSafe();
         }
 

--- a/src/Illuminate/Redis/RedisManager.php
+++ b/src/Illuminate/Redis/RedisManager.php
@@ -158,7 +158,7 @@ class RedisManager implements Factory
         $config = $this->config[$name] ?? [];
         $clusterOptions = $this->config['clusters']['options'] ?? [];
 
-        if (! empty($config['cross_slot_safe']) || ! empty($clusterOptions['cross_slot_safe']) || ! empty($this->config['options']['cross_slot_safe'] ?? false)) {
+        if (! empty($config['cross_slot_safe']) || ! empty($clusterOptions['cross_slot_safe']) || ! empty($this->config['options']['cross_slot_safe'])) {
             $connection->enableCrossSlotSafe();
         }
 

--- a/tests/Cache/CacheRedisStoreTest.php
+++ b/tests/Cache/CacheRedisStoreTest.php
@@ -169,7 +169,7 @@ class CacheRedisStoreTest extends TestCase
     protected function getRedis()
     {
         $mock = m::mock(Factory::class);
-        $mock->shouldReceive('hashTagsEnabled')->andReturn(false);
+        $mock->shouldReceive('isCrossSlotSafe')->andReturn(false);
 
         return new RedisStore($mock, 'prefix:');
     }

--- a/tests/Cache/CacheRedisStoreTest.php
+++ b/tests/Cache/CacheRedisStoreTest.php
@@ -168,6 +168,9 @@ class CacheRedisStoreTest extends TestCase
 
     protected function getRedis()
     {
-        return new RedisStore(m::mock(Factory::class), 'prefix:');
+        $mock = m::mock(Factory::class);
+        $mock->shouldReceive('hashTagsEnabled')->andReturn(false);
+
+        return new RedisStore($mock, 'prefix:');
     }
 }

--- a/tests/Cache/ConcurrencyLimiterTest.php
+++ b/tests/Cache/ConcurrencyLimiterTest.php
@@ -10,6 +10,8 @@ use Illuminate\Cache\Limiters\LimiterTimeoutException;
 use Illuminate\Cache\Repository;
 use Illuminate\Contracts\Cache\LockProvider;
 use Illuminate\Contracts\Cache\Store;
+use Illuminate\Redis\Connections\PhpRedisClusterConnection;
+use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Throwable;
 
@@ -208,6 +210,39 @@ class ConcurrencyLimiterTest extends TestCase
 
         $this->assertEquals([1], $store);
         $this->assertSame('ok', $result);
+    }
+
+    public function testAcquireUsesHashTaggedKeysForClusterConnections()
+    {
+        $connection = m::mock(PhpRedisClusterConnection::class);
+        $acquireArgs = null;
+
+        // acquire() -> eval() -> command('eval', [$script, $arguments, $numKeys])
+        $connection->shouldReceive('command')->once()->withArgs(function ($method, $parameters) use (&$acquireArgs) {
+            if ($method === 'eval') {
+                $acquireArgs = $parameters;
+            }
+
+            return true;
+        })->andReturn('test-limiter1');
+
+        // release() -> eval() -> command()
+        $connection->shouldReceive('command')->once()->andReturn(1);
+
+        $limiter = new \Illuminate\Redis\Limiters\ConcurrencyLimiter($connection, 'test-limiter', 3, 60);
+        $limiter->block(0, function () {
+            // noop
+        });
+
+        // $parameters = [$script, $arguments, $numKeys]
+        // $arguments = [...$slots, $name, $releaseAfter, $id]
+        $arguments = $acquireArgs[1];
+        $numKeys = $acquireArgs[2];
+
+        $this->assertSame(3, $numKeys);
+        $this->assertSame('{test-limiter}1', $arguments[0]);
+        $this->assertSame('{test-limiter}2', $arguments[1]);
+        $this->assertSame('{test-limiter}3', $arguments[2]);
     }
 
     public function testFunnelBackedEnumSharesKeyWithStringEquivalent()

--- a/tests/Cache/ConcurrencyLimiterTest.php
+++ b/tests/Cache/ConcurrencyLimiterTest.php
@@ -10,7 +10,6 @@ use Illuminate\Cache\Limiters\LimiterTimeoutException;
 use Illuminate\Cache\Repository;
 use Illuminate\Contracts\Cache\LockProvider;
 use Illuminate\Contracts\Cache\Store;
-use Illuminate\Redis\Connections\PhpRedisClusterConnection;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Throwable;
@@ -212,9 +211,10 @@ class ConcurrencyLimiterTest extends TestCase
         $this->assertSame('ok', $result);
     }
 
-    public function testAcquireUsesHashTaggedKeysForClusterConnections()
+    public function testAcquireUsesHashTaggedKeysWhenEnabled()
     {
-        $connection = m::mock(PhpRedisClusterConnection::class);
+        $connection = m::mock(\Illuminate\Redis\Connections\PhpRedisConnection::class)->makePartial();
+        $connection->enableHashTags();
         $acquireArgs = null;
 
         // acquire() -> eval() -> command('eval', [$script, $arguments, $numKeys])

--- a/tests/Cache/ConcurrencyLimiterTest.php
+++ b/tests/Cache/ConcurrencyLimiterTest.php
@@ -214,7 +214,7 @@ class ConcurrencyLimiterTest extends TestCase
     public function testAcquireUsesHashTaggedKeysWhenEnabled()
     {
         $connection = m::mock(\Illuminate\Redis\Connections\PhpRedisConnection::class)->makePartial();
-        $connection->enableHashTags();
+        $connection->enableCrossSlotSafe();
         $acquireArgs = null;
 
         // acquire() -> eval() -> command('eval', [$script, $arguments, $numKeys])

--- a/tests/Cache/ConcurrencyLimiterTest.php
+++ b/tests/Cache/ConcurrencyLimiterTest.php
@@ -216,6 +216,7 @@ class ConcurrencyLimiterTest extends TestCase
         $connection = m::mock(\Illuminate\Redis\Connections\PhpRedisConnection::class)->makePartial();
         $connection->enableCrossSlotSafe();
         $acquireArgs = null;
+        $releaseArgs = null;
 
         // acquire() -> eval() -> command('eval', [$script, $arguments, $numKeys])
         $connection->shouldReceive('command')->once()->withArgs(function ($method, $parameters) use (&$acquireArgs) {
@@ -224,10 +225,16 @@ class ConcurrencyLimiterTest extends TestCase
             }
 
             return true;
-        })->andReturn('test-limiter1');
+        })->andReturn('{test-limiter}1');
 
         // release() -> eval() -> command()
-        $connection->shouldReceive('command')->once()->andReturn(1);
+        $connection->shouldReceive('command')->once()->withArgs(function ($method, $parameters) use (&$releaseArgs) {
+            if ($method === 'eval') {
+                $releaseArgs = $parameters;
+            }
+
+            return true;
+        })->andReturn(1);
 
         $limiter = new \Illuminate\Redis\Limiters\ConcurrencyLimiter($connection, 'test-limiter', 3, 60);
         $limiter->block(0, function () {
@@ -243,6 +250,50 @@ class ConcurrencyLimiterTest extends TestCase
         $this->assertSame('{test-limiter}1', $arguments[0]);
         $this->assertSame('{test-limiter}2', $arguments[1]);
         $this->assertSame('{test-limiter}3', $arguments[2]);
+        $this->assertSame('{test-limiter}', $arguments[3]);
+
+        // The release key should match the actual hash-tagged Redis key
+        $this->assertSame('{test-limiter}1', $releaseArgs[1][0]);
+    }
+
+    public function testDurationLimiterAcquireUsesHashTaggedKeyWhenEnabled()
+    {
+        $connection = m::mock(\Illuminate\Redis\Connections\PhpRedisConnection::class)->makePartial();
+        $connection->enableCrossSlotSafe();
+        $acquireArgs = null;
+
+        $connection->shouldReceive('command')->once()->withArgs(function ($method, $parameters) use (&$acquireArgs) {
+            if ($method === 'eval') {
+                $acquireArgs = $parameters;
+            }
+
+            return true;
+        })->andReturn([1, time() + 60, 4]);
+
+        $limiter = new \Illuminate\Redis\Limiters\DurationLimiter($connection, 'test-limiter', 5, 60);
+        $limiter->acquire();
+
+        // $parameters = [$script, $arguments, $numKeys]
+        $this->assertSame(1, $acquireArgs[2]);
+        $this->assertSame('{test-limiter}', $acquireArgs[1][0]);
+    }
+
+    public function testDurationLimiterClearUsesHashTaggedKeyWhenEnabled()
+    {
+        $connection = m::mock(\Illuminate\Redis\Connections\PhpRedisConnection::class)->makePartial();
+        $connection->enableCrossSlotSafe();
+        $delArgs = null;
+
+        $connection->shouldReceive('command')->once()->withArgs(function ($method, $parameters) use (&$delArgs) {
+            $delArgs = $parameters;
+
+            return true;
+        })->andReturn(1);
+
+        $limiter = new \Illuminate\Redis\Limiters\DurationLimiter($connection, 'test-limiter', 5, 60);
+        $limiter->clear();
+
+        $this->assertSame('{test-limiter}', $delArgs[0]);
     }
 
     public function testFunnelBackedEnumSharesKeyWithStringEquivalent()

--- a/tests/Integration/Cache/RedisStoreTest.php
+++ b/tests/Integration/Cache/RedisStoreTest.php
@@ -271,6 +271,40 @@ class RedisStoreTest extends TestCase
         $this->assertSame('buz', $results['fizz']);
     }
 
+    public function testPutManyCallsPutWhenCrossSlotSafe()
+    {
+        $connection = m::mock(\Illuminate\Redis\Connections\PhpRedisConnection::class)->makePartial();
+        $connection->enableCrossSlotSafe();
+
+        $store = m::mock(RedisStore::class)->makePartial();
+        $store->expects('connection')->andReturn($connection);
+        $store->expects('put')
+            ->twice()
+            ->andReturn(true);
+
+        $store->putMany([
+            'foo' => 'bar',
+            'fizz' => 'buz',
+        ], 10);
+    }
+
+    public function testManyCallsGetWhenCrossSlotSafe()
+    {
+        $connection = m::mock(\Illuminate\Redis\Connections\PhpRedisConnection::class)->makePartial();
+        $connection->enableCrossSlotSafe();
+
+        $store = m::mock(RedisStore::class)->makePartial();
+        $store->expects('connection')->andReturn($connection);
+        $store->expects('get')
+            ->twice()
+            ->andReturn('bar', 'buz');
+
+        $results = $store->many(['foo', 'fizz']);
+
+        $this->assertSame('bar', $results['foo']);
+        $this->assertSame('buz', $results['fizz']);
+    }
+
     public function testIncrementWithSerializationEnabled()
     {
         $this->markTestSkipped('Test makes no sense anymore. Application must explicitly wrap such code in runClean() when used with serialization/compression enabled.');

--- a/tests/Integration/Cache/RedisStoreTest.php
+++ b/tests/Integration/Cache/RedisStoreTest.php
@@ -4,9 +4,12 @@ namespace Illuminate\Tests\Integration\Cache;
 
 use DateTime;
 use Illuminate\Cache\RedisStore;
+use Illuminate\Cache\RedisTaggedCache;
+use Illuminate\Cache\RedisTagSet;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
 use Illuminate\Redis\Connections\PhpRedisClusterConnection;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\LazyCollection;
 use Illuminate\Support\Sleep;
 use Mockery as m;
 use Orchestra\Testbench\TestCase;
@@ -289,6 +292,31 @@ class RedisStoreTest extends TestCase
 
         $this->assertSame('bar', $results['foo']);
         $this->assertSame('buz', $results['fizz']);
+    }
+
+    public function testTaggedCacheFlushUsesIndividualDeletesWhenCrossSlotSafe()
+    {
+        $connection = m::mock(\Illuminate\Redis\Connections\PhpRedisConnection::class)->makePartial();
+        $connection->enableCrossSlotSafe();
+
+        $store = m::mock(RedisStore::class)->makePartial();
+        $store->shouldReceive('connection')->andReturn($connection);
+        $store->shouldReceive('getPrefix')->andReturn('prefix:');
+
+        $tags = m::mock(RedisTagSet::class);
+        $tags->shouldReceive('entries')->once()->andReturn(
+            new LazyCollection(['key1', 'key2', 'key3'])
+        );
+        $tags->shouldReceive('flush')->once();
+        $tags->shouldReceive('getNames')->andReturn([]);
+
+        $connection->shouldReceive('del')->with('prefix:key1')->once();
+        $connection->shouldReceive('del')->with('prefix:key2')->once();
+        $connection->shouldReceive('del')->with('prefix:key3')->once();
+
+        $taggedCache = new RedisTaggedCache($store, $tags);
+
+        $this->assertTrue($taggedCache->flush());
     }
 
     public function testIncrementWithSerializationEnabled()

--- a/tests/Integration/Cache/RedisStoreTest.php
+++ b/tests/Integration/Cache/RedisStoreTest.php
@@ -257,20 +257,6 @@ class RedisStoreTest extends TestCase
         ], 10);
     }
 
-    public function testManyCallsGetWhenClustered()
-    {
-        $store = m::mock(RedisStore::class)->makePartial();
-        $store->expects('connection')->andReturn(m::mock(PhpRedisClusterConnection::class));
-        $store->expects('get')
-            ->twice()
-            ->andReturn('bar', 'buz');
-
-        $results = $store->many(['foo', 'fizz']);
-
-        $this->assertSame('bar', $results['foo']);
-        $this->assertSame('buz', $results['fizz']);
-    }
-
     public function testPutManyCallsPutWhenCrossSlotSafe()
     {
         $connection = m::mock(\Illuminate\Redis\Connections\PhpRedisConnection::class)->makePartial();

--- a/tests/Integration/Cache/RedisStoreTest.php
+++ b/tests/Integration/Cache/RedisStoreTest.php
@@ -257,6 +257,20 @@ class RedisStoreTest extends TestCase
         ], 10);
     }
 
+    public function testManyCallsGetWhenClustered()
+    {
+        $store = m::mock(RedisStore::class)->makePartial();
+        $store->expects('connection')->andReturn(m::mock(PhpRedisClusterConnection::class));
+        $store->expects('get')
+            ->twice()
+            ->andReturn('bar', 'buz');
+
+        $results = $store->many(['foo', 'fizz']);
+
+        $this->assertSame('bar', $results['foo']);
+        $this->assertSame('buz', $results['fizz']);
+    }
+
     public function testIncrementWithSerializationEnabled()
     {
         $this->markTestSkipped('Test makes no sense anymore. Application must explicitly wrap such code in runClean() when used with serialization/compression enabled.');

--- a/tests/Queue/QueueRedisQueueTest.php
+++ b/tests/Queue/QueueRedisQueueTest.php
@@ -7,7 +7,6 @@ use Illuminate\Contracts\Redis\Factory;
 use Illuminate\Queue\LuaScripts;
 use Illuminate\Queue\Queue;
 use Illuminate\Queue\RedisQueue;
-use Illuminate\Redis\Connections\PhpRedisClusterConnection;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
 use Mockery as m;
@@ -29,7 +28,8 @@ class QueueRedisQueueTest extends TestCase
         $queue = $this->getMockBuilder(RedisQueue::class)->onlyMethods(['getRandomId'])->setConstructorArgs([$redis = m::mock(Factory::class), 'default'])->getMock();
         $queue->expects($this->once())->method('getRandomId')->willReturn('foo');
         $queue->setContainer($container = m::spy(Container::class));
-        $redis->shouldReceive('connection')->once()->andReturn($redis);
+        $redis->shouldReceive('connection')->andReturn($redis);
+        $redis->shouldReceive('hashTagsEnabled')->andReturn(false);
         $redis->shouldReceive('eval')->once()->with(LuaScripts::push(), 2, 'queues:default', 'queues:default:notify', json_encode(['uuid' => $uuid, 'displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'maxExceptions' => null, 'failOnTimeout' => false, 'backoff' => null, 'timeout' => null, 'data' => ['data'], 'createdAt' => $time->getTimestamp(), 'id' => 'foo', 'attempts' => 0, 'delay' => null]));
 
         $id = $queue->push('foo', ['data']);
@@ -54,7 +54,8 @@ class QueueRedisQueueTest extends TestCase
         $queue = $this->getMockBuilder(RedisQueue::class)->onlyMethods(['getRandomId'])->setConstructorArgs([$redis = m::mock(Factory::class), 'default'])->getMock();
         $queue->expects($this->once())->method('getRandomId')->willReturn('foo');
         $queue->setContainer($container = m::spy(Container::class));
-        $redis->shouldReceive('connection')->once()->andReturn($redis);
+        $redis->shouldReceive('connection')->andReturn($redis);
+        $redis->shouldReceive('hashTagsEnabled')->andReturn(false);
         $redis->shouldReceive('eval')->once()->with(LuaScripts::push(), 2, 'queues:default', 'queues:default:notify', json_encode(['uuid' => $uuid, 'displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'maxExceptions' => null, 'failOnTimeout' => false, 'backoff' => null, 'timeout' => null, 'data' => ['data'], 'createdAt' => $time->getTimestamp(), 'custom' => 'taylor', 'id' => 'foo', 'attempts' => 0, 'delay' => null]));
 
         Queue::createPayloadUsing(function ($connection, $queue, $payload) {
@@ -85,7 +86,8 @@ class QueueRedisQueueTest extends TestCase
         $queue = $this->getMockBuilder(RedisQueue::class)->onlyMethods(['getRandomId'])->setConstructorArgs([$redis = m::mock(Factory::class), 'default'])->getMock();
         $queue->expects($this->once())->method('getRandomId')->willReturn('foo');
         $queue->setContainer($container = m::spy(Container::class));
-        $redis->shouldReceive('connection')->once()->andReturn($redis);
+        $redis->shouldReceive('connection')->andReturn($redis);
+        $redis->shouldReceive('hashTagsEnabled')->andReturn(false);
         $redis->shouldReceive('eval')->once()->with(LuaScripts::push(), 2, 'queues:default', 'queues:default:notify', json_encode(['uuid' => $uuid, 'displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'maxExceptions' => null, 'failOnTimeout' => false, 'backoff' => null, 'timeout' => null, 'data' => ['data'], 'createdAt' => $time->getTimestamp(), 'custom' => 'taylor', 'bar' => 'foo', 'id' => 'foo', 'attempts' => 0, 'delay' => null]));
 
         Queue::createPayloadUsing(function ($connection, $queue, $payload) {
@@ -122,7 +124,8 @@ class QueueRedisQueueTest extends TestCase
         $queue->expects($this->once())->method('getRandomId')->willReturn('foo');
         $queue->expects($this->once())->method('availableAt')->with(1)->willReturn(2);
 
-        $redis->shouldReceive('connection')->once()->andReturn($redis);
+        $redis->shouldReceive('connection')->andReturn($redis);
+        $redis->shouldReceive('hashTagsEnabled')->andReturn(false);
         $redis->shouldReceive('eval')->once()->with(
             LuaScripts::later(),
             1,
@@ -139,24 +142,27 @@ class QueueRedisQueueTest extends TestCase
         Str::createUuidsNormally();
     }
 
-    public function testGetQueueUsesHashTagsForClusterConnections()
+    public function testGetQueueUsesHashTagsWhenEnabled()
     {
         $redis = m::mock(Factory::class);
         $queue = new RedisQueue($redis, 'default');
 
-        $clusterConnection = m::mock(PhpRedisClusterConnection::class);
-        $redis->shouldReceive('connection')->andReturn($clusterConnection);
+        $connection = m::mock(\Illuminate\Redis\Connections\Connection::class);
+        $connection->shouldReceive('hashTagsEnabled')->andReturn(true);
+        $redis->shouldReceive('connection')->andReturn($connection);
 
         $this->assertSame('queues:{default}', $queue->getQueue(null));
         $this->assertSame('queues:{custom}', $queue->getQueue('custom'));
     }
 
-    public function testGetQueueDoesNotUseHashTagsForNonClusterConnections()
+    public function testGetQueueDoesNotUseHashTagsWhenDisabled()
     {
         $redis = m::mock(Factory::class);
         $queue = new RedisQueue($redis, 'default');
 
-        $redis->shouldReceive('connection')->andReturn($redis);
+        $connection = m::mock(\Illuminate\Redis\Connections\Connection::class);
+        $connection->shouldReceive('hashTagsEnabled')->andReturn(false);
+        $redis->shouldReceive('connection')->andReturn($connection);
 
         $this->assertSame('queues:default', $queue->getQueue(null));
         $this->assertSame('queues:custom', $queue->getQueue('custom'));
@@ -177,7 +183,8 @@ class QueueRedisQueueTest extends TestCase
         $queue->expects($this->once())->method('getRandomId')->willReturn('foo');
         $queue->expects($this->once())->method('availableAt')->with($date)->willReturn(5);
 
-        $redis->shouldReceive('connection')->once()->andReturn($redis);
+        $redis->shouldReceive('connection')->andReturn($redis);
+        $redis->shouldReceive('hashTagsEnabled')->andReturn(false);
         $redis->shouldReceive('eval')->once()->with(
             LuaScripts::later(),
             1,

--- a/tests/Queue/QueueRedisQueueTest.php
+++ b/tests/Queue/QueueRedisQueueTest.php
@@ -29,7 +29,7 @@ class QueueRedisQueueTest extends TestCase
         $queue->expects($this->once())->method('getRandomId')->willReturn('foo');
         $queue->setContainer($container = m::spy(Container::class));
         $redis->shouldReceive('connection')->andReturn($redis);
-        $redis->shouldReceive('hashTagsEnabled')->andReturn(false);
+        $redis->shouldReceive('isCrossSlotSafe')->andReturn(false);
         $redis->shouldReceive('eval')->once()->with(LuaScripts::push(), 2, 'queues:default', 'queues:default:notify', json_encode(['uuid' => $uuid, 'displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'maxExceptions' => null, 'failOnTimeout' => false, 'backoff' => null, 'timeout' => null, 'data' => ['data'], 'createdAt' => $time->getTimestamp(), 'id' => 'foo', 'attempts' => 0, 'delay' => null]));
 
         $id = $queue->push('foo', ['data']);
@@ -55,7 +55,7 @@ class QueueRedisQueueTest extends TestCase
         $queue->expects($this->once())->method('getRandomId')->willReturn('foo');
         $queue->setContainer($container = m::spy(Container::class));
         $redis->shouldReceive('connection')->andReturn($redis);
-        $redis->shouldReceive('hashTagsEnabled')->andReturn(false);
+        $redis->shouldReceive('isCrossSlotSafe')->andReturn(false);
         $redis->shouldReceive('eval')->once()->with(LuaScripts::push(), 2, 'queues:default', 'queues:default:notify', json_encode(['uuid' => $uuid, 'displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'maxExceptions' => null, 'failOnTimeout' => false, 'backoff' => null, 'timeout' => null, 'data' => ['data'], 'createdAt' => $time->getTimestamp(), 'custom' => 'taylor', 'id' => 'foo', 'attempts' => 0, 'delay' => null]));
 
         Queue::createPayloadUsing(function ($connection, $queue, $payload) {
@@ -87,7 +87,7 @@ class QueueRedisQueueTest extends TestCase
         $queue->expects($this->once())->method('getRandomId')->willReturn('foo');
         $queue->setContainer($container = m::spy(Container::class));
         $redis->shouldReceive('connection')->andReturn($redis);
-        $redis->shouldReceive('hashTagsEnabled')->andReturn(false);
+        $redis->shouldReceive('isCrossSlotSafe')->andReturn(false);
         $redis->shouldReceive('eval')->once()->with(LuaScripts::push(), 2, 'queues:default', 'queues:default:notify', json_encode(['uuid' => $uuid, 'displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'maxExceptions' => null, 'failOnTimeout' => false, 'backoff' => null, 'timeout' => null, 'data' => ['data'], 'createdAt' => $time->getTimestamp(), 'custom' => 'taylor', 'bar' => 'foo', 'id' => 'foo', 'attempts' => 0, 'delay' => null]));
 
         Queue::createPayloadUsing(function ($connection, $queue, $payload) {
@@ -125,7 +125,7 @@ class QueueRedisQueueTest extends TestCase
         $queue->expects($this->once())->method('availableAt')->with(1)->willReturn(2);
 
         $redis->shouldReceive('connection')->andReturn($redis);
-        $redis->shouldReceive('hashTagsEnabled')->andReturn(false);
+        $redis->shouldReceive('isCrossSlotSafe')->andReturn(false);
         $redis->shouldReceive('eval')->once()->with(
             LuaScripts::later(),
             1,
@@ -148,7 +148,7 @@ class QueueRedisQueueTest extends TestCase
         $queue = new RedisQueue($redis, 'default');
 
         $connection = m::mock(\Illuminate\Redis\Connections\Connection::class);
-        $connection->shouldReceive('hashTagsEnabled')->andReturn(true);
+        $connection->shouldReceive('isCrossSlotSafe')->andReturn(true);
         $redis->shouldReceive('connection')->andReturn($connection);
 
         $this->assertSame('queues:{default}', $queue->getQueue(null));
@@ -161,7 +161,7 @@ class QueueRedisQueueTest extends TestCase
         $queue = new RedisQueue($redis, 'default');
 
         $connection = m::mock(\Illuminate\Redis\Connections\Connection::class);
-        $connection->shouldReceive('hashTagsEnabled')->andReturn(false);
+        $connection->shouldReceive('isCrossSlotSafe')->andReturn(false);
         $redis->shouldReceive('connection')->andReturn($connection);
 
         $this->assertSame('queues:default', $queue->getQueue(null));
@@ -184,7 +184,7 @@ class QueueRedisQueueTest extends TestCase
         $queue->expects($this->once())->method('availableAt')->with($date)->willReturn(5);
 
         $redis->shouldReceive('connection')->andReturn($redis);
-        $redis->shouldReceive('hashTagsEnabled')->andReturn(false);
+        $redis->shouldReceive('isCrossSlotSafe')->andReturn(false);
         $redis->shouldReceive('eval')->once()->with(
             LuaScripts::later(),
             1,

--- a/tests/Queue/QueueRedisQueueTest.php
+++ b/tests/Queue/QueueRedisQueueTest.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Redis\Factory;
 use Illuminate\Queue\LuaScripts;
 use Illuminate\Queue\Queue;
 use Illuminate\Queue\RedisQueue;
+use Illuminate\Redis\Connections\PhpRedisClusterConnection;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
 use Mockery as m;
@@ -136,6 +137,29 @@ class QueueRedisQueueTest extends TestCase
 
         Carbon::setTestNow();
         Str::createUuidsNormally();
+    }
+
+    public function testGetQueueUsesHashTagsForClusterConnections()
+    {
+        $redis = m::mock(Factory::class);
+        $queue = new RedisQueue($redis, 'default');
+
+        $clusterConnection = m::mock(PhpRedisClusterConnection::class);
+        $redis->shouldReceive('connection')->andReturn($clusterConnection);
+
+        $this->assertSame('queues:{default}', $queue->getQueue(null));
+        $this->assertSame('queues:{custom}', $queue->getQueue('custom'));
+    }
+
+    public function testGetQueueDoesNotUseHashTagsForNonClusterConnections()
+    {
+        $redis = m::mock(Factory::class);
+        $queue = new RedisQueue($redis, 'default');
+
+        $redis->shouldReceive('connection')->andReturn($redis);
+
+        $this->assertSame('queues:default', $queue->getQueue(null));
+        $this->assertSame('queues:custom', $queue->getQueue('custom'));
     }
 
     public function testDelayedPushWithDateTimeProperlyPushesJobOntoRedis()

--- a/tests/Redis/RedisManagerExtensionTest.php
+++ b/tests/Redis/RedisManagerExtensionTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Redis;
 
 use Illuminate\Contracts\Redis\Connector;
 use Illuminate\Foundation\Application;
+use Illuminate\Redis\Connections\PhpRedisConnection;
 use Illuminate\Redis\RedisManager;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -55,6 +56,98 @@ class RedisManagerExtensionTest extends TestCase
         $this->assertSame(
             'my-redis-cluster-connection', $this->redis->resolve('my-cluster')
         );
+    }
+
+    public function testConfigureEnablesCrossSlotSafeFromConnectionConfig()
+    {
+        $connection = m::mock(PhpRedisConnection::class)->makePartial();
+
+        $redis = new RedisManager(new Application, 'my_custom_driver', [
+            'default' => [
+                'host' => 'localhost',
+                'port' => 6379,
+                'cross_slot_safe' => true,
+            ],
+        ]);
+        $redis->extend('my_custom_driver', function () use ($connection) {
+            return m::mock(Connector::class)
+                ->shouldReceive('connect')->andReturn($connection)
+                ->getMock();
+        });
+
+        $result = $redis->connection();
+
+        $this->assertTrue($result->isCrossSlotSafe());
+    }
+
+    public function testConfigureEnablesCrossSlotSafeFromGlobalOptions()
+    {
+        $connection = m::mock(PhpRedisConnection::class)->makePartial();
+
+        $redis = new RedisManager(new Application, 'my_custom_driver', [
+            'default' => [
+                'host' => 'localhost',
+                'port' => 6379,
+            ],
+            'options' => [
+                'cross_slot_safe' => true,
+            ],
+        ]);
+        $redis->extend('my_custom_driver', function () use ($connection) {
+            return m::mock(Connector::class)
+                ->shouldReceive('connect')->andReturn($connection)
+                ->getMock();
+        });
+
+        $result = $redis->connection();
+
+        $this->assertTrue($result->isCrossSlotSafe());
+    }
+
+    public function testConfigureEnablesCrossSlotSafeFromClusterOptions()
+    {
+        $connection = m::mock(PhpRedisConnection::class)->makePartial();
+
+        $redis = new RedisManager(new Application, 'my_custom_driver', [
+            'clusters' => [
+                'default' => [
+                    ['host' => 'localhost', 'port' => 6379],
+                ],
+                'options' => [
+                    'cross_slot_safe' => true,
+                ],
+            ],
+        ]);
+        $redis->extend('my_custom_driver', function () use ($connection) {
+            return m::mock(Connector::class)
+                ->shouldReceive('connectToCluster')->andReturn($connection)
+                ->getMock();
+        });
+
+        $result = $redis->connection();
+
+        $this->assertTrue($result->isCrossSlotSafe());
+    }
+
+    public function testConfigureDoesNotEnableCrossSlotSafeByDefault()
+    {
+        $connection = m::mock(PhpRedisConnection::class)->makePartial();
+
+        $redis = new RedisManager(new Application, 'my_custom_driver', [
+            'default' => [
+                'host' => 'localhost',
+                'port' => 6379,
+            ],
+        ]);
+        $redis->extend('my_custom_driver', function () use ($connection) {
+            return m::mock(Connector::class)
+                ->shouldReceive('connect')->andReturn($connection)
+                ->getMock();
+        });
+
+        $result = $redis->connection();
+
+        $this->assertFalse($result->isCrossSlotSafe());
     }
 
     public function testParseConnectionConfigurationForCluster()


### PR DESCRIPTION
When using Redis Cluster, Valkey serverless, or any slot-sharded Redis server, multi-key operations fail with `CROSSSLOT Keys in request don't hash to the same slot`. This happens because Redis distributes keys across 16,384 hash slots, and commands like `MGET` or Lua scripts operating on multiple keys require all keys to be in the same slot.                                                                       
                                                                                                                                             
  The current workaround is setting `REDIS_PREFIX={xxx}` with hash tags, which forces all keys to a single shard — defeating the purpose of sharding and preventing data distribution across the cluster.                                                                              
                                                                                                                                             
This PR adds a `cross_slot_safe` connection option that addresses this in two ways:

  **1. Hash-tagged keys for related operations**

  Queue Lua scripts and the concurrency limiter operate atomically on multiple related keys. When `cross_slot_safe` is enabled, these keys are wrapped in Redis hash tags so they map to the same slot.
                                                                                                                                             
  **Before:**                                               
  ```
  queues:default
  queues:default:delayed
  queues:default:reserved
  queues:default:notify
  ```

  **After:**
  ```
  queues:{default}
  queues:{default}:delayed                                                                                                                   
  queues:{default}:reserved
  queues:{default}:notify                                                                                                                    
  ```                                                       

The same applies to the `ConcurrencyLimiter` slot keys (`name1` → `{name}1`).

  Different queues still distribute across shards — `queues:{default}` and `queues:{emails}` hash on `default` vs `emails`, landing on different slots naturally.
                                                                                                                                             
  **2. Individual operation fallbacks for unrelated keys**  

  `RedisStore::many()`, `RedisStore::putMany()`, and `RedisTaggedCache::flushValues()` operate on arbitrary, unrelated keys. These now fall back to individual operations when `cross_slot_safe` is enabled or when using a cluster connection. This also fixes a gap where `many()` was missing a `PhpRedisClusterConnection` fallback (it only handled `PredisClusterConnection`).                                            
                                                            
  ---

  **Usage:**

  ```php
  // config/database.php
  'redis' => [
      'default' => [
          'host' => 'my-valkey-serverless.amazonaws.com',
          'cross_slot_safe' => true,
      ],
  ],                                                                                                                                         
  ```
                                                                                                                                             
  The option can also be set globally under `redis.options.cross_slot_safe`.

  **Why this is opt-in:** Enabling `cross_slot_safe` changes queue key names, which would orphan in-flight jobs for existing users. The `instanceof` cluster connection checks for `many()`/`putMany()`/`flushValues()` are non-breaking and apply automatically, but the key format changes require explicit opt-in.        