### PR TITLE
[13.x] Add spatie/fork to composer suggestions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -168,6 +168,7 @@
         "psr/http-message": "Required to allow Storage::put to accept a StreamInterface (^1.0).",
         "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (^6.0 || ^7.0).",
         "resend/resend-php": "Required to enable support for the Resend mail transport (^0.10.0 || ^1.0).",
+        "spatie/fork": "Required to use the 'fork' concurrency driver (^1.2).",
         "symfony/cache": "Required to PSR-6 cache bridge (^7.4 || ^8.0).",
         "symfony/filesystem": "Required to enable support for relative symbolic links (^7.4 || ^8.0).",
         "symfony/http-client": "Required to enable support for the Symfony API mail transports (^7.4 || ^8.0).",

--- a/src/Illuminate/Concurrency/ForkDriver.php
+++ b/src/Illuminate/Concurrency/ForkDriver.php
@@ -22,7 +22,7 @@ class ForkDriver implements Driver
         $keys = array_keys($tasks);
         $values = array_values($tasks);
 
-        /** @phpstan-ignore class.notFound */
+        /** @phpstan-ignore class.notFound (spatie/fork is not installed as it is practically incompatible with Windows) */
         $results = Fork::new()->run(...$values);
 
         ksort($results);

--- a/src/Illuminate/Concurrency/composer.json
+++ b/src/Illuminate/Concurrency/composer.json
@@ -21,6 +21,9 @@
         "illuminate/support": "^13.0",
         "laravel/serializable-closure": "^2.0.10"
     },
+    "suggest": {
+        "spatie/fork": "Required to use the 'fork' concurrency driver (^1.2)."
+    },
     "minimum-stability": "dev",
     "autoload": {
         "psr-4": {

--- a/tests/Integration/Concurrency/ConcurrencyTest.php
+++ b/tests/Integration/Concurrency/ConcurrencyTest.php
@@ -72,18 +72,20 @@ PHP);
         $this->assertArrayHasKey('first', $syncOutput);
         $this->assertArrayHasKey('second', $syncOutput);
 
-        /** As of now, the spatie/fork package is not included by default.
-         * $forkOutput = Concurrency::driver('fork')->run([
-         * 'first' => fn() => 1 + 1,
-         * 'second' => fn() => 2 + 2,
-         * ]);.
-         *
-         * $this->assertIsArray($forkOutput);
-         * $this->assertArrayHasKey('first', $forkOutput);
-         * $this->assertArrayHasKey('second', $forkOutput);
-         * $this->assertEquals(2, $forkOutput['first']);
-         * $this->assertEquals(4, $forkOutput['second']);
+        /**
+         * As of now, the spatie/fork package is not included by default,
+         * as it is practically incompatible with Windows.
          */
+        // $forkOutput = Concurrency::driver('fork')->run([
+        //     'first' => fn () => 1 + 1,
+        //     'second' => fn () => 2 + 2,
+        // ]);
+
+        // $this->assertIsArray($forkOutput);
+        // $this->assertArrayHasKey('first', $forkOutput);
+        // $this->assertArrayHasKey('second', $forkOutput);
+        // $this->assertEquals(2, $forkOutput['first']);
+        // $this->assertEquals(4, $forkOutput['second']);
     }
 
     public function testRunHandlerProcessErrorWithDefaultExceptionWithoutParam()


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This is #59642 without adding spatie/fork as dev dependency, given there seems to be no trivial way to make this work with Windows. To 'alert' any future readers of this fact, comments have been updated to state this fact, which should subsequently lead back here and to #59642 when using git history.

FWIW I also decided to target 13.x instead as not adding this for actual tests makes this less relevant for 12.x in my eyes.