### PR TITLE
[13.x] Use SHA-256 for email verification hash

### DIFF
--- a/src/Illuminate/Auth/Notifications/VerifyEmail.php
+++ b/src/Illuminate/Auth/Notifications/VerifyEmail.php
@@ -85,7 +85,7 @@ class VerifyEmail extends Notification
             Carbon::now()->addMinutes(Config::get('auth.verification.expire', 60)),
             [
                 'id' => $notifiable->getKey(),
-                'hash' => sha1($notifiable->getEmailForVerification()),
+                'hash' => hash('sha256', $notifiable->getEmailForVerification()),
             ]
         );
     }

--- a/src/Illuminate/Foundation/Auth/EmailVerificationRequest.php
+++ b/src/Illuminate/Foundation/Auth/EmailVerificationRequest.php
@@ -19,7 +19,7 @@ class EmailVerificationRequest extends FormRequest
             return false;
         }
 
-        if (! hash_equals(sha1($this->user()->getEmailForVerification()), (string) $this->route('hash'))) {
+        if (! hash_equals(hash('sha256', $this->user()->getEmailForVerification()), (string) $this->route('hash'))) {
             return false;
         }
 


### PR DESCRIPTION
## Summary

- Replace `sha1()` with `hash('sha256', ...)` for email verification hashes in `VerifyEmail` notification and `EmailVerificationRequest` authorization
- SHA-1 has known collision attacks; SHA-256 is more appropriate for new code
- Both the URL generation and verification sides are updated for consistency