### PR TITLE
[13.x] Refactor UUID handling to use Symfony's Uid component

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,6 @@
         "psr/container": "^1.1.1 || ^2.0.1",
         "psr/log": "^1.0 || ^2.0 || ^3.0",
         "psr/simple-cache": "^1.0 || ^2.0 || ^3.0",
-        "ramsey/uuid": "^4.7",
         "symfony/console": "^7.4.0 || ^8.0.0",
         "symfony/error-handler": "^7.4.0 || ^8.0.0",
         "symfony/finder": "^7.4.0 || ^8.0.0",

--- a/src/Illuminate/Queue/composer.json
+++ b/src/Illuminate/Queue/composer.json
@@ -24,7 +24,6 @@
         "illuminate/pipeline": "^13.0",
         "illuminate/support": "^13.0",
         "laravel/serializable-closure": "^2.0.10",
-        "ramsey/uuid": "^4.7",
         "symfony/process": "^7.4.5 || ^8.0.5"
     },
     "suggest": {

--- a/src/Illuminate/Support/BinaryCodec.php
+++ b/src/Illuminate/Support/BinaryCodec.php
@@ -3,13 +3,12 @@
 namespace Illuminate\Support;
 
 use InvalidArgumentException;
-use Ramsey\Uuid\Uuid;
-use Ramsey\Uuid\UuidInterface;
 use Symfony\Component\Uid\Ulid;
+use Symfony\Component\Uid\Uuid;
 
 class BinaryCodec
 {
-    /** @var array<string, array{encode: callable(UuidInterface|Ulid|string|null): ?string, decode: callable(?string): ?string}> */
+    /** @var array<string, array{encode: callable(Uuid|Ulid|string|null): ?string, decode: callable(?string): ?string}> */
     protected static array $customCodecs = [];
 
     /**
@@ -28,7 +27,7 @@ class BinaryCodec
      *
      * @throws \InvalidArgumentException
      */
-    public static function encode(UuidInterface|Ulid|string|null $value, string $format): ?string
+    public static function encode(Uuid|Ulid|string|null $value, string $format): ?string
     {
         if (blank($value)) {
             return null;
@@ -40,9 +39,9 @@ class BinaryCodec
 
         return match ($format) {
             'uuid' => match (true) {
-                $value instanceof UuidInterface => $value->getBytes(),
+                $value instanceof Uuid => $value->toBinary(),
                 self::isBinary($value) => $value,
-                default => Uuid::fromString($value)->getBytes(),
+                default => Uuid::fromString($value)->toBinary(),
             },
             'ulid' => match (true) {
                 $value instanceof Ulid => $value->toBinary(),
@@ -69,7 +68,7 @@ class BinaryCodec
         }
 
         return match ($format) {
-            'uuid' => (self::isBinary($value) ? Uuid::fromBytes($value) : Uuid::fromString($value))->toString(),
+            'uuid' => (string) (self::isBinary($value) ? Uuid::fromBinary($value) : Uuid::fromString($value)),
             'ulid' => (self::isBinary($value) ? Ulid::fromBinary($value) : Ulid::fromString($value))->toString(),
             default => throw new InvalidArgumentException("Format [$format] is invalid."),
         };

--- a/src/Illuminate/Support/Carbon.php
+++ b/src/Illuminate/Support/Carbon.php
@@ -4,8 +4,11 @@ namespace Illuminate\Support;
 
 use Carbon\Carbon as BaseCarbon;
 use Carbon\CarbonImmutable as BaseCarbonImmutable;
+use Exception;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Dumpable;
+use Symfony\Component\Uid\BinaryUtil;
+use Symfony\Component\Uid\TimeBasedUidInterface;
 use Symfony\Component\Uid\Ulid;
 use Symfony\Component\Uid\Uuid;
 
@@ -29,6 +32,16 @@ class Carbon extends BaseCarbon
     {
         if (is_string($id)) {
             $id = Ulid::isValid($id) ? Ulid::fromString($id) : Uuid::fromString($id);
+        }
+
+        if (Str::isUuid($uuid = $id->toString(), 2)) {
+            return static::createFromInterface(
+                BinaryUtil::hexToDateTime('0'.substr($uuid, 15, 3).substr($uuid, 9, 4).'00000000')
+            );
+        }
+
+        if (! $id instanceof TimeBasedUidInterface) {
+            throw new Exception("Not a time-based UUID or ULID: [{$id->toString()}].");
         }
 
         return static::createFromInterface($id->getDateTime());

--- a/src/Illuminate/Support/Carbon.php
+++ b/src/Illuminate/Support/Carbon.php
@@ -6,8 +6,8 @@ use Carbon\Carbon as BaseCarbon;
 use Carbon\CarbonImmutable as BaseCarbonImmutable;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Dumpable;
-use Ramsey\Uuid\Uuid;
 use Symfony\Component\Uid\Ulid;
+use Symfony\Component\Uid\Uuid;
 
 class Carbon extends BaseCarbon
 {

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -9,13 +9,12 @@ use League\CommonMark\Extension\GithubFlavoredMarkdownExtension;
 use League\CommonMark\Extension\InlinesOnly\InlinesOnlyExtension;
 use League\CommonMark\GithubFlavoredMarkdownConverter;
 use League\CommonMark\MarkdownConverter;
-use Ramsey\Uuid\Codec\TimestampFirstCombCodec;
-use Ramsey\Uuid\Exception\InvalidUuidStringException;
-use Ramsey\Uuid\Generator\CombGenerator;
-use Ramsey\Uuid\Rfc4122\FieldsInterface;
-use Ramsey\Uuid\Uuid;
-use Ramsey\Uuid\UuidFactory;
+use Symfony\Component\Uid\Exception\InvalidArgumentException;
+use Symfony\Component\Uid\MaxUuid;
+use Symfony\Component\Uid\NilUuid;
 use Symfony\Component\Uid\Ulid;
+use Symfony\Component\Uid\Uuid;
+use Symfony\Component\Uid\UuidV7;
 use Throwable;
 use Traversable;
 use voku\helper\ASCII;
@@ -55,7 +54,7 @@ class Str
     /**
      * The callback that should be used to generate UUIDs.
      *
-     * @var (callable(): \Ramsey\Uuid\UuidInterface)|null
+     * @var (callable(): \Symfony\Component\Uid\Uuid)|null
      */
     protected static $uuidFactory;
 
@@ -652,33 +651,25 @@ class Str
             return false;
         }
 
-        if ($version === null) {
-            return preg_match('/^[\da-fA-F]{8}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{12}$/D', $value) > 0;
+        if (is_null($version)) {
+            return Uuid::isValid($value);
         }
-
-        $factory = new UuidFactory;
 
         try {
-            $factoryUuid = $factory->fromString($value);
-        } catch (InvalidUuidStringException) {
+            $uuid = Uuid::fromString($value);
+        } catch (InvalidArgumentException) {
             return false;
         }
 
-        $fields = $factoryUuid->getFields();
-
-        if (! ($fields instanceof FieldsInterface)) {
-            return false;
-        }
-
-        if ($version === 0 || $version === 'nil') {
-            return $fields->isNil();
+        if ($version === 'nil' || $version === 0) {
+            return $uuid instanceof NilUuid;
         }
 
         if ($version === 'max') {
-            return $fields->isMax();
+            return $uuid instanceof MaxUuid;
         }
 
-        return $fields->getVersion() === $version;
+        return $version === (int) $uuid->toString()[14];
     }
 
     /**
@@ -1922,32 +1913,32 @@ class Str
     /**
      * Generate a UUID (version 4).
      *
-     * @return \Ramsey\Uuid\UuidInterface
+     * @return \Symfony\Component\Uid\Uuid
      */
     public static function uuid()
     {
         return static::$uuidFactory
             ? call_user_func(static::$uuidFactory)
-            : Uuid::uuid4();
+            : Uuid::v4();
     }
 
     /**
      * Generate a UUID (version 7).
      *
      * @param  \DateTimeInterface|null  $time
-     * @return \Ramsey\Uuid\UuidInterface
+     * @return \Symfony\Component\Uid\Uuid
      */
     public static function uuid7($time = null)
     {
         return static::$uuidFactory
             ? call_user_func(static::$uuidFactory)
-            : Uuid::uuid7($time);
+            : new UuidV7(UuidV7::generate($time));
     }
 
     /**
      * Generate a time-ordered UUID.
      *
-     * @return \Ramsey\Uuid\UuidInterface
+     * @return \Symfony\Component\Uid\Uuid
      */
     public static function orderedUuid()
     {
@@ -1955,24 +1946,13 @@ class Str
             return call_user_func(static::$uuidFactory);
         }
 
-        $factory = new UuidFactory;
-
-        $factory->setRandomGenerator(new CombGenerator(
-            $factory->getRandomGenerator(),
-            $factory->getNumberConverter()
-        ));
-
-        $factory->setCodec(new TimestampFirstCombCodec(
-            $factory->getUuidBuilder()
-        ));
-
-        return $factory->uuid4();
+        return static::uuid7();
     }
 
     /**
      * Set the callable that will be used to generate UUIDs.
      *
-     * @param  (callable(): \Ramsey\Uuid\UuidInterface)|null  $factory
+     * @param  (callable(): \Symfony\Component\Uid\Uuid)|null  $factory
      * @return void
      */
     public static function createUuidsUsing(?callable $factory = null)
@@ -1983,8 +1963,8 @@ class Str
     /**
      * Set the sequence that will be used to generate UUIDs.
      *
-     * @param  \Ramsey\Uuid\UuidInterface[]  $sequence
-     * @param  (callable(): \Ramsey\Uuid\UuidInterface)|null  $whenMissing
+     * @param  \Symfony\Component\Uid\Uuid[]  $sequence
+     * @param  (callable(): \Symfony\Component\Uid\Uuid)|null  $whenMissing
      * @return void
      */
     public static function createUuidsUsingSequence(array $sequence, $whenMissing = null)
@@ -2017,8 +1997,8 @@ class Str
     /**
      * Always return the same UUID when generating new UUIDs.
      *
-     * @param  (\Closure(\Ramsey\Uuid\UuidInterface): mixed)|null  $callback
-     * @return \Ramsey\Uuid\UuidInterface
+     * @param  (\Closure(\Symfony\Component\Uid\Uuid): mixed)|null  $callback
+     * @return \Symfony\Component\Uid\Uuid
      */
     public static function freezeUuids(?Closure $callback = null)
     {

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -39,9 +39,8 @@
         "laravel/serializable-closure": "Required to use the once function (^2.0.10).",
         "league/commonmark": "Required to use Str::markdown() and Stringable::markdown() (^2.7).",
         "league/uri": "Required to use the Uri class (^7.5.1).",
-        "ramsey/uuid": "Required to use Str::uuid() (^4.7).",
         "symfony/process": "Required to use the Composer class (^7.4 || ^8.0).",
-        "symfony/uid": "Required to use Str::ulid() (^7.4 || ^8.0).",
+        "symfony/uid": "Required to use Str::uuid() or Str::ulid() (^7.4 || ^8.0).",
         "symfony/var-dumper": "Required to use the dd function (^7.4 || ^8.0).",
         "vlucas/phpdotenv": "Required to use the Env class and env helper (^5.6.1)."
     },

--- a/src/Illuminate/Validation/composer.json
+++ b/src/Illuminate/Validation/composer.json
@@ -30,7 +30,7 @@
     },
     "suggest": {
         "illuminate/database": "Required to use the database presence verifier (^13.0).",
-        "ramsey/uuid": "Required to use Validator::validateUuid() (^4.7)."
+        "symfony/uid": "Required to use Validator::validateUuid() or Validator::validateUlid() (^7.4 || ^8.0."
     },
     "minimum-stability": "dev",
     "autoload": {

--- a/tests/Database/DatabaseEloquentAsBinaryCastTest.php
+++ b/tests/Database/DatabaseEloquentAsBinaryCastTest.php
@@ -7,8 +7,8 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\BinaryCodec;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
-use Ramsey\Uuid\Uuid;
 use Symfony\Component\Uid\Ulid;
+use Symfony\Component\Uid\Uuid;
 
 class DatabaseEloquentAsBinaryCastTest extends TestCase
 {
@@ -45,7 +45,7 @@ class DatabaseEloquentAsBinaryCastTest extends TestCase
     {
         $uuid = '550e8400-e29b-41d4-a716-446655440000';
         $model = new AsBinaryTestModel;
-        $model->setRawAttributes(['uuid' => Uuid::fromString($uuid)->getBytes()]);
+        $model->setRawAttributes(['uuid' => Uuid::fromString($uuid)->toBinary()]);
 
         $this->assertSame($uuid, $model->uuid);
     }
@@ -56,7 +56,7 @@ class DatabaseEloquentAsBinaryCastTest extends TestCase
         $model = new AsBinaryTestModel;
         $model->uuid = $uuid;
 
-        $this->assertSame(Uuid::fromString($uuid)->getBytes(), $model->getAttributes()['uuid']);
+        $this->assertSame(Uuid::fromString($uuid)->toBinary(), $model->getAttributes()['uuid']);
     }
 
     public function testGetDecodesUlidFromBinary()

--- a/tests/Integration/Database/EloquentModelDecimalCastingTest.php
+++ b/tests/Integration/Database/EloquentModelDecimalCastingTest.php
@@ -71,7 +71,10 @@ class EloquentModelDecimalCastingTest extends DatabaseTestCase
         } catch (MathException $e) {
             $this->assertSame('Unable to cast value to a decimal.', $e->getMessage());
             $this->assertInstanceOf(NumberFormatException::class, $e->getPrevious());
-            $this->assertSame('The given value "foo" does not represent a valid number.', $e->getPrevious()->getMessage());
+            $this->assertTrue(in_array($e->getPrevious()->getMessage(), [
+                'The given value "foo" does not represent a valid number.',
+                'Value "foo" does not represent a valid number.',
+            ], true));
         }
     }
 

--- a/tests/Support/SupportBinaryCodecTest.php
+++ b/tests/Support/SupportBinaryCodecTest.php
@@ -6,8 +6,8 @@ use Illuminate\Support\BinaryCodec;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
-use Ramsey\Uuid\Uuid;
 use Symfony\Component\Uid\Ulid;
+use Symfony\Component\Uid\Uuid;
 
 class SupportBinaryCodecTest extends TestCase
 {
@@ -85,12 +85,12 @@ class SupportBinaryCodecTest extends TestCase
     {
         $uuid = '550e8400-e29b-41d4-a716-446655440000';
 
-        $this->assertSame(Uuid::fromString($uuid)->getBytes(), BinaryCodec::encode($uuid, 'uuid'));
+        $this->assertSame(Uuid::fromString($uuid)->toBinary(), BinaryCodec::encode($uuid, 'uuid'));
     }
 
     public function testUuidEncodeFromBinary()
     {
-        $bytes = Uuid::fromString('550e8400-e29b-41d4-a716-446655440000')->getBytes();
+        $bytes = Uuid::fromString('550e8400-e29b-41d4-a716-446655440000')->toBinary();
 
         $this->assertSame($bytes, BinaryCodec::encode($bytes, 'uuid'));
     }
@@ -99,13 +99,13 @@ class SupportBinaryCodecTest extends TestCase
     {
         $uuid = Uuid::fromString('550e8400-e29b-41d4-a716-446655440000');
 
-        $this->assertSame($uuid->getBytes(), BinaryCodec::encode($uuid, 'uuid'));
+        $this->assertSame($uuid->toBinary(), BinaryCodec::encode($uuid, 'uuid'));
     }
 
     public function testUuidDecodeFromBinary()
     {
         $uuid = '550e8400-e29b-41d4-a716-446655440000';
-        $bytes = Uuid::fromString($uuid)->getBytes();
+        $bytes = Uuid::fromString($uuid)->toBinary();
 
         $this->assertSame($uuid, BinaryCodec::decode($bytes, 'uuid'));
     }

--- a/tests/Support/SupportCarbonTest.php
+++ b/tests/Support/SupportCarbonTest.php
@@ -139,7 +139,7 @@ class SupportCarbonTest extends TestCase
         $this->assertEquals('2023-05-12 03:23:43.347428', $uuidv6->toDateTimeString('microsecond'));
 
         $uuidv7 = Carbon::createFromId('01880dfa-2825-72e4-acbb-b1e4981cf8af');
-        $this->assertEquals('2023-05-12 03:21:18.117000', $uuidv7->toDateTimeString('microsecond'));
+        $this->assertEquals('2023-05-12 03:21:18.117185', $uuidv7->toDateTimeString('microsecond'));
     }
 
     public function testPlus(): void

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -7,8 +7,8 @@ use Illuminate\Support\Str;
 use Illuminate\Tests\Support\Fixtures\StringableObjectStub;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Uid\Uuid;
 use ReflectionClass;
+use Symfony\Component\Uid\Uuid;
 use ValueError;
 
 class SupportStrTest extends TestCase

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Str;
 use Illuminate\Tests\Support\Fixtures\StringableObjectStub;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
-use Ramsey\Uuid\UuidInterface;
+use Symfony\Component\Uid\Uuid;
 use ReflectionClass;
 use ValueError;
 
@@ -1366,9 +1366,9 @@ class SupportStrTest extends TestCase
 
     public function testUuid()
     {
-        $this->assertInstanceOf(UuidInterface::class, Str::uuid());
-        $this->assertInstanceOf(UuidInterface::class, Str::orderedUuid());
-        $this->assertInstanceOf(UuidInterface::class, Str::uuid7());
+        $this->assertInstanceOf(Uuid::class, Str::uuid());
+        $this->assertInstanceOf(Uuid::class, Str::orderedUuid());
+        $this->assertInstanceOf(Uuid::class, Str::uuid7());
     }
 
     public function testAsciiNull()


### PR DESCRIPTION
This PR refactors `Uuids` to also be generated and validated using the `symfony/uid` package, which is already used for `Ulids`.
This completely removes the currently used `ramesy/uuid` package from the framework.

The main reason behind this PR:
Originally, I only wanted to use `brick/money@0.13.0` in a current project.
However, the required/allowed `brick/math` versions for `brick/money` and `ramesy/uuid` are incompatible.

There is an open [issue](https://github.com/ramsey/uuid/issues/636) and several open pull requests for this issue in the `ramsey/uuid` repository:
https://github.com/ramsey/uuid/pull/632
https://github.com/ramsey/uuid/pull/633
https://github.com/ramsey/uuid/pull/634

I also found a (rather old) discussion on this topic:
https://github.com/laravel/framework/discussions/47631

Digging a bit deeper in the laravel framework it it looks like the `ramesy/uuid` package could be easily replaced by the already used `symfony/uid` package. The impact of this change should be minimal, as developers actively working with the `ramesy/uuid` package can simply include it manually.