### PR TITLE
[13.x] Add enum support to MailManager mailer and driver methods

### DIFF
--- a/src/Illuminate/Contracts/Mail/Factory.php
+++ b/src/Illuminate/Contracts/Mail/Factory.php
@@ -7,7 +7,7 @@ interface Factory
     /**
      * Get a mailer instance by name.
      *
-     * @param  string|null  $name
+     * @param  \UnitEnum|string|null  $name
      * @return \Illuminate\Contracts\Mail\Mailer
      */
     public function mailer($name = null);

--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -29,6 +29,8 @@ use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport;
 use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransportFactory;
 use Symfony\Component\Mailer\Transport\Smtp\Stream\SocketStream;
 
+use function Illuminate\Support\enum_value;
+
 /**
  * @mixin \Illuminate\Mail\Mailer
  */
@@ -68,12 +70,12 @@ class MailManager implements FactoryContract
     /**
      * Get a mailer instance by name.
      *
-     * @param  string|null  $name
+     * @param  \UnitEnum|string|null  $name
      * @return \Illuminate\Contracts\Mail\Mailer
      */
     public function mailer($name = null)
     {
-        $name = $name ?: $this->getDefaultDriver();
+        $name = enum_value($name) ?: $this->getDefaultDriver();
 
         return $this->mailers[$name] = $this->get($name);
     }
@@ -81,7 +83,7 @@ class MailManager implements FactoryContract
     /**
      * Get a mailer driver instance.
      *
-     * @param  string|null  $driver
+     * @param  \UnitEnum|string|null  $driver
      * @return \Illuminate\Mail\Mailer
      */
     public function driver($driver = null)
@@ -552,12 +554,12 @@ class MailManager implements FactoryContract
     /**
      * Disconnect the given mailer and remove from local cache.
      *
-     * @param  string|null  $name
+     * @param  \UnitEnum|string|null  $name
      * @return void
      */
     public function purge($name = null)
     {
-        $name = $name ?: $this->getDefaultDriver();
+        $name = enum_value($name) ?: $this->getDefaultDriver();
 
         unset($this->mailers[$name]);
     }

--- a/src/Illuminate/Support/Facades/Mail.php
+++ b/src/Illuminate/Support/Facades/Mail.php
@@ -5,13 +5,13 @@ namespace Illuminate\Support\Facades;
 use Illuminate\Support\Testing\Fakes\MailFake;
 
 /**
- * @method static \Illuminate\Contracts\Mail\Mailer mailer(string|null $name = null)
- * @method static \Illuminate\Mail\Mailer driver(string|null $driver = null)
+ * @method static \Illuminate\Contracts\Mail\Mailer mailer(\UnitEnum|string|null $name = null)
+ * @method static \Illuminate\Mail\Mailer driver(\UnitEnum|string|null $driver = null)
  * @method static \Illuminate\Mail\Mailer build(array $config)
  * @method static \Symfony\Component\Mailer\Transport\TransportInterface createSymfonyTransport(array $config)
  * @method static string getDefaultDriver()
  * @method static void setDefaultDriver(string $name)
- * @method static void purge(string|null $name = null)
+ * @method static void purge(\UnitEnum|string|null $name = null)
  * @method static \Illuminate\Mail\MailManager extend(string $driver, \Closure $callback)
  * @method static \Illuminate\Contracts\Foundation\Application getApplication()
  * @method static \Illuminate\Mail\MailManager setApplication(\Illuminate\Contracts\Foundation\Application $app)

--- a/tests/Mail/MailManagerTest.php
+++ b/tests/Mail/MailManagerTest.php
@@ -125,10 +125,54 @@ class MailManagerTest extends TestCase
         $this->assertSame(5876, $transport->getStream()->getPort());
     }
 
+    public function testMailManagerCanResolveBackedEnumMailer(): void
+    {
+        $this->app['config']->set('mail.mailers.array', [
+            'transport' => 'array',
+        ]);
+
+        $mailer1 = $this->app['mail.manager']->mailer(MailerName::ArrayMailer);
+        $mailer2 = $this->app['mail.manager']->mailer('array');
+
+        $this->assertSame($mailer1, $mailer2);
+    }
+
+    public function testMailManagerCanResolveBackedEnumDriver(): void
+    {
+        $this->app['config']->set('mail.mailers.array', [
+            'transport' => 'array',
+        ]);
+
+        $mailer1 = $this->app['mail.manager']->driver(MailerName::ArrayMailer);
+        $mailer2 = $this->app['mail.manager']->driver('array');
+
+        $this->assertSame($mailer1, $mailer2);
+    }
+
+    public function testPurgeAcceptsBackedEnum(): void
+    {
+        $this->app['config']->set('mail.mailers.array', [
+            'transport' => 'array',
+        ]);
+
+        $manager = $this->app['mail.manager'];
+
+        $mailer1 = $manager->mailer(MailerName::ArrayMailer);
+        $manager->purge(MailerName::ArrayMailer);
+        $mailer2 = $manager->mailer(MailerName::ArrayMailer);
+
+        $this->assertNotSame($mailer1, $mailer2);
+    }
+
     public static function emptyTransportConfigDataProvider()
     {
         return [
             [null], [''], [' '],
         ];
     }
+}
+
+enum MailerName: string
+{
+    case ArrayMailer = 'array';
 }


### PR DESCRIPTION
## Summary

Adds \`UnitEnum|string|null\` support to \`MailManager\` selector methods, mirroring the enum support already merged for other manager classes.

The following methods now accept a \`BackedEnum\` (or any \`UnitEnum\`):
- \`mailer()\`
- \`driver()\`
- \`purge()\`

The matching \`Illuminate\Contracts\Mail\Factory\` interface and \`Illuminate\Support\Facades\Mail\` facade docblocks are updated for consistency.

\`setDefaultDriver(string \$name)\` is intentionally **not** changed because it has a real PHP type hint — modifying it would be a BC break, and the merged sibling PRs (#59389, #59391) left their typed equivalents alone.

## Context

This continues the enum-support wave already merged in 13.x:
- #59637 — \`CacheManager::store()\` and \`driver()\` (merged today)
- #59389 — \`QueueManager::connection()\`
- #59391 — \`LogManager::channel()\` and \`driver()\`
- \`DatabaseManager\`, \`FilesystemManager\`, \`RedisManager\`, \`BroadcastManager\` already support enums

## Usage

\`\`\`php
enum Mailer: string
{
    case Transactional = 'transactional';
    case Marketing = 'marketing';
}

Mail::mailer(Mailer::Transactional)->to(\$user)->send(new OrderShipped());
Mail::driver(Mailer::Marketing)->to(\$user)->send(new Newsletter());
\`\`\`

## Tests

Added three tests covering \`mailer()\`, \`driver()\`, and \`purge()\` with enum inputs. All 25 tests in \`MailManagerTest\` pass locally and Pint is clean on every changed file.