### PR TITLE
[13.x] Preserve percent-encoded local filesystem paths

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -774,10 +774,10 @@ class FilesystemAdapter implements CloudFilesystemContract
         // it as the base URL instead of the default path. This allows the developer to
         // have full control over the base path for this filesystem's generated URLs.
         if (isset($this->config['url'])) {
-            return $this->concatPathToUrl($this->config['url'], $path);
+            return $this->concatPathToUrl($this->config['url'], $this->escapeUrlPath($path));
         }
 
-        $path = '/storage/'.$path;
+        $path = '/storage/'.$this->escapeUrlPath($path);
 
         // If the path contains "storage/public", it probably means the developer is using
         // the default disk to generate the path instead of the "public" disk like they
@@ -869,6 +869,17 @@ class FilesystemAdapter implements CloudFilesystemContract
     protected function concatPathToUrl($url, $path)
     {
         return rtrim($url, '/').'/'.ltrim($path, '/');
+    }
+
+    /**
+     * Escape literal percent characters before exposing a storage path as a URL.
+     *
+     * @param  string  $path
+     * @return string
+     */
+    protected function escapeUrlPath($path)
+    {
+        return str_replace('%', '%25', $path);
     }
 
     /**

--- a/src/Illuminate/Filesystem/LocalFilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/LocalFilesystemAdapter.php
@@ -82,7 +82,7 @@ class LocalFilesystemAdapter extends FilesystemAdapter
         return $url->to($url->temporarySignedRoute(
             'storage.'.$this->disk,
             $expiration,
-            ['path' => $path],
+            ['path' => $this->escapeUrlPath($path)],
             absolute: false
         ));
     }
@@ -115,7 +115,7 @@ class LocalFilesystemAdapter extends FilesystemAdapter
             'url' => $url->to($url->temporarySignedRoute(
                 'storage.'.$this->disk.'.upload',
                 $expiration,
-                ['path' => $path, 'upload' => true],
+                ['path' => $this->escapeUrlPath($path), 'upload' => true],
                 absolute: false
             )),
             'headers' => [],

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -745,6 +745,13 @@ class FilesystemAdapterTest extends TestCase
         $this->assertSame('https://example.org/images/picture.jpeg', $filesystemAdapter->url('picture.jpeg'));
     }
 
+    public function testLocalUrlsEscapePercentCharacters()
+    {
+        $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter, ['url' => 'https://example.org/storage']);
+
+        $this->assertSame('https://example.org/storage/file%2520name.txt', $filesystemAdapter->url('file%20name.txt'));
+    }
+
     public function testGetChecksum()
     {
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);

--- a/tests/Integration/Filesystem/ReceiveFileTest.php
+++ b/tests/Integration/Filesystem/ReceiveFileTest.php
@@ -73,4 +73,36 @@ class ReceiveFileTest extends TestCase
 
         $response->assertForbidden();
     }
+
+    public function testItCanReceiveAFileWithPercentEncodedCharactersInItsName()
+    {
+        $path = 'uploaded%20document.txt';
+
+        $result = Storage::temporaryUploadUrl($path, Carbon::now()->addMinute());
+
+        $this->assertStringContainsString('uploaded%2520document.txt', $result['url']);
+
+        $response = $this->call('PUT', $result['url'], [], [], [], [], 'Hello World');
+
+        $response->assertNoContent();
+        Storage::assertExists($path, 'Hello World');
+
+        Storage::delete($path);
+    }
+
+    public function testItCanReceiveAFileWithSpacesInItsName()
+    {
+        $path = 'uploaded document.txt';
+
+        $result = Storage::temporaryUploadUrl($path, Carbon::now()->addMinute());
+
+        $this->assertStringContainsString('uploaded%20document.txt', $result['url']);
+
+        $response = $this->call('PUT', $result['url'], [], [], [], [], 'Hello World');
+
+        $response->assertNoContent();
+        Storage::assertExists($path, 'Hello World');
+
+        Storage::delete($path);
+    }
 }

--- a/tests/Integration/Filesystem/ServeFileTest.php
+++ b/tests/Integration/Filesystem/ServeFileTest.php
@@ -51,4 +51,40 @@ class ServeFileTest extends TestCase
 
         $response->assertForbidden();
     }
+
+    public function testItCanServeAFileWithPercentEncodedCharactersInItsName()
+    {
+        $path = 'hello%20world.txt';
+
+        Storage::put($path, 'Hello World');
+
+        $url = Storage::temporaryUrl($path, Carbon::now()->addMinute());
+
+        $this->assertStringContainsString('hello%2520world.txt', $url);
+
+        $response = $this->get($url);
+
+        $response->assertOk();
+        $this->assertSame('Hello World', $response->streamedContent());
+
+        Storage::delete($path);
+    }
+
+    public function testItCanServeAFileWithSpacesInItsName()
+    {
+        $path = 'hello world.txt';
+
+        Storage::put($path, 'Hello World');
+
+        $url = Storage::temporaryUrl($path, Carbon::now()->addMinute());
+
+        $this->assertStringContainsString('hello%20world.txt', $url);
+
+        $response = $this->get($url);
+
+        $response->assertOk();
+        $this->assertSame('Hello World', $response->streamedContent());
+
+        Storage::delete($path);
+    }
 }


### PR DESCRIPTION
Local filesystem URLs currently expose literal percent characters unchanged, so a storage path like `hello%20world.txt` can become indistinguishable from `hello world.txt` once the route parameter is decoded.

This escapes literal `%` characters while generating local file URLs and temporary local upload/download URLs. The route handlers can keep using Laravel’s existing decoded route parameter behavior, while filenames containing literal percent-encoded sequences are emitted as `%2520` and resolve back to the original storage path.

Existing filenames with spaces continue to use `%20`.

Closes #59709.

Tests:
- `/opt/homebrew/opt/php@8.4/bin/php vendor/bin/phpunit tests/Filesystem/FilesystemAdapterTest.php tests/Integration/Filesystem/ServeFileTest.php tests/Integration/Filesystem/ReceiveFileTest.php`
- `/opt/homebrew/opt/php@8.4/bin/php vendor/bin/pint --dirty`