### PR TITLE
[13.x] Fix RedisQueueTest

### DIFF
--- a/tests/Integration/Queue/RedisQueueTest.php
+++ b/tests/Integration/Queue/RedisQueueTest.php
@@ -62,9 +62,9 @@ class RedisQueueTest extends TestCase
         $this->queue->setContainer($this->container);
     }
 
-    private function getRedisKey($queue = null)
+    private function getQueueRedisKey($queue = null)
     {
-        return (new \ReflectionMethod($this->queue, 'getRedisKey'))->invoke($this->queue, $queue);
+        return (new \ReflectionMethod($this->queue, 'getQueueRedisKey'))->invoke($this->queue, $queue);
     }
 
     /**
@@ -93,7 +93,7 @@ class RedisQueueTest extends TestCase
         $this->assertEquals($jobs[3], unserialize(json_decode($this->queue->pop()->getRawBody())->data->command));
         $this->assertNull($this->queue->pop());
 
-        $redisKey = $this->getRedisKey($default);
+        $redisKey = $this->getQueueRedisKey($default);
         $this->assertEquals(1, $this->redis[$driver]->connection()->zcard("$redisKey:delayed"));
         $this->assertEquals(3, $this->redis[$driver]->connection()->zcard("$redisKey:reserved"));
     }
@@ -168,7 +168,7 @@ class RedisQueueTest extends TestCase
         $this->assertEquals($redisJob->getJobId(), json_decode($redisJob->getReservedJob())->id);
 
         // Check reserved queue
-        $redisKey = $this->getRedisKey($default);
+        $redisKey = $this->getQueueRedisKey($default);
         $this->assertEquals(1, $this->redis[$driver]->connection()->zcard("$redisKey:reserved"));
         $result = $this->redis[$driver]->connection()->zrangebyscore("$redisKey:reserved", -INF, INF, ['withscores' => true]);
         $reservedJob = array_keys($result)[0];
@@ -196,7 +196,7 @@ class RedisQueueTest extends TestCase
         $after = $this->currentTime();
 
         // Check reserved queue
-        $redisKey = $this->getRedisKey($default);
+        $redisKey = $this->getQueueRedisKey($default);
         $this->assertEquals(1, $this->redis[$driver]->connection()->zcard("$redisKey:reserved"));
         $result = $this->redis[$driver]->connection()->zrangebyscore("$redisKey:reserved", -INF, INF, ['withscores' => true]);
         $reservedJob = array_keys($result)[0];
@@ -227,7 +227,7 @@ class RedisQueueTest extends TestCase
         $after = $this->currentTime();
 
         // Check reserved queue
-        $redisKey = $this->getRedisKey($default);
+        $redisKey = $this->getQueueRedisKey($default);
         $this->assertEquals(1, $this->redis[$driver]->connection()->zcard("$redisKey:reserved"));
         $result = $this->redis[$driver]->connection()->zrangebyscore("$redisKey:reserved", -INF, INF, ['withscores' => true]);
         $reservedJob = array_keys($result)[0];
@@ -282,7 +282,7 @@ class RedisQueueTest extends TestCase
         $this->assertEquals($jobs[0], unserialize(json_decode($this->queue->pop()->getRawBody())->data->command));
         $this->assertEquals($jobs[1], unserialize(json_decode($this->queue->pop()->getRawBody())->data->command));
 
-        $redisKey = $this->getRedisKey($default);
+        $redisKey = $this->getQueueRedisKey($default);
         $this->assertEquals(0, $this->redis[$driver]->connection()->llen("$redisKey:notify"));
         $this->assertEquals(0, $this->redis[$driver]->connection()->zcard("$redisKey:delayed"));
         $this->assertEquals(2, $this->redis[$driver]->connection()->zcard("$redisKey:reserved"));
@@ -319,7 +319,7 @@ class RedisQueueTest extends TestCase
         $after = $this->currentTime();
 
         // Check reserved queue
-        $redisKey = $this->getRedisKey($default);
+        $redisKey = $this->getQueueRedisKey($default);
         $this->assertEquals(2, $this->redis[$driver]->connection()->zcard("$redisKey:reserved"));
         $result = $this->redis[$driver]->connection()->zrangebyscore("$redisKey:reserved", -INF, INF, ['withscores' => true]);
 
@@ -360,7 +360,7 @@ class RedisQueueTest extends TestCase
         $after = $this->currentTime();
 
         // Check reserved queue
-        $redisKey = $this->getRedisKey($default);
+        $redisKey = $this->getQueueRedisKey($default);
         $this->assertEquals(1, $this->redis[$driver]->connection()->zcard("$redisKey:reserved"));
         $result = $this->redis[$driver]->connection()->zrangebyscore("$redisKey:reserved", -INF, INF, ['withscores' => true]);
         $reservedJob = array_keys($result)[0];
@@ -391,7 +391,7 @@ class RedisQueueTest extends TestCase
         $after = $this->currentTime();
 
         // check the content of delayed queue
-        $redisKey = $this->getRedisKey($default);
+        $redisKey = $this->getQueueRedisKey($default);
         $this->assertEquals(1, $this->redis[$driver]->connection()->zcard("$redisKey:delayed"));
 
         $results = $this->redis[$driver]->connection()->zrangebyscore("$redisKey:delayed", -INF, INF, ['withscores' => true]);
@@ -447,7 +447,7 @@ class RedisQueueTest extends TestCase
 
         $redisJob->delete();
 
-        $redisKey = $this->getRedisKey($default);
+        $redisKey = $this->getQueueRedisKey($default);
         $this->assertEquals(0, $this->redis[$driver]->connection()->zcard("$redisKey:delayed"));
         $this->assertEquals(0, $this->redis[$driver]->connection()->zcard("$redisKey:reserved"));
         $this->assertEquals(0, $this->redis[$driver]->connection()->llen("$redisKey"));
@@ -472,7 +472,7 @@ class RedisQueueTest extends TestCase
 
         $this->assertEquals(2, $this->queue->clear(null));
         $this->assertEquals(0, $this->queue->size());
-        $redisKey = $this->getRedisKey($default);
+        $redisKey = $this->getQueueRedisKey($default);
         $this->assertEquals(0, $this->redis[$driver]->connection()->llen("$redisKey:notify"));
     }
 

--- a/tests/Queue/QueueRedisQueueTest.php
+++ b/tests/Queue/QueueRedisQueueTest.php
@@ -206,8 +206,8 @@ class QueueRedisQueueTest extends TestCase
         $connection->shouldReceive('isCluster')->andReturn(false);
         $redis->shouldReceive('connection')->andReturn($connection);
 
-        $this->assertSame('queues:default', $queue->testGetRedisKey(null));
-        $this->assertSame('queues:emails', $queue->testGetRedisKey('emails'));
+        $this->assertSame('queues:default', $queue->testgetQueueRedisKey(null));
+        $this->assertSame('queues:emails', $queue->testgetQueueRedisKey('emails'));
     }
 
     public function testGetRedisKeyWrapsWithHashTagsForPhpRedisCluster()
@@ -217,8 +217,8 @@ class QueueRedisQueueTest extends TestCase
         $connection->shouldReceive('isCluster')->andReturn(true);
         $redis->shouldReceive('connection')->andReturn($connection);
 
-        $this->assertSame('queues:{default}', $queue->testGetRedisKey(null));
-        $this->assertSame('queues:{emails}', $queue->testGetRedisKey('emails'));
+        $this->assertSame('queues:{default}', $queue->testgetQueueRedisKey(null));
+        $this->assertSame('queues:{emails}', $queue->testgetQueueRedisKey('emails'));
     }
 
     public function testGetRedisKeyWrapsWithHashTagsForPredisCluster()
@@ -228,8 +228,8 @@ class QueueRedisQueueTest extends TestCase
         $connection->shouldReceive('isCluster')->andReturn(true);
         $redis->shouldReceive('connection')->andReturn($connection);
 
-        $this->assertSame('queues:{default}', $queue->testGetRedisKey(null));
-        $this->assertSame('queues:{emails}', $queue->testGetRedisKey('emails'));
+        $this->assertSame('queues:{default}', $queue->testgetQueueRedisKey(null));
+        $this->assertSame('queues:{emails}', $queue->testgetQueueRedisKey('emails'));
     }
 
     public function testGetRedisKeyDoesNotDoubleWrapExistingHashTags()
@@ -239,8 +239,8 @@ class QueueRedisQueueTest extends TestCase
         $connection->shouldReceive('isCluster')->andReturn(true);
         $redis->shouldReceive('connection')->andReturn($connection);
 
-        $this->assertSame('queues:{default}', $queue->testGetRedisKey(null));
-        $this->assertSame('queues:{custom}', $queue->testGetRedisKey('{custom}'));
+        $this->assertSame('queues:{default}', $queue->testgetQueueRedisKey(null));
+        $this->assertSame('queues:{custom}', $queue->testgetQueueRedisKey('{custom}'));
     }
 
     public function testGetRedisKeySkipsWrappingWhenQueueNameContainsBraces()
@@ -251,7 +251,7 @@ class QueueRedisQueueTest extends TestCase
         $redis->shouldReceive('connection')->andReturn($connection);
 
         // Queue name already contains hash tags — skip wrapping
-        $this->assertSame('queues:process-{batch}-results', $queue->testGetRedisKey('process-{batch}-results'));
+        $this->assertSame('queues:process-{batch}-results', $queue->testgetQueueRedisKey('process-{batch}-results'));
     }
 
     public function testGetRedisKeyWrapsEmptyHashTagOnCluster()
@@ -262,7 +262,7 @@ class QueueRedisQueueTest extends TestCase
         $redis->shouldReceive('connection')->andReturn($connection);
 
         // Empty braces '{}' are not a valid hash tag — should still get wrapped
-        $this->assertSame('queues:{my{}queue}', $queue->testGetRedisKey('my{}queue'));
+        $this->assertSame('queues:{my{}queue}', $queue->testgetQueueRedisKey('my{}queue'));
     }
 
     public function testGetRedisKeyWrapsUnmatchedOpeningBrace()
@@ -273,7 +273,7 @@ class QueueRedisQueueTest extends TestCase
         $redis->shouldReceive('connection')->andReturn($connection);
 
         // Unmatched '{' is not a valid hash tag — should still get wrapped
-        $this->assertSame('queues:{my{broken}', $queue->testGetRedisKey('my{broken'));
+        $this->assertSame('queues:{my{broken}', $queue->testgetQueueRedisKey('my{broken'));
     }
 
     public function testGetRedisKeyWrapsUnmatchedClosingBrace()
@@ -284,7 +284,7 @@ class QueueRedisQueueTest extends TestCase
         $redis->shouldReceive('connection')->andReturn($connection);
 
         // Unmatched '}' is not a valid hash tag — should still get wrapped
-        $this->assertSame('queues:{broken}queue}', $queue->testGetRedisKey('broken}queue'));
+        $this->assertSame('queues:{broken}queue}', $queue->testgetQueueRedisKey('broken}queue'));
     }
 
     public function testGetRedisKeyWrapsEmptyFirstHashTagFollowedByValidPair()
@@ -296,7 +296,7 @@ class QueueRedisQueueTest extends TestCase
 
         // Redis spec: the first '{}' is an empty hash tag, so the whole key is hashed
         // even though '{bar}' looks valid. Must be wrapped to ensure slot affinity.
-        $this->assertSame('queues:{foo{}{bar}}', $queue->testGetRedisKey('foo{}{bar}'));
+        $this->assertSame('queues:{foo{}{bar}}', $queue->testgetQueueRedisKey('foo{}{bar}'));
     }
 
     public function testPushUsesGetRedisKeyForLuaScript()
@@ -421,9 +421,9 @@ class QueueRedisQueueTest extends TestCase
 
 class TestableRedisQueue extends RedisQueue
 {
-    public function testGetRedisKey($queue = null)
+    public function testgetQueueRedisKey($queue = null)
     {
-        return $this->getRedisKey($queue);
+        return $this->getQueueRedisKey($queue);
     }
 
     public function testIsClusterConnection()

--- a/tests/Queue/QueueRedisQueueTest.php
+++ b/tests/Queue/QueueRedisQueueTest.php
@@ -206,8 +206,8 @@ class QueueRedisQueueTest extends TestCase
         $connection->shouldReceive('isCluster')->andReturn(false);
         $redis->shouldReceive('connection')->andReturn($connection);
 
-        $this->assertSame('queues:default', $queue->testgetQueueRedisKey(null));
-        $this->assertSame('queues:emails', $queue->testgetQueueRedisKey('emails'));
+        $this->assertSame('queues:default', $queue->testGetQueueRedisKey(null));
+        $this->assertSame('queues:emails', $queue->testGetQueueRedisKey('emails'));
     }
 
     public function testGetRedisKeyWrapsWithHashTagsForPhpRedisCluster()
@@ -217,8 +217,8 @@ class QueueRedisQueueTest extends TestCase
         $connection->shouldReceive('isCluster')->andReturn(true);
         $redis->shouldReceive('connection')->andReturn($connection);
 
-        $this->assertSame('queues:{default}', $queue->testgetQueueRedisKey(null));
-        $this->assertSame('queues:{emails}', $queue->testgetQueueRedisKey('emails'));
+        $this->assertSame('queues:{default}', $queue->testGetQueueRedisKey(null));
+        $this->assertSame('queues:{emails}', $queue->testGetQueueRedisKey('emails'));
     }
 
     public function testGetRedisKeyWrapsWithHashTagsForPredisCluster()
@@ -228,8 +228,8 @@ class QueueRedisQueueTest extends TestCase
         $connection->shouldReceive('isCluster')->andReturn(true);
         $redis->shouldReceive('connection')->andReturn($connection);
 
-        $this->assertSame('queues:{default}', $queue->testgetQueueRedisKey(null));
-        $this->assertSame('queues:{emails}', $queue->testgetQueueRedisKey('emails'));
+        $this->assertSame('queues:{default}', $queue->testGetQueueRedisKey(null));
+        $this->assertSame('queues:{emails}', $queue->testGetQueueRedisKey('emails'));
     }
 
     public function testGetRedisKeyDoesNotDoubleWrapExistingHashTags()
@@ -239,8 +239,8 @@ class QueueRedisQueueTest extends TestCase
         $connection->shouldReceive('isCluster')->andReturn(true);
         $redis->shouldReceive('connection')->andReturn($connection);
 
-        $this->assertSame('queues:{default}', $queue->testgetQueueRedisKey(null));
-        $this->assertSame('queues:{custom}', $queue->testgetQueueRedisKey('{custom}'));
+        $this->assertSame('queues:{default}', $queue->testGetQueueRedisKey(null));
+        $this->assertSame('queues:{custom}', $queue->testGetQueueRedisKey('{custom}'));
     }
 
     public function testGetRedisKeySkipsWrappingWhenQueueNameContainsBraces()
@@ -251,7 +251,7 @@ class QueueRedisQueueTest extends TestCase
         $redis->shouldReceive('connection')->andReturn($connection);
 
         // Queue name already contains hash tags — skip wrapping
-        $this->assertSame('queues:process-{batch}-results', $queue->testgetQueueRedisKey('process-{batch}-results'));
+        $this->assertSame('queues:process-{batch}-results', $queue->testGetQueueRedisKey('process-{batch}-results'));
     }
 
     public function testGetRedisKeyWrapsEmptyHashTagOnCluster()
@@ -262,7 +262,7 @@ class QueueRedisQueueTest extends TestCase
         $redis->shouldReceive('connection')->andReturn($connection);
 
         // Empty braces '{}' are not a valid hash tag — should still get wrapped
-        $this->assertSame('queues:{my{}queue}', $queue->testgetQueueRedisKey('my{}queue'));
+        $this->assertSame('queues:{my{}queue}', $queue->testGetQueueRedisKey('my{}queue'));
     }
 
     public function testGetRedisKeyWrapsUnmatchedOpeningBrace()
@@ -273,7 +273,7 @@ class QueueRedisQueueTest extends TestCase
         $redis->shouldReceive('connection')->andReturn($connection);
 
         // Unmatched '{' is not a valid hash tag — should still get wrapped
-        $this->assertSame('queues:{my{broken}', $queue->testgetQueueRedisKey('my{broken'));
+        $this->assertSame('queues:{my{broken}', $queue->testGetQueueRedisKey('my{broken'));
     }
 
     public function testGetRedisKeyWrapsUnmatchedClosingBrace()
@@ -284,7 +284,7 @@ class QueueRedisQueueTest extends TestCase
         $redis->shouldReceive('connection')->andReturn($connection);
 
         // Unmatched '}' is not a valid hash tag — should still get wrapped
-        $this->assertSame('queues:{broken}queue}', $queue->testgetQueueRedisKey('broken}queue'));
+        $this->assertSame('queues:{broken}queue}', $queue->testGetQueueRedisKey('broken}queue'));
     }
 
     public function testGetRedisKeyWrapsEmptyFirstHashTagFollowedByValidPair()
@@ -296,7 +296,7 @@ class QueueRedisQueueTest extends TestCase
 
         // Redis spec: the first '{}' is an empty hash tag, so the whole key is hashed
         // even though '{bar}' looks valid. Must be wrapped to ensure slot affinity.
-        $this->assertSame('queues:{foo{}{bar}}', $queue->testgetQueueRedisKey('foo{}{bar}'));
+        $this->assertSame('queues:{foo{}{bar}}', $queue->testGetQueueRedisKey('foo{}{bar}'));
     }
 
     public function testPushUsesGetRedisKeyForLuaScript()
@@ -421,7 +421,7 @@ class QueueRedisQueueTest extends TestCase
 
 class TestableRedisQueue extends RedisQueue
 {
-    public function testgetQueueRedisKey($queue = null)
+    public function testGetQueueRedisKey($queue = null)
     {
         return $this->getQueueRedisKey($queue);
     }


### PR DESCRIPTION
Good morning! 

I am an avid watcher of the framework for new stuff, yah I'm sad like that, but noticed a bunch of tests going craaaazy see: https://github.com/laravel/framework/actions/runs/24197067940/job/70629967850

This method was renamed, but the test wasnt' afaik.. so this fixes that.