### PR TITLE
[13.x] Fix DatabaseStore incrementOrDecrement numeric check order

### DIFF
--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -292,11 +292,11 @@ class DatabaseStore implements CanFlushLocks, LockProvider, Store
             // Here we'll call this callback function that was given to the function which
             // is used to either increment or decrement the function. We use a callback
             // so we do not have to recreate all this logic in each of the functions.
-            $new = $callback((int) $current, $value);
-
             if (! is_numeric($current)) {
                 return false;
             }
+
+            $new = $callback((int) $current, $value);
 
             // Here we will update the values in the table. We will also encrypt the value
             // since database cache values are encrypted by default with secure storage


### PR DESCRIPTION
## Summary

In `DatabaseStore::incrementOrDecrement`, the callback computation (`$new = $callback((int) $current, $value)`) was executed before validating that `$current` is numeric. This meant we were unnecessarily casting and computing a value that would immediately be discarded when the `is_numeric` check failed on the next line.

This moves the `is_numeric` guard above the callback invocation so we bail early before doing any work with an invalid value.