### PR TITLE
[13.x] Fix BroadcastEvent deleteWhenMissingModels default

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastEvent.php
+++ b/src/Illuminate/Broadcasting/BroadcastEvent.php
@@ -76,7 +76,7 @@ class BroadcastEvent implements ShouldQueue
         $this->backoff = $this->getAttributeValue($event, Backoff::class, 'backoff');
         $this->afterCommit = property_exists($event, 'afterCommit') ? $event->afterCommit : null;
         $this->maxExceptions = $this->getAttributeValue($event, MaxExceptions::class, 'maxExceptions');
-        $this->deleteWhenMissingModels = $this->getAttributeValue($event, DeleteWhenMissingModels::class, 'deleteWhenMissingModels');
+        $this->deleteWhenMissingModels = $this->getAttributeValue($event, DeleteWhenMissingModels::class, 'deleteWhenMissingModels') ?? true;
     }
 
     /**


### PR DESCRIPTION
## Summary

- `BroadcastEvent::deleteWhenMissingModels` defaults to `true` (line 64), but `getAttributeValue()` returns `null` when the attribute isn't set on the event, which silently overrides the default to `null` (falsy)
- Added null coalescing (`?? true`) to preserve the intended default behavior when `getAttributeValue()` returns `null`