### PR TITLE
[13.x] Fix unhandled MathException in lt/lte validation rules with INF/NAN …

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1329,7 +1329,7 @@ trait ValidatesAttributes
         if (is_null($comparedToValue) && (is_numeric($value) && is_numeric($parameters[0]))) {
             try {
                 return BigNumber::of($this->getSize($attribute, $value))->isLessThan($this->trim($parameters[0]));
-            } catch (MathException) {
+            } catch (MathException|BrickMathException) {
                 return false;
             }
         }
@@ -1423,7 +1423,7 @@ trait ValidatesAttributes
         if (is_null($comparedToValue) && (is_numeric($value) && is_numeric($parameters[0]))) {
             try {
                 return BigNumber::of($this->getSize($attribute, $value))->isLessThanOrEqualTo($this->trim($parameters[0]));
-            } catch (MathException) {
+            } catch (MathException|BrickMathException) {
                 return false;
             }
         }

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -5,7 +5,6 @@ namespace Illuminate\Validation\Concerns;
 use Brick\Math\BigDecimal;
 use Brick\Math\BigNumber;
 use Brick\Math\Exception\MathException as BrickMathException;
-use Brick\Math\Exception\NumberFormatException;
 use DateTime;
 use DateTimeInterface;
 use DateTimeZone;
@@ -1436,7 +1435,7 @@ trait ValidatesAttributes
         if ($this->hasRule($attribute, $this->numericRules) && is_numeric($value) && is_numeric($comparedToValue)) {
             try {
                 return BigNumber::of($this->trim($value))->isLessThanOrEqualTo($this->trim($comparedToValue));
-            } catch (NumberFormatException) {
+            } catch (MathException) {
                 return false;
             }
         }

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1339,7 +1339,11 @@ trait ValidatesAttributes
         }
 
         if ($this->hasRule($attribute, $this->numericRules) && is_numeric($value) && is_numeric($comparedToValue)) {
-            return BigNumber::of($this->trim($value))->isLessThan($this->trim($comparedToValue));
+            try {
+                return BigNumber::of($this->trim($value))->isLessThan($this->trim($comparedToValue));
+            } catch (MathException) {
+                return false;
+            }
         }
 
         if (! $this->isSameType($value, $comparedToValue)) {

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -5,6 +5,7 @@ namespace Illuminate\Validation\Concerns;
 use Brick\Math\BigDecimal;
 use Brick\Math\BigNumber;
 use Brick\Math\Exception\MathException as BrickMathException;
+use Brick\Math\Exception\NumberFormatException as BrickMathNumberFormatException;
 use DateTime;
 use DateTimeInterface;
 use DateTimeZone;
@@ -1341,7 +1342,7 @@ trait ValidatesAttributes
         if ($this->hasRule($attribute, $this->numericRules) && is_numeric($value) && is_numeric($comparedToValue)) {
             try {
                 return BigNumber::of($this->trim($value))->isLessThan($this->trim($comparedToValue));
-            } catch (MathException) {
+            } catch (BrickMathNumberFormatException) {
                 return false;
             }
         }
@@ -1435,7 +1436,7 @@ trait ValidatesAttributes
         if ($this->hasRule($attribute, $this->numericRules) && is_numeric($value) && is_numeric($comparedToValue)) {
             try {
                 return BigNumber::of($this->trim($value))->isLessThanOrEqualTo($this->trim($comparedToValue));
-            } catch (MathException) {
+            } catch (BrickMathNumberFormatException) {
                 return false;
             }
         }

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -5,7 +5,6 @@ namespace Illuminate\Validation\Concerns;
 use Brick\Math\BigDecimal;
 use Brick\Math\BigNumber;
 use Brick\Math\Exception\MathException as BrickMathException;
-use Brick\Math\Exception\NumberFormatException as BrickMathNumberFormatException;
 use DateTime;
 use DateTimeInterface;
 use DateTimeZone;
@@ -1342,7 +1341,7 @@ trait ValidatesAttributes
         if ($this->hasRule($attribute, $this->numericRules) && is_numeric($value) && is_numeric($comparedToValue)) {
             try {
                 return BigNumber::of($this->trim($value))->isLessThan($this->trim($comparedToValue));
-            } catch (BrickMathNumberFormatException) {
+            } catch (BrickMathException) {
                 return false;
             }
         }
@@ -1436,7 +1435,7 @@ trait ValidatesAttributes
         if ($this->hasRule($attribute, $this->numericRules) && is_numeric($value) && is_numeric($comparedToValue)) {
             try {
                 return BigNumber::of($this->trim($value))->isLessThanOrEqualTo($this->trim($comparedToValue));
-            } catch (BrickMathNumberFormatException) {
+            } catch (BrickMathException) {
                 return false;
             }
         }

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -5,6 +5,7 @@ namespace Illuminate\Validation\Concerns;
 use Brick\Math\BigDecimal;
 use Brick\Math\BigNumber;
 use Brick\Math\Exception\MathException as BrickMathException;
+use Brick\Math\Exception\NumberFormatException;
 use DateTime;
 use DateTimeInterface;
 use DateTimeZone;
@@ -1433,7 +1434,11 @@ trait ValidatesAttributes
         }
 
         if ($this->hasRule($attribute, $this->numericRules) && is_numeric($value) && is_numeric($comparedToValue)) {
-            return BigNumber::of($this->trim($value))->isLessThanOrEqualTo($this->trim($comparedToValue));
+            try {
+                return BigNumber::of($this->trim($value))->isLessThanOrEqualTo($this->trim($comparedToValue));
+            } catch (NumberFormatException) {
+                return false;
+            }
         }
 
         if (! $this->isSameType($value, $comparedToValue)) {

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2577,6 +2577,12 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['lhs' => NAN, 'rhs' => 100], ['lhs' => 'numeric|lt:rhs']);
         $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['lhs' => INF], ['lhs' => 'numeric|lt:10']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['lhs' => NAN], ['lhs' => 'numeric|lt:10']);
