### PR TITLE
Apply conditional return PHPDoc to Conditionable trait

### DIFF
--- a/src/Illuminate/Conditionable/Traits/Conditionable.php
+++ b/src/Illuminate/Conditionable/Traits/Conditionable.php
@@ -16,7 +16,7 @@ trait Conditionable
      * @param  (\Closure($this): TWhenParameter)|TWhenParameter|null  $value
      * @param  (callable($this, TWhenParameter): TWhenReturnType)|null  $callback
      * @param  (callable($this, TWhenParameter): TWhenReturnType)|null  $default
-     * @return $this|TWhenReturnType
+     * @return (TWhenReturnType is void|null ? $this : TWhenReturnType)
      */
     public function when($value = null, ?callable $callback = null, ?callable $default = null)
     {
@@ -45,10 +45,10 @@ trait Conditionable
      * @template TUnlessParameter
      * @template TUnlessReturnType
      *
-     * @param  (\Closure($this): TUnlessParameter)|TUnlessParameter|null  $value
+     * @param  (\Closure($this): TUnlessParameter)|TUnlessParameter  $value
      * @param  (callable($this, TUnlessParameter): TUnlessReturnType)|null  $callback
      * @param  (callable($this, TUnlessParameter): TUnlessReturnType)|null  $default
-     * @return $this|TUnlessReturnType
+     * @return (TUnlessReturnType is void|null ? $this : TUnlessReturnType)
      */
     public function unless($value = null, ?callable $callback = null, ?callable $default = null)
     {

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -269,25 +269,25 @@ assertType('Illuminate\Support\Collection<int, User>', $collection->filter(funct
     return true;
 }));
 
-assertType('Illuminate\Support\Collection<int, User>|true', $collection->when(true, function ($collection) {
+assertType('true', $collection->when(true, function ($collection) {
     assertType('Illuminate\Support\Collection<int, User>', $collection);
 
     return true;
 }));
-assertType('Illuminate\Support\Collection<int, User>|null', $collection->when(true, function ($collection) {
+assertType('Illuminate\Support\Collection<int, User>', $collection->when(true, function ($collection) {
     assertType('Illuminate\Support\Collection<int, User>', $collection);
 }));
-assertType("'string'|Illuminate\Support\Collection<int, User>", $collection->when(true, function ($collection) {
+assertType("'string'", $collection->when(true, function ($collection) {
     assertType('Illuminate\Support\Collection<int, User>', $collection);
 
     return 'string';
 }));
-assertType('Illuminate\Support\Collection<int, User>|null', $collection->when('Taylor', function ($collection, $name) {
+assertType('Illuminate\Support\Collection<int, User>', $collection->when('Taylor', function ($collection, $name) {
     assertType('Illuminate\Support\Collection<int, User>', $collection);
     assertType("'Taylor'", $name);
 }));
 assertType(
-    'Illuminate\Support\Collection<int, User>|null',
+    'Illuminate\Support\Collection<int, User>',
     $collection->when(
         'Taylor',
         function ($collection, $name) {
@@ -300,12 +300,12 @@ assertType(
         }
     )
 );
-assertType('Illuminate\Support\Collection<int, User>|null', $collection->when(fn () => 'Taylor', function ($collection, $name) {
+assertType('Illuminate\Support\Collection<int, User>', $collection->when(fn () => 'Taylor', function ($collection, $name) {
     assertType('Illuminate\Support\Collection<int, User>', $collection);
     assertType("'Taylor'", $name);
 }));
 assertType(
-    'Illuminate\Support\Collection<int, User>|null',
+    'Illuminate\Support\Collection<int, User>',
     $collection->when(
         function ($collection) {
             assertType('Illuminate\Support\Collection<int, User>', $collection);
@@ -323,7 +323,7 @@ assertType(
     )
 );
 
-assertType('Illuminate\Support\Collection<int, User>|null', $collection->when($invokable, function ($collection, $param) {
+assertType('Illuminate\Support\Collection<int, User>', $collection->when($invokable, function ($collection, $param) {
     assertType('Illuminate\Support\Collection<int, User>', $collection);
     assertType('Invokable', $param);
 }));
@@ -356,25 +356,25 @@ assertType("'string'|Illuminate\Support\Collection<int, User>", $collection->whe
     return 'string';
 }));
 
-assertType('Illuminate\Support\Collection<int, User>|true', $collection->unless(true, function ($collection) {
+assertType('true', $collection->unless(true, function ($collection) {
     assertType('Illuminate\Support\Collection<int, User>', $collection);
 
     return true;
 }));
-assertType('Illuminate\Support\Collection<int, User>|null', $collection->unless(true, function ($collection) {
+assertType('Illuminate\Support\Collection<int, User>', $collection->unless(true, function ($collection) {
     assertType('Illuminate\Support\Collection<int, User>', $collection);
 }));
-assertType("'string'|Illuminate\Support\Collection<int, User>", $collection->unless(true, function ($collection) {
+assertType("'string'", $collection->unless(true, function ($collection) {
     assertType('Illuminate\Support\Collection<int, User>', $collection);
 
     return 'string';
 }));
-assertType('Illuminate\Support\Collection<int, User>|null', $collection->unless('Taylor', function ($collection, $name) {
+assertType('Illuminate\Support\Collection<int, User>', $collection->unless('Taylor', function ($collection, $name) {
     assertType('Illuminate\Support\Collection<int, User>', $collection);
     assertType("'Taylor'", $name);
 }));
 assertType(
-    'Illuminate\Support\Collection<int, User>|null',
+    'Illuminate\Support\Collection<int, User>',
     $collection->unless(
         'Taylor',
         function ($collection, $name) {
@@ -387,12 +387,12 @@ assertType(
         }
     )
 );
-assertType('Illuminate\Support\Collection<int, User>|null', $collection->unless(fn () => 'Taylor', function ($collection, $name) {
+assertType('Illuminate\Support\Collection<int, User>', $collection->unless(fn () => 'Taylor', function ($collection, $name) {
     assertType('Illuminate\Support\Collection<int, User>', $collection);
     assertType("'Taylor'", $name);
 }));
 assertType(
-    'Illuminate\Support\Collection<int, User>|null',
+    'Illuminate\Support\Collection<int, User>',
     $collection->unless(
         function ($collection) {
             assertType('Illuminate\Support\Collection<int, User>', $collection);
@@ -410,7 +410,7 @@ assertType(
     )
 );
 
-assertType('Illuminate\Support\Collection<int, User>|null', $collection->unless($invokable, function ($collection, $param) {
+assertType('Illuminate\Support\Collection<int, User>', $collection->unless($invokable, function ($collection, $param) {
     assertType('Illuminate\Support\Collection<int, User>', $collection);
     assertType('Invokable', $param);
 }));

--- a/types/Support/LazyCollection.php
+++ b/types/Support/LazyCollection.php
@@ -255,15 +255,15 @@ assertType('Illuminate\Support\LazyCollection<int, User>', $collection->filter(f
     return true;
 }));
 
-assertType('Illuminate\Support\LazyCollection<int, User>|true', $collection->when(true, function ($collection) {
+assertType('true', $collection->when(true, function ($collection) {
     assertType('Illuminate\Support\LazyCollection<int, User>', $collection);
 
     return true;
 }));
-assertType('Illuminate\Support\LazyCollection<int, User>|null', $collection->when(true, function ($collection) {
+assertType('Illuminate\Support\LazyCollection<int, User>', $collection->when(true, function ($collection) {
     assertType('Illuminate\Support\LazyCollection<int, User>', $collection);
 }));
-assertType("'string'|Illuminate\Support\LazyCollection<int, User>", $collection->when(true, function ($collection) {
+assertType("'string'", $collection->when(true, function ($collection) {
     assertType('Illuminate\Support\LazyCollection<int, User>', $collection);
 
     return 'string';
@@ -297,15 +297,15 @@ assertType("'string'|Illuminate\Support\LazyCollection<int, User>", $collection-
     return 'string';
 }));
 
-assertType('Illuminate\Support\LazyCollection<int, User>|true', $collection->unless(true, function ($collection) {
+assertType('true', $collection->unless(true, function ($collection) {
     assertType('Illuminate\Support\LazyCollection<int, User>', $collection);
 
     return true;
 }));
-assertType('Illuminate\Support\LazyCollection<int, User>|null', $collection->unless(true, function ($collection) {
+assertType('Illuminate\Support\LazyCollection<int, User>', $collection->unless(true, function ($collection) {
     assertType('Illuminate\Support\LazyCollection<int, User>', $collection);
 }));
-assertType("'string'|Illuminate\Support\LazyCollection<int, User>", $collection->unless(true, function ($collection) {
+assertType("'string'", $collection->unless(true, function ($collection) {
     assertType('Illuminate\Support\LazyCollection<int, User>', $collection);
 
     return 'string';


### PR DESCRIPTION
This allows IDEs to more precisely understand the return type based on the provided closure.