### PR TITLE
[13.x] Bind closure in MailManager::extend()

### DIFF
--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -18,6 +18,7 @@ use Illuminate\Support\Str;
 use InvalidArgumentException;
 use Psr\Log\LoggerInterface;
 use Resend;
+use RuntimeException;
 use Symfony\Component\HttpClient\HttpClient;
 use Symfony\Component\Mailer\Bridge\Mailgun\Transport\MailgunTransportFactory;
 use Symfony\Component\Mailer\Bridge\Postmark\Transport\PostmarkTransportFactory;
@@ -28,6 +29,7 @@ use Symfony\Component\Mailer\Transport\SendmailTransport;
 use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport;
 use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransportFactory;
 use Symfony\Component\Mailer\Transport\Smtp\Stream\SocketStream;
+use Throwable;
 
 /**
  * @mixin \Illuminate\Mail\Mailer
@@ -567,10 +569,19 @@ class MailManager implements FactoryContract
      *
      * @param  string  $driver
      * @param  \Closure  $callback
+     *
+     * @param-closure-this  $this  $callback
+     *
      * @return $this
      */
     public function extend($driver, Closure $callback)
     {
+        try {
+            $callback = $callback->bindTo($this, static::class) ?? throw new RuntimeException;
+        } catch (Throwable) {
+            $callback = $callback->bindTo(null, static::class);
+        }
+
         $this->customCreators[$driver] = $callback;
 
         return $this;

--- a/tests/Mail/MailManagerTest.php
+++ b/tests/Mail/MailManagerTest.php
@@ -6,6 +6,7 @@ use InvalidArgumentException;
 use Orchestra\Testbench\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\TestWith;
+use stdClass;
 use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport;
 
 class MailManagerTest extends TestCase
@@ -123,6 +124,26 @@ class MailManagerTest extends TestCase
         $this->assertSame('pwd', $transport->getPassword());
         $this->assertSame('127.0.0.2', $transport->getStream()->getHost());
         $this->assertSame(5876, $transport->getStream()->getPort());
+    }
+
+    public function testCustomTransportClosureBoundObjectIsMailManager(): void
+    {
+        $manager = $this->app['mail.manager'];
+
+        $manager->extend('custom', fn ($config) => $this);
+
+        $this->assertSame($manager, $manager->createSymfonyTransport(['transport' => 'custom']));
+    }
+
+    public function testCustomTransportStaticClosure(): void
+    {
+        $transport = new stdClass;
+
+        $manager = $this->app['mail.manager'];
+
+        $manager->extend('custom', static fn ($config) => $transport);
+
+        $this->assertSame($transport, $manager->createSymfonyTransport(['transport' => 'custom']));
     }
 
     public static function emptyTransportConfigDataProvider()


### PR DESCRIPTION
MailManager::extend() doesn't bind the custom creator closure to the manager instance unlike CacheManager, BroadcastManager, LogManager, FilesystemManager, and the base Manager class.

This adds the same closure binding so custom transport creators can access the manager via $this, consistent with the rest of the framework.