### PR TITLE
[13.x] Add locale parameter to Number::fileSize(), forHumans(), and abbreviate()

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -201,9 +201,10 @@ class Number
      * @param  int|float  $bytes
      * @param  int  $precision
      * @param  int|null  $maxPrecision
+     * @param  string|null  $locale
      * @return string
      */
-    public static function fileSize(int|float $bytes, int $precision = 0, ?int $maxPrecision = null)
+    public static function fileSize(int|float $bytes, int $precision = 0, ?int $maxPrecision = null, ?string $locale = null)
     {
         $units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
 
@@ -213,7 +214,7 @@ class Number
             $bytes /= 1024;
         }
 
-        return sprintf('%s %s', static::format($bytes, $precision, $maxPrecision), $units[$i]);
+        return sprintf('%s %s', static::format($bytes, $precision, $maxPrecision, $locale), $units[$i]);
     }
 
     /**
@@ -222,11 +223,12 @@ class Number
      * @param  int|float  $number
      * @param  int  $precision
      * @param  int|null  $maxPrecision
+     * @param  string|null  $locale
      * @return string|false
      */
-    public static function abbreviate(int|float $number, int $precision = 0, ?int $maxPrecision = null)
+    public static function abbreviate(int|float $number, int $precision = 0, ?int $maxPrecision = null, ?string $locale = null)
     {
-        return static::forHumans($number, $precision, $maxPrecision, abbreviate: true);
+        return static::forHumans($number, $precision, $maxPrecision, abbreviate: true, locale: $locale);
     }
 
     /**
@@ -236,9 +238,10 @@ class Number
      * @param  int  $precision
      * @param  int|null  $maxPrecision
      * @param  bool  $abbreviate
+     * @param  string|null  $locale
      * @return string|false
      */
-    public static function forHumans(int|float $number, int $precision = 0, ?int $maxPrecision = null, bool $abbreviate = false)
+    public static function forHumans(int|float $number, int $precision = 0, ?int $maxPrecision = null, bool $abbreviate = false, ?string $locale = null)
     {
         return static::summarize($number, $precision, $maxPrecision, $abbreviate ? [
             3 => 'K',
@@ -252,7 +255,7 @@ class Number
             9 => ' billion',
             12 => ' trillion',
             15 => ' quadrillion',
-        ]);
+        ], $locale);
     }
 
     /**
@@ -262,9 +265,10 @@ class Number
      * @param  int  $precision
      * @param  int|null  $maxPrecision
      * @param  array<int, string>  $units
+     * @param  string|null  $locale
      * @return string|false
      */
