### PR TITLE
[13.x] Flip misordered assertions arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,35 @@
 # Release Notes for 12.x
 
-## [Unreleased](https://github.com/laravel/framework/compare/v13.4.0...13.x)
+## [Unreleased](https://github.com/laravel/framework/compare/v13.5.0...13.x)
+
+## [v13.5.0](https://github.com/laravel/framework/compare/v13.4.0...v13.5.0) - 2026-04-14
+
+* [13.x] Support #[Delay] attribute on queued mailables by [@sumaiazaman](https://github.com/sumaiazaman) in https://github.com/laravel/framework/pull/59580
+* [13.x] Added inheritance support for Controller Middleware attributes. by [@niduranga](https://github.com/niduranga) in https://github.com/laravel/framework/pull/59597
+* [13.x] Normalize phpredis SSL context for single and cluster connections   by [@timmylindh](https://github.com/timmylindh) in https://github.com/laravel/framework/pull/59569
+* [13.x] Memoize the result of `TestCase@withoutBootingFramework()` by [@cosmastech](https://github.com/cosmastech) in https://github.com/laravel/framework/pull/59610
+* [13.x] Add missing [@throws](https://github.com/throws) and docblocks for concurrency and model in… by [@scabarcas17](https://github.com/scabarcas17) in https://github.com/laravel/framework/pull/59602
+* [13.x] Fix that retries of `ShouldBeUniqueUntilProcessing` jobs are force-releasing locks they don't own by [@kohlerdominik](https://github.com/kohlerdominik) in https://github.com/laravel/framework/pull/59567
+* [13.x] Add first-class Redis Cluster support for Queue and ConcurrencyLimiter by [@timmylindh](https://github.com/timmylindh) in https://github.com/laravel/framework/pull/59533
+* [13.x] chore: Update PHP version from 8.2 to 8.3 in `bin/test.sh` script by [@crynobone](https://github.com/crynobone) in https://github.com/laravel/framework/pull/59605
+* [13.x] Fix RedisQueueTest by [@jackbayliss](https://github.com/jackbayliss) in https://github.com/laravel/framework/pull/59613
+* [13.x] Add enum support to CacheManager store and driver methods by [@yousefkadah](https://github.com/yousefkadah) in https://github.com/laravel/framework/pull/59637
+* [13.x] Fix redirectUsersTo() overwriting redirectGuestsTo() callback by [@timmylindh](https://github.com/timmylindh) in https://github.com/laravel/framework/pull/59633
+* [13.x] Add ability to detect unserializable values returned from cache by [@jackbayliss](https://github.com/jackbayliss) in https://github.com/laravel/framework/pull/59630
+* [13.x] Fix loose comparison false positive in NotPwnedVerifier with magic hash passwords by [@scabarcas17](https://github.com/scabarcas17) in https://github.com/laravel/framework/pull/59644
+* [13.x] Refactor `Skip` middleware by [@cosmastech](https://github.com/cosmastech) in https://github.com/laravel/framework/pull/59651
+* [13.x] Resolve stan errors on MySqlSchemaState by [@jackbayliss](https://github.com/jackbayliss) in https://github.com/laravel/framework/pull/59652
+* [13.x] Allow closure values in updateOrCreate and firstOrNew by [@yousefkadah](https://github.com/yousefkadah) in https://github.com/laravel/framework/pull/59647
+* [13.x] Add enum support to MailManager mailer and driver methods by [@yousefkadah](https://github.com/yousefkadah) in https://github.com/laravel/framework/pull/59645
+* [13.x] Add enum support to AuthManager guard and shouldUse methods by [@yousefkadah](https://github.com/yousefkadah) in https://github.com/laravel/framework/pull/59646
+* [13.x] Add spatie/fork to composer suggestions by [@jnoordsij](https://github.com/jnoordsij) in https://github.com/laravel/framework/pull/59660
+* [13.x] Add enum support to Manager driver method by [@scabarcas17](https://github.com/scabarcas17) in https://github.com/laravel/framework/pull/59659
+* [13.x] Fix custom driver binding bug and improve  by [@ollieread](https://github.com/ollieread) in https://github.com/laravel/framework/pull/59614
+* [13.x] Improve PHPDoc for "safe" method with conditional return type by [@leo95batista](https://github.com/leo95batista) in https://github.com/laravel/framework/pull/59684
+* [13.x] Bump Retry action in CI by [@jackbayliss](https://github.com/jackbayliss) in https://github.com/laravel/framework/pull/59681
+* [13.x] Move Scope interface [@template](https://github.com/template) from method-level to class-level to fix LSP violation by [@kayw-geek](https://github.com/kayw-geek) in https://github.com/laravel/framework/pull/59675
+* [13.x] Combine consecutive `isset` and `unset` by [@lucasmichot](https://github.com/lucasmichot) in https://github.com/laravel/framework/pull/59685
+* [13.x] Changes `strlen` comparison to 0 to direct empty string compare by [@lucasmichot](https://github.com/lucasmichot) in https://github.com/laravel/framework/pull/59686
 
 ## [v13.4.0](https://github.com/laravel/framework/compare/v13.3.0...v13.4.0) - 2026-04-07
 

--- a/tests/Config/RepositoryTest.php
+++ b/tests/Config/RepositoryTest.php
@@ -52,7 +52,7 @@ class RepositoryTest extends TestCase
     public function testGetValueWhenKeyContainDot()
     {
         $this->assertSame(
-            $this->repository->get('a.b'), 'c'
+            'c', $this->repository->get('a.b')
         );
         $this->assertNull(
             $this->repository->get('a.b.c')
@@ -308,7 +308,7 @@ class RepositoryTest extends TestCase
     public function testItGetsAsArray(): void
     {
         $this->assertSame(
-            $this->repository->array('array'), ['aaa', 'zzz']
+            ['aaa', 'zzz'], $this->repository->array('array')
         );
     }
 
@@ -346,7 +346,7 @@ class RepositoryTest extends TestCase
     public function testItGetsAsInteger(): void
     {
         $this->assertSame(
-            $this->repository->integer('integer'), 1
+            1, $this->repository->integer('integer')
         );
     }
 
@@ -361,7 +361,7 @@ class RepositoryTest extends TestCase
     public function testItGetsAsFloat(): void
     {
         $this->assertSame(
-            $this->repository->float('float'), 1.1
+            1.1, $this->repository->float('float')
         );
     }
 

--- a/tests/Container/ContainerResolveNonInstantiableTest.php
+++ b/tests/Container/ContainerResolveNonInstantiableTest.php
@@ -29,7 +29,7 @@ class ContainerResolveNonInstantiableTest extends TestCase
         $container = new Container;
         $parent = $container->make(VariadicPrimitive::class);
 
-        $this->assertSame($parent->params, []);
+        $this->assertSame([], $parent->params);
     }
 }
 

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -628,7 +628,6 @@ class DatabaseEloquentFactoryTest extends TestCase
         $this->assertCount(6, FactoryTestPost::all());
         $this->assertCount(3, FactoryTestUser::latest()->first()->posts);
         $this->assertEquals(
-            FactoryTestPost::orderBy('title')->pluck('title')->all(),
             [
                 'Abigail Otwell Post 1',
                 'Abigail Otwell Post 2',
@@ -636,7 +635,8 @@ class DatabaseEloquentFactoryTest extends TestCase
                 'Taylor Otwell Post 1',
                 'Taylor Otwell Post 2',
                 'Taylor Otwell Post 3',
-            ]
+            ],
+            FactoryTestPost::orderBy('title')->pluck('title')->all()
         );
     }
 
@@ -999,8 +999,8 @@ class DatabaseEloquentFactoryTest extends TestCase
 
     public function test_factory_model_names_correct()
     {
-        $this->assertEquals(FactoryTestUseFactoryAttribute::factory()->modelName(), FactoryTestUseFactoryAttribute::class);
-        $this->assertEquals(FactoryTestGuessModel::factory()->modelName(), FactoryTestGuessModel::class);
+        $this->assertEquals(FactoryTestUseFactoryAttribute::class, FactoryTestUseFactoryAttribute::factory()->modelName());
+        $this->assertEquals(FactoryTestGuessModel::class, FactoryTestGuessModel::factory()->modelName());
     }
 
     public function test_factory_global_model_resolver()
@@ -1009,11 +1009,11 @@ class DatabaseEloquentFactoryTest extends TestCase
             return __NAMESPACE__.'\\'.Str::replaceLast('Factory', '', class_basename($factory::class));
         });
 
-        $this->assertEquals(FactoryTestGuessModel::factory()->modelName(), FactoryTestGuessModel::class);
-        $this->assertEquals(FactoryTestUseFactoryAttribute::factory()->modelName(), FactoryTestUseFactoryAttribute::class);
+        $this->assertEquals(FactoryTestGuessModel::class, FactoryTestGuessModel::factory()->modelName());
+        $this->assertEquals(FactoryTestUseFactoryAttribute::class, FactoryTestUseFactoryAttribute::factory()->modelName());
 
-        $this->assertEquals(FactoryTestUseFactoryAttributeFactory::new()->modelName(), FactoryTestUseFactoryAttribute::class);
-        $this->assertEquals(FactoryTestGuessModelFactory::new()->modelName(), FactoryTestGuessModel::class);
+        $this->assertEquals(FactoryTestUseFactoryAttribute::class, FactoryTestUseFactoryAttributeFactory::new()->modelName());
+        $this->assertEquals(FactoryTestGuessModel::class, FactoryTestGuessModelFactory::new()->modelName());
     }
 
     public function test_factory_model_has_many_relationship_has_pending_attributes()

--- a/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
@@ -132,7 +132,7 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
 
         $this->assertCount(1, $country);
         $this->assertTrue($country->first()->relationLoaded('posts'));
-        $this->assertEquals($country->first()->posts->pluck('title')->unique()->toArray(), ['A title']);
+        $this->assertEquals(['A title'], $country->first()->posts->pluck('title')->unique()->toArray());
     }
 
     public function testFindMethod()

--- a/tests/Database/DatabaseEloquentHasOneThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasOneThroughIntegrationTest.php
@@ -127,7 +127,7 @@ class DatabaseEloquentHasOneThroughIntegrationTest extends TestCase
 
         $this->assertCount(1, $position);
         $this->assertTrue($position->first()->relationLoaded('contract'));
-        $this->assertEquals($position->first()->contract->pluck('title')->unique()->toArray(), ['A title']);
+        $this->assertEquals(['A title'], $position->first()->contract->pluck('title')->unique()->toArray());
     }
 
     public function testFirstOrFailThrowsAnException()

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -1205,7 +1205,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertCount(1, $results);
         $this->assertSame('taylorotwell@gmail.com', $results->first()->email);
         $this->assertTrue($results->first()->relationLoaded('friends'));
-        $this->assertSame($results->first()->friends->pluck('email')->unique()->toArray(), ['abigailotwell@gmail.com']);
+        $this->assertSame(['abigailotwell@gmail.com'], $results->first()->friends->pluck('email')->unique()->toArray());
     }
 
     public function testHasOnNestedSelfReferencingBelongsToManyRelationship()
@@ -1247,8 +1247,8 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertCount(1, $results);
         $this->assertSame('taylorotwell@gmail.com', $results->first()->email);
         $this->assertTrue($results->first()->relationLoaded('friends'));
-        $this->assertSame($results->first()->friends->pluck('email')->unique()->toArray(), ['abigailotwell@gmail.com']);
-        $this->assertSame($results->first()->friends->pluck('friends')->flatten()->pluck('email')->unique()->toArray(), ['foo@gmail.com']);
+        $this->assertSame(['abigailotwell@gmail.com'], $results->first()->friends->pluck('email')->unique()->toArray());
+        $this->assertSame(['foo@gmail.com'], $results->first()->friends->pluck('friends')->flatten()->pluck('email')->unique()->toArray());
     }
 
     public function testHasOnSelfReferencingBelongsToManyRelationshipWithWherePivot()
@@ -1321,7 +1321,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertCount(1, $results);
         $this->assertSame('Child Post', $results->first()->name);
         $this->assertTrue($results->first()->relationLoaded('parentPost'));
-        $this->assertSame($results->first()->parentPost->name, 'Parent Post');
+        $this->assertSame('Parent Post', $results->first()->parentPost->name);
     }
 
     public function testHasOnNestedSelfReferencingBelongsToRelationship()
@@ -1363,9 +1363,9 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertCount(1, $results);
         $this->assertSame('Child Post', $results->first()->name);
         $this->assertTrue($results->first()->relationLoaded('parentPost'));
-        $this->assertSame($results->first()->parentPost->name, 'Parent Post');
+        $this->assertSame('Parent Post', $results->first()->parentPost->name);
         $this->assertTrue($results->first()->parentPost->relationLoaded('parentPost'));
-        $this->assertSame($results->first()->parentPost->parentPost->name, 'Grandparent Post');
+        $this->assertSame('Grandparent Post', $results->first()->parentPost->parentPost->name);
     }
 
     public function testHasOnSelfReferencingHasManyRelationship()
@@ -1404,7 +1404,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertCount(1, $results);
         $this->assertSame('Parent Post', $results->first()->name);
         $this->assertTrue($results->first()->relationLoaded('childPosts'));
-        $this->assertSame($results->first()->childPosts->pluck('name')->unique()->toArray(), ['Child Post']);
+        $this->assertSame(['Child Post'], $results->first()->childPosts->pluck('name')->unique()->toArray());
     }
 
     public function testHasOnNestedSelfReferencingHasManyRelationship()
@@ -1446,8 +1446,8 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertCount(1, $results);
         $this->assertSame('Grandparent Post', $results->first()->name);
         $this->assertTrue($results->first()->relationLoaded('childPosts'));
-        $this->assertSame($results->first()->childPosts->pluck('name')->unique()->toArray(), ['Parent Post']);
-        $this->assertSame($results->first()->childPosts->pluck('childPosts')->flatten()->pluck('name')->unique()->toArray(), ['Child Post']);
+        $this->assertSame(['Parent Post'], $results->first()->childPosts->pluck('name')->unique()->toArray());
+        $this->assertSame(['Child Post'], $results->first()->childPosts->pluck('childPosts')->flatten()->pluck('name')->unique()->toArray());
     }
 
     public function testHasWithNonWhereBindings()

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3138,8 +3138,8 @@ class DatabaseEloquentModelTest extends TestCase
 
         $this->assertCount($castCount + 2, $model->getCasts());
         $this->assertArrayHasKey('foo', $model->getCasts());
-        $this->assertEquals($model->getCasts()['foo'], 'MyClass:myArgumentA');
-        $this->assertEquals($model->getCasts()['bar'], 'MyClass:myArgumentA,myArgumentB');
+        $this->assertEquals('MyClass:myArgumentA', $model->getCasts()['foo']);
+        $this->assertEquals('MyClass:myArgumentA,myArgumentB', $model->getCasts()['bar']);
     }
 
     public function testUnsetCastAttributes()

--- a/tests/Database/DatabaseMigrationCreatorTest.php
+++ b/tests/Database/DatabaseMigrationCreatorTest.php
@@ -47,7 +47,7 @@ class DatabaseMigrationCreatorTest extends TestCase
         $creator->create('create_bar', 'foo', $table);
 
         $this->assertEquals($_SERVER['__migration.creator.table'], $table);
-        $this->assertEquals($_SERVER['__migration.creator.path'], 'foo/foo_create_bar.php');
+        $this->assertEquals('foo/foo_create_bar.php', $_SERVER['__migration.creator.path']);
 
         unset($_SERVER['__migration.creator.table'], $_SERVER['__migration.creator.path']);
     }

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -677,7 +677,7 @@ class FilesystemAdapterTest extends TestCase
 
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
 
-        $this->assertSame($filesystemAdapter->files(), ['body.txt', 'existing.txt', 'file.txt', 'file1.txt']);
+        $this->assertSame(['body.txt', 'existing.txt', 'file.txt', 'file1.txt'], $filesystemAdapter->files());
     }
 
     public function testProvidesTemporaryUrls()

--- a/tests/Filesystem/FilesystemManagerTest.php
+++ b/tests/Filesystem/FilesystemManagerTest.php
@@ -209,7 +209,7 @@ class FilesystemManagerTest extends TestCase
 
             $scoped->put('dirname/filename.txt', 'file content');
             $this->assertTrue(is_dir(__DIR__.'/../../to-be-scoped/path-prefix'));
-            $this->assertEquals(file_get_contents(__DIR__.'/../../to-be-scoped/path-prefix/dirname/filename.txt'), 'file content');
+            $this->assertEquals('file content', file_get_contents(__DIR__.'/../../to-be-scoped/path-prefix/dirname/filename.txt'));
         } finally {
             unlink(__DIR__.'/../../to-be-scoped/path-prefix/dirname/filename.txt');
             rmdir(__DIR__.'/../../to-be-scoped/path-prefix/dirname');

--- a/tests/Foundation/FoundationDocsCommandTest.php
+++ b/tests/Foundation/FoundationDocsCommandTest.php
@@ -51,7 +51,7 @@ class FoundationDocsCommandTest extends TestCase
             ->expectsOutputToContain('Opening the docs to: https://laravel.com/docs/8.x/installation')
             ->assertSuccessful();
 
-        $this->assertSame($this->openedUrl, 'https://laravel.com/docs/8.x/installation');
+        $this->assertSame('https://laravel.com/docs/8.x/installation', $this->openedUrl);
     }
 
     public function testItCanSpecifyAutocompleteInOriginalCasing(): void
@@ -61,7 +61,7 @@ class FoundationDocsCommandTest extends TestCase
             ->expectsOutputToContain('Opening the docs to: https://laravel.com/docs/8.x/dusk')
             ->assertSuccessful();
 
-        $this->assertSame($this->openedUrl, 'https://laravel.com/docs/8.x/dusk');
+        $this->assertSame('https://laravel.com/docs/8.x/dusk', $this->openedUrl);
     }
 
     public function testItCanSpecifyAutocompleteInLowerCasing(): void
@@ -71,7 +71,7 @@ class FoundationDocsCommandTest extends TestCase
             ->expectsOutputToContain('Opening the docs to: https://laravel.com/docs/8.x/dusk')
             ->assertSuccessful();
 
-        $this->assertSame($this->openedUrl, 'https://laravel.com/docs/8.x/dusk');
+        $this->assertSame('https://laravel.com/docs/8.x/dusk', $this->openedUrl);
     }
 
     public function testItMatchesSectionsThatStartWithInput()
@@ -80,7 +80,7 @@ class FoundationDocsCommandTest extends TestCase
             ->expectsOutputToContain('Opening the docs to: https://laravel.com/docs/8.x/eloquent-collections#method-unique')
             ->assertSuccessful();
 
-        $this->assertSame($this->openedUrl, 'https://laravel.com/docs/8.x/eloquent-collections#method-unique');
+        $this->assertSame('https://laravel.com/docs/8.x/eloquent-collections#method-unique', $this->openedUrl);
     }
 
     public function testItMatchesSectionsWithFuzzyMatching()
@@ -89,7 +89,7 @@ class FoundationDocsCommandTest extends TestCase
             ->expectsOutputToContain('Opening the docs to: https://laravel.com/docs/8.x/eloquent-collections#method-toquery')
             ->assertSuccessful();
 
-        $this->assertSame($this->openedUrl, 'https://laravel.com/docs/8.x/eloquent-collections#method-toquery');
+        $this->assertSame('https://laravel.com/docs/8.x/eloquent-collections#method-toquery', $this->openedUrl);
     }
 
     public function testItCanProvidePageToVisit(): void
@@ -98,7 +98,7 @@ class FoundationDocsCommandTest extends TestCase
             ->expectsOutputToContain('Opening the docs to: https://laravel.com/docs/8.x/eloquent-collections')
             ->assertSuccessful();
 
-        $this->assertSame($this->openedUrl, 'https://laravel.com/docs/8.x/eloquent-collections');
+        $this->assertSame('https://laravel.com/docs/8.x/eloquent-collections', $this->openedUrl);
     }
 
     public function testItCanUseHyphensInsteadOfEscapingSpaces(): void
@@ -107,7 +107,7 @@ class FoundationDocsCommandTest extends TestCase
             ->expectsOutputToContain('Opening the docs to: https://laravel.com/docs/8.x/eloquent-collections')
             ->assertSuccessful();
 
-        $this->assertSame($this->openedUrl, 'https://laravel.com/docs/8.x/eloquent-collections');
+        $this->assertSame('https://laravel.com/docs/8.x/eloquent-collections', $this->openedUrl);
     }
 
     public function testItHasMinimumScoreToMatch(): void
@@ -116,7 +116,7 @@ class FoundationDocsCommandTest extends TestCase
             ->expectsOutputToContain('Unable to determine the page you are trying to visit.')
             ->assertSuccessful();
 
-        $this->assertSame($this->openedUrl, 'https://laravel.com/docs/8.x');
+        $this->assertSame('https://laravel.com/docs/8.x', $this->openedUrl);
     }
 
     public function testItMinimumScoreAccountsForInputLength(): void
