### PR TITLE
[13.x] Add Number::duration() method for human-readable time formatting

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -309,10 +309,10 @@ class Number
         }
 
         $units = [
-            ['year', 'yr', 31536000],
-            ['week', 'wk', 604800],
-            ['day', 'd', 86400],
-            ['hour', 'hr', 3600],
+            ['year', 'yr', 31_536_000],
+            ['week', 'wk', 604_800],
+            ['day', 'd', 86_400],
+            ['hour', 'hr', 3_600],
             ['minute', 'min', 60],
             ['second', 's', 1],
         ];

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -293,6 +293,48 @@ class Number
     }
 
     /**
+     * Convert the given number of seconds to a human-readable duration.
+     *
+     * @param  int|float  $seconds
+     * @param  int|null  $parts
+     * @param  bool  $short
+     * @return string
+     */
+    public static function duration(int|float $seconds, ?int $parts = null, bool $short = false)
+    {
+        $seconds = (int) abs($seconds);
+
+        if ($seconds === 0) {
+            return $short ? '0s' : '0 seconds';
+        }
+
+        $units = [
+            ['year', 'yr', 31536000],
+            ['week', 'wk', 604800],
+            ['day', 'd', 86400],
+            ['hour', 'hr', 3600],
+            ['minute', 'min', 60],
+            ['second', 's', 1],
+        ];
+
+        $result = [];
+
+        foreach ($units as [$long, $shortUnit, $divisor]) {
+            $count = intdiv($seconds, $divisor);
+
+            if ($count > 0) {
+                $result[] = $short
+                    ? $count.$shortUnit
+                    : $count.' '.Str::plural($long, $count);
+
+                $seconds %= $divisor;
+            }
+        }
+
+        return implode(' ', $parts ? array_slice($result, 0, $parts) : $result);
+    }
+
+    /**
      * Clamp the given number between the given minimum and maximum.
      *
      * @param  int|float  $number

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -188,6 +188,40 @@ class SupportNumberTest extends TestCase
         $this->assertSame('1,024 YB', Number::fileSize(1024 ** 9));
     }
 
+    public function testDuration()
+    {
+        $this->assertSame('0 seconds', Number::duration(0));
+        $this->assertSame('1 second', Number::duration(1));
+        $this->assertSame('30 seconds', Number::duration(30));
+        $this->assertSame('1 minute', Number::duration(60));
+        $this->assertSame('1 minute 30 seconds', Number::duration(90));
+        $this->assertSame('1 hour', Number::duration(3600));
+        $this->assertSame('1 hour 30 minutes', Number::duration(5400));
+        $this->assertSame('1 day', Number::duration(86400));
+        $this->assertSame('1 day 1 hour 1 minute 1 second', Number::duration(90061));
+        $this->assertSame('2 weeks 3 days', Number::duration(1468800));
+        $this->assertSame('1 year', Number::duration(31536000));
+        $this->assertSame('1 year 1 day', Number::duration(31622400));
+    }
+
+    public function testDurationWithParts()
+    {
+        $this->assertSame('1 hour', Number::duration(3661, parts: 1));
+        $this->assertSame('1 hour 1 minute', Number::duration(3661, parts: 2));
+        $this->assertSame('1 hour 1 minute 1 second', Number::duration(3661, parts: 3));
+        $this->assertSame('1 day', Number::duration(90061, parts: 1));
+        $this->assertSame('1 day 1 hour', Number::duration(90061, parts: 2));
+    }
+
+    public function testDurationShort()
+    {
+        $this->assertSame('0s', Number::duration(0, short: true));
+        $this->assertSame('30s', Number::duration(30, short: true));
+        $this->assertSame('1min', Number::duration(60, short: true));
+        $this->assertSame('1hr 30min', Number::duration(5400, short: true));
+        $this->assertSame('1d 1hr', Number::duration(90061, parts: 2, short: true));
+    }
+
     public function testClamp()
     {
         $this->assertSame(2, Number::clamp(1, 2, 3));


### PR DESCRIPTION
## Summary

The `Number` class provides `fileSize()` for formatting bytes into human-readable strings like "5 GB", but has no equivalent for formatting seconds into human-readable durations.

This adds `Number::duration()` which converts seconds into readable time strings:

```php
Number::duration(3661);                    // "1 hour 1 minute 1 second"
Number::duration(90061, parts: 2);         // "1 day 1 hour"
Number::duration(5400, short: true);       // "1hr 30min"
Number::duration(86400);                   // "1 day"
Number::duration(31536000);                // "1 year"
Number::duration(0);                       // "0 seconds"
```

### Parameters
- `$seconds` — the number of seconds to format
- `$parts` — limit the number of units shown (e.g., `parts: 2` shows only the two largest units)
- `$short` — use abbreviated unit labels (`1hr 30min` instead of `1 hour 30 minutes`)

### Use Cases
- Displaying queue wait times and job processing durations
- Showing cache TTL in admin panels
- Formatting API response times
- Displaying uptime or elapsed time

This complements `Number::fileSize()` (bytes → human-readable) with the same pattern for time durations.

## Test Plan

- [x] Basic duration formatting (seconds, minutes, hours, days, weeks, years)
- [x] Plural handling (1 second vs 30 seconds)
- [x] Compound durations (1 day 1 hour 1 minute 1 second)
- [x] Parts limiting (show only N largest units)
- [x] Short format (abbreviated labels)
- [x] Zero seconds edge case