### PR TITLE
#59612 - Add test to prove behaviour

### DIFF
--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3842,6 +3842,16 @@ class DatabaseEloquentModelTest extends TestCase
 
         $this->assertNotInstanceOf(CustomBuilder::class, $eloquentBuilder);
     }
+
+    public function testTraitInitializersAreCalledInCorrectOrder()
+    {
+        $model = new EloquentModelTraitInitializeOrderStub;
+
+        $this->assertTrue(
+            $model->castsWereReadyDuringInit,
+            'HasAttributes::initializeHasAttributes() must run before dependent trait initializers that rely on getCasts().'
+        );
+    }
 }
 
 class CustomBuilder extends Builder
@@ -4785,4 +4795,24 @@ enum ConnectionNameBacked: string
 {
     case Foo = 'Foo';
     case Bar = 'Bar';
+}
+
+trait EloquentTraitInitializeOrderStub
+{
+    public bool $castsWereReadyDuringInit = false;
+
+    protected function initializeEloquentTraitInitializeOrderStub(): void
+    {
+        $this->castsWereReadyDuringInit = array_key_exists('status', $this->getCasts());
+    }
+}
+
+class EloquentModelTraitInitializeOrderStub extends Model
+{
+    use EloquentTraitInitializeOrderStub;
+
+    protected function casts(): array
+    {
+        return ['status' => 'string'];
+    }
 }


### PR DESCRIPTION
## Background & Problem

Eloquent models support a trait initializer convention: any trait used on a model can define an `initialize<TraitName>()` method that gets called automatically during model construction.

For example, some traits need to call `getCasts()` during their initialization — i.e. to inspect what casts are defined on the model. The issue is that this only works correctly if `HasAttributes::initializeHasAttributes()` has already run by the time those dependent trait initializers execute, since `HasAttributes` is responsible for setting up the casts infrastructure. Without a guaranteed initialization order, traits relying on `getCasts()` could silently receive incomplete or empty results.

With PHP 8.5 there have been fixes concerning the order on how trait methods are loaded. This results in the underlying architecture of the initialization logic to produce a different order of initializations. More info is described in https://github.com/laravel/framework/issues/59612.

## This PR

This PR adds a regression test that explicitly verifies the initialization order is correct. The test creates a model that uses a trait whose initializer calls `getCasts()`, and asserts that the casts were available at that point. If the order ever regresses, the test will catch it immediately.

This approach was chosen because the fix for the underlying behavior (issue #59612) lives elsewhere - this PR's role is to lock in the expected contract with a test, preventing future regressions.

## Possible fix

Described in the issue https://github.com/laravel/framework/issues/59612.

## Test Protocol

1. Check out this branch
2. Switch to PHP 8.4
3. Run the specific test:
   ```
   phpunit tests/Database/DatabaseEloquentModelTest.php --filter testTraitInitializersAreCalledInCorrectOrder
   ```
4. Confirm the test passes - it asserts that `getCasts()` returns the model's defined casts when called from within a trait initializer
5. Switch to PHP 8.5
6. Confirm the test fails
