### PR TITLE
[13.x] Fix serving local files with percent-encoded names

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemServiceProvider.php
+++ b/src/Illuminate/Filesystem/FilesystemServiceProvider.php
@@ -110,19 +110,23 @@ class FilesystemServiceProvider extends ServiceProvider
                 $isProduction = $app->isProduction();
 
                 Route::get($uri.'/{path}', function (Request $request) use ($disk, $config, $isProduction, $uri) {
+                    $path = Str::after($request->path(), trim($uri, '/').'/');
+
                     return (new ServeFile(
                         $disk,
                         $config,
                         $isProduction
-                    ))($request, $this->servedFilePath($request, $uri));
+                    ))($request, $path);
                 })->where('path', '.*')->name('storage.'.$disk);
 
                 Route::put($uri.'/{path}', function (Request $request) use ($disk, $config, $isProduction, $uri) {
+                    $path = Str::after($request->path(), trim($uri, '/').'/');
+
                     return (new ReceiveFile(
                         $disk,
                         $config,
                         $isProduction
-                    ))($request, $this->servedFilePath($request, $uri));
+                    ))($request, $path);
                 })->where('path', '.*')->name('storage.'.$disk.'.upload');
             });
         }
@@ -159,15 +163,4 @@ class FilesystemServiceProvider extends ServiceProvider
         return $this->app['config']['filesystems.cloud'];
     }
 
-    /**
-     * Get the path of the file being served.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  string  $uri
-     * @return string
-     */
-    protected function servedFilePath(Request $request, string $uri): string
-    {
-        return Str::after($request->path(), trim($uri, '/').'/');
-    }
 }

--- a/src/Illuminate/Filesystem/FilesystemServiceProvider.php
+++ b/src/Illuminate/Filesystem/FilesystemServiceProvider.php
@@ -162,5 +162,4 @@ class FilesystemServiceProvider extends ServiceProvider
     {
         return $this->app['config']['filesystems.cloud'];
     }
-
 }

--- a/src/Illuminate/Filesystem/FilesystemServiceProvider.php
+++ b/src/Illuminate/Filesystem/FilesystemServiceProvider.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Foundation\CachesRoutes;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Str;
 use InvalidArgumentException;
 
 class FilesystemServiceProvider extends ServiceProvider
@@ -108,20 +109,20 @@ class FilesystemServiceProvider extends ServiceProvider
 
                 $isProduction = $app->isProduction();
 
-                Route::get($uri.'/{path}', function (Request $request, string $path) use ($disk, $config, $isProduction) {
+                Route::get($uri.'/{path}', function (Request $request) use ($disk, $config, $isProduction, $uri) {
                     return (new ServeFile(
                         $disk,
                         $config,
                         $isProduction
-                    ))($request, $path);
+                    ))($request, $this->servedFilePath($request, $uri));
                 })->where('path', '.*')->name('storage.'.$disk);
 
-                Route::put($uri.'/{path}', function (Request $request, string $path) use ($disk, $config, $isProduction) {
+                Route::put($uri.'/{path}', function (Request $request) use ($disk, $config, $isProduction, $uri) {
                     return (new ReceiveFile(
                         $disk,
                         $config,
                         $isProduction
-                    ))($request, $path);
+                    ))($request, $this->servedFilePath($request, $uri));
                 })->where('path', '.*')->name('storage.'.$disk.'.upload');
             });
         }
@@ -156,5 +157,17 @@ class FilesystemServiceProvider extends ServiceProvider
     protected function getCloudDriver()
     {
         return $this->app['config']['filesystems.cloud'];
+    }
+
+    /**
+     * Get the path of the file being served.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  string  $uri
+     * @return string
+     */
+    protected function servedFilePath(Request $request, string $uri): string
+    {
+        return Str::after($request->path(), trim($uri, '/').'/');
     }
 }

--- a/tests/Integration/Filesystem/ServeFileTest.php
+++ b/tests/Integration/Filesystem/ServeFileTest.php
@@ -51,4 +51,18 @@ class ServeFileTest extends TestCase
 
         $response->assertForbidden();
     }
+
+    public function testItCanServeAFileWithUrlEncodedCharactersInItsName()
+    {
+        Storage::put('serve%20file%20test.txt', 'Hello World');
+
+        $url = Storage::temporaryUrl('serve%20file%20test.txt', Carbon::now()->addMinutes(1));
+
+        $response = $this->get($url);
+
+        $response->assertOk();
+        $this->assertEquals('Hello World', $response->streamedContent());
+
+        Storage::delete('serve%20file%20test.txt');
+    }
 }


### PR DESCRIPTION
## Summary

When serving files from a local disk with `serve => true`, the route `{path}` parameter is already decoded before it is passed to `ServeFile`.

This breaks files whose literal storage key contains percent-encoded characters such as `%20`, because the lookup is performed against the decoded path instead of the raw request path.

As a result, files stored with percent-encoded characters in their names cannot be served through their temporary URLs even though they exist on disk.

Fixes #59709.

## Changes

- Derive the served file path from the raw request path instead of the decoded route parameter
- Resolve the raw served path directly inside the serving route closures to avoid using the decoded route parameter
- Keep the fix scoped to local file serving route registration in `FilesystemServiceProvider`

## Why This Is Safe

- The change is limited to the local disk serving routes created when `serve => true`
- It does not change how files are stored or how temporary URLs are generated
- It preserves existing behavior for normal file names while fixing lookups for names containing percent-encoded characters

## Test Plan

- [x] Added an integration test covering a file whose name contains percent-encoded characters
- [x] Confirmed the new test fails before the fix with a `404`
- [x] Confirmed `tests/Integration/Filesystem/ServeFileTest.php` passes after the fix
