### PR TITLE
[13.x] Add flushState to FormRequest to reset global strict mode between tests

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -390,16 +390,6 @@ class FormRequest extends Request implements ValidatesWhenResolved
     }
 
     /**
-     * Flush the global state of the form request.
-     *
-     * @return void
-     */
-    public static function flushState(): void
-    {
-        static::$globalFailOnUnknownFields = false;
-    }
-
-    /**
      * Set the Validator instance.
      *
      * @param  \Illuminate\Contracts\Validation\Validator  $validator
@@ -436,5 +426,15 @@ class FormRequest extends Request implements ValidatesWhenResolved
         $this->container = $container;
 
         return $this;
+    }
+
+    /**
+     * Flush the global state of the form request.
+     *
+     * @return void
+     */
+    public static function flushState(): void
+    {
+        static::$globalFailOnUnknownFields = false;
     }
 }

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -390,6 +390,16 @@ class FormRequest extends Request implements ValidatesWhenResolved
     }
 
     /**
+     * Flush the global state of the form request.
+     *
+     * @return void
+     */
+    public static function flushState(): void
+    {
+        static::$globalFailOnUnknownFields = false;
+    }
+
+    /**
      * Set the Validator instance.
      *
      * @param  \Illuminate\Contracts\Validation\Validator  $validator

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
@@ -183,8 +183,8 @@ trait InteractsWithTestCaseLifecycle
         Component::forgetComponentsResolver();
         Component::forgetFactory();
         ConvertEmptyStringsToNull::flushState();
-        FormRequest::flushState();
         Factory::flushState();
+        FormRequest::flushState();
         EncodedHtmlString::flushState();
         EncryptCookies::flushState();
         HandleCors::flushState();

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Migrations\Migrator;
 use Illuminate\Foundation\Bootstrap\HandleExceptions;
 use Illuminate\Foundation\Bootstrap\RegisterProviders;
 use Illuminate\Foundation\Console\AboutCommand;
+use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull;
 use Illuminate\Foundation\Http\Middleware\PreventRequestForgery;
 use Illuminate\Foundation\Http\Middleware\PreventRequestsDuringMaintenance;
@@ -182,6 +183,7 @@ trait InteractsWithTestCaseLifecycle
         Component::forgetComponentsResolver();
         Component::forgetFactory();
         ConvertEmptyStringsToNull::flushState();
+        FormRequest::flushState();
         Factory::flushState();
         EncodedHtmlString::flushState();
         EncryptCookies::flushState();


### PR DESCRIPTION
## Summary

PR #59430 added `FormRequest::failOnUnknownFields()` which sets a static `$globalFailOnUnknownFields` flag. This flag persists across tests because FormRequest has no `flushState()` method and isn't included in the test lifecycle teardown.

### The Bug

```php
class FirstTest extends TestCase
{
    public function testStrictMode()
    {
        FormRequest::failOnUnknownFields();
        // test strict validation...
    }
}

class SecondTest extends TestCase
{
    public function testNormalMode()
    {
        // This test ALSO runs in strict mode because
        // $globalFailOnUnknownFields is still true!
    }
}
```

### The Fix

1. Add `flushState()` method to FormRequest that resets `$globalFailOnUnknownFields`
2. Call it in `InteractsWithTestCaseLifecycle` teardown alongside all other `flushState()` calls

### Context

Every other class with static state has `flushState()` called in the test teardown:
- `ConvertEmptyStringsToNull::flushState()`
- `TrimStrings::flushState()`
- `EncryptCookies::flushState()`
- `PreventRequestForgery::flushState()`
- `Validator::flushState()`
- etc.

FormRequest was missed because `failOnUnknownFields()` was just added in #59430.

### Changes

- `src/Illuminate/Foundation/Http/FormRequest.php` — Add `flushState()` method
- `src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php` — Call `FormRequest::flushState()` in teardown