### PR TITLE
[13.x] Fix Number::trim() throwing TypeError when passed INF or NAN

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -337,8 +337,11 @@ class Number
      * @param  int|float  $number
      * @return int|float
      */
-    public static function trim(int|float $number)
+    public static function trim(int|float $number): int|float
     {
+        if (! is_finite($number)) {
+            return $number;
+        }
         return json_decode(json_encode($number));
     }
 

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -334,6 +334,9 @@ class SupportNumberTest extends TestCase
         $this->assertSame(12.3, Number::trim(12.30));
         $this->assertSame(12.3456789, Number::trim(12.3456789));
         $this->assertSame(12.3456789, Number::trim(12.34567890000));
+        $this->assertSame(INF, Number::trim(INF));
+        $this->assertSame(-INF, Number::trim(-INF));
+        $this->assertNan(Number::trim(NAN));
     }
 
     #[RequiresPhpExtension('intl')]


### PR DESCRIPTION
`Number::trim()` uses `json_decode(json_encode($number))` internally.
However, `json_encode(INF)` and `json_encode(NAN)` return `false` in PHP
since these are not valid JSON values. `json_decode(false)` then returns
`null`, which violates the declared return type `int|float` and throws
a Fatal TypeError.

## How to reproduce
```php
Number::trim(INF);  // Fatal TypeError: Return value must be of type int|float, null returned
Number::trim(NAN);  // Fatal TypeError: Return value must be of type int|float, null returned
```

## Fix

Guard with `is_finite()` before encoding. Non-finite values are returned
as-is since there are no trailing zeros to trim.