### PR TITLE
[13.x] Allow assertDatabase has & missing to accept arrays

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -33,6 +33,14 @@ trait InteractsWithDatabase
             return $this;
         }
 
+        if (array_is_list($data) && count($data) > 0 && array_all($data, fn ($row) => is_array($row))) {
+            foreach ($data as $row) {
+                $this->assertDatabaseHas($table, $row, $connection);
+            }
+
+            return $this;
+        }
+
         if ($table instanceof Model) {
             $data = [
                 $table->getKeyName() => $table->getKey(),
@@ -60,6 +68,14 @@ trait InteractsWithDatabase
         if (is_iterable($table)) {
             foreach ($table as $item) {
                 $this->assertDatabaseMissing($item, $data, $connection);
+            }
+
+            return $this;
+        }
+
+        if (array_is_list($data) && count($data) > 0 && array_all($data, fn ($row) => is_array($row))) {
+            foreach ($data as $row) {
+                $this->assertDatabaseMissing($table, $row, $connection);
             }
 
             return $this;

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -33,7 +33,7 @@ trait InteractsWithDatabase
             return $this;
         }
 
-        if (array_is_list($data) && count($data) > 0 && array_all($data, fn ($row) => is_array($row))) {
+        if (array_is_list($data) && array_all($data, fn ($row) => is_array($row))) {
             foreach ($data as $row) {
                 $this->assertDatabaseHas($table, $row, $connection);
             }
@@ -73,7 +73,7 @@ trait InteractsWithDatabase
             return $this;
         }
 
-        if (array_is_list($data) && count($data) > 0 && array_all($data, fn ($row) => is_array($row))) {
+        if (array_is_list($data) && array_all($data, fn ($row) => is_array($row))) {
             foreach ($data as $row) {
                 $this->assertDatabaseMissing($table, $row, $connection);
             }

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -61,7 +61,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->assertDatabaseHas(new ProductStub(['id' => 1]), $data);
     }
 
-    public function testAssertDatabaseHasWithArrays()
+    public function testAssertDatabaseSupportsArrays()
     {
         $builder = m::mock(Builder::class);
         $builder->shouldReceive('where')->with(['title' => 'Spark', 'name' => 'Laravel'])->once()->andReturnSelf();
@@ -118,7 +118,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->assertDatabaseHas($this->table, $this->data);
     }
 
-    public function testAssertDatabaseMissingWithArrays()
+    public function testAssertDatabaseMissingSupportsArrays()
     {
         $builder = m::mock(Builder::class);
         $builder->shouldReceive('where')->with(['title' => 'Spark', 'name' => 'Laravel'])->once()->andReturnSelf();

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -61,6 +61,21 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->assertDatabaseHas(new ProductStub(['id' => 1]), $data);
     }
 
+    public function testAssertDatabaseHasWithArrays()
+    {
+        $builder = m::mock(Builder::class);
+        $builder->shouldReceive('where')->with(['title' => 'Spark', 'name' => 'Laravel'])->once()->andReturnSelf();
+        $builder->shouldReceive('where')->with(['title' => 'Forge', 'name' => 'Laravel'])->once()->andReturnSelf();
+        $builder->shouldReceive('exists')->twice()->andReturn(true);
+
+        $this->connection->shouldReceive('table')->with($this->table)->andReturn($builder);
+
+        $this->assertDatabaseHas($this->table, [
+            ['title' => 'Spark', 'name' => 'Laravel'],
+            ['title' => 'Forge', 'name' => 'Laravel'],
+        ]);
+    }
+
     public function testSeeInDatabaseDoesNotFindResults()
     {
         $this->expectException(ExpectationFailedException::class);
@@ -101,6 +116,21 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         );
 
         $this->assertDatabaseHas($this->table, $this->data);
+    }
+
+    public function testAssertDatabaseMissingWithArrays()
+    {
+        $builder = m::mock(Builder::class);
+        $builder->shouldReceive('where')->with(['title' => 'Spark', 'name' => 'Laravel'])->once()->andReturnSelf();
+        $builder->shouldReceive('where')->with(['title' => 'Forge', 'name' => 'Laravel'])->once()->andReturnSelf();
+        $builder->shouldReceive('exists')->twice()->andReturn(false);
+
+        $this->connection->shouldReceive('table')->with($this->table)->andReturn($builder);
+
+        $this->assertDatabaseMissing($this->table, [
+            ['title' => 'Spark', 'name' => 'Laravel'],
+            ['title' => 'Forge', 'name' => 'Laravel'],
+        ]);
     }
 
     public function testDontSeeInDatabaseDoesNotFindResults()

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -63,17 +63,9 @@ class FoundationInteractsWithDatabaseTest extends TestCase
 
     public function testAssertDatabaseHasWithArrays()
     {
-        $builder = m::mock(Builder::class);
-        $builder->shouldReceive('where')->with(['title' => 'Spark', 'name' => 'Laravel'])->once()->andReturnSelf();
-        $builder->shouldReceive('where')->with(['title' => 'Forge', 'name' => 'Laravel'])->once()->andReturnSelf();
-        $builder->shouldReceive('exists')->twice()->andReturn(true);
+        $this->mockCountBuilder(true);
 
-        $this->connection->shouldReceive('table')->with($this->table)->andReturn($builder);
-
-        $this->assertDatabaseHas($this->table, [
-            ['title' => 'Spark', 'name' => 'Laravel'],
-            ['title' => 'Forge', 'name' => 'Laravel'],
-        ]);
+        $this->assertDatabaseHas($this->table, [$this->data, $this->data]);
     }
 
     public function testSeeInDatabaseDoesNotFindResults()
@@ -120,17 +112,9 @@ class FoundationInteractsWithDatabaseTest extends TestCase
 
     public function testAssertDatabaseMissingWithArrays()
     {
-        $builder = m::mock(Builder::class);
-        $builder->shouldReceive('where')->with(['title' => 'Spark', 'name' => 'Laravel'])->once()->andReturnSelf();
-        $builder->shouldReceive('where')->with(['title' => 'Forge', 'name' => 'Laravel'])->once()->andReturnSelf();
-        $builder->shouldReceive('exists')->twice()->andReturn(false);
+        $this->mockCountBuilder(false);
 
-        $this->connection->shouldReceive('table')->with($this->table)->andReturn($builder);
-
-        $this->assertDatabaseMissing($this->table, [
-            ['title' => 'Spark', 'name' => 'Laravel'],
-            ['title' => 'Forge', 'name' => 'Laravel'],
-        ]);
+        $this->assertDatabaseMissing($this->table, [$this->data, $this->data]);
     }
 
     public function testDontSeeInDatabaseDoesNotFindResults()

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -63,9 +63,17 @@ class FoundationInteractsWithDatabaseTest extends TestCase
 
     public function testAssertDatabaseHasWithArrays()
     {
-        $this->mockCountBuilder(true);
+        $builder = m::mock(Builder::class);
+        $builder->shouldReceive('where')->with(['title' => 'Spark', 'name' => 'Laravel'])->once()->andReturnSelf();
+        $builder->shouldReceive('where')->with(['title' => 'Forge', 'name' => 'Laravel'])->once()->andReturnSelf();
+        $builder->shouldReceive('exists')->twice()->andReturn(true);
 
-        $this->assertDatabaseHas($this->table, [$this->data, $this->data]);
+        $this->connection->shouldReceive('table')->with($this->table)->andReturn($builder);
+
+        $this->assertDatabaseHas($this->table, [
+            ['title' => 'Spark', 'name' => 'Laravel'],
+            ['title' => 'Forge', 'name' => 'Laravel'],
+        ]);
     }
 
     public function testSeeInDatabaseDoesNotFindResults()
@@ -112,9 +120,17 @@ class FoundationInteractsWithDatabaseTest extends TestCase
 
     public function testAssertDatabaseMissingWithArrays()
     {
-        $this->mockCountBuilder(false);
+        $builder = m::mock(Builder::class);
+        $builder->shouldReceive('where')->with(['title' => 'Spark', 'name' => 'Laravel'])->once()->andReturnSelf();
+        $builder->shouldReceive('where')->with(['title' => 'Forge', 'name' => 'Laravel'])->once()->andReturnSelf();
+        $builder->shouldReceive('exists')->twice()->andReturn(false);
 
-        $this->assertDatabaseMissing($this->table, [$this->data, $this->data]);
+        $this->connection->shouldReceive('table')->with($this->table)->andReturn($builder);
+
+        $this->assertDatabaseMissing($this->table, [
+            ['title' => 'Spark', 'name' => 'Laravel'],
+            ['title' => 'Forge', 'name' => 'Laravel'],
+        ]);
     }
 
     public function testDontSeeInDatabaseDoesNotFindResults()


### PR DESCRIPTION
Happy Friday,

Going through tests atm,  so sat here thinking of nice things I can give back to Laravel. 

We have loads of assertDatabaseHas / assertDatabaseMissing tests in a row such as:  

```php
 $this->assertDatabaseHas(User::class, ['name' => 'Jack', 'email' => 'jack@example.com']);                                                                                                                   
 $this->assertDatabaseHas(User::class, ['name' => 'Taylor', 'email' => 'taylor@laravel.com']);
 
 $this->assertDatabaseMissing(User::class, ['name' => 'Dr Dre', 'email' => 'dre@laravel.com']);
 $this->assertDatabaseMissing(User::class, ['name' => 'Gucci Mane', 'email' => 'gman@laravel.com']);                                                                                                   
```
 
 But, it would be nice for it to allow: 
```php
  $this->assertDatabaseHas(User::class, [                                                                                                                                                                     
      ['name' => 'Jack', 'email' => 'jack@example.com'],    
      ['name' => 'Taylor', 'email' => 'taylor@example.com'],                                                                                                                                           
  ]);       
  
  $this->assertDatabaseMissing(User::class, [                                                                                                                                                                     
    ['name' => 'Dr Dre', 'email' => 'dre@laravel.com'],    
    ['name' => 'Gucci Mane', 'email' => 'gman@laravel.com'],                                                                                                                                           
]);                                                                                                                                                                                                                   
```  

This just calls the method internally, so no big brain functions as not bothered about performance atm, more dx. 

I couldn't reuse mockCountBuilder due to the data, so just did normal mocking.

I don't think this is a b/c as currently you cant pass an araray of arrays..