### PR TITLE
[13.x] Add ability to detect unserializable values returned from cache

### DIFF
--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -555,6 +555,17 @@ class CacheManager implements FactoryContract
     }
 
     /**
+     * Register a callback to be invoked when an unserializable class is encountered.
+     *
+     * @param  callable|null  $callback
+     * @return void
+     */
+    public function handleUnserializableClassUsing(?callable $callback): void
+    {
+        Repository::handleUnserializableClassUsing($callback);
+    }
+
+    /**
      * Dynamically call the default driver instance.
      *
      * @param  string  $method

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -834,17 +834,6 @@ class Repository implements ArrayAccess, CacheContract
     }
 
     /**
-     * Register a callback to be invoked when an unserializable class is encountered.
-     *
-     * @param  callable|null  $callback
-     * @return void
-     */
-    public static function handleUnserializableClassUsing(?callable $callback): void
-    {
-        static::$unserializableClassHandler = $callback;
-    }
-
-    /**
      * Handle a cache value that contains an incomplete class.
      *
      * @param  string  $key
@@ -988,6 +977,17 @@ class Repository implements ArrayAccess, CacheContract
     public function setEventDispatcher(Dispatcher $events)
     {
         $this->events = $events;
+    }
+
+    /**
+     * Register a callback to be invoked when an unserializable class is encountered.
+     *
+     * @param  callable|null  $callback
+     * @return void
+     */
+    public static function handleUnserializableClassUsing(?callable $callback): void
+    {
+        static::$unserializableClassHandler = $callback;
     }
 
     /**

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -76,6 +76,13 @@ class Repository implements ArrayAccess, CacheContract
     protected $config = [];
 
     /**
+     * The callback to invoke when an unserializable class is encountered.
+     *
+     * @var callable|null
+     */
+    protected static $unserializableClassHandler;
+
+    /**
      * Create a new cache repository instance.
      */
     public function __construct(Store $store, array $config = [])
@@ -131,6 +138,8 @@ class Repository implements ArrayAccess, CacheContract
 
             $value = value($default);
         } else {
+            $value = $this->handleIncompleteClass($key, $value);
+
             $this->event(new CacheHit($this->getName(), $key, $value));
         }
 
@@ -195,6 +204,8 @@ class Repository implements ArrayAccess, CacheContract
         // If we found a valid value we will fire the "hit" event and return the value
         // back from this function. The "hit" event gives developers an opportunity
         // to listen for every possible cache "hit" throughout this applications.
+        $value = $this->handleIncompleteClass($key, $value);
+
         $this->event(new CacheHit($this->getName(), $key, $value));
 
         return $value;
