### PR TITLE
#59612 - Fix `bootTraits` trait order

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -432,7 +432,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
             if (! in_array($method->getName(), $booted) &&
                 $method->isStatic() &&
                 (in_array($method->getName(), $conventionalBootMethods) ||
-                    $method->getAttributes(Boot::class) !== [])) {
+                $method->getAttributes(Boot::class) !== [])) {
                 $method->invoke(null);
 
                 $booted[] = $method->getName();

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -390,26 +390,37 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
 
         static::$traitInitializers[$class] = [];
 
-        $ref = (new ReflectionClass($class));
+        $ref = new ReflectionClass($class);
+        $uses = class_uses_recursive($class);
 
-        foreach (class_uses_recursive($class) as $trait) {
-            $conventionalBootMethod = 'boot'.class_basename($trait);
-            $conventionalInitMethod = 'initialize'.class_basename($trait);
+        $conventionalBootMethods = array_map(static fn ($trait) => 'boot'.class_basename($trait), $uses);
+        $conventionalInitMethods = array_map(static fn ($trait) => 'initialize'.class_basename($trait), $uses);
 
-            if ($ref->hasMethod($conventionalBootMethod) &&
-                ($method = $ref->getMethod($conventionalBootMethod)) &&
-                ! in_array($method->getName(), $booted) &&
-                $method->isStatic() &&
-                $method->getAttributes(Boot::class) !== []) {
-                $method->invoke(null);
+        foreach ($uses as $trait) {
+            foreach ((new ReflectionClass($trait))->getMethods() as $method) {
+                if ($method->getDeclaringClass()->getName() !== $trait) {
+                    continue;
+                }
 
-                $booted[] = $method->getName();
-            }
+                if (! $ref->hasMethod($method->getName())) {
+                    continue;
+                }
 
-            if ($ref->hasMethod($conventionalInitMethod) &&
-                ($method = $ref->getMethod($conventionalInitMethod)) ||
-                $method->getAttributes(Initialize::class) !== []) {
-                static::$traitInitializers[$class][] = $method->getName();
+                $classMethod = $ref->getMethod($method->getName());
+
+                if (! in_array($classMethod->getName(), $booted) &&
+                    $classMethod->isStatic() &&
+                    (in_array($classMethod->getName(), $conventionalBootMethods) ||
+                        $classMethod->getAttributes(Boot::class) !== [])) {
+                    $classMethod->invoke(null);
+
+                    $booted[] = $classMethod->getName();
+                }
+
+                if (in_array($classMethod->getName(), $conventionalInitMethods) ||
+                    $classMethod->getAttributes(Initialize::class) !== []) {
+                    static::$traitInitializers[$class][] = $classMethod->getName();
+                }
             }
         }
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -424,6 +424,26 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
             }
         }
 
+        foreach ($ref->getMethods() as $method) {
+            if ($method->getDeclaringClass()->getName() !== $class) {
+                continue;
+            }
+
+            if (! in_array($method->getName(), $booted) &&
+                $method->isStatic() &&
+                (in_array($method->getName(), $conventionalBootMethods) ||
+                    $method->getAttributes(Boot::class) !== [])) {
+                $method->invoke(null);
+
+                $booted[] = $method->getName();
+            }
+
+            if (in_array($method->getName(), $conventionalInitMethods) ||
+                $method->getAttributes(Initialize::class) !== []) {
+                static::$traitInitializers[$class][] = $method->getName();
+            }
+        }
+
         static::$traitInitializers[$class] = array_unique(static::$traitInitializers[$class]);
     }
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -390,22 +390,24 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
 
         static::$traitInitializers[$class] = [];
 
-        $uses = class_uses_recursive($class);
+        $ref = (new ReflectionClass($class));
 
