### PR TITLE
[12.x] Fix infinite rate limiter TTL on custom increments

### DIFF
--- a/src/Illuminate/Cache/RateLimiter.php
+++ b/src/Illuminate/Cache/RateLimiter.php
@@ -171,9 +171,9 @@ class RateLimiter
 
         $hits = (int) $this->cache->increment($key, $amount);
 
-        if (! $added && $hits == 1) {
+        if (! $added && $hits == $amount) {
             $this->withoutSerializationOrCompression(
-                fn () => $this->cache->put($key, 1, $decaySeconds)
+                fn () => $this->cache->put($key, $amount, $decaySeconds)
             );
         }
 

--- a/tests/Cache/CacheRateLimiterTest.php
+++ b/tests/Cache/CacheRateLimiterTest.php
@@ -71,6 +71,19 @@ class CacheRateLimiterTest extends TestCase
         $rateLimiter->hit('key', 1);
     }
 
+    public function testIncrementWithCustomAmountHasNoMemoryLeak()
+    {
+        $cache = m::mock(Cache::class);
+        $cache->shouldReceive('add')->once()->with('key:timer', m::type('int'), 60)->andReturn(true);
+        $cache->shouldReceive('add')->once()->with('key', 0, 60)->andReturn(false);
+        $cache->shouldReceive('increment')->once()->with('key', 2)->andReturn(1);
+        $cache->shouldReceive('put')->once()->with('key', 2, 60);
+        $cache->shouldReceive('getStore')->andReturn(new ArrayStore);
+        $rateLimiter = new RateLimiter($cache);
+
+        $rateLimiter->increment('key', 60, 2);
+    }
+
     public function testRemainingIsNotNegative(): void
     {
         $cache = m::mock(Cache::class);

--- a/tests/Cache/CacheRateLimiterTest.php
+++ b/tests/Cache/CacheRateLimiterTest.php
@@ -76,7 +76,7 @@ class CacheRateLimiterTest extends TestCase
         $cache = m::mock(Cache::class);
         $cache->shouldReceive('add')->once()->with('key:timer', m::type('int'), 60)->andReturn(true);
         $cache->shouldReceive('add')->once()->with('key', 0, 60)->andReturn(false);
-        $cache->shouldReceive('increment')->once()->with('key', 2)->andReturn(1);
+        $cache->shouldReceive('increment')->once()->with('key', 2)->andReturn(2);
         $cache->shouldReceive('put')->once()->with('key', 2, 60);
         $cache->shouldReceive('getStore')->andReturn(new ArrayStore);
         $rateLimiter = new RateLimiter($cache);


### PR DESCRIPTION
This fixes a race condition in `RateLimiter::increment()` when the increment `$amount` is greater than `1`.

If the counter key disappears after Laravel checks for it but before the `increment()` happens, the cache can recreate that key during `increment()`. When that happens, Laravel needs to write the value back with the proper decay time so the key does not live forever.

The bug was that this recovery logic only checked for `== 1`. That works for the default increment, but not for calls like `increment(..., 5)`, where the recreated value is `5`. This change checks against `$amount` instead, so custom increments also get the correct TTL.

See https://github.com/laravel/framework/pull/20684 for additional context.