### PR TITLE
[13.x] Add Rule::url() fluent builder

### DIFF
--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -13,7 +13,6 @@ use Illuminate\Validation\Rules\Dimensions;
 use Illuminate\Validation\Rules\Email;
 use Illuminate\Validation\Rules\Enum;
 use Illuminate\Validation\Rules\ExcludeIf;
-use Illuminate\Validation\Rules\ExcludeUnless;
 use Illuminate\Validation\Rules\Exists;
 use Illuminate\Validation\Rules\File;
 use Illuminate\Validation\Rules\ImageFile;
@@ -21,11 +20,9 @@ use Illuminate\Validation\Rules\In;
 use Illuminate\Validation\Rules\NotIn;
 use Illuminate\Validation\Rules\Numeric;
 use Illuminate\Validation\Rules\ProhibitedIf;
-use Illuminate\Validation\Rules\ProhibitedUnless;
 use Illuminate\Validation\Rules\RequiredIf;
-use Illuminate\Validation\Rules\RequiredUnless;
-use Illuminate\Validation\Rules\StringRule;
 use Illuminate\Validation\Rules\Unique;
+use Illuminate\Validation\Rules\Url;
 
 class Rule
 {
@@ -157,17 +154,6 @@ class Rule
     }
 
     /**
-     * Get a required_unless rule builder instance.
-     *
-     * @param  (\Closure(): bool)|bool|null  $callback
-     * @return \Illuminate\Validation\Rules\RequiredUnless
-     */
-    public static function requiredUnless($callback)
-    {
-        return new RequiredUnless($callback);
-    }
-
-    /**
      * Get a exclude_if rule builder instance.
      *
      * @param  (\Closure(): bool)|bool  $callback
@@ -179,17 +165,6 @@ class Rule
     }
 
     /**
-     * Get a exclude_unless rule builder instance.
-     *
-     * @param  (\Closure(): bool)|bool  $callback
-     * @return \Illuminate\Validation\Rules\ExcludeUnless
-     */
-    public static function excludeUnless($callback)
-    {
-        return new ExcludeUnless($callback);
-    }
-
-    /**
      * Get a prohibited_if rule builder instance.
      *
      * @param  (\Closure(): bool)|bool  $callback
@@ -198,17 +173,6 @@ class Rule
     public static function prohibitedIf($callback)
     {
         return new ProhibitedIf($callback);
-    }
-
-    /**
-     * Get a prohibited_unless rule builder instance.
-     *
-     * @param  (\Closure(): bool)|bool  $callback
-     * @return \Illuminate\Validation\Rules\ProhibitedUnless
-     */
-    public static function prohibitedUnless($callback)
-    {
-        return new ProhibitedUnless($callback);
     }
 
     /**
@@ -237,6 +201,16 @@ class Rule
     public static function email()
     {
         return new Email;
+    }
+
+    /**
+     * Get a URL rule builder instance.
+     *
+     * @return \Illuminate\Validation\Rules\Url
+     */
+    public static function url()
+    {
+        return new Url;
     }
 
     /**
@@ -280,16 +254,6 @@ class Rule
     public static function dimensions(array $constraints = [])
     {
         return new Dimensions($constraints);
-    }
-
-    /**
-     * Get a string rule builder instance.
-     *
-     * @return \Illuminate\Validation\Rules\StringRule
-     */
-    public static function string()
-    {
-        return new StringRule;
     }
 
     /**

--- a/src/Illuminate/Validation/Rules/Url.php
+++ b/src/Illuminate/Validation/Rules/Url.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+use Illuminate\Contracts\Validation\DataAwareRule;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Contracts\Validation\ValidatorAwareRule;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Traits\Conditionable;
+
+class Url implements DataAwareRule, ValidationRule, ValidatorAwareRule
+{
+    use Conditionable;
+
+    /**
+     * The protocols that are allowed.
+     *
+     * @var array
+     */
+    protected $protocols = [];
+
+    /**
+     * Indicates if the URL must be an "active" URL with a valid DNS record.
+     *
+     * @var bool
+     */
+    protected $active = false;
+
+    /**
+     * The validator performing the validation.
+     *
+     * @var \Illuminate\Validation\Validator
+     */
+    protected $validator;
+
+    /**
+     * The data under validation.
+     *
+     * @var array
+     */
+    protected $data;
+
+    /**
+     * Specify the allowed protocols for the URL.
+     *
+     * @param  array  $protocols
+     * @return $this
+     */
+    public function protocols(array $protocols)
+    {
+        $this->protocols = $protocols;
+
+        return $this;
+    }
+
+    /**
+     * Ensure the URL has a valid DNS record.
+     *
+     * @return $this
+     */
+    public function active()
+    {
+        $this->active = true;
+
+        return $this;
+    }
+
+    /**
+     * Run the validation rule.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  \Closure(string): \Illuminate\Translation\PotentiallyTranslatedString  $fail
+     * @return void
+     */
+    public function validate(string $attribute, mixed $value, \Closure $fail): void
+    {
+        $rules = $this->active ? ['active_url'] : [];
+
+        $rules[] = 'url'.($this->protocols ? ':'.implode(',', $this->protocols) : '');
+
+        $validator = Validator::make(
+            $this->data,
+            [$attribute => $rules],
+            $this->validator->customMessages,
+            $this->validator->customAttributes
+        );
+
+        if ($validator->fails()) {
+            foreach ($validator->messages()->all() as $message) {
+                $fail($message);
+            }
+        }
+    }
+
+    /**
+     * Set the current validator.
+     *
+     * @param  \Illuminate\Contracts\Validation\Validator  $validator
+     * @return $this
+     */
+    public function setValidator($validator)
+    {
+        $this->validator = $validator;
+
+        return $this;
+    }
+
+    /**
+     * Set the current data under validation.
+     *
+     * @param  array  $data
+     * @return $this
+     */
+    public function setData($data)
+    {
+        $this->data = $data;
+
+        return $this;
+    }
+
+    /**
+     * Convert the rule to a string representation.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        $rules = $this->active ? ['active_url'] : [];
+
+        $rules[] = 'url'.($this->protocols ? ':'.implode(',', $this->protocols) : '');
+
+        return implode('|', $rules);
+    }
+}

--- a/tests/Validation/ValidationUrlRuleTest.php
+++ b/tests/Validation/ValidationUrlRuleTest.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Illuminate\Support\Arr;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Validator;
+use PHPUnit\Framework\TestCase;
+
+class ValidationUrlRuleTest extends TestCase
+{
+    private const ATTRIBUTE = 'my_url';
+    private const ATTRIBUTE_REPLACED = 'my url';
+
+    public function testBasic()
+    {
+        $this->fails(
+            Rule::url(),
+            'foo',
+            ['The '.self::ATTRIBUTE_REPLACED.' field format is invalid.']
+        );
+
+        $this->passes(
+            Rule::url(),
+            'https://laravel.com'
+        );
+
+        $this->passes(
+            Rule::url(),
+            'http://laravel.com'
+        );
+    }
+
+    public function testProtocols()
+    {
+        $this->fails(
+            Rule::url()->protocols(['https']),
+            'http://laravel.com',
+            ['The '.self::ATTRIBUTE_REPLACED.' field format is invalid.']
+        );
+
+        $this->passes(
+            Rule::url()->protocols(['https']),
+            'https://laravel.com'
+        );
+
+        $this->passes(
+            Rule::url()->protocols(['http', 'https']),
+            'http://laravel.com'
+        );
+    }
+
+    public function testActive()
+    {
+        $this->fails(
+            Rule::url()->active(),
+            'https://non-existent-domain-123456789.com',
+            ['The '.self::ATTRIBUTE_REPLACED.' field format is invalid.']
+        );
+
+        $this->passes(
+            Rule::url()->active(),
+            'https://google.com'
+        );
+    }
+
+    /**
+     * @param  mixed  $rule
+     * @param  string|array  $values
+     * @param  array  $expectedMessages
+     * @return void
+     */
+    protected function fails($rule, $values, $expectedMessages)
+    {
+        $this->assertValidationRules($rule, $values, false, $expectedMessages);
+    }
+
+    /**
+     * @param  mixed  $rule
+     * @param  string|array  $values
+     * @param  bool  $expectToPass
+     * @param  array  $expectedMessages
+     * @return void
+     */
+    protected function assertValidationRules($rule, $values, $expectToPass, $expectedMessages = [])
+    {
+        $values = Arr::wrap($values);
+
+        $translator = $this->getTranslator();
+
+        foreach ($values as $value) {
+            $v = new Validator(
+                $translator,
+                [self::ATTRIBUTE => $value],
+                [self::ATTRIBUTE => is_object($rule) ? clone $rule : $rule]
+            );
+
+            // Mocking the container for the Validator
+            $container = new \Illuminate\Container\Container;
+            $container->singleton('validator', function () use ($translator) {
+                return new \Illuminate\Validation\Factory($translator);
+            });
+            \Illuminate\Support\Facades\Facade::setFacadeApplication($container);
+            $v->setContainer($container);
+
+            $this->assertSame($expectToPass, $v->passes(), 'Expected URL input '.$value.' to '.($expectToPass ? 'pass' : 'fail').'.');
+
+            if (! $expectToPass) {
+                $this->assertSame(
+                    [self::ATTRIBUTE => $expectedMessages],
+                    $v->messages()->toArray(),
+                    'Expected different message for URL input '.$value
+                );
+            }
+        }
+    }
+
+    /**
+     * @param  mixed  $rule
+     * @param  string|array  $values
+     * @return void
+     */
+    protected function passes($rule, $values)
+    {
+        $this->assertValidationRules($rule, $values, true);
+    }
+
+    protected function getTranslator()
+    {
+        $loader = new \Illuminate\Translation\ArrayLoader;
+        $loader->addMessages('en', 'validation', [
+            'url' => 'The :attribute field format is invalid.',
+            'active_url' => 'The :attribute field format is invalid.',
+        ]);
+
+        return new \Illuminate\Translation\Translator($loader, 'en');
+    }
+}


### PR DESCRIPTION
This PR adds a new `Rule::url()` fluent builder, providing a modern and expressive API for URL validation that aligns with existing patterns like `Rule::email()`.

### Usage

```php
// Basic URL validation
'website' => Rule::url()

// Restrict to specific protocols
'website' => Rule::url()->protocols(['https'])

// Ensure the URL has a valid DNS record
'website' => Rule::url()->active()