### PR TITLE
[13.x] Fix Number::abbreviate() and Number::forHumans() crash on INF/NAN

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -266,6 +266,10 @@ class Number
      */
     protected static function summarize(int|float $number, int $precision = 0, ?int $maxPrecision = null, array $units = [])
     {
+        if (! is_finite($number)) {
+            return (string) $number;
+        }
+
         if (empty($units)) {
             $units = [
                 3 => 'K',

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -253,6 +253,15 @@ class SupportNumberTest extends TestCase
         $this->assertSame('-1 thousand quadrillion', Number::forHumans(-1000000000000000000));
     }
 
+    public function testForHumansWithNonFiniteValues()
+    {
+        $this->assertSame('INF', Number::forHumans(INF));
+        $this->assertSame('-INF', Number::forHumans(-INF));
+        $this->assertSame('NAN', Number::forHumans(NAN));
+        $this->assertSame('INF', Number::abbreviate(INF));
+        $this->assertSame('NAN', Number::abbreviate(NAN));
+    }
+
     public function testSummarize()
     {
         $this->assertSame('1', Number::abbreviate(1));


### PR DESCRIPTION
## Summary

`Number::abbreviate()` and `Number::forHumans()` crash with memory exhaustion when passed `INF`, `-INF`, or `NAN`.

### The Bug

```php
Number::abbreviate(INF);
// Fatal error: Allowed memory size exhausted

Number::forHumans(INF);
// Same crash
```

### Root Cause

`summarize()` checks `$number >= 1e15` and recurses with `$number / 1e15`. When `$number` is `INF`, `INF / 1e15` is still `INF` — infinite recursion until memory runs out.

### The Fix

Return the string representation early for non-finite values:

```php
if (! is_finite($number)) {
    return (string) $number;
}
```

This is consistent with how `Number::format()` handles INF/NAN — it returns `∞` / `NAN` via the NumberFormatter.

### Context

PR #59544 fixes the same class of issue for `Number::trim()`. This PR covers `abbreviate()` and `forHumans()` which use the `summarize()` method.

### Changes

- `src/Illuminate/Support/Number.php` — Guard `summarize()` against non-finite values
- `tests/Support/SupportNumberTest.php` — Test INF/NAN for both methods