### PR TITLE
Fix @aware resolving distant ancestor data over nearest parent

### DIFF
--- a/src/Illuminate/View/Concerns/ManagesComponents.php
+++ b/src/Illuminate/View/Concerns/ManagesComponents.php
@@ -137,22 +137,27 @@ trait ManagesComponents
      */
     public function getConsumableComponentData($key, $default = null)
     {
-        if (array_key_exists($key, $this->currentComponentData)) {
-            return $this->currentComponentData[$key];
-        }
-
         $currentComponent = count($this->componentStack);
 
-        if ($currentComponent === 0) {
-            return value($default);
+        // Check the current component's own data first (explicitly passed props).
+        // After renderComponent pops the component, its data remains at this index.
+        if (isset($this->componentData[$currentComponent]) &&
+            array_key_exists($key, $this->componentData[$currentComponent])) {
+            return $this->componentData[$currentComponent][$key];
         }
 
+        // Then check parent components still on the stack (nearest parent → root).
         for ($i = $currentComponent - 1; $i >= 0; $i--) {
             $data = $this->componentData[$i] ?? [];
 
             if (array_key_exists($key, $data)) {
                 return $data[$key];
             }
+        }
+
+        // Fall back to data from already-rendered ancestor components.
+        if (array_key_exists($key, $this->currentComponentData)) {
+            return $this->currentComponentData[$key];
         }
 
         return value($default);

--- a/tests/Integration/View/BladeTest.php
+++ b/tests/Integration/View/BladeTest.php
@@ -259,6 +259,14 @@ class BladeTest extends TestCase
         $this->artisan('view:cache');
     }
 
+    public function test_aware_resolves_nearest_parent_over_distant_ancestor()
+    {
+        $view = View::make('aware-nested')->render();
+
+        $this->assertStringContainsString('BAR', trim($view));
+        $this->assertStringNotContainsString('FOO', trim($view));
+    }
+
     /** {@inheritdoc} */
     #[\Override]
     protected function defineEnvironment($app)

--- a/tests/Integration/View/templates/aware-nested.blade.php
+++ b/tests/Integration/View/templates/aware-nested.blade.php
@@ -1,0 +1,1 @@
+<x-aware-outer name="FOO" />

--- a/tests/Integration/View/templates/components/aware-inner.blade.php
+++ b/tests/Integration/View/templates/components/aware-inner.blade.php
@@ -1,0 +1,2 @@
+@aware(['name'])
+{{ $name }}

--- a/tests/Integration/View/templates/components/aware-middle.blade.php
+++ b/tests/Integration/View/templates/components/aware-middle.blade.php
@@ -1,0 +1,3 @@
+<x-aware-wrapper name="BAR">
+<x-aware-inner />
+</x-aware-wrapper>

--- a/tests/Integration/View/templates/components/aware-outer.blade.php
+++ b/tests/Integration/View/templates/components/aware-outer.blade.php
@@ -1,0 +1,2 @@
+@props(['name'])
+<x-aware-middle />

--- a/tests/Integration/View/templates/components/aware-wrapper.blade.php
+++ b/tests/Integration/View/templates/components/aware-wrapper.blade.php
@@ -1,0 +1,2 @@
+@props(['name'])
+{{ $slot }}


### PR DESCRIPTION
## Summary

- Fix incorrect `@aware` variable resolution when nested components share the same variable name at different depths
- The nearest parent's value is now correctly preferred over a distant ancestor's value

Fixes #57857

## Root Cause

`getConsumableComponentData()` checked `$currentComponentData` (a flat accumulator from already-rendered ancestors) before checking the active component stack. When a distant ancestor and a closer parent both define a variable with the same name, the distant ancestor's value was returned.

## Fix

Changed the lookup order in `getConsumableComponentData()` to:
1. Current component's own data (explicitly passed props)
2. Parent components still on the stack (nearest → root)
3. `currentComponentData` as fallback for already-rendered ancestors

## Test Plan

- Added `test_aware_resolves_nearest_parent_over_distant_ancestor` integration test with 4-level nesting (outer→middle→wrapper→inner)
- All existing tests pass (22/22)