### PR TITLE
[13.x] Fix `#[WithoutRelations]` queue attribute not being inherited by child classes

### DIFF
--- a/src/Illuminate/Queue/SerializesModels.php
+++ b/src/Illuminate/Queue/SerializesModels.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Queue;
 
 use Illuminate\Queue\Attributes\WithoutRelations;
+use Illuminate\Support\Reflector;
 use ReflectionClass;
 use ReflectionProperty;
 
@@ -24,7 +25,7 @@ trait SerializesModels
         [$class, $properties, $classLevelWithoutRelations] = [
             get_class($this),
             $reflectionClass->getProperties(),
-            ! empty($reflectionClass->getAttributes(WithoutRelations::class)),
+            ! is_null(Reflector::getClassAttribute($this, WithoutRelations::class, ascend: true)),
         ];
 
         foreach ($properties as $property) {

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -472,6 +472,22 @@ class ModelSerializationTest extends TestCase
         $this->assertEquals('hello', $unserialized->value->value);
     }
 
+    #[WithConfig('database.default', 'testing')]
+    public function test_it_respects_without_relations_attribute_applied_to_parent_class()
+    {
+        $user = User::create([
+            'email' => 'taylor@laravel.com',
+        ])->load(['roles']);
+
+        $serialized = serialize(new ModelSerializationAttributeTargetsParentClassTestClass($user, new DataValueObject('hello')));
+
+        /** @var ModelSerializationAttributeTargetsParentClassTestClass $unserialized */
+        $unserialized = unserialize($serialized);
+
+        $this->assertFalse($unserialized->user->relationLoaded('roles'));
+        $this->assertEquals('hello', $unserialized->value->value);
+    }
+
     public function test_serialization_types_empty_custom_eloquent_collection()
     {
         $class = new ModelSerializationTypedCustomCollectionTestClass(
@@ -786,6 +802,11 @@ class ModelSerializationAttributeTargetsClassTestClass
     public function __construct(public User $user, public DataValueObject $value)
     {
     }
+}
+
+class ModelSerializationAttributeTargetsParentClassTestClass extends ModelSerializationAttributeTargetsClassTestClass
+{
+    //
 }
 
 class ModelRelationSerializationTestClass


### PR DESCRIPTION
Currently, the `#[WithoutRelations]` attribute is only respected when applied directly to a class -- not when applied to a parent class. This means developers who have a base job class with `#[WithoutRelations]` must redundantly apply the attribute to every child job. Ex:

```php
class ProcessPodcast extends QueuedJob
{
    // ...
}
```

```php
namespace App\Jobs;

// ...

#[WithoutRelations] // ❌ Doesn't work
abstract class QueuedJob implements ShouldQueue
{
    use SerializesModels;
    use InteractsWithQueue;
}
```

This PR updates `SerializesModels` to use the built-in framework's `Reflector::getClassAttribute()` method with `ascend: true`, which walks up the inheritance chain to find the attribute on parent classes.
