### PR TITLE
[13.x] Add enum support to ChannelManager

### DIFF
--- a/src/Illuminate/Notifications/ChannelManager.php
+++ b/src/Illuminate/Notifications/ChannelManager.php
@@ -11,6 +11,8 @@ use Illuminate\Support\Queue\Concerns\ResolvesQueueRoutes;
 use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
 
+use function Illuminate\Support\enum_value;
+
 class ChannelManager extends Manager implements DispatcherContract, FactoryContract
 {
     use Macroable, ResolvesQueueRoutes;
@@ -64,7 +66,7 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
     /**
      * Get a channel instance.
      *
-     * @param  string|null  $name
+     * @param  \UnitEnum|string|null  $name
      * @return mixed
      */
     public function channel($name = null)
@@ -158,12 +160,12 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
     /**
      * Set the default channel driver name.
      *
-     * @param  string  $channel
+     * @param  \UnitEnum|string  $channel
      * @return void
      */
     public function deliverVia($channel)
     {
-        $this->defaultChannel = $channel;
+        $this->defaultChannel = enum_value($channel);
     }
 
     /**

--- a/tests/Notifications/NotificationChannelManagerTest.php
+++ b/tests/Notifications/NotificationChannelManagerTest.php
@@ -470,6 +470,37 @@ class NotificationChannelManagerTest extends TestCase
         $this->assertSame('test', NotificationChannelManagerWithAfterSendingMethodNotification::$afterSendingChannel);
         $this->assertSame($response, NotificationChannelManagerWithAfterSendingMethodNotification::$afterSendingResponse);
     }
+
+    public function testChannelManagerCanResolveBackedEnumChannel(): void
+    {
+        $container = new Container;
+        $container->instance('config', []);
+        Container::setInstance($container);
+
+        $channel = new \stdClass;
+        $manager = new ChannelManager($container);
+        $manager->extend('mail', static fn () => $channel);
+
+        $this->assertSame($channel, $manager->channel(NotificationChannelName::Mail));
+        $this->assertSame($manager->channel('mail'), $manager->channel(NotificationChannelName::Mail));
+    }
+
+    public function testDeliverViaAcceptsBackedEnum(): void
+    {
+        $container = new Container;
+        $container->instance('config', []);
+        Container::setInstance($container);
+
+        $manager = new ChannelManager($container);
+        $manager->deliverVia(NotificationChannelName::Mail);
+
+        $this->assertSame('mail', $manager->deliversVia());
+    }
+}
+
+enum NotificationChannelName: string
+{
+    case Mail = 'mail';
 }
 
 class TestSendQueuedNotifications implements ShouldQueue


### PR DESCRIPTION
## Summary

This PR adds enum support to `ChannelManager::channel()` and `ChannelManager::deliverVia()` using the `enum_value()` helper, aligning it with other manager classes that already support this pattern.

## Context

Several manager classes already accept enums for connection/driver names:

| Class | Supports Enums |
|---|---|
| `Manager::driver()` | ✅ (merged in #59659) |
| `CacheManager::store()` | ✅ (merged in #59637) |
| `AuthManager::guard()` | ✅ (merged in #59646) |
| `MailManager::mailer()` | ✅ (merged in #59645) |
| `QueueManager::connection()` | ✅ (merged in #59389) |
| `LogManager::channel()` | ✅ (merged in #59391) |
| `FilesystemManager::disk()` | ✅ |
| `RedisManager::connection()` | ✅ |
| `ChannelManager::channel()` | ❌ |
| `ChannelManager::deliverVia()` | ❌ |

This inconsistency means developers who define notification channel names as enums cannot pass them directly to `Notification::channel()` like they can with `Queue::connection()` or `Cache::store()`. More importantly, passing an enum to `deliverVia()` silently stores the enum object in `$defaultChannel` instead of its string value, causing a mismatch when the value is later used as a driver key.

## Solution

- Updated `@param` docblock on `channel()` to accept `\UnitEnum|string|null` — the parent `Manager::driver()` already calls `enum_value()`, so no logic change is needed here
- Added `enum_value()` call in `deliverVia()` to ensure the string value is stored in `$defaultChannel`
- Updated `@param` docblock on `deliverVia()` to accept `\UnitEnum|string`

## Example

```php
enum NotificationChannel: string
{
    case Mail     = 'mail';
    case Database = 'database';
}

// Before: deliverVia() silently stored the enum object, breaking driver resolution
Notification::deliverVia(NotificationChannel::Database);

// After: works as expected
Notification::channel(NotificationChannel::Mail)->send(...);
Notification::deliverVia(NotificationChannel::Database);
```

## Why This Doesn't Break Existing Features

- `enum_value()` returns the input unchanged for strings and `null` — all existing calls behave identically
- The `channel()` change is docblock-only; the underlying `Manager::driver()` already handles enum resolution
- Follows the exact same pattern already established across `CacheManager`, `AuthManager`, `MailManager`, `QueueManager`, `LogManager`, `FilesystemManager`, `RedisManager`, and the base `Manager` class

## Changes

- `src/Illuminate/Notifications/ChannelManager.php` — Added `enum_value()` in `deliverVia()`; updated docblocks on `channel()` and `deliverVia()`
- `tests/Notifications/NotificationChannelManagerTest.php` — Added 2 test cases

## Test Plan

- [x] `testChannelManagerCanResolveBackedEnumChannel` — Verifies backed enum resolves to the correct channel driver
- [x] `testDeliverViaAcceptsBackedEnum` — Verifies the string value is stored in `$defaultChannel`, not the enum object
- [x] Existing tests pass (no breaking changes)