### PR TITLE
[13.x] Add Arr::countBy()

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -131,6 +131,37 @@ class Arr
     }
 
     /**
+     * Count the occurrences of values using an optional callback.
+     *
+     * @template TKey of array-key
+     * @template TValue
+     *
+     * @param  array<TKey, TValue>  $array
+     * @param  (callable(TValue, TKey): array-key)|string|null  $countBy
+     * @return array<array-key, int>
+     */
+    public static function countBy(array $array, callable|string|null $countBy = null): array
+    {
+        $callback = is_null($countBy)
+            ? fn ($value) => $value
+            : (is_callable($countBy) ? $countBy : fn ($item) => data_get($item, $countBy));
+
+        $counts = [];
+
+        foreach ($array as $key => $value) {
+            $group = $callback($value, $key);
+
+            if (! isset($counts[$group])) {
+                $counts[$group] = 0;
+            }
+
+            $counts[$group]++;
+        }
+
+        return $counts;
+    }
+
+    /**
      * Cross join the given arrays, returning all possible permutations.
      *
      * @template TValue

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -120,6 +120,39 @@ class SupportArrTest extends TestCase
         $this->assertEquals([1, 2, 3, 'foo', 'bar', 'baz', 'boom'], Arr::collapse($mixedArray));
     }
 
+    public function testCountBy()
+    {
+        // count by value (default)
+        $result = Arr::countBy(['apple', 'banana', 'apple', 'cherry', 'banana', 'apple']);
+        $this->assertSame(['apple' => 3, 'banana' => 2, 'cherry' => 1], $result);
+
+        // count by string key
+        $data = [
+            ['type' => 'fruit', 'name' => 'apple'],
+            ['type' => 'vegetable', 'name' => 'carrot'],
+            ['type' => 'fruit', 'name' => 'banana'],
+            ['type' => 'fruit', 'name' => 'cherry'],
+        ];
+        $result = Arr::countBy($data, 'type');
+        $this->assertSame(['fruit' => 3, 'vegetable' => 1], $result);
+
+        // count by dot notation
+        $data = [
+            ['meta' => ['status' => 'active']],
+            ['meta' => ['status' => 'inactive']],
+            ['meta' => ['status' => 'active']],
+        ];
+        $result = Arr::countBy($data, 'meta.status');
+        $this->assertSame(['active' => 2, 'inactive' => 1], $result);
+
+        // count by callback
+        $result = Arr::countBy([1, 2, 3, 4, 5, 6], fn ($v) => $v % 2 === 0 ? 'even' : 'odd');
+        $this->assertSame(['odd' => 3, 'even' => 3], $result);
+
+        // empty array
+        $this->assertSame([], Arr::countBy([]));
+    }
+
     public function testCrossJoin()
     {
         // Single dimension
@@ -1713,7 +1746,8 @@ class SupportArrTest extends TestCase
         $this->assertSame($subject, Arr::from($items));
 
         $items = new WeakMap;
-        $items[$temp = new class {
+        $items[$temp = new class
+        {
         }] = 'bar';
         $this->assertSame(['bar'], Arr::from($items));
 


### PR DESCRIPTION
## Summary

Adds `Arr::countBy()` to count occurrences of values in an array, mirroring `Collection::countBy()`.

## Usage

```php
// Count by value (default)
Arr::countBy(['apple', 'banana', 'apple', 'cherry']);
// ['apple' => 2, 'banana' => 1, 'cherry' => 1]

// Count by key
Arr::countBy($items, 'status');

// Count by dot notation
Arr::countBy($items, 'meta.status');

// Count by callback
Arr::countBy($items, fn ($item) => $item['active'] ? 'active' : 'inactive');
```