### PR TITLE
[13.x] Move Scope interface @template from method-level to class-level to fix LSP violation

### DIFF
--- a/src/Illuminate/Database/Eloquent/Scope.php
+++ b/src/Illuminate/Database/Eloquent/Scope.php
@@ -2,12 +2,13 @@
 
 namespace Illuminate\Database\Eloquent;
 
+/**
+ * @template TModel of \Illuminate\Database\Eloquent\Model
+ */
 interface Scope
 {
     /**
      * Apply the scope to a given Eloquent query builder.
-     *
-     * @template TModel of \Illuminate\Database\Eloquent\Model
      *
      * @param  \Illuminate\Database\Eloquent\Builder<TModel>  $builder
      * @param  TModel  $model

--- a/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
@@ -2,6 +2,9 @@
 
 namespace Illuminate\Database\Eloquent;
 
+/**
+ * @implements \Illuminate\Database\Eloquent\Scope<\Illuminate\Database\Eloquent\Model>
+ */
 class SoftDeletingScope implements Scope
 {
     /**
@@ -11,15 +14,6 @@ class SoftDeletingScope implements Scope
      */
     protected $extensions = ['Restore', 'RestoreOrCreate', 'CreateOrRestore', 'WithTrashed', 'WithoutTrashed', 'OnlyTrashed'];
 
-    /**
-     * Apply the scope to a given Eloquent query builder.
-     *
-     * @template TModel of \Illuminate\Database\Eloquent\Model
-     *
-     * @param  \Illuminate\Database\Eloquent\Builder<TModel>  $builder
-     * @param  TModel  $model
-     * @return void
-     */
     public function apply(Builder $builder, Model $model)
     {
         $builder->whereNull($model->getQualifiedDeletedAtColumn());

--- a/types/Database/Eloquent/Scope.php
+++ b/types/Database/Eloquent/Scope.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Illuminate\Types\Scope;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Scope;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * @implements Scope<User>
+ */
+class UserScope implements Scope
+{
+    public function apply(Builder $builder, Model $model): void
+    {
+        assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Types\Scope\User>', $builder);
+        assertType('Illuminate\Types\Scope\User', $model);
+    }
+}
+
+/**
+ * @implements Scope<Model>
+ */
+class GenericScope implements Scope
+{
+    public function apply(Builder $builder, Model $model): void
+    {
+        assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Database\Eloquent\Model>', $builder);
+        assertType('Illuminate\Database\Eloquent\Model', $model);
+    }
+}
+
+class User extends Model
+{
+}


### PR DESCRIPTION
## Summary

The `@template TModel` on `Scope::apply()` was declared at the **method level**, which means every implementation must accept **any** `Model` subtype (universally quantified). This makes it impossible for user-defined scopes to narrow the model type via `@implements Scope<SpecificModel>` — doing so violates the Liskov Substitution Principle in PHPStan.

**Before (method-level template — broken):**
```php
interface Scope
{
    /** @template TModel of Model */
    public function apply(Builder $builder, Model $model);
}

// ❌ Cannot narrow TModel — LSP violation
class BillingScope implements Scope
{
    public function apply(Builder $builder, Model $model) { ... }
}
```

**After (interface-level template — correct):**
```php
/** @template TModel of Model */
interface Scope
{
    /** @param Builder<TModel> $builder  @param TModel $model */
    public function apply(Builder $builder, Model $model);
}

// ✅ Bind TModel via @implements
/** @implements Scope<Subscription> */
class BillingScope implements Scope
{
    public function apply(Builder $builder, Model $model) { ... }
}
```

### Changes

- **`Scope.php`** — Move `@template TModel` from `apply()` method to interface level
- **`SoftDeletingScope.php`** — Add `@implements Scope<Model>`, remove redundant method-level `@template` and `@param` (types inherited from interface)
- **`types/Database/Eloquent/Scope.php`** (new) — PHPStan type assertion tests covering both `Scope<SpecificModel>` and `Scope<Model>` binding