### PR TITLE
[13.x] Fix operator precedence in SqsQueue size methods

### DIFF
--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -99,7 +99,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
             'AttributeNames' => ['ApproximateNumberOfMessages'],
         ]);
 
-        return (int) $response['Attributes']['ApproximateNumberOfMessages'] ?? 0;
+        return (int) ($response['Attributes']['ApproximateNumberOfMessages'] ?? 0);
     }
 
     /**
@@ -115,7 +115,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
             'AttributeNames' => ['ApproximateNumberOfMessagesDelayed'],
         ]);
 
-        return (int) $response['Attributes']['ApproximateNumberOfMessagesDelayed'] ?? 0;
+        return (int) ($response['Attributes']['ApproximateNumberOfMessagesDelayed'] ?? 0);
     }
 
     /**
@@ -131,7 +131,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
             'AttributeNames' => ['ApproximateNumberOfMessagesNotVisible'],
         ]);
 
-        return (int) $response['Attributes']['ApproximateNumberOfMessagesNotVisible'] ?? 0;
+        return (int) ($response['Attributes']['ApproximateNumberOfMessagesNotVisible'] ?? 0);
     }
 
     /**


### PR DESCRIPTION
## Summary

- The `(int)` cast binds tighter than the `??` null-coalescing operator, so the fallback `?? 0` on the return statements in `size()`, `pendingCount()`, and `laterCount()` was dead code
- Added parentheses around the null-coalescing expressions so the fallback value of `0` is correctly used when the array key is missing