### PR TITLE
[12.x] Use --single-transaction for MySQL/MariaDB schema dumps

### DIFF
--- a/src/Illuminate/Database/Schema/MariaDbSchemaState.php
+++ b/src/Illuminate/Database/Schema/MariaDbSchemaState.php
@@ -32,7 +32,7 @@ class MariaDbSchemaState extends MySqlSchemaState
     {
         $versionInfo = $this->detectClientVersion();
 
-        $command = 'mariadb-dump '.$this->connectionString($versionInfo).' --no-tablespaces --skip-add-locks --skip-comments --skip-set-charset --tz-utc';
+        $command = 'mariadb-dump '.$this->connectionString($versionInfo).' --no-tablespaces --skip-add-locks --skip-comments --skip-set-charset --tz-utc --single-transaction';
 
         return $command.' "${:LARAVEL_LOAD_DATABASE}"';
     }

--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -93,7 +93,7 @@ class MySqlSchemaState extends SchemaState
     {
         $versionInfo = $this->detectClientVersion();
 
-        $command = 'mysqldump '.$this->connectionString($versionInfo).' --no-tablespaces --skip-add-locks --skip-comments --skip-set-charset --tz-utc --column-statistics=0';
+        $command = 'mysqldump '.$this->connectionString($versionInfo).' --no-tablespaces --skip-add-locks --skip-comments --skip-set-charset --tz-utc --column-statistics=0 --single-transaction';
 
         if (! $this->connection->isMaria()) {
             $command .= ' --set-gtid-purged=OFF';

--- a/tests/Database/DatabaseMariaDbSchemaStateTest.php
+++ b/tests/Database/DatabaseMariaDbSchemaStateTest.php
@@ -135,4 +135,29 @@ class DatabaseMariaDbSchemaStateTest extends TestCase
             ],
         ];
     }
+
+    public function testBaseDumpCommandIncludesSingleTransaction(): void
+    {
+        $connection = $this->createMock(MariaDbConnection::class);
+        $connection->method('getConfig')->willReturn([
+            'username' => 'root',
+            'host' => '127.0.0.1',
+            'database' => 'forge',
+        ]);
+
+        $schemaState = $this->getMockBuilder(MariaDbSchemaState::class)
+            ->setConstructorArgs([$connection])
+            ->onlyMethods(['detectClientVersion'])
+            ->getMock();
+
+        $schemaState->method('detectClientVersion')->willReturn([
+            'version' => '11.8.3',
+            'isMariaDb' => true,
+        ]);
+
+        $method = new ReflectionMethod(get_class($schemaState), 'baseDumpCommand');
+        $command = $method->invoke($schemaState);
+
+        self::assertStringContainsString('--single-transaction', $command);
+    }
 }

--- a/tests/Database/DatabaseMySqlSchemaStateTest.php
+++ b/tests/Database/DatabaseMySqlSchemaStateTest.php
@@ -138,6 +138,32 @@ class DatabaseMySqlSchemaStateTest extends TestCase
         ];
     }
 
