### PR TITLE
[13.x] Add optional disk storage for large SQS queue payloads

### DIFF
--- a/config/queue.php
+++ b/config/queue.php
@@ -62,12 +62,11 @@ return [
             'suffix' => env('SQS_SUFFIX'),
             'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
             'after_commit' => false,
-            'extended_store_options' => [
-                'enabled' => env('SQS_STORE_ENABLED', false),
-                'disk' => env('SQS_STORE_DISK', 's3'),
-                'prefix' => env('SQS_STORE_PREFIX', ''),
+            'overflow' => [
+                'enabled' => env('SQS_OVERFLOW_ENABLED', false),
+                'store' => env('SQS_OVERFLOW_STORE'),
                 'always' => false,
-                'cleanup' => true,
+                'delete_after_processing' => true,
             ],
         ],
 

--- a/config/queue.php
+++ b/config/queue.php
@@ -62,6 +62,13 @@ return [
             'suffix' => env('SQS_SUFFIX'),
             'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
             'after_commit' => false,
+            'extended_store_options' => [
+                'enabled' => env('SQS_STORE_ENABLED', false),
+                'disk' => env('SQS_STORE_DISK', 's3'),
+                'prefix' => env('SQS_STORE_PREFIX', ''),
+                'always' => false,
+                'cleanup' => true,
+            ],
         ],
 
         'redis' => [

--- a/src/Illuminate/Queue/Connectors/SqsConnector.php
+++ b/src/Illuminate/Queue/Connectors/SqsConnector.php
@@ -28,13 +28,13 @@ class SqsConnector implements ConnectorInterface
 
         return new SqsQueue(
             new SqsClient(
-                Arr::except($config, ['token', 'extended_store_options'])
+                Arr::except($config, ['token', 'overflow'])
             ),
             $config['queue'],
             $config['prefix'] ?? '',
             $config['suffix'] ?? '',
             $config['after_commit'] ?? null,
-            $config['extended_store_options'] ?? [],
+            $config['overflow'] ?? [],
         );
     }
 

--- a/src/Illuminate/Queue/Connectors/SqsConnector.php
+++ b/src/Illuminate/Queue/Connectors/SqsConnector.php
@@ -28,12 +28,13 @@ class SqsConnector implements ConnectorInterface
 
         return new SqsQueue(
             new SqsClient(
-                Arr::except($config, ['token'])
+                Arr::except($config, ['token', 'extended_store_options'])
             ),
             $config['queue'],
             $config['prefix'] ?? '',
             $config['suffix'] ?? '',
-            $config['after_commit'] ?? null
+            $config['after_commit'] ?? null,
+            $config['extended_store_options'] ?? [],
         );
     }
 

--- a/src/Illuminate/Queue/Jobs/SqsJob.php
+++ b/src/Illuminate/Queue/Jobs/SqsJob.php
@@ -87,8 +87,9 @@ class SqsJob extends Job implements JobContract
             'QueueUrl' => $this->queue, 'ReceiptHandle' => $this->job['ReceiptHandle'],
         ]);
 
-        if (Arr::get($this->overflowStorage, 'delete_after_processing') && $pointer = $this->resolvePointer()) {
-            $this->resolveStore()->forget($pointer);
+        if (Arr::get($this->overflowStorage, 'delete_after_processing') &&
+            $pointer = $this->overflowPointer()) {
+            $this->overflowStore()->forget($pointer);
         }
     }
 
@@ -123,31 +124,11 @@ class SqsJob extends Job implements JobContract
             return $this->cachedRawBody;
         }
 
-        if ($pointer = $this->resolvePointer()) {
-            return $this->cachedRawBody = $this->resolveStore()->get($pointer);
+        if ($pointer = $this->overflowPointer()) {
+            return $this->cachedRawBody = $this->overflowStore()->get($pointer);
         }
 
         return $this->job['Body'];
-    }
-
-    /**
-     * Get the underlying SQS client instance.
-     *
-     * @return \Aws\Sqs\SqsClient
-     */
-    public function getSqs()
-    {
-        return $this->sqs;
-    }
-
-    /**
-     * Get the underlying raw SQS job.
-     *
-     * @return array
-     */
-    public function getSqsJob()
-    {
-        return $this->job;
     }
 
     /**
@@ -155,7 +136,7 @@ class SqsJob extends Job implements JobContract
      *
      * @return string|null
      */
