### PR TITLE
[13.x] Add Str::isEmail(), Stringable::isEmail(), and whenIsEmail()

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -565,6 +565,23 @@ class Str
     }
 
     /**
+     * Determine if a given value is a valid email address.
+     *
+     * @param  mixed  $value
+     * @return bool
+     *
+     * @phpstan-assert-if-true =non-empty-string $value
+     */
+    public static function isEmail($value)
+    {
+        if (! is_string($value)) {
+            return false;
+        }
+
+        return filter_var($value, FILTER_VALIDATE_EMAIL) !== false;
+    }
+
+    /**
      * Determine if a given value is valid JSON.
      *
      * @param  mixed  $value

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -382,6 +382,16 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
+     * Determine if a given string is a valid email address.
+     *
+     * @return bool
+     */
+    public function isEmail()
+    {
+        return Str::isEmail($this->value);
+    }
+
+    /**
      * Determine if a given string is valid JSON.
      *
      * @return bool
@@ -1264,6 +1274,18 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     public function whenIsAscii($callback, $default = null)
     {
         return $this->when($this->isAscii(), $callback, $default);
+    }
+
+    /**
+     * Execute the given callback if the string is a valid email address.
+     *
+     * @param  callable  $callback
+     * @param  callable|null  $default
+     * @return static
+     */
+    public function whenIsEmail($callback, $default = null)
+    {
+        return $this->when($this->isEmail(), $callback, $default);
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -731,6 +731,20 @@ class SupportStrTest extends TestCase
         $this->assertSame(Str::isUuid($uuid, $version), $passes);
     }
 
+    public function testIsEmail()
+    {
+        $this->assertTrue(Str::isEmail('taylor@laravel.com'));
+        $this->assertTrue(Str::isEmail('user@example.org'));
+        $this->assertTrue(Str::isEmail('user+tag@domain.com'));
+
+        $this->assertFalse(Str::isEmail('invalid'));
+        $this->assertFalse(Str::isEmail('user@'));
+        $this->assertFalse(Str::isEmail('@domain.com'));
+        $this->assertFalse(Str::isEmail(''));
+        $this->assertFalse(Str::isEmail(null));
+        $this->assertFalse(Str::isEmail([]));
+    }
+
     public function testIsJson()
     {
         $this->assertTrue(Str::isJson('1'));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -65,6 +65,14 @@ class SupportStringableTest extends TestCase
         $this->assertFalse($this->stringable('01GJSNW9MAF-792C0XYY8RX6ssssss-QFT')->isUlid());
     }
 
+    public function testIsEmail()
+    {
+        $this->assertTrue($this->stringable('taylor@laravel.com')->isEmail());
+        $this->assertTrue($this->stringable('user+tag@domain.com')->isEmail());
+        $this->assertFalse($this->stringable('invalid')->isEmail());
+        $this->assertFalse($this->stringable('')->isEmail());
+    }
+
     public function testIsJson()
     {
         $this->assertTrue($this->stringable('1')->isJson());
@@ -395,6 +403,25 @@ class SupportStringableTest extends TestCase
             return $stringable->prepend('Ascii: ');
         }, function ($stringable) {
             return $stringable->prepend('Not Ascii: ');
+        }));
+    }
+
+    public function testWhenIsEmail()
+    {
+        $this->assertSame('Email: taylor@laravel.com', (string) $this->stringable('taylor@laravel.com')->whenIsEmail(function ($stringable) {
+            return $stringable->prepend('Email: ');
+        }, function ($stringable) {
+            return $stringable->prepend('Not Email: ');
+        }));
+
+        $this->assertSame('invalid', (string) $this->stringable('invalid')->whenIsEmail(function ($stringable) {
+            return $stringable->prepend('Email: ');
+        }));
+
+        $this->assertSame('Not Email: invalid', (string) $this->stringable('invalid')->whenIsEmail(function ($stringable) {
+            return $stringable->prepend('Email: ');
+        }, function ($stringable) {
+            return $stringable->prepend('Not Email: ');
         }));
     }
 


### PR DESCRIPTION
## Summary

The `Str::is*()` family provides quick type-checking for common string formats, but email — arguably the most commonly validated format — is missing:

| Method | Status |
|---|---|
| `Str::isAscii()` | Exists |
| `Str::isJson()` | Exists |
| `Str::isUrl()` | Exists |
| `Str::isUuid()` | Exists |
| `Str::isUlid()` | Exists |
| **`Str::isEmail()`** | **Added** |

This PR adds three methods that complete the pattern:

### `Str::isEmail($value)`
Quick email validation using `filter_var(FILTER_VALIDATE_EMAIL)` — same approach as `Str::isUrl()` uses `filter_var(FILTER_VALIDATE_URL)`.

```php
Str::isEmail('taylor@laravel.com'); // true
Str::isEmail('invalid');            // false
```

### `Stringable::isEmail()`
Fluent check delegating to `Str::isEmail()`.

```php
Str::of('taylor@laravel.com')->isEmail(); // true
```

### `Stringable::whenIsEmail()`
Conditional callback matching the existing `whenIsAscii()`, `whenIsUuid()`, `whenIsUlid()` pattern.

```php
Str::of($input)->whenIsEmail(
    fn ($s) => $s->before('@'), // extract username
    fn ($s) => $s->slug()       // fallback for non-emails
);
```

## Test Plan

- [x] `Str::isEmail()` — valid emails, invalid emails, non-string values (null, array)
- [x] `Stringable::isEmail()` — valid and invalid emails
- [x] `Stringable::whenIsEmail()` — callback, skip, and default callback behavior