### PR TITLE
[13.x] Add --max-pop-exceptions option to stop worker after consecutive queue pop failures

### DIFF
--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -41,6 +41,7 @@ class WorkCommand extends Command
                             {--backoff=0 : The number of seconds to wait before retrying a job that encountered an uncaught exception}
                             {--max-jobs=0 : The number of jobs to process before stopping}
                             {--max-time=0 : The maximum number of seconds the worker should run}
+                            {--max-pop-exceptions=0 : The maximum number of consecutive pop exceptions before stopping}
                             {--force : Force the worker to run even in maintenance mode}
                             {--memory=128 : The memory limit in megabytes}
                             {--sleep=3 : The number of seconds to sleep when no job is available}
@@ -169,6 +170,7 @@ class WorkCommand extends Command
             $this->option('max-jobs'),
             $this->option('max-time'),
             $this->option('rest'),
+            $this->option('max-pop-exceptions'),
         );
     }
 

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -100,6 +100,13 @@ class Worker
     public $paused = false;
 
     /**
+     * The number of consecutive pop exceptions that have occurred.
+     *
+     * @var int
+     */
+    protected $popExceptions = 0;
+
+    /**
      * The callbacks used to pop jobs from queues.
      *
      * @var callable[]
@@ -348,6 +355,7 @@ class Worker
             $options->stopWhenEmpty && is_null($job) => [static::EXIT_SUCCESS, WorkerStopReason::QueueEmpty],
             $options->maxTime && hrtime(true) / 1e9 - $startTime >= $options->maxTime => [static::EXIT_SUCCESS, WorkerStopReason::MaxTimeExceeded],
             $options->maxJobs && $jobsProcessed >= $options->maxJobs => [static::EXIT_SUCCESS, WorkerStopReason::MaxJobsExceeded],
+            $options->maxPopExceptions && $this->popExceptions >= $options->maxPopExceptions => [static::EXIT_ERROR, WorkerStopReason::MaxPopExceptionsExceeded],
             default => null
         };
     }
@@ -397,6 +405,8 @@ class Worker
                     $this->raiseAfterJobPopEvent($connection->getConnectionName(), $job);
                 }
 
+                $this->popExceptions = 0;
+
                 return $job;
             }
 
@@ -408,13 +418,19 @@ class Worker
                 if (! is_null($job = $popJobCallback($queue, $index))) {
                     $this->raiseAfterJobPopEvent($connection->getConnectionName(), $job);
 
+                    $this->popExceptions = 0;
+
                     return $job;
                 }
             }
+
+            $this->popExceptions = 0;
         } catch (Throwable $e) {
             $this->exceptions->report($e);
 
             $this->stopWorkerIfLostConnection($e);
+
+            $this->popExceptions++;
 
             $this->sleep(1);
         }

--- a/src/Illuminate/Queue/WorkerOptions.php
+++ b/src/Illuminate/Queue/WorkerOptions.php
@@ -82,6 +82,13 @@ class WorkerOptions
     public $maxTime;
 
     /**
+     * The maximum number of consecutive exceptions when popping jobs before stopping.
+     *
+     * @var int
+     */
+    public $maxPopExceptions;
+
+    /**
      * Create a new worker options instance.
      *
      * @param  string  $name
@@ -95,6 +102,7 @@ class WorkerOptions
      * @param  int  $maxJobs
      * @param  int  $maxTime
      * @param  int  $rest
+     * @param  int  $maxPopExceptions
      */
     public function __construct(
         $name = 'default',
@@ -108,6 +116,7 @@ class WorkerOptions
         $maxJobs = 0,
         $maxTime = 0,
         $rest = 0,
+        $maxPopExceptions = 0,
     ) {
         $this->name = $name;
         $this->backoff = $backoff;
@@ -120,5 +129,6 @@ class WorkerOptions
         $this->stopWhenEmpty = $stopWhenEmpty;
         $this->maxJobs = $maxJobs;
         $this->maxTime = $maxTime;
+        $this->maxPopExceptions = $maxPopExceptions;
     }
 }

--- a/src/Illuminate/Queue/WorkerStopReason.php
+++ b/src/Illuminate/Queue/WorkerStopReason.php
@@ -12,4 +12,5 @@ enum WorkerStopReason: string
     case QueueEmpty = 'empty';
     case ReceivedRestartSignal = 'restart_signal';
     case TimedOut = 'timed_out';
+    case MaxPopExceptionsExceeded = 'max_pop_exceptions';
 }

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -488,6 +488,34 @@ class QueueWorkerTest extends TestCase
         }));
     }
 
+    public function testWorkerStopsAfterMaxPopExceptions()
+    {
+        $workerOptions = new WorkerOptions;
+        $workerOptions->maxPopExceptions = 3;
+
+        $worker = new InsomniacWorker(
+            new WorkerFakeManager('default', new BrokenQueueConnection('default', new RuntimeException('Connection refused'))),
+            $this->events,
+            $this->exceptionHandler,
+            function () {
+                return false;
+            }
+        );
+
+        $status = $worker->daemon('default', 'queue', $workerOptions);
+
+        $this->assertSame(1, $status);
+
+        $this->exceptionHandler->shouldHaveReceived('report')->times(3);
+
+        $this->events->shouldHaveReceived('dispatch')->with(m::on(function ($event) use ($workerOptions) {
+            return $event instanceof WorkerStopping
+                && $event->status === 1
+                && $event->workerOptions === $workerOptions
+                && $event->reason === WorkerStopReason::MaxPopExceptionsExceeded;
+        }));
+    }
+
     public function testJobReleasedEvent()
     {
         $e = new RuntimeException;


### PR DESCRIPTION
When `getNextJob()` catches a non-database `Throwable` (e.g., SQS SDK timeout, Redis authentication failure), the worker reports the exception, sleeps 1 second, and loops back — indefinitely. `stopWorkerIfLostConnection()` only detects database connection errors via `DetectsLostConnections`, so non-database infrastructure failures cause the worker to loop forever while appearing healthy to process supervisors.

This adds a `--max-pop-exceptions` option that stops the worker after N consecutive exceptions when popping jobs from the queue. It follows the existing pattern of `--max-jobs` and `--max-time`:

- New `WorkerOptions::$maxPopExceptions` property (default `0` = unlimited, fully backward compatible)
- New `WorkerStopReason::MaxPopExceptionsExceeded` enum case
- Counter resets on any successful pop (with or without a job), so transient errors self-heal
- Worker exits with `EXIT_ERROR` (status 1) so process supervisors know to restart

Usage: `php artisan queue:work --max-pop-exceptions=10`

Fixes #59517