### PR TITLE
[13.x] Fix double queue name resolution in DatabaseQueue bulk

### DIFF
--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -269,7 +269,7 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
             function ($job) use ($queue, $data, $now) {
                 return $this->buildDatabaseRecord(
                     $queue,
-                    $this->createPayload($job, $this->getQueue($queue), $data),
+                    $this->createPayload($job, $queue, $data),
                     isset($job->delay) ? $this->availableAt($job->delay) : $now,
                 );
             }


### PR DESCRIPTION
## Summary

In `DatabaseQueue::bulk()`, the queue name is resolved via `$this->getQueue($queue)` at the top of the method (line 264), but was then passed through `getQueue()` a second time inside the `createPayload()` call. This removes the redundant second resolution to match the behavior of other methods that resolve the queue name once upfront.