### PR TITLE
[13.x] Fix @aware preferring nearer parent component data

### DIFF
--- a/src/Illuminate/View/Concerns/ManagesComponents.php
+++ b/src/Illuminate/View/Concerns/ManagesComponents.php
@@ -137,14 +137,12 @@ trait ManagesComponents
      */
     public function getConsumableComponentData($key, $default = null)
     {
-        if (array_key_exists($key, $this->currentComponentData)) {
-            return $this->currentComponentData[$key];
-        }
-
         $currentComponent = count($this->componentStack);
 
-        if ($currentComponent === 0) {
-            return value($default);
+        $data = $this->componentData[$currentComponent] ?? [];
+
+        if (array_key_exists($key, $data)) {
+            return $data[$key];
         }
 
         for ($i = $currentComponent - 1; $i >= 0; $i--) {
@@ -153,6 +151,10 @@ trait ManagesComponents
             if (array_key_exists($key, $data)) {
                 return $data[$key];
             }
+        }
+
+        if (array_key_exists($key, $this->currentComponentData)) {
+            return $this->currentComponentData[$key];
         }
 
         return value($default);

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -696,6 +696,46 @@ class ViewFactoryTest extends TestCase
         $this->assertSame('laravel.com', $contents);
     }
 
+    public function testConsumableComponentDataPrefersNearestParentOverRenderedAncestor()
+    {
+        $factory = new class(...$this->getFactoryArgs()) extends Factory
+        {
+            public function seedComponentState(array $currentComponentData, array $componentStack, array $componentData): void
+            {
+                $this->currentComponentData = $currentComponentData;
+                $this->componentStack = $componentStack;
+                $this->componentData = $componentData;
+            }
+        };
+
+        $factory->seedComponentState(['name' => 'FOO'], ['middle', 'wrapper'], [
+            ['name' => 'BAR'],
+            [],
+        ]);
+
+        $this->assertSame('BAR', $factory->getConsumableComponentData('name'));
+    }
+
+    public function testConsumableComponentDataPrefersCurrentComponentDataOverInheritedParentData()
+    {
+        $factory = new class(...$this->getFactoryArgs()) extends Factory
+        {
+            public function seedComponentState(array $currentComponentData, array $componentStack, array $componentData): void
+            {
+                $this->currentComponentData = $currentComponentData;
+                $this->componentStack = $componentStack;
+                $this->componentData = $componentData;
+            }
+        };
+
+        $factory->seedComponentState(['name' => 'BAR'], ['parent'], [
+            ['name' => 'FOO'],
+            ['name' => 'BAR'],
+        ]);
+
+        $this->assertSame('BAR', $factory->getConsumableComponentData('name'));
+    }
+
     public function testTranslation()
     {
         $container = new Container;


### PR DESCRIPTION
Fixes #57857.

When nested components reuse the same prop name, @aware may resolve a value from previously rendered ancestor component data before the nearest started parent component.

This changes getConsumableComponentData() to prefer the current component's explicit data, then the nearest started parent component data, and only then fall back to previously rendered ancestor data.

Tests:
- [x] ./vendor/bin/phpunit tests/View/ViewFactoryTest.php