### PR TITLE
[13.x] Add support for Cloudflare Email Service

### DIFF
--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -193,7 +193,7 @@ class MailManager implements FactoryContract
     {
         return new CloudflareTransport(
             $config['account_id'],
-            $config['token'],
+            $config['key'],
             $this->getHttpClient($config),
         );
     }

--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -184,21 +184,6 @@ class MailManager implements FactoryContract
     }
 
     /**
-     * Create an instance of the Cloudflare Transport driver.
-     *
-     * @param  array  $config
-     * @return \Illuminate\Mail\Transport\CloudflareTransport
-     */
-    protected function createCloudflareTransport(array $config)
-    {
-        return new CloudflareTransport(
-            $config['account_id'] ?? $this->app['config']->get('services.cloudflare.account_id'),
-            $config['token'] ?? $this->app['config']->get('services.cloudflare.token'),
-            $this->getHttpClient($config),
-        );
-    }
-
-    /**
      * Create an instance of the Symfony SMTP Transport driver.
      *
      * @param  array  $config
@@ -336,6 +321,25 @@ class MailManager implements FactoryContract
     {
         return new ResendTransport(
             Resend::client($config['key'] ?? $this->app['config']->get('services.resend.key')),
+        );
+    }
+
+    /**
+     * Create an instance of the Cloudflare Transport driver.
+     *
+     * @param  array  $config
+     * @return \Illuminate\Mail\Transport\CloudflareTransport
+     */
+    protected function createCloudflareTransport(array $config)
+    {
+        return new CloudflareTransport(
+            $config['account_id'] ??
+                $this->app['config']->get('services.cloudflare.account_id'),
+            $config['token'] ??
+                $config['key'] ??
+                $this->app['config']->get('services.cloudflare.token') ??
+                $this->app['config']->get('services.cloudflare.key'),
+            $this->getHttpClient($config),
         );
     }
 

--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -192,8 +192,8 @@ class MailManager implements FactoryContract
     protected function createCloudflareTransport(array $config)
     {
         return new CloudflareTransport(
-            $this->app['config']->get('services.cloudflare.account_id'),
-            $this->app['config']->get('services.cloudflare.token'),
+            $config['account_id'] ?? $this->app['config']->get('services.cloudflare.account_id'),
+            $config['token'] ?? $this->app['config']->get('services.cloudflare.token'),
             $this->getHttpClient($config),
         );
     }

--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -8,6 +8,7 @@ use Closure;
 use Illuminate\Contracts\Mail\Factory as FactoryContract;
 use Illuminate\Log\LogManager;
 use Illuminate\Mail\Transport\ArrayTransport;
+use Illuminate\Mail\Transport\CloudflareTransport;
 use Illuminate\Mail\Transport\LogTransport;
 use Illuminate\Mail\Transport\ResendTransport;
 use Illuminate\Mail\Transport\SesTransport;
@@ -180,6 +181,21 @@ class MailManager implements FactoryContract
         }
 
         return $this->{$method}($config);
+    }
+
+    /**
+     * Create an instance of the Cloudflare Transport driver.
+     *
+     * @param  array  $config
+     * @return \Illuminate\Mail\Transport\CloudflareTransport
+     */
+    protected function createCloudflareTransport(array $config)
+    {
+        return new CloudflareTransport(
+            $config['account_id'],
+            $config['token'],
+            $this->getHttpClient($config),
+        );
     }
 
     /**

--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -192,8 +192,8 @@ class MailManager implements FactoryContract
     protected function createCloudflareTransport(array $config)
     {
         return new CloudflareTransport(
-            $config['account_id'],
-            $config['key'],
+            $this->app['config']->get('services.cloudflare.account_id'),
+            $this->app['config']->get('services.cloudflare.token'),
             $this->getHttpClient($config),
         );
     }

--- a/src/Illuminate/Mail/Transport/CloudflareTransport.php
+++ b/src/Illuminate/Mail/Transport/CloudflareTransport.php
@@ -28,12 +28,12 @@ class CloudflareTransport extends AbstractTransport
      * Create a new Cloudflare transport instance.
      *
      * @param  string  $accountId
-     * @param  string  $apiToken
+     * @param  string  $key
      * @param  \Symfony\Contracts\HttpClient\HttpClientInterface|null  $client
      */
     public function __construct(
         protected string $accountId,
-        #[SensitiveParameter] protected string $apiToken,
+        #[SensitiveParameter] protected string $key,
         ?HttpClientInterface $client = null,
     ) {
         parent::__construct();
@@ -53,7 +53,7 @@ class CloudflareTransport extends AbstractTransport
                 'https://api.cloudflare.com/client/v4/accounts/%s/email/sending/send',
                 $this->accountId,
             ), [
-                'auth_bearer' => $this->apiToken,
+                'auth_bearer' => $this->key,
                 'headers' => ['Accept' => 'application/json'],
                 'json' => $this->getPayload($message),
             ]);
