### PR TITLE
[13.x] Add explicit null check in DatabaseSessionHandler read

### DIFF
--- a/src/Illuminate/Session/DatabaseSessionHandler.php
+++ b/src/Illuminate/Session/DatabaseSessionHandler.php
@@ -93,7 +93,13 @@ class DatabaseSessionHandler implements ExistenceAwareInterface, SessionHandlerI
      */
     public function read($sessionId): string|false
     {
-        $session = (object) $this->getQuery()->find($sessionId);
+        $session = $this->getQuery()->find($sessionId);
+
+        if (is_null($session)) {
+            return '';
+        }
+
+        $session = (object) $session;
 
         if ($this->expired($session)) {
             $this->exists = true;


### PR DESCRIPTION
## Summary

- In `DatabaseSessionHandler::read()`, `getQuery()->find()` returns `null` when no session record exists. Previously, this `null` was cast to an empty `stdClass` via `(object)`, which happened to work but was fragile and unclear in intent.
- Added an explicit `null` check with an early return before casting the result to an object, making the control flow clearer and avoiding unnecessary object casting.