### PR TITLE
[13.x] Allow Dependency Injection in the failed() method of queued jobs

### DIFF
--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -19,6 +19,7 @@ use Illuminate\Events\CallQueuedListener;
 use Illuminate\Log\Context\Repository as ContextRepository;
 use Illuminate\Pipeline\Pipeline;
 use RuntimeException;
+use Throwable;
 
 class CallQueuedHandler
 {
@@ -343,7 +344,7 @@ class CallQueuedHandler
         $this->ensureChainCatchCallbacksAreInvoked($uuid, $command, $e);
 
         if (method_exists($command, 'failed')) {
-            $this->container->call([$command, 'failed'], ['e' => $e, 'exception' => $e]);
+            $this->container->call([$command, 'failed'], [Throwable::class => $e]);
         }
     }
 

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -343,7 +343,7 @@ class CallQueuedHandler
         $this->ensureChainCatchCallbacksAreInvoked($uuid, $command, $e);
 
         if (method_exists($command, 'failed')) {
-            $command->failed($e);
+            $this->container->call([$command, 'failed'], ['e' => $e, 'exception' => $e]);
         }
     }
 

--- a/tests/Integration/Queue/CallQueuedHandlerTest.php
+++ b/tests/Integration/Queue/CallQueuedHandlerTest.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Tests\Integration\Queue;
 
-use Generator;
 use Illuminate\Bus\Batch;
 use Illuminate\Bus\Batchable;
 use Illuminate\Bus\BatchRepository;
@@ -17,7 +16,6 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Support\Facades\Event;
 use Mockery as m;
 use Orchestra\Testbench\TestCase;
-use PHPUnit\Framework\Attributes\DataProvider;
 use RuntimeException;
 use Throwable;
 
@@ -186,14 +184,10 @@ class CallQueuedHandlerTest extends TestCase
         Event::assertNotDispatched(JobFailed::class);
     }
 
-    /**
-     * @param  class-string<CallQueuedHandlerJobWithFailedHookStub>  $jobClass
-     */
-    #[DataProvider('failedMethodWithDependencyInjectionProvider')]
-    public function test_failed_method_receives_injected_dependencies(string $jobClass): void
+    public function test_failed_method_receives_injected_dependencies(): void
     {
-        $jobClass::$capturedServiceValue = null;
-        $jobClass::$capturedException = null;
+        CallQueuedHandlerJobWithFailedHook::$capturedServiceValue = null;
+        CallQueuedHandlerJobWithFailedHook::$capturedException = null;
 
         $this->app->bind(CallQueuedHandlerTestService::class, fn () => new CallQueuedHandlerTestService('injected'));
 
@@ -201,20 +195,14 @@ class CallQueuedHandlerTest extends TestCase
         $exception = new RuntimeException('something went wrong');
 
         $instance->failed(
-            ['command' => serialize(new $jobClass)],
+            ['command' => serialize(new CallQueuedHandlerJobWithFailedHook)],
             $exception,
             'test-uuid',
             m::mock(Job::class),
         );
 
-        $this->assertSame('injected', $jobClass::$capturedServiceValue);
-        $this->assertSame($exception, $jobClass::$capturedException);
-    }
-
-    public static function failedMethodWithDependencyInjectionProvider(): Generator
-    {
-        yield 'exception parameter named $e' => [CallQueuedHandlerJobWithFailedHook::class];
-        yield 'exception parameter named $exception' => [CallQueuedHandlerJobWithFailedHookExceptionParam::class];
+        $this->assertSame('injected', CallQueuedHandlerJobWithFailedHook::$capturedServiceValue);
+        $this->assertSame($exception, CallQueuedHandlerJobWithFailedHook::$capturedException);
     }
 
     public function test_failed_method_without_dependency_injection_still_works(): void
@@ -355,7 +343,7 @@ readonly class CallQueuedHandlerTestService
     }
 }
 
-abstract class CallQueuedHandlerJobWithFailedHookStub
+class CallQueuedHandlerJobWithFailedHook
 {
     use InteractsWithQueue, Queueable;
 
@@ -366,23 +354,11 @@ abstract class CallQueuedHandlerJobWithFailedHookStub
     public function handle(): void
     {
     }
-}
 
