### PR TITLE
[13.x] Omit empty `class`/`style` attribute from `@class` and `@style` directives

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesClasses.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesClasses.php
@@ -14,6 +14,6 @@ trait CompilesClasses
     {
         $expression = is_null($expression) ? '([])' : $expression;
 
-        return "class=\"<?php echo \Illuminate\Support\Arr::toCssClasses{$expression}; ?>\"";
+        return "<?php \$__classes = \Illuminate\Support\Arr::toCssClasses{$expression}; echo \$__classes !== '' ? 'class=\"'.\$__classes.'\"' : ''; ?>";
     }
 }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesStyles.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesStyles.php
@@ -14,6 +14,6 @@ trait CompilesStyles
     {
         $expression = is_null($expression) ? '([])' : $expression;
 
-        return "style=\"<?php echo \Illuminate\Support\Arr::toCssStyles{$expression} ?>\"";
+        return "<?php \$__styles = \Illuminate\Support\Arr::toCssStyles{$expression}; echo \$__styles !== '' ? 'style=\"'.\$__styles.'\"' : ''; ?>";
     }
 }

--- a/tests/View/Blade/BladeClassTest.php
+++ b/tests/View/Blade/BladeClassTest.php
@@ -7,8 +7,52 @@ class BladeClassTest extends AbstractBladeTestCase
     public function testClassesAreConditionallyCompiledFromArray()
     {
         $string = "<span @class(['font-bold', 'mt-4', 'ml-2' => true, 'mr-2' => false])></span>";
-        $expected = "<span class=\"<?php echo \Illuminate\Support\Arr::toCssClasses(['font-bold', 'mt-4', 'ml-2' => true, 'mr-2' => false]); ?>\"></span>";
+        $expected = "<span <?php \$__classes = \Illuminate\Support\Arr::toCssClasses(['font-bold', 'mt-4', 'ml-2' => true, 'mr-2' => false]); echo \$__classes !== '' ? 'class=\"'.\$__classes.'\"' : ''; ?>></span>";
 
         $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testClassAttributeIsOmittedWhenArrayIsEmpty()
+    {
+        $template = $this->compiler->compileString('<span @class([])></span>');
+
+        ob_start();
+        eval('?>'.$template);
+        $output = ob_get_clean();
+
+        $this->assertSame('<span ></span>', $output);
+    }
+
+    public function testClassAttributeIsOmittedWhenAllConditionsAreFalse()
+    {
+        $template = $this->compiler->compileString("<span @class(['foo' => false, 'bar' => false])></span>");
+
+        ob_start();
+        eval('?>'.$template);
+        $output = ob_get_clean();
+
+        $this->assertSame('<span ></span>', $output);
+    }
+
+    public function testClassAttributeIsRenderedWhenSomeConditionsAreTrue()
+    {
+        $template = $this->compiler->compileString("<span @class(['base', 'active' => true, 'hidden' => false])></span>");
+
+        ob_start();
+        eval('?>'.$template);
+        $output = ob_get_clean();
+
+        $this->assertSame('<span class="base active"></span>', $output);
+    }
+
+    public function testClassAttributeIsRenderedWithUnconditionalClassWhenAllConditionsAreFalse()
+    {
+        $template = $this->compiler->compileString("<span @class(['base', 'active' => false])></span>");
+
+        ob_start();
+        eval('?>'.$template);
+        $output = ob_get_clean();
+
+        $this->assertSame('<span class="base"></span>', $output);
     }
 }

