### PR TITLE
[13.x] Fix RateLimited middleware incrementing limiter before job runs

### DIFF
--- a/src/Illuminate/Queue/Middleware/RateLimited.php
+++ b/src/Illuminate/Queue/Middleware/RateLimited.php
@@ -99,11 +99,15 @@ class RateLimited
                     ? $job->release($this->releaseAfter ?: $this->getTimeUntilNextRetry($limit->key))
                     : false;
             }
+        }
 
+        $response = $next($job);
+
+        foreach ($limits as $limit) {
             $this->limiter->hit($limit->key, $limit->decaySeconds);
         }
 
-        return $next($job);
+        return $response;
     }
 
     /**


### PR DESCRIPTION
## Summary

The `RateLimited` queue middleware's `handleJob()` method calls `hit()` on the rate limiter **before** executing the job. If the job subsequently fails (throws an exception), the rate limit counter has already been consumed, penalizing failed attempts against the rate limit capacity.

This moves the `hit()` calls to **after** `$next($job)` returns successfully, so only completed job executions count against the rate limit.