### PR TITLE
[13.x] Add enum support to AuthManager guard and shouldUse methods

### DIFF
--- a/src/Illuminate/Auth/AuthManager.php
+++ b/src/Illuminate/Auth/AuthManager.php
@@ -8,6 +8,8 @@ use InvalidArgumentException;
 use RuntimeException;
 use Throwable;
 
+use function Illuminate\Support\enum_value;
+
 /**
  * @mixin \Illuminate\Contracts\Auth\Guard
  * @mixin \Illuminate\Contracts\Auth\StatefulGuard
@@ -61,12 +63,12 @@ class AuthManager implements FactoryContract
     /**
      * Attempt to get the guard from the local cache.
      *
-     * @param  string|null  $name
+     * @param  \UnitEnum|string|null  $name
      * @return \Illuminate\Contracts\Auth\Guard|\Illuminate\Contracts\Auth\StatefulGuard
      */
     public function guard($name = null)
     {
-        $name = $name ?: $this->getDefaultDriver();
+        $name = enum_value($name) ?: $this->getDefaultDriver();
 
         return $this->guards[$name] ??= $this->resolve($name);
     }
@@ -197,12 +199,12 @@ class AuthManager implements FactoryContract
     /**
      * Set the default guard driver the factory should serve.
      *
-     * @param  string  $name
+     * @param  \UnitEnum|string|null  $name
      * @return void
      */
     public function shouldUse($name)
     {
-        $name = $name ?: $this->getDefaultDriver();
+        $name = enum_value($name) ?: $this->getDefaultDriver();
 
         $this->setDefaultDriver($name);
 
@@ -212,12 +214,12 @@ class AuthManager implements FactoryContract
     /**
      * Set the default authentication driver name.
      *
-     * @param  string  $name
+     * @param  \UnitEnum|string  $name
      * @return void
      */
     public function setDefaultDriver($name)
     {
-        $this->app['config']['auth.defaults.guard'] = $name;
+        $this->app['config']['auth.defaults.guard'] = enum_value($name);
     }
 
     /**

--- a/src/Illuminate/Contracts/Auth/Factory.php
+++ b/src/Illuminate/Contracts/Auth/Factory.php
@@ -7,7 +7,7 @@ interface Factory
     /**
      * Get a guard instance by name.
      *
-     * @param  string|null  $name
+     * @param  \UnitEnum|string|null  $name
      * @return \Illuminate\Contracts\Auth\Guard|\Illuminate\Contracts\Auth\StatefulGuard
      */
     public function guard($name = null);
@@ -15,7 +15,7 @@ interface Factory
     /**
      * Set the default guard the factory should serve.
      *
-     * @param  string  $name
+     * @param  \UnitEnum|string|null  $name
      * @return void
      */
     public function shouldUse($name);

--- a/src/Illuminate/Support/Facades/Auth.php
+++ b/src/Illuminate/Support/Facades/Auth.php
@@ -6,12 +6,12 @@ use Laravel\Ui\UiServiceProvider;
 use RuntimeException;
 
 /**
- * @method static \Illuminate\Contracts\Auth\Guard|\Illuminate\Contracts\Auth\StatefulGuard guard(string|null $name = null)
+ * @method static \Illuminate\Contracts\Auth\Guard|\Illuminate\Contracts\Auth\StatefulGuard guard(\UnitEnum|string|null $name = null)
  * @method static \Illuminate\Auth\SessionGuard createSessionDriver(string $name, array $config)
  * @method static \Illuminate\Auth\TokenGuard createTokenDriver(string $name, array $config)
  * @method static string getDefaultDriver()
- * @method static void shouldUse(string $name)
- * @method static void setDefaultDriver(string $name)
+ * @method static void shouldUse(\UnitEnum|string|null $name)
+ * @method static void setDefaultDriver(\UnitEnum|string $name)
  * @method static \Illuminate\Auth\AuthManager viaRequest(string $driver, callable $callback)
  * @method static \Closure userResolver()
  * @method static \Illuminate\Auth\AuthManager resolveUsersUsing(\Closure $userResolver)

--- a/tests/Auth/AuthenticateMiddlewareTest.php
+++ b/tests/Auth/AuthenticateMiddlewareTest.php
@@ -162,6 +162,35 @@ class AuthenticateMiddlewareTest extends TestCase
         $this->assertSame($driver, $this->auth->guard(__CLASS__));
     }
 
+    public function testAuthManagerCanResolveBackedEnumGuard()
+    {
+        $driver = $this->registerAuthDriver('default', true);
+
+        $guard1 = $this->auth->guard(GuardName::Default);
+        $guard2 = $this->auth->guard('default');
+
+        $this->assertSame($guard1, $guard2);
+        $this->assertSame($driver, $guard1);
+    }
+
+    public function testShouldUseAcceptsBackedEnum()
+    {
+        $this->registerAuthDriver('default', true);
+        $secondary = $this->registerAuthDriver('secondary', true);
+
+        $this->auth->shouldUse(GuardName::Secondary);
+
+        $this->assertSame('secondary', $this->auth->getDefaultDriver());
+        $this->assertSame($secondary, $this->auth->guard());
+    }
+
+    public function testSetDefaultDriverAcceptsBackedEnum()
+    {
+        $this->auth->setDefaultDriver(GuardName::Secondary);
+
+        $this->assertSame('secondary', $this->auth->getDefaultDriver());
+    }
+
     /**
      * Create a new config repository instance.
      *
@@ -236,4 +265,10 @@ class AuthenticateMiddlewareTest extends TestCase
 
         $this->assertSame($request, $nextParam);
     }
+}
+
+enum GuardName: string
+{
+    case Default = 'default';
+    case Secondary = 'secondary';
 }


### PR DESCRIPTION
## Summary

Adds \`UnitEnum|string|null\` support to \`AuthManager\` selector methods, mirroring the enum support already merged for other manager classes.

The following methods now accept a \`BackedEnum\` (or any \`UnitEnum\`):
- \`guard()\`
- \`shouldUse()\`
- \`setDefaultDriver()\`

The matching \`Illuminate\Contracts\Auth\Factory\` interface and \`Illuminate\Support\Facades\Auth\` facade docblocks are updated for consistency.

## Context

This continues the enum-support wave already merged in 13.x:
- #59637 — \`CacheManager::store()\` and \`driver()\`
- #59389 — \`QueueManager::connection()\`
- #59391 — \`LogManager::channel()\` and \`driver()\`
- \`DatabaseManager\`, \`FilesystemManager\`, \`RedisManager\`, \`BroadcastManager\` already support enums

Guards are arguably the most natural enum candidate of all the managers — they're typically a small, fixed, well-known set defined in \`config/auth.php\` (\`web\`, \`api\`, \`admin\`, etc.) which is exactly the use case enums are designed for.

## Usage

\`\`\`php
enum Guard: string
{
    case Web = 'web';
    case Api = 'api';
    case Admin = 'admin';
}

Auth::guard(Guard::Api)->user();
Auth::shouldUse(Guard::Admin);

// Also works with the request helper
\$request->user(Guard::Api);
\`\`\`

## Tests

Added three tests covering \`guard()\`, \`shouldUse()\`, and \`setDefaultDriver()\` with enum inputs to the existing \`AuthenticateMiddlewareTest\` (the closest existing home for AuthManager tests). All 14 tests in the file pass locally and Pint is clean on every changed file.