### PR TITLE
[13.x] Add onSuccess callback to HTTP Client Response

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -265,6 +265,21 @@ class Response implements ArrayAccess, Stringable
     }
 
     /**
+     * Execute the given callback if the response was successful.
+     *
+     * @param  callable|(\Closure(\Illuminate\Http\Client\Response): mixed)  $callback
+     * @return $this
+     */
+    public function onSuccess(callable $callback)
+    {
+        if ($this->successful()) {
+            $callback($this);
+        }
+
+        return $this;
+    }
+
+    /**
      * Execute the given callback if there was a server or client error.
      *
      * @param  callable|(\Closure(\Illuminate\Http\Client\Response): mixed)  $callback

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -1559,6 +1559,54 @@ class HttpClientTest extends TestCase
         $this->assertTrue($throwCallbackCalled);
     }
 
+    public function testOnSuccessCallsClosureOnSuccess()
+    {
+        $status = 0;
+        $client = $this->factory->fake([
+            'laravel.com' => $this->factory::response('', 200),
+        ]);
+
+        $response = $client->get('laravel.com')
+            ->onSuccess(function ($response) use (&$status) {
+                $status = $response->status();
+            });
+
+        $this->assertSame(200, $status);
+        $this->assertSame(200, $response->status());
+    }
+
+    public function testOnSuccessDoesntCallClosureOnClientError()
+    {
+        $status = 0;
+        $client = $this->factory->fake([
+            'laravel.com' => $this->factory::response('', 401),
+        ]);
+
+        $response = $client->get('laravel.com')
+            ->onSuccess(function ($response) use (&$status) {
+                $status = $response->status();
+            });
+
+        $this->assertSame(0, $status);
+        $this->assertSame(401, $response->status());
+    }
+
+    public function testOnSuccessDoesntCallClosureOnServerError()
+    {
+        $status = 0;
+        $client = $this->factory->fake([
+            'laravel.com' => $this->factory::response('', 500),
+        ]);
+
+        $response = $client->get('laravel.com')
+            ->onSuccess(function ($response) use (&$status) {
+                $status = $response->status();
+            });
+
+        $this->assertSame(0, $status);
+        $this->assertSame(500, $response->status());
+    }
+
     public function testOnErrorDoesntCallClosureOnInformational()
     {
         $status = 0;


### PR DESCRIPTION
## Summary

The HTTP Client Response has an `onError()` method for fluent error handling, but no equivalent for successful responses. This adds `onSuccess()` to complete the pair.

**Before:**
```php
$response = Http::get('api.example.com/users');

// Must break fluent chain for success handling
if ($response->successful()) {
    $this->processUsers($response->json());
}

$response->onError(fn ($r) => report($r->body()));
```

**After:**
```php
Http::get('api.example.com/users')
    ->onSuccess(fn ($r) => $this->processUsers($r->json()))
    ->onError(fn ($r) => report($r->body()));
```

The method follows the exact same pattern as `onError()` — it accepts a callable, passes the response instance, and returns `$this` for chaining.

## Test Plan

- [x] Added test: `onSuccess` calls closure on 200 response
- [x] Added test: `onSuccess` does not call closure on 401 client error
- [x] Added test: `onSuccess` does not call closure on 500 server error
- [x] Mirrors the existing `onError` test structure