### PR TITLE
[13.x] Fix variable shadowing in Worker getNextJob loop

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -400,12 +400,12 @@ class Worker
                 return $job;
             }
 
-            foreach (explode(',', $queue) as $index => $queue) {
-                if ($this->queuePaused($connection->getConnectionName(), $queue)) {
+            foreach (explode(',', $queue) as $index => $queueName) {
+                if ($this->queuePaused($connection->getConnectionName(), $queueName)) {
                     continue;
                 }
 
-                if (! is_null($job = $popJobCallback($queue, $index))) {
+                if (! is_null($job = $popJobCallback($queueName, $index))) {
                     $this->raiseAfterJobPopEvent($connection->getConnectionName(), $job);
 
                     return $job;


### PR DESCRIPTION
## Summary

The `foreach` loop in `Worker::getNextJob()` reused `$queue` as the loop variable, shadowing the method parameter. This renames the loop variable to `$queueName` to avoid the shadowing and prevent potential issues if the original comma-separated queue string is needed after the loop.