### PR TITLE
[13.x] Fix null deprecation warnings in additional validation rules

### DIFF
--- a/src/Illuminate/Validation/Rules/AnyOf.php
+++ b/src/Illuminate/Validation/Rules/AnyOf.php
@@ -49,9 +49,11 @@ class AnyOf implements Rule, ValidatorAwareRule
      */
     public function passes($attribute, $value)
     {
+        $formattedValue = is_null($value) ? '' : $value;
+
         foreach ($this->rules as $rule) {
             $validator = Validator::make(
-                Arr::isAssoc(Arr::wrap($value)) ? $value : [$value],
+                Arr::isAssoc(Arr::wrap($formattedValue)) ? $formattedValue : [$formattedValue],
                 Arr::isAssoc(Arr::wrap($rule)) ? $rule : [$rule],
                 $this->validator->customMessages,
                 $this->validator->customAttributes

--- a/src/Illuminate/Validation/Rules/ArrayRule.php
+++ b/src/Illuminate/Validation/Rules/ArrayRule.php
@@ -42,7 +42,7 @@ class ArrayRule implements Stringable
         }
 
         $keys = array_map(
-            static fn ($key) => enum_value($key),
+            static fn ($key) => (string) enum_value($key),
             $this->keys,
         );
 

--- a/src/Illuminate/Validation/Rules/Can.php
+++ b/src/Illuminate/Validation/Rules/Can.php
@@ -54,6 +54,8 @@ class Can implements Rule, ValidatorAwareRule
 
         $model = array_shift($arguments);
 
+        $value = is_null($value) ? '' : $value;
+
         return Gate::allows($this->ability, array_filter([$model, ...$arguments, $value]));
     }
 


### PR DESCRIPTION
---

### **PR Description (Copy & Paste meka)**

**Description**
Fixes the null deprecation warnings in AnyOf, ArrayRule, and Can validation rules. These rules followed an identical pattern to the issues previously fixed in Contains, DoesntContain, In, and NotIn rules (#59561), where passing a null value to internal string functions triggered deprecation warnings in PHP 8.1+.

**Example**
```php
// AnyOf, ArrayRule, or Can with null values
Rule::anyOf([1, null, 'active']);
// Before: Deprecated warning (null cast to string)
// After: No warning (null cast to empty string)
```

<table>
    <thead>
        <tr>
            <th>Rule</th>
            <th>Fixed</th>
            <th>Reference</th>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>Contains</td>
            <td>✅</td>
            <td>#59561</td>
        </tr>
        <tr>
            <td>DoesntContain</td>
            <td>✅</td>
            <td>#59561</td>
        </tr>
        <tr>
            <td>In</td>
            <td>✅</td>
            <td>#59576</td>
        </tr>
        <tr>
            <td>NotIn</td>
            <td>✅</td>
            <td>#59576</td>
        </tr>
        <tr>
            <td>AnyOf</td>
            <td>✅</td>
            <td><b>This PR</b></td>
        </tr>
        <tr>
            <td>ArrayRule</td>
            <td>✅</td>
            <td><b>This PR</b></td>
        </tr>
        <tr>
            <td>Can</td>
            <td>✅</td>
            <td><b>This PR</b></td>
        </tr>
    </tbody>
</table>

**Changes**
* src/Illuminate/Validation/Rules/AnyOf.php - Cast value to string
* src/Illuminate/Validation/Rules/ArrayRule.php - Cast enum values to string
* src/Illuminate/Validation/Rules/Can.php - Cast value to string for Gate

---