@@ -128,12 +128,6 @@ class CloudflareTransport extends AbstractTransport
 
         return $headers;
     }
-
-    /**
-     * @param  Address[]  $addresses
-     * @return string[]
-     */
-
 
     /**
      * Get the address formatted for the Cloudflare API.

--- a/src/Illuminate/Mail/Transport/CloudflareTransport.php
+++ b/src/Illuminate/Mail/Transport/CloudflareTransport.php
@@ -69,8 +69,9 @@ class CloudflareTransport extends AbstractTransport
 
         throw_if(
             $response->getStatusCode() !== Response::HTTP_OK,
-            Exception::class,
+            TransportException::class,
             $result['errors'][0]['message'] ?? 'Unknown error',
+            $response->getStatusCode(),
         );
     }
 

--- a/src/Illuminate/Mail/Transport/CloudflareTransport.php
+++ b/src/Illuminate/Mail/Transport/CloudflareTransport.php
@@ -19,17 +19,11 @@ class CloudflareTransport extends AbstractTransport
 {
     /**
      * The HTTP Client instance.
-     *
-     * @var \Symfony\Contracts\HttpClient\HttpClientInterface
      */
     protected HttpClientInterface $client;
 
     /**
      * Create a new Cloudflare transport instance.
-     *
-     * @param  string  $accountId
-     * @param  string  $key
-     * @param  \Symfony\Contracts\HttpClient\HttpClientInterface|null  $client
      */
     public function __construct(
         protected string $accountId,
@@ -44,7 +38,7 @@ class CloudflareTransport extends AbstractTransport
     /**
      * {@inheritDoc}
      *
-     * @throws \Symfony\Component\Mailer\Exception\TransportException
+     * @throws TransportException
      */
     protected function doSend(SentMessage $message): void
     {
@@ -77,8 +71,6 @@ class CloudflareTransport extends AbstractTransport
 
     /**
      * Get the Cloudflare payload for the given message.
-     *
-     * @return array
      */
     protected function getPayload(SentMessage $message): array
     {
@@ -131,6 +123,27 @@ class CloudflareTransport extends AbstractTransport
     }
 
     /**
+     * Get the attachments formatted for the Cloudflare API.
+     */
+    protected function getAttachments(Email $email): array
+    {
+        $attachments = [];
+
+        foreach ($email->getAttachments() as $attachment) {
+            $headers = $attachment->getPreparedHeaders();
+
+            $attachments[] = [
+                'content' => str_replace("\r\n", '', $attachment->bodyToString()),
+                'filename' => $headers->getHeaderParameter('Content-Disposition', 'filename'),
+                'type' => $headers->get('Content-Type')->getBody(),
+                'disposition' => $headers->getHeaderBody('Content-Disposition') ?: 'attachment',
+            ];
+        }
+
+        return $attachments;
+    }
+
+    /**
      * Get the address formatted for the Cloudflare API.
      *
      * @return string|array
@@ -149,35 +162,10 @@ class CloudflareTransport extends AbstractTransport
 
     /**
      * Get multiple addresses formatted as strings for the Cloudflare API.
-     *
-     * @return array
      */
     protected function stringifyAddresses(array $addresses): array
     {
         return array_map(fn (Address $a) => $a->getAddress(), $addresses);
-    }
-
-    /**
-     * Get the attachments formatted for the Cloudflare API.
-     *
-     * @return array
-     */
-    protected function getAttachments(Email $email): array
-    {
-        $attachments = [];
-
-        foreach ($email->getAttachments() as $attachment) {
-            $headers = $attachment->getPreparedHeaders();
-
-            $attachments[] = [
-                'content' => str_replace("\r\n", '', $attachment->bodyToString()),
-                'filename' => $headers->getHeaderParameter('Content-Disposition', 'filename'),
-                'type' => $headers->get('Content-Type')->getBody(),
-                'disposition' => $headers->getHeaderBody('Content-Disposition') ?: 'attachment',
-            ];
-        }
-
-        return $attachments;
     }
 
     /**

--- a/src/Illuminate/Mail/Transport/CloudflareTransport.php
+++ b/src/Illuminate/Mail/Transport/CloudflareTransport.php
@@ -1,0 +1,195 @@
+<?php
+
+namespace Illuminate\Mail\Transport;
+
+use Exception;
+use SensitiveParameter;
+use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Mailer\Envelope;
+use Symfony\Component\Mailer\Exception\TransportException;
+use Symfony\Component\Mailer\SentMessage;
+use Symfony\Component\Mailer\Transport\AbstractTransport;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\Email;
+use Symfony\Component\Mime\MessageConverter;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+class CloudflareTransport extends AbstractTransport
+{
+    /**
+     * The HTTP Client instance.
+     *
+     * @var \Symfony\Contracts\HttpClient\HttpClientInterface
+     */
+    protected HttpClientInterface $client;
+
+    /**
+     * Create a new Cloudflare transport instance.
+     *
+     * @param  string  $accountId
+     * @param  string  $apiToken
+     * @param  \Symfony\Contracts\HttpClient\HttpClientInterface|null  $client
+     */
+    public function __construct(
+        protected string $accountId,
+        #[SensitiveParameter] protected string $apiToken,
+        ?HttpClientInterface $client = null,
+    ) {
+        parent::__construct();
+
+        $this->client = $client ?? HttpClient::create();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws \Symfony\Component\Mailer\Exception\TransportException
+     */
+    protected function doSend(SentMessage $message): void
+    {
+        try {
+            $response = $this->client->request('POST', sprintf(
+                'https://api.cloudflare.com/client/v4/accounts/%s/email/sending/send',
+                $this->accountId,
+            ), [
+                'auth_bearer' => $this->apiToken,
+                'headers' => ['Accept' => 'application/json'],
+                'json' => $this->getPayload($message),
+            ]);
+
+            $result = $response->toArray(false);
+        } catch (Exception $exception) {
+            throw new TransportException(
+                sprintf('Request to Cloudflare API failed. Reason: %s.', $exception->getMessage()),
+                is_int($exception->getCode()) ? $exception->getCode() : 0,
+                $exception,
+            );
+        }
+
+        throw_if(
+            $response->getStatusCode() !== Response::HTTP_OK,
+            Exception::class,
+            $result['errors'][0]['message'] ?? 'Unknown error',
+        );
+    }
+
+    /**
+     * Get the Cloudflare payload for the given message.
+     *
+     * @return array
+     */
+    protected function getPayload(SentMessage $message): array
+    {
+        $email = MessageConverter::toEmail($message->getOriginalMessage());
+
+        $envelope = $message->getEnvelope();
+
+        return array_filter([
+            'from' => $this->formatAddress($envelope->getSender()),
+            'to' => $this->stringifyAddresses($this->getRecipients($email, $envelope)),
+            'cc' => $this->stringifyAddresses($email->getCc()),
+            'bcc' => $this->stringifyAddresses($email->getBcc()),
+            'reply_to' => ($replyTo = $email->getReplyTo()) ? $this->formatAddress($replyTo[0]) : null,
+            'subject' => $email->getSubject(),
+            'html' => $email->getHtmlBody(),
+            'text' => $email->getTextBody(),
+            'headers' => $this->getCustomHeaders($email),
+            'attachments' => $this->getAttachments($email),
+        ], fn ($value) => $value !== null && $value !== [] && $value !== '');
+    }
+
+    /**
+     * Get the recipients without CC or BCC.
+     */
+    protected function getRecipients(Email $email, Envelope $envelope): array
+    {
+        return array_filter($envelope->getRecipients(), function (Address $address) use ($email) {
+            return in_array($address, array_merge($email->getCc(), $email->getBcc()), true) === false;
+        });
+    }
+
+    /**
+     * Get the custom headers for the email, excluding the standard ones.
+     */
+    protected function getCustomHeaders(Email $email): array
+    {
+        $headers = [];
+
+        $headersToBypass = ['from', 'to', 'cc', 'bcc', 'reply-to', 'sender', 'subject', 'content-type'];
+
+        foreach ($email->getHeaders()->all() as $name => $header) {
+            if (in_array($name, $headersToBypass, true)) {
+                continue;
+            }
+
+            $headers[$header->getName()] = $header->getBodyAsString();
+        }
+
+        return $headers;
+    }
+
+    /**
+     * @param  Address[]  $addresses
+     * @return string[]
+     */
+
+
+    /**
+     * Get the address formatted for the Cloudflare API.
+     *
+     * @return string|array
+     */
+    protected function formatAddress(Address $address)
+    {
+        if ($address->getName()) {
+            return [
+                'name' => $address->getName(),
+                'address' => $address->getAddress(),
+            ];
+        }
+
+        return $address->getAddress();
+    }
+
+    /**
+     * Get multiple addresses formatted as strings for the Cloudflare API.
+     *
+     * @return array
+     */
+    protected function stringifyAddresses(array $addresses): array
+    {
+        return array_map(fn (Address $a) => $a->getAddress(), $addresses);
+    }
+
+    /**
+     * Get the attachments formatted for the Cloudflare API.
+     *
+     * @return array
+     */
+    protected function getAttachments(Email $email): array
+    {
+        $attachments = [];
+
+        foreach ($email->getAttachments() as $attachment) {
+            $headers = $attachment->getPreparedHeaders();
+
+            $attachments[] = [
+                'content' => str_replace("\r\n", '', $attachment->bodyToString()),
+                'filename' => $headers->getHeaderParameter('Content-Disposition', 'filename'),
+                'type' => $headers->get('Content-Type')->getBody(),
+                'disposition' => $headers->getHeaderBody('Content-Disposition') ?: 'attachment',
+            ];
+        }
+
+        return $attachments;
+    }
+
+    /**
+     * Get the string representation of the transport.
+     */
+    public function __toString(): string
+    {
+        return 'cloudflare';
+    }
+}

--- a/tests/Mail/MailCloudflareTransportTest.php
+++ b/tests/Mail/MailCloudflareTransportTest.php
@@ -10,7 +10,6 @@ use Illuminate\Mail\Transport\CloudflareTransport;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
-use Symfony\Component\Mailer\Exception\TransportException;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 
@@ -177,8 +176,8 @@ class MailCloudflareTransportTest extends TestCase
                 'errors' => [
                     [
                         'code' => 10001,
-                        'message' => 'invalid_request_schema'
-                    ]
+                        'message' => 'invalid_request_schema',
+                    ],
                 ],
                 'messages' => [],
                 'result' => null,

--- a/tests/Mail/MailCloudflareTransportTest.php
+++ b/tests/Mail/MailCloudflareTransportTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Mail;
 
 use Exception;
+use Illuminate\Config\Repository;
 use Illuminate\Container\Container;
 use Illuminate\Mail\MailManager;
 use Illuminate\Mail\Transport\CloudflareTransport;
@@ -19,13 +20,20 @@ class MailCloudflareTransportTest extends TestCase
     {
         $container = new Container;
 
+        $container->singleton('config', function () {
+            return new Repository([
+                'services' => [
+                    'cloudflare' => [
+                        'account_id' => 'test-account-id',
+                        'token' => 'test-token',
+                    ],
+                ],
+            ]);
+        });
+
         $manager = new MailManager($container);
 
-        $transport = $manager->createSymfonyTransport([
-            'transport' => 'cloudflare',
-            'account_id' => 'test-account-id',
-            'key' => 'test-key',
-        ]);
+        $transport = $manager->createSymfonyTransport(['transport' => 'cloudflare']);
 
         $this->assertInstanceOf(CloudflareTransport::class, $transport);
         $this->assertSame('cloudflare', (string) $transport);

--- a/tests/Mail/MailCloudflareTransportTest.php
+++ b/tests/Mail/MailCloudflareTransportTest.php
@@ -24,7 +24,7 @@ class MailCloudflareTransportTest extends TestCase
         $transport = $manager->createSymfonyTransport([
             'transport' => 'cloudflare',
             'account_id' => 'test-account-id',
-            'token' => 'test-token',
+            'key' => 'test-key',
         ]);
 
         $this->assertInstanceOf(CloudflareTransport::class, $transport);
@@ -54,7 +54,7 @@ class MailCloudflareTransportTest extends TestCase
             ]), ['http_code' => 200]);
         });
 
