### PR TITLE
[13.x] Add #[FromQuery] and #[FromHeader] parameter attributes

### DIFF
--- a/src/Illuminate/Container/Attributes/FromHeader.php
+++ b/src/Illuminate/Container/Attributes/FromHeader.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Illuminate\Container\Attributes;
+
+use Attribute;
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Contracts\Container\ContextualAttribute;
+
+#[Attribute(Attribute::TARGET_PARAMETER)]
+class FromHeader implements ContextualAttribute
+{
+    /**
+     * Create a new class instance.
+     */
+    public function __construct(public string $key, public mixed $default = null)
+    {
+    }
+
+    /**
+     * Resolve the request header value.
+     *
+     * @param  self  $attribute
+     * @param  \Illuminate\Contracts\Container\Container  $container
+     * @return mixed
+     */
+    public static function resolve(self $attribute, Container $container)
+    {
+        return $container->make('request')->header($attribute->key, $attribute->default);
+    }
+}

--- a/src/Illuminate/Container/Attributes/FromQuery.php
+++ b/src/Illuminate/Container/Attributes/FromQuery.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Illuminate\Container\Attributes;
+
+use Attribute;
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Contracts\Container\ContextualAttribute;
+
+#[Attribute(Attribute::TARGET_PARAMETER)]
+class FromQuery implements ContextualAttribute
+{
+    /**
+     * Create a new class instance.
+     */
+    public function __construct(public string $key, public mixed $default = null)
+    {
+    }
+
+    /**
+     * Resolve the query string parameter.
+     *
+     * @param  self  $attribute
+     * @param  \Illuminate\Contracts\Container\Container  $container
+     * @return mixed
+     */
+    public static function resolve(self $attribute, Container $container)
+    {
+        return $container->make('request')->query($attribute->key, $attribute->default);
+    }
+}

--- a/tests/Container/ContextualAttributeBindingTest.php
+++ b/tests/Container/ContextualAttributeBindingTest.php
@@ -14,6 +14,8 @@ use Illuminate\Container\Attributes\Config;
 use Illuminate\Container\Attributes\Context;
 use Illuminate\Container\Attributes\CurrentUser;
 use Illuminate\Container\Attributes\Database;
+use Illuminate\Container\Attributes\FromHeader;
+use Illuminate\Container\Attributes\FromQuery;
 use Illuminate\Container\Attributes\Give;
 use Illuminate\Container\Attributes\Log;
 use Illuminate\Container\Attributes\RouteParameter;
@@ -234,6 +236,42 @@ class ContextualAttributeBindingTest extends TestCase
         });
 
         $container->make(RouteParameterTest::class);
+    }
+
+    public function testFromQueryAttribute()
+    {
+        $container = new Container;
+        $container->singleton('request', function () {
+            $request = m::mock(Request::class);
+            $request->shouldReceive('query')->with('sort', null)->andReturn('asc');
+            $request->shouldReceive('query')->with('per_page', 25)->andReturn(50);
+            $request->shouldReceive('query')->with('missing', 'fallback')->andReturn('fallback');
+
+            return $request;
+        });
+
+        $instance = $container->make(FromQueryTest::class);
+
+        $this->assertSame('asc', $instance->sort);
+        $this->assertSame(50, $instance->perPage);
+        $this->assertSame('fallback', $instance->missing);
+    }
+
+    public function testFromHeaderAttribute()
+    {
+        $container = new Container;
+        $container->singleton('request', function () {
+            $request = m::mock(Request::class);
+            $request->shouldReceive('header')->with('X-Tenant-Id', null)->andReturn('tenant-42');
+            $request->shouldReceive('header')->with('X-Requested-With', 'default')->andReturn('default');
+
+            return $request;
+        });
+
+        $instance = $container->make(FromHeaderTest::class);
+
+        $this->assertSame('tenant-42', $instance->tenantId);
+        $this->assertSame('default', $instance->requestedWith);
     }
 
     public function testContextAttribute(): void
