### PR TITLE
[13.x] Enforce static calls

### DIFF
--- a/src/Illuminate/Bus/UniqueLock.php
+++ b/src/Illuminate/Bus/UniqueLock.php
@@ -43,7 +43,7 @@ class UniqueLock
             ? ($job->uniqueVia() ?? $this->cache)
             : $this->cache;
 
-        return (bool) $cache->lock($this->getKey($job), $uniqueFor)->get();
+        return (bool) $cache->lock(self::getKey($job), $uniqueFor)->get();
     }
 
     /**
@@ -58,7 +58,7 @@ class UniqueLock
             ? ($job->uniqueVia() ?? $this->cache)
             : $this->cache;
 
-        $cache->lock($this->getKey($job))->forceRelease();
+        $cache->lock(self::getKey($job))->forceRelease();
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -827,7 +827,7 @@ class Event
         }
 
         return 'framework'.DIRECTORY_SEPARATOR.'schedule-'.
-            sha1($this->expression.$this->normalizeCommand($this->command ?? ''));
+            sha1($this->expression. self::normalizeCommand($this->command ?? ''));
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -827,7 +827,7 @@ class Event
         }
 
         return 'framework'.DIRECTORY_SEPARATOR.'schedule-'.
-            sha1($this->expression. self::normalizeCommand($this->command ?? ''));
+            sha1($this->expression.self::normalizeCommand($this->command ?? ''));
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -529,7 +529,7 @@ class Builder implements BuilderContract
             $values = [$values];
         }
 
-        $this->model->unguarded(function () use (&$values) {
+        $this->model::unguarded(function () use (&$values) {
             foreach ($values as $key => $rowValues) {
                 $values[$key] = tap(
                     $this->newModelInstance($rowValues),
@@ -1244,7 +1244,7 @@ class Builder implements BuilderContract
      */
     public function forceCreate(array $attributes)
     {
-        return $this->model->unguarded(function () use ($attributes) {
+        return $this->model::unguarded(function () use ($attributes) {
             return $this->newModelInstance()->create($attributes);
         });
     }

--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -104,7 +104,7 @@ trait SoftDeletes
 
         $count = 0;
 
-        foreach ($instance->withTrashed()->whereIn($key, $ids)->get() as $model) {
+        foreach ($instance::withTrashed()->whereIn($key, $ids)->get() as $model) {
             if ($model->forceDelete()) {
                 $count++;
             }

--- a/src/Illuminate/Foundation/Console/ChannelListCommand.php
+++ b/src/Illuminate/Foundation/Console/ChannelListCommand.php
@@ -78,7 +78,7 @@ class ChannelListCommand extends Command
             return mb_strlen($channelName);
         });
 
-        $terminalWidth = $this->getTerminalWidth();
+        $terminalWidth = self::getTerminalWidth();
 
         $channelCount = $this->determineChannelCountOutput($channels, $terminalWidth);
 

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -399,7 +399,7 @@ class RouteListCommand extends Command
 
         $maxMethod = mb_strlen($routes->max('method'));
 
-        $terminalWidth = $this->getTerminalWidth();
+        $terminalWidth = self::getTerminalWidth();
 
         $routeCount = $this->determineRouteCountOutput($routes, $terminalWidth);
 

--- a/src/Illuminate/Http/Concerns/InteractsWithContentTypes.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithContentTypes.php
@@ -80,7 +80,7 @@ trait InteractsWithContentTypes
 
                 $type = strtolower($type);
 
-                if ($this->matchesType($accept, $type) || $accept === strtok($type, '/').'/*') {
+                if (self::matchesType($accept, $type) || $accept === strtok($type, '/').'/*') {
                     return true;
                 }
             }
@@ -121,7 +121,7 @@ trait InteractsWithContentTypes
 
                 $type = strtolower($type);
 
-                if ($this->matchesType($type, $accept) || $accept === strtok($type, '/').'/*') {
+                if (self::matchesType($type, $accept) || $accept === strtok($type, '/').'/*') {
                     return $contentType;
                 }
             }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -821,7 +821,7 @@ class DatabaseEloquentModelTest extends TestCase
         $query->shouldReceive('update')->once()->with(['name' => 'taylor'])->andReturn(1);
         $model->expects($this->once())->method('newModelQuery')->willReturn($query);
         $model->expects($this->once())->method('updateTimestamps');
-        $model->setEventDispatcher($events = m::mock(Dispatcher::class));
+        $model::setEventDispatcher($events = m::mock(Dispatcher::class));
         $events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
         $events->shouldReceive('until')->once()->with('eloquent.updating: '.get_class($model), $model)->andReturn(true);
         $events->shouldReceive('dispatch')->once()->with('eloquent.updated: '.get_class($model), $model)->andReturn(true);
@@ -843,7 +843,7 @@ class DatabaseEloquentModelTest extends TestCase
         $query->shouldReceive('where')->once()->with('id', '=', 1);
         $query->shouldReceive('update')->once()->with(['created_at' => 'foo', 'updated_at' => 'bar'])->andReturn(1);
         $model->expects($this->once())->method('newModelQuery')->willReturn($query);
-        $model->setEventDispatcher($events = m::mock(Dispatcher::class));
+        $model::setEventDispatcher($events = m::mock(Dispatcher::class));
         $events->shouldReceive('until');
         $events->shouldReceive('dispatch');
 
@@ -860,7 +860,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model = $this->getMockBuilder(EloquentModelStub::class)->onlyMethods(['newModelQuery'])->getMock();
         $query = m::mock(Builder::class);
         $model->expects($this->once())->method('newModelQuery')->willReturn($query);
-        $model->setEventDispatcher($events = m::mock(Dispatcher::class));
+        $model::setEventDispatcher($events = m::mock(Dispatcher::class));
         $events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(false);
         $model->exists = true;
 
@@ -872,7 +872,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model = $this->getMockBuilder(EloquentModelStub::class)->onlyMethods(['newModelQuery'])->getMock();
         $query = m::mock(Builder::class);
         $model->expects($this->once())->method('newModelQuery')->willReturn($query);
-        $model->setEventDispatcher($events = m::mock(Dispatcher::class));
+        $model::setEventDispatcher($events = m::mock(Dispatcher::class));
         $events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
         $events->shouldReceive('until')->once()->with('eloquent.updating: '.get_class($model), $model)->andReturn(false);
         $model->exists = true;
@@ -886,7 +886,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model = $this->getMockBuilder(EloquentModelEventObjectStub::class)->onlyMethods(['newModelQuery'])->getMock();
         $query = m::mock(Builder::class);
         $model->expects($this->once())->method('newModelQuery')->willReturn($query);
-        $model->setEventDispatcher($events = m::mock(Dispatcher::class));
+        $model::setEventDispatcher($events = m::mock(Dispatcher::class));
         $events->shouldReceive('until')->once()->with(m::type(EloquentModelSavingEventStub::class))->andReturn(false);
         $model->exists = true;
 
@@ -919,7 +919,7 @@ class DatabaseEloquentModelTest extends TestCase
         $query->shouldReceive('update')->once()->with(['id' => 2, 'foo' => 'bar'])->andReturn(1);
         $model->expects($this->once())->method('newModelQuery')->willReturn($query);
         $model->expects($this->once())->method('updateTimestamps');
-        $model->setEventDispatcher($events = m::mock(Dispatcher::class));
+        $model::setEventDispatcher($events = m::mock(Dispatcher::class));
         $events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
         $events->shouldReceive('until')->once()->with('eloquent.updating: '.get_class($model), $model)->andReturn(true);
         $events->shouldReceive('dispatch')->once()->with('eloquent.updated: '.get_class($model), $model)->andReturn(true);
@@ -1065,7 +1065,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model->expects($this->once())->method('newModelQuery')->willReturn($query);
         $model->expects($this->once())->method('updateTimestamps');
 
-        $model->setEventDispatcher($events = m::mock(Dispatcher::class));
+        $model::setEventDispatcher($events = m::mock(Dispatcher::class));
         $events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
         $events->shouldReceive('until')->once()->with('eloquent.creating: '.get_class($model), $model)->andReturn(true);
         $events->shouldReceive('dispatch')->once()->with('eloquent.created: '.get_class($model), $model);
@@ -1085,7 +1085,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model->expects($this->once())->method('updateTimestamps');
         $model->setIncrementing(false);
 
-        $model->setEventDispatcher($events = m::mock(Dispatcher::class));
+        $model::setEventDispatcher($events = m::mock(Dispatcher::class));
         $events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
         $events->shouldReceive('until')->once()->with('eloquent.creating: '.get_class($model), $model)->andReturn(true);
         $events->shouldReceive('dispatch')->once()->with('eloquent.created: '.get_class($model), $model);
@@ -1104,7 +1104,7 @@ class DatabaseEloquentModelTest extends TestCase
         $query = m::mock(Builder::class);
         $query->shouldReceive('getConnection')->once();
         $model->expects($this->once())->method('newModelQuery')->willReturn($query);
-        $model->setEventDispatcher($events = m::mock(Dispatcher::class));
+        $model::setEventDispatcher($events = m::mock(Dispatcher::class));
         $events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
         $events->shouldReceive('until')->once()->with('eloquent.creating: '.get_class($model), $model)->andReturn(false);
 
@@ -1123,7 +1123,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model->expects($this->once())->method('newModelQuery')->willReturn($query);
         $model->expects($this->once())->method('updateTimestamps');
 
-        $model->setEventDispatcher($events = m::mock(Dispatcher::class));
+        $model::setEventDispatcher($events = m::mock(Dispatcher::class));
         $events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
         $events->shouldReceive('until')->once()->with('eloquent.creating: '.get_class($model), $model)->andReturn(true);
         $events->shouldReceive('dispatch')->once()->with('eloquent.created: '.get_class($model), $model);
@@ -1148,7 +1148,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model->expects($this->once())->method('newModelQuery')->willReturn($query);
         $model->expects($this->once())->method('updateTimestamps');
 
-        $model->setEventDispatcher($events = m::mock(Dispatcher::class));
+        $model::setEventDispatcher($events = m::mock(Dispatcher::class));
         $events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
         $events->shouldReceive('until')->once()->with('eloquent.creating: '.get_class($model), $model)->andReturn(true);
 
@@ -1171,7 +1171,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model->expects($this->once())->method('updateTimestamps');
         $model->setIncrementing(false);
 
-        $model->setEventDispatcher($events = m::mock(Dispatcher::class));
+        $model::setEventDispatcher($events = m::mock(Dispatcher::class));
         $events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
         $events->shouldReceive('until')->once()->with('eloquent.creating: '.get_class($model), $model)->andReturn(true);
         $events->shouldReceive('dispatch')->once()->with('eloquent.created: '.get_class($model), $model);
@@ -1196,7 +1196,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model->expects($this->once())->method('newModelQuery')->willReturn($query);
         $model->expects($this->once())->method('updateTimestamps');
 
-        $model->setEventDispatcher($events = m::mock(Dispatcher::class));
+        $model::setEventDispatcher($events = m::mock(Dispatcher::class));
         $events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
         $events->shouldReceive('until')->once()->with('eloquent.creating: '.get_class($model), $model)->andReturn(true);
 
@@ -2638,7 +2638,7 @@ class DatabaseEloquentModelTest extends TestCase
     {
         $model = new EloquentModelStub;
 
-        $model->setEventDispatcher($events = m::mock(Dispatcher::class));
+        $model::setEventDispatcher($events = m::mock(Dispatcher::class));
         $events->shouldReceive('dispatch')->once()->with('eloquent.replicating: '.get_class($model), m::on(function ($m) use ($model) {
             return $model->is($m);
         }));
@@ -2655,7 +2655,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model->updated_at = new DateTime;
         $replicated = $model->replicateQuietly();
 
-        $model->setEventDispatcher($events = m::mock(Dispatcher::class));
+        $model::setEventDispatcher($events = m::mock(Dispatcher::class));
         $events->shouldReceive('dispatch')->never()->with('eloquent.replicating: '.get_class($model), $model)->andReturn(true);
 
         $this->assertNull($replicated->id);
@@ -2698,7 +2698,7 @@ class DatabaseEloquentModelTest extends TestCase
         $query->shouldReceive('where')->andReturn($query);
         $query->shouldReceive('increment');
 
-        $model->setEventDispatcher($events = m::mock(Dispatcher::class));
+        $model::setEventDispatcher($events = m::mock(Dispatcher::class));
         $events->shouldReceive('until')->never()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
         $events->shouldReceive('until')->never()->with('eloquent.updating: '.get_class($model), $model)->andReturn(true);
         $events->shouldReceive('dispatch')->never()->with('eloquent.updated: '.get_class($model), $model)->andReturn(true);
@@ -2725,7 +2725,7 @@ class DatabaseEloquentModelTest extends TestCase
         $query->shouldReceive('where')->andReturn($query);
         $query->shouldReceive('decrement');
 
-        $model->setEventDispatcher($events = m::mock(Dispatcher::class));
+        $model::setEventDispatcher($events = m::mock(Dispatcher::class));
         $events->shouldReceive('until')->never()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
         $events->shouldReceive('until')->never()->with('eloquent.updating: '.get_class($model), $model)->andReturn(true);
         $events->shouldReceive('dispatch')->never()->with('eloquent.updated: '.get_class($model), $model)->andReturn(true);
@@ -2811,7 +2811,7 @@ class DatabaseEloquentModelTest extends TestCase
         $query->shouldReceive('where')->andReturn($query);
         $query->shouldReceive('incrementEach')->andReturn(1);
 
-        $model->setEventDispatcher($events = m::mock(Dispatcher::class));
+        $model::setEventDispatcher($events = m::mock(Dispatcher::class));
         $events->shouldReceive('until')->once()->with('eloquent.updating: '.get_class($model), $model)->andReturn(true);
         $events->shouldReceive('dispatch')->once()->with('eloquent.updated: '.get_class($model), $model);
 
@@ -2828,7 +2828,7 @@ class DatabaseEloquentModelTest extends TestCase
 
         $model->shouldReceive('newQueryWithoutScopes')->never();
 
-        $model->setEventDispatcher($events = m::mock(Dispatcher::class));
+        $model::setEventDispatcher($events = m::mock(Dispatcher::class));
         $events->shouldReceive('until')->once()->with('eloquent.updating: '.get_class($model), $model)->andReturn(false);
 
         $result = $model->publicIncrementEach(['foo' => 1]);

--- a/tests/Database/DatabaseMigratorIntegrationTest.php
+++ b/tests/Database/DatabaseMigratorIntegrationTest.php
@@ -89,8 +89,8 @@ class DatabaseMigratorIntegrationTest extends TestCase
     {
         $ran = $this->migrator->run([__DIR__.'/migrations/one']);
 
-        $this->assertTrue($this->db->schema()->hasTable('users'));
-        $this->assertTrue($this->db->schema()->hasTable('password_resets'));
+        $this->assertTrue($this->db::schema()->hasTable('users'));
+        $this->assertTrue($this->db::schema()->hasTable('password_resets'));
 
         $this->assertTrue(str_contains($ran[0], 'users'));
         $this->assertTrue(str_contains($ran[1], 'password_resets'));
@@ -102,12 +102,12 @@ class DatabaseMigratorIntegrationTest extends TestCase
             return $this->migrator->run([__DIR__.'/migrations/one'], ['database' => 'sqllite3']);
         });
 
-        $this->assertFalse($this->db->schema()->hasTable('users'));
-        $this->assertFalse($this->db->schema()->hasTable('password_resets'));
-        $this->assertTrue($this->db->schema('sqlite2')->hasTable('users'));
-        $this->assertTrue($this->db->schema('sqlite2')->hasTable('password_resets'));
-        $this->assertFalse($this->db->schema('sqlite3')->hasTable('users'));
-        $this->assertFalse($this->db->schema('sqlite3')->hasTable('password_resets'));
+        $this->assertFalse($this->db::schema()->hasTable('users'));
+        $this->assertFalse($this->db::schema()->hasTable('password_resets'));
+        $this->assertTrue($this->db::schema('sqlite2')->hasTable('users'));
+        $this->assertTrue($this->db::schema('sqlite2')->hasTable('password_resets'));
+        $this->assertFalse($this->db::schema('sqlite3')->hasTable('users'));
+        $this->assertFalse($this->db::schema('sqlite3')->hasTable('password_resets'));
 
         $this->assertTrue(Str::contains($ran[0], 'users'));
         $this->assertTrue(Str::contains($ran[1], 'password_resets'));
@@ -117,12 +117,12 @@ class DatabaseMigratorIntegrationTest extends TestCase
     {
         $ran = $this->migrator->run([__DIR__.'/migrations/connection_configured']);
 
-        $this->assertFalse($this->db->schema()->hasTable('failed_jobs'));
-        $this->assertFalse($this->db->schema()->hasTable('jobs'));
-        $this->assertFalse($this->db->schema('sqlite2')->hasTable('failed_jobs'));
-        $this->assertFalse($this->db->schema('sqlite2')->hasTable('jobs'));
-        $this->assertTrue($this->db->schema('sqlite3')->hasTable('failed_jobs'));
-        $this->assertTrue($this->db->schema('sqlite3')->hasTable('jobs'));
+        $this->assertFalse($this->db::schema()->hasTable('failed_jobs'));
+        $this->assertFalse($this->db::schema()->hasTable('jobs'));
+        $this->assertFalse($this->db::schema('sqlite2')->hasTable('failed_jobs'));
+        $this->assertFalse($this->db::schema('sqlite2')->hasTable('jobs'));
+        $this->assertTrue($this->db::schema('sqlite3')->hasTable('failed_jobs'));
+        $this->assertTrue($this->db::schema('sqlite3')->hasTable('jobs'));
 
         $this->assertTrue(Str::contains($ran[0], 'failed_jobs'));
         $this->assertTrue(Str::contains($ran[1], 'jobs'));
@@ -134,12 +134,12 @@ class DatabaseMigratorIntegrationTest extends TestCase
             return $this->migrator->run([__DIR__.'/migrations/connection_configured']);
         });
 
-        $this->assertFalse($this->db->schema()->hasTable('failed_jobs'));
-        $this->assertFalse($this->db->schema()->hasTable('jobs'));
-        $this->assertFalse($this->db->schema('sqlite2')->hasTable('failed_jobs'));
-        $this->assertFalse($this->db->schema('sqlite2')->hasTable('jobs'));
-        $this->assertTrue($this->db->schema('sqlite3')->hasTable('failed_jobs'));
-        $this->assertTrue($this->db->schema('sqlite3')->hasTable('jobs'));
+        $this->assertFalse($this->db::schema()->hasTable('failed_jobs'));
+        $this->assertFalse($this->db::schema()->hasTable('jobs'));
+        $this->assertFalse($this->db::schema('sqlite2')->hasTable('failed_jobs'));
+        $this->assertFalse($this->db::schema('sqlite2')->hasTable('jobs'));
+        $this->assertTrue($this->db::schema('sqlite3')->hasTable('failed_jobs'));
+        $this->assertTrue($this->db::schema('sqlite3')->hasTable('jobs'));
 
         $this->assertTrue(Str::contains($ran[0], 'failed_jobs'));
         $this->assertTrue(Str::contains($ran[1], 'jobs'));
@@ -148,11 +148,11 @@ class DatabaseMigratorIntegrationTest extends TestCase
     public function testMigrationsCanBeRolledBack()
     {
         $this->migrator->run([__DIR__.'/migrations/one']);
-        $this->assertTrue($this->db->schema()->hasTable('users'));
-        $this->assertTrue($this->db->schema()->hasTable('password_resets'));
+        $this->assertTrue($this->db::schema()->hasTable('users'));
+        $this->assertTrue($this->db::schema()->hasTable('password_resets'));
         $rolledBack = $this->migrator->rollback([__DIR__.'/migrations/one']);
-        $this->assertFalse($this->db->schema()->hasTable('users'));
-        $this->assertFalse($this->db->schema()->hasTable('password_resets'));
+        $this->assertFalse($this->db::schema()->hasTable('users'));
+        $this->assertFalse($this->db::schema()->hasTable('password_resets'));
 
         $this->assertTrue(str_contains($rolledBack[0], 'password_resets'));
         $this->assertTrue(str_contains($rolledBack[1], 'users'));
@@ -161,11 +161,11 @@ class DatabaseMigratorIntegrationTest extends TestCase
     public function testMigrationsCanBeResetUsingAnString()
     {
         $this->migrator->run([__DIR__.'/migrations/one']);
-        $this->assertTrue($this->db->schema()->hasTable('users'));
-        $this->assertTrue($this->db->schema()->hasTable('password_resets'));
+        $this->assertTrue($this->db::schema()->hasTable('users'));
+        $this->assertTrue($this->db::schema()->hasTable('password_resets'));
         $rolledBack = $this->migrator->reset(__DIR__.'/migrations/one');
-        $this->assertFalse($this->db->schema()->hasTable('users'));
-        $this->assertFalse($this->db->schema()->hasTable('password_resets'));
+        $this->assertFalse($this->db::schema()->hasTable('users'));
+        $this->assertFalse($this->db::schema()->hasTable('password_resets'));
 
         $this->assertTrue(str_contains($rolledBack[0], 'password_resets'));
         $this->assertTrue(str_contains($rolledBack[1], 'users'));
@@ -174,11 +174,11 @@ class DatabaseMigratorIntegrationTest extends TestCase
     public function testMigrationsCanBeResetUsingAnArray()
     {
         $this->migrator->run([__DIR__.'/migrations/one']);
-        $this->assertTrue($this->db->schema()->hasTable('users'));
-        $this->assertTrue($this->db->schema()->hasTable('password_resets'));
+        $this->assertTrue($this->db::schema()->hasTable('users'));
+        $this->assertTrue($this->db::schema()->hasTable('password_resets'));
         $rolledBack = $this->migrator->reset([__DIR__.'/migrations/one']);
-        $this->assertFalse($this->db->schema()->hasTable('users'));
-        $this->assertFalse($this->db->schema()->hasTable('password_resets'));
+        $this->assertFalse($this->db::schema()->hasTable('users'));
+        $this->assertFalse($this->db::schema()->hasTable('password_resets'));
 
         $this->assertTrue(str_contains($rolledBack[0], 'password_resets'));
         $this->assertTrue(str_contains($rolledBack[1], 'users'));
@@ -187,52 +187,52 @@ class DatabaseMigratorIntegrationTest extends TestCase
     public function testNoErrorIsThrownWhenNoOutstandingMigrationsExist()
     {
         $this->migrator->run([__DIR__.'/migrations/one']);
-        $this->assertTrue($this->db->schema()->hasTable('users'));
-        $this->assertTrue($this->db->schema()->hasTable('password_resets'));
+        $this->assertTrue($this->db::schema()->hasTable('users'));
+        $this->assertTrue($this->db::schema()->hasTable('password_resets'));
         $this->migrator->run([__DIR__.'/migrations/one']);
     }
 
     public function testNoErrorIsThrownWhenNothingToRollback()
     {
         $this->migrator->run([__DIR__.'/migrations/one']);
-        $this->assertTrue($this->db->schema()->hasTable('users'));
-        $this->assertTrue($this->db->schema()->hasTable('password_resets'));
+        $this->assertTrue($this->db::schema()->hasTable('users'));
+        $this->assertTrue($this->db::schema()->hasTable('password_resets'));
         $this->migrator->rollback([__DIR__.'/migrations/one']);
-        $this->assertFalse($this->db->schema()->hasTable('users'));
-        $this->assertFalse($this->db->schema()->hasTable('password_resets'));
+        $this->assertFalse($this->db::schema()->hasTable('users'));
+        $this->assertFalse($this->db::schema()->hasTable('password_resets'));
         $this->migrator->rollback([__DIR__.'/migrations/one']);
     }
 
     public function testMigrationsCanRunAcrossMultiplePaths()
     {
         $this->migrator->run([__DIR__.'/migrations/one', __DIR__.'/migrations/two']);
-        $this->assertTrue($this->db->schema()->hasTable('users'));
-        $this->assertTrue($this->db->schema()->hasTable('password_resets'));
-        $this->assertTrue($this->db->schema()->hasTable('flights'));
+        $this->assertTrue($this->db::schema()->hasTable('users'));
+        $this->assertTrue($this->db::schema()->hasTable('password_resets'));
+        $this->assertTrue($this->db::schema()->hasTable('flights'));
     }
 
     public function testMigrationsCanBeRolledBackAcrossMultiplePaths()
     {
         $this->migrator->run([__DIR__.'/migrations/one', __DIR__.'/migrations/two']);
-        $this->assertTrue($this->db->schema()->hasTable('users'));
-        $this->assertTrue($this->db->schema()->hasTable('password_resets'));
-        $this->assertTrue($this->db->schema()->hasTable('flights'));
+        $this->assertTrue($this->db::schema()->hasTable('users'));
+        $this->assertTrue($this->db::schema()->hasTable('password_resets'));
+        $this->assertTrue($this->db::schema()->hasTable('flights'));
         $this->migrator->rollback([__DIR__.'/migrations/one', __DIR__.'/migrations/two']);
-        $this->assertFalse($this->db->schema()->hasTable('users'));
-        $this->assertFalse($this->db->schema()->hasTable('password_resets'));
-        $this->assertFalse($this->db->schema()->hasTable('flights'));
+        $this->assertFalse($this->db::schema()->hasTable('users'));
+        $this->assertFalse($this->db::schema()->hasTable('password_resets'));
+        $this->assertFalse($this->db::schema()->hasTable('flights'));
     }
 
     public function testMigrationsCanBeResetAcrossMultiplePaths()
     {
         $this->migrator->run([__DIR__.'/migrations/one', __DIR__.'/migrations/two']);
-        $this->assertTrue($this->db->schema()->hasTable('users'));
-        $this->assertTrue($this->db->schema()->hasTable('password_resets'));
-        $this->assertTrue($this->db->schema()->hasTable('flights'));
+        $this->assertTrue($this->db::schema()->hasTable('users'));
+        $this->assertTrue($this->db::schema()->hasTable('password_resets'));
+        $this->assertTrue($this->db::schema()->hasTable('flights'));
         $this->migrator->reset([__DIR__.'/migrations/one', __DIR__.'/migrations/two']);
-        $this->assertFalse($this->db->schema()->hasTable('users'));
-        $this->assertFalse($this->db->schema()->hasTable('password_resets'));
-        $this->assertFalse($this->db->schema()->hasTable('flights'));
+        $this->assertFalse($this->db::schema()->hasTable('users'));
+        $this->assertFalse($this->db::schema()->hasTable('password_resets'));
+        $this->assertFalse($this->db::schema()->hasTable('flights'));
     }
 
     public function testMigrationsCanBeProperlySortedAcrossMultiplePaths()

--- a/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
@@ -43,14 +43,14 @@ class DatabaseSchemaBuilderIntegrationTest extends TestCase
 
     public function testHasColumnWithTablePrefix()
     {
-        $this->db->connection()->setTablePrefix('test_');
+        $this->db::connection()->setTablePrefix('test_');
 
-        $this->db->connection()->getSchemaBuilder()->create('table1', function (Blueprint $table) {
+        $this->db::connection()->getSchemaBuilder()->create('table1', function (Blueprint $table) {
             $table->integer('id');
             $table->string('name');
         });
 
-        $this->assertTrue($this->db->connection()->getSchemaBuilder()->hasColumn('table1', 'name'));
+        $this->assertTrue($this->db::connection()->getSchemaBuilder()->hasColumn('table1', 'name'));
     }
 
     public function testHasColumnAndIndexWithPrefixIndexDisabled()
@@ -89,7 +89,7 @@ class DatabaseSchemaBuilderIntegrationTest extends TestCase
 
     public function testDropColumnWithTablePrefix()
     {
-        $this->db->connection()->setTablePrefix('test_');
+        $this->db::connection()->setTablePrefix('test_');
 
         $this->schemaBuilder()->create('pandemic_table', function (Blueprint $table) {
             $table->integer('id');
@@ -112,6 +112,6 @@ class DatabaseSchemaBuilderIntegrationTest extends TestCase
 
     private function schemaBuilder()
     {
-        return $this->db->connection()->getSchemaBuilder();
+        return $this->db::connection()->getSchemaBuilder();
     }
 }

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -1410,7 +1410,7 @@ class HttpClientTest extends TestCase
         RequestException::truncateAt(60);
 
         $this->factory->fake([
-            '*' => $this->factory->response(['error'], 403),
+            '*' => $this->factory::response(['error'], 403),
         ]);
 
         $exception = null;
@@ -1436,7 +1436,7 @@ class HttpClientTest extends TestCase
         RequestException::truncateAt(60);
 
         $this->factory->fake([
-            '*' => $this->factory->response(['error'], 403),
+            '*' => $this->factory::response(['error'], 403),
         ]);
 
         $exception = null;
@@ -1459,7 +1459,7 @@ class HttpClientTest extends TestCase
         RequestException::dontTruncate();
 
         $this->factory->fake([
-            '*' => $this->factory->response(['error'], 403),
+            '*' => $this->factory::response(['error'], 403),
         ]);
 
         $exception = null;
@@ -1480,7 +1480,7 @@ class HttpClientTest extends TestCase
     {
         RequestException::dontTruncate();
         $this->factory->fake([
-            '*' => $this->factory->response(['error'], 403),
+            '*' => $this->factory::response(['error'], 403),
         ]);
 
         $exception = $this->factory->async()->throw()->truncateExceptionsAt(4)->get('http://foo.com/json')->wait();
@@ -2008,7 +2008,7 @@ class HttpClientTest extends TestCase
     public function testMiddlewareRunsInPool()
     {
         $this->factory->fake(function (Request $request) {
-            return $this->factory->response('Fake');
+            return $this->factory::response('Fake');
         });
 
         $history = [];
@@ -2094,7 +2094,7 @@ class HttpClientTest extends TestCase
 
         $factory = new Factory($events);
         $factory->fake([
-            '*' => $factory->response(['error'], 403),
+            '*' => $factory::response(['error'], 403),
         ]);
 
         $response = $factory->retry(2, 1000, null, false)->get('http://foo.com/get');
@@ -2118,7 +2118,7 @@ class HttpClientTest extends TestCase
 
     public function testTransferStatsArePresentWhenFakingTheRequestUsingAPromiseResponse()
     {
-        $this->factory->fake(['https://example.com' => $this->factory->response()]);
+        $this->factory->fake(['https://example.com' => $this->factory::response()]);
         $effectiveUri = $this->factory->get('https://example.com')->effectiveUri();
 
         $this->assertSame('https://example.com', (string) $effectiveUri);
@@ -2131,7 +2131,7 @@ class HttpClientTest extends TestCase
         $events->shouldReceive('dispatch')->once()->with(m::type(ResponseReceived::class));
 
         $factory = new Factory($events);
-        $factory->fake(['example.com' => $factory->response('foo', 200)]);
+        $factory->fake(['example.com' => $factory::response('foo', 200)]);
 
         $client = $factory->timeout(10);
         $clonedClient = clone $client;
@@ -2148,7 +2148,7 @@ class HttpClientTest extends TestCase
         $this->factory->fake(function (Request $request) {
             $this->assertSame('yes!', $request->customMethod());
 
-            return $this->factory->response();
+            return $this->factory::response();
         });
 
         $this->factory->get('https://example.com');
@@ -2157,7 +2157,7 @@ class HttpClientTest extends TestCase
     public function testRequestExceptionIsThrownWhenRetriesExhausted()
     {
         $this->factory->fake([
-            '*' => $this->factory->response(['error'], 403),
+            '*' => $this->factory::response(['error'], 403),
         ]);
 
         $exception = null;
@@ -2179,7 +2179,7 @@ class HttpClientTest extends TestCase
     public function testRequestExceptionIsThrownWhenRetriesExhaustedWithBackoffArray()
     {
         $this->factory->fake([
-            '*' => $this->factory->response(['error'], 403),
+            '*' => $this->factory::response(['error'], 403),
         ]);
 
         $exception = null;
@@ -2201,7 +2201,7 @@ class HttpClientTest extends TestCase
     public function testRequestExceptionIsThrownWithoutRetriesIfRetryNotNecessary()
     {
         $this->factory->fake([
-            '*' => $this->factory->response(['error'], 500),
+            '*' => $this->factory::response(['error'], 500),
         ]);
 
         $exception = null;
@@ -2230,7 +2230,7 @@ class HttpClientTest extends TestCase
     public function testRequestExceptionIsThrownWithoutRetriesIfRetryNotNecessaryWithBackoffArray()
     {
         $this->factory->fake([
-            '*' => $this->factory->response(['error'], 500),
+            '*' => $this->factory::response(['error'], 500),
         ]);
 
         $exception = null;
@@ -2259,7 +2259,7 @@ class HttpClientTest extends TestCase
     public function testRequestExceptionIsNotThrownWhenDisabledAndRetriesExhausted()
     {
         $this->factory->fake([
-            '*' => $this->factory->response(['error'], 403),
+            '*' => $this->factory::response(['error'], 403),
         ]);
 
         $response = $this->factory
@@ -2274,7 +2274,7 @@ class HttpClientTest extends TestCase
     public function testRequestExceptionIsNotThrownWhenDisabledAndRetriesExhaustedWithBackoffArray()
     {
         $this->factory->fake([
-            '*' => $this->factory->response(['error'], 403),
+            '*' => $this->factory::response(['error'], 403),
         ]);
 
         $response = $this->factory
@@ -2289,7 +2289,7 @@ class HttpClientTest extends TestCase
     public function testRequestExceptionIsNotThrownWithoutRetriesIfRetryNotNecessary()
     {
         $this->factory->fake([
-            '*' => $this->factory->response(['error'], 500),
+            '*' => $this->factory::response(['error'], 500),
         ]);
 
         $whenAttempts = 0;
@@ -2312,7 +2312,7 @@ class HttpClientTest extends TestCase
     public function testRequestExceptionIsNotThrownWithoutRetriesIfRetryNotNecessaryWithBackoffArray()
     {
         $this->factory->fake([
-            '*' => $this->factory->response(['error'], 500),
+            '*' => $this->factory::response(['error'], 500),
         ]);
 
         $whenAttempts = 0;
@@ -2385,7 +2385,7 @@ class HttpClientTest extends TestCase
     public function testExceptionThrownInRetryCallbackWithoutRetrying()
     {
         $this->factory->fake([
-            '*' => $this->factory->response(['error'], 500),
+            '*' => $this->factory::response(['error'], 500),
         ]);
 
         $exception = null;
@@ -2410,7 +2410,7 @@ class HttpClientTest extends TestCase
     public function testExceptionThrownInRetryCallbackWithoutRetryingWithBackoffArray()
     {
         $this->factory->fake([
-            '*' => $this->factory->response(['error'], 500),
+            '*' => $this->factory::response(['error'], 500),
         ]);
 
         $exception = null;
@@ -2465,7 +2465,7 @@ class HttpClientTest extends TestCase
     public function testRequestExceptionReturnedWhenRetriesExhaustedInPool()
     {
         $this->factory->fake([
-            '*' => $this->factory->response(['error'], 403),
+            '*' => $this->factory::response(['error'], 403),
         ]);
 
         [$exception] = $this->factory->pool(fn ($pool) => [
@@ -2481,7 +2481,7 @@ class HttpClientTest extends TestCase
     public function testRequestExceptionIsReturnedWithoutRetriesIfRetryNotNecessaryInPool()
     {
         $this->factory->fake([
-            '*' => $this->factory->response(['error'], 500),
+            '*' => $this->factory::response(['error'], 500),
         ]);
 
         $whenAttempts = collect();
@@ -2505,7 +2505,7 @@ class HttpClientTest extends TestCase
     public function testRequestExceptionIsNotReturnedWhenDisabledAndRetriesExhaustedInPool()
     {
         $this->factory->fake([
-            '*' => $this->factory->response(['error'], 403),
+            '*' => $this->factory::response(['error'], 403),
         ]);
 
         [$response] = $this->factory->pool(fn ($pool) => [
@@ -2522,7 +2522,7 @@ class HttpClientTest extends TestCase
     public function testRequestExceptionIsNotReturnedWithoutRetriesIfRetryNotNecessaryInPool()
     {
         $this->factory->fake([
-            '*' => $this->factory->response(['error'], 500),
+            '*' => $this->factory::response(['error'], 500),
         ]);
 
         $whenAttempts = collect();
@@ -2589,7 +2589,7 @@ class HttpClientTest extends TestCase
     public function testExceptionThrownInRetryCallbackIsReturnedWithoutRetryingInPool()
     {
         $this->factory->fake([
-            '*' => $this->factory->response(['error'], 500),
+            '*' => $this->factory::response(['error'], 500),
         ]);
 
         [$exception] = $this->factory->pool(fn ($pool) => [
@@ -2614,7 +2614,7 @@ class HttpClientTest extends TestCase
         $this->expectException(RuntimeException::class);
 
         $this->factory->fake(function (Request $request) {
-            return $this->factory->response('Fake');
+            return $this->factory::response('Fake');
         })->withMiddleware($middleware)
             ->retry(3, 1, function (Exception $exception, PendingRequest $request) {
                 return true;
@@ -2651,7 +2651,7 @@ class HttpClientTest extends TestCase
 
     public function testFailedRequest()
     {
-        $requestException = $this->factory->failedRequest(['code' => 'not_found'], 404, ['X-RateLimit-Remaining' => 199]);
+        $requestException = $this->factory::failedRequest(['code' => 'not_found'], 404, ['X-RateLimit-Remaining' => 199]);
 
         $this->assertInstanceOf(RequestException::class, $requestException);
         $this->assertEqualsCanonicalizing(['code' => 'not_found'], $requestException->response->json());
@@ -2661,7 +2661,7 @@ class HttpClientTest extends TestCase
 
     public function testFakeConnectionException()
     {
-        $this->factory->fake($this->factory->failedConnection('Fake'));
+        $this->factory->fake($this->factory::failedConnection('Fake'));
 
         $exception = null;
 
@@ -2683,7 +2683,7 @@ class HttpClientTest extends TestCase
 
     public function testFakeConnectionExceptionWithinFakeClosure()
     {
-        $this->factory->fake(fn () => $this->factory->failedConnection('Fake'));
+        $this->factory->fake(fn () => $this->factory::failedConnection('Fake'));
 
         $exception = null;
 
@@ -2702,7 +2702,7 @@ class HttpClientTest extends TestCase
 
     public function testFakeConnectionExceptionWithinArray()
     {
-        $this->factory->fake(['*' => $this->factory->failedConnection('Fake')]);
+        $this->factory->fake(['*' => $this->factory::failedConnection('Fake')]);
 
         $exception = null;
 
@@ -2747,7 +2747,7 @@ class HttpClientTest extends TestCase
     public function testMiddlewareRunsWhenFaked()
     {
         $this->factory->fake(function (Request $request) {
-            return $this->factory->response('Fake');
+            return $this->factory::response('Fake');
         });
 
         $history = [];
@@ -2770,7 +2770,7 @@ class HttpClientTest extends TestCase
     public function testMiddlewareRunsAndCanChangeRequestOnAssertSent()
     {
         $this->factory->fake(function (Request $request) {
-            return $this->factory->response('Fake');
+            return $this->factory::response('Fake');
         });
 
         $pendingRequest = $this->factory->withMiddleware(
@@ -2894,9 +2894,9 @@ class HttpClientTest extends TestCase
     public function testTooManyRedirectsWithFakedRedirectChain()
     {
         $this->factory->fake([
-            '1.example.com' => $this->factory->response(null, 301, ['Location' => 'https://2.example.com']),
-            '2.example.com' => $this->factory->response(null, 301, ['Location' => 'https://3.example.com']),
-            '3.example.com' => $this->factory->response('', 200),
+            '1.example.com' => $this->factory::response(null, 301, ['Location' => 'https://2.example.com']),
+            '2.example.com' => $this->factory::response(null, 301, ['Location' => 'https://3.example.com']),
+            '3.example.com' => $this->factory::response('', 200),
         ]);
 
         $this->expectException(ConnectionException::class);
@@ -2907,7 +2907,7 @@ class HttpClientTest extends TestCase
     public function testRequestExceptionIsNotThrownIfThePendingRequestIsSetToThrowOnFailureButTheResponseIsSuccessful()
     {
         $this->factory->fake([
-            '*' => $this->factory->response(['success'], 200),
+            '*' => $this->factory::response(['success'], 200),
         ]);
 
         $response = $this->factory
@@ -2920,7 +2920,7 @@ class HttpClientTest extends TestCase
     public function testRequestExceptionIsThrownIfThePendingRequestIsSetToThrowOnFailure()
     {
         $this->factory->fake([
-            '*' => $this->factory->response(['error'], 403),
+            '*' => $this->factory::response(['error'], 403),
         ]);
 
         $exception = null;
@@ -2940,7 +2940,7 @@ class HttpClientTest extends TestCase
     public function testRequestExceptionIsThrownIfTheThrowIfOnThePendingRequestIsSetToTrueOnFailure()
     {
         $this->factory->fake([
-            '*' => $this->factory->response(['error'], 403),
+            '*' => $this->factory::response(['error'], 403),
         ]);
 
         $exception = null;
@@ -2960,7 +2960,7 @@ class HttpClientTest extends TestCase
     public function testRequestExceptionIsNotThrownIfTheThrowIfOnThePendingRequestIsSetToFalseOnFailure()
     {
         $this->factory->fake([
-            '*' => $this->factory->response(['error'], 403),
+            '*' => $this->factory::response(['error'], 403),
         ]);
 
         $response = $this->factory
@@ -2973,7 +2973,7 @@ class HttpClientTest extends TestCase
     public function testRequestExceptionIsThrownIfTheThrowIfClosureOnThePendingRequestReturnsTrue()
     {
         $this->factory->fake([
-            '*' => $this->factory->response(['error'], 403),
+            '*' => $this->factory::response(['error'], 403),
         ]);
 
         $exception = null;
@@ -3007,7 +3007,7 @@ class HttpClientTest extends TestCase
     public function testRequestExceptionIsNotThrownIfTheThrowIfClosureOnThePendingRequestReturnsFalse()
     {
         $this->factory->fake([
-            '*' => $this->factory->response(['error'], 403),
+            '*' => $this->factory::response(['error'], 403),
         ]);
 
         $hitThrowCallback = false;
@@ -3030,7 +3030,7 @@ class HttpClientTest extends TestCase
     public function testRequestExceptionIsThrownWithCallbackIfThePendingRequestIsSetToThrowOnFailure()
     {
         $this->factory->fake([
-            '*' => $this->factory->response(['error'], 403),
+            '*' => $this->factory::response(['error'], 403),
         ]);
 
         $exception = null;
@@ -3109,7 +3109,7 @@ class HttpClientTest extends TestCase
     public function testRequestExceptionIsNotReturnedIfThePendingRequestIsSetToThrowOnFailureButTheResponseIsSuccessfulInPool()
     {
         $this->factory->fake([
-            '*' => $this->factory->response(['success'], 200),
+            '*' => $this->factory::response(['success'], 200),
         ]);
 
         [$response] = $this->factory->pool(fn ($pool) => [
@@ -3123,7 +3123,7 @@ class HttpClientTest extends TestCase
     public function testRequestExceptionIsReturnedIfThePendingRequestIsSetToThrowOnFailureInPool()
     {
         $this->factory->fake([
-            '*' => $this->factory->response(['error'], 403),
+            '*' => $this->factory::response(['error'], 403),
         ]);
 
         [$exception] = $this->factory->pool(fn ($pool) => [
@@ -3137,7 +3137,7 @@ class HttpClientTest extends TestCase
     public function testRequestExceptionIsReturnedIfTheThrowIfOnThePendingRequestIsSetToTrueOnFailureInPool()
     {
         $this->factory->fake([
-            '*' => $this->factory->response(['error'], 403),
+            '*' => $this->factory::response(['error'], 403),
         ]);
 
         [$exception] = $this->factory->pool(fn ($pool) => [
@@ -3151,7 +3151,7 @@ class HttpClientTest extends TestCase
     public function testRequestExceptionIsNotReturnedIfTheThrowIfOnThePendingRequestIsSetToFalseOnFailureInPool()
     {
         $this->factory->fake([
-            '*' => $this->factory->response(['error'], 403),
+            '*' => $this->factory::response(['error'], 403),
         ]);
 
         [$response] = $this->factory->pool(fn ($pool) => [
@@ -3165,7 +3165,7 @@ class HttpClientTest extends TestCase
     public function testRequestExceptionIsReturnedIfTheThrowIfClosureOnThePendingRequestReturnsTrueInPool()
     {
         $this->factory->fake([
-            '*' => $this->factory->response(['error'], 403),
+            '*' => $this->factory::response(['error'], 403),
         ]);
 
         $hitThrowCallback = collect();
@@ -3194,7 +3194,7 @@ class HttpClientTest extends TestCase
     public function testRequestExceptionIsNotReturnedIfTheThrowIfClosureOnThePendingRequestReturnsFalseInPool()
     {
         $this->factory->fake([
-            '*' => $this->factory->response(['error'], 403),
+            '*' => $this->factory::response(['error'], 403),
         ]);
 
         $hitThrowCallback = collect();
@@ -3217,7 +3217,7 @@ class HttpClientTest extends TestCase
     public function testRequestExceptionIsReturnedWithCallbackIfThePendingRequestIsSetToThrowOnFailureInPool()
     {
         $this->factory->fake([
-            '*' => $this->factory->response(['error'], 403),
+            '*' => $this->factory::response(['error'], 403),
         ]);
 
         $flag = collect();
@@ -3237,7 +3237,7 @@ class HttpClientTest extends TestCase
     public function testRequestExceptionIsReturnedAfterLastRetryInPool()
     {
         $this->factory->fake([
-            '*' => $this->factory->response(['error'], 403),
+            '*' => $this->factory::response(['error'], 403),
         ]);
 
         [$exception] = $this->factory->pool(fn ($pool) => [
@@ -3987,7 +3987,7 @@ class HttpClientTest extends TestCase
             $allowRedirects = $options['allow_redirects'];
             $headers = $request->headers();
 
-            return $factory->response('');
+            return $factory::response('');
         });
 
         $factory->get('https://laravel.com');

--- a/tests/Http/Middleware/TrustProxiesTest.php
+++ b/tests/Http/Middleware/TrustProxiesTest.php
@@ -42,7 +42,7 @@ class TrustProxiesTest extends TestCase
     public function test_does_trust_trusted_proxy()
     {
         $req = $this->createProxiedRequest();
-        $req->setTrustedProxies(['192.168.10.10'], $this->headerAll);
+        $req::setTrustedProxies(['192.168.10.10'], $this->headerAll);
 
         $this->assertSame('173.174.200.38', $req->getClientIp(), 'Assert trusted proxy x-forwarded-for header used');
         $this->assertSame('https', $req->getScheme(), 'Assert trusted proxy x-forwarded-proto header used');
@@ -396,7 +396,7 @@ class TrustProxiesTest extends TestCase
         // which is likely something like this:
         $request = Request::create('http://localhost:8888/tag/proxy', 'GET', [], [], [], $serverOverrides, null);
         // Need to make sure these haven't already been set
-        $request->setTrustedProxies([], $this->headerAll);
+        $request::setTrustedProxies([], $this->headerAll);
 
         return $request;
     }

--- a/tests/Support/DateFacadeTest.php
+++ b/tests/Support/DateFacadeTest.php
@@ -36,24 +36,24 @@ class DateFacadeTest extends TestCase
     {
         $start = Carbon::now()->getTimestamp();
         $this->assertSame(Carbon::class, get_class(Date::now()));
-        $this->assertBetweenStartAndNow($start, Date::now()->getTimestamp());
+        self::assertBetweenStartAndNow($start, Date::now()->getTimestamp());
         DateFactory::use(function (Carbon $date) {
             return new DateTime($date->format('Y-m-d H:i:s.u'), $date->getTimezone());
         });
         $start = Carbon::now()->getTimestamp();
         $this->assertSame(DateTime::class, get_class(Date::now()));
-        $this->assertBetweenStartAndNow($start, Date::now()->getTimestamp());
+        self::assertBetweenStartAndNow($start, Date::now()->getTimestamp());
     }
 
     public function testUseClassName()
     {
         $start = Carbon::now()->getTimestamp();
         $this->assertSame(Carbon::class, get_class(Date::now()));
-        $this->assertBetweenStartAndNow($start, Date::now()->getTimestamp());
+        self::assertBetweenStartAndNow($start, Date::now()->getTimestamp());
         DateFactory::use(DateTime::class);
         $start = Carbon::now()->getTimestamp();
         $this->assertSame(DateTime::class, get_class(Date::now()));
-        $this->assertBetweenStartAndNow($start, Date::now()->getTimestamp());
+        self::assertBetweenStartAndNow($start, Date::now()->getTimestamp());
     }
 
     public function testCarbonImmutable()

--- a/tests/View/Blade/BladeComponentsTest.php
+++ b/tests/View/Blade/BladeComponentsTest.php
@@ -26,14 +26,14 @@ class BladeComponentsTest extends AbstractBladeTestCase
 
     public function testEndComponentsAreCompiled()
     {
-        $this->compiler->newComponentHash('foo');
+        $this->compiler::newComponentHash('foo');
 
         $this->assertSame('<?php echo $__env->renderComponent(); ?>', $this->compiler->compileString('@endcomponent'));
     }
 
     public function testEndComponentClassesAreCompiled()
     {
-        $this->compiler->newComponentHash('foo');
+        $this->compiler::newComponentHash('foo');
 
         $this->assertSame(str_replace("\r\n", "\n", '<?php echo $__env->renderComponent(); ?>
 <?php endif; ?>

--- a/types/Database/Eloquent/Factories/Factory.php
+++ b/types/Database/Eloquent/Factories/Factory.php
@@ -165,10 +165,10 @@ Factory::guessModelNamesUsing(function (Factory $factory) {
     };
 });
 
-$factory->useNamespace('string');
+$factory::useNamespace('string');
 
 assertType('Illuminate\Database\Eloquent\Factories\Factory<User>', $factory::factoryForModel(User::class));
-assertType('class-string<Illuminate\Database\Eloquent\Factories\Factory<User>>', $factory->resolveFactoryName(User::class));
+assertType('class-string<Illuminate\Database\Eloquent\Factories\Factory<User>>', $factory::resolveFactoryName(User::class));
 
 Factory::guessFactoryNamesUsing(function (string $modelName) {
     return match ($modelName) {

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -64,16 +64,16 @@ assertType('Illuminate\Support\Collection<int, User>', $collection->each(functio
     assertType('User', $user);
 }));
 
-assertType('Illuminate\Support\Collection<int, int>', $collection->range(1, 100));
+assertType('Illuminate\Support\Collection<int, int>', $collection::range(1, 100));
 
-assertType('Illuminate\Support\Collection<(int|string), string>', $collection->wrap('string'));
-assertType('Illuminate\Support\Collection<(int|string), User>', $collection->wrap(new User));
+assertType('Illuminate\Support\Collection<(int|string), string>', $collection::wrap('string'));
+assertType('Illuminate\Support\Collection<(int|string), User>', $collection::wrap(new User));
 
-assertType('Illuminate\Support\Collection<(int|string), string>', $collection->wrap(['string']));
-assertType('Illuminate\Support\Collection<(int|string), User>', $collection->wrap(['string' => new User]));
+assertType('Illuminate\Support\Collection<(int|string), string>', $collection::wrap(['string']));
+assertType('Illuminate\Support\Collection<(int|string), User>', $collection::wrap(['string' => new User]));
 
-assertType("array<0, 'string'>", $collection->unwrap(['string']));
-assertType('array<int, User>', $collection->unwrap(
+assertType("array<0, 'string'>", $collection::unwrap(['string']));
+assertType('array<int, User>', $collection::unwrap(
     $collection
 ));
 
@@ -643,42 +643,42 @@ assertType('Illuminate\Support\Collection<int, string>', $collection::make(['str
 
 assertType('Illuminate\Support\Collection<int, User>', $collection->mapInto(User::class));
 
-assertType('Illuminate\Support\Collection<int, int>', $collection->make([1])->merge([2]));
-assertType('Illuminate\Support\Collection<int, string>', $collection->make(['string'])->merge(['string']));
+assertType('Illuminate\Support\Collection<int, int>', $collection::make([1])->merge([2]));
+assertType('Illuminate\Support\Collection<int, string>', $collection::make(['string'])->merge(['string']));
 
-assertType('Illuminate\Support\Collection<int, int|string>', $collection->make([1])->merge(['string']));
-assertType('Illuminate\Support\Collection<int, int|string>', $collection->make(['string'])->merge([1]));
+assertType('Illuminate\Support\Collection<int, int|string>', $collection::make([1])->merge(['string']));
+assertType('Illuminate\Support\Collection<int, int|string>', $collection::make(['string'])->merge([1]));
 
-assertType('Illuminate\Support\Collection<int, int|string>', $collection->make([1])->mergeRecursive([2 => 'string']));
-assertType('Illuminate\Support\Collection<int, string>', $collection->make(['string'])->mergeRecursive(['string']));
+assertType('Illuminate\Support\Collection<int, int|string>', $collection::make([1])->mergeRecursive([2 => 'string']));
+assertType('Illuminate\Support\Collection<int, string>', $collection::make(['string'])->mergeRecursive(['string']));
 
-assertType('Illuminate\Support\Collection<string, int>', $collection->make(['string' => 'string'])->combine([2]));
-assertType('Illuminate\Support\Collection<int, int>', $collection->make([1])->combine([1]));
-assertType('Illuminate\Support\Collection<string, string>', $collection->make(['string'])->combine(['string']));
+assertType('Illuminate\Support\Collection<string, int>', $collection::make(['string' => 'string'])->combine([2]));
+assertType('Illuminate\Support\Collection<int, int>', $collection::make([1])->combine([1]));
+assertType('Illuminate\Support\Collection<string, string>', $collection::make(['string'])->combine(['string']));
 
-assertType('Illuminate\Support\Collection<int, int>', $collection->make([1])->union([1]));
-assertType('Illuminate\Support\Collection<string, string>', $collection->make(['string' => 'string'])->union(['string' => 'string']));
+assertType('Illuminate\Support\Collection<int, int>', $collection::make([1])->union([1]));
+assertType('Illuminate\Support\Collection<string, string>', $collection::make(['string' => 'string'])->union(['string' => 'string']));
 
-assertType('mixed', $collection->make()->min());
-assertType('mixed', $collection->make([1])->min());
-assertType('mixed', $collection->make([1])->min('string'));
-assertType('mixed', $collection->make(['string' => 1])->min('string'));
-assertType('mixed', $collection->make([1])->min(function ($int) {
+assertType('mixed', $collection::make()->min());
+assertType('mixed', $collection::make([1])->min());
+assertType('mixed', $collection::make([1])->min('string'));
+assertType('mixed', $collection::make(['string' => 1])->min('string'));
+assertType('mixed', $collection::make([1])->min(function ($int) {
     assertType('int', $int);
 
     return 1;
 }));
-assertType('mixed', $collection->make([new User])->min('id'));
+assertType('mixed', $collection::make([new User])->min('id'));
 
-assertType('mixed', $collection->make()->max());
-assertType('mixed', $collection->make([1])->max());
-assertType('mixed', $collection->make([1])->max('string'));
-assertType('mixed', $collection->make([1])->max(function ($int) {
+assertType('mixed', $collection::make()->max());
+assertType('mixed', $collection::make([1])->max());
+assertType('mixed', $collection::make([1])->max('string'));
+assertType('mixed', $collection::make([1])->max(function ($int) {
     assertType('int', $int);
 
     return 1;
 }));
-assertType('mixed', $collection->make([new User])->max('id'));
+assertType('mixed', $collection::make([new User])->max('id'));
 
 assertType('Illuminate\Support\Collection<int, User>', $collection->nth(1, 2));
 
@@ -699,9 +699,9 @@ assertType('Illuminate\Support\Collection<int<0, 1>, Illuminate\Support\Collecti
 assertType('Illuminate\Support\Collection<int<0, 1>, Illuminate\Support\Collection<int, string>>', $collection::make(['string'])->partition('string', 'string'));
 assertType('Illuminate\Support\Collection<int<0, 1>, Illuminate\Support\Collection<int, string>>', $collection::make(['string'])->partition('string'));
 
-assertType('Illuminate\Support\Collection<int, int>', $collection->make([1])->concat([2]));
-assertType('Illuminate\Support\Collection<int, string>', $collection->make(['string'])->concat(['string']));
-assertType('Illuminate\Support\Collection<int, int|string>', $collection->make([1])->concat(['string']));
+assertType('Illuminate\Support\Collection<int, int>', $collection::make([1])->concat([2]));
+assertType('Illuminate\Support\Collection<int, string>', $collection::make(['string'])->concat(['string']));
+assertType('Illuminate\Support\Collection<int, int|string>', $collection::make([1])->concat(['string']));
 
 assertType('Illuminate\Support\Collection<int, int>', $collection::make([1])->random(2));
 assertType('string', $collection::make(['string'])->random());
@@ -760,8 +760,8 @@ assertType('Illuminate\Support\Collection<int, User>', $collection->replaceRecur
 
 assertType('Illuminate\Support\Collection<int, User>', $collection->reverse());
 
-// assertType('int|bool', $collection->make([1])->search(2));
-// assertType('string|bool', $collection->make(['string' => 'string'])->search('string'));
+// assertType('int|bool', $collection::make([1])->search(2));
+// assertType('string|bool', $collection::make(['string' => 'string'])->search('string'));
 // assertType('int|bool', $collection->search(function ($user, $int) {
 //     assertType('User', $user);
 //    assertType('int', $int);
@@ -769,13 +769,13 @@ assertType('Illuminate\Support\Collection<int, User>', $collection->reverse());
 //    return true;
 // }));
 
-assertType('Illuminate\Support\Collection<int, int>', $collection->make([1])->shuffle());
+assertType('Illuminate\Support\Collection<int, int>', $collection::make([1])->shuffle());
 assertType('Illuminate\Support\Collection<int, User>', $collection->shuffle());
 
-assertType('Illuminate\Support\Collection<int, int>', $collection->make([1])->skip(1));
+assertType('Illuminate\Support\Collection<int, int>', $collection::make([1])->skip(1));
 assertType('Illuminate\Support\Collection<int, User>', $collection->skip(1));
 
-assertType('Illuminate\Support\Collection<int, int>', $collection->make([1])->skipUntil(1));
+assertType('Illuminate\Support\Collection<int, int>', $collection::make([1])->skipUntil(1));
 assertType('Illuminate\Support\Collection<int, User>', $collection->skipUntil(new User));
 assertType('Illuminate\Support\Collection<int, User>', $collection->skipUntil(function ($user, $int) {
     assertType('User', $user);
@@ -784,7 +784,7 @@ assertType('Illuminate\Support\Collection<int, User>', $collection->skipUntil(fu
     return true;
 }));
 
-assertType('Illuminate\Support\Collection<int, int>', $collection->make([1])->skipWhile(1));
+assertType('Illuminate\Support\Collection<int, int>', $collection::make([1])->skipWhile(1));
 assertType('Illuminate\Support\Collection<int, User>', $collection->skipWhile(new User));
 assertType('Illuminate\Support\Collection<int, User>', $collection->skipWhile(function ($user, $int) {
     assertType('User', $user);
@@ -793,14 +793,14 @@ assertType('Illuminate\Support\Collection<int, User>', $collection->skipWhile(fu
     return true;
 }));
 
-assertType('Illuminate\Support\Collection<int, int>', $collection->make([1])->slice(1));
+assertType('Illuminate\Support\Collection<int, int>', $collection::make([1])->slice(1));
 assertType('Illuminate\Support\Collection<int, User>', $collection->slice(1, 2));
 
 assertType('Illuminate\Support\Collection<int, Illuminate\Support\Collection<int, User>>', $collection->split(3));
-assertType('Illuminate\Support\Collection<int, Illuminate\Support\Collection<int, int>>', $collection->make([1])->split(3));
+assertType('Illuminate\Support\Collection<int, Illuminate\Support\Collection<int, int>>', $collection::make([1])->split(3));
 
-assertType('string', $collection->make(['string' => 'string'])->sole('string', 'string'));
-assertType('string', $collection->make(['string' => 'string'])->sole('string', '=', 'string'));
+assertType('string', $collection::make(['string' => 'string'])->sole('string', 'string'));
+assertType('string', $collection::make(['string' => 'string'])->sole('string', '=', 'string'));
 assertType('User', $collection->sole(function ($user, $int) {
     assertType('User', $user);
     assertType('int', $int);
@@ -878,23 +878,23 @@ assertType('Illuminate\Support\Collection<int, User>', $collection->sortByDesc([
     return 1;
 }]));
 
-assertType('Illuminate\Support\Collection<int, int>', $collection->make([1])->sortKeys());
-assertType('Illuminate\Support\Collection<string, string>', $collection->make(['string' => 'string'])->sortKeys(1, true));
+assertType('Illuminate\Support\Collection<int, int>', $collection::make([1])->sortKeys());
+assertType('Illuminate\Support\Collection<string, string>', $collection::make(['string' => 'string'])->sortKeys(1, true));
 
-assertType('Illuminate\Support\Collection<int, int>', $collection->make([1])->sortKeysDesc());
-assertType('Illuminate\Support\Collection<string, string>', $collection->make(['string' => 'string'])->sortKeysDesc(1));
+assertType('Illuminate\Support\Collection<int, int>', $collection::make([1])->sortKeysDesc());
+assertType('Illuminate\Support\Collection<string, string>', $collection::make(['string' => 'string'])->sortKeysDesc(1));
 
-assertType('mixed', $collection->make([1])->sum('string'));
-assertType('int<1, 2>', $collection->make(['string'])->sum(function ($string) {
+assertType('mixed', $collection::make([1])->sum('string'));
+assertType('int<1, 2>', $collection::make(['string'])->sum(function ($string) {
     assertType('string', $string);
 
     return rand(1, 2);
 }));
 
-assertType('Illuminate\Support\Collection<int, int>', $collection->make([1])->take(1));
+assertType('Illuminate\Support\Collection<int, int>', $collection::make([1])->take(1));
 assertType('Illuminate\Support\Collection<int, User>', $collection->take(1));
 
-assertType('Illuminate\Support\Collection<int, int>', $collection->make([1])->takeUntil(1));
+assertType('Illuminate\Support\Collection<int, int>', $collection::make([1])->takeUntil(1));
 assertType('Illuminate\Support\Collection<int, User>', $collection->takeUntil(new User));
 assertType('Illuminate\Support\Collection<int, User>', $collection->takeUntil(function ($user, $int) {
     assertType('User', $user);
@@ -903,7 +903,7 @@ assertType('Illuminate\Support\Collection<int, User>', $collection->takeUntil(fu
     return true;
 }));
 
-assertType('Illuminate\Support\Collection<int, int>', $collection->make([1])->takeWhile(1));
+assertType('Illuminate\Support\Collection<int, int>', $collection::make([1])->takeWhile(1));
 assertType('Illuminate\Support\Collection<int, User>', $collection->takeWhile(new User));
 assertType('Illuminate\Support\Collection<int, User>', $collection->takeWhile(function ($user, $int) {
     assertType('User', $user);
@@ -921,7 +921,7 @@ assertType('Illuminate\Support\Collection<int, int>', $collection->pipe(function
 
     return collect([1]);
 }));
-assertType('1', $collection->make([1])->pipe(function ($collection) {
+assertType('1', $collection::make([1])->pipe(function ($collection) {
     assertType('Illuminate\Support\Collection<int, int>', $collection);
 
     return 1;
@@ -929,8 +929,8 @@ assertType('1', $collection->make([1])->pipe(function ($collection) {
 
 assertType('User', $collection->pipeInto(User::class));
 
-assertType('Illuminate\Support\Collection<(int|string), mixed>', $collection->make(['string' => 'string'])->pluck('string'));
-assertType('Illuminate\Support\Collection<(int|string), mixed>', $collection->make(['string' => 'string'])->pluck('string', 'string'));
+assertType('Illuminate\Support\Collection<(int|string), mixed>', $collection::make(['string' => 'string'])->pluck('string'));
+assertType('Illuminate\Support\Collection<(int|string), mixed>', $collection::make(['string' => 'string'])->pluck('string', 'string'));
 
 assertType('Illuminate\Support\Collection<int, User>', $collection->reject());
 assertType('Illuminate\Support\Collection<int, User>', $collection->reject(new User));
@@ -953,7 +953,7 @@ assertType('Illuminate\Support\Collection<int, User>', $collection->unique(funct
 
     return $user->getTable();
 }));
-assertType('Illuminate\Support\Collection<string, string>', $collection->make(['string' => 'string'])->unique(function ($stringA, $stringB) {
+assertType('Illuminate\Support\Collection<string, string>', $collection::make(['string' => 'string'])->unique(function ($stringA, $stringB) {
     assertType('string', $stringA);
     assertType('string', $stringB);
 
@@ -972,18 +972,18 @@ assertType('Illuminate\Support\Collection<int, User>', $collection->values());
 assertType('Illuminate\Support\Collection<int, string>', $collection::make(['string', 'string'])->values());
 assertType('Illuminate\Support\Collection<int, int|string>', $collection::make(['string', 1])->values());
 
-assertType('Illuminate\Support\Collection<int, int>', $collection->make([1])->pad(2, 0));
-assertType('Illuminate\Support\Collection<int, int|string>', $collection->make([1])->pad(2, 'string'));
+assertType('Illuminate\Support\Collection<int, int>', $collection::make([1])->pad(2, 0));
+assertType('Illuminate\Support\Collection<int, int|string>', $collection::make([1])->pad(2, 'string'));
 assertType('Illuminate\Support\Collection<int, int|User>', $collection->pad(2, 0));
 
-assertType('Illuminate\Support\Collection<(int|string), int>', $collection->make([1])->countBy());
-assertType('Illuminate\Support\Collection<(int|string), int>', $collection->make(['string' => 'string'])->countBy('string'));
-assertType('Illuminate\Support\Collection<(int|string), int>', $collection->make([new User])->countBy('email'));
-assertType('Illuminate\Support\Collection<(int|string), int>', $collection->make([new User])->countBy(static fn ($user) => 'email'));
-assertType('Illuminate\Support\Collection<(int|string), int>', $collection->make([new User])->countBy(static fn ($user) => 0));
-assertType('Illuminate\Support\Collection<(int|string), int>', $collection->make([new User])->countBy(static fn ($user) => Digit::One));
-assertType('Illuminate\Support\Collection<(int|string), int>', $collection->make([new User])->countBy(static fn ($user) => NamedDigit::One));
-assertType('Illuminate\Support\Collection<(int|string), int>', $collection->make(['string'])->countBy(function ($string, $int) {
+assertType('Illuminate\Support\Collection<(int|string), int>', $collection::make([1])->countBy());
+assertType('Illuminate\Support\Collection<(int|string), int>', $collection::make(['string' => 'string'])->countBy('string'));
+assertType('Illuminate\Support\Collection<(int|string), int>', $collection::make([new User])->countBy('email'));
+assertType('Illuminate\Support\Collection<(int|string), int>', $collection::make([new User])->countBy(static fn ($user) => 'email'));
+assertType('Illuminate\Support\Collection<(int|string), int>', $collection::make([new User])->countBy(static fn ($user) => 0));
+assertType('Illuminate\Support\Collection<(int|string), int>', $collection::make([new User])->countBy(static fn ($user) => Digit::One));
+assertType('Illuminate\Support\Collection<(int|string), int>', $collection::make([new User])->countBy(static fn ($user) => NamedDigit::One));
+assertType('Illuminate\Support\Collection<(int|string), int>', $collection::make(['string'])->countBy(function ($string, $int) {
     assertType('string', $string);
     assertType('int', $int);
 
@@ -995,9 +995,9 @@ assertType('Illuminate\Support\Collection<int, Illuminate\Support\Collection<int
 assertType('Illuminate\Support\Collection<int, Illuminate\Support\Collection<int, string>>', $collection::make(['string' => 'string'])->zip(['string']));
 
 assertType('Illuminate\Support\Collection<int, User>', $collection->collect());
-assertType('Illuminate\Support\Collection<int, int>', $collection->make([1])->collect());
+assertType('Illuminate\Support\Collection<int, int>', $collection::make([1])->collect());
 
-assertType('Illuminate\Support\Collection<int, int>', $collection->make([1])->push(2));
+assertType('Illuminate\Support\Collection<int, int>', $collection::make([1])->push(2));
 
 assertType('array<int, User>', $collection->all());
 
@@ -1021,10 +1021,10 @@ assertType('Illuminate\Support\Collection<int, string>', $collection::make([
     'string-key-2' => 'string-value-2',
 ])->pop(2));
 
-assertType('Illuminate\Support\Collection<int, int>', $collection->make([1])->prepend(2));
+assertType('Illuminate\Support\Collection<int, int>', $collection::make([1])->prepend(2));
 assertType('Illuminate\Support\Collection<int, User>', $collection->prepend(new User, 2));
 
-assertType('Illuminate\Support\Collection<int, int>', $collection->make([1])->push(2));
+assertType('Illuminate\Support\Collection<int, int>', $collection::make([1])->push(2));
 assertType('Illuminate\Support\Collection<int, User>', $collection->push(new User, new User));
 
 assertType('User|null', $collection->pull(1));

--- a/types/Support/LazyCollection.php
+++ b/types/Support/LazyCollection.php
@@ -57,16 +57,16 @@ assertType('Illuminate\Support\LazyCollection<int, User>', $collection->each(fun
     assertType('User', $user);
 }));
 
-assertType('Illuminate\Support\LazyCollection<int, int>', $collection->range(1, 100));
+assertType('Illuminate\Support\LazyCollection<int, int>', $collection::range(1, 100));
 
-assertType('Illuminate\Support\LazyCollection<(int|string), string>', $collection->wrap('string'));
-assertType('Illuminate\Support\LazyCollection<(int|string), User>', $collection->wrap(new User));
+assertType('Illuminate\Support\LazyCollection<(int|string), string>', $collection::wrap('string'));
+assertType('Illuminate\Support\LazyCollection<(int|string), User>', $collection::wrap(new User));
 
-assertType('Illuminate\Support\LazyCollection<(int|string), string>', $collection->wrap(['string']));
-assertType('Illuminate\Support\LazyCollection<(int|string), User>', $collection->wrap(['string' => new User]));
+assertType('Illuminate\Support\LazyCollection<(int|string), string>', $collection::wrap(['string']));
+assertType('Illuminate\Support\LazyCollection<(int|string), User>', $collection::wrap(['string' => new User]));
 
-assertType("array<0, 'string'>", $collection->unwrap(['string']));
-assertType('array<int, User>', $collection->unwrap(
+assertType("array<0, 'string'>", $collection::unwrap(['string']));
+assertType('array<int, User>', $collection::unwrap(
     $collection
 ));
 
@@ -536,40 +536,40 @@ assertType('Illuminate\Support\LazyCollection<int, string>', $collection::make([
 
 assertType('Illuminate\Support\LazyCollection<int, User>', $collection->mapInto(User::class));
 
-assertType('Illuminate\Support\LazyCollection<int, int>', $collection->make([1])->merge([2]));
-assertType('Illuminate\Support\LazyCollection<int, string>', $collection->make(['string'])->merge(['string']));
+assertType('Illuminate\Support\LazyCollection<int, int>', $collection::make([1])->merge([2]));
+assertType('Illuminate\Support\LazyCollection<int, string>', $collection::make(['string'])->merge(['string']));
 
-assertType('Illuminate\Support\LazyCollection<int, int|string>', $collection->make([1])->merge(['string']));
-assertType('Illuminate\Support\LazyCollection<int, int|string>', $collection->make(['string'])->merge([1]));
+assertType('Illuminate\Support\LazyCollection<int, int|string>', $collection::make([1])->merge(['string']));
+assertType('Illuminate\Support\LazyCollection<int, int|string>', $collection::make(['string'])->merge([1]));
 
-assertType('Illuminate\Support\LazyCollection<int, int>', $collection->make([1])->mergeRecursive([2]));
-assertType('Illuminate\Support\LazyCollection<int, string>', $collection->make(['string'])->mergeRecursive(['string']));
+assertType('Illuminate\Support\LazyCollection<int, int>', $collection::make([1])->mergeRecursive([2]));
+assertType('Illuminate\Support\LazyCollection<int, string>', $collection::make(['string'])->mergeRecursive(['string']));
 
-assertType('Illuminate\Support\LazyCollection<string, int>', $collection->make(['string' => 'string'])->combine([2]));
-assertType('Illuminate\Support\LazyCollection<int, int>', $collection->make([1])->combine([1]));
+assertType('Illuminate\Support\LazyCollection<string, int>', $collection::make(['string' => 'string'])->combine([2]));
+assertType('Illuminate\Support\LazyCollection<int, int>', $collection::make([1])->combine([1]));
 
-assertType('Illuminate\Support\LazyCollection<int, int>', $collection->make([1])->union([1]));
-assertType('Illuminate\Support\LazyCollection<string, string>', $collection->make(['string' => 'string'])->union(['string' => 'string']));
+assertType('Illuminate\Support\LazyCollection<int, int>', $collection::make([1])->union([1]));
+assertType('Illuminate\Support\LazyCollection<string, string>', $collection::make(['string' => 'string'])->union(['string' => 'string']));
 
-assertType('mixed', $collection->make()->min());
-assertType('mixed', $collection->make([1])->min());
-assertType('mixed', $collection->make([1])->min('string'));
-assertType('mixed', $collection->make([1])->min(function ($int) {
+assertType('mixed', $collection::make()->min());
+assertType('mixed', $collection::make([1])->min());
+assertType('mixed', $collection::make([1])->min('string'));
+assertType('mixed', $collection::make([1])->min(function ($int) {
     assertType('int', $int);
 
     return 1;
 }));
-assertType('mixed', $collection->make([new User])->min('id'));
+assertType('mixed', $collection::make([new User])->min('id'));
 
-assertType('mixed', $collection->make()->max());
-assertType('mixed', $collection->make([1])->max());
-assertType('mixed', $collection->make([1])->max('string'));
-assertType('mixed', $collection->make([1])->max(function ($int) {
+assertType('mixed', $collection::make()->max());
+assertType('mixed', $collection::make([1])->max());
+assertType('mixed', $collection::make([1])->max('string'));
+assertType('mixed', $collection::make([1])->max(function ($int) {
     assertType('int', $int);
 
     return 1;
 }));
-assertType('mixed', $collection->make([new User])->max('id'));
+assertType('mixed', $collection::make([new User])->max('id'));
 
 assertType('Illuminate\Support\LazyCollection<int, User>', $collection->nth(1, 2));
 
@@ -590,12 +590,12 @@ assertType('Illuminate\Support\LazyCollection<int<0, 1>, Illuminate\Support\Lazy
 assertType('Illuminate\Support\LazyCollection<int<0, 1>, Illuminate\Support\LazyCollection<int, string>>', $collection::make(['string'])->partition('string', 'string'));
 assertType('Illuminate\Support\LazyCollection<int<0, 1>, Illuminate\Support\LazyCollection<int, string>>', $collection::make(['string'])->partition('string'));
 
-assertType('Illuminate\Support\LazyCollection<int, int>', $collection->make([1])->concat([2]));
-assertType('Illuminate\Support\LazyCollection<int, string>', $collection->make(['string'])->concat(['string']));
-assertType('Illuminate\Support\LazyCollection<int, int|string>', $collection->make([1])->concat(['string']));
+assertType('Illuminate\Support\LazyCollection<int, int>', $collection::make([1])->concat([2]));
+assertType('Illuminate\Support\LazyCollection<int, string>', $collection::make(['string'])->concat(['string']));
+assertType('Illuminate\Support\LazyCollection<int, int|string>', $collection::make([1])->concat(['string']));
 
-assertType('Illuminate\Support\LazyCollection<int, int>|int', $collection->make([1])->random(2));
-assertType('Illuminate\Support\LazyCollection<int, string>|string', $collection->make(['string'])->random());
+assertType('Illuminate\Support\LazyCollection<int, int>|int', $collection::make([1])->random(2));
+assertType('Illuminate\Support\LazyCollection<int, string>|string', $collection::make(['string'])->random());
 
 assertType('1', $collection
     ->reduce(function ($null, $user) {
@@ -620,8 +620,8 @@ assertType('Illuminate\Support\LazyCollection<int, User>', $collection->replaceR
 
 assertType('Illuminate\Support\LazyCollection<int, User>', $collection->reverse());
 
-// assertType('int|bool', $collection->make([1])->search(2));
-// assertType('string|bool', $collection->make(['string' => 'string'])->search('string'));
+// assertType('int|bool', $collection::make([1])->search(2));
+// assertType('string|bool', $collection::make(['string' => 'string'])->search('string'));
 // assertType('int|bool', $collection->search(function ($user, $int) {
 //     assertType('User', $user);
 //     assertType('int', $int);
@@ -629,13 +629,13 @@ assertType('Illuminate\Support\LazyCollection<int, User>', $collection->reverse(
 //    return true;
 // }));
 
-assertType('Illuminate\Support\LazyCollection<int, int>', $collection->make([1])->shuffle());
+assertType('Illuminate\Support\LazyCollection<int, int>', $collection::make([1])->shuffle());
 assertType('Illuminate\Support\LazyCollection<int, User>', $collection->shuffle());
 
-assertType('Illuminate\Support\LazyCollection<int, int>', $collection->make([1])->skip(1));
+assertType('Illuminate\Support\LazyCollection<int, int>', $collection::make([1])->skip(1));
 assertType('Illuminate\Support\LazyCollection<int, User>', $collection->skip(1));
 
-assertType('Illuminate\Support\LazyCollection<int, int>', $collection->make([1])->skipUntil(1));
+assertType('Illuminate\Support\LazyCollection<int, int>', $collection::make([1])->skipUntil(1));
 assertType('Illuminate\Support\LazyCollection<int, User>', $collection->skipUntil(new User));
 assertType('Illuminate\Support\LazyCollection<int, User>', $collection->skipUntil(function ($user, $int) {
     assertType('User', $user);
@@ -644,7 +644,7 @@ assertType('Illuminate\Support\LazyCollection<int, User>', $collection->skipUnti
     return true;
 }));
 
-assertType('Illuminate\Support\LazyCollection<int, int>', $collection->make([1])->skipWhile(1));
+assertType('Illuminate\Support\LazyCollection<int, int>', $collection::make([1])->skipWhile(1));
 assertType('Illuminate\Support\LazyCollection<int, User>', $collection->skipWhile(new User));
 assertType('Illuminate\Support\LazyCollection<int, User>', $collection->skipWhile(function ($user, $int) {
     assertType('User', $user);
@@ -653,14 +653,14 @@ assertType('Illuminate\Support\LazyCollection<int, User>', $collection->skipWhil
     return true;
 }));
 
-assertType('Illuminate\Support\LazyCollection<int, int>', $collection->make([1])->slice(1));
+assertType('Illuminate\Support\LazyCollection<int, int>', $collection::make([1])->slice(1));
 assertType('Illuminate\Support\LazyCollection<int, User>', $collection->slice(1, 2));
 
 assertType('Illuminate\Support\LazyCollection<int, Illuminate\Support\LazyCollection<int, User>>', $collection->split(3));
-assertType('Illuminate\Support\LazyCollection<int, Illuminate\Support\LazyCollection<int, int>>', $collection->make([1])->split(3));
+assertType('Illuminate\Support\LazyCollection<int, Illuminate\Support\LazyCollection<int, int>>', $collection::make([1])->split(3));
 
-assertType('string', $collection->make(['string' => 'string'])->sole('string', 'string'));
-assertType('string', $collection->make(['string' => 'string'])->sole('string', '=', 'string'));
+assertType('string', $collection::make(['string' => 'string'])->sole('string', 'string'));
+assertType('string', $collection::make(['string' => 'string'])->sole('string', '=', 'string'));
 assertType('User', $collection->sole(function ($user, $int) {
     assertType('User', $user);
     assertType('int', $int);
@@ -738,23 +738,23 @@ assertType('Illuminate\Support\LazyCollection<int, User>', $collection->sortByDe
     return 1;
 }]));
 
-assertType('Illuminate\Support\LazyCollection<int, int>', $collection->make([1])->sortKeys());
-assertType('Illuminate\Support\LazyCollection<string, string>', $collection->make(['string' => 'string'])->sortKeys(1, true));
+assertType('Illuminate\Support\LazyCollection<int, int>', $collection::make([1])->sortKeys());
+assertType('Illuminate\Support\LazyCollection<string, string>', $collection::make(['string' => 'string'])->sortKeys(1, true));
 
-assertType('Illuminate\Support\LazyCollection<int, int>', $collection->make([1])->sortKeysDesc());
-assertType('Illuminate\Support\LazyCollection<string, string>', $collection->make(['string' => 'string'])->sortKeysDesc(1));
+assertType('Illuminate\Support\LazyCollection<int, int>', $collection::make([1])->sortKeysDesc());
+assertType('Illuminate\Support\LazyCollection<string, string>', $collection::make(['string' => 'string'])->sortKeysDesc(1));
 
-assertType('mixed', $collection->make([1])->sum('string'));
-assertType('int<1, 2>', $collection->make(['string'])->sum(function ($string) {
+assertType('mixed', $collection::make([1])->sum('string'));
+assertType('int<1, 2>', $collection::make(['string'])->sum(function ($string) {
     assertType('string', $string);
 
     return rand(1, 2);
 }));
 
-assertType('Illuminate\Support\LazyCollection<int, int>', $collection->make([1])->take(1));
+assertType('Illuminate\Support\LazyCollection<int, int>', $collection::make([1])->take(1));
 assertType('Illuminate\Support\LazyCollection<int, User>', $collection->take(1));
 
-assertType('Illuminate\Support\LazyCollection<int, int>', $collection->make([1])->takeUntil(1));
+assertType('Illuminate\Support\LazyCollection<int, int>', $collection::make([1])->takeUntil(1));
 assertType('Illuminate\Support\LazyCollection<int, User>', $collection->takeUntil(new User));
 assertType('Illuminate\Support\LazyCollection<int, User>', $collection->takeUntil(function ($user, $int) {
     assertType('User', $user);
@@ -769,7 +769,7 @@ assertType('Illuminate\Support\LazyCollection<int, User>', $collection->takeUnti
     // assertType('int|null', $int);
 }));
 
-assertType('Illuminate\Support\LazyCollection<int, int>', $collection->make([1])->takeWhile(1));
+assertType('Illuminate\Support\LazyCollection<int, int>', $collection::make([1])->takeWhile(1));
 assertType('Illuminate\Support\LazyCollection<int, User>', $collection->takeWhile(new User));
 assertType('Illuminate\Support\LazyCollection<int, User>', $collection->takeWhile(function ($user, $int) {
     assertType('User', $user);
@@ -787,7 +787,7 @@ assertType('Illuminate\Support\LazyCollection<int, 1>', $collection->pipe(functi
 
     return new LazyCollection([1]);
 }));
-assertType('1', $collection->make([1])->pipe(function ($collection) {
+assertType('1', $collection::make([1])->pipe(function ($collection) {
     assertType('Illuminate\Support\LazyCollection<int, int>', $collection);
 
     return 1;
@@ -795,8 +795,8 @@ assertType('1', $collection->make([1])->pipe(function ($collection) {
 
 assertType('User', $collection->pipeInto(User::class));
 
-assertType('Illuminate\Support\LazyCollection<(int|string), mixed>', $collection->make(['string' => 'string'])->pluck('string'));
-assertType('Illuminate\Support\LazyCollection<(int|string), mixed>', $collection->make(['string' => 'string'])->pluck('string', 'string'));
+assertType('Illuminate\Support\LazyCollection<(int|string), mixed>', $collection::make(['string' => 'string'])->pluck('string'));
+assertType('Illuminate\Support\LazyCollection<(int|string), mixed>', $collection::make(['string' => 'string'])->pluck('string', 'string'));
 
 assertType('Illuminate\Support\LazyCollection<int, User>', $collection->reject());
 assertType('Illuminate\Support\LazyCollection<int, User>', $collection->reject(function ($user) {
@@ -819,7 +819,7 @@ assertType('Illuminate\Support\LazyCollection<int, User>', $collection->unique(f
 
     return $user->getTable();
 }));
-assertType('Illuminate\Support\LazyCollection<string, string>', $collection->make(['string' => 'string'])->unique(function ($stringA, $stringB) {
+assertType('Illuminate\Support\LazyCollection<string, string>', $collection::make(['string' => 'string'])->unique(function ($stringA, $stringB) {
     assertType('string', $stringA);
     assertType('string', $stringB);
 
@@ -838,18 +838,18 @@ assertType('Illuminate\Support\LazyCollection<int, User>', $collection->values()
 assertType('Illuminate\Support\LazyCollection<int, string>', $collection::make(['string', 'string'])->values());
 assertType('Illuminate\Support\LazyCollection<int, int|string>', $collection::make(['string', 1])->values());
 
-assertType('Illuminate\Support\LazyCollection<int, int>', $collection->make([1])->pad(2, 0));
-assertType('Illuminate\Support\LazyCollection<int, int|string>', $collection->make([1])->pad(2, 'string'));
+assertType('Illuminate\Support\LazyCollection<int, int>', $collection::make([1])->pad(2, 0));
+assertType('Illuminate\Support\LazyCollection<int, int|string>', $collection::make([1])->pad(2, 'string'));
 assertType('Illuminate\Support\LazyCollection<int, int|User>', $collection->pad(2, 0));
 
-assertType('Illuminate\Support\LazyCollection<(int|string), int>', $collection->make([1])->countBy());
-assertType('Illuminate\Support\LazyCollection<(int|string), int>', $collection->make(['string' => 'string'])->countBy('string'));
-assertType('Illuminate\Support\LazyCollection<(int|string), int>', $collection->make([new User])->countBy('email'));
-assertType('Illuminate\Support\LazyCollection<(int|string), int>', $collection->make([new User])->countBy(static fn ($user) => 'email'));
-assertType('Illuminate\Support\LazyCollection<(int|string), int>', $collection->make([new User])->countBy(static fn ($user) => 0));
-assertType('Illuminate\Support\LazyCollection<(int|string), int>', $collection->make([new User])->countBy(static fn ($user) => Digit::One));
-assertType('Illuminate\Support\LazyCollection<(int|string), int>', $collection->make([new User])->countBy(static fn ($user) => NamedDigit::One));
-assertType('Illuminate\Support\LazyCollection<(int|string), int>', $collection->make(['string'])->countBy(function ($string, $int) {
+assertType('Illuminate\Support\LazyCollection<(int|string), int>', $collection::make([1])->countBy());
+assertType('Illuminate\Support\LazyCollection<(int|string), int>', $collection::make(['string' => 'string'])->countBy('string'));
+assertType('Illuminate\Support\LazyCollection<(int|string), int>', $collection::make([new User])->countBy('email'));
+assertType('Illuminate\Support\LazyCollection<(int|string), int>', $collection::make([new User])->countBy(static fn ($user) => 'email'));
+assertType('Illuminate\Support\LazyCollection<(int|string), int>', $collection::make([new User])->countBy(static fn ($user) => 0));
+assertType('Illuminate\Support\LazyCollection<(int|string), int>', $collection::make([new User])->countBy(static fn ($user) => Digit::One));
+assertType('Illuminate\Support\LazyCollection<(int|string), int>', $collection::make([new User])->countBy(static fn ($user) => NamedDigit::One));
+assertType('Illuminate\Support\LazyCollection<(int|string), int>', $collection::make(['string'])->countBy(function ($string, $int) {
     assertType('string', $string);
     assertType('int', $int);
 
@@ -861,7 +861,7 @@ assertType('Illuminate\Support\LazyCollection<int, Illuminate\Support\LazyCollec
 assertType('Illuminate\Support\LazyCollection<int, Illuminate\Support\LazyCollection<int, string>>', $collection::make(['string' => 'string'])->zip(['string']));
 
 assertType('Illuminate\Support\Collection<int, User>', $collection->collect());
-assertType('Illuminate\Support\Collection<int, int>', $collection->make([1])->collect());
+assertType('Illuminate\Support\Collection<int, int>', $collection::make([1])->collect());
 
 assertType('array<int, User>', $collection->all());
 


### PR DESCRIPTION
Replaces instance-syntax calls (`$obj->method()`) with static call syntax (`$obj::method()` / `self::method()`) wherever the called method is declared `static`, across `src/`, `tests/`, and `types/`.

Calling a static method via `$this->` or `$obj->` is valid PHP but semantically incorrect — it implies an instance context where none is needed. Using `::` makes the static nature of the call explicit and removes a layer of ambiguity for both humans and static analysis tools.