-        $transport = new CloudflareTransport('my-account-id', 'my-api-token', $client);
+        $transport = new CloudflareTransport('test-account-id', 'test-key', $client);
 
         $message = new Email();
         $message->subject('Test subject');
@@ -69,8 +69,8 @@ class MailCloudflareTransportTest extends TestCase
 
         $transport->send($message);
 
-        $this->assertStringContainsString('my-account-id', $requestUrl);
-        $this->assertSame('https://api.cloudflare.com/client/v4/accounts/my-account-id/email/sending/send', $requestUrl);
+        $this->assertStringContainsString('test-account-id', $requestUrl);
+        $this->assertSame('https://api.cloudflare.com/client/v4/accounts/test-account-id/email/sending/send', $requestUrl);
         $this->assertSame('sender@example.com', $requestBody['from']);
         $this->assertSame(['me@example.com'], $requestBody['to']);
         $this->assertSame(['cc@example.com'], $requestBody['cc']);
@@ -81,7 +81,7 @@ class MailCloudflareTransportTest extends TestCase
         $this->assertSame('Hello', $requestBody['text']);
         $this->assertSame('CustomValue', $requestBody['headers']['X-Custom-Header']);
         $this->assertArrayHasKey('authorization', $requestHeaders);
-        $this->assertSame(['Authorization: Bearer my-api-token'], $requestHeaders['authorization']);
+        $this->assertSame(['Authorization: Bearer test-key'], $requestHeaders['authorization']);
     }
 
     public function testSendWithNamedAddresses(): void