-class CallQueuedHandlerJobWithFailedHook extends CallQueuedHandlerJobWithFailedHookStub
-{
     public function failed(Throwable $e, CallQueuedHandlerTestService $service): void
     {
         static::$capturedServiceValue = $service->value;
         static::$capturedException = $e;
-    }
-}
-
-class CallQueuedHandlerJobWithFailedHookExceptionParam extends CallQueuedHandlerJobWithFailedHookStub
-{
-    public function failed(Throwable $exception, CallQueuedHandlerTestService $service): void
-    {
-        static::$capturedServiceValue = $service->value;
-        static::$capturedException = $exception;
     }
 }
 

--- a/tests/Integration/Queue/CallQueuedHandlerTest.php
+++ b/tests/Integration/Queue/CallQueuedHandlerTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Queue;
 
+use Generator;
 use Illuminate\Bus\Batch;
 use Illuminate\Bus\Batchable;
 use Illuminate\Bus\BatchRepository;
@@ -16,10 +17,13 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Support\Facades\Event;
 use Mockery as m;
 use Orchestra\Testbench\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use RuntimeException;
+use Throwable;
 
 class CallQueuedHandlerTest extends TestCase
 {
-    public function testJobCanBeDispatched()
+    public function test_job_can_be_dispatched()
     {
         CallQueuedHandlerTestJob::$handled = false;
 
@@ -39,7 +43,7 @@ class CallQueuedHandlerTest extends TestCase
         $this->assertTrue(CallQueuedHandlerTestJob::$handled);
     }
 
-    public function testJobCanBeDispatchedThroughMiddleware()
+    public function test_job_can_be_dispatched_through_middleware()
     {
         CallQueuedHandlerTestJobWithMiddleware::$handled = false;
         CallQueuedHandlerTestJobWithMiddleware::$middlewareCommand = null;
@@ -61,7 +65,7 @@ class CallQueuedHandlerTest extends TestCase
         $this->assertTrue(CallQueuedHandlerTestJobWithMiddleware::$handled);
     }
 
-    public function testJobCanBeDispatchedThroughMiddlewareOnDispatch()
+    public function test_job_can_be_dispatched_through_middleware_on_dispatch()
     {
         $_SERVER['__test.dispatchMiddleware'] = false;
         CallQueuedHandlerTestJobWithMiddleware::$handled = false;
@@ -88,7 +92,7 @@ class CallQueuedHandlerTest extends TestCase
         $this->assertTrue($_SERVER['__test.dispatchMiddleware']);
     }
 
-    public function testJobIsMarkedAsFailedIfModelNotFoundExceptionIsThrown()
+    public function test_job_is_marked_as_failed_if_model_not_found_exception_is_thrown()
     {
         $instance = new CallQueuedHandler(new Dispatcher($this->app), $this->app);
 
@@ -101,7 +105,7 @@ class CallQueuedHandlerTest extends TestCase
         ]);
     }
 
-    public function testJobIsDeletedIfHasDeleteProperty()
+    public function test_job_is_deleted_if_has_delete_property()
     {
         Event::fake();
 
@@ -123,7 +127,7 @@ class CallQueuedHandlerTest extends TestCase
         Event::assertNotDispatched(JobFailed::class);
     }
 
-    public function testJobIsDeletedIfHasDeleteAttribute()
+    public function test_job_is_deleted_if_has_delete_attribute()
     {
         Event::fake();
 
@@ -139,13 +143,13 @@ class CallQueuedHandlerTest extends TestCase
         $job->shouldReceive('failed')->never();
 
         $instance->call($job, [
-            'command' => serialize(new CallQueuedHandlerAttributeExceptionThrower()),
+            'command' => serialize(new CallQueuedHandlerAttributeExceptionThrower),
         ]);
 
         Event::assertNotDispatched(JobFailed::class);
     }
 
-    public function testBatchJobIsRecordedWhenDeletedDueToMissingModel()
+    public function test_batch_job_is_recorded_when_deleted_due_to_missing_model()
     {
         Event::fake();
 
@@ -180,6 +184,54 @@ class CallQueuedHandlerTest extends TestCase
         ]);
 
         Event::assertNotDispatched(JobFailed::class);