@@ -125,7 +125,7 @@ class FoundationDocsCommandTest extends TestCase
             ->expectsOutputToContain('Opening the docs to: https://laravel.com/docs/8.x/localization')
             ->assertSuccessful();
 
-        $this->assertSame($this->openedUrl, 'https://laravel.com/docs/8.x/localization');
+        $this->assertSame('https://laravel.com/docs/8.x/localization', $this->openedUrl);
     }
 
     public function testItCanUseCustomAskStrategy()
@@ -136,7 +136,7 @@ class FoundationDocsCommandTest extends TestCase
             ->expectsOutputToContain('Opening the docs to: https://laravel.com/docs/8.x/dusk')
             ->assertSuccessful();
 
-        $this->assertSame($this->openedUrl, 'https://laravel.com/docs/8.x/dusk');
+        $this->assertSame('https://laravel.com/docs/8.x/dusk', $this->openedUrl);
     }
 
     public function testItFallsbackToAutocompleteWhenAskStrategyContainsBadSyntax(): void
@@ -148,7 +148,7 @@ class FoundationDocsCommandTest extends TestCase
             ->expectsOutputToContain('Opening the docs to: https://laravel.com/docs/8.x/dusk')
             ->assertSuccessful();
 
-        $this->assertSame($this->openedUrl, 'https://laravel.com/docs/8.x/dusk');
+        $this->assertSame('https://laravel.com/docs/8.x/dusk', $this->openedUrl);
     }
 
     public function testItFallsbackToAutocompleteWithBadAskStrategyReturnValue(): void
