### PR TITLE
[13.x] Fix Vite CSS not loaded from nested chunk imports

### DIFF
--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -396,7 +396,7 @@ class Vite implements Htmlable
                 $manifest,
             ]);
 
-            foreach ($chunk['imports'] ?? [] as $import) {
+            foreach ($this->resolveImports($manifest, $chunk) as $import) {
                 $preloads->push([
                     $import,
                     $this->assetPath("{$buildDirectory}/{$manifest[$import]['file']}"),
@@ -982,6 +982,34 @@ class Vite implements Htmlable
         }
 
         return md5_file($path) ?: null;
+    }
+
+    /**
+     * Recursively resolve all imports for the given chunk.
+     *
+     * @param  array  $manifest
+     * @param  array  $chunk
+     * @param  array  $seen
+     * @return array
+     */
+    protected function resolveImports($manifest, $chunk, &$seen = [])
+    {
+        $imports = [];
+
+        foreach ($chunk['imports'] ?? [] as $import) {
+            if (isset($seen[$import])) {
+                continue;
+            }
+
+            $seen[$import] = true;
+            $imports[] = $import;
+
+            if (isset($manifest[$import])) {
+                $imports = array_merge($imports, $this->resolveImports($manifest, $manifest[$import], $seen));
+            }
+        }
+
+        return $imports;
     }
 
     /**

--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -992,7 +992,7 @@ class Vite implements Htmlable
      * @param  array  $seen
      * @return array
      */
-    protected function resolveImports($manifest, $chunk, &$seen = [])
+    protected function resolveImports($manifest, $chunk, $seen = [])
     {
         $imports = [];
 

--- a/tests/Foundation/FoundationViteTest.php
+++ b/tests/Foundation/FoundationViteTest.php
@@ -75,6 +75,46 @@ class FoundationViteTest extends TestCase
         );
     }
 
+    public function testViteWithNestedCssImport()
+    {
+        $buildDir = Str::random();
+        $this->makeViteManifest([
+            'resources/js/app.js' => [
+                'src' => 'resources/js/app.js',
+                'file' => 'assets/app.versioned.js',
+                'imports' => [
+                    '_layout.js',
+                ],
+            ],
+            '_layout.js' => [
+                'file' => 'assets/layout.versioned.js',
+                'css' => [
+                    'assets/layout.versioned.css',
+                ],
+                'imports' => [
+                    '_header.js',
+                ],
+            ],
+            '_header.js' => [
+                'file' => 'assets/header.versioned.js',
+                'css' => [
+                    'assets/header.versioned.css',
+                ],
+            ],
+        ], $buildDir);
+
+        $result = app(Vite::class)(['resources/js/app.js'], $buildDir);
+
+        $this->assertStringEndsWith(
+            '<link rel="stylesheet" href="https://example.com/'.$buildDir.'/assets/layout.versioned.css" />'
+            .'<link rel="stylesheet" href="https://example.com/'.$buildDir.'/assets/header.versioned.css" />'
+            .'<script type="module" src="https://example.com/'.$buildDir.'/assets/app.versioned.js"></script>',
+            $result->toHtml()
+        );
+
+        $this->cleanViteManifest($buildDir);
+    }
+
     public function testViteHotModuleReplacementWithJsOnly()
     {
         $this->makeViteHotFile();
@@ -728,12 +768,12 @@ class FoundationViteTest extends TestCase
             .'<link rel="modulepreload" as="script" href="https://example.com/'.$buildDir.'/assets/Login.8c52c4a3.js" />'
             .'<link rel="modulepreload" as="script" href="https://example.com/'.$buildDir.'/assets/app.a26d8e4d.js" />'
             .'<link rel="modulepreload" as="script" href="https://example.com/'.$buildDir.'/assets/AuthenticationCard.47ef70cc.js" />'
+            .'<link rel="modulepreload" as="script" href="https://example.com/'.$buildDir.'/assets/_plugin-vue_export-helper.cdc0426e.js" />'
             .'<link rel="modulepreload" as="script" href="https://example.com/'.$buildDir.'/assets/AuthenticationCardLogo.9999a373.js" />'
             .'<link rel="modulepreload" as="script" href="https://example.com/'.$buildDir.'/assets/Checkbox.33ba23f3.js" />'
             .'<link rel="modulepreload" as="script" href="https://example.com/'.$buildDir.'/assets/TextInput.e2f0248c.js" />'
             .'<link rel="modulepreload" as="script" href="https://example.com/'.$buildDir.'/assets/InputLabel.d245ec4e.js" />'
             .'<link rel="modulepreload" as="script" href="https://example.com/'.$buildDir.'/assets/PrimaryButton.931d2859.js" />'
-            .'<link rel="modulepreload" as="script" href="https://example.com/'.$buildDir.'/assets/_plugin-vue_export-helper.cdc0426e.js" />'
             .'<link rel="stylesheet" href="https://example.com/'.$buildDir.'/assets/app.9842b564.css" />'
             .'<script type="module" src="https://example.com/'.$buildDir.'/assets/Login.8c52c4a3.js"></script>', $result->toHtml()
         );
@@ -754,6 +794,10 @@ class FoundationViteTest extends TestCase
                 'rel="modulepreload"',
                 'as="script"',
             ],
