### PR TITLE
[13.x] Ensure queued listener constructors are called to resolve queue options

### DIFF
--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -703,7 +703,11 @@ class Dispatcher implements DispatcherContract
      */
     protected function createListenerAndJob($class, $method, $arguments)
     {
-        $listener = $this->container->make($class);
+        $reflection = new ReflectionClass($class);
+
+        $listener = $reflection->getConstructor()
+            ? $this->container->make($class)
+            : $reflection->newInstanceWithoutConstructor();
 
         return [$listener, $this->propagateListenerOptions(
             $listener, new CallQueuedListener($class, $method, $arguments)

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -703,7 +703,7 @@ class Dispatcher implements DispatcherContract
      */
     protected function createListenerAndJob($class, $method, $arguments)
     {
-        $listener = (new ReflectionClass($class))->newInstanceWithoutConstructor();
+        $listener = $this->container->make($class);
 
         return [$listener, $this->propagateListenerOptions(
             $listener, new CallQueuedListener($class, $method, $arguments)

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -4,10 +4,15 @@ namespace Illuminate\Tests\Events;
 
 use Error;
 use Exception;
+use Illuminate\Bus\Queueable;
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Queue\Queue;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Events\Dispatcher;
+use Illuminate\Queue\InteractsWithQueue;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use Ramsey\Collection\QueueInterface;
 
 class EventsDispatcherTest extends TestCase
 {
@@ -747,6 +752,79 @@ class EventsDispatcherTest extends TestCase
             Container::setInstance($originalContainer);
         }
     }
+
+    public function testListenerConstructorIsCalledWhenQueuing()
+    {
+        $container = new \Illuminate\Container\Container;
+        $dispatcher = new \Illuminate\Events\Dispatcher($container);
+        \Illuminate\Container\Container::setInstance($container);
+
+        $connection = \Mockery::mock(\Illuminate\Contracts\Queue\Queue::class);
+
+        $queueManager = \Mockery::mock(\Illuminate\Contracts\Queue\Factory::class);
+
+        $queueManager->shouldReceive('connection')->andReturn($connection);
+
+        $dispatcher->setQueueResolver(function () use ($queueManager) {
+            return $queueManager;
+        });
+
+        $connection->shouldReceive('pushOn')
+            ->once()
+            ->with('high', \Mockery::type(\Illuminate\Events\CallQueuedListener::class)) // Change this to 'high'
+            ->andReturn(1);
+
+        $dispatcher->listen('test.event', ListenerWithConstructorQueue::class);
+        $dispatcher->dispatch('test.event');
+    }
+
+    public function testListenerConstructorCorrectlySetsConnectionAndDelay()
+    {
+        $container = new \Illuminate\Container\Container;
+        $dispatcher = new \Illuminate\Events\Dispatcher($container);
+        \Illuminate\Container\Container::setInstance($container);
+
+        $connection = \Mockery::mock(\Illuminate\Contracts\Queue\Queue::class);
+        $queueManager = \Mockery::mock(\Illuminate\Contracts\Queue\Factory::class);
+
+        $queueManager->shouldReceive('connection')->with('redis')->andReturn($connection);
+
+        $dispatcher->setQueueResolver(function () use ($queueManager) {
+            return $queueManager;
+        });
+
+        $connection->shouldReceive('laterOn')
+            ->once()
+            ->with(
+                'high-priority',
+                60,
+                \Mockery::type(\Illuminate\Events\CallQueuedListener::class)
+            )
+            ->andReturn(1);
+
+        $dispatcher->listen('test.event', ListenerWithFullConstructorOptions::class);
+        $dispatcher->dispatch('test.event');
+    }
+
+    public function testListenerWithDependencyInjectionWorks()
+    {
+        $container = new \Illuminate\Container\Container;
+        $dispatcher = new \Illuminate\Events\Dispatcher($container);
+        \Illuminate\Container\Container::setInstance($container);
+
+        $connection = \Mockery::mock(\Illuminate\Contracts\Queue\Queue::class);
+        $queueManager = \Mockery::mock(\Illuminate\Contracts\Queue\Factory::class);
+        $queueManager->shouldReceive('connection')->andReturn($connection);
+        $dispatcher->setQueueResolver(function () use ($queueManager) { return $queueManager; });
+
+        $connection->shouldReceive('pushOn')
+            ->once()
+            ->with('high-priority', \Mockery::type(\Illuminate\Events\CallQueuedListener::class))
+            ->andReturn(1);
+
+        $dispatcher->listen('test.event', ListenerWithDependency::class);
+        $dispatcher->dispatch('test.event');
+    }
 }
 
 class TestListenerLean
@@ -907,5 +985,61 @@ class DispatchableNamedArgumentsEvent
         public string $first,
         public string $second,
     ) {
+    }
+}
+
+class ListenerWithConstructorQueue implements ShouldQueue
+{
+    use InteractsWithQueue;
+    use Queueable;
+
+    public function __construct()
+    {
+        $this->onQueue('high');
+    }
+
+    public function handle($event)
+    {
+        //
+    }
+}
+
+class ListenerWithFullConstructorOptions implements \Illuminate\Contracts\Queue\ShouldQueue
+{
+    use \Illuminate\Bus\Queueable;
+
+    public function __construct()
+    {
+        $this->onConnection('redis');
+        $this->onQueue('high-priority');
+        $this->delay(60);
+    }
+
+    public function handle($event)
+    {
+        //
+    }
+}
+
+class SimpleService
+{
+    public function doSomething()
+    {
+        return true;
+    }
+}
+
+class ListenerWithDependency implements \Illuminate\Contracts\Queue\ShouldQueue
+{
+    use \Illuminate\Bus\Queueable;
+
+    public function __construct(SimpleService $service)
+    {
+        $this->onQueue('high-priority');
+    }
+
+    public function handle($event)
+    {
+        //
     }
 }

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -6,13 +6,11 @@ use Error;
 use Exception;
 use Illuminate\Bus\Queueable;
 use Illuminate\Container\Container;
-use Illuminate\Contracts\Queue\Queue;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Queue\InteractsWithQueue;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
-use Ramsey\Collection\QueueInterface;
 
 class EventsDispatcherTest extends TestCase
 {
@@ -815,7 +813,9 @@ class EventsDispatcherTest extends TestCase
         $connection = \Mockery::mock(\Illuminate\Contracts\Queue\Queue::class);
         $queueManager = \Mockery::mock(\Illuminate\Contracts\Queue\Factory::class);
         $queueManager->shouldReceive('connection')->andReturn($connection);
-        $dispatcher->setQueueResolver(function () use ($queueManager) { return $queueManager; });
+        $dispatcher->setQueueResolver(function () use ($queueManager) {
+            return $queueManager;
+        });
 
         $connection->shouldReceive('pushOn')
             ->once()


### PR DESCRIPTION
------------------------------

Currently, the Illuminate\Events\Dispatcher instantiates queued listeners using newInstanceWithoutConstructor() when determining which queue, connection, or delay to use. This causes any configuration set within the listener's __construct method (via $this->onQueue(), $this->onConnection(), or $this->delay()) to be silently ignored, falling back to the default queue.
This PR changes the instantiation logic to use the Service Container ($this->container->make($class)). This ensures the constructor is executed, properties are correctly assigned, and dependency injection is supported for listeners.
## Root Cause
The createListenerAndJob method in Dispatcher.php purposefully avoids the constructor. While this may have been an intentional performance optimization, it breaks the documented behavior that allows developers to "specify the job's queue by calling the onQueue method within the job's constructor."

## Changes

* **Modified:** `Illuminate\Events\Dispatcher::createListenerAndJob` now resolves listeners via the container. 
* **Optimization:** To maintain performance, a "Reflection Guard" is used. If a listener class does not define a constructor, it continues to use `newInstanceWithoutConstructor()` for speed. If a constructor exists, it resolves via `$this->container->make()`.
* **Regression Test:** Added a new test case in `EventsDispatcherTest.php` to verify that `onQueue`, `onConnection`, and `delay` values set in a constructor are correctly respected when the listener is pushed to the queue.
------------------------------

