### PR TITLE
[13.x] Add enum support to CacheManager store and driver methods

### DIFF
--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -14,6 +14,8 @@ use Mockery\LegacyMockInterface;
 use RuntimeException;
 use Throwable;
 
+use function Illuminate\Support\enum_value;
+
 /**
  * @mixin \Illuminate\Cache\Repository
  * @mixin \Illuminate\Contracts\Cache\LockProvider
@@ -54,12 +56,12 @@ class CacheManager implements FactoryContract
     /**
      * Get a cache store instance by name, wrapped in a repository.
      *
-     * @param  string|null  $name
+     * @param  \UnitEnum|string|null  $name
      * @return \Illuminate\Contracts\Cache\Repository
      */
     public function store($name = null)
     {
-        $name = $name ?? $this->getDefaultDriver();
+        $name = enum_value($name) ?? $this->getDefaultDriver();
 
         return $this->stores[$name] ??= $this->resolve($name);
     }
@@ -67,7 +69,7 @@ class CacheManager implements FactoryContract
     /**
      * Get a cache driver instance.
      *
-     * @param  string|null  $driver
+     * @param  \UnitEnum|string|null  $driver
      * @return \Illuminate\Contracts\Cache\Repository
      */
     public function driver($driver = null)
@@ -78,12 +80,12 @@ class CacheManager implements FactoryContract
     /**
      * Get a memoized cache driver instance.
      *
-     * @param  string|null  $driver
+     * @param  \UnitEnum|string|null  $driver
      * @return \Illuminate\Contracts\Cache\Repository
      */
     public function memo($driver = null)
     {
-        $driver = $driver ?? $this->getDefaultDriver();
+        $driver = enum_value($driver) ?? $this->getDefaultDriver();
 
         $bindingKey = "cache.__memoized:{$driver}";
 
@@ -478,18 +480,18 @@ class CacheManager implements FactoryContract
     /**
      * Set the default cache driver name.
      *
-     * @param  string  $name
+     * @param  \UnitEnum|string  $name
      * @return void
      */
     public function setDefaultDriver($name)
     {
-        $this->app['config']['cache.default'] = $name;
+        $this->app['config']['cache.default'] = enum_value($name);
     }
 
     /**
      * Unset the given driver instances.
      *
-     * @param  array|string|null  $name
+     * @param  array|\UnitEnum|string|null  $name
      * @return $this
      */
     public function forgetDriver($name = null)
@@ -497,6 +499,8 @@ class CacheManager implements FactoryContract
         $name ??= $this->getDefaultDriver();
 
         foreach ((array) $name as $cacheName) {
+            $cacheName = enum_value($cacheName);
+
             if (isset($this->stores[$cacheName])) {
                 unset($this->stores[$cacheName]);
             }
@@ -508,12 +512,12 @@ class CacheManager implements FactoryContract
     /**
      * Disconnect the given driver and remove from local cache.
      *
-     * @param  string|null  $name
+     * @param  \UnitEnum|string|null  $name
      * @return void
      */
     public function purge($name = null)
     {
-        $name ??= $this->getDefaultDriver();
+        $name = enum_value($name) ?? $this->getDefaultDriver();
 
         unset($this->stores[$name]);
     }

--- a/src/Illuminate/Contracts/Cache/Factory.php
+++ b/src/Illuminate/Contracts/Cache/Factory.php
@@ -7,7 +7,7 @@ interface Factory
     /**
      * Get a cache store instance by name.
      *
-     * @param  string|null  $name
+     * @param  \UnitEnum|string|null  $name
      * @return \Illuminate\Contracts\Cache\Repository
      */
     public function store($name = null);

--- a/src/Illuminate/Support/Facades/Cache.php
+++ b/src/Illuminate/Support/Facades/Cache.php
@@ -5,17 +5,17 @@ namespace Illuminate\Support\Facades;
 use Mockery;
 
 /**
- * @method static \Illuminate\Contracts\Cache\Repository store(string|null $name = null)
- * @method static \Illuminate\Contracts\Cache\Repository driver(string|null $driver = null)
- * @method static \Illuminate\Contracts\Cache\Repository memo(string|null $driver = null)
+ * @method static \Illuminate\Contracts\Cache\Repository store(\UnitEnum|string|null $name = null)
+ * @method static \Illuminate\Contracts\Cache\Repository driver(\UnitEnum|string|null $driver = null)
+ * @method static \Illuminate\Contracts\Cache\Repository memo(\UnitEnum|string|null $driver = null)
  * @method static \Illuminate\Contracts\Cache\Repository resolve(string $name)
  * @method static \Illuminate\Cache\Repository build(array $config)
  * @method static \Illuminate\Cache\Repository repository(\Illuminate\Contracts\Cache\Store $store, array $config = [])
  * @method static void refreshEventDispatcher()
  * @method static string getDefaultDriver()
- * @method static void setDefaultDriver(string $name)
- * @method static \Illuminate\Cache\CacheManager forgetDriver(array|string|null $name = null)
- * @method static void purge(string|null $name = null)
+ * @method static void setDefaultDriver(\UnitEnum|string $name)
+ * @method static \Illuminate\Cache\CacheManager forgetDriver(array|\UnitEnum|string|null $name = null)
+ * @method static void purge(\UnitEnum|string|null $name = null)
  * @method static \Illuminate\Cache\CacheManager extend(string $driver, \Closure $callback)
  * @method static \Illuminate\Cache\CacheManager setApplication(\Illuminate\Contracts\Foundation\Application $app)
  * @method static bool has(\UnitEnum|array|string $key)

--- a/tests/Cache/CacheManagerTest.php
+++ b/tests/Cache/CacheManagerTest.php
@@ -332,6 +332,108 @@ class CacheManagerTest extends TestCase
         $this->assertNull($repoWithoutEvents->getEventDispatcher());
     }
 
+    public function testEnumStoreCanBeResolved()
+    {
+        $userConfig = [
+            'cache' => [
+                'stores' => [
+                    'array' => [
+                        'driver' => 'array',
+                    ],
+                ],
+            ],
+        ];
+
+        $app = $this->getApp($userConfig);
+        $cacheManager = new CacheManager($app);
+
+        $store = $cacheManager->store(CacheStoreName::ArrayStore);
+
+        $this->assertInstanceOf(ArrayStore::class, $store->getStore());
+        $this->assertSame($store, $cacheManager->store(CacheStoreName::ArrayStore));
+    }
+
+    public function testEnumDriverCanBeResolved()
+    {
+        $userConfig = [
+            'cache' => [
+                'stores' => [
+                    'array' => [
+                        'driver' => 'array',
+                    ],
+                ],
+            ],
+        ];
+
+        $app = $this->getApp($userConfig);
+        $cacheManager = new CacheManager($app);
+
+        $store = $cacheManager->driver(CacheStoreName::ArrayStore);
+
+        $this->assertInstanceOf(ArrayStore::class, $store->getStore());
+    }
+
+    public function testForgetDriverAcceptsEnum()
+    {
+        $userConfig = [
+            'cache' => [
+                'stores' => [
+                    'array' => [
+                        'driver' => 'array',
+                    ],
+                ],
+            ],
+        ];
+
+        $app = $this->getApp($userConfig);
+        $cacheManager = new CacheManager($app);
+
+        $repo1 = $cacheManager->store(CacheStoreName::ArrayStore);
+        $cacheManager->forgetDriver(CacheStoreName::ArrayStore);
+        $repo2 = $cacheManager->store(CacheStoreName::ArrayStore);
+
+        $this->assertNotSame($repo1, $repo2);
+    }
+
+    public function testPurgeAcceptsEnum()
+    {
+        $userConfig = [
+            'cache' => [
+                'stores' => [
+                    'array' => [
+                        'driver' => 'array',
+                    ],
+                ],
+            ],
+        ];
+
+        $app = $this->getApp($userConfig);
+        $cacheManager = new CacheManager($app);
+
+        $repo1 = $cacheManager->store(CacheStoreName::ArrayStore);
+        $cacheManager->purge(CacheStoreName::ArrayStore);
+        $repo2 = $cacheManager->store(CacheStoreName::ArrayStore);
+
+        $this->assertNotSame($repo1, $repo2);
+    }
+
+    public function testSetDefaultDriverAcceptsEnum()
+    {
+        $userConfig = [
+            'cache' => [
+                'default' => 'old',
+                'stores' => [],
+            ],
+        ];
+
+        $app = $this->getApp($userConfig);
+        $cacheManager = new CacheManager($app);
+
+        $cacheManager->setDefaultDriver(CacheStoreName::ArrayStore);
+
+        $this->assertSame('array', $app->get('config')->get('cache.default'));
+    }
+
     protected function getApp(array $userConfig)
     {
         $app = new Container;
@@ -339,4 +441,9 @@ class CacheManagerTest extends TestCase
 
         return $app;
     }
+}
+
+enum CacheStoreName: string
+{
+    case ArrayStore = 'array';
 }


### PR DESCRIPTION
## Summary

Adds `UnitEnum|string|null` support to `CacheManager` selector methods, mirroring the enum support already merged for other manager classes.

The following methods now accept a `BackedEnum` (or any `UnitEnum`):
- `store()`
- `driver()`
- `memo()`
- `forgetDriver()`
- `purge()`
- `setDefaultDriver()`

The matching `Illuminate\Contracts\Cache\Factory` and `Illuminate\Support\Facades\Cache` docblocks are updated to keep the contract consistent with the implementation.

## Context

This continues the enum-support wave already merged in 13.x:
- #59389 — `QueueManager::connection()`
- #59391 — `LogManager::channel()` and `driver()`
- `DatabaseManager`, `FilesystemManager`, `RedisManager`, `BroadcastManager` already support enums

`CacheManager` was the most-used manager class still without enum support.

## Usage

```php
enum CacheStore: string
{
    case Redis = 'redis';
    case Array = 'array';
}

Cache::store(CacheStore::Redis)->put('key', 'value');
Cache::driver(CacheStore::Array)->get('key');
```

## Tests

Added five tests covering `store()`, `driver()`, `forgetDriver()`, `purge()`, and `setDefaultDriver()` with enum inputs. All 18 tests in `CacheManagerTest` pass locally and Pint is clean on every changed file.