### PR TITLE
Hash token guard credentials during validation

### DIFF
--- a/src/Illuminate/Auth/TokenGuard.php
+++ b/src/Illuminate/Auth/TokenGuard.php
@@ -114,7 +114,11 @@ class TokenGuard implements Guard
             return false;
         }
 
-        $credentials = [$this->storageKey => $credentials[$this->inputKey]];
+        $credentials = [
+            $this->storageKey => $this->hash
+                ? hash('sha256', $credentials[$this->inputKey])
+                : $credentials[$this->inputKey],
+        ];
 
         return (bool) $this->provider->retrieveByCredentials($credentials);
     }

--- a/tests/Auth/AuthTokenGuardTest.php
+++ b/tests/Auth/AuthTokenGuardTest.php
@@ -85,6 +85,19 @@ class AuthTokenGuardTest extends TestCase
         $this->assertTrue($guard->validate(['api_token' => 'foo']));
     }
 
+    public function testValidateCanDetermineIfHashedCredentialsAreValid()
+    {
+        $provider = m::mock(UserProvider::class);
+        $user = new AuthTokenGuardTestUser;
+        $user->id = 1;
+        $provider->shouldReceive('retrieveByCredentials')->once()->with(['api_token' => hash('sha256', 'foo')])->andReturn($user);
+        $request = Request::create('/', 'GET', ['api_token' => 'foo']);
+
+        $guard = new TokenGuard($provider, $request, 'api_token', 'api_token', $hash = true);
+
+        $this->assertTrue($guard->validate(['api_token' => 'foo']));
+    }
+
     public function testValidateCanDetermineIfCredentialsAreInvalid()
     {
         $provider = m::mock(UserProvider::class);

--- a/tests/Integration/Auth/TokenGuardAuthenticationTest.php
+++ b/tests/Integration/Auth/TokenGuardAuthenticationTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Auth;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Tests\Integration\Auth\Fixtures\AuthenticationTestUser;
+use Orchestra\Testbench\Attributes\WithMigration;
+use Orchestra\Testbench\TestCase;
+
+#[WithMigration]
+class TokenGuardAuthenticationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function defineEnvironment($app)
+    {
+        $app['config']->set([
+            'auth.guards.api' => [
+                'driver' => 'token',
+                'provider' => 'users',
+                'hash' => true,
+            ],
+            'auth.providers.users.model' => AuthenticationTestUser::class,
+        ]);
+    }
+
+    protected function afterRefreshingDatabase()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('api_token')->nullable();
+        });
+    }
+
+    public function testTokenGuardValidateAuthenticatesHashedApiTokens()
+    {
+        AuthenticationTestUser::create([
+            'name' => 'Token User',
+            'email' => 'token@example.com',
+            'password' => 'password',
+            'api_token' => hash('sha256', 'plain-token'),
+        ]);
+
+        $this->assertTrue($this->app['auth']->guard('api')->validate([
+            'api_token' => 'plain-token',
+        ]));
+    }
+}


### PR DESCRIPTION
## Problem

`TokenGuard::validate` does not respect hashed token configuration (`hash => true`), leading to inconsistent behavior compared to `TokenGuard::user`.

Currently:

```php
Auth::guard('api')->user(); 
Auth::guard('api')->validate(['api_token' => 'plain-token']);
```

* `user()` → hashes the incoming token before lookup 
* `validate()` → passes the raw token directly 

For applications storing API tokens as SHA-256 hashes, this can cause `validate` to return `false` even when the provided plain token is valid.

---

## Solution

This change updates `TokenGuard::validate` to hash the provided credential when the guard is configured with `hash => true`, aligning its behavior with `TokenGuard::user`.

---

## Benefit to Users

* Ensures consistent behavior between `user()` and `validate()`
* Allows applications using hashed API tokens to validate credentials correctly
* Improves reliability for apps that avoid storing raw API tokens for security reasons

---

## Backward Compatibility

This change does not introduce breaking behavior:

* When `hash => false` (default), behavior remains unchanged
* The new behavior only applies when `hash => true`, where hashing is already expected and used in `TokenGuard::user`

This ensures existing applications relying on raw tokens continue to function as before.

---

## Tests

* Added unit test to ensure `validate` hashes credentials when `hash => true`
* Added integration test to verify full authentication flow with hashed API tokens

These tests confirm:

* Plain tokens are correctly validated when stored as hashes
* Behavior matches `TokenGuard::user`
* No regression when `hash => false`

The integration test ensures the complete authentication pipeline works correctly.


=>This pull request is a follow-up to a previously closed PR with the same change, updated to include a more detailed explanation and additional test coverage (including integration test).
