### PR TITLE
[13.x] Clean up redundant unreachable code in Gate

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -498,17 +498,13 @@ class Gate implements GateContract
             $reflection = new ReflectionClass($class);
 
             $method = $reflection->getMethod($method);
-        } catch (Exception) {
-            return false;
-        }
 
-        if ($method) {
             $parameters = $method->getParameters();
 
             return isset($parameters[0]) && $this->parameterAllowsGuests($parameters[0]);
+        } catch (Exception) {
+            return false;
         }
-
-        return false;
     }
 
     /**


### PR DESCRIPTION
This PR simplifies the `methodAllowsGuests` method in the `Gate` class by removing redundant logic and unreachable code paths.

### Summary of Changes:
- **Removed redundant check:** The `if ($method)` check was unnecessary because `ReflectionClass::getMethod()` either returns a `ReflectionMethod` object or throws an `Exception`. If it reaches that point, `$method` is guaranteed to be an instance of `ReflectionMethod`.
- **Removed unreachable code:** The final `return false` statement was unreachable as all previous logic paths already returned a value.
- **Refined Try-Catch:** Refactored the logic to be handled directly within the `try` block for better readability.

### Testing:
- Verified by running `./vendor/bin/phpunit tests/Auth/AuthAccessGateTest.php`.
- Result: **OK (106 tests, 226 assertions)**.