### PR TITLE
Fix issues in PostgresGrammar

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -254,7 +254,7 @@ class PostgresGrammar extends Grammar
     {
         return sprintf('alter table %s add column %s',
             $this->wrapTable($blueprint),
-            $this->getColumn($blueprint, $command->column)
+            $this->getColumn($blueprint, $command->get('column'))
         );
     }
 
@@ -267,15 +267,20 @@ class PostgresGrammar extends Grammar
      */
     public function compileAutoIncrementStartingValues(Blueprint $blueprint, Fluent $command)
     {
-        if ($command->column->autoIncrement
-            && $value = $command->column->get('startingValue', $command->column->get('from'))) {
+        /** @var \Illuminate\Database\Schema\ColumnDefinition $column */
+        $column = $command->get('column');
+
+        if ($column->get('autoIncrement')
+            && $value = $column->get('startingValue', $column->get('from'))) {
             return sprintf(
                 'select setval(pg_get_serial_sequence(%s, %s), %s, false)',
                 $this->quoteString($this->wrapTable($blueprint)),
-                $this->quoteString($command->column->name),
+                $this->quoteString($column->get('name')),
                 $value
             );
         }
+
+        return null;
     }
 
     /** @inheritDoc */


### PR DESCRIPTION
This PR improves the code quality of PostgresGrammar.php by resolving several undefined property access issues and ensuring consistent method return types.
Key Improvements:

   1. Refactored Property Access: Updated direct property access on Fluent and ColumnDefinition objects to use the get() method. This ensures more reliable access to dynamic properties like column, autoIncrement, and name.
   2. Standardized Return Paths: Added missing return statements to compileAutoIncrementStartingValues() to ensure the method always provides a return value, even when conditions are not met.
   3. Enhanced Type Safety: Used explicit method calls instead of magic property access to make the codebase more robust and easier for static analysis tools to understand.

Specific Changes:

* Replaced direct $command->column and $column->autoIncrement / $column->name access with get() method calls (Lines 257, 270, 271, 273, 274, 275, 278).
* Added a proper return statement for cases where auto-increment starting values are not applicable.

Testing:

* Verified that all existing database schema tests pass for PostgreSQL using vendor/bin/phpunit tests/Database/DatabasePostgresSchemaGrammarTest.php.
* Manual code review to ensure no breaking changes in SQL generation.

------------------------------