### PR TITLE
[13.x] Return null from Cursor::fromEncoded for malformed payloads

### DIFF
--- a/src/Illuminate/Pagination/Cursor.php
+++ b/src/Illuminate/Pagination/Cursor.php
@@ -125,6 +125,10 @@ class Cursor implements Arrayable
             return null;
         }
 
+        if (! is_array($parameters) || ! array_key_exists('_pointsToNextItems', $parameters)) {
+            return null;
+        }
+
         $pointsToNextItems = $parameters['_pointsToNextItems'];
 
         unset($parameters['_pointsToNextItems']);

--- a/tests/Pagination/CursorTest.php
+++ b/tests/Pagination/CursorTest.php
@@ -18,6 +18,30 @@ class CursorTest extends TestCase
         $this->assertEquals($cursor, Cursor::fromEncoded($cursor->encode()));
     }
 
+    public function testFromEncodedReturnsNullForNonStringInput()
+    {
+        $this->assertNull(Cursor::fromEncoded(null));
+        $this->assertNull(Cursor::fromEncoded(123));
+    }
+
+    public function testFromEncodedReturnsNullForInvalidJson()
+    {
+        $this->assertNull(Cursor::fromEncoded(base64_encode('not-json')));
+    }
+
+    public function testFromEncodedReturnsNullWhenDecodedPayloadIsNotAnArray()
+    {
+        $this->assertNull(Cursor::fromEncoded(base64_encode(json_encode('scalar'))));
+        $this->assertNull(Cursor::fromEncoded(base64_encode(json_encode(null))));
+    }
+
+    public function testFromEncodedReturnsNullWhenPointsToNextItemsKeyIsMissing()
+    {
+        $payload = base64_encode(json_encode(['id' => 422]));
+
+        $this->assertNull(Cursor::fromEncoded($payload));
+    }
+
     public function testCanGetParams()
     {
         $cursor = new Cursor([


### PR DESCRIPTION
`Cursor::fromEncoded()` currently returns `null` on non-string input and on payloads that fail JSON decoding, but it does not guard against two other forms of malformed input:

1. A payload that decodes to a valid non-array JSON value (e.g. a scalar or `null`).
2. A payload that decodes to an array missing the required `_pointsToNextItems` key.

In both cases the method proceeds to `$parameters['_pointsToNextItems']`, which triggers a PHP warning (`Undefined array key` / `Cannot access offset of type string on null`) and then returns a nonsensical `Cursor` instance, violating the documented `@return static|null` contract.

This can be reached by any user-supplied `cursor` query string parameter, so a crafted value will surface warnings in production logs and — in applications that convert warnings to exceptions — raise unexpected errors during request handling.

### Reproduction

```php
// Valid JSON, but not an array:
Cursor::fromEncoded(base64_encode(json_encode('oops')));

// Valid array, missing the expected key:
Cursor::fromEncoded(base64_encode(json_encode(['id' => 1])));
```

Both of the above currently emit PHP warnings and return a broken `Cursor`, rather than `null`.

### Fix

Add a single guard that returns `null` when the decoded payload is not an array, or when the `_pointsToNextItems` key is absent.

```php
if (! is_array(\$parameters) || ! array_key_exists('_pointsToNextItems', \$parameters)) {
    return null;
}
```

### Tests

Added four new test cases to `tests/Pagination/CursorTest.php` covering:

- non-string input
- invalid JSON input
- valid JSON that decodes to a non-array (scalar / `null`)
- valid array payload missing `_pointsToNextItems`

All existing pagination tests continue to pass.