### PR TITLE
Fix File::types() discarding prior chain configuration

### DIFF
--- a/src/Illuminate/Validation/Rules/File.php
+++ b/src/Illuminate/Validation/Rules/File.php
@@ -12,9 +12,16 @@ use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
 
+/**
+ * @method static static types(string|array<int, string> $mimetypes)
+ * @method $this types(string|array<int, string> $mimetypes)
+ */
 class File implements Rule, DataAwareRule, ValidatorAwareRule
 {
-    use Conditionable, Macroable;
+    use Conditionable, Macroable {
+        Macroable::__call as protected macroCall;
+        Macroable::__callStatic as protected macroCallStatic;
+    }
 
     /**
      * The MIME types that the given file should match. This array may also contain file extensions.
@@ -135,14 +142,48 @@ class File implements Rule, DataAwareRule, ValidatorAwareRule
     }
 
     /**
-     * Limit the uploaded file to the given MIME types or file extensions.
+     * Apply allowed MIME types or extensions to the given instance.
      *
      * @param  string|array<int, string>  $mimetypes
-     * @return static
+     * @return $this
      */
-    public static function types($mimetypes)
+    protected function applyTypes($mimetypes)
     {
-        return tap(new static(), fn ($file) => $file->allowedMimetypes = (array) $mimetypes);
+        $this->allowedMimetypes = (array) $mimetypes;
+
+        return $this;
+    }
+
+    /**
+     * Dynamically handle instance method calls into the rule.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return mixed
+     */
+    public function __call($method, $parameters)
+    {
+        if ($method === 'types') {
+            return $this->applyTypes(...$parameters);
+        }
+
+        return $this->macroCall($method, $parameters);
+    }
+
+    /**
+     * Dynamically handle static method calls into the rule.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return mixed
+     */
+    public static function __callStatic($method, $parameters)
+    {
+        if ($method === 'types') {
+            return (new static)->applyTypes(...$parameters);
+        }
+
+        return static::macroCallStatic($method, $parameters);
     }
 
     /**

--- a/tests/Validation/ValidationFileRuleTest.php
+++ b/tests/Validation/ValidationFileRuleTest.php
@@ -62,6 +62,31 @@ class ValidationFileRuleTest extends TestCase
         $this->assertValidationRules($rule, $values, true, []);
     }
 
+    public function testTypesPreservesPriorChainConfiguration()
+    {
+        $this->fails(
+            File::image()->max(1)->types(['jpg', 'jpeg']),
+            UploadedFile::fake()->image('photo.jpg')->size(8),
+            ['validation.max.file'],
+        );
+    }
+
+    public function testTypesIsChainableAfterMax()
+    {
+        $this->passes(
+            File::image()->max(2)->types(['jpg', 'jpeg']),
+            UploadedFile::fake()->image('tiny.jpg')->size(1),
+        );
+    }
+
+    public function testStaticTypesStillWorks()
+    {
+        $this->passes(
+            File::types(['png']),
+            UploadedFile::fake()->createWithContent('foo.png', file_get_contents(__DIR__.'/fixtures/image.png')),
+        );
+    }
+
     public function testSingleMimetype()
     {
         $this->fails(


### PR DESCRIPTION
## Summary
Fixes laravel/framework#59242. `File::types()` was a static factory returning `new static()`, so calling it fluently after `image()`/`max()` (e.g. `File::image()->max(1)->types(['jpg'])`) silently dropped all prior constraints with no warning.

This routes both static and instance calls to `types()` through `__call`/`__callStatic`, delegating to a protected `applyTypes()` setter:
- `File::types([...])` — still works (BC preserved), now via `__callStatic`.
- `File::image()->max(1)->types([...])` — now mutates the existing instance instead of throwing away configuration.

`Macroable`'s magic methods are aliased so existing macro support is unaffected. `@method` annotations are added so IDEs and static analysis still recognize both forms.

## Test plan
- [x] New regression test: `File::image()->max(1)->types(['jpg', 'jpeg'])` correctly fails on an oversized image.
- [x] New positive chain test: same chain passes when the file is within `max`.
- [x] New BC test: `File::types(['png'])` static form still works.
- [x] Full test suite green (13345 tests).