### PR TITLE
[13.x] Fix that retries of `ShouldBeUniqueUntilProcessing` jobs are force-releasing locks they don't own

### DIFF
--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -120,12 +120,12 @@ class CallQueuedHandler
         return (new Pipeline($this->container))->send($command)
             ->through(array_merge(method_exists($command, 'middleware') ? $command->middleware() : [], $command->middleware ?? []))
             ->finally(function ($command) use (&$lockReleased) {
-                if (! $lockReleased && $this->commandShouldBeUniqueUntilProcessing($command) && ! $command->job->isReleased()) {
+                if (! $lockReleased && $this->commandShouldBeUniqueUntilProcessing($command) && ! $command->job->isReleased() && $command->job->attempts() <= 1) {
                     $this->ensureUniqueJobLockIsReleased($command);
                 }
             })
             ->then(function ($command) use ($job, &$lockReleased) {
-                if ($this->commandShouldBeUniqueUntilProcessing($command)) {
+                if ($this->commandShouldBeUniqueUntilProcessing($command) && $job->attempts() <= 1) {
                     $this->ensureUniqueJobLockIsReleased($command);
 
                     $lockReleased = true;

--- a/tests/Events/QueuedEventsTest.php
+++ b/tests/Events/QueuedEventsTest.php
@@ -587,6 +587,7 @@ class QueuedEventsTest extends TestCase
         $job->shouldReceive('isDeleted')->andReturn(false);
         $job->shouldReceive('isReleased')->andReturn(false);
         $job->shouldReceive('isDeletedOrReleased')->andReturn(false);
+        $job->shouldReceive('attempts')->andReturn(1);
         $job->shouldReceive('delete')->once();
 
         $handler = new CallQueuedHandler(new BusDispatcher($container), $container);

--- a/tests/Integration/Queue/UniqueJobTest.php
+++ b/tests/Integration/Queue/UniqueJobTest.php
@@ -145,6 +145,31 @@ class UniqueJobTest extends QueueTestCase
         $this->assertTrue($this->app->get(Cache::class)->lock($this->getLockKey($job), 10)->get());
     }
 
+    public function testRetryOfUniqueUntilProcessingJobDoesNotForceReleaseSubsequentLock()
+    {
+        $this->markTestSkippedWhenUsingSyncQueueDriver();
+
+        dispatch($job = new UniqueUntilProcessingRetryJob);
+
+        // Lock acquired at dispatch time.
+        $this->assertFalse($this->app->get(Cache::class)->lock($this->getLockKey($job), 10)->get());
+
+        $this->runQueueWorkerCommand(['--once' => true]); // attempt 1: releases lock, then fails
+
+        $this->assertTrue($job::$handled);
+
+        // Lock was correctly released before attempt 1 ran. Simulate a subsequent external dispatch
+        // acquiring it (asserts it was free and holds it for the rest of the test).
+        $this->assertTrue($this->app->get(Cache::class)->lock($this->getLockKey($job), 60)->get());
+
+        // Attempt 2 (the retry) must not force-release the lock it did not acquire.
+        UniqueUntilProcessingRetryJob::$handled = false;
+        $this->runQueueWorkerCommand(['--once' => true]); // attempt 2
+
+        $this->assertTrue($job::$handled);
+        $this->assertFalse($this->app->get(Cache::class)->lock($this->getLockKey($job), 10)->get());
+    }
+
     public function testLockIsReleasedOnModelNotFoundException()
     {
         UniqueTestSerializesModelsJob::$handled = false;
@@ -300,6 +325,24 @@ class UniqueTestRetryJob extends UniqueTestFailJob
 class UniqueUntilStartTestJob extends UniqueTestJob implements ShouldBeUniqueUntilProcessing
 {
     public $tries = 2;
+}
+
+class UniqueUntilProcessingRetryJob implements ShouldQueue, ShouldBeUniqueUntilProcessing
+{
+    use InteractsWithQueue, Queueable, Dispatchable;
+
+    public $tries = 2;
+
+    public static $handled = false;
+
+    public function handle()
+    {
+        static::$handled = true;
+
+        if ($this->attempts() === 1) {
+            throw new Exception('First attempt failure.');
+        }
+    }
 }
 
 class UniqueTestSerializesModelsJob extends UniqueTestJob


### PR DESCRIPTION
When a `ShouldBeUniqueUntilProcessing` job fails and is retried, the retry was incorrectly calling `forceRelease()` on the unique lock — even though the retry never acquired it.

Since `ShouldBeUniqueUntilProcessing` releases the lock before the handler runs, a new dispatch can pick it up during the first attempt's execution. If that attempt fails, the retry would then destroy the new dispatch's lock, allowing another duplicate through, which gets its lock destroyed by the next retry, and so on — cascading into an unbounded number of duplicate jobs in the queue.

Retries are placed back on the queue by the worker directly, bypassing `dispatch()`, so they never acquire a lock and have nothing to release. This PR guards the lock release with `$job->attempts() <= 1` so only the attempt that actually acquired the lock can release it.

The `dispatchThroughMiddleware` code is identical on `12.x`, so the fix would apply cleanly there too — though backporting may not be desirable given that it changes existing behaviour.


