### PR TITLE
[13.x] Guard Job::payload() against corrupt JSON

### DIFF
--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -283,7 +283,7 @@ abstract class Job
      */
     public function payload()
     {
-        return json_decode($this->getRawBody(), true);
+        return json_decode($this->getRawBody(), true) ?? [];
     }
 
     /**

--- a/tests/Queue/QueueJobTest.php
+++ b/tests/Queue/QueueJobTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Illuminate\Tests\Queue;
+
+use Illuminate\Container\Container;
+use Illuminate\Queue\Jobs\SyncJob;
+use PHPUnit\Framework\TestCase;
+
+class QueueJobTest extends TestCase
+{
+    public function testPayloadReturnsDecodedArray()
+    {
+        $job = $this->makeJob(json_encode(['job' => 'foo', 'data' => ['bar']]));
+
+        $this->assertSame(['job' => 'foo', 'data' => ['bar']], $job->payload());
+    }
+
+    public function testPayloadReturnsEmptyArrayForCorruptJson()
+    {
+        $job = $this->makeJob('not-valid-json');
+
+        $this->assertSame([], $job->payload());
+    }
+
+    public function testPayloadReturnsEmptyArrayForEmptyBody()
+    {
+        $job = $this->makeJob('');
+
+        $this->assertSame([], $job->payload());
+    }
+
+    public function testGetNameDoesNotCrashOnCorruptPayload()
+    {
+        $job = $this->makeJob('not-valid-json');
+
+        $this->assertNull($job->payload()['job'] ?? null);
+    }
+
+    protected function makeJob(string $payload): SyncJob
+    {
+        return new SyncJob(new Container, $payload, 'sync', 'default');
+    }
+}


### PR DESCRIPTION
## Summary

`Job::payload()` calls `json_decode($this->getRawBody(), true)` which returns `null` when the raw body is malformed or empty JSON. Multiple callers — `getName()`, `maxTries()`, `maxExceptions()`, `retryUntil()`, `resolveName()` — then perform array-access on `null`, which either triggers a PHP warning or a null-coalescing fallback that returns `null` unexpectedly.

## Context

| Scenario | Before | After |
|---|---|---|
| Valid JSON body | ✅ Returns decoded array | ✅ Returns decoded array |
| Malformed JSON body | ❌ Returns `null` → crashes callers | ✅ Returns `[]` |
| Empty body | ❌ Returns `null` → crashes callers | ✅ Returns `[]` |

## Solution

Add a `?? []` null-coalescing fallback to the return value of `payload()`:

```php
// Before
public function payload()
{
    return json_decode($this->getRawBody(), true);
}

// After
public function payload()
{
    return json_decode($this->getRawBody(), true) ?? [];
}
```

This is the minimal, safe fix — all callers already use `??` for optional keys (`$this->payload()['maxTries'] ?? null`), so returning `[]` instead of `null` means they naturally return `null` without any risk of crashing.

## Safety

- No change in behavior for valid JSON payloads.
- Corrupt-payload jobs already cannot be dispatched normally; this prevents a secondary crash when the worker encounters one.
- No new exceptions are thrown — the behavior is strictly safer.

## Changes

- `src/Illuminate/Queue/Jobs/Job.php` — add `?? []` to `payload()` return
- `tests/Queue/QueueJobTest.php` — new tests covering valid JSON, corrupt JSON, and empty body

## Test Plan

- [x] `php vendor/bin/phpunit tests/Queue/QueueJobTest.php` — 4 tests, 4 assertions, all green