### PR TITLE
[13.x] Fix flaky QueueWorkerTest by freezing time before computing retryUntil

### DIFF
--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -241,6 +241,8 @@ class QueueWorkerTest extends TestCase
 
     public function testJobIsNotReleasedIfItHasExpired()
     {
+        Carbon::setTestNow($now = Carbon::create(2026, 1, 1, 0, 0, 0));
+
         $e = new RuntimeException;
 
         $job = new WorkerFakeJob(function ($job) use ($e) {
@@ -250,13 +252,11 @@ class QueueWorkerTest extends TestCase
             throw $e;
         });
 
-        $job->retryUntil = Carbon::now()->addSeconds(1)->getTimestamp();
+        $job->retryUntil = $now->copy()->addSecond()->getTimestamp();
 
         $job->attempts = 0;
 
-        Carbon::setTestNow(
-            Carbon::now()->addSeconds(1)
-        );
+        Carbon::setTestNow($now->copy()->addSecond());
 
         $worker = $this->getWorker('default', ['queue' => [$job]]);
         $worker->runNextJob('default', 'queue', $this->workerOptions());


### PR DESCRIPTION
### Problem

`QueueWorkerTest::testJobIsNotReleasedIfItHasExpired` intermittently fails on CI (observed on Windows runners):

```
MaxAttemptsExceededException: "WorkerFakeJob has been attempted too many times."
is not instance of expected class "RuntimeException"
```

### Root Cause

The test computes `retryUntil` and the frozen test time from two separate `Carbon::now()` calls against the real wall clock (no `setTestNow` is active yet):

```php
$job->retryUntil = Carbon::now()->addSeconds(1)->getTimestamp();  // line 253
Carbon::setTestNow(Carbon::now()->addSeconds(1));                 // line 257-258
```

If a real-time second boundary passes between these two lines (more likely on slow CI), the frozen `now` ends up 1 second ahead of `retryUntil`. This causes `markJobAsFailedIfAlreadyExceedsMaxAttempts` to see the job as already expired (`now > retryUntil`) and throw `MaxAttemptsExceededException` **before the job fires**, instead of letting the job run, throw `RuntimeException`, and then fail via `markJobAsFailedIfWillExceedMaxAttempts`.

### Fix

Freeze time with `Carbon::setTestNow()` **before** computing `retryUntil`, so both timestamps derive from the same deterministic base:

```php
Carbon::setTestNow($now = Carbon::create(2026, 1, 1, 0, 0, 0));
$job->retryUntil = $now->copy()->addSecond()->getTimestamp();
Carbon::setTestNow($now->copy()->addSecond());
```

This eliminates the real-time race entirely. The frozen `now` equals `retryUntil`, so the `<=` check in `markJobAsFailedIfAlreadyExceedsMaxAttempts` passes (returns early), the job fires normally, and the test exercises its intended path.

1 file changed, 4 insertions, 4 deletions.