### PR TITLE
[13.x] testsuite

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -34,7 +34,54 @@ use Rector\Php82\Rector\Class_\ReadOnlyClassRector;
 use Rector\Php83\Rector\ClassConst\AddTypeToConstRector;
 use Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector;
 use Rector\Php83\Rector\FuncCall\DynamicClassConstFetchRector;
+use Rector\PHPUnit\CodeQuality\Rector\CallLike\DirectInstanceOverMockArgRector;
+use Rector\PHPUnit\CodeQuality\Rector\Class_\ConstructClassMethodToSetUpTestCaseRector;
+use Rector\PHPUnit\CodeQuality\Rector\Class_\InlineStubPropertyToCreateStubMethodCallRector;
+use Rector\PHPUnit\CodeQuality\Rector\Class_\NarrowUnusedSetUpDefinedPropertyRector;
+use Rector\PHPUnit\CodeQuality\Rector\Class_\PreferPHPUnitThisCallRector;
+use Rector\PHPUnit\CodeQuality\Rector\Class_\RemoveNeverUsedMockPropertyRector;
+use Rector\PHPUnit\CodeQuality\Rector\ClassMethod\EntityDocumentCreateMockToDirectNewRector;
+use Rector\PHPUnit\CodeQuality\Rector\ClassMethod\RemoveEmptyTestMethodRector;
+use Rector\PHPUnit\CodeQuality\Rector\ClassMethod\RemoveStandaloneCreateMockRector;
+use Rector\PHPUnit\CodeQuality\Rector\ClassMethod\ReplaceTestAnnotationWithPrefixedFunctionRector;
+use Rector\PHPUnit\CodeQuality\Rector\Foreach_\SimplifyForeachInstanceOfRector;
+use Rector\PHPUnit\CodeQuality\Rector\FuncCall\AssertFuncCallToPHPUnitAssertRector;
+use Rector\PHPUnit\CodeQuality\Rector\MethodCall\MergeWithCallableAndWillReturnRector;
+use Rector\PHPUnit\CodeQuality\Rector\MethodCall\NarrowIdenticalWithConsecutiveRector;
+use Rector\PHPUnit\CodeQuality\Rector\MethodCall\NarrowSingleWillReturnCallbackRector;
+use Rector\PHPUnit\CodeQuality\Rector\MethodCall\RemoveExpectAnyFromMockRector;
+use Rector\PHPUnit\CodeQuality\Rector\MethodCall\SimplerWithIsInstanceOfRector;
+use Rector\PHPUnit\CodeQuality\Rector\MethodCall\SingleWithConsecutiveToWithRector;
+use Rector\PHPUnit\CodeQuality\Rector\MethodCall\UseSpecificWillMethodRector;
+use Rector\PHPUnit\CodeQuality\Rector\MethodCall\UseSpecificWithMethodRector;
+use Rector\PHPUnit\PHPUnit60\Rector\MethodCall\GetMockBuilderGetMockToCreateMockRector;
+use Rector\PHPUnit\PHPUnit90\Rector\MethodCall\ReplaceAtMethodWithDesiredMatcherRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnNeverTypeRector;
+
+$testsuiteRules = [
+    AssertFuncCallToPHPUnitAssertRector::class,
+    ConstructClassMethodToSetUpTestCaseRector::class,
+    DirectInstanceOverMockArgRector::class,
+    EntityDocumentCreateMockToDirectNewRector::class,
+    GetMockBuilderGetMockToCreateMockRector::class,
+    InlineStubPropertyToCreateStubMethodCallRector::class,
+    MergeWithCallableAndWillReturnRector::class,
+    NarrowIdenticalWithConsecutiveRector::class,
+    NarrowSingleWillReturnCallbackRector::class,
+    NarrowUnusedSetUpDefinedPropertyRector::class,
+    PreferPHPUnitThisCallRector::class,
+    RemoveEmptyTestMethodRector::class,
+    RemoveExpectAnyFromMockRector::class,
+    RemoveNeverUsedMockPropertyRector::class,
+    RemoveStandaloneCreateMockRector::class,
+    ReplaceAtMethodWithDesiredMatcherRector::class,
+    ReplaceTestAnnotationWithPrefixedFunctionRector::class,
+    SimplerWithIsInstanceOfRector::class,
+    SimplifyForeachInstanceOfRector::class,
+    SingleWithConsecutiveToWithRector::class,
+    UseSpecificWillMethodRector::class,
+    UseSpecificWithMethodRector::class,
+];
 
 return RectorConfig::configure()
     ->withRootFiles()
@@ -78,6 +125,7 @@ return RectorConfig::configure()
         'tests/Foundation/fixtures/bad-syntax-strategy.php',
     ])
     ->withRules([
+        ...$testsuiteRules,
         CountArrayToEmptyArrayComparisonRector::class,
         StrlenZeroToIdenticalEmptyStringRector::class,
     ])

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -116,7 +116,7 @@ class AuthGuardTest extends TestCase
         $guard->getProvider()->shouldReceive('retrieveByCredentials')->once()->andReturn($user);
         $guard->getProvider()->shouldReceive('validateCredentials')->with($user, ['foo'])->andReturn(true);
         $guard->getProvider()->shouldReceive('rehashPasswordIfRequired')->with($user, ['foo'])->once();
-        $guard->expects($this->once())->method('login')->with($this->equalTo($user));
+        $guard->expects($this->once())->method('login')->with($user);
         $this->assertTrue($guard->attempt(['foo']));
     }
 
@@ -160,15 +160,15 @@ class AuthGuardTest extends TestCase
         $mock->getProvider()->shouldReceive('rehashPasswordIfRequired')->with($user, ['foo'])->once();
 
         $this->assertTrue($mock->attemptWhen(['foo'], function ($user, $guard) {
-            static::assertInstanceOf(Authenticatable::class, $user);
-            static::assertInstanceOf(SessionGuard::class, $guard);
+            $this->assertInstanceOf(Authenticatable::class, $user);
+            $this->assertInstanceOf(SessionGuard::class, $guard);
 
             return true;
         }));
 
         $this->assertFalse($mock->attemptWhen(['foo'], function ($user, $guard) {
-            static::assertInstanceOf(Authenticatable::class, $user);
-            static::assertInstanceOf(SessionGuard::class, $guard);
+            $this->assertInstanceOf(Authenticatable::class, $user);
+            $this->assertInstanceOf(SessionGuard::class, $guard);
 
             return false;
         }));
@@ -196,7 +196,7 @@ class AuthGuardTest extends TestCase
         $guard->getProvider()->shouldReceive('retrieveByCredentials')->once()->andReturn($user);
         $guard->getProvider()->shouldReceive('validateCredentials')->with($user, ['foo'])->andReturn(true);
         $guard->getProvider()->shouldReceive('rehashPasswordIfRequired')->with($user, ['foo'])->once();
-        $guard->expects($this->once())->method('login')->with($this->equalTo($user));
+        $guard->expects($this->once())->method('login')->with($user);
         $this->assertTrue($guard->attempt(['foo']));
     }
 
@@ -216,7 +216,7 @@ class AuthGuardTest extends TestCase
         $guard->getProvider()->shouldReceive('retrieveByCredentials')->once()->andReturn($user);
         $guard->getProvider()->shouldReceive('validateCredentials')->with($user, ['foo'])->andReturn(true);
         $guard->getProvider()->shouldNotReceive('rehashPasswordIfRequired');
-        $guard->expects($this->once())->method('login')->with($this->equalTo($user));
+        $guard->expects($this->once())->method('login')->with($user);
         $this->assertTrue($guard->attempt(['foo']));
     }
 

