### PR TITLE
[13.x] Fix number abbreviation rollover between unit tiers

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -289,7 +289,15 @@ class Number
         $displayExponent = $numberExponent - ($numberExponent % 3);
         $number /= pow(10, $displayExponent);
 
-        return trim(sprintf('%s%s', static::format($number, $precision, $maxPrecision), $units[$displayExponent] ?? ''));
+        $formatted = static::format($number, $precision, $maxPrecision);
+
+        if(static::parseFloat($formatted) >= 1000 && isset($units[$displayExponent + 3])) {
+            $number /= 1000;
+            $displayExponent += 3;
+            $formatted = static::format($number, $precision, $maxPrecision);
+        }
+
+        return trim(sprintf('%s%s', $formatted, $units[$displayExponent] ?? ''));
     }
 
     /**

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -291,7 +291,7 @@ class Number
 
         $formatted = static::format($number, $precision, $maxPrecision);
 
-        if(static::parseFloat($formatted) >= 1000 && isset($units[$displayExponent + 3])) {
+        if (static::parseFloat($formatted) >= 1000 && isset($units[$displayExponent + 3])) {
             $number /= 1000;
             $displayExponent += 3;
             $formatted = static::format($number, $precision, $maxPrecision);

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -251,6 +251,10 @@ class SupportNumberTest extends TestCase
         $this->assertSame('-1.1 trillion', Number::forHumans(-1100000000000, maxPrecision: 1));
         $this->assertSame('-1 quadrillion', Number::forHumans(-1000000000000000));
         $this->assertSame('-1 thousand quadrillion', Number::forHumans(-1000000000000000000));
+
+        $this->assertSame('999 thousand', Number::forHumans(999499));
+        $this->assertSame('1 million', Number::forHumans(999500));
+        $this->assertSame('1 million', Number::forHumans(999999));
     }
 
     public function testSummarize()
@@ -307,6 +311,15 @@ class SupportNumberTest extends TestCase
         $this->assertSame('-1.1T', Number::abbreviate(-1100000000000, maxPrecision: 1));
         $this->assertSame('-1Q', Number::abbreviate(-1000000000000000));
         $this->assertSame('-1KQ', Number::abbreviate(-1000000000000000000));
+
+        $this->assertSame('999K', Number::abbreviate(999499));
+        $this->assertSame('1M', Number::abbreviate(999500));
+        $this->assertSame('1M', Number::abbreviate(999999));
+        $this->assertSame('1B', Number::abbreviate(999500000));
+        $this->assertSame('1B', Number::abbreviate(999999999));
+
+        Number::withLocale('de', fn () => $this->assertSame('1M', Number::abbreviate(999500)));
+        Number::withLocale('fr', fn () => $this->assertSame('1M', Number::abbreviate(999500)));
     }
 
     public function testPairs()


### PR DESCRIPTION
This PR fixes `Number::abbreviate()` and `Number::forHumans()` when a value rounds up across a unit boundary.

Before the change, values like `999500` were formatted as `1,000K` instead of `1M`, the same thing affected higher tiers.

e.g.
```
Before:
  - `Number::abbreviate(999500)` → `1,000K`
  - `Number::forHumans(999500)` → `1,000 thousand`

  After:
  - `Number::abbreviate(999500)` → `1M`
  - `Number::forHumans(999500)` → `1 million`
```
