### PR TITLE
[13.x] Add Number::fromFileSize() to parse human-readable file sizes

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -217,6 +217,36 @@ class Number
     }
 
     /**
+     * Parse a human-readable file size into bytes.
+     *
+     * @param  string  $size
+     * @return int|float
+     */
+    public static function fromFileSize(string $size)
+    {
+        $units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+
+        $size = trim($size);
+
+        if (! preg_match('/^([\d,._]+)\s*([a-zA-Z]+)$/u', $size, $matches)) {
+            return (int) $size;
+        }
+
+        $number = (float) str_replace([',', '_'], '', $matches[1]);
+        $unit = strtoupper(trim($matches[2]));
+
+        $exponent = array_search($unit, $units, true);
+
+        if ($exponent === false) {
+            return (int) $number;
+        }
+
+        $bytes = $number * (1024 ** $exponent);
+
+        return $bytes == (int) $bytes ? (int) $bytes : $bytes;
+    }
+
+    /**
      * Convert the number to its human-readable equivalent.
      *
      * @param  int|float  $number

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -219,12 +219,16 @@ class Number
     /**
      * Parse a human-readable file size into bytes.
      *
+     * Supports both binary units (KB, MB — base 1024, matching fileSize() output)
+     * and IEC binary units (KiB, MiB — explicitly base 1024).
+     *
      * @param  string  $size
      * @return int|float
      */
     public static function fromFileSize(string $size)
     {
-        $units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+        $binaryUnits = ['B' => 0, 'KB' => 1, 'MB' => 2, 'GB' => 3, 'TB' => 4, 'PB' => 5, 'EB' => 6, 'ZB' => 7, 'YB' => 8];
+        $iecUnits = ['B' => 0, 'KIB' => 1, 'MIB' => 2, 'GIB' => 3, 'TIB' => 4, 'PIB' => 5, 'EIB' => 6, 'ZIB' => 7, 'YIB' => 8];
 
         $size = trim($size);
 
@@ -235,13 +239,13 @@ class Number
         $number = (float) str_replace([',', '_'], '', $matches[1]);
         $unit = strtoupper(trim($matches[2]));
 
-        $exponent = array_search($unit, $units, true);
-
-        if ($exponent === false) {
+        if (isset($iecUnits[$unit])) {
+            $bytes = $number * (1024 ** $iecUnits[$unit]);
+        } elseif (isset($binaryUnits[$unit])) {
+            $bytes = $number * (1024 ** $binaryUnits[$unit]);
+        } else {
             return (int) $number;
         }
-
-        $bytes = $number * (1024 ** $exponent);
 
         return $bytes == (int) $bytes ? (int) $bytes : $bytes;
     }

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -207,6 +207,14 @@ class SupportNumberTest extends TestCase
         $this->assertSame(1048576, Number::fromFileSize('1MB'));
     }
 
+    public function testFromFileSizeWithIecUnits()
+    {
+        $this->assertSame(1024, Number::fromFileSize('1 KiB'));
+        $this->assertSame(1048576, Number::fromFileSize('1 MiB'));
+        $this->assertSame(1073741824, Number::fromFileSize('1 GiB'));
+        $this->assertSame(1099511627776, Number::fromFileSize('1 TiB'));
+    }
+
     public function testFromFileSizeRoundTrip()
     {
         $this->assertSame('1 KB', Number::fileSize(Number::fromFileSize('1 KB')));

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -188,6 +188,32 @@ class SupportNumberTest extends TestCase
         $this->assertSame('1,024 YB', Number::fileSize(1024 ** 9));
     }
 
+    public function testFromFileSize()
+    {
+        $this->assertSame(0, Number::fromFileSize('0 B'));
+        $this->assertSame(1, Number::fromFileSize('1 B'));
+        $this->assertSame(1024, Number::fromFileSize('1 KB'));
+        $this->assertSame(2048, Number::fromFileSize('2 KB'));
+        $this->assertSame(1048576, Number::fromFileSize('1 MB'));
+        $this->assertSame(1073741824, Number::fromFileSize('1 GB'));
+        $this->assertSame(1099511627776, Number::fromFileSize('1 TB'));
+        $this->assertSame(1536, Number::fromFileSize('1.5 KB'));
+        $this->assertSame(5368709120, Number::fromFileSize('5 GB'));
+    }
+
+    public function testFromFileSizeWithoutSpace()
+    {
+        $this->assertSame(1024, Number::fromFileSize('1KB'));
+        $this->assertSame(1048576, Number::fromFileSize('1MB'));
+    }
+
+    public function testFromFileSizeRoundTrip()
+    {
+        $this->assertSame('1 KB', Number::fileSize(Number::fromFileSize('1 KB')));
+        $this->assertSame('5 GB', Number::fileSize(Number::fromFileSize('5 GB')));
+        $this->assertSame('1 MB', Number::fileSize(Number::fromFileSize('1 MB')));
+    }
+
     public function testClamp()
     {
         $this->assertSame(2, Number::clamp(1, 2, 3));


### PR DESCRIPTION
## Summary

`Number::fileSize()` formats bytes into human-readable strings, but there's no inverse to parse them back. This adds `Number::fromFileSize()` as the parse counterpart — completing the format/parse pair, just like `Number::format()` has `Number::parse()`.

```php
Number::fromFileSize('1 KB');     // 1024
Number::fromFileSize('1.5 MB');   // 1572864
Number::fromFileSize('5 GB');     // 5368709120
Number::fromFileSize('1TB');      // 1099511627776  (no space required)
```

### Use Cases
- Parsing file size limits from configuration (`upload_max_filesize`, etc.)
- Processing user input for file size thresholds
- Parsing API responses that return human-readable sizes
- Round-trip validation: `Number::fileSize(Number::fromFileSize('5 GB'))` === `'5 GB'`

### Format/Parse Pairs in Number Class

| Format | Parse | Status |
|---|---|---|
| `format()` | `parse()` | Exists |
| `fileSize()` | `fromFileSize()` | **Added** |

## Test Plan

- [x] Standard units: B, KB, MB, GB, TB
- [x] Fractional values: `1.5 KB` → 1536
- [x] Without space: `1KB`, `1MB`
- [x] Round-trip: `fileSize(fromFileSize(x))` === `x`
- [x] Returns int when result is whole, float otherwise