### PR TITLE
Skip retry exception callbacks for redirects

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -1051,8 +1051,10 @@ class PendingRequest
                     }
 
                     try {
-                        $shouldRetry = $this->retryWhenCallback ? call_user_func($this->retryWhenCallback, $response->toException(), $this, $this->request->toPsrRequest()->getMethod()) : true;
-                    } catch (Exception $exception) {
+                        $shouldRetry = $this->retryWhenCallback && $response->failed()
+                            ? call_user_func($this->retryWhenCallback, $response->toException(), $this, $this->request->toPsrRequest()->getMethod())
+                            : true;
+                    } catch (Throwable $exception) {
                         $shouldRetry = false;
 
                         throw $exception;
@@ -1240,10 +1242,10 @@ class PendingRequest
         try {
             $shouldRetry = $this->retryWhenCallback ? call_user_func(
                 $this->retryWhenCallback,
-                $response instanceof Response ? $response->toException() : $response,
+                $response instanceof Response && $response->failed() ? $response->toException() : $response,
                 $this
             ) : true;
-        } catch (Exception $exception) {
+        } catch (Throwable $exception) {
             return $exception;
         }
 
@@ -1262,7 +1264,7 @@ class PendingRequest
             ($this->throwIfCallback === null || call_user_func($this->throwIfCallback, $response))) {
             try {
                 $response->throw($this->throwCallback);
-            } catch (Exception $exception) {
+            } catch (Throwable $exception) {
                 return $exception;
             }
         }

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -2382,6 +2382,31 @@ class HttpClientTest extends TestCase
         });
     }
 
+    public function testRetryWhenCallbackIsNotInvokedForRedirectResponses()
+    {
+        $this->factory->fake([
+            '*' => $this->factory->sequence()
+                ->push('', 302, ['Location' => 'http://foo.com/redirected'])
+                ->push(['ok'], 200),
+        ]);
+
+        $whenAttempts = 0;
+
+        $response = $this->factory
+            ->withoutRedirecting()
+            ->retry(2, 0, function (Exception $exception) use (&$whenAttempts) {
+                $whenAttempts++;
+
+                return true;
+            }, false)
+            ->get('http://foo.com/get');
+
+        $this->assertTrue($response->redirect());
+        $this->assertSame(0, $whenAttempts);
+
+        $this->factory->assertSentCount(1);
+    }
+
     public function testExceptionThrownInRetryCallbackWithoutRetrying()
     {
         $this->factory->fake([


### PR DESCRIPTION
## Summary

This PR avoids invoking the `Http::retry()` `when` callback for redirect responses.

Redirect responses are non-successful, but they do not produce an exception from `Response::toException()`. As a result, type-hinting `Exception` or `Throwable` in the `when` callback could currently trigger a `TypeError` when the response status is 3xx.

## Changes

- only invoke the retry `when` callback for failed responses
- catch `Throwable` around retry callback execution
- add a regression test covering redirect responses with a type-hinted `Exception` callback

Closes #59012.

## Tests

- `/opt/homebrew/opt/php@8.3/bin/php vendor/bin/phpunit tests/Http/HttpClientTest.php`
