### PR TITLE
[13.x] Memoize the result of `TestCase@withoutBootingFramework()`

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -31,6 +31,13 @@ abstract class TestCase extends BaseTestCase
     protected array $traitsUsedByTest;
 
     /**
+     * Memoized result of the withoutBootingFramework check.
+     *
+     * @var bool|null
+     */
+    protected ?bool $withoutBootingFramework = null;
+
+    /**
      * Creates the application.
      *
      * @return \Illuminate\Foundation\Application
@@ -105,10 +112,14 @@ abstract class TestCase extends BaseTestCase
      */
     protected function withoutBootingFramework(): bool
     {
+        if ($this->withoutBootingFramework !== null) {
+            return $this->withoutBootingFramework;
+        }
+
         try {
-            return (new ReflectionMethod(static::class, $this->name()))->getAttributes(UnitTest::class) !== [];
+            return $this->withoutBootingFramework = (new ReflectionMethod(static::class, $this->name()))->getAttributes(UnitTest::class) !== [];
         } catch (Throwable) {
-            return false;
+            return $this->withoutBootingFramework = false;
         }
     }
 


### PR DESCRIPTION
I realize that I need to check this myself inside of our base test case, figured this was light-weight enough, but could benefit from caching and checking inside of the setUp() method there.