### PR TITLE
Add vector distance support for MariaDB >= 11.8.2

### DIFF
--- a/src/Illuminate/Database/Eloquent/Casts/AsMariaDbVector.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsMariaDbVector.php
@@ -71,5 +71,4 @@ class AsMariaDbVector implements CastsAttributes
 
         return new Expression("vec_fromtext('.$vectorString.')");
     }
-
 }

--- a/src/Illuminate/Database/Eloquent/Casts/AsMariaDbVector.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsMariaDbVector.php
@@ -53,7 +53,7 @@ class AsMariaDbVector implements CastsAttributes
         foreach ($value as $v) {
             if (! is_numeric($v)) {
                 throw new InvalidArgumentException(
-                    "Vector values must be numeric; non-numeric value encountered: ".print_r($v, true)
+                    'Vector values must be numeric; non-numeric value encountered: '.print_r($v, true)
                 );
             }
         }

--- a/src/Illuminate/Database/Eloquent/Casts/AsMariaDbVector.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsMariaDbVector.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Query\Expression;
+use InvalidArgumentException;
+
+class AsMariaDbVector implements CastsAttributes
+{
+    public function get(Model $model, string $key, mixed $value, array $attributes)
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        // JSON string format from VEC_ToText() — e.g. "[0.1, 0.2, 0.3]"
+        if (is_string($value) && str_starts_with($value, '[')) {
+            $decoded = json_decode($value, true);
+
+            if ($decoded === null) {
+                throw new InvalidArgumentException(
+                    "Malformed JSON vector string for key '{$key}': {$value}"
+                );
+            }
+
+            return array_map('floatval', $decoded);
+        }
+
+        // Binary format: native MariaDB VECTOR storage (32-bit IEEE 754 little-endian floats).
+        // 'g*' forces little-endian interpretation regardless of host byte order.
+        if (is_string($value) && strlen($value) > 0) {
+            $unpacked = unpack('g*', $value);
+
+            return array_values($unpacked);
+        }
+
+        return null;
+    }
+
+    public function set(Model $model, string $key, mixed $value, array $attributes)
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (is_array($value) && count($value) === 0) {
+            return null;
+        }
+
+        // Pass 1: reject non-numeric values before floatval() silently coerces them to 0.0
+        foreach ($value as $v) {
+            if (! is_numeric($v)) {
+                throw new InvalidArgumentException(
+                    "Vector values must be numeric; non-numeric value encountered: " . print_r($v, true)
+                );
+            }
+        }
+
+        $floats = array_map('floatval', $value);
+
+        // Pass 2: reject NAN and INF, which pass is_numeric() but are not valid VECTOR values
+        foreach ($floats as $v) {
+            if (! is_finite($v)) {
+                throw new InvalidArgumentException('Vector values must be finite floats; NAN and INF are not supported.');
+            }
+        }
+
+        $vectorString = '[' . implode(', ', $floats) . ']';
+        return new Expression("vec_fromtext('.$vectorString.')");
+    }
+
+}

--- a/src/Illuminate/Database/Eloquent/Casts/AsMariaDbVector.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsMariaDbVector.php
@@ -53,7 +53,7 @@ class AsMariaDbVector implements CastsAttributes
         foreach ($value as $v) {
             if (! is_numeric($v)) {
                 throw new InvalidArgumentException(
-                    "Vector values must be numeric; non-numeric value encountered: " . print_r($v, true)
+                    "Vector values must be numeric; non-numeric value encountered: ".print_r($v, true)
                 );
             }
         }
@@ -67,7 +67,8 @@ class AsMariaDbVector implements CastsAttributes
             }
         }
 
-        $vectorString = '[' . implode(', ', $floats) . ']';
+        $vectorString = '['.implode(', ', $floats).']';
+
         return new Expression("vec_fromtext('.$vectorString.')");
     }
 

