### PR TITLE
[13.x] Enforce stricter assertions using `assertSame`

### DIFF
--- a/tests/Broadcasting/BroadcasterTest.php
+++ b/tests/Broadcasting/BroadcasterTest.php
@@ -53,13 +53,13 @@ class BroadcasterTest extends TestCase
             //
         };
         $parameters = $this->broadcaster->extractAuthParameters('asd', 'asd', $callback);
-        $this->assertEquals([], $parameters);
+        $this->assertSame([], $parameters);
 
         $callback = function ($user, $something) {
             //
         };
         $parameters = $this->broadcaster->extractAuthParameters('asd', 'asd', $callback);
-        $this->assertEquals([], $parameters);
+        $this->assertSame([], $parameters);
 
         // Test Explicit Binding...
         $container = new Container;

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -158,8 +158,8 @@ class BusBatchTest extends TestCase
 
         $batch = $batch->add([$job, $secondJob, $thirdJob]);
 
-        $this->assertEquals(3, $batch->totalJobs);
-        $this->assertEquals(3, $batch->pendingJobs);
+        $this->assertSame(3, $batch->totalJobs);
+        $this->assertSame(3, $batch->pendingJobs);
         $this->assertIsString($job->batchId);
         $this->assertInstanceOf(CarbonImmutable::class, $batch->createdAt);
     }
@@ -214,8 +214,8 @@ class BusBatchTest extends TestCase
         $batch->totalJobs = 10;
         $batch->pendingJobs = 4;
 
-        $this->assertEquals(6, $batch->processedJobs());
-        $this->assertEquals(60, $batch->progress());
+        $this->assertSame(6, $batch->processedJobs());
+        $this->assertSame(60, $batch->progress());
     }
 
     public function test_successful_jobs_can_be_recorded()
@@ -241,7 +241,7 @@ class BusBatchTest extends TestCase
         $connection->shouldReceive('bulk')->once();
 
         $batch = $batch->add([$job, $secondJob]);
-        $this->assertEquals(2, $batch->pendingJobs);
+        $this->assertSame(2, $batch->pendingJobs);
 
         $batch->recordSuccessfulJob('test-id');
         $batch->recordSuccessfulJob('test-id');
@@ -251,11 +251,11 @@ class BusBatchTest extends TestCase
         $this->assertInstanceOf(Batch::class, $_SERVER['__then.batch']);
 
         $batch = $batch->fresh();
-        $this->assertEquals(0, $batch->pendingJobs);
+        $this->assertSame(0, $batch->pendingJobs);
         $this->assertTrue($batch->finished());
-        $this->assertEquals(1, $_SERVER['__finally.count']);
-        $this->assertEquals(2, $_SERVER['__progress.count']);
-        $this->assertEquals(1, $_SERVER['__then.count']);
+        $this->assertSame(1, $_SERVER['__finally.count']);
+        $this->assertSame(2, $_SERVER['__progress.count']);
+        $this->assertSame(1, $_SERVER['__then.count']);
     }
 
     public function test_batch_finished_event_is_dispatched()
@@ -382,7 +382,7 @@ class BusBatchTest extends TestCase
         $connection->shouldReceive('bulk')->once();
 
         $batch = $batch->add([$job, $secondJob]);
-        $this->assertEquals(2, $batch->pendingJobs);
+        $this->assertSame(2, $batch->pendingJobs);
 
         $batch->recordFailedJob('test-id', new RuntimeException('Something went wrong.'));
         $batch->recordFailedJob('test-id', new RuntimeException('Something else went wrong.'));
@@ -391,13 +391,13 @@ class BusBatchTest extends TestCase
         $this->assertFalse(isset($_SERVER['__then.batch']));
 
         $batch = $batch->fresh();
-        $this->assertEquals(2, $batch->pendingJobs);
-        $this->assertEquals(2, $batch->failedJobs);
+        $this->assertSame(2, $batch->pendingJobs);
+        $this->assertSame(2, $batch->failedJobs);
         $this->assertTrue($batch->finished());
         $this->assertTrue($batch->cancelled());
-        $this->assertEquals(1, $_SERVER['__finally.count']);
-        $this->assertEquals(0, $_SERVER['__progress.count']);
-        $this->assertEquals(1, $_SERVER['__catch.count']);
+        $this->assertSame(1, $_SERVER['__finally.count']);
+        $this->assertSame(0, $_SERVER['__progress.count']);
+        $this->assertSame(1, $_SERVER['__catch.count']);
         $this->assertSame('Something went wrong.', $_SERVER['__catch.exception']->getMessage());
     }
 
@@ -424,7 +424,7 @@ class BusBatchTest extends TestCase
         $connection->shouldReceive('bulk')->once();
 
         $batch = $batch->add([$job, $secondJob]);
-        $this->assertEquals(2, $batch->pendingJobs);
+        $this->assertSame(2, $batch->pendingJobs);
 
         $batch->recordFailedJob('test-id', new RuntimeException('Something went wrong.'));
         $batch->recordFailedJob('test-id', new RuntimeException('Something else went wrong.'));
@@ -433,12 +433,12 @@ class BusBatchTest extends TestCase
         $this->assertFalse(isset($_SERVER['__then.batch']));
 
         $batch = $batch->fresh();
-        $this->assertEquals(2, $batch->pendingJobs);
-        $this->assertEquals(2, $batch->failedJobs);
+        $this->assertSame(2, $batch->pendingJobs);
+        $this->assertSame(2, $batch->failedJobs);
         $this->assertFalse($batch->finished());
         $this->assertFalse($batch->cancelled());
-        $this->assertEquals(1, $_SERVER['__catch.count']);
-        $this->assertEquals(2, $_SERVER['__progress.count']);
+        $this->assertSame(1, $_SERVER['__catch.count']);
+        $this->assertSame(2, $_SERVER['__progress.count']);
         $this->assertSame('Something went wrong.', $_SERVER['__catch.exception']->getMessage());
     }
 
@@ -517,7 +517,7 @@ class BusBatchTest extends TestCase
         $this->assertSame($batch->id, $_SERVER['__failure3.batch_id']);
         $this->assertSame(Batch::class, $_SERVER['__failure3.batch_class']);
         $this->assertSame(RuntimeException::class, $_SERVER['__failure3.exception_class']);
-        $this->assertEquals(2, $_SERVER['__failure3.param_count']);
+        $this->assertSame(2, $_SERVER['__failure3.param_count']);
     }
 
     public function test_batch_can_be_cancelled()
@@ -631,8 +631,8 @@ class BusBatchTest extends TestCase
             [$chainHeadJob, $secondJob, $thirdJob],
         ]);
 
-        $this->assertEquals(3, $batch->totalJobs);
-        $this->assertEquals(3, $batch->pendingJobs);
+        $this->assertSame(3, $batch->totalJobs);
+        $this->assertSame(3, $batch->pendingJobs);
         $this->assertSame('test-queue', $chainHeadJob->chainQueue);
         $this->assertIsString($chainHeadJob->batchId);
         $this->assertIsString($secondJob->batchId);

--- a/tests/Cache/CacheArrayStoreTest.php
+++ b/tests/Cache/CacheArrayStoreTest.php
@@ -101,12 +101,12 @@ class CacheArrayStoreTest extends TestCase
         $store = new ArrayStore;
         $store->put('foo', 1, 10);
         $result = $store->increment('foo');
-        $this->assertEquals(2, $result);
-        $this->assertEquals(2, $store->get('foo'));
+        $this->assertSame(2, $result);
+        $this->assertSame(2, $store->get('foo'));
 
         $result = $store->increment('foo', 2);
-        $this->assertEquals(4, $result);
-        $this->assertEquals(4, $store->get('foo'));
+        $this->assertSame(4, $result);
+        $this->assertSame(4, $store->get('foo'));
     }
 
     public function testValuesGetCastedByIncrementOrDecrement()
@@ -114,13 +114,13 @@ class CacheArrayStoreTest extends TestCase
         $store = new ArrayStore;
         $store->put('foo', '1', 10);
         $result = $store->increment('foo');
-        $this->assertEquals(2, $result);
-        $this->assertEquals(2, $store->get('foo'));
+        $this->assertSame(2, $result);
+        $this->assertSame(2, $store->get('foo'));
 
         $store->put('bar', '1', 10);
         $result = $store->decrement('bar');
-        $this->assertEquals(0, $result);
-        $this->assertEquals(0, $store->get('bar'));
+        $this->assertSame(0, $result);
+        $this->assertSame(0, $store->get('bar'));
     }
 
     public function testIncrementNonNumericValues()
@@ -128,8 +128,8 @@ class CacheArrayStoreTest extends TestCase
         $store = new ArrayStore;
         $store->put('foo', 'I am string', 10);
         $result = $store->increment('foo');
-        $this->assertEquals(1, $result);
-        $this->assertEquals(1, $store->get('foo'));
+        $this->assertSame(1, $result);
+        $this->assertSame(1, $store->get('foo'));
     }
 
     public function testNonExistingKeysCanBeIncremented()
@@ -138,12 +138,12 @@ class CacheArrayStoreTest extends TestCase
 
         $store = new ArrayStore;
         $result = $store->increment('foo');
-        $this->assertEquals(1, $result);
-        $this->assertEquals(1, $store->get('foo'));
+        $this->assertSame(1, $result);
+        $this->assertSame(1, $store->get('foo'));
 
         // Will be there forever
         Carbon::setTestNow(Carbon::now()->addYears(10));
-        $this->assertEquals(1, $store->get('foo'));
+        $this->assertSame(1, $store->get('foo'));
     }
 
     public function testExpiredKeysAreIncrementedLikeNonExistingKeys()
@@ -156,7 +156,7 @@ class CacheArrayStoreTest extends TestCase
         Carbon::setTestNow(Carbon::now()->addSeconds(10)->addSecond());
         $result = $store->increment('foo');
 
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
     }
 
     public function testValuesCanBeDecremented()
@@ -164,8 +164,8 @@ class CacheArrayStoreTest extends TestCase
         $store = new ArrayStore;
         $store->put('foo', 1, 10);
         $result = $store->decrement('foo');
-        $this->assertEquals(0, $result);
-        $this->assertEquals(0, $store->get('foo'));
+        $this->assertSame(0, $result);
+        $this->assertSame(0, $store->get('foo'));
 
         $result = $store->decrement('foo', 2);
         $this->assertEquals(-2, $result);

--- a/tests/Cache/CacheDatabaseStoreTest.php
+++ b/tests/Cache/CacheDatabaseStoreTest.php
@@ -190,7 +190,7 @@ class CacheDatabaseStoreTest extends TestCase
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
         $table->shouldReceive('where')->once()->with('key', 'prefixfoo')->andReturn($table);
         $table->shouldReceive('update')->once()->with(['value' => serialize(3)]);
-        $this->assertEquals(3, $store->increment('foo'));
+        $this->assertSame(3, $store->increment('foo'));
     }
 
     public function testDecrementReturnsCorrectValues()
@@ -229,7 +229,7 @@ class CacheDatabaseStoreTest extends TestCase
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
         $table->shouldReceive('where')->once()->with('key', 'prefixbar')->andReturn($table);
         $table->shouldReceive('update')->once()->with(['value' => serialize(2)]);
-        $this->assertEquals(2, $store->decrement('bar'));
+        $this->assertSame(2, $store->decrement('bar'));
     }
 
     public function testTouchExtendsTtl()

--- a/tests/Cache/CacheFileStoreTest.php
+++ b/tests/Cache/CacheFileStoreTest.php
@@ -241,7 +241,7 @@ class CacheFileStoreTest extends TestCase
         $files->expects($this->once())->method('put')->with($filePath, $valueAfterIncrement);
 
         $result = $store->increment('foo', 3);
-        $this->assertEquals(4, $result);
+        $this->assertSame(4, $result);
     }
 
     public function testDecrementCanAtomicallyJump()
@@ -257,7 +257,7 @@ class CacheFileStoreTest extends TestCase
         $files->expects($this->once())->method('put')->with($filePath, $valueAfterIncrement);
 
         $result = $store->decrement('foo', 2);
-        $this->assertEquals(0, $result);
+        $this->assertSame(0, $result);
     }
 
     public function testIncrementNonNumericValues()
@@ -272,7 +272,7 @@ class CacheFileStoreTest extends TestCase
         $files->expects($this->once())->method('put')->with($filePath, $valueAfterIncrement);
         $result = $store->increment('foo');
 
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
     }
 
     public function testIncrementNonExistentKeys()
@@ -287,7 +287,7 @@ class CacheFileStoreTest extends TestCase
         $files->expects($this->once())->method('put')->with($filePath, $valueAfterIncrement);
         $result = $store->increment('foo');
         $this->assertIsInt($result);
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
     }
 
     public function testIncrementDoesNotExtendCacheLife()

--- a/tests/Cache/CacheManagerTest.php
+++ b/tests/Cache/CacheManagerTest.php
@@ -190,7 +190,7 @@ class CacheManagerTest extends TestCase
 
         $cacheManager->setDefaultDriver('><((((@>');
 
-        $this->assertEquals('><((((@>', $app->get('config')->get('cache.default'));
+        $this->assertSame('><((((@>', $app->get('config')->get('cache.default'));
     }
 
     public function testItPurgesMemoizedStoreObjects()

--- a/tests/Cache/CacheRateLimiterTest.php
+++ b/tests/Cache/CacheRateLimiterTest.php
@@ -104,7 +104,7 @@ class CacheRateLimiterTest extends TestCase
         $cache->shouldReceive('getStore')->andReturn(new ArrayStore);
         $rateLimiter = new RateLimiter($cache);
 
-        $this->assertEquals(2, $rateLimiter->retriesLeft('key', 5));
+        $this->assertSame(2, $rateLimiter->retriesLeft('key', 5));
     }
 
     public function testClearClearsTheCacheKeys()

--- a/tests/Cache/CacheRedisStoreTest.php
+++ b/tests/Cache/CacheRedisStoreTest.php
@@ -50,7 +50,7 @@ class CacheRedisStoreTest extends TestCase
         $redis = $this->getRedis();
         $redis->getRedis()->shouldReceive('connection')->once()->with('default')->andReturn($redis->getRedis());
         $redis->getRedis()->shouldReceive('get')->once()->with('prefix:foo')->andReturn(1);
-        $this->assertEquals(1, $redis->get('foo'));
+        $this->assertSame(1, $redis->get('foo'));
     }
 
     public function testSetMethodProperlyCallsRedis()

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -87,7 +87,7 @@ class CacheRepositoryTest extends TestCase
     {
         $repo = $this->getRepository();
         $repo->setDefaultCacheTime(10);
-        $this->assertEquals(10, $repo->getDefaultCacheTime());
+        $this->assertSame(10, $repo->getDefaultCacheTime());
     }
 
     public function testHasMethod()

--- a/tests/Cache/CacheSessionStoreTest.php
+++ b/tests/Cache/CacheSessionStoreTest.php
@@ -109,12 +109,12 @@ class CacheSessionStoreTest extends TestCase
         $store = new SessionStore(self::getSession());
         $store->put('foo', 1, 10);
         $result = $store->increment('foo');
-        $this->assertEquals(2, $result);
-        $this->assertEquals(2, $store->get('foo'));
+        $this->assertSame(2, $result);
+        $this->assertSame(2, $store->get('foo'));
 
         $result = $store->increment('foo', 2);
-        $this->assertEquals(4, $result);
-        $this->assertEquals(4, $store->get('foo'));
+        $this->assertSame(4, $result);
+        $this->assertSame(4, $store->get('foo'));
     }
 
     public function testValuesGetCastedByIncrementOrDecrement()
@@ -122,13 +122,13 @@ class CacheSessionStoreTest extends TestCase
         $store = new SessionStore(self::getSession());
         $store->put('foo', '1', 10);
         $result = $store->increment('foo');
-        $this->assertEquals(2, $result);
-        $this->assertEquals(2, $store->get('foo'));
+        $this->assertSame(2, $result);
+        $this->assertSame(2, $store->get('foo'));
 
         $store->put('bar', '1', 10);
         $result = $store->decrement('bar');
-        $this->assertEquals(0, $result);
-        $this->assertEquals(0, $store->get('bar'));
+        $this->assertSame(0, $result);
+        $this->assertSame(0, $store->get('bar'));
     }
 
     public function testIncrementNonNumericValues()
@@ -136,20 +136,20 @@ class CacheSessionStoreTest extends TestCase
         $store = new SessionStore(self::getSession());
         $store->put('foo', 'I am string', 10);
         $result = $store->increment('foo');
-        $this->assertEquals(1, $result);
-        $this->assertEquals(1, $store->get('foo'));
+        $this->assertSame(1, $result);
+        $this->assertSame(1, $store->get('foo'));
     }
 
     public function testNonExistingKeysCanBeIncremented()
     {
         $store = new SessionStore(self::getSession());
         $result = $store->increment('foo');
-        $this->assertEquals(1, $result);
-        $this->assertEquals(1, $store->get('foo'));
+        $this->assertSame(1, $result);
+        $this->assertSame(1, $store->get('foo'));
 
         // Will be there forever
         Carbon::setTestNow(Carbon::now()->addYears(10));
-        $this->assertEquals(1, $store->get('foo'));
+        $this->assertSame(1, $store->get('foo'));
     }
 
     public function testExpiredKeysAreIncrementedLikeNonExistingKeys()
@@ -162,7 +162,7 @@ class CacheSessionStoreTest extends TestCase
         Carbon::setTestNow(Carbon::now()->addSeconds(10)->addSecond());
         $result = $store->increment('foo');
 
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
     }
 
     public function testValuesCanBeDecremented()
@@ -170,8 +170,8 @@ class CacheSessionStoreTest extends TestCase
         $store = new SessionStore(self::getSession());
         $store->put('foo', 1, 10);
         $result = $store->decrement('foo');
-        $this->assertEquals(0, $result);
-        $this->assertEquals(0, $store->get('foo'));
+        $this->assertSame(0, $result);
+        $this->assertSame(0, $store->get('foo'));
 
         $result = $store->decrement('foo', 2);
         $this->assertEquals(-2, $result);

--- a/tests/Cache/CacheSessionStoreTest.php
+++ b/tests/Cache/CacheSessionStoreTest.php
@@ -207,7 +207,7 @@ class CacheSessionStoreTest extends TestCase
     public function testItemKey()
     {
         $store = new SessionStore(self::getSession(), 'custom_prefix');
-        $this->assertEquals('custom_prefix.foo', $store->itemKey('foo'));
+        $this->assertSame('custom_prefix.foo', $store->itemKey('foo'));
     }
 
     public function testValuesAreStoredByReference()

--- a/tests/Cache/CacheTaggedCacheTest.php
+++ b/tests/Cache/CacheTaggedCacheTest.php
@@ -175,7 +175,7 @@ class CacheTaggedCacheTest extends TestCase
     {
         $store = new ArrayStore;
         $store->tags('bop')->increment('foo', 5);
-        $this->assertEquals(5, $store->tags('bop')->get('foo'));
+        $this->assertSame(5, $store->tags('bop')->get('foo'));
         $store->tags('bop')->flush();
         $this->assertNull($store->tags('bop')->get('foo'));
     }

--- a/tests/Console/CacheCommandMutexTest.php
+++ b/tests/Console/CacheCommandMutexTest.php
@@ -166,7 +166,7 @@ class CacheCommandMutexTest extends TestCase
         $this->cacheRepository->shouldReceive('add')
             ->once()
             ->withArgs(function ($key) {
-                $this->assertEquals('framework'.DIRECTORY_SEPARATOR.'command-command-name', $key);
+                $this->assertSame('framework'.DIRECTORY_SEPARATOR.'command-command-name', $key);
 
                 return true;
             })
@@ -196,7 +196,7 @@ class CacheCommandMutexTest extends TestCase
         $this->cacheRepository->shouldReceive('add')
             ->once()
             ->withArgs(function ($key) {
-                $this->assertEquals('framework'.DIRECTORY_SEPARATOR.'command-command-name-isolated', $key);
+                $this->assertSame('framework'.DIRECTORY_SEPARATOR.'command-command-name-isolated', $key);
 
                 return true;
             })

--- a/tests/Console/CommandMutexTest.php
+++ b/tests/Console/CommandMutexTest.php
@@ -65,7 +65,7 @@ class CommandMutexTest extends TestCase
 
         $this->runCommand();
 
-        $this->assertEquals(1, $this->command->ran);
+        $this->assertSame(1, $this->command->ran);
     }
 
     public function testCannotRunIsolatedCommandIfBlocked()
@@ -76,7 +76,7 @@ class CommandMutexTest extends TestCase
 
         $this->runCommand();
 
-        $this->assertEquals(0, $this->command->ran);
+        $this->assertSame(0, $this->command->ran);
     }
 
     public function testCanRunCommandAgainAfterOtherCommandFinished()
@@ -91,7 +91,7 @@ class CommandMutexTest extends TestCase
         $this->runCommand();
         $this->runCommand();
 
-        $this->assertEquals(2, $this->command->ran);
+        $this->assertSame(2, $this->command->ran);
     }
 
     public function testCanRunCommandAgainNonAutomated()
@@ -100,7 +100,7 @@ class CommandMutexTest extends TestCase
 
         $this->runCommand(false);
 
-        $this->assertEquals(1, $this->command->ran);
+        $this->assertSame(1, $this->command->ran);
     }
 
     protected function runCommand($withIsolated = true)

--- a/tests/Container/AfterResolvingAttributeCallbackTest.php
+++ b/tests/Container/AfterResolvingAttributeCallbackTest.php
@@ -55,7 +55,7 @@ class AfterResolvingAttributeCallbackTest extends TestCase
         $instance = $container->make(ContainerTestHasSelfConfiguringAttributeAndConstructor::class);
 
         $this->assertInstanceOf(ContainerTestHasSelfConfiguringAttributeAndConstructor::class, $instance);
-        $this->assertEquals('the-right-value', $instance->value);
+        $this->assertSame('the-right-value', $instance->value);
     }
 
     public function testCallbackIsCalledOnAppCall()

--- a/tests/Container/ContainerCallTest.php
+++ b/tests/Container/ContainerCallTest.php
@@ -129,7 +129,7 @@ class ContainerCallTest extends TestCase
         });
 
         $this->assertInstanceOf(stdClass::class, $result[0]);
-        $this->assertEquals([], $result[1]);
+        $this->assertSame([], $result[1]);
 
         $result = $container->call(function (stdClass $foo, $bar = []) {
             return func_get_args();

--- a/tests/Container/ContainerExtendTest.php
+++ b/tests/Container/ContainerExtendTest.php
@@ -32,7 +32,7 @@ class ContainerExtendTest extends TestCase
         $result = $container->make('foo');
 
         $this->assertSame('taylor', $result->name);
-        $this->assertEquals(26, $result->age);
+        $this->assertSame(26, $result->age);
         $this->assertSame($result, $container->make('foo'));
     }
 

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -919,7 +919,7 @@ class ContainerTest extends TestCase
         $r = $container->make(RequestDto::class);
 
         $this->assertInstanceOf(RequestDto::class, $r);
-        $this->assertEquals(999, $r->userId);
+        $this->assertSame(999, $r->userId);
         $this->assertEquals('taylor@laravel.com', $r->email);
     }
 
@@ -1118,9 +1118,7 @@ class WildcardConcrete implements WildcardOnlyInterface
 {
 }
 
-/*
- * The order of these attributes matters because we want to ensure we only fallback to '*' when there's no more specific environment.
- */
+// The order of these attributes matters because we want to ensure we only fallback to '*' when there's no more specific environment.
 #[Bind(FallbackConcrete::class)]
 #[Bind(ProdConcrete::class, environments: 'prod')]
 interface WildcardAndProdInterface

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -661,7 +661,7 @@ class ContainerTest extends TestCase
             return $config;
         });
 
-        $this->assertEquals([], $container->make('foo', ['something']));
+        $this->assertSame([], $container->make('foo', ['something']));
     }
 
     public function testSingletonBindingsNotRespectedWithMakeParameters()

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -920,7 +920,7 @@ class ContainerTest extends TestCase
 
         $this->assertInstanceOf(RequestDto::class, $r);
         $this->assertSame(999, $r->userId);
-        $this->assertEquals('taylor@laravel.com', $r->email);
+        $this->assertSame('taylor@laravel.com', $r->email);
     }
 
     // public function testContainerCanCatchCircularDependency()

--- a/tests/Container/ContextualAttributeBindingTest.php
+++ b/tests/Container/ContextualAttributeBindingTest.php
@@ -100,7 +100,7 @@ class ContextualAttributeBindingTest extends TestCase
         $class = $container->make(ContainerTestHasConfigValueProperty::class);
 
         $this->assertInstanceOf(ContainerTestHasConfigValueProperty::class, $class);
-        $this->assertEquals('Europe/Paris', $class->timezone);
+        $this->assertSame('Europe/Paris', $class->timezone);
     }
 
     public function testScalarDependencyCanBeResolvedFromAttributeResolveMethod()
@@ -115,7 +115,7 @@ class ContextualAttributeBindingTest extends TestCase
         $class = $container->make(ContainerTestHasConfigValueWithResolveProperty::class);
 
         $this->assertInstanceOf(ContainerTestHasConfigValueWithResolveProperty::class, $class);
-        $this->assertEquals('production', $class->env);
+        $this->assertSame('production', $class->env);
     }
 
     public function testDependencyWithAfterCallbackAttributeCanBeResolved()
@@ -124,7 +124,7 @@ class ContextualAttributeBindingTest extends TestCase
 
         $class = $container->make(ContainerTestHasConfigValueWithResolvePropertyAndAfterCallback::class);
 
-        $this->assertEquals('Developer', $class->person->role);
+        $this->assertSame('Developer', $class->person->role);
     }
 
     public function testAuthedAttribute()
@@ -289,7 +289,7 @@ class ContextualAttributeBindingTest extends TestCase
             return $hasAttribute->person;
         });
 
-        $this->assertEquals('Taylor', $person->name);
+        $this->assertSame('Taylor', $person->name);
     }
 
     public function testAttributeOnAppCall()
@@ -306,7 +306,7 @@ class ContextualAttributeBindingTest extends TestCase
             return $value;
         });
 
-        $this->assertEquals('Europe/Paris', $value);
+        $this->assertSame('Europe/Paris', $value);
 
         $value = $container->call(function (#[Config('app.locale')] ?string $value) {
             return $value;
@@ -329,7 +329,7 @@ class ContextualAttributeBindingTest extends TestCase
             return $object;
         });
 
-        $this->assertEquals('Europe/Paris', $value->timezone);
+        $this->assertSame('Europe/Paris', $value->timezone);
 
         $value = $container->call(function (LocaleObject $object) {
             return $object;

--- a/tests/Container/ContextualBindingTest.php
+++ b/tests/Container/ContextualBindingTest.php
@@ -193,7 +193,7 @@ class ContextualBindingTest extends TestCase
         $container->instance(IContainerContextContractStub::class, new ContainerImplementationStub);
         $container->instance(ContainerTestContextInjectInstantiations::class, new ContainerTestContextInjectInstantiations);
 
-        $this->assertEquals(1, ContainerTestContextInjectInstantiations::$instantiations);
+        $this->assertSame(1, ContainerTestContextInjectInstantiations::$instantiations);
 
         $container->when(ContainerTestContextInjectOne::class)->needs(IContainerContextContractStub::class)->give(ContainerTestContextInjectInstantiations::class);
 
@@ -202,7 +202,7 @@ class ContextualBindingTest extends TestCase
         $container->make(ContainerTestContextInjectOne::class);
         $container->make(ContainerTestContextInjectOne::class);
 
-        $this->assertEquals(1, ContainerTestContextInjectInstantiations::$instantiations);
+        $this->assertSame(1, ContainerTestContextInjectInstantiations::$instantiations);
     }
 
     public function testContainerCanInjectSimpleVariable()
@@ -210,7 +210,7 @@ class ContextualBindingTest extends TestCase
         $container = new Container;
         $container->when(ContainerInjectVariableStub::class)->needs('$something')->give(100);
         $instance = $container->make(ContainerInjectVariableStub::class);
-        $this->assertEquals(100, $instance->something);
+        $this->assertSame(100, $instance->something);
 
         $container = new Container;
         $container->when(ContainerInjectVariableStub::class)->needs('$something')->give(function ($container) {

--- a/tests/Container/ResolvingCallbackTest.php
+++ b/tests/Container/ResolvingCallbackTest.php
@@ -77,10 +77,10 @@ class ResolvingCallbackTest extends TestCase
         $container->bind(ResolvingContractStub::class, ResolvingImplementationStub::class);
 
         $container->make(ResolvingImplementationStub::class);
-        $this->assertEquals(1, $callCounter);
+        $this->assertSame(1, $callCounter);
 
         $container->make(ResolvingImplementationStub::class);
-        $this->assertEquals(2, $callCounter);
+        $this->assertSame(2, $callCounter);
     }
 
     public function testGlobalResolvingCallbacksAreCalledOnceForImplementation()
@@ -95,10 +95,10 @@ class ResolvingCallbackTest extends TestCase
         $container->bind(ResolvingContractStub::class, ResolvingImplementationStub::class);
 
         $container->make(ResolvingImplementationStub::class);
-        $this->assertEquals(1, $callCounter);
+        $this->assertSame(1, $callCounter);
 
         $container->make(ResolvingContractStub::class);
-        $this->assertEquals(2, $callCounter);
+        $this->assertSame(2, $callCounter);
     }
 
     public function testResolvingCallbacksAreCalledOnceForSingletonConcretes()
@@ -114,13 +114,13 @@ class ResolvingCallbackTest extends TestCase
         $container->bind(ResolvingImplementationStub::class);
 
         $container->make(ResolvingImplementationStub::class);
-        $this->assertEquals(1, $callCounter);
+        $this->assertSame(1, $callCounter);
 
         $container->make(ResolvingImplementationStub::class);
-        $this->assertEquals(2, $callCounter);
+        $this->assertSame(2, $callCounter);
 
         $container->make(ResolvingContractStub::class);
-        $this->assertEquals(3, $callCounter);
+        $this->assertSame(3, $callCounter);
     }
 
     public function testResolvingCallbacksCanStillBeAddedAfterTheFirstResolution()
@@ -137,7 +137,7 @@ class ResolvingCallbackTest extends TestCase
         });
 
         $container->make(ResolvingImplementationStub::class);
-        $this->assertEquals(1, $callCounter);
+        $this->assertSame(1, $callCounter);
     }
 
     public function testResolvingCallbacksAreCanceledWhenInterfaceGetsBoundToSomeOtherConcrete()
@@ -152,11 +152,11 @@ class ResolvingCallbackTest extends TestCase
         });
 
         $container->make(ResolvingContractStub::class);
-        $this->assertEquals(1, $callCounter);
+        $this->assertSame(1, $callCounter);
 
         $container->bind(ResolvingContractStub::class, ResolvingImplementationStubTwo::class);
         $container->make(ResolvingContractStub::class);
-        $this->assertEquals(1, $callCounter);
+        $this->assertSame(1, $callCounter);
     }
 
     public function testResolvingCallbacksAreCalledOnceForStringAbstractions()
@@ -171,10 +171,10 @@ class ResolvingCallbackTest extends TestCase
         $container->bind('foo', ResolvingImplementationStub::class);
 
         $container->make('foo');
-        $this->assertEquals(1, $callCounter);
+        $this->assertSame(1, $callCounter);
 
         $container->make('foo');
-        $this->assertEquals(2, $callCounter);
+        $this->assertSame(2, $callCounter);
     }
 
     public function testResolvingCallbacksForConcretesAreCalledOnceForStringAbstractions()
@@ -191,16 +191,16 @@ class ResolvingCallbackTest extends TestCase
         $container->bind(ResolvingContractStub::class, ResolvingImplementationStub::class);
 
         $container->make(ResolvingImplementationStub::class);
-        $this->assertEquals(1, $callCounter);
+        $this->assertSame(1, $callCounter);
 
         $container->make('foo');
-        $this->assertEquals(2, $callCounter);
+        $this->assertSame(2, $callCounter);
 
         $container->make('bar');
-        $this->assertEquals(3, $callCounter);
+        $this->assertSame(3, $callCounter);
 
         $container->make(ResolvingContractStub::class);
-        $this->assertEquals(4, $callCounter);
+        $this->assertSame(4, $callCounter);
     }
 
     public function testResolvingCallbacksAreCalledOnceForImplementation2()
@@ -217,16 +217,16 @@ class ResolvingCallbackTest extends TestCase
         });
 
         $container->make(ResolvingContractStub::class);
-        $this->assertEquals(1, $callCounter);
+        $this->assertSame(1, $callCounter);
 
         $container->make(ResolvingImplementationStub::class);
-        $this->assertEquals(2, $callCounter);
+        $this->assertSame(2, $callCounter);
 
         $container->make(ResolvingImplementationStub::class);
-        $this->assertEquals(3, $callCounter);
+        $this->assertSame(3, $callCounter);
 
         $container->make(ResolvingContractStub::class);
-        $this->assertEquals(4, $callCounter);
+        $this->assertSame(4, $callCounter);
     }
 
     public function testRebindingDoesNotAffectResolvingCallbacks()
@@ -244,16 +244,16 @@ class ResolvingCallbackTest extends TestCase
         });
 
         $container->make(ResolvingContractStub::class);
-        $this->assertEquals(1, $callCounter);
+        $this->assertSame(1, $callCounter);
 
         $container->make(ResolvingImplementationStub::class);
-        $this->assertEquals(2, $callCounter);
+        $this->assertSame(2, $callCounter);
 
         $container->make(ResolvingImplementationStub::class);
-        $this->assertEquals(3, $callCounter);
+        $this->assertSame(3, $callCounter);
 
         $container->make(ResolvingContractStub::class);
-        $this->assertEquals(4, $callCounter);
+        $this->assertSame(4, $callCounter);
     }
 
     public function testParametersPassedIntoResolvingCallbacks()
@@ -299,24 +299,24 @@ class ResolvingCallbackTest extends TestCase
         $container->bind(ResolvingContractStub::class, ResolvingImplementationStub::class);
 
         $container->make(ResolvingContractStub::class);
-        $this->assertEquals(1, $resolvingCallCounter);
-        $this->assertEquals(0, $rebindCallCounter);
+        $this->assertSame(1, $resolvingCallCounter);
+        $this->assertSame(0, $rebindCallCounter);
 
         $container->bind(ResolvingContractStub::class, ResolvingImplementationStubTwo::class);
-        $this->assertEquals(2, $resolvingCallCounter);
-        $this->assertEquals(1, $rebindCallCounter);
+        $this->assertSame(2, $resolvingCallCounter);
+        $this->assertSame(1, $rebindCallCounter);
 
         $container->make(ResolvingImplementationStubTwo::class);
-        $this->assertEquals(3, $resolvingCallCounter);
-        $this->assertEquals(1, $rebindCallCounter);
+        $this->assertSame(3, $resolvingCallCounter);
+        $this->assertSame(1, $rebindCallCounter);
 
         $container->bind(ResolvingContractStub::class, fn () => new ResolvingImplementationStubTwo);
-        $this->assertEquals(4, $resolvingCallCounter);
-        $this->assertEquals(2, $rebindCallCounter);
+        $this->assertSame(4, $resolvingCallCounter);
+        $this->assertSame(2, $rebindCallCounter);
 
         $container->make(ResolvingContractStub::class);
-        $this->assertEquals(5, $resolvingCallCounter);
-        $this->assertEquals(2, $rebindCallCounter);
+        $this->assertSame(5, $resolvingCallCounter);
+        $this->assertSame(2, $rebindCallCounter);
     }
 
     public function testResolvingCallbacksArentCalledWhenNoRebindingsAreRegistered()
@@ -331,19 +331,19 @@ class ResolvingCallbackTest extends TestCase
         $container->bind(ResolvingContractStub::class, ResolvingImplementationStub::class);
 
         $container->make(ResolvingContractStub::class);
-        $this->assertEquals(1, $callCounter);
+        $this->assertSame(1, $callCounter);
 
         $container->bind(ResolvingContractStub::class, ResolvingImplementationStubTwo::class);
-        $this->assertEquals(1, $callCounter);
+        $this->assertSame(1, $callCounter);
 
         $container->make(ResolvingImplementationStubTwo::class);
-        $this->assertEquals(2, $callCounter);
+        $this->assertSame(2, $callCounter);
 
         $container->bind(ResolvingContractStub::class, fn () => new ResolvingImplementationStubTwo);
-        $this->assertEquals(2, $callCounter);
+        $this->assertSame(2, $callCounter);
 
         $container->make(ResolvingContractStub::class);
-        $this->assertEquals(3, $callCounter);
+        $this->assertSame(3, $callCounter);
     }
 
     public function testRebindingDoesNotAffectMultipleResolvingCallbacks()
@@ -364,16 +364,16 @@ class ResolvingCallbackTest extends TestCase
 
         // it should call the callback for interface
         $container->make(ResolvingContractStub::class);
-        $this->assertEquals(1, $callCounter);
+        $this->assertSame(1, $callCounter);
 
         // it should call the callback for interface
         $container->make(ResolvingImplementationStub::class);
-        $this->assertEquals(2, $callCounter);
+        $this->assertSame(2, $callCounter);
 
         // should call the callback for the interface it implements
         // plus the callback for ResolvingImplementationStubTwo.
         $container->make(ResolvingImplementationStubTwo::class);
-        $this->assertEquals(4, $callCounter);
+        $this->assertSame(4, $callCounter);
     }
 
     public function testResolvingCallbacksAreCalledForInterfaces()
@@ -389,7 +389,7 @@ class ResolvingCallbackTest extends TestCase
 
         $container->make(ResolvingContractStub::class);
 
-        $this->assertEquals(1, $callCounter);
+        $this->assertSame(1, $callCounter);
     }
 
     public function testResolvingCallbacksAreCalledForConcretesWhenAttachedOnInterface()
@@ -404,10 +404,10 @@ class ResolvingCallbackTest extends TestCase
         $container->bind(ResolvingContractStub::class, ResolvingImplementationStub::class);
 
         $container->make(ResolvingContractStub::class);
-        $this->assertEquals(1, $callCounter);
+        $this->assertSame(1, $callCounter);
 
         $container->make(ResolvingImplementationStub::class);
-        $this->assertEquals(2, $callCounter);
+        $this->assertSame(2, $callCounter);
     }
 
     public function testResolvingCallbacksAreCalledForConcretesWhenAttachedOnConcretes()
@@ -422,10 +422,10 @@ class ResolvingCallbackTest extends TestCase
         $container->bind(ResolvingContractStub::class, ResolvingImplementationStub::class);
 
         $container->make(ResolvingContractStub::class);
-        $this->assertEquals(1, $callCounter);
+        $this->assertSame(1, $callCounter);
 
         $container->make(ResolvingImplementationStub::class);
-        $this->assertEquals(2, $callCounter);
+        $this->assertSame(2, $callCounter);
     }
 
     public function testResolvingCallbacksAreCalledForConcretesWithNoBinding()
@@ -438,9 +438,9 @@ class ResolvingCallbackTest extends TestCase
         });
 
         $container->make(ResolvingImplementationStub::class);
-        $this->assertEquals(1, $callCounter);
+        $this->assertSame(1, $callCounter);
         $container->make(ResolvingImplementationStub::class);
-        $this->assertEquals(2, $callCounter);
+        $this->assertSame(2, $callCounter);
     }
 
     public function testResolvingCallbacksAreCalledForInterFacesWithNoBinding()
@@ -453,10 +453,10 @@ class ResolvingCallbackTest extends TestCase
         });
 
         $container->make(ResolvingImplementationStub::class);
-        $this->assertEquals(1, $callCounter);
+        $this->assertSame(1, $callCounter);
 
         $container->make(ResolvingImplementationStub::class);
-        $this->assertEquals(2, $callCounter);
+        $this->assertSame(2, $callCounter);
     }
 
     public function testAfterResolvingCallbacksAreCalledOnceForImplementation()
@@ -471,10 +471,10 @@ class ResolvingCallbackTest extends TestCase
         $container->bind(ResolvingContractStub::class, ResolvingImplementationStub::class);
 
         $container->make(ResolvingImplementationStub::class);
-        $this->assertEquals(1, $callCounter);
+        $this->assertSame(1, $callCounter);
 
         $container->make(ResolvingContractStub::class);
-        $this->assertEquals(2, $callCounter);
+        $this->assertSame(2, $callCounter);
     }
 
     public function testBeforeResolvingCallbacksAreCalled()
@@ -493,11 +493,11 @@ class ResolvingCallbackTest extends TestCase
 
         // Then resolving the implementation stub increases the counter by one.
         $container->make(ResolvingImplementationStub::class);
-        $this->assertEquals(1, $callCounter);
+        $this->assertSame(1, $callCounter);
 
         // And resolving the contract stub increases the counter by one.
         $container->make(ResolvingContractStub::class);
-        $this->assertEquals(2, $callCounter);
+        $this->assertSame(2, $callCounter);
     }
 
     public function testGlobalBeforeResolvingCallbacksAreCalled()
@@ -513,7 +513,7 @@ class ResolvingCallbackTest extends TestCase
 
         // Then resolving anything increases the counter by one.
         $container->make(ResolvingImplementationStub::class);
-        $this->assertEquals(1, $callCounter);
+        $this->assertSame(1, $callCounter);
     }
 }
 

--- a/tests/Container/UtilTest.php
+++ b/tests/Container/UtilTest.php
@@ -26,7 +26,7 @@ class UtilTest extends TestCase
         $this->assertEquals(['a'], Util::arrayWrap($string));
         $this->assertEquals($array, Util::arrayWrap($array));
         $this->assertEquals([$object], Util::arrayWrap($object));
-        $this->assertEquals([], Util::arrayWrap(null));
+        $this->assertSame([], Util::arrayWrap(null));
         $this->assertEquals([null], Util::arrayWrap([null]));
         $this->assertEquals([null, null], Util::arrayWrap([null, null]));
         $this->assertEquals([''], Util::arrayWrap(''));

--- a/tests/Cookie/CookieTest.php
+++ b/tests/Cookie/CookieTest.php
@@ -82,7 +82,7 @@ class CookieTest extends TestCase
         $cookie = $this->getCreator();
         $cookie->queue($cookie->make('foo', ''));
         $this->assertTrue($cookie->hasQueued('foo'));
-        $this->assertEquals('', $cookie->queued('foo')->getValue());
+        $this->assertSame('', $cookie->queued('foo')->getValue());
     }
 
     public function testQueuedCookiesWithRepeatedValue(): void
@@ -90,7 +90,7 @@ class CookieTest extends TestCase
         $cookie = $this->getCreator();
         $cookie->queue($cookie->make('foo', 'newBar'));
         $this->assertTrue($cookie->hasQueued('foo'));
-        $this->assertEquals('newBar', $cookie->queued('foo')->getValue());
+        $this->assertSame('newBar', $cookie->queued('foo')->getValue());
 
         $this->expectException(ArgumentCountError::class);
         $cookie->queue('invalidCookie');

--- a/tests/Database/DatabaseConcernsHasAttributesTest.php
+++ b/tests/Database/DatabaseConcernsHasAttributesTest.php
@@ -54,7 +54,7 @@ class DatabaseConcernsHasAttributesTest extends TestCase
     public function testUnsettingCachedAttribute()
     {
         $instance = new HasCacheableAttributeWithAccessor();
-        $this->assertEquals('foo', $instance->getAttribute('cacheableProperty'));
+        $this->assertSame('foo', $instance->getAttribute('cacheableProperty'));
         $this->assertTrue($instance->cachedAttributeIsset('cacheableProperty'));
 
         unset($instance->cacheableProperty);

--- a/tests/Database/DatabaseConcernsPreventsCircularRecursionTest.php
+++ b/tests/Database/DatabaseConcernsPreventsCircularRecursionTest.php
@@ -183,7 +183,7 @@ class DatabaseConcernsPreventsCircularRecursionTest extends TestCase
             fn () => array_merge($mock->attributesToArray(), $mock->relationsToArray()),
             fn () => $mock->attributesToArray(),
         );
-        $this->assertEquals([], $toArray);
+        $this->assertSame([], $toArray);
     }
 }
 

--- a/tests/Database/DatabaseConcernsPreventsCircularRecursionTest.php
+++ b/tests/Database/DatabaseConcernsPreventsCircularRecursionTest.php
@@ -19,44 +19,44 @@ class DatabaseConcernsPreventsCircularRecursionTest extends TestCase
     {
         $instance = new PreventsCircularRecursionWithRecursiveMethod();
 
-        $this->assertEquals(0, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
-        $this->assertEquals(0, $instance->instanceStack);
+        $this->assertSame(0, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
+        $this->assertSame(0, $instance->instanceStack);
 
-        $this->assertEquals(0, $instance->callStack());
-        $this->assertEquals(1, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
-        $this->assertEquals(1, $instance->instanceStack);
+        $this->assertSame(0, $instance->callStack());
+        $this->assertSame(1, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
+        $this->assertSame(1, $instance->instanceStack);
 
-        $this->assertEquals(1, $instance->callStack());
-        $this->assertEquals(2, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
-        $this->assertEquals(2, $instance->instanceStack);
+        $this->assertSame(1, $instance->callStack());
+        $this->assertSame(2, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
+        $this->assertSame(2, $instance->instanceStack);
     }
 
     public function testRecursiveDefaultCallbackIsCalledOnlyOnRecursion()
     {
         $instance = new PreventsCircularRecursionWithRecursiveMethod();
 
-        $this->assertEquals(0, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
-        $this->assertEquals(0, $instance->instanceStack);
-        $this->assertEquals(0, $instance->defaultStack);
+        $this->assertSame(0, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
+        $this->assertSame(0, $instance->instanceStack);
+        $this->assertSame(0, $instance->defaultStack);
 
         $this->assertEquals(['instance' => 1, 'default' => 0], $instance->callCallableDefaultStack());
-        $this->assertEquals(1, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
-        $this->assertEquals(1, $instance->instanceStack);
-        $this->assertEquals(1, $instance->defaultStack);
+        $this->assertSame(1, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
+        $this->assertSame(1, $instance->instanceStack);
+        $this->assertSame(1, $instance->defaultStack);
 
         $this->assertEquals(['instance' => 2, 'default' => 1], $instance->callCallableDefaultStack());
-        $this->assertEquals(2, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
-        $this->assertEquals(2, $instance->instanceStack);
-        $this->assertEquals(2, $instance->defaultStack);
+        $this->assertSame(2, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
+        $this->assertSame(2, $instance->instanceStack);
+        $this->assertSame(2, $instance->defaultStack);
     }
 
     public function testRecursiveDefaultCallbackIsCalledOnlyOncePerCallStack()
     {
         $instance = new PreventsCircularRecursionWithRecursiveMethod();
 
-        $this->assertEquals(0, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
-        $this->assertEquals(0, $instance->instanceStack);
-        $this->assertEquals(0, $instance->defaultStack);
+        $this->assertSame(0, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
+        $this->assertSame(0, $instance->instanceStack);
+        $this->assertSame(0, $instance->defaultStack);
 
         $this->assertEquals(
             [
@@ -66,9 +66,9 @@ class DatabaseConcernsPreventsCircularRecursionTest extends TestCase
             ],
             $instance->callCallableDefaultStackRepeatedly(),
         );
-        $this->assertEquals(1, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
-        $this->assertEquals(1, $instance->instanceStack);
-        $this->assertEquals(1, $instance->defaultStack);
+        $this->assertSame(1, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
+        $this->assertSame(1, $instance->instanceStack);
+        $this->assertSame(1, $instance->defaultStack);
 
         $this->assertEquals(
             [
@@ -78,9 +78,9 @@ class DatabaseConcernsPreventsCircularRecursionTest extends TestCase
             ],
             $instance->callCallableDefaultStackRepeatedly(),
         );
-        $this->assertEquals(2, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
-        $this->assertEquals(2, $instance->instanceStack);
-        $this->assertEquals(2, $instance->defaultStack);
+        $this->assertSame(2, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
+        $this->assertSame(2, $instance->instanceStack);
+        $this->assertSame(2, $instance->defaultStack);
     }
 
     public function testRecursiveCallsAreLimitedToIndividualInstances()
@@ -88,29 +88,29 @@ class DatabaseConcernsPreventsCircularRecursionTest extends TestCase
         $instance = new PreventsCircularRecursionWithRecursiveMethod();
         $other = $instance->other;
 
-        $this->assertEquals(0, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
-        $this->assertEquals(0, $instance->instanceStack);
-        $this->assertEquals(0, $other->instanceStack);
+        $this->assertSame(0, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
+        $this->assertSame(0, $instance->instanceStack);
+        $this->assertSame(0, $other->instanceStack);
 
         $instance->callStack();
-        $this->assertEquals(1, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
-        $this->assertEquals(1, $instance->instanceStack);
-        $this->assertEquals(0, $other->instanceStack);
+        $this->assertSame(1, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
+        $this->assertSame(1, $instance->instanceStack);
+        $this->assertSame(0, $other->instanceStack);
 
         $instance->callStack();
-        $this->assertEquals(2, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
-        $this->assertEquals(2, $instance->instanceStack);
-        $this->assertEquals(0, $other->instanceStack);
+        $this->assertSame(2, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
+        $this->assertSame(2, $instance->instanceStack);
+        $this->assertSame(0, $other->instanceStack);
 
         $other->callStack();
-        $this->assertEquals(3, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
-        $this->assertEquals(2, $instance->instanceStack);
-        $this->assertEquals(1, $other->instanceStack);
+        $this->assertSame(3, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
+        $this->assertSame(2, $instance->instanceStack);
+        $this->assertSame(1, $other->instanceStack);
 
         $other->callStack();
-        $this->assertEquals(4, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
-        $this->assertEquals(2, $instance->instanceStack);
-        $this->assertEquals(2, $other->instanceStack);
+        $this->assertSame(4, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
+        $this->assertSame(2, $instance->instanceStack);
+        $this->assertSame(2, $other->instanceStack);
     }
 
     public function testRecursiveCallsToCircularReferenceCallsOtherInstanceOnce()
@@ -118,29 +118,29 @@ class DatabaseConcernsPreventsCircularRecursionTest extends TestCase
         $instance = new PreventsCircularRecursionWithRecursiveMethod();
         $other = $instance->other;
 
-        $this->assertEquals(0, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
-        $this->assertEquals(0, $instance->instanceStack);
-        $this->assertEquals(0, $other->instanceStack);
+        $this->assertSame(0, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
+        $this->assertSame(0, $instance->instanceStack);
+        $this->assertSame(0, $other->instanceStack);
 
         $instance->callOtherStack();
-        $this->assertEquals(2, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
-        $this->assertEquals(1, $instance->instanceStack);
-        $this->assertEquals(1, $other->instanceStack);
+        $this->assertSame(2, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
+        $this->assertSame(1, $instance->instanceStack);
+        $this->assertSame(1, $other->instanceStack);
 
         $instance->callOtherStack();
-        $this->assertEquals(4, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
-        $this->assertEquals(2, $instance->instanceStack);
-        $this->assertEquals(2, $other->instanceStack);
+        $this->assertSame(4, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
+        $this->assertSame(2, $instance->instanceStack);
+        $this->assertSame(2, $other->instanceStack);
 
         $other->callOtherStack();
-        $this->assertEquals(6, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
-        $this->assertEquals(3, $other->instanceStack);
-        $this->assertEquals(3, $instance->instanceStack);
+        $this->assertSame(6, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
+        $this->assertSame(3, $other->instanceStack);
+        $this->assertSame(3, $instance->instanceStack);
 
         $other->callOtherStack();
-        $this->assertEquals(8, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
-        $this->assertEquals(4, $other->instanceStack);
-        $this->assertEquals(4, $instance->instanceStack);
+        $this->assertSame(8, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
+        $this->assertSame(4, $other->instanceStack);
+        $this->assertSame(4, $instance->instanceStack);
     }
 
     public function testRecursiveCallsToCircularLinkedListCallsEachInstanceOnce()
@@ -150,28 +150,28 @@ class DatabaseConcernsPreventsCircularRecursionTest extends TestCase
         $third = new PreventsCircularRecursionWithRecursiveMethod($second);
         $instance->other = $third;
 
-        $this->assertEquals(0, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
-        $this->assertEquals(0, $instance->instanceStack);
-        $this->assertEquals(0, $second->instanceStack);
-        $this->assertEquals(0, $third->instanceStack);
+        $this->assertSame(0, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
+        $this->assertSame(0, $instance->instanceStack);
+        $this->assertSame(0, $second->instanceStack);
+        $this->assertSame(0, $third->instanceStack);
 
         $instance->callOtherStack();
-        $this->assertEquals(3, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
-        $this->assertEquals(1, $instance->instanceStack);
-        $this->assertEquals(1, $second->instanceStack);
-        $this->assertEquals(1, $third->instanceStack);
+        $this->assertSame(3, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
+        $this->assertSame(1, $instance->instanceStack);
+        $this->assertSame(1, $second->instanceStack);
+        $this->assertSame(1, $third->instanceStack);
 
         $second->callOtherStack();
-        $this->assertEquals(6, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
-        $this->assertEquals(2, $instance->instanceStack);
-        $this->assertEquals(2, $second->instanceStack);
-        $this->assertEquals(2, $third->instanceStack);
+        $this->assertSame(6, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
+        $this->assertSame(2, $instance->instanceStack);
+        $this->assertSame(2, $second->instanceStack);
+        $this->assertSame(2, $third->instanceStack);
 
         $third->callOtherStack();
-        $this->assertEquals(9, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
-        $this->assertEquals(3, $instance->instanceStack);
-        $this->assertEquals(3, $second->instanceStack);
-        $this->assertEquals(3, $third->instanceStack);
+        $this->assertSame(9, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
+        $this->assertSame(3, $instance->instanceStack);
+        $this->assertSame(3, $second->instanceStack);
+        $this->assertSame(3, $third->instanceStack);
     }
 
     public function testMockedModelCallToWithoutRecursionMethodWorks(): void

--- a/tests/Database/DatabaseConnectionFactoryTest.php
+++ b/tests/Database/DatabaseConnectionFactoryTest.php
@@ -148,9 +148,9 @@ class DatabaseConnectionFactoryTest extends TestCase
             'url' => 'sqlite:///:memory:?foreign_key_constraints=true',
         ], 'constraints_set');
 
-        $this->assertEquals(0, $this->db->getConnection()->select('PRAGMA foreign_keys')[0]->foreign_keys);
+        $this->assertSame(0, $this->db->getConnection()->select('PRAGMA foreign_keys')[0]->foreign_keys);
 
-        $this->assertEquals(1, $this->db->getConnection('constraints_set')->select('PRAGMA foreign_keys')[0]->foreign_keys);
+        $this->assertSame(1, $this->db->getConnection('constraints_set')->select('PRAGMA foreign_keys')[0]->foreign_keys);
     }
 
     public function testSqliteBusyTimeout()

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -195,7 +195,7 @@ class DatabaseConnectionTest extends TestCase
         try {
             $connection->beginTransaction();
         } catch (Exception) {
-            $this->assertEquals(0, $connection->transactionLevel());
+            $this->assertSame(0, $connection->transactionLevel());
         }
     }
 
@@ -207,7 +207,7 @@ class DatabaseConnectionTest extends TestCase
         $connection = $this->getMockConnection(['reconnect'], $pdo);
         $connection->expects($this->once())->method('reconnect');
         $connection->beginTransaction();
-        $this->assertEquals(1, $connection->transactionLevel());
+        $this->assertSame(1, $connection->transactionLevel());
     }
 
     public function testBeginTransactionMethodReconnectsMissingConnection()
@@ -219,7 +219,7 @@ class DatabaseConnectionTest extends TestCase
         });
         $connection->disconnect();
         $connection->beginTransaction();
-        $this->assertEquals(1, $connection->transactionLevel());
+        $this->assertSame(1, $connection->transactionLevel());
     }
 
     public function testBeginTransactionMethodNeverRetriesIfWithinTransaction()
@@ -234,11 +234,11 @@ class DatabaseConnectionTest extends TestCase
         $connection->setQueryGrammar($queryGrammar);
         $connection->expects($this->never())->method('reconnect');
         $connection->beginTransaction();
-        $this->assertEquals(1, $connection->transactionLevel());
+        $this->assertSame(1, $connection->transactionLevel());
         try {
             $connection->beginTransaction();
         } catch (Exception) {
-            $this->assertEquals(1, $connection->transactionLevel());
+            $this->assertSame(1, $connection->transactionLevel());
         }
     }
 
@@ -249,7 +249,7 @@ class DatabaseConnectionTest extends TestCase
         $connection = $this->getMockConnection([], $pdo);
         $connection->beginTransaction();
         $connection->disconnect();
-        $this->assertEquals(0, $connection->transactionLevel());
+        $this->assertSame(0, $connection->transactionLevel());
     }
 
     public function testBeganTransactionFiresEventsIfSet()

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -552,7 +552,7 @@ class DatabaseConnectionTest extends TestCase
 
         $log = $mock->getRawQueryLog();
 
-        $this->assertEquals("select * from tbl where col = 'foo'", $log[0]['raw_query']);
+        $this->assertSame("select * from tbl where col = 'foo'", $log[0]['raw_query']);
         $this->assertEquals(1.23, $log[0]['time']);
     }
 

--- a/tests/Database/DatabaseEloquentBelongsToManyAggregateTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyAggregateTest.php
@@ -32,7 +32,7 @@ class DatabaseEloquentBelongsToManyAggregateTest extends TestCase
             ->withSum('products as total_products', 'order_product.quantity')
             ->first();
 
-        $this->assertEquals(12, $order->total_products);
+        $this->assertSame(12, $order->total_products);
     }
 
     public function testWithSumSameTable()
@@ -43,7 +43,7 @@ class DatabaseEloquentBelongsToManyAggregateTest extends TestCase
             ->withSum('allocatedTo as total_allocated', 'allocations.amount')
             ->first();
 
-        $this->assertEquals(1200, $order->total_allocated);
+        $this->assertSame(1200, $order->total_allocated);
     }
 
     public function testWithSumExpression()
@@ -54,7 +54,7 @@ class DatabaseEloquentBelongsToManyAggregateTest extends TestCase
             ->withSum('allocatedTo as total_allocated', new Expression('allocations.amount * 2'))
             ->first();
 
-        $this->assertEquals(2400, $order->total_allocated);
+        $this->assertSame(2400, $order->total_allocated);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBelongsToManyExpressionTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyExpressionTest.php
@@ -37,7 +37,7 @@ class DatabaseEloquentBelongsToManyExpressionTest extends TestCase
             ->get();
 
         $this->assertCount(1, $tags);
-        $this->assertEquals(2, $tags->first()->getKey());
+        $this->assertSame(2, $tags->first()->getKey());
     }
 
     public function testQualifiedColumnExpression(): void
@@ -50,7 +50,7 @@ class DatabaseEloquentBelongsToManyExpressionTest extends TestCase
             ->get();
 
         $this->assertCount(1, $tags);
-        $this->assertEquals(3, $tags->first()->getKey());
+        $this->assertSame(3, $tags->first()->getKey());
     }
 
     public function testGlobalScopesAreAppliedToBelongsToManyRelation(): void

--- a/tests/Database/DatabaseEloquentBelongsToManyOrFailTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyOrFailTest.php
@@ -107,7 +107,7 @@ class DatabaseEloquentBelongsToManyOrFailTest extends TestCase
         $user->roles()->attachOrFail(1, ['active' => true]);
 
         $pivot = DB::table('role_user')->where('user_id', 1)->where('role_id', 1)->first();
-        $this->assertEquals(1, $pivot->active);
+        $this->assertSame(1, $pivot->active);
     }
 
     public function testDetachOrFail()
@@ -119,7 +119,7 @@ class DatabaseEloquentBelongsToManyOrFailTest extends TestCase
 
         $result = $user->roles()->detachOrFail([1, 2]);
 
-        $this->assertEquals(2, $result);
+        $this->assertSame(2, $result);
         $this->assertCount(1, $user->roles()->get());
     }
 
@@ -132,7 +132,7 @@ class DatabaseEloquentBelongsToManyOrFailTest extends TestCase
 
         $result = $user->roles()->detachOrFail();
 
-        $this->assertEquals(3, $result);
+        $this->assertSame(3, $result);
         $this->assertCount(0, $user->roles()->get());
     }
 
@@ -163,7 +163,7 @@ class DatabaseEloquentBelongsToManyOrFailTest extends TestCase
         $this->assertEmpty($result['updated']);
 
         $pivot = DB::table('role_user')->where('user_id', 1)->where('role_id', 1)->first();
-        $this->assertEquals(1, $pivot->active);
+        $this->assertSame(1, $pivot->active);
     }
 
     public function testUpdateExistingPivotOrFail()
@@ -175,10 +175,10 @@ class DatabaseEloquentBelongsToManyOrFailTest extends TestCase
 
         $result = $user->roles()->updateExistingPivotOrFail(1, ['active' => true]);
 
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
 
         $pivot = DB::table('role_user')->where('user_id', 1)->where('role_id', 1)->first();
-        $this->assertEquals(1, $pivot->active);
+        $this->assertSame(1, $pivot->active);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBelongsToTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToTest.php
@@ -154,10 +154,10 @@ class DatabaseEloquentBelongsToTest extends TestCase
             'foo'
         );
 
-        $this->assertEquals(1, $models[0]->foo->getAttribute('id'));
-        $this->assertEquals(2, $models[1]->foo->getAttribute('id'));
+        $this->assertSame(1, $models[0]->foo->getAttribute('id'));
+        $this->assertSame(2, $models[1]->foo->getAttribute('id'));
         $this->assertSame('3', (string) $models[2]->foo->getAttribute('id'));
-        $this->assertEquals(5, $models[3]->foo->getAttribute('id')->value);
+        $this->assertSame(5, $models[3]->foo->getAttribute('id')->value);
     }
 
     public function testAssociateMethodSetsForeignKeyOnModel()

--- a/tests/Database/DatabaseEloquentBuilderCreateOrFirstTest.php
+++ b/tests/Database/DatabaseEloquentBuilderCreateOrFirstTest.php
@@ -530,7 +530,7 @@ class DatabaseEloquentBuilderCreateOrFirstTest extends TestCase
 
         $result = $model->newQuery()->updateOrCreate(['attr' => 'foo'], fn () => ['val' => 'baz']);
         $this->assertFalse($result->wasRecentlyCreated);
-        $this->assertEquals('baz', $result->val);
+        $this->assertSame('baz', $result->val);
     }
 
     public function testUpdateOrCreateInvokesClosureExactlyOnceWhenCreating(): void

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -336,7 +336,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->getModel()->shouldReceive('newCollection')->with([])->andReturn(new Collection([]));
 
         $results = $builder->get(['foo']);
-        $this->assertEquals([], $results->all());
+        $this->assertSame([], $results->all());
     }
 
     public function testValueMethodWithModelFound()

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1107,7 +1107,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model = new EloquentBuilderTestStub();
         $this->mockConnectionForModel($model, 'SQLite');
         $query = $model->newQuery()->whereNot('name', 'foo')->whereNot('name', '<>', 'bar');
-        $this->assertEquals('select * from "table" where not "name" = ? and not "name" <> ?', $query->toSql());
+        $this->assertSame('select * from "table" where not "name" = ? and not "name" <> ?', $query->toSql());
         $this->assertEquals(['foo', 'bar'], $query->getBindings());
     }
 
@@ -1137,7 +1137,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model = new EloquentBuilderTestStub();
         $this->mockConnectionForModel($model, 'SQLite');
         $query = $model->newQuery()->orWhereNot('name', 'foo')->orWhereNot('name', '<>', 'bar');
-        $this->assertEquals('select * from "table" where not "name" = ? or not "name" <> ?', $query->toSql());
+        $this->assertSame('select * from "table" where not "name" = ? or not "name" <> ?', $query->toSql());
         $this->assertEquals(['foo', 'bar'], $query->getBindings());
     }
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -2593,7 +2593,7 @@ class DatabaseEloquentBuilderTest extends TestCase
             ->with('update "table" set "foo" = ?, "table"."updated_at" = ?', ['bar', $now])->andReturn(1);
 
         $result = $builder->update(['foo' => 'bar']);
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
     }
 
     public function testUpdateWithTimestampValue()
@@ -2609,7 +2609,7 @@ class DatabaseEloquentBuilderTest extends TestCase
             ->with('update "table" set "foo" = ?, "table"."updated_at" = ?', ['bar', null])->andReturn(1);
 
         $result = $builder->update(['foo' => 'bar', 'updated_at' => null]);
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
     }
 
     public function testUpdateWithQualifiedTimestampValue()
@@ -2625,7 +2625,7 @@ class DatabaseEloquentBuilderTest extends TestCase
             ->with('update "table" set "table"."foo" = ?, "table"."updated_at" = ?', ['bar', null])->andReturn(1);
 
         $result = $builder->update(['table.foo' => 'bar', 'table.updated_at' => null]);
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
     }
 
     public function testUpdateWithoutTimestamp()
@@ -2641,7 +2641,7 @@ class DatabaseEloquentBuilderTest extends TestCase
             ->with('update "table" set "foo" = ?', ['bar'])->andReturn(1);
 
         $result = $builder->update(['foo' => 'bar']);
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
     }
 
     public function testUpdateWithAlias()
@@ -2659,7 +2659,7 @@ class DatabaseEloquentBuilderTest extends TestCase
             ->with('update "table" as "alias" set "foo" = ?, "alias"."updated_at" = ?', ['bar', $now])->andReturn(1);
 
         $result = $builder->from('table as alias')->update(['foo' => 'bar']);
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
     }
 
     public function testUpdateWithAliasWithQualifiedTimestampValue()
@@ -2677,7 +2677,7 @@ class DatabaseEloquentBuilderTest extends TestCase
             ->with('update "table" as "alias" set "foo" = ?, "alias"."updated_at" = ?', ['bar', null])->andReturn(1);
 
         $result = $builder->from('table as alias')->update(['foo' => 'bar', 'alias.updated_at' => null]);
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
 
         Carbon::setTestNow(null);
     }
@@ -2702,7 +2702,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $result = $builder->upsert([['email' => 'foo', 'name' => 'bar'], ['name' => 'bar2', 'email' => 'foo2']], ['email']);
 
-        $this->assertEquals(2, $result);
+        $this->assertSame(2, $result);
     }
 
     public function testTouch()
@@ -2721,7 +2721,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $result = $builder->touch();
 
-        $this->assertEquals(2, $result);
+        $this->assertSame(2, $result);
     }
 
     public function testTouchWithCustomColumn()
@@ -2740,7 +2740,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $result = $builder->touch('published_at');
 
-        $this->assertEquals(2, $result);
+        $this->assertSame(2, $result);
     }
 
     public function testTouchWithMultipleColumns()
@@ -2759,7 +2759,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $result = $builder->touch(['published_at', 'verified_at']);
 
-        $this->assertEquals(2, $result);
+        $this->assertSame(2, $result);
     }
 
     public function testTouchWithoutUpdatedAtColumn()
@@ -2954,7 +2954,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->setModel($model);
 
         $result = $builder->incrementEach(['votes' => 5]);
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
     }
 
     public function testDecrementEachCallsToBaseWithUpdatedAt()
@@ -2977,7 +2977,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->setModel($model);
 
         $result = $builder->decrementEach(['votes' => 3]);
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
     }
 
     public function testIncrementEachWithoutTimestamps()
@@ -2992,7 +2992,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->setModel($model);
 
         $result = $builder->incrementEach(['votes' => 1]);
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
     }
 
     protected function getMockModel()

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -602,7 +602,7 @@ class DatabaseEloquentCollectionTest extends TestCase
     {
         $this->seedData();
         $c = EloquentAppendingTestUserModel::query()->get();
-        $this->assertEquals('hello', $c->toArray()[0]['appended_field']);
+        $this->assertSame('hello', $c->toArray()[0]['appended_field']);
 
         $c = $c->withoutAppends();
         $this->assertArrayNotHasKey('appended_field', $c->toArray()[0]);

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -77,13 +77,13 @@ class DatabaseEloquentCollectionTest extends TestCase
     public function testGettingMaxItemsFromCollection()
     {
         $c = new Collection([(object) ['foo' => 10], (object) ['foo' => 20]]);
-        $this->assertEquals(20, $c->max('foo'));
+        $this->assertSame(20, $c->max('foo'));
     }
 
     public function testGettingMinItemsFromCollection()
     {
         $c = new Collection([(object) ['foo' => 10], (object) ['foo' => 20]]);
-        $this->assertEquals(10, $c->min('foo'));
+        $this->assertSame(10, $c->min('foo'));
     }
 
     public function testContainsWithMultipleArguments()
@@ -220,12 +220,12 @@ class DatabaseEloquentCollectionTest extends TestCase
 
         $c->push($model1);
         $this->assertCount(1, $c->find([1]));
-        $this->assertEquals(1, $c->find([1])->first()->id);
+        $this->assertSame(1, $c->find([1])->first()->id);
         $this->assertCount(0, $c->find([2]));
 
         $c->push($model2)->push($model3);
         $this->assertCount(1, $c->find([2]));
-        $this->assertEquals(2, $c->find([2])->first()->id);
+        $this->assertSame(2, $c->find([2])->first()->id);
         $this->assertCount(2, $c->find([2, 3, 4]));
         $this->assertCount(2, $c->find(collect([2, 3, 4])));
         $this->assertEquals([2, 3], $c->find(collect([2, 3, 4]))->pluck('id')->all());
@@ -252,7 +252,7 @@ class DatabaseEloquentCollectionTest extends TestCase
 
         $c->push($model1);
         $this->assertCount(1, $c->findOrFail([1]));
-        $this->assertEquals(1, $c->findOrFail([1])->first()->id);
+        $this->assertSame(1, $c->findOrFail([1])->first()->id);
 
         $c->push($model2);
         $this->assertCount(2, $c->findOrFail([1, 2]));

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -439,7 +439,7 @@ class DatabaseEloquentCollectionTest extends TestCase
 
         $c1 = new Collection([$one, $two, $three]);
 
-        $this->assertEquals([], $c1->intersect(null)->all());
+        $this->assertSame([], $c1->intersect(null)->all());
     }
 
     public function testCollectionIntersectsWithGivenCollection()
@@ -543,7 +543,7 @@ class DatabaseEloquentCollectionTest extends TestCase
         $c = new Collection([new TestEloquentCollectionModel]);
         $c = $c->makeVisible(['hidden']);
 
-        $this->assertEquals([], $c[0]->getHidden());
+        $this->assertSame([], $c[0]->getHidden());
     }
 
     public function testMergeHiddenAddsHiddenOnEntireCollection()
@@ -628,7 +628,7 @@ class DatabaseEloquentCollectionTest extends TestCase
         $c = new Collection([new TestEloquentCollectionModel]);
         $c = $c->makeVisible('hidden');
 
-        $this->assertEquals([], $c[0]->getHidden());
+        $this->assertSame([], $c[0]->getHidden());
         $this->assertEquals(['visible', 'hidden'], $c[0]->getVisible());
     }
 
@@ -639,8 +639,8 @@ class DatabaseEloquentCollectionTest extends TestCase
 
         $c = new Collection([$a, $b]);
 
-        $this->assertEquals([], $c->multiply(-1)->all());
-        $this->assertEquals([], $c->multiply(0)->all());
+        $this->assertSame([], $c->multiply(-1)->all());
+        $this->assertSame([], $c->multiply(0)->all());
 
         $this->assertEquals([$a, $b], $c->multiply(1)->all());
 
@@ -704,7 +704,7 @@ class DatabaseEloquentCollectionTest extends TestCase
             },
         ]);
 
-        $this->assertEquals([], $c->getQueueableRelations());
+        $this->assertSame([], $c->getQueueableRelations());
     }
 
     public function testEmptyCollectionStayEmptyOnFresh()

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -185,7 +185,7 @@ class DatabaseEloquentFactoryTest extends TestCase
             ]),
         ]);
 
-        $this->assertEquals('post-options', $post->user->options);
+        $this->assertSame('post-options', $post->user->options);
     }
 
     public function test_make_creates_unpersisted_model_instance()
@@ -1031,56 +1031,56 @@ class DatabaseEloquentFactoryTest extends TestCase
     {
         FactoryTestUser::factory()->has(new FactoryTestPostFactory(), 'postsWithFooBarBazAsTitle')->create();
 
-        $this->assertEquals('foo bar baz', FactoryTestPost::first()->title);
+        $this->assertSame('foo bar baz', FactoryTestPost::first()->title);
     }
 
     public function test_factory_model_has_many_relationship_has_pending_attributes_override()
     {
         FactoryTestUser::factory()->has((new FactoryTestPostFactory())->state(['title' => 'other title']), 'postsWithFooBarBazAsTitle')->create();
 
-        $this->assertEquals('other title', FactoryTestPost::first()->title);
+        $this->assertSame('other title', FactoryTestPost::first()->title);
     }
 
     public function test_factory_model_has_one_relationship_has_pending_attributes()
     {
         FactoryTestUser::factory()->has(new FactoryTestPostFactory(), 'postWithFooBarBazAsTitle')->create();
 
-        $this->assertEquals('foo bar baz', FactoryTestPost::first()->title);
+        $this->assertSame('foo bar baz', FactoryTestPost::first()->title);
     }
 
     public function test_factory_model_has_one_relationship_has_pending_attributes_override()
     {
         FactoryTestUser::factory()->has((new FactoryTestPostFactory())->state(['title' => 'other title']), 'postWithFooBarBazAsTitle')->create();
 
-        $this->assertEquals('other title', FactoryTestPost::first()->title);
+        $this->assertSame('other title', FactoryTestPost::first()->title);
     }
 
     public function test_factory_model_belongs_to_many_relationship_has_pending_attributes()
     {
         FactoryTestUser::factory()->has(new FactoryTestRoleFactory(), 'rolesWithFooBarBazAsName')->create();
 
-        $this->assertEquals('foo bar baz', FactoryTestRole::first()->name);
+        $this->assertSame('foo bar baz', FactoryTestRole::first()->name);
     }
 
     public function test_factory_model_belongs_to_many_relationship_has_pending_attributes_override()
     {
         FactoryTestUser::factory()->has((new FactoryTestRoleFactory())->state(['name' => 'other name']), 'rolesWithFooBarBazAsName')->create();
 
-        $this->assertEquals('other name', FactoryTestRole::first()->name);
+        $this->assertSame('other name', FactoryTestRole::first()->name);
     }
 
     public function test_factory_model_morph_many_relationship_has_pending_attributes()
     {
         (new FactoryTestPostFactory())->has(new FactoryTestCommentFactory(), 'commentsWithFooBarBazAsBody')->create();
 
-        $this->assertEquals('foo bar baz', FactoryTestComment::first()->body);
+        $this->assertSame('foo bar baz', FactoryTestComment::first()->body);
     }
 
     public function test_factory_model_morph_many_relationship_has_pending_attributes_override()
     {
         (new FactoryTestPostFactory())->has((new FactoryTestCommentFactory())->state(['body' => 'other body']), 'commentsWithFooBarBazAsBody')->create();
 
-        $this->assertEquals('other body', FactoryTestComment::first()->body);
+        $this->assertSame('other body', FactoryTestComment::first()->body);
     }
 
     public function test_factory_can_insert()
@@ -1107,9 +1107,9 @@ class DatabaseEloquentFactoryTest extends TestCase
     {
         (new FactoryTestUserFactory())->forEachSequence(['name' => Name::Taylor, 'options' => 'abc'])->insert();
         $user = DB::table('users')->sole();
-        $this->assertEquals('abc', $user->options);
+        $this->assertSame('abc', $user->options);
         $userModel = FactoryTestUser::query()->sole();
-        $this->assertEquals('abc', $userModel->options);
+        $this->assertSame('abc', $userModel->options);
     }
 
     public function test_factory_can_insert_with_array_casts()

--- a/tests/Database/DatabaseEloquentGlobalScopesTest.php
+++ b/tests/Database/DatabaseEloquentGlobalScopesTest.php
@@ -41,7 +41,7 @@ class DatabaseEloquentGlobalScopesTest extends TestCase
         $model = new EloquentGlobalScopesTestModel;
         $query = $model->newQuery()->withoutGlobalScope(ActiveScope::class);
         $this->assertSame('select * from "table"', $query->toSql());
-        $this->assertEquals([], $query->getBindings());
+        $this->assertSame([], $query->getBindings());
     }
 
     public function testClassNameGlobalScopeIsApplied()
@@ -97,7 +97,7 @@ class DatabaseEloquentGlobalScopesTest extends TestCase
         $model = new EloquentClosureGlobalScopesTestModel;
         $query = $model->newQuery()->withoutGlobalScope('active_scope');
         $this->assertSame('select * from "table" order by "name" asc', $query->toSql());
-        $this->assertEquals([], $query->getBindings());
+        $this->assertSame([], $query->getBindings());
     }
 
     public function testGlobalScopeCanBeRemovedAfterTheQueryIsExecuted()
@@ -109,7 +109,7 @@ class DatabaseEloquentGlobalScopesTest extends TestCase
 
         $query->withoutGlobalScope('active_scope');
         $this->assertSame('select * from "table" order by "name" asc', $query->toSql());
-        $this->assertEquals([], $query->getBindings());
+        $this->assertSame([], $query->getBindings());
     }
 
     public function testAllGlobalScopesCanBeRemoved()
@@ -117,11 +117,11 @@ class DatabaseEloquentGlobalScopesTest extends TestCase
         $model = new EloquentClosureGlobalScopesTestModel;
         $query = $model->newQuery()->withoutGlobalScopes();
         $this->assertSame('select * from "table"', $query->toSql());
-        $this->assertEquals([], $query->getBindings());
+        $this->assertSame([], $query->getBindings());
 
         $query = EloquentClosureGlobalScopesTestModel::withoutGlobalScopes();
         $this->assertSame('select * from "table"', $query->toSql());
-        $this->assertEquals([], $query->getBindings());
+        $this->assertSame([], $query->getBindings());
     }
 
     public function testAllGlobalScopesCanBeRemovedExceptSpecified()

--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -59,7 +59,7 @@ class DatabaseEloquentHasManyTest extends TestCase
         $created = $this->expectForceCreatedModel($relation, ['name' => 'taylor']);
 
         $this->assertEquals($created, $relation->forceCreate(['name' => 'taylor']));
-        $this->assertEquals(1, $created->getAttribute('foreign_key'));
+        $this->assertSame(1, $created->getAttribute('foreign_key'));
     }
 
     public function testFindOrNewMethodFindsModel()
@@ -347,10 +347,10 @@ class DatabaseEloquentHasManyTest extends TestCase
         });
         $models = $relation->match([$model1, $model2, $model3], new Collection([$result1, $result2, $result3]), 'foo');
 
-        $this->assertEquals(1, $models[0]->foo[0]->foreign_key);
+        $this->assertSame(1, $models[0]->foo[0]->foreign_key);
         $this->assertCount(1, $models[0]->foo);
-        $this->assertEquals(2, $models[1]->foo[0]->foreign_key);
-        $this->assertEquals(2, $models[1]->foo[1]->foreign_key);
+        $this->assertSame(2, $models[1]->foo[0]->foreign_key);
+        $this->assertSame(2, $models[1]->foo[1]->foreign_key);
         $this->assertCount(2, $models[1]->foo);
         $this->assertNull($models[2]->foo);
     }

--- a/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
@@ -361,8 +361,8 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
             $count += $collection->count();
         });
 
-        $this->assertEquals(3, $i);
-        $this->assertEquals(6, $count);
+        $this->assertSame(3, $i);
+        $this->assertSame(6, $count);
     }
 
     public function testCursorReturnsCorrectModels()
@@ -472,7 +472,7 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
             ], array_keys($post->getAttributes()));
         });
 
-        $this->assertEquals(6, $i);
+        $this->assertSame(6, $i);
     }
 
     public function testIntermediateSoftDeletesAreIgnored()

--- a/tests/Database/DatabaseEloquentHasOneOfManyTest.php
+++ b/tests/Database/DatabaseEloquentHasOneOfManyTest.php
@@ -305,7 +305,7 @@ class DatabaseEloquentHasOneOfManyTest extends TestCase
         $user->logins()->create();
 
         $user = HasOneOfManyTestUser::withCount('latest_login')->first();
-        $this->assertEquals(1, $user->latest_login_count);
+        $this->assertSame(1, $user->latest_login_count);
     }
 
     public function testExists()

--- a/tests/Database/DatabaseEloquentHasOneTest.php
+++ b/tests/Database/DatabaseEloquentHasOneTest.php
@@ -110,7 +110,7 @@ class DatabaseEloquentHasOneTest extends TestCase
         $result = $relation->save($mockModel);
 
         $attributes = $result->getAttributes();
-        $this->assertEquals(1, $attributes['foreign_key']);
+        $this->assertSame(1, $attributes['foreign_key']);
     }
 
     public function testCreateMethodProperlyCreatesNewModel()
@@ -135,7 +135,7 @@ class DatabaseEloquentHasOneTest extends TestCase
         $relation->getRelated()->shouldReceive('forceCreate')->once()->with($attributes)->andReturn($created);
 
         $this->assertEquals($created, $relation->forceCreate(['name' => 'taylor']));
-        $this->assertEquals(1, $created->getAttribute('foreign_key'));
+        $this->assertSame(1, $created->getAttribute('foreign_key'));
     }
 
     public function testRelationIsProperlyInitialized()
@@ -189,8 +189,8 @@ class DatabaseEloquentHasOneTest extends TestCase
 
         $models = $relation->match([$model1, $model2, $model3, $model4], new Collection([$result1, $result2, $result3]), 'foo');
 
-        $this->assertEquals(1, $models[0]->foo->foreign_key);
-        $this->assertEquals(2, $models[1]->foo->foreign_key);
+        $this->assertSame(1, $models[0]->foo->foreign_key);
+        $this->assertSame(2, $models[1]->foo->foreign_key);
         $this->assertNull($models[2]->foo);
         $this->assertSame('4', (string) $models[3]->foo->foreign_key);
     }

--- a/tests/Database/DatabaseEloquentHasOneThroughOfManyTest.php
+++ b/tests/Database/DatabaseEloquentHasOneThroughOfManyTest.php
@@ -308,7 +308,7 @@ class DatabaseEloquentHasOneThroughOfManyTest extends TestCase
         $user->intermediates->first()->logins()->create();
 
         $user = HasOneThroughOfManyTestUser::withCount('latest_login')->first();
-        $this->assertEquals(1, $user->latest_login_count);
+        $this->assertSame(1, $user->latest_login_count);
     }
 
     public function testExists(): void

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -219,7 +219,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
     {
         EloquentTestUser::insert([['id' => 1, 'email' => 'taylorotwell@gmail.com'], ['id' => 2, 'email' => 'abigailotwell@gmail.com']]);
 
-        $this->assertEquals(2, EloquentTestUser::count());
+        $this->assertSame(2, EloquentTestUser::count());
 
         $this->assertFalse(EloquentTestUser::where('email', 'taylorotwell@gmail.com')->doesntExist());
         $this->assertTrue(EloquentTestUser::where('email', 'mohamed@laravel.com')->doesntExist());
@@ -231,11 +231,11 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
         $model = EloquentTestUser::find(1);
         $this->assertInstanceOf(EloquentTestUser::class, $model);
-        $this->assertEquals(1, $model->id);
+        $this->assertSame(1, $model->id);
 
         $model = EloquentTestUser::find(2);
         $this->assertInstanceOf(EloquentTestUser::class, $model);
-        $this->assertEquals(2, $model->id);
+        $this->assertSame(2, $model->id);
 
         $missing = EloquentTestUser::find(3);
         $this->assertNull($missing);
@@ -250,18 +250,18 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
         $models = EloquentTestUser::where('id', 1)->cursor();
         foreach ($models as $model) {
-            $this->assertEquals(1, $model->id);
+            $this->assertSame(1, $model->id);
             $this->assertSame('default', $model->getConnectionName());
         }
 
         $records = DB::table('users')->where('id', 1)->cursor();
         foreach ($records as $record) {
-            $this->assertEquals(1, $record->id);
+            $this->assertSame(1, $record->id);
         }
 
         $records = DB::cursor('select * from users where id = ?', [1]);
         foreach ($records as $record) {
-            $this->assertEquals(1, $record->id);
+            $this->assertSame(1, $record->id);
         }
     }
 
@@ -412,7 +412,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
         $query = EloquentTestUser::groupBy('email')->getQuery();
 
-        $this->assertEquals(3, $query->getCountForPagination());
+        $this->assertSame(3, $query->getCountForPagination());
     }
 
     public function testCountForPaginationWithGroupingAndSubSelects()
@@ -432,7 +432,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
             'friends_count' => EloquentTestUser::whereColumn('friend_id', 'user_id')->count(),
         ])->groupBy('email')->getQuery();
 
-        $this->assertEquals(4, $query->getCountForPagination());
+        $this->assertSame(4, $query->getCountForPagination());
     }
 
     public function testCursorPaginatedModelCollectionRetrieval()
@@ -651,7 +651,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         );
 
         $this->assertSame('Mohamed Said', $user3->name);
-        $this->assertEquals(2, EloquentTestUser::count());
+        $this->assertSame(2, EloquentTestUser::count());
     }
 
     public function testUpdateOrCreateOnDifferentConnection()
@@ -668,8 +668,8 @@ class DatabaseEloquentIntegrationTest extends TestCase
             ['name' => 'Mohamed Said']
         );
 
-        $this->assertEquals(1, EloquentTestUser::count());
-        $this->assertEquals(2, EloquentTestUser::on('second_connection')->count());
+        $this->assertSame(1, EloquentTestUser::count());
+        $this->assertSame(2, EloquentTestUser::on('second_connection')->count());
     }
 
     public function testCheckAndCreateMethodsOnMultiConnections()
@@ -693,12 +693,12 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertSame('second_connection', $user1->getConnectionName());
         $this->assertSame('second_connection', $user2->getConnectionName());
 
-        $this->assertEquals(1, EloquentTestUser::on('second_connection')->count());
+        $this->assertSame(1, EloquentTestUser::on('second_connection')->count());
         $user1 = EloquentTestUser::on('second_connection')->firstOrCreate(['email' => 'taylorotwell@gmail.com']);
         $user2 = EloquentTestUser::on('second_connection')->firstOrCreate(['email' => 'themsaid@gmail.com']);
         $this->assertSame('second_connection', $user1->getConnectionName());
         $this->assertSame('second_connection', $user2->getConnectionName());
-        $this->assertEquals(2, EloquentTestUser::on('second_connection')->count());
+        $this->assertSame(2, EloquentTestUser::on('second_connection')->count());
     }
 
     public function testCreatingModelWithEmptyAttributes()
@@ -732,7 +732,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
             $chunks++;
         });
 
-        $this->assertEquals(2, $chunks);
+        $this->assertSame(2, $chunks);
     }
 
     public function testChunksWithLimitsWhereLimitIsLessThanTotal()
@@ -757,7 +757,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
             $chunks++;
         });
 
-        $this->assertEquals(1, $chunks);
+        $this->assertSame(1, $chunks);
     }
 
     public function testChunksWithLimitsWhereLimitIsMoreThanTotal()
@@ -785,7 +785,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
             $chunks++;
         });
 
-        $this->assertEquals(2, $chunks);
+        $this->assertSame(2, $chunks);
     }
 
     public function testChunksWithOffset()
@@ -810,7 +810,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
             $chunks++;
         });
 
-        $this->assertEquals(1, $chunks);
+        $this->assertSame(1, $chunks);
     }
 
     public function testChunksWithOffsetWhereMoreThanTotal()
@@ -827,7 +827,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
             $chunks++;
         });
 
-        $this->assertEquals(0, $chunks);
+        $this->assertSame(0, $chunks);
     }
 
     public function testChunksWithLimitsAndOffsets()
@@ -859,7 +859,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
             $chunks++;
         });
 
-        $this->assertEquals(2, $chunks);
+        $this->assertSame(2, $chunks);
     }
 
     public function testChunkByIdWithLimits()
@@ -884,7 +884,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
             $chunks++;
         });
 
-        $this->assertEquals(1, $chunks);
+        $this->assertSame(1, $chunks);
     }
 
     public function testChunkByIdWithOffsets()
@@ -909,7 +909,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
             $chunks++;
         });
 
-        $this->assertEquals(1, $chunks);
+        $this->assertSame(1, $chunks);
     }
 
     public function testChunkByIdWithLimitsAndOffsets()
@@ -941,7 +941,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
             $chunks++;
         });
 
-        $this->assertEquals(2, $chunks);
+        $this->assertSame(2, $chunks);
     }
 
     public function testChunkByIdWithNonIncrementingKey()
@@ -962,7 +962,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
             }
             $i++;
         }, 'name');
-        $this->assertEquals(2, $i);
+        $this->assertSame(2, $i);
     }
 
     public function testEachByIdWithNonIncrementingKey()
@@ -1472,7 +1472,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
         $photos = EloquentTestPhoto::has('imageable')->get();
 
-        $this->assertEquals(1, $photos->count());
+        $this->assertSame(1, $photos->count());
     }
 
     public function testBelongsToManyRelationshipModelsAreProperlyHydratedWithSoleQuery()
@@ -1718,7 +1718,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         ]);
 
         $this->assertTrue($post->saveOrFail());
-        $this->assertEquals(1, EloquentTestPost::count());
+        $this->assertSame(1, EloquentTestPost::count());
     }
 
     public function testSavingJSONFields()
@@ -1763,7 +1763,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         ]);
 
         $this->assertTrue($result);
-        $this->assertEquals(2, EloquentTestPost::count());
+        $this->assertSame(2, EloquentTestPost::count());
     }
 
     public function testMultiInsertsWithSameValues()
@@ -1775,7 +1775,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         ]);
 
         $this->assertTrue($result);
-        $this->assertEquals(2, EloquentTestPost::count());
+        $this->assertSame(2, EloquentTestPost::count());
     }
 
     public function testNestedTransactions()
@@ -1809,7 +1809,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
             $user = EloquentTestUser::first();
             $this->assertSame('otwell@laravel.com', $user->email);
-            $this->assertEquals(1, $user->id);
+            $this->assertSame(1, $user->id);
         });
     }
 
@@ -1827,7 +1827,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
             $user = EloquentTestUser::first();
             $this->assertSame('taylor@laravel.com', $user->email);
-            $this->assertEquals(1, $user->id);
+            $this->assertSame(1, $user->id);
         });
     }
 
@@ -1911,11 +1911,11 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
         $results = EloquentTestUser::forPageBeforeId(15, 2);
         $this->assertInstanceOf(Builder::class, $results);
-        $this->assertEquals(1, $results->first()->id);
+        $this->assertSame(1, $results->first()->id);
 
         $results = EloquentTestUser::orderBy('id', 'desc')->forPageBeforeId(15, 2);
         $this->assertInstanceOf(Builder::class, $results);
-        $this->assertEquals(1, $results->first()->id);
+        $this->assertSame(1, $results->first()->id);
     }
 
     public function testForPageAfterIdCorrectlyPaginates()
@@ -1927,11 +1927,11 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
         $results = EloquentTestUser::forPageAfterId(15, 1);
         $this->assertInstanceOf(Builder::class, $results);
-        $this->assertEquals(2, $results->first()->id);
+        $this->assertSame(2, $results->first()->id);
 
         $results = EloquentTestUser::orderBy('id', 'desc')->forPageAfterId(15, 1);
         $this->assertInstanceOf(Builder::class, $results);
-        $this->assertEquals(2, $results->first()->id);
+        $this->assertSame(2, $results->first()->id);
     }
 
     public function testMorphToRelationsAcrossDatabaseConnections()
@@ -2475,10 +2475,10 @@ class DatabaseEloquentIntegrationTest extends TestCase
         ]);
 
         $this->assertInstanceOf(Pivot::class, $freshPivot = $pivot->fresh());
-        $this->assertEquals(2, $freshPivot->friend_level_id);
+        $this->assertSame(2, $freshPivot->friend_level_id);
 
         $this->assertSame($pivot, $pivot->refresh());
-        $this->assertEquals(2, $pivot->friend_level_id);
+        $this->assertSame(2, $pivot->friend_level_id);
     }
 
     public function testMorphPivotsCanBeRefreshed()
@@ -2662,7 +2662,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
             '22222222-0000-7000-0000-000000000000',
         ]);
 
-        $this->assertEquals(1, ModelWithUniqueStringIds::fillAndInsertOrIgnore([
+        $this->assertSame(1, ModelWithUniqueStringIds::fillAndInsertOrIgnore([
             [
                 'id' => 1, 'name' => 'Taylor', 'role' => IntBackedRole::Admin, 'role_string' => StringBackedRole::Admin,
             ],

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -2588,7 +2588,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertNull($users[0]->birthday);
         $this->assertInstanceOf(\DateTime::class, $users[1]->birthday);
         $this->assertInstanceOf(\DateTime::class, $users[2]->birthday);
-        $this->assertEquals('1987-11-01', $users[2]->birthday->format('Y-m-d'));
+        $this->assertSame('1987-11-01', $users[2]->birthday->format('Y-m-d'));
 
         DB::flushQueryLog();
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -632,9 +632,9 @@ class DatabaseEloquentModelTest extends TestCase
         unset($model['table']);
 
         $this->assertTrue(isset($model['attributes']));
-        $this->assertEquals(1, $model['attributes']);
+        $this->assertSame(1, $model['attributes']);
         $this->assertTrue(isset($model['connection']));
-        $this->assertEquals(2, $model['connection']);
+        $this->assertSame(2, $model['connection']);
         $this->assertFalse(isset($model['table']));
         $this->assertEquals(null, $model['table']);
         $this->assertFalse(isset($model['with']));
@@ -712,7 +712,7 @@ class DatabaseEloquentModelTest extends TestCase
         $_SERVER['__eloquent.saved'] = false;
         $model = EloquentModelSaveStub::forceCreate(['id' => 21]);
         $this->assertTrue($_SERVER['__eloquent.saved']);
-        $this->assertEquals(21, $model->id);
+        $this->assertSame(21, $model->id);
     }
 
     public function testFindMethodUseWritePdo()
@@ -1074,7 +1074,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model->name = 'taylor';
         $model->exists = false;
         $this->assertTrue($model->save());
-        $this->assertEquals(1, $model->id);
+        $this->assertSame(1, $model->id);
         $this->assertTrue($model->exists);
 
         $model = $this->getMockBuilder(EloquentModelStub::class)->onlyMethods(['newModelQuery', 'updateTimestamps', 'refresh'])->getMock();
@@ -1132,7 +1132,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model->name = 'taylor';
         $model->exists = false;
         $this->assertTrue($model->saveOrIgnore());
-        $this->assertEquals(1, $model->id);
+        $this->assertSame(1, $model->id);
         $this->assertTrue($model->exists);
         $this->assertTrue($model->wasRecentlyCreated);
     }
@@ -1242,7 +1242,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model->exists = false;
 
         $this->assertTrue($model->push());
-        $this->assertEquals(1, $model->id);
+        $this->assertSame(1, $model->id);
         $this->assertTrue($model->exists);
     }
 
@@ -1260,7 +1260,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model->setRelation('relationOne', null);
 
         $this->assertTrue($model->push());
-        $this->assertEquals(1, $model->id);
+        $this->assertSame(1, $model->id);
         $this->assertTrue($model->exists);
         $this->assertNull($model->relationOne);
     }
@@ -1288,11 +1288,11 @@ class DatabaseEloquentModelTest extends TestCase
         $model->setRelation('relationOne', $related1);
 
         $this->assertTrue($model->push());
-        $this->assertEquals(1, $model->id);
+        $this->assertSame(1, $model->id);
         $this->assertTrue($model->exists);
-        $this->assertEquals(2, $model->relationOne->id);
+        $this->assertSame(2, $model->relationOne->id);
         $this->assertTrue($model->relationOne->exists);
-        $this->assertEquals(2, $related1->id);
+        $this->assertSame(2, $related1->id);
         $this->assertTrue($related1->exists);
     }
 
@@ -1310,7 +1310,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model->setRelation('relationMany', new Collection([]));
 
         $this->assertTrue($model->push());
-        $this->assertEquals(1, $model->id);
+        $this->assertSame(1, $model->id);
         $this->assertTrue($model->exists);
         $this->assertCount(0, $model->relationMany);
     }
@@ -1347,7 +1347,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model->setRelation('relationMany', new Collection([$related1, $related2]));
 
         $this->assertTrue($model->push());
-        $this->assertEquals(1, $model->id);
+        $this->assertSame(1, $model->id);
         $this->assertTrue($model->exists);
         $this->assertCount(2, $model->relationMany);
         $this->assertEquals([2, 3], $model->relationMany->pluck('id')->all());
@@ -1402,7 +1402,7 @@ class DatabaseEloquentModelTest extends TestCase
     {
         $model = new EloquentModelStub;
         $model->id = 1;
-        $this->assertEquals(1, $model->getKey());
+        $this->assertSame(1, $model->getKey());
         $this->assertSame('id', $model->getKeyName());
     }
 
@@ -1777,7 +1777,7 @@ class DatabaseEloquentModelTest extends TestCase
     public function testForceFillMethodFillsGuardedAttributes()
     {
         $model = (new EloquentModelSaveStub)->forceFill(['id' => 21]);
-        $this->assertEquals(21, $model->id);
+        $this->assertSame(21, $model->id);
     }
 
     public function testFillingJSONAttributes()
@@ -2681,8 +2681,8 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertFalse($model->isDirty());
 
         $model->publicIncrement('foo', 1, ['category' => 1]);
-        $this->assertEquals(4, $model->foo);
-        $this->assertEquals(1, $model->category);
+        $this->assertSame(4, $model->foo);
+        $this->assertSame(1, $model->category);
         $this->assertTrue($model->isDirty('category'));
     }
 
@@ -2708,8 +2708,8 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertFalse($model->isDirty());
 
         $model->publicIncrementQuietly('foo', 1, ['category' => 1]);
-        $this->assertEquals(4, $model->foo);
-        $this->assertEquals(1, $model->category);
+        $this->assertSame(4, $model->foo);
+        $this->assertSame(1, $model->category);
         $this->assertTrue($model->isDirty('category'));
     }
 
@@ -2735,8 +2735,8 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertFalse($model->isDirty());
 
         $model->publicDecrementQuietly('foo', 1, ['category' => 1]);
-        $this->assertEquals(2, $model->foo);
-        $this->assertEquals(1, $model->category);
+        $this->assertSame(2, $model->foo);
+        $this->assertSame(1, $model->category);
         $this->assertTrue($model->isDirty('category'));
     }
 
@@ -2755,9 +2755,9 @@ class DatabaseEloquentModelTest extends TestCase
 
         $result = $model->publicIncrementEach(['foo' => 1, 'bar' => 2]);
 
-        $this->assertEquals(1, $result);
-        $this->assertEquals(3, $model->foo);
-        $this->assertEquals(7, $model->bar);
+        $this->assertSame(1, $result);
+        $this->assertSame(3, $model->foo);
+        $this->assertSame(7, $model->bar);
     }
 
     public function testDecrementEachOnExistingModelScopesQueryToModelKey()
@@ -2775,9 +2775,9 @@ class DatabaseEloquentModelTest extends TestCase
 
         $result = $model->publicDecrementEach(['foo' => 3, 'bar' => 2]);
 
-        $this->assertEquals(1, $result);
-        $this->assertEquals(7, $model->foo);
-        $this->assertEquals(3, $model->bar);
+        $this->assertSame(1, $result);
+        $this->assertSame(7, $model->foo);
+        $this->assertSame(3, $model->bar);
     }
 
     public function testIncrementEachWithExtraColumnsOnExistingModel()
@@ -2794,8 +2794,8 @@ class DatabaseEloquentModelTest extends TestCase
 
         $result = $model->publicIncrementEach(['foo' => 5], ['category' => 'test']);
 
-        $this->assertEquals(1, $result);
-        $this->assertEquals(7, $model->foo);
+        $this->assertSame(1, $result);
+        $this->assertSame(7, $model->foo);
         $this->assertEquals('test', $model->category);
     }
 
@@ -2836,7 +2836,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertFalse($result);
         // Note: attributes are set before the event fires, matching increment() behavior.
         // The in-memory value changes but the database is not updated.
-        $this->assertEquals(2, $model->foo);
+        $this->assertSame(2, $model->foo);
     }
 
     public function testIncrementEachOnNonExistingModelForwardsToQueryBuilder()
@@ -2849,7 +2849,7 @@ class DatabaseEloquentModelTest extends TestCase
 
         $result = $model->publicIncrementEach(['foo' => 1]);
 
-        $this->assertEquals(5, $result);
+        $this->assertSame(5, $result);
     }
 
     public function testRelationshipTouchOwnersIsPropagated()
@@ -3189,7 +3189,7 @@ class DatabaseEloquentModelTest extends TestCase
 
         $model = m::mock(EloquentModelStub::class.'[delete]');
         $model->delete = 123;
-        $this->assertEquals(123, $model->delete);
+        $this->assertSame(123, $model->delete);
     }
 
     public function testIntKeyTypePreserved()
@@ -3201,7 +3201,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model->expects($this->once())->method('newModelQuery')->willReturn($query);
 
         $this->assertTrue($model->save());
-        $this->assertEquals(1, $model->id);
+        $this->assertSame(1, $model->id);
     }
 
     public function testStringKeyTypePreserved()
@@ -3319,7 +3319,7 @@ class DatabaseEloquentModelTest extends TestCase
             $model = new EloquentModelStub(['id' => 1]);
             $model->exists = true;
 
-            $this->assertEquals(1, $model->id);
+            $this->assertSame(1, $model->id);
             $this->expectException(MissingAttributeException::class);
 
             $model->this_attribute_does_not_exist;
@@ -3355,7 +3355,7 @@ class DatabaseEloquentModelTest extends TestCase
 
             $this->assertInstanceOf(Address::class, $model->address);
 
-            $this->assertEquals(1, $model->id);
+            $this->assertSame(1, $model->id);
             $this->assertEquals('ok', $model->this_is_fine);
             $this->assertEquals('ok', $model->this_is_also_fine);
 
@@ -3383,7 +3383,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model = new EloquentModelStub(['id' => 1]);
         $model->exists = true;
 
-        $this->assertEquals(1, $model->id);
+        $this->assertSame(1, $model->id);
 
         $model->this_attribute_does_not_exist;
 
@@ -3403,7 +3403,7 @@ class DatabaseEloquentModelTest extends TestCase
             $model = new EloquentModelStub(['id' => 1]);
             $model->exists = false;
 
-            $this->assertEquals(1, $model->id);
+            $this->assertSame(1, $model->id);
             $this->assertNull($model->this_attribute_does_not_exist);
         } finally {
             Model::preventAccessingMissingAttributes($originalMode);
@@ -3420,7 +3420,7 @@ class DatabaseEloquentModelTest extends TestCase
             $model->exists = true;
             $model->wasRecentlyCreated = true;
 
-            $this->assertEquals(1, $model->id);
+            $this->assertSame(1, $model->id);
             $this->assertNull($model->this_attribute_does_not_exist);
         } finally {
             Model::preventAccessingMissingAttributes($originalMode);
@@ -3548,9 +3548,9 @@ class DatabaseEloquentModelTest extends TestCase
         ]);
 
         $this->assertIsInt($model->getOriginal('intAttribute'));
-        $this->assertEquals(1, $model->getOriginal('intAttribute'));
-        $this->assertEquals(2, $model->intAttribute);
-        $this->assertEquals(2, $model->getAttribute('intAttribute'));
+        $this->assertSame(1, $model->getOriginal('intAttribute'));
+        $this->assertSame(2, $model->intAttribute);
+        $this->assertSame(2, $model->getAttribute('intAttribute'));
 
         $this->assertIsFloat($model->getOriginal('floatAttribute'));
         $this->assertEquals(0.1234, $model->getOriginal('floatAttribute'));
@@ -3595,8 +3595,8 @@ class DatabaseEloquentModelTest extends TestCase
         ], true);
 
         $this->assertIsInt($model->duplicatedAttribute);
-        $this->assertEquals(1, $model->duplicatedAttribute);
-        $this->assertEquals(1, $model->getAttribute('duplicatedAttribute'));
+        $this->assertSame(1, $model->duplicatedAttribute);
+        $this->assertSame(1, $model->getAttribute('duplicatedAttribute'));
     }
 
     public function testCastsMethodIsTakenInConsiderationOnSerialization()
@@ -3609,8 +3609,8 @@ class DatabaseEloquentModelTest extends TestCase
         $model = unserialize(serialize($model));
 
         $this->assertIsInt($model->duplicatedAttribute);
-        $this->assertEquals(1, $model->duplicatedAttribute);
-        $this->assertEquals(1, $model->getAttribute('duplicatedAttribute'));
+        $this->assertSame(1, $model->duplicatedAttribute);
+        $this->assertSame(1, $model->getAttribute('duplicatedAttribute'));
     }
 
     public function testCastOnArrayFormatWithOneElement()

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1459,7 +1459,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertSame('boom', $array['names'][1]['bam']);
         $this->assertSame('abby', $array['partner']['name']);
         $this->assertNull($array['group']);
-        $this->assertEquals([], $array['multi']);
+        $this->assertSame([], $array['multi']);
         $this->assertFalse(isset($array['password']));
 
         $model->setAppends(['appendable']);
@@ -1814,7 +1814,7 @@ class DatabaseEloquentModelTest extends TestCase
     {
         $model = new EloquentModelStub;
         $model->fill(['_method' => 'PUT']);
-        $this->assertEquals([], $model->getAttributes());
+        $this->assertSame([], $model->getAttributes());
     }
 
     public function testGuarded()
@@ -2561,10 +2561,10 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertFalse($model->hasAppended('not_appended'));
 
         $model->setHidden(['is_admin', 'camelCased', 'StudlyCased']);
-        $this->assertEquals([], $model->toArray());
+        $this->assertSame([], $model->toArray());
 
         $model->setVisible([]);
-        $this->assertEquals([], $model->toArray());
+        $this->assertSame([], $model->toArray());
     }
 
     public function testMergeAppendsMergesAppends()

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -2796,7 +2796,7 @@ class DatabaseEloquentModelTest extends TestCase
 
         $this->assertSame(1, $result);
         $this->assertSame(7, $model->foo);
-        $this->assertEquals('test', $model->category);
+        $this->assertSame('test', $model->category);
     }
 
     public function testIncrementEachFiresModelEvents()
@@ -3138,8 +3138,8 @@ class DatabaseEloquentModelTest extends TestCase
 
         $this->assertCount($castCount + 2, $model->getCasts());
         $this->assertArrayHasKey('foo', $model->getCasts());
-        $this->assertEquals('MyClass:myArgumentA', $model->getCasts()['foo']);
-        $this->assertEquals('MyClass:myArgumentA,myArgumentB', $model->getCasts()['bar']);
+        $this->assertSame('MyClass:myArgumentA', $model->getCasts()['foo']);
+        $this->assertSame('MyClass:myArgumentA,myArgumentB', $model->getCasts()['bar']);
     }
 
     public function testUnsetCastAttributes()
@@ -3356,8 +3356,8 @@ class DatabaseEloquentModelTest extends TestCase
             $this->assertInstanceOf(Address::class, $model->address);
 
             $this->assertSame(1, $model->id);
-            $this->assertEquals('ok', $model->this_is_fine);
-            $this->assertEquals('ok', $model->this_is_also_fine);
+            $this->assertSame('ok', $model->this_is_fine);
+            $this->assertSame('ok', $model->this_is_also_fine);
 
             // Primitive castables, enum castable
             $expectedExceptionCount = count($primitiveCasts) + 1;
@@ -3388,7 +3388,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model->this_attribute_does_not_exist;
 
         $this->assertInstanceOf(EloquentModelStub::class, $callbackModel);
-        $this->assertEquals('this_attribute_does_not_exist', $callbackKey);
+        $this->assertSame('this_attribute_does_not_exist', $callbackKey);
 
         Model::preventAccessingMissingAttributes($originalMode);
         Model::handleMissingAttributeViolationUsing(null);
@@ -3630,7 +3630,7 @@ class DatabaseEloquentModelTest extends TestCase
     {
         $model = new EloquentModelCastingStub;
 
-        $this->assertEquals('int', $model->getCasts()['castStringableObject']);
+        $this->assertSame('int', $model->getCasts()['castStringableObject']);
     }
 
     public function testMergeingStringableObjectCastUSesStringRepresentation()
@@ -3642,7 +3642,7 @@ class DatabaseEloquentModelTest extends TestCase
             'something' => $stringable,
         ]);
 
-        $this->assertEquals('test', $model->getCasts()['something']);
+        $this->assertSame('test', $model->getCasts()['something']);
     }
 
     public function testUsingPlainObjectAsCastThrowsException()
@@ -3688,8 +3688,8 @@ class DatabaseEloquentModelTest extends TestCase
 
         $model->address_line_one = '123 Main Street';
 
-        $this->assertEquals('123 Main Street', $model->address->lineOne);
-        $this->assertEquals('123 MAIN STREET', $model->address_in_caps);
+        $this->assertSame('123 Main Street', $model->address->lineOne);
+        $this->assertSame('123 MAIN STREET', $model->address_in_caps);
 
         $model->discardChanges();
 
@@ -3805,7 +3805,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertInstanceOf(EloquentModelWithUseFactoryAttributeFactory::class, $model::factory());
         $this->assertInstanceOf(EloquentModelWithUseFactoryAttributeFactory::class, $model::newFactory());
         $this->assertEquals(EloquentModelWithUseFactoryAttribute::class, $factory->modelName());
-        $this->assertEquals('test name', $instance->name); // Small smoke test to ensure the factory is working
+        $this->assertSame('test name', $instance->name); // Small smoke test to ensure the factory is working
     }
 
     public function testNestedModelBootingIsDisallowed()

--- a/tests/Database/DatabaseEloquentPivotTest.php
+++ b/tests/Database/DatabaseEloquentPivotTest.php
@@ -125,7 +125,7 @@ class DatabaseEloquentPivotTest extends TestCase
         $pivot->expects($this->once())->method('newQueryWithoutRelationships')->willReturn($query);
 
         $rowsAffected = $pivot->delete();
-        $this->assertEquals(1, $rowsAffected);
+        $this->assertSame(1, (int) $rowsAffected);
     }
 
     public function testPivotModelTableNameIsSingular()

--- a/tests/Database/DatabaseEloquentPivotTest.php
+++ b/tests/Database/DatabaseEloquentPivotTest.php
@@ -69,7 +69,7 @@ class DatabaseEloquentPivotTest extends TestCase
         $parent->shouldReceive('getConnectionName')->once()->andReturn('connection');
         $pivot = Pivot::fromAttributes($parent, ['foo' => 'bar', 'shimy' => 'shake'], 'table', true);
 
-        $this->assertEquals([], $pivot->getDirty());
+        $this->assertSame([], $pivot->getDirty());
     }
 
     public function testPropertiesChangedAreDirty()

--- a/tests/Database/DatabaseEloquentPolymorphicIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentPolymorphicIntegrationTest.php
@@ -153,15 +153,15 @@ class DatabaseEloquentPolymorphicIntegrationTest extends TestCase
 
         $this->assertTrue($likes[0]->relationLoaded('likeable'));
         $this->assertTrue($likes[0]->likeable->relationLoaded('owner'));
-        $this->assertEquals(2, $likes[0]->likeable->likes_count);
+        $this->assertSame(2, $likes[0]->likeable->likes_count);
 
         $this->assertTrue($likes[1]->relationLoaded('likeable'));
         $this->assertTrue($likes[1]->likeable->relationLoaded('owner'));
-        $this->assertEquals(1, $likes[1]->likeable->comments_count);
+        $this->assertSame(1, $likes[1]->likeable->comments_count);
 
         $this->assertTrue($likes[2]->relationLoaded('likeable'));
         $this->assertTrue($likes[2]->likeable->relationLoaded('owner'));
-        $this->assertEquals(2, $likes[2]->likeable->likes_count);
+        $this->assertSame(2, $likes[2]->likeable->likes_count);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentPolymorphicRelationsIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentPolymorphicRelationsIntegrationTest.php
@@ -122,8 +122,8 @@ class DatabaseEloquentPolymorphicRelationsIntegrationTest extends TestCase
             $iterations++;
         });
 
-        $this->assertEquals(2, $iterations);
-        $this->assertEquals(3, $count);
+        $this->assertSame(2, $iterations);
+        $this->assertSame(3, $count);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -112,7 +112,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $users = SoftDeletesTestUser::all();
 
         $this->assertCount(1, $users);
-        $this->assertEquals(2, $users->first()->id);
+        $this->assertSame(2, $users->first()->id);
         $this->assertNull(SoftDeletesTestUser::find(1));
     }
 
@@ -148,7 +148,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $query->chunk(2, function ($user) use (&$count) {
             $count += count($user);
         });
-        $this->assertEquals(1, $count);
+        $this->assertSame(1, $count);
 
         $query = SoftDeletesTestUser::query();
         $this->assertCount(1, $query->pluck('email')->all());
@@ -170,8 +170,8 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $query = SoftDeletesTestUser::query();
         $this->assertCount(1, $query->cursorPaginate(2)->all());
 
-        $this->assertEquals(0, SoftDeletesTestUser::where('email', 'taylorotwell@gmail.com')->increment('id'));
-        $this->assertEquals(0, SoftDeletesTestUser::where('email', 'taylorotwell@gmail.com')->decrement('id'));
+        $this->assertSame(0, SoftDeletesTestUser::where('email', 'taylorotwell@gmail.com')->increment('id'));
+        $this->assertSame(0, SoftDeletesTestUser::where('email', 'taylorotwell@gmail.com')->decrement('id'));
     }
 
     public function testWithTrashedReturnsAllRecords()
@@ -206,7 +206,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $users = SoftDeletesTestUser::withTrashed()->get();
 
         $this->assertCount(1, $users);
-        $this->assertEquals(1, $users->first()->id);
+        $this->assertSame(1, $users->first()->id);
     }
 
     public function testForceDeleteUpdateExistsProperty()
@@ -255,7 +255,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $users = SoftDeletesTestUser::withTrashed()->get();
 
         $this->assertCount(1, $users);
-        $this->assertEquals(1, $users->first()->id);
+        $this->assertSame(1, $users->first()->id);
         $this->assertNull(SoftDeletesTestUser::find(2));
     }
 
@@ -269,7 +269,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $users = SoftDeletesTestUser::withTrashed()->get();
 
         $this->assertCount(1, $users);
-        $this->assertEquals(2, $users->first()->id);
+        $this->assertSame(2, $users->first()->id);
         $this->assertNull(SoftDeletesTestUser::find(1));
     }
 
@@ -303,7 +303,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $users = SoftDeletesTestUser::withTrashed()->get();
 
         $this->assertCount(1, $users);
-        $this->assertEquals(1, $users->first()->id);
+        $this->assertSame(1, $users->first()->id);
         $this->assertNull(SoftDeletesTestUser::find(2));
     }
 
@@ -330,7 +330,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $users = SoftDeletesTestUser::onlyTrashed()->get();
 
         $this->assertCount(1, $users);
-        $this->assertEquals(1, $users->first()->id);
+        $this->assertSame(1, $users->first()->id);
     }
 
     public function testOnlyWithoutTrashedOnlyReturnsTrashedRecords()
@@ -340,12 +340,12 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $users = SoftDeletesTestUser::withoutTrashed()->get();
 
         $this->assertCount(1, $users);
-        $this->assertEquals(2, $users->first()->id);
+        $this->assertSame(2, $users->first()->id);
 
         $users = SoftDeletesTestUser::withTrashed()->withoutTrashed()->get();
 
         $this->assertCount(1, $users);
-        $this->assertEquals(2, $users->first()->id);
+        $this->assertSame(2, $users->first()->id);
     }
 
     public function testFirstOrNew()
@@ -356,7 +356,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $this->assertNull($result->id);
 
         $result = SoftDeletesTestUser::withTrashed()->firstOrNew(['email' => 'taylorotwell@gmail.com']);
-        $this->assertEquals(1, $result->id);
+        $this->assertSame(1, $result->id);
     }
 
     public function testFindOrNew()
@@ -367,7 +367,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $this->assertNull($result->id);
 
         $result = SoftDeletesTestUser::withTrashed()->findOrNew(1);
-        $this->assertEquals(1, $result->id);
+        $this->assertSame(1, $result->id);
     }
 
     public function testFirstOrCreate()
@@ -632,19 +632,19 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         // check count before soft delete
         $abigail->posts()->create(['title' => 'First Title']);
         $abigail->posts()->create(['title' => 'Second Title']);
-        $this->assertEquals(2, $abigail->posts()->count());
+        $this->assertSame(2, $abigail->posts()->count());
 
         // check count after soft delete
         $abigail->posts()->where('title', 'Second Title')->delete();
-        $this->assertEquals(1, $abigail->posts()->count());
+        $this->assertSame(1, $abigail->posts()->count());
 
         // check count after restore
         $abigail->posts()->withTrashed()->restore();
-        $this->assertEquals(2, $abigail->posts()->count());
+        $this->assertSame(2, $abigail->posts()->count());
 
         // check count after a force delete
         $abigail->posts()->where('title', 'Second Title')->forceDelete();
-        $this->assertEquals(1, $abigail->posts()->count());
+        $this->assertSame(1, $abigail->posts()->count());
     }
 
     public function testRelationAggregatesHonorsSoftDelete()
@@ -656,31 +656,31 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $abigail->posts()->create(['title' => 'First Title', 'priority' => 2]);
         $abigail->posts()->create(['title' => 'Second Title', 'priority' => 4]);
         $abigail->posts()->create(['title' => 'Third Title', 'priority' => 6]);
-        $this->assertEquals(2, $abigail->posts()->min('priority'));
-        $this->assertEquals(6, $abigail->posts()->max('priority'));
-        $this->assertEquals(12, $abigail->posts()->sum('priority'));
-        $this->assertEquals(4, $abigail->posts()->avg('priority'));
+        $this->assertSame(2, $abigail->posts()->min('priority'));
+        $this->assertSame(6, $abigail->posts()->max('priority'));
+        $this->assertSame(12, $abigail->posts()->sum('priority'));
+        $this->assertSame(4.0, $abigail->posts()->avg('priority'));
 
         // check aggregates after soft delete
         $abigail->posts()->where('title', 'First Title')->delete();
-        $this->assertEquals(4, $abigail->posts()->min('priority'));
-        $this->assertEquals(6, $abigail->posts()->max('priority'));
-        $this->assertEquals(10, $abigail->posts()->sum('priority'));
-        $this->assertEquals(5, $abigail->posts()->avg('priority'));
+        $this->assertSame(4, $abigail->posts()->min('priority'));
+        $this->assertSame(6, $abigail->posts()->max('priority'));
+        $this->assertSame(10, $abigail->posts()->sum('priority'));
+        $this->assertSame(5.0, $abigail->posts()->avg('priority'));
 
         // check aggregates after restore
         $abigail->posts()->withTrashed()->restore();
-        $this->assertEquals(2, $abigail->posts()->min('priority'));
-        $this->assertEquals(6, $abigail->posts()->max('priority'));
-        $this->assertEquals(12, $abigail->posts()->sum('priority'));
-        $this->assertEquals(4, $abigail->posts()->avg('priority'));
+        $this->assertSame(2, $abigail->posts()->min('priority'));
+        $this->assertSame(6, $abigail->posts()->max('priority'));
+        $this->assertSame(12, $abigail->posts()->sum('priority'));
+        $this->assertSame(4.0, $abigail->posts()->avg('priority'));
 
         // check aggregates after a force delete
         $abigail->posts()->where('title', 'Third Title')->forceDelete();
-        $this->assertEquals(2, $abigail->posts()->min('priority'));
-        $this->assertEquals(4, $abigail->posts()->max('priority'));
-        $this->assertEquals(6, $abigail->posts()->sum('priority'));
-        $this->assertEquals(3, $abigail->posts()->avg('priority'));
+        $this->assertSame(2, $abigail->posts()->min('priority'));
+        $this->assertSame(4, $abigail->posts()->max('priority'));
+        $this->assertSame(6, $abigail->posts()->sum('priority'));
+        $this->assertSame(3.0, $abigail->posts()->avg('priority'));
     }
 
     public function testSoftDeleteIsAppliedToNewQuery()
@@ -812,27 +812,27 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $abigail->posts()->create(['title' => 'Third Title']);
 
         $user = SoftDeletesTestUser::withCount('posts')->orderBy('postsCount', 'desc')->first();
-        $this->assertEquals(2, $user->posts_count);
+        $this->assertSame(2, $user->posts_count);
 
         $user = SoftDeletesTestUser::withCount(['posts' => function ($q) {
             $q->onlyTrashed();
         }])->orderBy('postsCount', 'desc')->first();
-        $this->assertEquals(1, $user->posts_count);
+        $this->assertSame(1, $user->posts_count);
 
         $user = SoftDeletesTestUser::withCount(['posts' => function ($q) {
             $q->withTrashed();
         }])->orderBy('postsCount', 'desc')->first();
-        $this->assertEquals(3, $user->posts_count);
+        $this->assertSame(3, $user->posts_count);
 
         $user = SoftDeletesTestUser::withCount(['posts' => function ($q) {
             $q->withTrashed()->where('title', 'First Title');
         }])->orderBy('postsCount', 'desc')->first();
-        $this->assertEquals(1, $user->posts_count);
+        $this->assertSame(1, $user->posts_count);
 
         $user = SoftDeletesTestUser::withCount(['posts' => function ($q) {
             $q->where('title', 'First Title');
         }])->orderBy('postsCount', 'desc')->first();
-        $this->assertEquals(0, $user->posts_count);
+        $this->assertSame(0, $user->posts_count);
     }
 
     public function testOrWhereWithSoftDeleteConstraint()
@@ -966,7 +966,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $this->assertTrue($abigail->self_referencing->first()->is($taylor));
 
         $this->assertCount(0, $taylor->self_referencing);
-        $this->assertEquals(1, SoftDeletesTestUser::whereHas('self_referencing')->count());
+        $this->assertSame(1, SoftDeletesTestUser::whereHas('self_referencing')->count());
     }
 
     /**

--- a/tests/Database/DatabaseMigrationCreatorTest.php
+++ b/tests/Database/DatabaseMigrationCreatorTest.php
@@ -47,7 +47,7 @@ class DatabaseMigrationCreatorTest extends TestCase
         $creator->create('create_bar', 'foo', $table);
 
         $this->assertEquals($_SERVER['__migration.creator.table'], $table);
-        $this->assertEquals('foo/foo_create_bar.php', $_SERVER['__migration.creator.path']);
+        $this->assertSame('foo/foo_create_bar.php', $_SERVER['__migration.creator.path']);
 
         unset($_SERVER['__migration.creator.table'], $_SERVER['__migration.creator.path']);
     }

--- a/tests/Database/DatabaseMigrationRepositoryTest.php
+++ b/tests/Database/DatabaseMigrationRepositoryTest.php
@@ -81,7 +81,7 @@ class DatabaseMigrationRepositoryTest extends TestCase
         ])->getMock();
         $repo->expects($this->once())->method('getLastBatchNumber')->willReturn(1);
 
-        $this->assertEquals(2, $repo->getNextBatchNumber());
+        $this->assertSame(2, $repo->getNextBatchNumber());
     }
 
     public function testGetLastBatchNumberReturnsMaxBatch()
@@ -94,7 +94,7 @@ class DatabaseMigrationRepositoryTest extends TestCase
         $query->shouldReceive('max')->once()->andReturn(1);
         $query->shouldReceive('useWritePdo')->once()->andReturn($query);
 
-        $this->assertEquals(1, $repo->getLastBatchNumber());
+        $this->assertSame(1, $repo->getLastBatchNumber());
     }
 
     public function testCreateRepositoryCreatesProperDatabaseTable()

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -214,7 +214,7 @@ class DatabaseQueryBuilderTest extends TestCase
         };
 
         $default = function ($query, $condition) {
-            $this->assertEquals(0, $condition);
+            $this->assertSame(0, $condition);
 
             $query->where('id', '=', 2);
         };
@@ -267,7 +267,7 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testUnlessCallbackWithDefault()
     {
         $callback = function ($query, $condition) {
-            $this->assertEquals(0, $condition);
+            $this->assertSame(0, $condition);
 
             $query->where('id', '=', 1);
         };
@@ -2738,7 +2738,7 @@ class DatabaseQueryBuilderTest extends TestCase
         });
 
         $count = $builder->getCountForPagination();
-        $this->assertEquals(1, $count);
+        $this->assertSame(1, $count);
         $this->assertEquals([4], $builder->getBindings());
     }
 
@@ -2754,7 +2754,7 @@ class DatabaseQueryBuilderTest extends TestCase
         });
 
         $count = $builder->getCountForPagination($columns);
-        $this->assertEquals(1, $count);
+        $this->assertSame(1, $count);
     }
 
     public function testGetCountForPaginationWithUnion()
@@ -2768,7 +2768,7 @@ class DatabaseQueryBuilderTest extends TestCase
         });
 
         $count = $builder->getCountForPagination();
-        $this->assertEquals(1, $count);
+        $this->assertSame(1, $count);
     }
 
     public function testGetCountForPaginationWithUnionOrders()
@@ -2782,7 +2782,7 @@ class DatabaseQueryBuilderTest extends TestCase
         });
 
         $count = $builder->getCountForPagination();
-        $this->assertEquals(1, $count);
+        $this->assertSame(1, $count);
     }
 
     public function testGetCountForPaginationWithUnionLimitAndOffset()
@@ -2796,7 +2796,7 @@ class DatabaseQueryBuilderTest extends TestCase
         });
 
         $count = $builder->getCountForPagination();
-        $this->assertEquals(1, $count);
+        $this->assertSame(1, $count);
     }
 
     public function testWhereShortcut()
@@ -3921,7 +3921,7 @@ class DatabaseQueryBuilderTest extends TestCase
             return $results;
         });
         $results = $builder->from('users')->count();
-        $this->assertEquals(1, $results);
+        $this->assertSame(1, $results);
 
         $builder = $this->getBuilder();
         $builder->getConnection()->shouldReceive('select')->once()->with('select exists(select * from "users") as "exists"', [], true)->andReturn([['exists' => 1]]);
@@ -3939,7 +3939,7 @@ class DatabaseQueryBuilderTest extends TestCase
             return $results;
         });
         $results = $builder->from('users')->max('id');
-        $this->assertEquals(1, $results);
+        $this->assertSame(1, $results);
 
         $builder = $this->getBuilder();
         $builder->getConnection()->shouldReceive('select')->once()->with('select min("id") as aggregate from "users"', [], true, [])->andReturn([['aggregate' => 1]]);
@@ -3947,7 +3947,7 @@ class DatabaseQueryBuilderTest extends TestCase
             return $results;
         });
         $results = $builder->from('users')->min('id');
-        $this->assertEquals(1, $results);
+        $this->assertSame(1, $results);
 
         $builder = $this->getBuilder();
         $builder->getConnection()->shouldReceive('select')->once()->with('select sum("id") as aggregate from "users"', [], true, [])->andReturn([['aggregate' => 1]]);
@@ -3955,7 +3955,7 @@ class DatabaseQueryBuilderTest extends TestCase
             return $results;
         });
         $results = $builder->from('users')->sum('id');
-        $this->assertEquals(1, $results);
+        $this->assertSame(1, $results);
 
         $builder = $this->getBuilder();
         $builder->getConnection()->shouldReceive('select')->once()->with('select avg("id") as aggregate from "users"', [], true, [])->andReturn([['aggregate' => 1]]);
@@ -3963,7 +3963,7 @@ class DatabaseQueryBuilderTest extends TestCase
             return $results;
         });
         $results = $builder->from('users')->avg('id');
-        $this->assertEquals(1, $results);
+        $this->assertSame(1, $results);
 
         $builder = $this->getBuilder();
         $builder->getConnection()->shouldReceive('select')->once()->with('select avg("id") as aggregate from "users"', [], true, [])->andReturn([['aggregate' => 1]]);
@@ -3971,7 +3971,7 @@ class DatabaseQueryBuilderTest extends TestCase
             return $results;
         });
         $results = $builder->from('users')->average('id');
-        $this->assertEquals(1, $results);
+        $this->assertSame(1, $results);
     }
 
     public function testSqlServerExists()
@@ -4025,9 +4025,9 @@ class DatabaseQueryBuilderTest extends TestCase
         });
         $builder->from('users')->select('column1', 'column2');
         $count = $builder->count();
-        $this->assertEquals(1, $count);
+        $this->assertSame(1, $count);
         $sum = $builder->sum('id');
-        $this->assertEquals(2, $sum);
+        $this->assertSame(2, $sum);
         $result = $builder->get();
         $this->assertEquals([['column1' => 'foo', 'column2' => 'bar']], $result->all());
     }
@@ -4042,7 +4042,7 @@ class DatabaseQueryBuilderTest extends TestCase
         });
         $builder->from('users');
         $count = $builder->count('column1');
-        $this->assertEquals(1, $count);
+        $this->assertSame(1, $count);
         $result = $builder->select('column2', 'column3')->get();
         $this->assertEquals([['column2' => 'foo', 'column3' => 'bar']], $result->all());
     }
@@ -4057,7 +4057,7 @@ class DatabaseQueryBuilderTest extends TestCase
         });
         $builder->from('users');
         $count = $builder->count('column1');
-        $this->assertEquals(1, $count);
+        $this->assertSame(1, $count);
         $result = $builder->get(['column2', 'column3']);
         $this->assertEquals([['column2' => 'foo', 'column3' => 'bar']], $result->all());
     }
@@ -4073,7 +4073,7 @@ class DatabaseQueryBuilderTest extends TestCase
             $query->from('posts')->select('foo', 'bar')->where('title', 'foo');
         }, 'post');
         $count = $builder->count();
-        $this->assertEquals(1, $count);
+        $this->assertSame(1, $count);
         $this->assertSame('(select "foo", "bar" from "posts" where "title" = ?) as "post"', $builder->getGrammar()->getValue($builder->columns[0]));
         $this->assertEquals(['foo'], $builder->getBindings());
     }
@@ -4115,7 +4115,7 @@ class DatabaseQueryBuilderTest extends TestCase
             }
         );
 
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
     }
 
     public function testInsertUsingWithEmptyColumns()
@@ -4130,7 +4130,7 @@ class DatabaseQueryBuilderTest extends TestCase
             }
         );
 
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
     }
 
     public function testInsertUsingInvalidSubquery()
@@ -4153,7 +4153,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getMySqlBuilder();
         $builder->getConnection()->shouldReceive('affectingStatement')->once()->with('insert ignore into `users` (`email`) values (?)', ['foo'])->andReturn(1);
         $result = $builder->from('users')->insertOrIgnore(['email' => 'foo']);
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
     }
 
     public function testPostgresInsertOrIgnoreMethod()
@@ -4161,7 +4161,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getPostgresBuilder();
         $builder->getConnection()->shouldReceive('affectingStatement')->once()->with('insert into "users" ("email") values (?) on conflict do nothing', ['foo'])->andReturn(1);
         $result = $builder->from('users')->insertOrIgnore(['email' => 'foo']);
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
     }
 
     public function testSQLiteInsertOrIgnoreMethod()
@@ -4169,7 +4169,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getSQLiteBuilder();
         $builder->getConnection()->shouldReceive('affectingStatement')->once()->with('insert or ignore into "users" ("email") values (?)', ['foo'])->andReturn(1);
         $result = $builder->from('users')->insertOrIgnore(['email' => 'foo']);
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
     }
 
     public function testSqlServerInsertOrIgnoreMethod()
@@ -4388,7 +4388,7 @@ class DatabaseQueryBuilderTest extends TestCase
             }
         );
 
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
     }
 
     public function testMySqlInsertOrIgnoreUsingWithEmptyColumns()
@@ -4404,7 +4404,7 @@ class DatabaseQueryBuilderTest extends TestCase
             }
         );
 
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
     }
 
     public function testMySqlInsertOrIgnoreUsingInvalidSubquery()
@@ -4426,7 +4426,7 @@ class DatabaseQueryBuilderTest extends TestCase
             }
         );
 
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
     }
 
     public function testPostgresInsertOrIgnoreUsingWithEmptyColumns()
@@ -4441,7 +4441,7 @@ class DatabaseQueryBuilderTest extends TestCase
             }
         );
 
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
     }
 
     public function testPostgresInsertOrIgnoreUsingInvalidSubquery()
@@ -4464,7 +4464,7 @@ class DatabaseQueryBuilderTest extends TestCase
             }
         );
 
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
     }
 
     public function testSQLiteInsertOrIgnoreUsingWithEmptyColumns()
@@ -4480,7 +4480,7 @@ class DatabaseQueryBuilderTest extends TestCase
             }
         );
 
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
     }
 
     public function testSQLiteInsertOrIgnoreUsingInvalidSubquery()
@@ -4495,7 +4495,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->getProcessor()->shouldReceive('processInsertGetId')->once()->with($builder, 'insert into "users" ("email") values (?)', ['foo'], 'id')->andReturn(1);
         $result = $builder->from('users')->insertGetId(['email' => 'foo'], 'id');
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
     }
 
     public function testInsertGetIdMethodRemovesExpressions()
@@ -4503,7 +4503,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->getProcessor()->shouldReceive('processInsertGetId')->once()->with($builder, 'insert into "users" ("email", "bar") values (?, bar)', ['foo'], 'id')->andReturn(1);
         $result = $builder->from('users')->insertGetId(['email' => 'foo', 'bar' => new Raw('bar')], 'id');
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
     }
 
     public function testInsertGetIdWithEmptyValues()
@@ -4546,12 +4546,12 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->getConnection()->shouldReceive('update')->once()->with('update "users" set "email" = ?, "name" = ? where "id" = ?', ['foo', 'bar', 1])->andReturn(1);
         $result = $builder->from('users')->where('id', '=', 1)->update(['email' => 'foo', 'name' => 'bar']);
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
 
         $builder = $this->getMySqlBuilder();
         $builder->getConnection()->shouldReceive('update')->once()->with('update `users` set `email` = ?, `name` = ? where `id` = ? order by `foo` desc limit 5', ['foo', 'bar', 1])->andReturn(1);
         $result = $builder->from('users')->where('id', '=', 1)->orderBy('foo', 'desc')->limit(5)->update(['email' => 'foo', 'name' => 'bar']);
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
     }
 
     public function testUpsertMethod()
@@ -4561,29 +4561,29 @@ class DatabaseQueryBuilderTest extends TestCase
             ->shouldReceive('getConfig')->with('use_upsert_alias')->andReturn(false)
             ->shouldReceive('affectingStatement')->once()->with('insert into `users` (`email`, `name`) values (?, ?), (?, ?) on duplicate key update `email` = values(`email`), `name` = values(`name`)', ['foo', 'bar', 'foo2', 'bar2'])->andReturn(2);
         $result = $builder->from('users')->upsert([['email' => 'foo', 'name' => 'bar'], ['name' => 'bar2', 'email' => 'foo2']], 'email');
-        $this->assertEquals(2, $result);
+        $this->assertSame(2, $result);
 
         $builder = $this->getMySqlBuilder();
         $builder->getConnection()
             ->shouldReceive('getConfig')->with('use_upsert_alias')->andReturn(true)
             ->shouldReceive('affectingStatement')->once()->with('insert into `users` (`email`, `name`) values (?, ?), (?, ?) as laravel_upsert_alias on duplicate key update `email` = `laravel_upsert_alias`.`email`, `name` = `laravel_upsert_alias`.`name`', ['foo', 'bar', 'foo2', 'bar2'])->andReturn(2);
         $result = $builder->from('users')->upsert([['email' => 'foo', 'name' => 'bar'], ['name' => 'bar2', 'email' => 'foo2']], 'email');
-        $this->assertEquals(2, $result);
+        $this->assertSame(2, $result);
 
         $builder = $this->getPostgresBuilder();
         $builder->getConnection()->shouldReceive('affectingStatement')->once()->with('insert into "users" ("email", "name") values (?, ?), (?, ?) on conflict ("email") do update set "email" = "excluded"."email", "name" = "excluded"."name"', ['foo', 'bar', 'foo2', 'bar2'])->andReturn(2);
         $result = $builder->from('users')->upsert([['email' => 'foo', 'name' => 'bar'], ['name' => 'bar2', 'email' => 'foo2']], 'email');
-        $this->assertEquals(2, $result);
+        $this->assertSame(2, $result);
 
         $builder = $this->getSQLiteBuilder();
         $builder->getConnection()->shouldReceive('affectingStatement')->once()->with('insert into "users" ("email", "name") values (?, ?), (?, ?) on conflict ("email") do update set "email" = "excluded"."email", "name" = "excluded"."name"', ['foo', 'bar', 'foo2', 'bar2'])->andReturn(2);
         $result = $builder->from('users')->upsert([['email' => 'foo', 'name' => 'bar'], ['name' => 'bar2', 'email' => 'foo2']], 'email');
-        $this->assertEquals(2, $result);
+        $this->assertSame(2, $result);
 
         $builder = $this->getSqlServerBuilder();
         $builder->getConnection()->shouldReceive('affectingStatement')->once()->with('merge [users] using (values (?, ?), (?, ?)) [laravel_source] ([email], [name]) on [laravel_source].[email] = [users].[email] when matched then update set [email] = [laravel_source].[email], [name] = [laravel_source].[name] when not matched then insert ([email], [name]) values ([email], [name]);', ['foo', 'bar', 'foo2', 'bar2'])->andReturn(2);
         $result = $builder->from('users')->upsert([['email' => 'foo', 'name' => 'bar'], ['name' => 'bar2', 'email' => 'foo2']], 'email');
-        $this->assertEquals(2, $result);
+        $this->assertSame(2, $result);
     }
 
     public function testUpsertMethodWithUpdateColumns()
@@ -4593,29 +4593,29 @@ class DatabaseQueryBuilderTest extends TestCase
             ->shouldReceive('getConfig')->with('use_upsert_alias')->andReturn(false)
             ->shouldReceive('affectingStatement')->once()->with('insert into `users` (`email`, `name`) values (?, ?), (?, ?) on duplicate key update `name` = values(`name`)', ['foo', 'bar', 'foo2', 'bar2'])->andReturn(2);
         $result = $builder->from('users')->upsert([['email' => 'foo', 'name' => 'bar'], ['name' => 'bar2', 'email' => 'foo2']], 'email', ['name']);
-        $this->assertEquals(2, $result);
+        $this->assertSame(2, $result);
 
         $builder = $this->getMySqlBuilder();
         $builder->getConnection()
             ->shouldReceive('getConfig')->with('use_upsert_alias')->andReturn(true)
             ->shouldReceive('affectingStatement')->once()->with('insert into `users` (`email`, `name`) values (?, ?), (?, ?) as laravel_upsert_alias on duplicate key update `name` = `laravel_upsert_alias`.`name`', ['foo', 'bar', 'foo2', 'bar2'])->andReturn(2);
         $result = $builder->from('users')->upsert([['email' => 'foo', 'name' => 'bar'], ['name' => 'bar2', 'email' => 'foo2']], 'email', ['name']);
-        $this->assertEquals(2, $result);
+        $this->assertSame(2, $result);
 
         $builder = $this->getPostgresBuilder();
         $builder->getConnection()->shouldReceive('affectingStatement')->once()->with('insert into "users" ("email", "name") values (?, ?), (?, ?) on conflict ("email") do update set "name" = "excluded"."name"', ['foo', 'bar', 'foo2', 'bar2'])->andReturn(2);
         $result = $builder->from('users')->upsert([['email' => 'foo', 'name' => 'bar'], ['name' => 'bar2', 'email' => 'foo2']], 'email', ['name']);
-        $this->assertEquals(2, $result);
+        $this->assertSame(2, $result);
 
         $builder = $this->getSQLiteBuilder();
         $builder->getConnection()->shouldReceive('affectingStatement')->once()->with('insert into "users" ("email", "name") values (?, ?), (?, ?) on conflict ("email") do update set "name" = "excluded"."name"', ['foo', 'bar', 'foo2', 'bar2'])->andReturn(2);
         $result = $builder->from('users')->upsert([['email' => 'foo', 'name' => 'bar'], ['name' => 'bar2', 'email' => 'foo2']], 'email', ['name']);
-        $this->assertEquals(2, $result);
+        $this->assertSame(2, $result);
 
         $builder = $this->getSqlServerBuilder();
         $builder->getConnection()->shouldReceive('affectingStatement')->once()->with('merge [users] using (values (?, ?), (?, ?)) [laravel_source] ([email], [name]) on [laravel_source].[email] = [users].[email] when matched then update set [name] = [laravel_source].[name] when not matched then insert ([email], [name]) values ([email], [name]);', ['foo', 'bar', 'foo2', 'bar2'])->andReturn(2);
         $result = $builder->from('users')->upsert([['email' => 'foo', 'name' => 'bar'], ['name' => 'bar2', 'email' => 'foo2']], 'email', ['name']);
-        $this->assertEquals(2, $result);
+        $this->assertSame(2, $result);
     }
 
     public function testUpsertMethodWithEmptyUniqueByArray()
@@ -4639,7 +4639,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->getConnection()->shouldReceive('update')->once()->with('update "users" inner join "orders" on "users"."id" = "orders"."user_id" set "email" = ?, "name" = ? where "users"."id" = ?', ['foo', 'bar', 1])->andReturn(1);
         $result = $builder->from('users')->join('orders', 'users.id', '=', 'orders.user_id')->where('users.id', '=', 1)->update(['email' => 'foo', 'name' => 'bar']);
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
 
         $builder = $this->getBuilder();
         $builder->getConnection()->shouldReceive('update')->once()->with('update "users" inner join "orders" on "users"."id" = "orders"."user_id" and "users"."id" = ? set "email" = ?, "name" = ?', [1, 'foo', 'bar'])->andReturn(1);
@@ -4647,7 +4647,7 @@ class DatabaseQueryBuilderTest extends TestCase
             $join->on('users.id', '=', 'orders.user_id')
                 ->where('users.id', '=', 1);
         })->update(['email' => 'foo', 'name' => 'bar']);
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
     }
 
     public function testUpdateMethodWithJoinsOnSqlServer()
@@ -4655,7 +4655,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getSqlServerBuilder();
         $builder->getConnection()->shouldReceive('update')->once()->with('update [users] set [email] = ?, [name] = ? from [users] inner join [orders] on [users].[id] = [orders].[user_id] where [users].[id] = ?', ['foo', 'bar', 1])->andReturn(1);
         $result = $builder->from('users')->join('orders', 'users.id', '=', 'orders.user_id')->where('users.id', '=', 1)->update(['email' => 'foo', 'name' => 'bar']);
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
 
         $builder = $this->getSqlServerBuilder();
         $builder->getConnection()->shouldReceive('update')->once()->with('update [users] set [email] = ?, [name] = ? from [users] inner join [orders] on [users].[id] = [orders].[user_id] and [users].[id] = ?', ['foo', 'bar', 1])->andReturn(1);
@@ -4663,7 +4663,7 @@ class DatabaseQueryBuilderTest extends TestCase
             $join->on('users.id', '=', 'orders.user_id')
                 ->where('users.id', '=', 1);
         })->update(['email' => 'foo', 'name' => 'bar']);
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
     }
 
     public function testUpdateMethodWithJoinsOnMySql()
@@ -4671,7 +4671,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getMySqlBuilder();
         $builder->getConnection()->shouldReceive('update')->once()->with('update `users` inner join `orders` on `users`.`id` = `orders`.`user_id` set `email` = ?, `name` = ? where `users`.`id` = ?', ['foo', 'bar', 1])->andReturn(1);
         $result = $builder->from('users')->join('orders', 'users.id', '=', 'orders.user_id')->where('users.id', '=', 1)->update(['email' => 'foo', 'name' => 'bar']);
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
 
         $builder = $this->getMySqlBuilder();
         $builder->getConnection()->shouldReceive('update')->once()->with('update `users` inner join `orders` on `users`.`id` = `orders`.`user_id` and `users`.`id` = ? set `email` = ?, `name` = ?', [1, 'foo', 'bar'])->andReturn(1);
@@ -4679,7 +4679,7 @@ class DatabaseQueryBuilderTest extends TestCase
             $join->on('users.id', '=', 'orders.user_id')
                 ->where('users.id', '=', 1);
         })->update(['email' => 'foo', 'name' => 'bar']);
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
     }
 
     public function testUpdateMethodWithJoinsOnSQLite()
@@ -4687,12 +4687,12 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getSQLiteBuilder();
         $builder->getConnection()->shouldReceive('update')->once()->with('update "users" set "email" = ?, "name" = ? where "rowid" in (select "users"."rowid" from "users" where "users"."id" > ? order by "id" asc limit 3)', ['foo', 'bar', 1])->andReturn(1);
         $result = $builder->from('users')->where('users.id', '>', 1)->limit(3)->oldest('id')->update(['email' => 'foo', 'name' => 'bar']);
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
 
         $builder = $this->getSQLiteBuilder();
         $builder->getConnection()->shouldReceive('update')->once()->with('update "users" set "email" = ?, "name" = ? where "rowid" in (select "users"."rowid" from "users" inner join "orders" on "users"."id" = "orders"."user_id" where "users"."id" = ?)', ['foo', 'bar', 1])->andReturn(1);
         $result = $builder->from('users')->join('orders', 'users.id', '=', 'orders.user_id')->where('users.id', '=', 1)->update(['email' => 'foo', 'name' => 'bar']);
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
 
         $builder = $this->getSQLiteBuilder();
         $builder->getConnection()->shouldReceive('update')->once()->with('update "users" set "email" = ?, "name" = ? where "rowid" in (select "users"."rowid" from "users" inner join "orders" on "users"."id" = "orders"."user_id" and "users"."id" = ?)', ['foo', 'bar', 1])->andReturn(1);
@@ -4700,12 +4700,12 @@ class DatabaseQueryBuilderTest extends TestCase
             $join->on('users.id', '=', 'orders.user_id')
                 ->where('users.id', '=', 1);
         })->update(['email' => 'foo', 'name' => 'bar']);
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
 
         $builder = $this->getSQLiteBuilder();
         $builder->getConnection()->shouldReceive('update')->once()->with('update "users" as "u" set "email" = ?, "name" = ? where "rowid" in (select "u"."rowid" from "users" as "u" inner join "orders" as "o" on "u"."id" = "o"."user_id")', ['foo', 'bar'])->andReturn(1);
         $result = $builder->from('users as u')->join('orders as o', 'u.id', '=', 'o.user_id')->update(['email' => 'foo', 'name' => 'bar']);
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
     }
 
     public function testUpdateMethodWithJoinsAndAliasesOnSqlServer()
@@ -4713,7 +4713,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getSqlServerBuilder();
         $builder->getConnection()->shouldReceive('update')->once()->with('update [u] set [email] = ?, [name] = ? from [users] as [u] inner join [orders] on [u].[id] = [orders].[user_id] where [u].[id] = ?', ['foo', 'bar', 1])->andReturn(1);
         $result = $builder->from('users as u')->join('orders', 'u.id', '=', 'orders.user_id')->where('u.id', '=', 1)->update(['email' => 'foo', 'name' => 'bar']);
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
     }
 
     public function testUpdateMethodWithoutJoinsOnPostgres()
@@ -4721,17 +4721,17 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getPostgresBuilder();
         $builder->getConnection()->shouldReceive('update')->once()->with('update "users" set "email" = ?, "name" = ? where "id" = ?', ['foo', 'bar', 1])->andReturn(1);
         $result = $builder->from('users')->where('id', '=', 1)->update(['users.email' => 'foo', 'name' => 'bar']);
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
 
         $builder = $this->getPostgresBuilder();
         $builder->getConnection()->shouldReceive('update')->once()->with('update "users" set "email" = ?, "name" = ? where "id" = ?', ['foo', 'bar', 1])->andReturn(1);
         $result = $builder->from('users')->where('id', '=', 1)->selectRaw('?', ['ignore'])->update(['users.email' => 'foo', 'name' => 'bar']);
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
 
         $builder = $this->getPostgresBuilder();
         $builder->getConnection()->shouldReceive('update')->once()->with('update "users"."users" set "email" = ?, "name" = ? where "id" = ?', ['foo', 'bar', 1])->andReturn(1);
         $result = $builder->from('users.users')->where('id', '=', 1)->selectRaw('?', ['ignore'])->update(['users.users.email' => 'foo', 'name' => 'bar']);
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
     }
 
     public function testUpdateMethodWithJoinsOnPostgres()
@@ -4739,7 +4739,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getPostgresBuilder();
         $builder->getConnection()->shouldReceive('update')->once()->with('update "users" set "email" = ?, "name" = ? where "ctid" in (select "users"."ctid" from "users" inner join "orders" on "users"."id" = "orders"."user_id" where "users"."id" = ?)', ['foo', 'bar', 1])->andReturn(1);
         $result = $builder->from('users')->join('orders', 'users.id', '=', 'orders.user_id')->where('users.id', '=', 1)->update(['email' => 'foo', 'name' => 'bar']);
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
 
         $builder = $this->getPostgresBuilder();
         $builder->getConnection()->shouldReceive('update')->once()->with('update "users" set "email" = ?, "name" = ? where "ctid" in (select "users"."ctid" from "users" inner join "orders" on "users"."id" = "orders"."user_id" and "users"."id" = ?)', ['foo', 'bar', 1])->andReturn(1);
@@ -4747,7 +4747,7 @@ class DatabaseQueryBuilderTest extends TestCase
             $join->on('users.id', '=', 'orders.user_id')
                 ->where('users.id', '=', 1);
         })->update(['email' => 'foo', 'name' => 'bar']);
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
 
         $builder = $this->getPostgresBuilder();
         $builder->getConnection()->shouldReceive('update')->once()->with('update "users" set "email" = ?, "name" = ? where "ctid" in (select "users"."ctid" from "users" inner join "orders" on "users"."id" = "orders"."user_id" and "users"."id" = ? where "name" = ?)', ['foo', 'bar', 1, 'baz'])->andReturn(1);
@@ -4757,7 +4757,7 @@ class DatabaseQueryBuilderTest extends TestCase
                     ->where('users.id', '=', 1);
             })->where('name', 'baz')
             ->update(['email' => 'foo', 'name' => 'bar']);
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
     }
 
     public function testUpdateFromMethodWithJoinsOnPostgres()
@@ -4765,7 +4765,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getPostgresBuilder();
         $builder->getConnection()->shouldReceive('update')->once()->with('update "users" set "email" = ?, "name" = ? from "orders" where "users"."id" = ? and "users"."id" = "orders"."user_id"', ['foo', 'bar', 1])->andReturn(1);
         $result = $builder->from('users')->join('orders', 'users.id', '=', 'orders.user_id')->where('users.id', '=', 1)->updateFrom(['email' => 'foo', 'name' => 'bar']);
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
 
         $builder = $this->getPostgresBuilder();
         $builder->getConnection()->shouldReceive('update')->once()->with('update "users" set "email" = ?, "name" = ? from "orders" where "users"."id" = "orders"."user_id" and "users"."id" = ?', ['foo', 'bar', 1])->andReturn(1);
@@ -4773,7 +4773,7 @@ class DatabaseQueryBuilderTest extends TestCase
             $join->on('users.id', '=', 'orders.user_id')
                 ->where('users.id', '=', 1);
         })->updateFrom(['email' => 'foo', 'name' => 'bar']);
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
 
         $builder = $this->getPostgresBuilder();
         $builder->getConnection()->shouldReceive('update')->once()->with('update "users" set "email" = ?, "name" = ? from "orders" where "name" = ? and "users"."id" = "orders"."user_id" and "users"."id" = ?', ['foo', 'bar', 'baz', 1])->andReturn(1);
@@ -4783,7 +4783,7 @@ class DatabaseQueryBuilderTest extends TestCase
                     ->where('users.id', '=', 1);
             })->where('name', 'baz')
             ->updateFrom(['email' => 'foo', 'name' => 'bar']);
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
     }
 
     public function testUpdateMethodRespectsRaw()
@@ -4791,7 +4791,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->getConnection()->shouldReceive('update')->once()->with('update "users" set "email" = foo, "name" = ? where "id" = ?', ['bar', 1])->andReturn(1);
         $result = $builder->from('users')->where('id', '=', 1)->update(['email' => new Raw('foo'), 'name' => 'bar']);
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
     }
 
     public function testUpdateMethodWorksWithQueryAsValue()
@@ -4800,13 +4800,13 @@ class DatabaseQueryBuilderTest extends TestCase
         $subQueryBuilder = $this->getBuilder();
         $builder->getConnection()->shouldReceive('update')->once()->with('update "users" set "credits" = (select sum(credits) from "transactions" where "transactions"."user_id" = "users"."id" and "type" = ?) where "id" = ?', ['foo', 1])->andReturn(1);
         $result = $builder->from('users')->where('id', '=', 1)->update(['credits' => $subQueryBuilder->from('transactions')->selectRaw('sum(credits)')->whereColumn('transactions.user_id', 'users.id')->where('type', 'foo')]);
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
 
         $builder = $this->getBuilder();
         $subQueryBuilder = new EloquentBuilder($this->getBuilder());
         $builder->getConnection()->shouldReceive('update')->once()->with('update "users" set "credits" = (select sum(credits) from "transactions" where "transactions"."user_id" = "users"."id" and "type" = ?) where "id" = ?', ['foo', 1])->andReturn(1);
         $result = $builder->from('users')->where('id', '=', 1)->update(['credits' => $subQueryBuilder->from('transactions')->selectRaw('sum(credits)')->whereColumn('transactions.user_id', 'users.id')->where('type', 'foo')]);
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
     }
 
     public function testUpdateOrInsertMethod()
@@ -4857,37 +4857,37 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->getConnection()->shouldReceive('delete')->once()->with('delete from "users" where "email" = ?', ['foo'])->andReturn(1);
         $result = $builder->from('users')->where('email', '=', 'foo')->delete();
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
 
         $builder = $this->getBuilder();
         $builder->getConnection()->shouldReceive('delete')->once()->with('delete from "users" where "users"."id" = ?', [1])->andReturn(1);
         $result = $builder->from('users')->delete(1);
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
 
         $builder = $this->getBuilder();
         $builder->getConnection()->shouldReceive('delete')->once()->with('delete from "users" where "users"."id" = ?', [1])->andReturn(1);
         $result = $builder->from('users')->selectRaw('?', ['ignore'])->delete(1);
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
 
         $builder = $this->getSqliteBuilder();
         $builder->getConnection()->shouldReceive('delete')->once()->with('delete from "users" where "rowid" in (select "users"."rowid" from "users" where "email" = ? order by "id" asc limit 1)', ['foo'])->andReturn(1);
         $result = $builder->from('users')->where('email', '=', 'foo')->orderBy('id')->limit(1)->delete();
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
 
         $builder = $this->getMySqlBuilder();
         $builder->getConnection()->shouldReceive('delete')->once()->with('delete from `users` where `email` = ? order by `id` asc limit 1', ['foo'])->andReturn(1);
         $result = $builder->from('users')->where('email', '=', 'foo')->orderBy('id')->limit(1)->delete();
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
 
         $builder = $this->getSqlServerBuilder();
         $builder->getConnection()->shouldReceive('delete')->once()->with('delete from [users] where [email] = ?', ['foo'])->andReturn(1);
         $result = $builder->from('users')->where('email', '=', 'foo')->delete();
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
 
         $builder = $this->getSqlServerBuilder();
         $builder->getConnection()->shouldReceive('delete')->once()->with('delete top (1) from [users] where [email] = ?', ['foo'])->andReturn(1);
         $result = $builder->from('users')->where('email', '=', 'foo')->orderBy('id')->limit(1)->delete();
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
     }
 
     public function testDeleteWithJoinMethod()
@@ -4895,57 +4895,57 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getSqliteBuilder();
         $builder->getConnection()->shouldReceive('delete')->once()->with('delete from "users" where "rowid" in (select "users"."rowid" from "users" inner join "contacts" on "users"."id" = "contacts"."id" where "users"."email" = ? order by "users"."id" asc limit 1)', ['foo'])->andReturn(1);
         $result = $builder->from('users')->join('contacts', 'users.id', '=', 'contacts.id')->where('users.email', '=', 'foo')->orderBy('users.id')->limit(1)->delete();
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
 
         $builder = $this->getSqliteBuilder();
         $builder->getConnection()->shouldReceive('delete')->once()->with('delete from "users" as "u" where "rowid" in (select "u"."rowid" from "users" as "u" inner join "contacts" as "c" on "u"."id" = "c"."id")', [])->andReturn(1);
         $result = $builder->from('users as u')->join('contacts as c', 'u.id', '=', 'c.id')->delete();
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
 
         $builder = $this->getMySqlBuilder();
         $builder->getConnection()->shouldReceive('delete')->once()->with('delete `users` from `users` inner join `contacts` on `users`.`id` = `contacts`.`id` where `email` = ?', ['foo'])->andReturn(1);
         $result = $builder->from('users')->join('contacts', 'users.id', '=', 'contacts.id')->where('email', '=', 'foo')->delete();
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
 
         $builder = $this->getMySqlBuilder();
         $builder->getConnection()->shouldReceive('delete')->once()->with('delete `a` from `users` as `a` inner join `users` as `b` on `a`.`id` = `b`.`user_id` where `email` = ?', ['foo'])->andReturn(1);
         $result = $builder->from('users AS a')->join('users AS b', 'a.id', '=', 'b.user_id')->where('email', '=', 'foo')->delete();
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
 
         $builder = $this->getMySqlBuilder();
         $builder->getConnection()->shouldReceive('delete')->once()->with('delete `users` from `users` inner join `contacts` on `users`.`id` = `contacts`.`id` where `users`.`id` = ?', [1])->andReturn(1);
         $result = $builder->from('users')->join('contacts', 'users.id', '=', 'contacts.id')->delete(1);
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
 
         $builder = $this->getSqlServerBuilder();
         $builder->getConnection()->shouldReceive('delete')->once()->with('delete [users] from [users] inner join [contacts] on [users].[id] = [contacts].[id] where [email] = ?', ['foo'])->andReturn(1);
         $result = $builder->from('users')->join('contacts', 'users.id', '=', 'contacts.id')->where('email', '=', 'foo')->delete();
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
 
         $builder = $this->getSqlServerBuilder();
         $builder->getConnection()->shouldReceive('delete')->once()->with('delete [a] from [users] as [a] inner join [users] as [b] on [a].[id] = [b].[user_id] where [email] = ?', ['foo'])->andReturn(1);
         $result = $builder->from('users AS a')->join('users AS b', 'a.id', '=', 'b.user_id')->where('email', '=', 'foo')->orderBy('id')->limit(1)->delete();
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
 
         $builder = $this->getSqlServerBuilder();
         $builder->getConnection()->shouldReceive('delete')->once()->with('delete [users] from [users] inner join [contacts] on [users].[id] = [contacts].[id] where [users].[id] = ?', [1])->andReturn(1);
         $result = $builder->from('users')->join('contacts', 'users.id', '=', 'contacts.id')->delete(1);
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
 
         $builder = $this->getPostgresBuilder();
         $builder->getConnection()->shouldReceive('delete')->once()->with('delete from "users" where "ctid" in (select "users"."ctid" from "users" inner join "contacts" on "users"."id" = "contacts"."id" where "users"."email" = ?)', ['foo'])->andReturn(1);
         $result = $builder->from('users')->join('contacts', 'users.id', '=', 'contacts.id')->where('users.email', '=', 'foo')->delete();
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
 
         $builder = $this->getPostgresBuilder();
         $builder->getConnection()->shouldReceive('delete')->once()->with('delete from "users" as "a" where "ctid" in (select "a"."ctid" from "users" as "a" inner join "users" as "b" on "a"."id" = "b"."user_id" where "email" = ? order by "id" asc limit 1)', ['foo'])->andReturn(1);
         $result = $builder->from('users AS a')->join('users AS b', 'a.id', '=', 'b.user_id')->where('email', '=', 'foo')->orderBy('id')->limit(1)->delete();
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
 
         $builder = $this->getPostgresBuilder();
         $builder->getConnection()->shouldReceive('delete')->once()->with('delete from "users" where "ctid" in (select "users"."ctid" from "users" inner join "contacts" on "users"."id" = "contacts"."id" where "users"."id" = ? order by "id" asc limit 1)', [1])->andReturn(1);
         $result = $builder->from('users')->join('contacts', 'users.id', '=', 'contacts.id')->orderBy('id')->limit(1)->delete(1);
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
 
         $builder = $this->getPostgresBuilder();
         $builder->getConnection()->shouldReceive('delete')->once()->with('delete from "users" where "ctid" in (select "users"."ctid" from "users" inner join "contacts" on "users"."id" = "contacts"."user_id" and "users"."id" = ? where "name" = ?)', [1, 'baz'])->andReturn(1);
@@ -4955,12 +4955,12 @@ class DatabaseQueryBuilderTest extends TestCase
                     ->where('users.id', '=', 1);
             })->where('name', 'baz')
             ->delete();
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
 
         $builder = $this->getPostgresBuilder();
         $builder->getConnection()->shouldReceive('delete')->once()->with('delete from "users" where "ctid" in (select "users"."ctid" from "users" inner join "contacts" on "users"."id" = "contacts"."id")', [])->andReturn(1);
         $result = $builder->from('users')->join('contacts', 'users.id', '=', 'contacts.id')->delete();
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
     }
 
     public function testTruncateMethod()
@@ -5137,7 +5137,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getPostgresBuilder();
         $builder->getProcessor()->shouldReceive('processInsertGetId')->once()->with($builder, 'insert into "users" ("email") values (?) returning "id"', ['foo'], 'id')->andReturn(1);
         $result = $builder->from('users')->insertGetId(['email' => 'foo'], 'id');
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
     }
 
     public function testMySqlWrapping()
@@ -6277,7 +6277,7 @@ SQL;
 
         $result = $builder->paginate($perPage, $columns, $pageName, $page, 10);
 
-        $this->assertEquals(10, $result->total());
+        $this->assertSame(10, $result->total());
     }
 
     public function testCursorPaginate()

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -418,15 +418,15 @@ class DatabaseQueryBuilderTest extends TestCase
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereDay('created_at', new Raw('NOW()'));
-        $this->assertEquals([], $builder->getBindings());
+        $this->assertSame([], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereMonth('created_at', new Raw('NOW()'));
-        $this->assertEquals([], $builder->getBindings());
+        $this->assertSame([], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereYear('created_at', new Raw('NOW()'));
-        $this->assertEquals([], $builder->getBindings());
+        $this->assertSame([], $builder->getBindings());
     }
 
     public function testWhereDateMySql()
@@ -571,7 +571,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('users')->whereTime('created_at', new Raw('NOW()'));
         $this->assertSame('select * from [users] where cast([created_at] as time) = NOW()', $builder->toSql());
-        $this->assertEquals([], $builder->getBindings());
+        $this->assertSame([], $builder->getBindings());
     }
 
     public function testOrWhereTimeMySql()
@@ -1135,7 +1135,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereBetween('id', [new Raw(1), new Raw(2)]);
         $this->assertSame('select * from "users" where "id" between 1 and 2', $builder->toSql());
-        $this->assertEquals([], $builder->getBindings());
+        $this->assertSame([], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $period = Carbon::now()->startOfDay()->toPeriod(Carbon::now()->addDay()->startOfDay());
@@ -1248,17 +1248,17 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereBetweenColumns('id', ['users.created_at', 'users.updated_at']);
         $this->assertSame('select * from "users" where "id" between "users"."created_at" and "users"."updated_at"', $builder->toSql());
-        $this->assertEquals([], $builder->getBindings());
+        $this->assertSame([], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereNotBetweenColumns('id', ['created_at', 'updated_at']);
         $this->assertSame('select * from "users" where "id" not between "created_at" and "updated_at"', $builder->toSql());
-        $this->assertEquals([], $builder->getBindings());
+        $this->assertSame([], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereBetweenColumns('id', [new Raw(1), new Raw(2)]);
         $this->assertSame('select * from "users" where "id" between 1 and 2', $builder->toSql());
-        $this->assertEquals([], $builder->getBindings());
+        $this->assertSame([], $builder->getBindings());
 
         $subqueryBuilder = $this->getBuilder();
         $subqueryBuilder->select('created_at')->from('posts')->where('status', 'published')->orderByDesc('created_at')->limit(1);
@@ -1501,7 +1501,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereIn('id', []);
         $this->assertSame('select * from "users" where 0 = 1', $builder->toSql());
-        $this->assertEquals([], $builder->getBindings());
+        $this->assertSame([], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1)->orWhereIn('id', []);
@@ -1514,7 +1514,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereNotIn('id', []);
         $this->assertSame('select * from "users" where 1 = 1', $builder->toSql());
-        $this->assertEquals([], $builder->getBindings());
+        $this->assertSame([], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1)->orWhereNotIn('id', []);
@@ -1529,7 +1529,7 @@ class DatabaseQueryBuilderTest extends TestCase
             '1a', 2, Bar::FOO,
         ]);
         $this->assertSame('select * from "users" where "id" in (1, 2, 5)', $builder->toSql());
-        $this->assertEquals([], $builder->getBindings());
+        $this->assertSame([], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereIntegerInRaw('id', [
@@ -1539,7 +1539,7 @@ class DatabaseQueryBuilderTest extends TestCase
             ['id' => Bar::FOO],
         ]);
         $this->assertSame('select * from "users" where "id" in (1, 2, 3, 5)', $builder->toSql());
-        $this->assertEquals([], $builder->getBindings());
+        $this->assertSame([], $builder->getBindings());
     }
 
     public function testOrWhereIntegerInRaw()
@@ -1555,7 +1555,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereIntegerNotInRaw('id', ['1a', 2]);
         $this->assertSame('select * from "users" where "id" not in (1, 2)', $builder->toSql());
-        $this->assertEquals([], $builder->getBindings());
+        $this->assertSame([], $builder->getBindings());
     }
 
     public function testOrWhereIntegerNotInRaw()
@@ -1571,7 +1571,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereIntegerInRaw('id', []);
         $this->assertSame('select * from "users" where 0 = 1', $builder->toSql());
-        $this->assertEquals([], $builder->getBindings());
+        $this->assertSame([], $builder->getBindings());
     }
 
     public function testEmptyWhereIntegerNotInRaw()
@@ -1579,7 +1579,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereIntegerNotInRaw('id', []);
         $this->assertSame('select * from "users" where 1 = 1', $builder->toSql());
-        $this->assertEquals([], $builder->getBindings());
+        $this->assertSame([], $builder->getBindings());
     }
 
     public function testBasicWhereColumn()
@@ -1587,12 +1587,12 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereColumn('first_name', 'last_name')->orWhereColumn('first_name', 'middle_name');
         $this->assertSame('select * from "users" where "first_name" = "last_name" or "first_name" = "middle_name"', $builder->toSql());
-        $this->assertEquals([], $builder->getBindings());
+        $this->assertSame([], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereColumn('updated_at', '>', 'created_at');
         $this->assertSame('select * from "users" where "updated_at" > "created_at"', $builder->toSql());
-        $this->assertEquals([], $builder->getBindings());
+        $this->assertSame([], $builder->getBindings());
     }
 
     public function testArrayWhereColumn()
@@ -1605,7 +1605,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereColumn($conditions);
         $this->assertSame('select * from "users" where ("first_name" = "last_name" and "updated_at" > "created_at")', $builder->toSql());
-        $this->assertEquals([], $builder->getBindings());
+        $this->assertSame([], $builder->getBindings());
     }
 
     public function testWhereFulltextMySql()
@@ -2072,7 +2072,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereNull('id');
         $this->assertSame('select * from "users" where "id" is null', $builder->toSql());
-        $this->assertEquals([], $builder->getBindings());
+        $this->assertSame([], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1)->orWhereNull('id');
@@ -2085,7 +2085,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getMysqlBuilder();
         $builder->select('*')->from('users')->whereNull(new Raw('id'));
         $this->assertSame('select * from `users` where id is null', $builder->toSql());
-        $this->assertEquals([], $builder->getBindings());
+        $this->assertSame([], $builder->getBindings());
 
         $builder = $this->getMysqlBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1)->orWhereNull(new Raw('id'));
@@ -2126,7 +2126,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereNull(['id', 'expires_at']);
         $this->assertSame('select * from "users" where "id" is null and "expires_at" is null', $builder->toSql());
-        $this->assertEquals([], $builder->getBindings());
+        $this->assertSame([], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1)->orWhereNull(['id', 'expires_at']);
@@ -2139,7 +2139,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereNotNull('id');
         $this->assertSame('select * from "users" where "id" is not null', $builder->toSql());
-        $this->assertEquals([], $builder->getBindings());
+        $this->assertSame([], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('id', '>', 1)->orWhereNotNull('id');
@@ -2152,7 +2152,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereNotNull(['id', 'expires_at']);
         $this->assertSame('select * from "users" where "id" is not null and "expires_at" is not null', $builder->toSql());
-        $this->assertEquals([], $builder->getBindings());
+        $this->assertSame([], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('id', '>', 1)->orWhereNotNull(['id', 'expires_at']);
@@ -2413,7 +2413,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('users')->orderByRaw('?', [true]);
         $this->assertEquals([true], $builder->getBindings());
         $builder->reorder();
-        $this->assertEquals([], $builder->getBindings());
+        $this->assertSame([], $builder->getBindings());
     }
 
     public function testOrderBySubQueries()
@@ -2943,49 +2943,49 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereColumn([['foo', '_foo'], ['bar', '_bar']]);
         $this->assertSame('select * from "users" where ("foo" = "_foo" and "bar" = "_bar")', $builder->toSql());
-        $this->assertEquals([], $builder->getBindings());
+        $this->assertSame([], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereColumn([['foo', '_foo'], ['bar', '_bar']], boolean: 'or');
         $this->assertSame('select * from "users" where ("foo" = "_foo" or "bar" = "_bar")', $builder->toSql());
-        $this->assertEquals([], $builder->getBindings());
+        $this->assertSame([], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereColumn([['foo', '_foo'], ['bar', '_bar']], boolean: 'and');
         $this->assertSame('select * from "users" where ("foo" = "_foo" and "bar" = "_bar")', $builder->toSql());
-        $this->assertEquals([], $builder->getBindings());
+        $this->assertSame([], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereColumn(['foo' => '_foo', 'bar' => '_bar']);
         $this->assertSame('select * from "users" where ("foo" = "_foo" and "bar" = "_bar")', $builder->toSql());
-        $this->assertEquals([], $builder->getBindings());
+        $this->assertSame([], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereColumn(['foo' => '_foo', 'bar' => '_bar'], boolean: 'or');
         $this->assertSame('select * from "users" where ("foo" = "_foo" or "bar" = "_bar")', $builder->toSql());
-        $this->assertEquals([], $builder->getBindings());
+        $this->assertSame([], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereColumn(['foo' => '_foo', 'bar' => '_bar'], boolean: 'and');
         $this->assertSame('select * from "users" where ("foo" = "_foo" and "bar" = "_bar")', $builder->toSql());
-        $this->assertEquals([], $builder->getBindings());
+        $this->assertSame([], $builder->getBindings());
 
         // whereColumn(col1, <, col2)
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereColumn([['foo', '_foo'], ['bar', '<', '_bar']]);
         $this->assertSame('select * from "users" where ("foo" = "_foo" and "bar" < "_bar")', $builder->toSql());
-        $this->assertEquals([], $builder->getBindings());
+        $this->assertSame([], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereColumn([['foo', '_foo'], ['bar', '<', '_bar']], boolean: 'or');
         $this->assertSame('select * from "users" where ("foo" = "_foo" or "bar" < "_bar")', $builder->toSql());
-        $this->assertEquals([], $builder->getBindings());
+        $this->assertSame([], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereColumn([['foo', '_foo'], ['bar', '<', '_bar']], boolean: 'and');
         $this->assertSame('select * from "users" where ("foo" = "_foo" and "bar" < "_bar")', $builder->toSql());
-        $this->assertEquals([], $builder->getBindings());
+        $this->assertSame([], $builder->getBindings());
 
         // whereAll([...keys], value)
 
@@ -5866,7 +5866,7 @@ SQL;
         $builder->select('*');
 
         $this->assertSame('select * from "one"', $builder->toSql());
-        $this->assertEquals([], $builder->getBindings());
+        $this->assertSame([], $builder->getBindings());
     }
 
     public function testSelectExpression()
@@ -7569,7 +7569,7 @@ SQL;
         $this->assertEquals([0 => 'foo'], $builder->getBindings());
 
         $this->assertSame('select * from "users" order by "email" asc', $clone->toSql());
-        $this->assertEquals([], $clone->getBindings());
+        $this->assertSame([], $clone->getBindings());
     }
 
     public function testToRawSql()

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -6297,7 +6297,7 @@ SQL;
         $results = collect([['test' => 'foo'], ['test' => 'bar']]);
 
         $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results) {
-            $this->assertEquals(
+            $this->assertSame(
                 'select * from "foobar" where ("test" > ?) order by "test" asc limit 17',
                 $builder->toSql());
             $this->assertEquals(['bar'], $builder->bindings['where']);
@@ -6335,7 +6335,7 @@ SQL;
         $results = collect([['test' => 'foo', 'another' => 1], ['test' => 'bar', 'another' => 2]]);
 
         $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results) {
-            $this->assertEquals(
+            $this->assertSame(
                 'select * from "foobar" where ("test" > ? or ("test" = ? and ("another" > ?))) order by "test" asc, "another" asc limit 17',
                 $builder->toSql()
             );
@@ -6373,7 +6373,7 @@ SQL;
         $results = collect([['test' => 'foo'], ['test' => 'bar']]);
 
         $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results) {
-            $this->assertEquals(
+            $this->assertSame(
                 'select * from "foobar" where ("test" > ?) order by "test" asc limit 16',
                 $builder->toSql());
             $this->assertEquals(['bar'], $builder->bindings['where']);
@@ -6443,7 +6443,7 @@ SQL;
         $results = collect([['id' => 3, 'name' => 'Taylor'], ['id' => 5, 'name' => 'Mohamed']]);
 
         $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results) {
-            $this->assertEquals(
+            $this->assertSame(
                 'select * from "foobar" where ("id" > ?) order by "id" asc limit 17',
                 $builder->toSql());
             $this->assertEquals([2], $builder->bindings['where']);
@@ -6481,7 +6481,7 @@ SQL;
         $results = collect([['foo' => 1, 'bar' => 2, 'baz' => 4], ['foo' => 1, 'bar' => 1, 'baz' => 1]]);
 
         $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results) {
-            $this->assertEquals(
+            $this->assertSame(
                 'select * from "foobar" where ("foo" > ? or ("foo" = ? and ("bar" < ? or ("bar" = ? and ("baz" > ?))))) order by "foo" asc, "bar" desc, "baz" asc limit 17',
                 $builder->toSql()
             );
@@ -6519,7 +6519,7 @@ SQL;
         $results = collect([['test' => 'foo'], ['test' => 'bar']]);
 
         $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results) {
-            $this->assertEquals(
+            $this->assertSame(
                 'select *, (CONCAT(firstname, \' \', lastname)) as test from "foobar" where ((CONCAT(firstname, \' \', lastname)) > ?) order by "test" asc limit 16',
                 $builder->toSql());
             $this->assertEquals(['bar'], $builder->bindings['where']);
@@ -6560,7 +6560,7 @@ SQL;
         $results = collect([['test' => 'foo'], ['test' => 'bar']]);
 
         $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results) {
-            $this->assertEquals(
+            $this->assertSame(
                 'select *, (CAST(CONCAT(firstname, \' \', lastname) as VARCHAR)) as test from "foobar" where ((CAST(CONCAT(firstname, \' \', lastname) as VARCHAR)) > ?) order by "test" asc limit 16',
                 $builder->toSql());
             $this->assertEquals(['bar'], $builder->bindings['where']);
@@ -6601,7 +6601,7 @@ SQL;
         $results = collect([['test' => 'foo'], ['test' => 'bar']]);
 
         $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results) {
-            $this->assertEquals(
+            $this->assertSame(
                 'select *, (CONCAT(firstname, \' \', lastname)) as "test" from "foobar" where ((CONCAT(firstname, \' \', lastname)) > ?) order by "test" asc limit 16',
                 $builder->toSql());
             $this->assertEquals(['bar'], $builder->bindings['where']);
@@ -6651,7 +6651,7 @@ SQL;
         ]);
 
         $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results, $ts) {
-            $this->assertEquals(
+            $this->assertSame(
                 '(select "id", "start_time" as "created_at", \'video\' as type from "videos" where ("start_time" > ?)) union (select "id", "created_at", \'news\' as type from "news" where ("created_at" > ?)) order by "created_at" asc limit 17',
                 $builder->toSql());
             $this->assertEquals([$ts], $builder->bindings['where']);
@@ -6700,7 +6700,7 @@ SQL;
         ]);
 
         $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results, $ts) {
-            $this->assertEquals(
+            $this->assertSame(
                 '(select "id", "start_time" as "created_at", \'video\' as type from "videos" where ("start_time" > ?)) union (select "id", "created_at", \'news\' as type from "news" where "extra" = ? and ("created_at" > ?)) union (select "id", "created_at", \'podcast\' as type from "podcasts" where "extra" = ? and ("created_at" > ?)) order by "created_at" asc limit 17',
                 $builder->toSql());
             $this->assertEquals([$ts], $builder->bindings['where']);
@@ -6750,7 +6750,7 @@ SQL;
         ]);
 
         $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results, $ts) {
-            $this->assertEquals(
+            $this->assertSame(
                 '(select "id", "start_time" as "created_at", "type" from "videos" where "extra" = ? and ("id" > ? or ("id" = ? and ("start_time" < ? or ("start_time" = ? and ("type" > ?)))))) union (select "id", "created_at", "type" from "news" where "extra" = ? and ("id" > ? or ("id" = ? and ("start_time" < ? or ("start_time" = ? and ("type" > ?)))))) union (select "id", "created_at", "type" from "podcasts" where "extra" = ? and ("id" > ? or ("id" = ? and ("start_time" < ? or ("start_time" = ? and ("type" > ?)))))) order by "id" asc, "created_at" desc, "type" asc limit 17',
                 $builder->toSql());
             $this->assertEquals(['first', 1, 1, $ts, $ts, 'news'], $builder->bindings['where']);
@@ -6797,7 +6797,7 @@ SQL;
         ]);
 
         $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results, $ts) {
-            $this->assertEquals(
+            $this->assertSame(
                 '(select "id", "is_published", "start_time" as "created_at", \'video\' as type from "videos" where "is_published" = ? and ("start_time" > ?)) union (select "id", "is_published", "created_at", \'news\' as type from "news" where "is_published" = ? and ("created_at" > ?)) order by case when (id = 3 and type="news" then 0 else 1 end), "created_at" asc limit 17',
                 $builder->toSql());
             $this->assertEquals([true, $ts], $builder->bindings['where']);
@@ -6844,7 +6844,7 @@ SQL;
         ]);
 
         $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results, $ts) {
-            $this->assertEquals(
+            $this->assertSame(
                 '(select "id", "start_time" as "created_at", \'video\' as type from "videos" where ("start_time" < ?)) union (select "id", "created_at", \'news\' as type from "news" where ("created_at" < ?)) order by "created_at" desc limit 17',
                 $builder->toSql());
             $this->assertEquals([$ts], $builder->bindings['where']);
@@ -6891,7 +6891,7 @@ SQL;
         ]);
 
         $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results, $ts) {
-            $this->assertEquals(
+            $this->assertSame(
                 '(select "id", "start_time" as "created_at", \'video\' as type from "videos" where ("start_time" < ? or ("start_time" = ? and ("id" > ?)))) union (select "id", "created_at", \'news\' as type from "news" where ("created_at" < ? or ("created_at" = ? and ("id" > ?)))) order by "created_at" desc, "id" asc limit 17',
                 $builder->toSql());
             $this->assertEquals([$ts, $ts, 1], $builder->bindings['where']);
@@ -6940,7 +6940,7 @@ SQL;
         ]);
 
         $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results, $ts) {
-            $this->assertEquals(
+            $this->assertSame(
                 '(select "id", "start_time" as "created_at", \'video\' as type from "videos" where ("start_time" > ?)) union (select "id", "created_at", \'news\' as type from "news" where ("created_at" > ?)) union (select "id", "init_at" as "created_at", \'podcast\' as type from "podcasts" where ("init_at" > ?)) order by "created_at" asc limit 17',
                 $builder->toSql());
             $this->assertEquals([$ts], $builder->bindings['where']);

--- a/tests/Database/DatabaseTransactionsManagerTest.php
+++ b/tests/Database/DatabaseTransactionsManagerTest.php
@@ -304,21 +304,21 @@ class DatabaseTransactionsManagerTest extends TestCase
         $pendingTransactions = $manager->getPendingTransactions();
 
         $this->assertSame(1, $pendingTransactions[0]->level);
-        $this->assertEquals('default', $pendingTransactions[0]->connection);
+        $this->assertSame('default', $pendingTransactions[0]->connection);
         $this->assertSame(1, $pendingTransactions[1]->level);
-        $this->assertEquals('admin', $pendingTransactions[1]->connection);
+        $this->assertSame('admin', $pendingTransactions[1]->connection);
 
         $manager->stageTransactions('default', 1);
 
         $this->assertCount(1, $manager->getPendingTransactions());
         $this->assertCount(1, $manager->getCommittedTransactions());
-        $this->assertEquals('default', $manager->getCommittedTransactions()[0]->connection);
+        $this->assertSame('default', $manager->getCommittedTransactions()[0]->connection);
 
         $manager->stageTransactions('admin', 1);
 
         $this->assertCount(0, $manager->getPendingTransactions());
         $this->assertCount(2, $manager->getCommittedTransactions());
-        $this->assertEquals('admin', $manager->getCommittedTransactions()[1]->connection);
+        $this->assertSame('admin', $manager->getCommittedTransactions()[1]->connection);
     }
 
     public function testStageTransactionsOnlyStagesTheTransactionsAtOrAboveTheGivenLevel()

--- a/tests/Database/DatabaseTransactionsManagerTest.php
+++ b/tests/Database/DatabaseTransactionsManagerTest.php
@@ -17,11 +17,11 @@ class DatabaseTransactionsManagerTest extends TestCase
 
         $this->assertCount(3, $manager->getPendingTransactions());
         $this->assertSame('default', $manager->getPendingTransactions()[0]->connection);
-        $this->assertEquals(1, $manager->getPendingTransactions()[0]->level);
+        $this->assertSame(1, $manager->getPendingTransactions()[0]->level);
         $this->assertSame('default', $manager->getPendingTransactions()[1]->connection);
-        $this->assertEquals(2, $manager->getPendingTransactions()[1]->level);
+        $this->assertSame(2, $manager->getPendingTransactions()[1]->level);
         $this->assertSame('admin', $manager->getPendingTransactions()[2]->connection);
-        $this->assertEquals(1, $manager->getPendingTransactions()[2]->level);
+        $this->assertSame(1, $manager->getPendingTransactions()[2]->level);
     }
 
     public function testRollingBackTransactions()
@@ -37,10 +37,10 @@ class DatabaseTransactionsManagerTest extends TestCase
         $this->assertCount(2, $manager->getPendingTransactions());
 
         $this->assertSame('default', $manager->getPendingTransactions()[0]->connection);
-        $this->assertEquals(1, $manager->getPendingTransactions()[0]->level);
+        $this->assertSame(1, $manager->getPendingTransactions()[0]->level);
 
         $this->assertSame('admin', $manager->getPendingTransactions()[1]->connection);
-        $this->assertEquals(1, $manager->getPendingTransactions()[1]->level);
+        $this->assertSame(1, $manager->getPendingTransactions()[1]->level);
     }
 
     public function testRollingBackTransactionsAllTheWay()
@@ -56,7 +56,7 @@ class DatabaseTransactionsManagerTest extends TestCase
         $this->assertCount(1, $manager->getPendingTransactions());
 
         $this->assertSame('admin', $manager->getPendingTransactions()[0]->connection);
-        $this->assertEquals(1, $manager->getPendingTransactions()[0]->level);
+        $this->assertSame(1, $manager->getPendingTransactions()[0]->level);
     }
 
     public function testCommittingTransactions()
@@ -79,11 +79,11 @@ class DatabaseTransactionsManagerTest extends TestCase
 
         // Level 2 "admin" callback has been staged...
         $this->assertSame('admin', $manager->getCommittedTransactions()[0]->connection);
-        $this->assertEquals(2, $manager->getCommittedTransactions()[0]->level);
+        $this->assertSame(2, $manager->getCommittedTransactions()[0]->level);
 
         // Level 1 "admin" callback still pending...
         $this->assertSame('admin', $manager->getPendingTransactions()[0]->connection);
-        $this->assertEquals(1, $manager->getPendingTransactions()[0]->level);
+        $this->assertSame(1, $manager->getPendingTransactions()[0]->level);
     }
 
     public function testCallbacksAreAddedToTheCurrentTransaction()
@@ -303,9 +303,9 @@ class DatabaseTransactionsManagerTest extends TestCase
 
         $pendingTransactions = $manager->getPendingTransactions();
 
-        $this->assertEquals(1, $pendingTransactions[0]->level);
+        $this->assertSame(1, $pendingTransactions[0]->level);
         $this->assertEquals('default', $pendingTransactions[0]->connection);
-        $this->assertEquals(1, $pendingTransactions[1]->level);
+        $this->assertSame(1, $pendingTransactions[1]->level);
         $this->assertEquals('admin', $pendingTransactions[1]->connection);
 
         $manager->stageTransactions('default', 1);

--- a/tests/Database/EloquentModelCustomCastingTest.php
+++ b/tests/Database/EloquentModelCustomCastingTest.php
@@ -186,10 +186,10 @@ class EloquentModelCustomCastingTest extends TestCase
         $model->save();
 
         $this->assertInstanceOf(Euro::class, $model->amount);
-        $this->assertEquals('2', $model->amount->value);
+        $this->assertSame('2', $model->amount->value);
 
         $model->increment('amount', new Euro('1'));
-        $this->assertEquals('3.00', $model->amount->value);
+        $this->assertSame('3.00', $model->amount->value);
     }
 
     public function testModelWithCustomCastsCompareFunction()

--- a/tests/Database/PruneCommandTest.php
+++ b/tests/Database/PruneCommandTest.php
@@ -121,7 +121,7 @@ class PruneCommandTest extends TestCase
             $output,
         );
 
-        $this->assertEquals(2, Pruning\Models\PrunableTestSoftDeletedModelWithPrunableRecords::withTrashed()->count());
+        $this->assertSame(2, Pruning\Models\PrunableTestSoftDeletedModelWithPrunableRecords::withTrashed()->count());
     }
 
     public function testNonPrunableTest()
@@ -197,7 +197,7 @@ class PruneCommandTest extends TestCase
             $output->fetch(),
         );
 
-        $this->assertEquals(5, Pruning\Models\PrunableTestModelWithPrunableRecords::count());
+        $this->assertSame(5, Pruning\Models\PrunableTestModelWithPrunableRecords::count());
     }
 
     public function testTheCommandMayBePretendedOnSoftDeletedModel()
@@ -230,7 +230,7 @@ class PruneCommandTest extends TestCase
             $output->fetch(),
         );
 
-        $this->assertEquals(4, Pruning\Models\PrunableTestSoftDeletedModelWithPrunableRecords::withTrashed()->count());
+        $this->assertSame(4, Pruning\Models\PrunableTestSoftDeletedModelWithPrunableRecords::withTrashed()->count());
     }
 
     public function testTheCommandDispatchesEvents()

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -47,7 +47,7 @@ class EventsDispatcherTest extends TestCase
             return 'callback_result';
         });
 
-        $this->assertEquals('callback_result', $result);
+        $this->assertSame('callback_result', $result);
         $this->assertSame('bar', $_SERVER['__event.test']);
     }
 

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -579,7 +579,7 @@ class EventsDispatcherTest extends TestCase
         $d->listen('event', TestListener::class.'@handle');
         $d->dispatch('event');
 
-        $this->assertEquals(4, TestListener::$counter);
+        $this->assertSame(4, TestListener::$counter);
         TestListener::$counter = 0;
     }
 

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -196,7 +196,7 @@ class EventsDispatcherTest extends TestCase
         $d = new Dispatcher;
         $response = $d->dispatch('foo');
 
-        $this->assertEquals([], $response);
+        $this->assertSame([], $response);
 
         $response = $d->dispatch('foo', [], true);
         $this->assertNull($response);
@@ -605,7 +605,7 @@ class EventsDispatcherTest extends TestCase
         $d->listen(TestEvent::class, TestListener3::class);
 
         // Attaching events does not make any objects.
-        $this->assertEquals([], $_SERVER['__event.test']);
+        $this->assertSame([], $_SERVER['__event.test']);
 
         $d->dispatch(TestEvent::class);
 

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -445,7 +445,7 @@ class FilesystemAdapterTest extends TestCase
         $this->assertInstanceOf(FtpAdapter::class, $driver->getAdapter());
 
         $config = $driver->getConfig();
-        $this->assertEquals(0700, $config['permPublic']);
+        $this->assertSame(0700, $config['permPublic']);
         $this->assertSame('ftp.example.com', $config['host']);
         $this->assertSame('admin', $config['username']);
     }

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -742,7 +742,7 @@ class FilesystemAdapterTest extends TestCase
     {
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter, ['url' => 'https://example.org/', 'prefix' => 'images']);
 
-        $this->assertEquals('https://example.org/images/picture.jpeg', $filesystemAdapter->url('picture.jpeg'));
+        $this->assertSame('https://example.org/images/picture.jpeg', $filesystemAdapter->url('picture.jpeg'));
     }
 
     public function testGetChecksum()
@@ -750,8 +750,8 @@ class FilesystemAdapterTest extends TestCase
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
         $filesystemAdapter->write('path.txt', 'contents of file');
 
-        $this->assertEquals('730bed78bccf58c2cfe44c29b71e5e6b', $filesystemAdapter->checksum('path.txt'));
-        $this->assertEquals('a5c3556d', $filesystemAdapter->checksum('path.txt', ['checksum_algo' => 'crc32']));
+        $this->assertSame('730bed78bccf58c2cfe44c29b71e5e6b', $filesystemAdapter->checksum('path.txt'));
+        $this->assertSame('a5c3556d', $filesystemAdapter->checksum('path.txt', ['checksum_algo' => 'crc32']));
     }
 
     public function testUsesRightSeperatorForS3AdapterWithoutDoublePrefixing()
@@ -766,7 +766,7 @@ class FilesystemAdapterTest extends TestCase
         ]);
 
         $path = $filesystemAdapter->path('different');
-        $this->assertEquals('my-root/someprefix/different', $path);
+        $this->assertSame('my-root/someprefix/different', $path);
     }
 
     public function testTemporaryUploadUrlWithCustomCallback()

--- a/tests/Filesystem/FilesystemManagerTest.php
+++ b/tests/Filesystem/FilesystemManagerTest.php
@@ -57,7 +57,7 @@ class FilesystemManagerTest extends TestCase
         file_put_contents(__DIR__.'/../../my-custom-path/path.txt', 'contents');
 
         // read operations work
-        $this->assertEquals('contents', $disk->get('path.txt'));
+        $this->assertSame('contents', $disk->get('path.txt'));
         $this->assertEquals(['path.txt'], $disk->files());
 
         // write operations fail
@@ -95,7 +95,7 @@ class FilesystemManagerTest extends TestCase
             ]);
 
             $scoped->put('dirname/filename.txt', 'file content');
-            $this->assertEquals('file content', $local->get('path-prefix/dirname/filename.txt'));
+            $this->assertSame('file content', $local->get('path-prefix/dirname/filename.txt'));
             $local->deleteDirectory('path-prefix');
         } finally {
             rmdir(__DIR__.'/../../to-be-scoped');
@@ -127,7 +127,7 @@ class FilesystemManagerTest extends TestCase
             ]);
 
             $nestedScoped->put('dirname/filename.txt', 'file content');
-            $this->assertEquals('file content', $root->get('scoped-from-root-prefix/nested-scoped-prefix/dirname/filename.txt'));
+            $this->assertSame('file content', $root->get('scoped-from-root-prefix/nested-scoped-prefix/dirname/filename.txt'));
             $root->deleteDirectory('scoped-from-root-prefix');
         } finally {
             rmdir(__DIR__.'/../../root-to-be-scoped');
@@ -157,7 +157,7 @@ class FilesystemManagerTest extends TestCase
 
             $scoped->put('dirname/filename.txt', 'file content');
 
-            $this->assertEquals('private', $scoped->getVisibility('dirname/filename.txt'));
+            $this->assertSame('private', $scoped->getVisibility('dirname/filename.txt'));
         } finally {
             unlink(__DIR__.'/../../to-be-scoped/path-prefix/dirname/filename.txt');
             rmdir(__DIR__.'/../../to-be-scoped/path-prefix/dirname');
@@ -209,7 +209,7 @@ class FilesystemManagerTest extends TestCase
 
             $scoped->put('dirname/filename.txt', 'file content');
             $this->assertTrue(is_dir(__DIR__.'/../../to-be-scoped/path-prefix'));
-            $this->assertEquals('file content', file_get_contents(__DIR__.'/../../to-be-scoped/path-prefix/dirname/filename.txt'));
+            $this->assertSame('file content', file_get_contents(__DIR__.'/../../to-be-scoped/path-prefix/dirname/filename.txt'));
         } finally {
             unlink(__DIR__.'/../../to-be-scoped/path-prefix/dirname/filename.txt');
             rmdir(__DIR__.'/../../to-be-scoped/path-prefix/dirname');

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -725,6 +725,6 @@ class FilesystemTest extends TestCase
         $allFiles = $files->allFiles($dirPath);
 
         $this->assertCount(1, $allFiles);
-        $this->assertEquals('test.txt', $allFiles[0]->getFilename());
+        $this->assertSame('test.txt', $allFiles[0]->getFilename());
     }
 }

--- a/tests/Foundation/Configuration/MiddlewareTest.php
+++ b/tests/Foundation/Configuration/MiddlewareTest.php
@@ -240,10 +240,10 @@ class MiddlewareTest extends TestCase
         $this->assertEquals(['^(.+\.)?laravel\.test$'], $middleware->hosts());
 
         $configuration->trustHosts(at: [], subdomains: false);
-        $this->assertEquals([], $middleware->hosts());
+        $this->assertSame([], $middleware->hosts());
 
         $configuration->trustHosts(at: static fn () => [], subdomains: false);
-        $this->assertEquals([], $middleware->hosts());
+        $this->assertSame([], $middleware->hosts());
     }
 
     public function testEncryptCookies()

--- a/tests/Foundation/Configuration/MiddlewareTest.php
+++ b/tests/Foundation/Configuration/MiddlewareTest.php
@@ -155,7 +155,7 @@ class MiddlewareTest extends TestCase
         ], $method->invoke($middleware));
 
         $configuration->trustProxies(at: '*');
-        $this->assertEquals('*', $method->invoke($middleware));
+        $this->assertSame('*', $method->invoke($middleware));
 
         $configuration->trustProxies(at: [
             '192.168.1.3',

--- a/tests/Foundation/Console/RouteListCommandTest.php
+++ b/tests/Foundation/Console/RouteListCommandTest.php
@@ -80,9 +80,9 @@ class RouteListCommandTest extends TestCase
         $routes = json_decode($output, true);
 
         $this->assertCount(3, $routes);
-        $this->assertEquals('example', $routes[0]['uri']);
-        $this->assertEquals('example-group', $routes[1]['uri']);
-        $this->assertEquals('sub-example', $routes[2]['uri']);
+        $this->assertSame('example', $routes[0]['uri']);
+        $this->assertSame('example-group', $routes[1]['uri']);
+        $this->assertSame('sub-example', $routes[2]['uri']);
 
         foreach ($routes as $route) {
             $this->assertArrayHasKey('path', $route);
@@ -98,9 +98,9 @@ class RouteListCommandTest extends TestCase
         $routes = json_decode($output, true);
 
         $this->assertCount(3, $routes);
-        $this->assertEquals('sub-example', $routes[0]['uri']);
-        $this->assertEquals('example-group', $routes[1]['uri']);
-        $this->assertEquals('example', $routes[2]['uri']);
+        $this->assertSame('sub-example', $routes[0]['uri']);
+        $this->assertSame('example-group', $routes[1]['uri']);
+        $this->assertSame('example', $routes[2]['uri']);
 
         foreach ($routes as $route) {
             $this->assertArrayHasKey('path', $route);
@@ -116,9 +116,9 @@ class RouteListCommandTest extends TestCase
         $routes = json_decode($output, true);
 
         $this->assertCount(3, $routes);
-        $this->assertEquals('example', $routes[0]['uri']);
-        $this->assertEquals('example-group', $routes[1]['uri']);
-        $this->assertEquals('sub-example', $routes[2]['uri']);
+        $this->assertSame('example', $routes[0]['uri']);
+        $this->assertSame('example-group', $routes[1]['uri']);
+        $this->assertSame('sub-example', $routes[2]['uri']);
 
         foreach ($routes as $route) {
             $this->assertArrayHasKey('path', $route);
@@ -134,9 +134,9 @@ class RouteListCommandTest extends TestCase
         $routes = json_decode($output, true);
 
         $this->assertCount(3, $routes);
-        $this->assertEquals('example', $routes[0]['uri']);
-        $this->assertEquals('sub-example', $routes[1]['uri']);
-        $this->assertEquals('example-group', $routes[2]['uri']);
+        $this->assertSame('example', $routes[0]['uri']);
+        $this->assertSame('sub-example', $routes[1]['uri']);
+        $this->assertSame('example-group', $routes[2]['uri']);
 
         foreach ($routes as $route) {
             $this->assertArrayHasKey('path', $route);
@@ -216,11 +216,11 @@ class RouteListCommandTest extends TestCase
         $routes = json_decode($output, true);
 
         $this->assertCount(3, $routes);
-        $this->assertEquals('example', $routes[0]['uri']);
+        $this->assertSame('example', $routes[0]['uri']);
         $this->assertEquals(['exampleMiddleware'], $routes[0]['middleware']);
-        $this->assertEquals('example-group', $routes[1]['uri']);
+        $this->assertSame('example-group', $routes[1]['uri']);
         $this->assertEquals(['Middleware 5', 'Middleware 1', 'Middleware 4', 'Middleware 2', 'Middleware 3'], $routes[1]['middleware']);
-        $this->assertEquals('sub-example', $routes[2]['uri']);
+        $this->assertSame('sub-example', $routes[2]['uri']);
         $this->assertEquals(['exampleMiddleware'], $routes[2]['middleware']);
     }
 
@@ -232,7 +232,7 @@ class RouteListCommandTest extends TestCase
         $routes = json_decode($output, true);
 
         $this->assertCount(1, $routes);
-        $this->assertEquals('example-group', $routes[0]['uri']);
+        $this->assertSame('example-group', $routes[0]['uri']);
         $this->assertEquals(['web', 'auth'], $routes[0]['middleware']);
         $this->assertStringContainsString('RouteListCommandTest.php:', $routes[0]['path']);
     }

--- a/tests/Foundation/Console/ServeCommandLogParserTest.php
+++ b/tests/Foundation/Console/ServeCommandLogParserTest.php
@@ -11,21 +11,21 @@ class ServeCommandLogParserTest extends TestCase
     {
         $line = '[Mon Nov 19 10:30:45 2024] :8080 Info';
 
-        $this->assertEquals(8080, ServeCommand::getRequestPortFromLine($line));
+        $this->assertSame(8080, ServeCommand::getRequestPortFromLine($line));
     }
 
     public function testExtractRequestPortWithValidLogLineAndExtraData()
     {
         $line = '[Mon Nov 19 10:30:45 2024] :3000 [Client Connected]';
 
-        $this->assertEquals(3000, ServeCommand::getRequestPortFromLine($line));
+        $this->assertSame(3000, ServeCommand::getRequestPortFromLine($line));
     }
 
     public function testExtractRequestPortWithValidLogLineWithoutDate()
     {
         $line = ':5000 [Server Started]';
 
-        $this->assertEquals(5000, ServeCommand::getRequestPortFromLine($line));
+        $this->assertSame(5000, ServeCommand::getRequestPortFromLine($line));
     }
 
     public function testExtractRequestPortWithMissingPort()

--- a/tests/Foundation/Exceptions/Renderer/ListenerTest.php
+++ b/tests/Foundation/Exceptions/Renderer/ListenerTest.php
@@ -34,9 +34,9 @@ class ListenerTest extends TestCase
         $this->assertArrayHasKey('sql', $query);
         $this->assertArrayHasKey('bindings', $query);
 
-        $this->assertEquals('testing', $query['connectionName']);
+        $this->assertSame('testing', $query['connectionName']);
         $this->assertEquals(5.2, $query['time']);
-        $this->assertEquals('select * from users where id = ?', $query['sql']);
+        $this->assertSame('select * from users where id = ?', $query['sql']);
         $this->assertEquals(['foo'], $query['bindings']);
     }
 
@@ -55,8 +55,8 @@ class ListenerTest extends TestCase
         }
 
         $this->assertCount(100, $listener->queries());
-        $this->assertEquals('select 0', $listener->queries()[0]['sql']);
-        $this->assertEquals('select 99', $listener->queries()[99]['sql']);
+        $this->assertSame('select 0', $listener->queries()[0]['sql']);
+        $this->assertSame('select 99', $listener->queries()[99]['sql']);
     }
 
     public function test_large_sql_is_truncated()
@@ -144,7 +144,7 @@ class ListenerTest extends TestCase
             new QueryExecuted('select count(*) from users', [], 1.0, $connection)
         );
 
-        $this->assertEquals('select count(*) from users', $listener->queries()[0]['sql']);
+        $this->assertSame('select count(*) from users', $listener->queries()[0]['sql']);
         $this->assertEmpty($listener->queries()[0]['bindings']);
     }
 

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -146,7 +146,7 @@ class FoundationApplicationTest extends TestCase
         $obj = $app->make('foo');
         $this->assertInstanceOf(stdClass::class, $obj);
         $this->assertSame($obj, $app->make('foo'));
-        $this->assertEquals(1, ApplicationDeferredServiceProviderCountStub::$count);
+        $this->assertSame(1, ApplicationDeferredServiceProviderCountStub::$count);
     }
 
     public function testDeferredServiceDontRunWhenInstanceSet()
@@ -178,9 +178,9 @@ class FoundationApplicationTest extends TestCase
         $app = new Application;
         $app->setDeferredServices(['foo' => ApplicationFactoryProviderStub::class]);
         $this->assertTrue($app->bound('foo'));
-        $this->assertEquals(1, $app->make('foo'));
-        $this->assertEquals(2, $app->make('foo'));
-        $this->assertEquals(3, $app->make('foo'));
+        $this->assertSame(1, $app->make('foo'));
+        $this->assertSame(2, $app->make('foo'));
+        $this->assertSame(3, $app->make('foo'));
     }
 
     public function testSingleProviderCanProvideMultipleDeferredServices()
@@ -323,7 +323,7 @@ class FoundationApplicationTest extends TestCase
 
         $app->terminate();
 
-        $this->assertEquals(1, ConcreteTerminator::$counter);
+        $this->assertSame(1, ConcreteTerminator::$counter);
     }
 
     public function testBootingCallbacks()
@@ -346,7 +346,7 @@ class FoundationApplicationTest extends TestCase
 
         $application->boot();
 
-        $this->assertEquals(2, $counter);
+        $this->assertSame(2, $counter);
     }
 
     public function testBootedCallbacks()
@@ -374,11 +374,11 @@ class FoundationApplicationTest extends TestCase
         $application->booted($closure2);
         $application->boot();
 
-        $this->assertEquals(3, $counter);
+        $this->assertSame(3, $counter);
 
         $application->booted($closure3);
 
-        $this->assertEquals(4, $counter);
+        $this->assertSame(4, $counter);
     }
 
     public function testGetNamespace()

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -366,7 +366,7 @@ class FoundationExceptionsHandlerTest extends TestCase
 
         $response = $this->handler->render($this->request, new SuspiciousOperationException('Invalid method override "__CONSTRUCT"'));
 
-        $this->assertEquals(400, $response->getStatusCode());
+        $this->assertSame(400, $response->getStatusCode());
         $this->assertStringContainsString('"message": "Bad request."', $response->getContent());
 
         $logger = m::mock(LoggerInterface::class);
@@ -383,7 +383,7 @@ class FoundationExceptionsHandlerTest extends TestCase
 
         $response = $this->handler->render($this->request, new RecordsNotFoundException);
 
-        $this->assertEquals(404, $response->getStatusCode());
+        $this->assertSame(404, $response->getStatusCode());
         $this->assertStringContainsString('"message": "Not found."', $response->getContent());
 
         $logger = m::mock(LoggerInterface::class);

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -88,7 +88,7 @@ class FoundationFormRequestTest extends TestCase
         $request->validateResolved();
         $request->validated();
 
-        $this->assertEquals(1, FoundationTestFormRequestTwiceStub::$count);
+        $this->assertSame(1, FoundationTestFormRequestTwiceStub::$count);
     }
 
     public function testValidateThrowsWhenValidationFails()

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -229,7 +229,7 @@ class FoundationFormRequestTest extends TestCase
 
         $request->validateResolved();
 
-        $this->assertEquals([], $request->all());
+        $this->assertSame([], $request->all());
     }
 
     public function testRequestWithGetRules()

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -372,7 +372,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->assertEquals($this->table, $this->getTable(ProductStub::class));
         $this->assertEquals($this->table, $this->getTable(new ProductStub));
         $this->assertEquals($this->table, $this->getTable($this->table));
-        $this->assertEquals('all_products', $this->getTable((new ProductStub)->setTable('all_products')));
+        $this->assertSame('all_products', $this->getTable((new ProductStub)->setTable('all_products')));
     }
 
     public function testGetTableConnectionNameFromModel()
@@ -384,8 +384,8 @@ class FoundationInteractsWithDatabaseTest extends TestCase
 
     public function testGetTableCustomizedDeletedAtColumnName()
     {
-        $this->assertEquals('trashed_at', $this->getDeletedAtColumn(CustomProductStub::class));
-        $this->assertEquals('trashed_at', $this->getDeletedAtColumn(new CustomProductStub()));
+        $this->assertSame('trashed_at', $this->getDeletedAtColumn(CustomProductStub::class));
+        $this->assertSame('trashed_at', $this->getDeletedAtColumn(new CustomProductStub()));
     }
 
     public function testExpectsDatabaseQueryCount()

--- a/tests/Foundation/Http/KernelTest.php
+++ b/tests/Foundation/Http/KernelTest.php
@@ -17,14 +17,14 @@ class KernelTest extends TestCase
     {
         $kernel = new Kernel($this->getApplication(), $this->getRouter());
 
-        $this->assertEquals([], $kernel->getMiddlewareGroups());
+        $this->assertSame([], $kernel->getMiddlewareGroups());
     }
 
     public function testGetRouteMiddleware()
     {
         $kernel = new Kernel($this->getApplication(), $this->getRouter());
 
-        $this->assertEquals([], $kernel->getRouteMiddleware());
+        $this->assertSame([], $kernel->getRouteMiddleware());
     }
 
     public function testGetMiddlewarePriority()

--- a/tests/Foundation/Http/Middleware/TransformsRequestTest.php
+++ b/tests/Foundation/Http/Middleware/TransformsRequestTest.php
@@ -40,8 +40,8 @@ class TransformsRequestTest extends TestCase
 
         $middleware->handle($request, function (Request $request) {
             $this->assertSame('Damian', $request->get('name'));
-            $this->assertEquals(27, $request->get('age'));
-            $this->assertEquals(5, $request->get('beers'));
+            $this->assertSame(27, $request->get('age'));
+            $this->assertSame(5, $request->get('beers'));
         });
     }
 
@@ -87,8 +87,8 @@ class TransformsRequestTest extends TestCase
 
         $middleware->handle($request, function (Request $request) {
             $this->assertSame('Damian', $request->input('name'));
-            $this->assertEquals(27, $request->input('age'));
-            $this->assertEquals(5, $request->input('beers'));
+            $this->assertSame(27, $request->input('age'));
+            $this->assertSame(5, $request->input('beers'));
         });
     }
 }

--- a/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
+++ b/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
@@ -34,7 +34,7 @@ class MakesHttpRequestsTest extends TestCase
     {
         $this->withHeader('name', 'Milwad')->from('previous/url');
 
-        $this->assertEquals('Milwad', $this->defaultHeaders['name']);
+        $this->assertSame('Milwad', $this->defaultHeaders['name']);
 
         $this->withoutHeader('name')->from('previous/url');
 
@@ -48,8 +48,8 @@ class MakesHttpRequestsTest extends TestCase
             'foo' => 'bar',
         ])->from('previous/url');
 
-        $this->assertEquals('Milwad', $this->defaultHeaders['name']);
-        $this->assertEquals('bar', $this->defaultHeaders['foo']);
+        $this->assertSame('Milwad', $this->defaultHeaders['name']);
+        $this->assertSame('bar', $this->defaultHeaders['foo']);
 
         $this->withoutHeaders(['name', 'foo'])->from('previous/url');
 

--- a/tests/Foundation/Testing/DatabaseTransactionsManagerTest.php
+++ b/tests/Foundation/Testing/DatabaseTransactionsManagerTest.php
@@ -17,7 +17,7 @@ class DatabaseTransactionsManagerTest extends TestCase
         $manager->addCallback(fn () => $testObject->handle());
 
         $this->assertTrue($testObject->ran);
-        $this->assertEquals(1, $testObject->runs);
+        $this->assertSame(1, $testObject->runs);
     }
 
     public function testItIgnoresTheBaseTransactionForCallbackApplicableTransactions()
@@ -28,7 +28,7 @@ class DatabaseTransactionsManagerTest extends TestCase
         $manager->begin('foo', 2);
 
         $this->assertCount(1, $manager->callbackApplicableTransactions());
-        $this->assertEquals(2, $manager->callbackApplicableTransactions()[0]->level);
+        $this->assertSame(2, $manager->callbackApplicableTransactions()[0]->level);
     }
 
     public function testCommittingDoesNotRemoveTheBasePendingTransaction()
@@ -45,7 +45,7 @@ class DatabaseTransactionsManagerTest extends TestCase
         $manager->begin('foo', 2);
 
         $this->assertCount(1, $manager->callbackApplicableTransactions());
-        $this->assertEquals(2, $manager->callbackApplicableTransactions()[0]->level);
+        $this->assertSame(2, $manager->callbackApplicableTransactions()[0]->level);
     }
 
     public function testItExecutesCallbacksForTheSecondTransaction()
@@ -62,7 +62,7 @@ class DatabaseTransactionsManagerTest extends TestCase
         $manager->commit('foo', 2, 1);
         $manager->commit('foo', 1, 0);
         $this->assertTrue($testObject->ran);
-        $this->assertEquals(1, $testObject->runs);
+        $this->assertSame(1, $testObject->runs);
     }
 
     public function testItExecutesTransactionCallbacksAtLevelOne()

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -1428,7 +1428,7 @@ class HttpClientTest extends TestCase
         // Ensure that the truncation level is not changed when reporting the exception.
         $this->assertEquals("HTTP request returned status code 403:\n[\"e (truncated...)\n", $exception->getMessage());
 
-        $this->assertEquals(60, RequestException::$truncateAt);
+        $this->assertSame(60, RequestException::$truncateAt);
     }
 
     public function testNoTruncationOnRequestLevel()
@@ -1451,7 +1451,7 @@ class HttpClientTest extends TestCase
 
         $this->assertEquals("HTTP request returned status code 403:\nHTTP/1.1 403 Forbidden\r\nContent-Type: application/json\r\n\r\n[\"error\"]\n", $exception->getMessage());
 
-        $this->assertEquals(60, RequestException::$truncateAt);
+        $this->assertSame(60, RequestException::$truncateAt);
     }
 
     public function testRequestExceptionDoesNotTruncateButRequestDoes()
@@ -1519,7 +1519,7 @@ class HttpClientTest extends TestCase
         $exception->report();
         $exception->report();
 
-        $this->assertEquals(1, substr_count($exception->getMessage(), '{"error":{"code":403,"message":"The Request can not be completed"}}'));
+        $this->assertSame(1, substr_count($exception->getMessage(), '{"error":{"code":403,"message":"The Request can not be completed"}}'));
     }
 
     #[TestWith([false])]
@@ -2655,8 +2655,8 @@ class HttpClientTest extends TestCase
 
         $this->assertInstanceOf(RequestException::class, $requestException);
         $this->assertEqualsCanonicalizing(['code' => 'not_found'], $requestException->response->json());
-        $this->assertEquals(404, $requestException->response->status());
-        $this->assertEquals(199, $requestException->response->header('X-RateLimit-Remaining'));
+        $this->assertSame(404, $requestException->response->status());
+        $this->assertSame(199, (int) $requestException->response->header('X-RateLimit-Remaining'));
     }
 
     public function testFakeConnectionException()

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -1421,12 +1421,12 @@ class HttpClientTest extends TestCase
         }
 
         // Ensure the exception message is truncated according to the request level truncation setting.
-        $this->assertEquals("HTTP request returned status code 403:\n[\"e (truncated...)\n", $exception->getMessage());
+        $this->assertSame("HTTP request returned status code 403:\n[\"e (truncated...)\n", $exception->getMessage());
 
         $exception->report();
 
         // Ensure that the truncation level is not changed when reporting the exception.
-        $this->assertEquals("HTTP request returned status code 403:\n[\"e (truncated...)\n", $exception->getMessage());
+        $this->assertSame("HTTP request returned status code 403:\n[\"e (truncated...)\n", $exception->getMessage());
 
         $this->assertSame(60, RequestException::$truncateAt);
     }
@@ -1449,7 +1449,7 @@ class HttpClientTest extends TestCase
 
         $exception->report();
 
-        $this->assertEquals("HTTP request returned status code 403:\nHTTP/1.1 403 Forbidden\r\nContent-Type: application/json\r\n\r\n[\"error\"]\n", $exception->getMessage());
+        $this->assertSame("HTTP request returned status code 403:\nHTTP/1.1 403 Forbidden\r\nContent-Type: application/json\r\n\r\n[\"error\"]\n", $exception->getMessage());
 
         $this->assertSame(60, RequestException::$truncateAt);
     }
@@ -1471,7 +1471,7 @@ class HttpClientTest extends TestCase
 
         $exception->report();
 
-        $this->assertEquals("HTTP request returned status code 403:\n[\"e (truncated...)\n", $exception->getMessage());
+        $this->assertSame("HTTP request returned status code 403:\n[\"e (truncated...)\n", $exception->getMessage());
 
         $this->assertFalse(RequestException::$truncateAt);
     }
@@ -1488,7 +1488,7 @@ class HttpClientTest extends TestCase
         $exception->report();
 
         $this->assertInstanceOf(RequestException::class, $exception);
-        $this->assertEquals("HTTP request returned status code 403:\n[\"er (truncated...)\n", $exception->getMessage());
+        $this->assertSame("HTTP request returned status code 403:\n[\"er (truncated...)\n", $exception->getMessage());
         $this->assertFalse(RequestException::$truncateAt);
     }
 
@@ -2402,7 +2402,7 @@ class HttpClientTest extends TestCase
 
         $this->assertNotNull($exception);
         $this->assertInstanceOf(Exception::class, $exception);
-        $this->assertEquals('Foo bar', $exception->getMessage());
+        $this->assertSame('Foo bar', $exception->getMessage());
 
         $this->factory->assertSentCount(1);
     }
@@ -2427,7 +2427,7 @@ class HttpClientTest extends TestCase
 
         $this->assertNotNull($exception);
         $this->assertInstanceOf(Exception::class, $exception);
-        $this->assertEquals('Foo bar', $exception->getMessage());
+        $this->assertSame('Foo bar', $exception->getMessage());
 
         $this->factory->assertSentCount(1);
     }
@@ -2600,7 +2600,7 @@ class HttpClientTest extends TestCase
 
         $this->assertNotNull($exception);
         $this->assertInstanceOf(Exception::class, $exception);
-        $this->assertEquals('Foo bar', $exception->getMessage());
+        $this->assertSame('Foo bar', $exception->getMessage());
 
         $this->factory->assertSentCount(1);
     }
@@ -3693,7 +3693,7 @@ class HttpClientTest extends TestCase
         });
 
         $this->assertInstanceOf(StrayRequestException::class, $exception);
-        $this->assertEquals('Attempted request to [https://laravel.com] without a matching fake.', $exception->getMessage());
+        $this->assertSame('Attempted request to [https://laravel.com] without a matching fake.', $exception->getMessage());
     }
 
     public function testPreventingStrayRequests()
@@ -4411,7 +4411,7 @@ class HttpClientTest extends TestCase
         $this->assertInstanceOf(Request::class, $requestReceived);
         $this->assertSame('http://200.com', (string) $requestReceived->url());
         $this->assertInstanceOf(TestResponse::class, $o['401-response']);
-        $this->assertEquals('different', $o['401-response']->body());
+        $this->assertSame('different', $o['401-response']->body());
         $this->assertInstanceOf(RequestException::class, $o['401-throwing']);
         $this->assertInstanceOf(TestResponse::class, $o['401-throwing']->response);
     }

--- a/tests/Http/HttpRedirectResponseTest.php
+++ b/tests/Http/HttpRedirectResponseTest.php
@@ -78,8 +78,8 @@ class HttpRedirectResponseTest extends TestCase
             new Cookie('name', 'milwad'),
         ]);
 
-        $this->assertEquals('name', $response->headers->getCookies()[0]->getName());
-        $this->assertEquals('milwad', $response->headers->getCookies()[0]->getValue());
+        $this->assertSame('name', $response->headers->getCookies()[0]->getName());
+        $this->assertSame('milwad', $response->headers->getCookies()[0]->getValue());
     }
 
     public function testOnlyInputOnRedirect()

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -1719,7 +1719,7 @@ class HttpRequestTest extends TestCase
             return $route;
         });
 
-        $this->assertEquals(40, mb_strlen($request->fingerprint()));
+        $this->assertSame(40, mb_strlen($request->fingerprint()));
     }
 
     public function testFingerprintWithoutRoute()

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -1053,15 +1053,15 @@ class HttpRequestTest extends TestCase
         $request = Request::create('/', 'GET', ['developer' => ['name' => 'Taylor', 'age' => null]]);
         $this->assertEquals(['developer' => ['name' => 'Taylor']], $request->only('developer.name', 'developer.skills'));
         $this->assertEquals(['developer' => ['age' => null]], $request->only('developer.age'));
-        $this->assertEquals([], $request->only('developer.skills'));
+        $this->assertSame([], $request->only('developer.skills'));
     }
 
     public function testExceptMethod()
     {
         $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => 25]);
         $this->assertEquals(['name' => 'Taylor'], $request->except('age'));
-        $this->assertEquals([], $request->except('age', 'name'));
-        $this->assertEquals([], $request->except(['age', 'name']));
+        $this->assertSame([], $request->except('age', 'name'));
+        $this->assertSame([], $request->except(['age', 'name']));
     }
 
     public function testQueryMethod()
@@ -1764,12 +1764,12 @@ class HttpRequestTest extends TestCase
         $params = ['foo' => 'bar'];
 
         $getRequest = Request::create('/', 'GET', $params, [], [], []);
-        $this->assertEquals([], $getRequest->request->all());
+        $this->assertSame([], $getRequest->request->all());
         $this->assertEquals($getRequest->query->all(), $params);
 
         $postRequest = Request::create('/', 'POST', $params, [], [], []);
         $this->assertEquals($postRequest->request->all(), $params);
-        $this->assertEquals([], $postRequest->query->all());
+        $this->assertSame([], $postRequest->query->all());
     }
 
     /**

--- a/tests/Http/Middleware/PreventRequestForgeryTest.php
+++ b/tests/Http/Middleware/PreventRequestForgeryTest.php
@@ -29,7 +29,7 @@ class PreventRequestForgeryTest extends TestCase
 
         $response = $middleware->handle($request, fn () => new Response('OK'));
 
-        $this->assertEquals('OK', $response->getContent());
+        $this->assertSame('OK', $response->getContent());
     }
 
     public function test_same_site_header_rejected_by_default()
@@ -51,7 +51,7 @@ class PreventRequestForgeryTest extends TestCase
 
         $response = $middleware->handle($request, fn () => new Response('OK'));
 
-        $this->assertEquals('OK', $response->getContent());
+        $this->assertSame('OK', $response->getContent());
     }
 
     public function test_cross_site_with_valid_token_passes()
@@ -61,7 +61,7 @@ class PreventRequestForgeryTest extends TestCase
 
         $response = $middleware->handle($request, fn () => new Response('OK'));
 
-        $this->assertEquals('OK', $response->getContent());
+        $this->assertSame('OK', $response->getContent());
     }
 
     public function test_cross_site_without_token_fails()
@@ -118,7 +118,7 @@ class PreventRequestForgeryTest extends TestCase
 
         $response = $middleware->handle($request, fn () => new Response('OK'));
 
-        $this->assertEquals('OK', $response->getContent());
+        $this->assertSame('OK', $response->getContent());
     }
 
     protected function createRequest(array $server = [], ?string $token = null)

--- a/tests/Http/Middleware/TrimStringsTest.php
+++ b/tests/Http/Middleware/TrimStringsTest.php
@@ -22,7 +22,7 @@ class TrimStringsTest extends TestCase
         $middleware = new TrimStrings;
 
         $middleware->handle($request, function ($req) {
-            $this->assertEquals('This title does not contain any zero-width space', $req->title);
+            $this->assertSame('This title does not contain any zero-width space', $req->title);
         });
     }
 
@@ -40,7 +40,7 @@ class TrimStringsTest extends TestCase
         $middleware = new TrimStrings;
 
         $middleware->handle($request, function ($req) {
-            $this->assertEquals('This title contains a zero-width space at the beginning', $req->title);
+            $this->assertSame('This title contains a zero-width space at the beginning', $req->title);
         });
     }
 
@@ -57,7 +57,7 @@ class TrimStringsTest extends TestCase
         $middleware = new TrimStrings;
 
         $middleware->handle($request, function ($req) {
-            $this->assertEquals(' test title ', $req->globally_ignored_title);
+            $this->assertSame(' test title ', $req->globally_ignored_title);
         });
     }
 
@@ -75,7 +75,7 @@ class TrimStringsTest extends TestCase
         $middleware = new TrimStrings;
 
         $middleware->handle($request, function ($req) {
-            $this->assertEquals('This title contains a zero-width space at the end', $req->title);
+            $this->assertSame('This title contains a zero-width space at the end', $req->title);
         });
     }
 
@@ -93,7 +93,7 @@ class TrimStringsTest extends TestCase
         $middleware = new TrimStrings;
 
         $middleware->handle($request, function ($req) {
-            $this->assertEquals('This title contains a zero-width non-breakable space at the beginning', $req->title);
+            $this->assertSame('This title contains a zero-width non-breakable space at the beginning', $req->title);
         });
     }
 
@@ -111,7 +111,7 @@ class TrimStringsTest extends TestCase
         $middleware = new TrimStrings;
 
         $middleware->handle($request, function ($req) {
-            $this->assertEquals('This title contains a zero-width non-breakable space at the beginning', $req->title);
+            $this->assertSame('This title contains a zero-width non-breakable space at the beginning', $req->title);
         });
     }
 
@@ -129,7 +129,7 @@ class TrimStringsTest extends TestCase
         $middleware = new TrimStrings;
 
         $middleware->handle($request, function ($req) {
-            $this->assertEquals('This title contains a combination of zero-width non-breakable space and zero-width spaces characters at the beginning and the end', $req->title);
+            $this->assertSame('This title contains a combination of zero-width non-breakable space and zero-width spaces characters at the beginning and the end', $req->title);
         });
     }
 
@@ -147,7 +147,7 @@ class TrimStringsTest extends TestCase
         $middleware = new TrimStrings;
 
         $middleware->handle($request, function ($req) {
-            $this->assertEquals('This title contains a invisible character at the beginning', $req->title);
+            $this->assertSame('This title contains a invisible character at the beginning', $req->title);
         });
     }
 
@@ -165,7 +165,7 @@ class TrimStringsTest extends TestCase
         $middleware = new TrimStrings;
 
         $middleware->handle($request, function ($req) {
-            $this->assertEquals('This title contains a invisible character at the end', $req->title);
+            $this->assertSame('This title contains a invisible character at the end', $req->title);
         });
     }
 
@@ -183,7 +183,7 @@ class TrimStringsTest extends TestCase
         $middleware = new TrimStrings;
 
         $middleware->handle($request, function ($req) {
-            $this->assertEquals('This title contains a invisible character at the beginning', $req->title);
+            $this->assertSame('This title contains a invisible character at the beginning', $req->title);
         });
     }
 
@@ -201,7 +201,7 @@ class TrimStringsTest extends TestCase
         $middleware = new TrimStrings;
 
         $middleware->handle($request, function ($req) {
-            $this->assertEquals('This title contains a invisible character at the end', $req->title);
+            $this->assertSame('This title contains a invisible character at the end', $req->title);
         });
     }
 
@@ -219,7 +219,7 @@ class TrimStringsTest extends TestCase
         $middleware = new TrimStrings;
 
         $middleware->handle($request, function ($req) {
-            $this->assertEquals('This title contains a combination of a invisible character at beginning and the end', $req->title);
+            $this->assertSame('This title contains a combination of a invisible character at beginning and the end', $req->title);
         });
     }
 

--- a/tests/Http/Middleware/TrustProxiesTest.php
+++ b/tests/Http/Middleware/TrustProxiesTest.php
@@ -29,7 +29,7 @@ class TrustProxiesTest extends TestCase
         $this->assertSame('192.168.10.10', $req->getClientIp(), 'Assert untrusted proxy x-forwarded-for header not used');
         $this->assertSame('http', $req->getScheme(), 'Assert untrusted proxy x-forwarded-proto header not used');
         $this->assertSame('localhost', $req->getHost(), 'Assert untrusted proxy x-forwarded-host header not used');
-        $this->assertEquals(8888, $req->getPort(), 'Assert untrusted proxy x-forwarded-port header not used');
+        $this->assertSame(8888, $req->getPort(), 'Assert untrusted proxy x-forwarded-port header not used');
         $this->assertSame('', $req->getBaseUrl(), 'Assert untrusted proxy x-forwarded-prefix header not used');
     }
 
@@ -47,7 +47,7 @@ class TrustProxiesTest extends TestCase
         $this->assertSame('173.174.200.38', $req->getClientIp(), 'Assert trusted proxy x-forwarded-for header used');
         $this->assertSame('https', $req->getScheme(), 'Assert trusted proxy x-forwarded-proto header used');
         $this->assertSame('serversforhackers.com', $req->getHost(), 'Assert trusted proxy x-forwarded-host header used');
-        $this->assertEquals(443, $req->getPort(), 'Assert trusted proxy x-forwarded-port header used');
+        $this->assertSame(443, $req->getPort(), 'Assert trusted proxy x-forwarded-port header used');
         $this->assertSame('/prefix', $req->getBaseUrl(), 'Assert trusted proxy x-forwarded-prefix header used');
     }
 
@@ -199,7 +199,7 @@ class TrustProxiesTest extends TestCase
                 'Assert trusted proxy used forwarded header for scheme');
             $this->assertSame('serversforhackers.com', $request->getHost(),
                 'Assert trusted proxy used forwarded header for host');
-            $this->assertEquals(443, $request->getPort(), 'Assert trusted proxy used forwarded header for port');
+            $this->assertSame(443, $request->getPort(), 'Assert trusted proxy used forwarded header for port');
         });
     }
 
@@ -219,7 +219,7 @@ class TrustProxiesTest extends TestCase
                 'Assert trusted proxy did not use forwarded header for scheme');
             $this->assertSame('localhost', $request->getHost(),
                 'Assert trusted proxy did not use forwarded header for host');
-            $this->assertEquals(8888, $request->getPort(), 'Assert trusted proxy did not use forwarded header for port');
+            $this->assertSame(8888, $request->getPort(), 'Assert trusted proxy did not use forwarded header for port');
             $this->assertSame('', $request->getBaseUrl(), 'Assert trusted proxy did not use forwarded header for prefix');
         });
     }
@@ -240,7 +240,7 @@ class TrustProxiesTest extends TestCase
                 'Assert trusted proxy did not use forwarded header for scheme');
             $this->assertSame('serversforhackers.com', $request->getHost(),
                 'Assert trusted proxy used forwarded header for host');
-            $this->assertEquals(8888, $request->getPort(), 'Assert trusted proxy did not use forwarded header for port');
+            $this->assertSame(8888, $request->getPort(), 'Assert trusted proxy did not use forwarded header for port');
             $this->assertSame('', $request->getBaseUrl(), 'Assert trusted proxy did not use forwarded header for prefix');
         });
     }
@@ -261,7 +261,7 @@ class TrustProxiesTest extends TestCase
                 'Assert trusted proxy did not use forwarded header for scheme');
             $this->assertSame('localhost', $request->getHost(),
                 'Assert trusted proxy did not use forwarded header for host');
-            $this->assertEquals(443, $request->getPort(), 'Assert trusted proxy used forwarded header for port');
+            $this->assertSame(443, $request->getPort(), 'Assert trusted proxy used forwarded header for port');
             $this->assertSame('', $request->getBaseUrl(), 'Assert trusted proxy did not use forwarded header for prefix');
         });
     }
@@ -282,7 +282,7 @@ class TrustProxiesTest extends TestCase
                 'Assert trusted proxy did not use forwarded header for scheme');
             $this->assertSame('localhost', $request->getHost(),
                 'Assert trusted proxy did not use forwarded header for host');
-            $this->assertEquals(8888, $request->getPort(), 'Assert trusted proxy did not use forwarded header for port');
+            $this->assertSame(8888, $request->getPort(), 'Assert trusted proxy did not use forwarded header for port');
             $this->assertSame('/prefix', $request->getBaseUrl(), 'Assert trusted proxy used forwarded header for prefix');
         });
     }
@@ -303,7 +303,7 @@ class TrustProxiesTest extends TestCase
                 'Assert trusted proxy used forwarded header for scheme');
             $this->assertSame('localhost', $request->getHost(),
                 'Assert trusted proxy did not use forwarded header for host');
-            $this->assertEquals(8888, $request->getPort(), 'Assert trusted proxy did not use forwarded header for port');
+            $this->assertSame(8888, $request->getPort(), 'Assert trusted proxy did not use forwarded header for port');
             $this->assertSame('', $request->getBaseUrl(), 'Assert trusted proxy did not use forwarded header for prefix');
         });
     }
@@ -328,7 +328,7 @@ class TrustProxiesTest extends TestCase
                 'Assert trusted proxy used forwarded header for scheme');
             $this->assertSame('serversforhackers.com', $request->getHost(),
                 'Assert trusted proxy used forwarded header for host');
-            $this->assertEquals(443, $request->getPort(), 'Assert trusted proxy used forwarded header for port');
+            $this->assertSame(443, $request->getPort(), 'Assert trusted proxy used forwarded header for port');
             $this->assertSame('', $request->getBaseUrl(), 'Assert trusted proxy did not use forwarded header for prefix');
         });
     }

--- a/tests/Integration/Auth/AuthenticationTest.php
+++ b/tests/Integration/Auth/AuthenticationTest.php
@@ -154,19 +154,19 @@ class AuthenticationTest extends TestCase
         });
         Event::assertDispatched(Validated::class, function ($event) {
             $this->assertSame('web', $event->guard);
-            $this->assertEquals(1, $event->user->id);
+            $this->assertSame(1, $event->user->id);
 
             return true;
         });
         Event::assertDispatched(Login::class, function ($event) {
             $this->assertSame('web', $event->guard);
-            $this->assertEquals(1, $event->user->id);
+            $this->assertSame(1, $event->user->id);
 
             return true;
         });
         Event::assertDispatched(Authenticated::class, function ($event) {
             $this->assertSame('web', $event->guard);
-            $this->assertEquals(1, $event->user->id);
+            $this->assertSame(1, $event->user->id);
 
             return true;
         });
@@ -175,7 +175,7 @@ class AuthenticationTest extends TestCase
     public function testLoggingInUsingId()
     {
         $this->app['auth']->loginUsingId(1);
-        $this->assertEquals(1, $this->app['auth']->user()->id);
+        $this->assertSame(1, $this->app['auth']->user()->id);
 
         $this->assertFalse($this->app['auth']->loginUsingId(1000));
     }
@@ -185,13 +185,13 @@ class AuthenticationTest extends TestCase
         Event::fake();
 
         $this->app['auth']->loginUsingId(1);
-        $this->assertEquals(1, $this->app['auth']->user()->id);
+        $this->assertSame(1, $this->app['auth']->user()->id);
 
         $this->app['auth']->logout();
         $this->assertNull($this->app['auth']->user());
         Event::assertDispatched(Logout::class, function ($event) {
             $this->assertSame('web', $event->guard);
-            $this->assertEquals(1, $event->user->id);
+            $this->assertSame(1, $event->user->id);
 
             return true;
         });
@@ -205,14 +205,14 @@ class AuthenticationTest extends TestCase
 
         $user = $this->app['auth']->user();
 
-        $this->assertEquals(1, $user->id);
+        $this->assertSame(1, $user->id);
 
         $this->app['auth']->logoutOtherDevices('password');
-        $this->assertEquals(1, $user->id);
+        $this->assertSame(1, $user->id);
 
         Event::assertDispatched(OtherDeviceLogout::class, function ($event) {
             $this->assertSame('web', $event->guard);
-            $this->assertEquals(1, $event->user->id);
+            $this->assertSame(1, $event->user->id);
 
             return true;
         });
@@ -227,7 +227,7 @@ class AuthenticationTest extends TestCase
 
         $user = $this->app['auth']->user();
 
-        $this->assertEquals(1, $user->id);
+        $this->assertSame(1, $user->id);
 
         $this->app['auth']->logoutOtherDevices('adifferentpassword');
     }

--- a/tests/Integration/Auth/ForgotPasswordTest.php
+++ b/tests/Integration/Auth/ForgotPasswordTest.php
@@ -81,7 +81,7 @@ class ForgotPasswordTest extends TestCase
         ]);
 
         Event::assertDispatched(PasswordResetLinkSent::class, function ($event) {
-            $this->assertEquals(1, $event->user->id);
+            $this->assertSame(1, $event->user->id);
 
             return true;
         });

--- a/tests/Integration/Cache/DynamoDbStoreTest.php
+++ b/tests/Integration/Cache/DynamoDbStoreTest.php
@@ -20,7 +20,7 @@ class DynamoDbStoreTest extends TestCase
 
         Cache::driver('dynamodb')->put(['name' => 'Abigail', 'age' => 28], 10);
         $this->assertSame('Abigail', Cache::driver('dynamodb')->get('name'));
-        $this->assertEquals(28, Cache::driver('dynamodb')->get('age'));
+        $this->assertSame(28, Cache::driver('dynamodb')->get('age'));
 
         $this->assertEquals([
             'name' => 'Abigail',
@@ -46,10 +46,10 @@ class DynamoDbStoreTest extends TestCase
         Cache::driver('dynamodb')->increment('counter');
         Cache::driver('dynamodb')->increment('counter', 4);
 
-        $this->assertEquals(5, Cache::driver('dynamodb')->get('counter'));
+        $this->assertSame(5, Cache::driver('dynamodb')->get('counter'));
 
         Cache::driver('dynamodb')->decrement('counter', 5);
-        $this->assertEquals(0, Cache::driver('dynamodb')->get('counter'));
+        $this->assertSame(0, Cache::driver('dynamodb')->get('counter'));
     }
 
     public function testLocksCanBeAcquired()

--- a/tests/Integration/Cache/RedisCacheIntegrationTest.php
+++ b/tests/Integration/Cache/RedisCacheIntegrationTest.php
@@ -52,7 +52,7 @@ class RedisCacheIntegrationTest extends TestCase
         $rateLimiter = new RateLimiter($repository);
 
         $this->assertFalse($rateLimiter->tooManyAttempts('key', 1));
-        $this->assertEquals(1, $rateLimiter->hit('key', 60));
+        $this->assertSame(1, $rateLimiter->hit('key', 60));
         $this->assertTrue($rateLimiter->tooManyAttempts('key', 1));
         $this->assertFalse($rateLimiter->tooManyAttempts('key', 2));
     }

--- a/tests/Integration/Cache/RedisStoreTest.php
+++ b/tests/Integration/Cache/RedisStoreTest.php
@@ -108,7 +108,7 @@ class RedisStoreTest extends TestCase
         Cache::store('redis')->tags(['people', 'author'])->put('name', 'Sally', 5);
         Cache::store('redis')->tags(['people', 'author'])->put('age', 30, 5);
 
-        $this->assertEquals('Sally', Cache::store('redis')->tags(['people', 'author'])->get('name'));
+        $this->assertSame('Sally', Cache::store('redis')->tags(['people', 'author'])->get('name'));
         $this->assertSame(30, Cache::store('redis')->tags(['people', 'author'])->get('age'));
 
         Cache::store('redis')->tags(['people', 'author'])->flush();
@@ -124,7 +124,7 @@ class RedisStoreTest extends TestCase
         Cache::store('redis')->tags(['people', 'author'])->forever('name', 'Sally');
         Cache::store('redis')->tags(['people', 'author'])->forever('age', 30);
 
-        $this->assertEquals('Sally', Cache::store('redis')->tags(['people', 'author'])->get('name'));
+        $this->assertSame('Sally', Cache::store('redis')->tags(['people', 'author'])->get('name'));
         $this->assertSame(30, Cache::store('redis')->tags(['people', 'author'])->get('age'));
 
         Cache::store('redis')->tags(['people', 'author'])->flush();
@@ -198,7 +198,7 @@ class RedisStoreTest extends TestCase
 
         Cache::store('redis')->tags(['artist'])->flush();
 
-        $this->assertEquals('Sally', Cache::store('redis')->tags(['people', 'author'])->get('person-1'));
+        $this->assertSame('Sally', Cache::store('redis')->tags(['people', 'author'])->get('person-1'));
         $this->assertNull(Cache::store('redis')->tags(['people', 'artist'])->get('person-2'));
 
         $keyCount = Cache::store('redis')->connection()->keys('*');
@@ -285,9 +285,9 @@ class RedisStoreTest extends TestCase
             Cache::store('redis')->tags($tags)->put("key:{$i}", "value:{$i}", 300);
         }
 
-        $this->assertEquals('value:1', Cache::store('redis')->tags($tags)->get('key:1'));
-        $this->assertEquals('value:2500', Cache::store('redis')->tags($tags)->get('key:2500'));
-        $this->assertEquals('value:5000', Cache::store('redis')->tags($tags)->get('key:5000'));
+        $this->assertSame('value:1', Cache::store('redis')->tags($tags)->get('key:1'));
+        $this->assertSame('value:2500', Cache::store('redis')->tags($tags)->get('key:2500'));
+        $this->assertSame('value:5000', Cache::store('redis')->tags($tags)->get('key:5000'));
 
         Cache::store('redis')->tags($tags)->flush();
 

--- a/tests/Integration/Cache/RedisStoreTest.php
+++ b/tests/Integration/Cache/RedisStoreTest.php
@@ -240,7 +240,7 @@ class RedisStoreTest extends TestCase
             'norf' => null,
         ], $store->many(['foo', 'fizz', 'quz', 'norf']));
 
-        $this->assertEquals([], $store->many([]));
+        $this->assertSame([], $store->many([]));
     }
 
     public function testPutManyCallsPutWhenClustered()

--- a/tests/Integration/Cache/RedisStoreTest.php
+++ b/tests/Integration/Cache/RedisStoreTest.php
@@ -109,12 +109,12 @@ class RedisStoreTest extends TestCase
         Cache::store('redis')->tags(['people', 'author'])->put('age', 30, 5);
 
         $this->assertEquals('Sally', Cache::store('redis')->tags(['people', 'author'])->get('name'));
-        $this->assertEquals(30, Cache::store('redis')->tags(['people', 'author'])->get('age'));
+        $this->assertSame(30, Cache::store('redis')->tags(['people', 'author'])->get('age'));
 
         Cache::store('redis')->tags(['people', 'author'])->flush();
 
         $keyCount = Cache::store('redis')->connection()->keys('*');
-        $this->assertEquals(0, count($keyCount));
+        $this->assertSame(0, count($keyCount));
     }
 
     public function testTagEntriesCanBeStoredForever()
@@ -125,12 +125,12 @@ class RedisStoreTest extends TestCase
         Cache::store('redis')->tags(['people', 'author'])->forever('age', 30);
 
         $this->assertEquals('Sally', Cache::store('redis')->tags(['people', 'author'])->get('name'));
-        $this->assertEquals(30, Cache::store('redis')->tags(['people', 'author'])->get('age'));
+        $this->assertSame(30, Cache::store('redis')->tags(['people', 'author'])->get('age'));
 
         Cache::store('redis')->tags(['people', 'author'])->flush();
 
         $keyCount = Cache::store('redis')->connection()->keys('*');
-        $this->assertEquals(0, count($keyCount));
+        $this->assertSame(0, count($keyCount));
     }
 
     public function testTagEntriesCanBeIncremented()
@@ -141,12 +141,12 @@ class RedisStoreTest extends TestCase
         Cache::store('redis')->tags(['votes'])->increment('person-1');
         Cache::store('redis')->tags(['votes'])->increment('person-1');
 
-        $this->assertEquals(2, Cache::store('redis')->tags(['votes'])->get('person-1'));
+        $this->assertSame(2, Cache::store('redis')->tags(['votes'])->get('person-1'));
 
         Cache::store('redis')->tags(['votes'])->decrement('person-1');
         Cache::store('redis')->tags(['votes'])->decrement('person-1');
 
-        $this->assertEquals(0, Cache::store('redis')->tags(['votes'])->get('person-1'));
+        $this->assertSame(0, Cache::store('redis')->tags(['votes'])->get('person-1'));
     }
 
     public function testIncrementedTagEntriesProperlyTurnStale()
@@ -162,7 +162,7 @@ class RedisStoreTest extends TestCase
         Cache::store('redis')->tags(['votes'])->flushStale();
 
         $keyCount = Cache::store('redis')->connection()->keys('*');
-        $this->assertEquals(0, count($keyCount));
+        $this->assertSame(0, count($keyCount));
     }
 
     public function testPastTtlTagEntriesAreNotAdded()
@@ -175,7 +175,7 @@ class RedisStoreTest extends TestCase
         $this->assertNull($value);
 
         $keyCount = Cache::store('redis')->connection()->keys('*');
-        $this->assertEquals(0, count($keyCount));
+        $this->assertSame(0, count($keyCount));
     }
 
     public function testPutPastTtlTagEntriesProperlyTurnStale()
@@ -186,7 +186,7 @@ class RedisStoreTest extends TestCase
         Cache::store('redis')->tags(['votes'])->flushStale();
 
         $keyCount = Cache::store('redis')->connection()->keys('*');
-        $this->assertEquals(0, count($keyCount));
+        $this->assertSame(0, count($keyCount));
     }
 
     public function testTagsCanBeFlushedBySingleKey()
@@ -202,7 +202,7 @@ class RedisStoreTest extends TestCase
         $this->assertNull(Cache::store('redis')->tags(['people', 'artist'])->get('person-2'));
 
         $keyCount = Cache::store('redis')->connection()->keys('*');
-        $this->assertEquals(3, count($keyCount)); // Sets for people, authors, and actual entry for Sally
+        $this->assertSame(3, count($keyCount)); // Sets for people, authors, and actual entry for Sally
     }
 
     public function testStaleEntriesCanBeFlushed()
@@ -220,7 +220,7 @@ class RedisStoreTest extends TestCase
         Cache::store('redis')->tags(['people'])->flushStale();
 
         $keyCount = Cache::store('redis')->connection()->keys('*');
-        $this->assertEquals(4, count($keyCount)); // Sets for people, authors, and artists + individual entry for Jennifer
+        $this->assertSame(4, count($keyCount)); // Sets for people, authors, and artists + individual entry for Jennifer
     }
 
     public function testMultipleItemsCanBeSetAndRetrieved()
@@ -269,10 +269,10 @@ class RedisStoreTest extends TestCase
 
         $store->flush();
         $store->add('foo', 1, 10);
-        $this->assertEquals(1, $store->get('foo'));
+        $this->assertSame(1, $store->get('foo'));
 
         $store->increment('foo');
-        $this->assertEquals(2, $store->get('foo'));
+        $this->assertSame(2, $store->get('foo'));
     }
 
     public function testTagsCanBeFlushedWithLargeNumberOfKeys()

--- a/tests/Integration/Concurrency/ConcurrencyTest.php
+++ b/tests/Integration/Concurrency/ConcurrencyTest.php
@@ -39,8 +39,8 @@ PHP);
 
         [$first, $second] = $response->original;
 
-        $this->assertEquals(2, $first);
-        $this->assertEquals(4, $second);
+        $this->assertSame(2, $first);
+        $this->assertSame(4, $second);
     }
 
     public function testRunHandlerProcessErrorCode()
@@ -84,8 +84,8 @@ PHP);
         // $this->assertIsArray($forkOutput);
         // $this->assertArrayHasKey('first', $forkOutput);
         // $this->assertArrayHasKey('second', $forkOutput);
-        // $this->assertEquals(2, $forkOutput['first']);
-        // $this->assertEquals(4, $forkOutput['second']);
+        // $this->assertSame(2, $forkOutput['first']);
+        // $this->assertSame(4, $forkOutput['second']);
     }
 
     public function testRunHandlerProcessErrorWithDefaultExceptionWithoutParam()

--- a/tests/Integration/Concurrency/ConcurrencyTest.php
+++ b/tests/Integration/Concurrency/ConcurrencyTest.php
@@ -154,9 +154,9 @@ PHP);
             },
         ]);
 
-        $this->assertEquals('first', $first);
-        $this->assertEquals('second', $second);
-        $this->assertEquals('third', $third);
+        $this->assertSame('first', $first);
+        $this->assertSame('second', $second);
+        $this->assertSame('third', $third);
     }
 }
 

--- a/tests/Integration/Concurrency/Console/InvokeSerializedClosureCommandTest.php
+++ b/tests/Integration/Concurrency/Console/InvokeSerializedClosureCommandTest.php
@@ -48,7 +48,7 @@ class InvokeSerializedClosureCommandTest extends TestCase
 
         // Verify the result
         $this->assertTrue($result['successful']);
-        $this->assertEquals('Hello, World!', unserialize($result['result']));
+        $this->assertSame('Hello, World!', unserialize($result['result']));
     }
 
     public function testItCanInvokeSerializedClosureFromEnvironment()
@@ -71,7 +71,7 @@ class InvokeSerializedClosureCommandTest extends TestCase
 
         // Verify the result
         $this->assertTrue($result['successful']);
-        $this->assertEquals('From Environment', unserialize($result['result']));
+        $this->assertSame('From Environment', unserialize($result['result']));
 
         // Clean up
         unset($_SERVER['LARAVEL_INVOKABLE_CLOSURE']);
@@ -112,8 +112,8 @@ class InvokeSerializedClosureCommandTest extends TestCase
 
         // Verify the exception was caught
         $this->assertFalse($result['successful']);
-        $this->assertEquals('RuntimeException', $result['exception']);
-        $this->assertEquals('Test exception', $result['message']);
+        $this->assertSame('RuntimeException', $result['exception']);
+        $this->assertSame('Test exception', $result['message']);
     }
 
     public function testItHandlesCustomExceptionWithParameters()
@@ -136,6 +136,6 @@ class InvokeSerializedClosureCommandTest extends TestCase
         // Verify the exception was caught and parameters were captured
         $this->assertFalse($result['successful']);
         $this->assertArrayHasKey('parameters', $result);
-        $this->assertEquals('Test param', $result['parameters']['customParam'] ?? null);
+        $this->assertSame('Test param', $result['parameters']['customParam'] ?? null);
     }
 }

--- a/tests/Integration/Console/Scheduling/SubMinuteSchedulingTest.php
+++ b/tests/Integration/Console/Scheduling/SubMinuteSchedulingTest.php
@@ -86,8 +86,8 @@ class SubMinuteSchedulingTest extends TestCase
             ->expectsOutputToContain('Running [Callback]');
 
         Sleep::assertSleptTimes(600);
-        $this->assertEquals(60, $everySecondRuns);
-        $this->assertEquals(2, $everyThirtySecondsRuns);
+        $this->assertSame(60, $everySecondRuns);
+        $this->assertSame(2, $everyThirtySecondsRuns);
     }
 
     public function test_sub_minute_scheduling_can_be_interrupted()
@@ -113,8 +113,8 @@ class SubMinuteSchedulingTest extends TestCase
             ->expectsOutputToContain('Running [Callback]');
 
         Sleep::assertSleptTimes(300);
-        $this->assertEquals(30, $runs);
-        $this->assertEquals(30, $startedAt->diffInSeconds(Carbon::now()));
+        $this->assertSame(30, $runs);
+        $this->assertSame(30.0, $startedAt->diffInSeconds(Carbon::now()));
     }
 
     public function test_sub_minute_events_stop_for_the_rest_of_the_minute_once_maintenance_mode_is_enabled()
@@ -145,7 +145,7 @@ class SubMinuteSchedulingTest extends TestCase
             ->expectsOutputToContain('Running [Callback]');
 
         Sleep::assertSleptTimes(600);
-        $this->assertEquals(30, $runs);
+        $this->assertSame(30, $runs);
     }
 
     public function test_sub_minute_events_can_be_run_in_maintenance_mode()
@@ -172,7 +172,7 @@ class SubMinuteSchedulingTest extends TestCase
             ->expectsOutputToContain('Running [Callback]');
 
         Sleep::assertSleptTimes(600);
-        $this->assertEquals(60, $runs);
+        $this->assertSame(60, $runs);
     }
 
     public function test_sub_minute_events_can_be_run_when_schedule_is_paused()
@@ -197,7 +197,7 @@ class SubMinuteSchedulingTest extends TestCase
             ->expectsOutputToContain('Running [Callback]');
 
         Sleep::assertSleptTimes(600);
-        $this->assertEquals(60, $runs);
+        $this->assertSame(60, $runs);
     }
 
     public function test_sub_minute_events_stop_for_the_rest_of_the_minute_once_schedule_is_paused()
@@ -222,7 +222,7 @@ class SubMinuteSchedulingTest extends TestCase
             ->expectsOutputToContain('Running [Callback]');
 
         Sleep::assertSleptTimes(600);
-        $this->assertEquals(30, $runs);
+        $this->assertSame(30, $runs);
     }
 
     public function test_sub_minute_scheduling_respects_filters()
@@ -240,7 +240,7 @@ class SubMinuteSchedulingTest extends TestCase
             ->expectsOutputToContain('Running [Callback]');
 
         Sleep::assertSleptTimes(600);
-        $this->assertEquals(30, $runs);
+        $this->assertSame(30, $runs);
     }
 
     public function test_sub_minute_scheduling_can_run_on_one_server()
@@ -260,7 +260,7 @@ class SubMinuteSchedulingTest extends TestCase
             ->expectsOutputToContain('Running [test]');
 
         Sleep::assertSleptTimes(600);
-        $this->assertEquals(60, $runs);
+        $this->assertSame(60, $runs);
 
         // Fake a second server running at the same minute.
         Carbon::setTestNow($startedAt);
@@ -270,7 +270,7 @@ class SubMinuteSchedulingTest extends TestCase
             ->expectsOutputToContain('Skipping [test]');
 
         Sleep::assertSleptTimes(1200);
-        $this->assertEquals(60, $runs);
+        $this->assertSame(60, $runs);
     }
 
     public static function frequencyProvider()

--- a/tests/Integration/Container/BuildableIntegrationTest.php
+++ b/tests/Integration/Container/BuildableIntegrationTest.php
@@ -25,7 +25,7 @@ class BuildableIntegrationTest extends TestCase
 
         $config = $this->app->make(AolInstantMessengerConfig::class);
 
-        $this->assertEquals(500, $config->awayMessageDuration);
+        $this->assertSame(500, $config->awayMessageDuration);
         $this->assertEquals('sad emo lyrics', $config->awayMessage);
         $this->assertEquals('api-key', $config->apiKey);
         $this->assertEquals('cosmastech', $config->userName);

--- a/tests/Integration/Container/BuildableIntegrationTest.php
+++ b/tests/Integration/Container/BuildableIntegrationTest.php
@@ -26,9 +26,9 @@ class BuildableIntegrationTest extends TestCase
         $config = $this->app->make(AolInstantMessengerConfig::class);
 
         $this->assertSame(500, $config->awayMessageDuration);
-        $this->assertEquals('sad emo lyrics', $config->awayMessage);
-        $this->assertEquals('api-key', $config->apiKey);
-        $this->assertEquals('cosmastech', $config->userName);
+        $this->assertSame('sad emo lyrics', $config->awayMessage);
+        $this->assertSame('api-key', $config->apiKey);
+        $this->assertSame('cosmastech', $config->userName);
 
         config(['aim.away_message.duration' => 5]);
 

--- a/tests/Integration/Container/ContextualAttributesBindingIntegrationTest.php
+++ b/tests/Integration/Container/ContextualAttributesBindingIntegrationTest.php
@@ -31,10 +31,10 @@ class ContextualAttributesBindingIntegrationTest extends TestCase
         $records = new Collection($testHandler->getRecords());
 
         $this->assertCount(2, $records);
-        $this->assertEquals('hello', $records->firstWhere(function (LogRecord $record) {
+        $this->assertSame('hello', $records->firstWhere(function (LogRecord $record) {
             return $record->channel === 'testing';
         })->message);
-        $this->assertEquals('bye', $records->firstWhere(function (LogRecord $record) {
+        $this->assertSame('bye', $records->firstWhere(function (LogRecord $record) {
             return $record->channel === 'look-ma-a-channel-name';
         })->message);
     }

--- a/tests/Integration/Cookie/CookieTest.php
+++ b/tests/Integration/Cookie/CookieTest.php
@@ -24,7 +24,7 @@ class CookieTest extends TestCase
 
         $response = $this->get('/');
         $this->assertCount(2, $response->headers->getCookies());
-        $this->assertEquals(0, $response->headers->getCookies()[1]->getExpiresTime());
+        $this->assertSame(0, $response->headers->getCookies()[1]->getExpiresTime());
     }
 
     public function test_cookie_is_sent_back_with_proper_expire_time_with_respect_to_lifetime()

--- a/tests/Integration/Database/DatabaseTransactionsTest.php
+++ b/tests/Integration/Database/DatabaseTransactionsTest.php
@@ -36,8 +36,8 @@ class DatabaseTransactionsTest extends DatabaseTestCase
 
         $this->assertTrue($firstObject->ran);
         $this->assertTrue($secondObject->ran);
-        $this->assertEquals(1, $firstObject->runs);
-        $this->assertEquals(1, $secondObject->runs);
+        $this->assertSame(1, $firstObject->runs);
+        $this->assertSame(1, $secondObject->runs);
         $this->assertFalse($thirdObject->ran);
     }
 
@@ -70,8 +70,8 @@ class DatabaseTransactionsTest extends DatabaseTestCase
 
         $this->assertTrue($firstObject->ran);
         $this->assertTrue($secondObject->ran);
-        $this->assertEquals(1, $firstObject->runs);
-        $this->assertEquals(1, $secondObject->runs);
+        $this->assertSame(1, $firstObject->runs);
+        $this->assertSame(1, $secondObject->runs);
         $this->assertFalse($thirdObject->ran);
     }
 

--- a/tests/Integration/Database/EloquentAggregateTest.php
+++ b/tests/Integration/Database/EloquentAggregateTest.php
@@ -29,11 +29,11 @@ class EloquentAggregateTest extends DatabaseTestCase
 
         $this->assertEquals(-1, UserAggregateTest::query()->min('balance'));
         $this->assertNull(UserAggregateTest::query()->where('name', 'no-name')->min('balance'));
-        $this->assertEquals(1, UserAggregateTest::query()->where('c', '>', 3)->min('balance'));
+        $this->assertSame(1, UserAggregateTest::query()->where('c', '>', 3)->min('balance'));
 
-        $this->assertEquals(2, UserAggregateTest::query()->max('balance'));
+        $this->assertSame(2, UserAggregateTest::query()->max('balance'));
         $this->assertNull(UserAggregateTest::query()->where('name', 'no-name')->max('balance'));
-        $this->assertEquals(0, UserAggregateTest::query()->where('c', '<', 4)->max('balance'));
+        $this->assertSame(0, UserAggregateTest::query()->where('c', '<', 4)->max('balance'));
     }
 
     public function testAvg()
@@ -45,11 +45,11 @@ class EloquentAggregateTest extends DatabaseTestCase
         UserAggregateTest::create(['c' => 5, 'name' => 'test-name5', 'balance' => +20]);
         UserAggregateTest::create(['c' => 6, 'name' => 'test-name5', 'balance' => null]);
 
-        $this->assertEquals(2, UserAggregateTest::query()->avg('balance'));
+        $this->assertSame(2.0, UserAggregateTest::query()->avg('balance'));
         $this->assertNull(UserAggregateTest::query()->where('name', 'no-name')->avg('balance'));
-        $this->assertEquals(15, UserAggregateTest::query()->where('c', '>', 3)->avg('balance'));
+        $this->assertSame(15.0, UserAggregateTest::query()->where('c', '>', 3)->avg('balance'));
 
-        $this->assertEquals(2, UserAggregateTest::query()->average('balance'));
+        $this->assertSame(2.0, UserAggregateTest::query()->average('balance'));
         $this->assertNull(UserAggregateTest::query()->where('name', 'no-name')->average('balance'));
         $this->assertEquals(-10, UserAggregateTest::query()->where('c', '<', 3)->average('balance'));
     }
@@ -65,8 +65,8 @@ class EloquentAggregateTest extends DatabaseTestCase
         $this->assertEquals(-9, UserAggregateTest::query()->sum('balance'));
         $result = UserAggregateTest::query()->where('name', 'no-name')->sum('balance');
         $this->assertNotNull($result);
-        $this->assertEquals(0, $result);
-        $this->assertEquals(2, UserAggregateTest::query()->where('c', '>', 1)->sum('balance'));
+        $this->assertSame(0, $result);
+        $this->assertSame(2, UserAggregateTest::query()->where('c', '>', 1)->sum('balance'));
     }
 
     public function testNumericAggregate()
@@ -77,10 +77,10 @@ class EloquentAggregateTest extends DatabaseTestCase
         UserAggregateTest::create(['c' => 4, 'name' => 'name-4', 'balance' => 20]);
         UserAggregateTest::create(['c' => 5, 'name' => 'name-5', 'balance' => null]);
 
-        $this->assertEquals(20, UserAggregateTest::query()->numericAggregate('sum', ['balance']));
+        $this->assertSame(20, UserAggregateTest::query()->numericAggregate('sum', ['balance']));
         // When calculating the average, rows with NULL values are excluded
-        $this->assertEquals(5, UserAggregateTest::query()->numericAggregate('avg', ['balance']));
-        $this->assertEquals(40, UserAggregateTest::query()->numericAggregate('max', ['balance']));
+        $this->assertSame(5.0, UserAggregateTest::query()->numericAggregate('avg', ['balance']));
+        $this->assertSame(40, UserAggregateTest::query()->numericAggregate('max', ['balance']));
         $this->assertEquals(-40, UserAggregateTest::query()->numericAggregate('min', ['balance']));
     }
 }

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -162,9 +162,9 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $pivot->tag_id = 2;
         $pivot->save();
 
-        $this->assertEquals(1, PostTagPivot::count());
-        $this->assertEquals(1, PostTagPivot::first()->post_id);
-        $this->assertEquals(2, PostTagPivot::first()->tag_id);
+        $this->assertSame(1, PostTagPivot::count());
+        $this->assertSame(1, PostTagPivot::first()->post_id);
+        $this->assertSame(2, PostTagPivot::first()->tag_id);
     }
 
     public function testCustomPivotClassUsingSync()
@@ -1337,15 +1337,15 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $user->postsWithCustomPivot()->sync([$post1->uuid]);
         $this->assertEquals($user->uuid, $user->postsWithCustomPivot()->first()->pivot->user_uuid);
         $this->assertEquals($post1->uuid, $user->postsWithCustomPivot()->first()->pivot->post_uuid);
-        $this->assertEquals(1, $user->postsWithCustomPivot()->first()->pivot->is_draft);
+        $this->assertSame(1, $user->postsWithCustomPivot()->first()->pivot->is_draft);
 
         $user->postsWithCustomPivot()->sync([$post2->uuid]);
         $this->assertEquals($user->uuid, $user->postsWithCustomPivot()->first()->pivot->user_uuid);
         $this->assertEquals($post2->uuid, $user->postsWithCustomPivot()->first()->pivot->post_uuid);
-        $this->assertEquals(1, $user->postsWithCustomPivot()->first()->pivot->is_draft);
+        $this->assertSame(1, $user->postsWithCustomPivot()->first()->pivot->is_draft);
 
         $user->postsWithCustomPivot()->updateExistingPivot($post2->uuid, ['is_draft' => 0]);
-        $this->assertEquals(0, $user->postsWithCustomPivot()->first()->pivot->is_draft);
+        $this->assertSame(0, $user->postsWithCustomPivot()->first()->pivot->is_draft);
     }
 
     public function testOrderByPivotMethod()

--- a/tests/Integration/Database/EloquentCollectionLoadMissingTest.php
+++ b/tests/Integration/Database/EloquentCollectionLoadMissingTest.php
@@ -114,12 +114,12 @@ class EloquentCollectionLoadMissingTest extends DatabaseTestCase
         $user = User::first();
         $user->loadMissing('posts.postRelation.postSubRelations.postSubSubRelations');
 
-        $this->assertEquals(2, $user->posts->count());
+        $this->assertSame(2, $user->posts->count());
         $this->assertNull($user->posts[0]->postRelation);
         $this->assertInstanceOf(PostRelation::class, $user->posts[1]->postRelation);
-        $this->assertEquals(1, $user->posts[1]->postRelation->postSubRelations->count());
+        $this->assertSame(1, $user->posts[1]->postRelation->postSubRelations->count());
         $this->assertInstanceOf(PostSubRelation::class, $user->posts[1]->postRelation->postSubRelations[0]);
-        $this->assertEquals(1, $user->posts[1]->postRelation->postSubRelations[0]->postSubSubRelations->count());
+        $this->assertSame(1, $user->posts[1]->postRelation->postSubRelations[0]->postSubSubRelations->count());
         $this->assertInstanceOf(PostSubSubRelation::class, $user->posts[1]->postRelation->postSubRelations[0]->postSubSubRelations[0]);
     }
 
@@ -210,12 +210,12 @@ class EloquentCollectionLoadMissingTest extends DatabaseTestCase
         ]);
 
         $user = $users->first();
-        $this->assertEquals(2, $user->posts->count());
+        $this->assertSame(2, $user->posts->count());
         $this->assertNull($user->posts[0]->postRelation);
         $this->assertInstanceOf(PostRelation::class, $user->posts[1]->postRelation);
-        $this->assertEquals(1, $user->posts[1]->postRelation->postSubRelations->count());
+        $this->assertSame(1, $user->posts[1]->postRelation->postSubRelations->count());
         $this->assertInstanceOf(PostSubRelation::class, $user->posts[1]->postRelation->postSubRelations[0]);
-        $this->assertEquals(1, $user->posts[1]->postRelation->postSubRelations[0]->postSubSubRelations->count());
+        $this->assertSame(1, $user->posts[1]->postRelation->postSubRelations[0]->postSubSubRelations->count());
         $this->assertInstanceOf(PostSubSubRelation::class, $user->posts[1]->postRelation->postSubRelations[0]->postSubSubRelations[0]);
     }
 
@@ -231,12 +231,12 @@ class EloquentCollectionLoadMissingTest extends DatabaseTestCase
         ]);
 
         $user = $users->first();
-        $this->assertEquals(2, $user->posts->count());
+        $this->assertSame(2, $user->posts->count());
         $this->assertNull($user->posts[0]->postRelation);
         $this->assertInstanceOf(PostRelation::class, $user->posts[1]->postRelation);
-        $this->assertEquals(1, $user->posts[1]->postRelation->postSubRelations->count());
+        $this->assertSame(1, $user->posts[1]->postRelation->postSubRelations->count());
         $this->assertInstanceOf(PostSubRelation::class, $user->posts[1]->postRelation->postSubRelations[0]);
-        $this->assertEquals(1, $user->posts[1]->postRelation->postSubRelations[0]->postSubSubRelations->count());
+        $this->assertSame(1, $user->posts[1]->postRelation->postSubRelations[0]->postSubSubRelations->count());
         $this->assertInstanceOf(PostSubSubRelation::class, $user->posts[1]->postRelation->postSubRelations[0]->postSubSubRelations[0]);
     }
 }

--- a/tests/Integration/Database/EloquentCursorPaginateTest.php
+++ b/tests/Integration/Database/EloquentCursorPaginateTest.php
@@ -202,10 +202,10 @@ class EloquentCursorPaginateTest extends DatabaseTestCase
         $this->assertSame(['id'], $result->getOptions()['parameters']);
 
         $postB = $table2->where('id', '>', 1)->first();
-        $this->assertEquals('Post B', $postB->title, 'Expect `Post B` is the result of the second query');
+        $this->assertSame('Post B', $postB->title, 'Expect `Post B` is the result of the second query');
 
         $this->assertCount(1, $result->items(), 'Expect cursor paginated query should have 1 result');
-        $this->assertEquals('Post B', current($result->items())->title, 'Expect the paginated query would return `Post B`');
+        $this->assertSame('Post B', current($result->items())->title, 'Expect the paginated query would return `Post B`');
     }
 
     public function testPaginationWithMultipleAliases()
@@ -232,7 +232,7 @@ class EloquentCursorPaginateTest extends DatabaseTestCase
         $this->assertSame(['alias'], $result->getOptions()['parameters']);
 
         $this->assertCount(1, $result->items(), 'Expect cursor paginated query should have 1 result');
-        $this->assertEquals('B (post)', current($result->items())->alias, 'Expect the paginated query would return `B (post)`');
+        $this->assertSame('B (post)', current($result->items())->alias, 'Expect the paginated query would return `B (post)`');
     }
 
     public function testPaginationWithAliasedOrderBy()

--- a/tests/Integration/Database/EloquentCursorPaginateTest.php
+++ b/tests/Integration/Database/EloquentCursorPaginateTest.php
@@ -67,8 +67,8 @@ class EloquentCursorPaginateTest extends DatabaseTestCase
 
         $query = TestPost::query()->distinct();
 
-        $this->assertEquals(6, $query->get()->count());
-        $this->assertEquals(6, $query->count());
+        $this->assertSame(6, $query->get()->count());
+        $this->assertSame(6, $query->count());
         $this->assertCount(6, $query->cursorPaginate()->items());
     }
 
@@ -82,8 +82,8 @@ class EloquentCursorPaginateTest extends DatabaseTestCase
 
         $query = TestPost::query()->whereNull('user_id');
 
-        $this->assertEquals(3, $query->get()->count());
-        $this->assertEquals(3, $query->count());
+        $this->assertSame(3, $query->get()->count());
+        $this->assertSame(3, $query->count());
         $this->assertCount(3, $query->cursorPaginate()->items());
     }
 
@@ -100,8 +100,8 @@ class EloquentCursorPaginateTest extends DatabaseTestCase
 
         $query = TestUser::query()->has('posts');
 
-        $this->assertEquals(2, $query->get()->count());
-        $this->assertEquals(2, $query->count());
+        $this->assertSame(2, $query->get()->count());
+        $this->assertSame(2, $query->count());
         $this->assertCount(2, $query->cursorPaginate()->items());
     }
 
@@ -119,8 +119,8 @@ class EloquentCursorPaginateTest extends DatabaseTestCase
             $query->where('title', 'Howdy');
         });
 
-        $this->assertEquals(1, $query->get()->count());
-        $this->assertEquals(1, $query->count());
+        $this->assertSame(1, $query->get()->count());
+        $this->assertSame(1, $query->count());
         $this->assertCount(1, $query->cursorPaginate()->items());
     }
 
@@ -140,8 +140,8 @@ class EloquentCursorPaginateTest extends DatabaseTestCase
                 ->whereColumn('test_posts.user_id', 'test_users.id');
         });
 
-        $this->assertEquals(2, $query->get()->count());
-        $this->assertEquals(2, $query->count());
+        $this->assertSame(2, $query->get()->count());
+        $this->assertSame(2, $query->count());
         $this->assertCount(2, $query->cursorPaginate()->items());
     }
 
@@ -167,8 +167,8 @@ class EloquentCursorPaginateTest extends DatabaseTestCase
         $clonedQuery = $query->clone();
         $anotherQuery = $query->clone();
 
-        $this->assertEquals(2, $query->get()->count());
-        $this->assertEquals(2, $query->count());
+        $this->assertSame(2, $query->get()->count());
+        $this->assertSame(2, $query->count());
         $this->assertCount(2, $query->cursorPaginate()->items());
         $this->assertCount(1, $clonedQuery->cursorPaginate(1)->items());
         $this->assertCount(
@@ -243,8 +243,8 @@ class EloquentCursorPaginateTest extends DatabaseTestCase
         $clonedQuery = $query->clone();
         $anotherQuery = $query->clone();
 
-        $this->assertEquals(6, $query->get()->count());
-        $this->assertEquals(6, $query->count());
+        $this->assertSame(6, $query->get()->count());
+        $this->assertSame(6, $query->count());
         $this->assertCount(6, $query->cursorPaginate()->items());
         $this->assertCount(3, $clonedQuery->cursorPaginate(3)->items());
         $this->assertCount(
@@ -264,8 +264,8 @@ class EloquentCursorPaginateTest extends DatabaseTestCase
 
         $query = TestPost::query()->orderBy('title')->distinct('title')->select('title');
 
-        $this->assertEquals(2, $query->get()->count());
-        $this->assertEquals(2, $query->count());
+        $this->assertSame(2, $query->get()->count());
+        $this->assertSame(2, $query->count());
         $this->assertCount(2, $query->cursorPaginate()->items());
     }
 
@@ -288,8 +288,8 @@ class EloquentCursorPaginateTest extends DatabaseTestCase
         $query = TestUser::query()->join('test_posts', 'test_posts.user_id', '=', 'test_users.id')
             ->distinct('test_users.id')->select('test_users.*');
 
-        $this->assertEquals(5, $query->get()->count());
-        $this->assertEquals(5, $query->count());
+        $this->assertSame(5, $query->get()->count());
+        $this->assertSame(5, $query->count());
         $this->assertCount(5, $query->cursorPaginate()->items());
     }
 }

--- a/tests/Integration/Database/EloquentDeleteTest.php
+++ b/tests/Integration/Database/EloquentDeleteTest.php
@@ -174,7 +174,7 @@ class EloquentDeleteTest extends DatabaseTestCase
 
         $logs = PostStringyKey::query()->getConnection()->getQueryLog();
 
-        $this->assertEquals(0, PostStringyKey::query()->count());
+        $this->assertSame(0, PostStringyKey::query()->count());
 
         $this->assertStringStartsWith('select * from "my_posts" where "my_id" in (', str_replace(['`', '[', ']'], '"', $logs[0]['query']));
 

--- a/tests/Integration/Database/EloquentDeleteTest.php
+++ b/tests/Integration/Database/EloquentDeleteTest.php
@@ -133,7 +133,7 @@ class EloquentDeleteTest extends DatabaseTestCase
         $post = Post::query()->create([]);
         $result = $post->deleteQuietly();
 
-        $this->assertEquals('\(^_^)/', $_SERVER['(-_-)']);
+        $this->assertSame('\(^_^)/', $_SERVER['(-_-)']);
         $this->assertTrue($result);
         $this->assertFalse($post->exists);
 
@@ -144,7 +144,7 @@ class EloquentDeleteTest extends DatabaseTestCase
         $role = Role::create([]);
         $result = $role->deleteQuietly();
         $this->assertTrue($result);
-        $this->assertEquals('\(^_^)/', $_SERVER['(-_-)']);
+        $this->assertSame('\(^_^)/', $_SERVER['(-_-)']);
 
         unset($_SERVER['(-_-)']);
     }

--- a/tests/Integration/Database/EloquentHasManyThroughTest.php
+++ b/tests/Integration/Database/EloquentHasManyThroughTest.php
@@ -196,8 +196,8 @@ class EloquentHasManyThroughTest extends DatabaseTestCase
 
         $this->assertTrue($mate->wasRecentlyCreated);
         $this->assertNull($mate->team_id);
-        $this->assertEquals('Adam', $mate->name);
-        $this->assertEquals('adam', $mate->slug);
+        $this->assertSame('Adam', $mate->name);
+        $this->assertSame('adam', $mate->slug);
     }
 
     public function testFirstOrCreateWhenModelExists()
@@ -212,8 +212,8 @@ class EloquentHasManyThroughTest extends DatabaseTestCase
         $this->assertFalse($mate->wasRecentlyCreated);
         $this->assertNotNull($mate->team_id);
         $this->assertTrue($team->is($mate->team));
-        $this->assertEquals('Adam Wathan', $mate->name);
-        $this->assertEquals('adam', $mate->slug);
+        $this->assertSame('Adam Wathan', $mate->name);
+        $this->assertSame('adam', $mate->slug);
     }
 
     public function testFirstOrCreateRegressionIssue()
@@ -234,8 +234,8 @@ class EloquentHasManyThroughTest extends DatabaseTestCase
 
         $this->assertFalse($newJohn->wasRecentlyCreated);
         $this->assertTrue($john->is($newJohn));
-        $this->assertEquals('john', $newJohn->refresh()->slug);
-        $this->assertEquals('John', $newJohn->name);
+        $this->assertSame('john', $newJohn->refresh()->slug);
+        $this->assertSame('John', $newJohn->name);
 
         $this->assertSame('john', $john->refresh()->slug);
         $this->assertSame('John', $john->name);
@@ -254,7 +254,7 @@ class EloquentHasManyThroughTest extends DatabaseTestCase
         );
 
         $this->assertTrue($article->wasRecentlyCreated);
-        $this->assertEquals('Laravel Forever', $article->title);
+        $this->assertSame('Laravel Forever', $article->title);
         $this->assertTrue($tony->is($article->user));
     }
 
@@ -274,7 +274,7 @@ class EloquentHasManyThroughTest extends DatabaseTestCase
         );
 
         $this->assertFalse($newArticle->wasRecentlyCreated);
-        $this->assertEquals('Laravel Forever', $newArticle->title);
+        $this->assertSame('Laravel Forever', $newArticle->title);
         $this->assertTrue($taylor->is($newArticle->user));
         $this->assertTrue($existingArticle->is($newArticle));
     }
@@ -295,7 +295,7 @@ class EloquentHasManyThroughTest extends DatabaseTestCase
         ));
 
         $this->assertFalse($newArticle->wasRecentlyCreated);
-        $this->assertEquals('Laravel Forever', $newArticle->title);
+        $this->assertSame('Laravel Forever', $newArticle->title);
         $this->assertTrue($taylor->is($newArticle->user));
         $this->assertTrue($existingArticle->is($newArticle));
     }
@@ -317,7 +317,7 @@ class EloquentHasManyThroughTest extends DatabaseTestCase
 
         $this->assertFalse($newArticle->wasRecentlyCreated);
         $this->assertTrue($existingTaylorArticle->is($newArticle));
-        $this->assertEquals('Laravel Forever', $newArticle->refresh()->title);
+        $this->assertSame('Laravel Forever', $newArticle->refresh()->title);
         $this->assertTrue($taylor->is($newArticle->user));
 
         $this->assertSame('Laravel Forever', $existingTaylorArticle->refresh()->title);

--- a/tests/Integration/Database/EloquentMassPrunableTest.php
+++ b/tests/Integration/Database/EloquentMassPrunableTest.php
@@ -68,8 +68,8 @@ class EloquentMassPrunableTest extends DatabaseTestCase
 
         $count = (new MassPrunableTestModel)->pruneAll();
 
-        $this->assertEquals(1500, $count);
-        $this->assertEquals(3500, MassPrunableTestModel::count());
+        $this->assertSame(1500, $count);
+        $this->assertSame(3500, MassPrunableTestModel::count());
     }
 
     public function testPrunesSoftDeletedRecords()
@@ -87,9 +87,9 @@ class EloquentMassPrunableTest extends DatabaseTestCase
 
         $count = (new MassPrunableSoftDeleteTestModel)->pruneAll();
 
-        $this->assertEquals(3000, $count);
-        $this->assertEquals(0, MassPrunableSoftDeleteTestModel::count());
-        $this->assertEquals(2000, MassPrunableSoftDeleteTestModel::withTrashed()->count());
+        $this->assertSame(3000, $count);
+        $this->assertSame(0, MassPrunableSoftDeleteTestModel::count());
+        $this->assertSame(2000, MassPrunableSoftDeleteTestModel::withTrashed()->count());
     }
 }
 

--- a/tests/Integration/Database/EloquentModelLoadCountTest.php
+++ b/tests/Integration/Database/EloquentModelLoadCountTest.php
@@ -50,7 +50,7 @@ class EloquentModelLoadCountTest extends DatabaseTestCase
         $model->loadCount('related1');
 
         $this->assertCount(1, DB::getQueryLog());
-        $this->assertEquals(2, $model->related1_count);
+        $this->assertSame(2, $model->related1_count);
     }
 
     public function testLoadCountMultipleRelations()
@@ -62,8 +62,8 @@ class EloquentModelLoadCountTest extends DatabaseTestCase
         $model->loadCount(['related1', 'related2']);
 
         $this->assertCount(1, DB::getQueryLog());
-        $this->assertEquals(2, $model->related1_count);
-        $this->assertEquals(1, $model->related2_count);
+        $this->assertSame(2, $model->related1_count);
+        $this->assertSame(1, $model->related2_count);
     }
 
     public function testLoadCountDeletedRelations()
@@ -74,7 +74,7 @@ class EloquentModelLoadCountTest extends DatabaseTestCase
 
         $model->loadCount('deletedrelated');
 
-        $this->assertEquals(1, $model->deletedrelated_count);
+        $this->assertSame(1, $model->deletedrelated_count);
 
         DeletedRelated::first()->delete();
 
@@ -84,7 +84,7 @@ class EloquentModelLoadCountTest extends DatabaseTestCase
 
         $model->loadCount('deletedrelated');
 
-        $this->assertEquals(0, $model->deletedrelated_count);
+        $this->assertSame(0, $model->deletedrelated_count);
     }
 }
 

--- a/tests/Integration/Database/EloquentModelLoadMaxTest.php
+++ b/tests/Integration/Database/EloquentModelLoadMaxTest.php
@@ -45,7 +45,7 @@ class EloquentModelLoadMaxTest extends DatabaseTestCase
         $model->loadMax('related1', 'number');
 
         $this->assertCount(1, DB::getQueryLog());
-        $this->assertEquals(11, $model->related1_max_number);
+        $this->assertSame(11, $model->related1_max_number);
     }
 
     public function testLoadMaxMultipleRelations()
@@ -57,8 +57,8 @@ class EloquentModelLoadMaxTest extends DatabaseTestCase
         $model->loadMax(['related1', 'related2'], 'number');
 
         $this->assertCount(1, DB::getQueryLog());
-        $this->assertEquals(11, $model->related1_max_number);
-        $this->assertEquals(13, $model->related2_max_number);
+        $this->assertSame(11, $model->related1_max_number);
+        $this->assertSame(13, $model->related2_max_number);
     }
 }
 

--- a/tests/Integration/Database/EloquentModelLoadMinTest.php
+++ b/tests/Integration/Database/EloquentModelLoadMinTest.php
@@ -45,7 +45,7 @@ class EloquentModelLoadMinTest extends DatabaseTestCase
         $model->loadMin('related1', 'number');
 
         $this->assertCount(1, DB::getQueryLog());
-        $this->assertEquals(10, $model->related1_min_number);
+        $this->assertSame(10, $model->related1_min_number);
     }
 
     public function testLoadMinMultipleRelations()
@@ -57,8 +57,8 @@ class EloquentModelLoadMinTest extends DatabaseTestCase
         $model->loadMin(['related1', 'related2'], 'number');
 
         $this->assertCount(1, DB::getQueryLog());
-        $this->assertEquals(10, $model->related1_min_number);
-        $this->assertEquals(12, $model->related2_min_number);
+        $this->assertSame(10, $model->related1_min_number);
+        $this->assertSame(12, $model->related2_min_number);
     }
 }
 

--- a/tests/Integration/Database/EloquentModelLoadSumTest.php
+++ b/tests/Integration/Database/EloquentModelLoadSumTest.php
@@ -44,7 +44,7 @@ class EloquentModelLoadSumTest extends DatabaseTestCase
         $model->loadSum('related1', 'number');
 
         $this->assertCount(1, DB::getQueryLog());
-        $this->assertEquals(21, $model->related1_sum_number);
+        $this->assertSame(21, $model->related1_sum_number);
     }
 
     public function testLoadSumMultipleRelations()
@@ -56,8 +56,8 @@ class EloquentModelLoadSumTest extends DatabaseTestCase
         $model->loadSum(['related1', 'related2'], 'number');
 
         $this->assertCount(1, DB::getQueryLog());
-        $this->assertEquals(21, $model->related1_sum_number);
-        $this->assertEquals(12, $model->related2_sum_number);
+        $this->assertSame(21, $model->related1_sum_number);
+        $this->assertSame(12, $model->related2_sum_number);
     }
 }
 

--- a/tests/Integration/Database/EloquentModelRefreshTest.php
+++ b/tests/Integration/Database/EloquentModelRefreshTest.php
@@ -79,7 +79,7 @@ class EloquentModelRefreshTest extends DatabaseTestCase
 
         $post->children()->attach($child->getKey());
 
-        $this->assertEquals(1, $post->children->count());
+        $this->assertSame(1, $post->children->count());
 
         $post->children->first()->refresh();
     }

--- a/tests/Integration/Database/EloquentMorphCountEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentMorphCountEagerLoadingTest.php
@@ -57,7 +57,7 @@ class EloquentMorphCountEagerLoadingTest extends DatabaseTestCase
             ->get();
 
         $this->assertTrue($comments[0]->relationLoaded('commentable'));
-        $this->assertEquals(2, $comments[0]->commentable->likes_count);
+        $this->assertSame(2, $comments[0]->commentable->likes_count);
         $this->assertTrue($comments[1]->relationLoaded('commentable'));
         $this->assertNull($comments[1]->commentable->views_count);
     }
@@ -71,7 +71,7 @@ class EloquentMorphCountEagerLoadingTest extends DatabaseTestCase
             ->get();
 
         $this->assertTrue($comments[0]->relationLoaded('commentable'));
-        $this->assertEquals(2, $comments[0]->commentable->likes_count);
+        $this->assertSame(2, $comments[0]->commentable->likes_count);
     }
 }
 

--- a/tests/Integration/Database/EloquentMorphCountLazyEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentMorphCountLazyEagerLoadingTest.php
@@ -43,7 +43,7 @@ class EloquentMorphCountLazyEagerLoadingTest extends DatabaseTestCase
         ]);
 
         $this->assertTrue($comment->relationLoaded('commentable'));
-        $this->assertEquals(2, $comment->commentable->likes_count);
+        $this->assertSame(2, $comment->commentable->likes_count);
     }
 }
 

--- a/tests/Integration/Database/EloquentMultiDimensionalArrayEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentMultiDimensionalArrayEagerLoadingTest.php
@@ -117,7 +117,7 @@ class EloquentMultiDimensionalArrayEagerLoadingTest extends DatabaseTestCase
         $this->assertCount(1, $users);
         $this->assertTrue($users[0]->relationLoaded('posts'));
         $this->assertCount(2, $users[0]->posts);
-        $users[0]->posts->every(fn ($post) => $this->assertEquals(1, $post->comments_count));
+        $users[0]->posts->every(fn ($post) => $this->assertSame(1, $post->comments_count));
         $this->assertTrue($users[0]->posts->every->relationLoaded('comments'));
         $this->assertCount(2, $users[0]->posts->flatMap->comments);
         $this->assertTrue($users[0]->posts->flatMap->comments->every->relationLoaded('tags'));
@@ -192,7 +192,7 @@ class EloquentMultiDimensionalArrayEagerLoadingTest extends DatabaseTestCase
         $users[0]->posts->every(fn ($post) => $this->assertNull($post->content));
         $this->assertTrue($users[0]->posts->every->relationLoaded('comments'));
         $this->assertCount(2, $users[0]->posts->flatMap->comments);
-        $users[0]->posts->flatMap->comments->every(fn ($comment) => $this->assertEquals(3, $comment->tags_count));
+        $users[0]->posts->flatMap->comments->every(fn ($comment) => $this->assertSame(3, $comment->tags_count));
         $this->assertTrue($users[0]->posts->flatMap->comments->every->relationLoaded('tags'));
         $this->assertCount(6, $users[0]->posts->flatMap->comments->flatMap->tags);
     }

--- a/tests/Integration/Database/EloquentPaginateTest.php
+++ b/tests/Integration/Database/EloquentPaginateTest.php
@@ -43,9 +43,9 @@ class EloquentPaginateTest extends DatabaseTestCase
 
         $query = Post::query()->distinct();
 
-        $this->assertEquals(6, $query->get()->count());
-        $this->assertEquals(6, $query->count());
-        $this->assertEquals(6, $query->paginate()->total());
+        $this->assertSame(6, $query->get()->count());
+        $this->assertSame(6, $query->count());
+        $this->assertSame(6, $query->paginate()->total());
     }
 
     public function testPaginationWithDistinctAndSelect()
@@ -58,9 +58,9 @@ class EloquentPaginateTest extends DatabaseTestCase
 
         $query = Post::query()->distinct()->select('title');
 
-        $this->assertEquals(2, $query->get()->count());
-        $this->assertEquals(6, $query->count());
-        $this->assertEquals(6, $query->paginate()->total());
+        $this->assertSame(2, $query->get()->count());
+        $this->assertSame(6, $query->count());
+        $this->assertSame(6, $query->paginate()->total());
     }
 
     public function testPaginationWithDistinctColumnsAndSelect()
@@ -72,9 +72,9 @@ class EloquentPaginateTest extends DatabaseTestCase
 
         $query = Post::query()->distinct('title')->select('title');
 
-        $this->assertEquals(2, $query->get()->count());
-        $this->assertEquals(2, $query->count());
-        $this->assertEquals(2, $query->paginate()->total());
+        $this->assertSame(2, $query->get()->count());
+        $this->assertSame(2, $query->count());
+        $this->assertSame(2, $query->paginate()->total());
     }
 
     public function testPaginationWithDistinctColumnsAndSelectAndJoin()
@@ -92,9 +92,9 @@ class EloquentPaginateTest extends DatabaseTestCase
         $query = User::query()->join('posts', 'posts.user_id', '=', 'users.id')
             ->distinct('users.id')->select('users.*');
 
-        $this->assertEquals(5, $query->get()->count());
-        $this->assertEquals(5, $query->count());
-        $this->assertEquals(5, $query->paginate()->total());
+        $this->assertSame(5, $query->get()->count());
+        $this->assertSame(5, $query->count());
+        $this->assertSame(5, $query->paginate()->total());
     }
 }
 

--- a/tests/Integration/Database/EloquentPivotEventsTest.php
+++ b/tests/Integration/Database/EloquentPivotEventsTest.php
@@ -113,7 +113,7 @@ class EloquentPivotEventsTest extends DatabaseTestCase
 
         PivotEventsTestCollaborator::$eventsCalled = [];
         $project->contributors()->detach($user->id);
-        $this->assertEquals([], PivotEventsTestCollaborator::$eventsCalled);
+        $this->assertSame([], PivotEventsTestCollaborator::$eventsCalled);
     }
 
     public function testCustomPivotUpdateEventHasExistingAttributes()

--- a/tests/Integration/Database/EloquentPivotTest.php
+++ b/tests/Integration/Database/EloquentPivotTest.php
@@ -53,8 +53,8 @@ class EloquentPivotTest extends DatabaseTestCase
         $project->collaborators()->attach($user2);
 
         tap($project->contributors->first()->pivot, function ($pivot) {
-            $this->assertEquals(1, $pivot->getKey());
-            $this->assertEquals(1, $pivot->getQueueableId());
+            $this->assertSame(1, $pivot->getKey());
+            $this->assertSame(1, $pivot->getQueueableId());
             $this->assertSame('user_id', $pivot->getRelatedKey());
             $this->assertSame('project_id', $pivot->getForeignKey());
         });

--- a/tests/Integration/Database/EloquentPrunableTest.php
+++ b/tests/Integration/Database/EloquentPrunableTest.php
@@ -57,8 +57,8 @@ class EloquentPrunableTest extends DatabaseTestCase
 
         $count = (new PrunableTestModel)->pruneAll();
 
-        $this->assertEquals(1500, $count);
-        $this->assertEquals(3500, PrunableTestModel::count());
+        $this->assertSame(1500, $count);
+        $this->assertSame(3500, PrunableTestModel::count());
 
         Event::assertDispatched(ModelsPruned::class, 2);
     }
@@ -75,9 +75,9 @@ class EloquentPrunableTest extends DatabaseTestCase
 
         $count = (new PrunableSoftDeleteTestModel)->pruneAll();
 
-        $this->assertEquals(3000, $count);
-        $this->assertEquals(0, PrunableSoftDeleteTestModel::count());
-        $this->assertEquals(2000, PrunableSoftDeleteTestModel::withTrashed()->count());
+        $this->assertSame(3000, $count);
+        $this->assertSame(0, PrunableSoftDeleteTestModel::count());
+        $this->assertSame(2000, PrunableSoftDeleteTestModel::withTrashed()->count());
 
         Event::assertDispatched(ModelsPruned::class, 3);
     }
@@ -94,10 +94,10 @@ class EloquentPrunableTest extends DatabaseTestCase
 
         $count = (new PrunableWithCustomPruneMethodTestModel)->pruneAll();
 
-        $this->assertEquals(1000, $count);
+        $this->assertSame(1000, $count);
         $this->assertTrue((bool) PrunableWithCustomPruneMethodTestModel::first()->pruned);
         $this->assertFalse((bool) PrunableWithCustomPruneMethodTestModel::orderBy('id', 'desc')->first()->pruned);
-        $this->assertEquals(5000, PrunableWithCustomPruneMethodTestModel::count());
+        $this->assertSame(5000, PrunableWithCustomPruneMethodTestModel::count());
 
         Event::assertDispatched(ModelsPruned::class, 1);
     }
@@ -115,7 +115,7 @@ class EloquentPrunableTest extends DatabaseTestCase
 
         $count = (new PrunableWithException)->pruneAll();
 
-        $this->assertEquals(999, $count);
+        $this->assertSame(999, $count);
 
         Event::assertDispatched(ModelsPruned::class, 1);
         Event::assertDispatched(fn (ModelsPruned $event) => $event->count === 999);

--- a/tests/Integration/Database/EloquentThroughTest.php
+++ b/tests/Integration/Database/EloquentThroughTest.php
@@ -45,7 +45,7 @@ class EloquentThroughTest extends DatabaseTestCase
     {
         /** @var Post $post */
         $post = Post::first();
-        $this->assertEquals(2, $post->commentLikes()->count());
+        $this->assertSame(2, $post->commentLikes()->count());
     }
 }
 

--- a/tests/Integration/Database/EloquentTransactionWithAfterCommitTests.php
+++ b/tests/Integration/Database/EloquentTransactionWithAfterCommitTests.php
@@ -33,7 +33,7 @@ trait EloquentTransactionWithAfterCommitTests
         $user1 = User::create(UserFactory::new()->raw());
 
         $this->assertTrue($user1->exists);
-        $this->assertEquals(1, $observer::$calledTimes, 'Failed to assert the observer was called once.');
+        $this->assertSame(1, $observer::$calledTimes, 'Failed to assert the observer was called once.');
     }
 
     public function testObserverCalledWithAfterCommitWhenInsideTransaction()
@@ -43,7 +43,7 @@ trait EloquentTransactionWithAfterCommitTests
         $user1 = DB::transaction(fn () => User::create(UserFactory::new()->raw()));
 
         $this->assertTrue($user1->exists);
-        $this->assertEquals(1, $observer::$calledTimes, 'Failed to assert the observer was called once.');
+        $this->assertSame(1, $observer::$calledTimes, 'Failed to assert the observer was called once.');
     }
 
     public function testObserverCalledWithAfterCommitWhenInsideTransactionWithDispatchSync()
@@ -53,7 +53,7 @@ trait EloquentTransactionWithAfterCommitTests
         $user1 = DB::transaction(fn () => User::create(UserFactory::new()->raw()));
 
         $this->assertTrue($user1->exists);
-        $this->assertEquals(1, $observer::$calledTimes, 'Failed to assert the observer was called once.');
+        $this->assertSame(1, $observer::$calledTimes, 'Failed to assert the observer was called once.');
 
         $this->assertDatabaseHas('password_reset_tokens', [
             'email' => $user1->email,
@@ -68,7 +68,7 @@ trait EloquentTransactionWithAfterCommitTests
         $user1 = User::createOrFirst(UserFactory::new()->raw());
 
         $this->assertTrue($user1->exists);
-        $this->assertEquals(1, $observer::$calledTimes, 'Failed to assert the observer was called once.');
+        $this->assertSame(1, $observer::$calledTimes, 'Failed to assert the observer was called once.');
     }
 
     public function testObserverIsCalledOnTestsWithAfterCommitWhenUsingSavepointAndInsideTransaction()
@@ -78,7 +78,7 @@ trait EloquentTransactionWithAfterCommitTests
         $user1 = DB::transaction(fn () => User::createOrFirst(UserFactory::new()->raw()));
 
         $this->assertTrue($user1->exists);
-        $this->assertEquals(1, $observer::$calledTimes, 'Failed to assert the observer was called once.');
+        $this->assertSame(1, $observer::$calledTimes, 'Failed to assert the observer was called once.');
     }
 
     public function testObserverIsCalledEvenWhenDeeplyNestingTransactions()
@@ -89,18 +89,18 @@ trait EloquentTransactionWithAfterCommitTests
             return tap(DB::transaction(function () use ($observer) {
                 return tap(DB::transaction(function () use ($observer) {
                     return tap(User::createOrFirst(UserFactory::new()->raw()), function () use ($observer) {
-                        $this->assertEquals(0, $observer::$calledTimes, 'Should not have been called');
+                        $this->assertSame(0, $observer::$calledTimes, 'Should not have been called');
                     });
                 }), function () use ($observer) {
-                    $this->assertEquals(0, $observer::$calledTimes, 'Should not have been called');
+                    $this->assertSame(0, $observer::$calledTimes, 'Should not have been called');
                 });
             }), function () use ($observer) {
-                $this->assertEquals(0, $observer::$calledTimes, 'Should not have been called');
+                $this->assertSame(0, $observer::$calledTimes, 'Should not have been called');
             });
         });
 
         $this->assertTrue($user1->exists);
-        $this->assertEquals(1, $observer::$calledTimes, 'Failed to assert the observer was called once.');
+        $this->assertSame(1, $observer::$calledTimes, 'Failed to assert the observer was called once.');
     }
 
     public function testAfterCommitObserverCreatingEventFiresImmediately()
@@ -180,7 +180,7 @@ trait EloquentTransactionWithAfterCommitTests
 
         $this->assertTrue($firstObject->ran);
         $this->assertFalse($secondObject->ran);
-        $this->assertEquals(1, $firstObject->runs);
+        $this->assertSame(1, $firstObject->runs);
     }
 }
 

--- a/tests/Integration/Database/EloquentUniqueStringPrimaryKeysTest.php
+++ b/tests/Integration/Database/EloquentUniqueStringPrimaryKeysTest.php
@@ -130,7 +130,7 @@ class EloquentUniqueStringPrimaryKeysTest extends DatabaseTestCase
 
         ModelUpsertWithUuidPrimaryKey::upsert([['email' => 'foo3', 'name' => 'bar'], ['name' => 'bar2', 'email' => 'foo2']], ['email']);
 
-        $this->assertEquals(3, ModelUpsertWithUuidPrimaryKey::count());
+        $this->assertSame(3, ModelUpsertWithUuidPrimaryKey::count());
     }
 }
 

--- a/tests/Integration/Database/EloquentUpdateTest.php
+++ b/tests/Integration/Database/EloquentUpdateTest.php
@@ -124,8 +124,8 @@ class EloquentUpdateTest extends DatabaseTestCase
         TestUpdateModel3::increment('counter');
 
         $models = TestUpdateModel3::withoutGlobalScopes()->orderBy('id')->get();
-        $this->assertEquals(1, $models[0]->counter);
-        $this->assertEquals(0, $models[1]->counter);
+        $this->assertSame(1, $models[0]->counter);
+        $this->assertSame(0, $models[1]->counter);
     }
 
     public function testIncrementOrDecrementIgnoresGlobalScopes()
@@ -137,13 +137,13 @@ class EloquentUpdateTest extends DatabaseTestCase
 
         $deletedModel->increment('counter');
 
-        $this->assertEquals(1, $deletedModel->counter);
+        $this->assertSame(1, $deletedModel->counter);
 
         $deletedModel->fresh();
-        $this->assertEquals(1, $deletedModel->counter);
+        $this->assertSame(1, $deletedModel->counter);
 
         $deletedModel->decrement('counter');
-        $this->assertEquals(0, $deletedModel->fresh()->counter);
+        $this->assertSame(0, $deletedModel->fresh()->counter);
     }
 
     public function testUpdateSyncsPrevious()
@@ -185,7 +185,7 @@ class EloquentUpdateTest extends DatabaseTestCase
 
         $model->increment('counter');
 
-        $this->assertEquals(1, $model->counter);
+        $this->assertSame(1, $model->counter);
         $this->assertSame(['counter' => 1], $model->getChanges());
         $this->assertSame(['counter' => 0], $model->getPrevious());
     }
@@ -198,13 +198,13 @@ class EloquentUpdateTest extends DatabaseTestCase
 
         $post1->incrementEach(['views' => 1, 'likes' => 2]);
 
-        $this->assertEquals(11, $post1->views);
-        $this->assertEquals(7, $post1->likes);
+        $this->assertSame(11, $post1->views);
+        $this->assertSame(7, $post1->likes);
 
-        $this->assertEquals(50, $post2->fresh()->views);
-        $this->assertEquals(20, $post2->fresh()->likes);
-        $this->assertEquals(100, $post3->fresh()->views);
-        $this->assertEquals(40, $post3->fresh()->likes);
+        $this->assertSame(50, $post2->fresh()->views);
+        $this->assertSame(20, $post2->fresh()->likes);
+        $this->assertSame(100, $post3->fresh()->views);
+        $this->assertSame(40, $post3->fresh()->likes);
     }
 
     public function testDecrementEachOnModelInstanceOnlyAffectsThatRow()
@@ -214,11 +214,11 @@ class EloquentUpdateTest extends DatabaseTestCase
 
         $post1->decrementEach(['views' => 3, 'likes' => 2]);
 
-        $this->assertEquals(7, $post1->views);
-        $this->assertEquals(3, $post1->likes);
+        $this->assertSame(7, $post1->views);
+        $this->assertSame(3, $post1->likes);
 
-        $this->assertEquals(50, $post2->fresh()->views);
-        $this->assertEquals(20, $post2->fresh()->likes);
+        $this->assertSame(50, $post2->fresh()->views);
+        $this->assertSame(20, $post2->fresh()->likes);
     }
 
     public function testIncrementEachViaQueryBuilderStillAffectsAllMatchingRows()
@@ -229,8 +229,8 @@ class EloquentUpdateTest extends DatabaseTestCase
         TestUpdateModel4::incrementEach(['views' => 1]);
 
         $models = TestUpdateModel4::orderBy('id')->get();
-        $this->assertEquals(11, $models[0]->views);
-        $this->assertEquals(51, $models[1]->views);
+        $this->assertSame(11, $models[0]->views);
+        $this->assertSame(51, $models[1]->views);
     }
 
     public function testIncrementEachOnModelInstanceUpdatesTimestamps()
@@ -253,12 +253,12 @@ class EloquentUpdateTest extends DatabaseTestCase
 
         $post->incrementEach(['views' => 1, 'likes' => 1]);
 
-        $this->assertEquals(11, $post->views);
-        $this->assertEquals(6, $post->likes);
+        $this->assertSame(11, $post->views);
+        $this->assertSame(6, $post->likes);
 
         $fresh = TestUpdateModel4::withTrashed()->find($post->id);
-        $this->assertEquals(11, $fresh->views);
-        $this->assertEquals(6, $fresh->likes);
+        $this->assertSame(11, $fresh->views);
+        $this->assertSame(6, $fresh->likes);
     }
 
     public function testIncrementEachDoesNotResetUnrelatedDirtyAttributes()
@@ -279,8 +279,8 @@ class EloquentUpdateTest extends DatabaseTestCase
 
         $post->incrementEach(['views' => 1, 'likes' => 2]);
 
-        $this->assertEquals(11, $post->views);
-        $this->assertEquals(7, $post->likes);
+        $this->assertSame(11, $post->views);
+        $this->assertSame(7, $post->likes);
         $this->assertArrayHasKey('views', $post->getChanges());
         $this->assertArrayHasKey('likes', $post->getChanges());
     }

--- a/tests/Integration/Database/EloquentUpdateTest.php
+++ b/tests/Integration/Database/EloquentUpdateTest.php
@@ -269,7 +269,7 @@ class EloquentUpdateTest extends DatabaseTestCase
         $post->incrementEach(['views' => 1]);
 
         $this->assertTrue($post->isDirty('name'));
-        $this->assertEquals('Changed', $post->name);
+        $this->assertSame('Changed', $post->name);
         $this->assertFalse($post->isDirty('views'));
     }
 

--- a/tests/Integration/Database/EloquentWhereTest.php
+++ b/tests/Integration/Database/EloquentWhereTest.php
@@ -298,7 +298,7 @@ class EloquentWhereTest extends DatabaseTestCase
             'address' => 'test-address',
         ]);
 
-        $this->assertEquals('test-name', UserWhereTest::where('name', 'test-name')->soleValue('name'));
+        $this->assertSame('test-name', UserWhereTest::where('name', 'test-name')->soleValue('name'));
     }
 
     public function testChunkMap()

--- a/tests/Integration/Database/EloquentWithCountTest.php
+++ b/tests/Integration/Database/EloquentWithCountTest.php
@@ -54,10 +54,10 @@ class EloquentWithCountTest extends DatabaseTestCase
         $one->fours()->create();
 
         $result = Model1::withCount('fours')->first();
-        $this->assertEquals(0, $result->fours_count);
+        $this->assertSame(0, $result->fours_count);
 
         $result = Model1::withCount('allFours')->first();
-        $this->assertEquals(1, $result->all_fours_count);
+        $this->assertSame(1, $result->all_fours_count);
     }
 
     public function testSortingScopes()

--- a/tests/Integration/Database/MariaDb/DatabaseMariaDbSchemaBuilderTest.php
+++ b/tests/Integration/Database/MariaDb/DatabaseMariaDbSchemaBuilderTest.php
@@ -25,7 +25,7 @@ class DatabaseMariaDbSchemaBuilderTest extends MariaDbTestCase
             ->select('table_comment as table_comment')
             ->first();
 
-        $this->assertEquals('This is a comment', $tableInfo->table_comment);
+        $this->assertSame('This is a comment', $tableInfo->table_comment);
 
         Schema::drop('users');
     }

--- a/tests/Integration/Database/ModelInspectorTest.php
+++ b/tests/Integration/Database/ModelInspectorTest.php
@@ -58,7 +58,7 @@ class ModelInspectorTest extends DatabaseTestCase
     {
         $this->assertEquals(ModelInspectorTestModel::class, $modelInfo['class']);
         $this->assertEquals(Schema::getConnection()->getConfig()['name'], $modelInfo['database']);
-        $this->assertEquals('model_info_extractor_test_model', $modelInfo['table']);
+        $this->assertSame('model_info_extractor_test_model', $modelInfo['table']);
         $this->assertNull($modelInfo['policy']);
         $this->assertCount(8, $modelInfo['attributes']);
 
@@ -167,9 +167,9 @@ class ModelInspectorTest extends DatabaseTestCase
 
         $this->assertEmpty($modelInfo['events']);
         $this->assertCount(1, $modelInfo['observers']);
-        $this->assertEquals('created', $modelInfo['observers'][0]['event']);
+        $this->assertSame('created', $modelInfo['observers'][0]['event']);
         $this->assertCount(1, $modelInfo['observers'][0]['observer']);
-        $this->assertEquals("Illuminate\Tests\Integration\Database\ModelInspectorTestModelObserver@created", $modelInfo['observers'][0]['observer'][0]);
+        $this->assertSame("Illuminate\Tests\Integration\Database\ModelInspectorTestModelObserver@created", $modelInfo['observers'][0]['observer'][0]);
         $this->assertEquals(ModelInspectorTestModelEloquentCollection::class, $modelInfo['collection']);
         $this->assertEquals(ModelInspectorTestModelBuilder::class, $modelInfo['builder']);
     }

--- a/tests/Integration/Database/MySql/DatabaseMySqlConnectionTest.php
+++ b/tests/Integration/Database/MySql/DatabaseMySqlConnectionTest.php
@@ -163,7 +163,7 @@ class DatabaseMySqlConnectionTest extends MySqlTestCase
 
             $id = DB::table('auto_id_table')->insertGetId([]);
             $this->assertTrue($callbackExecuted, 'The query listener was not executed.');
-            $this->assertEquals(1, $id);
+            $this->assertSame(1, $id);
         } finally {
             Schema::drop('auto_id_table');
         }

--- a/tests/Integration/Database/MySql/DatabaseMySqlSchemaBuilderTest.php
+++ b/tests/Integration/Database/MySql/DatabaseMySqlSchemaBuilderTest.php
@@ -26,7 +26,7 @@ class DatabaseMySqlSchemaBuilderTest extends MySqlTestCase
             ->select('table_comment as table_comment')
             ->first();
 
-        $this->assertEquals('This is a comment', $tableInfo->table_comment);
+        $this->assertSame('This is a comment', $tableInfo->table_comment);
 
         Schema::drop('users');
     }

--- a/tests/Integration/Database/MySql/JoinLateralTest.php
+++ b/tests/Integration/Database/MySql/JoinLateralTest.php
@@ -77,8 +77,8 @@ class JoinLateralTest extends MySqlTestCase
             ->get();
 
         $this->assertCount(2, $userWithPosts);
-        $this->assertEquals(7, $userWithPosts[0]->best_post_rating);
-        $this->assertEquals(3, $userWithPosts[1]->best_post_rating);
+        $this->assertSame(7, $userWithPosts[0]->best_post_rating);
+        $this->assertSame(3, $userWithPosts[1]->best_post_rating);
 
         $userWithoutPosts = DB::table('users')
             ->where('id', 2)
@@ -102,8 +102,8 @@ class JoinLateralTest extends MySqlTestCase
             ->get();
 
         $this->assertCount(2, $userWithPosts);
-        $this->assertEquals(7, $userWithPosts[0]->best_post_rating);
-        $this->assertEquals(3, $userWithPosts[1]->best_post_rating);
+        $this->assertSame(7, $userWithPosts[0]->best_post_rating);
+        $this->assertSame(3, $userWithPosts[1]->best_post_rating);
 
         $userWithoutPosts = DB::table('users')
             ->where('id', 2)

--- a/tests/Integration/Database/Postgres/JoinLateralTest.php
+++ b/tests/Integration/Database/Postgres/JoinLateralTest.php
@@ -64,8 +64,8 @@ class JoinLateralTest extends PostgresTestCase
             ->get();
 
         $this->assertCount(2, $userWithPosts);
-        $this->assertEquals(7, $userWithPosts[0]->best_post_rating);
-        $this->assertEquals(3, $userWithPosts[1]->best_post_rating);
+        $this->assertSame(7, $userWithPosts[0]->best_post_rating);
+        $this->assertSame(3, $userWithPosts[1]->best_post_rating);
 
         $userWithoutPosts = DB::table('users')
             ->where('id', 2)
@@ -89,8 +89,8 @@ class JoinLateralTest extends PostgresTestCase
             ->get();
 
         $this->assertCount(2, $userWithPosts);
-        $this->assertEquals(7, $userWithPosts[0]->best_post_rating);
-        $this->assertEquals(3, $userWithPosts[1]->best_post_rating);
+        $this->assertSame(7, $userWithPosts[0]->best_post_rating);
+        $this->assertSame(3, $userWithPosts[1]->best_post_rating);
 
         $userWithoutPosts = DB::table('users')
             ->where('id', 2)

--- a/tests/Integration/Database/Postgres/PostgresSchemaBuilderTest.php
+++ b/tests/Integration/Database/Postgres/PostgresSchemaBuilderTest.php
@@ -117,7 +117,7 @@ class PostgresSchemaBuilderTest extends PostgresTestCase
             $table->comment('This is a comment');
         });
 
-        $this->assertEquals('This is a comment', DB::selectOne("select obj_description('public.posts'::regclass, 'pg_class')")->obj_description);
+        $this->assertSame('This is a comment', DB::selectOne("select obj_description('public.posts'::regclass, 'pg_class')")->obj_description);
     }
 
     public function testAddTableCommentOnExistingTable()
@@ -131,7 +131,7 @@ class PostgresSchemaBuilderTest extends PostgresTestCase
             $table->comment('This is a new comment');
         });
 
-        $this->assertEquals('This is a new comment', DB::selectOne("select obj_description('public.posts'::regclass, 'pg_class')")->obj_description);
+        $this->assertSame('This is a new comment', DB::selectOne("select obj_description('public.posts'::regclass, 'pg_class')")->obj_description);
     }
 
     public function testGetTables()

--- a/tests/Integration/Database/QueryBuilderTest.php
+++ b/tests/Integration/Database/QueryBuilderTest.php
@@ -92,7 +92,7 @@ class QueryBuilderTest extends DatabaseTestCase
             'wallet_2' => 20,
         ]);
 
-        $this->assertEquals(1, $affectedRowsCount);
+        $this->assertSame(1, $affectedRowsCount);
 
         $rows = DB::table('accounting')->get();
 
@@ -110,7 +110,7 @@ class QueryBuilderTest extends DatabaseTestCase
             'wallet_2' => '-32.5',
         ]);
 
-        $this->assertEquals(2, $affectedRowsCount);
+        $this->assertSame(2, $affectedRowsCount);
 
         $rows = DB::table('accounting')->get();
         $this->assertEquals([
@@ -134,7 +134,7 @@ class QueryBuilderTest extends DatabaseTestCase
             'wallet_1' => 3000,
         ], ['wallet_1' => 1.5]);
 
-        $this->assertEquals(2, $affectedRowsCount);
+        $this->assertSame(2, $affectedRowsCount);
 
         $rows = DB::table('accounting')->get();
 

--- a/tests/Integration/Database/QueryingWithEnumsTest.php
+++ b/tests/Integration/Database/QueryingWithEnumsTest.php
@@ -38,7 +38,7 @@ class QueryingWithEnumsTest extends DatabaseTestCase
         $this->assertNotNull($record3);
         $this->assertNotNull($record4);
         $this->assertSame('pending', $record->string_status);
-        $this->assertEquals(1, $record2->integer_status);
+        $this->assertSame(1, $record2->integer_status);
         $this->assertSame('pending', $record4->non_backed_status);
     }
 
@@ -54,7 +54,7 @@ class QueryingWithEnumsTest extends DatabaseTestCase
 
         $this->assertNotNull($record);
         $this->assertSame('pending', $record->string_status);
-        $this->assertEquals(1, $record->integer_status);
+        $this->assertSame(1, $record->integer_status);
         $this->assertSame('pending', $record->non_backed_status);
     }
 }

--- a/tests/Integration/Database/RefreshCommandTest.php
+++ b/tests/Integration/Database/RefreshCommandTest.php
@@ -40,9 +40,9 @@ class RefreshCommandTest extends TestCase
 
         $this->artisan('migrate:refresh', $options);
         DB::table('members')->insert(['name' => 'foo', 'email' => 'foo@bar', 'password' => 'secret']);
-        $this->assertEquals(1, DB::table('members')->count());
+        $this->assertSame(1, DB::table('members')->count());
 
         $this->artisan('migrate:refresh', $options);
-        $this->assertEquals(0, DB::table('members')->count());
+        $this->assertSame(0, DB::table('members')->count());
     }
 }

--- a/tests/Integration/Database/SchemaBuilderSchemaNameTest.php
+++ b/tests/Integration/Database/SchemaBuilderSchemaNameTest.php
@@ -526,16 +526,16 @@ class SchemaBuilderSchemaNameTest extends DatabaseTestCase
         $tableName = $connection === 'with-prefix' ? 'example_table' : 'table';
         $defaultSchema = $this->driver === 'pgsql' ? 'public' : 'laravel';
 
-        $this->assertEquals('comment on schema table',
+        $this->assertSame('comment on schema table',
             $tables->first(fn ($table) => $table['name'] === $tableName && $table['schema'] === 'my_schema')['comment']
         );
-        $this->assertEquals('comment on table',
+        $this->assertSame('comment on table',
             $tables->first(fn ($table) => $table['name'] === $tableName && $table['schema'] === $defaultSchema)['comment']
         );
-        $this->assertEquals('comment on schema column',
+        $this->assertSame('comment on schema column',
             collect($schema->getColumns('my_schema.table'))->firstWhere('name', 'name')['comment']
         );
-        $this->assertEquals('comment on column',
+        $this->assertSame('comment on column',
             collect($schema->getColumns('table'))->firstWhere('name', 'name')['comment']
         );
     }
@@ -579,7 +579,7 @@ class SchemaBuilderSchemaNameTest extends DatabaseTestCase
             'database.connections.'.$connection.'.password' => 'Passw0rd',
         ]);
 
-        $this->assertEquals('my_schema', $schema->getCurrentSchemaName());
+        $this->assertSame('my_schema', $schema->getCurrentSchemaName());
 
         $schema->create('table', function (Blueprint $table) {
             $table->id();

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -793,7 +793,7 @@ class SchemaBuilderTest extends DatabaseTestCase
     {
         Schema::macro('foo', fn () => 'foo');
 
-        $this->assertEquals('foo', Schema::foo());
+        $this->assertSame('foo', Schema::foo());
 
         Schema::macro('hasForeignKeyForColumn', function (string $column, string $table, string $foreignTable) {
             return collect(Schema::getForeignKeys($table))

--- a/tests/Integration/Database/SqlServer/JoinLateralTest.php
+++ b/tests/Integration/Database/SqlServer/JoinLateralTest.php
@@ -60,8 +60,8 @@ class JoinLateralTest extends SqlServerTestCase
             ->get();
 
         $this->assertCount(2, $userWithPosts);
-        $this->assertEquals(7, (int) $userWithPosts[0]->best_post_rating);
-        $this->assertEquals(3, (int) $userWithPosts[1]->best_post_rating);
+        $this->assertSame(7, (int) $userWithPosts[0]->best_post_rating);
+        $this->assertSame(3, (int) $userWithPosts[1]->best_post_rating);
 
         $userWithoutPosts = DB::table('users')
             ->where('id', 2)
@@ -85,8 +85,8 @@ class JoinLateralTest extends SqlServerTestCase
             ->get();
 
         $this->assertCount(2, $userWithPosts);
-        $this->assertEquals(7, (int) $userWithPosts[0]->best_post_rating);
-        $this->assertEquals(3, (int) $userWithPosts[1]->best_post_rating);
+        $this->assertSame(7, (int) $userWithPosts[0]->best_post_rating);
+        $this->assertSame(3, (int) $userWithPosts[1]->best_post_rating);
 
         $userWithoutPosts = DB::table('users')
             ->where('id', 2)

--- a/tests/Integration/Database/Sqlite/DatabaseSqliteSchemaBuilderTest.php
+++ b/tests/Integration/Database/Sqlite/DatabaseSqliteSchemaBuilderTest.php
@@ -72,7 +72,7 @@ SQL);
         $tableView = Schema::getViews();
 
         $this->assertCount(1, $tableView);
-        $this->assertEquals('users_view', $tableView[0]['name']);
+        $this->assertSame('users_view', $tableView[0]['name']);
 
         DB::connection('conn1')->statement(<<<'SQL'
 DROP VIEW IF EXISTS users_view;

--- a/tests/Integration/Events/DeferEventsTest.php
+++ b/tests/Integration/Events/DeferEventsTest.php
@@ -24,7 +24,7 @@ class DeferEventsTest extends TestCase
             return 'callback_result';
         });
 
-        $this->assertEquals('callback_result', $response);
+        $this->assertSame('callback_result', $response);
         $this->assertSame('bar', $_SERVER['__event.test']);
     }
 
@@ -45,7 +45,7 @@ class DeferEventsTest extends TestCase
             return 'model_event_response';
         });
 
-        $this->assertEquals('model_event_response', $response);
+        $this->assertSame('model_event_response', $response);
         $this->assertContains('saved', $_SERVER['__model_event.test']);
     }
 
@@ -74,7 +74,7 @@ class DeferEventsTest extends TestCase
             return 'multiple_models_response';
         });
 
-        $this->assertEquals('multiple_models_response', $response);
+        $this->assertSame('multiple_models_response', $response);
         $this->assertSame(['saved:TestModel', 'created:AnotherTestModel'], $_SERVER['__model_events']);
     }
 
@@ -100,7 +100,7 @@ class DeferEventsTest extends TestCase
             return 'specific_model_defer_result';
         }, ['eloquent.saved: '.TestModel::class]);
 
-        $this->assertEquals('specific_model_defer_result', $response);
+        $this->assertSame('specific_model_defer_result', $response);
         $this->assertSame(['creating', 'saved'], $_SERVER['__model_events']);
     }
 }

--- a/tests/Integration/Events/EventFakeTest.php
+++ b/tests/Integration/Events/EventFakeTest.php
@@ -183,7 +183,7 @@ class EventFakeTest extends TestCase
     {
         Event::macro('foo', fn () => 'bar');
 
-        $this->assertEquals('bar', Event::fake()->foo());
+        $this->assertSame('bar', Event::fake()->foo());
     }
 
     public function testShouldDispatchAfterCommitEventsAreNotDispatchedIfTransactionFails()

--- a/tests/Integration/Filesystem/ServeFileTest.php
+++ b/tests/Integration/Filesystem/ServeFileTest.php
@@ -29,7 +29,7 @@ class ServeFileTest extends TestCase
 
         $response = $this->get($url);
 
-        $this->assertEquals('Hello World', $response->streamedContent());
+        $this->assertSame('Hello World', $response->streamedContent());
     }
 
     public function testItWill404OnMissingFile()

--- a/tests/Integration/Foundation/CloudTest.php
+++ b/tests/Integration/Foundation/CloudTest.php
@@ -48,8 +48,8 @@ class CloudTest extends TestCase
 
         Cloud::configureDisks($this->app);
 
-        $this->assertEquals('test-disk-2', $this->app['config']->get('filesystems.default'));
-        $this->assertEquals('test-access-key-id', $this->app['config']->get('filesystems.disks.test-disk.key'));
+        $this->assertSame('test-disk-2', $this->app['config']->get('filesystems.default'));
+        $this->assertSame('test-access-key-id', $this->app['config']->get('filesystems.disks.test-disk.key'));
 
         unset($_SERVER['LARAVEL_CLOUD_DISK_CONFIG']);
     }
@@ -79,7 +79,7 @@ class CloudTest extends TestCase
 
         Cloud::configureCloudLogging($this->app);
 
-        $this->assertEquals('notice', $this->app['config']->get('logging.channels.laravel-cloud-socket.level'));
+        $this->assertSame('notice', $this->app['config']->get('logging.channels.laravel-cloud-socket.level'));
 
         unset($_SERVER['LOG_LEVEL']);
 

--- a/tests/Integration/Foundation/DiscoverEventsTest.php
+++ b/tests/Integration/Foundation/DiscoverEventsTest.php
@@ -81,7 +81,7 @@ class DiscoverEventsTest extends TestCase
     {
         $events = DiscoverEvents::within([], getcwd());
 
-        $this->assertEquals([], $events);
+        $this->assertSame([], $events);
     }
 
     public function testEventsCanBeDiscoveredUsingCustomClassNameGuessing()

--- a/tests/Integration/Foundation/ExceptionHandlerTest.php
+++ b/tests/Integration/Foundation/ExceptionHandlerTest.php
@@ -74,7 +74,7 @@ class ExceptionHandlerTest extends TestCase
             ->assertStatus(500)
             ->assertSee('shouldnt report');
 
-        $this->assertEquals([], $reported);
+        $this->assertSame([], $reported);
     }
 
     public function testItRendersAuthorizationExceptionsWithCustomStatusCode()

--- a/tests/Integration/Foundation/FoundationHelpersTest.php
+++ b/tests/Integration/Foundation/FoundationHelpersTest.php
@@ -13,14 +13,14 @@ class FoundationHelpersTest extends TestCase
 {
     public function testRescue()
     {
-        $this->assertEquals(
+        $this->assertSame(
             'rescued!',
             rescue(function () {
                 throw new Exception;
             }, 'rescued!')
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             'rescued!',
             rescue(function () {
                 throw new Exception;
@@ -29,7 +29,7 @@ class FoundationHelpersTest extends TestCase
             })
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             'no need to rescue',
             rescue(function () {
                 return 'no need to rescue';
@@ -44,7 +44,7 @@ class FoundationHelpersTest extends TestCase
             }
         };
 
-        $this->assertEquals(
+        $this->assertSame(
             'rescued!',
             rescue(function () use ($testClass) {
                 $testClass->test([]);

--- a/tests/Integration/Http/HttpClientTest.php
+++ b/tests/Integration/Http/HttpClientTest.php
@@ -86,8 +86,8 @@ class HttpClientTest extends TestCase
             })
             ->wait();
 
-        $this->assertEquals('faked response', $myFakedResponse);
-        $this->assertEquals('stub', $r);
+        $this->assertSame('faked response', (string) $myFakedResponse);
+        $this->assertSame('stub', $r);
     }
 
     public function testCanSetRequestAttributes()
@@ -105,10 +105,10 @@ class HttpClientTest extends TestCase
         $response3 = Http::get('https://some-store.myshopify.com/admin/api/2025-10/graphql.json');
         $response4 = Http::withAttributes(['name' => 'fourth'])->get('https://some-store.myshopify.com/admin/api/2025-10/graphql.json');
 
-        $this->assertEquals('first response', $response1->body());
-        $this->assertEquals('second response', $response2->body());
-        $this->assertEquals('unnamed', $response3->body());
-        $this->assertEquals('unnamed', $response4->body());
+        $this->assertSame('first response', $response1->body());
+        $this->assertSame('second response', $response2->body());
+        $this->assertSame('unnamed', $response3->body());
+        $this->assertSame('unnamed', $response4->body());
     }
 
     public function testAsyncCanHandleThrownException()

--- a/tests/Integration/Http/HttpClientTest.php
+++ b/tests/Integration/Http/HttpClientTest.php
@@ -66,8 +66,8 @@ class HttpClientTest extends TestCase
         }, 3);
 
         $this->assertInstanceOf(Response::class, $responses['laravel']);
-        $this->assertEquals(5, $responses['forge']);
-        $this->assertEquals(200, $responses['nightwatch']);
+        $this->assertSame(5, $responses['forge']);
+        $this->assertSame(200, $responses['nightwatch']);
 
         $this->assertCount(3, Http::recorded());
     }

--- a/tests/Integration/Http/Middleware/HandleCorsTest.php
+++ b/tests/Integration/Http/Middleware/HandleCorsTest.php
@@ -42,7 +42,7 @@ class HandleCorsTest extends TestCase
         ]);
 
         $this->assertSame('http://localhost', $crawler->headers->get('Access-Control-Allow-Origin'));
-        $this->assertEquals(204, $crawler->getStatusCode());
+        $this->assertSame(204, $crawler->getStatusCode());
     }
 
     public function testOptionsAllowOriginAllowed()
@@ -53,7 +53,7 @@ class HandleCorsTest extends TestCase
         ]);
 
         $this->assertSame('http://localhost', $crawler->headers->get('Access-Control-Allow-Origin'));
-        $this->assertEquals(204, $crawler->getStatusCode());
+        $this->assertSame(204, $crawler->getStatusCode());
     }
 
     public function testAllowAllOrigins()
@@ -66,7 +66,7 @@ class HandleCorsTest extends TestCase
         ]);
 
         $this->assertSame('*', $crawler->headers->get('Access-Control-Allow-Origin'));
-        $this->assertEquals(204, $crawler->getStatusCode());
+        $this->assertSame(204, $crawler->getStatusCode());
     }
 
     public function testAllowAllOriginsWildcard()
@@ -79,7 +79,7 @@ class HandleCorsTest extends TestCase
         ]);
 
         $this->assertSame('http://test.laravel.com', $crawler->headers->get('Access-Control-Allow-Origin'));
-        $this->assertEquals(204, $crawler->getStatusCode());
+        $this->assertSame(204, $crawler->getStatusCode());
     }
 
     public function testOriginsWildcardIncludesNestedSubdomains()
@@ -92,7 +92,7 @@ class HandleCorsTest extends TestCase
         ]);
 
         $this->assertSame('http://api.service.test.laravel.com', $crawler->headers->get('Access-Control-Allow-Origin'));
-        $this->assertEquals(204, $crawler->getStatusCode());
+        $this->assertSame(204, $crawler->getStatusCode());
     }
 
     public function testAllowAllOriginsWildcardNoMatch()
@@ -115,7 +115,7 @@ class HandleCorsTest extends TestCase
         ]);
 
         $this->assertSame('http://localhost', $crawler->headers->get('Access-Control-Allow-Origin'));
-        $this->assertEquals(204, $crawler->getStatusCode());
+        $this->assertSame(204, $crawler->getStatusCode());
     }
 
     public function testOptionsAllowOriginNotAllowed()
@@ -135,7 +135,7 @@ class HandleCorsTest extends TestCase
             'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'POST',
         ]);
         $this->assertEquals(null, $crawler->headers->get('Access-Control-Allow-Methods'));
-        $this->assertEquals(200, $crawler->getStatusCode());
+        $this->assertSame(200, $crawler->getStatusCode());
 
         $this->assertSame('PONG', $crawler->getContent());
     }
@@ -147,7 +147,7 @@ class HandleCorsTest extends TestCase
             'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'PUT',
         ]);
         $this->assertEquals(null, $crawler->headers->get('Access-Control-Allow-Methods'));
-        $this->assertEquals(200, $crawler->getStatusCode());
+        $this->assertSame(200, $crawler->getStatusCode());
     }
 
     public function testAllowHeaderAllowedOptions()
@@ -158,7 +158,7 @@ class HandleCorsTest extends TestCase
             'HTTP_ACCESS_CONTROL_REQUEST_HEADERS' => 'x-custom-1, x-custom-2',
         ]);
         $this->assertSame('x-custom-1, x-custom-2', $crawler->headers->get('Access-Control-Allow-Headers'));
-        $this->assertEquals(204, $crawler->getStatusCode());
+        $this->assertSame(204, $crawler->getStatusCode());
 
         $this->assertSame('', $crawler->getContent());
     }
@@ -173,7 +173,7 @@ class HandleCorsTest extends TestCase
             'HTTP_ACCESS_CONTROL_REQUEST_HEADERS' => 'x-custom-3',
         ]);
         $this->assertSame('x-custom-3', $crawler->headers->get('Access-Control-Allow-Headers'));
-        $this->assertEquals(204, $crawler->getStatusCode());
+        $this->assertSame(204, $crawler->getStatusCode());
 
         $this->assertSame('', $crawler->getContent());
     }
@@ -195,7 +195,7 @@ class HandleCorsTest extends TestCase
             'HTTP_ACCESS_CONTROL_REQUEST_HEADERS' => 'x-custom-1, x-custom-2',
         ]);
         $this->assertEquals(null, $crawler->headers->get('Access-Control-Allow-Headers'));
-        $this->assertEquals(200, $crawler->getStatusCode());
+        $this->assertSame(200, $crawler->getStatusCode());
 
         $this->assertSame('PONG', $crawler->getContent());
     }
@@ -209,7 +209,7 @@ class HandleCorsTest extends TestCase
             'HTTP_ACCESS_CONTROL_REQUEST_HEADERS' => 'x-custom-3',
         ]);
         $this->assertEquals(null, $crawler->headers->get('Access-Control-Allow-Headers'));
-        $this->assertEquals(200, $crawler->getStatusCode());
+        $this->assertSame(200, $crawler->getStatusCode());
 
         $this->assertSame('PONG', $crawler->getContent());
     }
@@ -221,7 +221,7 @@ class HandleCorsTest extends TestCase
             'HTTP_ACCESS_CONTROL_REQUEST_HEADERS' => 'x-custom-3',
         ]);
         $this->assertEquals(null, $crawler->headers->get('Access-Control-Allow-Headers'));
-        $this->assertEquals(200, $crawler->getStatusCode());
+        $this->assertSame(200, $crawler->getStatusCode());
     }
 
     public function testError()
@@ -232,7 +232,7 @@ class HandleCorsTest extends TestCase
         ]);
 
         $this->assertSame('http://localhost', $crawler->headers->get('Access-Control-Allow-Origin'));
-        $this->assertEquals(500, $crawler->getStatusCode());
+        $this->assertSame(500, $crawler->getStatusCode());
     }
 
     public function testValidationException()
@@ -242,7 +242,7 @@ class HandleCorsTest extends TestCase
             'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'POST',
         ]);
         $this->assertSame('http://localhost', $crawler->headers->get('Access-Control-Allow-Origin'));
-        $this->assertEquals(302, $crawler->getStatusCode());
+        $this->assertSame(302, $crawler->getStatusCode());
     }
 
     protected function addWebRoutes(Router $router)

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -907,7 +907,7 @@ class ResourceTest extends TestCase
             '/', ['Accept' => 'application/json']
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             '{"data":{"id":5,"title":"Test Title","reading_time":3.0}}',
             $response->baseResponse->content()
         );
@@ -925,7 +925,7 @@ class ResourceTest extends TestCase
             '/', ['Accept' => 'application/json']
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             '{"data":[{"id":5,"title":"Test Title","reading_time":3.0}]}',
             $response->baseResponse->content()
         );
@@ -946,7 +946,7 @@ class ResourceTest extends TestCase
             '/', ['Accept' => 'application/json']
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             '{"data":[{"id":5,"title":"Test Title","reading_time":3.0}],"links":{"first":"\/?page=1","last":"\/?page=1","prev":null,"next":null},"meta":{"current_page":1,"from":1,"last_page":1,"links":[{"url":null,"label":"&laquo; Previous","page":null,"active":false},{"url":"\/?page=1","label":"1","page":1,"active":true},{"url":null,"label":"Next &raquo;","page":null,"active":false}],"path":"\/","per_page":15,"to":1,"total":10}}',
             $response->baseResponse->content()
         );
@@ -966,7 +966,7 @@ class ResourceTest extends TestCase
             '/', ['Accept' => 'application/json']
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             '{"data":{"id":5,"title":"Test Title","reading_time":3.0}}',
             $response->baseResponse->content()
         );

--- a/tests/Integration/Http/ThrottleRequestsTest.php
+++ b/tests/Integration/Http/ThrottleRequestsTest.php
@@ -39,13 +39,13 @@ class ThrottleRequestsTest extends TestCase
 
         $response = $this->withoutExceptionHandling()->get('/');
         $this->assertSame('yes', $response->getContent());
-        $this->assertEquals(2, $response->headers->get('X-RateLimit-Limit'));
-        $this->assertEquals(1, $response->headers->get('X-RateLimit-Remaining'));
+        $this->assertSame(2, (int) $response->headers->get('X-RateLimit-Limit'));
+        $this->assertSame(1, (int) $response->headers->get('X-RateLimit-Remaining'));
 
         $response = $this->withoutExceptionHandling()->get('/');
         $this->assertSame('yes', $response->getContent());
-        $this->assertEquals(2, $response->headers->get('X-RateLimit-Limit'));
-        $this->assertEquals(0, $response->headers->get('X-RateLimit-Remaining'));
+        $this->assertSame(2, (int) $response->headers->get('X-RateLimit-Limit'));
+        $this->assertSame(0, (int) $response->headers->get('X-RateLimit-Remaining'));
 
         Carbon::setTestNow(Carbon::create(2018, 1, 1, 0, 0, 58));
 
@@ -53,10 +53,10 @@ class ThrottleRequestsTest extends TestCase
             $this->withoutExceptionHandling()->get('/');
         } catch (Throwable $e) {
             $this->assertInstanceOf(ThrottleRequestsException::class, $e);
-            $this->assertEquals(429, $e->getStatusCode());
-            $this->assertEquals(2, $e->getHeaders()['X-RateLimit-Limit']);
-            $this->assertEquals(0, $e->getHeaders()['X-RateLimit-Remaining']);
-            $this->assertEquals(2, $e->getHeaders()['Retry-After']);
+            $this->assertSame(429, $e->getStatusCode());
+            $this->assertSame(2, $e->getHeaders()['X-RateLimit-Limit']);
+            $this->assertSame(0, $e->getHeaders()['X-RateLimit-Remaining']);
+            $this->assertSame(2, $e->getHeaders()['Retry-After']);
             $this->assertEquals(Carbon::now()->addSeconds(2)->getTimestamp(), $e->getHeaders()['X-RateLimit-Reset']);
         }
     }
@@ -77,13 +77,13 @@ class ThrottleRequestsTest extends TestCase
 
         $response = $this->withoutExceptionHandling()->get('/');
         $this->assertSame('yes', $response->getContent());
-        $this->assertEquals(2, $response->headers->get('X-RateLimit-Limit'));
-        $this->assertEquals(1, $response->headers->get('X-RateLimit-Remaining'));
+        $this->assertSame(2, (int) $response->headers->get('X-RateLimit-Limit'));
+        $this->assertSame(1, (int) $response->headers->get('X-RateLimit-Remaining'));
 
         $response = $this->withoutExceptionHandling()->get('/');
         $this->assertSame('yes', $response->getContent());
-        $this->assertEquals(2, $response->headers->get('X-RateLimit-Limit'));
-        $this->assertEquals(0, $response->headers->get('X-RateLimit-Remaining'));
+        $this->assertSame(2, (int) $response->headers->get('X-RateLimit-Limit'));
+        $this->assertSame(0, (int) $response->headers->get('X-RateLimit-Remaining'));
 
         Carbon::setTestNow(Carbon::create(2018, 1, 1, 0, 0, 58));
 
@@ -91,10 +91,10 @@ class ThrottleRequestsTest extends TestCase
             $this->withoutExceptionHandling()->get('/');
         } catch (Throwable $e) {
             $this->assertInstanceOf(ThrottleRequestsException::class, $e);
-            $this->assertEquals(429, $e->getStatusCode());
-            $this->assertEquals(2, $e->getHeaders()['X-RateLimit-Limit']);
-            $this->assertEquals(0, $e->getHeaders()['X-RateLimit-Remaining']);
-            $this->assertEquals(2, $e->getHeaders()['Retry-After']);
+            $this->assertSame(429, $e->getStatusCode());
+            $this->assertSame(2, $e->getHeaders()['X-RateLimit-Limit']);
+            $this->assertSame(0, $e->getHeaders()['X-RateLimit-Remaining']);
+            $this->assertSame(2, $e->getHeaders()['Retry-After']);
             $this->assertEquals(Carbon::now()->addSeconds(2)->getTimestamp(), $e->getHeaders()['X-RateLimit-Reset']);
         }
     }
@@ -368,8 +368,8 @@ class ThrottleRequestsTest extends TestCase
 
         $response = $this->withoutExceptionHandling()->actingAs($user)->get('/');
         $this->assertSame('yes', $response->getContent());
-        $this->assertEquals(1, $response->headers->get('X-RateLimit-Limit'));
-        $this->assertEquals(0, $response->headers->get('X-RateLimit-Remaining'));
+        $this->assertSame(1, (int) $response->headers->get('X-RateLimit-Limit'));
+        $this->assertSame(0, (int) $response->headers->get('X-RateLimit-Remaining'));
 
         Carbon::setTestNow(Carbon::create(2018, 1, 1, 0, 0, 58));
 
@@ -377,10 +377,10 @@ class ThrottleRequestsTest extends TestCase
             $this->withoutExceptionHandling()->actingAs($user)->get('/');
         } catch (Throwable $e) {
             $this->assertInstanceOf(ThrottleRequestsException::class, $e);
-            $this->assertEquals(429, $e->getStatusCode());
-            $this->assertEquals(1, $e->getHeaders()['X-RateLimit-Limit']);
-            $this->assertEquals(0, $e->getHeaders()['X-RateLimit-Remaining']);
-            $this->assertEquals(2, $e->getHeaders()['Retry-After']);
+            $this->assertSame(429, $e->getStatusCode());
+            $this->assertSame(1, $e->getHeaders()['X-RateLimit-Limit']);
+            $this->assertSame(0, $e->getHeaders()['X-RateLimit-Remaining']);
+            $this->assertSame(2, $e->getHeaders()['Retry-After']);
             $this->assertEquals(Carbon::now()->addSeconds(2)->getTimestamp(), $e->getHeaders()['X-RateLimit-Reset']);
         }
     }
@@ -397,8 +397,8 @@ class ThrottleRequestsTest extends TestCase
 
         $response = $this->withoutExceptionHandling()->actingAs($user)->get('/');
         $this->assertSame('yes', $response->getContent());
-        $this->assertEquals(1, $response->headers->get('X-RateLimit-Limit'));
-        $this->assertEquals(0, $response->headers->get('X-RateLimit-Remaining'));
+        $this->assertSame(1, (int) $response->headers->get('X-RateLimit-Limit'));
+        $this->assertSame(0, (int) $response->headers->get('X-RateLimit-Remaining'));
 
         Carbon::setTestNow(Carbon::create(2018, 1, 1, 0, 0, 58));
 
@@ -406,10 +406,10 @@ class ThrottleRequestsTest extends TestCase
             $this->withoutExceptionHandling()->actingAs($user)->get('/');
         } catch (Throwable $e) {
             $this->assertInstanceOf(ThrottleRequestsException::class, $e);
-            $this->assertEquals(429, $e->getStatusCode());
-            $this->assertEquals(1, $e->getHeaders()['X-RateLimit-Limit']);
-            $this->assertEquals(0, $e->getHeaders()['X-RateLimit-Remaining']);
-            $this->assertEquals(2, $e->getHeaders()['Retry-After']);
+            $this->assertSame(429, $e->getStatusCode());
+            $this->assertSame(1, $e->getHeaders()['X-RateLimit-Limit']);
+            $this->assertSame(0, $e->getHeaders()['X-RateLimit-Remaining']);
+            $this->assertSame(2, $e->getHeaders()['Retry-After']);
             $this->assertEquals(Carbon::now()->addSeconds(2)->getTimestamp(), $e->getHeaders()['X-RateLimit-Reset']);
         }
     }

--- a/tests/Integration/Http/ThrottleRequestsWithRedisTest.php
+++ b/tests/Integration/Http/ThrottleRequestsWithRedisTest.php
@@ -31,22 +31,22 @@ class ThrottleRequestsWithRedisTest extends TestCase
 
             $response = $this->withoutExceptionHandling()->get('/');
             $this->assertSame('yes', $response->getContent());
-            $this->assertEquals(2, $response->headers->get('X-RateLimit-Limit'));
-            $this->assertEquals(1, $response->headers->get('X-RateLimit-Remaining'));
+            $this->assertSame(2, $response->headers->get('X-RateLimit-Limit'));
+            $this->assertSame(1, $response->headers->get('X-RateLimit-Remaining'));
 
             $response = $this->withoutExceptionHandling()->get('/');
             $this->assertSame('yes', $response->getContent());
-            $this->assertEquals(2, $response->headers->get('X-RateLimit-Limit'));
-            $this->assertEquals(0, $response->headers->get('X-RateLimit-Remaining'));
+            $this->assertSame(2, $response->headers->get('X-RateLimit-Limit'));
+            $this->assertSame(0, $response->headers->get('X-RateLimit-Remaining'));
 
             Carbon::setTestNow($finish = $now->addSeconds(58));
 
             try {
                 $this->withoutExceptionHandling()->get('/');
             } catch (Throwable $e) {
-                $this->assertEquals(429, $e->getStatusCode());
-                $this->assertEquals(2, $e->getHeaders()['X-RateLimit-Limit']);
-                $this->assertEquals(0, $e->getHeaders()['X-RateLimit-Remaining']);
+                $this->assertSame(429, $e->getStatusCode());
+                $this->assertSame(2, $e->getHeaders()['X-RateLimit-Limit']);
+                $this->assertSame(0, $e->getHeaders()['X-RateLimit-Remaining']);
                 // $this->assertTrue(in_array($e->getHeaders()['Retry-After'], [2, 3]));
                 // $this->assertTrue(in_array($e->getHeaders()['X-RateLimit-Reset'], [$finish->getTimestamp() + 2, $finish->getTimestamp() + 3]));
             }

--- a/tests/Integration/Log/ContextIntegrationTest.php
+++ b/tests/Integration/Log/ContextIntegrationTest.php
@@ -20,7 +20,7 @@ class ContextIntegrationTest extends TestCase
     public function test_it_can_hydrate_null()
     {
         Context::hydrate(null);
-        $this->assertEquals([], Context::all());
+        $this->assertSame([], Context::all());
     }
 
     public function test_it_handles_eloquent()

--- a/tests/Integration/Queue/DebouncedJobTest.php
+++ b/tests/Integration/Queue/DebouncedJobTest.php
@@ -131,7 +131,7 @@ class DebouncedJobTest extends QueueTestCase
 
         $restored = unserialize(serialize($job));
 
-        $this->assertEquals('test-owner-token-123', $restored->debounceOwner);
+        $this->assertSame('test-owner-token-123', $restored->debounceOwner);
     }
 
     public function testDifferentDebounceIdsDoNotInterfere()

--- a/tests/Integration/Queue/DebouncedJobTest.php
+++ b/tests/Integration/Queue/DebouncedJobTest.php
@@ -61,7 +61,7 @@ class DebouncedJobTest extends QueueTestCase
         $this->runQueueWorkerCommand(['--once' => true], 2);
 
         // Only the second (latest) dispatch should have executed.
-        $this->assertEquals(1, DebouncedTestJob::$handleCount);
+        $this->assertSame(1, DebouncedTestJob::$handleCount);
     }
 
     public function testTokenPersistsAfterSuccessfulExecution()
@@ -113,7 +113,7 @@ class DebouncedJobTest extends QueueTestCase
         $this->travelTo(now()->addSeconds(31));
         $this->runQueueWorkerCommand(['--once' => true], 2);
 
-        $this->assertEquals(1, $firedCount);
+        $this->assertSame(1, $firedCount);
     }
 
     public function testDebouncedAndUniqueThrowsLogicException()
@@ -147,7 +147,7 @@ class DebouncedJobTest extends QueueTestCase
         $this->runQueueWorkerCommand(['--once' => true], 2);
 
         // Both should execute — different identities.
-        $this->assertEquals(2, DebouncedTestJob::$handleCount);
+        $this->assertSame(2, DebouncedTestJob::$handleCount);
     }
 
     public function testDebounceLockKeyFormat()
@@ -245,7 +245,7 @@ class DebouncedJobTest extends QueueTestCase
         $this->runQueueWorkerCommand(['--once' => true], 3);
 
         // Only the second dispatch should have executed.
-        $this->assertEquals(1, DebouncedTestJob::$handleCount);
+        $this->assertSame(1, DebouncedTestJob::$handleCount);
 
         // Chain from superseded job should NOT have been dispatched.
         $this->assertFalse(ChainReceiverJob::$handled);
@@ -288,7 +288,7 @@ class DebouncedJobTest extends QueueTestCase
         unset($pending);
 
         // The job should be queued with delay=0 since max wait was exceeded.
-        $this->assertEquals(0, $job->delay);
+        $this->assertSame(0, $job->delay);
     }
 
     public function testDebounceWithoutMaxWaitAllowsIndefiniteDelay()
@@ -300,7 +300,7 @@ class DebouncedJobTest extends QueueTestCase
         $pending = dispatch($job1);
         unset($pending);
 
-        $this->assertEquals(30, $job1->delay);
+        $this->assertSame(30, $job1->delay);
 
         // Dispatch again much later — still gets the full delay.
         $this->travelTo(now()->addSeconds(600));
@@ -308,7 +308,7 @@ class DebouncedJobTest extends QueueTestCase
         $pending2 = dispatch($job2);
         unset($pending2);
 
-        $this->assertEquals(30, $job2->delay);
+        $this->assertSame(30, $job2->delay);
     }
 }
 

--- a/tests/Integration/Queue/DynamoBatchTest.php
+++ b/tests/Integration/Queue/DynamoBatchTest.php
@@ -65,8 +65,8 @@ class DynamoBatchTest extends TestCase
         /** @var DynamoBatchRepository */
         $repo = app(DynamoBatchRepository::class);
         $retrieved = $repo->find($batch->id);
-        $this->assertEquals(2, $retrieved->totalJobs);
-        $this->assertEquals(0, $retrieved->failedJobs);
+        $this->assertSame(2, $retrieved->totalJobs);
+        $this->assertSame(0, $retrieved->failedJobs);
         $this->assertTrue($retrieved->finishedAt->between(Carbon::now()->subSecond(30), Carbon::now()));
     }
 
@@ -112,8 +112,8 @@ class DynamoBatchTest extends TestCase
         /** @var DynamoBatchRepository */
         $repo = app(DynamoBatchRepository::class);
         $retrieved = $repo->find($batch->id);
-        $this->assertEquals(2, $retrieved->totalJobs);
-        $this->assertEquals(1, $retrieved->failedJobs);
+        $this->assertSame(2, $retrieved->totalJobs);
+        $this->assertSame(1, $retrieved->failedJobs);
         $this->assertTrue($retrieved->finishedAt->between(Carbon::now()->subSecond(30), Carbon::now()));
         $this->assertTrue($retrieved->cancelledAt->between(Carbon::now()->subSecond(30), Carbon::now()));
     }

--- a/tests/Integration/Queue/JobChainingTest.php
+++ b/tests/Integration/Queue/JobChainingTest.php
@@ -653,7 +653,7 @@ class JobChainingTest extends QueueTestCase
                 $chain->onConnection('sync2');
             });
 
-        $this->assertEquals('sync2', $chain->connection);
+        $this->assertSame('sync2', $chain->connection);
 
         $chain = Bus::chain([])
             ->onConnection('sync1')
@@ -661,7 +661,7 @@ class JobChainingTest extends QueueTestCase
                 $chain->onConnection('sync2');
             });
 
-        $this->assertEquals('sync1', $chain->connection);
+        $this->assertSame('sync1', $chain->connection);
     }
 
     public function testBatchConditionable()
@@ -672,14 +672,14 @@ class JobChainingTest extends QueueTestCase
                 $batch->onConnection('sync2');
             });
 
-        $this->assertEquals('sync2', $batch->connection());
+        $this->assertSame('sync2', $batch->connection());
         $batch = Bus::batch([])
             ->onConnection('sync1')
             ->when(false, function (PendingBatch $batch) {
                 $batch->onConnection('sync2');
             });
 
-        $this->assertEquals('sync1', $batch->connection());
+        $this->assertSame('sync1', $batch->connection());
     }
 
     public function testJobsAreChainedWhenDispatchIfIsTrue()

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -469,7 +469,7 @@ class ModelSerializationTest extends TestCase
         $unserialized = unserialize($serialized);
 
         $this->assertFalse($unserialized->user->relationLoaded('roles'));
-        $this->assertEquals('hello', $unserialized->value->value);
+        $this->assertSame('hello', $unserialized->value->value);
     }
 
     #[WithConfig('database.default', 'testing')]
@@ -485,7 +485,7 @@ class ModelSerializationTest extends TestCase
         $unserialized = unserialize($serialized);
 
         $this->assertFalse($unserialized->user->relationLoaded('roles'));
-        $this->assertEquals('hello', $unserialized->value->value);
+        $this->assertSame('hello', $unserialized->value->value);
     }
 
     public function test_serialization_types_empty_custom_eloquent_collection()

--- a/tests/Integration/Queue/QueueFakeTest.php
+++ b/tests/Integration/Queue/QueueFakeTest.php
@@ -46,7 +46,7 @@ class QueueFakeTest extends TestCase
             return 'test-value';
         });
 
-        $this->assertEquals('test-value', $result);
+        $this->assertSame('test-value', $result);
     }
 
     public function testFakeExceptForReturnValue()
@@ -55,7 +55,7 @@ class QueueFakeTest extends TestCase
             return 'test-value';
         }, []);
 
-        $this->assertEquals('test-value', $result);
+        $this->assertSame('test-value', $result);
     }
 }
 

--- a/tests/Integration/Queue/RedisQueueTest.php
+++ b/tests/Integration/Queue/RedisQueueTest.php
@@ -94,8 +94,8 @@ class RedisQueueTest extends TestCase
         $this->assertNull($this->queue->pop());
 
         $redisKey = $this->getQueueRedisKey($default);
-        $this->assertEquals(1, $this->redis[$driver]->connection()->zcard("$redisKey:delayed"));
-        $this->assertEquals(3, $this->redis[$driver]->connection()->zcard("$redisKey:reserved"));
+        $this->assertSame(1, $this->redis[$driver]->connection()->zcard("$redisKey:delayed"));
+        $this->assertSame(3, $this->redis[$driver]->connection()->zcard("$redisKey:reserved"));
     }
 
     /**
@@ -113,7 +113,7 @@ class RedisQueueTest extends TestCase
         if ($pid = pcntl_fork() > 0) {
             $this->setUpRedis();
             $this->setQueue($driver, $default, null, 60, 10);
-            $this->assertEquals(12, unserialize(json_decode($this->queue->pop()->getRawBody())->data->command)->i);
+            $this->assertSame(12, unserialize(json_decode($this->queue->pop()->getRawBody())->data->command)->i);
         } elseif ($pid == 0) {
             $this->setUpRedis();
             $this->setQueue('phpredis', $default);
@@ -162,14 +162,14 @@ class RedisQueueTest extends TestCase
         $after = $this->currentTime();
 
         $this->assertEquals($job, unserialize(json_decode($redisJob->getRawBody())->data->command));
-        $this->assertEquals(1, $redisJob->attempts());
+        $this->assertSame(1, $redisJob->attempts());
         $this->assertEquals($job, unserialize(json_decode($redisJob->getReservedJob())->data->command));
-        $this->assertEquals(1, json_decode($redisJob->getReservedJob())->attempts);
+        $this->assertSame(1, json_decode($redisJob->getReservedJob())->attempts);
         $this->assertEquals($redisJob->getJobId(), json_decode($redisJob->getReservedJob())->id);
 
         // Check reserved queue
         $redisKey = $this->getQueueRedisKey($default);
-        $this->assertEquals(1, $this->redis[$driver]->connection()->zcard("$redisKey:reserved"));
+        $this->assertSame(1, $this->redis[$driver]->connection()->zcard("$redisKey:reserved"));
         $result = $this->redis[$driver]->connection()->zrangebyscore("$redisKey:reserved", -INF, INF, ['withscores' => true]);
         $reservedJob = array_keys($result)[0];
         $score = (int) $result[$reservedJob];
@@ -197,7 +197,7 @@ class RedisQueueTest extends TestCase
 
         // Check reserved queue
         $redisKey = $this->getQueueRedisKey($default);
-        $this->assertEquals(1, $this->redis[$driver]->connection()->zcard("$redisKey:reserved"));
+        $this->assertSame(1, $this->redis[$driver]->connection()->zcard("$redisKey:reserved"));
         $result = $this->redis[$driver]->connection()->zrangebyscore("$redisKey:reserved", -INF, INF, ['withscores' => true]);
         $reservedJob = array_keys($result)[0];
         $score = (int) $result[$reservedJob];
@@ -228,7 +228,7 @@ class RedisQueueTest extends TestCase
 
         // Check reserved queue
         $redisKey = $this->getQueueRedisKey($default);
-        $this->assertEquals(1, $this->redis[$driver]->connection()->zcard("$redisKey:reserved"));
+        $this->assertSame(1, $this->redis[$driver]->connection()->zcard("$redisKey:reserved"));
         $result = $this->redis[$driver]->connection()->zrangebyscore("$redisKey:reserved", -INF, INF, ['withscores' => true]);
         $reservedJob = array_keys($result)[0];
         $score = (int) $result[$reservedJob];
@@ -283,9 +283,9 @@ class RedisQueueTest extends TestCase
         $this->assertEquals($jobs[1], unserialize(json_decode($this->queue->pop()->getRawBody())->data->command));
 
         $redisKey = $this->getQueueRedisKey($default);
-        $this->assertEquals(0, $this->redis[$driver]->connection()->llen("$redisKey:notify"));
-        $this->assertEquals(0, $this->redis[$driver]->connection()->zcard("$redisKey:delayed"));
-        $this->assertEquals(2, $this->redis[$driver]->connection()->zcard("$redisKey:reserved"));
+        $this->assertSame(0, $this->redis[$driver]->connection()->llen("$redisKey:notify"));
+        $this->assertSame(0, $this->redis[$driver]->connection()->zcard("$redisKey:delayed"));
+        $this->assertSame(2, $this->redis[$driver]->connection()->zcard("$redisKey:reserved"));
 
         Str::createUuidsNormally();
     }
@@ -320,7 +320,7 @@ class RedisQueueTest extends TestCase
 
         // Check reserved queue
         $redisKey = $this->getQueueRedisKey($default);
-        $this->assertEquals(2, $this->redis[$driver]->connection()->zcard("$redisKey:reserved"));
+        $this->assertSame(2, $this->redis[$driver]->connection()->zcard("$redisKey:reserved"));
         $result = $this->redis[$driver]->connection()->zrangebyscore("$redisKey:reserved", -INF, INF, ['withscores' => true]);
 
         foreach ($result as $payload => $score) {
@@ -361,7 +361,7 @@ class RedisQueueTest extends TestCase
 
         // Check reserved queue
         $redisKey = $this->getQueueRedisKey($default);
-        $this->assertEquals(1, $this->redis[$driver]->connection()->zcard("$redisKey:reserved"));
+        $this->assertSame(1, $this->redis[$driver]->connection()->zcard("$redisKey:reserved"));
         $result = $this->redis[$driver]->connection()->zrangebyscore("$redisKey:reserved", -INF, INF, ['withscores' => true]);
         $reservedJob = array_keys($result)[0];
         $score = (int) $result[$reservedJob];
@@ -392,7 +392,7 @@ class RedisQueueTest extends TestCase
 
         // check the content of delayed queue
         $redisKey = $this->getQueueRedisKey($default);
-        $this->assertEquals(1, $this->redis[$driver]->connection()->zcard("$redisKey:delayed"));
+        $this->assertSame(1, $this->redis[$driver]->connection()->zcard("$redisKey:delayed"));
 
         $results = $this->redis[$driver]->connection()->zrangebyscore("$redisKey:delayed", -INF, INF, ['withscores' => true]);
 
@@ -405,7 +405,7 @@ class RedisQueueTest extends TestCase
 
         $decoded = json_decode($payload);
 
-        $this->assertEquals(1, $decoded->attempts);
+        $this->assertSame(1, $decoded->attempts);
         $this->assertEquals($job, unserialize($decoded->data->command));
 
         // check if the queue has no ready item yet
@@ -448,9 +448,9 @@ class RedisQueueTest extends TestCase
         $redisJob->delete();
 
         $redisKey = $this->getQueueRedisKey($default);
-        $this->assertEquals(0, $this->redis[$driver]->connection()->zcard("$redisKey:delayed"));
-        $this->assertEquals(0, $this->redis[$driver]->connection()->zcard("$redisKey:reserved"));
-        $this->assertEquals(0, $this->redis[$driver]->connection()->llen("$redisKey"));
+        $this->assertSame(0, $this->redis[$driver]->connection()->zcard("$redisKey:delayed"));
+        $this->assertSame(0, $this->redis[$driver]->connection()->zcard("$redisKey:reserved"));
+        $this->assertSame(0, $this->redis[$driver]->connection()->llen("$redisKey"));
 
         $this->assertNull($this->queue->pop());
     }
@@ -470,10 +470,10 @@ class RedisQueueTest extends TestCase
         $this->queue->push($job1);
         $this->queue->push($job2);
 
-        $this->assertEquals(2, $this->queue->clear(null));
-        $this->assertEquals(0, $this->queue->size());
+        $this->assertSame(2, $this->queue->clear(null));
+        $this->assertSame(0, $this->queue->size());
         $redisKey = $this->getQueueRedisKey($default);
-        $this->assertEquals(0, $this->redis[$driver]->connection()->llen("$redisKey:notify"));
+        $this->assertSame(0, $this->redis[$driver]->connection()->llen("$redisKey:notify"));
     }
 
     /**
@@ -484,17 +484,17 @@ class RedisQueueTest extends TestCase
     {
         $default = config('queue.connections.redis.queue', 'default');
         $this->setQueue($driver, $default);
-        $this->assertEquals(0, $this->queue->size());
+        $this->assertSame(0, $this->queue->size());
         $this->queue->push(new RedisQueueIntegrationTestJob(1));
-        $this->assertEquals(1, $this->queue->size());
+        $this->assertSame(1, $this->queue->size());
         $this->queue->later(60, new RedisQueueIntegrationTestJob(2));
-        $this->assertEquals(2, $this->queue->size());
+        $this->assertSame(2, $this->queue->size());
         $this->queue->push(new RedisQueueIntegrationTestJob(3));
-        $this->assertEquals(3, $this->queue->size());
+        $this->assertSame(3, $this->queue->size());
         $job = $this->queue->pop();
-        $this->assertEquals(3, $this->queue->size());
+        $this->assertSame(3, $this->queue->size());
         $job->delete();
-        $this->assertEquals(2, $this->queue->size());
+        $this->assertSame(2, $this->queue->size());
     }
 
     /**
@@ -604,7 +604,7 @@ class RedisQueueTest extends TestCase
             // Verify the actual job data
             $command = unserialize($decoded->data->command);
             $this->assertEquals($job, $command, 'Unserialized job should match original');
-            $this->assertEquals(42, $command->i, 'Job property should be preserved');
+            $this->assertSame(42, $command->i, 'Job property should be preserved');
         } finally {
             // Restore original serializer setting
             $client->setOption($optSerializer, $originalSerializer);

--- a/tests/Integration/Queue/UniqueJobTest.php
+++ b/tests/Integration/Queue/UniqueJobTest.php
@@ -246,7 +246,7 @@ class UniqueJobTest extends QueueTestCase
 
     public function testUniqueLockCreatesKeyWithClassName()
     {
-        $this->assertEquals(
+        $this->assertSame(
             'laravel_unique_job:'.UniqueTestJob::class.':',
             UniqueLock::getKey(new UniqueTestJob)
         );
@@ -254,7 +254,7 @@ class UniqueJobTest extends QueueTestCase
 
     public function testUniqueLockCreatesKeyWithIdAndClassName()
     {
-        $this->assertEquals(
+        $this->assertSame(
             'laravel_unique_job:'.UniqueIdTestJob::class.':unique-id-1',
             UniqueLock::getKey(new UniqueIdTestJob)
         );
@@ -262,7 +262,7 @@ class UniqueJobTest extends QueueTestCase
 
     public function testUniqueLockCreatesKeyWithDisplayNameWhenAvailable()
     {
-        $this->assertEquals(
+        $this->assertSame(
             'laravel_unique_job:'.hash('xxh128', 'App\\Actions\\UniqueTestAction').':unique-id-2',
             UniqueLock::getKey(new UniqueIdTestJobWithDisplayName)
         );
@@ -270,7 +270,7 @@ class UniqueJobTest extends QueueTestCase
 
     public function testUniqueLockCreatesKeyWithIdAndDisplayNameWhenAvailable()
     {
-        $this->assertEquals(
+        $this->assertSame(
             'laravel_unique_job:'.hash('xxh128', 'App\\Actions\\UniqueTestAction').':unique-id-2',
             UniqueLock::getKey(new UniqueIdTestJobWithDisplayName)
         );

--- a/tests/Integration/Routing/FallbackRouteTest.php
+++ b/tests/Integration/Routing/FallbackRouteTest.php
@@ -19,7 +19,7 @@ class FallbackRouteTest extends TestCase
 
         $this->assertStringContainsString('one', $this->get('/one')->getContent());
         $this->assertStringContainsString('fallback', $this->get('/non-existing')->getContent());
-        $this->assertEquals(404, $this->get('/non-existing')->getStatusCode());
+        $this->assertSame(404, $this->get('/non-existing')->getStatusCode());
     }
 
     public function testFallbackWithPrefix()
@@ -58,7 +58,7 @@ class FallbackRouteTest extends TestCase
 
         tap($this->get('/non-existing'), function ($response) {
             $this->assertStringContainsString('wildcard', $response->getContent());
-            $this->assertEquals(200, $response->getStatusCode());
+            $this->assertSame(200, $response->getStatusCode());
 
             $this->assertSame('non-existing', $response->baseRequest->route('any'));
         });
@@ -71,7 +71,7 @@ class FallbackRouteTest extends TestCase
         });
 
         $this->assertStringContainsString('fallback', $this->get('/non-existing')->getContent());
-        $this->assertEquals(404, $this->get('/non-existing')->getStatusCode());
+        $this->assertSame(404, $this->get('/non-existing')->getStatusCode());
     }
 
     public function testRespondWithNamedFallbackRoute()
@@ -95,6 +95,6 @@ class FallbackRouteTest extends TestCase
         });
 
         $this->assertStringContainsString('one', $this->get('/one')->getContent());
-        $this->assertEquals(200, $this->get('/one')->getStatusCode());
+        $this->assertSame(200, $this->get('/one')->getStatusCode());
     }
 }

--- a/tests/Integration/Routing/PreviousUrlTest.php
+++ b/tests/Integration/Routing/PreviousUrlTest.php
@@ -17,7 +17,7 @@ class PreviousUrlTest extends TestCase
 
         $response = $this->postJson('/previous-url');
 
-        $this->assertEquals(422, $response->status());
+        $this->assertSame(422, $response->status());
     }
 
     protected function getApplicationProviders($app)

--- a/tests/Integration/Routing/ResponsableTest.php
+++ b/tests/Integration/Routing/ResponsableTest.php
@@ -16,7 +16,7 @@ class ResponsableTest extends TestCase
 
         $response = $this->get('/responsable');
 
-        $this->assertEquals(201, $response->status());
+        $this->assertSame(201, $response->status());
         $this->assertSame('Taylor', $response->headers->get('X-Test-Header'));
         $this->assertSame('hello world', $response->getContent());
     }

--- a/tests/Integration/Routing/RouteApiResourceTest.php
+++ b/tests/Integration/Routing/RouteApiResourceTest.php
@@ -14,26 +14,26 @@ class RouteApiResourceTest extends TestCase
         Route::apiResource('tests', ApiResourceTestController::class);
 
         $response = $this->get('/tests');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('I`m index', $response->getContent());
 
         $response = $this->post('/tests');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('I`m store', $response->getContent());
 
         $response = $this->get('/tests/1');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('I`m show', $response->getContent());
 
         $response = $this->put('/tests/1');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('I`m update', $response->getContent());
         $response = $this->patch('/tests/1');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('I`m update', $response->getContent());
 
         $response = $this->delete('/tests/1');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('I`m destroy', $response->getContent());
     }
 
@@ -42,17 +42,17 @@ class RouteApiResourceTest extends TestCase
         Route::apiResource('tests', ApiResourceTestController::class)->only(['index', 'store']);
 
         $response = $this->get('/tests');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('I`m index', $response->getContent());
 
         $response = $this->post('/tests');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('I`m store', $response->getContent());
 
-        $this->assertEquals(404, $this->get('/tests/1')->getStatusCode());
-        $this->assertEquals(404, $this->put('/tests/1')->getStatusCode());
-        $this->assertEquals(404, $this->patch('/tests/1')->getStatusCode());
-        $this->assertEquals(404, $this->delete('/tests/1')->getStatusCode());
+        $this->assertSame(404, $this->get('/tests/1')->getStatusCode());
+        $this->assertSame(404, $this->put('/tests/1')->getStatusCode());
+        $this->assertSame(404, $this->patch('/tests/1')->getStatusCode());
+        $this->assertSame(404, $this->delete('/tests/1')->getStatusCode());
     }
 
     public function testApiResources()
@@ -63,50 +63,50 @@ class RouteApiResourceTest extends TestCase
         ]);
 
         $response = $this->get('/tests');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('I`m index', $response->getContent());
 
         $response = $this->post('/tests');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('I`m store', $response->getContent());
 
         $response = $this->get('/tests/1');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('I`m show', $response->getContent());
 
         $response = $this->put('/tests/1');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('I`m update', $response->getContent());
         $response = $this->patch('/tests/1');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('I`m update', $response->getContent());
 
         $response = $this->delete('/tests/1');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('I`m destroy', $response->getContent());
 
         /////////////////////
         $response = $this->get('/tasks');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('I`m index tasks', $response->getContent());
 
         $response = $this->post('/tasks');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('I`m store tasks', $response->getContent());
 
         $response = $this->get('/tasks/1');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('I`m show tasks', $response->getContent());
 
         $response = $this->put('/tasks/1');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('I`m update tasks', $response->getContent());
         $response = $this->patch('/tasks/1');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('I`m update tasks', $response->getContent());
 
         $response = $this->delete('/tasks/1');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('I`m destroy tasks', $response->getContent());
     }
 }

--- a/tests/Integration/Routing/RouteSingletonTest.php
+++ b/tests/Integration/Routing/RouteSingletonTest.php
@@ -15,30 +15,30 @@ class RouteSingletonTest extends TestCase
         Route::singleton('avatar', SingletonTestController::class);
 
         $response = $this->get('/avatar/create');
-        $this->assertEquals(404, $response->getStatusCode());
+        $this->assertSame(404, $response->getStatusCode());
 
         $this->assertSame('http://localhost/avatar', route('avatar.show'));
         $response = $this->get('/avatar');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('singleton show', $response->getContent());
 
         $this->assertSame('http://localhost/avatar/edit', route('avatar.edit'));
         $response = $this->get('/avatar/edit');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('singleton edit', $response->getContent());
 
         $this->assertSame('http://localhost/avatar', route('avatar.update'));
         $response = $this->put('/avatar');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('singleton update', $response->getContent());
 
         $response = $this->patch('/avatar');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('singleton update', $response->getContent());
 
         // $this->assertSame('http://localhost/avatar', route('avatar.destroy'));
         // $response = $this->delete('/avatar');
-        // $this->assertEquals(404, $response->getStatusCode());
+        // $this->assertSame(404, $response->getStatusCode());
         // $this->assertSame('singleton destroy', $response->getContent());
     }
 
@@ -48,17 +48,17 @@ class RouteSingletonTest extends TestCase
 
         $this->assertSame('http://localhost/avatar/create', route('avatar.create'));
         $response = $this->get('/avatar/create');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('singleton create', $response->getContent());
 
         $this->assertSame('http://localhost/avatar', route('avatar.store'));
         $response = $this->post('/avatar');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('singleton store', $response->getContent());
 
         $this->assertSame('http://localhost/avatar', route('avatar.destroy'));
         $response = $this->delete('/avatar');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('singleton destroy', $response->getContent());
     }
 
@@ -67,25 +67,25 @@ class RouteSingletonTest extends TestCase
         Route::singleton('avatar', CreatableSingletonTestController::class)->creatable()->only('show');
 
         $response = $this->get('/avatar');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
 
         $response = $this->get('/avatar/create');
-        $this->assertEquals(404, $response->getStatusCode());
+        $this->assertSame(404, $response->getStatusCode());
 
         $response = $this->post('/avatar');
-        $this->assertEquals(405, $response->getStatusCode());
+        $this->assertSame(405, $response->getStatusCode());
 
         $response = $this->get('/avatar/edit');
-        $this->assertEquals(404, $response->getStatusCode());
+        $this->assertSame(404, $response->getStatusCode());
 
         $response = $this->put('/avatar');
-        $this->assertEquals(405, $response->getStatusCode());
+        $this->assertSame(405, $response->getStatusCode());
 
         $response = $this->patch('/avatar');
-        $this->assertEquals(405, $response->getStatusCode());
+        $this->assertSame(405, $response->getStatusCode());
 
         $response = $this->delete('/avatar');
-        $this->assertEquals(405, $response->getStatusCode());
+        $this->assertSame(405, $response->getStatusCode());
     }
 
     public function testCreatableSingletonExcept()
@@ -93,25 +93,25 @@ class RouteSingletonTest extends TestCase
         Route::singleton('avatar', CreatableSingletonTestController::class)->creatable()->except('show');
 
         $response = $this->get('/avatar');
-        $this->assertEquals(405, $response->getStatusCode());
+        $this->assertSame(405, $response->getStatusCode());
 
         $response = $this->get('/avatar/create');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
 
         $response = $this->post('/avatar');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
 
         $response = $this->get('/avatar/edit');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
 
         $response = $this->put('/avatar');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
 
         $response = $this->patch('/avatar');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
 
         $response = $this->delete('/avatar');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
     }
 
     public function testDestroyableSingleton()
@@ -120,22 +120,22 @@ class RouteSingletonTest extends TestCase
 
         $this->assertSame('http://localhost/avatar', route('avatar.show'));
         $response = $this->get('/avatar');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('singleton show', $response->getContent());
 
         $this->assertSame('http://localhost/avatar/edit', route('avatar.edit'));
         $response = $this->get('/avatar/edit');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('singleton edit', $response->getContent());
 
         $this->assertSame('http://localhost/avatar', route('avatar.update'));
         $response = $this->put('/avatar');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('singleton update', $response->getContent());
 
         $this->assertSame('http://localhost/avatar', route('avatar.destroy'));
         $response = $this->delete('/avatar');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('singleton destroy', $response->getContent());
     }
 
@@ -144,25 +144,25 @@ class RouteSingletonTest extends TestCase
         Route::singleton('avatar', SingletonTestController::class)->destroyable()->only('destroy');
 
         $response = $this->get('/avatar');
-        $this->assertEquals(405, $response->getStatusCode());
+        $this->assertSame(405, $response->getStatusCode());
 
         $response = $this->get('/avatar/create');
-        $this->assertEquals(404, $response->getStatusCode());
+        $this->assertSame(404, $response->getStatusCode());
 
         $response = $this->post('/avatar');
-        $this->assertEquals(405, $response->getStatusCode());
+        $this->assertSame(405, $response->getStatusCode());
 
         $response = $this->get('/avatar/edit');
-        $this->assertEquals(404, $response->getStatusCode());
+        $this->assertSame(404, $response->getStatusCode());
 
         $response = $this->put('/avatar');
-        $this->assertEquals(405, $response->getStatusCode());
+        $this->assertSame(405, $response->getStatusCode());
 
         $response = $this->patch('/avatar');
-        $this->assertEquals(405, $response->getStatusCode());
+        $this->assertSame(405, $response->getStatusCode());
 
         $response = $this->delete('/avatar');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
     }
 
     public function testDestroyableSingletonExcept()
@@ -170,25 +170,25 @@ class RouteSingletonTest extends TestCase
         Route::singleton('avatar', SingletonTestController::class)->destroyable()->except('destroy');
 
         $response = $this->get('/avatar');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
 
         $response = $this->get('/avatar/create');
-        $this->assertEquals(404, $response->getStatusCode());
+        $this->assertSame(404, $response->getStatusCode());
 
         $response = $this->post('/avatar');
-        $this->assertEquals(405, $response->getStatusCode());
+        $this->assertSame(405, $response->getStatusCode());
 
         $response = $this->get('/avatar/edit');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
 
         $response = $this->put('/avatar');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
 
         $response = $this->patch('/avatar');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
 
         $response = $this->delete('/avatar');
-        $this->assertEquals(405, $response->getStatusCode());
+        $this->assertSame(405, $response->getStatusCode());
     }
 
     public function testCreatableDestroyableSingletonOnlyExceptTest()
@@ -196,25 +196,25 @@ class RouteSingletonTest extends TestCase
         Route::singleton('avatar', SingletonTestController::class)->creatable()->destroyable()->only(['show'])->except(['destroy']);
 
         $response = $this->get('/avatar');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
 
         $response = $this->get('/avatar/create');
-        $this->assertEquals(404, $response->getStatusCode());
+        $this->assertSame(404, $response->getStatusCode());
 
         $response = $this->post('/avatar');
-        $this->assertEquals(405, $response->getStatusCode());
+        $this->assertSame(405, $response->getStatusCode());
 
         $response = $this->get('/avatar/edit');
-        $this->assertEquals(404, $response->getStatusCode());
+        $this->assertSame(404, $response->getStatusCode());
 
         $response = $this->put('/avatar');
-        $this->assertEquals(405, $response->getStatusCode());
+        $this->assertSame(405, $response->getStatusCode());
 
         $response = $this->patch('/avatar');
-        $this->assertEquals(405, $response->getStatusCode());
+        $this->assertSame(405, $response->getStatusCode());
 
         $response = $this->delete('/avatar');
-        $this->assertEquals(405, $response->getStatusCode());
+        $this->assertSame(405, $response->getStatusCode());
     }
 
     public function testApiSingleton()
@@ -222,14 +222,14 @@ class RouteSingletonTest extends TestCase
         Route::apiSingleton('avatar', SingletonTestController::class);
 
         $response = $this->get('/avatar/create');
-        $this->assertEquals(404, $response->getStatusCode());
+        $this->assertSame(404, $response->getStatusCode());
 
         $response = $this->post('/avatar');
-        $this->assertEquals(405, $response->getStatusCode());
+        $this->assertSame(405, $response->getStatusCode());
 
         $this->assertSame('http://localhost/avatar', route('avatar.update'));
         $response = $this->put('/avatar');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('singleton update', $response->getContent());
     }
 
@@ -238,16 +238,16 @@ class RouteSingletonTest extends TestCase
         Route::apiSingleton('avatar', CreatableSingletonTestController::class)->creatable();
 
         $response = $this->get('/avatar/create');
-        $this->assertEquals(404, $response->getStatusCode());
+        $this->assertSame(404, $response->getStatusCode());
 
         $this->assertSame('http://localhost/avatar', route('avatar.store'));
         $response = $this->post('/avatar');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('singleton store', $response->getContent());
 
         $this->assertSame('http://localhost/avatar', route('avatar.update'));
         $response = $this->put('/avatar');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('singleton update', $response->getContent());
     }
 
@@ -256,25 +256,25 @@ class RouteSingletonTest extends TestCase
         Route::apiSingleton('avatar', CreatableSingletonTestController::class)->creatable()->only(['create', 'store']);
 
         $response = $this->get('/avatar');
-        $this->assertEquals(405, $response->getStatusCode());
+        $this->assertSame(405, $response->getStatusCode());
 
         $response = $this->get('/avatar/create');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
 
         $response = $this->post('/avatar');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
 
         $response = $this->get('/avatar/edit');
-        $this->assertEquals(404, $response->getStatusCode());
+        $this->assertSame(404, $response->getStatusCode());
 
         $response = $this->put('/avatar');
-        $this->assertEquals(405, $response->getStatusCode());
+        $this->assertSame(405, $response->getStatusCode());
 
         $response = $this->patch('/avatar');
-        $this->assertEquals(405, $response->getStatusCode());
+        $this->assertSame(405, $response->getStatusCode());
 
         $response = $this->delete('/avatar');
-        $this->assertEquals(405, $response->getStatusCode());
+        $this->assertSame(405, $response->getStatusCode());
     }
 
     public function testCreatableApiSingletonExcept()
@@ -282,25 +282,25 @@ class RouteSingletonTest extends TestCase
         Route::apiSingleton('avatar', CreatableSingletonTestController::class)->creatable()->except(['create', 'store']);
 
         $response = $this->get('/avatar');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
 
         $response = $this->get('/avatar/create');
-        $this->assertEquals(404, $response->getStatusCode());
+        $this->assertSame(404, $response->getStatusCode());
 
         $response = $this->post('/avatar');
-        $this->assertEquals(405, $response->getStatusCode());
+        $this->assertSame(405, $response->getStatusCode());
 
         $response = $this->get('/avatar/edit');
-        $this->assertEquals(404, $response->getStatusCode());
+        $this->assertSame(404, $response->getStatusCode());
 
         $response = $this->put('/avatar');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
 
         $response = $this->patch('/avatar');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
 
         $response = $this->delete('/avatar');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
     }
 
     public function testDestroyableApiSingleton()
@@ -309,17 +309,17 @@ class RouteSingletonTest extends TestCase
 
         $this->assertSame('http://localhost/avatar', route('avatar.show'));
         $response = $this->get('/avatar');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('singleton show', $response->getContent());
 
         $this->assertSame('http://localhost/avatar', route('avatar.update'));
         $response = $this->put('/avatar');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('singleton update', $response->getContent());
 
         $this->assertSame('http://localhost/avatar', route('avatar.destroy'));
         $response = $this->delete('/avatar');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('singleton destroy', $response->getContent());
     }
 
@@ -328,25 +328,25 @@ class RouteSingletonTest extends TestCase
         Route::apiSingleton('avatar', CreatableSingletonTestController::class)->destroyable()->only(['destroy']);
 
         $response = $this->get('/avatar');
-        $this->assertEquals(405, $response->getStatusCode());
+        $this->assertSame(405, $response->getStatusCode());
 
         $response = $this->get('/avatar/create');
-        $this->assertEquals(404, $response->getStatusCode());
+        $this->assertSame(404, $response->getStatusCode());
 
         $response = $this->post('/avatar');
-        $this->assertEquals(405, $response->getStatusCode());
+        $this->assertSame(405, $response->getStatusCode());
 
         $response = $this->get('/avatar/edit');
-        $this->assertEquals(404, $response->getStatusCode());
+        $this->assertSame(404, $response->getStatusCode());
 
         $response = $this->put('/avatar');
-        $this->assertEquals(405, $response->getStatusCode());
+        $this->assertSame(405, $response->getStatusCode());
 
         $response = $this->patch('/avatar');
-        $this->assertEquals(405, $response->getStatusCode());
+        $this->assertSame(405, $response->getStatusCode());
 
         $response = $this->delete('/avatar');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
     }
 
     public function testDestroyableApiSingletonExcept()
@@ -354,25 +354,25 @@ class RouteSingletonTest extends TestCase
         Route::apiSingleton('avatar', CreatableSingletonTestController::class)->destroyable()->except(['destroy', 'show']);
 
         $response = $this->get('/avatar');
-        $this->assertEquals(405, $response->getStatusCode());
+        $this->assertSame(405, $response->getStatusCode());
 
         $response = $this->get('/avatar/create');
-        $this->assertEquals(404, $response->getStatusCode());
+        $this->assertSame(404, $response->getStatusCode());
 
         $response = $this->post('/avatar');
-        $this->assertEquals(405, $response->getStatusCode());
+        $this->assertSame(405, $response->getStatusCode());
 
         $response = $this->get('/avatar/edit');
-        $this->assertEquals(404, $response->getStatusCode());
+        $this->assertSame(404, $response->getStatusCode());
 
         $response = $this->put('/avatar');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
 
         $response = $this->patch('/avatar');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
 
         $response = $this->delete('/avatar');
-        $this->assertEquals(405, $response->getStatusCode());
+        $this->assertSame(405, $response->getStatusCode());
     }
 
     public function testCreatableDestroyableApiSingletonOnlyExceptTest()
@@ -380,25 +380,25 @@ class RouteSingletonTest extends TestCase
         Route::apiSingleton('avatar', CreatableSingletonTestController::class)->creatable()->destroyable()->only(['show'])->except(['destroy']);
 
         $response = $this->get('/avatar');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
 
         $response = $this->get('/avatar/create');
-        $this->assertEquals(404, $response->getStatusCode());
+        $this->assertSame(404, $response->getStatusCode());
 
         $response = $this->post('/avatar');
-        $this->assertEquals(405, $response->getStatusCode());
+        $this->assertSame(405, $response->getStatusCode());
 
         $response = $this->get('/avatar/edit');
-        $this->assertEquals(404, $response->getStatusCode());
+        $this->assertSame(404, $response->getStatusCode());
 
         $response = $this->put('/avatar');
-        $this->assertEquals(405, $response->getStatusCode());
+        $this->assertSame(405, $response->getStatusCode());
 
         $response = $this->patch('/avatar');
-        $this->assertEquals(405, $response->getStatusCode());
+        $this->assertSame(405, $response->getStatusCode());
 
         $response = $this->delete('/avatar');
-        $this->assertEquals(405, $response->getStatusCode());
+        $this->assertSame(405, $response->getStatusCode());
     }
 
     public function testSingletonOnly()
@@ -406,19 +406,19 @@ class RouteSingletonTest extends TestCase
         Route::singleton('avatar', SingletonTestController::class)->only('show');
 
         $response = $this->get('/avatar');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
 
         $response = $this->get('/avatar/edit');
-        $this->assertEquals(404, $response->getStatusCode());
+        $this->assertSame(404, $response->getStatusCode());
 
         $response = $this->put('/avatar');
-        $this->assertEquals(405, $response->getStatusCode());
+        $this->assertSame(405, $response->getStatusCode());
 
         $response = $this->patch('/avatar');
-        $this->assertEquals(405, $response->getStatusCode());
+        $this->assertSame(405, $response->getStatusCode());
 
         $response = $this->delete('/avatar');
-        $this->assertEquals(405, $response->getStatusCode());
+        $this->assertSame(405, $response->getStatusCode());
     }
 
     public function testSingletonExcept()
@@ -426,22 +426,22 @@ class RouteSingletonTest extends TestCase
         Route::singleton('avatar', SingletonTestController::class)->except('show');
 
         $response = $this->get('/avatar');
-        $this->assertEquals(405, $response->getStatusCode());
+        $this->assertSame(405, $response->getStatusCode());
 
         $response = $this->get('/avatar/edit');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('singleton edit', $response->getContent());
 
         $response = $this->put('/avatar');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('singleton update', $response->getContent());
 
         $response = $this->patch('/avatar');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('singleton update', $response->getContent());
 
         // $response = $this->delete('/avatar');
-        // $this->assertEquals(200, $response->getStatusCode());
+        // $this->assertSame(200, $response->getStatusCode());
         // $this->assertSame('singleton destroy', $response->getContent());
     }
 
@@ -464,23 +464,23 @@ class RouteSingletonTest extends TestCase
         Route::singleton('videos.thumbnail', NestedSingletonTestController::class);
 
         $response = $this->get('/videos/123/thumbnail');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('singleton show for 123', $response->getContent());
 
         $response = $this->get('/videos/123/thumbnail/edit');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('singleton edit for 123', $response->getContent());
 
         $response = $this->put('/videos/123/thumbnail');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('singleton update for 123', $response->getContent());
 
         $response = $this->patch('/videos/123/thumbnail');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('singleton update for 123', $response->getContent());
 
         $response = $this->delete('/videos/123/thumbnail');
-        $this->assertEquals(405, $response->getStatusCode());
+        $this->assertSame(405, $response->getStatusCode());
     }
 
     public function testCreatableNestedSingleton()
@@ -488,23 +488,23 @@ class RouteSingletonTest extends TestCase
         Route::singleton('videos.thumbnail', NestedSingletonTestController::class)->creatable();
 
         $response = $this->get('/videos/123/thumbnail');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('singleton show for 123', $response->getContent());
 
         $response = $this->get('/videos/123/thumbnail/edit');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('singleton edit for 123', $response->getContent());
 
         $response = $this->put('/videos/123/thumbnail');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('singleton update for 123', $response->getContent());
 
         $response = $this->patch('/videos/123/thumbnail');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('singleton update for 123', $response->getContent());
 
         $response = $this->delete('/videos/123/thumbnail');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('singleton destroy for 123', $response->getContent());
     }
 
@@ -513,23 +513,23 @@ class RouteSingletonTest extends TestCase
         Route::singleton('videos.thumbnail', NestedSingletonTestController::class)->destroyable();
 
         $response = $this->get('/videos/123/thumbnail');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('singleton show for 123', $response->getContent());
 
         $response = $this->get('/videos/123/thumbnail/edit');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('singleton edit for 123', $response->getContent());
 
         $response = $this->put('/videos/123/thumbnail');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('singleton update for 123', $response->getContent());
 
         $response = $this->patch('/videos/123/thumbnail');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('singleton update for 123', $response->getContent());
 
         $response = $this->delete('/videos/123/thumbnail');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('singleton destroy for 123', $response->getContent());
     }
 
@@ -539,7 +539,7 @@ class RouteSingletonTest extends TestCase
 
         $response = $this->get('/v/123/thumbnail');
 
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('singleton show for 123', $response->getContent());
     }
 
@@ -549,7 +549,7 @@ class RouteSingletonTest extends TestCase
 
         $response = $this->get('/v/123/thumbnail');
 
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('singleton show for 123', $response->getContent());
     }
 
@@ -559,7 +559,7 @@ class RouteSingletonTest extends TestCase
 
         $response = $this->get('/videos/123/thumbnail');
 
-        $this->assertEquals(404, $response->getStatusCode());
+        $this->assertSame(404, $response->getStatusCode());
     }
 
     public function testPrefixedSingleton()
@@ -568,6 +568,6 @@ class RouteSingletonTest extends TestCase
 
         $response = $this->get('/user/avatar');
 
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
     }
 }

--- a/tests/Integration/Routing/RouteViewTest.php
+++ b/tests/Integration/Routing/RouteViewTest.php
@@ -28,15 +28,15 @@ class RouteViewTest extends TestCase
         $this->assertStringContainsString('Test bar', $this->get('/route/value1')->getContent());
 
         tap($this->get('/route/value1/value2'), function ($response) {
-            $this->assertEquals('value1', $response->viewData('param'));
-            $this->assertEquals('value1', $response->baseRequest->route('param'));
-            $this->assertEquals('value2', $response->baseRequest->route('param2'));
+            $this->assertSame('value1', $response->viewData('param'));
+            $this->assertSame('value1', $response->baseRequest->route('param'));
+            $this->assertSame('value2', $response->baseRequest->route('param2'));
         });
 
         tap($this->get('/route/value1/value2'), function ($response) {
-            $this->assertEquals('value2', $response->viewData('param2'));
-            $this->assertEquals('value1', $response->baseRequest->route('param'));
-            $this->assertEquals('value2', $response->baseRequest->route('param2'));
+            $this->assertSame('value2', $response->viewData('param2'));
+            $this->assertSame('value1', $response->baseRequest->route('param'));
+            $this->assertSame('value2', $response->baseRequest->route('param2'));
         });
     }
 

--- a/tests/Integration/Session/CookieSessionHandlerTest.php
+++ b/tests/Integration/Session/CookieSessionHandlerTest.php
@@ -16,8 +16,8 @@ class CookieSessionHandlerTest extends TestCase
         $sessionIdCookie = $response->getCookie('laravel_session');
         $sessionValueCookie = $response->getCookie($sessionIdCookie->getValue());
 
-        $this->assertEquals(0, $sessionIdCookie->getExpiresTime());
-        $this->assertEquals(0, $sessionValueCookie->getExpiresTime());
+        $this->assertSame(0, $sessionIdCookie->getExpiresTime());
+        $this->assertSame(0, $sessionValueCookie->getExpiresTime());
     }
 
     public function testCookieSessionInheritsRequestSecureState()

--- a/tests/Integration/Session/DatabaseSessionHandlerTest.php
+++ b/tests/Integration/Session/DatabaseSessionHandlerTest.php
@@ -26,7 +26,7 @@ class DatabaseSessionHandlerTest extends DatabaseTestCase
         // write and read:
         $this->assertTrue($handler->write('valid_session_id_2425', json_encode(['foo' => 'bar'])));
         $this->assertEquals(['foo' => 'bar'], json_decode($handler->read('valid_session_id_2425'), true));
-        $this->assertEquals(1, $connection->table('sessions')->count());
+        $this->assertSame(1, $connection->table('sessions')->count());
 
         $session = $connection->table('sessions')->first();
         $this->assertNotNull($session->user_agent);
@@ -35,15 +35,15 @@ class DatabaseSessionHandlerTest extends DatabaseTestCase
         // re-write and read:
         $this->assertTrue($handler->write('valid_session_id_2425', json_encode(['over' => 'ride'])));
         $this->assertEquals(['over' => 'ride'], json_decode($handler->read('valid_session_id_2425'), true));
-        $this->assertEquals(1, $connection->table('sessions')->count());
+        $this->assertSame(1, $connection->table('sessions')->count());
 
         // handler object writes only one session id:
         $this->assertTrue($handler->write('other_id', 'data'));
-        $this->assertEquals(1, $connection->table('sessions')->count());
+        $this->assertSame(1, $connection->table('sessions')->count());
 
         $handler->setExists(false);
         $this->assertTrue($handler->write('other_id', 'data'));
-        $this->assertEquals(2, $connection->table('sessions')->count());
+        $this->assertSame(2, $connection->table('sessions')->count());
 
         // read expired:
         Carbon::setTestNow(Carbon::now()->addMinutes(2));
@@ -61,19 +61,19 @@ class DatabaseSessionHandlerTest extends DatabaseTestCase
         $handler = new DatabaseSessionHandler($connection, 'sessions', 1, $this->app);
         Carbon::setTestNow(Carbon::now());
         $handler->write('simple_id_1', 'abcd');
-        $this->assertEquals(0, $handler->gc(1));
+        $this->assertSame(0, $handler->gc(1));
 
         Carbon::setTestNow(Carbon::now()->addSeconds(2));
 
         $handler = new DatabaseSessionHandler($connection, 'sessions', 1, $this->app);
         $handler->write('simple_id_2', 'abcd');
-        $this->assertEquals(1, $handler->gc(2));
-        $this->assertEquals(1, $connection->table('sessions')->count());
+        $this->assertSame(1, $handler->gc(2));
+        $this->assertSame(1, $connection->table('sessions')->count());
 
         Carbon::setTestNow(Carbon::now()->addSeconds(2));
 
-        $this->assertEquals(1, $handler->gc(1));
-        $this->assertEquals(0, $connection->table('sessions')->count());
+        $this->assertSame(1, $handler->gc(1));
+        $this->assertSame(0, $connection->table('sessions')->count());
     }
 
     public function test_destroy()
@@ -88,12 +88,12 @@ class DatabaseSessionHandlerTest extends DatabaseTestCase
         // destroy invalid session-id:
         $this->assertEquals(true, $handler1->destroy('invalid_session_id'));
         // nothing deleted:
-        $this->assertEquals(2, $connection->table('sessions')->count());
+        $this->assertSame(2, $connection->table('sessions')->count());
 
         // destroy valid session-id:
         $this->assertEquals(true, $handler2->destroy('id_1'));
         // only one row is deleted:
-        $this->assertEquals(1, $connection->table('sessions')->where('id', 'id_2')->count());
+        $this->assertSame(1, $connection->table('sessions')->where('id', 'id_2')->count());
     }
 
     public function test_it_can_work_without_container()
@@ -104,7 +104,7 @@ class DatabaseSessionHandlerTest extends DatabaseTestCase
         // write and read:
         $this->assertTrue($handler->write('session_id', 'some data'));
         $this->assertEquals('some data', $handler->read('session_id'));
-        $this->assertEquals(1, $connection->table('sessions')->count());
+        $this->assertSame(1, $connection->table('sessions')->count());
 
         $session = $connection->table('sessions')->first();
         $this->assertNull($session->user_agent);

--- a/tests/Integration/Session/DatabaseSessionHandlerTest.php
+++ b/tests/Integration/Session/DatabaseSessionHandlerTest.php
@@ -17,7 +17,7 @@ class DatabaseSessionHandlerTest extends DatabaseTestCase
         $handler->setContainer($this->app);
 
         // read non-existing session id:
-        $this->assertEquals('', $handler->read('invalid_session_id'));
+        $this->assertSame('', $handler->read('invalid_session_id'));
 
         // open and close:
         $this->assertTrue($handler->open('', ''));
@@ -47,7 +47,7 @@ class DatabaseSessionHandlerTest extends DatabaseTestCase
 
         // read expired:
         Carbon::setTestNow(Carbon::now()->addMinutes(2));
-        $this->assertEquals('', $handler->read('valid_session_id_2425'));
+        $this->assertSame('', $handler->read('valid_session_id_2425'));
 
         // rewriting an expired session-id, makes it live:
         $this->assertTrue($handler->write('valid_session_id_2425', json_encode(['come' => 'alive'])));
@@ -103,7 +103,7 @@ class DatabaseSessionHandlerTest extends DatabaseTestCase
 
         // write and read:
         $this->assertTrue($handler->write('session_id', 'some data'));
-        $this->assertEquals('some data', $handler->read('session_id'));
+        $this->assertSame('some data', $handler->read('session_id'));
         $this->assertSame(1, $connection->table('sessions')->count());
 
         $session = $connection->table('sessions')->first();

--- a/tests/Log/LogLoggerTest.php
+++ b/tests/Log/LogLoggerTest.php
@@ -80,7 +80,7 @@ class LogLoggerTest extends TestCase
         $this->assertSame('foo', $_SERVER['__log.message']);
         unset($_SERVER['__log.message']);
         $this->assertTrue(isset($_SERVER['__log.context']));
-        $this->assertEquals([], $_SERVER['__log.context']);
+        $this->assertSame([], $_SERVER['__log.context']);
         unset($_SERVER['__log.context']);
     }
 

--- a/tests/Log/LogManagerTest.php
+++ b/tests/Log/LogManagerTest.php
@@ -47,7 +47,7 @@ class LogManagerTest extends TestCase
         //we don't specify any channel name
         $manager->channel();
         $this->assertCount(1, $manager->getChannels());
-        $this->assertEquals('single', $manager->getDefaultDriver());
+        $this->assertSame('single', $manager->getDefaultDriver());
     }
 
     public function testStackChannel()
@@ -726,7 +726,7 @@ class LogManagerTest extends TestCase
 
         $format = new ReflectionProperty(get_class($formatter), 'format');
 
-        $this->assertEquals(
+        $this->assertSame(
             '[%datetime%] %channel%.%level_name%: %message% %context% %extra%',
             rtrim($format->getValue($formatter)));
     }
@@ -750,7 +750,7 @@ class LogManagerTest extends TestCase
 
         // Then
         $this->assertCount(1, $loggerSpy->logs);
-        $this->assertEquals('some alert', $loggerSpy->logs[0]['message']);
+        $this->assertSame('some alert', $loggerSpy->logs[0]['message']);
     }
 
     public function testCustomDriverClosureBoundObjectIsLogManager()

--- a/tests/Mail/MailMailableTest.php
+++ b/tests/Mail/MailMailableTest.php
@@ -1183,12 +1183,12 @@ class MailMailableTest extends TestCase
         $this->assertSame('custom-message-id@example.com', $sentMessage->getMessageId());
 
         $this->assertTrue($sentMessage->getOriginalMessage()->getHeaders()->has('references'));
-        $this->assertEquals('References', $sentMessage->getOriginalMessage()->getHeaders()->get('references')->getName());
-        $this->assertEquals('<previous-message@example.com>', $sentMessage->getOriginalMessage()->getHeaders()->get('references')->getValue());
+        $this->assertSame('References', $sentMessage->getOriginalMessage()->getHeaders()->get('references')->getName());
+        $this->assertSame('<previous-message@example.com>', $sentMessage->getOriginalMessage()->getHeaders()->get('references')->getValue());
 
         $this->assertTrue($sentMessage->getOriginalMessage()->getHeaders()->has('x-custom-header'));
-        $this->assertEquals('X-Custom-Header', $sentMessage->getOriginalMessage()->getHeaders()->get('x-custom-header')->getName());
-        $this->assertEquals('Custom Value', $sentMessage->getOriginalMessage()->getHeaders()->get('x-custom-header')->getValue());
+        $this->assertSame('X-Custom-Header', $sentMessage->getOriginalMessage()->getHeaders()->get('x-custom-header')->getName());
+        $this->assertSame('Custom Value', $sentMessage->getOriginalMessage()->getHeaders()->get('x-custom-header')->getValue());
     }
 
     public function testMailableAttributesInBuild(): void

--- a/tests/Mail/MailMessageTest.php
+++ b/tests/Mail/MailMessageTest.php
@@ -84,7 +84,7 @@ class MailMessageTest extends TestCase
     public function testPriorityMethod(): void
     {
         $this->assertSame($this->message, $this->message->priority(1));
-        $this->assertEquals(1, $this->message->getSymfonyMessage()->getPriority());
+        $this->assertSame(1, $this->message->getSymfonyMessage()->getPriority());
     }
 
     public function testBasicAttachment(): void

--- a/tests/Mail/MailableAlternativeSyntaxTest.php
+++ b/tests/Mail/MailableAlternativeSyntaxTest.php
@@ -35,9 +35,9 @@ class MailableAlternativeSyntaxTest extends TestCase
 
         $this->assertEquals('test-view', $mailable->view);
         $this->assertEquals(['test-data-key' => 'test-data-value'], $mailable->viewData);
-        $this->assertEquals(2, count($mailable->to));
-        $this->assertEquals(1, count($mailable->cc));
-        $this->assertEquals(1, count($mailable->bcc));
+        $this->assertSame(2, count($mailable->to));
+        $this->assertSame(1, count($mailable->cc));
+        $this->assertSame(1, count($mailable->bcc));
     }
 
     public function testEnvelopesCanReceiveAdditionalRecipients(): void

--- a/tests/Mail/MailableAlternativeSyntaxTest.php
+++ b/tests/Mail/MailableAlternativeSyntaxTest.php
@@ -33,7 +33,7 @@ class MailableAlternativeSyntaxTest extends TestCase
         $method = $reflection->getMethod('prepareMailableForDelivery');
         $method->invoke($mailable);
 
-        $this->assertEquals('test-view', $mailable->view);
+        $this->assertSame('test-view', $mailable->view);
         $this->assertEquals(['test-data-key' => 'test-data-value'], $mailable->viewData);
         $this->assertSame(2, count($mailable->to));
         $this->assertSame(1, count($mailable->cc));
@@ -46,24 +46,24 @@ class MailableAlternativeSyntaxTest extends TestCase
         $envelope->to(new Address('taylorotwell@example.com'));
 
         $this->assertCount(2, $envelope->to);
-        $this->assertEquals('taylor@example.com', $envelope->to[0]->address);
-        $this->assertEquals('taylorotwell@example.com', $envelope->to[1]->address);
+        $this->assertSame('taylor@example.com', $envelope->to[0]->address);
+        $this->assertSame('taylorotwell@example.com', $envelope->to[1]->address);
 
         $envelope->to('abigailotwell@example.com', 'Abigail Otwell');
-        $this->assertEquals('abigailotwell@example.com', $envelope->to[2]->address);
-        $this->assertEquals('Abigail Otwell', $envelope->to[2]->name);
+        $this->assertSame('abigailotwell@example.com', $envelope->to[2]->address);
+        $this->assertSame('Abigail Otwell', $envelope->to[2]->name);
 
         $envelope->to('adam@example.com');
-        $this->assertEquals('adam@example.com', $envelope->to[3]->address);
+        $this->assertSame('adam@example.com', $envelope->to[3]->address);
         $this->assertNull($envelope->to[3]->name);
 
         $envelope->to(['jeffrey@example.com', 'tyler@example.com']);
-        $this->assertEquals('jeffrey@example.com', $envelope->to[4]->address);
-        $this->assertEquals('tyler@example.com', $envelope->to[5]->address);
+        $this->assertSame('jeffrey@example.com', $envelope->to[4]->address);
+        $this->assertSame('tyler@example.com', $envelope->to[5]->address);
 
         $envelope->from('dries@example.com', 'Dries Vints');
-        $this->assertEquals('dries@example.com', $envelope->from->address);
-        $this->assertEquals('Dries Vints', $envelope->from->name);
+        $this->assertSame('dries@example.com', $envelope->from->address);
+        $this->assertSame('Dries Vints', $envelope->from->name);
     }
 }
 

--- a/tests/Mail/MailableQueuedTest.php
+++ b/tests/Mail/MailableQueuedTest.php
@@ -159,7 +159,7 @@ class MailableQueuedTest extends TestCase
         $queueFake->assertPushedOn(null, SendQueuedMailable::class);
 
         $pushedJob = $queueFake->pushed(SendQueuedMailable::class)->first();
-        $this->assertEquals(30, $pushedJob->delay);
+        $this->assertSame(30, $pushedJob->delay);
     }
 
     public function testQueuedMailableDelayPropertyOverridesAttribute(): void
@@ -177,7 +177,7 @@ class MailableQueuedTest extends TestCase
         $queueFake->assertPushedOn(null, SendQueuedMailable::class);
 
         $pushedJob = $queueFake->pushed(SendQueuedMailable::class)->first();
-        $this->assertEquals(60, $pushedJob->delay);
+        $this->assertSame(60, $pushedJob->delay);
     }
 
     public function testQueuedMailableForwardsDeduplicationIdMethodToQueueJob(): void

--- a/tests/Notifications/NotificationMailMessageTest.php
+++ b/tests/Notifications/NotificationMailMessageTest.php
@@ -230,7 +230,7 @@ class NotificationMailMessageTest extends TestCase
         };
 
         $default = function (MailMessage $mailMessage, $condition) {
-            $this->assertEquals(0, $condition);
+            $this->assertSame(0, $condition);
 
             $mailMessage->cc('zero@example.com');
         };
@@ -283,7 +283,7 @@ class NotificationMailMessageTest extends TestCase
     public function testUnlessCallbackWithDefault()
     {
         $callback = function (MailMessage $mailMessage, $condition) {
-            $this->assertEquals(0, $condition);
+            $this->assertSame(0, $condition);
 
             $mailMessage->cc('zero@example.com');
         };

--- a/tests/Notifications/NotificationSendQueuedNotificationTest.php
+++ b/tests/Notifications/NotificationSendQueuedNotificationTest.php
@@ -60,7 +60,7 @@ class NotificationSendQueuedNotificationTest extends TestCase
 
         $job = new SendQueuedNotifications($notifiable, $notification);
 
-        $this->assertEquals(23, $job->maxExceptions);
+        $this->assertSame(23, $job->maxExceptions);
     }
 }
 

--- a/tests/Pagination/LengthAwarePaginatorTest.php
+++ b/tests/Pagination/LengthAwarePaginatorTest.php
@@ -40,8 +40,8 @@ class LengthAwarePaginatorTest extends TestCase
 
     public function testLengthAwarePaginatorCanGiveMeRelevantPageInformation()
     {
-        $this->assertEquals(2, $this->p->lastPage());
-        $this->assertEquals(2, $this->p->currentPage());
+        $this->assertSame(2, $this->p->lastPage());
+        $this->assertSame(2, $this->p->currentPage());
         $this->assertTrue($this->p->hasPages());
         $this->assertFalse($this->p->hasMorePages());
         $this->assertEquals(['item1', 'item2', 'item3', 'item4'], $this->p->items());
@@ -51,8 +51,8 @@ class LengthAwarePaginatorTest extends TestCase
     {
         $paginator = new LengthAwarePaginator([], 0, 2, 1);
 
-        $this->assertEquals(1, $paginator->lastPage());
-        $this->assertEquals(1, $paginator->currentPage());
+        $this->assertSame(1, $paginator->lastPage());
+        $this->assertSame(1, $paginator->currentPage());
         $this->assertFalse($paginator->hasPages());
         $this->assertFalse($paginator->hasMorePages());
         $this->assertEmpty($paginator->items());

--- a/tests/Pagination/PaginatorTest.php
+++ b/tests/Pagination/PaginatorTest.php
@@ -12,7 +12,7 @@ class PaginatorTest extends TestCase
         /** @var Paginator<int, string> $p */
         $p = new Paginator(['item3', 'item4', 'item5'], 2, 2);
 
-        $this->assertEquals(2, $p->currentPage());
+        $this->assertSame(2, $p->currentPage());
         $this->assertTrue($p->hasPages());
         $this->assertTrue($p->hasMorePages());
         $this->assertEquals(['item3', 'item4'], $p->items());

--- a/tests/Pipeline/PipelineTest.php
+++ b/tests/Pipeline/PipelineTest.php
@@ -121,7 +121,7 @@ class PipelineTest extends TestCase
             );
 
         $this->assertSame($object, $result);
-        $this->assertEquals(2, $object->value);
+        $this->assertSame(2, $object->value);
     }
 
     public function testPipelineThroughMethodOverwritesPreviouslySetAndAppendedPipes()
@@ -144,7 +144,7 @@ class PipelineTest extends TestCase
             ->then(fn ($piped) => $piped);
 
         $this->assertSame($object, $result);
-        $this->assertEquals(1, $object->value);
+        $this->assertSame(1, $object->value);
     }
 
     public function testPipelineUsageWithInvokableClass()

--- a/tests/Pipeline/PipelineTransactionTest.php
+++ b/tests/Pipeline/PipelineTransactionTest.php
@@ -25,7 +25,7 @@ class PipelineTransactionTest extends TestCase
             ])
             ->thenReturn();
 
-        $this->assertEquals('some string', $result);
+        $this->assertSame('some string', $result);
         Event::assertDispatchedTimes(TransactionBeginning::class, 1);
         Event::assertDispatchedTimes(TransactionCommitted::class, 1);
     }
@@ -55,7 +55,7 @@ class PipelineTransactionTest extends TestCase
             ])
             ->thenReturn();
 
-        $this->assertEquals('some string', $result);
+        $this->assertSame('some string', $result);
         Event::dispatched(TransactionBeginning::class, function (TransactionBeginning $event) use ($connectionName) {
             return $event->connection === $connectionName;
         });

--- a/tests/Process/ProcessTest.php
+++ b/tests/Process/ProcessTest.php
@@ -22,7 +22,7 @@ class ProcessTest extends TestCase
         $this->assertInstanceOf(ProcessResult::class, $result);
         $this->assertTrue($result->successful());
         $this->assertFalse($result->failed());
-        $this->assertEquals(0, $result->exitCode());
+        $this->assertSame(0, $result->exitCode());
         $this->assertTrue(str_contains($result->output(), 'ProcessTest.php'));
         $this->assertEquals('', $result->errorOutput());
 
@@ -171,7 +171,7 @@ class ProcessTest extends TestCase
 
         $this->assertEquals('', $result->output());
         $this->assertEquals('', $result->errorOutput());
-        $this->assertEquals(0, $result->exitCode());
+        $this->assertSame(0, $result->exitCode());
         $this->assertTrue($result->successful());
     }
 

--- a/tests/Process/ProcessTest.php
+++ b/tests/Process/ProcessTest.php
@@ -24,7 +24,7 @@ class ProcessTest extends TestCase
         $this->assertFalse($result->failed());
         $this->assertSame(0, $result->exitCode());
         $this->assertTrue(str_contains($result->output(), 'ProcessTest.php'));
-        $this->assertEquals('', $result->errorOutput());
+        $this->assertSame('', $result->errorOutput());
 
         $result->throw();
         $result->throwIf(true);
@@ -169,8 +169,8 @@ class ProcessTest extends TestCase
 
         $result = $factory->run('ls -la');
 
-        $this->assertEquals('', $result->output());
-        $this->assertEquals('', $result->errorOutput());
+        $this->assertSame('', $result->output());
+        $this->assertSame('', $result->errorOutput());
         $this->assertSame(0, $result->exitCode());
         $this->assertTrue($result->successful());
     }
@@ -243,56 +243,56 @@ class ProcessTest extends TestCase
         $factory->fake(fn () => $factory->result('test output'));
 
         $result = $factory->run('ls -la');
-        $this->assertEquals("test output\n", $result->output());
+        $this->assertSame("test output\n", $result->output());
 
         // Array of output...
         $factory = new Factory;
         $factory->fake(fn () => $factory->result(['line 1', 'line 2']));
 
         $result = $factory->run('ls -la');
-        $this->assertEquals("line 1\nline 2\n", $result->output());
+        $this->assertSame("line 1\nline 2\n", $result->output());
 
         // Array of output with empty line...
         $factory = new Factory;
         $factory->fake(fn () => $factory->result(['line 1', '', 'line 2']));
 
         $result = $factory->run('ls -la');
-        $this->assertEquals("line 1\n\nline 2\n", $result->output());
+        $this->assertSame("line 1\n\nline 2\n", $result->output());
 
         // Plain string...
         $factory = new Factory;
         $factory->fake(fn () => 'test output');
 
         $result = $factory->run('ls -la');
-        $this->assertEquals("test output\n", $result->output());
+        $this->assertSame("test output\n", $result->output());
 
         // Plain array...
         $factory = new Factory;
         $factory->fake(fn () => ['line 1', 'line 2']);
 
         $result = $factory->run('ls -la');
-        $this->assertEquals("line 1\nline 2\n", $result->output());
+        $this->assertSame("line 1\nline 2\n", $result->output());
 
         // Plain array with empty line...
         $factory = new Factory;
         $factory->fake(fn () => ['line 1', '', 'line 2']);
 
         $result = $factory->run('ls -la');
-        $this->assertEquals("line 1\n\nline 2\n", $result->output());
+        $this->assertSame("line 1\n\nline 2\n", $result->output());
 
         // Process description...
         $factory = new Factory;
         $factory->fake(fn () => $factory->describe()->output('line 1')->output('line 2'));
 
         $result = $factory->run('ls -la');
-        $this->assertEquals("line 1\nline 2\n", $result->output());
+        $this->assertSame("line 1\nline 2\n", $result->output());
 
         // Process description with empty line...
         $factory = new Factory;
         $factory->fake(fn () => $factory->describe()->output('line 1')->output('')->output('line 2'));
 
         $result = $factory->run('ls -la');
-        $this->assertEquals("line 1\n\nline 2\n", $result->output());
+        $this->assertSame("line 1\n\nline 2\n", $result->output());
     }
 
     public function testProcessFakeWithErrorOutput()
@@ -301,24 +301,24 @@ class ProcessTest extends TestCase
         $factory->fake(fn () => $factory->result('standard output', 'error output'));
 
         $result = $factory->run('ls -la');
-        $this->assertEquals("standard output\n", $result->output());
-        $this->assertEquals("error output\n", $result->errorOutput());
+        $this->assertSame("standard output\n", $result->output());
+        $this->assertSame("error output\n", $result->errorOutput());
 
         // Array of error output...
         $factory = new Factory;
         $factory->fake(fn () => $factory->result('standard output', ['line 1', 'line 2']));
 
         $result = $factory->run('ls -la');
-        $this->assertEquals("standard output\n", $result->output());
-        $this->assertEquals("line 1\nline 2\n", $result->errorOutput());
+        $this->assertSame("standard output\n", $result->output());
+        $this->assertSame("line 1\nline 2\n", $result->errorOutput());
 
         // Using process description...
         $factory = new Factory;
         $factory->fake(fn () => $factory->describe()->output('standard output')->errorOutput('error output'));
 
         $result = $factory->run('ls -la');
-        $this->assertEquals("standard output\n", $result->output());
-        $this->assertEquals("error output\n", $result->errorOutput());
+        $this->assertSame("standard output\n", $result->output());
+        $this->assertSame("error output\n", $result->errorOutput());
     }
 
     public function testCustomizedFakesPerCommand()
@@ -331,10 +331,10 @@ class ProcessTest extends TestCase
         ]);
 
         $result = $factory->run('ls -la');
-        $this->assertEquals("ls command\n", $result->output());
+        $this->assertSame("ls command\n", $result->output());
 
         $result = $factory->run('cat composer.json');
-        $this->assertEquals("cat command\n", $result->output());
+        $this->assertSame("cat command\n", $result->output());
     }
 
     public function testProcessFakeSequences()
@@ -349,13 +349,13 @@ class ProcessTest extends TestCase
         ]);
 
         $result = $factory->run('ls -la');
-        $this->assertEquals("ls command 1\n", $result->output());
+        $this->assertSame("ls command 1\n", $result->output());
 
         $result = $factory->run('ls -la');
-        $this->assertEquals("ls command 2\n", $result->output());
+        $this->assertSame("ls command 2\n", $result->output());
 
         $result = $factory->run('cat composer.json');
-        $this->assertEquals("cat command\n", $result->output());
+        $this->assertSame("cat command\n", $result->output());
     }
 
     public function testProcessFakeSequencesCanReturnEmptyResultsWhenSequenceIsEmpty()
@@ -370,13 +370,13 @@ class ProcessTest extends TestCase
         ]);
 
         $result = $factory->run('ls -la');
-        $this->assertEquals("ls command 1\n", $result->output());
+        $this->assertSame("ls command 1\n", $result->output());
 
         $result = $factory->run('ls -la');
-        $this->assertEquals("ls command 2\n", $result->output());
+        $this->assertSame("ls command 2\n", $result->output());
 
         $result = $factory->run('ls -la');
-        $this->assertEquals('', $result->output());
+        $this->assertSame('', $result->output());
     }
 
     public function testProcessFakeSequencesCanThrowWhenSequenceIsEmpty()
@@ -392,10 +392,10 @@ class ProcessTest extends TestCase
         ]);
 
         $result = $factory->run('ls -la');
-        $this->assertEquals("ls command 1\n", $result->output());
+        $this->assertSame("ls command 1\n", $result->output());
 
         $result = $factory->run('ls -la');
-        $this->assertEquals("ls command 2\n", $result->output());
+        $this->assertSame("ls command 2\n", $result->output());
 
         $result = $factory->run('ls -la');
     }
@@ -503,8 +503,8 @@ class ProcessTest extends TestCase
         $result = $factory->path(__DIR__)->run('echo "Hello World" >&2; exit 1;');
 
         $this->assertFalse($result->successful());
-        $this->assertEquals('', $result->output());
-        $this->assertEquals("Hello World\n", $result->errorOutput());
+        $this->assertSame('', $result->output());
+        $this->assertSame("Hello World\n", $result->errorOutput());
     }
 
     public function testFakeProcessesCanThrowWithoutOutput()
@@ -771,14 +771,14 @@ class ProcessTest extends TestCase
             $output[] = $process->output();
         }
 
-        $this->assertEquals("ONE\n", $latestOutput[0]);
-        $this->assertEquals("ONE\nTWO\n", $output[0]);
+        $this->assertSame("ONE\n", $latestOutput[0]);
+        $this->assertSame("ONE\nTWO\n", $output[0]);
 
-        $this->assertEquals("THREE\n", $latestOutput[1]);
-        $this->assertEquals("ONE\nTWO\nTHREE\n", $output[1]);
+        $this->assertSame("THREE\n", $latestOutput[1]);
+        $this->assertSame("ONE\nTWO\nTHREE\n", $output[1]);
 
-        $this->assertEquals('', $latestOutput[2]);
-        $this->assertEquals("ONE\nTWO\nTHREE\n", $output[2]);
+        $this->assertSame('', $latestOutput[2]);
+        $this->assertSame("ONE\nTWO\nTHREE\n", $output[2]);
     }
 
     public function testFakeInvokedProcessWaitUntil()
@@ -824,7 +824,7 @@ class ProcessTest extends TestCase
 
         $this->assertInstanceOf(ProcessResult::class, $result);
         $this->assertTrue($result->successful());
-        $this->assertEquals("OUTPUT\n", $result->output());
+        $this->assertSame("OUTPUT\n", $result->output());
     }
 
     public function testFakeInvokedProcessWaitUntilWithErrorOutput()
@@ -960,7 +960,7 @@ class ProcessTest extends TestCase
         $this->assertInstanceOf(ProcessResult::class, $result);
         $this->assertTrue($result->successful());
         $this->assertCount(1, $waitUntilCallbacks);
-        $this->assertEquals("FIRST\n", $waitUntilCallbacks[0]);
+        $this->assertSame("FIRST\n", $waitUntilCallbacks[0]);
         $this->assertCount(2, $waitCallbacks);
         $this->assertContains("SECOND\n", $waitCallbacks);
         $this->assertContains("THIRD\n", $waitCallbacks);
@@ -1082,7 +1082,7 @@ class ProcessTest extends TestCase
         ])->run('printenv TEST_VAR OTHER_VAR');
 
         $this->assertTrue($result->successful());
-        $this->assertEquals("test_value\nother_value\n", $result->output());
+        $this->assertSame("test_value\nother_value\n", $result->output());
 
         $result = $factory->env([
             'TEST_VAR' => 'new_test_value',
@@ -1090,7 +1090,7 @@ class ProcessTest extends TestCase
         ])->run('printenv TEST_VAR OTHER_VAR');
 
         $this->assertTrue($result->successful());
-        $this->assertEquals("new_test_value\nnew_other_value\n", $result->output());
+        $this->assertSame("new_test_value\nnew_other_value\n", $result->output());
 
         $factory->assertRanTimes(function ($process) {
             return str_contains($process->command, 'printenv TEST_VAR OTHER_VAR');

--- a/tests/Queue/DatabaseUuidFailedJobProviderTest.php
+++ b/tests/Queue/DatabaseUuidFailedJobProviderTest.php
@@ -52,9 +52,9 @@ class DatabaseUuidFailedJobProviderTest extends TestCase
         $provider->log('connection-1', 'queue-1', json_encode(['uuid' => 'uuid-1']), new RuntimeException());
 
         $this->assertNull($provider->find('uuid-2'));
-        $this->assertEquals('uuid-1', $provider->find('uuid-1')->id);
-        $this->assertEquals('queue-1', $provider->find('uuid-1')->queue);
-        $this->assertEquals('connection-1', $provider->find('uuid-1')->connection);
+        $this->assertSame('uuid-1', $provider->find('uuid-1')->id);
+        $this->assertSame('queue-1', $provider->find('uuid-1')->queue);
+        $this->assertSame('connection-1', $provider->find('uuid-1')->connection);
     }
 
     public function testRemovingJobsById()

--- a/tests/Queue/InteractsWithQueueTest.php
+++ b/tests/Queue/InteractsWithQueueTest.php
@@ -15,7 +15,7 @@ class InteractsWithQueueTest extends TestCase
         $queueJob = m::mock(Job::class);
         $queueJob->shouldReceive('fail')->withArgs(function ($e) {
             $this->assertInstanceOf(Exception::class, $e);
-            $this->assertEquals('Whoops!', $e->getMessage());
+            $this->assertSame('Whoops!', $e->getMessage());
 
             return true;
         });

--- a/tests/Queue/QueueDatabaseQueueIntegrationTest.php
+++ b/tests/Queue/QueueDatabaseQueueIntegrationTest.php
@@ -151,8 +151,8 @@ class QueueDatabaseQueueIntegrationTest extends TestCase
 
         $database_record = $this->connection()->table('jobs')->find($job['id']);
 
-        $this->assertEquals(1, $database_record->attempts, 'Job attempts not updated in the database!');
-        $this->assertEquals(1, $popped_job->attempts(), 'The "attempts" attribute of the Job object was not updated by pop!');
+        $this->assertSame(1, $database_record->attempts, 'Job attempts not updated in the database!');
+        $this->assertSame(1, $popped_job->attempts(), 'The "attempts" attribute of the Job object was not updated by pop!');
     }
 
     /**
@@ -180,8 +180,8 @@ class QueueDatabaseQueueIntegrationTest extends TestCase
                 'created_at' => Carbon::now()->getTimestamp(),
             ]]);
 
-        $this->assertEquals(2, $this->queue->clear($mock_queue_name));
-        $this->assertEquals(0, $this->queue->size());
+        $this->assertSame(2, $this->queue->clear($mock_queue_name));
+        $this->assertSame(0, $this->queue->size());
     }
 
     /**

--- a/tests/Queue/QueueDatabaseQueueUnitTest.php
+++ b/tests/Queue/QueueDatabaseQueueUnitTest.php
@@ -36,7 +36,7 @@ class QueueDatabaseQueueUnitTest extends TestCase
             $this->assertStringContainsString($jobStartsWith, $payload['job']);
 
             $this->assertSame('default', $array['queue']);
-            $this->assertEquals(0, $array['attempts']);
+            $this->assertSame(0, $array['attempts']);
             $this->assertNull($array['reserved_at']);
             $this->assertIsInt($array['available_at']);
         });
@@ -80,7 +80,7 @@ class QueueDatabaseQueueUnitTest extends TestCase
         $query->shouldReceive('insertGetId')->once()->andReturnUsing(function ($array) use ($uuid, $time) {
             $this->assertSame('default', $array['queue']);
             $this->assertSame(json_encode(['uuid' => $uuid, 'displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'maxExceptions' => null, 'failOnTimeout' => false, 'backoff' => null, 'timeout' => null, 'data' => ['data'], 'createdAt' => $time->getTimestamp(), 'delay' => 10]), $array['payload']);
-            $this->assertEquals(0, $array['attempts']);
+            $this->assertSame(0, $array['attempts']);
             $this->assertNull($array['reserved_at']);
             $this->assertIsInt($array['available_at']);
         });

--- a/tests/Queue/QueueDelayTest.php
+++ b/tests/Queue/QueueDelayTest.php
@@ -17,7 +17,7 @@ class QueueDelayTest extends TestCase
 
         dispatch($job);
 
-        $this->assertEquals(60, $job->delay);
+        $this->assertSame(60, $job->delay);
     }
 
     public function test_queue_without_delay()
@@ -28,7 +28,7 @@ class QueueDelayTest extends TestCase
 
         dispatch($job->withoutDelay());
 
-        $this->assertEquals(0, $job->delay);
+        $this->assertSame(0, $job->delay);
     }
 
     public function test_pending_dispatch_without_delay()
@@ -39,7 +39,7 @@ class QueueDelayTest extends TestCase
 
         dispatch($job)->withoutDelay();
 
-        $this->assertEquals(0, $job->delay);
+        $this->assertSame(0, $job->delay);
     }
 }
 

--- a/tests/Queue/QueueListenerTest.php
+++ b/tests/Queue/QueueListenerTest.php
@@ -52,7 +52,7 @@ class QueueListenerTest extends TestCase
 
         $this->assertInstanceOf(Process::class, $process);
         $this->assertEquals(__DIR__, $process->getWorkingDirectory());
-        $this->assertEquals(3, $process->getTimeout());
+        $this->assertSame(3.0, $process->getTimeout());
         $this->assertEquals($escape.php_binary().$escape." {$escape}{$artisanBinary}{$escape} {$escape}queue:work{$escape} {$escape}connection{$escape} {$escape}--once{$escape} {$escapeMsys}--name=default{$escapeMsys} {$escapeMsys}--queue=queue{$escapeMsys} {$escapeMsys}--backoff=1{$escapeMsys} {$escapeMsys}--memory=2{$escapeMsys} {$escapeMsys}--sleep=3{$escapeMsys} {$escapeMsys}--tries=1{$escapeMsys}", $process->getCommandLine());
     }
 
@@ -74,7 +74,7 @@ class QueueListenerTest extends TestCase
 
         $this->assertInstanceOf(Process::class, $process);
         $this->assertEquals(__DIR__, $process->getWorkingDirectory());
-        $this->assertEquals(3, $process->getTimeout());
+        $this->assertSame(3.0, $process->getTimeout());
         $this->assertEquals($escape.php_binary().$escape." {$escape}{$artisanBinary}{$escape} {$escape}queue:work{$escape} {$escape}connection{$escape} {$escape}--once{$escape} {$escapeMsys}--name=default{$escapeMsys} {$escapeMsys}--queue=queue{$escapeMsys} {$escapeMsys}--backoff=1{$escapeMsys} {$escapeMsys}--memory=2{$escapeMsys} {$escapeMsys}--sleep=3{$escapeMsys} {$escapeMsys}--tries=1{$escapeMsys} {$escapeMsys}--env=test{$escapeMsys}", $process->getCommandLine());
     }
 
@@ -96,7 +96,7 @@ class QueueListenerTest extends TestCase
 
         $this->assertInstanceOf(Process::class, $process);
         $this->assertEquals(__DIR__, $process->getWorkingDirectory());
-        $this->assertEquals(3, $process->getTimeout());
+        $this->assertSame(3.0, $process->getTimeout());
         $this->assertEquals($escape.php_binary().$escape." {$escape}{$artisanBinary}{$escape} {$escape}queue:work{$escape} {$escape}--once{$escape} {$escapeMsys}--name=default{$escapeMsys} {$escapeMsys}--queue=queue{$escapeMsys} {$escapeMsys}--backoff=1{$escapeMsys} {$escapeMsys}--memory=2{$escapeMsys} {$escapeMsys}--sleep=3{$escapeMsys} {$escapeMsys}--tries=1{$escapeMsys} {$escapeMsys}--env=test{$escapeMsys}", $process->getCommandLine());
     }
 }

--- a/tests/Queue/QueueSizeTest.php
+++ b/tests/Queue/QueueSizeTest.php
@@ -13,8 +13,8 @@ class QueueSizeTest extends TestCase
     {
         Queue::fake();
 
-        $this->assertEquals(0, Queue::size());
-        $this->assertEquals(0, Queue::size('Q2'));
+        $this->assertSame(0, Queue::size());
+        $this->assertSame(0, Queue::size('Q2'));
 
         $job = new TestJob1;
 
@@ -22,8 +22,8 @@ class QueueSizeTest extends TestCase
         dispatch(new TestJob2);
         dispatch($job)->onQueue('Q2');
 
-        $this->assertEquals(2, Queue::size());
-        $this->assertEquals(1, Queue::size('Q2'));
+        $this->assertSame(2, Queue::size());
+        $this->assertSame(1, Queue::size('Q2'));
     }
 }
 

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -191,7 +191,7 @@ class QueueSqsQueueTest extends TestCase
 
         $size = $queue->size($this->queueName);
 
-        $this->assertEquals(6, $size); // 1 + 2 + 3
+        $this->assertSame(6, $size); // 1 + 2 + 3
     }
 
     public function testGetQueueProperlyResolvesUrlWithPrefix()

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -242,7 +242,7 @@ class QueueSqsQueueTest extends TestCase
     {
         $this->queueName = 'emails.fifo';
         $queue = new SqsQueue($this->sqs, $this->queueName, $this->prefix, $suffix = '-staging');
-        $this->assertEquals("{$this->prefix}emails-staging.fifo", $queue->getQueue(null));
+        $this->assertSame("{$this->prefix}emails-staging.fifo", $queue->getQueue(null));
         $queueUrl = $this->baseUrl.'/'.$this->account.'/test'.$suffix.'.fifo';
         $this->assertEquals($queueUrl, $queue->getQueue('test.fifo'));
     }
@@ -258,7 +258,7 @@ class QueueSqsQueueTest extends TestCase
     public function testGetFifoQueueEnsuresTheQueueIsOnlySuffixedOnce()
     {
         $queue = new SqsQueue($this->sqs, "{$this->queueName}-staging.fifo", $this->prefix, $suffix = '-staging');
-        $this->assertEquals("{$this->prefix}{$this->queueName}{$suffix}.fifo", $queue->getQueue(null));
+        $this->assertSame("{$this->prefix}{$this->queueName}{$suffix}.fifo", $queue->getQueue(null));
         $queueUrl = $this->baseUrl.'/'.$this->account.'/test'.$suffix.'.fifo';
         $this->assertEquals($queueUrl, $queue->getQueue('test-staging.fifo'));
     }

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -174,7 +174,7 @@ class QueueWorkerTest extends TestCase
     {
         $worker = $this->getWorker('default', ['queue' => []]);
         $worker->runNextJob('default', 'queue', $this->workerOptions(['sleep' => 5]));
-        $this->assertEquals(5, $worker->sleptFor);
+        $this->assertSame(5, $worker->sleptFor);
     }
 
     public function testJobIsReleasedOnException()
@@ -188,7 +188,7 @@ class QueueWorkerTest extends TestCase
         $worker = $this->getWorker('default', ['queue' => [$job]]);
         $worker->runNextJob('default', 'queue', $this->workerOptions(['backoff' => 10]));
 
-        $this->assertEquals(10, $job->releaseAfter);
+        $this->assertSame(10, $job->releaseAfter);
         $this->assertFalse($job->deleted);
         $this->exceptionHandler->shouldHaveReceived('report')->with($e);
         $this->events->shouldHaveReceived('dispatch')->with(m::type(JobExceptionOccurred::class))->once();
@@ -341,7 +341,7 @@ class QueueWorkerTest extends TestCase
         $worker = $this->getWorker('default', ['queue' => [$job]]);
         $worker->runNextJob('default', 'queue', $this->workerOptions(['backoff' => 3, 'maxTries' => 0]));
 
-        $this->assertEquals(10, $job->releaseAfter);
+        $this->assertSame(10, $job->releaseAfter);
     }
 
     public function testJobRunsIfAppIsNotInMaintenanceMode()

--- a/tests/Redis/RedisConnectionTest.php
+++ b/tests/Redis/RedisConnectionTest.php
@@ -84,10 +84,10 @@ class RedisConnectionTest extends TestCase
             $redis->set('one', 'mohamed');
             $redis->set('two', 'mohamed');
 
-            $this->assertEquals(1, $redis->exists('one'));
-            $this->assertEquals(0, $redis->exists('nothing'));
-            $this->assertEquals(2, $redis->exists('one', 'two'));
-            $this->assertEquals(2, $redis->exists('one', 'two', 'nothing'));
+            $this->assertSame(1, $redis->exists('one'));
+            $this->assertSame(0, $redis->exists('nothing'));
+            $this->assertSame(2, $redis->exists('one', 'two'));
+            $this->assertSame(2, $redis->exists('one', 'two', 'nothing'));
 
             $redis->flushall();
         }
@@ -98,17 +98,17 @@ class RedisConnectionTest extends TestCase
         foreach ($this->connections() as $redis) {
             $redis->set('one', 'mohamed');
             $this->assertEquals(-1, $redis->ttl('one'));
-            $this->assertEquals(1, $redis->expire('one', 10));
+            $this->assertSame(1, $redis->expire('one', 10));
             $this->assertNotEquals(-1, $redis->ttl('one'));
 
-            $this->assertEquals(0, $redis->expire('nothing', 10));
+            $this->assertSame(0, $redis->expire('nothing', 10));
 
             $redis->set('two', 'mohamed');
             $this->assertEquals(-1, $redis->ttl('two'));
-            $this->assertEquals(1, $redis->pexpire('two', 10));
+            $this->assertSame(1, $redis->pexpire('two', 10));
             $this->assertNotEquals(-1, $redis->pttl('two'));
 
-            $this->assertEquals(0, $redis->pexpire('nothing', 10));
+            $this->assertSame(0, $redis->pexpire('nothing', 10));
 
             $redis->flushall();
         }
@@ -140,28 +140,28 @@ class RedisConnectionTest extends TestCase
     {
         foreach ($this->connections() as $redis) {
             $redis->zadd('set', 1, 'mohamed');
-            $this->assertEquals(1, $redis->zcard('set'));
+            $this->assertSame(1, $redis->zcard('set'));
 
             $redis->zadd('set', 2, 'taylor', 3, 'adam');
-            $this->assertEquals(3, $redis->zcard('set'));
+            $this->assertSame(3, $redis->zcard('set'));
 
             $redis->zadd('set', ['jeffrey' => 4, 'matt' => 5]);
-            $this->assertEquals(5, $redis->zcard('set'));
+            $this->assertSame(5, $redis->zcard('set'));
 
             $redis->zadd('set', 'NX', 1, 'beric');
-            $this->assertEquals(6, $redis->zcard('set'));
+            $this->assertSame(6, $redis->zcard('set'));
 
             $redis->zadd('set', 'NX', ['joffrey' => 1]);
-            $this->assertEquals(7, $redis->zcard('set'));
+            $this->assertSame(7, $redis->zcard('set'));
 
             $redis->zadd('set', 'XX', ['ned' => 1]);
-            $this->assertEquals(7, $redis->zcard('set'));
+            $this->assertSame(7, $redis->zcard('set'));
 
-            $this->assertEquals(1, $redis->zadd('set', ['sansa' => 10]));
-            $this->assertEquals(0, $redis->zadd('set', 'XX', 'CH', ['arya' => 11]));
+            $this->assertSame(1, $redis->zadd('set', ['sansa' => 10]));
+            $this->assertSame(0, $redis->zadd('set', 'XX', 'CH', ['arya' => 11]));
 
             $redis->zadd('set', ['mohamed' => 100]);
-            $this->assertEquals(100, $redis->zscore('set', 'mohamed'));
+            $this->assertSame(100, $redis->zscore('set', 'mohamed'));
 
             $redis->flushall();
         }
@@ -172,9 +172,9 @@ class RedisConnectionTest extends TestCase
         foreach ($this->connections() as $redis) {
             $redis->zadd('set', ['jeffrey' => 1, 'matt' => 10]);
 
-            $this->assertEquals(1, $redis->zcount('set', 1, 5));
-            $this->assertEquals(2, $redis->zcount('set', '-inf', '+inf'));
-            $this->assertEquals(2, $redis->zcard('set'));
+            $this->assertSame(1, $redis->zcount('set', 1, 5));
+            $this->assertSame(2, $redis->zcount('set', '-inf', '+inf'));
+            $this->assertSame(2, $redis->zcard('set'));
 
             $redis->flushall();
         }
@@ -185,7 +185,7 @@ class RedisConnectionTest extends TestCase
         foreach ($this->connections() as $redis) {
             $redis->zadd('set', ['jeffrey' => 1, 'matt' => 10]);
             $redis->zincrby('set', 2, 'jeffrey');
-            $this->assertEquals(3, $redis->zscore('set', 'jeffrey'));
+            $this->assertSame(3, $redis->zscore('set', 'jeffrey'));
 
             $redis->flushall();
         }
@@ -228,23 +228,23 @@ class RedisConnectionTest extends TestCase
             $redis->zadd('set2', ['jeffrey' => 2, 'matt' => 3]);
 
             $redis->zinterstore('output', ['set1', 'set2']);
-            $this->assertEquals(2, $redis->zcard('output'));
-            $this->assertEquals(3, $redis->zscore('output', 'jeffrey'));
-            $this->assertEquals(5, $redis->zscore('output', 'matt'));
+            $this->assertSame(2, $redis->zcard('output'));
+            $this->assertSame(3, $redis->zscore('output', 'jeffrey'));
+            $this->assertSame(5, $redis->zscore('output', 'matt'));
 
             $redis->zinterstore('output2', ['set1', 'set2'], [
                 'weights' => [3, 2],
                 'aggregate' => 'sum',
             ]);
-            $this->assertEquals(7, $redis->zscore('output2', 'jeffrey'));
-            $this->assertEquals(12, $redis->zscore('output2', 'matt'));
+            $this->assertSame(7, $redis->zscore('output2', 'jeffrey'));
+            $this->assertSame(12, $redis->zscore('output2', 'matt'));
 
             $redis->zinterstore('output3', ['set1', 'set2'], [
                 'weights' => [3, 2],
                 'aggregate' => 'min',
             ]);
-            $this->assertEquals(3, $redis->zscore('output3', 'jeffrey'));
-            $this->assertEquals(6, $redis->zscore('output3', 'matt'));
+            $this->assertSame(3, $redis->zscore('output3', 'jeffrey'));
+            $this->assertSame(6, $redis->zscore('output3', 'matt'));
 
             $redis->flushall();
         }
@@ -257,26 +257,26 @@ class RedisConnectionTest extends TestCase
             $redis->zadd('set2', ['jeffrey' => 2, 'matt' => 3]);
 
             $redis->zunionstore('output', ['set1', 'set2']);
-            $this->assertEquals(3, $redis->zcard('output'));
-            $this->assertEquals(3, $redis->zscore('output', 'jeffrey'));
-            $this->assertEquals(5, $redis->zscore('output', 'matt'));
-            $this->assertEquals(3, $redis->zscore('output', 'taylor'));
+            $this->assertSame(3, $redis->zcard('output'));
+            $this->assertSame(3, $redis->zscore('output', 'jeffrey'));
+            $this->assertSame(5, $redis->zscore('output', 'matt'));
+            $this->assertSame(3, $redis->zscore('output', 'taylor'));
 
             $redis->zunionstore('output2', ['set1', 'set2'], [
                 'weights' => [3, 2],
                 'aggregate' => 'sum',
             ]);
-            $this->assertEquals(7, $redis->zscore('output2', 'jeffrey'));
-            $this->assertEquals(12, $redis->zscore('output2', 'matt'));
-            $this->assertEquals(9, $redis->zscore('output2', 'taylor'));
+            $this->assertSame(7, $redis->zscore('output2', 'jeffrey'));
+            $this->assertSame(12, $redis->zscore('output2', 'matt'));
+            $this->assertSame(9, $redis->zscore('output2', 'taylor'));
 
             $redis->zunionstore('output3', ['set1', 'set2'], [
                 'weights' => [3, 2],
                 'aggregate' => 'min',
             ]);
-            $this->assertEquals(3, $redis->zscore('output3', 'jeffrey'));
-            $this->assertEquals(6, $redis->zscore('output3', 'matt'));
-            $this->assertEquals(9, $redis->zscore('output3', 'taylor'));
+            $this->assertSame(3, $redis->zscore('output3', 'jeffrey'));
+            $this->assertSame(6, $redis->zscore('output3', 'matt'));
+            $this->assertSame(9, $redis->zscore('output3', 'taylor'));
 
             $redis->flushall();
         }
@@ -363,8 +363,8 @@ class RedisConnectionTest extends TestCase
         foreach ($this->connections() as $redis) {
             $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10]);
 
-            $this->assertEquals(0, $redis->zrank('set', 'jeffrey'));
-            $this->assertEquals(2, $redis->zrank('set', 'taylor'));
+            $this->assertSame(0, $redis->zrank('set', 'jeffrey'));
+            $this->assertSame(2, $redis->zrank('set', 'taylor'));
 
             $redis->flushall();
         }
@@ -375,8 +375,8 @@ class RedisConnectionTest extends TestCase
         foreach ($this->connections() as $redis) {
             $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10]);
 
-            $this->assertEquals(1, $redis->zscore('set', 'jeffrey'));
-            $this->assertEquals(10, $redis->zscore('set', 'taylor'));
+            $this->assertSame(1, $redis->zscore('set', 'jeffrey'));
+            $this->assertSame(10, $redis->zscore('set', 'taylor'));
 
             $redis->flushall();
         }
@@ -388,10 +388,10 @@ class RedisConnectionTest extends TestCase
             $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10, 'adam' => 11]);
 
             $redis->zrem('set', 'jeffrey');
-            $this->assertEquals(3, $redis->zcard('set'));
+            $this->assertSame(3, $redis->zcard('set'));
 
             $redis->zrem('set', 'matt', 'adam');
-            $this->assertEquals(1, $redis->zcard('set'));
+            $this->assertSame(1, $redis->zcard('set'));
 
             $redis->flushall();
         }
@@ -402,7 +402,7 @@ class RedisConnectionTest extends TestCase
         foreach ($this->connections() as $redis) {
             $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10, 'adam' => 11]);
             $redis->ZREMRANGEBYSCORE('set', 5, '+inf');
-            $this->assertEquals(1, $redis->zcard('set'));
+            $this->assertSame(1, $redis->zcard('set'));
 
             $redis->flushall();
         }
@@ -413,7 +413,7 @@ class RedisConnectionTest extends TestCase
         foreach ($this->connections() as $redis) {
             $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10, 'adam' => 11]);
             $redis->ZREMRANGEBYRANK('set', 1, -1);
-            $this->assertEquals(1, $redis->zcard('set'));
+            $this->assertSame(1, $redis->zcard('set'));
 
             $redis->flushall();
         }
@@ -514,8 +514,8 @@ class RedisConnectionTest extends TestCase
             });
 
             $this->assertCount(4, $result);
-            $this->assertEquals(1, $result[1]);
-            $this->assertEquals(2, $result[3]);
+            $this->assertSame(1, $result[1]);
+            $this->assertSame(2, $result[3]);
 
             $redis->flushall();
         }
@@ -532,8 +532,8 @@ class RedisConnectionTest extends TestCase
             });
 
             $this->assertCount(4, $result);
-            $this->assertEquals(1, $result[1]);
-            $this->assertEquals(2, $result[3]);
+            $this->assertSame(1, $result[1]);
+            $this->assertSame(2, $result[3]);
 
             $redis->flushall();
         }

--- a/tests/Redis/RedisConnectorTest.php
+++ b/tests/Redis/RedisConnectorTest.php
@@ -226,7 +226,7 @@ class RedisConnectorTest extends TestCase
         ]);
 
         $phpRedisClient = $phpRedis->connection()->client();
-        $this->assertEquals(1, $phpRedisClient->getOption(Redis::OPT_TCP_KEEPALIVE));
+        $this->assertSame(1, $phpRedisClient->getOption(Redis::OPT_TCP_KEEPALIVE));
     }
 
     public function testPrefixOverrideBehaviour()

--- a/tests/Redis/RedisConnectorTest.php
+++ b/tests/Redis/RedisConnectorTest.php
@@ -251,7 +251,7 @@ class RedisConnectorTest extends TestCase
             ],
         ]);
         $predisClient1 = $predis1->client();
-        $this->assertEquals('test_default_options_', $predisClient1->getOptions()->prefix->getPrefix());
+        $this->assertSame('test_default_options_', $predisClient1->getOptions()->prefix->getPrefix());
 
         $predis2 = new RedisManager(new Application, 'predis', [
             'cluster' => false,
@@ -271,7 +271,7 @@ class RedisConnectorTest extends TestCase
             ],
         ]);
         $predisClient2 = $predis2->client();
-        $this->assertEquals('test_default_config_', $predisClient2->getOptions()->prefix->getPrefix());
+        $this->assertSame('test_default_config_', $predisClient2->getOptions()->prefix->getPrefix());
 
         $phpRedis1 = new RedisManager(new Application, 'phpredis', [
             'cluster' => false,
@@ -290,7 +290,7 @@ class RedisConnectorTest extends TestCase
             ],
         ]);
         $phpRedisClient1 = $phpRedis1->connection()->client();
-        $this->assertEquals('test_default_options_', $phpRedisClient1->getOption(Redis::OPT_PREFIX));
+        $this->assertSame('test_default_options_', $phpRedisClient1->getOption(Redis::OPT_PREFIX));
 
         $phpRedis2 = new RedisManager(new Application, 'phpredis', [
             'cluster' => false,
@@ -310,6 +310,6 @@ class RedisConnectorTest extends TestCase
             ],
         ]);
         $phpRedisClient2 = $phpRedis2->connection()->client();
-        $this->assertEquals('test_default_config_', $phpRedisClient2->getOption(Redis::OPT_PREFIX));
+        $this->assertSame('test_default_config_', $phpRedisClient2->getOption(Redis::OPT_PREFIX));
     }
 }

--- a/tests/Routing/RouteCollectionTest.php
+++ b/tests/Routing/RouteCollectionTest.php
@@ -357,7 +357,7 @@ class RouteCollectionTest extends TestCase
         $request = Request::create('users/1/show', 'GET');
 
         $this->assertCount(2, $this->routeCollection->getRoutes());
-        $this->assertEquals('first', $this->routeCollection->match($request)->getName());
+        $this->assertSame('first', $this->routeCollection->match($request)->getName());
     }
 
     public function testPrependsRoutesWithDomain()

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -1320,7 +1320,7 @@ class RouteRegistrarTest extends TestCase
 
         $this->router->removeMiddlewareFromGroup('web', 'test-middleware');
 
-        $this->assertEquals([], $this->router->getMiddlewareGroups()['web']);
+        $this->assertSame([], $this->router->getMiddlewareGroups()['web']);
     }
 
     public function testCanRemoveMiddlewareFromGroupNotUnregisteredMiddleware()
@@ -1329,14 +1329,14 @@ class RouteRegistrarTest extends TestCase
 
         $this->router->removeMiddlewareFromGroup('web', 'different-test-middleware');
 
-        $this->assertEquals([], $this->router->getMiddlewareGroups()['web']);
+        $this->assertSame([], $this->router->getMiddlewareGroups()['web']);
     }
 
     public function testCanRemoveMiddlewareFromGroupUnregisteredGroup()
     {
         $this->router->removeMiddlewareFromGroup('web', ['test-middleware']);
 
-        $this->assertEquals([], $this->router->getMiddlewareGroups());
+        $this->assertSame([], $this->router->getMiddlewareGroups());
     }
 
     public function testCanRegisterSingleton()

--- a/tests/Routing/RoutingRedirectorTest.php
+++ b/tests/Routing/RoutingRedirectorTest.php
@@ -52,7 +52,7 @@ class RoutingRedirectorTest extends TestCase
 
         $this->assertInstanceOf(RedirectResponse::class, $response);
         $this->assertSame('http://foo.com/bar', $response->getTargetUrl());
-        $this->assertEquals(302, $response->getStatusCode());
+        $this->assertSame(302, $response->getStatusCode());
         $this->assertEquals($this->session, $response->getSession());
     }
 
@@ -61,9 +61,9 @@ class RoutingRedirectorTest extends TestCase
         $response = $this->redirect->to('bar', 303, ['X-RateLimit-Limit' => 60, 'X-RateLimit-Remaining' => 59], true);
 
         $this->assertSame('https://foo.com/bar', $response->getTargetUrl());
-        $this->assertEquals(303, $response->getStatusCode());
-        $this->assertEquals(60, $response->headers->get('X-RateLimit-Limit'));
-        $this->assertEquals(59, $response->headers->get('X-RateLimit-Remaining'));
+        $this->assertSame(303, $response->getStatusCode());
+        $this->assertSame(60, (int) $response->headers->get('X-RateLimit-Limit'));
+        $this->assertSame(59, (int) $response->headers->get('X-RateLimit-Remaining'));
     }
 
     public function testGuestPutCurrentUrlInSession()

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -524,7 +524,7 @@ class RoutingRouteTest extends TestCase
         });
         $response = $router->dispatch(Request::create('foo/bar', 'OPTIONS'));
 
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('GET,HEAD,POST', $response->headers->get('Allow'));
     }
 
@@ -536,11 +536,11 @@ class RoutingRouteTest extends TestCase
         });
 
         $response = $router->dispatch(Request::create('foo', 'OPTIONS'));
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('GET,HEAD,POST', $response->headers->get('Allow'));
 
         $response = $router->dispatch(Request::create('foo', 'HEAD'));
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertEmpty($response->getContent());
 
         $router = $this->getRouter();
@@ -549,7 +549,7 @@ class RoutingRouteTest extends TestCase
         });
 
         $response = $router->dispatch(Request::create('foo', 'OPTIONS'));
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('GET,HEAD', $response->headers->get('Allow'));
 
         $router = $this->getRouter();
@@ -558,7 +558,7 @@ class RoutingRouteTest extends TestCase
         });
 
         $response = $router->dispatch(Request::create('foo', 'OPTIONS'));
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('POST', $response->headers->get('Allow'));
     }
 
@@ -721,7 +721,7 @@ class RoutingRouteTest extends TestCase
         $values = array_values($_SERVER['__test.controller_callAction_parameters']);
 
         $this->assertInstanceOf(Request::class, $values[0]);
-        $this->assertEquals(1, $values[1]->value);
+        $this->assertSame(1, (int) $values[1]->value);
         $this->assertNull($values[2]);
         $this->assertNull($values[3]);
     }
@@ -1378,7 +1378,7 @@ class RoutingRouteTest extends TestCase
             },
         ]);
 
-        $this->assertEquals(6, $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
+        $this->assertSame(6, (int) $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
     }
 
     public function testMergingControllerUses()
@@ -1710,7 +1710,7 @@ class RoutingRouteTest extends TestCase
         $this->assertSame('Hello World', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
         $this->assertTrue($_SERVER['route.test.controller.middleware']);
         $this->assertEquals(Response::class, $_SERVER['route.test.controller.middleware.class']);
-        $this->assertEquals(0, $_SERVER['route.test.controller.middleware.parameters.one']);
+        $this->assertSame(0, (int) $_SERVER['route.test.controller.middleware.parameters.one']);
         $this->assertEquals(['foo', 'bar'], $_SERVER['route.test.controller.middleware.parameters.two']);
         $this->assertFalse(isset($_SERVER['route.test.controller.except.middleware']));
     }
@@ -1730,7 +1730,7 @@ class RoutingRouteTest extends TestCase
         $this->assertSame('Hello World', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
         $this->assertTrue($_SERVER['route.test.controller.middleware']);
         $this->assertEquals(Response::class, $_SERVER['route.test.controller.middleware.class']);
-        $this->assertEquals(0, $_SERVER['route.test.controller.middleware.parameters.one']);
+        $this->assertSame(0, (int) $_SERVER['route.test.controller.middleware.parameters.one']);
         $this->assertEquals(['foo', 'bar'], $_SERVER['route.test.controller.middleware.parameters.two']);
         $this->assertFalse(isset($_SERVER['route.test.controller.except.middleware']));
         $action = $router->getRoutes()->getRoutes()[0]->getAction()['controller'];
@@ -1945,7 +1945,7 @@ class RoutingRouteTest extends TestCase
 
         $response = $router->dispatch($request);
         $this->assertTrue($response->isRedirect('/'));
-        $this->assertEquals(302, $response->getStatusCode());
+        $this->assertSame(302, $response->getStatusCode());
     }
 
     public function testImplicitBindingsWithMissingModelHandledByMissingOnGroupLevel()
@@ -1968,7 +1968,7 @@ class RoutingRouteTest extends TestCase
 
         $response = $router->dispatch($request);
         $this->assertTrue($response->isRedirect('/'));
-        $this->assertEquals(302, $response->getStatusCode());
+        $this->assertSame(302, $response->getStatusCode());
     }
 
     public function testImplicitBindingsWithOptionalParameterWithNoKeyInUri()
@@ -2104,7 +2104,7 @@ class RoutingRouteTest extends TestCase
 
         $response = $router->dispatch($request);
         $this->assertTrue($response->isRedirect('contact'));
-        $this->assertEquals(302, $response->getStatusCode());
+        $this->assertSame(302, $response->getStatusCode());
     }
 
     public function testRouteRedirectRetainsExistingStartingForwardSlash()
@@ -2123,7 +2123,7 @@ class RoutingRouteTest extends TestCase
 
         $response = $router->dispatch($request);
         $this->assertTrue($response->isRedirect('/contact'));
-        $this->assertEquals(302, $response->getStatusCode());
+        $this->assertSame(302, $response->getStatusCode());
     }
 
     public function testRouteRedirectStripsMissingStartingForwardSlash()
@@ -2142,7 +2142,7 @@ class RoutingRouteTest extends TestCase
 
         $response = $router->dispatch($request);
         $this->assertTrue($response->isRedirect('contact'));
-        $this->assertEquals(302, $response->getStatusCode());
+        $this->assertSame(302, $response->getStatusCode());
     }
 
     public function testRouteRedirectExceptionWhenMissingExpectedParameters()
@@ -2181,7 +2181,7 @@ class RoutingRouteTest extends TestCase
 
         $response = $router->dispatch($request);
         $this->assertTrue($response->isRedirect('contact'));
-        $this->assertEquals(301, $response->getStatusCode());
+        $this->assertSame(301, $response->getStatusCode());
     }
 
     public function testRoutePermanentRedirect()
@@ -2200,7 +2200,7 @@ class RoutingRouteTest extends TestCase
 
         $response = $router->dispatch($request);
         $this->assertTrue($response->isRedirect('contact'));
-        $this->assertEquals(301, $response->getStatusCode());
+        $this->assertSame(301, $response->getStatusCode());
     }
 
     public function testRouteCanMiddlewareCanBeAssigned()

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -708,7 +708,7 @@ class RoutingRouteTest extends TestCase
         unset($_SERVER['__test.controller_callAction_parameters']);
         $router->get(($str = Str::random()).'', RouteTestAnotherControllerWithParameterStub::class.'@oneArgument');
         $router->dispatch(Request::create($str, 'GET'));
-        $this->assertEquals([], $_SERVER['__test.controller_callAction_parameters']);
+        $this->assertSame([], $_SERVER['__test.controller_callAction_parameters']);
 
         // With model bindings
         unset($_SERVER['__test.controller_callAction_parameters']);

--- a/tests/Routing/RoutingSortedMiddlewareTest.php
+++ b/tests/Routing/RoutingSortedMiddlewareTest.php
@@ -41,7 +41,7 @@ class RoutingSortedMiddlewareTest extends TestCase
 
         $this->assertEquals($expected, (new SortedMiddleware($priority, $middleware))->all());
 
-        $this->assertEquals([], (new SortedMiddleware(['First'], []))->all());
+        $this->assertSame([], (new SortedMiddleware(['First'], []))->all());
         $this->assertEquals(['First'], (new SortedMiddleware(['First'], ['First']))->all());
         $this->assertEquals(['First', 'Second'], (new SortedMiddleware(['First', 'Second'], ['Second', 'First']))->all());
     }

--- a/tests/Session/CacheBasedSessionHandlerTest.php
+++ b/tests/Session/CacheBasedSessionHandlerTest.php
@@ -71,7 +71,7 @@ class CacheBasedSessionHandlerTest extends TestCase
     {
         $result = $this->sessionHandler->gc(lifetime: 120);
 
-        $this->assertEquals(0, $result);
+        $this->assertSame(0, $result);
     }
 
     public function test_get_cache_returns_cache_instance()

--- a/tests/Session/CacheBasedSessionHandlerTest.php
+++ b/tests/Session/CacheBasedSessionHandlerTest.php
@@ -37,7 +37,7 @@ class CacheBasedSessionHandlerTest extends TestCase
         $this->cacheMock->shouldReceive('get')->once()->with('session_id', '')->andReturn('session_data');
 
         $data = $this->sessionHandler->read(sessionId: 'session_id');
-        $this->assertEquals('session_data', $data);
+        $this->assertSame('session_data', $data);
     }
 
     public function test_read_returns_empty_string_if_no_data()
@@ -45,7 +45,7 @@ class CacheBasedSessionHandlerTest extends TestCase
         $this->cacheMock->shouldReceive('get')->once()->with('some_id', '')->andReturn('');
 
         $data = $this->sessionHandler->read(sessionId: 'some_id');
-        $this->assertEquals('', $data);
+        $this->assertSame('', $data);
     }
 
     public function test_write_stores_data_in_cache()

--- a/tests/Session/FileSessionHandlerTest.php
+++ b/tests/Session/FileSessionHandlerTest.php
@@ -122,7 +122,7 @@ class FileSessionHandlerTest extends TestCase
         // act:
         $count = $session->gc(5);
 
-        $this->assertEquals(2, $count);
+        $this->assertSame(2, $count);
 
         unlink(__DIR__.'/tmp/a1');
         unlink(__DIR__.'/tmp/a2');

--- a/tests/Session/FileSessionHandlerTest.php
+++ b/tests/Session/FileSessionHandlerTest.php
@@ -49,7 +49,7 @@ class FileSessionHandlerTest extends TestCase
 
         $result = $this->sessionHandler->read($sessionId);
 
-        $this->assertEquals('session_data', $result);
+        $this->assertSame('session_data', $result);
     }
 
     public function test_read_returns_data_when_file_exists_but_expired()
@@ -66,7 +66,7 @@ class FileSessionHandlerTest extends TestCase
 
         $result = $this->sessionHandler->read($sessionId);
 
-        $this->assertEquals('', $result);
+        $this->assertSame('', $result);
     }
 
     public function test_read_returns_empty_string_when_file_does_not_exist()
@@ -79,7 +79,7 @@ class FileSessionHandlerTest extends TestCase
 
         $result = $this->sessionHandler->read($sessionId);
 
-        $this->assertEquals('', $result);
+        $this->assertSame('', $result);
     }
 
     public function test_write_stores_data()

--- a/tests/Session/Middleware/AuthenticateSessionTest.php
+++ b/tests/Session/Middleware/AuthenticateSessionTest.php
@@ -24,7 +24,7 @@ class AuthenticateSessionTest extends TestCase
 
         $middleware = new AuthenticateSession($authFactory);
         $response = $middleware->handle($request, $next);
-        $this->assertEquals('next-1', $response);
+        $this->assertSame('next-1', $response);
     }
 
     public function test_handle_with_session_without_request_user()
@@ -40,7 +40,7 @@ class AuthenticateSessionTest extends TestCase
         $next = fn () => 'next-2';
         $middleware = new AuthenticateSession($authFactory);
         $response = $middleware->handle($request, $next);
-        $this->assertEquals('next-2', $response);
+        $this->assertSame('next-2', $response);
     }
 
     public function test_handle_with_session_without_auth_password()
@@ -67,7 +67,7 @@ class AuthenticateSessionTest extends TestCase
         $middleware = new AuthenticateSession($authFactory);
         $response = $middleware->handle($request, $next);
 
-        $this->assertEquals('next-3', $response);
+        $this->assertSame('next-3', $response);
     }
 
     public function test_handle_with_session_with_user_auth_password_on_request_via_remember_false()
@@ -96,8 +96,8 @@ class AuthenticateSessionTest extends TestCase
         $middleware = new AuthenticateSession($authFactory);
         $response = $middleware->handle($request, fn () => 'next-4');
 
-        $this->assertEquals('mac:my-pass-(*&^%$#!@', $session->get('password_hash_web'));
-        $this->assertEquals('next-4', $response);
+        $this->assertSame('mac:my-pass-(*&^%$#!@', $session->get('password_hash_web'));
+        $this->assertSame('next-4', $response);
     }
 
     public function test_handle_with_invalid_password_hash()
@@ -140,9 +140,9 @@ class AuthenticateSessionTest extends TestCase
             $middleware->handle($request, fn () => 'next-7');
         } catch (AuthenticationException $e) {
             $message = $e->getMessage();
-            $this->assertEquals('i-wanna-go-home', $e->redirectTo($request));
+            $this->assertSame('i-wanna-go-home', $e->redirectTo($request));
         }
-        $this->assertEquals('Unauthenticated.', $message);
+        $this->assertSame('Unauthenticated.', $message);
 
         // ensure session is flushed:
         $this->assertNull($session->get('a'));
@@ -185,7 +185,7 @@ class AuthenticateSessionTest extends TestCase
         } catch (AuthenticationException $e) {
             $message = $e->getMessage();
         }
-        $this->assertEquals('Unauthenticated.', $message);
+        $this->assertSame('Unauthenticated.', $message);
 
         // ensure session is flushed
         $this->assertNull($session->get('password_hash_web'));
@@ -230,7 +230,7 @@ class AuthenticateSessionTest extends TestCase
         } catch (AuthenticationException $e) {
             $message = $e->getMessage();
         }
-        $this->assertEquals('Unauthenticated.', $message);
+        $this->assertSame('Unauthenticated.', $message);
 
         // ensure session is flushed:
         $this->assertNull($session->get('password_hash_web'));
@@ -271,11 +271,11 @@ class AuthenticateSessionTest extends TestCase
         $middleware = new AuthenticateSession($authFactory);
         $response = $middleware->handle($request, fn () => 'next-8');
 
-        $this->assertEquals('next-8', $response);
+        $this->assertSame('next-8', $response);
         // ensure session is flushed:
-        $this->assertEquals('mac:my-pass-(*&^%$#!@', $session->get('password_hash_web'));
-        $this->assertEquals('1', $session->get('a'));
-        $this->assertEquals('2', $session->get('b'));
+        $this->assertSame('mac:my-pass-(*&^%$#!@', $session->get('password_hash_web'));
+        $this->assertSame('1', $session->get('a'));
+        $this->assertSame('2', $session->get('b'));
     }
 
     public function test_handle_with_old_format_cookie_for_backward_compatibility()
@@ -311,11 +311,11 @@ class AuthenticateSessionTest extends TestCase
         $response = $middleware->handle($request, fn () => 'next-9');
 
         // Should succeed because of backward compatibility fallback
-        $this->assertEquals('next-9', $response);
+        $this->assertSame('next-9', $response);
         // Session should be updated to new format (HMAC)
-        $this->assertEquals('mac:my-pass-(*&^%$#!@', $session->get('password_hash_web'));
-        $this->assertEquals('1', $session->get('a'));
-        $this->assertEquals('2', $session->get('b'));
+        $this->assertSame('mac:my-pass-(*&^%$#!@', $session->get('password_hash_web'));
+        $this->assertSame('1', $session->get('a'));
+        $this->assertSame('2', $session->get('b'));
     }
 
     public function test_handle_with_old_format_cookie_and_legacy_guard()
@@ -351,10 +351,10 @@ class AuthenticateSessionTest extends TestCase
         $response = $middleware->handle($request, fn () => 'next-9');
 
         // Should succeed because of backward compatibility fallback
-        $this->assertEquals('next-9', $response);
+        $this->assertSame('next-9', $response);
         // Session should stay intact
-        $this->assertEquals('my-pass-(*&^%$#!@', $session->get('password_hash_web'));
-        $this->assertEquals('1', $session->get('a'));
-        $this->assertEquals('2', $session->get('b'));
+        $this->assertSame('my-pass-(*&^%$#!@', $session->get('password_hash_web'));
+        $this->assertSame('1', $session->get('a'));
+        $this->assertSame('2', $session->get('b'));
     }
 }

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -229,14 +229,14 @@ class SessionStoreTest extends TestCase
 
         $this->assertTrue($session->hasOldInput('foo'));
         $this->assertSame('bar', $session->getOldInput('foo'));
-        $this->assertEquals(0, $session->getOldInput('bar'));
+        $this->assertSame(0, $session->getOldInput('bar'));
         $this->assertFalse($session->hasOldInput('boom'));
 
         $session->ageFlashData();
 
         $this->assertTrue($session->hasOldInput('foo'));
         $this->assertSame('bar', $session->getOldInput('foo'));
-        $this->assertEquals(0, $session->getOldInput('bar'));
+        $this->assertSame(0, $session->getOldInput('bar'));
         $this->assertFalse($session->hasOldInput('boom'));
 
         $this->assertSame('default', $session->getOldInput('input', 'default'));
@@ -252,14 +252,14 @@ class SessionStoreTest extends TestCase
 
         $this->assertTrue($session->has('foo'));
         $this->assertSame('bar', $session->get('foo'));
-        $this->assertEquals(0, $session->get('bar'));
+        $this->assertSame(0, $session->get('bar'));
         $this->assertTrue($session->get('baz'));
 
         $session->ageFlashData();
 
         $this->assertTrue($session->has('foo'));
         $this->assertSame('bar', $session->get('foo'));
-        $this->assertEquals(0, $session->get('bar'));
+        $this->assertSame(0, $session->get('bar'));
 
         $session->ageFlashData();
 
@@ -275,7 +275,7 @@ class SessionStoreTest extends TestCase
 
         $this->assertTrue($session->has('foo'));
         $this->assertSame('bar', $session->get('foo'));
-        $this->assertEquals(0, $session->get('bar'));
+        $this->assertSame(0, $session->get('bar'));
 
         $session->ageFlashData();
 
@@ -376,15 +376,15 @@ class SessionStoreTest extends TestCase
 
         $session->put('foo', 5);
         $foo = $session->increment('foo');
-        $this->assertEquals(6, $foo);
-        $this->assertEquals(6, $session->get('foo'));
+        $this->assertSame(6, $foo);
+        $this->assertSame(6, $session->get('foo'));
 
         $foo = $session->increment('foo', 4);
-        $this->assertEquals(10, $foo);
-        $this->assertEquals(10, $session->get('foo'));
+        $this->assertSame(10, $foo);
+        $this->assertSame(10, $session->get('foo'));
 
         $session->increment('bar');
-        $this->assertEquals(1, $session->get('bar'));
+        $this->assertSame(1, $session->get('bar'));
     }
 
     public function testDecrement()
@@ -393,12 +393,12 @@ class SessionStoreTest extends TestCase
 
         $session->put('foo', 5);
         $foo = $session->decrement('foo');
-        $this->assertEquals(4, $foo);
-        $this->assertEquals(4, $session->get('foo'));
+        $this->assertSame(4, $foo);
+        $this->assertSame(4, $session->get('foo'));
 
         $foo = $session->decrement('foo', 4);
-        $this->assertEquals(0, $foo);
-        $this->assertEquals(0, $session->get('foo'));
+        $this->assertSame(0, $foo);
+        $this->assertSame(0, $session->get('foo'));
 
         $session->decrement('bar');
         $this->assertEquals(-1, $session->get('bar'));

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -816,7 +816,7 @@ class SessionStoreTest extends TestCase
 
         $this->assertInstanceOf(ViewErrorBag::class, $errors);
         $this->assertInstanceOf(MessageBag::class, $errors->getBags()['default']);
-        $this->assertEquals('<p>:message</p>', $errors->getBags()['default']->getFormat());
+        $this->assertSame('<p>:message</p>', $errors->getBags()['default']->getFormat());
         $this->assertEquals(['first_name' => [
             'Your first name is required',
             'Your first name must be at least 1 character',

--- a/tests/Support/SleepTest.php
+++ b/tests/Support/SleepTest.php
@@ -34,7 +34,7 @@ class SleepTest extends TestCase
 
     public function testCallbacksMayBeExecutedUsingThen()
     {
-        $this->assertEquals(123, Sleep::for(1)->milliseconds()->then(fn () => 123));
+        $this->assertSame(123, Sleep::for(1)->milliseconds()->then(fn () => 123));
     }
 
     public function testSleepRespectsWhile()
@@ -48,8 +48,8 @@ class SleepTest extends TestCase
             return array_shift($results);
         })->then(fn () => 100);
 
-        $this->assertEquals(3, $_SERVER['__sleep.while']);
-        $this->assertEquals(100, $result);
+        $this->assertSame(3, $_SERVER['__sleep.while']);
+        $this->assertSame(100, $result);
 
         unset($_SERVER['__sleep.while']);
     }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -108,7 +108,7 @@ class SupportArrTest extends TestCase
 
         // Case with empty two-dimensional arrays
         $emptyArray = [[], [], []];
-        $this->assertEquals([], Arr::collapse($emptyArray));
+        $this->assertSame([], Arr::collapse($emptyArray));
 
         // Case with both empty arrays and arrays with elements
         $mixedArray = [[], [1, 2], [], ['foo', 'bar']];
@@ -170,8 +170,8 @@ class SupportArrTest extends TestCase
     {
         // Test dividing an empty array
         [$keys, $values] = Arr::divide([]);
-        $this->assertEquals([], $keys);
-        $this->assertEquals([], $values);
+        $this->assertSame([], $keys);
+        $this->assertSame([], $values);
 
         // Test dividing an array with a single key-value pair
         [$keys, $values] = Arr::divide(['name' => 'Desk']);
@@ -349,16 +349,16 @@ class SupportArrTest extends TestCase
         $array = ['a' => 1, 'b' => 2, 'c' => 1, 'd' => 3];
         $this->assertEquals(['b' => 2, 'd' => 3], Arr::exceptValues($array, 1));
 
-        $this->assertEquals([], Arr::exceptValues([], 'foo'));
+        $this->assertSame([], Arr::exceptValues([], 'foo'));
         $this->assertEquals(['foo', 'bar'], Arr::exceptValues(['foo', 'bar'], []));
 
         $array = [1, '1', 2, '2', 3];
         $this->assertEquals([1 => '1', 3 => '2'], Arr::exceptValues($array, [1, 2, 3], true));
-        $this->assertEquals([], Arr::exceptValues($array, [1, 2, 3]));
+        $this->assertSame([], Arr::exceptValues($array, [1, 2, 3]));
 
         $array = ['a' => true, 'b' => false, 'c' => 1, 'd' => 0];
         $this->assertEquals(['a' => true, 'b' => false], Arr::exceptValues($array, [1, 0], true));
-        $this->assertEquals([], Arr::exceptValues($array, [1, 0]));
+        $this->assertSame([], Arr::exceptValues($array, [1, 0]));
     }
 
     public function testExists()
@@ -384,7 +384,7 @@ class SupportArrTest extends TestCase
         $this->assertEquals([1, 2, 3], $array);
 
         $array = array_values(Arr::whereNotNull([null, null, null]));
-        $this->assertEquals([], $array);
+        $this->assertSame([], $array);
 
         $array = array_values(Arr::whereNotNull(['a', null, 'b', null, 'c']));
         $this->assertEquals(['a', 'b', 'c'], $array);
@@ -939,8 +939,8 @@ class SupportArrTest extends TestCase
         $array = ['a' => 1, 'b' => 2, 'c' => 1, 'd' => 3];
         $this->assertEquals(['a' => 1, 'c' => 1], Arr::onlyValues($array, 1));
 
-        $this->assertEquals([], Arr::onlyValues([], 'foo'));
-        $this->assertEquals([], Arr::onlyValues(['foo', 'bar'], []));
+        $this->assertSame([], Arr::onlyValues([], 'foo'));
+        $this->assertSame([], Arr::onlyValues(['foo', 'bar'], []));
 
         $array = [1, '1', 2, '2', 3];
         $this->assertEquals([0 => 1, 2 => 2, 4 => 3], Arr::onlyValues($array, [1, 2, 3], true));
@@ -1091,7 +1091,7 @@ class SupportArrTest extends TestCase
         $mapped = Arr::map([], static function ($value, $key) {
             return $key.'-'.$value;
         });
-        $this->assertEquals([], $mapped);
+        $this->assertSame([], $mapped);
     }
 
     public function testMapNullValues()
@@ -1410,7 +1410,7 @@ class SupportArrTest extends TestCase
 
     public function testEmptyShuffle()
     {
-        $this->assertEquals([], Arr::shuffle([]));
+        $this->assertSame([], Arr::shuffle([]));
     }
 
     public function testSort()
@@ -1732,7 +1732,7 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['a'], Arr::wrap($string));
         $this->assertEquals($array, Arr::wrap($array));
         $this->assertEquals([$object], Arr::wrap($object));
-        $this->assertEquals([], Arr::wrap(null));
+        $this->assertSame([], Arr::wrap(null));
         $this->assertEquals([null], Arr::wrap([null]));
         $this->assertEquals([null, null], Arr::wrap([null, null]));
         $this->assertEquals([''], Arr::wrap(''));
@@ -1848,7 +1848,7 @@ class SupportArrTest extends TestCase
         $this->assertEquals([4, 5, 6], Arr::take($array, -3));
 
         // Test with zero limit, should return an empty array.
-        $this->assertEquals([], Arr::take($array, 0));
+        $this->assertSame([], Arr::take($array, 0));
 
         // Test with a limit greater than the array size, should return the entire array.
         $this->assertEquals([1, 2, 3, 4, 5, 6], Arr::take($array, 10));

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -405,13 +405,13 @@ class SupportArrTest extends TestCase
         }));
 
         // Callback is null and array is not empty
-        $this->assertEquals(100, Arr::first($array));
+        $this->assertSame(100, Arr::first($array));
 
         // Callback is not null and array is not empty
         $value = Arr::first($array, function ($value) {
             return $value >= 150;
         });
-        $this->assertEquals(200, $value);
+        $this->assertSame(200, $value);
 
         // Callback is not null, array is not empty but no satisfied item
         $value2 = Arr::first($array, function ($value) {
@@ -431,7 +431,7 @@ class SupportArrTest extends TestCase
         $this->assertNull($value2);
         $this->assertSame('bar', $value3);
         $this->assertSame('baz', $value4);
-        $this->assertEquals(100, $value5);
+        $this->assertSame(100, $value5);
 
         $cursor = (function () {
             while (false) {
@@ -475,13 +475,13 @@ class SupportArrTest extends TestCase
         }));
 
         // Callback is null and array is not empty
-        $this->assertEquals(300, Arr::last($array));
+        $this->assertSame(300, Arr::last($array));
 
         // Callback is not null and array is not empty
         $value = Arr::last($array, function ($value) {
             return $value < 250;
         });
-        $this->assertEquals(200, $value);
+        $this->assertSame(200, $value);
 
         // Callback is not null, array is not empty but no satisfied item
         $value2 = Arr::last($array, function ($value) {
@@ -501,7 +501,7 @@ class SupportArrTest extends TestCase
         $this->assertNull($value2);
         $this->assertSame('bar', $value3);
         $this->assertSame('baz', $value4);
-        $this->assertEquals(200, $value5);
+        $this->assertSame(200, $value5);
     }
 
     public function testFlatten()
@@ -1713,7 +1713,9 @@ class SupportArrTest extends TestCase
         $this->assertSame($subject, Arr::from($items));
 
         $items = new WeakMap;
-        $items[$temp = new class {}] = 'bar';
+        $items[$temp = new class
+        {
+        }] = 'bar';
         $this->assertSame(['bar'], Arr::from($items));
 
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Support/SupportCarbonTest.php
+++ b/tests/Support/SupportCarbonTest.php
@@ -127,19 +127,19 @@ class SupportCarbonTest extends TestCase
     public function testCreateFromUid()
     {
         $ulid = Carbon::createFromId('01DXH9C4P0ED4AGJJP9CRKQ55C');
-        $this->assertEquals('2020-01-01 19:30:00.000000', $ulid->toDateTimeString('microsecond'));
+        $this->assertSame('2020-01-01 19:30:00.000000', $ulid->toDateTimeString('microsecond'));
 
         $uuidv1 = Carbon::createFromId('71513cb4-f071-11ed-a0cf-325096b39f47');
-        $this->assertEquals('2023-05-12 03:02:34.147346', $uuidv1->toDateTimeString('microsecond'));
+        $this->assertSame('2023-05-12 03:02:34.147346', $uuidv1->toDateTimeString('microsecond'));
 
         $uuidv2 = Carbon::createFromId('000003e8-f072-21ed-9200-325096b39f47');
-        $this->assertEquals('2023-05-12 03:06:33.529139', $uuidv2->toDateTimeString('microsecond'));
+        $this->assertSame('2023-05-12 03:06:33.529139', $uuidv2->toDateTimeString('microsecond'));
 
         $uuidv6 = Carbon::createFromId('1edf0746-5d1c-6ce8-88ad-e0cb4effa035');
-        $this->assertEquals('2023-05-12 03:23:43.347428', $uuidv6->toDateTimeString('microsecond'));
+        $this->assertSame('2023-05-12 03:23:43.347428', $uuidv6->toDateTimeString('microsecond'));
 
         $uuidv7 = Carbon::createFromId('01880dfa-2825-72e4-acbb-b1e4981cf8af');
-        $this->assertEquals('2023-05-12 03:21:18.117000', $uuidv7->toDateTimeString('microsecond'));
+        $this->assertSame('2023-05-12 03:21:18.117000', $uuidv7->toDateTimeString('microsecond'));
     }
 
     public function testPlus(): void

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -345,12 +345,12 @@ class SupportCollectionTest extends TestCase
         $result = $data->last(function ($value) {
             return $value < 250;
         });
-        $this->assertEquals(200, $result);
+        $this->assertSame(200, $result);
 
         $result = $data->last(function ($value, $key) {
             return $key < 2;
         });
-        $this->assertEquals(200, $result);
+        $this->assertSame(200, $result);
 
         $result = $data->last(function ($value) {
             return $value > 300;
@@ -1290,7 +1290,7 @@ class SupportCollectionTest extends TestCase
     {
         $c = new $collection([['id' => 1, 'balance' => 0], ['id' => 2, 'balance' => 200]]);
 
-        $this->assertEquals(0, $c->value('balance'));
+        $this->assertSame(0, $c->value('balance'));
 
         $c = new $collection([['id' => 1, 'balance' => ''], ['id' => 2, 'balance' => 200]]);
 
@@ -1302,11 +1302,11 @@ class SupportCollectionTest extends TestCase
 
         $c = new $collection([['id' => 1], ['id' => 2, 'balance' => 200]]);
 
-        $this->assertEquals(200, $c->value('balance'));
+        $this->assertSame(200, $c->value('balance'));
 
         $c = new $collection([['id' => 1], ['id' => 2, 'balance' => 0], ['id' => 3, 'balance' => 200]]);
 
-        $this->assertEquals(0, $c->value('balance'));
+        $this->assertSame(0, $c->value('balance'));
     }
 
     #[DataProvider('collectionClassProvider')]
@@ -1326,7 +1326,7 @@ class SupportCollectionTest extends TestCase
             literal(id: 3, balance: literal(currency: 'USD', value: 200)),
         ]);
 
-        $this->assertEquals(0, $c->value('balance.value'));
+        $this->assertSame(0, $c->value('balance.value'));
     }
 
     #[DataProvider('collectionClassProvider')]
@@ -2586,10 +2586,12 @@ class SupportCollectionTest extends TestCase
     #[DataProvider('collectionClassProvider')]
     public function testImplodeModels($collection)
     {
-        $model = new class extends Model {
+        $model = new class extends Model
+        {
         };
         $model->setAttribute('email', 'foo');
-        $modelTwo = new class extends Model {
+        $modelTwo = new class extends Model
+        {
         };
         $modelTwo->setAttribute('email', 'bar');
         $data = new $collection([$model, $modelTwo]);
@@ -4049,10 +4051,10 @@ class SupportCollectionTest extends TestCase
     public function testGettingSumFromCollection($collection)
     {
         $c = new $collection([(object) ['foo' => 50], (object) ['foo' => 50]]);
-        $this->assertEquals(100, $c->sum('foo'));
+        $this->assertSame(100, $c->sum('foo'));
 
         $c = new $collection([(object) ['foo' => 50], (object) ['foo' => 50]]);
-        $this->assertEquals(100, $c->sum(function ($i) {
+        $this->assertSame(100, $c->sum(function ($i) {
             return $i->foo;
         }));
     }
@@ -4061,14 +4063,14 @@ class SupportCollectionTest extends TestCase
     public function testCanSumValuesWithoutACallback($collection)
     {
         $c = new $collection([1, 2, 3, 4, 5]);
-        $this->assertEquals(15, $c->sum());
+        $this->assertSame(15, $c->sum());
     }
 
     #[DataProvider('collectionClassProvider')]
     public function testGettingSumFromEmptyCollection($collection)
     {
         $c = new $collection;
-        $this->assertEquals(0, $c->sum('foo'));
+        $this->assertSame(0, $c->sum('foo'));
     }
 
     #[DataProvider('collectionClassProvider')]
@@ -4192,10 +4194,10 @@ class SupportCollectionTest extends TestCase
     {
         $c = new $collection([1, 2, 3, 4, 5, 2, 5, 'foo' => 'bar']);
 
-        $this->assertEquals(1, $c->search(2));
-        $this->assertEquals(1, $c->search('2'));
+        $this->assertSame(1, $c->search(2));
+        $this->assertSame(1, $c->search('2'));
         $this->assertSame('foo', $c->search('bar'));
-        $this->assertEquals(4, $c->search(function ($value) {
+        $this->assertSame(4, $c->search(function ($value) {
             return $value > 4;
         }));
         $this->assertSame('foo', $c->search(function ($value) {
@@ -4209,11 +4211,11 @@ class SupportCollectionTest extends TestCase
         $c = new $collection([false, 0, 1, [], '']);
         $this->assertFalse($c->search('false', true));
         $this->assertFalse($c->search('1', true));
-        $this->assertEquals(0, $c->search(false, true));
-        $this->assertEquals(1, $c->search(0, true));
-        $this->assertEquals(2, $c->search(1, true));
-        $this->assertEquals(3, $c->search([], true));
-        $this->assertEquals(4, $c->search('', true));
+        $this->assertSame(0, $c->search(false, true));
+        $this->assertSame(1, $c->search(0, true));
+        $this->assertSame(2, $c->search(1, true));
+        $this->assertSame(3, $c->search([], true));
+        $this->assertSame(4, $c->search('', true));
     }
 
     #[DataProvider('collectionClassProvider')]
@@ -4236,14 +4238,14 @@ class SupportCollectionTest extends TestCase
     {
         $c = new $collection([1, 2, 3, 4, 5, 2, 5, 'name' => 'taylor', 'framework' => 'laravel']);
 
-        $this->assertEquals(1, $c->before(2));
-        $this->assertEquals(1, $c->before('2'));
-        $this->assertEquals(5, $c->before('taylor'));
+        $this->assertSame(1, $c->before(2));
+        $this->assertSame(1, $c->before('2'));
+        $this->assertSame(5, $c->before('taylor'));
         $this->assertSame('taylor', $c->before('laravel'));
-        $this->assertEquals(4, $c->before(function ($value) {
+        $this->assertSame(4, $c->before(function ($value) {
             return $value > 4;
         }));
-        $this->assertEquals(5, $c->before(function ($value) {
+        $this->assertSame(5, $c->before(function ($value) {
             return ! is_numeric($value);
         }));
     }
@@ -4256,8 +4258,8 @@ class SupportCollectionTest extends TestCase
         $this->assertNull($c->before('1', true));
         $this->assertNull($c->before(false, true));
         $this->assertEquals(false, $c->before(0, true));
-        $this->assertEquals(0, $c->before(1, true));
-        $this->assertEquals(1, $c->before([], true));
+        $this->assertSame(0, $c->before(1, true));
+        $this->assertSame(1, $c->before([], true));
         $this->assertEquals([], $c->before('', true));
     }
 
@@ -4295,14 +4297,14 @@ class SupportCollectionTest extends TestCase
     {
         $c = new $collection([1, 2, 3, 4, 2, 5, 'name' => 'taylor', 'framework' => 'laravel']);
 
-        $this->assertEquals(2, $c->after(1));
-        $this->assertEquals(3, $c->after(2));
-        $this->assertEquals(4, $c->after(3));
-        $this->assertEquals(2, $c->after(4));
+        $this->assertSame(2, $c->after(1));
+        $this->assertSame(3, $c->after(2));
+        $this->assertSame(4, $c->after(3));
+        $this->assertSame(2, $c->after(4));
         $this->assertEquals('taylor', $c->after(5));
         $this->assertEquals('laravel', $c->after('taylor'));
 
-        $this->assertEquals(4, $c->after(function ($value) {
+        $this->assertSame(4, $c->after(function ($value) {
             return $value > 2;
         }));
         $this->assertEquals('laravel', $c->after(function ($value) {
@@ -4318,7 +4320,7 @@ class SupportCollectionTest extends TestCase
         $this->assertNull($c->after('false', true));
         $this->assertNull($c->after('1', true));
         $this->assertNull($c->after('', true));
-        $this->assertEquals(0, $c->after(false, true));
+        $this->assertSame(0, $c->after(false, true));
         $this->assertEquals([], $c->after(1, true));
         $this->assertEquals('', $c->after([], true));
     }
@@ -4543,18 +4545,18 @@ class SupportCollectionTest extends TestCase
     public function testGettingMaxItemsFromCollection($collection)
     {
         $c = new $collection([(object) ['foo' => 10], (object) ['foo' => 20]]);
-        $this->assertEquals(20, $c->max(function ($item) {
+        $this->assertSame(20, $c->max(function ($item) {
             return $item->foo;
         }));
-        $this->assertEquals(20, $c->max('foo'));
-        $this->assertEquals(20, $c->max->foo);
+        $this->assertSame(20, $c->max('foo'));
+        $this->assertSame(20, $c->max->foo);
 
         $c = new $collection([['foo' => 10], ['foo' => 20]]);
-        $this->assertEquals(20, $c->max('foo'));
-        $this->assertEquals(20, $c->max->foo);
+        $this->assertSame(20, $c->max('foo'));
+        $this->assertSame(20, $c->max->foo);
 
         $c = new $collection([1, 2, 3, 4, 5]);
-        $this->assertEquals(5, $c->max());
+        $this->assertSame(5, $c->max());
 
         $c = new $collection;
         $this->assertNull($c->max());
@@ -4564,28 +4566,28 @@ class SupportCollectionTest extends TestCase
     public function testGettingMinItemsFromCollection($collection)
     {
         $c = new $collection([(object) ['foo' => 10], (object) ['foo' => 20]]);
-        $this->assertEquals(10, $c->min(function ($item) {
+        $this->assertSame(10, $c->min(function ($item) {
             return $item->foo;
         }));
-        $this->assertEquals(10, $c->min('foo'));
-        $this->assertEquals(10, $c->min->foo);
+        $this->assertSame(10, $c->min('foo'));
+        $this->assertSame(10, $c->min->foo);
 
         $c = new $collection([['foo' => 10], ['foo' => 20]]);
-        $this->assertEquals(10, $c->min('foo'));
-        $this->assertEquals(10, $c->min->foo);
+        $this->assertSame(10, $c->min('foo'));
+        $this->assertSame(10, $c->min->foo);
 
         $c = new $collection([['foo' => 10], ['foo' => 20], ['foo' => null]]);
-        $this->assertEquals(10, $c->min('foo'));
-        $this->assertEquals(10, $c->min->foo);
+        $this->assertSame(10, $c->min('foo'));
+        $this->assertSame(10, $c->min->foo);
 
         $c = new $collection([1, 2, 3, 4, 5]);
-        $this->assertEquals(1, $c->min());
+        $this->assertSame(1, $c->min());
 
         $c = new $collection([1, null, 3, 4, 5]);
-        $this->assertEquals(1, $c->min());
+        $this->assertSame(1, $c->min());
 
         $c = new $collection([0, 1, 2, 3, 4]);
-        $this->assertEquals(0, $c->min());
+        $this->assertSame(0, $c->min());
 
         $c = new $collection;
         $this->assertNull($c->min());
@@ -4697,32 +4699,32 @@ class SupportCollectionTest extends TestCase
     public function testGettingAvgItemsFromCollection($collection)
     {
         $c = new $collection([(object) ['foo' => 10], (object) ['foo' => 20]]);
-        $this->assertEquals(15, $c->avg(function ($item) {
+        $this->assertSame(15, $c->avg(function ($item) {
             return $item->foo;
         }));
-        $this->assertEquals(15, $c->avg('foo'));
-        $this->assertEquals(15, $c->avg->foo);
+        $this->assertSame(15, $c->avg('foo'));
+        $this->assertSame(15, $c->avg->foo);
 
         $c = new $collection([(object) ['foo' => 10], (object) ['foo' => 20], (object) ['foo' => null]]);
-        $this->assertEquals(15, $c->avg(function ($item) {
+        $this->assertSame(15, $c->avg(function ($item) {
             return $item->foo;
         }));
-        $this->assertEquals(15, $c->avg('foo'));
-        $this->assertEquals(15, $c->avg->foo);
+        $this->assertSame(15, $c->avg('foo'));
+        $this->assertSame(15, $c->avg->foo);
 
         $c = new $collection([['foo' => 10], ['foo' => 20]]);
-        $this->assertEquals(15, $c->avg('foo'));
-        $this->assertEquals(15, $c->avg->foo);
+        $this->assertSame(15, $c->avg('foo'));
+        $this->assertSame(15, $c->avg->foo);
 
         $c = new $collection([1, 2, 3, 4, 5]);
-        $this->assertEquals(3, $c->avg());
+        $this->assertSame(3, $c->avg());
 
         $c = new $collection;
         $this->assertNull($c->avg());
 
         $c = new $collection([['foo' => '4'], ['foo' => '2']]);
         $this->assertIsInt($c->avg('foo'));
-        $this->assertEquals(3, $c->avg('foo'));
+        $this->assertSame(3, $c->avg('foo'));
 
         $c = new $collection([['foo' => 1], ['foo' => 2]]);
         $this->assertIsFloat($c->avg('foo'));
@@ -4732,10 +4734,10 @@ class SupportCollectionTest extends TestCase
             ['foo' => 1], ['foo' => 2],
             (object) ['foo' => 6],
         ]);
-        $this->assertEquals(3, $c->avg('foo'));
+        $this->assertSame(3, $c->avg('foo'));
 
         $c = new $collection([0]);
-        $this->assertEquals(0, $c->avg());
+        $this->assertSame(0, $c->avg());
     }
 
     #[DataProvider('collectionClassProvider')]
@@ -4889,7 +4891,7 @@ class SupportCollectionTest extends TestCase
     public function testReduce($collection)
     {
         $data = new $collection([1, 2, 3]);
-        $this->assertEquals(6, $data->reduce(function ($carry, $element) {
+        $this->assertSame(6, $data->reduce(function ($carry, $element) {
             return $carry += $element;
         }));
 
@@ -4915,8 +4917,8 @@ class SupportCollectionTest extends TestCase
             return [$sum, $max, $min];
         }, 0, PHP_INT_MIN, PHP_INT_MAX);
 
-        $this->assertEquals(14, $sum);
-        $this->assertEquals(5, $max);
+        $this->assertSame(14, $sum);
+        $this->assertSame(5, $max);
         $this->assertEquals(-1, $min);
     }
 
@@ -4946,7 +4948,7 @@ class SupportCollectionTest extends TestCase
     {
         $data = new $collection([1, 2, 3]);
 
-        $this->assertEquals(6, $data->pipe(function ($data) {
+        $this->assertSame(6, $data->pipe(function ($data) {
             return $data->sum();
         }));
     }
@@ -4977,7 +4979,7 @@ class SupportCollectionTest extends TestCase
             },
         ]);
 
-        $this->assertEquals(15, $result);
+        $this->assertSame(15, $result);
     }
 
     #[DataProvider('collectionClassProvider')]
@@ -4985,7 +4987,7 @@ class SupportCollectionTest extends TestCase
     {
         $data = new $collection([1, 2, 2, 4]);
 
-        $this->assertEquals(2, $data->median());
+        $this->assertSame(2, $data->median());
     }
 
     #[DataProvider('collectionClassProvider')]
@@ -4997,7 +4999,7 @@ class SupportCollectionTest extends TestCase
             (object) ['foo' => 2],
             (object) ['foo' => 4],
         ]);
-        $this->assertEquals(2, $data->median('foo'));
+        $this->assertSame(2, $data->median('foo'));
     }
 
     #[DataProvider('collectionClassProvider')]
@@ -5009,7 +5011,7 @@ class SupportCollectionTest extends TestCase
             (object) ['foo' => 4],
             (object) ['foo' => null],
         ]);
-        $this->assertEquals(2, $data->median('foo'));
+        $this->assertSame(2, $data->median('foo'));
     }
 
     #[DataProvider('collectionClassProvider')]
@@ -5030,7 +5032,7 @@ class SupportCollectionTest extends TestCase
             (object) ['foo' => 5],
             (object) ['foo' => 3],
         ]);
-        $this->assertEquals(3, $data->median('foo'));
+        $this->assertSame(3, $data->median('foo'));
     }
 
     #[DataProvider('collectionClassProvider')]

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1263,8 +1263,8 @@ class SupportCollectionTest extends TestCase
     {
         $c = new $collection([['id' => 1, 'name' => 'Hello'], ['id' => 2, 'name' => 'World']]);
 
-        $this->assertEquals('Hello', $c->value('name'));
-        $this->assertEquals('World', $c->where('id', 2)->value('name'));
+        $this->assertSame('Hello', $c->value('name'));
+        $this->assertSame('World', $c->where('id', 2)->value('name'));
 
         $c = new $collection([
             ['id' => 1, 'pivot' => ['value' => 'foo']],
@@ -1272,8 +1272,8 @@ class SupportCollectionTest extends TestCase
         ]);
 
         $this->assertEquals(['value' => 'foo'], $c->value('pivot'));
-        $this->assertEquals('foo', $c->value('pivot.value'));
-        $this->assertEquals('bar', $c->where('id', 2)->value('pivot.value'));
+        $this->assertSame('foo', $c->value('pivot.value'));
+        $this->assertSame('bar', $c->where('id', 2)->value('pivot.value'));
     }
 
     #[DataProvider('collectionClassProvider')]
@@ -1294,7 +1294,7 @@ class SupportCollectionTest extends TestCase
 
         $c = new $collection([['id' => 1, 'balance' => ''], ['id' => 2, 'balance' => 200]]);
 
-        $this->assertEquals('', $c->value('balance'));
+        $this->assertSame('', $c->value('balance'));
 
         $c = new $collection([['id' => 1, 'balance' => null], ['id' => 2, 'balance' => 200]]);
 
@@ -1318,7 +1318,7 @@ class SupportCollectionTest extends TestCase
             literal(id: 3, balance: 200),
         ]);
 
-        $this->assertEquals('', $c->value('balance'));
+        $this->assertSame('', $c->value('balance'));
 
         $c = new $collection([
             literal(id: 1),
@@ -4301,13 +4301,13 @@ class SupportCollectionTest extends TestCase
         $this->assertSame(3, $c->after(2));
         $this->assertSame(4, $c->after(3));
         $this->assertSame(2, $c->after(4));
-        $this->assertEquals('taylor', $c->after(5));
-        $this->assertEquals('laravel', $c->after('taylor'));
+        $this->assertSame('taylor', $c->after(5));
+        $this->assertSame('laravel', $c->after('taylor'));
 
         $this->assertSame(4, $c->after(function ($value) {
             return $value > 2;
         }));
-        $this->assertEquals('laravel', $c->after(function ($value) {
+        $this->assertSame('laravel', $c->after(function ($value) {
             return ! is_numeric($value);
         }));
     }
@@ -4322,7 +4322,7 @@ class SupportCollectionTest extends TestCase
         $this->assertNull($c->after('', true));
         $this->assertSame(0, $c->after(false, true));
         $this->assertSame([], $c->after(1, true));
-        $this->assertEquals('', $c->after([], true));
+        $this->assertSame('', $c->after([], true));
     }
 
     #[DataProvider('collectionClassProvider')]
@@ -5774,7 +5774,7 @@ class SupportCollectionTest extends TestCase
     public function testGetWithDefaultValue($collection)
     {
         $data = new $collection(['name' => 'taylor', 'framework' => 'laravel']);
-        $this->assertEquals('34', $data->get('age', 34));
+        $this->assertSame('34', (string) $data->get('age', 34));
     }
 
     #[DataProvider('collectionClassProvider')]
@@ -5784,7 +5784,7 @@ class SupportCollectionTest extends TestCase
         $result = $data->get('email', function () {
             return 'taylor@example.com';
         });
-        $this->assertEquals('taylor@example.com', $result);
+        $this->assertSame('taylor@example.com', $result);
     }
 
     #[DataProvider('collectionClassProvider')]

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1187,7 +1187,7 @@ class SupportCollectionTest extends TestCase
         ]);
         $this->assertEquals([['v' => 2, 'g' => 3]], $c->where('v', 2)->where('g', 3)->values()->all());
         $this->assertEquals([['v' => 2, 'g' => 3]], $c->where('v', 2)->where('g', '>', 2)->values()->all());
-        $this->assertEquals([], $c->where('v', 2)->where('g', 4)->values()->all());
+        $this->assertSame([], $c->where('v', 2)->where('g', 4)->values()->all());
         $this->assertEquals([['v' => 2, 'g' => null]], $c->where('v', 2)->whereNull('g')->values()->all());
     }
 
@@ -1216,7 +1216,7 @@ class SupportCollectionTest extends TestCase
     {
         $c = new $collection([['v' => 1], ['v' => 2], ['v' => 3], ['v' => '3'], ['v' => 4]]);
         $this->assertEquals([['v' => 1], ['v' => 3], ['v' => '3']], $c->whereIn('v', [1, 3])->values()->all());
-        $this->assertEquals([], $c->whereIn('v', [2])->whereIn('v', [1, 3])->values()->all());
+        $this->assertSame([], $c->whereIn('v', [2])->whereIn('v', [1, 3])->values()->all());
         $this->assertEquals([['v' => 1]], $c->whereIn('v', [1])->whereIn('v', [1, 3])->values()->all());
     }
 
@@ -1463,8 +1463,8 @@ class SupportCollectionTest extends TestCase
     {
         $c = new $collection(['Hello', 1, ['tags' => ['a', 'b'], 'admin']]);
 
-        $this->assertEquals([], $c->multiply(-1)->all());
-        $this->assertEquals([], $c->multiply(0)->all());
+        $this->assertSame([], $c->multiply(-1)->all());
+        $this->assertSame([], $c->multiply(0)->all());
 
         $this->assertEquals(
             ['Hello', 1, ['tags' => ['a', 'b'], 'admin']],
@@ -1757,7 +1757,7 @@ class SupportCollectionTest extends TestCase
     public function testIntersectNull($collection)
     {
         $c = new $collection(['id' => 1, 'first_word' => 'Hello']);
-        $this->assertEquals([], $c->intersect(null)->all());
+        $this->assertSame([], $c->intersect(null)->all());
     }
 
     #[DataProvider('collectionClassProvider')]
@@ -1772,7 +1772,7 @@ class SupportCollectionTest extends TestCase
     {
         $collect = new $collection(['green', 'brown', 'blue']);
 
-        $this->assertEquals([], $collect->intersectUsing(null, 'strcasecmp')->all());
+        $this->assertSame([], $collect->intersectUsing(null, 'strcasecmp')->all());
     }
 
     #[DataProvider('collectionClassProvider')]
@@ -1788,7 +1788,7 @@ class SupportCollectionTest extends TestCase
     {
         $array1 = new $collection(['a' => 'green', 'b' => 'brown', 'c' => 'blue', 'red']);
 
-        $this->assertEquals([], $array1->intersectAssoc(null)->all());
+        $this->assertSame([], $array1->intersectAssoc(null)->all());
     }
 
     #[DataProvider('collectionClassProvider')]
@@ -1805,7 +1805,7 @@ class SupportCollectionTest extends TestCase
     {
         $array1 = new $collection(['a' => 'green', 'b' => 'brown', 'c' => 'blue', 'red']);
 
-        $this->assertEquals([], $array1->intersectAssocUsing(null, 'strcasecmp')->all());
+        $this->assertSame([], $array1->intersectAssocUsing(null, 'strcasecmp')->all());
     }
 
     #[DataProvider('collectionClassProvider')]
@@ -1821,7 +1821,7 @@ class SupportCollectionTest extends TestCase
     public function testIntersectByKeysNull($collection)
     {
         $c = new $collection(['name' => 'Mateus', 'age' => 18]);
-        $this->assertEquals([], $c->intersectByKeys(null)->all());
+        $this->assertSame([], $c->intersectByKeys(null)->all());
     }
 
     #[DataProvider('collectionClassProvider')]
@@ -1920,7 +1920,7 @@ class SupportCollectionTest extends TestCase
 
         // Case with empty two-dimensional arrays
         $data = new $collection([[], [], []]);
-        $this->assertEquals([], $data->collapse()->all());
+        $this->assertSame([], $data->collapse()->all());
 
         // Case with both empty arrays and arrays with elements
         $data = new $collection([[], [1, 2], [], ['foo', 'bar']]);
@@ -1947,7 +1947,7 @@ class SupportCollectionTest extends TestCase
 
         // Case with an already flat collection
         $data = new $collection(['a', 'b', 'c']);
-        $this->assertEquals([], $data->collapseWithKeys()->all());
+        $this->assertSame([], $data->collapseWithKeys()->all());
     }
 
     #[DataProvider('collectionClassProvider')]
@@ -2888,10 +2888,10 @@ class SupportCollectionTest extends TestCase
     public function testMakeMethodFromNull($collection)
     {
         $data = $collection::make(null);
-        $this->assertEquals([], $data->all());
+        $this->assertSame([], $data->all());
 
         $data = $collection::make();
-        $this->assertEquals([], $data->all());
+        $this->assertSame([], $data->all());
     }
 
     #[DataProvider('collectionClassProvider')]
@@ -3092,10 +3092,10 @@ class SupportCollectionTest extends TestCase
     public function testConstructMethodFromNull($collection)
     {
         $data = new $collection(null);
-        $this->assertEquals([], $data->all());
+        $this->assertSame([], $data->all());
 
         $data = new $collection;
-        $this->assertEquals([], $data->all());
+        $this->assertSame([], $data->all());
     }
 
     #[DataProvider('collectionClassProvider')]
@@ -4103,7 +4103,7 @@ class SupportCollectionTest extends TestCase
         $c->pull(0);
         $this->assertEquals([1 => 'bar'], $c->all());
         $c->pull(1);
-        $this->assertEquals([], $c->all());
+        $this->assertSame([], $c->all());
     }
 
     public function testPullRemovesItemFromNestedCollection()
@@ -4260,7 +4260,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(false, $c->before(0, true));
         $this->assertSame(0, $c->before(1, true));
         $this->assertSame(1, $c->before([], true));
-        $this->assertEquals([], $c->before('', true));
+        $this->assertSame([], $c->before('', true));
     }
 
     #[DataProvider('collectionClassProvider')]
@@ -4321,7 +4321,7 @@ class SupportCollectionTest extends TestCase
         $this->assertNull($c->after('1', true));
         $this->assertNull($c->after('', true));
         $this->assertSame(0, $c->after(false, true));
-        $this->assertEquals([], $c->after(1, true));
+        $this->assertSame([], $c->after(1, true));
         $this->assertEquals('', $c->after([], true));
     }
 
@@ -4371,7 +4371,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['one', 'two'], $c->forPage(0, 2)->all());
         $this->assertEquals(['one', 'two'], $c->forPage(1, 2)->all());
         $this->assertEquals([2 => 'three', 3 => 'four'], $c->forPage(2, 2)->all());
-        $this->assertEquals([], $c->forPage(3, 2)->all());
+        $this->assertSame([], $c->forPage(3, 2)->all());
     }
 
     #[IgnoreDeprecations]

--- a/tests/Support/SupportFluentTest.php
+++ b/tests/Support/SupportFluentTest.php
@@ -82,7 +82,7 @@ class SupportFluentTest extends TestCase
         $fluent = new Fluent(['attributes' => '1']);
 
         $this->assertTrue(isset($fluent['attributes']));
-        $this->assertEquals(1, $fluent['attributes']);
+        $this->assertSame(1, (int) $fluent['attributes']);
 
         $fluent->attributes();
 
@@ -99,7 +99,7 @@ class SupportFluentTest extends TestCase
 
         $this->assertSame('Taylor', $fluent->name);
         $this->assertTrue($fluent->developer);
-        $this->assertEquals(25, $fluent->age);
+        $this->assertSame(25, $fluent->age);
         $this->assertInstanceOf(Fluent::class, $fluent->programmer());
     }
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -340,8 +340,8 @@ class SupportHelpersTest extends TestCase
 
         $this->assertEquals(['taylor', 'abigail', 'abigail', 'dayle', 'dayle', 'taylor'], data_get($array, 'posts.*.comments.*.author'));
         $this->assertEquals([4, 3, 2, null, null, 1], data_get($array, 'posts.*.comments.*.likes'));
-        $this->assertEquals([], data_get($array, 'posts.*.users.*.name', 'irrelevant'));
-        $this->assertEquals([], data_get($array, 'posts.*.users.*.name'));
+        $this->assertSame([], data_get($array, 'posts.*.users.*.name', 'irrelevant'));
+        $this->assertSame([], data_get($array, 'posts.*.users.*.name'));
     }
 
     public function testDataGetFirstLastDirectives()

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -57,7 +57,7 @@ class SupportHelpersTest extends TestCase
     public function testEWithInvalidCodePoints()
     {
         $str = mb_convert_encoding('føø bar', 'ISO-8859-1', 'UTF-8');
-        $this->assertEquals('f�� bar', e($str));
+        $this->assertSame('f�� bar', e($str));
     }
 
     public function testEWithEnums()
@@ -127,26 +127,26 @@ class SupportHelpersTest extends TestCase
 
     public function testWhen()
     {
-        $this->assertEquals('Hello', when(true, 'Hello'));
+        $this->assertSame('Hello', when(true, 'Hello'));
         $this->assertNull(when(false, 'Hello'));
-        $this->assertEquals('There', when(1 === 1, 'There')); // strict types
-        $this->assertEquals('There', when(1 == '1', 'There')); // loose types
+        $this->assertSame('There', when(1 === 1, 'There')); // strict types
+        $this->assertSame('There', when(1 == '1', 'There')); // loose types
         $this->assertNull(when(1 == 2, 'There'));
         $this->assertNull(when('1', fn () => null));
         $this->assertNull(when(0, fn () => null));
-        $this->assertEquals('True', when([1, 2, 3, 4], 'True')); // Array
+        $this->assertSame('True', when([1, 2, 3, 4], 'True')); // Array
         $this->assertNull(when([], 'True')); // Empty Array = Falsy
-        $this->assertEquals('True', when(new StdClass, fn () => 'True')); // Object
-        $this->assertEquals('World', when(false, 'Hello', 'World'));
-        $this->assertEquals('World', when(1 === 0, 'Hello', 'World')); // strict types
-        $this->assertEquals('World', when(1 == '0', 'Hello', 'World')); // loose types
+        $this->assertSame('True', when(new StdClass, fn () => 'True')); // Object
+        $this->assertSame('World', when(false, 'Hello', 'World'));
+        $this->assertSame('World', when(1 === 0, 'Hello', 'World')); // strict types
+        $this->assertSame('World', when(1 == '0', 'Hello', 'World')); // loose types
         $this->assertNull(when('', fn () => 'There', fn () => null));
         $this->assertNull(when(0, fn () => 'There', fn () => null));
-        $this->assertEquals('False', when([], 'True', 'False'));  // Empty Array = Falsy
+        $this->assertSame('False', when([], 'True', 'False'));  // Empty Array = Falsy
         $this->assertTrue(when(true, fn ($value) => $value, fn ($value) => ! $value)); // lazy evaluation
         $this->assertTrue(when(false, fn ($value) => $value, fn ($value) => ! $value)); // lazy evaluation
-        $this->assertEquals('Hello', when(fn () => true, 'Hello')); // lazy evaluation condition
-        $this->assertEquals('World', when(fn () => false, 'Hello', 'World')); // lazy evaluation condition
+        $this->assertSame('Hello', when(fn () => true, 'Hello')); // lazy evaluation condition
+        $this->assertSame('World', when(fn () => false, 'Hello', 'World')); // lazy evaluation condition
     }
 
     public function testFilled()
@@ -364,13 +364,13 @@ class SupportHelpersTest extends TestCase
             'empty' => [],
         ];
 
-        $this->assertEquals('LHR', data_get($array, 'flights.0.segments.{first}.from'));
-        $this->assertEquals('PKX', data_get($array, 'flights.0.segments.{last}.to'));
+        $this->assertSame('LHR', data_get($array, 'flights.0.segments.{first}.from'));
+        $this->assertSame('PKX', data_get($array, 'flights.0.segments.{last}.to'));
 
-        $this->assertEquals('LHR', data_get($array, 'flights.{first}.segments.{first}.from'));
-        $this->assertEquals('PEK', data_get($array, 'flights.{last}.segments.{last}.to'));
-        $this->assertEquals('PKX', data_get($array, 'flights.{first}.segments.{last}.to'));
-        $this->assertEquals('LGW', data_get($array, 'flights.{last}.segments.{first}.from'));
+        $this->assertSame('LHR', data_get($array, 'flights.{first}.segments.{first}.from'));
+        $this->assertSame('PEK', data_get($array, 'flights.{last}.segments.{last}.to'));
+        $this->assertSame('PKX', data_get($array, 'flights.{first}.segments.{last}.to'));
+        $this->assertSame('LGW', data_get($array, 'flights.{last}.segments.{first}.from'));
 
         $this->assertEquals(['LHR', 'IST'], data_get($array, 'flights.{first}.segments.*.from'));
         $this->assertEquals(['SAW', 'PEK'], data_get($array, 'flights.{last}.segments.*.to'));
@@ -378,8 +378,8 @@ class SupportHelpersTest extends TestCase
         $this->assertEquals(['LHR', 'LGW'], data_get($array, 'flights.*.segments.{first}.from'));
         $this->assertEquals(['PKX', 'PEK'], data_get($array, 'flights.*.segments.{last}.to'));
 
-        $this->assertEquals('Not found', data_get($array, 'empty.{first}', 'Not found'));
-        $this->assertEquals('Not found', data_get($array, 'empty.{last}', 'Not found'));
+        $this->assertSame('Not found', data_get($array, 'empty.{first}', 'Not found'));
+        $this->assertSame('Not found', data_get($array, 'empty.{last}', 'Not found'));
     }
 
     public function testDataGetFirstLastDirectivesOnArrayAccessIterable()
@@ -402,13 +402,13 @@ class SupportHelpersTest extends TestCase
             'empty' => new SupportTestArrayAccessIterable([]),
         ];
 
-        $this->assertEquals('LHR', data_get($arrayAccessIterable, 'flights.0.segments.{first}.from'));
-        $this->assertEquals('PKX', data_get($arrayAccessIterable, 'flights.0.segments.{last}.to'));
+        $this->assertSame('LHR', data_get($arrayAccessIterable, 'flights.0.segments.{first}.from'));
+        $this->assertSame('PKX', data_get($arrayAccessIterable, 'flights.0.segments.{last}.to'));
 
-        $this->assertEquals('LHR', data_get($arrayAccessIterable, 'flights.{first}.segments.{first}.from'));
-        $this->assertEquals('PEK', data_get($arrayAccessIterable, 'flights.{last}.segments.{last}.to'));
-        $this->assertEquals('PKX', data_get($arrayAccessIterable, 'flights.{first}.segments.{last}.to'));
-        $this->assertEquals('LGW', data_get($arrayAccessIterable, 'flights.{last}.segments.{first}.from'));
+        $this->assertSame('LHR', data_get($arrayAccessIterable, 'flights.{first}.segments.{first}.from'));
+        $this->assertSame('PEK', data_get($arrayAccessIterable, 'flights.{last}.segments.{last}.to'));
+        $this->assertSame('PKX', data_get($arrayAccessIterable, 'flights.{first}.segments.{last}.to'));
+        $this->assertSame('LGW', data_get($arrayAccessIterable, 'flights.{last}.segments.{first}.from'));
 
         $this->assertEquals(['LHR', 'IST'], data_get($arrayAccessIterable, 'flights.{first}.segments.*.from'));
         $this->assertEquals(['SAW', 'PEK'], data_get($arrayAccessIterable, 'flights.{last}.segments.*.to'));
@@ -416,8 +416,8 @@ class SupportHelpersTest extends TestCase
         $this->assertEquals(['LHR', 'LGW'], data_get($arrayAccessIterable, 'flights.*.segments.{first}.from'));
         $this->assertEquals(['PKX', 'PEK'], data_get($arrayAccessIterable, 'flights.*.segments.{last}.to'));
 
-        $this->assertEquals('Not found', data_get($arrayAccessIterable, 'empty.{first}', 'Not found'));
-        $this->assertEquals('Not found', data_get($arrayAccessIterable, 'empty.{last}', 'Not found'));
+        $this->assertSame('Not found', data_get($arrayAccessIterable, 'empty.{first}', 'Not found'));
+        $this->assertSame('Not found', data_get($arrayAccessIterable, 'empty.{last}', 'Not found'));
     }
 
     public function testDataGetFirstLastDirectivesOnKeyedArrays()
@@ -435,11 +435,11 @@ class SupportHelpersTest extends TestCase
             ],
         ];
 
-        $this->assertEquals('second', data_get($array, 'numericKeys.0'));
-        $this->assertEquals('first', data_get($array, 'numericKeys.{first}'));
-        $this->assertEquals('last', data_get($array, 'numericKeys.{last}'));
-        $this->assertEquals('first', data_get($array, 'stringKeys.{first}'));
-        $this->assertEquals('last', data_get($array, 'stringKeys.{last}'));
+        $this->assertSame('second', data_get($array, 'numericKeys.0'));
+        $this->assertSame('first', data_get($array, 'numericKeys.{first}'));
+        $this->assertSame('last', data_get($array, 'numericKeys.{last}'));
+        $this->assertSame('first', data_get($array, 'stringKeys.{first}'));
+        $this->assertSame('last', data_get($array, 'stringKeys.{last}'));
     }
 
     public function testDataGetEscapedSegmentKeys()
@@ -452,12 +452,12 @@ class SupportHelpersTest extends TestCase
             ],
         ];
 
-        $this->assertEquals('caret', data_get($array, 'symbols.\{first}.description'));
-        $this->assertEquals('dollar', data_get($array, 'symbols.{first}.description'));
-        $this->assertEquals('asterisk', data_get($array, 'symbols.\*.description'));
+        $this->assertSame('caret', data_get($array, 'symbols.\{first}.description'));
+        $this->assertSame('dollar', data_get($array, 'symbols.{first}.description'));
+        $this->assertSame('asterisk', data_get($array, 'symbols.\*.description'));
         $this->assertEquals(['dollar', 'asterisk', 'caret'], data_get($array, 'symbols.*.description'));
-        $this->assertEquals('dollar', data_get($array, 'symbols.\{last}.description'));
-        $this->assertEquals('caret', data_get($array, 'symbols.{last}.description'));
+        $this->assertSame('dollar', data_get($array, 'symbols.\{last}.description'));
+        $this->assertSame('caret', data_get($array, 'symbols.{last}.description'));
     }
 
     public function testDataGetStar()
@@ -1557,7 +1557,7 @@ class SupportHelpersTest extends TestCase
     public function testLiteral(): void
     {
         $this->assertSame(1, literal(1));
-        $this->assertEquals('taylor', literal('taylor'));
+        $this->assertSame('taylor', literal('taylor'));
         $this->assertEquals((object) ['name' => 'Taylor', 'role' => 'Developer'], literal(name: 'Taylor', role: 'Developer'));
     }
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -270,7 +270,7 @@ class SupportHelpersTest extends TestCase
         $this->assertSame('Taylor', data_get($dottedArray, ['users', 'first.name']));
         $this->assertNull(data_get($dottedArray, ['users', 'middle.name']));
         $this->assertSame('Not found', data_get($dottedArray, ['users', 'last.name'], 'Not found'));
-        $this->assertEquals(56, data_get($arrayAccess, 'price'));
+        $this->assertSame(56, data_get($arrayAccess, 'price'));
         $this->assertSame('John', data_get($arrayAccess, 'user.name'));
         $this->assertSame('void', data_get($arrayAccess, 'foo', 'void'));
         $this->assertSame('void', data_get($arrayAccess, 'user.foo', 'void'));
@@ -828,7 +828,7 @@ class SupportHelpersTest extends TestCase
     public function testTap()
     {
         $object = (object) ['id' => 1];
-        $this->assertEquals(2, tap($object, function ($object) {
+        $this->assertSame(2, tap($object, function ($object) {
             $object->id = 2;
         })->id);
 
@@ -938,7 +938,7 @@ class SupportHelpersTest extends TestCase
     {
         $this->assertNull(optional(null)->something());
 
-        $this->assertEquals(10, optional(new class
+        $this->assertSame(10, optional(new class
         {
             public function something()
             {
@@ -955,7 +955,7 @@ class SupportHelpersTest extends TestCase
             );
         }));
 
-        $this->assertEquals(10, optional(5, function ($number) {
+        $this->assertSame(10, optional(5, function ($number) {
             return $number * 2;
         }));
     }
@@ -1045,7 +1045,7 @@ class SupportHelpersTest extends TestCase
         }, 100);
 
         // Make sure we made two attempts
-        $this->assertEquals(2, $attempts);
+        $this->assertSame(2, $attempts);
 
         // Make sure we waited 100ms for the first attempt
         Sleep::assertSleptTimes(1);
@@ -1068,7 +1068,7 @@ class SupportHelpersTest extends TestCase
         }, CarbonInterval::milliseconds(100));
 
         // Make sure we made two attempts
-        $this->assertEquals(2, $attempts);
+        $this->assertSame(2, $attempts);
 
         // Make sure we waited 100ms for the first attempt
         Sleep::assertSleptTimes(1);
@@ -1095,7 +1095,7 @@ class SupportHelpersTest extends TestCase
         });
 
         // Make sure we made three attempts
-        $this->assertEquals(3, $attempts);
+        $this->assertSame(3, $attempts);
 
         // Make sure we waited 300ms for the first two attempts
         Sleep::assertSleptTimes(2);
@@ -1121,7 +1121,7 @@ class SupportHelpersTest extends TestCase
         });
 
         // Make sure we made two attempts
-        $this->assertEquals(2, $attempts);
+        $this->assertSame(2, $attempts);
 
         // Make sure we waited 100ms for the first attempt
         Sleep::assertSleptTimes(1);
@@ -1159,7 +1159,7 @@ class SupportHelpersTest extends TestCase
         });
 
         // Make sure we made four attempts
-        $this->assertEquals(4, $attempts);
+        $this->assertSame(4, $attempts);
 
         Sleep::assertSleptTimes(3);
 
@@ -1183,7 +1183,7 @@ class SupportHelpersTest extends TestCase
         }, 100);
 
         // Make sure we made two attempts
-        $this->assertEquals(2, $attempts);
+        $this->assertSame(2, $attempts);
 
         // Make sure we waited 100ms for the first attempt
         Sleep::assertSleptTimes(1);
@@ -1195,7 +1195,7 @@ class SupportHelpersTest extends TestCase
 
     public function testTransform()
     {
-        $this->assertEquals(10, transform(5, function ($value) {
+        $this->assertSame(10, transform(5, function ($value) {
             return $value * 2;
         }));
 
@@ -1219,9 +1219,9 @@ class SupportHelpersTest extends TestCase
 
     public function testWith()
     {
-        $this->assertEquals(10, with(10));
+        $this->assertSame(10, with(10));
 
-        $this->assertEquals(10, with(5, function ($five) {
+        $this->assertSame(10, with(5, function ($five) {
             return $five + 5;
         }));
     }
@@ -1556,7 +1556,7 @@ class SupportHelpersTest extends TestCase
 
     public function testLiteral(): void
     {
-        $this->assertEquals(1, literal(1));
+        $this->assertSame(1, literal(1));
         $this->assertEquals('taylor', literal('taylor'));
         $this->assertEquals((object) ['name' => 'Taylor', 'role' => 'Developer'], literal(name: 'Taylor', role: 'Developer'));
     }

--- a/tests/Support/SupportHtmlStringTest.php
+++ b/tests/Support/SupportHtmlStringTest.php
@@ -26,7 +26,7 @@ class SupportHtmlStringTest extends TestCase
 
         // Check if HtmlString correctly handles an empty string
         $emptyHtml = new HtmlString('');
-        $this->assertEquals('', $emptyHtml->toHtml());
+        $this->assertSame('', $emptyHtml->toHtml());
 
         // Check if HtmlString correctly converts a plain text string
         $str = 'foo bar';

--- a/tests/Support/SupportJsTest.php
+++ b/tests/Support/SupportJsTest.php
@@ -24,7 +24,7 @@ class SupportJsTest extends TestCase
         $this->assertSame('null', (string) Js::from(null));
         $this->assertSame("'Hello world'", (string) Js::from('Hello world'));
         $this->assertSame("'Hèlló world'", (string) Js::from('Hèlló world'));
-        $this->assertEquals(
+        $this->assertSame(
             "'\\u003Cdiv class=\\u0022foo\\u0022\\u003E\\u0027quoted html\\u0027\\u003C\\/div\\u003E'",
             (string) Js::from('<div class="foo">\'quoted html\'</div>')
         );
@@ -32,12 +32,12 @@ class SupportJsTest extends TestCase
 
     public function testArrays()
     {
-        $this->assertEquals(
+        $this->assertSame(
             "JSON.parse('[\\u0022hello\\u0022,\\u0022world\\u0022]')",
             (string) Js::from(['hello', 'world'])
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             "JSON.parse('{\\u0022foo\\u0022:\\u0022hello\\u0022,\\u0022bar\\u0022:\\u0022world\\u0022}')",
             (string) Js::from(['foo' => 'hello', 'bar' => 'world'])
         );
@@ -45,7 +45,7 @@ class SupportJsTest extends TestCase
 
     public function testObjects()
     {
-        $this->assertEquals(
+        $this->assertSame(
             "JSON.parse('{\\u0022foo\\u0022:\\u0022hello\\u0022,\\u0022bar\\u0022:\\u0022world\\u0022}')",
             (string) Js::from((object) ['foo' => 'hello', 'bar' => 'world'])
         );
@@ -72,7 +72,7 @@ class SupportJsTest extends TestCase
             }
         };
 
-        $this->assertEquals(
+        $this->assertSame(
             "JSON.parse('{\\u0022foo\\u0022:\\u0022hello\\u0022,\\u0022bar\\u0022:\\u0022world\\u0022}')",
             (string) Js::from($data)
         );
@@ -104,7 +104,7 @@ class SupportJsTest extends TestCase
             }
         };
 
-        $this->assertEquals(
+        $this->assertSame(
             "JSON.parse('{\\u0022foo\\u0022:\\u0022hello\\u0022,\\u0022bar\\u0022:\\u0022world\\u0022}')",
             (string) Js::from($data)
         );
@@ -124,7 +124,7 @@ class SupportJsTest extends TestCase
             }
         };
 
-        $this->assertEquals(
+        $this->assertSame(
             "JSON.parse('{\\u0022foo\\u0022:\\u0022hello\\u0022,\\u0022bar\\u0022:\\u0022world\\u0022}')",
             (string) Js::from($data)
         );
@@ -140,7 +140,7 @@ class SupportJsTest extends TestCase
             }
         };
 
-        $this->assertEquals("'\u003Cp\u003EHello, World!\u003C\/p\u003E'", (string) Js::from($data));
+        $this->assertSame("'\u003Cp\u003EHello, World!\u003C\/p\u003E'", (string) Js::from($data));
 
         $data = new class implements Htmlable, Arrayable
         {
@@ -155,7 +155,7 @@ class SupportJsTest extends TestCase
             }
         };
 
-        $this->assertEquals(
+        $this->assertSame(
             "JSON.parse('{\\u0022foo\\u0022:\\u0022hello\\u0022,\\u0022bar\\u0022:\\u0022world\\u0022}')",
             (string) Js::from($data)
         );
@@ -173,7 +173,7 @@ class SupportJsTest extends TestCase
             }
         };
 
-        $this->assertEquals(
+        $this->assertSame(
             "JSON.parse('{\\u0022foo\\u0022:\\u0022hello\\u0022,\\u0022bar\\u0022:\\u0022world\\u0022}')",
             (string) Js::from($data)
         );
@@ -191,7 +191,7 @@ class SupportJsTest extends TestCase
             }
         };
 
-        $this->assertEquals(
+        $this->assertSame(
             "JSON.parse('{\\u0022foo\\u0022:\\u0022hello\\u0022,\\u0022bar\\u0022:\\u0022world\\u0022}')",
             (string) Js::from($data)
         );

--- a/tests/Support/SupportLazyCollectionIsLazyTest.php
+++ b/tests/Support/SupportLazyCollectionIsLazyTest.php
@@ -22,7 +22,7 @@ class SupportLazyCollectionIsLazyTest extends TestCase
 
         LazyCollection::make($closure);
 
-        $this->assertEquals([], $recorder->all());
+        $this->assertSame([], $recorder->all());
     }
 
     public function testMakeWithLazyCollectionIsLazy()

--- a/tests/Support/SupportLazyCollectionTest.php
+++ b/tests/Support/SupportLazyCollectionTest.php
@@ -132,38 +132,38 @@ class SupportLazyCollectionTest extends TestCase
         $a = $collection->getIterator();
         $b = $collection->getIterator();
 
-        $this->assertEquals(1, $a->current());
-        $this->assertEquals(1, $b->current());
+        $this->assertSame(1, $a->current());
+        $this->assertSame(1, $b->current());
 
         $b->next();
 
-        $this->assertEquals(1, $a->current());
-        $this->assertEquals(2, $b->current());
+        $this->assertSame(1, $a->current());
+        $this->assertSame(2, $b->current());
 
         $b->next();
 
-        $this->assertEquals(1, $a->current());
-        $this->assertEquals(3, $b->current());
+        $this->assertSame(1, $a->current());
+        $this->assertSame(3, $b->current());
 
         $a->next();
 
-        $this->assertEquals(2, $a->current());
-        $this->assertEquals(3, $b->current());
+        $this->assertSame(2, $a->current());
+        $this->assertSame(3, $b->current());
 
         $a->next();
 
-        $this->assertEquals(3, $a->current());
-        $this->assertEquals(3, $b->current());
+        $this->assertSame(3, $a->current());
+        $this->assertSame(3, $b->current());
 
         $a->next();
 
-        $this->assertEquals(4, $a->current());
-        $this->assertEquals(3, $b->current());
+        $this->assertSame(4, $a->current());
+        $this->assertSame(3, $b->current());
 
         $b->next();
 
-        $this->assertEquals(4, $a->current());
-        $this->assertEquals(4, $b->current());
+        $this->assertSame(4, $a->current());
+        $this->assertSame(4, $b->current());
     }
 
     public function testRememberWithDuplicateKeys()

--- a/tests/Support/SupportMailTest.php
+++ b/tests/Support/SupportMailTest.php
@@ -15,7 +15,7 @@ class SupportMailTest extends TestCase
             : 'it failed.',
         );
 
-        $this->assertEquals('it works!', Mail::test('foo'));
+        $this->assertSame('it works!', Mail::test('foo'));
     }
 
     public function testItRegisterAndCallMacrosWhenFaked()
@@ -27,7 +27,7 @@ class SupportMailTest extends TestCase
 
         Mail::fake();
 
-        $this->assertEquals('it works!', Mail::test('foo'));
+        $this->assertSame('it works!', Mail::test('foo'));
     }
 
     public function testEmailSent()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -811,8 +811,8 @@ class SupportStrTest extends TestCase
 
     public function testLength()
     {
-        $this->assertEquals(11, Str::length('foo bar baz'));
-        $this->assertEquals(11, Str::length('foo bar baz', 'UTF-8'));
+        $this->assertSame(11, Str::length('foo bar baz'));
+        $this->assertSame(11, Str::length('foo bar baz', 'UTF-8'));
     }
 
     public function testNumbers()
@@ -828,7 +828,7 @@ class SupportStrTest extends TestCase
 
     public function testRandom()
     {
-        $this->assertEquals(16, strlen(Str::random()));
+        $this->assertSame(16, strlen(Str::random()));
         $randomInteger = random_int(1, 100);
         $this->assertEquals($randomInteger, strlen(Str::random($randomInteger)));
         $this->assertIsString(Str::random());
@@ -1422,8 +1422,8 @@ class SupportStrTest extends TestCase
 
     public function testWordCount()
     {
-        $this->assertEquals(2, Str::wordCount('Hello, world!'));
-        $this->assertEquals(10, Str::wordCount('Hi, this is my first contribution to the Laravel framework.'));
+        $this->assertSame(2, Str::wordCount('Hello, world!'));
+        $this->assertSame(10, Str::wordCount('Hi, this is my first contribution to the Laravel framework.'));
 
         // str_word_count() without $characters does not reliably handle multibyte
         // strings — results depend on the system locale's isalpha() behavior
@@ -1431,11 +1431,11 @@ class SupportStrTest extends TestCase
         $this->assertEquals(str_word_count('мама'), Str::wordCount('мама'));
         $this->assertEquals(str_word_count('мама мыла раму'), Str::wordCount('мама мыла раму'));
 
-        $this->assertEquals(1, Str::wordCount('мама', 'абвгдеёжзийклмнопрстуфхцчшщъыьэюяАБВГДЕЁЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯ'));
-        $this->assertEquals(3, Str::wordCount('мама мыла раму', 'абвгдеёжзийклмнопрстуфхцчшщъыьэюяАБВГДЕЁЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯ'));
+        $this->assertSame(1, Str::wordCount('мама', 'абвгдеёжзийклмнопрстуфхцчшщъыьэюяАБВГДЕЁЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯ'));
+        $this->assertSame(3, Str::wordCount('мама мыла раму', 'абвгдеёжзийклмнопрстуфхцчшщъыьэюяАБВГДЕЁЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯ'));
 
-        $this->assertEquals(1, Str::wordCount('МАМА', 'абвгдеёжзийклмнопрстуфхцчшщъыьэюяАБВГДЕЁЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯ'));
-        $this->assertEquals(3, Str::wordCount('МАМА МЫЛА РАМУ', 'абвгдеёжзийклмнопрстуфхцчшщъыьэюяАБВГДЕЁЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯ'));
+        $this->assertSame(1, Str::wordCount('МАМА', 'абвгдеёжзийклмнопрстуфхцчшщъыьэюяАБВГДЕЁЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯ'));
+        $this->assertSame(3, Str::wordCount('МАМА МЫЛА РАМУ', 'абвгдеёжзийклмнопрстуфхцчшщъыьэюяАБВГДЕЁЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯ'));
     }
 
     public function testWordWrap()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -573,8 +573,8 @@ class SupportStrTest extends TestCase
 
     public function testWrap()
     {
-        $this->assertEquals('"value"', Str::wrap('value', '"'));
-        $this->assertEquals('foo-bar-baz', Str::wrap('-bar-', 'foo', 'baz'));
+        $this->assertSame('"value"', Str::wrap('value', '"'));
+        $this->assertSame('foo-bar-baz', Str::wrap('-bar-', 'foo', 'baz'));
     }
 
     public function testWrapEdgeCases()
@@ -590,11 +590,11 @@ class SupportStrTest extends TestCase
 
     public function testUnwrap()
     {
-        $this->assertEquals('value', Str::unwrap('"value"', '"'));
-        $this->assertEquals('value', Str::unwrap('"value', '"'));
-        $this->assertEquals('value', Str::unwrap('value"', '"'));
-        $this->assertEquals('bar', Str::unwrap('foo-bar-baz', 'foo-', '-baz'));
-        $this->assertEquals('some: "json"', Str::unwrap('{some: "json"}', '{', '}'));
+        $this->assertSame('value', Str::unwrap('"value"', '"'));
+        $this->assertSame('value', Str::unwrap('"value', '"'));
+        $this->assertSame('value', Str::unwrap('value"', '"'));
+        $this->assertSame('bar', Str::unwrap('foo-bar-baz', 'foo-', '-baz'));
+        $this->assertSame('some: "json"', Str::unwrap('{some: "json"}', '{', '}'));
     }
 
     public function testIs()
@@ -1244,10 +1244,10 @@ class SupportStrTest extends TestCase
 
     public function testCharAt()
     {
-        $this->assertEquals('р', Str::charAt('Привет, мир!', 1));
-        $this->assertEquals('ち', Str::charAt('「こんにちは世界」', 4));
-        $this->assertEquals('w', Str::charAt('Привет, world!', 8));
-        $this->assertEquals('界', Str::charAt('「こんにちは世界」', -2));
+        $this->assertSame('р', Str::charAt('Привет, мир!', 1));
+        $this->assertSame('ち', Str::charAt('「こんにちは世界」', 4));
+        $this->assertSame('w', Str::charAt('Привет, world!', 8));
+        $this->assertSame('界', Str::charAt('「こんにちは世界」', -2));
         $this->assertEquals(null, Str::charAt('「こんにちは世界」', -200));
         $this->assertEquals(null, Str::charAt('Привет, мир!', 100));
     }
@@ -1440,10 +1440,10 @@ class SupportStrTest extends TestCase
 
     public function testWordWrap()
     {
-        $this->assertEquals('Hello<br />World', Str::wordWrap('Hello World', 3, '<br />'));
-        $this->assertEquals('Hel<br />lo<br />Wor<br />ld', Str::wordWrap('Hello World', 3, '<br />', true));
+        $this->assertSame('Hello<br />World', Str::wordWrap('Hello World', 3, '<br />'));
+        $this->assertSame('Hel<br />lo<br />Wor<br />ld', Str::wordWrap('Hello World', 3, '<br />', true));
 
-        $this->assertEquals('❤Multi<br />Byte☆❤☆❤☆❤', Str::wordWrap('❤Multi Byte☆❤☆❤☆❤', 3, '<br />'));
+        $this->assertSame('❤Multi<br />Byte☆❤☆❤☆❤', Str::wordWrap('❤Multi Byte☆❤☆❤☆❤', 3, '<br />'));
     }
 
     public static function validUuidList()

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -1409,8 +1409,8 @@ class SupportStringableTest extends TestCase
 
     public function testWordCount()
     {
-        $this->assertEquals(2, $this->stringable('Hello, world!')->wordCount());
-        $this->assertEquals(10, $this->stringable('Hi, this is my first contribution to the Laravel framework.')->wordCount());
+        $this->assertSame(2, $this->stringable('Hello, world!')->wordCount());
+        $this->assertSame(10, $this->stringable('Hi, this is my first contribution to the Laravel framework.')->wordCount());
     }
 
     public function testWrap()

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -1202,10 +1202,10 @@ class SupportStringableTest extends TestCase
 
     public function testCharAt()
     {
-        $this->assertEquals('р', $this->stringable('Привет, мир!')->charAt(1));
-        $this->assertEquals('ち', $this->stringable('「こんにちは世界」')->charAt(4));
-        $this->assertEquals('w', $this->stringable('Привет, world!')->charAt(8));
-        $this->assertEquals('界', $this->stringable('「こんにちは世界」')->charAt(-2));
+        $this->assertSame('р', $this->stringable('Привет, мир!')->charAt(1));
+        $this->assertSame('ち', $this->stringable('「こんにちは世界」')->charAt(4));
+        $this->assertSame('w', $this->stringable('Привет, world!')->charAt(8));
+        $this->assertSame('界', $this->stringable('「こんにちは世界」')->charAt(-2));
         $this->assertEquals(null, $this->stringable('「こんにちは世界」')->charAt(-200));
         $this->assertEquals(null, $this->stringable('Привет, мир!')->charAt('Привет, мир!', 100));
     }
@@ -1345,8 +1345,8 @@ class SupportStringableTest extends TestCase
 
     public function testMarkdown()
     {
-        $this->assertEquals("<p><em>hello world</em></p>\n", $this->stringable('*hello world*')->markdown());
-        $this->assertEquals("<h1>hello world</h1>\n", $this->stringable('# hello world')->markdown());
+        $this->assertSame("<p><em>hello world</em></p>\n", (string) $this->stringable('*hello world*')->markdown());
+        $this->assertSame("<h1>hello world</h1>\n", (string) $this->stringable('# hello world')->markdown());
 
         $extension = new class implements ExtensionInterface
         {
@@ -1363,8 +1363,8 @@ class SupportStringableTest extends TestCase
 
     public function testInlineMarkdown()
     {
-        $this->assertEquals("<em>hello world</em>\n", $this->stringable('*hello world*')->inlineMarkdown());
-        $this->assertEquals("<a href=\"https://laravel.com\"><strong>Laravel</strong></a>\n", $this->stringable('[**Laravel**](https://laravel.com)')->inlineMarkdown());
+        $this->assertSame("<em>hello world</em>\n", (string) $this->stringable('*hello world*')->inlineMarkdown());
+        $this->assertSame("<a href=\"https://laravel.com\"><strong>Laravel</strong></a>\n", (string) $this->stringable('[**Laravel**](https://laravel.com)')->inlineMarkdown());
 
         $extension = new class implements ExtensionInterface
         {
@@ -1415,15 +1415,15 @@ class SupportStringableTest extends TestCase
 
     public function testWrap()
     {
-        $this->assertEquals('This is me!', $this->stringable('is')->wrap('This ', ' me!'));
-        $this->assertEquals('"value"', $this->stringable('value')->wrap('"'));
+        $this->assertSame('This is me!', (string) $this->stringable('is')->wrap('This ', ' me!'));
+        $this->assertSame('"value"', (string) $this->stringable('value')->wrap('"'));
     }
 
     public function testUnwrap()
     {
-        $this->assertEquals('value', $this->stringable('"value"')->unwrap('"'));
-        $this->assertEquals('bar', $this->stringable('foo-bar-baz')->unwrap('foo-', '-baz'));
-        $this->assertEquals('some: "json"', $this->stringable('{some: "json"}')->unwrap('{', '}'));
+        $this->assertSame('value', (string) $this->stringable('"value"')->unwrap('"'));
+        $this->assertSame('bar', (string) $this->stringable('foo-bar-baz')->unwrap('foo-', '-baz'));
+        $this->assertSame('some: "json"', (string) $this->stringable('{some: "json"}')->unwrap('{', '}'));
     }
 
     public function testToHtmlString()

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -381,7 +381,7 @@ class SupportTestingMailFakeTest extends TestCase
     {
         $this->mailManager->shouldReceive('foo')->andReturn('bar');
 
-        $this->assertEquals('bar', $this->fake->foo());
+        $this->assertSame('bar', $this->fake->foo());
     }
 
     public function testAssertMailer()

--- a/tests/Support/SupportTestingQueueFakeTest.php
+++ b/tests/Support/SupportTestingQueueFakeTest.php
@@ -89,11 +89,11 @@ class SupportTestingQueueFakeTest extends TestCase
 
     public function testQueueSize()
     {
-        $this->assertEquals(0, $this->fake->size());
+        $this->assertSame(0, $this->fake->size());
 
         $this->fake->push($this->job);
 
-        $this->assertEquals(1, $this->fake->size());
+        $this->assertSame(1, $this->fake->size());
     }
 
     public function testAssertNotPushed()

--- a/tests/Support/SupportUriTest.php
+++ b/tests/Support/SupportUriTest.php
@@ -29,7 +29,7 @@ class SupportUriTest extends TestCase
         $this->assertEquals('laravel.com', $uri->host());
         $this->assertNull($uri->port());
         $this->assertEquals('docs/installation', $uri->path());
-        $this->assertEquals([], $uri->query()->toArray());
+        $this->assertSame([], $uri->query()->toArray());
         $this->assertEquals('', (string) $uri->query());
         $this->assertEquals('', $uri->query()->decode());
         $this->assertNull($uri->fragment());
@@ -259,7 +259,7 @@ class SupportUriTest extends TestCase
     {
         $uri = Uri::of('https://laravel.com');
 
-        $this->assertEquals([], $uri->pathSegments()->toArray());
+        $this->assertSame([], $uri->pathSegments()->toArray());
 
         $uri = Uri::of('https://laravel.com/one/two/three');
 

--- a/tests/Support/SupportUriTest.php
+++ b/tests/Support/SupportUriTest.php
@@ -41,7 +41,7 @@ class SupportUriTest extends TestCase
         $this->assertEquals('password', $uri->password());
         $this->assertEquals('hello', $uri->fragment());
         $this->assertEquals(['version' => 1], $uri->query()->all());
-        $this->assertEquals(1, $uri->query()->integer('version'));
+        $this->assertSame(1, $uri->query()->integer('version'));
         $this->assertEquals('taylor:password@laravel.com', $uri->authority());
     }
 
@@ -268,15 +268,15 @@ class SupportUriTest extends TestCase
 
         $uri = Uri::of('https://laravel.com/one/two/three?foo=bar');
 
-        $this->assertEquals(3, $uri->pathSegments()->count());
+        $this->assertSame(3, $uri->pathSegments()->count());
 
         $uri = Uri::of('https://laravel.com/one/two/three/?foo=bar');
 
-        $this->assertEquals(3, $uri->pathSegments()->count());
+        $this->assertSame(3, $uri->pathSegments()->count());
 
         $uri = Uri::of('https://laravel.com/one/two/three/#foo=bar');
 
-        $this->assertEquals(3, $uri->pathSegments()->count());
+        $this->assertSame(3, $uri->pathSegments()->count());
     }
 
     public function test_macroable()

--- a/tests/Support/SupportUriTest.php
+++ b/tests/Support/SupportUriTest.php
@@ -12,37 +12,37 @@ class SupportUriTest extends TestCase
     {
         Uri::setUrlGeneratorResolver(fn () => new CustomUrlGeneratorResolver);
 
-        $this->assertEquals('https://laravel.com/to', Uri::to('')->value());
-        $this->assertEquals('https://laravel.com/route', Uri::route('')->value());
-        $this->assertEquals('https://laravel.com/signed-route', Uri::signedRoute('')->value());
-        $this->assertEquals('https://laravel.com/signed-route', Uri::temporarySignedRoute('', '')->value());
-        $this->assertEquals('https://laravel.com/action', Uri::action('')->value());
+        $this->assertSame('https://laravel.com/to', Uri::to('')->value());
+        $this->assertSame('https://laravel.com/route', Uri::route('')->value());
+        $this->assertSame('https://laravel.com/signed-route', Uri::signedRoute('')->value());
+        $this->assertSame('https://laravel.com/signed-route', Uri::temporarySignedRoute('', '')->value());
+        $this->assertSame('https://laravel.com/action', Uri::action('')->value());
     }
 
     public function test_basic_uri_interactions()
     {
         $uri = Uri::of($originalUri = 'https://laravel.com/docs/installation');
 
-        $this->assertEquals('https', $uri->scheme());
+        $this->assertSame('https', $uri->scheme());
         $this->assertNull($uri->user());
         $this->assertNull($uri->password());
-        $this->assertEquals('laravel.com', $uri->host());
+        $this->assertSame('laravel.com', $uri->host());
         $this->assertNull($uri->port());
-        $this->assertEquals('docs/installation', $uri->path());
+        $this->assertSame('docs/installation', $uri->path());
         $this->assertSame([], $uri->query()->toArray());
-        $this->assertEquals('', (string) $uri->query());
-        $this->assertEquals('', $uri->query()->decode());
+        $this->assertSame('', (string) $uri->query());
+        $this->assertSame('', $uri->query()->decode());
         $this->assertNull($uri->fragment());
         $this->assertEquals($originalUri, (string) $uri);
 
         $uri = Uri::of('https://taylor:password@laravel.com/docs/installation?version=1#hello');
 
-        $this->assertEquals('taylor', $uri->user());
-        $this->assertEquals('password', $uri->password());
-        $this->assertEquals('hello', $uri->fragment());
+        $this->assertSame('taylor', $uri->user());
+        $this->assertSame('password', $uri->password());
+        $this->assertSame('hello', $uri->fragment());
         $this->assertEquals(['version' => 1], $uri->query()->all());
         $this->assertSame(1, $uri->query()->integer('version'));
-        $this->assertEquals('taylor:password@laravel.com', $uri->authority());
+        $this->assertSame('taylor:password@laravel.com', $uri->authority());
     }
 
     public function test_is_empty_and_is_not_empty()
@@ -58,15 +58,15 @@ class SupportUriTest extends TestCase
     {
         $uri = Uri::of('https://laravel.com/docs/installation#introduction');
 
-        $this->assertEquals('introduction', $uri->fragment());
+        $this->assertSame('introduction', $uri->fragment());
 
         $withoutFragment = $uri->withoutFragment();
 
         $this->assertNull($withoutFragment->fragment());
-        $this->assertEquals('https://laravel.com/docs/installation', $withoutFragment->value());
+        $this->assertSame('https://laravel.com/docs/installation', $withoutFragment->value());
 
         // Original URI should be unchanged (immutability).
-        $this->assertEquals('introduction', $uri->fragment());
+        $this->assertSame('introduction', $uri->fragment());
     }
 
     public function test_without_fragment_on_uri_without_fragment()
@@ -76,7 +76,7 @@ class SupportUriTest extends TestCase
         $withoutFragment = $uri->withoutFragment();
 
         $this->assertNull($withoutFragment->fragment());
-        $this->assertEquals('https://laravel.com/docs', $withoutFragment->value());
+        $this->assertSame('https://laravel.com/docs', $withoutFragment->value());
     }
 
     public function test_complicated_query_string_parsing()
@@ -107,7 +107,7 @@ class SupportUriTest extends TestCase
             'flag_value' => '',
         ], $uri->query()->all());
 
-        $this->assertEquals('key_1=value&key_2[sub_field]=value&key_3[]=value&key_4[9]=value&key_5[][][foo][9]=bar&key.6=value&flag_value', $uri->query()->decode());
+        $this->assertSame('key_1=value&key_2[sub_field]=value&key_3[]=value&key_4[9]=value&key_5[][][foo][9]=bar&key.6=value&flag_value', $uri->query()->decode());
     }
 
     public function test_uri_building()
@@ -147,8 +147,8 @@ class SupportUriTest extends TestCase
             'flag' => '',
         ])->withoutQuery(['name']);
 
-        $this->assertEquals('age=38&role[title]=Developer&role[focus]=PHP&tags[0]=person&tags[1]=employee&flag=', $uri->query()->decode());
-        $this->assertEquals('name=Taylor', $uri->replaceQuery(['name' => 'Taylor'])->query()->decode());
+        $this->assertSame('age=38&role[title]=Developer&role[focus]=PHP&tags[0]=person&tags[1]=employee&flag=', $uri->query()->decode());
+        $this->assertSame('name=Taylor', $uri->replaceQuery(['name' => 'Taylor'])->query()->decode());
 
         // Push onto multi-value and missing items...
         $uri = Uri::of('https://laravel.com?tags[]=foo');
@@ -167,22 +167,22 @@ class SupportUriTest extends TestCase
     {
         $uri = Uri::of('https://dot.test/?foo.bar=baz');
 
-        $this->assertEquals('foo.bar=baz&foo[bar]=zab', $uri->withQuery(['foo.bar' => 'zab'])->query()->decode());
-        $this->assertEquals('foo[bar]=zab', $uri->replaceQuery(['foo.bar' => 'zab'])->query()->decode());
+        $this->assertSame('foo.bar=baz&foo[bar]=zab', $uri->withQuery(['foo.bar' => 'zab'])->query()->decode());
+        $this->assertSame('foo[bar]=zab', $uri->replaceQuery(['foo.bar' => 'zab'])->query()->decode());
     }
 
     public function test_decoding_the_entire_uri()
     {
         $uri = Uri::of('https://laravel.com/docs/11.x/installation')->withQuery(['tags' => ['first', 'second']]);
 
-        $this->assertEquals('https://laravel.com/docs/11.x/installation?tags[0]=first&tags[1]=second', $uri->decode());
+        $this->assertSame('https://laravel.com/docs/11.x/installation?tags[0]=first&tags[1]=second', $uri->decode());
     }
 
     public function test_decoding_the_entire_uri_preserves_the_fragment()
     {
         $uri = Uri::of('https://laravel.com/docs/11.x/routing?q=laravel%20docs#route-model-binding');
 
-        $this->assertEquals('https://laravel.com/docs/11.x/routing?q=laravel docs#route-model-binding', $uri->decode());
+        $this->assertSame('https://laravel.com/docs/11.x/routing?q=laravel docs#route-model-binding', $uri->decode());
     }
 
     public function test_with_query_if_missing()
@@ -195,7 +195,7 @@ class SupportUriTest extends TestCase
             'existing' => 'new_value',
         ]);
 
-        $this->assertEquals('existing=value&new=parameter', $uri->query()->decode());
+        $this->assertSame('existing=value&new=parameter', $uri->query()->decode());
 
         // Test adding complex nested arrays to empty query string
         $uri = Uri::of('https://laravel.com');
@@ -212,7 +212,7 @@ class SupportUriTest extends TestCase
             ],
         ]);
 
-        $this->assertEquals('name=Taylor&role[title]=Developer&role[focus]=PHP&tags[0]=person&tags[1]=employee', $uri->query()->decode());
+        $this->assertSame('name=Taylor&role[title]=Developer&role[focus]=PHP&tags[0]=person&tags[1]=employee', $uri->query()->decode());
 
         // Test partial array merging and preserving indexed arrays
         $uri = Uri::of('https://laravel.com?name=Taylor&tags[0]=person');
@@ -223,7 +223,7 @@ class SupportUriTest extends TestCase
             'tags' => ['should', 'not', 'change'],
         ]);
 
-        $this->assertEquals('name=Taylor&tags[0]=person&age=38', $uri->query()->decode());
+        $this->assertSame('name=Taylor&tags[0]=person&age=38', $uri->query()->decode());
         $this->assertEquals(['name' => 'Taylor', 'tags' => ['person'], 'age' => 38], $uri->query()->all());
 
         $uri = Uri::of('https://laravel.com?user[name]=Taylor');
@@ -251,8 +251,8 @@ class SupportUriTest extends TestCase
     {
         $uri = Uri::of('https://laravel.com');
 
-        $this->assertEquals('https://laravel.com', (string) $uri);
-        $this->assertEquals('https://laravel.com', (string) $uri->withQuery([]));
+        $this->assertSame('https://laravel.com', (string) $uri);
+        $this->assertSame('https://laravel.com', (string) $uri->withQuery([]));
     }
 
     public function test_path_segments()
@@ -264,7 +264,7 @@ class SupportUriTest extends TestCase
         $uri = Uri::of('https://laravel.com/one/two/three');
 
         $this->assertEquals(['one', 'two', 'three'], $uri->pathSegments()->toArray());
-        $this->assertEquals('one', $uri->pathSegments()->first());
+        $this->assertSame('one', $uri->pathSegments()->first());
 
         $uri = Uri::of('https://laravel.com/one/two/three?foo=bar');
 

--- a/tests/Support/ValidatedInputTest.php
+++ b/tests/Support/ValidatedInputTest.php
@@ -556,6 +556,6 @@ class ValidatedInputTest extends TestCase
 
         $this->assertEquals(['name' => 'Fatih', 'surname' => 'AYDIN', 'foo' => ['bar' => null]], $input->except('foo.baz'));
         $this->assertEquals(['surname' => 'AYDIN'], $input->except('name', 'foo'));
-        $this->assertEquals([], $input->except('name', 'surname', 'foo'));
+        $this->assertSame([], $input->except('name', 'surname', 'foo'));
     }
 }

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -246,7 +246,7 @@ class TestResponseTest extends TestCase
             'gatherData' => ['foo' => 'bar', 'baz' => 'qux'],
         ]);
 
-        $this->assertEquals('bar', $response->viewData('foo'));
+        $this->assertSame('bar', $response->viewData('foo'));
 
         $this->assertEquals(['foo' => 'bar', 'baz' => 'qux'], $response->viewData());
     }

--- a/tests/Translation/TranslationFileLoaderTest.php
+++ b/tests/Translation/TranslationFileLoaderTest.php
@@ -161,7 +161,7 @@ class TranslationFileLoaderTest extends TestCase
         $files->shouldReceive('exists')->once()->with(__DIR__.'/en/foo.php')->andReturn(false);
         $files->shouldReceive('getRequire')->never();
 
-        $this->assertEquals([], $loader->load('en', 'foo', null));
+        $this->assertSame([], $loader->load('en', 'foo', null));
     }
 
     public function testEmptyArraysReturnedWhenFilesDontExistForNamespacedItems()
@@ -169,7 +169,7 @@ class TranslationFileLoaderTest extends TestCase
         $loader = new FileLoader($files = m::mock(Filesystem::class), __DIR__);
         $files->shouldReceive('getRequire')->never();
 
-        $this->assertEquals([], $loader->load('en', 'foo', 'bar'));
+        $this->assertSame([], $loader->load('en', 'foo', 'bar'));
     }
 
     public function testLoadMethodForJSONProperlyCallsLoader()

--- a/tests/Translation/TranslationMessageSelectorTest.php
+++ b/tests/Translation/TranslationMessageSelectorTest.php
@@ -20,14 +20,14 @@ class TranslationMessageSelectorTest extends TestCase
     {
         $selector = new MessageSelector;
 
-        $this->assertEquals('many', $selector->choose('{0} zero|{1} one|[2,*] many', 2.75, 'pl'));
+        $this->assertSame('many', $selector->choose('{0} zero|{1} one|[2,*] many', 2.75, 'pl'));
     }
 
     public function testChoosePluralizesFloats()
     {
         $selector = new MessageSelector;
 
-        $this->assertEquals('plural', $selector->choose('singular|plural', 0.5, 'en'));
+        $this->assertSame('plural', $selector->choose('singular|plural', 0.5, 'en'));
     }
 
     public static function chooseTestData()

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -189,7 +189,7 @@ class TranslationTranslatorTest extends TestCase
         $t->setSelector($selector = m::mock(MessageSelector::class));
         $selector->shouldReceive('choose')->once()->with('{1} :count foos|[2,*] :count foos', 1234, 'en')->andReturn(':count foos');
 
-        $this->assertEquals('1,234 foos', $t->choice(':count foos', 1234, ['count' => '1,234']));
+        $this->assertSame('1,234 foos', $t->choice(':count foos', 1234, ['count' => '1,234']));
     }
 
     public function testGetJson()

--- a/tests/Validation/ValidationDatabasePresenceVerifierTest.php
+++ b/tests/Validation/ValidationDatabasePresenceVerifierTest.php
@@ -27,7 +27,7 @@ class ValidationDatabasePresenceVerifierTest extends TestCase
         $builder->shouldReceive('where')->with('not', '!=', 'admin');
         $builder->shouldReceive('count')->once()->andReturn(100);
 
-        $this->assertEquals(100, $verifier->getCount('table', 'column', 'value', null, null, $extra));
+        $this->assertSame(100, $verifier->getCount('table', 'column', 'value', null, null, $extra));
     }
 
     public function testBasicCountWithClosures()
@@ -53,7 +53,7 @@ class ValidationDatabasePresenceVerifierTest extends TestCase
         $builder->shouldReceive('where')->with('closure', 1);
         $builder->shouldReceive('count')->once()->andReturn(100);
 
-        $this->assertEquals(100, $verifier->getCount('table', 'column', 'value', null, null, $extra));
+        $this->assertSame(100, $verifier->getCount('table', 'column', 'value', null, null, $extra));
     }
 
     public function testGetCountWithValidExcludeId()
@@ -67,6 +67,6 @@ class ValidationDatabasePresenceVerifierTest extends TestCase
         $builder->shouldReceive('where')->with('id', '<>', 123)->andReturn($builder);
         $builder->shouldReceive('count')->once()->andReturn(100);
 
-        $this->assertEquals(100, $verifier->getCount('table', 'column', 'value', 123, 'id', []));
+        $this->assertSame(100, $verifier->getCount('table', 'column', 'value', 123, 'id', []));
     }
 }

--- a/tests/Validation/ValidationDateRuleTest.php
+++ b/tests/Validation/ValidationDateRuleTest.php
@@ -15,7 +15,7 @@ class ValidationDateRuleTest extends TestCase
     public function testDefaultDateRule()
     {
         $rule = Rule::date();
-        $this->assertEquals('date', (string) $rule);
+        $this->assertSame('date', (string) $rule);
 
         $rule = new Date;
         $this->assertSame('date', (string) $rule);
@@ -24,76 +24,76 @@ class ValidationDateRuleTest extends TestCase
     public function testDateFormatRule()
     {
         $rule = Rule::date()->format('d/m/Y');
-        $this->assertEquals('date_format:d/m/Y', (string) $rule);
+        $this->assertSame('date_format:d/m/Y', (string) $rule);
     }
 
     public function testAfterTodayRule()
     {
         $rule = Rule::date()->afterToday();
-        $this->assertEquals('date|after:today', (string) $rule);
+        $this->assertSame('date|after:today', (string) $rule);
 
         $rule = Rule::date()->todayOrAfter();
-        $this->assertEquals('date|after_or_equal:today', (string) $rule);
+        $this->assertSame('date|after_or_equal:today', (string) $rule);
     }
 
     public function testBeforeTodayRule()
     {
         $rule = Rule::date()->beforeToday();
-        $this->assertEquals('date|before:today', (string) $rule);
+        $this->assertSame('date|before:today', (string) $rule);
 
         $rule = Rule::date()->todayOrBefore();
-        $this->assertEquals('date|before_or_equal:today', (string) $rule);
+        $this->assertSame('date|before_or_equal:today', (string) $rule);
     }
 
     public function testAfterSpecificDateRule()
     {
         $rule = Rule::date()->after(Carbon::parse('2024-01-01'));
-        $this->assertEquals('date|after:2024-01-01', (string) $rule);
+        $this->assertSame('date|after:2024-01-01', (string) $rule);
 
         $rule = Rule::date()->format('d/m/Y')->after(Carbon::parse('2024-01-01'));
-        $this->assertEquals('date_format:d/m/Y|after:01/01/2024', (string) $rule);
+        $this->assertSame('date_format:d/m/Y|after:01/01/2024', (string) $rule);
     }
 
     public function testBeforeSpecificDateRule()
     {
         $rule = Rule::date()->before(Carbon::parse('2024-01-01'));
-        $this->assertEquals('date|before:2024-01-01', (string) $rule);
+        $this->assertSame('date|before:2024-01-01', (string) $rule);
 
         $rule = Rule::date()->format('d/m/Y')->before(Carbon::parse('2024-01-01'));
-        $this->assertEquals('date_format:d/m/Y|before:01/01/2024', (string) $rule);
+        $this->assertSame('date_format:d/m/Y|before:01/01/2024', (string) $rule);
     }
 
     public function testAfterOrEqualSpecificDateRule()
     {
         $rule = Rule::date()->afterOrEqual(Carbon::parse('2024-01-01'));
-        $this->assertEquals('date|after_or_equal:2024-01-01', (string) $rule);
+        $this->assertSame('date|after_or_equal:2024-01-01', (string) $rule);
 
         $rule = Rule::date()->format('d/m/Y')->afterOrEqual(Carbon::parse('2024-01-01'));
-        $this->assertEquals('date_format:d/m/Y|after_or_equal:01/01/2024', (string) $rule);
+        $this->assertSame('date_format:d/m/Y|after_or_equal:01/01/2024', (string) $rule);
     }
 
     public function testBeforeOrEqualSpecificDateRule()
     {
         $rule = Rule::date()->beforeOrEqual(Carbon::parse('2024-01-01'));
-        $this->assertEquals('date|before_or_equal:2024-01-01', (string) $rule);
+        $this->assertSame('date|before_or_equal:2024-01-01', (string) $rule);
 
         $rule = Rule::date()->format('d/m/Y')->beforeOrEqual(Carbon::parse('2024-01-01'));
-        $this->assertEquals('date_format:d/m/Y|before_or_equal:01/01/2024', (string) $rule);
+        $this->assertSame('date_format:d/m/Y|before_or_equal:01/01/2024', (string) $rule);
     }
 
     public function testBetweenDatesRule()
     {
         $rule = Rule::date()->between(Carbon::parse('2024-01-01'), Carbon::parse('2024-02-01'));
-        $this->assertEquals('date|after:2024-01-01|before:2024-02-01', (string) $rule);
+        $this->assertSame('date|after:2024-01-01|before:2024-02-01', (string) $rule);
 
         $rule = Rule::date()->format('d/m/Y')->between(Carbon::parse('2024-01-01'), Carbon::parse('2024-02-01'));
-        $this->assertEquals('date_format:d/m/Y|after:01/01/2024|before:01/02/2024', (string) $rule);
+        $this->assertSame('date_format:d/m/Y|after:01/01/2024|before:01/02/2024', (string) $rule);
     }
 
     public function testBetweenOrEqualDatesRule()
     {
         $rule = Rule::date()->betweenOrEqual('2024-01-01', '2024-02-01');
-        $this->assertEquals('date|after_or_equal:2024-01-01|before_or_equal:2024-02-01', (string) $rule);
+        $this->assertSame('date|after_or_equal:2024-01-01|before_or_equal:2024-02-01', (string) $rule);
     }
 
     public function testChainedRules()
@@ -102,7 +102,7 @@ class ValidationDateRuleTest extends TestCase
             ->format('Y-m-d')
             ->after('2024-01-01 00:00:00')
             ->before('2025-01-01 00:00:00');
-        $this->assertEquals('date_format:Y-m-d|after:2024-01-01 00:00:00|before:2025-01-01 00:00:00', (string) $rule);
+        $this->assertSame('date_format:Y-m-d|after:2024-01-01 00:00:00|before:2025-01-01 00:00:00', (string) $rule);
 
         $rule = Rule::date()
             ->format('Y-m-d')

--- a/tests/Validation/ValidationExceptionTest.php
+++ b/tests/Validation/ValidationExceptionTest.php
@@ -137,7 +137,7 @@ class ValidationExceptionTest extends TestCase
         $exception = $this->getException([], ['foo' => 'required']);
         $exception->errorBag('milwad');
 
-        $this->assertEquals('milwad', $exception->errorBag);
+        $this->assertSame('milwad', $exception->errorBag);
     }
 
     public function testExceptionRedirectToOneError()
@@ -145,7 +145,7 @@ class ValidationExceptionTest extends TestCase
         $exception = $this->getException([], ['foo' => 'required']);
         $exception->redirectTo('https://google.com');
 
-        $this->assertEquals('https://google.com', $exception->redirectTo);
+        $this->assertSame('https://google.com', $exception->redirectTo);
     }
 
     public function testExceptionGetResponseOneError()

--- a/tests/Validation/ValidationExceptionTest.php
+++ b/tests/Validation/ValidationExceptionTest.php
@@ -129,7 +129,7 @@ class ValidationExceptionTest extends TestCase
         $exception = $this->getException([], ['foo' => 'required']);
         $exception->status(500);
 
-        $this->assertEquals(500, $exception->status);
+        $this->assertSame(500, $exception->status);
     }
 
     public function testExceptionErrorBagOneError()

--- a/tests/Validation/ValidationExcludeIfTest.php
+++ b/tests/Validation/ValidationExcludeIfTest.php
@@ -47,7 +47,7 @@ class ValidationExcludeIfTest extends TestCase
                 new ExcludeIf($condition);
                 $this->fail('The ExcludeIf constructor must not accept '.gettype($condition));
             } catch (InvalidArgumentException $exception) {
-                $this->assertEquals('The provided condition must be a callable or boolean.', $exception->getMessage());
+                $this->assertSame('The provided condition must be a callable or boolean.', $exception->getMessage());
             }
         }
     }

--- a/tests/Validation/ValidationInArrayKeysTest.php
+++ b/tests/Validation/ValidationInArrayKeysTest.php
@@ -67,7 +67,7 @@ class ValidationInArrayKeysTest extends TestCase
 
         $v = new Validator($trans, ['foo' => ['wrong_key' => 'bar']], ['foo' => 'in_array_keys:first_key,second_key']);
         $this->assertFalse($v->passes());
-        $this->assertEquals(
+        $this->assertSame(
             'The foo field must contain at least one of the following keys: first_key, second_key.',
             $v->messages()->first('foo')
         );

--- a/tests/Validation/ValidationNumericRuleTest.php
+++ b/tests/Validation/ValidationNumericRuleTest.php
@@ -14,7 +14,7 @@ class ValidationNumericRuleTest extends TestCase
     public function testDefaultNumericRule()
     {
         $rule = Rule::numeric();
-        $this->assertEquals('numeric', (string) $rule);
+        $this->assertSame('numeric', (string) $rule);
 
         $rule = new Numeric();
         $this->assertSame('numeric', (string) $rule);
@@ -23,118 +23,118 @@ class ValidationNumericRuleTest extends TestCase
     public function testBetweenRule()
     {
         $rule = Rule::numeric()->between(1, 10);
-        $this->assertEquals('numeric|between:1,10', (string) $rule);
+        $this->assertSame('numeric|between:1,10', (string) $rule);
 
         $rule = Rule::numeric()->between(1.5, 10.5);
-        $this->assertEquals('numeric|between:1.5,10.5', (string) $rule);
+        $this->assertSame('numeric|between:1.5,10.5', (string) $rule);
     }
 
     public function testDecimalRule()
     {
         $rule = Rule::numeric()->decimal(2, 4);
-        $this->assertEquals('numeric|decimal:2,4', (string) $rule);
+        $this->assertSame('numeric|decimal:2,4', (string) $rule);
 
         $rule = Rule::numeric()->decimal(2);
-        $this->assertEquals('numeric|decimal:2', (string) $rule);
+        $this->assertSame('numeric|decimal:2', (string) $rule);
     }
 
     public function testDifferentRule()
     {
         $rule = Rule::numeric()->different('some_field');
-        $this->assertEquals('numeric|different:some_field', (string) $rule);
+        $this->assertSame('numeric|different:some_field', (string) $rule);
     }
 
     public function testDigitsRule()
     {
         $rule = Rule::numeric()->digits(10);
-        $this->assertEquals('numeric|integer|digits:10', (string) $rule);
+        $this->assertSame('numeric|integer|digits:10', (string) $rule);
     }
 
     public function testDigitsBetweenRule()
     {
         $rule = Rule::numeric()->digitsBetween(2, 10);
-        $this->assertEquals('numeric|integer|digits_between:2,10', (string) $rule);
+        $this->assertSame('numeric|integer|digits_between:2,10', (string) $rule);
     }
 
     public function testGreaterThanRule()
     {
         $rule = Rule::numeric()->greaterThan('some_field');
-        $this->assertEquals('numeric|gt:some_field', (string) $rule);
+        $this->assertSame('numeric|gt:some_field', (string) $rule);
     }
 
     public function testGreaterThanOrEqualRule()
     {
         $rule = Rule::numeric()->greaterThanOrEqualTo('some_field');
-        $this->assertEquals('numeric|gte:some_field', (string) $rule);
+        $this->assertSame('numeric|gte:some_field', (string) $rule);
     }
 
     public function testIntegerRule()
     {
         $rule = Rule::numeric()->integer();
-        $this->assertEquals('numeric|integer', (string) $rule);
+        $this->assertSame('numeric|integer', (string) $rule);
 
         $rule = Rule::numeric()->integer(strict: true);
-        $this->assertEquals('numeric|integer:strict', (string) $rule);
+        $this->assertSame('numeric|integer:strict', (string) $rule);
     }
 
     public function testLessThanRule()
     {
         $rule = Rule::numeric()->lessThan('some_field');
-        $this->assertEquals('numeric|lt:some_field', (string) $rule);
+        $this->assertSame('numeric|lt:some_field', (string) $rule);
     }
 
     public function testLessThanOrEqualRule()
     {
         $rule = Rule::numeric()->lessThanOrEqualTo('some_field');
-        $this->assertEquals('numeric|lte:some_field', (string) $rule);
+        $this->assertSame('numeric|lte:some_field', (string) $rule);
     }
 
     public function testMaxRule()
     {
         $rule = Rule::numeric()->max(10);
-        $this->assertEquals('numeric|max:10', (string) $rule);
+        $this->assertSame('numeric|max:10', (string) $rule);
 
         $rule = Rule::numeric()->max(10.5);
-        $this->assertEquals('numeric|max:10.5', (string) $rule);
+        $this->assertSame('numeric|max:10.5', (string) $rule);
     }
 
     public function testMaxDigitsRule()
     {
         $rule = Rule::numeric()->maxDigits(10);
-        $this->assertEquals('numeric|max_digits:10', (string) $rule);
+        $this->assertSame('numeric|max_digits:10', (string) $rule);
     }
 
     public function testMinRule()
     {
         $rule = Rule::numeric()->min(10);
-        $this->assertEquals('numeric|min:10', (string) $rule);
+        $this->assertSame('numeric|min:10', (string) $rule);
 
         $rule = Rule::numeric()->min(10.5);
-        $this->assertEquals('numeric|min:10.5', (string) $rule);
+        $this->assertSame('numeric|min:10.5', (string) $rule);
     }
 
     public function testMinDigitsRule()
     {
         $rule = Rule::numeric()->minDigits(10);
-        $this->assertEquals('numeric|min_digits:10', (string) $rule);
+        $this->assertSame('numeric|min_digits:10', (string) $rule);
     }
 
     public function testMultipleOfRule()
     {
         $rule = Rule::numeric()->multipleOf(10);
-        $this->assertEquals('numeric|multiple_of:10', (string) $rule);
+        $this->assertSame('numeric|multiple_of:10', (string) $rule);
     }
 
     public function testSameRule()
     {
         $rule = Rule::numeric()->same('some_field');
-        $this->assertEquals('numeric|same:some_field', (string) $rule);
+        $this->assertSame('numeric|same:some_field', (string) $rule);
     }
 
     public function testSizeRule()
     {
         $rule = Rule::numeric()->exactly(10);
-        $this->assertEquals('numeric|integer|size:10', (string) $rule);
+        $this->assertSame('numeric|integer|size:10', (string) $rule);
     }
 
     public function testChainedRules()
@@ -144,7 +144,7 @@ class ValidationNumericRuleTest extends TestCase
             ->multipleOf(10)
             ->lessThanOrEqualTo('some_field')
             ->max(100);
-        $this->assertEquals('numeric|integer|multiple_of:10|lte:some_field|max:100', (string) $rule);
+        $this->assertSame('numeric|integer|multiple_of:10|lte:some_field|max:100', (string) $rule);
 
         $rule = Rule::numeric()
             ->decimal(2)
@@ -356,6 +356,6 @@ class ValidationNumericRuleTest extends TestCase
     public function testUniquenessValidation()
     {
         $rule = Rule::numeric()->integer()->digits(2)->exactly(2);
-        $this->assertEquals('numeric|integer|digits:2|size:2', (string) $rule);
+        $this->assertSame('numeric|integer|digits:2|size:2', (string) $rule);
     }
 }

--- a/tests/Validation/ValidationProhibitedIfTest.php
+++ b/tests/Validation/ValidationProhibitedIfTest.php
@@ -47,7 +47,7 @@ class ValidationProhibitedIfTest extends TestCase
                 new ProhibitedIf($condition);
                 $this->fail('The ProhibitedIf constructor must not accept '.gettype($condition));
             } catch (InvalidArgumentException $exception) {
-                $this->assertEquals('The provided condition must be a callable or boolean.', $exception->getMessage());
+                $this->assertSame('The provided condition must be a callable or boolean.', $exception->getMessage());
             }
         }
     }

--- a/tests/Validation/ValidationRuleCanTest.php
+++ b/tests/Validation/ValidationRuleCanTest.php
@@ -59,7 +59,7 @@ class ValidationRuleCanTest extends TestCase
     public function testValidationFails()
     {
         $this->gate()->define('update-company', function ($user, $value) {
-            $this->assertEquals('1', $value);
+            $this->assertSame('1', $value);
 
             return false;
         });
@@ -78,7 +78,7 @@ class ValidationRuleCanTest extends TestCase
         $this->gate()->define('update-company', function ($user, $class, $model, $value) {
             $this->assertEquals(\App\Models\Company::class, $class);
             $this->assertInstanceOf(stdClass::class, $model);
-            $this->assertEquals('1', $value);
+            $this->assertSame('1', $value);
 
             return true;
         });

--- a/tests/Validation/ValidationRuleParserTest.php
+++ b/tests/Validation/ValidationRuleParserTest.php
@@ -217,7 +217,7 @@ class ValidationRuleParserTest extends TestCase
         ]);
 
         $this->assertEquals(['name' => ['required']], $results->rules);
-        $this->assertEquals([], $results->implicitAttributes);
+        $this->assertSame([], $results->implicitAttributes);
     }
 
     public function testExplodeHandlesForwardSlashesInWildcardRule()

--- a/tests/Validation/ValidationRuleParserTest.php
+++ b/tests/Validation/ValidationRuleParserTest.php
@@ -187,7 +187,7 @@ class ValidationRuleParserTest extends TestCase
             'users.*.name' => Rule::forEach(function ($value, $attribute, $data, $context) {
                 $this->assertSame('Taylor Otwell', $value);
                 $this->assertSame('users.0.name', $attribute);
-                $this->assertEquals('Taylor Otwell', $data['users.0.name']);
+                $this->assertSame('Taylor Otwell', $data['users.0.name']);
                 $this->assertEquals(['name' => 'Taylor Otwell', 'email' => 'taylor@laravel.com'], $context);
 
                 return [Rule::requiredIf(true)];

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -6955,7 +6955,7 @@ class ValidationValidatorTest extends TestCase
         $v->sometimes(['users'], 'array', function ($i, $item) {
             return (bool) $item;
         });
-        $this->assertEquals([], $v->getRules());
+        $this->assertSame([], $v->getRules());
 
         // ['company.users'] -> if users is not empty it must be validated as array
         $trans = $this->getIlluminateArrayTranslator();

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4653,10 +4653,10 @@ class ValidationValidatorTest extends TestCase
         ]);
 
         $this->assertFalse($v->passes());
-        $this->assertEquals('The numeric field must be greater than 10.', $v->messages()->first('numeric'));
-        $this->assertEquals('The string field must be greater than 5 characters.', $v->messages()->first('string'));
-        $this->assertEquals('The file field must be greater than 9 kilobytes.', $v->messages()->first('file'));
-        $this->assertEquals('The array field must have more than 4 items.', $v->messages()->first('array'));
+        $this->assertSame('The numeric field must be greater than 10.', $v->messages()->first('numeric'));
+        $this->assertSame('The string field must be greater than 5 characters.', $v->messages()->first('string'));
+        $this->assertSame('The file field must be greater than 9 kilobytes.', $v->messages()->first('file'));
+        $this->assertSame('The array field must have more than 4 items.', $v->messages()->first('array'));
     }
 
     public function testValidateGteMessagesAreCorrect()
@@ -4693,10 +4693,10 @@ class ValidationValidatorTest extends TestCase
         ]);
 
         $this->assertFalse($v->passes());
-        $this->assertEquals('The numeric field must be greater than or equal to 10.', $v->messages()->first('numeric'));
-        $this->assertEquals('The string field must be greater than or equal to 5 characters.', $v->messages()->first('string'));
-        $this->assertEquals('The file field must be greater than or equal to 9 kilobytes.', $v->messages()->first('file'));
-        $this->assertEquals('The array field must have 4 items or more.', $v->messages()->first('array'));
+        $this->assertSame('The numeric field must be greater than or equal to 10.', $v->messages()->first('numeric'));
+        $this->assertSame('The string field must be greater than or equal to 5 characters.', $v->messages()->first('string'));
+        $this->assertSame('The file field must be greater than or equal to 9 kilobytes.', $v->messages()->first('file'));
+        $this->assertSame('The array field must have 4 items or more.', $v->messages()->first('array'));
     }
 
     public function testValidateLtMessagesAreCorrect()
@@ -4733,10 +4733,10 @@ class ValidationValidatorTest extends TestCase
         ]);
 
         $this->assertFalse($v->passes());
-        $this->assertEquals('The numeric field must be less than 5.', $v->messages()->first('numeric'));
-        $this->assertEquals('The string field must be less than 3 characters.', $v->messages()->first('string'));
-        $this->assertEquals('The file field must be less than 8 kilobytes.', $v->messages()->first('file'));
-        $this->assertEquals('The array field must have less than 2 items.', $v->messages()->first('array'));
+        $this->assertSame('The numeric field must be less than 5.', $v->messages()->first('numeric'));
+        $this->assertSame('The string field must be less than 3 characters.', $v->messages()->first('string'));
+        $this->assertSame('The file field must be less than 8 kilobytes.', $v->messages()->first('file'));
+        $this->assertSame('The array field must have less than 2 items.', $v->messages()->first('array'));
     }
 
     public function testValidateLteMessagesAreCorrect()
@@ -4773,10 +4773,10 @@ class ValidationValidatorTest extends TestCase
         ]);
 
         $this->assertFalse($v->passes());
-        $this->assertEquals('The numeric field must be less than or equal to 5.', $v->messages()->first('numeric'));
-        $this->assertEquals('The string field must be less than or equal to 3 characters.', $v->messages()->first('string'));
-        $this->assertEquals('The file field must be less than or equal to 8 kilobytes.', $v->messages()->first('file'));
-        $this->assertEquals('The array field must not have more than 2 items.', $v->messages()->first('array'));
+        $this->assertSame('The numeric field must be less than or equal to 5.', $v->messages()->first('numeric'));
+        $this->assertSame('The string field must be less than or equal to 3 characters.', $v->messages()->first('string'));
+        $this->assertSame('The file field must be less than or equal to 8 kilobytes.', $v->messages()->first('file'));
+        $this->assertSame('The array field must not have more than 2 items.', $v->messages()->first('array'));
     }
 
     public function testValidateIp()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1103,7 +1103,8 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['name' => ''], ['name' => 'required']);
 
-        $exception = new class($v) extends ValidationException {
+        $exception = new class($v) extends ValidationException
+        {
         };
         $v->setException($exception);
 
@@ -4144,15 +4145,15 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['items' => '3'], ['items' => 'gt:4']);
         $this->assertFalse($v->passes());
-        $this->assertEquals(4, $v->messages()->first('items'));
+        $this->assertSame(4, (int) $v->messages()->first('items'));
 
         $v = new Validator($trans, ['items' => 3, 'more' => 5], ['items' => 'numeric|gt:more']);
         $this->assertFalse($v->passes());
-        $this->assertEquals(5, $v->messages()->first('items'));
+        $this->assertSame(5, (int) $v->messages()->first('items'));
 
         $v = new Validator($trans, ['items' => 'abc', 'more' => 'abcde'], ['items' => 'gt:more']);
         $this->assertFalse($v->passes());
-        $this->assertEquals(5, $v->messages()->first('items'));
+        $this->assertSame(5, (int) $v->messages()->first('items'));
 
         $v = new Validator($trans, ['max' => 10], ['min' => 'numeric', 'max' => 'numeric|gt:min'], [], ['min' => 'minimum value', 'max' => 'maximum value']);
         $this->assertFalse($v->passes());
@@ -4167,11 +4168,11 @@ class ValidationValidatorTest extends TestCase
         $biggerFile->method('isValid')->willReturn(true);
         $v = new Validator($trans, ['photo' => $file, 'bigger' => $biggerFile], ['photo' => 'file|gt:bigger']);
         $this->assertFalse($v->passes());
-        $this->assertEquals(5, $v->messages()->first('photo'));
+        $this->assertSame(5, (int) $v->messages()->first('photo'));
 
         $v = new Validator($trans, ['items' => [1, 2, 3], 'more' => [0, 1, 2, 3]], ['items' => 'gt:more']);
         $this->assertFalse($v->passes());
-        $this->assertEquals(4, $v->messages()->first('items'));
+        $this->assertSame(4, (int) $v->messages()->first('items'));
     }
 
     public function testValidateLtPlaceHolderIsReplacedProperly()
@@ -4186,15 +4187,15 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['items' => '3'], ['items' => 'lt:2']);
         $this->assertFalse($v->passes());
-        $this->assertEquals(2, $v->messages()->first('items'));
+        $this->assertSame(2, (int) $v->messages()->first('items'));
 
         $v = new Validator($trans, ['items' => 3, 'less' => 2], ['items' => 'numeric|lt:less']);
         $this->assertFalse($v->passes());
-        $this->assertEquals(2, $v->messages()->first('items'));
+        $this->assertSame(2, (int) $v->messages()->first('items'));
 
         $v = new Validator($trans, ['items' => 'abc', 'less' => 'ab'], ['items' => 'lt:less']);
         $this->assertFalse($v->passes());
-        $this->assertEquals(2, $v->messages()->first('items'));
+        $this->assertSame(2, (int) $v->messages()->first('items'));
 
         $v = new Validator($trans, ['min' => 1], ['min' => 'numeric|lt:max', 'max' => 'numeric'], [], ['min' => 'minimum value', 'max' => 'maximum value']);
         $this->assertFalse($v->passes());
@@ -4209,11 +4210,11 @@ class ValidationValidatorTest extends TestCase
         $smallerFile->method('isValid')->willReturn(true);
         $v = new Validator($trans, ['photo' => $file, 'smaller' => $smallerFile], ['photo' => 'file|lt:smaller']);
         $this->assertFalse($v->passes());
-        $this->assertEquals(2, $v->messages()->first('photo'));
+        $this->assertSame(2, (int) $v->messages()->first('photo'));
 
         $v = new Validator($trans, ['items' => [1, 2, 3], 'less' => [0, 1]], ['items' => 'lt:less']);
         $this->assertFalse($v->passes());
-        $this->assertEquals(2, $v->messages()->first('items'));
+        $this->assertSame(2, (int) $v->messages()->first('items'));
     }
 
     public function testValidateGtePlaceHolderIsReplacedProperly()
@@ -4228,15 +4229,15 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['items' => '3'], ['items' => 'gte:4']);
         $this->assertFalse($v->passes());
-        $this->assertEquals(4, $v->messages()->first('items'));
+        $this->assertSame(4, (int) $v->messages()->first('items'));
 
         $v = new Validator($trans, ['items' => 3, 'more' => 5], ['items' => 'numeric|gte:more']);
         $this->assertFalse($v->passes());
-        $this->assertEquals(5, $v->messages()->first('items'));
+        $this->assertSame(5, (int) $v->messages()->first('items'));
 
         $v = new Validator($trans, ['items' => 'abc', 'more' => 'abcde'], ['items' => 'gte:more']);
         $this->assertFalse($v->passes());
-        $this->assertEquals(5, $v->messages()->first('items'));
+        $this->assertSame(5, (int) $v->messages()->first('items'));
 
         $v = new Validator($trans, ['max' => 10], ['min' => 'numeric', 'max' => 'numeric|gte:min'], [], ['min' => 'minimum value', 'max' => 'maximum value']);
         $this->assertFalse($v->passes());
@@ -4251,11 +4252,11 @@ class ValidationValidatorTest extends TestCase
         $biggerFile->method('isValid')->willReturn(true);
         $v = new Validator($trans, ['photo' => $file, 'bigger' => $biggerFile], ['photo' => 'file|gte:bigger']);
         $this->assertFalse($v->passes());
-        $this->assertEquals(5, $v->messages()->first('photo'));
+        $this->assertSame(5, (int) $v->messages()->first('photo'));
 
         $v = new Validator($trans, ['items' => [1, 2, 3], 'more' => [0, 1, 2, 3]], ['items' => 'gte:more']);
         $this->assertFalse($v->passes());
-        $this->assertEquals(4, $v->messages()->first('items'));
+        $this->assertSame(4, (int) $v->messages()->first('items'));
     }
 
     public function testValidateLtePlaceHolderIsReplacedProperly()
@@ -4270,15 +4271,15 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['items' => '3'], ['items' => 'lte:2']);
         $this->assertFalse($v->passes());
-        $this->assertEquals(2, $v->messages()->first('items'));
+        $this->assertSame(2, (int) $v->messages()->first('items'));
 
         $v = new Validator($trans, ['items' => 3, 'less' => 2], ['items' => 'numeric|lte:less']);
         $this->assertFalse($v->passes());
-        $this->assertEquals(2, $v->messages()->first('items'));
+        $this->assertSame(2, (int) $v->messages()->first('items'));
 
         $v = new Validator($trans, ['items' => 'abc', 'less' => 'ab'], ['items' => 'lte:less']);
         $this->assertFalse($v->passes());
-        $this->assertEquals(2, $v->messages()->first('items'));
+        $this->assertSame(2, (int) $v->messages()->first('items'));
 
         $v = new Validator($trans, ['min' => 1], ['min' => 'numeric|lte:max', 'max' => 'numeric'], [], ['min' => 'minimum value', 'max' => 'maximum value']);
         $this->assertFalse($v->passes());
@@ -4293,11 +4294,11 @@ class ValidationValidatorTest extends TestCase
         $smallerFile->method('isValid')->willReturn(true);
         $v = new Validator($trans, ['photo' => $file, 'smaller' => $smallerFile], ['photo' => 'file|lte:smaller']);
         $this->assertFalse($v->passes());
-        $this->assertEquals(2, $v->messages()->first('photo'));
+        $this->assertSame(2, (int) $v->messages()->first('photo'));
 
         $v = new Validator($trans, ['items' => [1, 2, 3], 'less' => [0, 1]], ['items' => 'lte:less']);
         $this->assertFalse($v->passes());
-        $this->assertEquals(2, $v->messages()->first('items'));
+        $this->assertSame(2, (int) $v->messages()->first('items'));
     }
 
     public function testValidateContains()
@@ -8905,7 +8906,7 @@ class ValidationValidatorTest extends TestCase
         $v->validated();
 
         $this->assertEquals(['first' => 'john', 'preferred' => 'john'], $data);
-        $this->assertEquals(1, $validateCount);
+        $this->assertSame(1, $validateCount);
     }
 
     public function testMultiplePassesCalls()

--- a/tests/View/Blade/BladeBoolTest.php
+++ b/tests/View/Blade/BladeBoolTest.php
@@ -34,28 +34,28 @@ class BladeBoolTest extends AbstractBladeTestCase
 
         ob_start();
         eval(substr($compiled, 6, -3));
-        $this->assertEquals('true', ob_get_clean());
+        $this->assertSame('true', ob_get_clean());
 
         $someViewVarFalsey = '0';
         $compiled = $this->compiler->compileString('@bool($someViewVarFalsey)');
 
         ob_start();
         eval(substr($compiled, 6, -3));
-        $this->assertEquals('false', ob_get_clean());
+        $this->assertSame('false', ob_get_clean());
 
         $anotherSomeViewVarTruthy = new SomeClass();
         $compiled = $this->compiler->compileString('@bool($anotherSomeViewVarTruthy)');
 
         ob_start();
         eval(substr($compiled, 6, -3));
-        $this->assertEquals('true', ob_get_clean());
+        $this->assertSame('true', ob_get_clean());
 
         $anotherSomeViewVarFalsey = null;
         $compiled = $this->compiler->compileString('@bool($anotherSomeViewVarFalsey)');
 
         ob_start();
         eval(substr($compiled, 6, -3));
-        $this->assertEquals('false', ob_get_clean());
+        $this->assertSame('false', ob_get_clean());
     }
 }
 

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -822,15 +822,17 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
             }
         };
 
-        $model = new class extends Model {
+        $model = new class extends Model
+        {
         };
 
-        $paginator = new class extends AbstractPaginator {
+        $paginator = new class extends AbstractPaginator
+        {
         };
 
         $this->assertEquals(e('<hi>'), BladeCompiler::sanitizeComponentAttribute('<hi>'));
         $this->assertEquals(e('1'), BladeCompiler::sanitizeComponentAttribute('1'));
-        $this->assertEquals(1, BladeCompiler::sanitizeComponentAttribute(1));
+        $this->assertSame(1, BladeCompiler::sanitizeComponentAttribute(1));
         $this->assertEquals(e('<hi>'), BladeCompiler::sanitizeComponentAttribute($class));
         $this->assertSame($model, BladeCompiler::sanitizeComponentAttribute($model));
         $this->assertSame($paginator, BladeCompiler::sanitizeComponentAttribute($paginator));

--- a/tests/View/ViewComponentAttributeBagTest.php
+++ b/tests/View/ViewComponentAttributeBagTest.php
@@ -279,7 +279,7 @@ class ViewComponentAttributeBagTest extends TestCase
         $result = $bag->whenFilled('name', function ($value) {
             return 'callback-'.$value;
         });
-        $this->assertEquals('callback-test', $result);
+        $this->assertSame('callback-test', $result);
 
         $result = $bag->whenFilled('empty', function ($value) {
             return 'callback-'.$value;
@@ -291,7 +291,7 @@ class ViewComponentAttributeBagTest extends TestCase
         }, function () {
             return 'default-callback';
         });
-        $this->assertEquals('default-callback', $result);
+        $this->assertSame('default-callback', $result);
     }
 
     public function testWhenHas()
@@ -301,7 +301,7 @@ class ViewComponentAttributeBagTest extends TestCase
         $result = $bag->whenHas('name', function ($value) {
             return 'callback-'.$value;
         });
-        $this->assertEquals('callback-test', $result);
+        $this->assertSame('callback-test', $result);
 
         $result = $bag->whenHas('missing', function ($value) {
             return 'callback-'.$value;
@@ -313,7 +313,7 @@ class ViewComponentAttributeBagTest extends TestCase
         }, function () {
             return 'default-callback';
         });
-        $this->assertEquals('default-callback', $result);
+        $this->assertSame('default-callback', $result);
     }
 
     public function testWhenMissing()
@@ -328,14 +328,14 @@ class ViewComponentAttributeBagTest extends TestCase
         $result = $bag->whenMissing('missing', function () {
             return 'callback';
         });
-        $this->assertEquals('callback', $result);
+        $this->assertSame('callback', $result);
 
         $result = $bag->whenMissing('name', function () {
             return 'callback';
         }, function () {
             return 'default-callback';
         });
-        $this->assertEquals('default-callback', $result);
+        $this->assertSame('default-callback', $result);
     }
 
     public function testString()
@@ -347,10 +347,10 @@ class ViewComponentAttributeBagTest extends TestCase
         ]);
 
         $this->assertInstanceOf(\Illuminate\Support\Stringable::class, $bag->string('name'));
-        $this->assertEquals('test', (string) $bag->string('name'));
-        $this->assertEquals('', (string) $bag->string('empty'));
-        $this->assertEquals('123', (string) $bag->string('number'));
-        $this->assertEquals('default', (string) $bag->string('missing', 'default'));
+        $this->assertSame('test', (string) $bag->string('name'));
+        $this->assertSame('', (string) $bag->string('empty'));
+        $this->assertSame('123', (string) $bag->string('number'));
+        $this->assertSame('default', (string) $bag->string('missing', 'default'));
     }
 
     public function testBoolean()

--- a/tests/View/ViewComponentTest.php
+++ b/tests/View/ViewComponentTest.php
@@ -16,7 +16,7 @@ class ViewComponentTest extends TestCase
 
         $variables = $component->data();
 
-        $this->assertEquals(10, $variables['votes']);
+        $this->assertSame(10, $variables['votes']);
         $this->assertSame('world', $variables['hello']());
         $this->assertSame('taylor', $variables['hello']('taylor'));
     }
@@ -91,18 +91,18 @@ class ViewComponentTest extends TestCase
     {
         $component = new TestSampleViewComponent;
 
-        $this->assertEquals(0, $component->counter);
-        $this->assertEquals(0, TestSampleViewComponent::$publicStaticCounter);
+        $this->assertSame(0, $component->counter);
+        $this->assertSame(0, TestSampleViewComponent::$publicStaticCounter);
         $variables = $component->data();
-        $this->assertEquals(0, $component->counter);
-        $this->assertEquals(0, TestSampleViewComponent::$publicStaticCounter);
+        $this->assertSame(0, $component->counter);
+        $this->assertSame(0, TestSampleViewComponent::$publicStaticCounter);
 
         $this->assertSame('noArgs val', $variables['noArgs']());
         $this->assertSame('noArgs val', (string) $variables['noArgs']);
-        $this->assertEquals(0, $variables['counter']);
+        $this->assertSame(0, $variables['counter']);
 
         // make sure non-public members are not invoked nor counted.
-        $this->assertEquals(2, $component->counter);
+        $this->assertSame(2, $component->counter);
         $this->assertArrayHasKey('publicHello', $variables);
         $this->assertArrayNotHasKey('protectedHello', $variables);
         $this->assertArrayNotHasKey('privateHello', $variables);
@@ -112,11 +112,11 @@ class ViewComponentTest extends TestCase
         $this->assertArrayNotHasKey('privateCounter', $variables);
 
         // test each time we invoke data(), the non-argument methods aren't invoked
-        $this->assertEquals(2, $component->counter);
+        $this->assertSame(2, $component->counter);
         $component->data();
-        $this->assertEquals(2, $component->counter);
+        $this->assertSame(2, $component->counter);
         $component->data();
-        $this->assertEquals(2, $component->counter);
+        $this->assertSame(2, $component->counter);
     }
 
     public function testItIgnoresExceptedMethodsAndProperties()

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -1022,17 +1022,17 @@ class ViewFactoryTest extends TestCase
 
         $factory->incrementLoopIndices();
 
-        $this->assertEquals(1, $factory->getLoopStack()[0]['iteration']);
-        $this->assertEquals(0, $factory->getLoopStack()[0]['index']);
-        $this->assertEquals(3, $factory->getLoopStack()[0]['remaining']);
+        $this->assertSame(1, $factory->getLoopStack()[0]['iteration']);
+        $this->assertSame(0, $factory->getLoopStack()[0]['index']);
+        $this->assertSame(3, $factory->getLoopStack()[0]['remaining']);
         $this->assertTrue($factory->getLoopStack()[0]['odd']);
         $this->assertFalse($factory->getLoopStack()[0]['even']);
 
         $factory->incrementLoopIndices();
 
-        $this->assertEquals(2, $factory->getLoopStack()[0]['iteration']);
-        $this->assertEquals(1, $factory->getLoopStack()[0]['index']);
-        $this->assertEquals(2, $factory->getLoopStack()[0]['remaining']);
+        $this->assertSame(2, $factory->getLoopStack()[0]['iteration']);
+        $this->assertSame(1, $factory->getLoopStack()[0]['index']);
+        $this->assertSame(2, $factory->getLoopStack()[0]['remaining']);
         $this->assertFalse($factory->getLoopStack()[0]['odd']);
         $this->assertTrue($factory->getLoopStack()[0]['even']);
     }
@@ -1060,8 +1060,8 @@ class ViewFactoryTest extends TestCase
 
         $factory->incrementLoopIndices();
 
-        $this->assertEquals(2, $factory->getLoopStack()[0]['iteration']);
-        $this->assertEquals(1, $factory->getLoopStack()[0]['index']);
+        $this->assertSame(2, $factory->getLoopStack()[0]['iteration']);
+        $this->assertSame(1, $factory->getLoopStack()[0]['index']);
         $this->assertFalse($factory->getLoopStack()[0]['first']);
         $this->assertNull($factory->getLoopStack()[0]['remaining']);
         $this->assertNull($factory->getLoopStack()[0]['last']);


### PR DESCRIPTION
Enforce stricter assertions using `assertSame` instead of `assertEquals`