### PR TITLE
[13.x] Add dispatchSyncIf and dispatchSyncUnless to Dispatchable

### DIFF
--- a/src/Illuminate/Foundation/Bus/Dispatchable.php
+++ b/src/Illuminate/Foundation/Bus/Dispatchable.php
@@ -77,6 +77,50 @@ trait Dispatchable
     }
 
     /**
+     * Dispatch a command to its handler in the current process if the given truth test passes.
+     *
+     * @param  bool|\Closure  $boolean
+     * @param  mixed  ...$arguments
+     * @return mixed
+     */
+    public static function dispatchSyncIf($boolean, ...$arguments)
+    {
+        if ($boolean instanceof Closure) {
+            $dispatchable = new static(...$arguments);
+
+            return value($boolean, $dispatchable)
+                ? app(Dispatcher::class)->dispatchSync($dispatchable)
+                : new Fluent;
+        }
+
+        return value($boolean)
+            ? app(Dispatcher::class)->dispatchSync(new static(...$arguments))
+            : new Fluent;
+    }
+
+    /**
+     * Dispatch a command to its handler in the current process unless the given truth test passes.
+     *
+     * @param  bool|\Closure  $boolean
+     * @param  mixed  ...$arguments
+     * @return mixed
+     */
+    public static function dispatchSyncUnless($boolean, ...$arguments)
+    {
+        if ($boolean instanceof Closure) {
+            $dispatchable = new static(...$arguments);
+
+            return ! value($boolean, $dispatchable)
+                ? app(Dispatcher::class)->dispatchSync($dispatchable)
+                : new Fluent;
+        }
+
+        return ! value($boolean)
+            ? app(Dispatcher::class)->dispatchSync(new static(...$arguments))
+            : new Fluent;
+    }
+
+    /**
      * Dispatch a command to its appropriate handler after the current process.
      *
      * @param  mixed  ...$arguments

--- a/tests/Integration/Queue/JobDispatchingTest.php
+++ b/tests/Integration/Queue/JobDispatchingTest.php
@@ -102,6 +102,54 @@ class JobDispatchingTest extends QueueTestCase
         $this->assertTrue(Job::$ran);
     }
 
+    public function testDispatchesSyncConditionallyWithBoolean()
+    {
+        Job::dispatchSyncIf(false, 'test');
+
+        $this->assertFalse(Job::$ran);
+        $this->assertNull(Job::$value);
+
+        Job::dispatchSyncIf(true, 'test');
+
+        $this->assertTrue(Job::$ran);
+        $this->assertSame('test', Job::$value);
+    }
+
+    public function testDispatchesSyncConditionallyWithClosure()
+    {
+        Job::dispatchSyncIf(fn ($job) => $job instanceof Job ? 0 : 1, 'test');
+
+        $this->assertFalse(Job::$ran);
+
+        Job::dispatchSyncIf(fn ($job) => $job instanceof Job ? 1 : 0, 'test');
+
+        $this->assertTrue(Job::$ran);
+    }
+
+    public function testDoesNotDispatchSyncConditionallyWithBoolean()
+    {
+        Job::dispatchSyncUnless(true, 'test');
+
+        $this->assertFalse(Job::$ran);
+        $this->assertNull(Job::$value);
+
+        Job::dispatchSyncUnless(false, 'test');
+
+        $this->assertTrue(Job::$ran);
+        $this->assertSame('test', Job::$value);
+    }
+
+    public function testDoesNotDispatchSyncConditionallyWithClosure()
+    {
+        Job::dispatchSyncUnless(fn ($job) => $job instanceof Job ? 1 : 0, 'test');
+
+        $this->assertFalse(Job::$ran);
+
+        Job::dispatchSyncUnless(fn ($job) => $job instanceof Job ? 0 : 1, 'test');
+
+        $this->assertTrue(Job::$ran);
+    }
+
     public function testUniqueJobLockIsReleasedForJobDispatchedAfterResponse()
     {
         // get initial terminatingCallbacks


### PR DESCRIPTION
Adds `dispatchSyncIf` and `dispatchSyncUnless` to complete the conditional-dispatch API on the `Dispatchable` trait.

### Motivation

`Dispatchable` already has conditional variants for the queued dispatch path:

```php
Job::dispatchIf($boolean, ...$arguments);
Job::dispatchUnless($boolean, ...$arguments);
```

…but the synchronous dispatch path has no matching variants. Users who want to conditionally run a job **in the current process** are forced to an explicit `if` statement, and the naming of `dispatchIf` actively invites a subtle bug:

```php
// LOOKS like conditional sync dispatch. IS NOT — this queues the job.
Job::dispatchIf($shouldRunNow, $order);
```

There is no chainable fallback either — `PendingDispatch` has no `->sync()` method — so the conditional-sync case has no fluent equivalent today.

### New methods

| Method | Behavior |
|---|---|
| `dispatchSyncIf($boolean, ...$args)` | Dispatches synchronously when truthy; returns `Fluent` no-op otherwise |
| `dispatchSyncUnless($boolean, ...$args)` | Dispatches synchronously when falsy; returns `Fluent` no-op otherwise |

Both accept a `bool` or `Closure`, matching the exact shape of `dispatchIf` / `dispatchUnless`.

### Usage

```php
// Before
if ($shouldSync) {
    ProcessPayment::dispatchSync($order);
}

// After
ProcessPayment::dispatchSyncIf($shouldSync, $order);
ProcessPayment::dispatchSyncUnless($queued, $order);
```

### Tests

Added 4 new integration tests in `tests/Integration/Queue/JobDispatchingTest.php` mirroring the existing coverage for `dispatchIf` / `dispatchUnless`: boolean + Closure cases for both methods. All 13 tests in the file and 79 `tests/Bus/` tests pass.

### No breaking changes

New methods only; existing behavior untouched.
