### PR TITLE
[13.x] Add #[Locked] attribute for declarative atomic locks on controller actions

### DIFF
--- a/src/Illuminate/Routing/Attributes/Controllers/Locked.php
+++ b/src/Illuminate/Routing/Attributes/Controllers/Locked.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Illuminate\Routing\Attributes\Controllers;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+class Locked
+{
+    /**
+     * Create a new attribute instance.
+     *
+     * @param  string|null  $key
+     * @param  int  $seconds
+     * @param  string|null  $owner
+     * @return void
+     */
+    public function __construct(
+        public string|null $key = null,
+        public int $seconds = 10,
+        public string|null $owner = null
+    ) {
+    }
+}
+

--- a/src/Illuminate/Routing/Attributes/Controllers/Locked.php
+++ b/src/Illuminate/Routing/Attributes/Controllers/Locked.php
@@ -22,4 +22,3 @@ class Locked
     ) {
     }
 }
-

--- a/src/Illuminate/Routing/Attributes/Controllers/Locked.php
+++ b/src/Illuminate/Routing/Attributes/Controllers/Locked.php
@@ -16,9 +16,9 @@ class Locked
      * @return void
      */
     public function __construct(
-        public string|null $key = null,
+        public ?string $key = null,
         public int $seconds = 10,
-        public string|null $owner = null
+        public ?string $owner = null
     ) {
     }
 }

--- a/src/Illuminate/Routing/Middleware/HandleAtomicLocks.php
+++ b/src/Illuminate/Routing/Middleware/HandleAtomicLocks.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Illuminate\Routing\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+class HandleAtomicLocks
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     *
+     * @throws \Symfony\Component\HttpKernel\Exception\HttpException
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        $route = $request->route();
+
+        $attribute = $route->getLockedAttribute();
+
+        if (! $attribute) {
+            return $next($request);
+        }
+
+        $lockKey = $this->resolveLockKey($request, $attribute);
+
+        $lock = app('cache')->lock($lockKey, $attribute->seconds);
+
+        if (! $lock->get()) {
+            throw new \Symfony\Component\HttpKernel\Exception\HttpException(423, 'Locked.');
+        }
+
+        try {
+            return $next($request);
+        } finally {
+            $lock->release();
+        }
+    }
+
+    /**
+     * Resolve the lock key for the request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Illuminate\Routing\Attributes\Controllers\Locked  $attribute
+     * @return string
+     */
+    protected function resolveLockKey($request, $attribute)
+    {
+        $baseKey = 'laravel_lock:' . $request->route()->getName();
+        $userKey = $request->user()?->id ?: $request->ip();
+
+        return $attribute->key
+            ? "{$baseKey}:{$attribute->key}:{$userKey}"
+            : "{$baseKey}:{$userKey}";
+    }
+}
+

--- a/src/Illuminate/Routing/Middleware/HandleAtomicLocks.php
+++ b/src/Illuminate/Routing/Middleware/HandleAtomicLocks.php
@@ -5,6 +5,7 @@ namespace Illuminate\Routing\Middleware;
 use Closure;
 use Illuminate\Contracts\Cache\Factory as CacheFactory;
 use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 class HandleAtomicLocks
 {
@@ -30,7 +31,7 @@ class HandleAtomicLocks
      * Handle the request.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @param  \Closure  $next
+     * @param  \Closure(\Illuminate\Http\Request): \Illuminate\Http\Response  $next
      * @return mixed
      */
     public function handle(Request $request, Closure $next)
@@ -46,7 +47,7 @@ class HandleAtomicLocks
         $lock = $this->cache->lock($lockKey, $attribute->seconds);
 
         if (! $lock->get()) {
-            throw new \Symfony\Component\HttpKernel\Exception\HttpException(423, 'Locked.');
+            throw new \Symfony\Component\HttpKernel\Exception\HttpException(Response::HTTP_LOCKED, 'Locked.');
         }
 
         try {

--- a/src/Illuminate/Routing/Middleware/HandleAtomicLocks.php
+++ b/src/Illuminate/Routing/Middleware/HandleAtomicLocks.php
@@ -58,4 +58,3 @@ class HandleAtomicLocks
             : "{$baseKey}:{$userKey}";
     }
 }
-

