### PR TITLE
[13.x] Add `orderByFullText` to the query builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3099,6 +3099,46 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Add a fulltext relevance "order by" clause to the query.
+     *
+     * @param  string|string[]  $columns
+     * @param  string  $value
+     * @param  array  $options
+     * @param  string  $direction
+     * @return $this
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function orderByFullText($columns, $value, array $options = [], $direction = 'desc')
+    {
+        $columns = (array) $columns;
+
+        $direction = strtolower($direction);
+
+        if (! in_array($direction, ['asc', 'desc'], true)) {
+            throw new InvalidArgumentException('Order direction must be "asc" or "desc".');
+        }
+
+        return $this->orderByRaw(
+            $this->grammar->compileOrderByFullText($columns, $options, $direction),
+            [$value]
+        );
+    }
+
+    /**
+     * Add an ascending fulltext relevance "order by" clause to the query.
+     *
+     * @param  string|string[]  $columns
+     * @param  string  $value
+     * @param  array  $options
+     * @return $this
+     */
+    public function orderByFullTextAsc($columns, $value, array $options = [])
+    {
+        return $this->orderByFullText($columns, $value, $options, 'asc');
+    }
+
+    /**
      * Add a raw "order by" clause to the query.
      *
      * @param  literal-string  $sql

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -836,6 +836,19 @@ class Grammar extends BaseGrammar
     }
 
     /**
+     * Compile a fulltext relevance "order by" clause.
+     *
+     * @param  array  $columns
+     * @param  array  $options
+     * @param  string  $direction
+     * @return string
+     */
+    public function compileOrderByFullText($columns, array $options, $direction)
+    {
+        throw new RuntimeException('This database engine does not support fulltext search ordering.');
+    }
+
+    /**
      * Compile a clause based on an expression.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -134,6 +134,29 @@ class MySqlGrammar extends Grammar
     }
 
     /**
+     * Compile a fulltext relevance "order by" clause.
+     *
+     * @param  array  $columns
+     * @param  array  $options
+     * @param  string  $direction
+     * @return string
+     */
+    public function compileOrderByFullText($columns, array $options, $direction)
+    {
+        $columns = $this->columnize($columns);
+
+        $mode = ($options['mode'] ?? []) === 'boolean'
+            ? ' in boolean mode'
+            : ' in natural language mode';
+
+        $expanded = ($options['expanded'] ?? []) && ($options['mode'] ?? []) !== 'boolean'
+            ? ' with query expansion'
+            : '';
+
+        return "match ({$columns}) against (?{$mode}{$expanded}) {$direction}";
+    }
+
+    /**
      * Compile the index hints for the query.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -193,6 +193,43 @@ class PostgresGrammar extends Grammar
     }
 
     /**
+     * Compile a fulltext relevance "order by" clause.
+     *
+     * @param  array  $columns
+     * @param  array  $options
+     * @param  string  $direction
+     * @return string
+     */
+    public function compileOrderByFullText($columns, array $options, $direction)
+    {
+        $language = $options['language'] ?? 'english';
+
+        if (! in_array($language, $this->validFullTextLanguages())) {
+            $language = 'english';
+        }
+
+        $columns = (new Collection($columns))
+            ->map(fn ($column) => "to_tsvector('{$language}', {$this->wrap($column)})")
+            ->implode(' || ');
+
+        $mode = 'plainto_tsquery';
+
+        if (($options['mode'] ?? []) === 'phrase') {
+            $mode = 'phraseto_tsquery';
+        }
+
+        if (($options['mode'] ?? []) === 'websearch') {
+            $mode = 'websearch_to_tsquery';
+        }
+
+        if (($options['mode'] ?? []) === 'raw') {
+            $mode = 'to_tsquery';
+        }
+
+        return "ts_rank({$columns}, {$mode}('{$language}', ?)) {$direction}";
+    }
+
+    /**
      * Get an array of valid full text languages.
      *
      * @return array

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1699,6 +1699,89 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(['Car Plane'], $builder->getBindings());
     }
 
+    public function testOrderByFulltextMySql()
+    {
+        $builder = $this->getMySqlBuilderWithProcessor();
+        $builder->select('*')->from('users')->whereFullText('body', 'Hello World')->orderByFullText('body', 'Hello World');
+        $this->assertSame('select * from `users` where match (`body`) against (? in natural language mode) order by match (`body`) against (? in natural language mode) desc', $builder->toSql());
+        $this->assertEquals(['Hello World', 'Hello World'], $builder->getBindings());
+
+        $builder = $this->getMySqlBuilderWithProcessor();
+        $builder->select('*')->from('users')->orderByFullText('body', 'Hello World', ['expanded' => true]);
+        $this->assertSame('select * from `users` order by match (`body`) against (? in natural language mode with query expansion) desc', $builder->toSql());
+        $this->assertEquals(['Hello World'], $builder->getBindings());
+
+        $builder = $this->getMySqlBuilderWithProcessor();
+        $builder->select('*')->from('users')->orderByFullText('body', '+Hello -World', ['mode' => 'boolean']);
+        $this->assertSame('select * from `users` order by match (`body`) against (? in boolean mode) desc', $builder->toSql());
+        $this->assertEquals(['+Hello -World'], $builder->getBindings());
+
+        $builder = $this->getMySqlBuilderWithProcessor();
+        $builder->select('*')->from('users')->orderByFullText('body', '+Hello -World', ['mode' => 'boolean', 'expanded' => true]);
+        $this->assertSame('select * from `users` order by match (`body`) against (? in boolean mode) desc', $builder->toSql());
+        $this->assertEquals(['+Hello -World'], $builder->getBindings());
+
+        $builder = $this->getMySqlBuilderWithProcessor();
+        $builder->select('*')->from('users')->orderByFullText(['body', 'title'], 'Car,Plane');
+        $this->assertSame('select * from `users` order by match (`body`, `title`) against (? in natural language mode) desc', $builder->toSql());
+        $this->assertEquals(['Car,Plane'], $builder->getBindings());
+    }
+
+    public function testOrderByFulltextPostgres()
+    {
+        $builder = $this->getPostgresBuilderWithProcessor();
+        $builder->select('*')->from('users')->whereFullText('body', 'Hello World')->orderByFullText('body', 'Hello World');
+        $this->assertSame('select * from "users" where (to_tsvector(\'english\', "body")) @@ plainto_tsquery(\'english\', ?) order by ts_rank(to_tsvector(\'english\', "body"), plainto_tsquery(\'english\', ?)) desc', $builder->toSql());
+        $this->assertEquals(['Hello World', 'Hello World'], $builder->getBindings());
+
+        $builder = $this->getPostgresBuilderWithProcessor();
+        $builder->select('*')->from('users')->orderByFullText('body', 'Hello World', ['language' => 'simple']);
+        $this->assertSame('select * from "users" order by ts_rank(to_tsvector(\'simple\', "body"), plainto_tsquery(\'simple\', ?)) desc', $builder->toSql());
+        $this->assertEquals(['Hello World'], $builder->getBindings());
+
+        $builder = $this->getPostgresBuilderWithProcessor();
+        $builder->select('*')->from('users')->orderByFullText('body', 'Hello World', ['mode' => 'phrase']);
+        $this->assertSame('select * from "users" order by ts_rank(to_tsvector(\'english\', "body"), phraseto_tsquery(\'english\', ?)) desc', $builder->toSql());
+        $this->assertEquals(['Hello World'], $builder->getBindings());
+
+        $builder = $this->getPostgresBuilderWithProcessor();
+        $builder->select('*')->from('users')->orderByFullText('body', '+Hello -World', ['mode' => 'websearch']);
+        $this->assertSame('select * from "users" order by ts_rank(to_tsvector(\'english\', "body"), websearch_to_tsquery(\'english\', ?)) desc', $builder->toSql());
+        $this->assertEquals(['+Hello -World'], $builder->getBindings());
+
+        $builder = $this->getPostgresBuilderWithProcessor();
+        $builder->select('*')->from('users')->orderByFullText(['body', 'title'], 'Car Plane');
+        $this->assertSame('select * from "users" order by ts_rank(to_tsvector(\'english\', "body") || to_tsvector(\'english\', "title"), plainto_tsquery(\'english\', ?)) desc', $builder->toSql());
+        $this->assertEquals(['Car Plane'], $builder->getBindings());
+
+        $builder = $this->getPostgresBuilderWithProcessor();
+        $builder->select('*')->from('users')->orderByFullText('body', 'Hello World', ['language' => 'simple', 'mode' => 'phrase']);
+        $this->assertSame('select * from "users" order by ts_rank(to_tsvector(\'simple\', "body"), phraseto_tsquery(\'simple\', ?)) desc', $builder->toSql());
+        $this->assertEquals(['Hello World'], $builder->getBindings());
+
+        $builder = $this->getPostgresBuilderWithProcessor();
+        $builder->select('*')->from('users')->orderByFullText('body', 'Hello World', [], 'asc');
+        $this->assertSame('select * from "users" order by ts_rank(to_tsvector(\'english\', "body"), plainto_tsquery(\'english\', ?)) asc', $builder->toSql());
+        $this->assertEquals(['Hello World'], $builder->getBindings());
+    }
+
+    public function testOrderByFulltextInvalidDirection()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $builder = $this->getPostgresBuilderWithProcessor();
+        $builder->select('*')->from('users')->orderByFullText('body', 'Hello World', [], 'asec');
+    }
+
+    public function testOrderByFulltextUnsupportedDriver()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('This database engine does not support fulltext search ordering.');
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->orderByFullText('body', 'Hello World');
+    }
+
     public function testWhereAll()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
## Summary

`whereFullText()` filters by relevance but can't sort by it. Ranking results requires raw, database-specific SQL. This adds `orderByFullText()`.

## Before

```php
// PostgreSQL - single column
Post::whereFullText('body', 'laravel')
    ->orderByRaw("ts_rank(to_tsvector('english', body), plainto_tsquery('english', ?)) desc", ['laravel'])
    ->get();

// PostgreSQL - multiple columns
Post::whereFullText(['title', 'body'], 'laravel')
    ->orderByRaw("ts_rank(to_tsvector('english', title) || to_tsvector('english', body), plainto_tsquery('english', ?)) desc", ['laravel'])
    ->get();

// MySQL - single column
Post::whereFullText('body', 'laravel')
    ->orderByRaw("match (body) against (? in natural language mode) desc", ['laravel'])
    ->get();

// MySQL - multiple columns
Post::whereFullText(['title', 'body'], 'laravel')
    ->orderByRaw("match (title, body) against (? in natural language mode) desc", ['laravel'])
    ->get();
```

## After

```php
// Single column - works on both PostgreSQL and MySQL
Post::whereFullText('body', 'laravel')
    ->orderByFullText('body', 'laravel')
    ->get();

// Multiple columns
Post::whereFullText(['title', 'body'], 'laravel')
    ->orderByFullText(['title', 'body'], 'laravel')
    ->get();

// With language (PostgreSQL)
Post::whereFullText('body', 'laravel', ['language' => 'french'])
    ->orderByFullText('body', 'laravel', ['language' => 'french'])
    ->get();

// With search mode (PostgreSQL)
Post::whereFullText('body', '+laravel -ruby', ['mode' => 'websearch'])
    ->orderByFullText('body', '+laravel -ruby', ['mode' => 'websearch'])
    ->get();

// Ascending (lowest relevance first)
Post::orderByFullText('body', 'laravel', [], 'asc')->get();
```

Supports PostgreSQL (`ts_rank`) and MySQL (`MATCH ... AGAINST` as a relevance score). Defaults to `desc`.
