### PR TITLE
[13.x] Fix stale cache in Request::allFiles()

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -15,6 +15,13 @@ trait InteractsWithInput
     use Dumpable, InteractsWithData;
 
     /**
+     * The raw files for the request.
+     *
+     * @var array
+     */
+    protected $rawConvertedFiles;
+
+    /**
      * Retrieve a server variable from the request.
      *
      * @param  string|null  $key
@@ -184,7 +191,12 @@ trait InteractsWithInput
     {
         $files = $this->files->all();
 
-        return $this->convertedFiles = $this->convertedFiles ?? $this->convertUploadedFiles($files);
+        if ($this->convertedFiles === null || $this->rawConvertedFiles !== $files) {
+            $this->rawConvertedFiles = $files;
+            $this->convertedFiles = $this->convertUploadedFiles($files);
+        }
+
+        return $this->convertedFiles;
     }
 
     /**

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -15,13 +15,6 @@ trait InteractsWithInput
     use Dumpable, InteractsWithData;
 
     /**
-     * The raw files for the request.
-     *
-     * @var array
-     */
-    protected $rawConvertedFiles;
-
-    /**
      * Retrieve a server variable from the request.
      *
      * @param  string|null  $key

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -71,6 +71,13 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     protected $cachedAcceptHeader;
 
     /**
+     * The raw files for the request.
+     *
+     * @var array
+     */
+    protected $rawConvertedFiles;
+
+    /**
      * Create a new Illuminate HTTP request from server variables.
      *
      * @return static

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -1938,4 +1938,47 @@ class HttpRequestTest extends TestCase
         $this->assertSame(22.4, $request->clamp('per_page', 1.11, 22.4, 2));
         $this->assertSame(9.24, $request->clamp('float', 1, 10));
     }
+
+    public function testAllFilesReflectsChangesWhenFilesAreAddedLater()
+    {
+        $request = Request::create('/', 'POST');
+
+        $file1 = \Illuminate\Http\UploadedFile::fake()->create('avatar.jpg');
+        $request->files->set('avatar', $file1);
+
+        $this->assertCount(1, $request->allFiles());
+
+        $file2 = \Illuminate\Http\UploadedFile::fake()->create('banner.jpg');
+        $request->files->set('banner', $file2);
+
+        $this->assertCount(2, $request->allFiles());
+        $this->assertArrayHasKey('banner', $request->allFiles());
+    }
+
+    public function testAllFilesReturnsCachedResultWhenNoChangesAreMade()
+    {
+        $request = Request::create('/', 'POST');
+        $file = \Illuminate\Http\UploadedFile::fake()->create('test.jpg');
+        $request->files->set('test', $file);
+
+        $firstCall = $request->allFiles();
+        $secondCall = $request->allFiles();
+
+        $this->assertSame($firstCall, $secondCall);
+    }
+
+    public function testAllFilesReflectsChangesInPutRequests()
+    {
+        $request = \Illuminate\Http\Request::create('/', 'PUT');
+
+        $file1 = \Illuminate\Http\UploadedFile::fake()->create('document.pdf');
+        $request->files->set('document', $file1);
+
+        $this->assertCount(1, $request->allFiles());
+
+        $file2 = \Illuminate\Http\UploadedFile::fake()->create('signature.png');
+        $request->files->set('signature', $file2);
+
+        $this->assertCount(2, $request->allFiles());
+    }
 }


### PR DESCRIPTION
Currently, allFiles() caches the converted files on the first call. If the underlying Symfony file bag is modified later (e.g. via middleware), allFiles() continues to return the old cached array instead of the updated files.

This PR ensures the cache is invalidated if the source files have changed. I've also added regression tests to verify that allFiles() correctly reflects mutations in both POST and PUT requests.

fixes: #59631