### PR TITLE
[13.x] Allow closure values in updateOrCreate and firstOrNew

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -687,16 +687,16 @@ class Builder implements BuilderContract
      * Get the first record matching the attributes or instantiate it.
      *
      * @param  array  $attributes
-     * @param  array  $values
+     * @param  (\Closure(): array)|array  $values
      * @return TModel
      */
-    public function firstOrNew(array $attributes = [], array $values = [])
+    public function firstOrNew(array $attributes = [], Closure|array $values = [])
     {
         if (! is_null($instance = $this->where($attributes)->first())) {
             return $instance;
         }
 
-        return $this->newModelInstance(array_merge($attributes, $values));
+        return $this->newModelInstance(array_merge($attributes, value($values)));
     }
 
     /**
@@ -737,14 +737,14 @@ class Builder implements BuilderContract
      * Create or update a record matching the attributes, and fill it with values.
      *
      * @param  array  $attributes
-     * @param  array  $values
+     * @param  (\Closure(): array)|array  $values
      * @return TModel
      */
-    public function updateOrCreate(array $attributes, array $values = [])
+    public function updateOrCreate(array $attributes, Closure|array $values = [])
     {
         return tap($this->firstOrCreate($attributes, $values), function ($instance) use ($values) {
             if (! $instance->wasRecentlyCreated) {
-                $instance->fill($values)->save();
+                $instance->fill(value($values))->save();
             }
         });
     }

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -631,13 +631,13 @@ class BelongsToMany extends Relation
      * Get the first related model record matching the attributes or instantiate it.
      *
      * @param  array  $attributes
-     * @param  array  $values
+     * @param  (\Closure(): array)|array  $values
      * @return TRelatedModel&object{pivot: TPivotModel}
      */
