### PR TITLE
[13.x] Ensure Queue::route string defaults to queue only

### DIFF
--- a/src/Illuminate/Queue/QueueRoutes.php
+++ b/src/Illuminate/Queue/QueueRoutes.php
@@ -26,7 +26,7 @@ class QueueRoutes
         }
 
         return is_string($route)
-            ? $route
+            ? null
             : $route[0];
     }
 

--- a/tests/Queue/QueueRoutesTest.php
+++ b/tests/Queue/QueueRoutesTest.php
@@ -68,6 +68,16 @@ class QueueRoutesTest extends TestCase
         $this->assertSame('job-connection', $defaults->getConnection(new SomeJob));
         $this->assertNull($defaults->getConnection(new Payment));
     }
+
+    public function testStringRouteDefaultsToQueueNotConnection()
+    {
+        $defaults = new QueueRoutes();
+
+        $defaults->set([BaseNotification::class => 'notifications']);
+
+        $this->assertSame('notifications', $defaults->getQueue(new FinanceNotification));
+        $this->assertNull($defaults->getConnection(new FinanceNotification));
+    }
 }
 
 trait CustomTrait


### PR DESCRIPTION
As per https://github.com/laravel/docs/blob/545534afef3d8d0e350dbcb3dc97cc6c4b79f532/queues.md?plain=1#L1311

This ensures if it's only a string specified, it doesn't apply to the connection, only queue. 

Technically could be considered a B/C, but I dont think it's a real one as this feels correct behavior. 

This means the below works:

```php
Queue::route([
   Job:class => 'queue'
]);
```


Added a test too.