### PR TITLE
Use error output for console components

### DIFF
--- a/src/Illuminate/Console/OutputStyle.php
+++ b/src/Illuminate/Console/OutputStyle.php
@@ -4,12 +4,20 @@ namespace Illuminate\Console;
 
 use Illuminate\Console\Contracts\NewLineAware;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 class OutputStyle extends SymfonyStyle implements NewLineAware
 {
+    /**
+     * The input instance.
+     *
+     * @var \Symfony\Component\Console\Input\InputInterface
+     */
+    private $input;
+
     /**
      * The output instance.
      *
@@ -43,6 +51,7 @@ class OutputStyle extends SymfonyStyle implements NewLineAware
      */
     public function __construct(InputInterface $input, OutputInterface $output)
     {
+        $this->input = $input;
         $this->output = $output;
 
         parent::__construct($input, $output);
@@ -194,5 +203,19 @@ class OutputStyle extends SymfonyStyle implements NewLineAware
     public function getOutput()
     {
         return $this->output;
+    }
+
+    /**
+     * Get an output style instance that writes to the error output when available.
+     *
+     * @return static
+     */
+    public function errorStyle()
+    {
+        if (! $this->output instanceof ConsoleOutputInterface) {
+            return $this;
+        }
+
+        return new static($this->input, $this->output->getErrorOutput());
     }
 }

--- a/src/Illuminate/Console/View/Components/Component.php
+++ b/src/Illuminate/Console/View/Components/Component.php
@@ -5,7 +5,9 @@ namespace Illuminate\Console\View\Components;
 use Illuminate\Console\OutputStyle;
 use Illuminate\Console\QuestionHelper;
 use ReflectionClass;
+use ReflectionProperty;
 use Symfony\Component\Console\Helper\SymfonyQuestionHelper;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
 
 use function Termwind\render;
 use function Termwind\renderUsing;
@@ -129,6 +131,12 @@ abstract class Component
     protected function resolveOutput($output)
     {
         if (! $output instanceof OutputStyle) {
+            return $output;
+        }
+
+        $property = new ReflectionProperty(OutputStyle::class, 'output');
+
+        if (! $property->isInitialized($output) || ! $property->getValue($output) instanceof ConsoleOutputInterface) {
             return $output;
         }
 

--- a/src/Illuminate/Console/View/Components/Component.php
+++ b/src/Illuminate/Console/View/Components/Component.php
@@ -33,7 +33,7 @@ abstract class Component
      */
     public function __construct($output)
     {
-        $this->output = $output;
+        $this->output = $this->resolveOutput($output);
     }
 
     /**
@@ -118,5 +118,20 @@ abstract class Component
         } finally {
             $property->setValue($this->output, $currentHelper);
         }
+    }
+
+    /**
+     * Resolve the output instance used by the component.
+     *
+     * @param  mixed  $output
+     * @return mixed
+     */
+    protected function resolveOutput($output)
+    {
+        if (! $output instanceof OutputStyle) {
+            return $output;
+        }
+
+        return $output->errorStyle();
     }
 }

--- a/tests/Console/OutputStyleTest.php
+++ b/tests/Console/OutputStyleTest.php
@@ -6,6 +6,9 @@ use Illuminate\Console\OutputStyle;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
+use Symfony\Component\Console\Output\ConsoleSectionOutput;
+use Symfony\Component\Console\Output\OutputInterface;
 
 class OutputStyleTest extends TestCase
 {
@@ -70,5 +73,61 @@ class OutputStyleTest extends TestCase
 
         $style->writeln('Foo', OutputStyle::VERBOSITY_VERBOSE);
         $this->assertTrue($style->newLineWritten());
+    }
+
+    public function testErrorStyleReturnsSameInstanceWhenErrorOutputIsUnavailable()
+    {
+        $style = new OutputStyle(new ArrayInput([]), new BufferedOutput());
+
+        $this->assertSame($style, $style->errorStyle());
+    }
+
+    public function testErrorStyleUsesErrorOutputWhenAvailable()
+    {
+        $output = new TestConsoleOutput;
+        $style = new OutputStyle(new ArrayInput([]), $output);
+
+        $errorStyle = $style->errorStyle();
+        $errorStyle->writeln('Laravel');
+
+        $this->assertSame('', $output->fetch());
+        $this->assertStringContainsString('Laravel', $output->errorOutput()->fetch());
+    }
+}
+
+class TestConsoleOutput extends BufferedOutput implements ConsoleOutputInterface
+{
+    /**
+     * The error output instance.
+     *
+     * @var \Symfony\Component\Console\Output\BufferedOutput
+     */
+    protected $errorOutput;
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->errorOutput = new BufferedOutput();
+    }
+
+    public function getErrorOutput(): OutputInterface
+    {
+        return $this->errorOutput;
+    }
+
+    public function setErrorOutput(OutputInterface $error): void
+    {
+        $this->errorOutput = $error;
+    }
+
+    public function section(): ConsoleSectionOutput
+    {
+        throw new \BadMethodCallException('Sections are not required for this test.');
+    }
+
+    public function errorOutput(): BufferedOutput
+    {
+        return $this->errorOutput;
     }
 }

