### PR TITLE
[13.x] Add BackedEnum support to SimpleMessage mailer method

### DIFF
--- a/src/Illuminate/Notifications/Messages/SimpleMessage.php
+++ b/src/Illuminate/Notifications/Messages/SimpleMessage.php
@@ -4,6 +4,9 @@ namespace Illuminate\Notifications\Messages;
 
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Notifications\Action;
+use UnitEnum;
+
+use function Illuminate\Support\enum_value;
 
 class SimpleMessage
 {
@@ -260,12 +263,12 @@ class SimpleMessage
     /**
      * Set the name of the mailer that should send the notification.
      *
-     * @param  string  $mailer
+     * @param  UnitEnum|string  $mailer
      * @return $this
      */
     public function mailer($mailer)
     {
-        $this->mailer = $mailer;
+        $this->mailer = enum_value($mailer);
 
         return $this;
     }

--- a/tests/Notifications/NotificationMessageTest.php
+++ b/tests/Notifications/NotificationMessageTest.php
@@ -17,6 +17,30 @@ class NotificationMessageTest extends TestCase
         $this->assertSame('error', $message->level);
     }
 
+    public function testMailerCanBeSetFromString()
+    {
+        $message = new Message;
+        $message->mailer('postmark');
+
+        $this->assertSame('postmark', $message->mailer);
+    }
+
+    public function testMailerCanBeSetFromBackedEnum()
+    {
+        $message = new Message;
+        $message->mailer(NotificationMessageMailerEnum::Postmark);
+
+        $this->assertSame('postmark', $message->mailer);
+    }
+
+    public function testMailerCanBeSetFromUnitEnum()
+    {
+        $message = new Message;
+        $message->mailer(NotificationMessageMailerUnitEnum::Postmark);
+
+        $this->assertSame('Postmark', $message->mailer);
+    }
+
     public function testMessageFormatsMultiLineText()
     {
         $message = new Message;
@@ -35,4 +59,14 @@ class NotificationMessageTest extends TestCase
 
         $this->assertSame('This is a single line of text.', $message->introLines[0]);
     }
+}
+
+enum NotificationMessageMailerEnum: string
+{
+    case Postmark = 'postmark';
+}
+
+enum NotificationMessageMailerUnitEnum
+{
+    case Postmark;
 }


### PR DESCRIPTION
Adds `Enum` support to the `mailer()` method on `Illuminate\Notifications\Messages\SimpleMessage` (and therefore `MailMessage`), matching the behavior already present in `Illuminate\Mail\MailManager::mailer()`.
                                                     
This allows a dedicated mailer to be selected using an enum when composing a mail notification, instead of a hard-coded string:
                                                                          
```php                                                                                                                                                               
enum Mailer: string
{
    case Postmark = 'postmark';
    case Ses = 'ses';
}

public function toMail(object $notifiable): MailMessage
{
    return (new MailMessage)                                                                                                                                                
        ->mailer(Mailer::Postmark)
        ->subject('Welcome')
        ->line('Thanks for signing up!');
}
```

Plain strings continue to work as before — the value is resolved through the `enum_value()` helper.