### PR TITLE
[13.x] Fix loose comparison false positive in NotPwnedVerifier with magic hash passwords

### DIFF
--- a/src/Illuminate/Validation/NotPwnedVerifier.php
+++ b/src/Illuminate/Validation/NotPwnedVerifier.php
@@ -55,7 +55,7 @@ class NotPwnedVerifier implements UncompromisedVerifier
             ->contains(function ($line) use ($hash, $hashPrefix, $threshold) {
                 [$hashSuffix, $count] = explode(':', $line);
 
-                return $hashPrefix.$hashSuffix == $hash && $count > $threshold;
+                return $hashPrefix.$hashSuffix === $hash && $count > $threshold;
             });
     }
 

--- a/tests/Validation/ValidationNotPwnedVerifierTest.php
+++ b/tests/Validation/ValidationNotPwnedVerifierTest.php
@@ -105,6 +105,53 @@ class ValidationNotPwnedVerifierTest extends TestCase
         ]));
     }
 
+    public function testMagicHashDoesNotCauseFalsePositive()
+    {
+        // "aaroZmOk" produces a SHA-1 hash that is all digits prefixed with "0E",
+        // which PHP treats as scientific notation (zero) during loose comparison,
+        // causing any other all-digit "0E" hash to falsely match.
+        $password = 'aaroZmOk';
+        $hash = strtoupper(sha1($password));
+        $hashPrefix = substr($hash, 0, 5);
+
+        $differentSuffix = '00000000000000000000000000000000000';
+
+        $httpFactory = m::mock(HttpFactory::class);
+        $response = m::mock(Response::class);
+
+        $httpFactory
+            ->shouldReceive('withHeaders')
+            ->once()
+            ->with(['Add-Padding' => true])
+            ->andReturn($httpFactory);
+
+        $httpFactory
+            ->shouldReceive('timeout')
+            ->once()
+            ->with(30)
+            ->andReturn($httpFactory);
+
+        $httpFactory->shouldReceive('get')
+            ->once()
+            ->with('https://api.pwnedpasswords.com/range/'.$hashPrefix)
+            ->andReturn($response);
+
+        $response->shouldReceive('successful')
+            ->once()
+            ->andReturn(true);
+
+        $response->shouldReceive('body')
+            ->once()
+            ->andReturn($differentSuffix.':5');
+
+        $verifier = new NotPwnedVerifier($httpFactory);
+
+        $this->assertTrue($verifier->verify([
+            'value' => $password,
+            'threshold' => 0,
+        ]));
+    }
+
     public function testDnsDown()
     {
         $container = Container::getInstance();


### PR DESCRIPTION
## Summary                                                                                                                                                                
  - Fixed loose comparison (`==`) in `NotPwnedVerifier::verify()` that caused false positives with "magic hash" passwords                                                   
  - Passwords like `"aaroZmOk"` produce SHA-1 hashes consisting entirely of digits prefixed with `0E`, which PHP interprets as scientific notation (`0 × 10^n = 0`), causing
   unrelated hash suffixes to incorrectly match                                                                                                                             
                                                                                                                                                                            
  ## Fix                                                                                                                                                                    
  Replaced `==` with `===` on line 58 to ensure string-level comparison, eliminating type juggling                                                                          
                                                                                                  
  ## Test                                                                                                                                                                   
  Added test that verifies magic hash passwords are not falsely flagged as compromised when the API returns a different all-digit hash suffix
                                                                                                                                                                            
  Fixes #59634 