### PR TITLE
Add dumpFirst() and dumpRandom() methods to Collection

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -264,6 +264,32 @@ trait EnumeratesValues
     }
 
     /**
+     * Dump the first item.
+     *
+     * @param  mixed  ...$args
+     * @return $this
+     */
+    public function dumpFirst(...$args)
+    {
+        dump($this->first(), ...$args);
+
+        return $this;
+    }
+
+    /**
+     * Dump a random item.
+     *
+     * @param  mixed  ...$args
+     * @return $this
+     */
+    public function dumpRandom(...$args)
+    {
+        dump($this->random(), ...$args);
+
+        return $this;
+    }
+
+    /**
      * Execute a callback over each item.
      *
      * @param  callable(TValue, TKey): mixed  $callback

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -284,7 +284,7 @@ trait EnumeratesValues
      */
     public function dumpRandom(...$args)
     {
-        dump($this->random(), ...$args);
+        dump($this->isEmpty() ? null : $this->random(), ...$args);
 
         return $this;
     }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -4885,6 +4885,23 @@ class SupportCollectionTest extends TestCase
         VarDumper::setHandler(null);
     }
 
+
+    #[DataProvider('collectionClassProvider')]
+    public function testDumpFirst($collection)
+    {
+        $log = new Collection;
+
+        VarDumper::setHandler(function ($value) use ($log) {
+            $log->add($value);
+        });
+
+        (new $collection([1, 2, 3]))->dumpFirst('two');
+
+        $this->assertSame([1, 'two'], $log->all());
+
+        VarDumper::setHandler(null);
+    }
+
     #[DataProvider('collectionClassProvider')]
     public function testReduce($collection)
     {

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -4885,7 +4885,6 @@ class SupportCollectionTest extends TestCase
         VarDumper::setHandler(null);
     }
 
-
     #[DataProvider('collectionClassProvider')]
     public function testDumpFirst($collection)
     {
@@ -4900,6 +4899,21 @@ class SupportCollectionTest extends TestCase
         $this->assertSame([1, 'two'], $log->all());
 
         VarDumper::setHandler(null);
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testDumpRandom($collection)
+    {
+        $log = new Collection;
+
+        VarDumper::setHandler(function ($value) use ($log) {
+            $log->add($value);
+        });
+
+        $data = new $collection([1, 2, 3, 4, 5, 6]);
+        $data->dumpRandom();
+
+        $this->assertContains($log->sole(), $data->all());
     }
 
     #[DataProvider('collectionClassProvider')]


### PR DESCRIPTION
The method names should be self-explanatory. I was debugging code this week and, because I was stuck working with 5000 item collections, ended up with something like this:
```php
$collection->map(...);
dump($collection->random());
$collection->map(...);
dump($collection->random());
// etc.
```

So with this PR it's possible to fluently dump the first item or a random item in the collection:
```php
$collection->map(...)
    ->dumpFirst()
    ->map(...)
    ->dumpRandom();
```

Added tests for both methods, and will submit a PR for documentation as well.