### PR TITLE
[13.x] Use null coalescing assignment in MailManager::purge()

### DIFF
--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -557,7 +557,7 @@ class MailManager implements FactoryContract
      */
     public function purge($name = null)
     {
-        $name = $name ?: $this->getDefaultDriver();
+        $name ??= $this->getDefaultDriver();
 
         unset($this->mailers[$name]);
     }


### PR DESCRIPTION
Aligns `MailManager::purge()` with `CacheManager`, `BroadcastManager`, and `FilesystemManager` which all use `??=` instead of `?:`.