### PR TITLE
[13.x] Dispatch PasswordReset event from the password broker

### DIFF
--- a/src/Illuminate/Auth/Passwords/PasswordBroker.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBroker.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Auth\Passwords;
 
 use Closure;
+use Illuminate\Auth\Events\PasswordReset;
 use Illuminate\Auth\Events\PasswordResetLinkSent;
 use Illuminate\Contracts\Auth\CanResetPassword as CanResetPasswordContract;
 use Illuminate\Contracts\Auth\PasswordBroker as PasswordBrokerContract;
@@ -139,6 +140,8 @@ class PasswordBroker implements PasswordBrokerContract
             $callback($user, $password);
 
             $this->tokens->delete($user);
+
+            $this->events?->dispatch(new PasswordReset($user));
 
             $timebox->returnEarly();
 

--- a/tests/Auth/AuthPasswordBrokerTest.php
+++ b/tests/Auth/AuthPasswordBrokerTest.php
@@ -2,11 +2,13 @@
 
 namespace Illuminate\Tests\Auth;
 
+use Illuminate\Auth\Events\PasswordReset;
 use Illuminate\Auth\Passwords\PasswordBroker;
 use Illuminate\Auth\Passwords\TokenRepositoryInterface;
 use Illuminate\Contracts\Auth\CanResetPassword;
 use Illuminate\Contracts\Auth\PasswordBroker as PasswordBrokerContract;
 use Illuminate\Contracts\Auth\UserProvider;
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Arr;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -102,6 +104,20 @@ class AuthPasswordBrokerTest extends TestCase
 
         $this->assertSame(PasswordBrokerContract::PASSWORD_RESET, $broker->reset(['password' => 'password', 'token' => 'token'], $callback));
         $this->assertEquals(['user' => $user, 'password' => 'password'], $_SERVER['__password.reset.test']);
+    }
+
+    public function testResetDispatchesPasswordResetEvent()
+    {
+        $mocks = $this->getMocks();
+        $events = m::mock(Dispatcher::class);
+        $broker = m::mock(PasswordBroker::class, array_values($mocks) + [2 => $events])->makePartial()->shouldAllowMockingProtectedMethods();
+        $broker->shouldReceive('validateReset')->once()->andReturn($user = m::mock(CanResetPassword::class));
+        $mocks['tokens']->shouldReceive('delete')->once()->with($user);
+        $events->shouldReceive('dispatch')->once()->with(m::type(PasswordReset::class));
+
+        $this->assertSame(PasswordBrokerContract::PASSWORD_RESET, $broker->reset(['password' => 'password', 'token' => 'token'], function () {
+            //
+        }));
     }
 
     public function testExecutesCallbackInsteadOfSendingNotification()

--- a/tests/Integration/Auth/ForgotPasswordTest.php
+++ b/tests/Integration/Auth/ForgotPasswordTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Auth;
 
+use Illuminate\Auth\Events\PasswordReset;
 use Illuminate\Auth\Events\PasswordResetLinkSent;
 use Illuminate\Auth\Notifications\ResetPassword;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -85,6 +86,50 @@ class ForgotPasswordTest extends TestCase
 
             return true;
         });
+    }
+
+    public function testItCanTriggerPasswordResetEvent()
+    {
+        Event::fake([PasswordReset::class]);
+
+        UserFactory::new()->create();
+
+        $user = AuthenticationTestUser::first();
+
+        $token = Password::broker()->createToken($user);
+
+        Password::broker()->reset([
+            'email' => $user->email,
+            'password' => 'new-password',
+            'token' => $token,
+        ], function ($user, $password) {
+            $user->forceFill(['password' => bcrypt($password)])->save();
+        });
+
+        Event::assertDispatched(PasswordReset::class, function ($event) {
+            $this->assertEquals(1, $event->user->id);
+
+            return true;
+        });
+    }
+
+    public function testPasswordResetEventIsNotDispatchedOnFailedReset()
+    {
+        Event::fake([PasswordReset::class]);
+
+        UserFactory::new()->create();
+
+        $user = AuthenticationTestUser::first();
+
+        Password::broker()->reset([
+            'email' => $user->email,
+            'password' => 'new-password',
+            'token' => 'invalid-token',
+        ], function ($user, $password) {
+            $user->forceFill(['password' => bcrypt($password)])->save();
+        });
+
+        Event::assertNotDispatched(PasswordReset::class);
     }
 
     public function testItCanSendForgotPasswordEmailViaCreateUrlUsing()


### PR DESCRIPTION
## Problem

The `PasswordReset` event class has existed since 5.5 (#19188), but the password broker has never dispatched it.

The event was originally dispatched by the `ResetsPasswords` trait in Foundation, which was later removed. Today, the only reason the event fires at all is because Fortify and Breeze manually dispatch it inside their reset callbacks:

- **Fortify:** `CompletePasswordReset::__invoke()` calls `event(new PasswordReset($user))`
- **Breeze:** Scaffolded `NewPasswordController` stubs call `event(new PasswordReset($user))`

Anyone using `Password::broker()->reset()` directly -- without Fortify or Breeze -- gets no event.

Meanwhile, `sendResetLink()` dispatches `PasswordResetLinkSent` directly from the broker (line 109), establishing a clear pattern that the broker is responsible for its own lifecycle events.

## Solution

Dispatch the existing `PasswordReset` event from the broker's `reset()` method, after the callback executes and the token is deleted. This mirrors the `sendResetLink()` pattern exactly:

```php
$this->tokens->delete($user);

$this->events?->dispatch(new PasswordReset($user));

$timebox->returnEarly();
```

## Impact on Fortify and Breeze

Both Fortify and Breeze currently dispatch this event manually inside their reset callback as a workaround for the broker not doing it. With this change, apps using either package would receive the event twice per reset -- once from their callback, once from the broker.

This is not a bug (event listeners should be idempotent), but it is redundant. If this PR is merged, a follow-up PR to Fortify could remove the now-unnecessary dispatch from `CompletePasswordReset::__invoke()`. Breeze stubs are scaffolded into user code, so they would be updated in a future release -- existing apps would continue working and could optionally remove their own dispatch.

## Benefits

- Apps using the broker directly (without Fortify/Breeze) can now listen for password resets
- The broker's event API becomes consistent: `sendResetLink()` fires `PasswordResetLinkSent`, `reset()` fires `PasswordReset`
- The event dispatch lives at the correct architectural level (the broker) rather than being duplicated across consumer packages

## Test plan

- [x] Unit test verifying event is dispatched with correct user via mock dispatcher
- [x] Integration test verifying full reset flow dispatches the event
- [x] Negative test verifying event is NOT dispatched on failed reset (invalid token)