-    public function firstOrNew(array $attributes = [], array $values = [])
+    public function firstOrNew(array $attributes = [], Closure|array $values = [])
     {
         if (is_null($instance = $this->related->where($attributes)->first())) {
-            $instance = $this->related->newInstance(array_merge($attributes, $values));
+            $instance = $this->related->newInstance(array_merge($attributes, value($values)));
         }
 
         return $instance;
@@ -701,16 +701,16 @@ class BelongsToMany extends Relation
      * Create or update a related record matching the attributes, and fill it with values.
      *
      * @param  array  $attributes
-     * @param  array  $values
+     * @param  (\Closure(): array)|array  $values
      * @param  array  $joining
      * @param  bool  $touch
      * @return TRelatedModel&object{pivot: TPivotModel}
      */
-    public function updateOrCreate(array $attributes, array $values = [], array $joining = [], $touch = true)
+    public function updateOrCreate(array $attributes, Closure|array $values = [], array $joining = [], $touch = true)
     {
         return tap($this->firstOrCreate($attributes, $values, $joining, $touch), function ($instance) use ($values) {
             if (! $instance->wasRecentlyCreated) {
-                $instance->fill($values);
+                $instance->fill(value($values));
 
                 $instance->save(['touch' => false]);
             }

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -240,13 +240,13 @@ abstract class HasOneOrMany extends Relation
      * Get the first related model record matching the attributes or instantiate it.
      *
      * @param  array  $attributes
-     * @param  array  $values
+     * @param  (\Closure(): array)|array  $values
      * @return TRelatedModel
      */
-    public function firstOrNew(array $attributes = [], array $values = [])
+    public function firstOrNew(array $attributes = [], Closure|array $values = [])
     {
         if (is_null($instance = $this->where($attributes)->first())) {
-            $instance = $this->related->newInstance(array_merge($attributes, $values));
+            $instance = $this->related->newInstance(array_merge($attributes, value($values)));
 
             $this->setForeignAttributesForCreate($instance);
         }
@@ -292,14 +292,14 @@ abstract class HasOneOrMany extends Relation
      * Create or update a related record matching the attributes, and fill it with values.
      *
      * @param  array  $attributes
-     * @param  array  $values
+     * @param  (\Closure(): array)|array  $values
      * @return TRelatedModel
      */
-    public function updateOrCreate(array $attributes, array $values = [])
+    public function updateOrCreate(array $attributes, Closure|array $values = [])
     {
         return tap($this->firstOrCreate($attributes, $values), function ($instance) use ($values) {
             if (! $instance->wasRecentlyCreated) {
-                $instance->fill($values)->save();
+                $instance->fill(value($values))->save();
             }
         });
     }

--- a/tests/Database/DatabaseEloquentBelongsToManyCreateOrFirstTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyCreateOrFirstTest.php
@@ -456,6 +456,116 @@ class DatabaseEloquentBelongsToManyCreateOrFirstTest extends TestCase
         ], $result->toArray());
     }
 
+    public function testUpdateOrCreateMethodAcceptsClosureValuesAndCreates(): void
+    {
+        $source = new class() extends BelongsToManyCreateOrFirstTestSourceModel
+        {
+            protected function newBelongsToMany(Builder $query, Model $parent, $table, $foreignPivotKey, $relatedPivotKey, $parentKey, $relatedKey, $relationName = null): BelongsToMany
+            {
+                $relation = m::mock(BelongsToMany::class)->makePartial();
+                $relation->__construct(...func_get_args());
+                $instance = new BelongsToManyCreateOrFirstTestRelatedModel([
+                    'id' => 456,
+                    'attr' => 'foo',
+                    'val' => 'bar',
+                    'created_at' => '2023-01-01T00:00:00.000000Z',
+                    'updated_at' => '2023-01-01T00:00:00.000000Z',
+                ]);
+                $instance->exists = true;
+                $instance->wasRecentlyCreated = true;
+                $instance->syncOriginal();
+                $relation
+                    ->expects('firstOrCreate')
+                    ->withArgs(function ($attributes, $values, $joining, $touch) {
+                        return $attributes === ['attr' => 'foo']
+                            && $values instanceof Closure
+                            && $joining === []
+                            && $touch === true;
+                    })
+                    ->andReturn($instance);
+
+                return $relation;
+            }
+        };
+        $source->id = 123;
+        $this->mockConnectionForModels(
+            [$source, new BelongsToManyCreateOrFirstTestRelatedModel()],
+            'SQLite',
+        );
+
+        $callCount = 0;
+        $result = $source->related()->updateOrCreate(['attr' => 'foo'], function () use (&$callCount) {
+            $callCount++;
+
+            return ['val' => 'baz'];
+        });
+
+        // Closure is forwarded to firstOrCreate which would resolve it on the create path.
+        // Because we mocked firstOrCreate above, the closure was never invoked here.
+        $this->assertSame(0, $callCount);
+        $this->assertSame('bar', $result->val);
+    }
+
+    public function testUpdateOrCreateMethodAcceptsClosureValuesAndUpdates(): void
+    {
+        $source = new class() extends BelongsToManyCreateOrFirstTestSourceModel
+        {
+            protected function newBelongsToMany(Builder $query, Model $parent, $table, $foreignPivotKey, $relatedPivotKey, $parentKey, $relatedKey, $relationName = null): BelongsToMany
+            {
+                $relation = m::mock(BelongsToMany::class)->makePartial();
+                $relation->__construct(...func_get_args());
+                $instance = new BelongsToManyCreateOrFirstTestRelatedModel([
+                    'id' => 456,
+                    'attr' => 'foo',
+                    'val' => 'bar',
+                    'created_at' => '2023-01-01T00:00:00.000000Z',
+                    'updated_at' => '2023-01-01T00:00:00.000000Z',
+                ]);
+                $instance->exists = true;
+                $instance->wasRecentlyCreated = false;
+                $instance->syncOriginal();
+                $relation
+                    ->expects('firstOrCreate')
+                    ->withArgs(function ($attributes, $values, $joining, $touch) {
+                        return $attributes === ['attr' => 'foo']
+                            && $values instanceof Closure
+                            && $joining === []
+                            && $touch === true;
+                    })
+                    ->andReturn($instance);
+
+                return $relation;
+            }
+        };
+        $source->id = 123;
+        $this->mockConnectionForModels(
+            [$source, new BelongsToManyCreateOrFirstTestRelatedModel()],
+            'SQLite',
+        );
+        $source->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
+        $source->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+
+        $source->getConnection()
+            ->expects('update')
+            ->with(
+                'update "related_table" set "val" = ?, "updated_at" = ? where "id" = ?',
+                ['baz', '2023-01-01 00:00:00', 456],
+            )
+            ->andReturn(1);
+
+        $callCount = 0;
+        $result = $source->related()->updateOrCreate(['attr' => 'foo'], function () use (&$callCount) {
+            $callCount++;
+
+            return ['val' => 'baz'];
+        });
+
+        // On the update path firstOrCreate was mocked away, so the closure
+        // is only resolved once for the fill() call.
+        $this->assertSame(1, $callCount);
+        $this->assertSame('baz', $result->val);
+    }
+
     public static function createOrFirstValues(): array
     {
         return [

--- a/tests/Database/DatabaseEloquentBuilderCreateOrFirstTest.php
+++ b/tests/Database/DatabaseEloquentBuilderCreateOrFirstTest.php
@@ -473,6 +473,178 @@ class DatabaseEloquentBuilderCreateOrFirstTest extends TestCase
         ], $result->toArray());
     }
 
+    #[DataProvider('createOrFirstValues')]
+    public function testUpdateOrCreateMethodAcceptsClosureValuesAndCreates(Closure|array $values): void
+    {
+        $model = new EloquentBuilderCreateOrFirstTestModel();
+        $this->mockConnectionForModel($model, 'SQLite', [123]);
+        $model->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
+        $model->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+
+        $model->getConnection()
+            ->expects('select')
+            ->with('select * from "table" where ("attr" = ?) limit 1', ['foo'], true, [])
+            ->andReturn([]);
+
+        $model->getConnection()->expects('insert')->with(
+            'insert into "table" ("attr", "val", "updated_at", "created_at") values (?, ?, ?, ?)',
+            ['foo', 'bar', '2023-01-01 00:00:00', '2023-01-01 00:00:00'],
+        )->andReturnTrue();
+
+        $result = $model->newQuery()->updateOrCreate(['attr' => 'foo'], $values);
+        $this->assertTrue($result->wasRecentlyCreated);
+        $this->assertEquals([
+            'id' => 123,
+            'attr' => 'foo',
+            'val' => 'bar',
+            'created_at' => '2023-01-01T00:00:00.000000Z',
+            'updated_at' => '2023-01-01T00:00:00.000000Z',
+        ], $result->toArray());
+    }
+
+    public function testUpdateOrCreateMethodAcceptsClosureValuesAndUpdates(): void
+    {
+        $model = new EloquentBuilderCreateOrFirstTestModel();
+        $this->mockConnectionForModel($model, 'SQLite');
+        $model->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
+        $model->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+
+        $model->getConnection()
+            ->expects('select')
+            ->with('select * from "table" where ("attr" = ?) limit 1', ['foo'], true, [])
+            ->andReturn([[
+                'id' => 123,
+                'attr' => 'foo',
+                'val' => 'bar',
+                'created_at' => '2023-01-01 00:00:00',
+                'updated_at' => '2023-01-01 00:00:00',
+            ]]);
+
+        $model->getConnection()
+            ->expects('update')
+            ->with(
+                'update "table" set "val" = ?, "updated_at" = ? where "id" = ?',
+                ['baz', '2023-01-01 00:00:00', 123],
+            )
+            ->andReturn(1);
+
+        $result = $model->newQuery()->updateOrCreate(['attr' => 'foo'], fn () => ['val' => 'baz']);
+        $this->assertFalse($result->wasRecentlyCreated);
+        $this->assertEquals('baz', $result->val);
+    }
+
+    public function testUpdateOrCreateInvokesClosureExactlyOnceWhenCreating(): void
+    {
+        $model = new EloquentBuilderCreateOrFirstTestModel();
+        $this->mockConnectionForModel($model, 'SQLite', [123]);
+        $model->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
+        $model->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+
+        $model->getConnection()
+            ->expects('select')
+            ->with('select * from "table" where ("attr" = ?) limit 1', ['foo'], true, [])
+            ->andReturn([]);
+
+        $model->getConnection()->expects('insert')->with(
+            'insert into "table" ("attr", "val", "updated_at", "created_at") values (?, ?, ?, ?)',
+            ['foo', 'bar', '2023-01-01 00:00:00', '2023-01-01 00:00:00'],
+        )->andReturnTrue();
+
+        $callCount = 0;
+        $model->newQuery()->updateOrCreate(['attr' => 'foo'], function () use (&$callCount) {
+            $callCount++;
+
+            return ['val' => 'bar'];
+        });
+
+        $this->assertSame(1, $callCount);
+    }
+
+    public function testUpdateOrCreateInvokesClosureExactlyOnceWhenUpdating(): void
+    {
+        $model = new EloquentBuilderCreateOrFirstTestModel();
+        $this->mockConnectionForModel($model, 'SQLite');
+        $model->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
+        $model->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+
+        $model->getConnection()
+            ->expects('select')
+            ->with('select * from "table" where ("attr" = ?) limit 1', ['foo'], true, [])
+            ->andReturn([[
+                'id' => 123,
+                'attr' => 'foo',
+                'val' => 'bar',
+                'created_at' => '2023-01-01 00:00:00',
+                'updated_at' => '2023-01-01 00:00:00',
+            ]]);
+
+        $model->getConnection()
+            ->expects('update')
+            ->with(
+                'update "table" set "val" = ?, "updated_at" = ? where "id" = ?',
+                ['baz', '2023-01-01 00:00:00', 123],
+            )
+            ->andReturn(1);
+
+        $callCount = 0;
+        $model->newQuery()->updateOrCreate(['attr' => 'foo'], function () use (&$callCount) {
+            $callCount++;
+
+            return ['val' => 'baz'];
+        });
+
+        $this->assertSame(1, $callCount);
+    }
+
+    #[DataProvider('createOrFirstValues')]
+    public function testFirstOrNewMethodAcceptsClosureValuesAndInstantiates(Closure|array $values): void
+    {
+        $model = new EloquentBuilderCreateOrFirstTestModel();
+        $this->mockConnectionForModel($model, 'SQLite');
+        $model->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
+        $model->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+
+        $model->getConnection()
+            ->expects('select')
+            ->with('select * from "table" where ("attr" = ?) limit 1', ['foo'], true, [])
+            ->andReturn([]);
+
+        $result = $model->newQuery()->firstOrNew(['attr' => 'foo'], $values);
+        $this->assertFalse($result->exists);
+        $this->assertSame('foo', $result->attr);
+        $this->assertSame('bar', $result->val);
+    }
+
+    public function testFirstOrNewDoesNotInvokeClosureWhenRecordExists(): void
+    {
+        $model = new EloquentBuilderCreateOrFirstTestModel();
+        $this->mockConnectionForModel($model, 'SQLite');
+        $model->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
+        $model->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+
+        $model->getConnection()
+            ->expects('select')
+            ->with('select * from "table" where ("attr" = ?) limit 1', ['foo'], true, [])
+            ->andReturn([[
+                'id' => 123,
+                'attr' => 'foo',
+                'val' => 'bar',
+                'created_at' => '2023-01-01 00:00:00',
+                'updated_at' => '2023-01-01 00:00:00',
+            ]]);
+
+        $callCount = 0;
+        $result = $model->newQuery()->firstOrNew(['attr' => 'foo'], function () use (&$callCount) {
+            $callCount++;
+
+            return ['val' => 'should-not-be-called'];
+        });
+
+        $this->assertSame(0, $callCount);
+        $this->assertTrue($result->exists);
+        $this->assertSame('bar', $result->val);
+    }
+
     public static function createOrFirstValues(): array
     {
         return [

--- a/tests/Database/DatabaseEloquentHasManyCreateOrFirstTest.php
+++ b/tests/Database/DatabaseEloquentHasManyCreateOrFirstTest.php
@@ -320,6 +320,92 @@ class DatabaseEloquentHasManyCreateOrFirstTest extends TestCase
         ], $result->toArray());
     }
 
