### PR TITLE
[13.x] Added inheritance support for Controller Middleware attributes.

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -1179,16 +1179,27 @@ class Route
     {
         try {
             $reflectionClass = new ReflectionClass($class);
-
             $reflectionMethod = $reflectionClass->getMethod($method);
         } catch (ReflectionException) {
             return [];
         }
 
-        return (new Collection(array_merge(
-            $reflectionClass->getAttributes(MiddlewareAttribute::class, ReflectionAttribute::IS_INSTANCEOF),
-            $reflectionMethod->getAttributes(MiddlewareAttribute::class, ReflectionAttribute::IS_INSTANCEOF),
-        )))->map(function (ReflectionAttribute $attribute) use ($method) {
+        $attributes = new Collection;
+
+        $current = $reflectionClass;
+        while ($current) {
+            $classAttributes = array_reverse($current->getAttributes(MiddlewareAttribute::class, ReflectionAttribute::IS_INSTANCEOF));
+
+            foreach ($classAttributes as $attr) {
+                $attributes->prepend($attr);
+            }
+
+            $current = $current->getParentClass();
+        }
+
+        return $attributes->merge(
+            $reflectionMethod->getAttributes(MiddlewareAttribute::class, ReflectionAttribute::IS_INSTANCEOF)
+        )->map(function (ReflectionAttribute $attribute) use ($method) {
             $instance = $attribute->newInstance();
 
             return static::methodExcludedByOptions(

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -1187,6 +1187,7 @@ class Route
         $attributes = new Collection;
 
         $current = $reflectionClass;
+
         while ($current) {
             $classAttributes = array_reverse($current->getAttributes(MiddlewareAttribute::class, ReflectionAttribute::IS_INSTANCEOF));
 

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -1189,10 +1189,12 @@ class Route
         $current = $reflectionClass;
 
         while ($current) {
-            $classAttributes = array_reverse($current->getAttributes(MiddlewareAttribute::class, ReflectionAttribute::IS_INSTANCEOF));
+            $classAttributes = array_reverse($current->getAttributes(
+                MiddlewareAttribute::class, ReflectionAttribute::IS_INSTANCEOF
+            ));
 
-            foreach ($classAttributes as $attr) {
-                $attributes->prepend($attr);
+            foreach ($classAttributes as $attribute) {
+                $attributes->prepend($attribute);
             }
 
             $current = $current->getParentClass();

--- a/tests/Routing/RoutingControllerAttributeTest.php
+++ b/tests/Routing/RoutingControllerAttributeTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Illuminate\Tests\Routing;
+
+use Illuminate\Container\Container;
+use Illuminate\Routing\Attributes\Controllers\Middleware;
+use Illuminate\Routing\Route;
+use PHPUnit\Framework\TestCase;
+
+class RoutingControllerAttributeTest extends TestCase
+{
+    public function testControllerMiddlewareAttributesAreInherited()
+    {
+        $route = new Route('GET', 'foo', ['uses' => InheritMiddlewareController::class.'@index']);
+        $route->setContainer(new Container);
+
+        $this->assertEquals(['auth', 'log'], $route->gatherMiddleware());
+    }
+}
+
+abstract class Controller
+{
+    //
+}
+
+#[Middleware('auth')]
+abstract class BaseMiddlewareController extends Controller
+{
+    //
+}
+
+#[Middleware('log')]
+class InheritMiddlewareController extends BaseMiddlewareController
+{
+    public function index()
+    {
+        //
+    }
+}

--- a/tests/Routing/RoutingControllerAttributeTest.php
+++ b/tests/Routing/RoutingControllerAttributeTest.php
@@ -16,6 +16,14 @@ class RoutingControllerAttributeTest extends TestCase
 
         $this->assertEquals(['auth', 'log'], $route->gatherMiddleware());
     }
+
+    public function testControllerMiddlewareAttributesAreInheritedInDeclarationOrder()
+    {
+        $route = new Route('GET', 'foo', ['uses' => InheritMiddlewareDeclarationOrderController::class.'@index']);
+        $route->setContainer(new Container);
+
+        $this->assertEquals(['middleware1', 'middleware2', 'middleware3'], $route->gatherMiddleware());
+    }
 }
 
 abstract class Controller
@@ -31,6 +39,22 @@ abstract class BaseMiddlewareController extends Controller
 
 #[Middleware('log')]
 class InheritMiddlewareController extends BaseMiddlewareController
+{
+    public function index()
+    {
+        //
+    }
+}
+
+#[Middleware('middleware1')]
+#[Middleware('middleware2')]
+abstract class BaseMiddlewareDeclarationOrderController extends Controller
+{
+    //
+}
+
+#[Middleware('middleware3')]
+class InheritMiddlewareDeclarationOrderController extends BaseMiddlewareDeclarationOrderController
 {
     public function index()
     {


### PR DESCRIPTION
Previously, attributes like #[Middleware] on a base controller were ignored by child controllers. I updated Route::attributeProvidedControllerMiddleware to traverse the class hierarchy and collect attributes in the correct order (Parent to Child), ensuring consistent behavior across the framework.

---

### **Example Usage (Inheritance Support)**

With these changes, you can now define common configurations in a base controller, and they will be automatically inherited by all child classes.

```php
use Illuminate\Routing\Attributes\Middleware;

#[Middleware('auth')]
#[Middleware('log:api')]
abstract class AdminBaseController extends Controller
{
    // Common admin logic...
}

class AdminController extends AdminBaseController
{
    public function index()
    {
        // This method automatically inherits 'auth' and 'log:api' middleware.
    }
}
```

---