-        $conventionalBootMethods = array_map(static fn ($trait) => 'boot'.class_basename($trait), $uses);
-        $conventionalInitMethods = array_map(static fn ($trait) => 'initialize'.class_basename($trait), $uses);
+        foreach (class_uses_recursive($class) as $trait) {
+            $conventionalBootMethod = 'boot'.class_basename($trait);
+            $conventionalInitMethod = 'initialize'.class_basename($trait);
 
-        foreach ((new ReflectionClass($class))->getMethods() as $method) {
-            if (! in_array($method->getName(), $booted) &&
+            if ($ref->hasMethod($conventionalBootMethod) &&
+                ($method = $ref->getMethod($conventionalBootMethod)) &&
+                ! in_array($method->getName(), $booted) &&
                 $method->isStatic() &&
-                (in_array($method->getName(), $conventionalBootMethods) ||
-                $method->getAttributes(Boot::class) !== [])) {
+                $method->getAttributes(Boot::class) !== []) {
                 $method->invoke(null);
 
                 $booted[] = $method->getName();
             }
 
-            if (in_array($method->getName(), $conventionalInitMethods) ||
+            if ($ref->hasMethod($conventionalInitMethod) &&
+                ($method = $ref->getMethod($conventionalInitMethod)) ||
                 $method->getAttributes(Initialize::class) !== []) {
                 static::$traitInitializers[$class][] = $method->getName();
             }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -411,7 +411,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
                 if (! in_array($classMethod->getName(), $booted) &&
                     $classMethod->isStatic() &&
                     (in_array($classMethod->getName(), $conventionalBootMethods) ||
-                        $classMethod->getAttributes(Boot::class) !== [])) {
+                    $classMethod->getAttributes(Boot::class) !== [])) {
                     $classMethod->invoke(null);
 
                     $booted[] = $classMethod->getName();

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3842,6 +3842,16 @@ class DatabaseEloquentModelTest extends TestCase
 
         $this->assertNotInstanceOf(CustomBuilder::class, $eloquentBuilder);
     }
+
+    public function testTraitInitializersAreCalledInCorrectOrder()
+    {
+        $model = new EloquentModelTraitInitializeOrderStub;
+
+        $this->assertTrue(
+            $model->castsWereReadyDuringInit,
+            'HasAttributes::initializeHasAttributes() must run before dependent trait initializers that rely on getCasts().'
+        );
+    }
 }
 
 class CustomBuilder extends Builder
@@ -4785,4 +4795,24 @@ enum ConnectionNameBacked: string
 {
     case Foo = 'Foo';
     case Bar = 'Bar';
+}
+
+trait EloquentTraitInitializeOrderStub
+{
+    public bool $castsWereReadyDuringInit = false;
+
+    protected function initializeEloquentTraitInitializeOrderStub(): void
+    {
+        $this->castsWereReadyDuringInit = array_key_exists('status', $this->getCasts());
+    }
+}
+
+class EloquentModelTraitInitializeOrderStub extends Model
+{
+    use EloquentTraitInitializeOrderStub;
+
+    protected function casts(): array
+    {
+        return ['status' => 'string'];
+    }
 }


### PR DESCRIPTION
Fixes #59612

## Background & Problem

Eloquent models support a trait initializer convention: any trait used on a model can define an `initialize<TraitName>()` method that gets called automatically during model construction.

For example, some traits need to call `getCasts()` during their initialization - i.e. to inspect what casts are defined on the model. The issue is that this only works correctly if `HasAttributes::initializeHasAttributes()` has already run by the time those dependent trait initializers execute, since `HasAttributes` is responsible for setting up the casts infrastructure. Without a guaranteed initialization order, traits relying on `getCasts()` could silently receive incomplete or empty results.

With PHP 8.5 there have been fixes concerning the order on how trait methods are loaded. This results in the underlying architecture of the initialization logic to produce a different order of initializations. More info is described in https://github.com/laravel/framework/issues/59612.

## This PR

As described in #59612, it is possible to loop over `class_uses_recursive` instead of just `(new ReflectionClass($class))->getMethods` as the latter has changed in the output order. This will keep the traits loading in the same order as previous php versions.

A test is also added to ensure the behaviour stays the same for future versions.

You can see the test in action without the fix under https://github.com/laravel/framework/pull/59700.