### PR TITLE
[13.x] Refactor `Skip` middleware

### DIFF
--- a/src/Illuminate/Queue/Middleware/Skip.php
+++ b/src/Illuminate/Queue/Middleware/Skip.php
@@ -18,7 +18,7 @@ class Skip
      *
      * @param  bool|(\Closure(): bool)  $condition
      */
-    public static function when(Closure|bool $condition): self
+    public static function when(Closure|bool $condition): static
     {
         return new static(value($condition));
     }
@@ -28,7 +28,7 @@ class Skip
      *
      * @param  bool|(\Closure(): bool)  $condition
      */
-    public static function unless(Closure|bool $condition): self
+    public static function unless(Closure|bool $condition): static
     {
         return new static(! value($condition));
     }

--- a/src/Illuminate/Queue/Middleware/Skip.php
+++ b/src/Illuminate/Queue/Middleware/Skip.php
@@ -6,6 +6,9 @@ use Closure;
 
 class Skip
 {
+    /**
+     * @param  bool  Whether the job should be skipped.
+     */
     public function __construct(protected bool $skip = false)
     {
     }
@@ -13,21 +16,21 @@ class Skip
     /**
      * Apply the middleware if the given condition is truthy.
      *
-     * @param  bool|Closure(): bool  $condition
+     * @param  bool|(\Closure(): bool)  $condition
      */
     public static function when(Closure|bool $condition): self
     {
-        return new self(value($condition));
+        return new static(value($condition));
     }
 
     /**
      * Apply the middleware unless the given condition is truthy.
      *
-     * @param  bool|Closure(): bool  $condition
+     * @param  bool|(\Closure(): bool)  $condition
      */
     public static function unless(Closure|bool $condition): self
     {
-        return new self(! value($condition));
+        return new static(! value($condition));
     }
 
     /**

--- a/src/Illuminate/Queue/Middleware/Skip.php
+++ b/src/Illuminate/Queue/Middleware/Skip.php
@@ -7,7 +7,7 @@ use Closure;
 class Skip
 {
     /**
-     * @param  bool  Whether the job should be skipped.
+     * @param  bool  $param  Whether the job should be skipped.
      */
     public function __construct(protected bool $skip = false)
     {


### PR DESCRIPTION
Needed a reference file for creating my own middleware and fixed a few tiny issues:

* Docblocks for Closure now reference the FQCN (per the Laravel conventions, I bet it's even documented but I'm tokenmaxxing right now and don't have time to read)
* static factory methods reference `self` instead of `static` which disallows extension