### PR TITLE
[13.x] Support #[Delay] attribute on queued mailables

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -12,6 +12,7 @@ use Illuminate\Contracts\Queue\Factory as Queue;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Contracts\Translation\HasLocalePreference;
+use Illuminate\Queue\Attributes\Delay;
 use Illuminate\Support\Collection;
 use Illuminate\Support\EncodedHtmlString;
 use Illuminate\Support\HtmlString;
@@ -20,6 +21,7 @@ use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\ForwardsCalls;
 use Illuminate\Support\Traits\Localizable;
 use Illuminate\Support\Traits\Macroable;
+use Illuminate\Support\Traits\ReadsClassAttributes;
 use Illuminate\Support\Traits\Tappable;
 use Illuminate\Testing\Constraints\SeeInOrder;
 use PHPUnit\Framework\Assert as PHPUnit;
@@ -31,7 +33,7 @@ use Symfony\Component\Mime\Address;
 
 class Mailable implements MailableContract, Renderable
 {
-    use Conditionable, ForwardsCalls, Localizable, Tappable, Macroable {
+    use Conditionable, ForwardsCalls, Localizable, ReadsClassAttributes, Tappable, Macroable {
         __call as macroCall;
     }
 
@@ -224,8 +226,10 @@ class Mailable implements MailableContract, Renderable
      */
     public function queue(Queue $queue)
     {
-        if (isset($this->delay)) {
-            return $this->later($this->delay, $queue);
+        $delay = $this->getAttributeValue($this, Delay::class, 'delay');
+
+        if (isset($delay)) {
+            return $this->later($delay, $queue);
         }
 
         $connection = property_exists($this, 'connection') ? $this->connection : null;

--- a/tests/Mail/MailableQueuedTest.php
+++ b/tests/Mail/MailableQueuedTest.php
@@ -12,6 +12,7 @@ use Illuminate\Foundation\Application;
 use Illuminate\Mail\Mailable;
 use Illuminate\Mail\Mailer;
 use Illuminate\Mail\SendQueuedMailable;
+use Illuminate\Queue\Attributes\Delay;
 use Illuminate\Support\Testing\Fakes\QueueFake;
 use Laravel\SerializableClosure\SerializableClosure;
 use Mockery as m;
@@ -147,6 +148,41 @@ class MailableQueuedTest extends TestCase
         $this->assertEquals($mockedDeduplicator, $pushedJob->deduplicator->getClosure());
     }
 
+    public function testQueuedMailableRespectsDelayAttribute(): void
+    {
+        $queueFake = new QueueFake(new Application);
+        $mailer = $this->getMockBuilder(Mailer::class)
+            ->setConstructorArgs($this->getMocks())
+            ->onlyMethods(['createMessage', 'to'])
+            ->getMock();
+        $mailer->setQueue($queueFake);
+        $mailable = new MailableQueueableStubWithDelayAttribute;
+        $queueFake->assertNothingPushed();
+        $mailer->send($mailable);
+        $queueFake->assertPushedOn(null, SendQueuedMailable::class);
+
+        $pushedJob = $queueFake->pushed(SendQueuedMailable::class)->first();
+        $this->assertEquals(30, $pushedJob->delay);
+    }
+
+    public function testQueuedMailableDelayPropertyOverridesAttribute(): void
+    {
+        $queueFake = new QueueFake(new Application);
+        $mailer = $this->getMockBuilder(Mailer::class)
+            ->setConstructorArgs($this->getMocks())
+            ->onlyMethods(['createMessage', 'to'])
+            ->getMock();
+        $mailer->setQueue($queueFake);
+        $mailable = new MailableQueueableStubWithDelayAttribute;
+        $mailable->delay = 60;
+        $queueFake->assertNothingPushed();
+        $mailer->send($mailable);
+        $queueFake->assertPushedOn(null, SendQueuedMailable::class);
+
+        $pushedJob = $queueFake->pushed(SendQueuedMailable::class)->first();
+        $this->assertEquals(60, $pushedJob->delay);
+    }
+
     public function testQueuedMailableForwardsDeduplicationIdMethodToQueueJob(): void
     {
         $queueFake = new QueueFake(new Application);
@@ -203,6 +239,22 @@ class MailableQueueableStubWithMessageGroup extends Mailable implements ShouldQu
     public function messageGroup(): string
     {
         return 'group-1';
+    }
+}
+
+#[Delay(30)]
+class MailableQueueableStubWithDelayAttribute extends Mailable implements ShouldQueue
+{
+    use Queueable;
+
+    public function build(): self
+    {
+        $this
+            ->subject('lorem ipsum')
+            ->html('foo bar baz')
+            ->to('foo@example.tld');
+
+        return $this;
     }
 }
 


### PR DESCRIPTION
## Summary

The `#[Delay]` attribute is supported for queued jobs (`Bus\Dispatcher`), event listeners (`Events\Dispatcher`), and notifications (`NotificationSender`), but queued mailables only check the `$delay` property and ignore the attribute entirely.

This means the following does **not** work as expected:

```php
use Illuminate\Queue\Attributes\Delay;

#[Delay(30)]
class WelcomeEmail extends Mailable implements ShouldQueue
{
    // The #[Delay] attribute is ignored — mailable is queued immediately
}
```

## Changes

- Added `ReadsClassAttributes` support trait to `Mailable`
- Updated `Mailable::queue()` to use `getAttributeValue()` for reading delay, consistent with how `Bus\Dispatcher::pushCommandToQueue()`, `Events\Dispatcher::queueHandler()`, and `NotificationSender::queueNotification()` handle the `#[Delay]` attribute
- The `$delay` property still takes precedence when explicitly set (not default), matching the behavior of `getAttributeValue()`

Follows up on #59577 with the suggested change to use the support trait.

## Test Plan

- [x] Added test to verify `#[Delay]` attribute is respected on queued mailables
- [x] Added test to verify property override still takes precedence over attribute
- [x] Existing queued mailable tests still pass