### PR TITLE
[13.x] Allow Table Attribute on child to override parent

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -435,7 +435,17 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     {
         $table = static::resolveClassAttribute(Table::class);
 
-        $this->table ??= $table->name ?? null;
+        $reflection = new ReflectionClass(static::class);
+
+        $declaresTable = $reflection->hasProperty('table')
+            && $reflection->getProperty('table')->getDeclaringClass()->getName() === static::class;
+
+        if (! $declaresTable && $reflection->getAttributes(Table::class) !== []) {
+            $this->table = $table->name ?? null;
+        } else {
+            $this->table ??= $table->name ?? null;
+        }
+
         $this->connection ??= static::resolveClassAttribute(Connection::class, 'name');
 
         if ($this->primaryKey === 'id' && $table && $table->key !== null) {

--- a/tests/Database/DatabaseEloquentModelAttributesTest.php
+++ b/tests/Database/DatabaseEloquentModelAttributesTest.php
@@ -54,6 +54,27 @@ class DatabaseEloquentModelAttributesTest extends TestCase
         $this->assertSame('property_table', $model->getTable());
     }
 
+    public function test_child_table_attribute_overrides_inherited_table_property(): void
+    {
+        $model = new ChildModelWithTableAttribute;
+
+        $this->assertSame('child_attr', $model->getTable());
+    }
+
+    public function test_child_inherits_parent_table_attribute(): void
+    {
+        $model = new ChildModelWithNoTable;
+
+        $this->assertSame('parent_attr', $model->getTable());
+    }
+
+    public function test_child_table_property_overrides_parent_table_attribute(): void
+    {
+        $model = new ChildModelWithTableProperty;
+
+        $this->assertSame('child_prop', $model->getTable());
+    }
+
     public function test_primary_key_attribute(): void
     {
         $model = new ModelWithPrimaryKeyAttribute;
@@ -404,6 +425,33 @@ class ModelWithTableAttribute extends Model
 class ModelWithTableAttributeAndProperty extends Model
 {
     protected $table = 'property_table';
+}
+
+class ParentModelWithTableProperty extends Model
+{
+    protected $table = 'parent_prop';
+}
+
+#[Table(name: 'child_attr')]
+class ChildModelWithTableAttribute extends ParentModelWithTableProperty
+{
+    //
+}
+
+#[Table(name: 'parent_attr')]
+class ParentModelWithTableAttribute extends Model
+{
+    //
+}
+
+class ChildModelWithNoTable extends ParentModelWithTableAttribute
+{
+    //
+}
+
+class ChildModelWithTableProperty extends ParentModelWithTableAttribute
+{
+    protected $table = 'child_prop';
 }
 
 #[Table(key: 'custom_id')]


### PR DESCRIPTION
Imagine you're using a package that specifies `$table = xxx` that you can override when you extend it.

You now want to use Laravel 13's cool attributes, but, the `#[Table]` attribute does not override a parents property if you're extending it.

A good example is [Spatie's activity log](https://github.com/spatie/laravel-activitylog/blob/145a8d825d1626d6c9c4bf8b107a03a1cef794e3/src/Models/Activity.php#L43) 

Where it's a class you dont control, but where you want to do: 

```
#[Table(name: 'i_wanna_be_cool')]
class Activity extends BaseActivity
{
}
``` 

Performance should be fine, as we're only using hasProperty / getDeclaringClass, so no newInstance hit afaik

I've added plenty of tests to cover all scenarios I can think of, so no B/C

You may see a nicer way to do this, so please conduct surgery as you see fit! 🙇🏻 

