### PR TITLE
route:list command  - Add a new option  '---without-middleware'

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -306,6 +306,7 @@ class RouteListCommand extends Command
             ($this->option('method') && ! Str::contains($route['method'], strtoupper($this->option('method')))) ||
             ($this->option('domain') && ! Str::contains((string) $route['domain'], $this->option('domain'))) ||
             ($this->option('middleware') && ! Str::contains($route['middleware'], $this->option('middleware'))) ||
+            ($this->option('without-middleware') && Str::contains($route['middleware'], $this->option('without-middleware'))) ||
             ($this->option('except-vendor') && $route['vendor']) ||
             ($this->option('only-vendor') && ! $route['vendor'])) {
             return;
@@ -545,6 +546,7 @@ class RouteListCommand extends Command
             ['name', null, InputOption::VALUE_OPTIONAL, 'Filter the routes by name'],
             ['domain', null, InputOption::VALUE_OPTIONAL, 'Filter the routes by domain'],
             ['middleware', null, InputOption::VALUE_OPTIONAL, 'Filter the routes by middleware'],
+            ['without-middleware', null, InputOption::VALUE_OPTIONAL, 'Filter the routes by middleware that the route is missing'],
             ['path', null, InputOption::VALUE_OPTIONAL, 'Only show routes matching the given path pattern'],
             ['except-path', null, InputOption::VALUE_OPTIONAL, 'Do not display the routes matching the given path pattern'],
             ['reverse', 'r', InputOption::VALUE_NONE, 'Reverse the ordering of the routes'],

--- a/tests/Foundation/Console/RouteListCommandTest.php
+++ b/tests/Foundation/Console/RouteListCommandTest.php
@@ -258,7 +258,7 @@ class RouteListCommandTest extends TestCase
         $this->app->call('route:list', ['--json' => true, '-v' => true, '--without-middleware' => 'exampleMiddleware']);
         $output = $this->app->output();
 
-        $routes = json_decode($output, true);       
+        $routes = json_decode($output, true);
 
         $this->assertCount(1, $routes);
         $this->assertEquals('example-group', $routes[0]['uri']);

--- a/tests/Foundation/Console/RouteListCommandTest.php
+++ b/tests/Foundation/Console/RouteListCommandTest.php
@@ -237,6 +237,35 @@ class RouteListCommandTest extends TestCase
         $this->assertStringContainsString('RouteListCommandTest.php:', $routes[0]['path']);
     }
 
+    public function testFilterWithoutMiddlewareGroup()
+    {
+        $this->app->call('route:list', ['--json' => true, '-v' => true, '--without-middleware' => 'auth']);
+        $output = $this->app->output();
+
+        $routes = json_decode($output, true);
+
+        $this->assertCount(2, $routes);
+        $this->assertEquals('example', $routes[0]['uri']);
+        $this->assertEquals(['exampleMiddleware'], $routes[0]['middleware']);
+        $this->assertStringContainsString('RouteListCommandTest.php:', $routes[0]['path']);
+        $this->assertEquals('sub-example', $routes[1]['uri']);
+        $this->assertEquals(['exampleMiddleware'], $routes[1]['middleware']);
+        $this->assertStringContainsString('RouteListCommandTest.php:', $routes[1]['path']);
+    }
+
+    public function testFilterWithoutMiddleware()
+    {
+        $this->app->call('route:list', ['--json' => true, '-v' => true, '--without-middleware' => 'exampleMiddleware']);
+        $output = $this->app->output();
+
+        $routes = json_decode($output, true);       
+
+        $this->assertCount(1, $routes);
+        $this->assertEquals('example-group', $routes[0]['uri']);
+        $this->assertEquals(['web', 'auth'], $routes[0]['middleware']);
+        $this->assertStringContainsString('RouteListCommandTest.php:', $routes[0]['path']);
+    }
+
     public function testClosureRouteShowsPathInCli()
     {
         RouteListCommand::resolveTerminalWidthUsing(fn () => 200);


### PR DESCRIPTION
### What this all about?
Add a new option to the route:list command,   '--without-middleware'.


### Why?
I wanted a simpler way to filter routes by middleware they don't have.

Identifying routes that are missing the Authenticate middleware for example might be part of an security audit


### How to use it?
```
php artisan route:list --without-middleware='Authenticate'
```

### Backwards Compatibility

Not a breaking change, a new option is added,  and all tests continue to pass.
