### PR TITLE
[13.x] Fix indirect modification of overloaded property in nested validation

### DIFF
--- a/src/Illuminate/Validation/ValidationData.php
+++ b/src/Illuminate/Validation/ValidationData.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Validation;
 
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Arr;
 
 class ValidationData
@@ -33,13 +34,40 @@ class ValidationData
     {
         $explicitPath = static::getLeadingExplicitAttributePath($attribute);
 
-        $data = static::extractDataFromPath($explicitPath, $masterData);
+        $data = static::initializeAndArrayify(
+            static::extractDataFromPath($explicitPath, $masterData)
+        );
 
         if (! str_contains($attribute, '*') || str_ends_with($attribute, '*')) {
             return $data;
         }
 
         return data_set($data, $attribute, null, true);
+    }
+
+    /**
+     * Recursively convert the given data into a plain array.
+     *
+     * @param  mixed  $data
+     * @return mixed
+     */
+    public static function initializeAndArrayify($data)
+    {
+        if ($data instanceof Arrayable) {
+            $data = $data->toArray();
+        }
+
+        if (! is_array($data)) {
+            return $data;
+        }
+
+        foreach ($data as $key => $value) {
+            if (is_array($value) || $value instanceof Arrayable || $value instanceof \Traversable) {
+                $data[$key] = static::initializeAndArrayify($value);
+            }
+        }
+
+        return $data;
     }
 
     /**

--- a/tests/Validation/ValidationDataTest.php
+++ b/tests/Validation/ValidationDataTest.php
@@ -10,18 +10,20 @@ class ValidationDataTest extends TestCase
 {
     public function testItDoesNotModifyOriginalEloquentModelsDuringInitialization()
     {
-        $person = new class extends Model {
+        $person = new class extends Model
+        {
             protected $attributes = ['email' => 'test@example.com'];
         };
 
-        $ticket = new class extends Model {
+        $ticket = new class extends Model
+        {
             protected $attributes = ['departure' => 'Colombo'];
         };
 
         $ticket->setRelation('people', collect([$person]));
 
         $data = [
-            'tickets' => collect([$ticket])
+            'tickets' => collect([$ticket]),
         ];
 
         $attribute = 'tickets.*.people.*.email';
@@ -39,7 +41,7 @@ class ValidationDataTest extends TestCase
     {
         $nestedData = collect([
             'user' => collect(['name' => 'Nilukshana']),
-            'tags' => ['php', 'laravel']
+            'tags' => ['php', 'laravel'],
         ]);
 
         $result = ValidationData::initializeAndArrayify($nestedData);

--- a/tests/Validation/ValidationDataTest.php
+++ b/tests/Validation/ValidationDataTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Validation\ValidationData;
+use PHPUnit\Framework\TestCase;
+
+class ValidationDataTest extends TestCase
+{
+    public function testItDoesNotModifyOriginalEloquentModelsDuringInitialization()
+    {
+        $person = new class extends Model {
+            protected $attributes = ['email' => 'test@example.com'];
+        };
+
+        $ticket = new class extends Model {
+            protected $attributes = ['departure' => 'Colombo'];
+        };
+
+        $ticket->setRelation('people', collect([$person]));
+
+        $data = [
+            'tickets' => collect([$ticket])
+        ];
+
+        $attribute = 'tickets.*.people.*.email';
+
+        $results = ValidationData::initializeAndGatherData($attribute, $data);
+
+        $this->assertIsArray($results);
+        $this->ArrayHasKey('tickets.0.people.0.email', $results);
+
+        $this->assertEquals('test@example.com', $person->email);
+        $this->assertEquals('Colombo', $ticket->departure);
+    }
+
+    public function testInitializeAndArrayifyConvertsNestedCollectionsToArrays()
+    {
+        $nestedData = collect([
+            'user' => collect(['name' => 'Nilukshana']),
+            'tags' => ['php', 'laravel']
+        ]);
+
+        $result = ValidationData::initializeAndArrayify($nestedData);
+
+        $this->assertIsArray($result);
+        $this->assertIsArray($result['user']);
+        $this->assertEquals('Nilukshana', $result['user']['name']);
+    }
+}


### PR DESCRIPTION
fixes: #59650

I encountered an ErrorException: Indirect modification of overloaded property when performing wildcard validation on nested data structures containing Eloquent models.

The issue stems from ValidationData::initializeAttributeOnData using the data_set helper, which attempts to modify values by reference. Since Eloquent models manage attributes through magic methods, PHP throws an error when these properties are modified indirectly.

This PR introduces a recursive initializeAndArrayify method to ensure the validator works on a safe array snapshot during the discovery phase, preserving the integrity of the original models and preventing the crash.
