### PR TITLE
Add `authorize` method to `Authorizable`

### DIFF
--- a/src/Illuminate/Contracts/Auth/Access/Authorizable.php
+++ b/src/Illuminate/Contracts/Auth/Access/Authorizable.php
@@ -5,6 +5,17 @@ namespace Illuminate\Contracts\Auth\Access;
 interface Authorizable
 {
     /**
+     * Determine if the given ability should be granted for the entity.
+     *
+     * @param  \UnitEnum|string  $ability
+     * @param  mixed  $arguments
+     * @return \Illuminate\Auth\Access\Response
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException
+     */
+    public function authorize($ability, $arguments = []);
+
+    /**
      * Determine if the entity has a given ability.
      *
      * @param  iterable|string  $abilities

--- a/src/Illuminate/Foundation/Auth/Access/Authorizable.php
+++ b/src/Illuminate/Foundation/Auth/Access/Authorizable.php
@@ -7,6 +7,20 @@ use Illuminate\Contracts\Auth\Access\Gate;
 trait Authorizable
 {
     /**
+     * Determine if the given ability should be granted for the entity.
+     *
+     * @param  \UnitEnum|string  $ability
+     * @param  mixed  $arguments
+     * @return \Illuminate\Auth\Access\Response
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException
+     */
+    public function authorize($ability, $arguments = [])
+    {
+        return app(Gate::class)->forUser($this)->authorize($ability, $arguments);
+    }
+
+    /**
      * Determine if the entity has the given abilities.
      *
      * @param  iterable|\UnitEnum|string  $abilities


### PR DESCRIPTION
This adds an `authorize` method to the `Authorizable` contract and trait.

Right now in order to specify the user to authorize you must:
```php
Gate::forUser($user)->authorize('viewAny', Model::class);
```

This would allow `authorize` to be called directly on the user, just like is possible with `can`:
```php
$user->authorize('viewAny', Model::class);
```

This targets `master` since it adds a new method to a trait and contract.