### PR TITLE
[13.x] Fix unhandled BrickMathException in gt/gte validation rules with INF/NAN values

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1282,7 +1282,7 @@ trait ValidatesAttributes
         if (is_null($comparedToValue) && (is_numeric($value) && is_numeric($parameters[0]))) {
             try {
                 return BigNumber::of($this->getSize($attribute, $value))->isGreaterThan($this->trim($parameters[0]));
-            } catch (MathException) {
+            } catch (MathException|BrickMathException) {
                 return false;
             }
         }
@@ -1294,7 +1294,7 @@ trait ValidatesAttributes
         if ($this->hasRule($attribute, $this->numericRules) && is_numeric($value) && is_numeric($comparedToValue)) {
             try {
                 return BigNumber::of($this->trim($value))->isGreaterThan($this->trim($comparedToValue));
-            } catch (MathException) {
+            } catch (MathException|BrickMathException) {
                 return false;
             }
         }
@@ -1372,7 +1372,7 @@ trait ValidatesAttributes
         if (is_null($comparedToValue) && (is_numeric($value) && is_numeric($parameters[0]))) {
             try {
                 return BigNumber::of($this->getSize($attribute, $value))->isGreaterThanOrEqualTo($this->trim($parameters[0]));
-            } catch (MathException) {
+            } catch (MathException|BrickMathException) {
                 return false;
             }
         }
@@ -1384,7 +1384,7 @@ trait ValidatesAttributes
         if ($this->hasRule($attribute, $this->numericRules) && is_numeric($value) && is_numeric($comparedToValue)) {
             try {
                 return BigNumber::of($this->trim($value))->isGreaterThanOrEqualTo($this->trim($comparedToValue));
-            } catch (MathException) {
+            } catch (MathException|BrickMathException) {
                 return false;
             }
         }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2476,6 +2476,18 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['lhs' => 15], ['lhs' => 'numeric|gt:10']);
         $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['lhs' => INF, 'rhs' => 10], ['lhs' => 'numeric|gt:rhs']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['lhs' => INF], ['lhs' => 'numeric|gt:10']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['lhs' => NAN, 'rhs' => 15], ['lhs' => 'numeric|gt:rhs']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['lhs' => NAN], ['lhs' => 'numeric|gt:10']);
+        $this->assertTrue($v->fails());
     }
 
     public function testLowercase()
@@ -2612,6 +2624,18 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['lhs' => 15], ['lhs' => 'numeric|gte:15']);
         $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['lhs' => INF, 'rhs' => 10], ['lhs' => 'numeric|gte:rhs']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['lhs' => INF], ['lhs' => 'numeric|gte:10']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['lhs' => NAN, 'rhs' => 15], ['lhs' => 'numeric|gte:rhs']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['lhs' => NAN], ['lhs' => 'numeric|gte:10']);
+        $this->assertTrue($v->fails());
     }
 
     public function testLessThanOrEqual()


### PR DESCRIPTION
## Summary
The gt and gte validation rules throw an unhandled `Brick\Math\Exception\MathException` when the value is `INF` or `NAN`. This results in an uncaught exception instead of a graceful validation failure.

### The Bug
```php
Validator::make(
    ['lhs' => INF],
    ['lhs' => 'numeric|gt:10']
)->validate();
// Brick\Math\Exception\MathException: NAN or INF cannot be converted to a BigDecimal
```

### This affects two rules:
- gt
- gte

### Why This Happens
BigNumber::of() (from brick/math) cannot handle INF or NAN float values and throws Brick\Math\Exception\MathException. The existing catch blocks only caught Illuminate\Support\Exceptions\MathException, which is a separate class hierarchy. The exception was therefore unhandled.

### Changes
- src/Illuminate/Validation/Concerns/ValidatesAttributes.php — Updated 4 catch blocks in validateGt() and validateGte() to catch both exception types
- tests/Validation/ValidationValidatorTest.php — Added INF and NAN test cases to testGreaterThan() and testGreaterThanOrEqual()