### PR TITLE
[13.x] Get rid of useless Mockery::close

### DIFF
--- a/tests/Auth/AuthPasswordBrokerManagerTest.php
+++ b/tests/Auth/AuthPasswordBrokerManagerTest.php
@@ -11,11 +11,6 @@ use PHPUnit\Framework\TestCase;
 
 class AuthPasswordBrokerManagerTest extends TestCase
 {
-    protected function tearDown(): void
-    {
-        m::close();
-    }
-
     public function testBrokerCanResolveBackedEnum(): void
     {
         $app = $this->getApp();

--- a/tests/Queue/QueueRedisQueueTest.php
+++ b/tests/Queue/QueueRedisQueueTest.php
@@ -16,12 +16,6 @@ use PHPUnit\Framework\TestCase;
 
 class QueueRedisQueueTest extends TestCase
 {
-    protected function tearDown(): void
-    {
-        m::close();
-        parent::tearDown();
-    }
-
     public function testPushProperlyPushesJobOntoRedis()
     {
         $uuid = Str::uuid();

--- a/tests/Redis/ConcurrencyLimiterTest.php
+++ b/tests/Redis/ConcurrencyLimiterTest.php
@@ -12,12 +12,6 @@ use PHPUnit\Framework\TestCase;
 
 class ConcurrencyLimiterTest extends TestCase
 {
-    protected function tearDown(): void
-    {
-        m::close();
-        parent::tearDown();
-    }
-
     public function testAcquireUsesHashTagsOnPhpRedisClusterConnection()
     {
         $connection = m::mock(PhpRedisClusterConnection::class);


### PR DESCRIPTION
Get rid of useless Mockery::close
As this is already done in `\Illuminate\Tests\AfterEachTestSubscriber::notify`