### PR TITLE
[13.x] Replace throw_if and throw_unless by simple conditions

### DIFF
--- a/src/Illuminate/Collections/Traits/TransformsToResourceCollection.php
+++ b/src/Illuminate/Collections/Traits/TransformsToResourceCollection.php
@@ -43,12 +43,16 @@ trait TransformsToResourceCollection
 
         $model = $this->items[0] ?? null;
 
-        throw_unless(is_object($model), LogicException::class, 'Resource collection guesser expects the collection to contain objects.');
+        if (! is_object($model)) {
+            throw new LogicException('Resource collection guesser expects the collection to contain objects.');
+        }
 
         /** @var class-string<Model> $className */
         $className = get_class($model);
 
-        throw_unless(method_exists($className, 'guessResourceName'), LogicException::class, sprintf('Expected class %s to implement guessResourceName method. Make sure the model uses the TransformsToResource trait.', $className));
+        if (! method_exists($className, 'guessResourceName')) {
+            throw new LogicException(sprintf('Expected class %s to implement guessResourceName method. Make sure the model uses the TransformsToResource trait.', $className));
+        }
 
         $useResourceCollection = $this->resolveResourceCollectionFromAttribute($className);
 

--- a/src/Illuminate/Console/View/Components/Factory.php
+++ b/src/Illuminate/Console/View/Components/Factory.php
@@ -52,9 +52,11 @@ class Factory
     {
         $component = '\Illuminate\Console\View\Components\\'.ucfirst($method);
 
-        throw_unless(class_exists($component), new InvalidArgumentException(sprintf(
-            'Console component [%s] not found.', $method
-        )));
+        if (! class_exists($component)) {
+            throw new InvalidArgumentException(sprintf(
+                'Console component [%s] not found.', $method
+            ));
+        }
 
         return (new $component($this->output))->render(...$parameters);
     }

