### PR TITLE
[13.x] Fix Str::markdown() and Str::inlineMarkdown() crash on null input

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -140,7 +140,7 @@ class Str
      */
     public static function transliterate($string, $unknown = '?', $strict = false)
     {
-        return ASCII::to_transliterate($string, $unknown, $strict);
+        return ASCII::to_transliterate((string) $string, $unknown, $strict);
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -791,6 +791,8 @@ class Str
      */
     public static function markdown($string, array $options = [], array $extensions = [])
     {
+        $string = (string) $string;
+
         $converter = new GithubFlavoredMarkdownConverter($options);
 
         $environment = $converter->getEnvironment();
@@ -812,6 +814,8 @@ class Str
      */
     public static function inlineMarkdown($string, array $options = [], array $extensions = [])
     {
+        $string = (string) $string;
+
         $environment = new Environment($options);
 
         $environment->addExtension(new GithubFlavoredMarkdownExtension());

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1622,6 +1622,7 @@ class SupportStrTest extends TestCase
     {
         $this->assertSame('HHH', Str::transliterate('🎂🚧🏆', 'H'));
         $this->assertSame('Hello', Str::transliterate('🎂', 'Hello'));
+        $this->assertSame('', Str::transliterate(null));
     }
 
     #[DataProvider('specialCharacterProvider')]

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1574,12 +1574,14 @@ class SupportStrTest extends TestCase
     {
         $this->assertSame("<p><em>hello world</em></p>\n", Str::markdown('*hello world*'));
         $this->assertSame("<h1>hello world</h1>\n", Str::markdown('# hello world'));
+        $this->assertSame('', Str::markdown(null));
     }
 
     public function testInlineMarkdown()
     {
         $this->assertSame("<em>hello world</em>\n", Str::inlineMarkdown('*hello world*'));
         $this->assertSame("<a href=\"https://laravel.com\"><strong>Laravel</strong></a>\n", Str::inlineMarkdown('[**Laravel**](https://laravel.com)'));
+        $this->assertSame('', Str::inlineMarkdown(null));
     }
 
     public function testRepeat()


### PR DESCRIPTION
## Summary

`Str::markdown()` and `Str::inlineMarkdown()` throw a `TypeError` when `null` is passed as input.

### The Bug

```php
Str::markdown(null);
// TypeError: MarkdownConverter::convert(): Argument #1 ($input) must be of type string, null given

Str::inlineMarkdown(null);
// Same TypeError
```

This can happen when rendering user content that may be nullable — for example, a model attribute that hasn't been set yet:

```php
{!! Str::markdown($post->body) !!}
// If $post->body is null → crash
```

### The Fix

Cast input to string before passing to the converter:

```php
$string = (string) $string;
```

`null` becomes `''`, which the converter handles correctly and returns `''`.

### Changes

- `src/Illuminate/Support/Str.php` — Cast to string in both methods
- `tests/Support/SupportStrTest.php` — Add null assertions to existing tests