### PR TITLE
fix: prevent redirectUsersTo from overwriting guest redirect callback

### DIFF
--- a/src/Illuminate/Foundation/Configuration/Middleware.php
+++ b/src/Illuminate/Foundation/Configuration/Middleware.php
@@ -561,7 +561,7 @@ class Middleware
      */
     public function redirectTo(callable|string|null $guests = null, callable|string|null $users = null)
     {
-        $guests = is_string($guests) || is_null($guests) ? fn () => $guests : $guests;
+        $guests = is_string($guests) ? fn () => $guests : $guests;
         $users = is_string($users) ? fn () => $users : $users;
 
         if ($guests) {

--- a/tests/Foundation/Configuration/MiddlewareTest.php
+++ b/tests/Foundation/Configuration/MiddlewareTest.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Tests\Foundation\Configuration;
 
+use Illuminate\Auth\AuthenticationException;
+use Illuminate\Auth\Middleware\Authenticate;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Encryption\Encrypter;
 use Illuminate\Contracts\Foundation\Application;
@@ -31,6 +33,8 @@ class MiddlewareTest extends TestCase
         PreventRequestsDuringMaintenance::flushState();
         TrimStrings::flushState();
         TrustProxies::flushState();
+        Authenticate::redirectUsing(fn () => null);
+        AuthenticationException::redirectUsing(fn () => null);
 
         parent::tearDown();
     }
@@ -302,5 +306,41 @@ class MiddlewareTest extends TestCase
         $reflection = new ReflectionClass(PreventRequestForgery::class);
         $this->assertTrue($reflection->getStaticPropertyValue('originOnly'));
         $this->assertTrue($reflection->getStaticPropertyValue('allowSameSite'));
+    }
+
+    public function testRedirectUsersToDoesNotOverwriteRedirectGuestsTo()
+    {
+        $configuration = new Middleware();
+
+        $configuration->redirectGuestsTo('/login');
+        $configuration->redirectUsersTo('/dashboard');
+
+        $request = Request::create('/protected', 'GET');
+
+        $authenticateCallback = (new ReflectionClass(Authenticate::class))
+            ->getStaticPropertyValue('redirectToCallback');
+
+        $exceptionCallback = (new ReflectionClass(AuthenticationException::class))
+            ->getStaticPropertyValue('redirectToCallback');
+
+        $this->assertSame('/login', $authenticateCallback($request));
+        $this->assertSame('/login', $exceptionCallback($request));
+    }
+
+    public function testRedirectGuestsToWithCallable()
+    {
+        $configuration = new Middleware();
+
+        $configuration->redirectGuestsTo(fn (Request $request) => $request->is('admin/*') ? '/admin/login' : '/login');
+        $configuration->redirectUsersTo('/dashboard');
+
+        $regularRequest = Request::create('/protected', 'GET');
+        $adminRequest = Request::create('/admin/settings', 'GET');
+
+        $callback = (new ReflectionClass(Authenticate::class))
+            ->getStaticPropertyValue('redirectToCallback');
+
+        $this->assertSame('/login', $callback($regularRequest));
+        $this->assertSame('/admin/login', $callback($adminRequest));
     }
 }


### PR DESCRIPTION
## Problem

When `redirectGuestsTo()` and `redirectUsersTo()` are called seperately in `bootstrap/app.php`:

```php
$middleware->redirectGuestsTo(fn (Request $request) => route('login'));
$middleware->redirectUsersTo(fn (Request $request) => route('dashboard'));
```

The second call (`redirectUsersTo`) somehow **overwrites** the guest redirect callback, causing unauth requests to receive a `401` response instead of being redirected to the login page.

### Root cause

In `Middleware::redirectTo()`, the `$guests` parameter defaults to `null`. The condition on line 564:

```php
$guests = is_string($guests) || is_null($guests) ? fn () => $guests : $guests;
```

wraps `null` into `fn () => null` — a truth closure — which passes the `if ($guests)` guard and overwrites the previously configured guest redirect callback with one that returns `null`.

The exception handler then receives `null` from `$exception->redirectTo()` and returns `response()->noContent(401)` instead of redirecting.

### Workaround

Using a single `redirectTo()` call with both parameters avoids the issue:

```php
$middleware->redirectTo(
    guests: fn (Request $request) => route('login'),
    users: fn (Request $request) => route('dashboard'),
);
```

## Solution

Remove `is_null()` from the aforementioned condition so that a default `null` parameter stays `null` and is naturally skipped by the `if ($guests)` guard:

```php
$guests = is_string($guests) ? fn () => $guests : $guests;
```

## Tests

Added two tests:

- **`testRedirectUsersToDoesNotOverwriteRedirectGuestsTo`** — verifies the Authenticate and AuthenticationException callbacks remain intact after calling both `redirectGuestsTo()` and `redirectUsersTo()`.
- **`testRedirectGuestsToWithCallable`** — verifies callable-based guest redirect works correctly alongside `redirectUsersTo()`.