### PR TITLE
[13.x] Add Arr::sum(), Arr::avg(), Arr::average(), and Arr::median()

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -57,6 +57,47 @@ class Arr
     }
 
     /**
+     * Get the average value of a given key.
+     *
+     * @template TKey of array-key
+     * @template TValue
+     *
+     * @param  array<TKey, TValue>  $array
+     * @param  (callable(TValue): float|int)|string|null  $callback
+     * @return float|int|null
+     */
+    public static function avg(array $array, callable|string|null $callback = null): float|int|null
+    {
+        $callback = is_null($callback)
+            ? fn ($value) => $value
+            : (is_callable($callback) ? $callback : fn ($item) => data_get($item, $callback));
+
+        $values = array_filter(
+            array_map($callback, $array),
+            fn ($value) => ! is_null($value)
+        );
+
+        $count = count($values);
+
+        return $count ? array_sum($values) / $count : null;
+    }
+
+    /**
+     * Alias for the "avg" method.
+     *
+     * @template TKey of array-key
+     * @template TValue
+     *
+     * @param  array<TKey, TValue>  $array
+     * @param  (callable(TValue): float|int)|string|null  $callback
+     * @return float|int|null
+     */
+    public static function average(array $array, callable|string|null $callback = null): float|int|null
+    {
+        return static::avg($array, $callback);
+    }
+
+    /**
      * Add an element to an array using "dot" notation if it doesn't exist.
      *
      * @param  array  $array
@@ -895,6 +936,40 @@ class Arr
     }
 
     /**
+     * Get the median of a given key.
+     *
+     * @template TKey of array-key
+     * @template TValue
+     *
+     * @param  array<TKey, TValue>  $array
+     * @param  string|null  $key
+     * @return float|int|null
+     */
+    public static function median(array $array, ?string $key = null): float|int|null
+    {
+        $values = array_values(array_filter(
+            isset($key) ? static::pluck($array, $key) : $array,
+            fn ($value) => ! is_null($value)
+        ));
+
+        sort($values);
+
+        $count = count($values);
+
+        if ($count === 0) {
+            return null;
+        }
+
+        $middle = intdiv($count, 2);
+
+        if ($count % 2) {
+            return $values[$middle];
+        }
+
+        return ($values[$middle - 1] + $values[$middle]) / 2;
+    }
+
+    /**
      * Push an item onto the beginning of an array.
      *
      * @param  array  $array
@@ -1177,6 +1252,25 @@ class Arr
         }
 
         return $value;
+    }
+
+    /**
+     * Get the sum of the given values.
+     *
+     * @template TKey of array-key
+     * @template TValue
+     *
+     * @param  array<TKey, TValue>  $array
+     * @param  (callable(TValue): float|int)|string|null  $callback
+     * @return float|int
+     */
+    public static function sum(array $array, callable|string|null $callback = null): float|int
+    {
+        $callback = is_null($callback)
+            ? fn ($value) => $value
+            : (is_callable($callback) ? $callback : fn ($item) => data_get($item, $callback));
+
+        return array_reduce($array, fn ($result, $item) => $result + $callback($item), 0);
     }
 
     /**

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1938,4 +1938,78 @@ class SupportArrTest extends TestCase
 
         $this->assertEquals([[0 => 'John', 1 => 'Jane'], [2 => 'Greg']], $result);
     }
+
+    public function testSum()
+    {
+        $this->assertSame(6, Arr::sum([1, 2, 3]));
+        $this->assertSame(0, Arr::sum([]));
+        $this->assertSame(6.5, Arr::sum([1.5, 2, 3]));
+
+        // with string key
+        $array = [['price' => 10], ['price' => 20], ['price' => 30]];
+        $this->assertSame(60, Arr::sum($array, 'price'));
+
+        // with callback
+        $this->assertSame(60, Arr::sum($array, fn ($item) => $item['price']));
+
+        // dot notation
+        $array = [['product' => ['price' => 5]], ['product' => ['price' => 15]]];
+        $this->assertSame(20, Arr::sum($array, 'product.price'));
+    }
+
+    public function testAvg()
+    {
+        $this->assertSame(2, Arr::avg([1, 2, 3]));
+        $this->assertNull(Arr::avg([]));
+
+        // nulls are excluded
+        $this->assertSame(2, Arr::avg([1, null, 3]));
+
+        // with string key
+        $array = [['score' => 10], ['score' => 20], ['score' => 30]];
+        $this->assertSame(20, Arr::avg($array, 'score'));
+
+        // with callback
+        $this->assertSame(20, Arr::avg($array, fn ($item) => $item['score']));
+
+        // non-integer average
+        $this->assertSame(1.5, Arr::avg([1, 2]));
+
+        // dot notation
+        $array = [['item' => ['value' => 4]], ['item' => ['value' => 8]]];
+        $this->assertSame(6, Arr::avg($array, 'item.value'));
+    }
+
+    public function testAverage()
+    {
+        $this->assertSame(2, Arr::average([1, 2, 3]));
+        $this->assertNull(Arr::average([]));
+        $this->assertSame(20, Arr::average([['score' => 10], ['score' => 30]], 'score'));
+    }
+
+    public function testMedian()
+    {
+        // odd count
+        $this->assertSame(3, Arr::median([1, 3, 5]));
+
+        // even count - average of two middle values
+        $this->assertSame(2.5, Arr::median([1, 2, 3, 4]));
+
+        // unsorted input
+        $this->assertSame(3, Arr::median([5, 1, 3]));
+
+        // empty array
+        $this->assertNull(Arr::median([]));
+
+        // nulls are excluded
+        $this->assertSame(3, Arr::median([1, null, 3, null, 5]));
+
+        // with string key
+        $array = [['age' => 10], ['age' => 20], ['age' => 30]];
+        $this->assertSame(20, Arr::median($array, 'age'));
+
+        // even count with key — result is exact integer division
+        $array = [['age' => 10], ['age' => 20], ['age' => 30], ['age' => 40]];
+        $this->assertSame(25, Arr::median($array, 'age'));
+    }
 }


### PR DESCRIPTION
## Summary

- Adds `Arr::sum()`, `Arr::avg()`, `Arr::average()`, and `Arr::median()` static methods to the `Arr` utility class
- Brings `Arr` to feature parity with `Collection` for these common aggregation operations
- All methods support plain values, string/dot-notation keys, and callable callbacks

## Context

`Collection` has had `sum()`, `avg()`/`average()`, and `median()` for years. Developers working with plain PHP arrays currently have to convert to a `Collection` just to use these:

| Method | Collection | Arr (before) | Arr (after) |
|---|---|---|---|
| `sum()` | ✅ | ❌ | ✅ |
| `avg()` | ✅ | ❌ | ✅ |
| `average()` | ✅ | ❌ | ✅ |
| `median()` | ✅ | ❌ | ✅ |

## Solution

Static implementations that mirror the `Collection` API — same signatures, same null-exclusion behaviour, same dot-notation support.

## Example

**Before:**
```php
$total = collect($items)->sum('price');
$avg   = collect($items)->avg('price');
$mid   = collect($items)->median('price');
```

**After:**
```php
$total = Arr::sum($items, 'price');
$avg   = Arr::avg($items, 'price');
$mid   = Arr::median($items, 'price');
```

All three forms are supported:
```php
Arr::sum([1, 2, 3]);                          // 6
Arr::sum($items, 'price');                    // dot-notation key
Arr::sum($items, fn ($i) => $i['price'] * 2); // callback

Arr::avg([1, null, 3]);   // 2 — nulls excluded, same as Collection
Arr::median([1, 2, 3, 4]); // 2.5 — even count averages the two middle values
```

## Safety

- Purely additive — no existing methods changed
- Null values are skipped in `avg()` and `median()`, consistent with `Collection` behaviour
- `avg()` returns `null` for an empty array (same as `Collection`)
- `median()` returns `null` for an empty array (same as `Collection`)

## Changes

- `src/Illuminate/Collections/Arr.php`
- `tests/Support/SupportArrTest.php`

## Test Plan

- [x] `testSum` — plain values, string key, callback, dot notation, floats, empty
- [x] `testAvg` — plain values, null exclusion, string key, callback, non-integer result, dot notation, empty
- [x] `testAverage` — alias delegates to `avg()`
- [x] `testMedian` — odd/even count, unsorted input, null exclusion, string key, empty
- [x] All 85 existing `SupportArrTest` assertions still pass