### PR TITLE
[13.x] Remove unused variable in `catch()`

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -22,7 +22,6 @@ use Rector\Php71\Rector\BinaryOp\BinaryOpBetweenNumberAndStringRector;
 use Rector\Php71\Rector\FuncCall\RemoveExtraParametersRector;
 use Rector\Php74\Rector\Assign\NullCoalescingOperatorRector;
 use Rector\Php74\Rector\Closure\ClosureToArrowFunctionRector;
-use Rector\Php80\Rector\Catch_\RemoveUnusedVariableInCatchRector;
 use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
 use Rector\Php80\Rector\Class_\StringableForToStringRector;
 use Rector\Php80\Rector\ClassConstFetch\ClassOnThisVariableObjectRector;
@@ -73,7 +72,6 @@ return RectorConfig::configure()
         ReadOnlyClassRector::class,
         ReadOnlyPropertyRector::class,
         RemoveExtraParametersRector::class,
-        RemoveUnusedVariableInCatchRector::class,
         ReturnNeverTypeRector::class,
         StaticCallOnNonStaticToInstanceCallRector::class,
         StringClassNameToClassConstantRector::class,

--- a/src/Illuminate/Database/Connectors/ConnectionFactory.php
+++ b/src/Illuminate/Database/Connectors/ConnectionFactory.php
@@ -179,18 +179,20 @@ class ConnectionFactory
     protected function createPdoResolverWithHosts(array $config)
     {
         return function () use ($config) {
+            $exception = null;
+
             foreach (Arr::shuffle($this->parseHosts($config)) as $host) {
                 $config['host'] = $host;
 
                 try {
                     return $this->createConnector($config)->connect($config);
-                } catch (PDOException) {
-                    continue;
+                } catch (PDOException $e) {
+                    $exception = $e;
                 }
             }
 
-            if (isset($e)) {
-                throw $e;
+            if ($exception !== null) {
+                throw $exception;
             }
         };
     }

--- a/src/Illuminate/Database/Connectors/ConnectionFactory.php
+++ b/src/Illuminate/Database/Connectors/ConnectionFactory.php
@@ -184,7 +184,7 @@ class ConnectionFactory
 
                 try {
                     return $this->createConnector($config)->connect($config);
-                } catch (PDOException $e) {
+                } catch (PDOException) {
                     continue;
                 }
             }

--- a/src/Illuminate/Filesystem/ReceiveFile.php
+++ b/src/Illuminate/Filesystem/ReceiveFile.php
@@ -34,7 +34,7 @@ class ReceiveFile
             Storage::disk($this->disk)->put($path, $request->getContent());
 
             return response()->noContent();
-        } catch (PathTraversalDetected $e) {
+        } catch (PathTraversalDetected) {
             abort(404);
         }
     }

--- a/src/Illuminate/Filesystem/ServeFile.php
+++ b/src/Illuminate/Filesystem/ServeFile.php
@@ -44,7 +44,7 @@ class ServeFile
                     }
                 }
             );
-        } catch (PathTraversalDetected $e) {
+        } catch (PathTraversalDetected) {
             abort(404);
         }
     }

--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -199,7 +199,7 @@ abstract class Job
 
             try {
                 $batchRepository->rollBack();
-            } catch (Throwable $e) {
+            } catch (Throwable) {
                 // ...
             }
         }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1231,7 +1231,7 @@ class Str
     {
         try {
             return (string) $value;
-        } catch (Throwable $e) {
+        } catch (Throwable) {
             return $fallback;
         }
     }

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -475,7 +475,7 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         try {
             $post->tags()->findSole($tag);
             $this->fail('Expected RecordsNotFoundException was not thrown.');
-        } catch (RecordsNotFoundException $e) {
+        } catch (RecordsNotFoundException) {
             $this->assertTrue(true);
         }
     }

--- a/tests/Integration/Events/EventFakeTest.php
+++ b/tests/Integration/Events/EventFakeTest.php
@@ -196,7 +196,7 @@ class EventFakeTest extends TestCase
 
                 throw new Exception('foo');
             });
-        } catch (Exception $e) {
+        } catch (Exception) {
         }
 
         Event::assertNotDispatched(ShouldDispatchAfterCommitEvent::class);

--- a/tests/Integration/Events/ShouldDispatchAfterCommitEventTest.php
+++ b/tests/Integration/Events/ShouldDispatchAfterCommitEventTest.php
@@ -186,7 +186,7 @@ class ShouldDispatchAfterCommitEventTest extends TestCase
                     Event::dispatch(new AnotherShouldDispatchAfterCommitTestEvent);
                     throw new \Exception;
                 });
-            } catch (\Exception $e) {
+            } catch (\Exception) {
             }
         });
 
@@ -207,7 +207,7 @@ class ShouldDispatchAfterCommitEventTest extends TestCase
 
                     throw new \Exception;
                 });
-            } catch (\Exception $e) {
+            } catch (\Exception) {
                 //
             }
         });
@@ -232,7 +232,7 @@ class ShouldDispatchAfterCommitEventTest extends TestCase
                     Event::dispatch(new AnotherShouldDispatchAfterCommitTestEvent);
                     throw new \Exception;
                 });
-            } catch (\Exception $e) {
+            } catch (\Exception) {
             }
         });
 
@@ -255,7 +255,7 @@ class ShouldDispatchAfterCommitEventTest extends TestCase
 
                     throw new \Exception;
                 });
-            } catch (\Exception $e) {
+            } catch (\Exception) {
             }
         });
 

--- a/tests/Redis/RedisEventsTest.php
+++ b/tests/Redis/RedisEventsTest.php
@@ -53,7 +53,7 @@ class RedisEventsTest extends TestCase
 
         try {
             $connection->command('get', ['key']);
-        } catch (Exception $e) {
+        } catch (Exception) {
             // Expected exception
         }
     }
@@ -77,7 +77,7 @@ class RedisEventsTest extends TestCase
 
         try {
             $connection->command('get', ['key']);
-        } catch (Exception $e) {
+        } catch (Exception) {
             // Expected exception
         }
     }

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -1750,7 +1750,7 @@ EOT
         try {
             $response->assertExactJsonStructure(['*' => ['foo', 'bar']]);
             $failed = false;
-        } catch (AssertionFailedError $e) {
+        } catch (AssertionFailedError) {
             $failed = true;
         }
 


### PR DESCRIPTION
Remove unused variable in `catch()`