### PR TITLE
Hash token guard credentials during validation

### DIFF
--- a/src/Illuminate/Auth/TokenGuard.php
+++ b/src/Illuminate/Auth/TokenGuard.php
@@ -114,7 +114,11 @@ class TokenGuard implements Guard
             return false;
         }
 
-        $credentials = [$this->storageKey => $credentials[$this->inputKey]];
+        $credentials = [
+            $this->storageKey => $this->hash
+                ? hash('sha256', $credentials[$this->inputKey])
+                : $credentials[$this->inputKey],
+        ];
 
         return (bool) $this->provider->retrieveByCredentials($credentials);
     }

--- a/tests/Auth/AuthTokenGuardTest.php
+++ b/tests/Auth/AuthTokenGuardTest.php
@@ -85,6 +85,19 @@ class AuthTokenGuardTest extends TestCase
         $this->assertTrue($guard->validate(['api_token' => 'foo']));
     }
 
+    public function testValidateCanDetermineIfHashedCredentialsAreValid()
+    {
+        $provider = m::mock(UserProvider::class);
+        $user = new AuthTokenGuardTestUser;
+        $user->id = 1;
+        $provider->shouldReceive('retrieveByCredentials')->once()->with(['api_token' => hash('sha256', 'foo')])->andReturn($user);
+        $request = Request::create('/', 'GET', ['api_token' => 'foo']);
+
+        $guard = new TokenGuard($provider, $request, 'api_token', 'api_token', $hash = true);
+
+        $this->assertTrue($guard->validate(['api_token' => 'foo']));
+    }
+
     public function testValidateCanDetermineIfCredentialsAreInvalid()
     {
         $provider = m::mock(UserProvider::class);


### PR DESCRIPTION
This pull request updates `TokenGuard::validate` to respect hashed token storage.

`TokenGuard::user` already hashes the incoming token before retrieving the user when the guard is configured with hashed token storage. However, `TokenGuard::validate` was passing the raw token to the user provider, which caused validation to fail for valid plain-text tokens when the stored API token is hashed.

This change makes `validate` use the same hashing behavior as `user`.

A regression test has been added to verify that hashed token validation passes the hashed credential value to the user provider.
