### PR TITLE
[13.x] Add Conditionable trait to HTTP Response classes

### DIFF
--- a/src/Illuminate/Http/JsonResponse.php
+++ b/src/Illuminate/Http/JsonResponse.php
@@ -4,6 +4,7 @@ namespace Illuminate\Http;
 
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
+use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
 use JsonSerializable;
@@ -11,7 +12,7 @@ use Symfony\Component\HttpFoundation\JsonResponse as BaseJsonResponse;
 
 class JsonResponse extends BaseJsonResponse
 {
-    use ResponseTrait, Macroable {
+    use Conditionable, ResponseTrait, Macroable {
         Macroable::__call as macroCall;
     }
 

--- a/src/Illuminate/Http/RedirectResponse.php
+++ b/src/Illuminate/Http/RedirectResponse.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Support\MessageProvider;
 use Illuminate\Session\Store as SessionStore;
 use Illuminate\Support\MessageBag;
 use Illuminate\Support\Str;
+use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\ForwardsCalls;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Support\Uri;
@@ -15,7 +16,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse as BaseRedirectResponse;
 
 class RedirectResponse extends BaseRedirectResponse
 {
-    use ForwardsCalls, ResponseTrait, Macroable {
+    use Conditionable, ForwardsCalls, ResponseTrait, Macroable {
         Macroable::__call as macroCall;
     }
 

--- a/src/Illuminate/Http/Response.php
+++ b/src/Illuminate/Http/Response.php
@@ -6,6 +6,7 @@ use ArrayObject;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Renderable;
+use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
 use JsonSerializable;
@@ -14,7 +15,7 @@ use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 
 class Response extends SymfonyResponse
 {
-    use ResponseTrait, Macroable {
+    use Conditionable, ResponseTrait, Macroable {
         Macroable::__call as macroCall;
     }
 

--- a/tests/Http/HttpJsonResponseTest.php
+++ b/tests/Http/HttpJsonResponseTest.php
@@ -108,6 +108,41 @@ class HttpJsonResponseTest extends TestCase
 
         $this->assertSame('bar', $response->getData()->foo);
     }
+
+    public function testJsonResponseConditionable()
+    {
+        $response = new JsonResponse(['foo' => 'bar']);
+
+        $result = $response->when(true, function (JsonResponse $r) {
+            $r->setData(['foo' => 'baz']);
+        });
+
+        $this->assertSame($response, $result);
+        $this->assertSame('baz', $response->getData()->foo);
+
+        $response->when(false, function (JsonResponse $r) {
+            $r->setData(['foo' => 'qux']);
+        });
+
+        $this->assertSame('baz', $response->getData()->foo);
+    }
+
+    public function testJsonResponseUnless()
+    {
+        $response = new JsonResponse(['foo' => 'bar']);
+
+        $response->unless(false, function (JsonResponse $r) {
+            $r->setData(['foo' => 'baz']);
+        });
+
+        $this->assertSame('baz', $response->getData()->foo);
+
+        $response->unless(true, function (JsonResponse $r) {
+            $r->setData(['foo' => 'qux']);
+        });
+
+        $this->assertSame('baz', $response->getData()->foo);
+    }
 }
 
 class JsonResponseTestJsonableObject implements Jsonable

--- a/tests/Http/HttpResponseTest.php
+++ b/tests/Http/HttpResponseTest.php
@@ -245,6 +245,76 @@ class HttpResponseTest extends TestCase
         $response = new RedirectResponse('foo.bar');
         $response->doesNotExist('bar');
     }
+
+    public function testResponseConditionable()
+    {
+        $response = new Response('foo');
+
+        $result = $response->when(true, function (Response $r) {
+            $r->setContent('bar');
+        });
+
+        $this->assertSame($response, $result);
+        $this->assertSame('bar', $response->getContent());
+
+        $response->when(false, function (Response $r) {
+            $r->setContent('baz');
+        });
+
+        $this->assertSame('bar', $response->getContent());
+    }
+
+    public function testResponseUnless()
+    {
+        $response = new Response('foo');
+
+        $response->unless(false, function (Response $r) {
+            $r->setContent('bar');
+        });
+
+        $this->assertSame('bar', $response->getContent());
+
+        $response->unless(true, function (Response $r) {
+            $r->setContent('baz');
+        });
+
+        $this->assertSame('bar', $response->getContent());
+    }
+
+    public function testRedirectResponseConditionable()
+    {
+        $response = new RedirectResponse('foo.bar');
+
+        $result = $response->when(true, function (RedirectResponse $r) {
+            $r->setTargetUrl('baz.qux');
+        });
+
+        $this->assertSame($response, $result);
+        $this->assertSame('baz.qux', $response->getTargetUrl());
+
+        $response->when(false, function (RedirectResponse $r) {
+            $r->setTargetUrl('should.not.change');
+        });
+
+        $this->assertSame('baz.qux', $response->getTargetUrl());
+    }
+
+    public function testRedirectResponseUnless()
+    {
+        $response = new RedirectResponse('foo.bar');
+
+        $response->unless(false, function (RedirectResponse $r) {
+            $r->setTargetUrl('baz.qux');
+        });
+
+        $this->assertSame('baz.qux', $response->getTargetUrl());
+
+        $response->unless(true, function (RedirectResponse $r) {
+            $r->setTargetUrl('should.not.change');
+        });
+
+        $this->assertSame('baz.qux', $response->getTargetUrl());
+    }
 }
 
 class ArrayableStub implements Arrayable


### PR DESCRIPTION
## Summary

- Adds the `Conditionable` trait to `Response`, `JsonResponse`, and `RedirectResponse`
- Enables fluent `->when()` / `->unless()` chaining on all HTTP response classes
- `Request` already uses `Conditionable`; this brings response classes to parity

## Context

| Class | Before | After |
|---|---|---|
| `Response` | `Macroable` only | `Conditionable` + `Macroable` |
| `JsonResponse` | `Macroable` only | `Conditionable` + `Macroable` |
| `RedirectResponse` | `ForwardsCalls` + `Macroable` | `Conditionable` + `ForwardsCalls` + `Macroable` |

## Solution

Added `use Conditionable` to each response class, consistent with how `Request`, `Pipeline`, `Mailable`, `FilesystemAdapter`, and many other fluent classes in the framework already use it.

## Example

**Before:**
```php
$response = response()->json($data);
if ($isAdmin) {
    $response->header('X-Admin', '1');
}
return $response;
```

**After:**
```php
return response()->json($data)
    ->when($isAdmin, fn ($r) => $r->header('X-Admin', '1'))
    ->unless($isProd, fn ($r) => $r->header('X-Debug', '1'));
```

## Safety

- No conflicts with Symfony parent classes (`when` / `unless` are not defined upstream)
- No conflicts with `Macroable` — trait resolution is unchanged
- Purely additive change

## Changes

- `src/Illuminate/Http/Response.php`
- `src/Illuminate/Http/JsonResponse.php`
- `src/Illuminate/Http/RedirectResponse.php`
- `tests/Http/HttpResponseTest.php`
- `tests/Http/HttpJsonResponseTest.php`

## Test Plan

- [x] `testResponseConditionable` — `when(true)` modifies content; `when(false)` skips
- [x] `testResponseUnless` — `unless(false)` modifies content; `unless(true)` skips
- [x] `testJsonResponseConditionable` — `when(true/false)` on `JsonResponse`
- [x] `testJsonResponseUnless` — `unless(false/true)` on `JsonResponse`
- [x] `testRedirectResponseConditionable` — `when(true/false)` on `RedirectResponse`
- [x] `testRedirectResponseUnless` — `unless(false/true)` on `RedirectResponse`
- [x] All 60 existing HTTP response tests still pass