### PR TITLE
[13.x] Fix deprecation warning in In and NotIn rules when values contain null

### DIFF
--- a/src/Illuminate/Validation/Rules/In.php
+++ b/src/Illuminate/Validation/Rules/In.php
@@ -49,7 +49,7 @@ class In implements Stringable
         $values = array_map(function ($value) {
             $value = enum_value($value);
 
-            return '"'.str_replace('"', '""', $value).'"';
+            return '"'.str_replace('"', '""', (string) $value).'"';
         }, $this->values);
 
         return $this->rule.':'.implode(',', $values);

--- a/src/Illuminate/Validation/Rules/NotIn.php
+++ b/src/Illuminate/Validation/Rules/NotIn.php
@@ -47,7 +47,7 @@ class NotIn implements Stringable
         $values = array_map(function ($value) {
             $value = enum_value($value);
 
-            return '"'.str_replace('"', '""', $value).'"';
+            return '"'.str_replace('"', '""', (string) $value).'"';
         }, $this->values);
 
         return $this->rule.':'.implode(',', $values);


### PR DESCRIPTION
## Summary

PR #59561 fixed the null deprecation warning in `Contains` and `DoesntContain` rules. The `In` and `NotIn` rules have the identical pattern that was missed.

### Before

```php
Rule::in([1, null, 'active']);
// Deprecated: str_replace(): Passing null to parameter #3 ($subject)
```

### After

```php
Rule::in([1, null, 'active']);
// No warning — null cast to empty string
```

### All four rules now consistent

| Rule | Fixed |
|---|---|
| `Contains` | ✅ #59561 |
| `DoesntContain` | ✅ #59561 |
| **`In`** | **✅ this PR** |
| **`NotIn`** | **✅ this PR** |

### Changes

- `src/Illuminate/Validation/Rules/In.php` — Cast value to string
- `src/Illuminate/Validation/Rules/NotIn.php` — Cast value to string