### PR TITLE
[13.x] Add `authorizeAll` method to `AuthorizesRequests` trait

### DIFF
--- a/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
+++ b/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
@@ -26,6 +26,23 @@ trait AuthorizesRequests
     }
 
     /**
+     * Authorize all of the given actions for the current user.
+     *
+     * @param  array|mixed  $abilities
+     * @return void
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException
+     */
+    public function authorizeAll($abilities)
+    {
+        $abilities = is_array($abilities) ? $abilities : func_get_args();
+
+        foreach ($abilities as $ability) {
+            $this->authorize($ability);
+        }
+    }
+
+    /**
      * Authorize a given action for a user.
      *
      * @param  \Illuminate\Contracts\Auth\Authenticatable|mixed  $user

--- a/tests/Foundation/FoundationAuthorizesRequestsTraitTest.php
+++ b/tests/Foundation/FoundationAuthorizesRequestsTraitTest.php
@@ -69,6 +69,64 @@ class FoundationAuthorizesRequestsTraitTest extends TestCase
         (new FoundationTestAuthorizeTraitClass)->authorize('baz');
     }
 
+    public function testMultipleGateChecksMayBeAuthorized()
+    {
+        unset($_SERVER['_test.authorizes.trait.authorize_all.first']);
+        unset($_SERVER['_test.authorizes.trait.authorize_all.second']);
+
+        $gate = $this->getBasicGate();
+
+        $gate->define('baz', function () {
+            $_SERVER['_test.authorizes.trait.authorize_all.first'] = true;
+
+            return true;
+        });
+
+        $gate->define('qux', function () {
+            $_SERVER['_test.authorizes.trait.authorize_all.second'] = true;
+
+            return true;
+        });
+
+        (new FoundationTestAuthorizeTraitClass)->authorizeAll('baz', 'qux');
+
+        $this->assertTrue($_SERVER['_test.authorizes.trait.authorize_all.first']);
+        $this->assertTrue($_SERVER['_test.authorizes.trait.authorize_all.second']);
+    }
+
+    public function testMultipleGateChecksCanBeAuthorizedWithArray()
+    {
+        $gate = $this->getBasicGate();
+
+        $gate->define('baz', function () {
+            return true;
+        });
+
+        $gate->define('qux', function () {
+            return true;
+        });
+
+        (new FoundationTestAuthorizeTraitClass)->authorizeAll(['baz', 'qux']);
+    }
+
+    public function testExceptionIsThrownIfAnyGateCheckFails()
+    {
+        $this->expectException(AuthorizationException::class);
+        $this->expectExceptionMessage('This action is unauthorized.');
+
+        $gate = $this->getBasicGate();
+
+        $gate->define('baz', function () {
+            return true;
+        });
+
+        $gate->define('qux', function () {
+            return false;
+        });
+
+        (new FoundationTestAuthorizeTraitClass)->authorizeAll('baz', 'qux');
+    }
+
     public function testPoliciesMayBeCalled()
     {
         unset($_SERVER['_test.authorizes.trait.policy']);


### PR DESCRIPTION
This PR adds an authorizeAll method to the AuthorizesRequests trait. It authorizes multiple abilities at once, throwing an AuthorizationException if any of them fail.                   
   
  Before:                                                                                                                                                                                  
  $this->authorize('view');
  $this->authorize('update');
  $this->authorize('delete');

  After:
  $this->authorizeAll('view', 'update', 'delete');
                                                  
  // or with an array
  $this->authorizeAll(['view', 'update', 'delete']);