### PR TITLE
[13.x] Add @inline Blade directive

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesIncludes.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesIncludes.php
@@ -5,6 +5,49 @@ namespace Illuminate\View\Compilers\Concerns;
 trait CompilesIncludes
 {
     /**
+     * Compile the inline statements into valid PHP.
+     *
+     * Reads the partial's Blade source at compile time, strips any @props
+     * directive, compiles it, and embeds the resulting PHP directly into
+     * the parent view — eliminating view factory overhead at runtime.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileInline($expression)
+    {
+        $expression = $this->stripParentheses($expression);
+
+        $str = \Illuminate\Support\Str::of($expression);
+
+        // The view name must be a string literal — extract it from quotes.
+        $view = $str->before(',')->trim('\'" ')->toString();
+
+        // Resolve the view file path through the view finder.
+        $finder = \Illuminate\Container\Container::getInstance()->make('view.finder');
+        $path = $finder->find($view);
+
+        $source = $this->files->get($path);
+
+        // Strip @props — not needed for inlined partials since variables
+        // come from the parent scope. Avoids ComponentAttributeBag overhead.
+        $source = preg_replace('/@props\s*\([\s\S]*?\)\s*\n?/', '', $source);
+
+        $compiled = $this->compileString($source);
+
+        // If a data array was passed, emit an extract() call so the
+        // array values become local variables at runtime.
+        if ($str->contains(',')) {
+            $data = $str->after(',')->trim()->toString();
+
+            $compiled = "<?php extract({$data}); ?>".$compiled;
+        }
+
+        return $compiled;
+    }
+
+
+    /**
      * Compile the each statements into valid PHP.
      *
      * @param  string  $expression

--- a/tests/View/Blade/BladeInlineTest.php
+++ b/tests/View/Blade/BladeInlineTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Illuminate\Tests\View\Blade;
+
+use Illuminate\Container\Container;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\View\Compilers\BladeCompiler;
+use Illuminate\View\FileViewFinder;
+use Mockery as m;
+
+class BladeInlineTest extends AbstractBladeTestCase
+{
+    protected $files;
+
+    protected function setUp(): void
+    {
+        $this->files = m::mock(Filesystem::class);
+
+        $this->files->shouldReceive('get')
+            ->with('/views/partials/greeting.blade.php')
+            ->andReturn('Hello, {{ $name }}!');
+
+        $this->files->shouldReceive('get')
+            ->with('/views/partials/props.blade.php')
+            ->andReturn("@props(['name'])\nHello, {{ \$name }}!");
+
+        $this->files->shouldReceive('get')
+            ->with('/views/partials/card.blade.php')
+            ->andReturn('<div>{{ $title }}</div>');
+
+        $this->compiler = new BladeCompiler($this->files, __DIR__);
+
+        $container = Container::setInstance(new Container);
+
+        $finder = m::mock(FileViewFinder::class);
+        $finder->shouldReceive('find')->with('partials.greeting')->andReturn('/views/partials/greeting.blade.php');
+        $finder->shouldReceive('find')->with('partials.props')->andReturn('/views/partials/props.blade.php');
+        $finder->shouldReceive('find')->with('partials.card')->andReturn('/views/partials/card.blade.php');
+
+        $container->instance('view.finder', $finder);
+    }
+
+    protected function tearDown(): void
+    {
+        Container::setInstance(null);
+        m::close();
+
+        parent::tearDown();
+    }
+
+    public function testInlineIsCompiled()
+    {
+        $result = $this->compiler->compileString("@inline('partials.greeting')");
+
+        $this->assertStringContainsString('<?php echo e($name); ?>', $result);
+        $this->assertStringContainsString('Hello, ', $result);
+    }
+
+    public function testInlineWithDataArray()
+    {
+        $result = $this->compiler->compileString("@inline('partials.card', ['title' => \$item->name])");
+
+        $this->assertStringContainsString("extract(['title' => \$item->name]);", $result);
+        $this->assertStringContainsString('<?php echo e($title); ?>', $result);
+    }
+
+    public function testInlineStripsPropsDirective()
+    {
+        $result = $this->compiler->compileString("@inline('partials.props')");
+
+        $this->assertStringNotContainsString('@props', $result);
+        $this->assertStringContainsString('Hello, ', $result);
+        $this->assertStringContainsString('<?php echo e($name); ?>', $result);
+    }
+
+    public function testInlinePreservesSurroundingContent()
+    {
+        $result = $this->compiler->compileString("Before @inline('partials.greeting') After");
+
+        $this->assertStringStartsWith('Before ', $result);
+        $this->assertStringEndsWith(' After', $result);
+        $this->assertStringContainsString('<?php echo e($name); ?>', $result);
+    }
+}


### PR DESCRIPTION
## Summary

When `@include` is used inside a loop, Laravel's view factory resolves the file, creates a new view instance, and compiles the template **on every iteration**. For pages rendering 100+ partials, this overhead adds up.

`@inline` compiles the partial once at compile time and embeds the resulting PHP directly into the parent view. At runtime, the loop body is plain PHP — no view factory, no file lookups, no `ComponentAttributeBag`.

This was initially built as a standalone package: [degecko/laravel-blade-inline](https://github.com/degecko/laravel-blade-inline)

```blade
{{-- Each iteration pays the full view factory cost --}}
@foreach ($items as $item)
    @include('components.card')
@endforeach

{{-- Compiled once, inlined as raw PHP --}}
@foreach ($items as $item)
    @inline('components.card')
@endforeach
```

### How it works

1. At **compile time**, `@inline` reads the partial's Blade source via the view finder
2. Strips any `@props` directive (unnecessary since variables come from the parent scope)
3. Compiles the Blade to PHP via `compileString()`
4. Embeds the compiled PHP directly into the parent view

### Passing variables

Variables can be passed via a data array, which emits an `extract()` call at runtime:

```blade
@foreach ($products as $product)
    @inline('components.product-card', [
        'highlight' => $loop->first,
        'lazy' => $loop->index > 6,
    ])
@endforeach
```

### Benchmarks

Rendering a listing card partial across different loop sizes (Laravel 13, PHP 8.4):

| Cards | `@include` | `@inline` | Improvement |
|------:|-----------:|----------:|------------:|
| 13    | 1.61ms     | 1.51ms    | 6%          |
| 104   | 13.6ms     | 10.1ms    | **26%**     |
| 260   | 32.6ms     | 27.6ms    | **16%**     |

### When to use

Use `@inline` when:
- A partial is rendered many times in a loop (listing pages, tables, feeds)
- The partial doesn't need isolated variable scope
- You want to eliminate view factory overhead

Stick with `@include` when:
- The partial is rendered once or twice
- You need isolated variable scope
- You use `$attributes` or component features

### Important notes

- **Shared scope**: The partial accesses the same variables as the parent view — no isolated scope like `@include`
- **No `$attributes`**: Since `@props` is stripped, the `$attributes` bag is not available
- **Cache**: Changes to the partial require `php artisan view:clear` (same as any compiled Blade change)
- **All Blade directives work**: `@if`, `@foreach`, `{{ }}`, etc. are fully supported inside inlined partials

## Test plan

- [x] Basic inline compilation
- [x] Inline with data array (runtime expressions like `$loop->first`)
- [x] `@props` stripping
- [x] Surrounding content preservation
- [x] Existing `@include` tests still pass