@@ -160,7 +160,7 @@ class FoundationDocsCommandTest extends TestCase
             ->expectsOutputToContain('Opening the docs to: https://laravel.com/docs/8.x/dusk')
             ->assertSuccessful();
 
-        $this->assertSame($this->openedUrl, 'https://laravel.com/docs/8.x/dusk');
+        $this->assertSame('https://laravel.com/docs/8.x/dusk', $this->openedUrl);
     }
 
     public function testItCatchesAndHandlesProcessInterruptExceptionsInAskStrategies()
@@ -209,7 +209,7 @@ Working directory: expected-working-directory');
             ->expectsOutputToContain('Opening the docs to: https://laravel.com/docs/8.x/eloquent')
             ->assertSuccessful();
 
-        $this->assertSame($this->openedUrl, 'https://laravel.com/docs/8.x/eloquent');
+        $this->assertSame('https://laravel.com/docs/8.x/eloquent', $this->openedUrl);
     }
 
     public function testItCanGuessTheRequestedPageWhenItIsContainedSomewhereInThePageTitle()
@@ -218,7 +218,7 @@ Working directory: expected-working-directory');
             ->expectsOutputToContain('Opening the docs to: https://laravel.com/docs/8.x/eloquent')
             ->assertSuccessful();
 
-        $this->assertSame($this->openedUrl, 'https://laravel.com/docs/8.x/eloquent');
+        $this->assertSame('https://laravel.com/docs/8.x/eloquent', $this->openedUrl);
     }
 
     public function testItCanGuessTheWithTopAndTailMatching()
