### PR TITLE
[13.x] Add missing @throws and docblocks for concurrency and model in…

### DIFF
--- a/src/Illuminate/Concurrency/ProcessDriver.php
+++ b/src/Illuminate/Concurrency/ProcessDriver.php
@@ -26,6 +26,8 @@ class ProcessDriver implements Driver
 
     /**
      * Run the given tasks concurrently and return an array containing the results.
+     *
+     * @throws \Throwable
      */
     public function run(Closure|array $tasks): array
     {

--- a/src/Illuminate/Database/Eloquent/ModelInfo.php
+++ b/src/Illuminate/Database/Eloquent/ModelInfo.php
@@ -77,21 +77,39 @@ class ModelInfo implements Arrayable, ArrayAccess
         ];
     }
 
+    /**
+     * Determine if the given offset exists.
+     */
     public function offsetExists(mixed $offset): bool
     {
         return property_exists($this, $offset);
     }
 
+    /**
+     * Get the value for a given offset.
+     *
+     * @throws \InvalidArgumentException
+     */
     public function offsetGet(mixed $offset): mixed
     {
         return property_exists($this, $offset) ? $this->{$offset} : throw new InvalidArgumentException("Property {$offset} does not exist.");
     }
 
+    /**
+     * Set the value at the given offset.
+     *
+     * @throws \LogicException
+     */
     public function offsetSet(mixed $offset, mixed $value): void
     {
         throw new LogicException(self::class.' may not be mutated using array access.');
     }
 
+    /**
+     * Unset the value at the given offset.
+     *
+     * @throws \LogicException
+     */
     public function offsetUnset(mixed $offset): void
     {
         throw new LogicException(self::class.' may not be mutated using array access.');


### PR DESCRIPTION
This PR adds missing '@throws' annotations and docblocks in two files:                                                               
                                                                                                                                       
  **`Concurrency/ProcessDriver.php`**                                                                                                  
  - Added `@throws \Throwable` to `run()` which throws on process failure (line 46) and re-throws subprocess exceptions (line 58).
                                                                                                                                       
  **`Database/Eloquent/ModelInfo.php`**                                                                                                
  - Added docblocks to `ArrayAccess` methods (`offsetExists`, `offsetGet`, `offsetSet`, `offsetUnset`) to be consistent with other
  implementations such as `Fluent` and `Repository`.                                                                                   
  - Added `@throws \InvalidArgumentException` to `offsetGet()` and `@throws \LogicException` to `offsetSet()` / `offsetUnset()`.
                                                                                                                                       
  These are documentation-only changes. No functionality is affected.