### PR TITLE
feat: Add support to enum on cache repository tags method.

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -33,7 +33,6 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\InteractsWithTime;
 use Illuminate\Support\Traits\Macroable;
-use Illuminate\Validation\Rules\Enum;
 use InvalidArgumentException;
 
 use function Illuminate\Support\defer;
@@ -788,14 +787,15 @@ class Repository implements ArrayAccess, CacheContract
     }
 
     /**
-     * Parse $names to accept string and Enums
+     * Parse $names to accept string and Enums.
      *
-     * @param mixed $names
+     * @param  mixed  $names
      * @return array
      */
     private function parseNames($names): array
     {
         $collection = collect($names);
+
         return $collection->map(function ($name) {
             if (is_string($name)) {
                 return $name;
@@ -803,6 +803,7 @@ class Repository implements ArrayAccess, CacheContract
             if ($name instanceof \UnitEnum || $name instanceof \BackedEnum) {
                 return enum_value($name);
             }
+
             return $name;
         })->toArray();
     }

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -33,6 +33,7 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\InteractsWithTime;
 use Illuminate\Support\Traits\Macroable;
+use Illuminate\Validation\Rules\Enum;
 use InvalidArgumentException;
 
 use function Illuminate\Support\defer;
@@ -787,6 +788,26 @@ class Repository implements ArrayAccess, CacheContract
     }
 
     /**
+     * Parse $names to accept string and Enums
+     *
+     * @param mixed $names
+     * @return array
+     */
+    private function parseNames($names): array
+    {
+        $collection = collect($names);
+        return $collection->map(function ($name) {
+            if (is_string($name)) {
+                return $name;
+            }
+            if ($name instanceof \UnitEnum || $name instanceof \BackedEnum) {
+                return enum_value($name);
+            }
+            return $name;
+        })->toArray();
+    }
+
+    /**
      * Begin executing a new tags operation if the store supports it.
      *
      * @param  mixed  $names
@@ -800,7 +821,7 @@ class Repository implements ArrayAccess, CacheContract
             throw new BadMethodCallException('This cache store does not support tagging.');
         }
 
-        $cache = $this->store->tags(is_array($names) ? $names : func_get_args());
+        $cache = $this->store->tags($this->parseNames(is_array($names) ? $names : func_get_args()));
 
         $cache->config = $this->config;
 

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -372,6 +372,17 @@ class CacheRepositoryTest extends TestCase
         $repo->tags('foo', 'bar', 'baz');
     }
 
+    public function testAllTagsArePassedToTaggableStoreWithEnum()
+    {
+        $store = m::mock(ArrayStore::class);
+        $repo = new Repository($store);
+
+        $taggedCache = m::mock();
+        $taggedCache->shouldReceive('setDefaultCacheTime');
+        $store->shouldReceive('tags')->once()->with(['foo'])->andReturn($taggedCache);
+        $repo->tags(TestCacheKey::FOO);
+    }
+
     public function testItThrowsExceptionWhenStoreDoesNotSupportTags()
     {
         $this->expectException(BadMethodCallException::class);


### PR DESCRIPTION
I needed to use the same tag in several places for caching, and to maintain naming consistency I decided to use enums. But this method doesn't support enums. So I decided to incorporate that support.
