### PR TITLE
[13.x] Validate MAC across all decryption keys

### DIFF
--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -162,16 +162,20 @@ class Encrypter implements EncrypterContract, StringEncrypter
             $tag = empty($payload['tag']) ? null : base64_decode($payload['tag'])
         );
 
-        $foundValidMac = false;
+        $keys = $this->getAllKeys();
+        $validKey = null;
 
         // Here we will decrypt the value. If we are able to successfully decrypt it
         // we will then unserialize it and return it out to the caller. If we are
         // unable to decrypt this value we will throw out an exception message.
-        foreach ($this->getAllKeys() as $key) {
-            if (
-                $this->shouldValidateMac() &&
-                ! ($foundValidMac = $foundValidMac || $this->validMacForKey($payload, $key))
-            ) {
+        foreach ($keys as $key) {
+            if ($this->shouldValidateMac()) {
+                $validMac = $this->validMacForKey($payload, $key);
+
+                if ($validMac && $validKey === null) {
+                    $validKey = $key;
+                }
+
                 continue;
             }
 
@@ -184,8 +188,14 @@ class Encrypter implements EncrypterContract, StringEncrypter
             }
         }
 
-        if ($this->shouldValidateMac() && ! $foundValidMac) {
+        if ($this->shouldValidateMac() && $validKey === null) {
             throw new DecryptException('The MAC is invalid.');
+        }
+
+        if ($this->shouldValidateMac()) {
+            $decrypted = \openssl_decrypt(
+                $payload['value'], strtolower($this->cipher), $validKey, 0, $iv, $tag ?? ''
+            );
         }
 
         if (($decrypted ?? false) === false) {

--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -162,8 +162,7 @@ class Encrypter implements EncrypterContract, StringEncrypter
             $tag = empty($payload['tag']) ? null : base64_decode($payload['tag'])
         );
 
-        $keys = $this->getAllKeys();
-        $validKey = null;
+        [$keys, $validKey] = [$this->getAllKeys(), null];
 
         // Here we will decrypt the value. If we are able to successfully decrypt it
         // we will then unserialize it and return it out to the caller. If we are

--- a/tests/Encryption/EncrypterTest.php
+++ b/tests/Encryption/EncrypterTest.php
@@ -62,6 +62,17 @@ class EncrypterTest extends TestCase
         $this->assertSame('foo', $new->decryptString($encrypted));
     }
 
+    public function testItDecryptsUsingTheFirstMacValidatedKey()
+    {
+        $previous = new Encrypter(str_repeat('b', 16));
+        $encrypted = $previous->encryptString('foo');
+
+        $new = new Encrypter(str_repeat('a', 16));
+        $new->previousKeys([str_repeat('b', 16), str_repeat('c', 16)]);
+
+        $this->assertSame('foo', $new->decryptString($encrypted));
+    }
+
     public function testEncryptionUsingBase64EncodedKey()
     {
         $e = new Encrypter(random_bytes(16));


### PR DESCRIPTION
This PR addresses #59363.

When multiple decryption keys are configured, `Encrypter::decrypt()` currently stops MAC validation as soon as a matching key is found. That means the amount of work depends on where the matching key appears in the rotation list.

This change makes MAC validation run across all configured keys, remembers the first matching key, and then decrypts only once with that key.

The behavior stays the same, but the implementation no longer short-circuits based on key position.

This is also intentionally narrower than #59366. It only changes `Encrypter`, keeps the fix focused on #59363, and avoids the extra array-building logic from that earlier attempt.

A regression test was added to cover decryption when multiple previous keys are configured.
