### PR TITLE
[13.x] Add whenIsJson and whenIsUrl methods to Stringable

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1267,6 +1267,30 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
+     * Execute the given callback if the string is valid JSON.
+     *
+     * @param  callable  $callback
+     * @param  callable|null  $default
+     * @return static
+     */
+    public function whenIsJson($callback, $default = null)
+    {
+        return $this->when($this->isJson(), $callback, $default);
+    }
+
+    /**
+     * Execute the given callback if the string is a valid URL.
+     *
+     * @param  callable  $callback
+     * @param  callable|null  $default
+     * @return static
+     */
+    public function whenIsUrl($callback, $default = null)
+    {
+        return $this->when($this->isUrl(), $callback, $default);
+    }
+
+    /**
      * Execute the given callback if the string is a valid UUID.
      *
      * @param  callable  $callback

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -398,6 +398,44 @@ class SupportStringableTest extends TestCase
         }));
     }
 
+    public function testWhenIsJson()
+    {
+        $this->assertSame('Json: {"key":"value"}', (string) $this->stringable('{"key":"value"}')->whenIsJson(function ($stringable) {
+            return $stringable->prepend('Json: ');
+        }, function ($stringable) {
+            return $stringable->prepend('Not Json: ');
+        }));
+
+        $this->assertSame('not-json', (string) $this->stringable('not-json')->whenIsJson(function ($stringable) {
+            return $stringable->prepend('Json: ');
+        }));
+
+        $this->assertSame('Not Json: not-json', (string) $this->stringable('not-json')->whenIsJson(function ($stringable) {
+            return $stringable->prepend('Json: ');
+        }, function ($stringable) {
+            return $stringable->prepend('Not Json: ');
+        }));
+    }
+
+    public function testWhenIsUrl()
+    {
+        $this->assertSame('Url: https://laravel.com', (string) $this->stringable('https://laravel.com')->whenIsUrl(function ($stringable) {
+            return $stringable->prepend('Url: ');
+        }, function ($stringable) {
+            return $stringable->prepend('Not Url: ');
+        }));
+
+        $this->assertSame('not-a-url', (string) $this->stringable('not-a-url')->whenIsUrl(function ($stringable) {
+            return $stringable->prepend('Url: ');
+        }));
+
+        $this->assertSame('Not Url: not-a-url', (string) $this->stringable('not-a-url')->whenIsUrl(function ($stringable) {
+            return $stringable->prepend('Url: ');
+        }, function ($stringable) {
+            return $stringable->prepend('Not Url: ');
+        }));
+    }
+
     public function testWhenIsUuid()
     {
         $this->assertSame('Uuid: 2cdc7039-65a6-4ac7-8e5d-d554a98e7b15', (string) $this->stringable('2cdc7039-65a6-4ac7-8e5d-d554a98e7b15')->whenIsUuid(function ($stringable) {


### PR DESCRIPTION
## Summary

Stringable provides conditional `when*` methods for type checking — `whenIsAscii()`, `whenIsUuid()`, and `whenIsUlid()` — but is missing the equivalent methods for `isJson()` and `isUrl()`, which both already exist as check methods on Stringable.

This adds `whenIsJson()` and `whenIsUrl()` to complete the set.

**Example usage:**

```php
// Parse JSON input conditionally
Str::of($input)->whenIsJson(
    fn ($s) => json_decode($s, true),
    fn ($s) => ['raw' => (string) $s]
);

// Process URLs conditionally
Str::of($value)->whenIsUrl(
    fn ($s) => $s->after('://'),
    fn ($s) => $s->slug()
);
```

| Check Method | `when*` Method | Status |
|---|---|---|
| `isAscii()` | `whenIsAscii()` | Exists |
| `isUuid()` | `whenIsUuid()` | Exists |
| `isUlid()` | `whenIsUlid()` | Exists |
| `isJson()` | `whenIsJson()` | **Added** |
| `isUrl()` | `whenIsUrl()` | **Added** |

## Test Plan

- [x] Added test: `whenIsJson` calls callback on valid JSON string
- [x] Added test: `whenIsJson` skips callback on non-JSON string
- [x] Added test: `whenIsJson` calls default callback on non-JSON string
- [x] Added test: `whenIsUrl` calls callback on valid URL
- [x] Added test: `whenIsUrl` skips callback on non-URL string
- [x] Added test: `whenIsUrl` calls default callback on non-URL string