+            'https://example.com/'.$buildDir.'/assets/_plugin-vue_export-helper.cdc0426e.js' => [
+                'rel="modulepreload"',
+                'as="script"',
+            ],
             'https://example.com/'.$buildDir.'/assets/AuthenticationCardLogo.9999a373.js' => [
                 'rel="modulepreload"',
                 'as="script"',
@@ -771,10 +815,6 @@ class FoundationViteTest extends TestCase
                 'as="script"',
             ],
             'https://example.com/'.$buildDir.'/assets/PrimaryButton.931d2859.js' => [
-                'rel="modulepreload"',
-                'as="script"',
-            ],
-            'https://example.com/'.$buildDir.'/assets/_plugin-vue_export-helper.cdc0426e.js' => [
                 'rel="modulepreload"',
                 'as="script"',
             ],


### PR DESCRIPTION
## Description

The `__invoke` method in `Illuminate\Foundation\Vite` only resolves CSS from **direct imports** of an entrypoint (one level deep). When Vite 8 (which uses [Rolldown](https://rolldown.rs/) instead of Rollup) builds the manifest, it keeps CSS on the chunk where the component is defined rather than hoisting it to the nearest entry. This causes CSS from deeply nested imports to never receive a `<link rel="stylesheet">` tag in the rendered HTML.

### The problem

Given this manifest structure:

```
entry.js
  └── imports: [_layout.js]
        ├── css: [layout.css]        ✅ loaded (direct import)
        └── imports: [_header.js]
              └── css: [header.css]  ❌ never loaded (nested import)
```

The current code at [line 399](https://github.com/laravel/framework/blob/13.x/src/Illuminate/Foundation/Vite.php#L399) iterates `$chunk['imports']` but does not recurse into those imports' own imports:

```php
foreach ($chunk['imports'] ?? [] as $import) {
    // only walks direct imports, misses nested ones
}
```

### The fix

This PR extracts import resolution into a `resolveImports()` method that recursively walks the full import tree with cycle detection via a `$seen` array. The single call site in `__invoke` changes from:

```php
foreach ($chunk['imports'] ?? [] as $import) {
```

to:

```php
foreach ($this->resolveImports($manifest, $chunk) as $import) {
```

This matches the approach already used by the [prefetch code in the same file](https://github.com/laravel/framework/blob/13.x/src/Illuminate/Foundation/Vite.php#L470-L482), which recursively walks imports using a closure.

### Why this is backward-compatible

With older Vite versions (5–7) that use Rollup, CSS from nested components was hoisted to the nearest entry or parent chunk. In those manifests, nested chunks have empty or no `css` arrays, so the recursive walk produces **identical output** to the current code. The fix only adds CSS tags for chunks that actually declare CSS — which only happens with Vite 8+ (Rolldown) manifests.

### References

- Vite's [Backend Integration guide](https://vite.dev/guide/backend-integration) explicitly documents that imports should be resolved **recursively**: *"For each import in the entry point's imports list, **recursively** follow all the chunks in the imported chunk's imports list"*
- Vite 8 switched from Rollup to [Rolldown](https://rolldown.rs/) which changed how CSS is associated with chunks in the manifest
- The prefetch strategy code in the same file ([lines 470–482](https://github.com/laravel/framework/blob/13.x/src/Illuminate/Foundation/Vite.php#L470-L482)) already resolves imports recursively

### Impact

In a real-world project with 100+ entrypoints, this bug caused **18 CSS files** to silently go missing from production builds after upgrading to Vite 8, while everything worked correctly in dev mode (where Vite's dev server handles CSS inline).

## Tests

- Added `testViteWithNestedCssImport` that creates a manifest with a 3-level import chain (entry → layout → header), each with its own CSS, and asserts both CSS files are loaded
- Updated `testItGeneratesPreloadDirectivesForJsAndCssImports` to reflect the new (depth-first) discovery order of preload directives
- All 54 existing Vite tests pass