### PR TITLE
[12.x] Support named credential providers for SQS queue connections

### DIFF
--- a/src/Illuminate/Foundation/Cloud.php
+++ b/src/Illuminate/Foundation/Cloud.php
@@ -30,7 +30,7 @@ class Cloud
                 static::configureDisks($app);
                 static::configureUnpooledPostgresConnection($app);
                 static::ensureMigrationsUseUnpooledConnection($app);
-                static::configureManagedQueues();
+                static::configureManagedQueues($app);
             },
             HandleExceptions::class => function () use ($app) {
                 static::configureCloudLogging($app);
@@ -117,10 +117,22 @@ class Cloud
     /**
      * Configure managed queues if applicable.
      */
-    public static function configureManagedQueues(): void
+    public static function configureManagedQueues(Application $app): void
     {
         if ((int) ($_SERVER['LARAVEL_CLOUD_MANAGED_QUEUES'] ?? 0) === 1) {
             Worker::$restartable = false;
+
+            $app['config']->set(
+                'queue.connections.sqs.credentials',
+                'ecs'
+            );
+
+            if (isset($_SERVER['LARAVEL_CLOUD_REGION'])) {
+                $app['config']->set(
+                    'queue.connections.sqs.region',
+                    $_SERVER['LARAVEL_CLOUD_REGION']
+                );
+            }
         }
     }
 

--- a/src/Illuminate/Queue/Connectors/SqsConnector.php
+++ b/src/Illuminate/Queue/Connectors/SqsConnector.php
@@ -2,9 +2,11 @@
 
 namespace Illuminate\Queue\Connectors;
 
+use Aws\Credentials\CredentialProvider;
 use Aws\Sqs\SqsClient;
 use Illuminate\Queue\SqsQueue;
 use Illuminate\Support\Arr;
+use InvalidArgumentException;
 
 class SqsConnector implements ConnectorInterface
 {
@@ -18,7 +20,9 @@ class SqsConnector implements ConnectorInterface
     {
         $config = $this->getDefaultConfiguration($config);
 
-        if (! empty($config['key']) && ! empty($config['secret'])) {
+        if ($credentials = $this->resolveCredentialProvider($config)) {
+            $config['credentials'] = $credentials;
+        } elseif (! empty($config['key']) && ! empty($config['secret'])) {
             $config['credentials'] = Arr::only($config, ['key', 'secret']);
 
             if (! empty($config['token'])) {
@@ -35,6 +39,35 @@ class SqsConnector implements ConnectorInterface
             $config['suffix'] ?? '',
             $config['after_commit'] ?? null
         );
+    }
+
+    /**
+     * Resolve a credential provider from the given config.
+     *
+     * @param  array  $config
+     * @return callable|null
+     *
+     * @throws \InvalidArgumentException
+     */
+    protected function resolveCredentialProvider(array $config)
+    {
+        $credentials = $config['credentials'] ?? null;
+
+        $provider = is_string($credentials) ? $credentials : ($credentials['provider'] ?? null);
+
+        if (is_null($provider)) {
+            return null;
+        }
+
+        $options = is_array($credentials) ? Arr::except($credentials, ['provider']) : [];
+
+        return match ($provider) {
+            'ecs' => CredentialProvider::ecsCredentials($options),
+            'instance' => CredentialProvider::instanceProfile($options),
+            default => throw new InvalidArgumentException(
+                "Invalid credential provider [{$provider}]."
+            ),
+        };
     }
 
     /**

--- a/tests/Integration/Foundation/CloudTest.php
+++ b/tests/Integration/Foundation/CloudTest.php
@@ -60,12 +60,49 @@ class CloudTest extends TestCase
         $_SERVER['LARAVEL_CLOUD_MANAGED_QUEUES'] = '1';
 
         try {
-            Cloud::configureManagedQueues();
+            Cloud::configureManagedQueues($this->app);
 
             $this->assertFalse(Worker::$restartable);
         } finally {
             unset($_SERVER['LARAVEL_CLOUD_MANAGED_QUEUES']);
             Worker::$restartable = true;
+        }
+    }
+
+    #[WithConfig('queue.connections.sqs', ['driver' => 'sqs', 'region' => 'us-east-1', 'queue' => 'default'])]
+    public function test_it_configures_managed_queue_credentials()
+    {
+        $_SERVER['LARAVEL_CLOUD_MANAGED_QUEUES'] = '1';
+
+        try {
+            Cloud::configureManagedQueues($this->app);
+
+            $this->assertEquals('ecs', $this->app['config']->get('queue.connections.sqs.credentials'));
+        } finally {
+            unset($_SERVER['LARAVEL_CLOUD_MANAGED_QUEUES']);
+        }
+    }
+
+    #[WithConfig('queue.connections.sqs', ['driver' => 'sqs', 'region' => 'us-east-1', 'queue' => 'default'])]
+    public function test_it_does_not_configure_managed_queues_when_not_enabled()
+    {
+        Cloud::configureManagedQueues($this->app);
+
+        $this->assertNull($this->app['config']->get('queue.connections.sqs.credentials'));
+    }
+
+    #[WithConfig('queue.connections.sqs', ['driver' => 'sqs', 'region' => 'us-east-1', 'queue' => 'default'])]
+    public function test_it_configures_managed_queue_region()
+    {
+        $_SERVER['LARAVEL_CLOUD_MANAGED_QUEUES'] = '1';
+        $_SERVER['LARAVEL_CLOUD_REGION'] = 'us-west-2';
+
+        try {
+            Cloud::configureManagedQueues($this->app);
+
+            $this->assertEquals('us-west-2', $this->app['config']->get('queue.connections.sqs.region'));
+        } finally {
+            unset($_SERVER['LARAVEL_CLOUD_MANAGED_QUEUES'], $_SERVER['LARAVEL_CLOUD_REGION']);
         }
     }
 


### PR DESCRIPTION
Backport of #59733.

## Summary
- Allow SQS queue connections to specify a credential provider by name (`ecs`, `instance`) via the `credentials` config key
- `Cloud.php` automatically sets `credentials` to `ecs` and overrides the SQS region when `LARAVEL_CLOUD_MANAGED_QUEUES=1` is set

## Why
Laravel users may have environment variables configured that AWS's PHP SDK will detect in the default credential chain, breaking Managed Queue AWS authentication. This change forces Cloud Managed Queues to use EKS Pod Identity, and correctly configures the region.

## Changes
- **SqsConnector**: resolves string `credentials` values to `CredentialProvider` callables before passing to the SDK; supports `ecs` and `instance` providers with optional config arrays
- **Cloud.php**: sets SQS credentials to `ecs` and region to `LARAVEL_CLOUD_REGION` within the existing managed queues check
- **CloudTest**: adds tests for credential configuration, region override, and the disabled case