### PR TITLE
[13.x] Add enum support to BroadcastManager

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -30,6 +30,8 @@ use ReflectionException;
 use RuntimeException;
 use Throwable;
 
+use function Illuminate\Support\enum_value;
+
 /**
  * @mixin \Illuminate\Contracts\Broadcasting\Broadcaster
  */
@@ -250,9 +252,9 @@ class BroadcastManager implements FactoryContract
     }
 
     /**
-     * Get a driver instance.
+     * Get a broadcaster instance by name.
      *
-     * @param  string|null  $name
+     * @param  \UnitEnum|string|null  $name
      * @return mixed
      */
     public function connection($name = null)
@@ -263,12 +265,12 @@ class BroadcastManager implements FactoryContract
     /**
      * Get a driver instance.
      *
-     * @param  string|null  $name
+     * @param  \UnitEnum|string|null  $name
      * @return mixed
      */
     public function driver($name = null)
     {
-        $name = $name ?: $this->getDefaultDriver();
+        $name = enum_value($name) ?: $this->getDefaultDriver();
 
         return $this->drivers[$name] = $this->get($name);
     }
@@ -473,23 +475,23 @@ class BroadcastManager implements FactoryContract
     /**
      * Set the default driver name.
      *
-     * @param  string  $name
+     * @param  \UnitEnum|string  $name
      * @return void
      */
     public function setDefaultDriver($name)
     {
-        $this->app['config']['broadcasting.default'] = $name;
+        $this->app['config']['broadcasting.default'] = enum_value($name);
     }
 
     /**
      * Disconnect the given driver / connection and remove it from local cache.
      *
-     * @param  string|null  $name
+     * @param  \UnitEnum|string|null  $name
      * @return void
      */
     public function purge($name = null)
     {
-        $name ??= $this->getDefaultDriver();
+        $name = enum_value($name) ?? $this->getDefaultDriver();
 
         unset($this->drivers[$name]);
     }

--- a/tests/Integration/Broadcasting/BroadcastManagerTest.php
+++ b/tests/Integration/Broadcasting/BroadcastManagerTest.php
@@ -224,6 +224,77 @@ class BroadcastManagerTest extends TestCase
         }
     }
 
+    public function testBroadcastManagerCanResolveBackedEnumConnection(): void
+    {
+        $app = $this->getApp([
+            'broadcasting' => [
+                'connections' => [
+                    'log' => ['driver' => 'log'],
+                ],
+            ],
+        ]);
+
+        $driver = new stdClass;
+        $manager = new BroadcastManager($app);
+        $manager->extend('log', static fn () => $driver);
+
+        $this->assertSame($driver, $manager->connection(BroadcastConnectionName::Log));
+        $this->assertSame($manager->connection('log'), $manager->connection(BroadcastConnectionName::Log));
+    }
+
+    public function testBroadcastManagerCanResolveBackedEnumDriver(): void
+    {
+        $app = $this->getApp([
+            'broadcasting' => [
+                'connections' => [
+                    'log' => ['driver' => 'log'],
+                ],
+            ],
+        ]);
+
+        $driver = new stdClass;
+        $manager = new BroadcastManager($app);
+        $manager->extend('log', static fn () => $driver);
+
+        $this->assertSame($driver, $manager->driver(BroadcastConnectionName::Log));
+        $this->assertSame($manager->driver('log'), $manager->driver(BroadcastConnectionName::Log));
+    }
+
+    public function testSetDefaultDriverAcceptsBackedEnum(): void
+    {
+        $app = $this->getApp([
+            'broadcasting' => [
+                'default' => 'null',
+                'connections' => [],
+            ],
+        ]);
+
+        $manager = new BroadcastManager($app);
+        $manager->setDefaultDriver(BroadcastConnectionName::Log);
+
+        $this->assertSame('log', $app['config']['broadcasting.default']);
+    }
+
+    public function testPurgeAcceptsBackedEnum(): void
+    {
+        $app = $this->getApp([
+            'broadcasting' => [
+                'connections' => [
+                    'log' => ['driver' => 'log'],
+                ],
+            ],
+        ]);
+
+        $manager = new BroadcastManager($app);
+        $manager->extend('log', static fn () => new stdClass);
+
+        $instance1 = $manager->connection(BroadcastConnectionName::Log);
+        $manager->purge(BroadcastConnectionName::Log);
+        $instance2 = $manager->connection(BroadcastConnectionName::Log);
+
+        $this->assertNotSame($instance1, $instance2);
+    }
+
     protected function getApp(array $userConfig)
     {
         $app = new Container;
@@ -231,6 +302,11 @@ class BroadcastManagerTest extends TestCase
 
         return $app;
     }
