### PR TITLE
Change attempts column type from tiny to small integer

### DIFF
--- a/src/Illuminate/Queue/Console/stubs/jobs.stub
+++ b/src/Illuminate/Queue/Console/stubs/jobs.stub
@@ -15,7 +15,7 @@ return new class extends Migration
             $table->bigIncrements('id');
             $table->string('queue')->index();
             $table->longText('payload');
-            $table->unsignedTinyInteger('attempts');
+            $table->unsignedSmallInteger('attempts');
             $table->unsignedInteger('reserved_at')->nullable();
             $table->unsignedInteger('available_at');
             $table->unsignedInteger('created_at');


### PR DESCRIPTION
Why are jobs restricted to "only" 255 attempts ? 

I reached the maximum on a unique job that try to reach an external service, every minute during a full day.

`SQLSTATE[22003]: Numeric value out of range: 1264 Out of range value for column 'attempts' at row 1 (Connection: mysql, Host: 127.0.0.1, Port: 3306, Database: my_db, SQL: update `jobs` set `reserved_at` = 1776316936, `attempts` = 256 where `id` = 10884941)`

I think this column can be extended without consequences.