### PR TITLE
[13.x] Fix TokenGuard treating falsy token values as absent

### DIFF
--- a/src/Illuminate/Auth/TokenGuard.php
+++ b/src/Illuminate/Auth/TokenGuard.php
@@ -97,9 +97,9 @@ class TokenGuard implements Guard
     public function getTokenForRequest()
     {
         return $this->request->query($this->inputKey)
-            ?: $this->request->input($this->inputKey)
-            ?: $this->request->bearerToken()
-            ?: $this->request->getPassword();
+            ?? $this->request->input($this->inputKey)
+            ?? $this->request->bearerToken()
+            ?? $this->request->getPassword();
     }
 
     /**


### PR DESCRIPTION
## Summary

- Replace `?:` (ternary shorthand) with `??` (null coalescing) in `TokenGuard::getTokenForRequest()` so that falsy but valid token values (e.g. `"0"`) are not incorrectly skipped in favor of the next token source.
- The `?:` operator treats any falsy value as absent, while `??` only falls through on `null`, which is the correct behavior when checking for a missing token.