### PR TITLE
[13.x] Add isNotEmpty method to Context Repository

### DIFF
--- a/src/Illuminate/Log/Context/Repository.php
+++ b/src/Illuminate/Log/Context/Repository.php
@@ -578,6 +578,16 @@ class Repository
     }
 
     /**
+     * Determine if the context is not empty.
+     *
+     * @return bool
+     */
+    public function isNotEmpty()
+    {
+        return ! $this->isEmpty();
+    }
+
+    /**
      * Execute the given callback when context is about to be dehydrated.
      *
      * @param  (callable(static): void)  $callback

--- a/tests/Log/ContextTest.php
+++ b/tests/Log/ContextTest.php
@@ -112,6 +112,26 @@ class ContextTest extends TestCase
         $this->assertNull(Context::dehydrate());
     }
 
+    public function test_is_not_empty()
+    {
+        $this->assertTrue(Context::isEmpty());
+        $this->assertFalse(Context::isNotEmpty());
+
+        Context::add('key', 'value');
+
+        $this->assertFalse(Context::isEmpty());
+        $this->assertTrue(Context::isNotEmpty());
+    }
+
+    public function test_is_not_empty_with_hidden_values()
+    {
+        $this->assertFalse(Context::isNotEmpty());
+
+        Context::addHidden('secret', 'value');
+
+        $this->assertTrue(Context::isNotEmpty());
+    }
+
     public function test_hydrating_null_triggers_hydrating_event()
     {
         $called = false;


### PR DESCRIPTION
## Summary

The Context Repository has an `isEmpty()` method but no `isNotEmpty()` counterpart. This is inconsistent with other Laravel classes that provide both methods:

| Class | `isEmpty()` | `isNotEmpty()` |
|---|---|---|
| Collection | Yes | Yes |
| Uri | Yes | Yes |
| Stringable | Yes | Yes |
| **Context Repository** | **Yes** | **Missing** |

This adds `isNotEmpty()` for consistency, enabling cleaner guard clauses:

```php
// Before
if (! Context::isEmpty()) {
    // ...
}

// After
if (Context::isNotEmpty()) {
    // ...
}
```

## Test Plan

- [x] Added test: `isNotEmpty` returns false when context is empty
- [x] Added test: `isNotEmpty` returns true after adding regular values
- [x] Added test: `isNotEmpty` returns true after adding hidden values only