+    #[DataProvider('createOrFirstValues')]
+    public function testUpdateOrCreateMethodAcceptsClosureValuesAndCreates(Closure|array $values): void
+    {
+        $model = new HasManyCreateOrFirstTestParentModel();
+        $model->id = 123;
+        $this->mockConnectionForModel($model, 'SQLite', [456]);
+        $model->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
+        $model->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+
+        $model->getConnection()
+            ->expects('select')
+            ->with('select * from "child_table" where "child_table"."parent_id" = ? and "child_table"."parent_id" is not null and ("attr" = ?) limit 1', [123, 'foo'], true, [])
+            ->andReturn([]);
+
+        $model->getConnection()->expects('insert')->with(
+            'insert into "child_table" ("attr", "val", "parent_id", "updated_at", "created_at") values (?, ?, ?, ?, ?)',
+            ['foo', 'bar', 123, '2023-01-01 00:00:00', '2023-01-01 00:00:00'],
+        )->andReturnTrue();
+
+        $result = $model->children()->updateOrCreate(['attr' => 'foo'], $values);
+        $this->assertTrue($result->wasRecentlyCreated);
+        $this->assertSame('bar', $result->val);
+    }
+
+    public function testUpdateOrCreateMethodAcceptsClosureValuesAndUpdates(): void
+    {
+        $model = new HasManyCreateOrFirstTestParentModel();
+        $model->id = 123;
+        $this->mockConnectionForModel($model, 'SQLite');
+        $model->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
+        $model->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+
+        $model->getConnection()
+            ->expects('select')
+            ->with('select * from "child_table" where "child_table"."parent_id" = ? and "child_table"."parent_id" is not null and ("attr" = ?) limit 1', [123, 'foo'], true, [])
+            ->andReturn([[
+                'id' => 456,
+                'parent_id' => 123,
+                'attr' => 'foo',
+                'val' => 'bar',
+                'created_at' => '2023-01-01T00:00:00.000000Z',
+                'updated_at' => '2023-01-01T00:00:00.000000Z',
+            ]]);
+
+        $model->getConnection()->expects('update')->with(
+            'update "child_table" set "val" = ?, "updated_at" = ? where "id" = ?',
+            ['baz', '2023-01-01 00:00:00', 456],
+        )->andReturn(1);
+
+        $result = $model->children()->updateOrCreate(['attr' => 'foo'], fn () => ['val' => 'baz']);
+        $this->assertFalse($result->wasRecentlyCreated);
+        $this->assertSame('baz', $result->val);
+    }
+
+    public function testFirstOrNewDoesNotInvokeClosureWhenRecordExists(): void
+    {
+        $model = new HasManyCreateOrFirstTestParentModel();
+        $model->id = 123;
+        $this->mockConnectionForModel($model, 'SQLite');
+        $model->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
+        $model->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+
+        $model->getConnection()
+            ->expects('select')
+            ->with('select * from "child_table" where "child_table"."parent_id" = ? and "child_table"."parent_id" is not null and ("attr" = ?) limit 1', [123, 'foo'], true, [])
+            ->andReturn([[
+                'id' => 456,
+                'parent_id' => 123,
+                'attr' => 'foo',
+                'val' => 'bar',
+                'created_at' => '2023-01-01 00:00:00',
+                'updated_at' => '2023-01-01 00:00:00',
+            ]]);
+
+        $callCount = 0;
+        $result = $model->children()->firstOrNew(['attr' => 'foo'], function () use (&$callCount) {
+            $callCount++;
+
+            return ['val' => 'should-not-be-called'];
+        });
+
+        $this->assertSame(0, $callCount);
+        $this->assertTrue($result->exists);
+        $this->assertSame('bar', $result->val);
+    }
+
     public static function createOrFirstValues(): array
     {
         return [


### PR DESCRIPTION
## Summary

Extends the lazy-evaluation pattern from #58639 to the two remaining \`*OrCreate\` / \`*OrNew\` methods that were not updated. After this PR, every method in the family accepts a \`Closure|array\` for \`\$values\`:

| Method | Before | After |
|---|---|---|
| \`firstOrCreate\` | ✅ Closure (#58639) | ✅ Closure |
| \`createOrFirst\` | ✅ Closure (#58639) | ✅ Closure |
| \`updateOrCreate\` | ❌ array only | ✅ **Closure** |
| \`firstOrNew\` | ❌ array only | ✅ **Closure** |

Applied consistently across:
- \`Eloquent\Builder\`
- \`Eloquent\Relations\HasOneOrMany\` (covers \`HasOne\` and \`HasMany\`)
- \`Eloquent\Relations\BelongsToMany\`

## The bug today

\`updateOrCreate\` already calls \`firstOrCreate\` internally, so on the surface it looks like Closure values would just pass through. But the implementation is:

\`\`\`php
public function updateOrCreate(array \$attributes, array \$values = [])
{
    return tap(\$this->firstOrCreate(\$attributes, \$values), function (\$instance) use (\$values) {
        if (! \$instance->wasRecentlyCreated) {
            \$instance->fill(\$values)->save(); // <-- \$values is still the original closure
        }
    });
}
\`\`\`

If you pass a Closure today (which the type signature forbids — but PHP doesn't enforce array types at runtime through this code path for everyone), the create path works (because \`createOrFirst\` resolves it via \`value()\`), but the **update path passes the unresolved Closure straight to \`fill()\` and crashes**. The type signature lies about the runtime contract.

## The fix

Resolve the closure **exactly once** per call:

\`\`\`php
public function updateOrCreate(array \$attributes, Closure|array \$values = [])
{
    return tap(\$this->firstOrCreate(\$attributes, \$values), function (\$instance) use (\$values) {
        if (! \$instance->wasRecentlyCreated) {
            \$instance->fill(value(\$values))->save();
        }
    });
}
\`\`\`

- **Path A (record does not exist):** \`firstOrCreate\` → \`createOrFirst\` resolves \`\$values\` via \`value()\` once. The \`tap\` callback sees \`wasRecentlyCreated=true\` and skips the \`fill()\` block. Closure called once.
- **Path B (record exists):** \`firstOrCreate\` short-circuits at the \`where()\` check before resolving anything. The \`tap\` callback then calls \`fill(value(\$values))\`. Closure called once.

The closure is **always** called exactly once — preserving the lazy-evaluation guarantee from #58639.

\`firstOrNew\` gets the same treatment for consistency with the rest of the family — it never resolved \`\$values\` to begin with, so it just gains the new lazy-evaluation property where the closure is skipped entirely if the record exists.

## Use case

Same as #58639 — defer expensive operations (geocoding, encryption, API calls) until you know the record actually needs to be created or updated:

\`\`\`php
\$location = Location::updateOrCreate(
    ['address' => \$address],
    fn () => ['coordinates' => Geocoder::resolve(\$address)],
);
\`\`\`

Today this throws on the update path. After this PR, the geocode call is deferred until \`fill()\` actually needs the values.

## Tests

13 new tests across the three \`*CreateOrFirst\` test files covering:

| Test | Asserts |
|---|---|
| \`testUpdateOrCreateMethodAcceptsClosureValuesAndCreates\` (data provider, both array + closure) | Result is correct on the create path |
| \`testUpdateOrCreateMethodAcceptsClosureValuesAndUpdates\` | Result is correct on the update path |
| \`testUpdateOrCreateInvokesClosureExactlyOnceWhenCreating\` | Closure runs **exactly once** on create — guards against double-execution regressions |
| \`testUpdateOrCreateInvokesClosureExactlyOnceWhenUpdating\` | Closure runs **exactly once** on update |
| \`testFirstOrNewMethodAcceptsClosureValuesAndInstantiates\` | Closure result is merged into the new model |
| \`testFirstOrNewDoesNotInvokeClosureWhenRecordExists\` | Closure is **never invoked** when the record already exists — proves the lazy-evaluation property |

All 54 tests across the four \`*CreateOrFirst\` files pass locally. Pint is clean on all 6 changed files.

## Why this is safe

- No method signature changes that break callers — \`Closure|array\` is a strict superset of \`array\`
- The \`@param\` docblock matches the existing \`firstOrCreate\` / \`createOrFirst\` style: \`(\Closure(): array)|array\`
- Exact same pattern that Taylor merged in #58639 — this is the missing follow-up