### PR TITLE
[13.x] Add support for streamed HTTP client responses

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -622,6 +622,18 @@ class PendingRequest
     }
 
     /**
+     * Indicate that the response body should be streamed instead of buffered in memory.
+     *
+     * @return $this
+     */
+    public function stream()
+    {
+        $this->options['stream'] = true;
+
+        return $this;
+    }
+
+    /**
      * Specify the timeout (in seconds) for the request.
      *
      * @param  int|float  $seconds

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -3,7 +3,9 @@
 namespace Illuminate\Http\Client;
 
 use ArrayAccess;
+use Generator;
 use GuzzleHttp\Psr7\StreamWrapper;
+use GuzzleHttp\Psr7\Utils;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Fluent;
 use Illuminate\Support\Traits\Macroable;
@@ -161,6 +163,26 @@ class Response implements ArrayAccess, Stringable
     public function resource()
     {
         return StreamWrapper::getResource($this->response->getBody());
+    }
+
+    /**
+     * Get an iterator that yields each line of the response body.
+     *
+     * @return \Generator<int, string>
+     */
+    public function lines(): Generator
+    {
+        $body = $this->response->getBody();
+
+        while (! $body->eof()) {
+            $line = Utils::readLine($body);
+
+            if ($line === '') {
+                continue;
+            }
+
+            yield rtrim($line, "\r\n");
+        }
     }
 
     /**

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -1682,6 +1682,77 @@ class HttpClientTest extends TestCase
         $this->assertSame(json_encode(['page' => 'foo']), stream_get_contents($resource));
     }
 
+    public function testStreamMethodSetsGuzzleStreamOption()
+    {
+        $request = $this->factory->stream();
+
+        $this->assertTrue($request->getOptions()['stream']);
+    }
+
+    public function testStreamMethodIsChainable()
+    {
+        $this->factory->fake([
+            '*' => $this->factory::response('ok'),
+        ]);
+
+        $response = $this->factory->stream()->get('http://example.com');
+
+        $this->assertTrue($response->successful());
+    }
+
+    public function testResponseLinesYieldsEachLineOfTheBody()
+    {
+        $this->factory->fake([
+            '*' => $this->factory::response("first\nsecond\nthird"),
+        ]);
+
+        $response = $this->factory->stream()->get('http://example.com');
+
+        $this->assertSame(
+            ['first', 'second', 'third'],
+            iterator_to_array($response->lines(), false),
+        );
+    }
+
+    public function testResponseLinesHandlesMixedLineEndings()
+    {
+        $this->factory->fake([
+            '*' => $this->factory::response("alpha\r\nbeta\ngamma\r\ndelta"),
+        ]);
+
+        $response = $this->factory->stream()->get('http://example.com');
+
+        $this->assertSame(
+            ['alpha', 'beta', 'gamma', 'delta'],
+            iterator_to_array($response->lines(), false),
+        );
+    }
+
+    public function testResponseLinesPreservesBlankLinesBetweenContent()
+    {
+        $this->factory->fake([
+            '*' => $this->factory::response("one\n\ntwo\n\nthree\n"),
+        ]);
+
+        $response = $this->factory->stream()->get('http://example.com');
+
+        $this->assertSame(
+            ['one', '', 'two', '', 'three'],
+            iterator_to_array($response->lines(), false),
+        );
+    }
+
+    public function testResponseLinesReturnsEmptyGeneratorForEmptyBody()
+    {
+        $this->factory->fake([
+            '*' => $this->factory::response(''),
+        ]);
+
+        $response = $this->factory->stream()->get('http://example.com');
+
+        $this->assertSame([], iterator_to_array($response->lines(), false));
+    }
+
     public function testCanAssertAgainstOrderOfHttpRequestsWithUrlStrings()
     {
         $this->factory->fake();


### PR DESCRIPTION
This PR adds first-class support for consuming streamed HTTP responses (NDJSON, SSE from LLMs, log tailing, or any line-delimited protocol) without dropping out of the HTTP client into raw Guzzle.

Today it looks like this:

```php
$response = Http::withOptions(['stream' => true])->post($url, $payload);
$body = $response->toPsrResponse()->getBody();

while (! $body->eof()) {
    $line = trim(\GuzzleHttp\Psr7\Utils::readLine($body));
    // ...
}
```

With this PR:

```php
$response = Http::stream()->post($url, $payload);

foreach ($response->lines() as $line) {
    // ...
}
```

Quick demo of it in use:


https://github.com/user-attachments/assets/94f83e2d-a2e5-4c8b-8510-3b7a410aa42c