@@ -537,6 +575,25 @@ final class RouteParameterTest
 {
     public function __construct(#[RouteParameter('foo')] Model $foo, #[RouteParameter('bar')] string $bar)
     {
+    }
+}
+
+final class FromQueryTest
+{
+    public function __construct(
+        #[FromQuery('sort')] public readonly string $sort,
+        #[FromQuery('per_page', 25)] public readonly int $perPage,
+        #[FromQuery('missing', 'fallback')] public readonly string $missing,
+    ) {
+    }
+}
+
+final class FromHeaderTest
+{
+    public function __construct(
+        #[FromHeader('X-Tenant-Id')] public readonly string $tenantId,
+        #[FromHeader('X-Requested-With', 'default')] public readonly string $requestedWith,
+    ) {
     }
 }
 

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -10,6 +10,8 @@ use Illuminate\Auth\Middleware\Authenticate;
 use Illuminate\Auth\Middleware\Authorize;
 use Illuminate\Config\Repository;
 use Illuminate\Container\Attributes\Config;
+use Illuminate\Container\Attributes\FromHeader;
+use Illuminate\Container\Attributes\FromQuery;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Routing\Registrar;
 use Illuminate\Contracts\Support\Responsable;
@@ -674,6 +676,81 @@ class RoutingRouteTest extends TestCase
             return $bar;
         })->defaults('bar', 'foo');
         $this->assertSame('foo', $router->dispatch(Request::create('foo', 'GET'))->getContent());
+    }
+
+    public function testFromQueryAttributeResolvesQueryStringValuesOnControllerActions()
+    {
+        $container = new Container;
+        $router = $this->getRouter($container);
+        $router->get('search', RouteTestControllerWithFromQueryStub::class.'@search');
+
+        $request = Request::create('search?sort=desc&per_page=50', 'GET');
+        $container->instance('request', $request);
+
+        $response = $router->dispatch($request);
+
+        $this->assertSame('sort=desc per_page=50', $response->getContent());
+    }
+
+    public function testFromQueryAttributeReturnsDefaultWhenQueryStringMissing()
+    {
+        $container = new Container;
+        $router = $this->getRouter($container);
+        $router->get('search', RouteTestControllerWithFromQueryStub::class.'@search');
+
+        $request = Request::create('search', 'GET');
+        $container->instance('request', $request);
+
+        $response = $router->dispatch($request);
+
+        $this->assertSame('sort=asc per_page=25', $response->getContent());
+    }
+
+    public function testFromQueryAttributeWorksOnRouteClosures()
+    {
+        $container = new Container;
+        $router = $this->getRouter($container);
+        $router->get('search', function (#[FromQuery('q')] ?string $q = null) {
+            return $q ?? 'empty';
+        });
+
+        $request = Request::create('search?q=laravel', 'GET');
+        $container->instance('request', $request);
+        $this->assertSame('laravel', $router->dispatch($request)->getContent());
+
+        $request = Request::create('search', 'GET');
+        $container->instance('request', $request);
+        $this->assertSame('empty', $router->dispatch($request)->getContent());
+    }
+
+    public function testFromHeaderAttributeResolvesRequestHeadersOnControllerActions()
+    {
+        $container = new Container;
+        $router = $this->getRouter($container);
+        $router->get('api/me', RouteTestControllerWithFromHeaderStub::class.'@me');
+
+        $request = Request::create('api/me', 'GET');
+        $request->headers->set('X-Tenant-Id', 'tenant-42');
+        $request->headers->set('X-Api-Version', '2');
+        $container->instance('request', $request);
+
+        $response = $router->dispatch($request);
+
+        $this->assertSame('tenant=tenant-42 version=2', $response->getContent());
+    }
+
+    public function testFromHeaderAttributeReturnsDefaultWhenHeaderMissing()
+    {
+        $container = new Container;
+        $router = $this->getRouter($container);
+        $router->get('api/me', RouteTestControllerWithFromHeaderStub::class.'@me');
+
+        $request = Request::create('api/me', 'GET');
+        $container->instance('request', $request);
+
+        $response = $router->dispatch($request);
+
+        $this->assertSame('tenant=default-tenant version=1', $response->getContent());
     }
 
     public function testControllerCallActionMethodParameters()
@@ -2321,6 +2398,26 @@ class RouteTestControllerWithParameterStub extends Controller
     public function returnParameter($bar = '')
     {
         return $bar;
+    }
+}
+
+class RouteTestControllerWithFromQueryStub extends Controller
+{
+    public function search(
+        #[FromQuery('sort', 'asc')] string $sort,
+        #[FromQuery('per_page', 25)] int $perPage,
+    ) {
+        return 'sort='.$sort.' per_page='.$perPage;
+    }
+}
+
+class RouteTestControllerWithFromHeaderStub extends Controller
+{
+    public function me(
+        #[FromHeader('X-Tenant-Id', 'default-tenant')] string $tenantId,
+        #[FromHeader('X-Api-Version', 1)] int $apiVersion,
+    ) {
+        return 'tenant='.$tenantId.' version='.$apiVersion;
     }
 }
 