--- a/tests/Console/View/ComponentsTest.php
+++ b/tests/Console/View/ComponentsTest.php
@@ -7,7 +7,11 @@ use Illuminate\Console\View\Components;
 use Illuminate\Database\Migrations\MigrationResult;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
+use Symfony\Component\Console\Output\ConsoleSectionOutput;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ChoiceQuestion;
 
 class ComponentsTest extends TestCase
@@ -69,6 +73,7 @@ class ComponentsTest extends TestCase
     public function testConfirm()
     {
         $output = m::mock(OutputStyle::class);
+        $output->shouldReceive('errorStyle')->andReturnSelf();
 
         $output->shouldReceive('confirm')
             ->with('Question?', false)
@@ -90,6 +95,7 @@ class ComponentsTest extends TestCase
     public function testChoice()
     {
         $output = m::mock(OutputStyle::class);
+        $output->shouldReceive('errorStyle')->andReturnSelf();
 
         $output->shouldReceive('askQuestion')
             ->with(m::type(ChoiceQuestion::class))
@@ -120,6 +126,35 @@ class ComponentsTest extends TestCase
         $this->assertStringContainsString('SKIPPED', $result);
     }
 
+    public function testAlertUsesErrorOutputWhenAvailable()
+    {
+        $output = new TestConsoleOutput;
+        $style = new OutputStyle(new ArrayInput([]), $output);
+
+        (new Components\Alert($style))->render('The application is in the [production] environment');
+
+        $this->assertSame('', $output->fetch());
+        $this->assertStringContainsString(
+            'THE APPLICATION IS IN THE [PRODUCTION] ENVIRONMENT.',
+            $output->errorOutput()->fetch()
+        );
+    }
+
+    public function testTaskUsesErrorOutputWhenAvailable()
+    {
+        $output = new TestConsoleOutput;
+        $style = new OutputStyle(new ArrayInput([]), $output);
+
+        (new Components\Task($style))->render('My task', fn () => MigrationResult::Success->value);
+
+        $this->assertSame('', $output->fetch());
+
+        $result = $output->errorOutput()->fetch();
+
+        $this->assertStringContainsString('My task', $result);
+        $this->assertStringContainsString('DONE', $result);
+    }
+
     public function testTwoColumnDetail()
     {
         $output = new BufferedOutput();
@@ -146,5 +181,42 @@ class ComponentsTest extends TestCase
         (new Components\Warn($output))->render('The application is in the [production] environment');
 
         $this->assertStringContainsString('WARN  The application is in the [production] environment.', $output->fetch());
+    }
+}
+
+class TestConsoleOutput extends BufferedOutput implements ConsoleOutputInterface
+{
+    /**
+     * The error output instance.
+     *
+     * @var \Symfony\Component\Console\Output\BufferedOutput
+     */
+    protected $errorOutput;
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->errorOutput = new BufferedOutput();
+    }
+
+    public function getErrorOutput(): OutputInterface
+    {
+        return $this->errorOutput;
+    }
+
+    public function setErrorOutput(OutputInterface $error): void
+    {
+        $this->errorOutput = $error;
+    }
+
+    public function section(): ConsoleSectionOutput
+    {
+        throw new \BadMethodCallException('Sections are not required for this test.');
+    }
+
+    public function errorOutput(): BufferedOutput
+    {
+        return $this->errorOutput;
     }
 }

