### PR TITLE
[13.x] Cast to string before preg_match in decimal, max_digits, and min_digits rules

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -673,7 +673,7 @@ trait ValidatesAttributes
 
         $matches = [];
 
-        if (preg_match('/^[+-]?\d*\.?(\d*)$/', $value, $matches) !== 1) {
+        if (preg_match('/^[+-]?\d*\.?(\d*)$/', (string) $value, $matches) !== 1) {
             return false;
         }
 
@@ -1699,7 +1699,7 @@ trait ValidatesAttributes
 
         $length = strlen((string) $value);
 
-        return ! preg_match('/[^0-9]/', $value) && $length <= $parameters[0];
+        return ! preg_match('/[^0-9]/', (string) $value) && $length <= $parameters[0];
     }
 
     /**
@@ -1809,7 +1809,7 @@ trait ValidatesAttributes
 
         $length = strlen((string) $value);
 
-        return ! preg_match('/[^0-9]/', $value) && $length >= $parameters[0];
+        return ! preg_match('/[^0-9]/', (string) $value) && $length >= $parameters[0];
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3256,12 +3256,24 @@ class ValidationValidatorTest extends TestCase
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['x' => ['array']], ['x' => 'max_digits:5']);
         $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => 123], ['x' => 'max_digits:5']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => 123456], ['x' => 'max_digits:5']);
+        $this->assertFalse($v->passes());
     }
 
     public function testValidateMinDigitsDoesNotThrowOnNonStringValue()
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['x' => ['array']], ['x' => 'min_digits:1']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => 123], ['x' => 'min_digits:2']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => 1], ['x' => 'min_digits:2']);
         $this->assertFalse($v->passes());
     }
 
@@ -3717,6 +3729,12 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['foo' => '123.34'], ['foo' => 'Decimal:0,2']);
         $this->assertTrue($v->passes());
         $v = new Validator($trans, ['foo' => '123.34'], ['foo' => 'Decimal:0,2']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => 123], ['foo' => 'Decimal:0']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => 1.23], ['foo' => 'Decimal:0,3']);
         $this->assertTrue($v->passes());
     }
 


### PR DESCRIPTION
## Summary

- `validateDecimal`, `validateMaxDigits`, and `validateMinDigits` now explicitly cast the value to `string` before passing it to `preg_match`

## Context

| Rule | Before | After |
|---|---|---|
| `decimal` | `preg_match('/^[+-]?\d*\.?(\d*)$/', $value, ...)` | `preg_match('/^[+-]?\d*\.?(\d*)$/', (string) $value, ...)` |
| `max_digits` | `preg_match('/[^0-9]/', $value)` | `preg_match('/[^0-9]/', (string) $value)` |
| `min_digits` | `preg_match('/[^0-9]/', $value)` | `preg_match('/[^0-9]/', (string) $value)` |

All three rules already check `is_string($value) || is_numeric($value)` before the `preg_match` call, so numeric types are valid inputs. The `strlen()` call in the same methods already casts with `(string) $value` — making `preg_match` the only place relying on PHP's implicit cast.

This follows the same convention used in `validateAlphaDash` and `validateAlphaNum`, and matches the fix applied to `validateDigitsBetween` previously.

## Solution

Added an explicit `(string)` cast to the `$value` argument in each `preg_match` call.

## Example

**Before:**
```php
// preg_match relied on PHP's implicit cast of int/float to string
$v = new Validator($trans, ['foo' => 123], ['foo' => 'decimal:0']);
// worked by accident, but explicit cast makes the intent clear
```

**After:**
```php
// The value is explicitly cast to string — no reliance on implicit coercion
preg_match('/^[+-]?\d*\.?(\d*)$/', (string) $value, $matches)
```

## Why no breaking changes

The cast produces the same string that PHP would have generated implicitly. Existing behavior is preserved; only the expression is made explicit.

## Changes

- `src/Illuminate/Validation/Concerns/ValidatesAttributes.php` — three `(string)` casts added
- `tests/Validation/ValidationValidatorTest.php` — added integer/float assertions to the three relevant test methods

## Test Plan

- [x] `php83 vendor/bin/phpunit tests/Validation/ValidationValidatorTest.php --filter "testValidateDecimal|testValidateMaxDigits|testValidateMinDigits"` — all 3 tests, 65 assertions pass