### PR TITLE
[13.x] Normalize phpredis SSL context for single and cluster connections  

### DIFF
--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -179,7 +179,7 @@ class PhpRedisConnector implements Connector
         }
 
         if (version_compare(phpversion('redis'), '5.3.0', '>=') && ! is_null($context = Arr::get($config, 'context'))) {
-            $parameters[] = $context;
+            $parameters[] = $this->normalizeContext($context);
         }
 
         $client->{$persistent ? 'pconnect' : 'connect'}(...$parameters);
@@ -207,7 +207,7 @@ class PhpRedisConnector implements Connector
         }
 
         if (version_compare(phpversion('redis'), '5.3.2', '>=') && ! is_null($context = Arr::get($options, 'context'))) {
-            $parameters[] = $context;
+            $parameters[] = $this->normalizeClusterContext($context);
         }
 
         return tap(new RedisCluster(...$parameters), function ($client) use ($options) {
@@ -239,6 +239,49 @@ class PhpRedisConnector implements Connector
                 $client->setOption(Redis::OPT_TCP_KEEPALIVE, $options['tcp_keepalive']);
             }
         });
+    }
+
+    /**
+     * Normalize the SSL context for a single Redis connection.
+     *
+     * Redis::connect() expects the context as ['stream' => ['verify_peer' => false, ...]].
+     *
+     * @param  array  $context
+     * @return array
+     */
+    protected function normalizeContext(array $context)
+    {
+        if (isset($context['stream'])) {
+            return $context;
+        }
+
+        if (isset($context['ssl']) && is_array($context['ssl'])) {
+            return ['stream' => $context['ssl']];
+        }
+
+        return ['stream' => $context];
+    }
+
+    /**
+     * Normalize the SSL context for a RedisCluster connection.
+     *
+     * RedisCluster::__construct() expects a flat context ['verify_peer' => false, ...]
+     * because phpredis internally wraps each key under the 'ssl' stream context wrapper.
+     *
+     * @param  array  $context
+     * @return array
+     */
+    protected function normalizeClusterContext(array $context)
+    {
+        if (isset($context['ssl']) && is_array($context['ssl'])) {
+            return $context['ssl'];
+        }
+
+        if (isset($context['stream']) && is_array($context['stream'])) {
+            return $context['stream'];
+        }
+
+        return $context;
     }
 
     /**

--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -242,6 +242,21 @@ class PhpRedisConnector implements Connector
     }
 
     /**
+     * Format the host using the scheme if available.
+     *
+     * @param  array  $options
+     * @return string
+     */
+    protected function formatHost(array $options)
+    {
+        if (isset($options['scheme'])) {
+            return Str::start($options['host'], "{$options['scheme']}://");
+        }
+
+        return $options['host'];
+    }
+
+    /**
      * Normalize the SSL context for a single Redis connection.
      *
      * Redis::connect() expects the context as ['stream' => ['verify_peer' => false, ...]].
@@ -265,8 +280,7 @@ class PhpRedisConnector implements Connector
     /**
      * Normalize the SSL context for a RedisCluster connection.
      *
-     * RedisCluster::__construct() expects a flat context ['verify_peer' => false, ...]
-     * because phpredis internally wraps each key under the 'ssl' stream context wrapper.
+     * RedisCluster::__construct() expects a flat context ['verify_peer' => false, ...].
      *
      * @param  array  $context
      * @return array
@@ -282,21 +296,6 @@ class PhpRedisConnector implements Connector
         }
 
         return $context;
-    }
-
-    /**
-     * Format the host using the scheme if available.
-     *
-     * @param  array  $options
-     * @return string
-     */
-    protected function formatHost(array $options)
-    {
-        if (isset($options['scheme'])) {
-            return Str::start($options['host'], "{$options['scheme']}://");
-        }
-
-        return $options['host'];
     }
 
     /**

--- a/tests/Redis/PhpRedisConnectorTest.php
+++ b/tests/Redis/PhpRedisConnectorTest.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace Illuminate\Tests\Redis;
+
+use Illuminate\Redis\Connectors\PhpRedisConnector;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+class PhpRedisConnectorTest extends TestCase
+{
+    protected PhpRedisConnector $connector;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->connector = new PhpRedisConnector;
+    }
+
+    public function testNormalizeContextWrapsFlatArrayInStream()
+    {
+        $result = $this->callNormalizeContext([
+            'verify_peer' => false,
+            'verify_peer_name' => false,
+        ]);
+
+        $this->assertSame([
+            'stream' => [
+                'verify_peer' => false,
+                'verify_peer_name' => false,
+            ],
+        ], $result);
+    }
+
+    public function testNormalizeContextConvertsSslKeyToStream()
+    {
+        $result = $this->callNormalizeContext([
+            'ssl' => [
+                'verify_peer' => false,
+                'cafile' => '/path/to/ca.pem',
+            ],
+        ]);
+
+        $this->assertSame([
+            'stream' => [
+                'verify_peer' => false,
+                'cafile' => '/path/to/ca.pem',
+            ],
+        ], $result);
+    }
+
+    public function testNormalizeContextPassesThroughStreamKey()
+    {
+        $context = [
+            'stream' => [
+                'verify_peer' => false,
+            ],
+        ];
+
+        $result = $this->callNormalizeContext($context);
+
+        $this->assertSame($context, $result);
+    }
+
+    public function testNormalizeClusterContextUnwrapsSslKey()
+    {
+        $result = $this->callNormalizeClusterContext([
+            'ssl' => [
+                'verify_peer' => false,
+                'peer_name' => 'example.com',
+            ],
+        ]);
+
+        $this->assertSame([
+            'verify_peer' => false,
+            'peer_name' => 'example.com',
+        ], $result);
+    }
+
+    public function testNormalizeClusterContextUnwrapsStreamKey()
+    {
+        $result = $this->callNormalizeClusterContext([
+            'stream' => [
+                'verify_peer' => false,
+            ],
+        ]);
+
+        $this->assertSame([
+            'verify_peer' => false,
+        ], $result);
+    }
+
+    public function testNormalizeClusterContextPassesThroughFlatArray()
+    {
+        $context = [
+            'verify_peer' => false,
+            'verify_peer_name' => false,
+        ];
+
+        $result = $this->callNormalizeClusterContext($context);
+
+        $this->assertSame($context, $result);
+    }
+
+    public function testNormalizeContextSslKeyTakesPrecedenceOverFlatKeys()
+    {
+        $result = $this->callNormalizeContext([
+            'verify_peer' => true,
+            'ssl' => [
+                'verify_peer' => false,
+            ],
+        ]);
+
+        $this->assertSame([
+            'stream' => [
+                'verify_peer' => false,
+            ],
+        ], $result);
+    }
+
+    public function testNormalizeClusterContextSslKeyTakesPrecedenceOverFlatKeys()
+    {
+        $result = $this->callNormalizeClusterContext([
+            'verify_peer' => true,
+            'ssl' => [
+                'verify_peer' => false,
+            ],
+        ]);
+
+        $this->assertSame([
+            'verify_peer' => false,
+        ], $result);
+    }
+
+    protected function callNormalizeContext(array $context): array
+    {
+        $method = new ReflectionMethod(PhpRedisConnector::class, 'normalizeContext');
+
+        return $method->invoke($this->connector, $context);
+    }
+
+    protected function callNormalizeClusterContext(array $context): array
+    {
+        $method = new ReflectionMethod(PhpRedisConnector::class, 'normalizeClusterContext');
+
+        return $method->invoke($this->connector, $context);
+    }
+}


### PR DESCRIPTION
The phpredis extension expects different SSL context array formats depending on whether you're using a single `Redis` connection or a `RedisCluster` connection:            
                                                                                                                                             
  - `Redis::connect()` expects `['stream' => ['verify_peer' => false]]` — it [looks for a `stream` key](https://github.com/phpredis/phpredis/blob/develop/redis.c#L613) and passes the inner array to `redis_sock_set_context_zval()`         
  - `RedisCluster::__construct()` expects `['verify_peer' => false]` — it [passes the context directly](https://github.com/phpredis/phpredis/blob/develop/redis_cluster.c#L250) to `redis_sock_set_context_zval()`                       
   
  Both ultimately go through [`alloc_stream_context()`](https://github.com/phpredis/phpredis/blob/develop/library.c#L3358) which iterates the stored HashTable and wraps each key under `ssl` when calling `php_stream_context_set_option()`. This means the flat array `['verify_peer'=> false]` becomes `ssl.verify_peer = false`, but `['ssl' => ['verify_peer' => false]]` becomes `ssl.ssl = ['verify_peer' => false]` — the options are never applied.                               


Laravel's `PhpRedisConnector` previously passed the `context` config value as-is to both, which meant no single format worked for both connection types. Users configuring `'context' => ['ssl' => ['verify_peer' => false]]` would get:
                                                                                                                                             
  - **Single connection:** SSL options silently ignored (no `stream` key found)
  - **Cluster connection:** Double-wrapped as `ssl.ssl.verify_peer`, options ignored — often surfacing as `Couldn't map cluster keyspace using any provided seed`                                                                                                                   
   
This PR adds context normalization in `PhpRedisConnector` so that any of these formats work for both connection types:                     
                                                           
  ```php
  // All three now work for both single and cluster connections:
  'context' => ['ssl' => ['verify_peer' => false]]                                                                                           
  'context' => ['stream' => ['verify_peer' => false]]
  'context' => ['verify_peer' => false]          
  ```                                                                                            
                                                           
  If ssl or stream is present alongside flat keys, the wrapped key takes precedence.                                                         
   
### Backward compatibility                                                                                                                     
                                                           
  - Users already using the correct ['stream' => [...]] format for single connections will see no change
  - Users already using the correct flat format for cluster connections will see no change
  - Users whose SSL context was silently broken (most common: ['ssl' => [...]]) will now have it work correctly                              
  - No configuration changes required — existing configs continue to work, previously broken configs are fixed