--- a/tests/Integration/Console/ConsoleComponentErrorOutputTest.php
+++ b/tests/Integration/Console/ConsoleComponentErrorOutputTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Console\Kernel;
+use Orchestra\Testbench\TestCase;
+use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
+use Symfony\Component\Console\Output\ConsoleSectionOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ConsoleComponentErrorOutputTest extends TestCase
+{
+    public function testConsoleComponentsWriteToErrorOutputWhenAvailable(): void
+    {
+        $this->app[Kernel::class]->registerCommand(new class extends Command
+        {
+            protected $signature = 'test:console-components-output {--json}';
+
+            public function handle(): int
+            {
+                $this->components->task('Doing work', fn () => true);
+
+                if ($this->option('json')) {
+                    $this->output->writeln(json_encode([['nice' => 'valid JSON!']], JSON_PRETTY_PRINT));
+                }
+
+                return self::SUCCESS;
+            }
+        });
+
+        $output = new TestConsoleOutput;
+
+        $this->app[Kernel::class]->handle(new StringInput('test:console-components-output --json'), $output);
+
+        $standardOutput = $output->fetch();
+
+        $this->assertJson($standardOutput);
+        $this->assertJsonStringEqualsJsonString(
+            json_encode([['nice' => 'valid JSON!']], JSON_PRETTY_PRINT),
+            $standardOutput
+        );
+
+        $errorOutput = $output->errorOutput()->fetch();
+
+        $this->assertStringContainsString('Doing work', $errorOutput);
+        $this->assertStringContainsString('DONE', $errorOutput);
+    }
+}
+
+class TestConsoleOutput extends BufferedOutput implements ConsoleOutputInterface
+{
+    /**
+     * The error output instance.
+     *
+     * @var \Symfony\Component\Console\Output\BufferedOutput
+     */
+    protected $errorOutput;
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->errorOutput = new BufferedOutput();
+    }
+
+    public function getErrorOutput(): OutputInterface
+    {
+        return $this->errorOutput;
+    }
+
+    public function setErrorOutput(OutputInterface $error): void
+    {
+        $this->errorOutput = $error;
+    }
+
+    public function section(): ConsoleSectionOutput
+    {
+        throw new \BadMethodCallException('Sections are not required for this test.');
+    }
+
+    public function errorOutput(): BufferedOutput
+    {
+        return $this->errorOutput;
+    }
+}


### PR DESCRIPTION
## Summary

This PR updates console view components to prefer the error output stream when it is available.

This keeps command payloads on stdout while sending auxiliary console UI output, such as `task()` and alert-style components, to stderr.

## Changes

- added `OutputStyle::errorStyle()`
- updated console view components to use the error style when available
- added regression coverage for `OutputStyle` and console components
- added an integration test that verifies JSON output stays on stdout while component output is written to stderr

## Tests

- `/opt/homebrew/opt/php@8.3/bin/php vendor/bin/phpunit tests/Console/OutputStyleTest.php tests/Console/View/ComponentsTest.php tests/Integration/Console/ConsoleComponentErrorOutputTest.php tests/Integration/Console/Events/EventListCommandTest.php tests/Integration/Console/Scheduling/ScheduleListCommandTest.php`
