### PR TITLE
[13.x] Fix Batch using stale totalJobs in isFirstJobProcessed

### DIFF
--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -399,7 +399,7 @@ class Batch implements Arrayable, JsonSerializable
      */
     protected function isFirstJobProcessed(UpdatedBatchJobCounts $counts): bool
     {
-        return $this->totalJobs - $counts->pendingJobs + $counts->failedJobs === 1;
+        return $counts->totalJobs - $counts->pendingJobs + $counts->failedJobs === 1;
     }
 
     /**

--- a/src/Illuminate/Bus/DatabaseBatchRepository.php
+++ b/src/Illuminate/Bus/DatabaseBatchRepository.php
@@ -139,6 +139,7 @@ class DatabaseBatchRepository implements PrunableBatchRepository
     {
         $values = $this->updateAtomicValues($batchId, function ($batch) use ($jobId) {
             return [
+                'total_jobs' => $batch->total_jobs,
                 'pending_jobs' => $batch->pending_jobs - 1,
                 'failed_jobs' => $batch->failed_jobs,
                 'failed_job_ids' => json_encode(array_values(array_diff((array) json_decode($batch->failed_job_ids, true), [$jobId]))),
@@ -146,6 +147,7 @@ class DatabaseBatchRepository implements PrunableBatchRepository
         });
 
         return new UpdatedBatchJobCounts(
+            $values['total_jobs'],
             $values['pending_jobs'],
             $values['failed_jobs']
         );
@@ -162,6 +164,7 @@ class DatabaseBatchRepository implements PrunableBatchRepository
     {
         $values = $this->updateAtomicValues($batchId, function ($batch) use ($jobId) {
             return [
+                'total_jobs' => $batch->total_jobs,
                 'pending_jobs' => $batch->pending_jobs,
                 'failed_jobs' => $batch->failed_jobs + 1,
                 'failed_job_ids' => json_encode(array_values(array_unique(array_merge((array) json_decode($batch->failed_job_ids, true), [$jobId])))),
@@ -169,6 +172,7 @@ class DatabaseBatchRepository implements PrunableBatchRepository
         });
 
         return new UpdatedBatchJobCounts(
+            $values['total_jobs'],
             $values['pending_jobs'],
             $values['failed_jobs']
         );

--- a/src/Illuminate/Bus/DynamoBatchRepository.php
+++ b/src/Illuminate/Bus/DynamoBatchRepository.php
@@ -255,6 +255,7 @@ class DynamoBatchRepository implements BatchRepository
         $values = $this->marshaler->unmarshalItem($batch['Attributes']);
 
         return new UpdatedBatchJobCounts(
+            $values['total_jobs'],
             $values['pending_jobs'],
             $values['failed_jobs']
         );
@@ -294,6 +295,7 @@ class DynamoBatchRepository implements BatchRepository
         $values = $this->marshaler->unmarshalItem($batch['Attributes']);
 
         return new UpdatedBatchJobCounts(
+            $values['total_jobs'],
             $values['pending_jobs'],
             $values['failed_jobs']
         );

--- a/src/Illuminate/Bus/UpdatedBatchJobCounts.php
+++ b/src/Illuminate/Bus/UpdatedBatchJobCounts.php
@@ -5,6 +5,13 @@ namespace Illuminate\Bus;
 class UpdatedBatchJobCounts
 {
     /**
+     * The total number of jobs that belong to the batch.
+     *
+     * @var int
+     */
+    public $totalJobs;
+
+    /**
      * The number of pending jobs remaining for the batch.
      *
      * @var int
@@ -21,11 +28,13 @@ class UpdatedBatchJobCounts
     /**
      * Create a new batch job counts object.
      *
+     * @param  int  $totalJobs
      * @param  int  $pendingJobs
      * @param  int  $failedJobs
      */
-    public function __construct(int $pendingJobs = 0, int $failedJobs = 0)
+    public function __construct(int $totalJobs = 0, int $pendingJobs = 0, int $failedJobs = 0)
     {
+        $this->totalJobs = $totalJobs;
         $this->pendingJobs = $pendingJobs;
         $this->failedJobs = $failedJobs;
     }


### PR DESCRIPTION
## Summary

- `Batch::isFirstJobProcessed()` used `$this->totalJobs` which is cached at batch creation time and becomes stale when jobs are added via `add()` after the batch is created
- Added a `totalJobs` property to `UpdatedBatchJobCounts` so the fresh value from the database is available alongside `pendingJobs` and `failedJobs`
- Updated `DatabaseBatchRepository` and `DynamoBatchRepository` to pass the current `totalJobs` when constructing `UpdatedBatchJobCounts`
- Changed `isFirstJobProcessed()` to use `$counts->totalJobs` instead of `$this->totalJobs`