--- a/src/Illuminate/Database/Console/DbCommand.php
+++ b/src/Illuminate/Database/Console/DbCommand.php
@@ -54,7 +54,9 @@ class DbCommand extends Command
                 $this->output->write($buffer);
             });
         } catch (ProcessFailedException $e) {
-            throw_unless($e->getProcess()->getExitCode() === 127, $e);
+            if ($e->getProcess()->getExitCode() !== 127) {
+                throw $e;
+            }
 
             $this->error("{$command} not found in path.");
 

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -295,7 +295,9 @@ class FilesystemAdapter implements CloudFilesystemContract
         try {
             return $this->driver->read($path);
         } catch (UnableToReadFile $e) {
-            throw_if($this->throwsExceptions(), $e);
+            if ($this->throwsExceptions()) {
+                throw $e;
+            }
 
             $this->report($e);
         }
@@ -425,7 +427,9 @@ class FilesystemAdapter implements CloudFilesystemContract
                 ? $this->driver->writeStream($path, $contents, $options)
                 : $this->driver->write($path, $contents, $options);
         } catch (UnableToWriteFile|UnableToSetVisibility $e) {
-            throw_if($this->throwsExceptions(), $e);
+            if ($this->throwsExceptions()) {
+                throw $e;
+            }
 
             $this->report($e);
 
@@ -512,7 +516,9 @@ class FilesystemAdapter implements CloudFilesystemContract
         try {
             $this->driver->setVisibility($path, $this->parseVisibility($visibility));
         } catch (UnableToSetVisibility $e) {
-            throw_if($this->throwsExceptions(), $e);
+            if ($this->throwsExceptions()) {
+                throw $e;
+            }
 
             $this->report($e);
 
@@ -572,7 +578,9 @@ class FilesystemAdapter implements CloudFilesystemContract
             try {
                 $this->driver->delete($path);
             } catch (UnableToDeleteFile $e) {
-                throw_if($this->throwsExceptions(), $e);
+                if ($this->throwsExceptions()) {
+                    throw $e;
+                }
 
                 $this->report($e);
 
@@ -595,7 +603,9 @@ class FilesystemAdapter implements CloudFilesystemContract
         try {
             $this->driver->copy($from, $to);
         } catch (UnableToCopyFile $e) {
-            throw_if($this->throwsExceptions(), $e);
+            if ($this->throwsExceptions()) {
+                throw $e;
+            }
 
             $this->report($e);
 
@@ -617,7 +627,9 @@ class FilesystemAdapter implements CloudFilesystemContract
         try {
             $this->driver->move($from, $to);
         } catch (UnableToMoveFile $e) {
-            throw_if($this->throwsExceptions(), $e);
+            if ($this->throwsExceptions()) {
+                throw $e;
+            }
 
             $this->report($e);
 
@@ -650,7 +662,9 @@ class FilesystemAdapter implements CloudFilesystemContract
         try {
             return $this->driver->checksum($path, $options);
         } catch (UnableToProvideChecksum $e) {
-            throw_if($this->throwsExceptions(), $e);
+            if ($this->throwsExceptions()) {
+                throw $e;
+            }
 
             $this->report($e);
 
@@ -669,7 +683,9 @@ class FilesystemAdapter implements CloudFilesystemContract
         try {
             return $this->driver->mimeType($path);
         } catch (UnableToRetrieveMetadata $e) {
-            throw_if($this->throwsExceptions(), $e);
+            if ($this->throwsExceptions()) {
+                throw $e;
+            }
 
             $this->report($e);
         }
@@ -696,7 +712,9 @@ class FilesystemAdapter implements CloudFilesystemContract
         try {
             return $this->driver->readStream($path);
         } catch (UnableToReadFile $e) {
-            throw_if($this->throwsExceptions(), $e);
+            if ($this->throwsExceptions()) {
+                throw $e;
+            }
 
             $this->report($e);
         }
@@ -710,7 +728,9 @@ class FilesystemAdapter implements CloudFilesystemContract
         try {
             $this->driver->writeStream($path, $resource, $options);
         } catch (UnableToWriteFile|UnableToSetVisibility $e) {
-            throw_if($this->throwsExceptions(), $e);
+            if ($this->throwsExceptions()) {
+                throw $e;
+            }
 
             $this->report($e);
 
@@ -960,7 +980,9 @@ class FilesystemAdapter implements CloudFilesystemContract
         try {
             $this->driver->createDirectory($path);
         } catch (UnableToCreateDirectory|UnableToSetVisibility $e) {
-            throw_if($this->throwsExceptions(), $e);
+            if ($this->throwsExceptions()) {
+                throw $e;
+            }
 
             $this->report($e);
 
@@ -981,7 +1003,9 @@ class FilesystemAdapter implements CloudFilesystemContract
         try {
             $this->driver->deleteDirectory($directory);
         } catch (UnableToDeleteDirectory $e) {
-            throw_if($this->throwsExceptions(), $e);
+            if ($this->throwsExceptions()) {
+                throw $e;
+            }
 
             $this->report($e);
 

--- a/src/Illuminate/Mail/Transport/ResendTransport.php
+++ b/src/Illuminate/Mail/Transport/ResendTransport.php
@@ -113,7 +113,9 @@ class ResendTransport extends AbstractTransport
                 'attachments' => $attachments,
             ]);
 
-            throw_if(isset($result['statusCode']) && $result['statusCode'] != Response::HTTP_OK, Exception::class, $result['message']);
+            if (isset($result['statusCode']) && $result['statusCode'] != Response::HTTP_OK) {
+                throw new Exception($result['message']);
+            }
         } catch (Exception $exception) {
             throw new TransportException(
                 sprintf('Request to Resend API failed. Reason: %s.', $exception->getMessage()),

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -595,7 +595,9 @@ class Validator implements ValidatorContract
      */
     public function validate()
     {
-        throw_if($this->fails(), $this->exception, $this);
+        if ($this->fails()) {
+            throw new $this->exception($this);
+        }
 
         return $this->validated();
     }
@@ -647,7 +649,9 @@ class Validator implements ValidatorContract
             $this->passes();
         }
 
-        throw_if($this->messages->isNotEmpty(), $this->exception, $this);
+        if ($this->messages->isNotEmpty()) {
+            throw new $this->exception($this);
+        }
 
         $results = [];
 


### PR DESCRIPTION
Replace throw_if and throw_unless by simple conditions.
Those helpers are great to use in an app, but not directly in the framework

For the same reasons already explained by @browner12 : https://github.com/laravel/framework/pull/59252#issuecomment-4083596849