--- a/src/Illuminate/Routing/Middleware/HandleAtomicLocks.php
+++ b/src/Illuminate/Routing/Middleware/HandleAtomicLocks.php
@@ -50,7 +50,7 @@ class HandleAtomicLocks
      */
     protected function resolveLockKey($request, $attribute)
     {
-        $baseKey = 'laravel_lock:' . $request->route()->getName();
+        $baseKey = 'laravel_lock:'.$request->route()->getName();
         $userKey = $request->user()?->id ?: $request->ip();
 
         return $attribute->key

--- a/src/Illuminate/Routing/Middleware/HandleAtomicLocks.php
+++ b/src/Illuminate/Routing/Middleware/HandleAtomicLocks.php
@@ -3,8 +3,8 @@
 namespace Illuminate\Routing\Middleware;
 
 use Closure;
-use Illuminate\Http\Request;
 use Illuminate\Contracts\Cache\Factory as CacheFactory;
+use Illuminate\Http\Request;
 
 class HandleAtomicLocks
 {

--- a/src/Illuminate/Routing/Middleware/HandleAtomicLocks.php
+++ b/src/Illuminate/Routing/Middleware/HandleAtomicLocks.php
@@ -4,31 +4,46 @@ namespace Illuminate\Routing\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
+use Illuminate\Contracts\Cache\Factory as CacheFactory;
 
 class HandleAtomicLocks
 {
     /**
-     * Handle an incoming request.
+     * The instance of the cache factory.
+     *
+     * @var \Illuminate\Contracts\Cache\Factory
+     */
+    protected $cache;
+
+    /**
+     * Create the Middleware instance.
+     *
+     * @param  \Illuminate\Contracts\Cache\Factory  $cache
+     * @return void
+     */
+    public function __construct(CacheFactory $cache)
+    {
+        $this->cache = $cache;
+    }
+
+    /**
+     * Handle the request.
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  \Closure  $next
      * @return mixed
-     *
-     * @throws \Symfony\Component\HttpKernel\Exception\HttpException
      */
     public function handle(Request $request, Closure $next)
     {
         $route = $request->route();
 
-        $attribute = $route->getLockedAttribute();
-
-        if (! $attribute) {
+        if (! $attribute = $route->getLockedAttribute()) {
             return $next($request);
         }
 
         $lockKey = $this->resolveLockKey($request, $attribute);
 
-        $lock = app('cache')->lock($lockKey, $attribute->seconds);
+        $lock = $this->cache->lock($lockKey, $attribute->seconds);
 
         if (! $lock->get()) {
             throw new \Symfony\Component\HttpKernel\Exception\HttpException(423, 'Locked.');
@@ -42,16 +57,19 @@ class HandleAtomicLocks
     }
 
     /**
-     * Resolve the lock key for the request.
+     * Create the lock key corresponding to the request.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @param  \Illuminate\Routing\Attributes\Controllers\Locked  $attribute
+     * @param  \Illuminate\Routing\Attributes\Locked  $attribute
      * @return string
      */
     protected function resolveLockKey($request, $attribute)
     {
-        $baseKey = 'laravel_lock:'.$request->route()->getName();
-        $userKey = $request->user()?->id ?: $request->ip();
+        $routeIdentifier = $request->route()->getName() ?? $request->route()->getActionName();
+
+        $baseKey = 'laravel_lock:'.md5($routeIdentifier);
+
+        $userKey = $request->user()?->getAuthIdentifier() ?: $request->ip();
 
         return $attribute->key
             ? "{$baseKey}:{$attribute->key}:{$userKey}"

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -169,6 +169,13 @@ class Route
     public static $validators;
 
     /**
+     * The resolved "Locked" attribute instance for the route.
+     *
+     * @var \Illuminate\Routing\Attributes\Controllers\Locked|null
+     */
+    public $lockedAttribute;
+
+    /**
      * Create a new Route instance.
      *
      * @param  array|string  $methods
@@ -1062,9 +1069,15 @@ class Route
 
         $this->computedMiddleware = [];
 
-        return $this->computedMiddleware = Router::uniqueMiddleware(array_merge(
+        $middleware = array_merge(
             $this->middleware(), $this->controllerMiddleware()
-        ));
+        );
+
+        if ($this->hasLockedAttribute()) {
+            $middleware[] = \Illuminate\Routing\Middleware\HandleAtomicLocks::class;
+        }
+
+        return $this->computedMiddleware = Router::uniqueMiddleware($middleware);
     }
 
     /**
@@ -1461,5 +1474,42 @@ class Route
     public function __get($key)
     {
         return $this->parameter($key);
+    }
+
+    /**
+     * Determine if the route action has the "Locked" attribute.
+     *
+     * @return bool
+     */
+    protected function hasLockedAttribute()
+    {
+        return ! is_null($this->getLockedAttribute());
+    }
+
+    /**
+     * Get the "Locked" attribute instance assigned to the route action.
+     *
+     * @return object|null
+     */
+    public function getLockedAttribute()
+    {
+        return $this->lockedAttribute ??= (function () {
+            $action = $this->getAction();
+
+            if (! is_string($action['uses']) || ! str_contains($action['uses'], '@')) {
+                return null;
+            }
+
+            [$class, $method] = explode('@', $action['uses']);
+
+            if (! class_exists($class) || ! method_exists($class, $method)) {
+                return null;
+            }
+
+            $attributes = (new \ReflectionMethod($class, $method))
+                ->getAttributes(\Illuminate\Routing\Attributes\Controllers\Locked::class);
+
+            return count($attributes) > 0 ? $attributes[0]->newInstance() : null;
+        })();
     }
 }

--- a/tests/Routing/RoutingLockedAttributeTest.php
+++ b/tests/Routing/RoutingLockedAttributeTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Illuminate\Tests\Routing;
+
+use Illuminate\Routing\Attributes\Controllers\Locked;
+use Illuminate\Routing\Middleware\HandleAtomicLocks;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Route;
+use Orchestra\Testbench\TestCase;
+
+class RoutingLockedAttributeTest extends TestCase
+{
+    protected function getPackageProviders($app)
+    {
+        return [\Illuminate\Routing\RoutingServiceProvider::class];
+    }
+
+    public function test_route_can_be_locked_via_attribute()
+    {
+        Cache::shouldReceive('lock')
+            ->once()
+            ->andReturn($lock = \Mockery::mock());
+
+        $lock->shouldReceive('get')->once()->andReturn(true);
+        $lock->shouldReceive('release')->once();
+
+        Route::get('/withdraw', [LockedControllerStub::class, 'withdraw'])
+            ->middleware(HandleAtomicLocks::class);
+
+        $response = $this->get('/withdraw');
+
+        $response->assertOk();
+    }
+
+    public function test_route_returns_423_when_locked()
+    {
+        Cache::shouldReceive('lock')
+            ->once()
+            ->andReturn($lock = \Mockery::mock());
+
+        $lock->shouldReceive('get')->once()->andReturn(false);
+
+        Route::get('/withdraw-locked', [LockedControllerStub::class, 'withdraw'])
+            ->middleware(HandleAtomicLocks::class);
+
+        $response = $this->get('/withdraw-locked');
+
+        $response->assertStatus(423);
+    }
+}
+
+class LockedControllerStub
+{
+    #[Locked(seconds: 10)]
+    public function withdraw()
+    {
+        return 'success';
+    }
+}

--- a/tests/Routing/RoutingLockedAttributeTest.php
+++ b/tests/Routing/RoutingLockedAttributeTest.php
@@ -19,6 +19,7 @@ class RoutingLockedAttributeTest extends TestCase
     {
         Cache::shouldReceive('lock')
             ->once()
+            ->withAnyArgs()
             ->andReturn($lock = \Mockery::mock());
 
         $lock->shouldReceive('get')->once()->andReturn(true);
@@ -30,12 +31,14 @@ class RoutingLockedAttributeTest extends TestCase
         $response = $this->get('/withdraw');
 
         $response->assertOk();
+        $response->assertSee('success');
     }
 
     public function test_route_returns_423_when_locked()
     {
         Cache::shouldReceive('lock')
             ->once()
+            ->withAnyArgs()
             ->andReturn($lock = \Mockery::mock());
 
         $lock->shouldReceive('get')->once()->andReturn(false);
@@ -46,6 +49,24 @@ class RoutingLockedAttributeTest extends TestCase
         $response = $this->get('/withdraw-locked');
 
         $response->assertStatus(423);
+    }
+
+    public function test_it_locks_unnamed_routes_successfully()
+    {
+        Cache::shouldReceive('lock')
+            ->once()
+            ->withAnyArgs()
+            ->andReturn($lock = \Mockery::mock());
+
+        $lock->shouldReceive('get')->once()->andReturn(true);
+        $lock->shouldReceive('release')->once();
+
+        Route::get('/test-unnamed', [LockedControllerStub::class, 'withdraw'])
+            ->middleware(HandleAtomicLocks::class);
+
+        $response = $this->get('/test-unnamed');
+
+        $response->assertOk();
     }
 }
 


### PR DESCRIPTION
------------------------------
This PR introduces a new #[Locked] attribute that allows developers to apply Atomic Locks directly to controller methods. This simplifies concurrency management for critical operations like payments or inventory updates without writing manual Cache::lock() boilerplate.
Motivation
Currently, protecting an action from race conditions requires several lines of boilerplate inside the controller:

```php
public function withdraw(Request $request)
{
    $lock = Cache::lock('withdraw-'.$request->user()->id, 10);

    if ($lock->get()) {
        // Business logic...
        $lock->release();
    }
}
```

With this PR, the same protection is achieved declaratively, keeping the controller clean:

```php
#[Locked(seconds: 10)]
public function withdraw(Request $request)
{
    // Business logic only...
}
```

Key Features

* Automatic Detection: The Route class detects the attribute and automatically appends the HandleAtomicLocks middleware.
* Smart Key Resolution: Generates a unique lock key based on the route name or action name (MD5 hashed) combined with the authenticated user's ID or IP address.
* Dependency Injection: The middleware uses Illuminate\Contracts\Cache\Factory for better testability and adherence to core standards.
* Performance: Attribute reflection is cached on the Route instance to ensure zero overhead on subsequent middleware checks during the same request.

Implementation Details

   1. Added Illuminate\Routing\Attributes\Locked attribute.
   2. Added Illuminate\Routing\Middleware\HandleAtomicLocks middleware.
   3. Updated Illuminate\Routing\Route to resolve and cache the attribute.

------------------------------

