### PR TITLE
feat: add Arr::variations() for cartesian product generation

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -1296,6 +1296,66 @@ class Arr
     }
 
     /**
+     * Generate all possible combinations by selecting one element from each array.
+     *
+     * The first array provides the base items. Each subsequent array is an attribute
+     * set. One value is picked from each array per combination. The first attribute
+     * array cycles fastest in the output, making it easy to build product variation
+     * matrices for e-commerce and similar use cases.
+     *
+     * Example:
+     *   Arr::variations(['Black', 'Maroon'], [32, 34], ['S', 'M'])
+     *   // → [
+     *   //     ['Black', 32, 'S'], ['Black', 34, 'S'],
+     *   //     ['Black', 32, 'M'], ['Black', 34, 'M'],
+     *   //     ['Maroon', 32, 'S'], ['Maroon', 34, 'S'],
+     *   //     ['Maroon', 32, 'M'], ['Maroon', 34, 'M'],
+     *   //   ]
+     *
+     * @param  array  ...$arrays
+     * @return array
+     */
+    public static function variations(array ...$arrays): array
+    {
+        if (empty($arrays)) {
+            return [];
+        }
+
+        $base = array_shift($arrays);
+
+        if (empty($arrays)) {
+            return array_values(array_map(fn ($item) => [$item], $base));
+        }
+
+        // Build the cartesian product of attribute arrays by processing them in
+        // reverse order and prepending each item. This ensures the first attribute
+        // array (earliest argument) cycles fastest in the final output.
+        $attrCombinations = [[]];
+
+        foreach (array_reverse($arrays) as $array) {
+            $append = [];
+
+            foreach ($attrCombinations as $combination) {
+                foreach ($array as $item) {
+                    $append[] = array_merge([$item], $combination);
+                }
+            }
+
+            $attrCombinations = $append;
+        }
+
+        $results = [];
+
+        foreach (array_values($base) as $baseItem) {
+            foreach ($attrCombinations as $attrCombo) {
+                $results[] = array_merge([$baseItem], $attrCombo);
+            }
+        }
+
+        return $results;
+    }
+
+    /**
      * If the given value is not an array and not null, wrap it in one.
      *
      * @template TKey of array-key = array-key

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1713,7 +1713,8 @@ class SupportArrTest extends TestCase
         $this->assertSame($subject, Arr::from($items));
 
         $items = new WeakMap;
-        $items[$temp = new class {
+        $items[$temp = new class
+        {
         }] = 'bar';
         $this->assertSame(['bar'], Arr::from($items));
 
@@ -1937,5 +1938,48 @@ class SupportArrTest extends TestCase
         $result = Arr::partition($array, fn (string $value) => str_contains($value, 'J'));
 
         $this->assertEquals([[0 => 'John', 1 => 'Jane'], [2 => 'Greg']], $result);
+    }
+
+    public function testVariations()
+    {
+        // Single attribute: picks one from each array per combination
+        $this->assertSame([
+            [1, 6], [1, 8],
+            [2, 6], [2, 8],
+            [3, 6], [3, 8],
+        ], Arr::variations([1, 2, 3], [6, 8]));
+
+        // Multiple attributes: full cartesian product
+        $result = Arr::variations(['Black', 'Maroon', 'Red'], [32, 34, 36], ['S', 'M', 'L'], ['BD', 'USA']);
+
+        // Total: 3 colors × 3 waists × 3 sizes × 2 origins = 54
+        $this->assertCount(54, $result);
+
+        // First attribute (waist) cycles fastest
+        $this->assertSame(['Black', 32, 'S', 'BD'], $result[0]);
+        $this->assertSame(['Black', 34, 'S', 'BD'], $result[1]);
+        $this->assertSame(['Black', 36, 'S', 'BD'], $result[2]);
+        $this->assertSame(['Black', 32, 'M', 'BD'], $result[3]);
+        $this->assertSame(['Black', 34, 'M', 'BD'], $result[4]);
+        $this->assertSame(['Black', 36, 'M', 'BD'], $result[5]);
+        $this->assertSame(['Black', 32, 'L', 'BD'], $result[6]);
+        $this->assertSame(['Black', 34, 'L', 'BD'], $result[7]);
+        $this->assertSame(['Black', 36, 'L', 'BD'], $result[8]);
+
+        // Origin cycles after all waist+size combos
+        $this->assertSame(['Black', 32, 'S', 'USA'], $result[9]);
+
+        // Base (color) cycles slowest
+        $this->assertSame(['Maroon', 32, 'S', 'BD'], $result[18]);
+        $this->assertSame(['Red', 32, 'S', 'BD'], $result[36]);
+
+        // No attributes: wraps each base item
+        $this->assertSame([[1], [2], [3]], Arr::variations([1, 2, 3]));
+
+        // Empty base: returns []
+        $this->assertSame([], Arr::variations([], [6, 8]));
+
+        // No arguments: returns []
+        $this->assertSame([], Arr::variations());
     }
 }


### PR DESCRIPTION
## Description

Adds `Arr::variations()` — a helper that generates all possible combinations
by selecting one element from each of the given arrays. Useful for building
product variation matrices (colors × sizes × origins, etc.).

## How it works

The first array provides the base items. Each subsequent array is an attribute
set. The first attribute array cycles fastest in the output.

```php
Arr::variations(['Black', 'Maroon'], [32, 34], ['S', 'M']);

// Result:
// [['Black', 32, 'S'], ['Black', 34, 'S'],
//  ['Black', 32, 'M'], ['Black', 34, 'M'],
//  ['Maroon', 32, 'S'], ['Maroon', 34, 'S'],
//  ['Maroon', 32, 'M'], ['Maroon', 32, 'M']]
```

## Difference from `Arr::crossJoin()`

`crossJoin()` returns nested indexed arrays: `[[0 => 'Black', 1 => 32], ...]`  
`variations()` returns flat arrays in argument order: `[['Black', 32, 'S'], ...]`  
`variations()` also supports a natural cycling order and scales to N arrays.