### PR TITLE
[13.x] Add Arr::unique()

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -643,7 +643,6 @@ class Arr
      *
      * An array is "associative" if it doesn't have sequential numerical keys beginning with zero.
      *
-     * @param  array  $array
      * @return ($array is list ? false : true)
      */
     public static function isAssoc(array $array)
@@ -829,8 +828,6 @@ class Arr
     /**
      * Run a map over each of the items in the array.
      *
-     * @param  array  $array
-     * @param  callable  $callback
      * @return array
      */
     public static function map(array $array, callable $callback)
@@ -1030,11 +1027,6 @@ class Arr
 
     /**
      * Push an item into an array using "dot" notation.
-     *
-     * @param  \ArrayAccess|array  $array
-     * @param  string|int|null  $key
-     * @param  mixed  $values
-     * @return array
      */
     public static function push(ArrayAccess|array &$array, string|int|null $key, mixed ...$values): array
     {
@@ -1223,6 +1215,39 @@ class Arr
         }
 
         return implode(' ', $styles);
+    }
+
+    /**
+     * Return unique items from the array, optionally keyed by a field or callback.
+     *
+     * @template TKey of array-key
+     * @template TValue
+     *
+     * @param  array<TKey, TValue>  $array
+     * @param  (callable(TValue, TKey): mixed)|string|null  $key
+     * @return array<TKey, TValue>
+     */
+    public static function unique(array $array, callable|string|null $key = null, bool $strict = false): array
+    {
+        if (is_null($key) && $strict === false) {
+            return array_unique($array, SORT_REGULAR);
+        }
+
+        $callback = is_null($key)
+            ? fn ($value) => $value
+            : (is_callable($key) ? $key : fn ($item) => data_get($item, $key));
+
+        $exists = [];
+
+        return static::reject($array, function ($item, $k) use ($callback, $strict, &$exists) {
+            if (in_array($id = $callback($item, $k), $exists, $strict)) {
+                return true;
+            }
+
+            $exists[] = $id;
+
+            return false;
+        });
     }
 
     /**

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -375,6 +375,47 @@ class SupportArrTest extends TestCase
         $this->assertFalse(Arr::exists(new Collection(['a' => null]), 'b'));
     }
 
+    public function testUnique()
+    {
+        // scalar values, no callback
+        $this->assertSame(['apple', 'banana', 'cherry'], array_values(Arr::unique(['apple', 'banana', 'apple', 'cherry', 'banana'])));
+
+        // preserves keys by default
+        $result = Arr::unique(['a' => 1, 'b' => 2, 'c' => 1]);
+        $this->assertSame(['a' => 1, 'b' => 2], $result);
+
+        // by string key
+        $data = [
+            ['id' => 1, 'type' => 'fruit'],
+            ['id' => 2, 'type' => 'vegetable'],
+            ['id' => 3, 'type' => 'fruit'],
+        ];
+        $result = array_values(Arr::unique($data, 'type'));
+        $this->assertCount(2, $result);
+        $this->assertSame('fruit', $result[0]['type']);
+        $this->assertSame('vegetable', $result[1]['type']);
+
+        // by dot notation
+        $data = [
+            ['meta' => ['tag' => 'php']],
+            ['meta' => ['tag' => 'laravel']],
+            ['meta' => ['tag' => 'php']],
+        ];
+        $result = array_values(Arr::unique($data, 'meta.tag'));
+        $this->assertCount(2, $result);
+
+        // by callback
+        $result = array_values(Arr::unique([1, 2, 3, 4, 5], fn ($v) => $v % 2));
+        $this->assertCount(2, $result);
+
+        // strict mode
+        $result = array_values(Arr::unique([1, '1', true], null, true));
+        $this->assertCount(3, $result);
+
+        // empty array
+        $this->assertSame([], Arr::unique([]));
+    }
+
     public function testWhereNotNull(): void
     {
         $array = array_values(Arr::whereNotNull([null, 0, false, '', null, []]));
@@ -1713,7 +1754,8 @@ class SupportArrTest extends TestCase
         $this->assertSame($subject, Arr::from($items));
 
         $items = new WeakMap;
-        $items[$temp = new class {
+        $items[$temp = new class
+        {
         }] = 'bar';
         $this->assertSame(['bar'], Arr::from($items));
 


### PR DESCRIPTION
## Summary

Adds `Arr::unique()` to return unique array items with optional key/callback support, mirroring `Collection::unique()`.

PHP's built-in `array_unique()` only works on scalar values and doesn't support extracting a key from nested items. This fills that gap.

## Usage

```php
// Scalar deduplication (delegates to array_unique)
Arr::unique(['a', 'b', 'a', 'c']);
// ['a', 'b', 'c'] (keys preserved)

// By array key
Arr::unique($items, 'status');

// By dot notation
Arr::unique($items, 'meta.status');

// By callback
Arr::unique($items, fn ($item) => $item['type']);

// Strict comparison
Arr::unique([1, '1', true], null, strict: true);
```