### PR TITLE
[13.x] Fix RedisStore putMany discarding MULTI/EXEC results

### DIFF
--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -162,19 +162,14 @@ class RedisStore extends TaggableStore implements CanFlushLocks, LockProvider
 
         $connection->multi();
 
-        $manyResult = null;
-
         foreach ($serializedValues as $key => $value) {
-            $result = (bool) $connection->setex(
+            $connection->setex(
                 $key, (int) max(1, $seconds), $value
             );
-
-            $manyResult = is_null($manyResult) ? $result : $result && $manyResult;
         }
+        $results = $connection->exec();
 
-        $connection->exec();
-
-        return $manyResult ?: false;
+        return is_array($results) && ! in_array(false, $results, true);
     }
 
     /**

--- a/tests/Cache/CacheRedisStoreTest.php
+++ b/tests/Cache/CacheRedisStoreTest.php
@@ -72,7 +72,7 @@ class CacheRedisStoreTest extends TestCase
         $redis->getRedis()->shouldReceive('setex')->once()->with('prefix:foo', 60, serialize('bar'))->andReturn('OK');
         $redis->getRedis()->shouldReceive('setex')->once()->with('prefix:baz', 60, serialize('qux'))->andReturn('OK');
         $redis->getRedis()->shouldReceive('setex')->once()->with('prefix:bar', 60, serialize('norf'))->andReturn('OK');
-        $connection->shouldReceive('exec')->once();
+        $connection->shouldReceive('exec')->once()->andReturn(['OK', 'OK', 'OK']);
 
         $result = $redis->putMany([
             'foo' => 'bar',


### PR DESCRIPTION
## Summary

In `RedisStore::putMany()`, the return values from individual `setex()` calls inside a `MULTI` transaction are Redis connection objects (for chaining), not actual command results. The real results are returned by `exec()`, which was being discarded.

This fix uses the `exec()` return value to determine success, checking that all commands in the transaction completed without failure.