### PR TITLE
Fix default session cookie name for non-alphanumeric APP_NAME

### DIFF
--- a/config/session.php
+++ b/config/session.php
@@ -129,7 +129,7 @@ return [
 
     'cookie' => env(
         'SESSION_COOKIE',
-        Str::snake((string) env('APP_NAME', 'laravel')).'_session'
+        Str::slug(Str::snake((string) env('APP_NAME', 'laravel')), '_').'_session'
     ),
 
     /*

--- a/tests/Integration/Session/SessionCookieNameTest.php
+++ b/tests/Integration/Session/SessionCookieNameTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Session;
+
+use Illuminate\Support\Str;
+use PHPUnit\Framework\TestCase;
+
+class SessionCookieNameTest extends TestCase
+{
+    /**
+     * Resolve the default session cookie name the same way config/session.php does
+     * for a given APP_NAME value.
+     */
+    protected function resolveCookieName(string $appName): string
+    {
+        return Str::slug(Str::snake($appName), '_').'_session';
+    }
+
+    public function testSimpleAppNameProducesSnakeCasedCookie()
+    {
+        $this->assertSame('my_app_session', $this->resolveCookieName('My App'));
+        $this->assertSame('laravel_session', $this->resolveCookieName('laravel'));
+    }
+
+    public function testAppNameWithBracketsIsStrippedToSafeCharacters()
+    {
+        $this->assertSame(
+            'l_o_c_a_l_my_awesome_app_session',
+            $this->resolveCookieName('[LOCAL] My Awesome App'),
+        );
+    }
+
+    public function testAppNameWithDotIsStrippedToSafeCharacters()
+    {
+        $this->assertSame('admindomain_session', $this->resolveCookieName('admin.domain'));
+        $this->assertSame('examplecom_session', $this->resolveCookieName('example.com'));
+    }
+
+    public function testResolvedCookieNameOnlyContainsRfc6265SafeCharacters()
+    {
+        $names = [
+            '[LOCAL] My Awesome App',
+            'admin.domain',
+            'My App!',
+            'foo/bar',
+            'one;two',
+        ];
+
+        foreach ($names as $name) {
+            $this->assertMatchesRegularExpression(
+                '/^[A-Za-z0-9_]+$/',
+                $this->resolveCookieName($name),
+                "Cookie name for [$name] contained unsafe characters.",
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Fixes laravel/framework#59344. Since #56172 switched the default session cookie name from `Str::slug(APP_NAME, '_')` to `Str::snake(APP_NAME)`, applications whose `APP_NAME` contains characters like `[`, `]`, `.`, or whitespace produce cookie names browsers refuse to round-trip. The result: every request creates a new session and authenticated users are silently logged out.

Examples from the issue:
- `APP_NAME="[LOCAL] My Awesome App"` → `[_l_o_c_a_l]_my_awesome_app_session`
- `APP_NAME="admin.domain"` → `admin.domain_session`

This wraps the snake-cased result in `Str::slug(..., '_')` so the resolved name is always restricted to RFC 6265–safe characters (`[A-Za-z0-9_]`) while preserving the snake_case style for normal `APP_NAME` values introduced in #56172.

- `My App` → `my_app_session` (unchanged)
- `[LOCAL] My Awesome App` → `l_o_c_a_l_my_awesome_app_session`
- `admin.domain` → `admindomain_session`

## Test plan
- [x] New test file `tests/Integration/Session/SessionCookieNameTest.php` covering simple names, bracketed names, dotted names, and a regex check that the resolved name is always RFC 6265 safe across a variety of unsafe inputs.
- [x] All 4 new tests pass.