@@ -820,6 +831,39 @@ class Repository implements ArrayAccess, CacheContract
     protected function itemKey($key)
     {
         return $key;
+    }
+
+    /**
+     * Register a callback to be invoked when an unserializable class is encountered.
+     *
+     * @param  callable|null  $callback
+     * @return void
+     */
+    public static function handleUnserializableClassUsing(?callable $callback): void
+    {
+        static::$unserializableClassHandler = $callback;
+    }
+
+    /**
+     * Handle a cache value that contains an incomplete class.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return mixed
+     */
+    protected function handleIncompleteClass(string $key, mixed $value): mixed
+    {
+        if (! ($value instanceof \__PHP_Incomplete_Class)) {
+            return $value;
+        }
+
+        $class = ((array) $value)['__PHP_Incomplete_Class_Name'] ?? null;
+
+        if (isset(static::$unserializableClassHandler)) {
+            (static::$unserializableClassHandler)($key, $class);
+        }
+
+        return $value;
     }
 
     /**

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -26,6 +26,7 @@ use InvalidArgumentException;
 use Mockery as m;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use stdClass;
 
 class CacheRepositoryTest extends TestCase
 {
@@ -39,6 +40,7 @@ class CacheRepositoryTest extends TestCase
     protected function tearDown(): void
     {
         Carbon::setTestNow(null);
+        Repository::handleUnserializableClassUsing(null);
 
         parent::tearDown();
     }
@@ -579,6 +581,46 @@ class CacheRepositoryTest extends TestCase
         $cache->put(TestCacheKey::FOO, 5);
         $this->assertSame(6, $cache->increment(TestCacheKey::FOO));
         $this->assertSame(5, $cache->decrement(TestCacheKey::FOO));
+    }
+
+    public function testGetReturnsIncompleteClassWhenNoHandlerRegistered()
+    {
+        $repo = $this->getRepository();
+        $repo->getStore()->shouldReceive('get')->once()->with('foo')->andReturn(unserialize(serialize(new stdClass), ['allowed_classes' => false]));
+
+        $this->assertInstanceOf(\__PHP_Incomplete_Class::class, $repo->get('foo'));
+    }
+
+    public function testGetCallsHandlerWithKeyAndClassForIncompleteClass()
+    {
+        $class = null;
+        $key = null;
+
+        Repository::handleUnserializableClassUsing(function ($k, $c) use (&$class, &$key) {
+            $key = $k;
+            $class = $c;
+        });
+
+        $repo = $this->getRepository();
+        $repo->getStore()->shouldReceive('get')->once()->with('foo')->andReturn(unserialize(serialize(new stdClass), ['allowed_classes' => false]));
+        $repo->get('foo');
+
+        $this->assertSame('foo', $key);
+        $this->assertSame('stdClass', $class);
+    }
+
+    public function testManyCallsHandlerForEachIncompleteClass()
+    {
+        $handled = [];
+        Repository::handleUnserializableClassUsing(function ($key, $class) use (&$handled) {
+            $handled[] = $key;
+        });
+
+        $repo = $this->getRepository();
+        $repo->getStore()->shouldReceive('many')->once()->with(['foo', 'bar'])->andReturn(['foo' => unserialize(serialize(new stdClass), ['allowed_classes' => false]), 'bar' => 'baz']);
+        $repo->many(['foo', 'bar']);
+
+        $this->assertSame(['foo'], $handled);
     }
 
     protected function getRepository()


### PR DESCRIPTION
Good Morn!

In Laravel 13.x we have the`serializable_classes` config, when you use Cache::get with a class that wasnt in the array... PHP's unserialize() returns `__PHP_Incomplete_Class`

For large old existing apps adopting it aka mine, it can be difficult to track anywhere you've missed as the cache still reports a hit and the broken object only surfaces when something tries to use it, which can be far from the cache call.

This PR adds `handleUnserializableClassUsing` to surface it, inspired by `Model::handleMissingAttributeViolationUsing`:

This means, we can do stuff like...
```php
Cache::handleUnserializableClassUsing(function (string $key, ?string $class): void {
      if (app()->isProduction()) {
          Log::warning("Cache hit [{$key}] returned unserializable class [{$class}]");                                                                                                                                                                                                                                                                                                                                                     
          return;                                                                                                                                                                                                                                                                                                                                                                                                                          
      }                                                                                                                                                                                                                                                                                                                                                                                                                                    
      // Can do what we want basically.. even trigger Slack.                                                                                                                                                                                                                                                                                                                                                                                                                                    
      throw new RuntimeException("Cache hit [{$key}] returned unserializable class [{$class}]");                                                                                                                                                                                                                                                                                                                                           
});                                                                                                                                                                                                                                                                                                                                                                                                           
```

It's basically all on the Repository, but added it into the cache manager too as it felt natural to use the Cache facade. 

TLDR is I wanted a way for this to be super clear for me and my team, just so we dont end up missing anything, as it's something I want to adopt. This would also help as a defensive tool just so nothing ever sneaks in as no doubt I'll forget about this at some point... :D  I could probably fudge the CacheHit event, but this felt more explicit..

No handler is registered by default, so no B/C afaik

May need a bit of Otwell love, so open to changing the method names etc, or tell me to pack it up and throw it away if im over engineering!                                                                                                                                                                                                                                                                                                                                                 

<details>

<summary> Images </summary> 

Before: 


<img width="483" height="200" alt="Screenshot 2026-04-09 at 17 56 48" src="https://github.com/user-attachments/assets/61af2a8a-9899-42a1-a143-cf836eb09b10" />

After (I can do do what I want, so can make it throw if i want..) : 
<img width="767" height="220" alt="Screenshot 2026-04-09 at 17 53 50" src="https://github.com/user-attachments/assets/d9fff96d-caae-43c8-932d-f3ce8f64f498" />

</details>