--- a/tests/Auth/AuthListenersSendEmailVerificationNotificationHandleFunctionTest.php
+++ b/tests/Auth/AuthListenersSendEmailVerificationNotificationHandleFunctionTest.php
@@ -16,7 +16,7 @@ class AuthListenersSendEmailVerificationNotificationHandleFunctionTest extends T
      */
     public function testWillExecuted()
     {
-        $user = $this->getMockBuilder(MustVerifyEmail::class)->getMock();
+        $user = $this->createMock(MustVerifyEmail::class);
         $user->method('hasVerifiedEmail')->willReturn(false);
         $user->expects($this->once())->method('sendEmailVerificationNotification');
 
@@ -43,7 +43,7 @@ class AuthListenersSendEmailVerificationNotificationHandleFunctionTest extends T
      */
     public function testHasVerifiedEmailAsTrue()
     {
-        $user = $this->getMockBuilder(MustVerifyEmail::class)->getMock();
+        $user = $this->createMock(MustVerifyEmail::class);
         $user->method('hasVerifiedEmail')->willReturn(true);
         $user->expects($this->never())->method('sendEmailVerificationNotification');
 

--- a/tests/Cache/CacheApcStoreTest.php
+++ b/tests/Cache/CacheApcStoreTest.php
@@ -12,7 +12,7 @@ class CacheApcStoreTest extends TestCase
     public function testGetReturnsNullWhenNotFound()
     {
         $apc = $this->getMockBuilder(ApcWrapper::class)->onlyMethods(['get'])->getMock();
-        $apc->expects($this->once())->method('get')->with($this->equalTo('foobar'))->willReturn(null);
+        $apc->expects($this->once())->method('get')->with('foobar')->willReturn(null);
         $store = new ApcStore($apc, 'foo');
         $this->assertNull($store->get('bar'));
     }
@@ -53,7 +53,7 @@ class CacheApcStoreTest extends TestCase
     {
         $apc = $this->getMockBuilder(ApcWrapper::class)->onlyMethods(['put'])->getMock();
         $apc->expects($this->once())
-            ->method('put')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo(60))
+            ->method('put')->with('foo', 'bar', 60)
             ->willReturn(true);
         $store = new ApcStore($apc);
         $result = $store->put('foo', 'bar', 60);
@@ -91,7 +91,7 @@ class CacheApcStoreTest extends TestCase
     public function testIncrementMethodProperlyCallsAPC()
     {
         $apc = $this->getMockBuilder(ApcWrapper::class)->onlyMethods(['increment'])->getMock();
-        $apc->expects($this->once())->method('increment')->with($this->equalTo('foo'), $this->equalTo(5));
+        $apc->expects($this->once())->method('increment')->with('foo', 5);
         $store = new ApcStore($apc);
         $store->increment('foo', 5);
     }
@@ -99,7 +99,7 @@ class CacheApcStoreTest extends TestCase
     public function testDecrementMethodProperlyCallsAPC()
     {
         $apc = $this->getMockBuilder(ApcWrapper::class)->onlyMethods(['decrement'])->getMock();
-        $apc->expects($this->once())->method('decrement')->with($this->equalTo('foo'), $this->equalTo(5));
+        $apc->expects($this->once())->method('decrement')->with('foo', 5);
         $store = new ApcStore($apc);
         $store->decrement('foo', 5);
     }
@@ -108,7 +108,7 @@ class CacheApcStoreTest extends TestCase
     {
         $apc = $this->getMockBuilder(ApcWrapper::class)->onlyMethods(['put'])->getMock();
         $apc->expects($this->once())
-            ->method('put')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo(0))
+            ->method('put')->with('foo', 'bar', 0)
             ->willReturn(true);
         $store = new ApcStore($apc);
         $result = $store->forever('foo', 'bar');
@@ -118,7 +118,7 @@ class CacheApcStoreTest extends TestCase
     public function testForgetMethodProperlyCallsAPC()
     {
         $apc = $this->getMockBuilder(ApcWrapper::class)->onlyMethods(['delete'])->getMock();
-        $apc->expects($this->once())->method('delete')->with($this->equalTo('foo'))->willReturn(true);
+        $apc->expects($this->once())->method('delete')->with('foo')->willReturn(true);
         $store = new ApcStore($apc);
         $result = $store->forget('foo');
         $this->assertTrue($result);
@@ -131,8 +131,8 @@ class CacheApcStoreTest extends TestCase
 
         $apc = $this->getMockBuilder(ApcWrapper::class)->onlyMethods(['get', 'put'])->getMock();
 
-        $apc->expects($this->once())->method('get')->with($this->equalTo($key))->willReturn('bar');
-        $apc->expects($this->once())->method('put')->with($this->equalTo($key), $this->equalTo('bar'), $this->equalTo($ttl))->willReturn(true);
+        $apc->expects($this->once())->method('get')->with($key)->willReturn('bar');
+        $apc->expects($this->once())->method('put')->with($key, 'bar', $ttl)->willReturn(true);
 
         $this->assertTrue((new ApcStore($apc))->touch($key, $ttl));
     }

--- a/tests/Cache/CacheArrayStoreTest.php
+++ b/tests/Cache/CacheArrayStoreTest.php
@@ -90,7 +90,7 @@ class CacheArrayStoreTest extends TestCase
     {
         $mock = $this->getMockBuilder(ArrayStore::class)->onlyMethods(['put'])->getMock();
         $mock->expects($this->once())
-            ->method('put')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo(0))
+            ->method('put')->with('foo', 'bar', 0)
             ->willReturn(true);
         $result = $mock->forever('foo', 'bar');
         $this->assertTrue($result);

--- a/tests/Cache/CacheDatabaseStoreTest.php
+++ b/tests/Cache/CacheDatabaseStoreTest.php
@@ -114,7 +114,7 @@ class CacheDatabaseStoreTest extends TestCase
     public function testForeverCallsStoreItemWithReallyLongTime()
     {
         $store = $this->getMockBuilder(DatabaseStore::class)->onlyMethods(['put'])->setConstructorArgs($this->getMocks())->getMock();
-        $store->expects($this->once())->method('put')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo(315360000))->willReturn(true);
+        $store->expects($this->once())->method('put')->with('foo', 'bar', 315360000)->willReturn(true);
         $result = $store->forever('foo', 'bar');
         $this->assertTrue($result);
     }

--- a/tests/Cache/CacheFileStoreTest.php
+++ b/tests/Cache/CacheFileStoreTest.php
@@ -24,7 +24,7 @@ class CacheFileStoreTest extends TestCase
     public function testNullIsReturnedIfFileDoesntExist()
     {
         $files = $this->mockFilesystem();
-        $files->expects($this->once())->method('get')->will($this->throwException(new FileNotFoundException));
+        $files->expects($this->once())->method('get')->willThrowException(new FileNotFoundException);
         $store = new FileStore($files, __DIR__);
         $value = $store->get('foo');
         $this->assertNull($value);
@@ -36,8 +36,8 @@ class CacheFileStoreTest extends TestCase
         $hash = sha1('foo');
         $contents = '0000000000';
         $full_dir = __DIR__.'/'.substr($hash, 0, 2).'/'.substr($hash, 2, 2);
-        $files->expects($this->once())->method('makeDirectory')->with($this->equalTo($full_dir), $this->equalTo(0777), $this->equalTo(true));
-        $files->expects($this->once())->method('put')->with($this->equalTo($full_dir.'/'.$hash))->willReturn(strlen($contents));
+        $files->expects($this->once())->method('makeDirectory')->with($full_dir, 0777, true);
+        $files->expects($this->once())->method('put')->with($full_dir.'/'.$hash)->willReturn(strlen($contents));
         $store = new FileStore($files, __DIR__);
         $result = $store->put('foo', $contents, 0);
         $this->assertTrue($result);
@@ -54,9 +54,9 @@ class CacheFileStoreTest extends TestCase
         $exclusiveLock = true;
 
         $files->expects($this->once())->method('put')->with(
-            $this->equalTo($filePath),
-            $this->equalTo($fileContents),
-            $this->equalTo($exclusiveLock) // Ensure we do lock the file while putting.
+            $filePath,
+            $fileContents,
+            $exclusiveLock // Ensure we do lock the file while putting.
         )->willReturn(strlen($fileContents));
 
         (new FileStore($files, __DIR__))->put('O--L / key', 'gold', 0);
@@ -72,8 +72,8 @@ class CacheFileStoreTest extends TestCase
         $fileContents = $ten9s.serialize('gold');
 
         $files->expects($this->once())->method('put')->with(
-            $this->equalTo($filePath),
-            $this->equalTo($fileContents),
+            $filePath,
+            $fileContents,
         );
 
         (new FileStore($files, __DIR__))->put('O--L / key', 'gold', (int) $ten9s + 1);
@@ -103,11 +103,11 @@ class CacheFileStoreTest extends TestCase
     {
         $files = $this->mockFilesystem();
         $store = $this->getMockBuilder(FileStore::class)->onlyMethods(['expiration'])->setConstructorArgs([$files, __DIR__])->getMock();
-        $store->expects($this->once())->method('expiration')->with($this->equalTo(10))->willReturn(1111111111);
+        $store->expects($this->once())->method('expiration')->with(10)->willReturn(1111111111);
         $contents = '1111111111'.serialize('Hello World');
         $hash = sha1('foo');
         $cache_dir = substr($hash, 0, 2).'/'.substr($hash, 2, 2);
-        $files->expects($this->once())->method('put')->with($this->equalTo(__DIR__.'/'.$cache_dir.'/'.$hash), $this->equalTo($contents))->willReturn(strlen($contents));
+        $files->expects($this->once())->method('put')->with(__DIR__.'/'.$cache_dir.'/'.$hash, $contents)->willReturn(strlen($contents));
         $result = $store->put('foo', 'Hello World', 10);
         $this->assertTrue($result);
     }
@@ -127,7 +127,7 @@ class CacheFileStoreTest extends TestCase
 
         $store->expects($this->once())
             ->method('expiration')
-            ->with($this->equalTo($ttl))
+            ->with($ttl)
             ->willReturn($now->clone()->addSeconds($ttl)->getTimestamp());
         $store->expects($this->once())
             ->method('getPayload')
@@ -136,9 +136,9 @@ class CacheFileStoreTest extends TestCase
         $files->expects($this->once())
             ->method('put')
             ->with(
-                $this->equalTo($path),
-                $this->equalTo($now->clone()->addSeconds($ttl)->getTimestamp().serialize($content)),
-                $this->equalTo(true)
+                $path,
+                $now->clone()->addSeconds($ttl)->getTimestamp().serialize($content),
+                true
             )
             ->willReturn(1);
 
@@ -195,7 +195,7 @@ class CacheFileStoreTest extends TestCase
         $contents = '9999999999'.serialize('Hello World');
         $hash = sha1('foo');
         $cache_dir = substr($hash, 0, 2).'/'.substr($hash, 2, 2);
-        $files->expects($this->once())->method('put')->with($this->equalTo(__DIR__.'/'.$cache_dir.'/'.$hash), $this->equalTo($contents))->willReturn(strlen($contents));
+        $files->expects($this->once())->method('put')->with(__DIR__.'/'.$cache_dir.'/'.$hash, $contents)->willReturn(strlen($contents));
         $store = new FileStore($files, __DIR__);
         $result = $store->forever('foo', 'Hello World', 10);
         $this->assertTrue($result);
@@ -223,8 +223,8 @@ class CacheFileStoreTest extends TestCase
         $valueAfterIncrement = '9999999999'.serialize(3);
         $store = new FileStore($files, __DIR__);
 
-        $files->expects($this->once())->method('get')->with($this->equalTo($filePath), $this->equalTo(true))->willReturn($initialValue);
-        $files->expects($this->once())->method('put')->with($this->equalTo($filePath), $this->equalTo($valueAfterIncrement));
+        $files->expects($this->once())->method('get')->with($filePath, true)->willReturn($initialValue);
+        $files->expects($this->once())->method('put')->with($filePath, $valueAfterIncrement);
 
         $result = $store->increment('foo', 3);
     }
@@ -237,8 +237,8 @@ class CacheFileStoreTest extends TestCase
         $valueAfterIncrement = '9999999999'.serialize(4);
         $store = new FileStore($files, __DIR__);
 
-        $files->expects($this->once())->method('get')->with($this->equalTo($filePath), $this->equalTo(true))->willReturn($initialValue);
-        $files->expects($this->once())->method('put')->with($this->equalTo($filePath), $this->equalTo($valueAfterIncrement));
+        $files->expects($this->once())->method('get')->with($filePath, true)->willReturn($initialValue);
+        $files->expects($this->once())->method('put')->with($filePath, $valueAfterIncrement);
 
         $result = $store->increment('foo', 3);
         $this->assertEquals(4, $result);
@@ -253,8 +253,8 @@ class CacheFileStoreTest extends TestCase
         $valueAfterIncrement = '9999999999'.serialize(0);
         $store = new FileStore($files, __DIR__);
 
-        $files->expects($this->once())->method('get')->with($this->equalTo($filePath), $this->equalTo(true))->willReturn($initialValue);
-        $files->expects($this->once())->method('put')->with($this->equalTo($filePath), $this->equalTo($valueAfterIncrement));
+        $files->expects($this->once())->method('get')->with($filePath, true)->willReturn($initialValue);
+        $files->expects($this->once())->method('put')->with($filePath, $valueAfterIncrement);
 
         $result = $store->decrement('foo', 2);
         $this->assertEquals(0, $result);
@@ -268,8 +268,8 @@ class CacheFileStoreTest extends TestCase
         $initialValue = '1999999909'.serialize('foo');
         $valueAfterIncrement = '1999999909'.serialize(1);
         $store = new FileStore($files, __DIR__);
-        $files->expects($this->once())->method('get')->with($this->equalTo($filePath), $this->equalTo(true))->willReturn($initialValue);
-        $files->expects($this->once())->method('put')->with($this->equalTo($filePath), $this->equalTo($valueAfterIncrement));
+        $files->expects($this->once())->method('get')->with($filePath, true)->willReturn($initialValue);
+        $files->expects($this->once())->method('put')->with($filePath, $valueAfterIncrement);
         $result = $store->increment('foo');
 
         $this->assertEquals(1, $result);
@@ -283,8 +283,8 @@ class CacheFileStoreTest extends TestCase
         $valueAfterIncrement = '9999999999'.serialize(1);
         $store = new FileStore($files, __DIR__);
         // simulates a missing item in file store by the exception
-        $files->expects($this->once())->method('get')->with($this->equalTo($filePath), $this->equalTo(true))->willThrowException(new Exception);
-        $files->expects($this->once())->method('put')->with($this->equalTo($filePath), $this->equalTo($valueAfterIncrement));
+        $files->expects($this->once())->method('get')->with($filePath, true)->willThrowException(new Exception);
+        $files->expects($this->once())->method('put')->with($filePath, $valueAfterIncrement);
         $result = $store->increment('foo');
         $this->assertIsInt($result);
         $this->assertEquals(1, $result);
@@ -302,7 +302,7 @@ class CacheFileStoreTest extends TestCase
         $files->expects($this->once())->method('get')->willReturn($initialValue);
         $hash = sha1('foo');
         $cache_dir = substr($hash, 0, 2).'/'.substr($hash, 2, 2);
-        $files->expects($this->once())->method('put')->with($this->equalTo(__DIR__.'/'.$cache_dir.'/'.$hash), $this->equalTo($valueAfterIncrement));
+        $files->expects($this->once())->method('put')->with(__DIR__.'/'.$cache_dir.'/'.$hash, $valueAfterIncrement);
         $store->increment('foo');
     }
 
@@ -311,7 +311,7 @@ class CacheFileStoreTest extends TestCase
         $files = $this->mockFilesystem();
         $hash = sha1('foobull');
         $cache_dir = substr($hash, 0, 2).'/'.substr($hash, 2, 2);
-        $files->expects($this->once())->method('exists')->with($this->equalTo(__DIR__.'/'.$cache_dir.'/'.$hash))->willReturn(false);
+        $files->expects($this->once())->method('exists')->with(__DIR__.'/'.$cache_dir.'/'.$hash)->willReturn(false);
         $store = new FileStore($files, __DIR__);
         $store->forget('foobull');
     }