@@ -227,7 +227,7 @@ Working directory: expected-working-directory');
             ->expectsOutputToContain('Opening the docs to: https://laravel.com/docs/8.x/eloquent-collections')
             ->assertSuccessful();
 
-        $this->assertSame($this->openedUrl, 'https://laravel.com/docs/8.x/eloquent-collections');
+        $this->assertSame('https://laravel.com/docs/8.x/eloquent-collections', $this->openedUrl);
     }
 
     public function testItCanSpecifyCustomOpenCommandsViaEnvVariables()
@@ -282,7 +282,7 @@ Working directory: expected-working-directory');
             ->expectsOutputToContain('Opening the docs to: https://laravel.com/docs/8.x?q=here%20is%20my%20search%20term%20for%20the%20laravel%20website')
             ->assertSuccessful();
 
-        $this->assertSame($this->openedUrl, 'https://laravel.com/docs/8.x?q=here%20is%20my%20search%20term%20for%20the%20laravel%20website');
+        $this->assertSame('https://laravel.com/docs/8.x?q=here%20is%20my%20search%20term%20for%20the%20laravel%20website', $this->openedUrl);
 
         $_SERVER['argv'] = $argCache;
     }
@@ -302,7 +302,7 @@ Working directory: expected-working-directory');
             ->expectsOutputToContain('Opening the docs to: https://laravel.com/docs/8.x/filesystem')
             ->assertSuccessful();
 
-        $this->assertSame($this->openedUrl, 'https://laravel.com/docs/8.x/filesystem');
+        $this->assertSame('https://laravel.com/docs/8.x/filesystem', $this->openedUrl);
     }
 
     public function testItHandlesPoorSpelling()
@@ -311,7 +311,7 @@ Working directory: expected-working-directory');
             ->expectsOutputToContain('Opening the docs to: https://laravel.com/docs/8.x/views')
             ->assertSuccessful();
 
-        $this->assertSame($this->openedUrl, 'https://laravel.com/docs/8.x/views');
+        $this->assertSame('https://laravel.com/docs/8.x/views', $this->openedUrl);
     }
 
     public function testItHandlesNoInteractionOption()
@@ -320,7 +320,7 @@ Working directory: expected-working-directory');
             ->expectsOutputToContain('Opening the docs to: https://laravel.com/docs/8.x')
             ->assertSuccessful();
 
-        $this->assertSame($this->openedUrl, 'https://laravel.com/docs/8.x');
+        $this->assertSame('https://laravel.com/docs/8.x', $this->openedUrl);
     }
 
     public function testCanGetHelpWithoutInstantiatingDependencies()

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -1764,12 +1764,12 @@ class HttpRequestTest extends TestCase
         $params = ['foo' => 'bar'];
 
         $getRequest = Request::create('/', 'GET', $params, [], [], []);
-        $this->assertEquals($getRequest->request->all(), []);
+        $this->assertEquals([], $getRequest->request->all());
         $this->assertEquals($getRequest->query->all(), $params);
 
         $postRequest = Request::create('/', 'POST', $params, [], [], []);
         $this->assertEquals($postRequest->request->all(), $params);
