### PR TITLE
Fix Http::retry callback handling for redirect responses.

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -1046,12 +1046,14 @@ class PendingRequest
                     $this->dispatchResponseReceivedEvent($response);
                     $response = $this->runAfterResponseCallbacks($response);
 
+                    $responseException = $response->toException() ?? new \Illuminate\Http\Client\RequestException($response);
+
                     if ($response->successful()) {
                         return;
                     }
 
                     try {
-                        $shouldRetry = $this->retryWhenCallback ? call_user_func($this->retryWhenCallback, $response->toException(), $this, $this->request->toPsrRequest()->getMethod()) : true;
+                        $shouldRetry = $this->retryWhenCallback ? call_user_func($this->retryWhenCallback, $responseException, $this, $this->request->toPsrRequest()->getMethod()) : true;
                     } catch (Exception $exception) {
                         $shouldRetry = false;
 
@@ -1069,11 +1071,11 @@ class PendingRequest
                         : $this->tries;
 
                     if ($attempt < $potentialTries && $shouldRetry) {
-                        $response->throw();
+                        throw $responseException;
                     }
 
                     if ($potentialTries > 1 && $this->retryThrow) {
-                        $response->throw();
+                        throw $responseException;
                     }
                 });
             } catch (TransferException $e) {

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -2256,6 +2256,34 @@ class HttpClientTest extends TestCase
         $this->factory->assertSentCount(1);
     }
 
+    public function testRequestCanBeRetriedWhenRetryCallbackTypeHintsThrowableForRedirectResponses()
+    {
+        $this->factory->fake([
+            '*' => $this->factory->sequence()
+                ->push(['redirect'], 301)
+                ->push(['ok'], 200),
+        ]);
+
+        $whenAttempts = 0;
+
+        $response = $this->factory
+            ->retry(2, 0, function (Throwable $exception, PendingRequest $request) use (&$whenAttempts) {
+                $whenAttempts++;
+
+                $this->assertInstanceOf(RequestException::class, $exception);
+                $this->assertSame(301, $exception->response->status());
+                $this->assertInstanceOf(PendingRequest::class, $request);
+
+                return true;
+            }, false)
+            ->get('http://foo.com/get');
+
+        $this->assertTrue($response->successful());
+        $this->assertSame(1, $whenAttempts);
+
+        $this->factory->assertSentCount(2);
+    }
+
     public function testRequestExceptionIsNotThrownWhenDisabledAndRetriesExhausted()
     {
         $this->factory->fake([


### PR DESCRIPTION
This PR fixes `Http::retry()` when the retry callback type-hints `Throwable` or `Exception` and the response is a redirect.

`Response::toException()` returns `null` for 3xx responses, which meant the retry callback could receive `null` instead of an exception. I now create a `RequestException` for non-success responses before calling the retry callback, so redirect responses behave consistently with the rest of the retry flow.

What changed:
- pass a real `RequestException` into the retry callback for redirect / non-success responses
- keep the existing retry behavior for successful responses unchanged
- add a regression test for a `Throwable`-typed retry callback on a 301 response

Tests:
- `./vendor/bin/phpunit --filter testRequestCanBeRetriedWhenRetryCallbackTypeHintsThrowableForRedirectResponses tests/Http/HttpClientTest.php`
- `./vendor/bin/phpunit tests/Http/HttpClientTest.php`