@@ -332,9 +332,9 @@ class CacheFileStoreTest extends TestCase
     public function testFlushCleansDirectory()
     {
         $files = $this->mockFilesystem();
-        $files->expects($this->once())->method('isDirectory')->with($this->equalTo(__DIR__))->willReturn(true);
-        $files->expects($this->once())->method('directories')->with($this->equalTo(__DIR__))->willReturn(['foo']);
-        $files->expects($this->once())->method('deleteDirectory')->with($this->equalTo('foo'))->willReturn(true);
+        $files->expects($this->once())->method('isDirectory')->with(__DIR__)->willReturn(true);
+        $files->expects($this->once())->method('directories')->with(__DIR__)->willReturn(['foo']);
+        $files->expects($this->once())->method('deleteDirectory')->with('foo')->willReturn(true);
 
         $store = new FileStore($files, __DIR__);
         $result = $store->flush();
@@ -344,9 +344,9 @@ class CacheFileStoreTest extends TestCase
     public function testFlushFailsDirectoryClean()
     {
         $files = $this->mockFilesystem();
-        $files->expects($this->once())->method('isDirectory')->with($this->equalTo(__DIR__))->willReturn(true);
-        $files->expects($this->once())->method('directories')->with($this->equalTo(__DIR__))->willReturn(['foo']);
-        $files->expects($this->once())->method('deleteDirectory')->with($this->equalTo('foo'))->willReturn(false);
+        $files->expects($this->once())->method('isDirectory')->with(__DIR__)->willReturn(true);
+        $files->expects($this->once())->method('directories')->with(__DIR__)->willReturn(['foo']);
+        $files->expects($this->once())->method('deleteDirectory')->with('foo')->willReturn(false);
 
         $store = new FileStore($files, __DIR__);
         $result = $store->flush();
@@ -356,7 +356,7 @@ class CacheFileStoreTest extends TestCase
     public function testFlushIgnoreNonExistingDirectory()
     {
         $files = $this->mockFilesystem();
-        $files->expects($this->once())->method('isDirectory')->with($this->equalTo(__DIR__.'--wrong'))->willReturn(false);
+        $files->expects($this->once())->method('isDirectory')->with(__DIR__.'--wrong')->willReturn(false);
 
         $store = new FileStore($files, __DIR__.'--wrong');
         $result = $store->flush();
@@ -367,9 +367,9 @@ class CacheFileStoreTest extends TestCase
     {
         $lockDir = __DIR__.'/locks';
         $files = $this->mockFilesystem();
-        $files->expects($this->once())->method('isDirectory')->with($this->equalTo($lockDir))->willReturn(true);
-        $files->expects($this->once())->method('directories')->with($this->equalTo($lockDir))->willReturn(['foo']);
-        $files->expects($this->once())->method('deleteDirectory')->with($this->equalTo('foo'))->willReturn(true);
+        $files->expects($this->once())->method('isDirectory')->with($lockDir)->willReturn(true);
+        $files->expects($this->once())->method('directories')->with($lockDir)->willReturn(['foo']);
+        $files->expects($this->once())->method('deleteDirectory')->with('foo')->willReturn(true);
 
         $store = new FileStore($files, __DIR__);
         $store->setLockDirectory($lockDir);
@@ -381,9 +381,9 @@ class CacheFileStoreTest extends TestCase
     {
         $lockDir = __DIR__.'/locks';
         $files = $this->mockFilesystem();
-        $files->expects($this->once())->method('isDirectory')->with($this->equalTo($lockDir))->willReturn(true);
-        $files->expects($this->once())->method('directories')->with($this->equalTo($lockDir))->willReturn(['foo']);
-        $files->expects($this->once())->method('deleteDirectory')->with($this->equalTo('foo'))->willReturn(false);
+        $files->expects($this->once())->method('isDirectory')->with($lockDir)->willReturn(true);
+        $files->expects($this->once())->method('directories')->with($lockDir)->willReturn(['foo']);
+        $files->expects($this->once())->method('deleteDirectory')->with('foo')->willReturn(false);
 
         $store = new FileStore($files, __DIR__);
         $store->setLockDirectory($lockDir);
@@ -395,7 +395,7 @@ class CacheFileStoreTest extends TestCase
     {
         $lockDir = __DIR__.'/locks';
         $files = $this->mockFilesystem();
-        $files->expects($this->once())->method('isDirectory')->with($this->equalTo($lockDir))->willReturn(false);
+        $files->expects($this->once())->method('isDirectory')->with($lockDir)->willReturn(false);
 
         $store = new FileStore($files, __DIR__);
         $store->setLockDirectory($lockDir);

--- a/tests/Cache/CacheMemcachedStoreTest.php
+++ b/tests/Cache/CacheMemcachedStoreTest.php
@@ -15,7 +15,7 @@ class CacheMemcachedStoreTest extends TestCase
     public function testGetReturnsNullWhenNotFound()
     {
         $memcache = $this->getMockBuilder(Memcached::class)->onlyMethods(['get', 'getResultCode'])->getMock();
-        $memcache->expects($this->once())->method('get')->with($this->equalTo('foo:bar'))->willReturn(null);
+        $memcache->expects($this->once())->method('get')->with('foo:bar')->willReturn(null);
         $memcache->expects($this->once())->method('getResultCode')->willReturn(1);
         $store = new MemcachedStore($memcache, 'foo:');
         $this->assertNull($store->get('bar'));
@@ -53,7 +53,7 @@ class CacheMemcachedStoreTest extends TestCase
     {
         Carbon::setTestNow($now = Carbon::now());
         $memcache = $this->getMockBuilder(Memcached::class)->onlyMethods(['set'])->getMock();
-        $memcache->expects($this->once())->method('set')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo($now->timestamp + 60))->willReturn(true);
+        $memcache->expects($this->once())->method('set')->with('foo', 'bar', $now->timestamp + 60)->willReturn(true);
         $store = new MemcachedStore($memcache);
         $result = $store->put('foo', 'bar', 60);
         $this->assertTrue($result);
@@ -69,7 +69,7 @@ class CacheMemcachedStoreTest extends TestCase
 
         $memcache = $this->getMockBuilder(Memcached::class)->onlyMethods(['touch'])->getMock();
 
-        $memcache->expects($this->once())->method('touch')->with($this->equalTo($key), $this->equalTo($now->addSeconds($ttl)->getTimestamp()))->willReturn(true);
+        $memcache->expects($this->once())->method('touch')->with($key, $now->addSeconds($ttl)->getTimestamp())->willReturn(true);
 
         $this->assertTrue((new MemcachedStore($memcache))->touch($key, $ttl));
     }
@@ -95,7 +95,7 @@ class CacheMemcachedStoreTest extends TestCase
     public function testStoreItemForeverProperlyCallsMemcached()
     {
         $memcache = $this->getMockBuilder(Memcached::class)->onlyMethods(['set'])->getMock();
-        $memcache->expects($this->once())->method('set')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo(0))->willReturn(true);
+        $memcache->expects($this->once())->method('set')->with('foo', 'bar', 0)->willReturn(true);
         $store = new MemcachedStore($memcache);
         $result = $store->forever('foo', 'bar');
         $this->assertTrue($result);
@@ -104,7 +104,7 @@ class CacheMemcachedStoreTest extends TestCase
     public function testForgetMethodProperlyCallsMemcache()
     {
         $memcache = $this->getMockBuilder(Memcached::class)->onlyMethods(['delete'])->getMock();
-        $memcache->expects($this->once())->method('delete')->with($this->equalTo('foo'));
+        $memcache->expects($this->once())->method('delete')->with('foo');
         $store = new MemcachedStore($memcache);
         $store->forget('foo');
     }

--- a/tests/Cache/CacheSessionStoreTest.php
+++ b/tests/Cache/CacheSessionStoreTest.php
@@ -98,7 +98,7 @@ class CacheSessionStoreTest extends TestCase
             ->onlyMethods(['put'])
             ->getMock();
         $mock->expects($this->once())
-            ->method('put')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo(0))
+            ->method('put')->with('foo', 'bar', 0)
             ->willReturn(true);
         $result = $mock->forever('foo', 'bar');
         $this->assertTrue($result);

--- a/tests/Console/ConsoleApplicationTest.php
+++ b/tests/Console/ConsoleApplicationTest.php
@@ -42,7 +42,7 @@ class ConsoleApplicationTest extends TestCase
         $artisan = $this->getMockConsole(['addToParent']);
         $command = m::mock(Command::class);
         $command->shouldReceive('setLaravel')->once()->with(m::type(ApplicationContract::class));
-        $artisan->expects($this->once())->method('addToParent')->with($this->equalTo($command))->willReturn($command);
+        $artisan->expects($this->once())->method('addToParent')->with($command)->willReturn($command);
         $result = $artisan->add($command);
 
         $this->assertSame($command, $result);
@@ -53,7 +53,7 @@ class ConsoleApplicationTest extends TestCase
         $artisan = $this->getMockConsole(['addToParent']);
         $command = m::mock(SymfonyCommand::class);
         $command->shouldReceive('setLaravel')->never();
-        $artisan->expects($this->once())->method('addToParent')->with($this->equalTo($command))->willReturn($command);
+        $artisan->expects($this->once())->method('addToParent')->with($command)->willReturn($command);
         $result = $artisan->add($command);
 
         $this->assertSame($command, $result);
@@ -64,7 +64,7 @@ class ConsoleApplicationTest extends TestCase
         $artisan = $this->getMockConsole(['addToParent']);
         $command = m::mock(SymfonyCommand::class);
         $artisan->getLaravel()->shouldReceive('make')->once()->with('foo')->andReturn(m::mock(SymfonyCommand::class));
-        $artisan->expects($this->once())->method('addToParent')->with($this->equalTo($command))->willReturn($command);
+        $artisan->expects($this->once())->method('addToParent')->with($command)->willReturn($command);
         $result = $artisan->resolve('foo');
 
         $this->assertSame($command, $result);

--- a/tests/Console/Scheduling/ScheduleTest.php
+++ b/tests/Console/Scheduling/ScheduleTest.php
@@ -11,7 +11,6 @@ use Illuminate\Container\Container;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Tests\Console\Fixtures\JobToTestWithSchedule;
 use Mockery as m;
-use Mockery\MockInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -20,8 +19,6 @@ use PHPUnit\Framework\TestCase;
 final class ScheduleTest extends TestCase
 {
     private Container $container;
-    private EventMutex&MockInterface $eventMutex;
-    private SchedulingMutex&MockInterface $schedulingMutex;
 
     protected function setUp(): void
     {
@@ -29,10 +26,10 @@ final class ScheduleTest extends TestCase
 
         $this->container = new Container;
         Container::setInstance($this->container);
-        $this->eventMutex = m::mock(EventMutex::class);
-        $this->container->instance(EventMutex::class, $this->eventMutex);
-        $this->schedulingMutex = m::mock(SchedulingMutex::class);
-        $this->container->instance(SchedulingMutex::class, $this->schedulingMutex);
+        $eventMutex = m::mock(EventMutex::class);
+        $this->container->instance(EventMutex::class, $eventMutex);
+        $schedulingMutex = m::mock(SchedulingMutex::class);
+        $this->container->instance(SchedulingMutex::class, $schedulingMutex);
     }
 
     #[DataProvider('jobHonoursDisplayNameIfMethodExistsProvider')]
@@ -40,8 +37,8 @@ final class ScheduleTest extends TestCase
     {
         $schedule = new Schedule();
         $scheduledJob = $schedule->job($job);
-        self::assertSame($jobName, $scheduledJob->description);
-        self::assertFalse($this->container->resolved(JobToTestWithSchedule::class));
+        $this->assertSame($jobName, $scheduledJob->description);
+        $this->assertFalse($this->container->resolved(JobToTestWithSchedule::class));
     }
 
     public static function jobHonoursDisplayNameIfMethodExistsProvider(): array
@@ -64,7 +61,7 @@ final class ScheduleTest extends TestCase
     {
         $schedule = new Schedule();
         $scheduledJob = $schedule->job(JobToTestWithSchedule::class);
-        self::assertSame(JobToTestWithSchedule::class, $scheduledJob->description);
-        self::assertFalse($this->container->resolved(JobToTestWithSchedule::class));
+        $this->assertSame(JobToTestWithSchedule::class, $scheduledJob->description);
+        $this->assertFalse($this->container->resolved(JobToTestWithSchedule::class));
     }
 }

--- a/tests/Container/ContainerExtendTest.php
+++ b/tests/Container/ContainerExtendTest.php
@@ -196,13 +196,13 @@ class ContainerExtendTest extends TestCase
             ->give(fn () => new ContainerExtendInterfaceImplementationStub('foo'));
 
         $container->extend(ContainerExtendInterfaceStub::class, function ($instance) {
-            self::assertInstanceOf(ContainerExtendInterfaceImplementationStub::class, $instance);
-            self::assertSame('foo', $instance->value);
+            $this->assertInstanceOf(ContainerExtendInterfaceImplementationStub::class, $instance);
+            $this->assertSame('foo', $instance->value);
 
             return new ContainerExtendInterfaceImplementationStub('bar');
         });
 
-        self::assertSame('bar', $container->make(ContainerExtendConsumesInterfaceStub::class)->stub->value);
+        $this->assertSame('bar', $container->make(ContainerExtendConsumesInterfaceStub::class)->stub->value);
     }
 
     // https://github.com/laravel/framework/issues/53501
@@ -216,13 +216,13 @@ class ContainerExtendTest extends TestCase
         $container->make(ContainerExtendConsumesInterfaceStub::class);
 
         $container->extend(ContainerExtendInterfaceStub::class, function ($instance) {
-            self::assertInstanceOf(ContainerExtendInterfaceImplementationStub::class, $instance);
-            self::assertSame('foo', $instance->value);
+            $this->assertInstanceOf(ContainerExtendInterfaceImplementationStub::class, $instance);
+            $this->assertSame('foo', $instance->value);
 
             return new ContainerExtendInterfaceImplementationStub('bar');
         });
 
-        self::assertSame('bar', $container->make(ContainerExtendConsumesInterfaceStub::class)->stub->value);
+        $this->assertSame('bar', $container->make(ContainerExtendConsumesInterfaceStub::class)->stub->value);
     }
 }
 

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -90,7 +90,7 @@ class DatabaseConnectionTest extends TestCase
         $pdo->expects($this->once())->method('prepare')->with('foo')->willReturn($statement);
         $mock = $this->getMockConnection(['prepareBindings'], $writePdo);
         $mock->setReadPdo($pdo);
-        $mock->expects($this->once())->method('prepareBindings')->with($this->equalTo(['foo' => 'bar']))->willReturn(['foo' => 'bar']);
+        $mock->expects($this->once())->method('prepareBindings')->with(['foo' => 'bar'])->willReturn(['foo' => 'bar']);
         $results = $mock->select('foo', ['foo' => 'bar']);
         $this->assertEquals(['boom'], $results);
         $log = $mock->getQueryLog();
@@ -119,7 +119,7 @@ class DatabaseConnectionTest extends TestCase
         $pdo->expects($this->once())->method('prepare')->with('CALL a_procedure(?)')->willReturn($statement);
         $mock = $this->getMockConnection(['prepareBindings'], $writePdo);
         $mock->setReadPdo($pdo);
-        $mock->expects($this->once())->method('prepareBindings')->with($this->equalTo(['foo']))->willReturn(['foo']);
+        $mock->expects($this->once())->method('prepareBindings')->with(['foo'])->willReturn(['foo']);
         $results = $mock->selectResultsets('CALL a_procedure(?)', ['foo']);
         $this->assertEquals([['boom'], ['boom']], $results);
         $log = $mock->getQueryLog();
@@ -131,7 +131,7 @@ class DatabaseConnectionTest extends TestCase
     public function testInsertCallsTheStatementMethod()
     {
         $connection = $this->getMockConnection(['statement']);
-        $connection->expects($this->once())->method('statement')->with($this->equalTo('foo'), $this->equalTo(['bar']))->willReturn('baz');
+        $connection->expects($this->once())->method('statement')->with('foo', ['bar'])->willReturn('baz');
         $results = $connection->insert('foo', ['bar']);
         $this->assertSame('baz', $results);
     }
@@ -139,7 +139,7 @@ class DatabaseConnectionTest extends TestCase
     public function testUpdateCallsTheAffectingStatementMethod()
     {
         $connection = $this->getMockConnection(['affectingStatement']);
-        $connection->expects($this->once())->method('affectingStatement')->with($this->equalTo('foo'), $this->equalTo(['bar']))->willReturn('baz');
+        $connection->expects($this->once())->method('affectingStatement')->with('foo', ['bar'])->willReturn('baz');
         $results = $connection->update('foo', ['bar']);
         $this->assertSame('baz', $results);
     }
@@ -147,7 +147,7 @@ class DatabaseConnectionTest extends TestCase
     public function testDeleteCallsTheAffectingStatementMethod()
     {
         $connection = $this->getMockConnection(['affectingStatement']);
-        $connection->expects($this->once())->method('affectingStatement')->with($this->equalTo('foo'), $this->equalTo(['bar']))->willReturn(true);
+        $connection->expects($this->once())->method('affectingStatement')->with('foo', ['bar'])->willReturn(true);
         $results = $connection->delete('foo', ['bar']);
         $this->assertTrue($results);
     }
@@ -158,9 +158,9 @@ class DatabaseConnectionTest extends TestCase
         $statement = $this->getMockBuilder('PDOStatement')->onlyMethods(['execute', 'bindValue'])->getMock();
         $statement->expects($this->once())->method('bindValue')->with(1, 'bar', 2);
         $statement->expects($this->once())->method('execute')->willReturn(true);
-        $pdo->expects($this->once())->method('prepare')->with($this->equalTo('foo'))->willReturn($statement);
+        $pdo->expects($this->once())->method('prepare')->with('foo')->willReturn($statement);
         $mock = $this->getMockConnection(['prepareBindings'], $pdo);
-        $mock->expects($this->once())->method('prepareBindings')->with($this->equalTo(['bar']))->willReturn(['bar']);
+        $mock->expects($this->once())->method('prepareBindings')->with(['bar'])->willReturn(['bar']);
         $results = $mock->statement('foo', ['bar']);
         $this->assertTrue($results);
         $log = $mock->getQueryLog();
@@ -178,7 +178,7 @@ class DatabaseConnectionTest extends TestCase
         $statement->expects($this->once())->method('rowCount')->willReturn(42);
         $pdo->expects($this->once())->method('prepare')->with('foo')->willReturn($statement);
         $mock = $this->getMockConnection(['prepareBindings'], $pdo);
-        $mock->expects($this->once())->method('prepareBindings')->with($this->equalTo(['foo' => 'bar']))->willReturn(['foo' => 'bar']);
+        $mock->expects($this->once())->method('prepareBindings')->with(['foo' => 'bar'])->willReturn(['foo' => 'bar']);
         $results = $mock->update('foo', ['foo' => 'bar']);
         $this->assertSame(42, $results);
         $log = $mock->getQueryLog();
@@ -190,7 +190,7 @@ class DatabaseConnectionTest extends TestCase
     public function testTransactionLevelNotIncrementedOnTransactionException()
     {
         $pdo = $this->createMock(DatabaseConnectionTestMockPDO::class);
-        $pdo->expects($this->once())->method('beginTransaction')->will($this->throwException(new Exception));
+        $pdo->expects($this->once())->method('beginTransaction')->willThrowException(new Exception);
         $connection = $this->getMockConnection([], $pdo);
         try {
             $connection->beginTransaction();
@@ -226,7 +226,7 @@ class DatabaseConnectionTest extends TestCase
     {
         $pdo = $this->createMock(DatabaseConnectionTestMockPDO::class);
         $pdo->expects($this->once())->method('beginTransaction');
-        $pdo->expects($this->once())->method('exec')->will($this->throwException(new Exception));
+        $pdo->expects($this->once())->method('exec')->willThrowException(new Exception);
         $connection = $this->getMockConnection(['reconnect'], $pdo);
         $queryGrammar = $this->createMock(Grammar::class);
         $queryGrammar->expects($this->once())->method('compileSavepoint')->willReturn('trans1');
@@ -256,7 +256,7 @@ class DatabaseConnectionTest extends TestCase
     {
         $pdo = $this->createMock(DatabaseConnectionTestMockPDO::class);
         $connection = $this->getMockConnection(['getName'], $pdo);
-        $connection->expects($this->any())->method('getName')->willReturn('name');
+        $connection->method('getName')->willReturn('name');
         $connection->setEventDispatcher($events = m::mock(Dispatcher::class));
         $events->shouldReceive('dispatch')->once()->with(m::type(TransactionBeginning::class));
         $connection->beginTransaction();
@@ -266,7 +266,7 @@ class DatabaseConnectionTest extends TestCase
     {
         $pdo = $this->createMock(DatabaseConnectionTestMockPDO::class);
         $connection = $this->getMockConnection(['getName'], $pdo);
-        $connection->expects($this->any())->method('getName')->willReturn('name');
+        $connection->method('getName')->willReturn('name');
         $connection->setEventDispatcher($events = m::mock(Dispatcher::class));
         $events->shouldReceive('dispatch')->once()->with(m::type(TransactionCommitted::class));
         $connection->commit();
@@ -276,8 +276,8 @@ class DatabaseConnectionTest extends TestCase
     {
         $pdo = $this->createMock(DatabaseConnectionTestMockPDO::class);
         $connection = $this->getMockConnection(['getName', 'transactionLevel'], $pdo);
-        $connection->expects($this->any())->method('getName')->willReturn('name');
-        $connection->expects($this->any())->method('transactionLevel')->willReturn(1);
+        $connection->method('getName')->willReturn('name');
+        $connection->method('transactionLevel')->willReturn(1);
         $connection->setEventDispatcher($events = m::mock(Dispatcher::class));
         $events->shouldReceive('dispatch')->once()->with(m::type(TransactionCommitting::class));
         $events->shouldReceive('dispatch')->once()->with(m::type(TransactionCommitted::class));
@@ -288,7 +288,7 @@ class DatabaseConnectionTest extends TestCase
     {
         $pdo = $this->createMock(DatabaseConnectionTestMockPDO::class);
         $connection = $this->getMockConnection(['getName'], $pdo);
-        $connection->expects($this->any())->method('getName')->willReturn('name');
+        $connection->method('getName')->willReturn('name');
         $connection->beginTransaction();
         $connection->setEventDispatcher($events = m::mock(Dispatcher::class));
         $events->shouldReceive('dispatch')->once()->with(m::type(TransactionRolledBack::class));
@@ -299,7 +299,7 @@ class DatabaseConnectionTest extends TestCase
     {
         $pdo = $this->createMock(DatabaseConnectionTestMockPDO::class);
         $connection = $this->getMockConnection(['getName'], $pdo);
-        $connection->expects($this->any())->method('getName')->willReturn('name');
+        $connection->method('getName')->willReturn('name');
         $connection->setEventDispatcher($events = m::mock(Dispatcher::class));
         $events->shouldNotReceive('dispatch');
         $connection->rollBack();
@@ -344,7 +344,7 @@ class DatabaseConnectionTest extends TestCase
 
         $pdo = $this->getMockBuilder(DatabaseConnectionTestMockPDO::class)->onlyMethods(['inTransaction', 'beginTransaction', 'commit', 'rollBack'])->getMock();
         $mock = $this->getMockConnection([], $pdo);
-        $pdo->expects($this->exactly(3))->method('commit')->will($this->throwException(new DatabaseConnectionTestMockPDOException('Serialization failure', '40001')));
+        $pdo->expects($this->exactly(3))->method('commit')->willThrowException(new DatabaseConnectionTestMockPDOException('Serialization failure', '40001'));
         $pdo->expects($this->exactly(3))->method('beginTransaction');
         $pdo->method('inTransaction')->willReturn(true);
         $pdo->expects($this->exactly(2))->method('rollBack');

--- a/tests/Database/DatabaseConnectorTest.php
+++ b/tests/Database/DatabaseConnectorTest.php
@@ -29,8 +29,8 @@ class DatabaseConnectorTest extends TestCase
     {
         $connector = $this->getMockBuilder(MySqlConnector::class)->onlyMethods(['createConnection', 'getOptions'])->getMock();
         $connection = m::mock(PDO::class);
-        $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->willReturn(['options']);
-        $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->willReturn($connection);
+        $connector->expects($this->once())->method('getOptions')->with($config)->willReturn(['options']);
+        $connector->expects($this->once())->method('createConnection')->with($dsn, $config, ['options'])->willReturn($connection);
         $connection->shouldReceive('exec')->once()->with('use `bar`;')->andReturn(true);
         $connection->shouldReceive('exec')->once()->with("SET NAMES 'utf8' COLLATE 'utf8_unicode_ci';")->andReturn(true);
         $result = $connector->connect($config);
@@ -54,8 +54,8 @@ class DatabaseConnectorTest extends TestCase
 
         $connector = $this->getMockBuilder(MySqlConnector::class)->onlyMethods(['createConnection', 'getOptions'])->getMock();
         $connection = m::mock(PDO::class);
-        $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->willReturn(['options']);
-        $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->willReturn($connection);
+        $connector->expects($this->once())->method('getOptions')->with($config)->willReturn(['options']);
+        $connector->expects($this->once())->method('createConnection')->with($dsn, $config, ['options'])->willReturn($connection);
         $connection->shouldReceive('exec')->once()->with('use `bar`;')->andReturn(true);
         $connection->shouldReceive('exec')->once()->with('SET SESSION TRANSACTION ISOLATION LEVEL REPEATABLE READ;')->andReturn(true);
         $connection->shouldReceive('exec')->once()->with("SET NAMES 'utf8' COLLATE 'utf8_unicode_ci';")->andReturn(true);
@@ -70,8 +70,8 @@ class DatabaseConnectorTest extends TestCase
         $config = ['host' => 'foo', 'database' => 'bar', 'port' => 111, 'charset' => 'utf8'];
         $connector = $this->getMockBuilder(PostgresConnector::class)->onlyMethods(['createConnection', 'getOptions'])->getMock();
         $connection = m::mock(stdClass::class);
-        $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->willReturn(['options']);
-        $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->willReturn($connection);
+        $connector->expects($this->once())->method('getOptions')->with($config)->willReturn(['options']);
+        $connector->expects($this->once())->method('createConnection')->with($dsn, $config, ['options'])->willReturn($connection);
         $statement = m::mock(PDOStatement::class);
         $connection->shouldReceive('prepare')->zeroOrMoreTimes()->andReturn($statement);
         $statement->shouldReceive('execute')->zeroOrMoreTimes();
@@ -91,8 +91,8 @@ class DatabaseConnectorTest extends TestCase
         $config = ['host' => 'foo', 'database' => 'bar', 'search_path' => $searchPath, 'charset' => 'utf8'];
         $connector = $this->getMockBuilder(PostgresConnector::class)->onlyMethods(['createConnection', 'getOptions'])->getMock();
         $connection = m::mock(stdClass::class);
-        $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->willReturn(['options']);
-        $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->willReturn($connection);
+        $connector->expects($this->once())->method('getOptions')->with($config)->willReturn(['options']);
+        $connector->expects($this->once())->method('createConnection')->with($dsn, $config, ['options'])->willReturn($connection);
         $statement = m::mock(PDOStatement::class);
         $connection->shouldReceive('prepare')->once()->with($expectedSql)->andReturn($statement);
         $statement->shouldReceive('execute')->once();
@@ -177,8 +177,8 @@ class DatabaseConnectorTest extends TestCase
         $config = ['host' => 'foo', 'database' => 'bar', 'schema' => ['public', '"user"'], 'charset' => 'utf8'];
         $connector = $this->getMockBuilder(PostgresConnector::class)->onlyMethods(['createConnection', 'getOptions'])->getMock();
         $connection = m::mock(stdClass::class);
-        $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->willReturn(['options']);
-        $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->willReturn($connection);
+        $connector->expects($this->once())->method('getOptions')->with($config)->willReturn(['options']);
+        $connector->expects($this->once())->method('createConnection')->with($dsn, $config, ['options'])->willReturn($connection);
         $statement = m::mock(PDOStatement::class);
         $connection->shouldReceive('prepare')->once()->with('set search_path to "public", "user"')->andReturn($statement);
         $statement->shouldReceive('execute')->once();
@@ -193,8 +193,8 @@ class DatabaseConnectorTest extends TestCase
         $config = ['host' => 'foo', 'database' => 'bar', 'charset' => 'utf8', 'application_name' => 'Laravel App'];
         $connector = $this->getMockBuilder(PostgresConnector::class)->onlyMethods(['createConnection', 'getOptions'])->getMock();
         $connection = m::mock(stdClass::class);
-        $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->willReturn(['options']);
-        $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->willReturn($connection);
+        $connector->expects($this->once())->method('getOptions')->with($config)->willReturn(['options']);
+        $connector->expects($this->once())->method('createConnection')->with($dsn, $config, ['options'])->willReturn($connection);
         $statement = m::mock(PDOStatement::class);
         $connection->shouldReceive('prepare')->zeroOrMoreTimes()->andReturn($statement);
         $statement->shouldReceive('execute')->zeroOrMoreTimes();
@@ -209,8 +209,8 @@ class DatabaseConnectorTest extends TestCase
         $config = ['database' => 'bar', 'connect_via_database' => 'baz'];
         $connector = $this->getMockBuilder(PostgresConnector::class)->onlyMethods(['createConnection', 'getOptions'])->getMock();
         $connection = m::mock(stdClass::class);
-        $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->willReturn(['options']);
-        $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->willReturn($connection);
+        $connector->expects($this->once())->method('getOptions')->with($config)->willReturn(['options']);
+        $connector->expects($this->once())->method('createConnection')->with($dsn, $config, ['options'])->willReturn($connection);
         $statement = m::mock(PDOStatement::class);
         $connection->shouldReceive('prepare')->zeroOrMoreTimes()->andReturn($statement);
         $statement->shouldReceive('execute')->zeroOrMoreTimes();
@@ -225,8 +225,8 @@ class DatabaseConnectorTest extends TestCase
         $config = ['database' => 'bar', 'connect_via_database' => 'baz', 'port' => 5432, 'connect_via_port' => 2345];
         $connector = $this->getMockBuilder(PostgresConnector::class)->onlyMethods(['createConnection', 'getOptions'])->getMock();
         $connection = m::mock(stdClass::class);
-        $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->willReturn(['options']);
-        $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->willReturn($connection);
+        $connector->expects($this->once())->method('getOptions')->with($config)->willReturn(['options']);
+        $connector->expects($this->once())->method('createConnection')->with($dsn, $config, ['options'])->willReturn($connection);
         $statement = m::mock(PDOStatement::class);
         $connection->shouldReceive('prepare')->zeroOrMoreTimes()->andReturn($statement);
         $statement->shouldReceive('execute')->zeroOrMoreTimes();
@@ -241,8 +241,8 @@ class DatabaseConnectorTest extends TestCase
         $config = ['host' => 'foo', 'database' => 'bar', 'port' => 111, 'isolation_level' => 'SERIALIZABLE'];
         $connector = $this->getMockBuilder(PostgresConnector::class)->onlyMethods(['createConnection', 'getOptions'])->getMock();
         $connection = m::mock(PDO::class);
-        $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->willReturn(['options']);
-        $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->willReturn($connection);
+        $connector->expects($this->once())->method('getOptions')->with($config)->willReturn(['options']);
+        $connector->expects($this->once())->method('createConnection')->with($dsn, $config, ['options'])->willReturn($connection);
         $statement = m::mock(PDOStatement::class);
         $connection->shouldReceive('prepare')->once()->with('set session characteristics as transaction isolation level SERIALIZABLE')->andReturn($statement);
         $statement->shouldReceive('execute')->zeroOrMoreTimes();
@@ -258,8 +258,8 @@ class DatabaseConnectorTest extends TestCase
         $config = ['database' => ':memory:'];
         $connector = $this->getMockBuilder(SQLiteConnector::class)->onlyMethods(['createConnection', 'getOptions'])->getMock();
         $connection = m::mock(stdClass::class);
-        $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->willReturn(['options']);
-        $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->willReturn($connection);
+        $connector->expects($this->once())->method('getOptions')->with($config)->willReturn(['options']);
+        $connector->expects($this->once())->method('createConnection')->with($dsn, $config, ['options'])->willReturn($connection);
         $result = $connector->connect($config);
 
         $this->assertSame($result, $connection);
@@ -271,8 +271,8 @@ class DatabaseConnectorTest extends TestCase
         $config = ['database' => 'file:mydb?mode=memory&cache=shared'];
         $connector = $this->getMockBuilder(SQLiteConnector::class)->onlyMethods(['createConnection', 'getOptions'])->getMock();
         $connection = m::mock(stdClass::class);
-        $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->willReturn(['options']);
-        $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->willReturn($connection);
+        $connector->expects($this->once())->method('getOptions')->with($config)->willReturn(['options']);
+        $connector->expects($this->once())->method('createConnection')->with($dsn, $config, ['options'])->willReturn($connection);
         $result = $connector->connect($config);
 
         $this->assertSame($result, $connection);
@@ -284,8 +284,8 @@ class DatabaseConnectorTest extends TestCase
         $config = ['database' => __DIR__];
         $connector = $this->getMockBuilder(SQLiteConnector::class)->onlyMethods(['createConnection', 'getOptions'])->getMock();
         $connection = m::mock(stdClass::class);
-        $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->willReturn(['options']);
-        $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->willReturn($connection);
+        $connector->expects($this->once())->method('getOptions')->with($config)->willReturn(['options']);
+        $connector->expects($this->once())->method('createConnection')->with($dsn, $config, ['options'])->willReturn($connection);
         $result = $connector->connect($config);
 
         $this->assertSame($result, $connection);
@@ -297,8 +297,8 @@ class DatabaseConnectorTest extends TestCase
         $dsn = $this->getDsn($config);
         $connector = $this->getMockBuilder(SqlServerConnector::class)->onlyMethods(['createConnection', 'getOptions'])->getMock();
         $connection = m::mock(stdClass::class);
-        $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->willReturn(['options']);
-        $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->willReturn($connection);
+        $connector->expects($this->once())->method('getOptions')->with($config)->willReturn(['options']);
+        $connector->expects($this->once())->method('createConnection')->with($dsn, $config, ['options'])->willReturn($connection);
         $result = $connector->connect($config);
 
         $this->assertSame($result, $connection);
@@ -310,8 +310,8 @@ class DatabaseConnectorTest extends TestCase
         $dsn = $this->getDsn($config);
         $connector = $this->getMockBuilder(SqlServerConnector::class)->onlyMethods(['createConnection', 'getOptions'])->getMock();
         $connection = m::mock(stdClass::class);
-        $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->willReturn(['options']);
-        $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->willReturn($connection);
+        $connector->expects($this->once())->method('getOptions')->with($config)->willReturn(['options']);
+        $connector->expects($this->once())->method('createConnection')->with($dsn, $config, ['options'])->willReturn($connection);
         $result = $connector->connect($config);
 
         $this->assertSame($result, $connection);
@@ -324,8 +324,8 @@ class DatabaseConnectorTest extends TestCase
         $dsn = $this->getDsn($config);
         $connector = $this->getMockBuilder(SqlServerConnector::class)->onlyMethods(['createConnection', 'getOptions'])->getMock();
         $connection = m::mock(stdClass::class);
-        $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->willReturn(['options']);
-        $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->willReturn($connection);
+        $connector->expects($this->once())->method('getOptions')->with($config)->willReturn(['options']);
+        $connector->expects($this->once())->method('createConnection')->with($dsn, $config, ['options'])->willReturn($connection);
         $result = $connector->connect($config);
 
         $this->assertSame($result, $connection);

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -902,7 +902,7 @@ class DatabaseEloquentModelTest extends TestCase
         $query->shouldReceive('update')->once()->with(['name' => 'taylor'])->andReturn(1);
         $model->expects($this->once())->method('newModelQuery')->willReturn($query);
         $model->expects($this->never())->method('updateTimestamps');
-        $model->expects($this->any())->method('fireModelEvent')->willReturn(true);
+        $model->method('fireModelEvent')->willReturn(true);
 
         $model->id = 1;
         $model->syncOriginal();
@@ -937,7 +937,7 @@ class DatabaseEloquentModelTest extends TestCase
     public function testTimestampsAreReturnedAsObjects()
     {
         $model = $this->getMockBuilder(EloquentDateModelStub::class)->onlyMethods(['getDateFormat'])->getMock();
-        $model->expects($this->any())->method('getDateFormat')->willReturn('Y-m-d');
+        $model->method('getDateFormat')->willReturn('Y-m-d');
         $model->setRawAttributes([
             'created_at' => '2012-12-04',
             'updated_at' => '2012-12-05',
@@ -950,7 +950,7 @@ class DatabaseEloquentModelTest extends TestCase
     public function testTimestampsAreReturnedAsObjectsFromPlainDatesAndTimestamps()
     {
         $model = $this->getMockBuilder(EloquentDateModelStub::class)->onlyMethods(['getDateFormat'])->getMock();
-        $model->expects($this->any())->method('getDateFormat')->willReturn('Y-m-d H:i:s');
+        $model->method('getDateFormat')->willReturn('Y-m-d H:i:s');
         $model->setRawAttributes([
             'created_at' => '2012-12-04',
             'updated_at' => $this->currentTime(),
@@ -1047,7 +1047,7 @@ class DatabaseEloquentModelTest extends TestCase
     public function testFromDateTimeMilliseconds()
     {
         $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentDateModelStub')->onlyMethods(['getDateFormat'])->getMock();
-        $model->expects($this->any())->method('getDateFormat')->willReturn('Y-m-d H:s.vi');
+        $model->method('getDateFormat')->willReturn('Y-m-d H:s.vi');
         $model->setRawAttributes([
             'created_at' => '2012-12-04 22:59.32130',
         ]);
@@ -1861,7 +1861,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model->fillable(['name']);
         $model->fill(['name' => 'Leto Atreides', 'age' => 51]);
 
-        self::assertSame(
+        $this->assertSame(
             ['name' => 'Leto Atreides', 'age' => 51],
             $model->getAttributes(),
         );

--- a/tests/Database/DatabaseMariaDbSchemaStateTest.php
+++ b/tests/Database/DatabaseMariaDbSchemaStateTest.php
@@ -25,13 +25,13 @@ class DatabaseMariaDbSchemaStateTest extends TestCase
         $method = new ReflectionMethod(get_class($schemaState), 'connectionString');
         $connString = $method->invoke($schemaState, $versionInfo);
 
-        self::assertEquals($expectedConnectionString, $connString);
+        $this->assertEquals($expectedConnectionString, $connString);
 
         // test baseVariables
         $method = new ReflectionMethod(get_class($schemaState), 'baseVariables');
         $variables = $method->invoke($schemaState, $dbConfig);
 
-        self::assertEquals($expectedVariables, $variables);
+        $this->assertEquals($expectedVariables, $variables);
     }
 
     public static function provider(): Generator

--- a/tests/Database/DatabaseMigrationCreatorTest.php
+++ b/tests/Database/DatabaseMigrationCreatorTest.php
@@ -14,7 +14,7 @@ class DatabaseMigrationCreatorTest extends TestCase
     {
         $creator = $this->getCreator();
 
-        $creator->expects($this->any())->method('getDatePrefix')->willReturn('foo');
+        $creator->method('getDatePrefix')->willReturn('foo');
         $creator->getFilesystem()->shouldReceive('exists')->once()->with('stubs/migration.stub')->andReturn(false);
         $creator->getFilesystem()->shouldReceive('get')->once()->with($creator->stubPath().'/migration.stub')->andReturn('return new class');
         $creator->getFilesystem()->shouldReceive('ensureDirectoryExists')->once()->with('foo');
@@ -36,7 +36,7 @@ class DatabaseMigrationCreatorTest extends TestCase
             $_SERVER['__migration.creator.path'] = $path;
         });
 
-        $creator->expects($this->any())->method('getDatePrefix')->willReturn('foo');
+        $creator->method('getDatePrefix')->willReturn('foo');
         $creator->getFilesystem()->shouldReceive('exists')->once()->with('stubs/migration.update.stub')->andReturn(false);
         $creator->getFilesystem()->shouldReceive('get')->once()->with($creator->stubPath().'/migration.update.stub')->andReturn('return new class DummyTable');
         $creator->getFilesystem()->shouldReceive('ensureDirectoryExists')->once()->with('foo');
@@ -55,7 +55,7 @@ class DatabaseMigrationCreatorTest extends TestCase
     public function testTableUpdateMigrationStoresMigrationFile()
     {
         $creator = $this->getCreator();
-        $creator->expects($this->any())->method('getDatePrefix')->willReturn('foo');
+        $creator->method('getDatePrefix')->willReturn('foo');
         $creator->getFilesystem()->shouldReceive('exists')->once()->with('stubs/migration.update.stub')->andReturn(false);
         $creator->getFilesystem()->shouldReceive('get')->once()->with($creator->stubPath().'/migration.update.stub')->andReturn('return new class DummyTable');
         $creator->getFilesystem()->shouldReceive('ensureDirectoryExists')->once()->with('foo');
@@ -69,7 +69,7 @@ class DatabaseMigrationCreatorTest extends TestCase
     public function testTableCreationMigrationStoresMigrationFile()
     {
         $creator = $this->getCreator();
-        $creator->expects($this->any())->method('getDatePrefix')->willReturn('foo');
+        $creator->method('getDatePrefix')->willReturn('foo');
         $creator->getFilesystem()->shouldReceive('exists')->once()->with('stubs/migration.create.stub')->andReturn(false);
         $creator->getFilesystem()->shouldReceive('get')->once()->with($creator->stubPath().'/migration.create.stub')->andReturn('return new class DummyTable');
         $creator->getFilesystem()->shouldReceive('ensureDirectoryExists')->once()->with('foo');

--- a/tests/Database/DatabaseMigrationMigrateCommandTest.php
+++ b/tests/Database/DatabaseMigrationMigrateCommandTest.php
@@ -76,7 +76,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
         $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
         $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => false]);
         $migrator->shouldReceive('repositoryExists')->once()->andReturn(false);
-        $command->expects($this->once())->method('callSilent')->with($this->equalTo('migrate:install'), $this->equalTo([]));
+        $command->expects($this->once())->method('callSilent')->with('migrate:install', []);
 
         $this->runCommand($command);
     }

--- a/tests/Database/DatabaseMySqlSchemaStateTest.php
+++ b/tests/Database/DatabaseMySqlSchemaStateTest.php
@@ -27,13 +27,13 @@ class DatabaseMySqlSchemaStateTest extends TestCase
         $method = new ReflectionMethod(get_class($schemaState), 'connectionString');
         $connString = $method->invoke($schemaState, $versionInfo);
 
-        self::assertEquals($expectedConnectionString, $connString);
+        $this->assertEquals($expectedConnectionString, $connString);
 
         // test baseVariables
         $method = new ReflectionMethod(get_class($schemaState), 'baseVariables');
         $variables = $method->invoke($schemaState, $dbConfig);
 
-        self::assertEquals($expectedVariables, $variables);
+        $this->assertEquals($expectedVariables, $variables);
     }
 
     public static function provider(): Generator
@@ -141,8 +141,8 @@ class DatabaseMySqlSchemaStateTest extends TestCase
     {
         $mockProcess = $this->createMock(Process::class);
         $mockProcess->method('setTimeout')->willReturnSelf();
-        $mockProcess->method('mustRun')->will(
-            $this->throwException(new Exception('column-statistics'))
+        $mockProcess->method('mustRun')->willThrowException(
+            new Exception('column-statistics')
         );
 
         $mockOutput = $this->createMock(\stdClass::class);

--- a/tests/Database/DatabaseProcessorTest.php
+++ b/tests/Database/DatabaseProcessorTest.php
@@ -14,7 +14,7 @@ class DatabaseProcessorTest extends TestCase
     public function testInsertGetIdProcessing()
     {
         $pdo = $this->createMock(ProcessorTestPDOStub::class);
-        $pdo->expects($this->once())->method('lastInsertId')->with($this->equalTo('id'))->willReturn('1');
+        $pdo->expects($this->once())->method('lastInsertId')->with('id')->willReturn('1');
         $connection = m::mock(Connection::class);
         $connection->shouldReceive('insert')->once()->with('sql', ['foo']);
         $connection->shouldReceive('getPdo')->once()->andReturn($pdo);

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -557,7 +557,7 @@ class FilesystemAdapterTest extends TestCase
         $exceptionHandler->shouldReceive('report')
             ->once()
             ->andReturnUsing(function (UnableToReadFile $e) {
-                self::assertStringContainsString(
+                $this->assertStringContainsString(
                     'Unable to read file from location: foo.txt.',
                     $e->getMessage(),
                 );
@@ -585,7 +585,7 @@ class FilesystemAdapterTest extends TestCase
         $exceptionHandler->shouldReceive('report')
             ->once()
             ->andReturnUsing(function (UnableToReadFile $e) {
-                self::assertStringContainsString(
+                $this->assertStringContainsString(
                     'Unable to read file from location: foo.txt.',
                     $e->getMessage(),
                 );
@@ -613,7 +613,7 @@ class FilesystemAdapterTest extends TestCase
         $exceptionHandler->shouldReceive('report')
             ->once()
             ->andReturnUsing(function (UnableToWriteFile $e) {
-                self::assertStringContainsString(
+                $this->assertStringContainsString(
                     'Unable to write file at location: foo.txt.',
                     $e->getMessage(),
                 );
@@ -647,7 +647,7 @@ class FilesystemAdapterTest extends TestCase
         $exceptionHandler->shouldReceive('report')
             ->once()
             ->andReturnUsing(function (UnableToRetrieveMetadata $e) {
-                self::assertStringContainsString(
+                $this->assertStringContainsString(
                     'Unable to retrieve the mime_type for file at location: unknown.mime-type.',
                     $e->getMessage(),
                 );

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -480,8 +480,8 @@ class HttpClientTest extends TestCase
         $body = '{"test":"phpunit"}';
 
         $fakeRequest = function (Request $request) use ($body) {
-            self::assertSame($body, $request->body());
-            self::assertContains('application/json', $request->header('Content-Type'));
+            $this->assertSame($body, $request->body());
+            $this->assertContains('application/json', $request->header('Content-Type'));
 
             return ['my' => 'response'];
         };
@@ -496,8 +496,8 @@ class HttpClientTest extends TestCase
         $body = str_repeat('A thousand &. ', 1000);
 
         $fakeRequest = function (Request $request) use ($body) {
-            self::assertSame($body, $request->body());
-            self::assertContains('text/plain', $request->header('Content-Type'));
+            $this->assertSame($body, $request->body());
+            $this->assertContains('text/plain', $request->header('Content-Type'));
 
             return ['my' => 'response'];
         };
@@ -516,8 +516,8 @@ class HttpClientTest extends TestCase
         $body = Utils::streamFor($resource);
 
         $fakeRequest = function (Request $request) use ($string) {
-            self::assertSame($string, $request->body());
-            self::assertContains('text/plain', $request->header('Content-Type'));
+            $this->assertSame($string, $request->body());
+            $this->assertContains('text/plain', $request->header('Content-Type'));
 
             return ['my' => 'response'];
         };
@@ -2582,8 +2582,8 @@ class HttpClientTest extends TestCase
             ];
         });
 
-        self::assertInstanceOf(ConnectionException::class, $responses[0]);
-        self::assertSame($requestException, $responses[0]->getPrevious());
+        $this->assertInstanceOf(ConnectionException::class, $responses[0]);
+        $this->assertSame($requestException, $responses[0]->getPrevious());
     }
 
     public function testExceptionThrownInRetryCallbackIsReturnedWithoutRetryingInPool()

--- a/tests/Integration/Database/AfterQueryTest.php
+++ b/tests/Integration/Database/AfterQueryTest.php
@@ -44,9 +44,7 @@ class AfterQueryTest extends DatabaseTestCase
             ->afterQuery(function (Collection $users) use ($afterQueryIds) {
                 $afterQueryIds->push(...$users->pluck('id')->all());
 
-                foreach ($users as $user) {
-                    $this->assertInstanceOf(AfterQueryUser::class, $user);
-                }
+                $this->assertContainsOnlyInstancesOf(AfterQueryUser::class, $users);
             })
             ->get();
 
@@ -87,9 +85,7 @@ class AfterQueryTest extends DatabaseTestCase
             ->afterQuery(function (Collection $users) use ($afterQueryIds) {
                 $afterQueryIds->push(...$users->pluck('id')->all());
 
-                foreach ($users as $user) {
-                    $this->assertInstanceOf(AfterQueryUser::class, $user);
-                }
+                $this->assertContainsOnlyInstancesOf(AfterQueryUser::class, $users);
             })
             ->cursor();
 
@@ -177,9 +173,7 @@ class AfterQueryTest extends DatabaseTestCase
             ->afterQuery(function (Collection $posts) use ($afterQueryIds) {
                 $afterQueryIds->push(...$posts->pluck('id')->all());
 
-                foreach ($posts as $post) {
-                    $this->assertInstanceOf(AfterQueryPost::class, $post);
-                }
+                $this->assertContainsOnlyInstancesOf(AfterQueryPost::class, $posts);
             })
             ->get();
 
@@ -215,9 +209,7 @@ class AfterQueryTest extends DatabaseTestCase
             ->afterQuery(function (Collection $teamMates) use ($afterQueryIds) {
                 $afterQueryIds->push(...$teamMates->pluck('id')->all());
 
-                foreach ($teamMates as $teamMate) {
-                    $this->assertInstanceOf(AfterQueryUser::class, $teamMate);
-                }
+                $this->assertContainsOnlyInstancesOf(AfterQueryUser::class, $teamMates);
             })
             ->get();
 

--- a/tests/Integration/Database/DatabaseConnectionsTest.php
+++ b/tests/Integration/Database/DatabaseConnectionsTest.php
@@ -47,7 +47,7 @@ class DatabaseConnectionsTest extends DatabaseTestCase
 
         $result = $connection->selectOne('SELECT COUNT(*) as total FROM test_1');
 
-        self::assertSame(1, $result->total);
+        $this->assertSame(1, $result->total);
     }
 
     public function testThrowExceptionIfConnectionAlreadyExists()
@@ -92,9 +92,9 @@ class DatabaseConnectionsTest extends DatabaseTestCase
         // longer be available. It's a new and fresh database
         $resultAfterOverride = $connection->select("SELECT name FROM sqlite_master WHERE type='table';");
 
-        self::assertSame('test_1', $resultBeforeOverride[0]->name);
+        $this->assertSame('test_1', $resultBeforeOverride[0]->name);
 
-        self::assertEmpty($resultAfterOverride);
+        $this->assertEmpty($resultAfterOverride);
     }
 
     public function testEstablishingAConnectionWillDispatchAnEvent()
@@ -116,13 +116,13 @@ class DatabaseConnectionsTest extends DatabaseTestCase
             'database' => ':memory:',
         ]);
 
-        self::assertInstanceOf(
+        $this->assertInstanceOf(
             ConnectionEstablished::class,
             $event,
             'Expected the ConnectionEstablished event to be dispatched when establishing a connection.'
         );
 
-        self::assertSame('my-phpunit-connection', $event->connectionName);
+        $this->assertSame('my-phpunit-connection', $event->connectionName);
     }
 
     public function testTablePrefix()

--- a/tests/Mail/MailableQueuedTest.php
+++ b/tests/Mail/MailableQueuedTest.php
@@ -6,7 +6,6 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Contracts\View\Factory;
-use Illuminate\Filesystem\Filesystem;
 use Illuminate\Filesystem\FilesystemManager;
 use Illuminate\Foundation\Application;
 use Illuminate\Mail\Mailable;
@@ -58,8 +57,6 @@ class MailableQueuedTest extends TestCase
     {
         $app = new Application;
         $container = Container::getInstance();
-        $this->getMockBuilder(Filesystem::class)
-            ->getMock();
         $filesystemFactory = $this->getMockBuilder(FilesystemManager::class)
             ->setConstructorArgs([$app])
             ->getMock();

--- a/tests/Queue/QueueDatabaseQueueUnitTest.php
+++ b/tests/Queue/QueueDatabaseQueueUnitTest.php
@@ -26,7 +26,7 @@ class QueueDatabaseQueueUnitTest extends TestCase
         });
 
         $queue = $this->getMockBuilder(DatabaseQueue::class)->onlyMethods(['currentTime'])->setConstructorArgs([$database = m::mock(Connection::class), 'table', 'default'])->getMock();
-        $queue->expects($this->any())->method('currentTime')->willReturn('time');
+        $queue->method('currentTime')->willReturn('time');
         $queue->setContainer($container = m::spy(Container::class));
         $database->shouldReceive('table')->with('table')->andReturn($query = m::mock(stdClass::class));
         $query->shouldReceive('insertGetId')->once()->andReturnUsing(function ($array) use ($uuid, $displayNameStartsWith, $jobStartsWith) {
@@ -74,7 +74,7 @@ class QueueDatabaseQueueUnitTest extends TestCase
             ->onlyMethods(['currentTime'])
             ->setConstructorArgs([$database = m::mock(Connection::class), 'table', 'default'])
             ->getMock();
-        $queue->expects($this->any())->method('currentTime')->willReturn('time');
+        $queue->method('currentTime')->willReturn('time');
         $queue->setContainer($container = m::spy(Container::class));
         $database->shouldReceive('table')->with('table')->andReturn($query = m::mock(stdClass::class));
         $query->shouldReceive('insertGetId')->once()->andReturnUsing(function ($array) use ($uuid, $time) {
@@ -104,7 +104,7 @@ class QueueDatabaseQueueUnitTest extends TestCase
         $job = (new MyBatchableJob)->withBatchId('test-batch-id');
 
         $queue = $this->getMockBuilder(DatabaseQueue::class)->onlyMethods(['currentTime'])->setConstructorArgs([$database = m::mock(Connection::class), 'table', 'default'])->getMock();
-        $queue->expects($this->any())->method('currentTime')->willReturn('time');
+        $queue->method('currentTime')->willReturn('time');
         $queue->setContainer($container = m::spy(Container::class));
         $database->shouldReceive('table')->with('table')->andReturn($query = m::mock(stdClass::class));
         $query->shouldReceive('insertGetId')->once()->andReturnUsing(function ($array) {
@@ -163,8 +163,8 @@ class QueueDatabaseQueueUnitTest extends TestCase
 
         $database = m::mock(Connection::class);
         $queue = $this->getMockBuilder(DatabaseQueue::class)->onlyMethods(['currentTime', 'availableAt'])->setConstructorArgs([$database, 'table', 'default'])->getMock();
-        $queue->expects($this->any())->method('currentTime')->willReturn('created');
-        $queue->expects($this->any())->method('availableAt')->willReturn('available');
+        $queue->method('currentTime')->willReturn('created');
+        $queue->method('availableAt')->willReturn('available');
         $database->shouldReceive('table')->with('table')->andReturn($query = m::mock(stdClass::class));
         $query->shouldReceive('insert')->once()->andReturnUsing(function ($records) use ($uuid, $time) {
             $this->assertEquals([[

--- a/tests/Support/DateFacadeTest.php
+++ b/tests/Support/DateFacadeTest.php
@@ -23,7 +23,7 @@ class DateFacadeTest extends TestCase
 
     protected static function assertBetweenStartAndNow($start, $actual)
     {
-        static::assertThat(
+        self::assertThat(
             $actual,
             static::logicalAnd(
                 static::greaterThanOrEqual($start),
@@ -36,24 +36,24 @@ class DateFacadeTest extends TestCase
     {
         $start = Carbon::now()->getTimestamp();
         $this->assertSame(Carbon::class, get_class(Date::now()));
-        $this->assertBetweenStartAndNow($start, Date::now()->getTimestamp());
+        self::assertBetweenStartAndNow($start, Date::now()->getTimestamp());
         DateFactory::use(function (Carbon $date) {
             return new DateTime($date->format('Y-m-d H:i:s.u'), $date->getTimezone());
         });
         $start = Carbon::now()->getTimestamp();
         $this->assertSame(DateTime::class, get_class(Date::now()));
-        $this->assertBetweenStartAndNow($start, Date::now()->getTimestamp());
+        self::assertBetweenStartAndNow($start, Date::now()->getTimestamp());
     }
 
     public function testUseClassName()
     {
         $start = Carbon::now()->getTimestamp();
         $this->assertSame(Carbon::class, get_class(Date::now()));
-        $this->assertBetweenStartAndNow($start, Date::now()->getTimestamp());
+        self::assertBetweenStartAndNow($start, Date::now()->getTimestamp());
         DateFactory::use(DateTime::class);
         $start = Carbon::now()->getTimestamp();
         $this->assertSame(DateTime::class, get_class(Date::now()));
-        $this->assertBetweenStartAndNow($start, Date::now()->getTimestamp());
+        self::assertBetweenStartAndNow($start, Date::now()->getTimestamp());
     }
 
     public function testCarbonImmutable()

--- a/tests/Testing/AssertRedirectToActionTest.php
+++ b/tests/Testing/AssertRedirectToActionTest.php
@@ -12,11 +12,6 @@ use Orchestra\Testbench\TestCase;
 class AssertRedirectToActionTest extends TestCase
 {
     /**
-     * @var \Illuminate\Contracts\Routing\Registrar
-     */
-    private $router;
-
-    /**
      * @var \Illuminate\Routing\UrlGenerator
      */
     public $urlGenerator;
@@ -25,16 +20,16 @@ class AssertRedirectToActionTest extends TestCase
     {
         parent::setUp();
 
-        $this->router = $this->app->make(Registrar::class);
+        $router = $this->app->make(Registrar::class);
 
-        $this->router->get('controller/index', [TestActionController::class, 'index']);
-        $this->router->get('controller/show/{id}', [TestActionController::class, 'show']);
+        $router->get('controller/index', [TestActionController::class, 'index']);
+        $router->get('controller/show/{id}', [TestActionController::class, 'show']);
 
-        $this->router->get('redirect-to-index', function () {
+        $router->get('redirect-to-index', function () {
             return new RedirectResponse($this->urlGenerator->action([TestActionController::class, 'index']));
         });
 
-        $this->router->get('redirect-to-show', function () {
+        $router->get('redirect-to-show', function () {
             return new RedirectResponse($this->urlGenerator->action([TestActionController::class, 'show'], ['id' => 123]));
         });
 

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -1688,7 +1688,7 @@ EOT
         try {
             $response->assertExactJsonStructure(['foo']);
             $failed = false;
-        } catch (AssertionFailedError $e) {
+        } catch (AssertionFailedError) {
             $failed = true;
         }
 
@@ -1700,7 +1700,7 @@ EOT
         try {
             $response->assertExactJsonStructure(['foobar' => ['foobar_foo'], 'foo', 0, 'bars', 'baz', 'barfoo', 'numeric_keys']);
             $failed = false;
-        } catch (AssertionFailedError $e) {
+        } catch (AssertionFailedError) {
             $failed = true;
         }
 
@@ -1712,7 +1712,7 @@ EOT
         try {
             $response->assertExactJsonStructure(['bars' => ['*' => ['bar']], 'foo', 'foobar', 0, 'baz', 'barfoo', 'numeric_keys']);
             $failed = false;
-        } catch (AssertionFailedError $e) {
+        } catch (AssertionFailedError) {
             $failed = true;
         }
 
@@ -1724,7 +1724,7 @@ EOT
         try {
             $response->assertExactJsonStructure(['numeric_keys' => ['*' => ['bar']], 'foo', 'foobar', 0, 'bars', 'baz', 'barfoo']);
             $failed = false;
-        } catch (AssertionFailedError $e) {
+        } catch (AssertionFailedError) {
             $failed = true;
         }
 
@@ -1736,7 +1736,7 @@ EOT
         try {
             $response->assertExactJsonStructure(['baz' => ['*' => ['foo', 'bar' => ['foo']]], 'foo', 'foobar', 0, 'bars', 'barfoo', 'numeric_keys']);
             $failed = false;
-        } catch (AssertionFailedError $e) {
+        } catch (AssertionFailedError) {
             $failed = true;
         }
 

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -18,19 +18,19 @@ class TranslationTranslatorTest extends TestCase
     public function testHasMethodReturnsFalseWhenReturnedTranslationIsNull()
     {
         $t = $this->getMockBuilder(Translator::class)->onlyMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
-        $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('bar'))->willReturn('foo');
+        $t->expects($this->once())->method('get')->with('foo', [], 'bar')->willReturn('foo');
         $this->assertFalse($t->has('foo', 'bar'));
 
         $t = $this->getMockBuilder(Translator::class)->onlyMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en', 'sp'])->getMock();
-        $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('bar'))->willReturn('bar');
+        $t->expects($this->once())->method('get')->with('foo', [], 'bar')->willReturn('bar');
         $this->assertTrue($t->has('foo', 'bar'));
 
         $t = $this->getMockBuilder(Translator::class)->onlyMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
-        $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('bar'), false)->willReturn('bar');
+        $t->expects($this->once())->method('get')->with('foo', [], 'bar', false)->willReturn('bar');
         $this->assertTrue($t->hasForLocale('foo', 'bar'));
 
         $t = $this->getMockBuilder(Translator::class)->onlyMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
-        $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('bar'), false)->willReturn('foo');
+        $t->expects($this->once())->method('get')->with('foo', [], 'bar', false)->willReturn('foo');
         $this->assertFalse($t->hasForLocale('foo', 'bar'));
 
         $t = new Translator($this->getLoader(), 'en');
@@ -135,8 +135,8 @@ class TranslationTranslatorTest extends TestCase
     public function testChoiceMethodProperlyLoadsAndRetrievesItemForAnInt()
     {
         $t = $this->getMockBuilder(Translator::class)->onlyMethods(['get', 'localeForChoice'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
-        $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('en'))->willReturn('line');
-        $t->expects($this->once())->method('localeForChoice')->with($this->equalTo('foo'), $this->equalTo(null))->willReturn('en');
+        $t->expects($this->once())->method('get')->with('foo', [], 'en')->willReturn('line');
+        $t->expects($this->once())->method('localeForChoice')->with('foo', null)->willReturn('en');
         $t->setSelector($selector = m::mock(MessageSelector::class));
         $selector->shouldReceive('choose')->once()->with('line', 10, 'en')->andReturn('choiced');
 
@@ -146,8 +146,8 @@ class TranslationTranslatorTest extends TestCase
     public function testChoiceMethodProperlyLoadsAndRetrievesItemForAFloat()
     {
         $t = $this->getMockBuilder(Translator::class)->onlyMethods(['get', 'localeForChoice'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
-        $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('en'))->willReturn('line');
-        $t->expects($this->once())->method('localeForChoice')->with($this->equalTo('foo'), $this->equalTo(null))->willReturn('en');
+        $t->expects($this->once())->method('get')->with('foo', [], 'en')->willReturn('line');
+        $t->expects($this->once())->method('localeForChoice')->with('foo', null)->willReturn('en');
         $t->setSelector($selector = m::mock(MessageSelector::class));
         $selector->shouldReceive('choose')->once()->with('line', 1.2, 'en')->andReturn('choiced');
 
@@ -157,8 +157,8 @@ class TranslationTranslatorTest extends TestCase
     public function testChoiceMethodProperlyCountsCollectionsAndLoadsAndRetrievesItem()
     {
         $t = $this->getMockBuilder(Translator::class)->onlyMethods(['get', 'localeForChoice'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
-        $t->expects($this->exactly(2))->method('get')->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('en'))->willReturn('line');
-        $t->expects($this->exactly(2))->method('localeForChoice')->with($this->equalTo('foo'), $this->equalTo(null))->willReturn('en');
+        $t->expects($this->exactly(2))->method('get')->with('foo', [], 'en')->willReturn('line');
+        $t->expects($this->exactly(2))->method('localeForChoice')->with('foo', null)->willReturn('en');
         $t->setSelector($selector = m::mock(MessageSelector::class));
         $selector->shouldReceive('choose')->twice()->with('line', 3, 'en')->andReturn('choiced');
 
@@ -173,8 +173,8 @@ class TranslationTranslatorTest extends TestCase
     {
         $t = $this->getMockBuilder(Translator::class)->onlyMethods(['get', 'hasForLocale'])->setConstructorArgs([$this->getLoader(), 'cs'])->getMock();
         $t->setFallback('en');
-        $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('en'))->willReturn('line');
-        $t->expects($this->once())->method('hasForLocale')->with($this->equalTo('foo'), $this->equalTo('cs'))->willReturn(false);
+        $t->expects($this->once())->method('get')->with('foo', [], 'en')->willReturn('line');
+        $t->expects($this->once())->method('hasForLocale')->with('foo', 'cs')->willReturn(false);
         $t->setSelector($selector = m::mock(MessageSelector::class));
         $selector->shouldReceive('choose')->once()->with('line', 10, 'en')->andReturn('choiced');
 
@@ -184,8 +184,8 @@ class TranslationTranslatorTest extends TestCase
     public function testChoiceMethodProperlyUsesCustomCountReplacement()
     {
         $t = $this->getMockBuilder(Translator::class)->onlyMethods(['get', 'localeForChoice'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
-        $t->expects($this->once())->method('get')->with($this->equalTo(':count foos'), $this->equalTo([]), $this->equalTo('en'))->willReturn('{1} :count foos|[2,*] :count foos');
-        $t->expects($this->once())->method('localeForChoice')->with($this->equalTo(':count foos'), $this->equalTo(null))->willReturn('en');
+        $t->expects($this->once())->method('get')->with(':count foos', [], 'en')->willReturn('{1} :count foos|[2,*] :count foos');
+        $t->expects($this->once())->method('localeForChoice')->with(':count foos', null)->willReturn('en');
         $t->setSelector($selector = m::mock(MessageSelector::class));
         $selector->shouldReceive('choose')->once()->with('{1} :count foos|[2,*] :count foos', 1234, 'en')->andReturn(':count foos');
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2468,9 +2468,9 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->fails());
 
         $fileOne = $this->getMockBuilder(File::class)->onlyMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
-        $fileOne->expects($this->any())->method('getSize')->willReturn(5472);
+        $fileOne->method('getSize')->willReturn(5472);
         $fileTwo = $this->getMockBuilder(File::class)->onlyMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
-        $fileTwo->expects($this->any())->method('getSize')->willReturn(3151);
+        $fileTwo->method('getSize')->willReturn(3151);
         $v = new Validator($trans, ['lhs' => $fileOne, 'rhs' => $fileTwo], ['lhs' => 'gt:rhs']);
         $this->assertTrue($v->passes());
 
@@ -2563,9 +2563,9 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
 
         $fileOne = $this->getMockBuilder(File::class)->onlyMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
-        $fileOne->expects($this->any())->method('getSize')->willReturn(5472);
+        $fileOne->method('getSize')->willReturn(5472);
         $fileTwo = $this->getMockBuilder(File::class)->onlyMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
-        $fileTwo->expects($this->any())->method('getSize')->willReturn(3151);
+        $fileTwo->method('getSize')->willReturn(3151);
         $v = new Validator($trans, ['lhs' => $fileOne, 'rhs' => $fileTwo], ['lhs' => 'lt:rhs']);
         $this->assertTrue($v->fails());
 
@@ -2604,9 +2604,9 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->fails());
 
         $fileOne = $this->getMockBuilder(File::class)->onlyMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
-        $fileOne->expects($this->any())->method('getSize')->willReturn(5472);
+        $fileOne->method('getSize')->willReturn(5472);
         $fileTwo = $this->getMockBuilder(File::class)->onlyMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
-        $fileTwo->expects($this->any())->method('getSize')->willReturn(5472);
+        $fileTwo->method('getSize')->willReturn(5472);
         $v = new Validator($trans, ['lhs' => $fileOne, 'rhs' => $fileTwo], ['lhs' => 'gte:rhs']);
         $this->assertTrue($v->passes());
 
@@ -2645,9 +2645,9 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
 
         $fileOne = $this->getMockBuilder(File::class)->onlyMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
-        $fileOne->expects($this->any())->method('getSize')->willReturn(5472);
+        $fileOne->method('getSize')->willReturn(5472);
         $fileTwo = $this->getMockBuilder(File::class)->onlyMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
-        $fileTwo->expects($this->any())->method('getSize')->willReturn(5472);
+        $fileTwo->method('getSize')->willReturn(5472);
         $v = new Validator($trans, ['lhs' => $fileOne, 'rhs' => $fileTwo], ['lhs' => 'lte:rhs']);
         $this->assertTrue($v->passes());
 
@@ -3825,12 +3825,12 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
 
         $file = $this->getMockBuilder(File::class)->onlyMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
-        $file->expects($this->any())->method('getSize')->willReturn(3072);
+        $file->method('getSize')->willReturn(3072);
         $v = new Validator($trans, ['photo' => $file], ['photo' => 'Size:3']);
         $this->assertTrue($v->passes());
 
         $file = $this->getMockBuilder(File::class)->onlyMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
-        $file->expects($this->any())->method('getSize')->willReturn(4072);
+        $file->method('getSize')->willReturn(4072);
         $v = new Validator($trans, ['photo' => $file], ['photo' => 'Size:3']);
         $this->assertFalse($v->passes());
     }
@@ -3881,12 +3881,12 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
 
         $file = $this->getMockBuilder(File::class)->onlyMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
-        $file->expects($this->any())->method('getSize')->willReturn(3072);
+        $file->method('getSize')->willReturn(3072);
         $v = new Validator($trans, ['photo' => $file], ['photo' => 'Between:1,5']);
         $this->assertTrue($v->passes());
 
         $file = $this->getMockBuilder(File::class)->onlyMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
-        $file->expects($this->any())->method('getSize')->willReturn(4072);
+        $file->method('getSize')->willReturn(4072);
         $v = new Validator($trans, ['photo' => $file], ['photo' => 'Between:1,2']);
         $this->assertFalse($v->passes());
     }
@@ -3940,12 +3940,12 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
 
         $file = $this->getMockBuilder(File::class)->onlyMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
-        $file->expects($this->any())->method('getSize')->willReturn(3072);
+        $file->method('getSize')->willReturn(3072);
         $v = new Validator($trans, ['photo' => $file], ['photo' => 'Min:2']);
         $this->assertTrue($v->passes());
 
         $file = $this->getMockBuilder(File::class)->onlyMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
-        $file->expects($this->any())->method('getSize')->willReturn(4072);
+        $file->method('getSize')->willReturn(4072);
         $v = new Validator($trans, ['photo' => $file], ['photo' => 'Min:10']);
         $this->assertFalse($v->passes());
     }
@@ -4007,7 +4007,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
 
         $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['isValid'])->setConstructorArgs([__FILE__, basename(__FILE__)])->getMock();
-        $file->expects($this->any())->method('isValid')->willReturn(false);
+        $file->method('isValid')->willReturn(false);
         $v = new Validator($trans, ['photo' => $file], ['photo' => 'Max:10']);
         $this->assertFalse($v->passes());
     }
@@ -4114,8 +4114,8 @@ class ValidationValidatorTest extends TestCase
         $this->assertSame('string', $v->messages()->first('name'));
 
         $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
-        $file->expects($this->any())->method('getSize')->willReturn(4072);
-        $file->expects($this->any())->method('isValid')->willReturn(true);
+        $file->method('getSize')->willReturn(4072);
+        $file->method('isValid')->willReturn(true);
         $v = new Validator($trans, ['photo' => $file], ['photo' => 'Max:3']);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
@@ -4150,11 +4150,11 @@ class ValidationValidatorTest extends TestCase
         $this->assertSame('minimum value', $v->messages()->first('max'));
 
         $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
-        $file->expects($this->any())->method('getSize')->willReturn(4072);
-        $file->expects($this->any())->method('isValid')->willReturn(true);
+        $file->method('getSize')->willReturn(4072);
+        $file->method('isValid')->willReturn(true);
         $biggerFile = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
-        $biggerFile->expects($this->any())->method('getSize')->willReturn(5120);
-        $biggerFile->expects($this->any())->method('isValid')->willReturn(true);
+        $biggerFile->method('getSize')->willReturn(5120);
+        $biggerFile->method('isValid')->willReturn(true);
         $v = new Validator($trans, ['photo' => $file, 'bigger' => $biggerFile], ['photo' => 'file|gt:bigger']);
         $this->assertFalse($v->passes());
         $this->assertEquals(5, $v->messages()->first('photo'));
@@ -4192,11 +4192,11 @@ class ValidationValidatorTest extends TestCase
         $this->assertSame('maximum value', $v->messages()->first('min'));
 
         $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
-        $file->expects($this->any())->method('getSize')->willReturn(4072);
-        $file->expects($this->any())->method('isValid')->willReturn(true);
+        $file->method('getSize')->willReturn(4072);
+        $file->method('isValid')->willReturn(true);
         $smallerFile = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
-        $smallerFile->expects($this->any())->method('getSize')->willReturn(2048);
-        $smallerFile->expects($this->any())->method('isValid')->willReturn(true);
+        $smallerFile->method('getSize')->willReturn(2048);
+        $smallerFile->method('isValid')->willReturn(true);
         $v = new Validator($trans, ['photo' => $file, 'smaller' => $smallerFile], ['photo' => 'file|lt:smaller']);
         $this->assertFalse($v->passes());
         $this->assertEquals(2, $v->messages()->first('photo'));
@@ -4234,11 +4234,11 @@ class ValidationValidatorTest extends TestCase
         $this->assertSame('minimum value', $v->messages()->first('max'));
 
         $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
-        $file->expects($this->any())->method('getSize')->willReturn(4072);
-        $file->expects($this->any())->method('isValid')->willReturn(true);
+        $file->method('getSize')->willReturn(4072);
+        $file->method('isValid')->willReturn(true);
         $biggerFile = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
-        $biggerFile->expects($this->any())->method('getSize')->willReturn(5120);
-        $biggerFile->expects($this->any())->method('isValid')->willReturn(true);
+        $biggerFile->method('getSize')->willReturn(5120);
+        $biggerFile->method('isValid')->willReturn(true);
         $v = new Validator($trans, ['photo' => $file, 'bigger' => $biggerFile], ['photo' => 'file|gte:bigger']);
         $this->assertFalse($v->passes());
         $this->assertEquals(5, $v->messages()->first('photo'));
@@ -4276,11 +4276,11 @@ class ValidationValidatorTest extends TestCase
         $this->assertSame('maximum value', $v->messages()->first('min'));
 
         $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
-        $file->expects($this->any())->method('getSize')->willReturn(4072);
-        $file->expects($this->any())->method('isValid')->willReturn(true);
+        $file->method('getSize')->willReturn(4072);
+        $file->method('isValid')->willReturn(true);
         $smallerFile = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
-        $smallerFile->expects($this->any())->method('getSize')->willReturn(2048);
-        $smallerFile->expects($this->any())->method('isValid')->willReturn(true);
+        $smallerFile->method('getSize')->willReturn(2048);
+        $smallerFile->method('isValid')->willReturn(true);
         $v = new Validator($trans, ['photo' => $file, 'smaller' => $smallerFile], ['photo' => 'file|lte:smaller']);
         $this->assertFalse($v->passes());
         $this->assertEquals(2, $v->messages()->first('photo'));
@@ -4619,11 +4619,11 @@ class ValidationValidatorTest extends TestCase
         ], 'en');
 
         $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
-        $file->expects($this->any())->method('getSize')->willReturn(8919);
-        $file->expects($this->any())->method('isValid')->willReturn(true);
+        $file->method('getSize')->willReturn(8919);
+        $file->method('isValid')->willReturn(true);
         $otherFile = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
-        $otherFile->expects($this->any())->method('getSize')->willReturn(9216);
-        $otherFile->expects($this->any())->method('isValid')->willReturn(true);
+        $otherFile->method('getSize')->willReturn(9216);
+        $otherFile->method('isValid')->willReturn(true);
 
         $v = new Validator($trans, [
             'numeric' => 7,
@@ -4659,11 +4659,11 @@ class ValidationValidatorTest extends TestCase
         ], 'en');
 
         $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
-        $file->expects($this->any())->method('getSize')->willReturn(8919);
-        $file->expects($this->any())->method('isValid')->willReturn(true);
+        $file->method('getSize')->willReturn(8919);
+        $file->method('isValid')->willReturn(true);
         $otherFile = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
-        $otherFile->expects($this->any())->method('getSize')->willReturn(9216);
-        $otherFile->expects($this->any())->method('isValid')->willReturn(true);
+        $otherFile->method('getSize')->willReturn(9216);
+        $otherFile->method('isValid')->willReturn(true);
 
         $v = new Validator($trans, [
             'numeric' => 7,
@@ -4699,11 +4699,11 @@ class ValidationValidatorTest extends TestCase
         ], 'en');
 
         $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
-        $file->expects($this->any())->method('getSize')->willReturn(8919);
-        $file->expects($this->any())->method('isValid')->willReturn(true);
+        $file->method('getSize')->willReturn(8919);
+        $file->method('isValid')->willReturn(true);
         $otherFile = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
-        $otherFile->expects($this->any())->method('getSize')->willReturn(8192);
-        $otherFile->expects($this->any())->method('isValid')->willReturn(true);
+        $otherFile->method('getSize')->willReturn(8192);
+        $otherFile->method('isValid')->willReturn(true);
 
         $v = new Validator($trans, [
             'numeric' => 7,
@@ -4739,11 +4739,11 @@ class ValidationValidatorTest extends TestCase
         ], 'en');
 
         $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
-        $file->expects($this->any())->method('getSize')->willReturn(8919);
-        $file->expects($this->any())->method('isValid')->willReturn(true);
+        $file->method('getSize')->willReturn(8919);
+        $file->method('isValid')->willReturn(true);
         $otherFile = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
-        $otherFile->expects($this->any())->method('getSize')->willReturn(8192);
-        $otherFile->expects($this->any())->method('isValid')->willReturn(true);
+        $otherFile->method('getSize')->willReturn(8192);
+        $otherFile->method('isValid')->willReturn(true);
 
         $v = new Validator($trans, [
             'numeric' => 7,
@@ -5269,69 +5269,69 @@ class ValidationValidatorTest extends TestCase
         $uploadedFile = [__FILE__, '', null, null, true];
 
         $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
-        $file->expects($this->any())->method('guessExtension')->willReturn('php');
-        $file->expects($this->any())->method('getClientOriginalExtension')->willReturn('php');
+        $file->method('guessExtension')->willReturn('php');
+        $file->method('getClientOriginalExtension')->willReturn('php');
         $v = new Validator($trans, ['x' => $file], ['x' => 'image']);
         $this->assertFalse($v->passes());
 
         $file2 = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
-        $file2->expects($this->any())->method('guessExtension')->willReturn('jpeg');
-        $file2->expects($this->any())->method('getClientOriginalExtension')->willReturn('jpeg');
+        $file2->method('guessExtension')->willReturn('jpeg');
+        $file2->method('getClientOriginalExtension')->willReturn('jpeg');
         $v = new Validator($trans, ['x' => $file2], ['x' => 'image']);
         $this->assertTrue($v->passes());
 
         $file2 = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
-        $file2->expects($this->any())->method('guessExtension')->willReturn('jpg');
-        $file2->expects($this->any())->method('getClientOriginalExtension')->willReturn('jpg');
+        $file2->method('guessExtension')->willReturn('jpg');
+        $file2->method('getClientOriginalExtension')->willReturn('jpg');
         $v = new Validator($trans, ['x' => $file2], ['x' => 'image']);
         $this->assertTrue($v->passes());
 
         $file2 = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
-        $file2->expects($this->any())->method('guessExtension')->willReturn('jpg');
-        $file2->expects($this->any())->method('getClientOriginalExtension')->willReturn('jpg');
+        $file2->method('guessExtension')->willReturn('jpg');
+        $file2->method('getClientOriginalExtension')->willReturn('jpg');
         $v = new Validator($trans, ['x' => $file2], ['x' => 'image']);
         $this->assertTrue($v->passes());
 
         $file3 = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
-        $file3->expects($this->any())->method('guessExtension')->willReturn('gif');
-        $file3->expects($this->any())->method('getClientOriginalExtension')->willReturn('gif');
+        $file3->method('guessExtension')->willReturn('gif');
+        $file3->method('getClientOriginalExtension')->willReturn('gif');
         $v = new Validator($trans, ['x' => $file3], ['x' => 'image']);
         $this->assertTrue($v->passes());
 
         $file4 = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
-        $file4->expects($this->any())->method('guessExtension')->willReturn('bmp');
-        $file4->expects($this->any())->method('getClientOriginalExtension')->willReturn('bmp');
+        $file4->method('guessExtension')->willReturn('bmp');
+        $file4->method('getClientOriginalExtension')->willReturn('bmp');
         $v = new Validator($trans, ['x' => $file4], ['x' => 'image']);
         $this->assertTrue($v->passes());
 
         $file5 = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
-        $file5->expects($this->any())->method('guessExtension')->willReturn('png');
-        $file5->expects($this->any())->method('getClientOriginalExtension')->willReturn('png');
+        $file5->method('guessExtension')->willReturn('png');
+        $file5->method('getClientOriginalExtension')->willReturn('png');
         $v = new Validator($trans, ['x' => $file5], ['x' => 'image']);
         $this->assertTrue($v->passes());
 
         $file6 = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
-        $file6->expects($this->any())->method('guessExtension')->willReturn('svg');
-        $file6->expects($this->any())->method('getClientOriginalExtension')->willReturn('svg');
+        $file6->method('guessExtension')->willReturn('svg');
+        $file6->method('getClientOriginalExtension')->willReturn('svg');
         $v = new Validator($trans, ['x' => $file6], ['x' => 'image']);
         $this->assertFalse($v->passes());
 
         $file6 = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
-        $file6->expects($this->any())->method('guessExtension')->willReturn('svg');
-        $file6->expects($this->any())->method('getClientOriginalExtension')->willReturn('svg');
+        $file6->method('guessExtension')->willReturn('svg');
+        $file6->method('getClientOriginalExtension')->willReturn('svg');
         $v = new Validator($trans, ['x' => $file6], ['x' => 'image:allow_svg']);
         $this->assertTrue($v->passes());
 
         $file7 = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
-        $file7->expects($this->any())->method('guessExtension')->willReturn('webp');
-        $file7->expects($this->any())->method('getClientOriginalExtension')->willReturn('webp');
+        $file7->method('guessExtension')->willReturn('webp');
+        $file7->method('getClientOriginalExtension')->willReturn('webp');
 
         $v = new Validator($trans, ['x' => $file7], ['x' => 'Image']);
         $this->assertTrue($v->passes());
 
         $file2 = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
-        $file2->expects($this->any())->method('guessExtension')->willReturn('jpg');
-        $file2->expects($this->any())->method('getClientOriginalExtension')->willReturn('jpg');
+        $file2->method('guessExtension')->willReturn('jpg');
+        $file2->method('getClientOriginalExtension')->willReturn('jpg');
         $v = new Validator($trans, ['x' => $file2], ['x' => 'Image']);
         $this->assertTrue($v->passes());
     }
@@ -5342,8 +5342,8 @@ class ValidationValidatorTest extends TestCase
         $uploadedFile = [__FILE__, '', null, null, true];
 
         $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
-        $file->expects($this->any())->method('guessExtension')->willReturn('jpeg');
-        $file->expects($this->any())->method('getClientOriginalExtension')->willReturn('php');
+        $file->method('guessExtension')->willReturn('jpeg');
+        $file->method('getClientOriginalExtension')->willReturn('php');
         $v = new Validator($trans, ['x' => $file], ['x' => 'image']);
         $this->assertFalse($v->passes());
     }
@@ -5487,21 +5487,21 @@ class ValidationValidatorTest extends TestCase
         $uploadedFile = [__DIR__.'/ValidationMacroTest.php', '', null, null, true];
 
         $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
-        $file->expects($this->any())->method('guessExtension')->willReturn('rtf');
-        $file->expects($this->any())->method('getClientOriginalExtension')->willReturn('rtf');
+        $file->method('guessExtension')->willReturn('rtf');
+        $file->method('getClientOriginalExtension')->willReturn('rtf');
 
         $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['getMimeType'])->setConstructorArgs($uploadedFile)->getMock();
-        $file->expects($this->any())->method('getMimeType')->willReturn('text/rtf');
+        $file->method('getMimeType')->willReturn('text/rtf');
         $v = new Validator($trans, ['x' => $file], ['x' => 'mimetypes:text/*']);
         $this->assertTrue($v->passes());
 
         $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['getMimeType'])->setConstructorArgs($uploadedFile)->getMock();
-        $file->expects($this->any())->method('getMimeType')->willReturn('application/pdf');
+        $file->method('getMimeType')->willReturn('application/pdf');
         $v = new Validator($trans, ['x' => $file], ['x' => 'mimetypes:text/rtf']);
         $this->assertFalse($v->passes());
 
         $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['getMimeType'])->setConstructorArgs($uploadedFile)->getMock();
-        $file->expects($this->any())->method('getMimeType')->willReturn('image/jpeg');
+        $file->method('getMimeType')->willReturn('image/jpeg');
         $v = new Validator($trans, ['x' => $file], ['x' => 'mimetypes:image/jpeg']);
         $this->assertTrue($v->passes());
     }
@@ -5512,26 +5512,26 @@ class ValidationValidatorTest extends TestCase
         $uploadedFile = [__FILE__, '', null, null, true];
 
         $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
-        $file->expects($this->any())->method('guessExtension')->willReturn('pdf');
-        $file->expects($this->any())->method('getClientOriginalExtension')->willReturn('pdf');
+        $file->method('guessExtension')->willReturn('pdf');
+        $file->method('getClientOriginalExtension')->willReturn('pdf');
         $v = new Validator($trans, ['x' => $file], ['x' => 'mimes:pdf']);
         $this->assertTrue($v->passes());
 
         $file2 = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['guessExtension', 'isValid'])->setConstructorArgs($uploadedFile)->getMock();
-        $file2->expects($this->any())->method('guessExtension')->willReturn('pdf');
-        $file2->expects($this->any())->method('isValid')->willReturn(false);
+        $file2->method('guessExtension')->willReturn('pdf');
+        $file2->method('isValid')->willReturn(false);
         $v = new Validator($trans, ['x' => $file2], ['x' => 'mimes:pdf']);
         $this->assertFalse($v->passes());
 
         $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
-        $file->expects($this->any())->method('guessExtension')->willReturn('jpg');
-        $file->expects($this->any())->method('getClientOriginalExtension')->willReturn('jpg');
+        $file->method('guessExtension')->willReturn('jpg');
+        $file->method('getClientOriginalExtension')->willReturn('jpg');
         $v = new Validator($trans, ['x' => $file], ['x' => 'mimes:jpeg']);
         $this->assertTrue($v->passes());
 
         $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
-        $file->expects($this->any())->method('guessExtension')->willReturn('jpg');
-        $file->expects($this->any())->method('getClientOriginalExtension')->willReturn('jpeg');
+        $file->method('guessExtension')->willReturn('jpg');
+        $file->method('getClientOriginalExtension')->willReturn('jpeg');
         $v = new Validator($trans, ['x' => $file], ['x' => 'mimes:jpg']);
         $this->assertTrue($v->passes());
     }
@@ -5542,28 +5542,28 @@ class ValidationValidatorTest extends TestCase
         $uploadedFile = [__FILE__, '', null, null, true];
 
         $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
-        $file->expects($this->any())->method('getClientOriginalExtension')->willReturn('pdf');
+        $file->method('getClientOriginalExtension')->willReturn('pdf');
         $v = new Validator($trans, ['x' => $file], ['x' => 'extensions:pdf']);
         $this->assertTrue($v->passes());
 
         $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
-        $file->expects($this->any())->method('getClientOriginalExtension')->willReturn('jpg');
+        $file->method('getClientOriginalExtension')->willReturn('jpg');
         $v = new Validator($trans, ['x' => $file], ['x' => 'extensions:jpg']);
         $this->assertTrue($v->passes());
 
         $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
-        $file->expects($this->any())->method('getClientOriginalExtension')->willReturn('jpg');
+        $file->method('getClientOriginalExtension')->willReturn('jpg');
         $v = new Validator($trans, ['x' => $file], ['x' => 'extensions:jpeg,jpg']);
         $this->assertTrue($v->passes());
 
         $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
-        $file->expects($this->any())->method('getClientOriginalExtension')->willReturn('jpg');
+        $file->method('getClientOriginalExtension')->willReturn('jpg');
         $v = new Validator($trans, ['x' => $file], ['x' => 'extensions:jpeg']);
         $this->assertFalse($v->passes());
 
         $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
-        $file->expects($this->any())->method('guessExtension')->willReturn('jpg');
-        $file->expects($this->any())->method('getClientOriginalExtension')->willReturn('jpeg');
+        $file->method('guessExtension')->willReturn('jpg');
+        $file->method('getClientOriginalExtension')->willReturn('jpeg');
         $v = new Validator($trans, ['x' => $file], ['x' => 'mimes:jpg|extensions:jpg']);
         $this->assertFalse($v->passes());
     }
@@ -5574,14 +5574,14 @@ class ValidationValidatorTest extends TestCase
         $uploadedFile = [__FILE__, '', null, null, true];
 
         $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
-        $file->expects($this->any())->method('guessExtension')->willReturn('pdf');
-        $file->expects($this->any())->method('getClientOriginalExtension')->willReturn('php');
+        $file->method('guessExtension')->willReturn('pdf');
+        $file->method('getClientOriginalExtension')->willReturn('php');
         $v = new Validator($trans, ['x' => $file], ['x' => 'mimes:pdf']);
         $this->assertFalse($v->passes());
 
         $file2 = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
-        $file2->expects($this->any())->method('guessExtension')->willReturn('php');
-        $file2->expects($this->any())->method('getClientOriginalExtension')->willReturn('php');
+        $file2->method('guessExtension')->willReturn('php');
+        $file2->method('getClientOriginalExtension')->willReturn('php');
         $v = new Validator($trans, ['x' => $file2], ['x' => 'mimes:pdf,php']);
         $this->assertTrue($v->passes());
     }


### PR DESCRIPTION
## Description

This PR applies a set of PHPUnit-specific Rector rules to the framework's test suite (`tests/`) to modernise assertions, clean up mock usage, and align test structure with current PHPUnit best practices.

A dedicated `$testsuiteRules` group has been added to `rector.php` and spread into `->withRules()` alongside the existing rules.

## Changes

### New Rector rules (`$testsuiteRules`)

**Assertions**
- `AssertFuncCallToPHPUnitAssertRector` — converts bare `assert*()` function calls to `$this->assert*()` PHPUnit methods
- `SimplifyForeachInstanceOfRector` — simplifies `foreach` + `assertInstanceOf` patterns

**Test structure**
- `ConstructClassMethodToSetUpTestCaseRector` — moves constructor logic to `setUp()`
- `NarrowUnusedSetUpDefinedPropertyRector` — removes properties defined in `setUp()` that are never used
- `PreferPHPUnitThisCallRector` — enforces `$this->...` over static `self::...` calls where appropriate
- `RemoveEmptyTestMethodRector` — removes test methods with no body
- `ReplaceTestAnnotationWithPrefixedFunctionRector` — replaces `@test` docblock annotations with `test_` prefixed method names

**Mock quality**
- `DirectInstanceOverMockArgRector` — passes direct instances instead of mock wrappers where the mock isn't needed
- `EntityDocumentCreateMockToDirectNewRector` — replaces `createMock()` with direct instantiation for plain value objects
- `GetMockBuilderGetMockToCreateMockRector` — replaces verbose `getMockBuilder()->getMock()` chains with `createMock()`
- `InlineStubPropertyToCreateStubMethodCallRector` — inlines stub properties directly into `createStub()` calls
- `MergeWithCallableAndWillReturnRector` — merges separate `with()` and `willReturn()` calls where possible
- `NarrowIdenticalWithConsecutiveRector` — tightens `withConsecutive()` argument matching
- `NarrowSingleWillReturnCallbackRector` — simplifies single-call `willReturnCallback()` to `willReturn()`
- `RemoveExpectAnyFromMockRector` — drops redundant `->expects($this->any())` calls
- `RemoveNeverUsedMockPropertyRector` — removes mock properties that are never referenced
- `RemoveStandaloneCreateMockRector` — removes `createMock()` calls whose result is never used
- `ReplaceAtMethodWithDesiredMatcherRector` — replaces deprecated `$this->at()` matcher with the appropriate specific matcher
- `SimplerWithIsInstanceOfRector` — simplifies `with($this->isInstanceOf(...))` to the dedicated helper
- `SingleWithConsecutiveToWithRector` — converts single-element `withConsecutive()` to a plain `with()`
- `UseSpecificWillMethodRector` — replaces generic `will(new ReturnStub(...))` with the dedicated `willReturn*()` shorthand
- `UseSpecificWithMethodRector` — replaces generic `with($this->equalTo(...))` with type-specific constraint methods

## Notes

- No production source code is modified; all changes are scoped to `tests/`.
- The `$testsuiteRules` variable is intentionally kept separate from the general rules for clarity and future maintainability.
- All other existing skip rules and PHP 8.3 target remain unchanged.