### PR TITLE
[13.x] Fix Worker sleep truncating fractional seconds

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -900,11 +900,7 @@ class Worker
      */
     public function sleep($seconds)
     {
-        if ($seconds < 1) {
-            usleep($seconds * 1_000_000);
-        } else {
-            sleep($seconds);
-        }
+        usleep((int) ($seconds * 1_000_000));
     }
 
     /**


### PR DESCRIPTION
## Summary

The `Worker::sleep()` method uses PHP's `sleep()` for values >= 1 second, which casts to int and silently truncates fractional seconds (e.g., 1.5 becomes 1). This replaces the branching logic with a single `usleep()` call that correctly handles both integer and fractional sleep durations.