--- a/tests/View/Blade/BladePhpStatementsTest.php
+++ b/tests/View/Blade/BladePhpStatementsTest.php
@@ -122,12 +122,12 @@ class BladePhpStatementsTest extends AbstractBladeTestCase
     public function testUnclosedParenthesisForBladeTags()
     {
         $string = "<span @class(['(']></span>";
-        $expected = "<span class=\"<?php echo \Illuminate\Support\Arr::toCssClasses([]); ?>\"(['(']></span>";
+        $expected = "<span <?php \$__classes = \Illuminate\Support\Arr::toCssClasses([]); echo \$__classes !== '' ? 'class=\"'.\$__classes.'\"' : ''; ?>(['(']></span>";
 
         $this->assertEquals($expected, $this->compiler->compileString($string));
 
         $string = "<span @class(['']></span>";
-        $expected = "<span class=\"<?php echo \Illuminate\Support\Arr::toCssClasses([]); ?>\"(['']></span>";
+        $expected = "<span <?php \$__classes = \Illuminate\Support\Arr::toCssClasses([]); echo \$__classes !== '' ? 'class=\"'.\$__classes.'\"' : ''; ?>(['']></span>";
 
         $this->assertEquals($expected, $this->compiler->compileString($string));
 
@@ -145,31 +145,31 @@ class BladePhpStatementsTest extends AbstractBladeTestCase
     public function testNestedTagCalls()
     {
         $string = "<span @class(['k' => @empty(\$v)])></span>";
-        $expected = '<span class="<?php echo \Illuminate\Support\Arr::toCssClasses([\'k\' => @empty($v)]); ?>"></span>';
+        $expected = '<span <?php $__classes = \Illuminate\Support\Arr::toCssClasses([\'k\' => @empty($v)]); echo $__classes !== \'\' ? \'class="\'.$__classes.\'"\' : \'\'; ?>></span>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
 
         $string = "<span @class(['k))' => @empty(\$v)])></span>";
-        $expected = '<span class="<?php echo \Illuminate\Support\Arr::toCssClasses([\'k))\' => @empty($v)]); ?>"></span>';
+        $expected = '<span <?php $__classes = \Illuminate\Support\Arr::toCssClasses([\'k))\' => @empty($v)]); echo $__classes !== \'\' ? \'class="\'.$__classes.\'"\' : \'\'; ?>></span>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
 
         $string = "<span @class(['k' => @empty(\$v), 't' => @empty(\$v1)])></span>";
-        $expected = '<span class="<?php echo \Illuminate\Support\Arr::toCssClasses([\'k\' => @empty($v), \'t\' => @empty($v1)]); ?>"></span>';
+        $expected = '<span <?php $__classes = \Illuminate\Support\Arr::toCssClasses([\'k\' => @empty($v), \'t\' => @empty($v1)]); echo $__classes !== \'\' ? \'class="\'.$__classes.\'"\' : \'\'; ?>></span>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
 
         $string = "<span @class(['k' => @empty(\$v), 't' => @empty(\$v1)])></span>";
-        $expected = '<span class="<?php echo \Illuminate\Support\Arr::toCssClasses([\'k\' => @empty($v), \'t\' => @empty($v1)]); ?>"></span>';
+        $expected = '<span <?php $__classes = \Illuminate\Support\Arr::toCssClasses([\'k\' => @empty($v), \'t\' => @empty($v1)]); echo $__classes !== \'\' ? \'class="\'.$__classes.\'"\' : \'\'; ?>></span>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
 
         $string = "<span @class(['k' => @empty(\$v), 't' => @empty(\$v1), 'r' => @empty(\$v2)])></span>";
-        $expected = '<span class="<?php echo \Illuminate\Support\Arr::toCssClasses([\'k\' => @empty($v), \'t\' => @empty($v1), \'r\' => @empty($v2)]); ?>"></span>';
+        $expected = '<span <?php $__classes = \Illuminate\Support\Arr::toCssClasses([\'k\' => @empty($v), \'t\' => @empty($v1), \'r\' => @empty($v2)]); echo $__classes !== \'\' ? \'class="\'.$__classes.\'"\' : \'\'; ?>></span>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
 
         $string = "<span @class(['k' => @empty(\$v), 't))' => @empty(\$v1), 'r' => @empty(\$v2)])></span>";
-        $expected = '<span class="<?php echo \Illuminate\Support\Arr::toCssClasses([\'k\' => @empty($v), \'t))\' => @empty($v1), \'r\' => @empty($v2)]); ?>"></span>';
+        $expected = '<span <?php $__classes = \Illuminate\Support\Arr::toCssClasses([\'k\' => @empty($v), \'t))\' => @empty($v1), \'r\' => @empty($v2)]); echo $__classes !== \'\' ? \'class="\'.$__classes.\'"\' : \'\'; ?>></span>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
 
         $string = "<span @class(['k' => @empty(\$v), 't' => @empty(\$v1), 'r' => @empty(\$v2), 'l' => 'l'])></span><span @class(['k' => @empty(\$v)])></span>";
-        $expected = '<span class="<?php echo \Illuminate\Support\Arr::toCssClasses([\'k\' => @empty($v), \'t\' => @empty($v1), \'r\' => @empty($v2), \'l\' => \'l\']); ?>"></span><span class="<?php echo \Illuminate\Support\Arr::toCssClasses([\'k\' => @empty($v)]); ?>"></span>';
+        $expected = '<span <?php $__classes = \Illuminate\Support\Arr::toCssClasses([\'k\' => @empty($v), \'t\' => @empty($v1), \'r\' => @empty($v2), \'l\' => \'l\']); echo $__classes !== \'\' ? \'class="\'.$__classes.\'"\' : \'\'; ?>></span><span <?php $__classes = \Illuminate\Support\Arr::toCssClasses([\'k\' => @empty($v)]); echo $__classes !== \'\' ? \'class="\'.$__classes.\'"\' : \'\'; ?>></span>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 

--- a/tests/View/Blade/BladeStyleTest.php
+++ b/tests/View/Blade/BladeStyleTest.php
@@ -7,8 +7,52 @@ class BladeStyleTest extends AbstractBladeTestCase
     public function testStylesAreConditionallyCompiledFromArray()
     {
         $string = "<span @style(['font-weight: bold', 'text-decoration: underline', 'color: red' => true, 'margin-top: 10px' => false])></span>";
-        $expected = "<span style=\"<?php echo \Illuminate\Support\Arr::toCssStyles(['font-weight: bold', 'text-decoration: underline', 'color: red' => true, 'margin-top: 10px' => false]) ?>\"></span>";
+        $expected = "<span <?php \$__styles = \Illuminate\Support\Arr::toCssStyles(['font-weight: bold', 'text-decoration: underline', 'color: red' => true, 'margin-top: 10px' => false]); echo \$__styles !== '' ? 'style=\"'.\$__styles.'\"' : ''; ?>></span>";
 
         $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testStyleAttributeIsOmittedWhenArrayIsEmpty()
+    {
+        $template = $this->compiler->compileString('<span @style([])></span>');
+
+        ob_start();
+        eval('?>'.$template);
+        $output = ob_get_clean();
+
+        $this->assertSame('<span ></span>', $output);
+    }
+
+    public function testStyleAttributeIsOmittedWhenAllConditionsAreFalse()
+    {
+        $template = $this->compiler->compileString("<span @style(['color: red' => false, 'margin: 0' => false])></span>");
+
+        ob_start();
+        eval('?>'.$template);
+        $output = ob_get_clean();
+
+        $this->assertSame('<span ></span>', $output);
+    }
+
+    public function testStyleAttributeIsRenderedWhenSomeConditionsAreTrue()
+    {
+        $template = $this->compiler->compileString("<span @style(['font-weight: bold', 'color: red' => true, 'margin: 0' => false])></span>");
+
+        ob_start();
+        eval('?>'.$template);
+        $output = ob_get_clean();
+
+        $this->assertSame('<span style="font-weight: bold; color: red;"></span>', $output);
+    }
+
+    public function testStyleAttributeIsRenderedWithUnconditionalStyleWhenAllConditionsAreFalse()
+    {
+        $template = $this->compiler->compileString("<span @style(['font-weight: bold', 'color: red' => false])></span>");
+
+        ob_start();
+        eval('?>'.$template);
+        $output = ob_get_clean();
+
+        $this->assertSame('<span style="font-weight: bold;"></span>', $output);
     }
 }


### PR DESCRIPTION
## Summary

`@class([...])` and `@style([...])` currently render `class=""` / `style=""` on the target element when all conditions evaluate to `false` (or the input array is empty). The compiler traits hardcode the attribute wrapper around the result of `Arr::toCssClasses` / `Arr::toCssStyles`, so an empty string from the helper still produces an empty-valued attribute in the rendered HTML.

This PR changes both compilers to emit the attribute only when the helper returns a non-empty string.

## Before / after

Given:
```blade
<span @class(['highlight' => $required])></span>
```

When `$required` is `false`:

| | Rendered HTML |
|---|---|
| Before | `<span class=""></span>` |
| After | `<span></span>` |

When `$required` is `true`, output is unchanged: `<span class="highlight"></span>`. Same shape for `@style`.

## Why this is a bug, not just cosmetic

The directive's API contract is "apply classes/styles conditionally." Emitting an empty attribute when no classes/styles apply leaks the compiler's internal wrapping into HTML, where downstream tooling observes it differently from the absent-attribute state:

- CSS `[class]` / `[style]` attribute selectors unexpectedly match elements with no styling intent
- `element.hasAttribute('class')` returns `true` and `getAttribute('class')` returns `""`, rather than `false` / `null`
- HTML-equality snapshot assertions include noise attributes unrelated to styling intent
- Raw server-rendered HTML bytes carry the attribute for no semantic gain

## Scope

**Only the two compiler traits** (`CompilesClasses`, `CompilesStyles`) are changed. `ComponentAttributeBag::__toString()` is intentionally untouched because boolean HTML attributes (`disabled`, `checked`, `required`, etc.) flow through it and legitimately render with empty values per the HTML spec. `class` and `style` are value attributes (not boolean), so their dedicated compiler traits are the correct place for this fix.

## Related work

This PR complements #57467 ("Improved empty and whitespace-only string handling in Blade component attributes"), which takes a parallel approach inside `ComponentAttributeBag`. Both changes move toward Vue-aligned attribute-emission behavior.

Related: #57463, #57235.

## Why this doesn't break typical usage

The observable change only occurs when every class in a `@class([...])` or `@style([...])` call is conditional **and** all conditions evaluate to `false`. Templates with at least one unconditional class — the common pattern like `@class(['base', 'active' => $cond])` — are entirely unaffected.

In the narrow case that *is* affected, the rendered output is semantically identical to the previous behavior: CSS rules matching specific class names still don't match (no classes are present either way); visual layout is identical. The only observable difference is attribute *presence* for tooling that specifically inspects it (e.g. CSS `[class]` attribute selectors, JavaScript `hasAttribute` checks). This is uncommon enough that no existing tests in the framework exercised it, and the new behavior aligns with the Vue-style attribute emission referenced on #57467.

## Tests

- `BladeClassTest`: updated the existing compilation assertion and added four runtime tests (empty array, all-false, mixed true/false, base class + all-false).
- `BladeStyleTest`: parallel coverage for `@style`.
- `BladePhpStatementsTest`: updated nine existing assertions whose expected strings referenced the old compiled output. No semantic change to those tests.

Runtime tests use the `ob_start()` + `eval('?>'.$compiled)` pattern already established in `BladeBoolTest`, `BladeComponentsTest`, and `BladeEchoHandlerTest`.