### PR TITLE
[13.x] Fix queue worker entering infinite loop on persistent pop exceptions

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -107,6 +107,13 @@ class Worker
     protected static $popCallbacks = [];
 
     /**
+     * The number of consecutive pop failures.
+     *
+     * @var int
+     */
+    protected $popFailures = 0;
+
+    /**
      * The custom exit code to be used when memory is exceeded.
      *
      * @var int|null
@@ -397,6 +404,8 @@ class Worker
                     $this->raiseAfterJobPopEvent($connection->getConnectionName(), $job);
                 }
 
+                $this->popFailures = 0;
+
                 return $job;
             }
 
@@ -408,13 +417,21 @@ class Worker
                 if (! is_null($job = $popJobCallback($queue, $index))) {
                     $this->raiseAfterJobPopEvent($connection->getConnectionName(), $job);
 
+                    $this->popFailures = 0;
+
                     return $job;
                 }
             }
+
+            $this->popFailures = 0;
         } catch (Throwable $e) {
             $this->exceptions->report($e);
 
             $this->stopWorkerIfLostConnection($e);
+
+            if (++$this->popFailures > 100) {
+                $this->shouldQuit = true;
+            }
 
             $this->sleep(1);
         }

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -507,6 +507,50 @@ class QueueWorkerTest extends TestCase
         }))->once();
     }
 
+    public function testWorkerQuitsAfterConsecutivePopFailures()
+    {
+        $worker = new InsomniacWorker(
+            new WorkerFakeManager('default', new BrokenQueueConnection('default', new RuntimeException('Connection refused'))),
+            $this->events,
+            $this->exceptionHandler,
+            function () {
+                return false;
+            }
+        );
+
+        $workerOptions = new WorkerOptions;
+        $workerOptions->stopWhenEmpty = false;
+
+        $status = $worker->daemon('default', 'queue', $workerOptions);
+
+        $this->assertSame(0, $status);
+        $this->assertTrue($worker->shouldQuit);
+    }
+
+    public function testWorkerPopFailureCounterResetsOnSuccess()
+    {
+        $connection = new IntermittentBrokenQueueConnection(
+            'default', new RuntimeException('Connection refused'), 3
+        );
+
+        $worker = new InsomniacWorker(
+            new WorkerFakeManager('default', $connection),
+            $this->events,
+            $this->exceptionHandler,
+            function () {
+                return false;
+            }
+        );
+
+        $workerOptions = new WorkerOptions;
+        $workerOptions->stopWhenEmpty = true;
+
+        $status = $worker->daemon('default', 'queue', $workerOptions);
+
+        $this->assertSame(0, $status);
+        $this->assertFalse($worker->shouldQuit);
+    }
+
     /**
      * Helpers...
      */
@@ -787,6 +831,37 @@ class WorkerFakeJob implements QueueJobContract
     public function resolveQueuedJobClass()
     {
         return 'WorkerFakeJob';
+    }
+}
+
+class IntermittentBrokenQueueConnection
+{
+    public $connectionName;
+    public $exception;
+    public $failCount;
+    public $callCount = 0;
+
+    public function __construct($connectionName, $exception, $failCount)
+    {
+        $this->connectionName = $connectionName;
+        $this->exception = $exception;
+        $this->failCount = $failCount;
+    }
+
+    public function pop($queue)
+    {
+        $this->callCount++;
+
+        if ($this->callCount <= $this->failCount) {
+            throw $this->exception;
+        }
+
+        return null;
+    }
+
+    public function getConnectionName()
+    {
+        return $this->connectionName;
     }
 }
 


### PR DESCRIPTION
### The Problem

When `Worker::getNextJob()` catches a `Throwable` that is **not** a database connection error (e.g. SQS SDK timeout, Redis auth failure, Beanstalkd connection drop), the worker enters an infinite silent loop:

```
catch → report → stopWorkerIfLostConnection (no match) → sleep(1) → retry → catch → forever
```

`stopWorkerIfLostConnection()` uses the `DetectsLostConnections` trait which only matches **database** error strings (MySQL, PostgreSQL, SQLite). Queue infrastructure failures from SQS, Redis, or HTTP-based drivers never trigger a stop condition. The `--timeout` flag also cannot help because `pcntl_alarm` is only registered **after** `getNextJob()` returns.

The result: workers appear healthy to process supervisors (Docker, Supervisor) but silently process **zero messages** — potentially for days (as reported in #59517).

### The Fix

Adds a lightweight consecutive pop failure counter (`$popFailures`) directly in `getNextJob()`:

- **Increment** on each caught exception
- **Reset to 0** on any successful pop (including empty queue returns)
- **Set `$this->shouldQuit = true`** after 100 consecutive failures

This uses the existing `shouldQuit` → `stopIfNecessary()` → graceful exit path with no new CLI options, no new enum cases, and no new public API surface. The worker exits cleanly with status 0, allowing Supervisor/Docker to restart it.

100 consecutive failures (with 1s sleep between each) means the worker tolerates ~1.5 minutes of transient errors before giving up — enough to ride out brief network blips while still catching persistent infrastructure failures.

### Benefit to end users

Queue workers will no longer silently become zombies when the queue backend (SQS, Redis, etc.) has a persistent connection issue. They will exit gracefully after sustained failures, allowing process managers to restart them with a fresh connection.

### Why this doesn't break existing features

- The counter only increments on exceptions inside `getNextJob()` — normal job processing is completely unaffected
- The counter resets on **every** successful pop (including when the queue is empty), so transient/intermittent errors never accumulate
- Workers that hit a database connection error still take the existing `lostConnection` exit path (which fires first)
- The 100-failure threshold is deliberately high to avoid false positives
- No changes to `WorkerOptions`, CLI arguments, or public API

### Tests

Two new tests in `QueueWorkerTest`:

1. **`testWorkerQuitsAfterConsecutivePopFailures`** — verifies the worker exits after sustained pop exceptions using `BrokenQueueConnection`
2. **`testWorkerPopFailureCounterResetsOnSuccess`** — verifies intermittent failures followed by success don't trigger a quit, using a new `IntermittentBrokenQueueConnection` fake

All 27 existing queue worker tests continue to pass.

Fixes #59517