### PR TITLE
[13.x] Fix Cache::many when PhpRedis serialization is enabled

### DIFF
--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -109,9 +109,13 @@ class RedisStore extends TaggableStore implements CanFlushLocks, LockProvider
             return $this->manyAlias($keys);
         }
 
-        $values = $connection->mget(array_map(function ($key) {
+        $prefixedKeys = array_map(function ($key) {
             return $this->prefix.$key;
-        }, $keys));
+        }, $keys);
+
+        $values = $connection instanceof PhpRedisConnection && ($connection->serialized() || $connection->compressed())
+            ? $connection->unpack($connection->withoutSerializationOrCompression(fn () => $connection->mget($prefixedKeys)))
+            : $connection->mget($prefixedKeys);
 
         foreach ($values as $index => $value) {
             $results[$keys[$index]] = ! is_null($value) ? $this->connectionAwareUnserialize($value, $connection) : null;

--- a/src/Illuminate/Redis/Connections/PacksPhpRedisValues.php
+++ b/src/Illuminate/Redis/Connections/PacksPhpRedisValues.php
@@ -86,6 +86,57 @@ trait PacksPhpRedisValues
     }
 
     /**
+     * Unpack the given values, including decompression and unserialization.
+     *
+     * @param  array<int|string, string|null>  $values
+     * @return array<int|string, mixed>
+     *
+     * @throws \RuntimeException
+     * @throws \UnexpectedValueException
+     */
+    public function unpack(array $values): array
+    {
+        if (empty($values)) {
+            return $values;
+        }
+
+        if ($this->supportsPacking()) {
+            return array_map(fn ($value) => $value !== null ? $this->client->_unpack($value) : null, $values);
+        }
+
+        if ($this->compressed()) {
+            if ($this->supportsLzf() && $this->lzfCompressed()) {
+                if (! function_exists('lzf_decompress')) {
+                    throw new RuntimeException("'lzf' extension required to call 'lzf_decompress'.");
+                }
+
+                $processor = function ($value) {
+                    return $value !== null ? $this->client->_unserialize(\lzf_decompress($value)) : null;
+                };
+            } elseif ($this->supportsZstd() && $this->zstdCompressed()) {
+                if (! function_exists('zstd_uncompress')) {
+                    throw new RuntimeException("'zstd' extension required to call 'zstd_uncompress'.");
+                }
+
+                $processor = function ($value) {
+                    return $value !== null ? $this->client->_unserialize(\zstd_uncompress($value)) : null;
+                };
+            } else {
+                throw new UnexpectedValueException(sprintf(
+                    'Unsupported phpredis compression in use [%d].',
+                    $this->client->getOption(Redis::OPT_COMPRESSION)
+                ));
+            }
+        } else {
+            $processor = function ($value) {
+                return $value !== null ? $this->client->_unserialize($value) : null;
+            };
+        }
+
+        return array_map($processor, $values);
+    }
+
+    /**
      * Execute the given callback without serialization or compression when applicable.
      *
      * @param  callable  $callback

--- a/tests/Cache/CacheRedisStoreTest.php
+++ b/tests/Cache/CacheRedisStoreTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Cache;
 
 use Illuminate\Cache\RedisStore;
 use Illuminate\Contracts\Redis\Factory;
+use Illuminate\Redis\Connections\PhpRedisConnection;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
@@ -42,6 +43,27 @@ class CacheRedisStoreTest extends TestCase
         $this->assertSame('bar', $results['foo']);
         $this->assertSame('buzz', $results['fizz']);
         $this->assertSame('quz', $results['norf']);
+        $this->assertNull($results['null']);
+    }
+
+    public function testRedisMultipleValuesAreReturnedWhenPhpRedisSerializationIsEnabled()
+    {
+        $factory = m::mock(Factory::class);
+        $client = m::mock();
+        $connection = m::mock(PhpRedisConnection::class, [$client, null, []]);
+
+        $factory->shouldReceive('connection')->once()->with('default')->andReturn($connection);
+
+        $connection->shouldReceive('serialized')->andReturn(true);
+        $connection->shouldReceive('compressed')->andReturn(false);
+        $connection->shouldReceive('withoutSerializationOrCompression')->once()->andReturnUsing(fn ($callback) => $callback());
+        $connection->shouldReceive('mget')->once()->with(['prefix:foo', 'prefix:fizz', 'prefix:null'])->andReturn(['raw-bar', 'raw-buzz', null]);
+        $connection->shouldReceive('unpack')->once()->with(['raw-bar', 'raw-buzz', null])->andReturn(['bar', 'buzz', null]);
+
+        $results = (new RedisStore($factory, 'prefix:'))->many(['foo', 'fizz', 'null']);
+
+        $this->assertSame('bar', $results['foo']);
+        $this->assertSame('buzz', $results['fizz']);
         $this->assertNull($results['null']);
     }
 


### PR DESCRIPTION
This fixes #56855.

When PhpRedis native serialization or compression is enabled, `Cache::many()` currently relies on `mget()`, which can return values that are not hydrated consistently with the single `get()` path.

This change temporarily disables native serialization/compression for the `mget()` call and then unpacks each returned value explicitly using the PhpRedis connection helpers.

Tests:
- [x] `./vendor/bin/phpunit tests/Cache/CacheRedisStoreTest.php` (PHP 8.3)