### PR TITLE
Add whereLikeAny and whereLikeAll to Query Builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1367,6 +1367,124 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Add a "where like any" clause to the query.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  array  $values
+     * @param  bool  $caseSensitive
+     * @param  string  $boolean
+     * @param  bool  $not
+     * @return $this
+     */
+    public function whereLikeAny($column, array $values, $caseSensitive = false, $boolean = 'and', $not = false)
+    {
+        return $this->where(function ($query) use ($column, $values, $caseSensitive, $not) {
+            foreach ($values as $value) {
+                $query->whereLike($column, $value, $caseSensitive, $not ? 'and' : 'or', $not);
+            }
+        }, null, null, $boolean);
+    }
+
+    /**
+     * Add an "or where like any" clause to the query.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  array  $values
+     * @param  bool  $caseSensitive
+     * @return $this
+     */
+    public function orWhereLikeAny($column, array $values, $caseSensitive = false)
+    {
+        return $this->whereLikeAny($column, $values, $caseSensitive, 'or');
+    }
+
+    /**
+     * Add a "where not like any" clause to the query.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  array  $values
+     * @param  bool  $caseSensitive
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereNotLikeAny($column, array $values, $caseSensitive = false, $boolean = 'and')
+    {
+        return $this->whereLikeAny($column, $values, $caseSensitive, $boolean, true);
+    }
+
+    /**
+     * Add an "or where not like any" clause to the query.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  array  $values
+     * @param  bool  $caseSensitive
+     * @return $this
+     */
+    public function orWhereNotLikeAny($column, array $values, $caseSensitive = false)
+    {
+        return $this->whereNotLikeAny($column, $values, $caseSensitive, 'or');
+    }
+
+    /**
+     * Add a "where like all" clause to the query.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  array  $values
+     * @param  bool  $caseSensitive
+     * @param  string  $boolean
+     * @param  bool  $not
+     * @return $this
+     */
+    public function whereLikeAll($column, array $values, $caseSensitive = false, $boolean = 'and', $not = false)
+    {
+        return $this->where(function ($query) use ($column, $values, $caseSensitive, $not) {
+            foreach ($values as $value) {
+                $query->whereLike($column, $value, $caseSensitive, $not ? 'or' : 'and', $not);
+            }
+        }, null, null, $boolean);
+    }
+
+    /**
+     * Add an "or where like all" clause to the query.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  array  $values
+     * @param  bool  $caseSensitive
+     * @return $this
+     */
+    public function orWhereLikeAll($column, array $values, $caseSensitive = false)
+    {
+        return $this->whereLikeAll($column, $values, $caseSensitive, 'or');
+    }
+
+    /**
+     * Add a "where not like all" clause to the query.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  array  $values
+     * @param  bool  $caseSensitive
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereNotLikeAll($column, array $values, $caseSensitive = false, $boolean = 'and')
+    {
+        return $this->whereLikeAll($column, $values, $caseSensitive, $boolean, true);
+    }
+
+    /**
+     * Add an "or where not like all" clause to the query.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  array  $values
+     * @param  bool  $caseSensitive
+     * @return $this
+     */
+    public function orWhereNotLikeAll($column, array $values, $caseSensitive = false)
+    {
+        return $this->whereNotLikeAll($column, $values, $caseSensitive, 'or');
+    }
+
+    /**
      * Add a "where in" clause to the query.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -931,6 +931,118 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => '1'], $builder->getBindings());
     }
 
+    public function testWhereLikeAny()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereLikeAny('name', ['%abc%', '%def%']);
+        $this->assertSame('select * from `users` where (`name` like ? or `name` like ?)', $builder->toSql());
+        $this->assertEquals(['%abc%', '%def%'], $builder->getBindings());
+    }
+
+    public function testOrWhereLikeAny()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->where('active', true)->orWhereLikeAny('name', ['%abc%', '%def%']);
+        $this->assertSame('select * from `users` where `active` = ? or (`name` like ? or `name` like ?)', $builder->toSql());
+        $this->assertEquals([true, '%abc%', '%def%'], $builder->getBindings());
+    }
+
+    public function testWhereNotLikeAny()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereNotLikeAny('name', ['%abc%', '%def%']);
+        $this->assertSame('select * from `users` where (`name` not like ? and `name` not like ?)', $builder->toSql());
+        $this->assertEquals(['%abc%', '%def%'], $builder->getBindings());
+    }
+
+    public function testOrWhereNotLikeAny()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->where('active', true)->orWhereNotLikeAny('name', ['%abc%', '%def%']);
+        $this->assertSame('select * from `users` where `active` = ? or (`name` not like ? and `name` not like ?)', $builder->toSql());
+        $this->assertEquals([true, '%abc%', '%def%'], $builder->getBindings());
+    }
+
+    public function testWhereLikeAll()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereLikeAll('name', ['%abc%', '%def%']);
+        $this->assertSame('select * from `users` where (`name` like ? and `name` like ?)', $builder->toSql());
+        $this->assertEquals(['%abc%', '%def%'], $builder->getBindings());
+    }
+
+    public function testOrWhereLikeAll()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->where('active', true)->orWhereLikeAll('name', ['%abc%', '%def%']);
+        $this->assertSame('select * from `users` where `active` = ? or (`name` like ? and `name` like ?)', $builder->toSql());
+        $this->assertEquals([true, '%abc%', '%def%'], $builder->getBindings());
+    }
+
+    public function testWhereNotLikeAll()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereNotLikeAll('name', ['%abc%', '%def%']);
+        $this->assertSame('select * from `users` where (`name` not like ? or `name` not like ?)', $builder->toSql());
+        $this->assertEquals(['%abc%', '%def%'], $builder->getBindings());
+    }
+
+    public function testOrWhereNotLikeAll()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->where('active', true)->orWhereNotLikeAll('name', ['%abc%', '%def%']);
+        $this->assertSame('select * from `users` where `active` = ? or (`name` not like ? or `name` not like ?)', $builder->toSql());
+        $this->assertEquals([true, '%abc%', '%def%'], $builder->getBindings());
+    }
+
+    public function testWhereLikeAnyCaseSensitiveMysql()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereLikeAny('name', ['%abc%', '%def%'], true);
+        $this->assertSame('select * from `users` where (`name` like binary ? or `name` like binary ?)', $builder->toSql());
+        $this->assertEquals(['%abc%', '%def%'], $builder->getBindings());
+    }
+
+    public function testWhereLikeAnyPostgres()
+    {
+        $builder = $this->getPostgresBuilder();
+        $builder->select('*')->from('users')->whereLikeAny('name', ['%abc%', '%def%']);
+        $this->assertSame('select * from "users" where ("name"::text ilike ? or "name"::text ilike ?)', $builder->toSql());
+        $this->assertEquals(['%abc%', '%def%'], $builder->getBindings());
+    }
+
+    public function testWhereLikeAnyCaseSensitivePostgres()
+    {
+        $builder = $this->getPostgresBuilder();
+        $builder->select('*')->from('users')->whereLikeAny('name', ['%abc%', '%def%'], true);
+        $this->assertSame('select * from "users" where ("name"::text like ? or "name"::text like ?)', $builder->toSql());
+        $this->assertEquals(['%abc%', '%def%'], $builder->getBindings());
+    }
+
+    public function testWhereLikeAnySqlite()
+    {
+        $builder = $this->getSQLiteBuilder();
+        $builder->select('*')->from('users')->whereLikeAny('name', ['%abc%', '%def%']);
+        $this->assertSame('select * from "users" where ("name" like ? or "name" like ?)', $builder->toSql());
+        $this->assertEquals(['%abc%', '%def%'], $builder->getBindings());
+    }
+
+    public function testWhereLikeAnyWithEmptyArray()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereLikeAny('name', []);
+        $this->assertSame('select * from `users`', $builder->toSql());
+        $this->assertEquals([], $builder->getBindings());
+    }
+
+    public function testWhereLikeAllWithSingleValue()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereLikeAll('name', ['%abc%']);
+        $this->assertSame('select * from `users` where (`name` like ?)', $builder->toSql());
+        $this->assertEquals(['%abc%'], $builder->getBindings());
+    }
+
     public function testWhereDateSqlite()
     {
         $builder = $this->getSQLiteBuilder();


### PR DESCRIPTION
Adds symmetric "one column, multiple patterns" LIKE filtering to complement the existing "multiple columns, one pattern" `whereAny` / `whereAll` API.

### Motivation

Currently there is no clean way to check if a column matches any (or all) of several LIKE patterns. Users must manually build nested closures:

```php
User::where(function ($q) use ($patterns) {
    foreach ($patterns as $p) {
        $q->orWhereLike('name', $p);
    }
})->get();
```

This PR adds first-class methods that mirror the existing `whereAny`/`whereAll` naming convention.

### New Methods

| Method | SQL |
|---|---|
| `whereLikeAny($col, $values)` | `(col LIKE ? OR col LIKE ?)` |
| `whereNotLikeAny($col, $values)` | `(col NOT LIKE ? AND col NOT LIKE ?)` |
| `whereLikeAll($col, $values)` | `(col LIKE ? AND col LIKE ?)` |
| `whereNotLikeAll($col, $values)` | `(col NOT LIKE ? OR col NOT LIKE ?)` |

Plus `or` variants: `orWhereLikeAny`, `orWhereNotLikeAny`, `orWhereLikeAll`, `orWhereNotLikeAll`.

All methods support the `$caseSensitive` flag and delegate to the existing `whereLike` internally — **zero grammar changes required**. MySQL `like binary`, Postgres `ilike`, SQLite `glob` all work automatically.

### Usage

```php
// Match any pattern
User::whereLikeAny('name', ['%john%', '%jane%'])->get();

// Match all patterns
User::whereLikeAll('bio', ['%laravel%', '%php%'])->get();

// Exclude any pattern
User::whereNotLikeAny('email', ['%spam%', '%temp%'])->get();

// Case-sensitive on MySQL
User::whereLikeAny('name', ['%John%'], caseSensitive: true)->get();
```

### Negation semantics (De Morgan's)

`whereNotLikeAny` negates "match any" → flips `OR` to `AND`.
`whereNotLikeAll` negates "match all" → flips `AND` to `OR`.

### Tests

14 new test cases covering:
- All 8 methods (Any/All × positive/negative × and/or)
- Case-sensitive flag on MySQL and Postgres
- Postgres `ilike` / `::text` cast
- SQLite dialect
- Empty array (no-op)
- Single value