### PR TITLE
[13.x] Fix session cookie name with non-alphanumeric APP_NAME values

### DIFF
--- a/config/session.php
+++ b/config/session.php
@@ -129,7 +129,7 @@ return [
 
     'cookie' => env(
         'SESSION_COOKIE',
-        Str::snake((string) env('APP_NAME', 'laravel')).'_session'
+        Str::slug((string) env('APP_NAME', 'laravel'), '_').'_session'
     ),
 
     /*

--- a/tests/Integration/Session/SessionCookieNameTest.php
+++ b/tests/Integration/Session/SessionCookieNameTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Session;
+
+use Illuminate\Support\Str;
+use PHPUnit\Framework\TestCase;
+
+class SessionCookieNameTest extends TestCase
+{
+    public function testSessionCookieNameStripsNonAlphanumericCharacters()
+    {
+        $this->assertSame(
+            'local_my_app_session',
+            Str::slug('[LOCAL] My App', '_').'_session'
+        );
+    }
+
+    public function testSessionCookieNameHandlesDots()
+    {
+        $this->assertSame(
+            'admindomain_session',
+            Str::slug('admin.domain', '_').'_session'
+        );
+    }
+
+    public function testSessionCookieNameHandlesSimpleAppName()
+    {
+        $this->assertSame(
+            'laravel_session',
+            Str::slug('laravel', '_').'_session'
+        );
+    }
+
+    public function testSessionCookieNameHandlesMultiWordAppName()
+    {
+        $this->assertSame(
+            'my_awesome_app_session',
+            Str::slug('My Awesome App', '_').'_session'
+        );
+    }
+}


### PR DESCRIPTION
This PR fixes a bug where `Str::snake()` in the default session cookie name generation preserves special characters (brackets, dots, etc.) that are invalid in HTTP cookie names, completely breaking session persistence.

### Problem

PR #56172 changed session cookie generation from `Str::slug($name, '_')` to `Str::snake($name)`. While this works for simple app names, `Str::snake()` does not strip non-alphanumeric characters:

```php
Str::snake('[LOCAL] My App').'_session'  // "[_l_o_c_a_l]_my_app_session" ❌
Str::snake('admin.domain').'_session'    // "admin.domain_session" ❌
```

These produce invalid cookie names, causing sessions to break silently — users get logged out on every request.

### Fix

Reverts to `Str::slug()` with underscore separator, which strips all non-alphanumeric characters and produces valid cookie names:

```php
Str::slug('[LOCAL] My App', '_').'_session'  // "local_my_app_session" ✅
Str::slug('admin.domain', '_').'_session'    // "admindomain_session" ✅
Str::slug('My Awesome App', '_').'_session'  // "my_awesome_app_session" ✅
```

### Benefit to end users

Apps with `APP_NAME` containing dots, brackets, or other special characters will have working sessions again without needing to manually set `SESSION_COOKIE` in `.env`.

### Why this doesn't break existing features

- `Str::slug($name, '_')` was the original behavior before #56172
- Apps with simple alphanumeric `APP_NAME` values produce identical output
- Apps that already set `SESSION_COOKIE` explicitly are unaffected (the env var takes priority)
- The cache and Redis prefix changes from #56172 are not affected — they correctly use `Str::slug()` with the default hyphen separator

### Tests

Added `SessionCookieNameTest` covering:
- Special characters (brackets) are stripped
- Dots are stripped
- Simple app names work correctly
- Multi-word app names use underscores

Fixes #59344