### PR TITLE
[13.x] Add enum support to Manager driver method

### DIFF
--- a/src/Illuminate/Support/Manager.php
+++ b/src/Illuminate/Support/Manager.php
@@ -7,8 +7,6 @@ use Illuminate\Contracts\Container\Container;
 use InvalidArgumentException;
 use Throwable;
 
-use function Illuminate\Support\enum_value;
-
 abstract class Manager
 {
     /**

--- a/src/Illuminate/Support/Manager.php
+++ b/src/Illuminate/Support/Manager.php
@@ -7,6 +7,8 @@ use Illuminate\Contracts\Container\Container;
 use InvalidArgumentException;
 use Throwable;
 
+use function Illuminate\Support\enum_value;
+
 abstract class Manager
 {
     /**
@@ -58,14 +60,14 @@ abstract class Manager
     /**
      * Get a driver instance.
      *
-     * @param  string|null  $driver
+     * @param  \UnitEnum|string|null  $driver
      * @return mixed
      *
      * @throws \InvalidArgumentException
      */
     public function driver($driver = null)
     {
-        $driver = $driver ?: $this->getDefaultDriver();
+        $driver = enum_value($driver) ?: $this->getDefaultDriver();
 
         if (is_null($driver)) {
             throw new InvalidArgumentException(sprintf(

--- a/tests/Integration/Support/ManagerTest.php
+++ b/tests/Integration/Support/ManagerTest.php
@@ -31,4 +31,56 @@ class ManagerTest extends TestCase
         $manager->extend(__CLASS__, static fn () => $driver);
         $this->assertSame($driver, $manager->driver(__CLASS__));
     }
+
+    public function testEnumDriverCanBeResolved()
+    {
+        $manager = new NullableManager($this->app);
+        $driver = new stdClass;
+
+        $manager->extend('my_driver', static fn () => $driver);
+        $this->assertSame($driver, $manager->driver(ManagerDriverName::MyDriver));
+    }
+
+    public function testEnumDriverIsCached()
+    {
+        $manager = new NullableManager($this->app);
+
+        $manager->extend('my_driver', static fn () => new stdClass);
+
+        $driver1 = $manager->driver(ManagerDriverName::MyDriver);
+        $driver2 = $manager->driver(ManagerDriverName::MyDriver);
+
+        $this->assertSame($driver1, $driver2);
+    }
+
+    public function testEnumDriverMatchesStringDriver()
+    {
+        $manager = new NullableManager($this->app);
+
+        $manager->extend('my_driver', static fn () => new stdClass);
+
+        $fromEnum = $manager->driver(ManagerDriverName::MyDriver);
+        $fromString = $manager->driver('my_driver');
+
+        $this->assertSame($fromEnum, $fromString);
+    }
+
+    public function testUnitEnumDriverCanBeResolved()
+    {
+        $manager = new NullableManager($this->app);
+        $driver = new stdClass;
+
+        $manager->extend('MyDriver', static fn () => $driver);
+        $this->assertSame($driver, $manager->driver(ManagerUnitDriverName::MyDriver));
+    }
+}
+
+enum ManagerDriverName: string
+{
+    case MyDriver = 'my_driver';
+}
+
+enum ManagerUnitDriverName
+{
+    case MyDriver;
 }


### PR DESCRIPTION
This PR adds enum support to the base `Manager::driver()` method, using the
same `enum_value()` pattern established in #59637, #59645, and #59646.

Since `HashManager`, `SessionManager`, `ChannelManager`, and other managers
extend this base class, this change propagates enum support to all of them
without requiring individual PRs for each.

The `?:` operator is preserved to maintain the existing falsy-fallthrough
behavior (matching `AuthManager::guard()`).

### Tests

* Added tests for enum-based driver resolution
* Verified caching behavior remains unchanged
* Ensured enum and equivalent string drivers resolve to the same instance
* Added coverage for `UnitEnum` handling

### Backward Compatibility

* No breaking changes
* Existing behavior is preserved for strings, null values, and falsy fallbacks
