### PR TITLE
[13.x] Add UnitEnum support to Application and Translator locale methods

### DIFF
--- a/src/Illuminate/Contracts/Foundation/Application.php
+++ b/src/Illuminate/Contracts/Foundation/Application.php
@@ -225,7 +225,7 @@ interface Application extends Container
     /**
      * Set the current application locale.
      *
-     * @param  string  $locale
+     * @param  \UnitEnum|string  $locale
      * @return void
      */
     public function setLocale($locale);

--- a/src/Illuminate/Contracts/Translation/Translator.php
+++ b/src/Illuminate/Contracts/Translation/Translator.php
@@ -35,7 +35,7 @@ interface Translator
     /**
      * Set the default locale.
      *
-     * @param  string  $locale
+     * @param  \UnitEnum|string  $locale
      * @return void
      */
     public function setLocale($locale);

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -35,6 +35,7 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 use function Illuminate\Filesystem\join_paths;
+use function Illuminate\Support\enum_value;
 
 class Application extends Container implements ApplicationContract, CachesConfiguration, CachesRoutes, HttpKernelInterface
 {
@@ -1590,11 +1591,13 @@ class Application extends Container implements ApplicationContract, CachesConfig
     /**
      * Set the current application locale.
      *
-     * @param  string  $locale
+     * @param  \UnitEnum|string  $locale
      * @return void
      */
     public function setLocale($locale)
     {
+        $locale = enum_value($locale);
+
         $previous = $this['config']->get('app.locale');
 
         $this['config']->set('app.locale', $locale);
@@ -1607,11 +1610,13 @@ class Application extends Container implements ApplicationContract, CachesConfig
     /**
      * Set the current application fallback locale.
      *
-     * @param  string  $fallbackLocale
+     * @param  \UnitEnum|string  $fallbackLocale
      * @return void
      */
     public function setFallbackLocale($fallbackLocale)
     {
+        $fallbackLocale = enum_value($fallbackLocale);
+
         $this['config']->set('app.fallback_locale', $fallbackLocale);
 
         $this['translator']->setFallback($fallbackLocale);
@@ -1620,12 +1625,12 @@ class Application extends Container implements ApplicationContract, CachesConfig
     /**
      * Determine if the application locale is the given locale.
      *
-     * @param  string  $locale
+     * @param  \UnitEnum|string  $locale
      * @return bool
      */
     public function isLocale($locale)
     {
-        return $this->getLocale() == $locale;
+        return $this->getLocale() == enum_value($locale);
     }
 
     /**

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -530,13 +530,15 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
     /**
      * Set the default locale.
      *
-     * @param  string  $locale
+     * @param  \UnitEnum|string  $locale
      * @return void
      *
      * @throws \InvalidArgumentException
      */
     public function setLocale($locale)
     {
+        $locale = enum_value($locale);
+
         if (Str::contains($locale, ['/', '\\'])) {
             throw new InvalidArgumentException('Invalid characters present in locale.');
         }
@@ -557,12 +559,12 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
     /**
      * Set the fallback locale being used.
      *
-     * @param  string  $fallback
+     * @param  \UnitEnum|string  $fallback
      * @return void
      */
     public function setFallback($fallback)
     {
-        $this->fallback = $fallback;
+        $this->fallback = enum_value($fallback);
     }
 
     /**

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -33,6 +33,61 @@ class FoundationApplicationTest extends TestCase
         $app->setLocale('foo');
     }
 
+    public function testSetLocaleAcceptsBackedEnum()
+    {
+        $app = new Application;
+
+        $app['config'] = $config = m::mock(stdClass::class);
+        $config->shouldReceive('get')->once()->with('app.locale')->andReturn('en');
+        $config->shouldReceive('set')->once()->with('app.locale', 'ja');
+        $app['translator'] = $trans = m::mock(stdClass::class);
+        $trans->shouldReceive('setLocale')->once()->with('ja');
+        $app['events'] = $events = m::mock(stdClass::class);
+        $events->shouldReceive('dispatch')->once()->with(m::on(function (LocaleUpdated $event) {
+            return $event->locale === 'ja' && $event->previousLocale === 'en';
+        }));
+
+        $app->setLocale(ApplicationLocaleEnum::Japanese);
+    }
+
+    public function testSetLocaleAcceptsUnitEnum()
+    {
+        $app = new Application;
+
+        $app['config'] = $config = m::mock(stdClass::class);
+        $config->shouldReceive('get')->once()->with('app.locale')->andReturn('en');
+        $config->shouldReceive('set')->once()->with('app.locale', 'Korean');
+        $app['translator'] = $trans = m::mock(stdClass::class);
+        $trans->shouldReceive('setLocale')->once()->with('Korean');
+        $app['events'] = $events = m::mock(stdClass::class);
+        $events->shouldReceive('dispatch')->once();
+
+        $app->setLocale(ApplicationPureLocaleEnum::Korean);
+    }
+
+    public function testSetFallbackLocaleAcceptsBackedEnum()
+    {
+        $app = new Application;
+
+        $app['config'] = $config = m::mock(stdClass::class);
+        $config->shouldReceive('set')->once()->with('app.fallback_locale', 'ja');
+        $app['translator'] = $trans = m::mock(stdClass::class);
+        $trans->shouldReceive('setFallback')->once()->with('ja');
+
+        $app->setFallbackLocale(ApplicationLocaleEnum::Japanese);
+    }
+
+    public function testIsLocaleAcceptsEnum()
+    {
+        $app = new Application;
+
+        $app['config'] = $config = m::mock(stdClass::class);
+        $config->shouldReceive('get')->twice()->with('app.locale')->andReturn('ja');
+
+        $this->assertTrue($app->isLocale(ApplicationLocaleEnum::Japanese));
+        $this->assertFalse($app->isLocale(ApplicationLocaleEnum::English));
+    }
+
     public function testServiceProvidersAreCorrectlyRegistered()
     {
         $provider = m::mock(ApplicationBasicServiceProviderStub::class);
@@ -660,6 +715,17 @@ class FoundationApplicationTest extends TestCase
         $this->assertTrue($app->isAlias(\Illuminate\Contracts\Auth\PasswordBroker::class));
         $this->assertSame('auth.password.broker', $app->getAlias(\Illuminate\Contracts\Auth\PasswordBroker::class));
     }
+}
+
+enum ApplicationLocaleEnum: string
+{
+    case English = 'en';
+    case Japanese = 'ja';
+}
+
+enum ApplicationPureLocaleEnum
+{
+    case Korean;
 }
 
 class ApplicationBasicServiceProviderStub extends ServiceProvider

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -102,6 +102,34 @@ class TranslationTranslatorTest extends TestCase
         $this->assertSame('foo', $t->get('foo::bar.foo'));
     }
 
+    public function testSetLocaleAcceptsBackedEnum()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+        $t->setLocale(Baz::February);
+        $this->assertSame('February', $t->getLocale());
+    }
+
+    public function testSetLocaleAcceptsUnitEnum()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+        $t->setLocale(Foo::Hosni);
+        $this->assertSame('Hosni', $t->getLocale());
+    }
+
+    public function testSetFallbackAcceptsBackedEnum()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+        $t->setFallback(Baz::February);
+        $this->assertSame('February', $t->getFallback());
+    }
+
+    public function testSetFallbackAcceptsUnitEnum()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+        $t->setFallback(Foo::Hosni);
+        $this->assertSame('Hosni', $t->getFallback());
+    }
+
     public function testGetMethodProperlyLoadsAndRetrievesItemForFallback()
     {
         $t = new Translator($this->getLoader(), 'en');


### PR DESCRIPTION
This PR extends the recent enum-support pass across the framework's manager classes (#59614, #59637, #59645, #59646, #59389, #59391, #59420) to the application's locale primitives.

`Notification::locale()` already accepts a `UnitEnum` (#55922), but the underlying primitives still required a string, forcing users with a typed `Locale` enum to call `->value` everywhere.

### Changes

The following methods now accept `\UnitEnum|string` and normalize via the existing `Illuminate\Support\enum_value()` helper:

- `Illuminate\Foundation\Application::setLocale()`
- `Illuminate\Foundation\Application::setFallbackLocale()`
- `Illuminate\Foundation\Application::isLocale()`
- `Illuminate\Translation\Translator::setLocale()`
- `Illuminate\Translation\Translator::setFallback()`

Contracts (`Illuminate\Contracts\Foundation\Application`, `Illuminate\Contracts\Translation\Translator`) updated with matching docblocks.

### Usage

```php
enum Locale: string {
    case English  = 'en';
    case Japanese = 'ja';
    case Korean   = 'ko';
}

App::setLocale(Locale::Japanese);        // now works
App::setFallbackLocale(Locale::English); // now works
App::isLocale(Locale::Japanese);         // now works
```

Both `BackedEnum` (uses `->value`) and pure `UnitEnum` (uses `->name`) are supported, matching the behavior of `enum_value()` used elsewhere in the framework.

### Tests

Added unit tests covering backed and pure enum inputs for all five methods:

- `FoundationApplicationTest::testSetLocaleAcceptsBackedEnum`
- `FoundationApplicationTest::testSetLocaleAcceptsUnitEnum`
- `FoundationApplicationTest::testSetFallbackLocaleAcceptsBackedEnum`
- `FoundationApplicationTest::testIsLocaleAcceptsEnum`
- `TranslationTranslatorTest::testSetLocaleAcceptsBackedEnum`
- `TranslationTranslatorTest::testSetLocaleAcceptsUnitEnum`
- `TranslationTranslatorTest::testSetFallbackAcceptsBackedEnum`
- `TranslationTranslatorTest::testSetFallbackAcceptsUnitEnum`

Closes #59667