-    protected function resolvePointer()
+    protected function overflowPointer()
     {
         if (! Arr::get($this->overflowStorage, 'enabled', false)) {
             return null;
@@ -181,10 +162,30 @@ class SqsJob extends Job implements JobContract
      *
      * @return \Illuminate\Contracts\Cache\Repository
      */
-    protected function resolveStore()
+    protected function overflowStore()
     {
         return $this->container->make('cache')->store(
             Arr::get($this->overflowStorage, 'store')
         );
+    }
+
+    /**
+     * Get the underlying SQS client instance.
+     *
+     * @return \Aws\Sqs\SqsClient
+     */
+    public function getSqs()
+    {
+        return $this->sqs;
+    }
+
+    /**
+     * Get the underlying raw SQS job.
+     *
+     * @return array
+     */
+    public function getSqsJob()
+    {
+        return $this->job;
     }
 }

--- a/src/Illuminate/Queue/Jobs/SqsJob.php
+++ b/src/Illuminate/Queue/Jobs/SqsJob.php
@@ -24,11 +24,11 @@ class SqsJob extends Job implements JobContract
     protected $job;
 
     /**
-     * The extended store options for large payload offloading.
+     * The overflow storage options for large payload offloading.
      *
      * @var array
      */
-    protected $extendedStoreOptions = [];
+    protected $overflowStorage = [];
 
     /**
      * The cached raw body of the job.
@@ -45,16 +45,16 @@ class SqsJob extends Job implements JobContract
      * @param  array  $job
      * @param  string  $connectionName
      * @param  string  $queue
-     * @param  array  $extendedStoreOptions
+     * @param  array  $overflowStorage
      */
-    public function __construct(Container $container, SqsClient $sqs, array $job, $connectionName, $queue, array $extendedStoreOptions = [])
+    public function __construct(Container $container, SqsClient $sqs, array $job, $connectionName, $queue, array $overflowStorage = [])
     {
         $this->sqs = $sqs;
         $this->job = $job;
         $this->queue = $queue;
         $this->container = $container;
         $this->connectionName = $connectionName;
-        $this->extendedStoreOptions = $extendedStoreOptions;
+        $this->overflowStorage = $overflowStorage;
     }
 
     /**
@@ -87,8 +87,8 @@ class SqsJob extends Job implements JobContract
             'QueueUrl' => $this->queue, 'ReceiptHandle' => $this->job['ReceiptHandle'],
         ]);
 
-        if (Arr::get($this->extendedStoreOptions, 'cleanup') && $pointer = $this->resolvePointer()) {
-            $this->resolveDisk()->delete($pointer);
+        if (Arr::get($this->overflowStorage, 'delete_after_processing') && $pointer = $this->resolvePointer()) {
+            $this->resolveStore()->forget($pointer);
         }
     }
 
@@ -124,7 +124,7 @@ class SqsJob extends Job implements JobContract
         }
 
         if ($pointer = $this->resolvePointer()) {
-            return $this->cachedRawBody = $this->resolveDisk()->get($pointer);
+            return $this->cachedRawBody = $this->resolveStore()->get($pointer);
         }
 
         return $this->job['Body'];
@@ -157,6 +157,10 @@ class SqsJob extends Job implements JobContract
      */
     protected function resolvePointer()
     {
+        if (! Arr::get($this->overflowStorage, 'enabled', false)) {
+            return null;
+        }
+
         $body = $this->job['Body'] ?? null;
 
         if (! is_string($body) || $body === '') {
@@ -173,14 +177,14 @@ class SqsJob extends Job implements JobContract
     }
 
     /**
-     * Resolve the configured filesystem disk for extended storage.
+     * Resolve the configured cache store for extended storage.
      *
-     * @return \Illuminate\Filesystem\FilesystemAdapter
+     * @return \Illuminate\Contracts\Cache\Repository
      */
-    protected function resolveDisk()
+    protected function resolveStore()
     {
-        return $this->container->make('filesystem')->disk(
-            Arr::get($this->extendedStoreOptions, 'disk')
+        return $this->container->make('cache')->store(
+            Arr::get($this->overflowStorage, 'store')
         );
     }
 }

--- a/src/Illuminate/Queue/Jobs/SqsJob.php
+++ b/src/Illuminate/Queue/Jobs/SqsJob.php
@@ -5,6 +5,7 @@ namespace Illuminate\Queue\Jobs;
 use Aws\Sqs\SqsClient;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Queue\Job as JobContract;
+use Illuminate\Support\Arr;
 
 class SqsJob extends Job implements JobContract
 {
@@ -23,6 +24,20 @@ class SqsJob extends Job implements JobContract
     protected $job;
 
     /**
+     * The extended store options for large payload offloading.
+     *
+     * @var array
+     */
+    protected $extendedStoreOptions = [];
+
+    /**
+     * The cached raw body of the job.
+     *
+     * @var string|null
+     */
+    protected $cachedRawBody = null;
+
+    /**
      * Create a new job instance.
      *
      * @param  \Illuminate\Container\Container  $container
@@ -30,14 +45,16 @@ class SqsJob extends Job implements JobContract
      * @param  array  $job
      * @param  string  $connectionName
      * @param  string  $queue
+     * @param  array  $extendedStoreOptions
      */
-    public function __construct(Container $container, SqsClient $sqs, array $job, $connectionName, $queue)
+    public function __construct(Container $container, SqsClient $sqs, array $job, $connectionName, $queue, array $extendedStoreOptions = [])
     {
         $this->sqs = $sqs;
         $this->job = $job;
         $this->queue = $queue;
         $this->container = $container;
         $this->connectionName = $connectionName;
+        $this->extendedStoreOptions = $extendedStoreOptions;
     }
 
     /**
@@ -69,6 +86,10 @@ class SqsJob extends Job implements JobContract
         $this->sqs->deleteMessage([
             'QueueUrl' => $this->queue, 'ReceiptHandle' => $this->job['ReceiptHandle'],
         ]);
+
+        if (Arr::get($this->extendedStoreOptions, 'cleanup') && $pointer = $this->resolvePointer()) {
+            $this->resolveDisk()->delete($pointer);
+        }
     }
 
     /**
@@ -98,6 +119,14 @@ class SqsJob extends Job implements JobContract
      */
     public function getRawBody()
     {
+        if ($this->cachedRawBody !== null) {
+            return $this->cachedRawBody;
+        }
+
+        if ($pointer = $this->resolvePointer()) {
+            return $this->cachedRawBody = $this->resolveDisk()->get($pointer);
+        }
+
         return $this->job['Body'];
     }
 
@@ -119,5 +148,39 @@ class SqsJob extends Job implements JobContract
     public function getSqsJob()
     {
         return $this->job;
+    }
+
+    /**
+     * Resolve the pointer path from the job body, if present.
+     *
+     * @return string|null
+     */
+    protected function resolvePointer()
+    {
+        $body = $this->job['Body'] ?? null;
+
+        if (! is_string($body) || $body === '') {
+            return null;
+        }
+
+        $decoded = json_decode($body, true);
+
+        if (! is_array($decoded) || ! isset($decoded['@pointer'])) {
+            return null;
+        }
+
+        return is_string($decoded['@pointer']) ? $decoded['@pointer'] : null;
+    }
+
+    /**
+     * Resolve the configured filesystem disk for extended storage.
+     *
+     * @return \Illuminate\Filesystem\FilesystemAdapter
+     */
+    protected function resolveDisk()
+    {
+        return $this->container->make('filesystem')->disk(
+            Arr::get($this->extendedStoreOptions, 'disk')
+        );
     }
 }

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -20,6 +20,13 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
     const MAX_SQS_PAYLOAD_SIZE = 1048576;
 
     /**
+     * The cache key prefix for extended SQS payloads.
+     *
+     * @var string
+     */
+    const EXTENDED_PAYLOAD_CACHE_PREFIX = 'laravel:sqs-payloads:';
+
+    /**
      * The Amazon SQS instance.
      *
      * @var \Aws\Sqs\SqsClient
@@ -48,11 +55,11 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
     protected $suffix;
 
     /**
-     * The extended store options for large payload offloading.
+     * The overflow storage options for large payload offloading.
      *
      * @var array
      */
-    protected $extendedStoreOptions = [];
+    protected $overflowStorage = [];
 
     /**
      * Create a new Amazon SQS queue instance.
@@ -62,7 +69,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
      * @param  string  $prefix
      * @param  string  $suffix
      * @param  bool  $dispatchAfterCommit
-     * @param  array  $extendedStoreOptions
+     * @param  array  $overflowStorage
      */
     public function __construct(
         SqsClient $sqs,
@@ -70,14 +77,14 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
         $prefix = '',
         $suffix = '',
         $dispatchAfterCommit = false,
-        array $extendedStoreOptions = [],
+        array $overflowStorage = [],
     ) {
         $this->sqs = $sqs;
         $this->prefix = $prefix;
         $this->default = $default;
         $this->suffix = $suffix;
         $this->dispatchAfterCommit = $dispatchAfterCommit;
-        $this->extendedStoreOptions = $extendedStoreOptions;
+        $this->overflowStorage = $overflowStorage;
     }
 
     /**
@@ -230,8 +237,8 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
      */
     public function pushRaw($payload, $queue = null, array $options = [])
     {
-        if ($this->shouldStoreToDisk($payload)) {
-            $payload = $this->storeToDisk($payload);
+        if ($this->shouldStoreInCache($payload)) {
+            $payload = $this->storeInCache($payload);
         }
 
         return $this->sqs->sendMessage([
@@ -358,7 +365,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
         if (! is_null($response['Messages']) && count($response['Messages']) > 0) {
             return new SqsJob(
                 $this->container, $this->sqs, $response['Messages'][0],
-                $this->connectionName, $queue, $this->extendedStoreOptions
+                $this->connectionName, $queue, $this->overflowStorage
             );
         }
     }
@@ -375,10 +382,6 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
             $this->sqs->purgeQueue([
                 'QueueUrl' => $this->getQueue($queue),
             ]);
-
-            if (Arr::get($this->extendedStoreOptions, 'cleanup') && Arr::get($this->extendedStoreOptions, 'prefix')) {
-                $this->resolveDisk()->deleteDirectory(Arr::get($this->extendedStoreOptions, 'prefix'));
-            }
         });
     }
 
@@ -416,51 +419,49 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
     }
 
     /**
-     * Determine if the payload should be stored on disk.
+     * Determine if the payload should be stored in cache.
      *
      * @param  string  $payload
      * @return bool
      */
-    protected function shouldStoreToDisk($payload)
+    protected function shouldStoreInCache($payload)
     {
-        if (! Arr::get($this->extendedStoreOptions, 'enabled', false)) {
+        if (! Arr::get($this->overflowStorage, 'enabled', false)) {
             return false;
         }
 
-        return Arr::get($this->extendedStoreOptions, 'always', false)
+        return Arr::get($this->overflowStorage, 'always', false)
             || strlen($payload) >= static::MAX_SQS_PAYLOAD_SIZE;
     }
 
     /**
-     * Store the payload on disk and return a pointer payload.
+     * Store the payload in cache and return a pointer payload.
      *
      * @param  string  $payload
      * @return string
      */
-    protected function storeToDisk($payload)
+    protected function storeInCache($payload)
     {
         $decoded = json_decode($payload);
 
-        $uuid = $decoded->uuid ?? (string) Str::uuid();
+        $uuid = is_object($decoded) && isset($decoded->uuid) ? $decoded->uuid : (string) Str::uuid();
 
-        $prefix = Arr::get($this->extendedStoreOptions, 'prefix', '');
+        $path = static::EXTENDED_PAYLOAD_CACHE_PREFIX.$uuid;
 
-        $path = ltrim($prefix.'/'.$uuid.'.json', '/');
-
-        $this->resolveDisk()->put($path, $payload);
+        $this->resolveStore()->put($path, $payload);
 
         return json_encode(['@pointer' => $path]);
     }
 
     /**
-     * Resolve the configured filesystem disk for extended storage.
+     * Resolve the configured cache store for extended storage.
      *
-     * @return \Illuminate\Filesystem\FilesystemAdapter
+     * @return \Illuminate\Contracts\Cache\Repository
      */
-    protected function resolveDisk()
+    protected function resolveStore()
     {
-        return $this->container->make('filesystem')->disk(
-            Arr::get($this->extendedStoreOptions, 'disk')
+        return $this->container->make('cache')->store(
+            Arr::get($this->overflowStorage, 'store')
         );
     }
 

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -237,8 +237,8 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
      */
     public function pushRaw($payload, $queue = null, array $options = [])
     {
-        if ($this->shouldStoreInCache($payload)) {
-            $payload = $this->storeInCache($payload);
+        if ($this->willOverflow($payload)) {
+            $payload = $this->overflow($payload);
         }
 
         return $this->sqs->sendMessage([
@@ -350,6 +350,45 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
     }
 
     /**
+     * Determine if the payload should be stored in cache.
+     *
+     * @param  string  $payload
+     * @return bool
+     */
+    protected function willOverflow($payload)
+    {
+        if (! Arr::get($this->overflowStorage, 'enabled', false)) {
+            return false;
+        }
+
+        return Arr::get($this->overflowStorage, 'always', false)
+            || strlen($payload) >= static::MAX_SQS_PAYLOAD_SIZE;
+    }
+
+    /**
+     * Store the payload in cache and return a pointer payload.
+     *
+     * @param  string  $payload
+     * @return string
+     */
+    protected function overflow($payload)
+    {
+        $decoded = json_decode($payload);
+
+        $uuid = is_object($decoded) && isset($decoded->uuid)
+            ? $decoded->uuid
+            : (string) Str::uuid();
+
+        $this->container->make('cache')->store(
+            Arr::get($this->overflowStorage, 'store')
+        )->put(
+            $path = static::EXTENDED_PAYLOAD_CACHE_PREFIX.$uuid, $payload
+        );
+
+        return json_encode(['@pointer' => $path]);
+    }
+
+    /**
      * Pop the next job off of the queue.
      *
      * @param  string|null  $queue
@@ -416,53 +455,6 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
         }
 
         return rtrim($this->prefix, '/').'/'.Str::finish($queue, $this->suffix);
-    }
-
-    /**
-     * Determine if the payload should be stored in cache.
-     *
-     * @param  string  $payload
-     * @return bool
-     */
-    protected function shouldStoreInCache($payload)
-    {
-        if (! Arr::get($this->overflowStorage, 'enabled', false)) {
-            return false;
-        }
-
-        return Arr::get($this->overflowStorage, 'always', false)
-            || strlen($payload) >= static::MAX_SQS_PAYLOAD_SIZE;
-    }
-
-    /**
-     * Store the payload in cache and return a pointer payload.
-     *
-     * @param  string  $payload
-     * @return string
-     */
-    protected function storeInCache($payload)
-    {
-        $decoded = json_decode($payload);
-
-        $uuid = is_object($decoded) && isset($decoded->uuid) ? $decoded->uuid : (string) Str::uuid();
-
-        $path = static::EXTENDED_PAYLOAD_CACHE_PREFIX.$uuid;
-
-        $this->resolveStore()->put($path, $payload);
-
-        return json_encode(['@pointer' => $path]);
-    }
-
-    /**
-     * Resolve the configured cache store for extended storage.
-     *
-     * @return \Illuminate\Contracts\Cache\Repository
-     */
-    protected function resolveStore()
-    {
-        return $this->container->make('cache')->store(
-            Arr::get($this->overflowStorage, 'store')
-        );
     }
 
     /**

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -5,7 +5,6 @@ namespace Illuminate\Queue;
 use Aws\Sqs\SqsClient;
 use Illuminate\Contracts\Queue\ClearableQueue;
 use Illuminate\Contracts\Queue\Queue as QueueContract;
-use Illuminate\Filesystem\FilesystemAdapter;
 use Illuminate\Queue\Jobs\SqsJob;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -5,12 +5,21 @@ namespace Illuminate\Queue;
 use Aws\Sqs\SqsClient;
 use Illuminate\Contracts\Queue\ClearableQueue;
 use Illuminate\Contracts\Queue\Queue as QueueContract;
+use Illuminate\Filesystem\FilesystemAdapter;
 use Illuminate\Queue\Jobs\SqsJob;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 
 class SqsQueue extends Queue implements QueueContract, ClearableQueue
 {
+    /**
+     * The maximum SQS payload size in bytes (1 MB).
+     *
+     * @var int
+     */
+    const MAX_SQS_PAYLOAD_SIZE = 1048576;
+
     /**
      * The Amazon SQS instance.
      *
@@ -40,6 +49,13 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
     protected $suffix;
 
     /**
+     * The extended store options for large payload offloading.
+     *
+     * @var array
+     */
+    protected $extendedStoreOptions = [];
+
+    /**
      * Create a new Amazon SQS queue instance.
      *
      * @param  \Aws\Sqs\SqsClient  $sqs
@@ -47,6 +63,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
      * @param  string  $prefix
      * @param  string  $suffix
      * @param  bool  $dispatchAfterCommit
+     * @param  array  $extendedStoreOptions
      */
     public function __construct(
         SqsClient $sqs,
@@ -54,12 +71,14 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
         $prefix = '',
         $suffix = '',
         $dispatchAfterCommit = false,
+        array $extendedStoreOptions = [],
     ) {
         $this->sqs = $sqs;
         $this->prefix = $prefix;
         $this->default = $default;
         $this->suffix = $suffix;
         $this->dispatchAfterCommit = $dispatchAfterCommit;
+        $this->extendedStoreOptions = $extendedStoreOptions;
     }
 
     /**
@@ -212,6 +231,10 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
      */
     public function pushRaw($payload, $queue = null, array $options = [])
     {
+        if ($this->shouldStoreToDisk($payload)) {
+            $payload = $this->storeToDisk($payload);
+        }
+
         return $this->sqs->sendMessage([
             'QueueUrl' => $this->getQueue($queue), 'MessageBody' => $payload, ...$options,
         ])->get('MessageId');
@@ -336,7 +359,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
         if (! is_null($response['Messages']) && count($response['Messages']) > 0) {
             return new SqsJob(
                 $this->container, $this->sqs, $response['Messages'][0],
-                $this->connectionName, $queue
+                $this->connectionName, $queue, $this->extendedStoreOptions
             );
         }
     }
@@ -353,6 +376,10 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
             $this->sqs->purgeQueue([
                 'QueueUrl' => $this->getQueue($queue),
             ]);
+
+            if (Arr::get($this->extendedStoreOptions, 'cleanup') && Arr::get($this->extendedStoreOptions, 'prefix')) {
+                $this->resolveDisk()->deleteDirectory(Arr::get($this->extendedStoreOptions, 'prefix'));
+            }
         });
     }
 
@@ -387,6 +414,55 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
         }
 
         return rtrim($this->prefix, '/').'/'.Str::finish($queue, $this->suffix);
+    }
+
+    /**
+     * Determine if the payload should be stored on disk.
+     *
+     * @param  string  $payload
+     * @return bool
+     */
+    protected function shouldStoreToDisk($payload)
+    {
+        if (! Arr::get($this->extendedStoreOptions, 'enabled', false)) {
+            return false;
+        }
+
+        return Arr::get($this->extendedStoreOptions, 'always', false)
+            || strlen($payload) >= static::MAX_SQS_PAYLOAD_SIZE;
+    }
+
+    /**
+     * Store the payload on disk and return a pointer payload.
+     *
+     * @param  string  $payload
+     * @return string
+     */
+    protected function storeToDisk($payload)
+    {
+        $decoded = json_decode($payload);
+
+        $uuid = $decoded->uuid ?? (string) Str::uuid();
+
+        $prefix = Arr::get($this->extendedStoreOptions, 'prefix', '');
+
+        $path = ltrim($prefix.'/'.$uuid.'.json', '/');
+
+        $this->resolveDisk()->put($path, $payload);
+
+        return json_encode(['@pointer' => $path]);
+    }
+
+    /**
+     * Resolve the configured filesystem disk for extended storage.
+     *
+     * @return \Illuminate\Filesystem\FilesystemAdapter
+     */
+    protected function resolveDisk()
+    {
+        return $this->container->make('filesystem')->disk(
+            Arr::get($this->extendedStoreOptions, 'disk')
+        );
     }
 
     /**

--- a/tests/Queue/QueueSqsJobTest.php
+++ b/tests/Queue/QueueSqsJobTest.php
@@ -4,8 +4,8 @@ namespace Illuminate\Tests\Queue;
 
 use Aws\Sqs\SqsClient;
 use Illuminate\Container\Container;
-use Illuminate\Contracts\Filesystem\Factory as FilesystemFactory;
-use Illuminate\Filesystem\FilesystemAdapter;
+use Illuminate\Contracts\Cache\Factory as CacheFactory;
+use Illuminate\Contracts\Cache\Repository as CacheRepository;
 use Illuminate\Queue\Jobs\SqsJob;
 use Illuminate\Queue\SqsQueue;
 use Mockery as m;
@@ -96,29 +96,28 @@ class QueueSqsJobTest extends TestCase
         $this->assertTrue($job->isReleased());
     }
 
-    public function testGetRawBodyResolvesPointerFromDisk()
+    public function testGetRawBodyResolvesPointerFromCache()
     {
         $fullPayload = json_encode(['job' => 'foo', 'data' => ['key' => 'value']]);
-        $pointerPath = 'sqs-payloads/some-uuid.json';
+        $pointerPath = 'laravel:sqs-payloads:some-uuid';
         $pointerBody = json_encode(['@pointer' => $pointerPath]);
 
-        $disk = m::mock(FilesystemAdapter::class);
-        $disk->shouldReceive('get')->once()->with($pointerPath)->andReturn($fullPayload);
+        $store = m::mock(CacheRepository::class);
+        $store->shouldReceive('get')->once()->with($pointerPath)->andReturn($fullPayload);
 
-        $filesystem = m::mock(FilesystemFactory::class);
-        $filesystem->shouldReceive('disk')->with('s3')->andReturn($disk);
+        $cache = m::mock(CacheFactory::class);
+        $cache->shouldReceive('store')->with('database')->andReturn($store);
 
         $container = m::mock(Container::class);
-        $container->shouldReceive('make')->with('filesystem')->andReturn($filesystem);
+        $container->shouldReceive('make')->with('cache')->andReturn($cache);
 
         $jobData = $this->mockedJobData;
         $jobData['Body'] = $pointerBody;
 
         $job = new SqsJob($container, $this->mockedSqsClient, $jobData, 'connection-name', $this->queueUrl, [
             'enabled' => true,
-            'disk' => 's3',
-            'prefix' => 'sqs-payloads',
-            'cleanup' => true,
+            'store' => 'database',
+            'delete_after_processing' => true,
         ]);
 
         $this->assertEquals($fullPayload, $job->getRawBody());
@@ -130,49 +129,60 @@ class QueueSqsJobTest extends TestCase
         $this->assertEquals($this->mockedPayload, $job->getRawBody());
     }
 
+    public function testGetRawBodyReturnsPointerBodyWhenExtendedStoreIsDisabled()
+    {
+        $pointerBody = json_encode(['@pointer' => 'laravel:sqs-payloads:some-uuid']);
+
+        $jobData = $this->mockedJobData;
+        $jobData['Body'] = $pointerBody;
+
+        $job = new SqsJob($this->mockedContainer, $this->mockedSqsClient, $jobData, 'connection-name', $this->queueUrl);
+
+        $this->assertEquals($pointerBody, $job->getRawBody());
+    }
+
     public function testGetRawBodyCachesResult()
     {
         $fullPayload = json_encode(['job' => 'foo', 'data' => ['key' => 'value']]);
-        $pointerPath = 'sqs-payloads/some-uuid.json';
+        $pointerPath = 'laravel:sqs-payloads:some-uuid';
         $pointerBody = json_encode(['@pointer' => $pointerPath]);
 
-        $disk = m::mock(FilesystemAdapter::class);
-        $disk->shouldReceive('get')->once()->with($pointerPath)->andReturn($fullPayload);
+        $store = m::mock(CacheRepository::class);
+        $store->shouldReceive('get')->once()->with($pointerPath)->andReturn($fullPayload);
 
-        $filesystem = m::mock(FilesystemFactory::class);
-        $filesystem->shouldReceive('disk')->with('s3')->andReturn($disk);
+        $cache = m::mock(CacheFactory::class);
+        $cache->shouldReceive('store')->with('database')->andReturn($store);
 
         $container = m::mock(Container::class);
-        $container->shouldReceive('make')->with('filesystem')->andReturn($filesystem);
+        $container->shouldReceive('make')->with('cache')->andReturn($cache);
 
         $jobData = $this->mockedJobData;
         $jobData['Body'] = $pointerBody;
 
         $job = new SqsJob($container, $this->mockedSqsClient, $jobData, 'connection-name', $this->queueUrl, [
             'enabled' => true,
-            'disk' => 's3',
-            'prefix' => 'sqs-payloads',
-            'cleanup' => true,
+            'store' => 'database',
+            'delete_after_processing' => true,
         ]);
 
-        // Call twice — disk should only be hit once.
+        // Call twice; cache should only be hit once.
         $job->getRawBody();
         $this->assertEquals($fullPayload, $job->getRawBody());
     }
 
-    public function testDeleteCleansUpDiskFileWhenCleanupEnabled()
+    public function testDeleteCleansUpCacheKeyWhenCleanupEnabled()
     {
-        $pointerPath = 'sqs-payloads/some-uuid.json';
+        $pointerPath = 'laravel:sqs-payloads:some-uuid';
         $pointerBody = json_encode(['@pointer' => $pointerPath]);
 
-        $disk = m::mock(FilesystemAdapter::class);
-        $disk->shouldReceive('delete')->once()->with($pointerPath);
+        $store = m::mock(CacheRepository::class);
+        $store->shouldReceive('forget')->once()->with($pointerPath);
 
-        $filesystem = m::mock(FilesystemFactory::class);
-        $filesystem->shouldReceive('disk')->with('s3')->andReturn($disk);
+        $cache = m::mock(CacheFactory::class);
+        $cache->shouldReceive('store')->with('database')->andReturn($store);
 
         $container = m::mock(Container::class);
-        $container->shouldReceive('make')->with('filesystem')->andReturn($filesystem);
+        $container->shouldReceive('make')->with('cache')->andReturn($cache);
 
         $jobData = $this->mockedJobData;
         $jobData['Body'] = $pointerBody;
@@ -182,9 +192,8 @@ class QueueSqsJobTest extends TestCase
 
         $job = new SqsJob($container, $sqsClient, $jobData, 'connection-name', $this->queueUrl, [
             'enabled' => true,
-            'disk' => 's3',
-            'prefix' => 'sqs-payloads',
-            'cleanup' => true,
+            'store' => 'database',
+            'delete_after_processing' => true,
         ]);
 
         $job->delete();
@@ -192,7 +201,7 @@ class QueueSqsJobTest extends TestCase
 
     public function testDeleteDoesNotCleanUpWhenCleanupDisabled()
     {
-        $pointerPath = 'sqs-payloads/some-uuid.json';
+        $pointerPath = 'laravel:sqs-payloads:some-uuid';
         $pointerBody = json_encode(['@pointer' => $pointerPath]);
 
         $jobData = $this->mockedJobData;
@@ -203,9 +212,8 @@ class QueueSqsJobTest extends TestCase
 
         $job = new SqsJob($this->mockedContainer, $sqsClient, $jobData, 'connection-name', $this->queueUrl, [
             'enabled' => true,
-            'disk' => 's3',
-            'prefix' => 'sqs-payloads',
-            'cleanup' => false,
+            'store' => 'database',
+            'delete_after_processing' => false,
         ]);
 
         $job->delete();
@@ -218,9 +226,8 @@ class QueueSqsJobTest extends TestCase
 
         $job = new SqsJob($this->mockedContainer, $sqsClient, $this->mockedJobData, 'connection-name', $this->queueUrl, [
             'enabled' => true,
-            'disk' => 's3',
-            'prefix' => 'sqs-payloads',
-            'cleanup' => true,
+            'store' => 'database',
+            'delete_after_processing' => true,
         ]);
 
         $job->delete();

--- a/tests/Queue/QueueSqsJobTest.php
+++ b/tests/Queue/QueueSqsJobTest.php
@@ -4,6 +4,8 @@ namespace Illuminate\Tests\Queue;
 
 use Aws\Sqs\SqsClient;
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Filesystem\Factory as FilesystemFactory;
+use Illuminate\Filesystem\FilesystemAdapter;
 use Illuminate\Queue\Jobs\SqsJob;
 use Illuminate\Queue\SqsQueue;
 use Mockery as m;
@@ -92,6 +94,136 @@ class QueueSqsJobTest extends TestCase
         $job->getSqs()->shouldReceive('changeMessageVisibility')->once()->with(['QueueUrl' => $this->queueUrl, 'ReceiptHandle' => $this->mockedReceiptHandle, 'VisibilityTimeout' => $this->releaseDelay]);
         $job->release($this->releaseDelay);
         $this->assertTrue($job->isReleased());
+    }
+
+    public function testGetRawBodyResolvesPointerFromDisk()
+    {
+        $fullPayload = json_encode(['job' => 'foo', 'data' => ['key' => 'value']]);
+        $pointerPath = 'sqs-payloads/some-uuid.json';
+        $pointerBody = json_encode(['@pointer' => $pointerPath]);
+
+        $disk = m::mock(FilesystemAdapter::class);
+        $disk->shouldReceive('get')->once()->with($pointerPath)->andReturn($fullPayload);
+
+        $filesystem = m::mock(FilesystemFactory::class);
+        $filesystem->shouldReceive('disk')->with('s3')->andReturn($disk);
+
+        $container = m::mock(Container::class);
+        $container->shouldReceive('make')->with('filesystem')->andReturn($filesystem);
+
+        $jobData = $this->mockedJobData;
+        $jobData['Body'] = $pointerBody;
+
+        $job = new SqsJob($container, $this->mockedSqsClient, $jobData, 'connection-name', $this->queueUrl, [
+            'enabled' => true,
+            'disk' => 's3',
+            'prefix' => 'sqs-payloads',
+            'cleanup' => true,
+        ]);
+
+        $this->assertEquals($fullPayload, $job->getRawBody());
+    }
+
+    public function testGetRawBodyReturnsNormalBodyWithoutPointer()
+    {
+        $job = $this->getJob();
+        $this->assertEquals($this->mockedPayload, $job->getRawBody());
+    }
+
+    public function testGetRawBodyCachesResult()
+    {
+        $fullPayload = json_encode(['job' => 'foo', 'data' => ['key' => 'value']]);
+        $pointerPath = 'sqs-payloads/some-uuid.json';
+        $pointerBody = json_encode(['@pointer' => $pointerPath]);
+
+        $disk = m::mock(FilesystemAdapter::class);
+        $disk->shouldReceive('get')->once()->with($pointerPath)->andReturn($fullPayload);
+
+        $filesystem = m::mock(FilesystemFactory::class);
+        $filesystem->shouldReceive('disk')->with('s3')->andReturn($disk);
+
+        $container = m::mock(Container::class);
+        $container->shouldReceive('make')->with('filesystem')->andReturn($filesystem);
+
+        $jobData = $this->mockedJobData;
+        $jobData['Body'] = $pointerBody;
+
+        $job = new SqsJob($container, $this->mockedSqsClient, $jobData, 'connection-name', $this->queueUrl, [
+            'enabled' => true,
+            'disk' => 's3',
+            'prefix' => 'sqs-payloads',
+            'cleanup' => true,
+        ]);
+
+        // Call twice — disk should only be hit once.
+        $job->getRawBody();
+        $this->assertEquals($fullPayload, $job->getRawBody());
+    }
+
+    public function testDeleteCleansUpDiskFileWhenCleanupEnabled()
+    {
+        $pointerPath = 'sqs-payloads/some-uuid.json';
+        $pointerBody = json_encode(['@pointer' => $pointerPath]);
+
+        $disk = m::mock(FilesystemAdapter::class);
+        $disk->shouldReceive('delete')->once()->with($pointerPath);
+
+        $filesystem = m::mock(FilesystemFactory::class);
+        $filesystem->shouldReceive('disk')->with('s3')->andReturn($disk);
+
+        $container = m::mock(Container::class);
+        $container->shouldReceive('make')->with('filesystem')->andReturn($filesystem);
+
+        $jobData = $this->mockedJobData;
+        $jobData['Body'] = $pointerBody;
+
+        $sqsClient = m::mock(SqsClient::class)->makePartial();
+        $sqsClient->shouldReceive('deleteMessage')->once();
+
+        $job = new SqsJob($container, $sqsClient, $jobData, 'connection-name', $this->queueUrl, [
+            'enabled' => true,
+            'disk' => 's3',
+            'prefix' => 'sqs-payloads',
+            'cleanup' => true,
+        ]);
+
+        $job->delete();
+    }
+
+    public function testDeleteDoesNotCleanUpWhenCleanupDisabled()
+    {
+        $pointerPath = 'sqs-payloads/some-uuid.json';
+        $pointerBody = json_encode(['@pointer' => $pointerPath]);
+
+        $jobData = $this->mockedJobData;
+        $jobData['Body'] = $pointerBody;
+
+        $sqsClient = m::mock(SqsClient::class)->makePartial();
+        $sqsClient->shouldReceive('deleteMessage')->once();
+
+        $job = new SqsJob($this->mockedContainer, $sqsClient, $jobData, 'connection-name', $this->queueUrl, [
+            'enabled' => true,
+            'disk' => 's3',
+            'prefix' => 'sqs-payloads',
+            'cleanup' => false,
+        ]);
+
+        $job->delete();
+    }
+
+    public function testDeleteDoesNotCleanUpWhenNoPointer()
+    {
+        $sqsClient = m::mock(SqsClient::class)->makePartial();
+        $sqsClient->shouldReceive('deleteMessage')->once();
+
+        $job = new SqsJob($this->mockedContainer, $sqsClient, $this->mockedJobData, 'connection-name', $this->queueUrl, [
+            'enabled' => true,
+            'disk' => 's3',
+            'prefix' => 'sqs-payloads',
+            'cleanup' => true,
+        ]);
+
+        $job->delete();
     }
 
     protected function getJob()

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -7,8 +7,8 @@ use Aws\Sqs\SqsClient;
 use Illuminate\Bus\Dispatcher;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Bus\Dispatcher as DispatcherContract;
-use Illuminate\Contracts\Filesystem\Factory as FilesystemFactory;
-use Illuminate\Filesystem\FilesystemAdapter;
+use Illuminate\Contracts\Cache\Factory as CacheFactory;
+use Illuminate\Contracts\Cache\Repository as CacheRepository;
 use Illuminate\Queue\Jobs\SqsJob;
 use Illuminate\Queue\QueueRoutes;
 use Illuminate\Queue\SqsQueue;
@@ -679,28 +679,27 @@ class QueueSqsQueueTest extends TestCase
         Str::createUuidsNormally();
     }
 
-    public function testPushRawStoresPayloadToDiskWhenExceedingThreshold()
+    public function testPushRawStoresPayloadToCacheWhenExceedingThreshold()
     {
         $uuid = 'test-uuid-1234';
         $largePayload = json_encode(['uuid' => $uuid, 'job' => 'App\\Jobs\\TestJob', 'data' => str_repeat('x', SqsQueue::MAX_SQS_PAYLOAD_SIZE)]);
-        $expectedPath = 'sqs-payloads/'.$uuid.'.json';
+        $expectedPath = 'laravel:sqs-payloads:'.$uuid;
         $expectedPointer = json_encode(['@pointer' => $expectedPath]);
 
-        $disk = m::mock(FilesystemAdapter::class);
-        $disk->shouldReceive('put')->once()->with($expectedPath, $largePayload);
+        $store = m::mock(CacheRepository::class);
+        $store->shouldReceive('put')->once()->with($expectedPath, $largePayload);
 
-        $filesystem = m::mock(FilesystemFactory::class);
-        $filesystem->shouldReceive('disk')->with('s3')->andReturn($disk);
+        $cache = m::mock(CacheFactory::class);
+        $cache->shouldReceive('store')->with('database')->andReturn($store);
 
         $container = m::mock(Container::class);
-        $container->shouldReceive('make')->with('filesystem')->andReturn($filesystem);
+        $container->shouldReceive('make')->with('cache')->andReturn($cache);
 
         $queue = new SqsQueue($this->sqs, $this->queueName, $this->prefix, '', false, [
             'enabled' => true,
-            'disk' => 's3',
-            'prefix' => 'sqs-payloads',
+            'store' => 'database',
             'always' => false,
-            'cleanup' => true,
+            'delete_after_processing' => true,
         ]);
         $queue->setContainer($container);
 
@@ -711,16 +710,15 @@ class QueueSqsQueueTest extends TestCase
         $queue->pushRaw($largePayload, $this->queueName);
     }
 
-    public function testPushRawDoesNotStoreToDiskWhenBelowThreshold()
+    public function testPushRawDoesNotStoreToCacheWhenBelowThreshold()
     {
         $smallPayload = json_encode(['uuid' => 'test-uuid', 'job' => 'App\\Jobs\\TestJob', 'data' => 'small']);
 
         $queue = new SqsQueue($this->sqs, $this->queueName, $this->prefix, '', false, [
             'enabled' => true,
-            'disk' => 's3',
-            'prefix' => 'sqs-payloads',
+            'store' => 'database',
             'always' => false,
-            'cleanup' => true,
+            'delete_after_processing' => true,
         ]);
         $queue->setContainer(m::mock(Container::class));
 
@@ -731,28 +729,27 @@ class QueueSqsQueueTest extends TestCase
         $queue->pushRaw($smallPayload, $this->queueName);
     }
 
-    public function testPushRawAlwaysStoresToDiskWhenAlwaysIsTrue()
+    public function testPushRawAlwaysStoresToCacheWhenAlwaysIsTrue()
     {
         $uuid = 'test-uuid-always';
         $smallPayload = json_encode(['uuid' => $uuid, 'job' => 'App\\Jobs\\TestJob', 'data' => 'small']);
-        $expectedPath = 'sqs-payloads/'.$uuid.'.json';
+        $expectedPath = 'laravel:sqs-payloads:'.$uuid;
         $expectedPointer = json_encode(['@pointer' => $expectedPath]);
 
-        $disk = m::mock(FilesystemAdapter::class);
-        $disk->shouldReceive('put')->once()->with($expectedPath, $smallPayload);
+        $store = m::mock(CacheRepository::class);
+        $store->shouldReceive('put')->once()->with($expectedPath, $smallPayload);
 
-        $filesystem = m::mock(FilesystemFactory::class);
-        $filesystem->shouldReceive('disk')->with('s3')->andReturn($disk);
+        $cache = m::mock(CacheFactory::class);
+        $cache->shouldReceive('store')->with('database')->andReturn($store);
 
         $container = m::mock(Container::class);
-        $container->shouldReceive('make')->with('filesystem')->andReturn($filesystem);
+        $container->shouldReceive('make')->with('cache')->andReturn($cache);
 
         $queue = new SqsQueue($this->sqs, $this->queueName, $this->prefix, '', false, [
             'enabled' => true,
-            'disk' => 's3',
-            'prefix' => 'sqs-payloads',
+            'store' => 'database',
             'always' => true,
-            'cleanup' => true,
+            'delete_after_processing' => true,
         ]);
         $queue->setContainer($container);
 
@@ -763,7 +760,7 @@ class QueueSqsQueueTest extends TestCase
         $queue->pushRaw($smallPayload, $this->queueName);
     }
 
-    public function testPushRawDoesNotStoreToDiskWhenNotEnabled()
+    public function testPushRawDoesNotStoreToCacheWhenNotEnabled()
     {
         $largePayload = json_encode(['uuid' => 'test-uuid', 'job' => 'App\\Jobs\\TestJob', 'data' => str_repeat('x', SqsQueue::MAX_SQS_PAYLOAD_SIZE)]);
 
@@ -777,46 +774,15 @@ class QueueSqsQueueTest extends TestCase
         $queue->pushRaw($largePayload, $this->queueName);
     }
 
-    public function testClearDeletesDiskDirectoryWhenCleanupEnabled()
-    {
-        $disk = m::mock(FilesystemAdapter::class);
-        $disk->shouldReceive('deleteDirectory')->once()->with('sqs-payloads');
-
-        $filesystem = m::mock(FilesystemFactory::class);
-        $filesystem->shouldReceive('disk')->with('s3')->andReturn($disk);
-
-        $container = m::mock(Container::class);
-        $container->shouldReceive('make')->with('filesystem')->andReturn($filesystem);
-
-        $queue = $this->getMockBuilder(SqsQueue::class)
-            ->onlyMethods(['getQueue', 'size'])
-            ->setConstructorArgs([$this->sqs, $this->queueName, $this->prefix, '', false, [
-                'enabled' => true,
-                'disk' => 's3',
-                'prefix' => 'sqs-payloads',
-                'always' => false,
-                'cleanup' => true,
-            ]])
-            ->getMock();
-        $queue->setContainer($container);
-        $queue->expects($this->once())->method('getQueue')->willReturn($this->queueUrl);
-        $queue->expects($this->once())->method('size')->willReturn(5);
-
-        $this->sqs->shouldReceive('purgeQueue')->once();
-
-        $queue->clear($this->queueName);
-    }
-
-    public function testClearDoesNotDeleteDiskDirectoryWhenCleanupDisabled()
+    public function testClearDoesNotFlushCacheStore()
     {
         $queue = $this->getMockBuilder(SqsQueue::class)
             ->onlyMethods(['getQueue', 'size'])
             ->setConstructorArgs([$this->sqs, $this->queueName, $this->prefix, '', false, [
                 'enabled' => true,
-                'disk' => 's3',
-                'prefix' => 'sqs-payloads',
+                'store' => 'database',
                 'always' => false,
-                'cleanup' => false,
+                'delete_after_processing' => true,
             ]])
             ->getMock();
         $queue->setContainer(m::mock(Container::class));
@@ -828,19 +794,18 @@ class QueueSqsQueueTest extends TestCase
         $queue->clear($this->queueName);
     }
 
-    public function testPopPassesExtendedStoreOptionsToJob()
+    public function testPopPassesOverflowStorageOptionsToJob()
     {
-        $extendedStoreOptions = [
+        $overflowStorage = [
             'enabled' => true,
-            'disk' => 's3',
-            'prefix' => 'sqs-payloads',
+            'store' => 'database',
             'always' => false,
-            'cleanup' => true,
+            'delete_after_processing' => true,
         ];
 
         $queue = $this->getMockBuilder(SqsQueue::class)
             ->onlyMethods(['getQueue'])
-            ->setConstructorArgs([$this->sqs, $this->queueName, $this->account, '', false, $extendedStoreOptions])
+            ->setConstructorArgs([$this->sqs, $this->queueName, $this->account, '', false, $overflowStorage])
             ->getMock();
         $queue->setContainer(m::mock(Container::class));
         $queue->expects($this->once())->method('getQueue')->with($this->queueName)->willReturn($this->queueUrl);

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -7,6 +7,8 @@ use Aws\Sqs\SqsClient;
 use Illuminate\Bus\Dispatcher;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Bus\Dispatcher as DispatcherContract;
+use Illuminate\Contracts\Filesystem\Factory as FilesystemFactory;
+use Illuminate\Filesystem\FilesystemAdapter;
 use Illuminate\Queue\Jobs\SqsJob;
 use Illuminate\Queue\QueueRoutes;
 use Illuminate\Queue\SqsQueue;
@@ -675,5 +677,178 @@ class QueueSqsQueueTest extends TestCase
         $container->shouldHaveReceived('bound')->with('events')->twice();
 
         Str::createUuidsNormally();
+    }
+
+    public function testPushRawStoresPayloadToDiskWhenExceedingThreshold()
+    {
+        $uuid = 'test-uuid-1234';
+        $largePayload = json_encode(['uuid' => $uuid, 'job' => 'App\\Jobs\\TestJob', 'data' => str_repeat('x', SqsQueue::MAX_SQS_PAYLOAD_SIZE)]);
+        $expectedPath = 'sqs-payloads/'.$uuid.'.json';
+        $expectedPointer = json_encode(['@pointer' => $expectedPath]);
+
+        $disk = m::mock(FilesystemAdapter::class);
+        $disk->shouldReceive('put')->once()->with($expectedPath, $largePayload);
+
+        $filesystem = m::mock(FilesystemFactory::class);
+        $filesystem->shouldReceive('disk')->with('s3')->andReturn($disk);
+
+        $container = m::mock(Container::class);
+        $container->shouldReceive('make')->with('filesystem')->andReturn($filesystem);
+
+        $queue = new SqsQueue($this->sqs, $this->queueName, $this->prefix, '', false, [
+            'enabled' => true,
+            'disk' => 's3',
+            'prefix' => 'sqs-payloads',
+            'always' => false,
+            'cleanup' => true,
+        ]);
+        $queue->setContainer($container);
+
+        $this->sqs->shouldReceive('sendMessage')->once()->withArgs(function ($args) use ($expectedPointer) {
+            return $args['MessageBody'] === $expectedPointer;
+        })->andReturn($this->mockedSendMessageResponseModel);
+
+        $queue->pushRaw($largePayload, $this->queueName);
+    }
+
+    public function testPushRawDoesNotStoreToDiskWhenBelowThreshold()
+    {
+        $smallPayload = json_encode(['uuid' => 'test-uuid', 'job' => 'App\\Jobs\\TestJob', 'data' => 'small']);
+
+        $queue = new SqsQueue($this->sqs, $this->queueName, $this->prefix, '', false, [
+            'enabled' => true,
+            'disk' => 's3',
+            'prefix' => 'sqs-payloads',
+            'always' => false,
+            'cleanup' => true,
+        ]);
+        $queue->setContainer(m::mock(Container::class));
+
+        $this->sqs->shouldReceive('sendMessage')->once()->withArgs(function ($args) use ($smallPayload) {
+            return $args['MessageBody'] === $smallPayload;
+        })->andReturn($this->mockedSendMessageResponseModel);
+
+        $queue->pushRaw($smallPayload, $this->queueName);
+    }
+
+    public function testPushRawAlwaysStoresToDiskWhenAlwaysIsTrue()
+    {
+        $uuid = 'test-uuid-always';
+        $smallPayload = json_encode(['uuid' => $uuid, 'job' => 'App\\Jobs\\TestJob', 'data' => 'small']);
+        $expectedPath = 'sqs-payloads/'.$uuid.'.json';
+        $expectedPointer = json_encode(['@pointer' => $expectedPath]);
+
+        $disk = m::mock(FilesystemAdapter::class);
+        $disk->shouldReceive('put')->once()->with($expectedPath, $smallPayload);
+
+        $filesystem = m::mock(FilesystemFactory::class);
+        $filesystem->shouldReceive('disk')->with('s3')->andReturn($disk);
+
+        $container = m::mock(Container::class);
+        $container->shouldReceive('make')->with('filesystem')->andReturn($filesystem);
+
+        $queue = new SqsQueue($this->sqs, $this->queueName, $this->prefix, '', false, [
+            'enabled' => true,
+            'disk' => 's3',
+            'prefix' => 'sqs-payloads',
+            'always' => true,
+            'cleanup' => true,
+        ]);
+        $queue->setContainer($container);
+
+        $this->sqs->shouldReceive('sendMessage')->once()->withArgs(function ($args) use ($expectedPointer) {
+            return $args['MessageBody'] === $expectedPointer;
+        })->andReturn($this->mockedSendMessageResponseModel);
+
+        $queue->pushRaw($smallPayload, $this->queueName);
+    }
+
+    public function testPushRawDoesNotStoreToDiskWhenNotEnabled()
+    {
+        $largePayload = json_encode(['uuid' => 'test-uuid', 'job' => 'App\\Jobs\\TestJob', 'data' => str_repeat('x', SqsQueue::MAX_SQS_PAYLOAD_SIZE)]);
+
+        $queue = new SqsQueue($this->sqs, $this->queueName, $this->prefix);
+        $queue->setContainer(m::mock(Container::class));
+
+        $this->sqs->shouldReceive('sendMessage')->once()->withArgs(function ($args) use ($largePayload) {
+            return $args['MessageBody'] === $largePayload;
+        })->andReturn($this->mockedSendMessageResponseModel);
+
+        $queue->pushRaw($largePayload, $this->queueName);
+    }
+
+    public function testClearDeletesDiskDirectoryWhenCleanupEnabled()
+    {
+        $disk = m::mock(FilesystemAdapter::class);
+        $disk->shouldReceive('deleteDirectory')->once()->with('sqs-payloads');
+
+        $filesystem = m::mock(FilesystemFactory::class);
+        $filesystem->shouldReceive('disk')->with('s3')->andReturn($disk);
+
+        $container = m::mock(Container::class);
+        $container->shouldReceive('make')->with('filesystem')->andReturn($filesystem);
+
+        $queue = $this->getMockBuilder(SqsQueue::class)
+            ->onlyMethods(['getQueue', 'size'])
+            ->setConstructorArgs([$this->sqs, $this->queueName, $this->prefix, '', false, [
+                'enabled' => true,
+                'disk' => 's3',
+                'prefix' => 'sqs-payloads',
+                'always' => false,
+                'cleanup' => true,
+            ]])
+            ->getMock();
+        $queue->setContainer($container);
+        $queue->expects($this->once())->method('getQueue')->willReturn($this->queueUrl);
+        $queue->expects($this->once())->method('size')->willReturn(5);
+
+        $this->sqs->shouldReceive('purgeQueue')->once();
+
+        $queue->clear($this->queueName);
+    }
+
+    public function testClearDoesNotDeleteDiskDirectoryWhenCleanupDisabled()
+    {
+        $queue = $this->getMockBuilder(SqsQueue::class)
+            ->onlyMethods(['getQueue', 'size'])
+            ->setConstructorArgs([$this->sqs, $this->queueName, $this->prefix, '', false, [
+                'enabled' => true,
+                'disk' => 's3',
+                'prefix' => 'sqs-payloads',
+                'always' => false,
+                'cleanup' => false,
+            ]])
+            ->getMock();
+        $queue->setContainer(m::mock(Container::class));
+        $queue->expects($this->once())->method('getQueue')->willReturn($this->queueUrl);
+        $queue->expects($this->once())->method('size')->willReturn(5);
+
+        $this->sqs->shouldReceive('purgeQueue')->once();
+
+        $queue->clear($this->queueName);
+    }
+
+    public function testPopPassesExtendedStoreOptionsToJob()
+    {
+        $extendedStoreOptions = [
+            'enabled' => true,
+            'disk' => 's3',
+            'prefix' => 'sqs-payloads',
+            'always' => false,
+            'cleanup' => true,
+        ];
+
+        $queue = $this->getMockBuilder(SqsQueue::class)
+            ->onlyMethods(['getQueue'])
+            ->setConstructorArgs([$this->sqs, $this->queueName, $this->account, '', false, $extendedStoreOptions])
+            ->getMock();
+        $queue->setContainer(m::mock(Container::class));
+        $queue->expects($this->once())->method('getQueue')->with($this->queueName)->willReturn($this->queueUrl);
+
+        $this->sqs->shouldReceive('receiveMessage')->once()->andReturn($this->mockedReceiveMessageResponseModel);
+
+        $job = $queue->pop($this->queueName);
+
+        $this->assertInstanceOf(SqsJob::class, $job);
     }
 }


### PR DESCRIPTION
When using the SQS queue driver, sending a job with a payload that exceeds the queue's maximum message size causes AWS to reject it with an `InvalidParameterValue` error:

```bash
One or more parameters are invalid. Reason: Message must be shorter than 262144 bytes.
```

> Note: AWS did increase the SQS max from 256 KiB to 1 MiB in August 2025, but large payloads can still hit this limit.

This adds native support for automatically offloading large payloads to a configured filesystem disk (e.g. S3) and sending a small pointer through SQS instead. The worker then fetches the full payload from disk when processing the job.

This is a well-known and AWS-recommended strategy for working around this limitation. And Java and Python implementations exist doing it: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-managing-large-messages.html

This is fully opt-in and backwards compatible, existing SQS users are unaffected. The feature is controlled by a new `extended_store_options` block in the SQS queue connection config, with `enabled` defaulting
to `false`:

```php
'sqs' => [
    // ...existing config...
    'extended_store_options' => [
        'enabled' => env('SQS_STORE_ENABLED', false),
        'disk' => env('SQS_STORE_DISK', 's3'),
        'prefix' => env('SQS_STORE_PREFIX', ''),
        'always' => false,
        'cleanup' => true,
    ],
],
```

- enabled - Turn the feature on/off. Defaults to false.
- disk - Which filesystem disk to store payloads on (e.g. s3).
- prefix - Path prefix for stored payload files on the disk.
- always - When true, store every payload to disk regardless of size (useful for consistency).
- cleanup - When true, delete the disk file after the job is successfully processed.

How it works

- On push: if the payload exceeds 1 MB (or always is enabled), the payload is written to disk at {prefix}/{uuid}.json and SQS receives a pointer message containing {"@pointer": "path/to/file.json"}.
- On pop: SqsJob::getRawBody() detects the @pointer key, fetches the real payload from disk, and caches it for the lifetime of the job.
- On delete: if cleanup is enabled and the message was a pointer, the disk file is removed.
- On clear: if cleanup is enabled and a prefix is configured, the entire prefix directory is removed from disk.

The @pointer key uses an @ prefix which cannot be a PHP class property, so there is no risk of collision with normal job payloads.