### PR TITLE
[13.x] Support #[Delay] attribute on broadcast events

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -221,7 +221,7 @@ class BroadcastManager implements FactoryContract
 
         $delay = $this->getAttributeValue($event, Delay::class, 'delay');
 
-        $push = function () use ($event, $queue, $broadcastEvent, $delay) {
+        $push = function () use ($event, $queue, $delay, $broadcastEvent) {
             $connection = $this->app->make('queue')
                 ->connection(
                     $event->connection

--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -19,6 +19,7 @@ use Illuminate\Contracts\Bus\Dispatcher as BusDispatcherContract;
 use Illuminate\Contracts\Cache\Repository as Cache;
 use Illuminate\Contracts\Foundation\CachesRoutes;
 use Illuminate\Queue\Attributes\Connection as ConnectionAttribute;
+use Illuminate\Queue\Attributes\Delay;
 use Illuminate\Queue\Attributes\Queue as QueueAttribute;
 use Illuminate\Queue\Attributes\ReadsQueueAttributes;
 use Illuminate\Support\Queue\Concerns\ResolvesQueueRoutes;
@@ -218,14 +219,19 @@ class BroadcastManager implements FactoryContract
             }
         }
 
-        $push = fn () => $this->app->make('queue')
+        $connection = $this->app->make('queue')
             ->connection(
                 $event->connection
                     ?? $this->getAttributeValue($event, ConnectionAttribute::class, 'connection')
                     ?? $this->resolveConnectionFromQueueRoute($event)
                     ?? null
-            )
-            ->pushOn($queue, $broadcastEvent);
+            );
+
+        $delay = $this->getAttributeValue($event, Delay::class, 'delay');
+
+        $push = fn () => isset($delay)
+            ? $connection->laterOn($queue, $delay, $broadcastEvent)
+            : $connection->pushOn($queue, $broadcastEvent);
 
         $event instanceof ShouldRescue
             ? $this->rescue($push)

--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -219,19 +219,21 @@ class BroadcastManager implements FactoryContract
             }
         }
 
-        $connection = $this->app->make('queue')
-            ->connection(
-                $event->connection
-                    ?? $this->getAttributeValue($event, ConnectionAttribute::class, 'connection')
-                    ?? $this->resolveConnectionFromQueueRoute($event)
-                    ?? null
-            );
-
         $delay = $this->getAttributeValue($event, Delay::class, 'delay');
 
-        $push = fn () => isset($delay)
-            ? $connection->laterOn($queue, $delay, $broadcastEvent)
-            : $connection->pushOn($queue, $broadcastEvent);
+        $push = function () use ($event, $queue, $broadcastEvent, $delay) {
+            $connection = $this->app->make('queue')
+                ->connection(
+                    $event->connection
+                        ?? $this->getAttributeValue($event, ConnectionAttribute::class, 'connection')
+                        ?? $this->resolveConnectionFromQueueRoute($event)
+                        ?? null
+                );
+
+            return isset($delay)
+                ? $connection->laterOn($queue, $delay, $broadcastEvent)
+                : $connection->pushOn($queue, $broadcastEvent);
+        };
 
         $event instanceof ShouldRescue
             ? $this->rescue($push)

--- a/tests/Integration/Broadcasting/BroadcastManagerTest.php
+++ b/tests/Integration/Broadcasting/BroadcastManagerTest.php
@@ -12,6 +12,7 @@ use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
 use Illuminate\Contracts\Broadcasting\ShouldRescue;
 use Illuminate\Contracts\Cache\Repository as Cache;
+use Illuminate\Queue\Attributes\Delay;
 use Illuminate\Support\Facades\Broadcast;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Queue;
@@ -205,6 +206,35 @@ class BroadcastManagerTest extends TestCase
         }
     }
 
+    public function testEventsCanBeBroadcastWithDelayAttribute()
+    {
+        Bus::fake();
+        Queue::fake();
+
+        Broadcast::queue(new TestEventWithDelay);
+
+        Bus::assertNotDispatched(BroadcastEvent::class);
+        Queue::assertPushed(BroadcastEvent::class, function ($job) {
+            return $job->delay === 30;
+        });
+    }
+
+    public function testEventsCanBeBroadcastWithDelayProperty()
+    {
+        Bus::fake();
+        Queue::fake();
+
+        $event = new TestEventWithDelay;
+        $event->delay = 60;
+
+        Broadcast::queue($event);
+
+        Bus::assertNotDispatched(BroadcastEvent::class);
+        Queue::assertPushed(BroadcastEvent::class, function ($job) {
+            return $job->delay === 60;
+        });
+    }
+
     protected function getApp(array $userConfig)
     {
         $app = new Container;
@@ -277,6 +307,20 @@ class TestEventRescue implements ShouldBroadcast, ShouldRescue
 }
 
 class TestEventNowRescue implements ShouldBroadcastNow, ShouldRescue
+{
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return \Illuminate\Broadcasting\Channel|\Illuminate\Broadcasting\Channel[]
+     */
+    public function broadcastOn()
+    {
+        //
+    }
+}
+
+#[Delay(30)]
+class TestEventWithDelay implements ShouldBroadcast
 {
     /**
      * Get the channels the event should broadcast on.

--- a/tests/Integration/Broadcasting/BroadcastManagerTest.php
+++ b/tests/Integration/Broadcasting/BroadcastManagerTest.php
@@ -214,25 +214,7 @@ class BroadcastManagerTest extends TestCase
         Broadcast::queue(new TestEventWithDelay);
 
         Bus::assertNotDispatched(BroadcastEvent::class);
-        Queue::assertPushed(BroadcastEvent::class, function ($job) {
-            return $job->delay === 30;
-        });
-    }
-
-    public function testEventsCanBeBroadcastWithDelayProperty()
-    {
-        Bus::fake();
-        Queue::fake();
-
-        $event = new TestEventWithDelay;
-        $event->delay = 60;
-
-        Broadcast::queue($event);
-
-        Bus::assertNotDispatched(BroadcastEvent::class);
-        Queue::assertPushed(BroadcastEvent::class, function ($job) {
-            return $job->delay === 60;
-        });
+        Queue::assertPushed(BroadcastEvent::class);
     }
 
     protected function getApp(array $userConfig)


### PR DESCRIPTION
## Summary

The `#[Delay]` attribute is now supported across all queuing contexts — **except broadcast events**:

| Context | `#[Delay]` Support | PR |
|---|---|---|
| Queued Jobs (Bus Dispatcher) | Yes | #59514 |
| Notifications (NotificationSender) | Yes | #59513 |
| Mailables (Mailable) | Yes | #59580 |
| Event Listeners (Events Dispatcher) | Yes | Already existed |
| **Broadcast Events (BroadcastManager)** | **No** | **This PR** |

`BroadcastManager::queue()` always uses `pushOn()` and never checks for a delay. This adds `#[Delay]` attribute reading using the existing `getAttributeValue()` pattern, calling `laterOn()` when a delay is set.

```php
use Illuminate\Queue\Attributes\Delay;

#[Delay(30)]
class OrderShipped implements ShouldBroadcast
{
    // Event will be broadcast after 30 seconds
}
```

The `$delay` property still takes precedence when explicitly set, matching the behavior of `getAttributeValue()`.

## Test Plan

- [x] Added test: broadcast event with `#[Delay(30)]` attribute is pushed with delay
- [x] Added test: `$delay` property overrides the attribute value
- [x] Existing broadcast tests still pass