### PR TITLE
[13.x] Fire NotificationSending event in NotificationFake

### DIFF
--- a/src/Illuminate/Support/Facades/Notification.php
+++ b/src/Illuminate/Support/Facades/Notification.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Support\Facades;
 
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Notifications\AnonymousNotifiable;
 use Illuminate\Notifications\ChannelManager;
 use Illuminate\Support\Testing\Fakes\NotificationFake;
@@ -52,7 +53,7 @@ class Notification extends Facade
      */
     public static function fake()
     {
-        return tap(new NotificationFake, function ($fake) {
+        return tap(new NotificationFake(static::$app->make(Dispatcher::class)), function ($fake) {
             static::swap($fake);
         });
     }

--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -4,11 +4,13 @@ namespace Illuminate\Support\Testing\Fakes;
 
 use Closure;
 use Exception;
+use Illuminate\Contracts\Events\Dispatcher as EventDispatcher;
 use Illuminate\Contracts\Notifications\Dispatcher as NotificationDispatcher;
 use Illuminate\Contracts\Notifications\Factory as NotificationFactory;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Contracts\Translation\HasLocalePreference;
 use Illuminate\Notifications\AnonymousNotifiable;
+use Illuminate\Notifications\Events\NotificationSending;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
@@ -18,6 +20,13 @@ use PHPUnit\Framework\Assert as PHPUnit;
 class NotificationFake implements Fake, NotificationDispatcher, NotificationFactory
 {
     use Macroable, ReflectsClosures;
+
+    /**
+     * The event dispatcher.
+     *
+     * @var \Illuminate\Contracts\Events\Dispatcher|null
+     */
+    protected $events = null;
 
     /**
      * All of the notifications that have been sent.
@@ -39,6 +48,17 @@ class NotificationFake implements Fake, NotificationDispatcher, NotificationFact
      * @var bool
      */
     protected $serializeAndRestore = false;
+
+    /**
+     * Create a new notification fake instance.
+     *
+     * @param  \Illuminate\Contracts\Events\Dispatcher|null  $events
+     * @return void
+     */
+    public function __construct(?EventDispatcher $events = null)
+    {
+        $this->events = $events;
+    }
 
     /**
      * Assert if a notification was sent on-demand based on a truth-test callback.
@@ -323,6 +343,15 @@ class NotificationFake implements Fake, NotificationDispatcher, NotificationFact
                 $notifiableChannels = array_filter(
                     $notifiableChannels,
                     fn ($channel) => $notification->shouldSend($notifiable, $channel) !== false
+                );
+            }
+
+            if ($this->events) {
+                $notifiableChannels = array_filter(
+                    $notifiableChannels,
+                    fn ($channel) => $this->events->until(
+                        new NotificationSending($notifiable, $notification, $channel)
+                    ) !== false
                 );
             }
 

--- a/tests/Support/SupportTestingNotificationFakeTest.php
+++ b/tests/Support/SupportTestingNotificationFakeTest.php
@@ -4,10 +4,12 @@ namespace Illuminate\Tests\Support;
 
 use Exception;
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Events\Dispatcher as EventDispatcher;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Contracts\Translation\HasLocalePreference;
 use Illuminate\Foundation\Auth\User;
 use Illuminate\Notifications\AnonymousNotifiable;
+use Illuminate\Notifications\Events\NotificationSending;
 use Illuminate\Notifications\Notification;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Testing\Fakes\NotificationFake;
@@ -224,6 +226,32 @@ class SupportTestingNotificationFakeTest extends TestCase
         $this->fake->assertNotSentTo($user, NotificationWithFalsyShouldSendStub::class);
     }
 
+    public function testNotificationSendingEventBlocksNotification()
+    {
+        $events = $this->createMock(EventDispatcher::class);
+        $events->method('until')->willReturn(false);
+
+        $fake = new NotificationFake($events);
+        $fake->send($this->user, new NotificationStub);
+
+        $fake->assertNotSentTo($this->user, NotificationStub::class);
+    }
+
+    public function testNotificationSendingEventCanBlockIndividualChannels()
+    {
+        $events = $this->createMock(EventDispatcher::class);
+        $events->method('until')->willReturnCallback(
+            fn (NotificationSending $event) => $event->channel === 'mail' ? false : null
+        );
+
+        $fake = new NotificationFake($events);
+        $fake->send($this->user, new NotificationWithMultipleChannelsStub);
+
+        $fake->assertSentTo($this->user, NotificationWithMultipleChannelsStub::class, function ($notification, $channels) {
+            return array_values($channels) === ['database'];
+        });
+    }
+
     public function testAssertItCanSerializeAndRestoreNotifications()
     {
         $this->fake->serializeAndRestore();
@@ -240,6 +268,14 @@ class NotificationStub extends Notification
     public function via($notifiable)
     {
         return ['mail'];
+    }
+}
+
+class NotificationWithMultipleChannelsStub extends Notification
+{
+    public function via($notifiable)
+    {
+        return ['mail', 'database'];
     }
 }
 


### PR DESCRIPTION
## Problem

When using `Notification::fake()`, any listeners on the [NotificationSending](https://laravel.com/docs/13.x/notifications#notification-events) event are silently bypassed. 

This is a problem when your application uses a listener to suppress notifications conditionally (blocking mail for unverified users, for example). The fake records the notification regardless, making assertions unreliable.

## What changed

`NotificationFake` now accepts an optional `Illuminate\Contracts\Events\Dispatcher` and fires `NotificationSending` per channel in `sendNow()`, mirroring what `NotificationSender` does in production. `Notification::fake()` injects the application dispatcher automatically.

## No breaking changes

The constructor parameter defaults to null, so direct instantiation of `NotificationFake` without arguments continues to work as before.

## Benefit to developers

Listener-gated notification logic can now be tested through the fake. If a `NotificationSending` listener returns false for a channel, that channel is excluded from what the fake records. 

Simply put: `assertSentTo`, `assertNotSentTo`, and channel-specific assertions reflect what the real dispatcher would actually send when using a `NotificationSending` listener.