### PR TITLE
[13.x] Ignore PHPUnit security advisory GHSA-qrr6-mg7r-m243

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -215,6 +215,7 @@
         },
         "audit": {
             "ignore": {
+                "GHSA-qrr6-mg7r-m243": "Ensure testing features are compatible with affected PHPUnit versions",
                 "GHSA-vvj3-c3rp-c85p": "Ensure testing features are compatible with affected PHPUnit versions"
             }
         },


### PR DESCRIPTION
A new PHPUnit security advisory ([GHSA-qrr6-mg7r-m243](https://github.com/advisories/GHSA-qrr6-mg7r-m243)) was published on April 18, 2026, affecting `phpunit/phpunit` versions `>=13.0.0,<=13.1.5` and `<=12.5.21`. This is currently blocking `composer install` in CI for all open pull requests against `13.x`.

This PR adds the advisory to the audit ignore list, following the same pattern as the existing `GHSA-vvj3-c3rp-c85p` entry.