### PR TITLE
Add option to omit empty arrays from Arr::dot()

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -179,18 +179,21 @@ class Arr
      * @param  iterable  $array
      * @param  string  $prepend
      * @param  int  $depth
+     * @param  bool  $preserveEmptyArrays
      * @return array
      */
-    public static function dot($array, $prepend = '', $depth = INF)
+    public static function dot($array, $prepend = '', $depth = INF, $preserveEmptyArrays = true)
     {
         $results = [];
 
-        $flatten = function ($data, $prefix, $currentDepth) use (&$results, &$flatten, $depth): void {
+        $flatten = function ($data, $prefix, $currentDepth) use (&$results, &$flatten, $depth, $preserveEmptyArrays): void {
             foreach ($data as $key => $value) {
                 $newKey = $prefix.$key;
 
                 if (is_array($value) && ! empty($value) && $currentDepth < $depth) {
                     $flatten($value, $newKey.'.', $currentDepth + 1);
+                } elseif (is_array($value) && empty($value) && ! $preserveEmptyArrays) {
+                    continue;
                 } else {
                     $results[$newKey] = $value;
                 }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -256,6 +256,30 @@ class SupportArrTest extends TestCase
         ], $array);
     }
 
+    public function testDotOmittingEmptyArrays()
+    {
+        $array = Arr::dot(['foo' => []], '', INF, false);
+        $this->assertSame([], $array);
+
+        $array = Arr::dot(['foo' => ['bar' => []]], '', INF, false);
+        $this->assertSame([], $array);
+
+        $array = Arr::dot(
+            ['foo' => 'bar', 'empty_array' => [], 'user' => ['name' => 'Taylor', 'tags' => []], 'key' => 'value'],
+            '',
+            INF,
+            false,
+        );
+        $this->assertSame([
+            'foo' => 'bar',
+            'user.name' => 'Taylor',
+            'key' => 'value',
+        ], $array);
+
+        $array = Arr::dot(['foo' => ['bar' => []]], '', 1, false);
+        $this->assertSame([], $array);
+    }
+
     public function testDotWithDepth()
     {
         $array = Arr::dot(['user' => ['name' => 'Taylor', 'address' => ['city' => 'Dallas']]], '', 1);
@@ -1713,7 +1737,9 @@ class SupportArrTest extends TestCase
         $this->assertSame($subject, Arr::from($items));
 
         $items = new WeakMap;
-        $items[$temp = new class {}] = 'bar';
+        $items[$temp = new class
+        {
+        }] = 'bar';
         $this->assertSame(['bar'], Arr::from($items));
 
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1737,8 +1737,7 @@ class SupportArrTest extends TestCase
         $this->assertSame($subject, Arr::from($items));
 
         $items = new WeakMap;
-        $items[$temp = new class
-        {
+        $items[$temp = new class {
         }] = 'bar';
         $this->assertSame(['bar'], Arr::from($items));
 


### PR DESCRIPTION
Adds an optional `$preserveEmptyArrays` parameter (default `true`) to `Arr::dot()` that, when set to `false`, omits keys whose values are empty arrays from the flattened output.

Default behavior is unchanged — existing callers continue to receive empty arrays preserved as `[]`.

Closes #57305

## Example

```php
$data = ['foo' => 'bar', 'tags' => [], 'user' => ['name' => 'Taylor', 'roles' => []]];

Arr::dot($data);
// ['foo' => 'bar', 'tags' => [], 'user.name' => 'Taylor', 'user.roles' => []]

Arr::dot($data, '', INF, false);
// ['foo' => 'bar', 'user.name' => 'Taylor']

This makes the result directly usable with array_diff() and other functions that don't handle nested arrays.

Test plan

1. Added testDotOmittingEmptyArrays covering top-level, nested, and depth-limited cases
2. Existing testDot / testDotWithDepth still pass (82 assertions, 495 total)
3. vendor/bin/pint clean

