### PR TITLE
[13.x] Fix deprecation warning in In and NotIn rules when values contain null

### DIFF
--- a/src/Illuminate/Validation/Rules/In.php
+++ b/src/Illuminate/Validation/Rules/In.php
@@ -49,7 +49,7 @@ class In implements Stringable
         $values = array_map(function ($value) {
             $value = enum_value($value);
 
-            return '"'.str_replace('"', '""', $value).'"';
+            return '"'.str_replace('"', '""', (string) $value).'"';
         }, $this->values);
 
         return $this->rule.':'.implode(',', $values);

--- a/src/Illuminate/Validation/Rules/NotIn.php
+++ b/src/Illuminate/Validation/Rules/NotIn.php
@@ -47,7 +47,7 @@ class NotIn implements Stringable
         $values = array_map(function ($value) {
             $value = enum_value($value);
 
-            return '"'.str_replace('"', '""', $value).'"';
+            return '"'.str_replace('"', '""', (string) $value).'"';
         }, $this->values);
 
         return $this->rule.':'.implode(',', $values);

--- a/tests/Validation/ValidationInRuleTest.php
+++ b/tests/Validation/ValidationInRuleTest.php
@@ -71,6 +71,10 @@ class ValidationInRuleTest extends TestCase
         $rule = Rule::in([PureEnum::one]);
 
         $this->assertSame('in:"one"', (string) $rule);
+
+        $rule = new In([1, null, 'a']);
+
+        $this->assertSame('in:"1","","a"', (string) $rule);
     }
 
     public function testInRuleValidation()


### PR DESCRIPTION
## Summary

The \`In\` and \`NotIn\` validation rules generate PHP deprecation warnings when the values array contains \`null\`.

### The Bug

\`\`\`php
Rule::in([1, null, 'active']);
// Deprecated: str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated

Rule::notIn([null, 'banned']);
// Same warning
\`\`\`

This happens in \`__toString()\` where \`str_replace('"', '""', $value)\` receives \`null\` after \`enum_value(null)\` returns \`null\`.

Passing null values in \`in\` / \`not_in\` rules is a valid use case — checking if a field is null.

### The Fix

Cast to string before passing to \`str_replace()\`:

\`\`\`php
return '"'.str_replace('"', '""', (string) $value).'"';
\`\`\`

This will become a TypeError in PHP 9.0 when null-to-string deprecations are promoted to errors.

### Changes

- \`src/Illuminate/Validation/Rules/In.php\` — Cast value to string
- \`src/Illuminate/Validation/Rules/NotIn.php\` — Cast value to string
- \`tests/Validation/ValidationInRuleTest.php\` — Test with null in values array