### PR TITLE
[13.x] Fix TypeError in retry when callback for non-failed responses

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -1051,7 +1051,11 @@ class PendingRequest
                     }
 
                     try {
-                        $shouldRetry = $this->retryWhenCallback ? call_user_func($this->retryWhenCallback, $response->toException(), $this, $this->request->toPsrRequest()->getMethod()) : true;
+                        $exception = $response->toException();
+
+                        $shouldRetry = $this->retryWhenCallback && $exception
+                            ? call_user_func($this->retryWhenCallback, $exception, $this, $this->request->toPsrRequest()->getMethod())
+                            : true;
                     } catch (Exception $exception) {
                         $shouldRetry = false;
 
@@ -1238,11 +1242,11 @@ class PendingRequest
         }
 
         try {
-            $shouldRetry = $this->retryWhenCallback ? call_user_func(
-                $this->retryWhenCallback,
-                $response instanceof Response ? $response->toException() : $response,
-                $this
-            ) : true;
+            $exception = $response instanceof Response ? $response->toException() : $response;
+
+            $shouldRetry = $this->retryWhenCallback && $exception
+                ? call_user_func($this->retryWhenCallback, $exception, $this)
+                : true;
         } catch (Exception $exception) {
             return $exception;
         }

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -2462,6 +2462,26 @@ class HttpClientTest extends TestCase
         ]);
     }
 
+    public function testRetryWhenCallbackIsNotCalledForNonFailedResponse()
+    {
+        $this->factory->fake([
+            '*' => $this->factory->response(['redirecting'], 301),
+        ]);
+
+        $whenCalled = false;
+
+        $response = $this->factory
+            ->retry(2, 0, function (Exception $exception) use (&$whenCalled) {
+                $whenCalled = true;
+
+                return true;
+            }, false)
+            ->get('http://foo.com/get');
+
+        $this->assertSame(301, $response->status());
+        $this->assertFalse($whenCalled);
+    }
+
     public function testRequestExceptionReturnedWhenRetriesExhaustedInPool()
     {
         $this->factory->fake([


### PR DESCRIPTION
When using `Http::retry()` with a `when` callback that type-hints `Exception`, a `TypeError` is thrown if the response is 3xx (redirect). This happens because `Response::toException()` returns `null` for non-failed responses (it only creates `RequestException` for 4xx/5xx).

The fix skips the `when` callback when `toException()` returns `null`, defaulting `$shouldRetry` to `true` — which matches the behavior when no `when` callback is provided. This is semantically correct: a 3xx is not a failure, so there is no exception to inspect, and the default retry behavior should apply.

Fixed in both the synchronous and asynchronous request paths.

Fixes #59012