### PR TITLE
[13.x] Add explicit int cast for signed route expiration comparison

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -505,7 +505,7 @@ class UrlGenerator implements UrlGeneratorContract
     {
         $expires = $request->query('expires');
 
-        return ! ($expires && Carbon::now()->getTimestamp() > $expires);
+        return ! ($expires && Carbon::now()->getTimestamp() > (int) $expires);
     }
 
     /**


### PR DESCRIPTION
## Summary

- In `UrlGenerator::signatureHasNotExpired()`, the `expires` query parameter is a string value compared against an integer timestamp from `Carbon::now()->getTimestamp()`.
- Adds an explicit `(int)` cast to avoid relying on PHP's implicit type coercion and improve code clarity.