### PR TITLE
[12.x] Add spatie/fork to suggestions and dev dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -168,7 +168,7 @@ jobs:
         with:
           timeout_minutes: 5
           max_attempts: 5
-          command: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress --with="phpunit/phpunit:~${{ matrix.phpunit }}"
+          command: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress --ignore-platform-req=ext-sockets --ignore-platform-req=ext-pcntl --with="phpunit/phpunit:~${{ matrix.phpunit }}"
 
       - name: Execute tests
         run: vendor/bin/phpunit --no-coverage

--- a/composer.json
+++ b/composer.json
@@ -200,6 +200,7 @@
         "psr/http-message": "Required to allow Storage::put to accept a StreamInterface (^1.0).",
         "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (^6.0|^7.0).",
         "resend/resend-php": "Required to enable support for the Resend mail transport (^0.10.0|^1.0).",
+        "spatie/fork": "Required to use the 'fork' concurrency driver.",
         "symfony/cache": "Required to PSR-6 cache bridge (^7.2).",
         "symfony/filesystem": "Required to enable support for relative symbolic links (^7.2).",
         "symfony/http-client": "Required to enable support for the Symfony API mail transports (^7.2).",

--- a/composer.json
+++ b/composer.json
@@ -123,6 +123,7 @@
         "phpunit/phpunit": "^10.5.35|^11.5.3|^12.0.1",
         "predis/predis": "^2.3|^3.0",
         "resend/resend-php": "^0.10.0|^1.0",
+        "spatie/fork": "^1.2",
         "symfony/cache": "^7.2.0",
         "symfony/http-client": "^7.2.0",
         "symfony/psr-http-message-bridge": "^7.2.0",

--- a/src/Illuminate/Concurrency/ForkDriver.php
+++ b/src/Illuminate/Concurrency/ForkDriver.php
@@ -22,7 +22,6 @@ class ForkDriver implements Driver
         $keys = array_keys($tasks);
         $values = array_values($tasks);
 
-        /** @phpstan-ignore class.notFound */
         $results = Fork::new()->run(...$values);
 
         ksort($results);

--- a/src/Illuminate/Concurrency/composer.json
+++ b/src/Illuminate/Concurrency/composer.json
@@ -31,6 +31,9 @@
             "dev-master": "11.x-dev"
         }
     },
+    "suggest": {
+        "spatie/fork": "Required to use the 'fork' concurrency driver."
+    },
     "config": {
         "sort-packages": true
     },

--- a/src/Illuminate/Concurrency/composer.json
+++ b/src/Illuminate/Concurrency/composer.json
@@ -21,6 +21,9 @@
         "illuminate/support": "^12.0",
         "laravel/serializable-closure": "^1.3|^2.0"
     },
+    "require-dev": {
+        "spatie/fork": "^1.2"
+    },
     "autoload": {
         "psr-4": {
             "Illuminate\\Concurrency\\": ""

--- a/tests/Integration/Concurrency/ConcurrencyTest.php
+++ b/tests/Integration/Concurrency/ConcurrencyTest.php
@@ -72,18 +72,16 @@ PHP);
         $this->assertArrayHasKey('first', $syncOutput);
         $this->assertArrayHasKey('second', $syncOutput);
 
-        /** As of now, the spatie/fork package is not included by default.
-         * $forkOutput = Concurrency::driver('fork')->run([
-         * 'first' => fn() => 1 + 1,
-         * 'second' => fn() => 2 + 2,
-         * ]);.
-         *
-         * $this->assertIsArray($forkOutput);
-         * $this->assertArrayHasKey('first', $forkOutput);
-         * $this->assertArrayHasKey('second', $forkOutput);
-         * $this->assertEquals(2, $forkOutput['first']);
-         * $this->assertEquals(4, $forkOutput['second']);
-         */
+        $forkOutput = Concurrency::driver('fork')->run([
+            'first' => fn () => 1 + 1,
+            'second' => fn () => 2 + 2,
+        ]);
+
+        $this->assertIsArray($forkOutput);
+        $this->assertArrayHasKey('first', $forkOutput);
+        $this->assertArrayHasKey('second', $forkOutput);
+        $this->assertEquals(2, $forkOutput['first']);
+        $this->assertEquals(4, $forkOutput['second']);
     }
 
     public function testRunHandlerProcessErrorWithDefaultExceptionWithoutParam()


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
While removing some `@phpstan-ignore class.notFound` clauses while working on #59640, I encountered a similar clause for the Spatie Fork class. Given that I could not think of any good reason not to install this in dev environments, I've opted to create this PR to add this as a dev dependency and also add it to the suggests. Subsequently I've also enabled the related test that was written but never enabled for this.