### PR TITLE
Fix HTTP batch cleanup after callback exceptions

### DIFF
--- a/src/Illuminate/Http/Client/Batch.php
+++ b/src/Illuminate/Http/Client/Batch.php
@@ -265,12 +265,13 @@ class Batch
     public function send(): array
     {
         $this->inProgress = true;
+        $results = [];
+        try{
 
         if ($this->beforeCallback !== null) {
             call_user_func($this->beforeCallback, $this);
         }
 
-        $results = [];
 
         if (! empty($this->requests)) {
             $eachPromiseOptions = [
@@ -347,11 +348,13 @@ class Batch
         if ($this->finallyCallback !== null) {
             call_user_func($this->finallyCallback, $this, $results);
         }
+        return $results;
+    } finally{
 
         $this->finishedAt = new CarbonImmutable;
         $this->inProgress = false;
+    }
 
-        return $results;
     }
 
     /**

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -4342,6 +4342,34 @@ class HttpClientTest extends TestCase
         $this->assertSame(0, $batch->failedRequests);
     }
 
+    public function testBatchResetsStateWhenProgressCallbackThrows(): void
+    {
+        $this->factory->fake([
+            'https://200.com' => $this->factory::response('OK', 200),
+        ]);
+
+        $batch = $this->factory->batch(function (Batch $batch) {
+            $batch->as('first')->get('https://200.com');
+        })->progress(function () {
+            throw new RuntimeException('Progress callback failed.');
+        });
+
+        try {
+            $batch->send();
+
+            $this->fail('Expected the progress callback exception to be thrown.');
+        } catch (RuntimeException $e) {
+            $this->assertSame('Progress callback failed.', $e->getMessage());
+        }
+
+        $this->assertFalse($this->getPropertyValue($batch, 'inProgress'));
+        $this->assertTrue($batch->finished());
+
+        $batch->as('second')->get('https://200.com');
+
+        $this->assertCount(2, $batch->getRequests());
+    }
+
     public static function methodsReceivingArrayableDataProvider()
     {
         return [
@@ -4350,6 +4378,11 @@ class HttpClientTest extends TestCase
             'post' => ['post'],
             'delete' => ['delete'],
         ];
+    }
+
+    protected function getPropertyValue(object $target, string $property): mixed
+    {
+        return (new \ReflectionProperty($target, $property))->getValue($target);
     }
 
     public function testAfterResponse()


### PR DESCRIPTION
## Summary
- ensure HTTP client batches always clean up internal state when a batch callback throws
- add a regression test covering exceptions thrown from the `progress` callback

## Problem
`Illuminate\Http\Client\Batch::send()` marked the batch as in progress before dispatching requests, but only reset `inProgress` and `finishedAt` at the normal end of the method.

If a user-supplied batch callback like `progress(...)` threw an exception, execution exited `send()` early and skipped that cleanup. This left the batch object in a stale state where it still appeared to be running.

## Fix
- wrap the main `send()` flow in `try / finally`
- keep exception behavior unchanged
- always reset:
  - `finishedAt`
  - `inProgress`

