### PR TITLE
[13.x] Add `#[Via]` attribute for notifications

### DIFF
--- a/src/Illuminate/Notifications/Attributes/Via.php
+++ b/src/Illuminate/Notifications/Attributes/Via.php
@@ -21,6 +21,6 @@ class Via
      */
     public function __construct(string|array $channels)
     {
-        $this->channels = is_array($channels) ? $channels : [$channels];
+        $this->channels = (array) $channels;
     }
 }

--- a/src/Illuminate/Notifications/Attributes/Via.php
+++ b/src/Illuminate/Notifications/Attributes/Via.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Illuminate\Notifications\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class Via
+{
+    /**
+     * The channels that the notification should be sent on.
+     *
+     * @var array
+     */
+    public array $channels;
+
+    /**
+     * Create a new attribute instance.
+     *
+     * @param  string|list<string>  $channels
+     */
+    public function __construct(string|array $channels)
+    {
+        $this->channels = is_array($channels) ? $channels : [$channels];
+    }
+}

--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Contracts\Translation\HasLocalePreference;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Notifications\Attributes\Via;
 use Illuminate\Notifications\Events\NotificationFailed;
 use Illuminate\Notifications\Events\NotificationSending;
 use Illuminate\Notifications\Events\NotificationSent;
@@ -108,7 +109,10 @@ class NotificationSender
         $original = clone $notification;
 
         foreach ($notifiables as $notifiable) {
-            if (empty($viaChannels = $channels ?: $original->via($notifiable))) {
+            $viaChannels = $channels
+                ?: ($this->getAttributeValue($original, Via::class) ?? $original->via($notifiable));
+
+            if (empty($viaChannels)) {
                 continue;
             }
 
@@ -224,7 +228,9 @@ class NotificationSender
         foreach ($notifiables as $notifiable) {
             $notificationId = (string) Str::uuid();
 
-            foreach ((array) $original->via($notifiable) as $channel) {
+            $viaChannels = $this->getAttributeValue($original, Via::class, 'via') ?? $original->via($notifiable);
+
+            foreach ((array) $viaChannels as $channel) {
                 $notification = clone $original;
 
                 if (! $notification->id) {

--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -9,15 +9,17 @@ use Illuminate\Contracts\Notifications\Factory as NotificationFactory;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Contracts\Translation\HasLocalePreference;
 use Illuminate\Notifications\AnonymousNotifiable;
+use Illuminate\Notifications\Attributes\Via;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
+use Illuminate\Support\Traits\ReadsClassAttributes;
 use Illuminate\Support\Traits\ReflectsClosures;
 use PHPUnit\Framework\Assert as PHPUnit;
 
 class NotificationFake implements Fake, NotificationDispatcher, NotificationFactory
 {
-    use Macroable, ReflectsClosures;
+    use Macroable, ReadsClassAttributes, ReflectsClosures;
 
     /**
      * All of the notifications that have been sent.
@@ -317,7 +319,7 @@ class NotificationFake implements Fake, NotificationDispatcher, NotificationFact
                 $notification->id = (string) Str::uuid();
             }
 
-            $notifiableChannels = $channels ?: $notification->via($notifiable);
+            $notifiableChannels = $channels ?: ($this->getAttributeValue($notification, Via::class) ?? $notification->via($notifiable));
 
             if (method_exists($notification, 'shouldSend')) {
                 $notifiableChannels = array_filter(

--- a/tests/Notifications/NotificationSenderTest.php
+++ b/tests/Notifications/NotificationSenderTest.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Bus\Dispatcher as BusDispatcher;
 use Illuminate\Contracts\Events\Dispatcher as EventDispatcher;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\AnonymousNotifiable;
+use Illuminate\Notifications\Attributes\Via;
 use Illuminate\Notifications\ChannelManager;
 use Illuminate\Notifications\Events\NotificationFailed;
 use Illuminate\Notifications\Events\NotificationSending;
@@ -15,6 +16,7 @@ use Illuminate\Notifications\Notification;
 use Illuminate\Notifications\NotificationSender;
 use Illuminate\Queue\Attributes\Queue;
 use Mockery as m;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Mailer\Exception\HttpTransportException;
 use Symfony\Component\Mailer\Exception\TransportException;
@@ -39,7 +41,9 @@ class NotificationSenderTest extends TestCase
         $sender->send($notifiable, new DummyQueuedNotificationWithStringVia);
     }
 
-    public function test_it_can_send_queued_notifications_with_an_array_via()
+    #[TestWith([DummyQueuedNotificationWithArrayVia::class])]
+    #[TestWith([DummyQueuedNotificationWithArrayViaAttribute::class])]
+    public function test_it_can_send_queued_notifications_with_an_array_via(string $notificationClass)
     {
         $notifiable = m::mock(Notifiable::class);
         $manager = m::mock(ChannelManager::class);
@@ -61,7 +65,27 @@ class NotificationSenderTest extends TestCase
 
         $sender = new NotificationSender($manager, $bus, $events);
 
-        $sender->send($notifiable, new DummyQueuedNotificationWithArrayVia);
+        $sender->send($notifiable, new $notificationClass);
+    }
+
+    public function test_it_can_send_notifications_with_a_string_via_attribute()
+    {
+        $notifiable = m::mock(Notifiable::class);
+        $manager = m::mock(ChannelManager::class);
+        $manager->shouldReceive('getContainer')->andReturn(app());
+        $bus = m::mock(BusDispatcher::class);
+        $bus->shouldReceive('dispatch')
+            ->once()
+            ->withArgs(function ($job) {
+                return $job->queue === 'dummy' && $job->channels === ['mail'] && $job->connection === 'redis';
+            });
+
+        $events = m::mock(EventDispatcher::class);
+        $events->shouldReceive('listen')->once();
+
+        $sender = new NotificationSender($manager, $bus, $events);
+
+        $sender->send($notifiable, new DummyQueuedNotificationWithStringViaAttribute);
     }
 
     public function test_it_can_send_notifications_with_an_empty_string_via()
@@ -402,6 +426,30 @@ class DummyQueuedNotificationWithArrayVia extends Notification implements Should
     public function via($notifiable)
     {
         return ['mail', 'database'];
+    }
+}
+
+#[Via(['mail', 'database'])]
+class DummyQueuedNotificationWithArrayViaAttribute extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct()
+    {
+        $this->connection = 'redis';
+        $this->queue = 'dummy';
+    }
+}
+
+#[Via(['mail'])]
+class DummyQueuedNotificationWithStringViaAttribute extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct()
+    {
+        $this->connection = 'redis';
+        $this->queue = 'dummy';
     }
 }
 


### PR DESCRIPTION
Hey!

This PR proposes a new `#[Via]` attribute which could be used to define the channels for a notification class.

## Context

I quite often need to create notifications which use a hardcoded set of values in the `via` method (for example, `return ['mail', 'sms']`).

I thought it could be pretty cool to define these hardcoded values using an attribute rather than using the `via` method.

For example, our notification class might currently look like this using the `via` method:

```php
namespace App\Notifications\Users;

use App\Models\User;
use Illuminate\Bus\Queueable;
use Illuminate\Contracts\Queue\ShouldQueue;
use Illuminate\Notifications\Messages\MailMessage;
use Illuminate\Notifications\Notification;

class UserApproved extends Notification implements ShouldQueue
{
    use Queueable;

    // ...

    public function via(): array
    {
        return ['mail'];
    }

    public function toMail(User $notifiable): MailMessage
    {
        // Mail body here...
    }
}
```

And with the `#[Via]` attribute, it could look like this:

```php
namespace App\Notifications\Users;

use App\Models\User;
use Illuminate\Bus\Queueable;
use Illuminate\Contracts\Queue\ShouldQueue;
use Illuminate\Notifications\Attributes\Via;
use Illuminate\Notifications\Messages\MailMessage;
use Illuminate\Notifications\Notification;

#[Via('mail')]
class UserApproved extends Notification implements ShouldQueue
{
    use Queueable;

    // ...

    public function toMail(User $notifiable): MailMessage
    {
        // Mail body here...
    }
}
```

## Usage

The `#[Via]` attribute can accept a string or array of strings. For example, these would both be valid usages:

- `#[Via(['mail', 'database'])]`
- `#[Via('mail')]`

## Benefits

In my opinion, I really like the idea of adding the `#[Via]` attribute so it can be used to remove simple "config" (for lack of a better word) from the notification classes so they can focus more on the actual content of the notification.

As far as I can see, this approach is fully backwards-compatible, so people can continue to use the `via` method as usual. This will be particularly useful if you want to return a dynamic set of values from the `via` method depending on certain conditions, such as:

```php
public function via(User $user): array
{
    $via = ['mail'];

    if ($user->hasSlackConnection()) {
        $via[] = 'slack';
    ]

    return $via;
}
```

Another benefit is that I think it ties well into the current Laravel 13 adoption of attributes (which I'm loving, by the way!). If this is merged, it's definitely something I'll be using across all my projects.

If this is something you'd consider merging, please give me a shout if there's anything you'd like changing 😄