+        $this->assertTrue($v->fails());
     }
 
     public function testGreaterThanOrEqual()
@@ -2664,6 +2670,12 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->fails());
 
         $v = new Validator($trans, ['lhs' => NAN, 'rhs' => 100], ['lhs' => 'numeric|lte:rhs']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['lhs' => INF], ['lhs' => 'numeric|lte:10']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['lhs' => NAN], ['lhs' => 'numeric|lte:10']);
         $this->assertTrue($v->fails());
     }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2571,6 +2571,12 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['lhs' => 15], ['lhs' => 'numeric|lt:10']);
         $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['lhs' => INF, 'rhs' => 100], ['lhs' => 'numeric|lt:rhs']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['lhs' => NAN, 'rhs' => 100], ['lhs' => 'numeric|lt:rhs']);
+        $this->assertTrue($v->fails());
     }
 
     public function testGreaterThanOrEqual()
@@ -2652,6 +2658,12 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['lhs' => 15], ['lhs' => 'numeric|lte:10']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['lhs' => INF, 'rhs' => 100], ['lhs' => 'numeric|lte:rhs']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['lhs' => NAN, 'rhs' => 100], ['lhs' => 'numeric|lte:rhs']);
         $this->assertTrue($v->fails());
     }
 


### PR DESCRIPTION
The lt and lte validation rules throw an unhandled Brick\Math\Exception\NumberFormatException when the value is INF or NAN. This results in an HTTP 500 instead of gracefully failing validation.

### The Bugs:
```php
Validator::make(
    ['a' => INF, 'b' => 100],
    ['a' => 'numeric|lt:b']
)->validate();
// Brick\Math\Exception\NumberFormatException: The given value "INF" does not represent a valid number.
// HTTP 500 instead of 422

```php
Validator::make(
    ['a' => INF, 'b' => 100],
    ['a' => 'numeric|lte:b']
)->validate();
// Brick\Math\Exception\NumberFormatException: The given value "INF" does not represent a valid number.
// HTTP 500 instead of 422
```

### This affects two rules:
- lt
- lte

### Why This Happens
PHP's is_numeric() returns true for INF and NAN, so the numeric comparison branch is entered. However, BigNumber::of() cannot parse "INF" or "NAN" strings and throws. The sibling rules gt and gte already wrap this call in a try-catch, but lt and lte were missed.

```php
// gt — SAFE (has try-catch)
if ($this->hasRule($attribute, $this->numericRules) && is_numeric($value) && is_numeric($comparedToValue)) {
    try {
        return BigNumber::of($this->trim($value))->isGreaterThan($this->trim($comparedToValue));
    } catch (MathException) {
        return false;
    }
}
// lt — BROKEN (no try-catch)
if ($this->hasRule($attribute, $this->numericRules) && is_numeric($value) && is_numeric($comparedToValue)) {
    return BigNumber::of($this->trim($value))->isLessThan($this->trim($comparedToValue));
}
```

### The Fix
Wrap the BigNumber::of() calls in validateLt() and validateLte() with try-catch, matching the pattern already used in validateGt() and validateGte(). Non-parsable numeric values fail validation gracefully instead of throwing.

### Changes
- src/Illuminate/Validation/Concerns/ValidatesAttributes.php — Add try-catch around BigNumber::of() in validateLt() and validateLte()
- tests/Validation/ValidationValidatorTest.php — Tests verifying lt/lte return false instead of throwing on INF/NAN values