-        $this->assertEquals($postRequest->query->all(), []);
+        $this->assertEquals([], $postRequest->query->all());
     }
 
     /**

--- a/tests/Http/Middleware/TrustProxiesTest.php
+++ b/tests/Http/Middleware/TrustProxiesTest.php
@@ -346,27 +346,27 @@ class TrustProxiesTest extends TestCase
             $this->assertEquals($request->getTrustedHeaderSet(), $this->headerAll,
                 'Assert trusted proxy used all "X-Forwarded-*" header');
 
-            $this->assertEquals($request->getTrustedProxies(), ['192.168.1.1', '192.168.1.2'],
+            $this->assertEquals(['192.168.1.1', '192.168.1.2'], $request->getTrustedProxies(),
                 'Assert trusted proxy using proxies as string separated by comma.');
         });
 
         // or, if your proxy instead uses the "Forwarded" header
         $trustedProxy = $this->createTrustedProxy('HEADER_FORWARDED', '192.168.1.1, 192.168.1.2');
         $trustedProxy->handle($request, function (Request $request) {
-            $this->assertEquals($request->getTrustedHeaderSet(), Request::HEADER_FORWARDED,
+            $this->assertEquals(Request::HEADER_FORWARDED, $request->getTrustedHeaderSet(),
                 'Assert trusted proxy used forwarded header');
 
-            $this->assertEquals($request->getTrustedProxies(), ['192.168.1.1', '192.168.1.2'],
+            $this->assertEquals(['192.168.1.1', '192.168.1.2'], $request->getTrustedProxies(),
                 'Assert trusted proxy using proxies as string separated by comma.');
         });
 
         // or, if you're using AWS ELB
         $trustedProxy = $this->createTrustedProxy('HEADER_X_FORWARDED_AWS_ELB', '192.168.1.1, 192.168.1.2');
         $trustedProxy->handle($request, function (Request $request) {
-            $this->assertEquals($request->getTrustedHeaderSet(), Request::HEADER_X_FORWARDED_AWS_ELB,
+            $this->assertEquals(Request::HEADER_X_FORWARDED_AWS_ELB, $request->getTrustedHeaderSet(),
                 'Assert trusted proxy used AWS ELB header');
 
-            $this->assertEquals($request->getTrustedProxies(), ['192.168.1.1', '192.168.1.2'],
+            $this->assertEquals(['192.168.1.1', '192.168.1.2'], $request->getTrustedProxies(),
                 'Assert trusted proxy using proxies as string separated by comma.');
         });
     }

--- a/tests/Integration/Cache/MemoizedStoreTest.php
+++ b/tests/Integration/Cache/MemoizedStoreTest.php
@@ -143,16 +143,16 @@ class MemoizedStoreTest extends TestCase
     {
         $live = Cache::getMultiple(['name.0', 'name.1']);
         $memoized = Cache::memo()->getMultiple(['name.0', 'name.1']);
-        $this->assertSame($live, ['name.0' => null, 'name.1' => null]);
-        $this->assertSame($memoized, ['name.0' => null, 'name.1' => null]);
+        $this->assertSame(['name.0' => null, 'name.1' => null], $live);
+        $this->assertSame(['name.0' => null, 'name.1' => null], $memoized);
 
         Cache::put('name.0', 'MacDonald', 60);
         Cache::put('name.1', 'Otwell', 60);
 
         $live = Cache::getMultiple(['name.0', 'name.1']);
         $memoized = Cache::memo()->getMultiple(['name.0', 'name.1']);
-        $this->assertSame($live, ['name.0' => 'MacDonald', 'name.1' => 'Otwell']);
-        $this->assertSame($memoized, ['name.0' => null, 'name.1' => null]);
+        $this->assertSame(['name.0' => 'MacDonald', 'name.1' => 'Otwell'], $live);
+        $this->assertSame(['name.0' => null, 'name.1' => null], $memoized);
     }
 
     public function test_it_can_retrieve_already_memoized_and_not_yet_memoized_values_when_retrieving_multiple_values()

--- a/tests/Integration/Generators/ProviderMakeCommandTest.php
+++ b/tests/Integration/Generators/ProviderMakeCommandTest.php
@@ -21,8 +21,8 @@ class ProviderMakeCommandTest extends TestCase
             'public function boot()',
         ], 'app/Providers/FooServiceProvider.php');
 
-        $this->assertEquals(require $this->app->getBootstrapProvidersPath(), [
+        $this->assertEquals([
             'App\Providers\FooServiceProvider',
-        ]);
+        ], require $this->app->getBootstrapProvidersPath());
     }
 }

--- a/tests/Integration/Routing/HasMiddlewareTest.php
+++ b/tests/Integration/Routing/HasMiddlewareTest.php
@@ -12,10 +12,10 @@ class HasMiddlewareTest extends TestCase
     public function test_has_middleware_is_respected()
     {
         $route = Route::get('/', [HasMiddlewareTestController::class, 'index']);
-        $this->assertEquals($route->controllerMiddleware(), ['all', 'only-index']);
+        $this->assertEquals(['all', 'only-index'], $route->controllerMiddleware());
 
         $route = Route::get('/', [HasMiddlewareTestController::class, 'show']);
-        $this->assertEquals($route->controllerMiddleware(), ['all', 'except-index']);
+        $this->assertEquals(['all', 'except-index'], $route->controllerMiddleware());
     }
 }
 

--- a/tests/Log/ContextTest.php
+++ b/tests/Log/ContextTest.php
@@ -165,17 +165,17 @@ class ContextTest extends TestCase
 
         Context::hydrate($dehydrated);
 
-        $this->assertSame(Context::get('string'), 'string');
-        $this->assertSame(Context::get('bool'), false);
-        $this->assertSame(Context::get('int'), 5);
-        $this->assertSame(Context::get('float'), 5.5);
-        $this->assertSame(Context::get('null'), null);
-        $this->assertSame(Context::get('array'), [1, 2, 3]);
-        $this->assertSame(Context::get('hash'), ['foo' => 'bar']);
+        $this->assertSame('string', Context::get('string'));
+        $this->assertSame(false, Context::get('bool'));
+        $this->assertSame(5, Context::get('int'));
+        $this->assertSame(5.5, Context::get('float'));
+        $this->assertSame(null, Context::get('null'));
+        $this->assertSame([1, 2, 3], Context::get('array'));
+        $this->assertSame(['foo' => 'bar'], Context::get('hash'));
         $this->assertEquals(Context::get('object'), (object) ['foo' => 'bar']);
-        $this->assertSame(Context::get('enum'), Suit::Clubs);
-        $this->assertSame(Context::get('backed_enum'), StringBackedSuit::Clubs);
-        $this->assertSame(Context::getHidden('number'), 55);
+        $this->assertSame(Suit::Clubs, Context::get('enum'));
+        $this->assertSame(StringBackedSuit::Clubs, Context::get('backed_enum'));
+        $this->assertSame(55, Context::getHidden('number'));
     }
 
     public function test_it_can_push_to_list()

--- a/tests/Log/LogManagerTest.php
+++ b/tests/Log/LogManagerTest.php
@@ -111,8 +111,8 @@ class LogManagerTest extends TestCase
         $manager->channel('stack');
 
         $this->assertSame(
-            array_keys($manager->getChannels()),
-            ['single', 'daily', 'stderr', 'stack']
+            ['single', 'daily', 'stderr', 'stack'],
+            array_keys($manager->getChannels())
         );
     }
 
@@ -646,7 +646,7 @@ class LogManagerTest extends TestCase
             'invocation-id' => 'expected-id',
         ]);
 
-        $this->assertSame($manager->sharedContext(), ['invocation-id' => 'expected-id']);
+        $this->assertSame(['invocation-id' => 'expected-id'], $manager->sharedContext());
     }
 
     public function testItSharesContextWithStacksWhenTheyAreResolved()

--- a/tests/Pagination/CursorPaginatorTest.php
+++ b/tests/Pagination/CursorPaginatorTest.php
@@ -61,7 +61,7 @@ class CursorPaginatorTest extends TestCase
         $p = new CursorPaginator($array = [['id' => 4], ['id' => 5], ['id' => 6]], 2, null,
             $options = ['path' => 'http://website.com/test', 'parameters' => ['id']]);
 
-        $this->assertSame($p->path(), 'http://website.com/test');
+        $this->assertSame('http://website.com/test', $p->path());
     }
 
     public function testCanTransformPaginatorItems()

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -953,13 +953,13 @@ class RouteRegistrarTest extends TestCase
             ->middlewareFor(['edit'], ['one', 'two']);
         $this->router->getRoutes()->refreshNameLookups();
 
-        $this->assertEquals($this->router->getRoutes()->getByName('users.index')->gatherMiddleware(), ['default', RouteRegistrarMiddlewareStub::class]);
-        $this->assertEquals($this->router->getRoutes()->getByName('users.create')->gatherMiddleware(), ['default', 'one']);
-        $this->assertEquals($this->router->getRoutes()->getByName('users.store')->gatherMiddleware(), ['default', 'one']);
-        $this->assertEquals($this->router->getRoutes()->getByName('users.show')->gatherMiddleware(), ['default']);
-        $this->assertEquals($this->router->getRoutes()->getByName('users.edit')->gatherMiddleware(), ['default', 'one', 'two']);
-        $this->assertEquals($this->router->getRoutes()->getByName('users.update')->gatherMiddleware(), ['default']);
-        $this->assertEquals($this->router->getRoutes()->getByName('users.destroy')->gatherMiddleware(), ['default']);
+        $this->assertEquals(['default', RouteRegistrarMiddlewareStub::class], $this->router->getRoutes()->getByName('users.index')->gatherMiddleware());
+        $this->assertEquals(['default', 'one'], $this->router->getRoutes()->getByName('users.create')->gatherMiddleware());
+        $this->assertEquals(['default', 'one'], $this->router->getRoutes()->getByName('users.store')->gatherMiddleware());
+        $this->assertEquals(['default'], $this->router->getRoutes()->getByName('users.show')->gatherMiddleware());
+        $this->assertEquals(['default', 'one', 'two'], $this->router->getRoutes()->getByName('users.edit')->gatherMiddleware());
+        $this->assertEquals(['default'], $this->router->getRoutes()->getByName('users.update')->gatherMiddleware());
+        $this->assertEquals(['default'], $this->router->getRoutes()->getByName('users.destroy')->gatherMiddleware());
 
         $this->router->resource('users', RouteRegistrarControllerStub::class)
             ->middlewareFor('index', RouteRegistrarMiddlewareStub::class)
@@ -968,13 +968,13 @@ class RouteRegistrarTest extends TestCase
             ->middleware('default');
         $this->router->getRoutes()->refreshNameLookups();
 
-        $this->assertEquals($this->router->getRoutes()->getByName('users.index')->gatherMiddleware(), [RouteRegistrarMiddlewareStub::class, 'default']);
-        $this->assertEquals($this->router->getRoutes()->getByName('users.create')->gatherMiddleware(), ['one', 'default']);
-        $this->assertEquals($this->router->getRoutes()->getByName('users.store')->gatherMiddleware(), ['one', 'default']);
-        $this->assertEquals($this->router->getRoutes()->getByName('users.show')->gatherMiddleware(), ['default']);
-        $this->assertEquals($this->router->getRoutes()->getByName('users.edit')->gatherMiddleware(), ['one', 'two', 'default']);
-        $this->assertEquals($this->router->getRoutes()->getByName('users.update')->gatherMiddleware(), ['default']);
-        $this->assertEquals($this->router->getRoutes()->getByName('users.destroy')->gatherMiddleware(), ['default']);
+        $this->assertEquals([RouteRegistrarMiddlewareStub::class, 'default'], $this->router->getRoutes()->getByName('users.index')->gatherMiddleware());
+        $this->assertEquals(['one', 'default'], $this->router->getRoutes()->getByName('users.create')->gatherMiddleware());
+        $this->assertEquals(['one', 'default'], $this->router->getRoutes()->getByName('users.store')->gatherMiddleware());
+        $this->assertEquals(['default'], $this->router->getRoutes()->getByName('users.show')->gatherMiddleware());
+        $this->assertEquals(['one', 'two', 'default'], $this->router->getRoutes()->getByName('users.edit')->gatherMiddleware());
+        $this->assertEquals(['default'], $this->router->getRoutes()->getByName('users.update')->gatherMiddleware());
+        $this->assertEquals(['default'], $this->router->getRoutes()->getByName('users.destroy')->gatherMiddleware());
     }
 
     public function testResourceWithoutMiddlewareRegistration()
@@ -997,13 +997,13 @@ class RouteRegistrarTest extends TestCase
             ->withoutMiddlewareFor(['create', 'store'], 'three')
             ->withoutMiddlewareFor(['edit'], ['four', 'five']);
 
-        $this->assertEquals($this->router->getRoutes()->getByName('users.index')->excludedMiddleware(), ['one', 'two']);
-        $this->assertEquals($this->router->getRoutes()->getByName('users.create')->excludedMiddleware(), ['one', 'three']);
-        $this->assertEquals($this->router->getRoutes()->getByName('users.store')->excludedMiddleware(), ['one', 'three']);
-        $this->assertEquals($this->router->getRoutes()->getByName('users.show')->excludedMiddleware(), ['one']);
-        $this->assertEquals($this->router->getRoutes()->getByName('users.edit')->excludedMiddleware(), ['one', 'four', 'five']);
-        $this->assertEquals($this->router->getRoutes()->getByName('users.update')->excludedMiddleware(), ['one']);
-        $this->assertEquals($this->router->getRoutes()->getByName('users.destroy')->excludedMiddleware(), ['one']);
+        $this->assertEquals(['one', 'two'], $this->router->getRoutes()->getByName('users.index')->excludedMiddleware());
+        $this->assertEquals(['one', 'three'], $this->router->getRoutes()->getByName('users.create')->excludedMiddleware());
+        $this->assertEquals(['one', 'three'], $this->router->getRoutes()->getByName('users.store')->excludedMiddleware());
+        $this->assertEquals(['one'], $this->router->getRoutes()->getByName('users.show')->excludedMiddleware());
+        $this->assertEquals(['one', 'four', 'five'], $this->router->getRoutes()->getByName('users.edit')->excludedMiddleware());
+        $this->assertEquals(['one'], $this->router->getRoutes()->getByName('users.update')->excludedMiddleware());
+        $this->assertEquals(['one'], $this->router->getRoutes()->getByName('users.destroy')->excludedMiddleware());
     }
 
     public function testResourceWithMiddlewareAsStringable()
@@ -1499,12 +1499,12 @@ class RouteRegistrarTest extends TestCase
             ->middlewareFor(['edit'], ['one', 'two']);
         $this->router->getRoutes()->refreshNameLookups();
 
-        $this->assertEquals($this->router->getRoutes()->getByName('users.create')->gatherMiddleware(), ['default', 'one']);
-        $this->assertEquals($this->router->getRoutes()->getByName('users.store')->gatherMiddleware(), ['default', 'one']);
-        $this->assertEquals($this->router->getRoutes()->getByName('users.show')->gatherMiddleware(), ['default', RouteRegistrarMiddlewareStub::class]);
-        $this->assertEquals($this->router->getRoutes()->getByName('users.edit')->gatherMiddleware(), ['default', 'one', 'two']);
-        $this->assertEquals($this->router->getRoutes()->getByName('users.update')->gatherMiddleware(), ['default']);
-        $this->assertEquals($this->router->getRoutes()->getByName('users.destroy')->gatherMiddleware(), ['default']);
+        $this->assertEquals(['default', 'one'], $this->router->getRoutes()->getByName('users.create')->gatherMiddleware());
+        $this->assertEquals(['default', 'one'], $this->router->getRoutes()->getByName('users.store')->gatherMiddleware());
+        $this->assertEquals(['default', RouteRegistrarMiddlewareStub::class], $this->router->getRoutes()->getByName('users.show')->gatherMiddleware());
+        $this->assertEquals(['default', 'one', 'two'], $this->router->getRoutes()->getByName('users.edit')->gatherMiddleware());
+        $this->assertEquals(['default'], $this->router->getRoutes()->getByName('users.update')->gatherMiddleware());
+        $this->assertEquals(['default'], $this->router->getRoutes()->getByName('users.destroy')->gatherMiddleware());
 
         $this->router->singleton('users', RouteRegistrarControllerStub::class)
             ->creatable()
@@ -1515,12 +1515,12 @@ class RouteRegistrarTest extends TestCase
             ->middleware('default');
         $this->router->getRoutes()->refreshNameLookups();
 
-        $this->assertEquals($this->router->getRoutes()->getByName('users.create')->gatherMiddleware(), ['one', 'default']);
-        $this->assertEquals($this->router->getRoutes()->getByName('users.store')->gatherMiddleware(), ['one', 'default']);
-        $this->assertEquals($this->router->getRoutes()->getByName('users.show')->gatherMiddleware(), [RouteRegistrarMiddlewareStub::class, 'default']);
-        $this->assertEquals($this->router->getRoutes()->getByName('users.edit')->gatherMiddleware(), ['one', 'two', 'default']);
-        $this->assertEquals($this->router->getRoutes()->getByName('users.update')->gatherMiddleware(), ['default']);
-        $this->assertEquals($this->router->getRoutes()->getByName('users.destroy')->gatherMiddleware(), ['default']);
+        $this->assertEquals(['one', 'default'], $this->router->getRoutes()->getByName('users.create')->gatherMiddleware());
+        $this->assertEquals(['one', 'default'], $this->router->getRoutes()->getByName('users.store')->gatherMiddleware());
+        $this->assertEquals([RouteRegistrarMiddlewareStub::class, 'default'], $this->router->getRoutes()->getByName('users.show')->gatherMiddleware());
+        $this->assertEquals(['one', 'two', 'default'], $this->router->getRoutes()->getByName('users.edit')->gatherMiddleware());
+        $this->assertEquals(['default'], $this->router->getRoutes()->getByName('users.update')->gatherMiddleware());
+        $this->assertEquals(['default'], $this->router->getRoutes()->getByName('users.destroy')->gatherMiddleware());
     }
 
     public function testCanSetExcludedMiddlewareForSpecifiedMethodsOnRegisteredSingletonResource()
@@ -1533,12 +1533,12 @@ class RouteRegistrarTest extends TestCase
             ->withoutMiddlewareFor(['create', 'store'], 'three')
             ->withoutMiddlewareFor(['edit'], ['four', 'five']);
 
-        $this->assertEquals($this->router->getRoutes()->getByName('users.create')->excludedMiddleware(), ['one', 'three']);
-        $this->assertEquals($this->router->getRoutes()->getByName('users.store')->excludedMiddleware(), ['one', 'three']);
-        $this->assertEquals($this->router->getRoutes()->getByName('users.show')->excludedMiddleware(), ['one', 'two']);
-        $this->assertEquals($this->router->getRoutes()->getByName('users.edit')->excludedMiddleware(), ['one', 'four', 'five']);
-        $this->assertEquals($this->router->getRoutes()->getByName('users.update')->excludedMiddleware(), ['one']);
-        $this->assertEquals($this->router->getRoutes()->getByName('users.destroy')->excludedMiddleware(), ['one']);
+        $this->assertEquals(['one', 'three'], $this->router->getRoutes()->getByName('users.create')->excludedMiddleware());
+        $this->assertEquals(['one', 'three'], $this->router->getRoutes()->getByName('users.store')->excludedMiddleware());
+        $this->assertEquals(['one', 'two'], $this->router->getRoutes()->getByName('users.show')->excludedMiddleware());
+        $this->assertEquals(['one', 'four', 'five'], $this->router->getRoutes()->getByName('users.edit')->excludedMiddleware());
+        $this->assertEquals(['one'], $this->router->getRoutes()->getByName('users.update')->excludedMiddleware());
+        $this->assertEquals(['one'], $this->router->getRoutes()->getByName('users.destroy')->excludedMiddleware());
     }
 
     /**

--- a/tests/Support/SleepTest.php
+++ b/tests/Support/SleepTest.php
@@ -80,7 +80,7 @@ class SleepTest extends TestCase
 
         $sleep = Sleep::for(1.5)->minutes();
 
-        $this->assertSame((float) $sleep->duration->totalMicroseconds, 90_000_000.0);
+        $this->assertSame(90_000_000.0, (float) $sleep->duration->totalMicroseconds);
     }
 
     public function testItCanSpecifyMinute()
@@ -89,7 +89,7 @@ class SleepTest extends TestCase
 
         $sleep = Sleep::for(1)->minute();
 
-        $this->assertSame((float) $sleep->duration->totalMicroseconds, 60_000_000.0);
+        $this->assertSame(60_000_000.0, (float) $sleep->duration->totalMicroseconds);
     }
 
     public function testItCanSpecifySeconds()
@@ -98,7 +98,7 @@ class SleepTest extends TestCase
 
         $sleep = Sleep::for(1.5)->seconds();
 
-        $this->assertSame((float) $sleep->duration->totalMicroseconds, 1_500_000.0);
+        $this->assertSame(1_500_000.0, (float) $sleep->duration->totalMicroseconds);
     }
 
     public function testItCanSpecifySecond()
@@ -107,7 +107,7 @@ class SleepTest extends TestCase
 
         $sleep = Sleep::for(1)->second();
 
-        $this->assertSame((float) $sleep->duration->totalMicroseconds, 1_000_000.0);
+        $this->assertSame(1_000_000.0, (float) $sleep->duration->totalMicroseconds);
     }
 
     public function testItCanSpecifyMilliseconds()
@@ -116,7 +116,7 @@ class SleepTest extends TestCase
 
         $sleep = Sleep::for(1.5)->milliseconds();
 
-        $this->assertSame((float) $sleep->duration->totalMicroseconds, 1_500.0);
+        $this->assertSame(1_500.0, (float) $sleep->duration->totalMicroseconds);
     }
 
     public function testItCanSpecifyMillisecond()
@@ -125,7 +125,7 @@ class SleepTest extends TestCase
 
         $sleep = Sleep::for(1)->millisecond();
 
-        $this->assertSame((float) $sleep->duration->totalMicroseconds, 1_000.0);
+        $this->assertSame(1_000.0, (float) $sleep->duration->totalMicroseconds);
     }
 
     public function testItCanSpecifyMicroseconds()
@@ -135,7 +135,7 @@ class SleepTest extends TestCase
         $sleep = Sleep::for(1.5)->microseconds();
 
         // rounded as microseconds is the smallest unit supported...
-        $this->assertSame((float) $sleep->duration->totalMicroseconds, 1.0);
+        $this->assertSame(1.0, (float) $sleep->duration->totalMicroseconds);
     }
 
     public function testItCanSpecifyMicrosecond()
@@ -144,7 +144,7 @@ class SleepTest extends TestCase
 
         $sleep = Sleep::for(1)->microsecond();
 
-        $this->assertSame((float) $sleep->duration->totalMicroseconds, 1.0);
+        $this->assertSame(1.0, (float) $sleep->duration->totalMicroseconds);
     }
 
     public function testItCanChainDurations()
@@ -154,7 +154,7 @@ class SleepTest extends TestCase
         $sleep = Sleep::for(1)->second()
             ->and(500)->microseconds();
 
-        $this->assertSame((float) $sleep->duration->totalMicroseconds, 1000500.0);
+        $this->assertSame(1000500.0, (float) $sleep->duration->totalMicroseconds);
     }
 
     public function testItCanUseDateInterval()
@@ -163,7 +163,7 @@ class SleepTest extends TestCase
 
         $sleep = Sleep::for(CarbonInterval::seconds(1)->addMilliseconds(5));
 
-        $this->assertSame((float) $sleep->duration->totalMicroseconds, 1_005_000.0);
+        $this->assertSame(1_005_000.0, (float) $sleep->duration->totalMicroseconds);
     }
 
     public function testItThrowsForUnknownTimeUnit()
@@ -486,15 +486,15 @@ class SleepTest extends TestCase
 
         // A static macro can be referenced
         $sleep = Sleep::forSomeConfiguredAmountOfTime();
-        $this->assertSame((float) $sleep->duration->totalMicroseconds, 3000000.0);
+        $this->assertSame(3000000.0, (float) $sleep->duration->totalMicroseconds);
 
         // A macro can specify a new duration
         $sleep = $sleep->useSomeOtherAmountOfTime();
-        $this->assertSame((float) $sleep->duration->totalMicroseconds, 1234000.0);
+        $this->assertSame(1234000.0, (float) $sleep->duration->totalMicroseconds);
 
         // A macro can supplement an existing duration
         $sleep = $sleep->andSomeMoreGranularControl();
-        $this->assertSame((float) $sleep->duration->totalMicroseconds, 1234567.0);
+        $this->assertSame(1234567.0, (float) $sleep->duration->totalMicroseconds);
     }
 
     public function testItCanReplacePreviouslyDefinedDurations()
@@ -506,13 +506,13 @@ class SleepTest extends TestCase
         });
 
         $sleep = Sleep::for(1)->second();
-        $this->assertSame((float) $sleep->duration->totalMicroseconds, 1000000.0);
+        $this->assertSame(1000000.0, (float) $sleep->duration->totalMicroseconds);
 
         $sleep->setDuration(2)->second();
-        $this->assertSame((float) $sleep->duration->totalMicroseconds, 2000000.0);
+        $this->assertSame(2000000.0, (float) $sleep->duration->totalMicroseconds);
 
         $sleep->setDuration(500)->milliseconds();
-        $this->assertSame((float) $sleep->duration->totalMicroseconds, 500000.0);
+        $this->assertSame(500000.0, (float) $sleep->duration->totalMicroseconds);
     }
 
     public function testItCanSleepConditionallyWhen()

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -818,11 +818,11 @@ class SupportHelpersTest extends TestCase
 
         $strAccessor = str();
         $this->assertTrue((new ReflectionClass($strAccessor))->isAnonymous());
-        $this->assertSame($strAccessor->limit('string-value', 3), 'str...');
+        $this->assertSame('str...', $strAccessor->limit('string-value', 3));
 
         $strAccessor = str();
         $this->assertTrue((new ReflectionClass($strAccessor))->isAnonymous());
-        $this->assertSame((string) $strAccessor, '');
+        $this->assertSame('', (string) $strAccessor);
     }
 
     public function testTap()

--- a/tests/Validation/ValidationAddFailureTest.php
+++ b/tests/Validation/ValidationAddFailureTest.php
@@ -34,7 +34,7 @@ class ValidationAddFailureTest extends TestCase
         $validator = $this->makeValidator();
         $validator->addFailure($attribute, 'not_in');
         $messages = json_decode($validator->messages());
-        $this->assertSame($messages->{'foo.bar.baz'}[0], 'validation.required', 'initial data in messages is lost');
-        $this->assertSame($messages->{$attribute}[0], 'validation.not_in', 'new data in messages was not added');
+        $this->assertSame('validation.required', $messages->{'foo.bar.baz'}[0], 'initial data in messages is lost');
+        $this->assertSame('validation.not_in', $messages->{$attribute}[0], 'new data in messages was not added');
     }
 }

--- a/tests/Validation/ValidationPasswordRuleTest.php
+++ b/tests/Validation/ValidationPasswordRuleTest.php
@@ -348,7 +348,7 @@ class ValidationPasswordRuleTest extends TestCase
             ->letters()
             ->symbols();
 
-        $this->assertSame($password->appliedRules(), [
+        $this->assertSame([
             'min' => 2,
             'max' => 4,
             'mixedCase' => true,
@@ -358,11 +358,11 @@ class ValidationPasswordRuleTest extends TestCase
             'uncompromised' => false,
             'compromisedThreshold' => 0,
             'customRules' => [],
-        ]);
+        ], $password->appliedRules());
 
         $password = Password::min(2);
 
-        $this->assertSame($password->appliedRules(), [
+        $this->assertSame([
             'min' => 2,
             'max' => null,
             'mixedCase' => false,
@@ -372,7 +372,7 @@ class ValidationPasswordRuleTest extends TestCase
             'uncompromised' => false,
             'compromisedThreshold' => 0,
             'customRules' => [],
-        ]);
+        ], $password->appliedRules());
     }
 
     public function testRequired()

--- a/tests/Validation/ValidationRuleParserTest.php
+++ b/tests/Validation/ValidationRuleParserTest.php
@@ -187,7 +187,7 @@ class ValidationRuleParserTest extends TestCase
             'users.*.name' => Rule::forEach(function ($value, $attribute, $data, $context) {
                 $this->assertSame('Taylor Otwell', $value);
                 $this->assertSame('users.0.name', $attribute);
-                $this->assertEquals($data['users.0.name'], 'Taylor Otwell');
+                $this->assertEquals('Taylor Otwell', $data['users.0.name']);
                 $this->assertEquals(['name' => 'Taylor Otwell', 'email' => 'taylor@laravel.com'], $context);
 
                 return [Rule::requiredIf(true)];

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1178,9 +1178,9 @@ class ValidationValidatorTest extends TestCase
             ], ['foo' => ['required' => 'Foo is required']]);
 
         $this->assertFalse($validator->passes());
-        $this->assertEquals($validator->errors()->messages(), [
+        $this->assertEquals([
             'foo' => ['foo must be false'],
-        ]);
+        ], $validator->errors()->messages());
     }
 
     public function testInlineValidationMessagesAreRespectedWithAsterisks()

--- a/tests/Validation/ValidatorAfterRuleTest.php
+++ b/tests/Validation/ValidatorAfterRuleTest.php
@@ -19,11 +19,11 @@ class ValidatorAfterRuleTest extends TestCase
             new AfterMethodRule,
         ])->messages()->messages();
 
-        $this->assertSame($validator->messages()->messages(), [
+        $this->assertSame([
             'closure' => ['true'],
             'invokableAfterRule' => ['true'],
             'afterMethodRule' => ['true'],
-        ]);
+        ], $validator->messages()->messages());
     }
 }
 

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -892,8 +892,8 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         eval(" ?> $template <?php ");
         ob_get_clean();
 
-        $this->assertSame($attributes->get('userId'), 'bar');
-        $this->assertSame($attributes->get('other'), 'ok');
+        $this->assertSame('bar', $attributes->get('userId'));
+        $this->assertSame('ok', $attributes->get('other'));
     }
 
     public function testOriginalAttributesAreRestoredAfterRenderingChildComponentWithProps()
@@ -942,8 +942,8 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         eval(" ?> $template <?php ");
         ob_get_clean();
 
-        $this->assertSame($attributes->get('userId'), 'bar');
-        $this->assertSame($attributes->get('other'), 'ok');
+        $this->assertSame('bar', $attributes->get('userId'));
+        $this->assertSame('ok', $attributes->get('other'));
     }
 
     protected function mockViewFactory($existsSucceeds = true)

--- a/tests/View/Blade/BladePropsTest.php
+++ b/tests/View/Blade/BladePropsTest.php
@@ -51,13 +51,13 @@ unset($__defined_vars, $__key, $__value); ?>', $this->compiler->compileString('@
         eval(" ?> $template <?php ");
         ob_get_clean();
 
-        $this->assertSame($test1, 'value1');
-        $this->assertSame($test2, 'value2');
+        $this->assertSame('value1', $test1);
+        $this->assertSame('value2', $test2);
         $this->assertFalse(isset($test3));
-        $this->assertSame($test4, 'default');
+        $this->assertSame('default', $test4);
 
         $this->assertNull($attributes->get('test1'));
         $this->assertNull($attributes->get('test2'));
-        $this->assertSame($attributes->get('test3'), 'value3');
+        $this->assertSame('value3', $attributes->get('test3'));
     }
 }

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -675,7 +675,7 @@ class ViewFactoryTest extends TestCase
         $factory->getDispatcher()->shouldReceive('hasListeners')->andReturn(false);
         $factory->startComponent(function ($data) use ($factory) {
             $this->assertArrayHasKey('name', $data);
-            $this->assertSame($data['name'], 'Taylor');
+            $this->assertSame('Taylor', $data['name']);
 
             return $factory->make('component');
         }, ['name' => 'Taylor']);


### PR DESCRIPTION
Flip misordered assertions arguments, and clearly differentiate what is `$actual` and what is `$expected`