### PR TITLE
[13.x] Add enum support to PasswordBrokerManager

### DIFF
--- a/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
@@ -5,6 +5,8 @@ namespace Illuminate\Auth\Passwords;
 use Illuminate\Contracts\Auth\PasswordBrokerFactory as FactoryContract;
 use InvalidArgumentException;
 
+use function Illuminate\Support\enum_value;
+
 /**
  * @mixin \Illuminate\Contracts\Auth\PasswordBroker
  */
@@ -37,12 +39,12 @@ class PasswordBrokerManager implements FactoryContract
     /**
      * Attempt to get the broker from the local cache.
      *
-     * @param  string|null  $name
+     * @param  \UnitEnum|string|null  $name
      * @return \Illuminate\Contracts\Auth\PasswordBroker
      */
     public function broker($name = null)
     {
-        $name = $name ?: $this->getDefaultDriver();
+        $name = enum_value($name) ?: $this->getDefaultDriver();
 
         return $this->brokers[$name] ?? ($this->brokers[$name] = $this->resolve($name));
     }
@@ -132,12 +134,12 @@ class PasswordBrokerManager implements FactoryContract
     /**
      * Set the default password broker name.
      *
-     * @param  string  $name
+     * @param  \UnitEnum|string  $name
      * @return void
      */
     public function setDefaultDriver($name)
     {
-        $this->app['config']['auth.defaults.passwords'] = $name;
+        $this->app['config']['auth.defaults.passwords'] = enum_value($name);
     }
 
     /**

--- a/tests/Auth/AuthPasswordBrokerManagerTest.php
+++ b/tests/Auth/AuthPasswordBrokerManagerTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Illuminate\Tests\Auth;
+
+use Illuminate\Auth\Passwords\PasswordBroker;
+use Illuminate\Auth\Passwords\PasswordBrokerManager;
+use Illuminate\Config\Repository as Config;
+use Illuminate\Container\Container;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class AuthPasswordBrokerManagerTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    public function testBrokerCanResolveBackedEnum(): void
+    {
+        $app = $this->getApp();
+
+        $broker = m::mock(PasswordBroker::class);
+
+        $manager = m::mock(PasswordBrokerManager::class, [$app])->makePartial()->shouldAllowMockingProtectedMethods();
+        $manager->shouldReceive('resolve')->with('users')->andReturn($broker);
+
+        $result1 = $manager->broker(PasswordBrokerName::Users);
+        $result2 = $manager->broker('users');
+
+        $this->assertSame($broker, $result1);
+        $this->assertSame($result1, $result2);
+    }
+
+    public function testSetDefaultDriverAcceptsBackedEnum(): void
+    {
+        $app = $this->getApp();
+
+        $manager = new PasswordBrokerManager($app);
+        $manager->setDefaultDriver(PasswordBrokerName::Users);
+
+        $this->assertSame('users', $app['config']['auth.defaults.passwords']);
+    }
+
+    protected function getApp(): Container
+    {
+        $app = new Container;
+
+        $app->singleton('config', fn () => new Config([
+            'auth' => [
+                'defaults' => ['passwords' => 'users'],
+                'passwords' => [
+                    'users' => [
+                        'provider' => 'users',
+                        'table' => 'password_reset_tokens',
+                        'expire' => 60,
+                        'throttle' => 60,
+                    ],
+                ],
+            ],
+        ]));
+
+        return $app;
+    }
+}
+
+enum PasswordBrokerName: string
+{
+    case Users = 'users';
+}


### PR DESCRIPTION
## Summary

This PR adds enum support to `PasswordBrokerManager::broker()` and `PasswordBrokerManager::setDefaultDriver()` using the `enum_value()` helper, aligning it with other manager classes that already support this pattern.

## Context

Several manager classes already accept enums for connection/driver names:

| Class | Supports Enums |
|---|---|
| `Manager::driver()` | ✅ (merged in #59659) |
| `CacheManager::store()` | ✅ (merged in #59637) |
| `AuthManager::guard()` | ✅ (merged in #59646) |
| `MailManager::mailer()` | ✅ (merged in #59645) |
| `QueueManager::connection()` | ✅ (merged in #59389) |
| `LogManager::channel()` | ✅ (merged in #59391) |
| `FilesystemManager::disk()` | ✅ |
| `RedisManager::connection()` | ✅ |
| `BroadcastManager::connection()` | ❌ |
| `PasswordBrokerManager::broker()` | ❌ |
| `PasswordBrokerManager::setDefaultDriver()` | ❌ |

This inconsistency means developers who define password broker names as enums cannot pass them directly to `Password::broker()` like they can with `Queue::connection()` or `Cache::store()`.

## Solution

- Added `enum_value()` call in `PasswordBrokerManager::broker()`
- Added `enum_value()` call in `PasswordBrokerManager::setDefaultDriver()`
- Updated `@param` docblocks on both methods to accept `\UnitEnum|string|null`

## Example

```php
enum PasswordBroker: string
{
    case Users  = 'users';
    case Admins = 'admins';
}

// Before: would not resolve correctly
Password::broker(PasswordBroker::Admins)->sendResetLink($credentials);

// After: works as expected
Password::broker(PasswordBroker::Admins)->sendResetLink($credentials);
Password::setDefaultDriver(PasswordBroker::Admins);
```

## Why This Doesn't Break Existing Features

- `enum_value()` returns the input unchanged for strings and `null` — all existing calls behave identically
- The updated `@param` types are docblock-only changes; no method signature change is required
- Follows the exact same pattern already established across `CacheManager`, `AuthManager`, `MailManager`, `QueueManager`, `LogManager`, `FilesystemManager`, `RedisManager`, and the base `Manager` class

## Changes

- `src/Illuminate/Auth/Passwords/PasswordBrokerManager.php` — Added `enum_value()` in `broker()` and `setDefaultDriver()`; updated docblocks
- `tests/Auth/AuthPasswordBrokerManagerTest.php` — New test class with 2 test cases

## Test Plan

- [x] `testBrokerCanResolveBackedEnum` — Verifies backed enum resolves to the correct password broker
- [x] `testSetDefaultDriverAcceptsBackedEnum` — Verifies the string value is stored in config
- [x] Existing tests pass (no breaking changes)