### PR TITLE
[13.x] Add `refresh()` to Eloquent `Collection`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -466,6 +466,43 @@ class Collection extends BaseCollection implements QueueableCollection
     }
 
     /**
+     * Reload the attributes for every model in the collection from the database.
+     *
+     * @return $this
+     */
+    public function refresh()
+    {
+        if ($this->isEmpty()) {
+            return $this;
+        }
+
+        $model = $this->first();
+
+        $freshModels = $model->newQueryWithoutScopes()
+            ->useWritePdo()
+            ->whereIn($model->getKeyName(), $this->modelKeys())
+            ->get()
+            ->getDictionary();
+
+        foreach ($this->items as $key => &$model) {
+            if (! isset($freshModels[$model->getKey()])) {
+                $model = null;
+
+                continue;
+            }
+
+            $model->setRawAttributes(
+                $freshModels[$model->getKey()]->getAttributes()
+            );
+
+            $model->syncOriginal();
+        }
+        unset($model);
+
+        return $this;
+    }
+
+    /**
      * Diff the collection with the given items.
      *
      * @param  iterable<array-key, TModel>  $items

--- a/tests/Integration/Database/EloquentCollectionRefreshTest.php
+++ b/tests/Integration/Database/EloquentCollectionRefreshTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Tests\Integration\Database\Fixtures\User;
+
+class EloquentCollectionRefreshTest extends DatabaseTestCase
+{
+    protected function afterRefreshingDatabase()
+    {
+        Schema::create('users', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('email');
+            $table->timestamps();
+        });
+    }
+
+    public function testRefreshMutatesExistingModelInstances()
+    {
+        User::insert([
+            ['email' => 'taylor@laravel.com'],
+            ['email' => 'mohamed@laravel.com'],
+        ]);
+
+        $collection = User::all();
+        $first = $collection->first();
+
+        User::where('id', $first->id)->update(['email' => 'updated@laravel.com']);
+
+        $collection->refresh();
+
+        $this->assertSame($first, $collection->first());
+        $this->assertSame('updated@laravel.com', $first->email);
+    }
+
+    public function testRefreshSyncsOriginal()
+    {
+        User::insert([
+            ['email' => 'taylor@laravel.com'],
+        ]);
+
+        $collection = User::all();
+
+        User::where('id', $collection->first()->id)->update(['email' => 'updated@laravel.com']);
+
+        $collection->refresh();
+
+        $this->assertEmpty($collection->first()->getDirty());
+        $this->assertSame('updated@laravel.com', $collection->first()->getOriginal('email'));
+    }
+
+    public function testRefreshNullsDeletedModels()
+    {
+        User::insert([
+            ['email' => 'taylor@laravel.com'],
+            ['email' => 'mohamed@laravel.com'],
+        ]);
+
+        $collection = User::all();
+
+        $collection->first()->delete();
+
+        $collection->refresh();
+
+        $this->assertNull($collection->first());
+        $this->assertCount(2, $collection);
+    }
+
+    public function testRefreshReturnsEmptyCollectionWhenEmpty()
+    {
+        $collection = new EloquentCollection;
+
+        $result = $collection->refresh();
+
+        $this->assertSame($collection, $result);
+        $this->assertCount(0, $result);
+    }
+
+    public function testRefreshReturnsSelf()
+    {
+        User::insert([
+            ['email' => 'taylor@laravel.com'],
+        ]);
+
+        $collection = User::all();
+        $result = $collection->refresh();
+
+        $this->assertSame($collection, $result);
+    }
+}


### PR DESCRIPTION
Earlier I was reviewing a colleague's code. I saw this in the test:

```php
$modelA->refresh();
$modelB->refresh();
$modelC->refresh();
```

I was about to suggest:
```php
new Illuminate\Database\Eloquent\Collection([$modelA, $modelB, $modelC])->refresh();
```

only to discover this method does not exist 😢 