### PR TITLE
[13x] Add `whereDoesntBelongTo()` methods for relationship querying

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -782,6 +782,66 @@ trait QueriesRelationships
     }
 
     /**
+     * Add a "belongs to" relationship where not clause to the query.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection<int, \Illuminate\Database\Eloquent\Model>  $related
+     * @param  string|null  $relationshipName
+     * @param  string  $boolean
+     * @return $this
+     *
+     * @throws \InvalidArgumentException
+     * @throws \Illuminate\Database\Eloquent\RelationNotFoundException
+     */
+    public function whereDoesntBelongTo($related, $relationshipName = null, $boolean = 'and')
+    {
+        if (! $related instanceof EloquentCollection) {
+            $relatedCollection = $related->newCollection([$related]);
+        } else {
+            $relatedCollection = $related;
+
+            $related = $relatedCollection->first();
+        }
+
+        if ($relatedCollection->isEmpty()) {
+            throw new InvalidArgumentException('Collection given to whereBelongsTo method may not be empty.');
+        }
+
+        if ($relationshipName === null) {
+            $relationshipName = Str::camel(class_basename($related));
+        }
+
+        try {
+            $relationship = $this->model->{$relationshipName}();
+        } catch (BadMethodCallException) {
+            throw RelationNotFoundException::make($this->model, $relationshipName);
+        }
+
+        if (! $relationship instanceof BelongsTo) {
+            throw RelationNotFoundException::make($this->model, $relationshipName, BelongsTo::class);
+        }
+
+        $this->whereNotIn(
+            $relationship->getQualifiedForeignKeyName(),
+            $relatedCollection->pluck($relationship->getOwnerKeyName())->toArray(),
+            $boolean,
+        );
+
+        return $this;
+    }
+
+    /**
+     * Add a "BelongsTo" relationship with an "or where not" clause to the query.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $related
+     * @param  string|null  $relationshipName
+     * @return $this
+     */
+    public function orWhereDoesntBelongTo($related, $relationshipName = null)
+    {
+        return $this->whereDoesntBelongTo($related, $relationshipName, 'or');
+    }
+
+    /**
      * Add a "belongs to many" relationship where clause to the query.
      *
      * @param  \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection<int, \Illuminate\Database\Eloquent\Model>  $related

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1279,6 +1279,59 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals($result, $builder);
     }
 
+    public function testWhereDoesntBelongTo()
+    {
+        $related = new EloquentBuilderTestWhereBelongsToStub([
+            'id' => 1,
+            'parent_id' => 2,
+        ]);
+
+        $parent = new EloquentBuilderTestWhereBelongsToStub([
+            'id' => 2,
+            'parent_id' => 1,
+        ]);
+
+        $builder = $this->getBuilder();
+        $builder->shouldReceive('from')->with('eloquent_builder_test_where_belongs_to_stubs');
+        $builder->setModel($related);
+        $builder->getQuery()->shouldReceive('whereNotIn')->once()->with('eloquent_builder_test_where_belongs_to_stubs.parent_id', [2], 'and');
+
+        $result = $builder->whereDoesntBelongTo($parent);
+        $this->assertEquals($result, $builder);
+
+        $builder = $this->getBuilder();
+        $builder->shouldReceive('from')->with('eloquent_builder_test_where_belongs_to_stubs');
+        $builder->setModel($related);
+        $builder->getQuery()->shouldReceive('whereNotIn')->once()->with('eloquent_builder_test_where_belongs_to_stubs.parent_id', [2], 'and');
+
+        $result = $builder->whereDoesntBelongTo($parent, 'parent');
+        $this->assertEquals($result, $builder);
+
+        $parents = new Collection([new EloquentBuilderTestWhereBelongsToStub([
+            'id' => 2,
+            'parent_id' => 1,
+        ]), new EloquentBuilderTestWhereBelongsToStub([
+            'id' => 3,
+            'parent_id' => 1,
+        ])]);
+
+        $builder = $this->getBuilder();
+        $builder->shouldReceive('from')->with('eloquent_builder_test_where_belongs_to_stubs');
+        $builder->setModel($related);
+        $builder->getQuery()->shouldReceive('whereNotIn')->once()->with('eloquent_builder_test_where_belongs_to_stubs.parent_id', [2, 3], 'and');
+
+        $result = $builder->whereDoesntBelongTo($parents);
+        $this->assertEquals($result, $builder);
+
+        $builder = $this->getBuilder();
+        $builder->shouldReceive('from')->with('eloquent_builder_test_where_belongs_to_stubs');
+        $builder->setModel($related);
+        $builder->getQuery()->shouldReceive('whereNotIn')->once()->with('eloquent_builder_test_where_belongs_to_stubs.parent_id', [2, 3], 'and');
+
+        $result = $builder->whereDoesntBelongTo($parents, 'parent');
+        $this->assertEquals($result, $builder);
+    }
+
     public function testWhereAttachedTo()
     {
         $related = new EloquentBuilderTestModelFarRelatedStub;


### PR DESCRIPTION
This PR adds two methods that are the inverse of `whereBelongsTo()` and `orWhereBelongsTo()`:

```
Model::query()->whereDoesntBelongTo(...);
Model::query()->orWhereDoesntBelongTo(...);
```

They mirror their counterparts exactly apart from using a `whereNotIn(...)` in place of the `whereIn(...)`.
The tests also have the same symmetry.

These feel like a natural addition in that they;
- Follow the `whereDoesnt...` nomenclature of other relationship query method inversions
- Save developers needing to write out the whole `whereNotIn($foreign_key, $derived_ids)` plus needing to derive the ids in the exact same way the `whereBelongsTo()` method does

### Optional

While looking for the method signatures and testing patterns, I noticed that the `orWhereBelongsTo()` does not have a dedicated test like other ors like `orWhereMorphedTo()` does. If this PR's idea is accepted and it's agreeable, I would be happy to add the missing coverage for this `or` method and the one it mirrors?