### PR TITLE
[13.x] Implement CanFlushLocks on FailoverStore

### DIFF
--- a/src/Illuminate/Cache/FailoverStore.php
+++ b/src/Illuminate/Cache/FailoverStore.php
@@ -3,12 +3,13 @@
 namespace Illuminate\Cache;
 
 use Illuminate\Cache\Events\CacheFailedOver;
+use Illuminate\Contracts\Cache\CanFlushLocks;
 use Illuminate\Contracts\Cache\LockProvider;
 use Illuminate\Contracts\Events\Dispatcher;
 use RuntimeException;
 use Throwable;
 
-class FailoverStore extends TaggableStore implements LockProvider
+class FailoverStore extends TaggableStore implements CanFlushLocks, LockProvider
 {
     /**
      * The caches which failed on the last action.
@@ -197,6 +198,38 @@ class FailoverStore extends TaggableStore implements LockProvider
                 break;
             }
         }
+    }
+
+    /**
+     * Flush all of the stale locks from every backing store.
+     *
+     * @return bool
+     */
+    public function flushLocks(): bool
+    {
+        $result = true;
+
+        foreach ($this->stores as $store) {
+            $underlyingStore = $this->store($store)->getStore();
+
+            if ($underlyingStore instanceof CanFlushLocks) {
+                if (! $underlyingStore->flushLocks()) {
+                    $result = false;
+                }
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Determine if the lock store is separate from the cache store.
+     *
+     * @return bool
+     */
+    public function hasSeparateLockStore(): bool
+    {
+        return true;
     }
 
     /**

--- a/tests/Cache/CacheFailoverStoreTest.php
+++ b/tests/Cache/CacheFailoverStoreTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Illuminate\Tests\Cache;
+
+use Illuminate\Cache\ArrayStore;
+use Illuminate\Cache\CacheManager;
+use Illuminate\Cache\FailoverStore;
+use Illuminate\Cache\Repository;
+use Illuminate\Contracts\Cache\CanFlushLocks;
+use Illuminate\Contracts\Events\Dispatcher;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class CacheFailoverStoreTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    public function testImplementsCanFlushLocks()
+    {
+        $store = $this->makeFailoverStore([]);
+
+        $this->assertInstanceOf(CanFlushLocks::class, $store);
+    }
+
+    public function testFlushLocksCallsFlushLocksOnAllBackingStores()
+    {
+        $storeA = new ArrayStore;
+        $storeB = new ArrayStore;
+
+        $storeA->lock('lock-a', 60)->get();
+        $storeB->lock('lock-b', 60)->get();
+
+        $cache = m::mock(CacheManager::class);
+        $cache->shouldReceive('store')->with('store-a')->andReturn(new Repository($storeA));
+        $cache->shouldReceive('store')->with('store-b')->andReturn(new Repository($storeB));
+
+        $failover = new FailoverStore($cache, m::mock(Dispatcher::class), ['store-a', 'store-b']);
+
+        $result = $failover->flushLocks();
+
+        $this->assertTrue($result);
+        $this->assertEmpty($storeA->locks);
+        $this->assertEmpty($storeB->locks);
+    }
+
+    public function testFlushLocksReturnsTrueWhenNoStoreSupportsIt()
+    {
+        $store = $this->makeFailoverStore([]);
+
+        $this->assertTrue($store->flushLocks());
+    }
+
+    protected function makeFailoverStore(array $stores): FailoverStore
+    {
+        return new FailoverStore(
+            m::mock(CacheManager::class),
+            m::mock(Dispatcher::class),
+            $stores
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- `FailoverStore` now implements `CanFlushLocks` and the `flushLocks()` / `hasSeparateLockStore()` methods
- `Cache::flushLocks()` now works when the `failover` cache driver is in use

## Context

Every cache store that ships with Laravel implements `CanFlushLocks`:

| Store | `CanFlushLocks` before | `CanFlushLocks` after |
|---|---|---|
| `ArrayStore` | ✅ | ✅ |
| `DatabaseStore` | ✅ | ✅ |
| `FileStore` | ✅ | ✅ |
| `RedisStore` | ✅ | ✅ |
| `FailoverStore` | ❌ | ✅ |

`FailoverStore` already implements `LockProvider` (for acquiring locks), but calling `Cache::flushLocks()` with the failover driver threw `"This cache store does not support flushing locks."` because the store didn't implement `CanFlushLocks`.

## Solution

Added `CanFlushLocks` to the class declaration and implemented two methods:

**`flushLocks(): bool`** — iterates through every backing store and calls `flushLocks()` on those that implement `CanFlushLocks`. Unlike `attemptOnAllStores()` (which returns on the first success), this flushes **all** stores, because locks may have been acquired on any of them during failover.

**`hasSeparateLockStore(): bool`** — returns `true`. The failover store delegates entirely to its backing stores, each of which manages lock storage independently.

## Example

**Before:**
```php
// config/cache.php: 'default' => 'failover'
Cache::flushLocks(); // throws BadMethodCallException: "This cache store does not support flushing locks."
```

**After:**
```php
Cache::flushLocks(); // true — flushes locks on all backing stores
```

## Why no breaking changes

This is a purely additive change. No existing method signatures are modified, and no existing callers are affected.

## Changes

- `src/Illuminate/Cache/FailoverStore.php` — added `CanFlushLocks` import, added to class declaration, implemented `flushLocks()` and `hasSeparateLockStore()`
- `tests/Cache/CacheFailoverStoreTest.php` — new unit test file

## Test Plan

- [x] `php83 vendor/bin/phpunit tests/Cache/CacheFailoverStoreTest.php` — all 3 tests pass