### PR TITLE
[13.x] Fix stale cache in Request::allFiles() when files are mutated

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -184,7 +184,16 @@ trait InteractsWithInput
     {
         $files = $this->files->all();
 
-        return $this->convertedFiles = $this->convertedFiles ?? $this->convertUploadedFiles($files);
+        // The converted files are cached so repeated calls do not re-wrap each
+        // Symfony UploadedFile. The cache is invalidated whenever the source
+        // file bag is mutated (e.g. by middleware that adds, replaces, or
+        // removes files after the first call to allFiles()).
+        if ($files !== $this->rawConvertedFiles) {
+            $this->rawConvertedFiles = $files;
+            $this->convertedFiles = $this->convertUploadedFiles($files);
+        }
+
+        return $this->convertedFiles;
     }
 
     /**

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -50,6 +50,16 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     protected $convertedFiles;
 
     /**
+     * The raw Symfony file bag snapshot that produced the cached converted files.
+     *
+     * Used to invalidate the converted files cache when the underlying file
+     * bag is mutated after the first call to allFiles().
+     *
+     * @var array<string, \Symfony\Component\HttpFoundation\File\UploadedFile|\Symfony\Component\HttpFoundation\File\UploadedFile[]>|null
+     */
+    protected $rawConvertedFiles;
+
+    /**
      * The user resolver callback.
      *
      * @var \Closure

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -1146,6 +1146,100 @@ class HttpRequestTest extends TestCase
         $this->assertFalse($request->hasFile('bar'));
     }
 
+    public function testAllFilesReflectsFilesAddedAfterFirstCall()
+    {
+        $request = Request::create('/', 'POST', [], [], [
+            'avatar' => [
+                'size' => 500,
+                'name' => 'avatar.jpg',
+                'tmp_name' => __FILE__,
+                'type' => 'image/jpeg',
+                'error' => null,
+            ],
+        ]);
+
+        $first = $request->allFiles();
+        $this->assertArrayHasKey('avatar', $first);
+        $this->assertArrayNotHasKey('banner', $first);
+
+        $request->files->set('banner', new SymfonyUploadedFile(__FILE__, 'banner.jpg', 'image/jpeg', null, true));
+
+        $second = $request->allFiles();
+        $this->assertArrayHasKey('avatar', $second);
+        $this->assertArrayHasKey('banner', $second);
+    }
+
+    public function testAllFilesReflectsFilesReplacedAfterFirstCall()
+    {
+        $request = Request::create('/', 'POST', [], [], [
+            'avatar' => [
+                'size' => 500,
+                'name' => 'original.jpg',
+                'tmp_name' => __FILE__,
+                'type' => 'image/jpeg',
+                'error' => null,
+            ],
+        ]);
+
+        $first = $request->allFiles();
+        $this->assertSame('original.jpg', $first['avatar']->getClientOriginalName());
+
+        $request->files->set('avatar', new SymfonyUploadedFile(__FILE__, 'replacement.jpg', 'image/jpeg', null, true));
+
+        $second = $request->allFiles();
+        $this->assertSame('replacement.jpg', $second['avatar']->getClientOriginalName());
+    }
+
+    public function testAllFilesReflectsFilesRemovedAfterFirstCall()
+    {
+        $request = Request::create('/', 'POST', [], [], [
+            'avatar' => [
+                'size' => 500,
+                'name' => 'avatar.jpg',
+                'tmp_name' => __FILE__,
+                'type' => 'image/jpeg',
+                'error' => null,
+            ],
+            'banner' => [
+                'size' => 800,
+                'name' => 'banner.jpg',
+                'tmp_name' => __FILE__,
+                'type' => 'image/jpeg',
+                'error' => null,
+            ],
+        ]);
+
+        $first = $request->allFiles();
+        $this->assertArrayHasKey('avatar', $first);
+        $this->assertArrayHasKey('banner', $first);
+
+        $request->files->remove('banner');
+
+        $second = $request->allFiles();
+        $this->assertArrayHasKey('avatar', $second);
+        $this->assertArrayNotHasKey('banner', $second);
+    }
+
+    public function testAllFilesReturnsCachedResultWhenFilesAreNotMutated()
+    {
+        $request = Request::create('/', 'POST', [], [], [
+            'avatar' => [
+                'size' => 500,
+                'name' => 'avatar.jpg',
+                'tmp_name' => __FILE__,
+                'type' => 'image/jpeg',
+                'error' => null,
+            ],
+        ]);
+
+        $first = $request->allFiles();
+        $second = $request->allFiles();
+
+        // The same UploadedFile instance should be returned on repeated calls
+        // so the cache is preserved when the file bag is not mutated.
+        $this->assertSame($first['avatar'], $second['avatar']);
+    }
+
     public function testServerMethod()
     {
         $request = Request::create('/', 'GET', [], [], [], ['foo' => 'bar']);


### PR DESCRIPTION
Fixes a stale cache bug in \`Illuminate\Http\Request::allFiles()\` that surfaces when downstream code mutates the request's file bag after the first call.

## The bug

\`allFiles()\` memoizes the converted files on the first call and returns the cached array on every subsequent call without checking whether the underlying \`Symfony\\HttpFoundation\\FileBag\` has been mutated:

```php
// Before
public function allFiles()
{
    $files = $this->files->all();

    return $this->convertedFiles = $this->convertedFiles ?? $this->convertUploadedFiles($files);
}
```

If any middleware or request-mutation flow adds, replaces, or removes a file after the first \`allFiles()\` read, the mutation is silently ignored.

## Reproduction

```php
$request = Request::create('upload', 'POST');
$request->files->set('avatar', $avatarFile);

$request->allFiles();  // caches ['avatar' => UploadedFile]

$request->files->set('banner', $bannerFile);

$request->allFiles();  // ['avatar' => ...] — 'banner' is missing!
```

This also impacts repeated \`\$request->file('key')\` lookups and \`\$request->all()\` calls, because both call \`allFiles()\` internally — so any code that reads files, mutates the bag, and then reads files again hits the bug.

## Fix

The fix stores the raw Symfony file bag snapshot alongside the converted cache and invalidates the cache when the source array no longer matches on strict equality. This preserves the performance benefit of the cache for the common case (repeated \`allFiles()\` calls without mutation) while correctly reflecting any mutations:

```php
// After
public function allFiles()
{
    $files = $this->files->all();

    // The converted files are cached so repeated calls do not re-wrap each
    // Symfony UploadedFile. The cache is invalidated whenever the source
    // file bag is mutated (e.g. by middleware that adds, replaces, or
    // removes files after the first call to allFiles()).
    if ($files !== $this->rawConvertedFiles) {
        $this->rawConvertedFiles = \$files;
        $this->convertedFiles = $this->convertUploadedFiles($files);
    }

    return $this->convertedFiles;
}
```

PHP's \`!==\` operator on arrays with object values compares by content and then by reference for each object, so any added, removed, or replaced file is caught — while repeat reads without mutation preserve the cache (same array contents, same object references).

## Tests

Added four regression tests to \`tests/Http/HttpRequestTest.php\`:

- `testAllFilesReflectsFilesAddedAfterFirstCall` — cache invalidates on add
- `testAllFilesReflectsFilesReplacedAfterFirstCall` — cache invalidates on replace (same key, different file)
- `testAllFilesReflectsFilesRemovedAfterFirstCall` — cache invalidates on remove
- `testAllFilesReturnsCachedResultWhenFilesAreNotMutated` — asserts `assertSame` on the returned instance across two calls, guarding the performance behavior for the no-mutation case

Verified the bug is real by running the three mutation tests against the unmodified code — they fail with the expected messages:

```
1) testAllFilesReflectsFilesAddedAfterFirstCall
   Failed asserting that an array has the key 'banner'.

2) testAllFilesReflectsFilesReplacedAfterFirstCall
   Failed asserting that two strings are identical.
   --- Expected
   +++ Actual
   -'replacement.jpg'
   +'original.jpg'

3) testAllFilesReflectsFilesRemovedAfterFirstCall
   Failed asserting that an array does not have the key 'banner'.
```

After the fix, all 4 new tests pass. The full `HttpRequestTest` file (141 tests, 585 assertions) passes locally, and Pint is clean on all 3 changed files.

## Relationship to #59631

Reported as part of #59631. **This PR only addresses the stale cache bug that the reporter spotted while working around an unrelated PHP SAPI limitation on multipart PUT/PATCH/DELETE requests.** The PHP SAPI limitation (\`\$_POST\` and \`\$_FILES\` only being populated for \`POST\` requests) is out of scope here — that's a PHP-level. The stale-cache bug is an independent issue the reporter noticed while building their workaround, and is genuinely a Laravel-side bug regardless of which HTTP verb the request uses.