+}
+
+enum BroadcastConnectionName: string
+{
+    case Log = 'log';
 }
 
 class TestEvent implements ShouldBroadcast


### PR DESCRIPTION
## Summary

This PR adds enum support to `BroadcastManager::connection()`, `BroadcastManager::driver()`, `BroadcastManager::setDefaultDriver()`, and `BroadcastManager::purge()` using the `enum_value()` helper, aligning it with other manager classes that already support this pattern.

## Context

Several manager classes already accept enums for connection/driver names:

| Class | Supports Enums |
|---|---|
| `Manager::driver()` | ✅ (merged in #59659) |
| `CacheManager::store()` | ✅ (merged in #59637) |
| `AuthManager::guard()` | ✅ (merged in #59646) |
| `MailManager::mailer()` | ✅ (merged in #59645) |
| `QueueManager::connection()` | ✅ (merged in #59389) |
| `LogManager::channel()` | ✅ (merged in #59391) |
| `FilesystemManager::disk()` | ✅ |
| `RedisManager::connection()` | ✅ |
| `BroadcastManager::connection()` | ❌ |
| `BroadcastManager::driver()` | ❌ |
| `BroadcastManager::setDefaultDriver()` | ❌ |
| `BroadcastManager::purge()` | ❌ |

This inconsistency means developers who define broadcaster names as enums cannot pass them directly to `Broadcast::connection()` like they can with `Queue::connection()` or `Cache::store()`.

## Solution

- Added `enum_value()` call in `BroadcastManager::driver()`
- Added `enum_value()` call in `BroadcastManager::setDefaultDriver()`
- Added `enum_value()` call in `BroadcastManager::purge()`
- Updated `@param` docblocks on `connection()`, `driver()`, `setDefaultDriver()`, and `purge()` to accept `\UnitEnum|string|null`
- Corrected the misleading docblock on `connection()` ("Get a driver instance" → "Get a broadcaster instance by name")

## Example

```php
enum BroadcastConnection: string
{
    case Pusher = 'pusher';
    case Ably   = 'ably';
}

// Before: would not resolve correctly
Broadcast::connection(BroadcastConnection::Pusher);

// After: works as expected
Broadcast::connection(BroadcastConnection::Pusher)->broadcast(...);
Broadcast::setDefaultDriver(BroadcastConnection::Pusher);
Broadcast::purge(BroadcastConnection::Pusher);
```

## Why This Doesn't Break Existing Features

- `enum_value()` returns the input unchanged for strings and `null` — all existing calls behave identically
- The updated `@param` types are docblock-only changes; no method signature change is required
- Follows the exact same pattern already established across `CacheManager`, `AuthManager`, `MailManager`, `QueueManager`, `LogManager`, `FilesystemManager`, `RedisManager`, and the base `Manager` class

## Changes

- `src/Illuminate/Broadcasting/BroadcastManager.php` — Added `enum_value()` in `driver()`, `setDefaultDriver()`, and `purge()`; updated docblocks
- `tests/Integration/Broadcasting/BroadcastManagerTest.php` — Added 4 test cases

## Test Plan

- [x] `testBroadcastManagerCanResolveBackedEnumConnection` — Verifies backed enum resolves to correct broadcaster via `connection()`
- [x] `testBroadcastManagerCanResolveBackedEnumDriver` — Verifies backed enum resolves to correct broadcaster via `driver()`
- [x] `testSetDefaultDriverAcceptsBackedEnum` — Verifies the string value is stored in config
- [x] `testPurgeAcceptsBackedEnum` — Verifies purge forces re-resolution after clearing the cache
- [x] Existing tests pass (no breaking changes)