### PR TITLE
[13.x] Fix race condition in Worker maxExceptions counter

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -629,12 +629,12 @@ class Worker
             return;
         }
 
-        if (! $this->cache->get('job-exceptions:'.$uuid)) {
-            $this->cache->put('job-exceptions:'.$uuid, 0, Carbon::now()->addDay());
-        }
+        $key = 'job-exceptions:'.$uuid;
 
-        if ($maxExceptions <= $this->cache->increment('job-exceptions:'.$uuid)) {
-            $this->cache->forget('job-exceptions:'.$uuid);
+        $this->cache->add($key, 0, Carbon::now()->addDay());
+
+        if ($maxExceptions <= $this->cache->increment($key)) {
+            $this->cache->forget($key);
 
             $this->failJob($job, $e);
         }


### PR DESCRIPTION
## Summary

- Replace non-atomic `get`/`put` sequence with `Cache::add()` in `Worker::markJobAsFailedIfWillExceedMaxExceptions` to eliminate a TOCTOU race condition
- When multiple workers process retries of the same job UUID simultaneously, the previous `get`-then-`put` could allow both workers to see a missing key and reset the counter, causing the exception count to be lost
- `Cache::add()` is atomic (set-if-not-exists), ensuring only one worker initializes the counter while others proceed directly to increment