--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -177,6 +177,30 @@ abstract class Grammar
     }
 
     /**
+     * Wrap the given vector distance.
+     *
+     * @param  string  $value
+     * @return string
+     *
+     * @throws \RuntimeException
+     */
+    public function wrapVectorDistance($field)
+    {
+        throw new RuntimeException('This database engine does not support Vector operations.');
+    }
+
+    /**
+     * Wrap the given select vector distance.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    public function wrapSelectVectorDistance($value)
+    {
+        throw new RuntimeException('This database engine does not support Vector operations.');
+    }
+
+    /**
      * Determine if the given string is a JSON selector.
      *
      * @param  string  $value

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -4766,7 +4766,7 @@ class Builder implements BuilderContract
     protected function ensureConnectionSupportsVectors()
     {
         if ($this->connection instanceof MariaDbConnection) {
-            if (version_compare($this->connection->getServerVersion(), '11.8.2', '<')) { 
+            if (version_compare($this->connection->getServerVersion(), '11.8.2', '<')) {
                 throw new RuntimeException('Vector distance queries are only supported on MariaDB in version 11.8.2 or later.');
             }
         } elseif (! $this->connection instanceof PostgresConnection) {

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -16,6 +16,7 @@ use Illuminate\Database\Concerns\ExplainsQueries;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Database\MariaDbConnection;
 use Illuminate\Database\PostgresConnection;
 use Illuminate\Database\Query\Grammars\Grammar;
 use Illuminate\Database\Query\Processors\Processor;
@@ -516,7 +517,7 @@ class Builder implements BuilderContract
         $as = $this->getGrammar()->wrap($as ?? $column.'_distance');
 
         return $this->addSelect(
-            new Expression("({$this->getGrammar()->wrap($column)} <=> ?) as {$as}")
+            new Expression("({$this->getGrammar()->wrapSelectVectorDistance($column)}) as {$as}")
         );
     }
 
@@ -1249,7 +1250,7 @@ class Builder implements BuilderContract
         }
 
         return $this->whereRaw(
-            "({$this->getGrammar()->wrap($column)} <=> ?) <= ?",
+            "({$this->getGrammar()->wrapVectorDistance($column)}) <= ?",
             [
                 json_encode(
                     $vector instanceof Arrayable
@@ -3050,7 +3051,7 @@ class Builder implements BuilderContract
         );
 
         $this->{$this->unions ? 'unionOrders' : 'orders'}[] = [
-            'column' => new Expression("({$this->getGrammar()->wrap($column)} <=> ?)"),
+            'column' => new Expression("({$this->getGrammar()->wrapVectorDistance($column)})"),
             'direction' => 'asc',
         ];
 
@@ -4764,7 +4765,11 @@ class Builder implements BuilderContract
      */
     protected function ensureConnectionSupportsVectors()
     {
-        if (! $this->connection instanceof PostgresConnection) {
+        if ($this->connection instanceof MariaDbConnection) {
+            if (version_compare($this->connection->getServerVersion(), '11.8.2', '<')) { 
+                throw new RuntimeException('Vector distance queries are only supported on MariaDB in version 11.8.2 or later.');
+            }
+        } elseif (! $this->connection instanceof PostgresConnection) {
             throw new RuntimeException('Vector distance queries are only supported by Postgres.');
         }
     }

--- a/src/Illuminate/Database/Query/Grammars/MariaDbGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MariaDbGrammar.php
@@ -7,7 +7,7 @@ use Illuminate\Database\Query\JoinLateralClause;
 use RuntimeException;
 
 class MariaDbGrammar extends MySqlGrammar
-{ 
+{
     /**
      * Compile a "lateral join" clause.
      *

--- a/src/Illuminate/Database/Query/Grammars/MariaDbGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MariaDbGrammar.php
@@ -7,7 +7,7 @@ use Illuminate\Database\Query\JoinLateralClause;
 use RuntimeException;
 
 class MariaDbGrammar extends MySqlGrammar
-{
+{ 
     /**
      * Compile a "lateral join" clause.
      *
@@ -65,5 +65,27 @@ class MariaDbGrammar extends MySqlGrammar
         [$field, $path] = $this->wrapJsonFieldAndPath($value);
 
         return 'json_value('.$field.$path.')';
+    }
+
+    /**
+     * Wrap the given vector distance.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    public function wrapVectorDistance($value)
+    {
+        return 'vec_distance('.$value.', ?)';
+    }
+
+    /**
+     * Wrap the given select vector distance.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    public function wrapSelectVectorDistance($value)
+    {
+        return 'vec_distance('.$value.', vec_fromtext(?))';
     }
 }

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -717,6 +717,28 @@ class PostgresGrammar extends Grammar
     }
 
     /**
+     * Wrap the given vector distance.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    public function wrapVectorDistance($value)
+    {
+        return "{$this->wrap($value)} <=> ?";
+    }
+
+    /**
+     * Wrap the given select vector distance.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    public function wrapSelectVectorDistance($value)
+    {
+        return "{$this->wrap($value)} <=> ?";
+    }
+
+    /**
      * Wrap the given JSON selector.
      *
      * @param  string  $value

--- a/src/Illuminate/Database/Schema/Grammars/MariaDbGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MariaDbGrammar.php
@@ -18,6 +18,23 @@ class MariaDbGrammar extends MySqlGrammar
     }
 
     /**
+     * Compile a vector index key command.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
+     * @return string
+     */
+    public function compileVectorIndex(Blueprint $blueprint, Fluent $command)
+    {
+        return sprintf(
+            'alter table %s add vector index %s (%s)',
+            $this->wrapTable($blueprint),
+            $this->wrap($command->index),
+            $this->columnize($command->columns)
+        );
+    }
+
+    /**
      * Create the column definition for a uuid type.
      *
      * @param  \Illuminate\Support\Fluent  $column


### PR DESCRIPTION
Adds support for MariaDB vector distance in Eloquent and Schema in a way that is flexible enough to add the same support for other database engines in the future.

- ensureConnectionSupportsVectors: added check for instance of MariaDbConnection and minimum required server version, falling back to the original non-Postgres check.

- compileVectorIndex: MariaDB Grammar for creating vector indexes

- AsMariaDbVector cast: required in Eloquent models to convert to and from the array format expected rather than the binary representation

- All 3 existing functions are implemented: selectVectorDistance, whereVectorDistanceLessThan, orderByVectorDistance.

This provides identical functionality to the existing Postgres pgvector extension implementation for users of MariaDB >= 11.8.2. Note that support for MySQL has not been added.

```php
use Illuminate\Database\Eloquent\Casts\AsMariaDbVector;

class ExampleModel extends Model
{
    use HasFactory;

    protected function casts(): array
    {
        return [
            'embedding' => AsMariaDbVector::class,
        ];
    }
}
```