### PR TITLE
[13.x] Allow null in redirectUsersTo() to match redirectGuestsTo()

### DIFF
--- a/src/Illuminate/Foundation/Configuration/Middleware.php
+++ b/src/Illuminate/Foundation/Configuration/Middleware.php
@@ -562,7 +562,7 @@ class Middleware
     public function redirectTo(callable|string|null $guests = null, callable|string|null $users = null)
     {
         $guests = is_string($guests) || is_null($guests) ? fn () => $guests : $guests;
-        $users = is_string($users) || is_null($users) ? fn () => $users : $users;
+        $users = is_string($users) ? fn () => $users : $users;
 
         if ($guests) {
             Authenticate::redirectUsing($guests);

--- a/src/Illuminate/Foundation/Configuration/Middleware.php
+++ b/src/Illuminate/Foundation/Configuration/Middleware.php
@@ -544,10 +544,10 @@ class Middleware
     /**
      * Configure where users are redirected by the "guest" middleware.
      *
-     * @param  callable|string  $redirect
+     * @param  callable|string|null  $redirect
      * @return $this
      */
-    public function redirectUsersTo(callable|string $redirect)
+    public function redirectUsersTo(callable|string|null $redirect)
     {
         return $this->redirectTo(users: $redirect);
     }
@@ -562,7 +562,7 @@ class Middleware
     public function redirectTo(callable|string|null $guests = null, callable|string|null $users = null)
     {
         $guests = is_string($guests) || is_null($guests) ? fn () => $guests : $guests;
-        $users = is_string($users) ? fn () => $users : $users;
+        $users = is_string($users) || is_null($users) ? fn () => $users : $users;
 
         if ($guests) {
             Authenticate::redirectUsing($guests);


### PR DESCRIPTION
## Summary

PR #59526 added `null` support to `redirectGuestsTo()` and the `$guests` parameter in `redirectTo()`. The `$users` side was missed:

1. `redirectUsersTo()` still only accepts `callable|string` — missing `null`
2. `redirectTo()` wraps `$guests` with `is_null()` check but not `$users`

### Before

```php
// This works after #59526
->redirectGuestsTo(null)   // ✅

// This doesn't
->redirectUsersTo(null)    // ❌ TypeError
```

### After

```php
->redirectGuestsTo(null)   // ✅
->redirectUsersTo(null)    // ✅
```

### Consistency

| Method | Accepts null |
|---|---|
| `redirectGuestsTo()` | ✅ (fixed in #59526) |
| **`redirectUsersTo()`** | **❌ → ✅ (this PR)** |
| `redirectTo($guests, $users)` | `$guests` ✅, **`$users` ❌ → ✅ (this PR)** |

### Changes

- `src/Illuminate/Foundation/Configuration/Middleware.php` — Add `null` to `redirectUsersTo()` signature and `$users` null handling in `redirectTo()`