### PR TITLE
[13.x]  Allow array of pivot arrays to be passed to hasAttached

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -724,6 +724,11 @@ abstract class Factory
      */
     public function hasAttached($factory, $pivot = [], $relationship = null)
     {
+        if (is_array($pivot) && count($pivot) > 0 && array_all($pivot, fn ($p) => is_array($p))) {
+            $factory = $factory instanceof Factory && $factory->count === null ? $factory->count(count($pivot)) : $factory;
+            $pivot = new Sequence(...$pivot);
+        }
+
         return $this->newInstance([
             'has' => $this->has->concat([new BelongsToManyRelationship(
                 $factory,

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -725,7 +725,10 @@ abstract class Factory
     public function hasAttached($factory, $pivot = [], $relationship = null)
     {
         if (is_array($pivot) && count($pivot) > 0 && array_all($pivot, fn ($p) => is_array($p))) {
-            $factory = $factory instanceof Factory && $factory->count === null ? $factory->count(count($pivot)) : $factory;
+            $factory = $factory instanceof Factory && $factory->count === null 
+                ? $factory->count(count($pivot)) 
+                : $factory;
+
             $pivot = new Sequence(...$pivot);
         }
 

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -556,6 +556,17 @@ class DatabaseEloquentFactoryTest extends TestCase
         unset($_SERVER['__test.role.creating-role']);
     }
 
+    public function test_belongs_to_many_relationship_with_pivot_arrays()
+    {
+        $user = FactoryTestUserFactory::new()
+            ->hasAttached(FactoryTestRoleFactory::new(), [['admin' => 'Y'], ['admin' => 'N']])
+            ->create();
+
+        $this->assertCount(2, $user->factoryTestRoles);
+        $this->assertSame('Y', $user->factoryTestRoles[0]->pivot->admin);
+        $this->assertSame('N', $user->factoryTestRoles[1]->pivot->admin);
+    }
+
     public function test_sequences()
     {
         $users = FactoryTestUserFactory::times(2)->sequence(


### PR DESCRIPTION
 Morning Taylor!
 
 I am a real human who typed this with my hands, maybe a bit of copy & paste! 
 I'll be at Laravel Live UK in case someone wants to verify 😃 
 
I see a lot of: 

```php
$user = User::factory()                                                                                                                                                                                                                                                                                                                                                                                                        
      ->hasAttached(Role::factory(), ['admin' => 'Y'])      
      ->hasAttached(Role::factory(), ['admin' => 'N']) // This becomes very long when you need a lot!
      .....
      ->create();                         
```

Or we reach for Sequence explicitly:                                                                                                                                                                                                                                                                                                                                                                                     
```php                                    
  $user = User::factory()  
      // Feels nasty to me 😞                                                                                                                                                                                                                                                                                                                                                                                                       
      ->hasAttached(Role::factory()->count(2), new Sequence(['admin' => 'Y'], ['admin' => 'N']))                                                                                                                                                                                                                                                                                                                              
      ->create();
```

This PR becomes the below, and is very useful when you need different pivot values:

```php
  $user = User::factory()
      // It infers the count too  😎      
      ->hasAttached(Role::factory(), [['admin' => 'Y'], ['admin' => 'N']])                                                                                                                                                                                                                                                                                                                                 
      ->create();                             
```  

No B/C afaik just a bit of added DX imo.

It uses `sequence` internally, so no big maintenance burden... and is the similar to the has{Relation} magic methods we did here : https://github.com/laravel/framework/pull/59343