@@ -107,7 +107,7 @@ class MailCloudflareTransportTest extends TestCase
             ]), ['http_code' => 200]);
         });
 
-        $transport = new CloudflareTransport('my-account-id', 'my-api-token', $client);
+        $transport = new CloudflareTransport('test-account-id', 'test-key', $client);
 
         $message = new Email();
         $message->subject('Test subject');
@@ -143,7 +143,7 @@ class MailCloudflareTransportTest extends TestCase
             ]), ['http_code' => 200]);
         });
 
-        $transport = new CloudflareTransport('my-account-id', 'my-api-token', $client);
+        $transport = new CloudflareTransport('test-account-id', 'test-key', $client);
 
         $message = new Email();
         $message->subject('With attachment');
@@ -177,7 +177,7 @@ class MailCloudflareTransportTest extends TestCase
             ]), ['http_code' => 400]);
         });
 
-        $transport = new CloudflareTransport('my-account-id', 'my-api-token', $client);
+        $transport = new CloudflareTransport('test-account-id', 'test-key', $client);
 
         $message = new Email();
         $message->subject('Fail');

--- a/tests/Mail/MailCloudflareTransportTest.php
+++ b/tests/Mail/MailCloudflareTransportTest.php
@@ -94,13 +94,9 @@ class MailCloudflareTransportTest extends TestCase
     public function testSendWithNamedAddresses(): void
     {
         $requestBody = null;
-        $requestUrl = null;
-        $requestHeaders = null;
 
-        $client = new MockHttpClient(function ($method, $url, $options) use (&$requestBody, &$requestUrl, &$requestHeaders) {
-            $requestUrl = $url;
+        $client = new MockHttpClient(function ($method, $url, $options) use (&$requestBody) {
             $requestBody = json_decode($options['body'], true);
-            $requestHeaders = $options['normalized_headers'];
 
             return new MockResponse(json_encode([
                 'success' => true,

--- a/tests/Mail/MailCloudflareTransportTest.php
+++ b/tests/Mail/MailCloudflareTransportTest.php
@@ -2,8 +2,6 @@
 
 namespace Illuminate\Tests\Mail;
 
-use Exception;
-use Symfony\Component\Mailer\Exception\TransportException;
 use Illuminate\Config\Repository;
 use Illuminate\Container\Container;
 use Illuminate\Mail\MailManager;
@@ -11,6 +9,7 @@ use Illuminate\Mail\Transport\CloudflareTransport;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\Mailer\Exception\TransportException;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 

--- a/tests/Mail/MailCloudflareTransportTest.php
+++ b/tests/Mail/MailCloudflareTransportTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Mail;
 
 use Exception;
+use Symfony\Component\Mailer\Exception\TransportException;
 use Illuminate\Config\Repository;
 use Illuminate\Container\Container;
 use Illuminate\Mail\MailManager;
@@ -188,7 +189,7 @@ class MailCloudflareTransportTest extends TestCase
         $message->sender('sender@example.com');
         $message->to('me@example.com');
 
-        $this->expectException(Exception::class);
+        $this->expectException(TransportException::class);
         $this->expectExceptionMessage('invalid_request_schema');
 
         $transport->send($message);

--- a/tests/Mail/MailCloudflareTransportTest.php
+++ b/tests/Mail/MailCloudflareTransportTest.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace Illuminate\Tests\Mail;
+
+use Exception;
+use Illuminate\Container\Container;
+use Illuminate\Mail\MailManager;
+use Illuminate\Mail\Transport\CloudflareTransport;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\Mailer\Exception\TransportException;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\Email;
+
+class MailCloudflareTransportTest extends TestCase
+{
+    public function testGetTransport(): void
+    {
+        $container = new Container;
+
+        $manager = new MailManager($container);
+
+        $transport = $manager->createSymfonyTransport([
+            'transport' => 'cloudflare',
+            'account_id' => 'test-account-id',
+            'token' => 'test-token',
+        ]);
+
+        $this->assertInstanceOf(CloudflareTransport::class, $transport);
+        $this->assertSame('cloudflare', (string) $transport);
+    }
+
+    public function testSend(): void
+    {
+        $requestBody = null;
+        $requestUrl = null;
+        $requestHeaders = null;
+
+        $client = new MockHttpClient(function ($method, $url, $options) use (&$requestBody, &$requestUrl, &$requestHeaders) {
+            $requestUrl = $url;
+            $requestBody = json_decode($options['body'], true);
+            $requestHeaders = $options['normalized_headers'];
+
+            return new MockResponse(json_encode([
+                'success' => true,
+                'errors' => [],
+                'messages' => [],
+                'result' => [
+                    'delivered' => ['me@example.com'],
+                    'permanent_bounces' => [],
+                    'queued' => [],
+                ],
+            ]), ['http_code' => 200]);
+        });
+
+        $transport = new CloudflareTransport('my-account-id', 'my-api-token', $client);
+
+        $message = new Email();
+        $message->subject('Test subject');
+        $message->html('<p>Hello</p>');
+        $message->text('Hello');
+        $message->sender('sender@example.com');
+        $message->to('me@example.com');
+        $message->cc('cc@example.com');
+        $message->bcc('bcc@example.com');
+        $message->replyTo('taylor@example.com');
+        $message->getHeaders()->addTextHeader('X-Custom-Header', 'CustomValue');
+
+        $transport->send($message);
+
+        $this->assertStringContainsString('my-account-id', $requestUrl);
+        $this->assertSame('https://api.cloudflare.com/client/v4/accounts/my-account-id/email/sending/send', $requestUrl);
+        $this->assertSame('sender@example.com', $requestBody['from']);
+        $this->assertSame(['me@example.com'], $requestBody['to']);
+        $this->assertSame(['cc@example.com'], $requestBody['cc']);
+        $this->assertSame(['bcc@example.com'], $requestBody['bcc']);
+        $this->assertSame('taylor@example.com', $requestBody['reply_to']);
+        $this->assertSame('Test subject', $requestBody['subject']);
+        $this->assertSame('<p>Hello</p>', $requestBody['html']);
+        $this->assertSame('Hello', $requestBody['text']);
+        $this->assertSame('CustomValue', $requestBody['headers']['X-Custom-Header']);
+        $this->assertArrayHasKey('authorization', $requestHeaders);
+        $this->assertSame(['Authorization: Bearer my-api-token'], $requestHeaders['authorization']);
+    }
+
+    public function testSendWithNamedAddresses(): void
+    {
+        $requestBody = null;
+        $requestUrl = null;
+        $requestHeaders = null;
+
+        $client = new MockHttpClient(function ($method, $url, $options) use (&$requestBody, &$requestUrl, &$requestHeaders) {
+            $requestUrl = $url;
+            $requestBody = json_decode($options['body'], true);
+            $requestHeaders = $options['normalized_headers'];
+
+            return new MockResponse(json_encode([
+                'success' => true,
+                'errors' => [],
+                'messages' => [],
+                'result' => [
+                    'delivered' => ['me@example.com'],
+                    'permanent_bounces' => [],
+                    'queued' => [],
+                ],
+            ]), ['http_code' => 200]);
+        });
+
+        $transport = new CloudflareTransport('my-account-id', 'my-api-token', $client);
+
+        $message = new Email();
+        $message->subject('Test subject');
+        $message->text('Hello');
+        $message->sender(new Address('sender@example.com', 'Taylor Otwell'));
+        $message->to('me@example.com');
+        $message->replyTo(new Address('taylor@example.com', 'Taylor Otwell'));
+
+        $transport->send($message);
+
+        $this->assertSame([
+            'name' => 'Taylor Otwell',
+            'address' => 'sender@example.com',
+        ], $requestBody['from']);
+        $this->assertSame([
+            'name' => 'Taylor Otwell',
+            'address' => 'taylor@example.com',
+        ], $requestBody['reply_to']);
+    }
+
+    public function testSendWithAttachment(): void
+    {
+        $requestBody = null;
+
+        $client = new MockHttpClient(function ($method, $url, $options) use (&$requestBody) {
+            $requestBody = json_decode($options['body'], true);
+
+            return new MockResponse(json_encode([
+                'success' => true,
+                'errors' => [],
+                'messages' => [],
+                'result' => ['delivered' => ['me@example.com'], 'permanent_bounces' => [], 'queued' => []],
+            ]), ['http_code' => 200]);
+        });
+
+        $transport = new CloudflareTransport('my-account-id', 'my-api-token', $client);
+
+        $message = new Email();
+        $message->subject('With attachment');
+        $message->text('See attached');
+        $message->sender('sender@example.com');
+        $message->to('me@example.com');
+        $message->attach('file contents', 'document.txt', 'text/plain');
+
+        $transport->send($message);
+
+        $this->assertCount(1, $requestBody['attachments']);
+        $this->assertSame('document.txt', $requestBody['attachments'][0]['filename']);
+        $this->assertSame('text/plain', $requestBody['attachments'][0]['type']);
+        $this->assertSame('attachment', $requestBody['attachments'][0]['disposition']);
+        $this->assertNotEmpty($requestBody['attachments'][0]['content']);
+    }
+
+    public function testSendThrowsOnApiFailure(): void
+    {
+        $client = new MockHttpClient(function () {
+            return new MockResponse(json_encode([
+                'success' => false,
+                'errors' => [
+                    [
+                        'code' => 10001,
+                        'message' => 'invalid_request_schema'
+                    ]
+                ],
+                'messages' => [],
+                'result' => null,
+            ]), ['http_code' => 400]);
+        });
+
+        $transport = new CloudflareTransport('my-account-id', 'my-api-token', $client);
+
+        $message = new Email();
+        $message->subject('Fail');
+        $message->text('Body');
+        $message->sender('sender@example.com');
+        $message->to('me@example.com');
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('invalid_request_schema');
+
+        $transport->send($message);
+    }
+}


### PR DESCRIPTION
This adds a new transport for the [Cloudflare Email Service](https://developers.cloudflare.com/email-service/) which was [entered public beta today](https://blog.cloudflare.com/email-for-agents/). I thought it was worth considering given the prominence of Cloudflare itself, that it's a cost effective option, and also that it's a provider for Laravel Cloud.

I fully appreciate that you may want to wait until this is out of beta, or to see if it pops up as a Symfony transport that we can leverage instead. Happy to look at PRing this to Symfony instead to see if they'd be happy to include it.

---

Similar to other transports it requires Symfony's HTTP Client so it can share the same implementation and setup in the `MailManager`. This could easily be replaced with Laravel's HTTP interface if preferred but thought it was better to stick with convention.

```
composer require symfony/http-client
```

Then you can configure the transport and credentials in `config/services.php`.
 

```php
'cloudflare' => [
    'account_id' => env('CLOUDFLARE_ACCOUNT_ID'),
    'token' => env('CLOUDFLARE_TOKEN'),
],
```

This implementation was inspired by the existing `ResendTransport`, as well as reviewing how some of the Symfony mailers Laravel uses under the hood (like Postmark) work.

---

There are some quirks in the [email formatting required by the API](https://developers.cloudflare.com/api/resources/email_sending/methods/send) - it doesn't support the named syntax (`Taylor Otwell <taylor@example.com>`). However it does support it as an object with name/address for `from` and `reply_to`, though not for any of the recipients.