### PR TITLE
[13.x] Fix Str::unwrap() to only strip when both sides match

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -493,12 +493,14 @@ class Str
      */
     public static function unwrap($value, $before, $after = null)
     {
-        if (static::startsWith($value, $before)) {
-            $value = static::substr($value, static::length($before));
-        }
+        $after ??= $before;
 
-        if (static::endsWith($value, $after ??= $before)) {
-            $value = static::substr($value, 0, -static::length($after));
+        if (static::startsWith($value, $before) && static::endsWith($value, $after)) {
+            $value = static::substr($value, static::length($before));
+
+            if ($after !== '') {
+                $value = static::substr($value, 0, -static::length($after));
+            }
         }
 
         return $value;

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -591,10 +591,12 @@ class SupportStrTest extends TestCase
     public function testUnwrap()
     {
         $this->assertEquals('value', Str::unwrap('"value"', '"'));
-        $this->assertEquals('value', Str::unwrap('"value', '"'));
-        $this->assertEquals('value', Str::unwrap('value"', '"'));
+        $this->assertEquals('"value', Str::unwrap('"value', '"'));
+        $this->assertEquals('value"', Str::unwrap('value"', '"'));
         $this->assertEquals('bar', Str::unwrap('foo-bar-baz', 'foo-', '-baz'));
         $this->assertEquals('some: "json"', Str::unwrap('{some: "json"}', '{', '}'));
+        $this->assertEquals('foo-bar', Str::unwrap('foo-bar', 'foo-', '-baz'));
+        $this->assertEquals('bar-baz', Str::unwrap('bar-baz', 'foo-', '-baz'));
     }
 
     public function testIs()


### PR DESCRIPTION
## Summary

`Str::unwrap()` currently strips the `$before` and `$after` strings independently. This means it mutates strings where only one side matches, which is unexpected — `unwrap` should be the strict inverse of `wrap`.

## Context

| Input | Before | After |
|---|---|---|
| `'"value"'` unwrap `'"'` | ✅ `'value'` | ✅ `'value'` |
| `'"value'` unwrap `'"'` (only start matches) | ❌ `'value'` (partial strip) | ✅ `'"value'` (unchanged) |
| `'value"'` unwrap `'"'` (only end matches) | ❌ `'value'` (partial strip) | ✅ `'value"'` (unchanged) |
| `'foo-bar-baz'` unwrap `'foo-'`, `'-baz'` | ✅ `'bar'` | ✅ `'bar'` |
| `'foo-bar'` unwrap `'foo-'`, `'-baz'` (only start matches) | ❌ `'bar'` (partial strip) | ✅ `'foo-bar'` (unchanged) |

## Solution

Require both `startsWith($before)` and `endsWith($after)` to be true before stripping either end:

```php
// Before
public static function unwrap($value, $before, $after = null)
{
    if (static::startsWith($value, $before)) {
        $value = static::substr($value, static::length($before));
    }

    if (static::endsWith($value, $after ??= $before)) {
        $value = static::substr($value, 0, -static::length($after));
    }

    return $value;
}

// After
public static function unwrap($value, $before, $after = null)
{
    $after ??= $before;

    if (static::startsWith($value, $before) && static::endsWith($value, $after)) {
        $value = static::substr($value, static::length($before));

        if ($after !== '') {
            $value = static::substr($value, 0, -static::length($after));
        }
    }

    return $value;
}
```

## Safety

All existing fully-wrapped cases continue to work identically. The only behavioral change is for partially-wrapped strings, which now return the original value instead of silently stripping one end.

## Changes

- `src/Illuminate/Support/Str.php` — fix `unwrap()` to require both sides to match
- `tests/Support/SupportStrTest.php` — update assertions for partial-wrap cases and add new assertions

## Test Plan

- [x] `php vendor/bin/phpunit tests/Support/SupportStrTest.php --filter testUnwrap` — passes
- [x] `php vendor/bin/phpunit tests/Support/SupportStringableTest.php --filter testUnwrap` — passes