+    public function testBaseDumpCommandIncludesSingleTransaction(): void
+    {
+        $connection = $this->createMock(MySqlConnection::class);
+        $connection->method('getConfig')->willReturn([
+            'username' => 'root',
+            'host' => '127.0.0.1',
+            'database' => 'forge',
+        ]);
+        $connection->method('isMaria')->willReturn(false);
+
+        $schemaState = $this->getMockBuilder(MySqlSchemaState::class)
+            ->setConstructorArgs([$connection])
+            ->onlyMethods(['detectClientVersion'])
+            ->getMock();
+
+        $schemaState->method('detectClientVersion')->willReturn([
+            'version' => '8.0.0',
+            'isMariaDb' => false,
+        ]);
+
+        $method = new ReflectionMethod(get_class($schemaState), 'baseDumpCommand');
+        $command = $method->invoke($schemaState);
+
+        self::assertStringContainsString('--single-transaction', $command);
+    }
+
     public function testExecuteDumpProcessForDepth()
     {
         $mockProcess = $this->createMock(Process::class);


### PR DESCRIPTION
## Problem

`schema:dump` invokes `mysqldump` (or `mariadb-dump`) without `--single-transaction`, so the dump falls back to server-side `LOCK TABLES`. `--skip-add-locks` (already present) only suppresses lock statements in the *output*; it does not change the server-side locking behavior during the dump.

This breaks or degrades three common workflows:

1. **Read-only users cannot dump the schema.** `LOCK TABLES` requires the `LOCK TABLES` privilege, which RO users routinely lack — even `SELECT`-only users hit:
   ```
   ERROR 1044 (42000): Access denied for user 'readonly'@'%' to database ...
                       Reason: LOCK TABLES
   ```
   This matters when teams use RO replicas for ops tasks (dumps, rebasing a local DB snapshot, etc.).

2. **Schema dumps against a read-replica block replication.** Server-side `LOCK TABLES` stalls replication for the duration of the dump, even for `--no-data` schema dumps. Making `schema:dump` safe to run against a replica avoids taking out a primary for a routine ops task.

3. **Dumps against a busy primary briefly stall writers.** For `--no-data` dumps that's usually fast, but it's still a non-zero impact that has no upside.

## Fix

Add `--single-transaction` to both `MySqlSchemaState::baseDumpCommand()` and `MariaDbSchemaState::baseDumpCommand()`.

`--single-transaction` issues `START TRANSACTION WITH CONSISTENT SNAPSHOT` (REPEATABLE READ) instead of acquiring `LOCK TABLES`, which:

- Requires only `SELECT` privileges → works for RO users.
- Does not issue `LOCK TABLES` → non-blocking on replicas and primaries.
- Is the [documented best-practice flag](https://dev.mysql.com/doc/refman/8.0/en/mysqldump.html#option_mysqldump_single-transaction) for consistent InnoDB dumps.

### Caveats

- **MyISAM tables aren't covered by the snapshot.** In practice this isn't a concern here: Laravel migrations default to InnoDB and have since the framework was introduced (MySQL has defaulted to InnoDB since 5.5, 2010). The existing `--skip-add-locks` flag already signals that preserving table-locking semantics isn't a design goal of `schema:dump`.
- **Concurrent DDL during the dump is not isolated.** Per both the [MySQL](https://dev.mysql.com/doc/refman/8.0/en/mysqldump.html#option_mysqldump_single-transaction) and [MariaDB](https://mariadb.com/kb/en/mariadb-dump/#-single-transaction) docs, if another connection runs `ALTER TABLE`, `CREATE TABLE`, `DROP TABLE`, `RENAME TABLE`, or `TRUNCATE TABLE` while the dump is in progress, the dump may contain incorrect contents or fail. With the prior `LOCK TABLES` behavior, concurrent DDL would queue behind the dump instead of racing with it. For `schema:dump` this is low-risk — it is typically run immediately after a migration batch, often against a replica, with no concurrent schema changes — but it is a real semantic change.
- **`schema:dump` runs the dump command twice.** Once for schema (`--no-data`), once to append migration-table rows via `appendMigrationData()`. Each invocation opens its own transaction, so the two outputs are not a single atomic snapshot. This is not a regression — today they are likewise two independent `LOCK TABLES` sessions — but worth noting.
- **Long-running transaction on the source.** The transaction remains open for the dump's duration, contributing to InnoDB history-list growth on a busy primary. Negligible for `--no-data` schema dumps, non-zero otherwise.

## Prior art

- #39126 (`--no-tablespaces`) — similar targeted flag addition, merged
- #43027 (`--column-statistics=0` for MariaDB) — similar, merged
- The `--set-gtid-purged=OFF` and column-statistics fallback logic in `executeDumpProcess()` — existing pattern of opinionated flag choices in this class
- #35563 attempted to expose dump flags as a configurable CLI option and was closed for scope. This PR is deliberately a single, unconditional flag — matching the merge-friendly pattern above.

## Test plan

- [x] Two unit tests added, one per state class, asserting `--single-transaction` is present in the generated command string
- [x] Existing `DatabaseMySqlSchemaStateTest` and `DatabaseMariaDbSchemaStateTest` still pass
- [x] CI green

## Motivating context

I hit case (1) above in a work project: our team dumps the schema from a prod RO replica (via an SSH tunnel) to regenerate `database/schema/mysql-schema.sql` after a batch of structural migrations. The RO user (`SELECT`-only) can't acquire `LOCK TABLES`, so `php artisan schema:dump` fails. Patching the command to include `--single-transaction` fixes it for us, and it seems like the change benefits anyone dumping against a replica or constrained user.

## References

- [MySQL 8.0 Reference Manual — mysqldump `--single-transaction`](https://dev.mysql.com/doc/refman/8.0/en/mysqldump.html#option_mysqldump_single-transaction)
- [MariaDB Knowledge Base — mariadb-dump `--single-transaction`](https://mariadb.com/kb/en/mariadb-dump/#-single-transaction)