### PR TITLE
[13.x] Support JSON responses for the built-in health route

### DIFF
--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -238,7 +238,7 @@ class ApplicationBuilder
 
                     if ($request->expectsJson()) {
                         return response()->json([
-                            'status' => $exception ? 'Application experiencing problems' : 'Application is up',
+                            'status' => $exception ? 'down' : 'up',
                         ], $status);
                     }
 

--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -13,6 +13,7 @@ use Illuminate\Foundation\Events\DiagnosingHealth;
 use Illuminate\Foundation\Http\Middleware\PreventRequestsDuringMaintenance;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as AppEventServiceProvider;
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as AppRouteServiceProvider;
+use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Broadcast;
 use Illuminate\Support\Facades\Event;
@@ -218,7 +219,7 @@ class ApplicationBuilder
             }
 
             if (is_string($health)) {
-                Route::get($health, function () {
+                Route::get($health, function (Request $request) {
                     $exception = null;
 
                     try {
@@ -233,9 +234,17 @@ class ApplicationBuilder
                         $exception = $e->getMessage();
                     }
 
+                    $status = $exception ? 500 : 200;
+
+                    if ($request->expectsJson()) {
+                        return response()->json([
+                            'status' => $exception ? 'Application experiencing problems' : 'Application is up',
+                        ], $status);
+                    }
+
                     return response(View::file(__DIR__.'/../resources/health-up.blade.php', [
                         'exception' => $exception,
-                    ]), status: $exception ? 500 : 200);
+                    ]), status: $status);
                 });
             }
 

--- a/tests/Integration/Foundation/Support/Providers/RouteServiceProviderHealthTest.php
+++ b/tests/Integration/Foundation/Support/Providers/RouteServiceProviderHealthTest.php
@@ -44,7 +44,7 @@ class RouteServiceProviderHealthTest extends TestCase
     {
         $this->getJson('/up')
             ->assertOk()
-            ->assertExactJson(['status' => 'Application is up']);
+            ->assertExactJson(['status' => 'up']);
     }
 
     public function test_it_returns_json_failure_status_when_diagnosis_reports_a_problem()
@@ -55,7 +55,7 @@ class RouteServiceProviderHealthTest extends TestCase
 
         $this->getJson('/up')
             ->assertStatus(500)
-            ->assertExactJson(['status' => 'Application experiencing problems']);
+            ->assertExactJson(['status' => 'down']);
     }
 
     public function test_it_renders_html_failure_page_when_diagnosis_reports_a_problem()

--- a/tests/Integration/Foundation/Support/Providers/RouteServiceProviderHealthTest.php
+++ b/tests/Integration/Foundation/Support/Providers/RouteServiceProviderHealthTest.php
@@ -3,10 +3,14 @@
 namespace Illuminate\Tests\Integration\Foundation\Support\Providers;
 
 use Illuminate\Foundation\Application;
+use Illuminate\Foundation\Events\DiagnosingHealth;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Str;
 use Orchestra\Testbench\Attributes\WithConfig;
 use Orchestra\Testbench\TestCase;
+use RuntimeException;
 
+#[WithConfig('app.debug', false)]
 #[WithConfig('filesystems.disks.local.serve', false)]
 class RouteServiceProviderHealthTest extends TestCase
 {
@@ -31,6 +35,37 @@ class RouteServiceProviderHealthTest extends TestCase
 
     public function test_it_can_load_health_page()
     {
-        $this->get('/up')->assertOk();
+        $this->get('/up')
+            ->assertOk()
+            ->assertSee('Application up');
+    }
+
+    public function test_it_returns_json_when_request_expects_json()
+    {
+        $this->getJson('/up')
+            ->assertOk()
+            ->assertExactJson(['status' => 'Application is up']);
+    }
+
+    public function test_it_returns_json_failure_status_when_diagnosis_reports_a_problem()
+    {
+        Event::listen(DiagnosingHealth::class, function () {
+            throw new RuntimeException('Database connection refused.');
+        });
+
+        $this->getJson('/up')
+            ->assertStatus(500)
+            ->assertExactJson(['status' => 'Application experiencing problems']);
+    }
+
+    public function test_it_renders_html_failure_page_when_diagnosis_reports_a_problem()
+    {
+        Event::listen(DiagnosingHealth::class, function () {
+            throw new RuntimeException('Database connection refused.');
+        });
+
+        $this->get('/up')
+            ->assertStatus(500)
+            ->assertSee('experiencing problems');
     }
 }


### PR DESCRIPTION
The framework's built-in health route always renders HTML, which is awkward for API-only applications whose load balancers, uptime monitors, and orchestrators expect JSON. Today those clients either scrape the HTML or register their own replacement route.

When the incoming request expects JSON (`$request->expectsJson()`), `/up` now returns:

```json
{"status": "Application is up"}
```

or, when a `DiagnosingHealth` listener throws and debug mode is off:

```json
{"status": "Application experiencing problems"}
```

Status codes (`200` / `500`) are unchanged, and requests that don't expect JSON keep getting the existing Blade page.