+    }
+
+    /**
+     * @param  class-string<CallQueuedHandlerJobWithFailedHookStub>  $jobClass
+     */
+    #[DataProvider('failedMethodWithDependencyInjectionProvider')]
+    public function test_failed_method_receives_injected_dependencies(string $jobClass): void
+    {
+        $jobClass::$capturedServiceValue = null;
+        $jobClass::$capturedException = null;
+
+        $this->app->bind(CallQueuedHandlerTestService::class, fn () => new CallQueuedHandlerTestService('injected'));
+
+        $instance = new CallQueuedHandler(new Dispatcher($this->app), $this->app);
+        $exception = new RuntimeException('something went wrong');
+
+        $instance->failed(
+            ['command' => serialize(new $jobClass)],
+            $exception,
+            'test-uuid',
+            m::mock(Job::class),
+        );
+
+        $this->assertSame('injected', $jobClass::$capturedServiceValue);
+        $this->assertSame($exception, $jobClass::$capturedException);
+    }
+
+    public static function failedMethodWithDependencyInjectionProvider(): Generator
+    {
+        yield 'exception parameter named $e' => [CallQueuedHandlerJobWithFailedHook::class];
+        yield 'exception parameter named $exception' => [CallQueuedHandlerJobWithFailedHookExceptionParam::class];
+    }
+
+    public function test_failed_method_without_dependency_injection_still_works(): void
+    {
+        CallQueuedHandlerJobWithFailedHookNoDI::$capturedException = null;
+
+        $instance = new CallQueuedHandler(new Dispatcher($this->app), $this->app);
+        $exception = new RuntimeException('simple failure');
+
+        $instance->failed(
+            ['command' => serialize(new CallQueuedHandlerJobWithFailedHookNoDI)],
+            $exception,
+            'test-uuid',
+            m::mock(Job::class),
+        );
+
+        $this->assertSame($exception, CallQueuedHandlerJobWithFailedHookNoDI::$capturedException);
     }
 }
 
@@ -293,5 +345,59 @@ class TestJobMiddleware
         $_SERVER['__test.dispatchMiddleware'] = true;
 
         return $next($command);
+    }
+}
+
+readonly class CallQueuedHandlerTestService
+{
+    public function __construct(public string $value)
+    {
+    }
+}
+
+abstract class CallQueuedHandlerJobWithFailedHookStub
+{
+    use InteractsWithQueue, Queueable;
+
+    public static ?string $capturedServiceValue = null;
+
+    public static ?Throwable $capturedException = null;
+
+    public function handle(): void
+    {
+    }
+}
+
+class CallQueuedHandlerJobWithFailedHook extends CallQueuedHandlerJobWithFailedHookStub
+{
+    public function failed(Throwable $e, CallQueuedHandlerTestService $service): void
+    {
+        static::$capturedServiceValue = $service->value;
+        static::$capturedException = $e;
+    }
+}
+
+class CallQueuedHandlerJobWithFailedHookExceptionParam extends CallQueuedHandlerJobWithFailedHookStub
+{
+    public function failed(Throwable $exception, CallQueuedHandlerTestService $service): void
+    {
+        static::$capturedServiceValue = $service->value;
+        static::$capturedException = $exception;
+    }
+}
+
+class CallQueuedHandlerJobWithFailedHookNoDI
+{
+    use InteractsWithQueue, Queueable;
+
+    public static ?Throwable $capturedException = null;
+
+    public function handle(): void
+    {
+    }
+
+    public function failed(Throwable $e): void
+    {
+        static::$capturedException = $e;
     }
 }


### PR DESCRIPTION
Currently, the `failed()` method on queued jobs does not support Dependency Injection. When a job fails, developers are forced to resolve services manually through the service container, which is difficult to test and inconsistent with the rest of the framework:

```php
public function failed(Throwable $e): void
{
    app(OrderRepository::class)->markAsFailed($this->orderId);
}
```

This PR enables type-hinting dependencies directly in `failed()`, consistent with how `handle()` already works:

```php
public function failed(Throwable $e, OrderRepository $repository, Mailer $mailer): void
{
    $repository->markAsFailed($this->orderId);
    $mailer->notifyTeam($this->orderId, $e);
}
```

## Benefit to end users

Developers can now inject any service registered in the container into `failed()`, making failure-handling logic cleaner, more expressive, and fully testable without relying on `app()` helpers.

## Backwards compatibility

The change is fully backwards compatible. Existing `failed(Throwable $e)` methods continue to work without modification — the exception is resolved by its type, consistent with how the container resolves other dependencies. Any additional parameters are injected from the container automatically, identical to how `handle()` behaves.

## Tests

The tests verify both the new approach to dependency injection and legacy backward-compatibility scenarios.
