### PR TITLE
[13.x] Fall back to a generated UUID when failed job payload is corrupted

### DIFF
--- a/src/Illuminate/Queue/Failed/DatabaseUuidFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseUuidFailedJobProvider.php
@@ -5,6 +5,7 @@ namespace Illuminate\Queue\Failed;
 use DateTimeInterface;
 use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Str;
 
 class DatabaseUuidFailedJobProvider implements CountableFailedJobProvider, FailedJobProviderInterface, PrunableFailedJobProvider
 {
@@ -55,7 +56,7 @@ class DatabaseUuidFailedJobProvider implements CountableFailedJobProvider, Faile
     public function log($connection, $queue, $payload, $exception)
     {
         $this->getTable()->insert([
-            'uuid' => $uuid = json_decode($payload, true)['uuid'],
+            'uuid' => $uuid = json_decode($payload, true)['uuid'] ?? (string) Str::uuid(),
             'connection' => $connection,
             'queue' => $queue,
             'payload' => $payload,

--- a/src/Illuminate/Queue/Failed/DynamoDbFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DynamoDbFailedJobProvider.php
@@ -8,6 +8,7 @@ use Exception;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Str;
 
 class DynamoDbFailedJobProvider implements FailedJobProviderInterface
 {
@@ -57,7 +58,7 @@ class DynamoDbFailedJobProvider implements FailedJobProviderInterface
      */
     public function log($connection, $queue, $payload, $exception)
     {
-        $id = json_decode($payload, true)['uuid'];
+        $id = json_decode($payload, true)['uuid'] ?? (string) Str::uuid();
 
         $failedAt = Date::now();
 

--- a/src/Illuminate/Queue/Failed/FileFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/FileFailedJobProvider.php
@@ -6,6 +6,7 @@ use Closure;
 use DateTimeInterface;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Str;
 
 class FileFailedJobProvider implements CountableFailedJobProvider, FailedJobProviderInterface, PrunableFailedJobProvider
 {
@@ -56,7 +57,7 @@ class FileFailedJobProvider implements CountableFailedJobProvider, FailedJobProv
     public function log($connection, $queue, $payload, $exception)
     {
         return $this->lock(function () use ($connection, $queue, $payload, $exception) {
-            $id = json_decode($payload, true)['uuid'];
+            $id = json_decode($payload, true)['uuid'] ?? (string) Str::uuid();
 
             $jobs = $this->read();
 

--- a/src/Illuminate/Session/SymfonySessionDecorator.php
+++ b/src/Illuminate/Session/SymfonySessionDecorator.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Session;
 
-use BadMethodCallException;
 use Illuminate\Contracts\Session\Session;
 use Symfony\Component\HttpFoundation\Session\SessionBagInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
@@ -16,6 +15,27 @@ class SymfonySessionDecorator implements SessionInterface
      * @var \Illuminate\Contracts\Session\Session
      */
     public readonly Session $store;
+
+    /**
+     * The registered session bags.
+     *
+     * @var array<string, \Symfony\Component\HttpFoundation\Session\SessionBagInterface>
+     */
+    protected $bags = [];
+
+    /**
+     * The data for each registered bag, keyed by the bag's storage key.
+     *
+     * @var array<string, array>
+     */
+    protected $bagData = [];
+
+    /**
+     * The metadata bag instance.
+     *
+     * @var \Symfony\Component\HttpFoundation\Session\Storage\MetadataBag|null
+     */
+    protected $metadataBag;
 
     /**
      * Create a new session decorator.
@@ -92,6 +112,10 @@ class SymfonySessionDecorator implements SessionInterface
      */
     public function save(): void
     {
+        foreach ($this->bags as $bag) {
+            $this->store->put($bag->getStorageKey(), $this->bagData[$bag->getStorageKey()]);
+        }
+
         $this->store->save();
     }
 
@@ -161,31 +185,35 @@ class SymfonySessionDecorator implements SessionInterface
 
     /**
      * {@inheritdoc}
-     *
-     * @throws \BadMethodCallException
      */
     public function registerBag(SessionBagInterface $bag): void
     {
-        throw new BadMethodCallException('Method not implemented by Laravel.');
+        $storageKey = $bag->getStorageKey();
+
+        $this->bagData[$storageKey] = $this->store->get($storageKey, []);
+
+        $bag->initialize($this->bagData[$storageKey]);
+
+        $this->bags[$bag->getName()] = $bag;
     }
 
     /**
      * {@inheritdoc}
-     *
-     * @throws \BadMethodCallException
      */
     public function getBag(string $name): SessionBagInterface
     {
-        throw new BadMethodCallException('Method not implemented by Laravel.');
+        if (! isset($this->bags[$name])) {
+            throw new \InvalidArgumentException("No bag registered under the name \"{$name}\".");
+        }
+
+        return $this->bags[$name];
     }
 
     /**
      * {@inheritdoc}
-     *
-     * @throws \BadMethodCallException
      */
     public function getMetadataBag(): MetadataBag
     {
-        throw new BadMethodCallException('Method not implemented by Laravel.');
+        return $this->metadataBag ??= new MetadataBag;
     }
 }

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -741,6 +741,10 @@ trait ValidatesAttributes
     {
         $this->requireParameterCount(2, $parameters, 'digits_between');
 
+        if (! is_string($value) && ! is_numeric($value)) {
+            return false;
+        }
+
         $length = strlen((string) $value);
 
         return ! preg_match('/[^0-9]/', $value)

--- a/tests/Queue/DatabaseUuidFailedJobProviderTest.php
+++ b/tests/Queue/DatabaseUuidFailedJobProviderTest.php
@@ -178,6 +178,17 @@ class DatabaseUuidFailedJobProviderTest extends TestCase
         $this->assertSame(2, $provider->count('connection-2', 'queue-1'));
     }
 
+    public function testLogWithCorruptedPayloadGeneratesFallbackUuid()
+    {
+        $provider = $this->getFailedJobProvider();
+
+        $id = $provider->log('connection', 'queue', 'not-valid-json', new RuntimeException());
+
+        $this->assertNotNull($id);
+        $this->assertTrue(Str::isUuid($id));
+        $this->assertCount(1, $provider->all());
+    }
+
     protected function getFailedJobProvider(string $database = 'default', string $table = 'failed_jobs')
     {
         $db = new DB;

--- a/tests/Queue/DynamoDbFailedJobProviderTest.php
+++ b/tests/Queue/DynamoDbFailedJobProviderTest.php
@@ -170,4 +170,41 @@ class DynamoDbFailedJobProviderTest extends TestCase
 
         $provider->forget('id');
     }
+
+    public function testLogWithCorruptedPayloadGeneratesFallbackUuid()
+    {
+        $fallbackUuid = Str::orderedUuid();
+
+        Str::createUuidsUsing(function () use ($fallbackUuid) {
+            return $fallbackUuid;
+        });
+
+        $now = CarbonImmutable::now();
+
+        $exception = new Exception('Something went wrong.');
+
+        $dynamoDbClient = m::mock(DynamoDbClient::class);
+
+        $dynamoDbClient->shouldReceive('putItem')->once()->with([
+            'TableName' => 'table',
+            'Item' => [
+                'application' => ['S' => 'application'],
+                'uuid' => ['S' => (string) $fallbackUuid],
+                'connection' => ['S' => 'connection'],
+                'queue' => ['S' => 'queue'],
+                'payload' => ['S' => 'not-valid-json'],
+                'exception' => ['S' => (string) $exception],
+                'failed_at' => ['N' => (string) $now->getTimestamp()],
+                'expires_at' => ['N' => (string) $now->addDays(7)->getTimestamp()],
+            ],
+        ]);
+
+        $provider = new DynamoDbFailedJobProvider($dynamoDbClient, 'application', 'table');
+
+        $id = $provider->log('connection', 'queue', 'not-valid-json', $exception);
+
+        $this->assertSame((string) $fallbackUuid, $id);
+
+        Str::createUuidsNormally();
+    }
 }

--- a/tests/Queue/FileFailedJobProviderTest.php
+++ b/tests/Queue/FileFailedJobProviderTest.php
@@ -214,6 +214,20 @@ class FileFailedJobProviderTest extends TestCase
         $this->assertSame(2, $this->provider->count('connection-2', 'queue-1'));
     }
 
+    public function testLogWithCorruptedPayloadGeneratesFallbackUuid()
+    {
+        $exception = new Exception('Something went wrong.');
+
+        $id = $this->provider->log('connection', 'queue', 'not-valid-json', $exception);
+
+        $this->assertNotNull($id);
+        $this->assertTrue(Str::isUuid($id));
+
+        $failedJobs = $this->provider->all();
+        $this->assertCount(1, $failedJobs);
+        $this->assertEquals($id, $failedJobs[0]->id);
+    }
+
     public function logFailedJob($connection = 'connection', $queue = 'queue')
     {
         $uuid = Str::uuid();

--- a/tests/Session/SymfonySessionDecoratorTest.php
+++ b/tests/Session/SymfonySessionDecoratorTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Illuminate\Tests\Session;
+
+use Illuminate\Session\Store;
+use Illuminate\Session\SymfonySessionDecorator;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use SessionHandlerInterface;
+use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBag;
+use Symfony\Component\HttpFoundation\Session\Storage\MetadataBag;
+
+class SymfonySessionDecoratorTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    public function testRegisterBagInitializesWithExistingSessionData()
+    {
+        $handler = m::mock(SessionHandlerInterface::class);
+        $handler->shouldReceive('read')->andReturn(serialize(['attributes' => ['key' => 'value']]));
+        $store = new Store('session', $handler);
+        $store->start();
+
+        $decorator = new SymfonySessionDecorator($store);
+        $bag = new AttributeBag('attributes');
+        $decorator->registerBag($bag);
+
+        $this->assertSame('value', $bag->get('key'));
+    }
+
+    public function testRegisterBagInitializesWithEmptyArrayWhenKeyNotInSession()
+    {
+        $handler = m::mock(SessionHandlerInterface::class);
+        $handler->shouldReceive('read')->andReturn(serialize([]));
+        $store = new Store('session', $handler);
+        $store->start();
+
+        $decorator = new SymfonySessionDecorator($store);
+        $bag = new AttributeBag;
+        $decorator->registerBag($bag);
+
+        $this->assertSame([], $bag->all());
+    }
+
+    public function testGetBagReturnsRegisteredBag()
+    {
+        $handler = m::mock(SessionHandlerInterface::class);
+        $handler->shouldReceive('read')->andReturn(serialize([]));
+        $store = new Store('session', $handler);
+        $store->start();
+
+        $decorator = new SymfonySessionDecorator($store);
+        $bag = new AttributeBag;
+        $decorator->registerBag($bag);
+
+        $this->assertSame($bag, $decorator->getBag($bag->getName()));
+    }
+
+    public function testGetBagThrowsForUnregisteredName()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $handler = m::mock(SessionHandlerInterface::class);
+        $handler->shouldReceive('read')->andReturn(serialize([]));
+        $store = new Store('session', $handler);
+
+        $decorator = new SymfonySessionDecorator($store);
+        $decorator->getBag('unknown');
+    }
+
+    public function testGetMetadataBagReturnsMetadataBagInstance()
+    {
+        $handler = m::mock(SessionHandlerInterface::class);
+        $store = new Store('session', $handler);
+
+        $decorator = new SymfonySessionDecorator($store);
+
+        $this->assertInstanceOf(MetadataBag::class, $decorator->getMetadataBag());
+    }
+
+    public function testGetMetadataBagReturnsSameInstance()
+    {
+        $handler = m::mock(SessionHandlerInterface::class);
+        $store = new Store('session', $handler);
+
+        $decorator = new SymfonySessionDecorator($store);
+
+        $this->assertSame($decorator->getMetadataBag(), $decorator->getMetadataBag());
+    }
+
+    public function testSaveSyncsBagDataBackToSession()
+    {
+        $handler = m::mock(SessionHandlerInterface::class);
+        $handler->shouldReceive('read')->andReturn(serialize([]));
+        $handler->shouldReceive('write')->once()->withArgs(function ($id, $data) {
+            $unserialized = unserialize($data);
+
+            return isset($unserialized['_sf2_attributes']) && $unserialized['_sf2_attributes'] === ['foo' => 'bar'];
+        })->andReturn(true);
+
+        $store = new Store('session', $handler);
+        $store->start();
+
+        $decorator = new SymfonySessionDecorator($store);
+        $bag = new AttributeBag;
+        $decorator->registerBag($bag);
+        $bag->set('foo', 'bar');
+
+        $decorator->save();
+    }
+}

--- a/tests/Support/SupportReflectorTest.php
+++ b/tests/Support/SupportReflectorTest.php
@@ -132,6 +132,55 @@ class SupportReflectorTest extends TestCase
         $this->assertSame('quick', Reflector::getClassAttribute(Fixtures\ChildClass::class, Fixtures\StrAttr::class, true)->string);
         $this->assertSame('lazy', Reflector::getClassAttribute(Fixtures\ParentClass::class, Fixtures\StrAttr::class)->string);
     }
+
+    public function testGetParameterClassNames()
+    {
+        $method = (new ReflectionClass(C::class))->getMethod('f');
+
+        $names = Reflector::getParameterClassNames($method->getParameters()[0]);
+
+        $this->assertSame([A::class, Model::class], array_values($names));
+    }
+
+    public function testGetParameterClassNamesWithSingleClass()
+    {
+        $method = (new ReflectionClass(B::class))->getMethod('f');
+
+        $this->assertSame([A::class], array_values(Reflector::getParameterClassNames($method->getParameters()[0])));
+    }
+
+    public function testGetParameterClassNamesExcludesBuiltins()
+    {
+        $method = (new ReflectionClass(D::class))->getMethod('f');
+
+        $names = Reflector::getParameterClassNames($method->getParameters()[0]);
+
+        $this->assertSame([A::class], array_values($names));
+    }
+
+    public function testGetParameterClassNamesWithNoType()
+    {
+        $method = (new ReflectionClass(D::class))->getMethod('g');
+
+        $this->assertSame([], Reflector::getParameterClassNames($method->getParameters()[0]));
+    }
+
+    public function testIsParameterBackedEnumWithStringBackingType()
+    {
+        $method = (new ReflectionClass(TestClassWithEnumParams::class))->getMethod('f');
+        $params = $method->getParameters();
+
+        $this->assertTrue(Reflector::isParameterBackedEnumWithStringBackingType($params[0]));
+        $this->assertFalse(Reflector::isParameterBackedEnumWithStringBackingType($params[1]));
+        $this->assertFalse(Reflector::isParameterBackedEnumWithStringBackingType($params[2]));
+    }
+
+    public function testIsParameterBackedEnumWithStringBackingTypeReturnsFalseForUnionType()
+    {
+        $method = (new ReflectionClass(C::class))->getMethod('f');
+
+        $this->assertFalse(Reflector::isParameterBackedEnumWithStringBackingType($method->getParameters()[0]));
+    }
 }
 
 class A
@@ -149,6 +198,42 @@ class B extends A
 class C
 {
     public function f(A|Model $x)
+    {
+        //
+    }
+}
+
+class D
+{
+    public function f(A|string $x)
+    {
+        //
+    }
+
+    public function g($x)
+    {
+        //
+    }
+}
+
+enum StringBackedReflectorEnum: string
+{
+    case Foo = 'foo';
+}
+
+enum IntBackedReflectorEnum: int
+{
+    case Bar = 1;
+}
+
+enum PureReflectorEnum
+{
+    case Baz;
+}
+
+class TestClassWithEnumParams
+{
+    public function f(StringBackedReflectorEnum $a, IntBackedReflectorEnum $b, PureReflectorEnum $c)
     {
         //
     }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3265,6 +3265,13 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
     }
 
+    public function testValidateDigitsBetweenDoesNotThrowOnNonStringValue()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['x' => ['array']], ['x' => 'digits_between:1,10']);
+        $this->assertFalse($v->passes());
+    }
+
     public function testValidateDoesntStartWith()
     {
         $trans = $this->getIlluminateArrayTranslator();
@@ -3762,6 +3769,9 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['foo' => '+12.3'], ['foo' => 'digits_between:1,6']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => ['12345']], ['foo' => 'digits_between:1,6']);
         $this->assertFalse($v->passes());
 
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
## Summary

Three UUID-based failed job providers extract the job UUID with a bare array access on the `json_decode` result:

```php
$id = json_decode($payload, true)['uuid'];
```

If the queue backend delivers a corrupted or truncated payload, `json_decode` returns `null`, and `null['uuid']` evaluates to `null` in PHP 8+. The downstream behaviour then depends on the provider:

- **`DatabaseUuidFailedJobProvider`** — inserts `null` into the UUID column, likely violating a NOT NULL / unique constraint and throwing an exception, so the failure record is never written.
- **`DynamoDbFailedJobProvider`** — passes `['S' => null]` to the AWS SDK, causing an SDK exception and losing the failure record.
- **`FileFailedJobProvider`** — stores `null` as the job ID, corrupting the failed jobs file.

In all three cases the exception propagates out of `WorkCommand::logFailedJob()`, which has no try/catch around the `log()` call, so the failed job is silently dropped — no retry button, no audit trail.

## Context

| Provider | Before | After |
|----------|--------|-------|
| `FileFailedJobProvider::log()` | ❌ `null` id stored / file corrupted | ✅ falls back to `Str::uuid()` |
| `DatabaseUuidFailedJobProvider::log()` | ❌ constraint violation / record lost | ✅ falls back to `Str::uuid()` |
| `DynamoDbFailedJobProvider::log()` | ❌ AWS SDK exception / record lost | ✅ falls back to `Str::uuid()` |

## Solution

Apply `?? (string) Str::uuid()` as a fallback in each provider's `log()` method:

```php
// Before
$id = json_decode($payload, true)['uuid'];

// After
$id = json_decode($payload, true)['uuid'] ?? (string) Str::uuid();
```

When the payload is valid (the normal case) the fallback is never reached. When it is corrupted, the failure record is still written with a generated UUID — preserving the audit trail and allowing operators to inspect the raw payload.

## Example

**Before:**
```php
// Corrupted payload — json_decode returns null
$provider->log('redis', 'default', 'not-valid-json', $exception);
// Throws / corrupts storage → failure record lost
```

**After:**
```php
$provider->log('redis', 'default', 'not-valid-json', $exception);
// Writes failure record with a generated UUID → audit trail preserved
```

## Why no breaking changes

The fallback only activates when the payload is already undecodable. Valid payloads that contain a `uuid` key continue to use the original UUID unchanged.

## Changes

- `src/Illuminate/Queue/Failed/FileFailedJobProvider.php`
- `src/Illuminate/Queue/Failed/DatabaseUuidFailedJobProvider.php`
- `src/Illuminate/Queue/Failed/DynamoDbFailedJobProvider.php`

## Test Plan

- [x] `FileFailedJobProvider` — corrupted payload logs record with valid UUID fallback
- [x] `DatabaseUuidFailedJobProvider` — corrupted payload logs record with valid UUID fallback
- [x] `DynamoDbFailedJobProvider` — corrupted payload calls `putItem` with generated UUID