### PR TITLE
[13.x] Fix deprecation warning in Contains and DoesntContain rules when values contain null

### DIFF
--- a/src/Illuminate/Validation/Rules/Contains.php
+++ b/src/Illuminate/Validation/Rules/Contains.php
@@ -40,7 +40,7 @@ class Contains implements Stringable
         $values = array_map(function ($value) {
             $value = enum_value($value);
 
-            return '"'.str_replace('"', '""', $value).'"';
+            return '"'.str_replace('"', '""', (string) $value).'"';
         }, $this->values);
 
         return 'contains:'.implode(',', $values);

--- a/src/Illuminate/Validation/Rules/DoesntContain.php
+++ b/src/Illuminate/Validation/Rules/DoesntContain.php
@@ -40,7 +40,7 @@ class DoesntContain implements Stringable
         $values = array_map(function ($value) {
             $value = enum_value($value);
 
-            return '"'.str_replace('"', '""', $value).'"';
+            return '"'.str_replace('"', '""', (string) $value).'"';
         }, $this->values);
 
         return 'doesnt_contain:'.implode(',', $values);


### PR DESCRIPTION
## Summary

Same issue as #59560 (In/NotIn) — the `Contains` and `DoesntContain` rules generate PHP deprecation warnings when the values array contains `null`.

### The Bug

```php
Rule::contains([1, null, 'a']);
// Deprecated: str_replace(): Passing null to parameter #3 ($subject)

Rule::doesntContain([null, 'banned']);
// Same warning
```

All four rules (`In`, `NotIn`, `Contains`, `DoesntContain`) share the same `__toString()` pattern:

```php
return '"'.str_replace('"', '""', $value).'"';
```

PR #59560 fixes `In` and `NotIn`. This PR fixes `Contains` and `DoesntContain`.

### The Fix

```php
return '"'.str_replace('"', '""', (string) $value).'"';
```

### Changes

- `src/Illuminate/Validation/Rules/Contains.php` — Cast value to string
- `src/Illuminate/Validation/Rules/DoesntContain.php` — Cast value to string