-    protected static function summarize(int|float $number, int $precision = 0, ?int $maxPrecision = null, array $units = [])
+    protected static function summarize(int|float $number, int $precision = 0, ?int $maxPrecision = null, array $units = [], ?string $locale = null)
     {
         if (empty($units)) {
             $units = [
@@ -278,23 +282,23 @@ class Number
 
         switch (true) {
             case (float) $number === 0.0:
-                return $precision > 0 ? static::format(0, $precision, $maxPrecision) : '0';
+                return $precision > 0 ? static::format(0, $precision, $maxPrecision, $locale) : '0';
             case $number < 0:
-                return sprintf('-%s', static::summarize(abs($number), $precision, $maxPrecision, $units));
+                return sprintf('-%s', static::summarize(abs($number), $precision, $maxPrecision, $units, $locale));
             case $number >= 1e15:
-                return sprintf('%s'.end($units), static::summarize($number / 1e15, $precision, $maxPrecision, $units));
+                return sprintf('%s'.end($units), static::summarize($number / 1e15, $precision, $maxPrecision, $units, $locale));
         }
 
         $numberExponent = floor(log10($number));
         $displayExponent = $numberExponent - ($numberExponent % 3);
         $number /= pow(10, $displayExponent);
 
-        $formatted = static::format($number, $precision, $maxPrecision);
+        $formatted = static::format($number, $precision, $maxPrecision, $locale);
 
-        if (static::parseFloat($formatted) >= 1000 && isset($units[$displayExponent + 3])) {
+        if (static::parseFloat($formatted, locale: $locale) >= 1000 && isset($units[$displayExponent + 3])) {
             $number /= 1000;
             $displayExponent += 3;
-            $formatted = static::format($number, $precision, $maxPrecision);
+            $formatted = static::format($number, $precision, $maxPrecision, $locale);
         }
 
         return trim(sprintf('%s%s', $formatted, $units[$displayExponent] ?? ''));

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -186,6 +186,8 @@ class SupportNumberTest extends TestCase
         $this->assertSame('1 ZB', Number::fileSize(1024 ** 7));
         $this->assertSame('1 YB', Number::fileSize(1024 ** 8));
         $this->assertSame('1,024 YB', Number::fileSize(1024 ** 9));
+        $this->assertSame('2,00 KB', Number::fileSize(2048, precision: 2, locale: 'de'));
+        $this->assertSame('2,00 KB', Number::fileSize(2048, precision: 2, locale: 'fr'));
     }
 
     public function testClamp()
@@ -320,6 +322,8 @@ class SupportNumberTest extends TestCase
 
         Number::withLocale('de', fn () => $this->assertSame('1M', Number::abbreviate(999500)));
         Number::withLocale('fr', fn () => $this->assertSame('1M', Number::abbreviate(999500)));
+        $this->assertSame('1,23K', Number::abbreviate(1234, precision: 2, locale: 'de'));
+        $this->assertSame('1,23 thousand', Number::forHumans(1234, precision: 2, locale: 'fr'));
     }
 
     public function testPairs()


### PR DESCRIPTION
## Summary

- `Number::fileSize()`, `Number::forHumans()`, and `Number::abbreviate()` now accept an optional `?string $locale = null` parameter
- The locale is threaded through to the internal `Number::format()` and `Number::parseFloat()` calls inside `summarize()`
- All other formatting methods (`format`, `percentage`, `currency`, `spell`, `ordinal`, `spellOrdinal`, `parse`, `parseInt`, `parseFloat`) already supported this parameter — this closes the inconsistency

## Context

| Method | `locale` param before | `locale` param after |
|---|---|---|
| `Number::format()` | ✅ | ✅ |
| `Number::percentage()` | ✅ | ✅ |
| `Number::currency()` | ✅ | ✅ |
| `Number::spell()` | ✅ | ✅ |
| `Number::ordinal()` | ✅ | ✅ |
| `Number::fileSize()` | ❌ | ✅ |
| `Number::forHumans()` | ❌ | ✅ |
| `Number::abbreviate()` | ❌ | ✅ |

## Solution

Added `?string $locale = null` as the last parameter to `fileSize()`, `abbreviate()`, `forHumans()`, and the internal `summarize()` method. The locale is forwarded to every `static::format()` and `static::parseFloat()` call within those methods.

## Example

**Before:**
```php
// No way to pass a per-call locale — had to use withLocale() wrapper
Number::withLocale('de', fn () => Number::fileSize(2048, precision: 2)); // '2,00 KB'
Number::withLocale('de', fn () => Number::abbreviate(1234, precision: 2)); // '1,23K'
```

**After:**
```php
Number::fileSize(2048, precision: 2, locale: 'de');    // '2,00 KB'
Number::abbreviate(1234, precision: 2, locale: 'de');  // '1,23K'
Number::forHumans(1234, precision: 2, locale: 'fr');   // '1,23 thousand'
```

## Why no breaking changes

All three parameters are appended at the end with a default of `null`, preserving full backwards compatibility. Existing calls are unaffected.

## Changes

- `src/Illuminate/Support/Number.php` — added `?string $locale = null` to `fileSize()`, `abbreviate()`, `forHumans()`, and `summarize()`
- `tests/Support/SupportNumberTest.php` — added locale assertions to `testBytesToHuman` and `testSummarize`

## Test Plan

- [x] `php83 vendor/bin/phpunit tests/Support/SupportNumberTest.php` — all 22 tests pass