### PR TITLE
Fix parsing of string-like credentials in configuration URLs

### DIFF
--- a/src/Illuminate/Support/ConfigurationUrlParser.php
+++ b/src/Illuminate/Support/ConfigurationUrlParser.php
@@ -44,6 +44,12 @@ class ConfigurationUrlParser
         $decodedComponents = $this->parseStringsToNativeTypes(
             array_map(rawurldecode(...), $rawComponents)
         );
+        if (array_key_exists('user', $rawComponents)) {
+            $decodedComponents['user'] = rawurldecode($rawComponents['user']);
+        }
+        if (array_key_exists('pass', $rawComponents)) {
+            $decodedComponents['pass'] = rawurldecode($rawComponents['pass']);
+        }
 
         return array_merge(
             $config,

--- a/tests/Support/ConfigurationUrlParserTest.php
+++ b/tests/Support/ConfigurationUrlParserTest.php
@@ -188,6 +188,26 @@ class ConfigurationUrlParserTest extends TestCase
                     'timezone' => '+00:00',
                 ],
             ],
+            'URL with string credentials that look like native values' => [
+                'mysql://false:null@localhost/database',
+                [
+                    'driver' => 'mysql',
+                    'username' => 'false',
+                    'password' => 'null',
+                    'host' => 'localhost',
+                    'database' => 'database',
+                ],
+            ],
+            'URL with string credentials named false and true' => [
+                'mysql://false:true@localhost/database',
+                [
+                    'driver' => 'mysql',
+                    'username' => 'false',
+                    'password' => 'true',
+                    'host' => 'localhost',
+                    'database' => 'database',
+                ],
+            ],
             'URL with mssql alias driver' => [
                 'mssql://null',
                 [


### PR DESCRIPTION
## Summary

This fixes an issue where configuration URL credentials such as `false`, `true`, and `null` could be parsed into native PHP types instead of being preserved as strings.

## Changes

- preserve raw decoded `user` and `pass` values after native type parsing
- add test coverage for credentials that look like native values

## Example

Before:
- `mysql://false:null@localhost/database`
- `username` could become `false`
- `password` could become `null`

After:
- `username` is `'false'`
- `password` is `'null'`