### PR DESCRIPTION
## Summary

Adds two new contextual parameter attributes that resolve request query string values and headers directly into typed controller action parameters and route closure arguments.


```
public function search(
    #[FromQuery('sort')] string \$sort,
    #[FromQuery('per_page', 25)] int \$perPage,
    #[FromHeader('X-Tenant-Id')] string \$tenantId,
    #[FromHeader('X-Api-Version', 1)] int \$apiVersion,
) {
    // $sort, $perPage, $tenantId, \$apiVersion are already typed and ready to use.
}
```


## The problem this solves

Laravel has first-class parameter binding for:

- **Request object** — \`Request \$request\` injected by type hint
- **Route model binding** — \`User \$user\` resolved from \`{user}\` URL segment
- **Container parameter attributes** — \`#[Auth]\`, \`#[Config]\`, \`#[CurrentUser]\`, \`#[RouteParameter]\`, \`#[Cache]\`, \`#[Database]\`, \`#[Storage]\`, \`#[Tag]\`, \`#[Log]\`

But the two most common HTTP request surfaces — **query strings** and **headers** — have no first-class parameter binding. The current workaround:


```
public function search(Request $request)
{
    $sort = $request->query('sort', 'asc');         // mixed
    $perPage = $request->query('per_page', 25);     // mixed
    $tenantId = $request->header('X-Tenant-Id');    // mixed
}
```


Every query and header value is \`mixed\`, defeating IDE autocomplete, static analysis, and PHP's type system. You can type-hint the local variable manually, but that's noise.

## The solution

\`#[FromQuery]\` and \`#[FromHeader]\` are **parameter-level contextual attributes** that mirror the existing \`#[RouteParameter]\`, \`#[Config]\`, and \`#[Auth]\` pattern exactly. They plug into the container's \`resolveFromAttribute\` path with **zero core modifications** — just two new attribute classes.


```
// src/Illuminate/Container/Attributes/FromQuery.php
#[Attribute(Attribute::TARGET_PARAMETER)]
class FromQuery implements ContextualAttribute
{
    public function __construct(public string $key, public mixed $default = null)
    {
    }

    public static function resolve(self $attribute, Container $container)
    {
        return $container->make('request')->query($attribute->key, $attribute->default);
    }
}
```


\`FromHeader\` is identical except it calls \`->header(\$key, \$default)\`.

## Type coercion

Scalar type hints (\`int\`, \`float\`, \`string\`, \`?string\`) work out of the box via PHP's existing parameter-level weak type coercion at the call boundary. No resolver changes needed.


```
// URL: /search?per_page=50
public function search(#[FromQuery('per_page', 25)] int $perPage)
{
    // $perPage === 50 (string "50" is coerced to int at the call boundary)
}

```

## Design alignment with existing attributes

Same shape as \`#[Config]\` which is already merged and widely used:

| Attribute | Constructor | Resolves |
|---|---|---|
| \`#[Config('app.name')]\` | \`string \$key, mixed \$default\` | \`config('app.name')\` |
| \`#[RouteParameter('user')]\` | \`string \$parameter\` | \`\$request->route('user')\` |
| \`#[FromQuery('sort')]\` | \`string \$key, mixed \$default\` | \`\$request->query('sort')\` |
| \`#[FromHeader('X-Tenant-Id')]\` | \`string \$key, mixed \$default\` | \`\$request->header('X-Tenant-Id')\` |

## Tests

7 new tests across 2 test files, all passing:

**\`tests/Container/ContextualAttributeBindingTest.php\`** (2 tests)
- \`testFromQueryAttribute\` — container resolves query values by key into constructor params with defaults
- \`testFromHeaderAttribute\` — container resolves header values by key with defaults

**\`tests/Routing/RoutingRouteTest.php\`** (5 tests)
- \`testFromQueryAttributeResolvesQueryStringValuesOnControllerActions\` — full router dispatch with query values
- \`testFromQueryAttributeReturnsDefaultWhenQueryStringMissing\` — default fallback path
- \`testFromQueryAttributeWorksOnRouteClosures\` — works on \`Route::get('/', fn (#[FromQuery] ...) => ...)\`
- \`testFromHeaderAttributeResolvesRequestHeadersOnControllerActions\` — full router dispatch with headers
- \`testFromHeaderAttributeReturnsDefaultWhenHeaderMissing\` — default fallback path