### PR TITLE
[13.x] Add getListeners and getRawListeners to EventFake

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/EventFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/EventFake.php
@@ -277,6 +277,27 @@ class EventFake implements Dispatcher, Fake
     }
 
     /**
+     * Get all of the listeners for a given event name.
+     *
+     * @param  string  $eventName
+     * @return array
+     */
+    public function getListeners($eventName)
+    {
+        return $this->dispatcher->getListeners($eventName);
+    }
+
+    /**
+     * Get all of the raw listeners.
+     *
+     * @return array
+     */
+    public function getRawListeners()
+    {
+        return $this->dispatcher->getRawListeners();
+    }
+
+    /**
      * Register an event and payload to be dispatched later.
      *
      * @param  string  $event


### PR DESCRIPTION
## Summary

`getListeners()` and `getRawListeners()` are documented on the Event facade and exist on the Dispatcher, but are missing from EventFake. Calling these methods after `Event::fake()` throws an error.

### The Bug

```php
Event::fake();

Event::getListeners(UserCreated::class);
// Error: method does not exist

Event::getRawListeners();
// Error: method does not exist
```

### Context

EventFake already delegates several methods to the real dispatcher:
- `listen()` → `$this->dispatcher->listen()` ✅
- `hasListeners()` → `$this->dispatcher->hasListeners()` ✅
- `subscribe()` → `$this->dispatcher->subscribe()` ✅
- **`getListeners()`** → ❌ missing
- **`getRawListeners()`** → ❌ missing

### Precedent

Same pattern as:
- PR #59448 — added `driver()` to MailFake
- NotificationFake already has `channel()` delegating to the real manager

### Changes

- `src/Illuminate/Support/Testing/Fakes/EventFake.php` — Add `getListeners()` and `getRawListeners()` delegating to the real dispatcher