### PR TITLE
[13.x] Add Arr::duplicates() and Arr::duplicatesStrict()

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -223,6 +223,72 @@ class Arr
     }
 
     /**
+     * Retrieve duplicate items from the array.
+     *
+     * @template TKey of array-key
+     * @template TValue
+     *
+     * @param  array<TKey, TValue>  $array
+     * @param  (callable(TValue, TKey): mixed)|string|null  $callback
+     * @param  bool  $strict
+     * @return array<TKey, TValue>
+     */
+    public static function duplicates($array, $callback = null, $strict = false)
+    {
+        if ($callback === null && $strict === false) {
+            return array_diff_assoc($array, array_unique($array));
+        }
+
+        $items = static::map(
+            $array,
+            is_null($callback)
+                ? fn ($value) => $value
+                : (is_callable($callback) ? $callback : fn ($item) => data_get($item, $callback))
+        );
+
+        $seen = [];
+        $uniqueItems = [];
+
+        foreach ($items as $value) {
+            if (! in_array($value, $seen, $strict)) {
+                $seen[] = $value;
+                $uniqueItems[] = $value;
+            }
+        }
+
+        $compare = $strict
+            ? fn ($a, $b) => $a === $b
+            : fn ($a, $b) => $a == $b;
+
+        $duplicates = [];
+
+        foreach ($items as $key => $value) {
+            if (! empty($uniqueItems) && $compare($value, reset($uniqueItems))) {
+                array_shift($uniqueItems);
+            } else {
+                $duplicates[$key] = $value;
+            }
+        }
+
+        return $duplicates;
+    }
+
+    /**
+     * Retrieve duplicate items from the array using strict comparison.
+     *
+     * @template TKey of array-key
+     * @template TValue
+     *
+     * @param  array<TKey, TValue>  $array
+     * @param  (callable(TValue, TKey): mixed)|string|null  $callback
+     * @return array<TKey, TValue>
+     */
+    public static function duplicatesStrict($array, $callback = null)
+    {
+        return static::duplicates($array, $callback, true);
+    }
+
+    /**
      * Get all of the given array except for a specified array of keys.
      *
      * @param  array  $array

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -317,6 +317,49 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['foo', 'foo' => ['bar' => 'baz', 'baz' => ['a' => 'b']]], $array);
     }
 
+    public function testDuplicates()
+    {
+        // basic scalar duplicates
+        $result = Arr::duplicates(['a', 'b', 'a', 'c', 'b']);
+        $this->assertSame([2 => 'a', 4 => 'b'], $result);
+
+        // no duplicates
+        $this->assertSame([], Arr::duplicates(['a', 'b', 'c']));
+
+        // by string key
+        $data = [
+            ['role' => 'admin', 'name' => 'Alice'],
+            ['role' => 'editor', 'name' => 'Bob'],
+            ['role' => 'admin', 'name' => 'Carol'],
+        ];
+        $result = Arr::duplicates($data, 'role');
+        $this->assertSame([2 => 'admin'], $result);
+
+        // by dot notation
+        $data = [
+            ['meta' => ['type' => 'fruit']],
+            ['meta' => ['type' => 'vegetable']],
+            ['meta' => ['type' => 'fruit']],
+        ];
+        $result = Arr::duplicates($data, 'meta.type');
+        $this->assertSame([2 => 'fruit'], $result);
+
+        // by callback (returns mapped values for duplicate positions)
+        $result = Arr::duplicates([1, 2, 3, 4, 5], fn ($v) => $v % 2);
+        $this->assertSame([2 => 1, 3 => 0, 4 => 1], $result);
+
+        // duplicatesStrict
+        $result = Arr::duplicatesStrict([1, '1', 1]);
+        $this->assertSame([2 => 1], $result);
+
+        // loose comparison does not distinguish types
+        $result = Arr::duplicates([1, '1']);
+        $this->assertSame([1 => '1'], $result);
+
+        // empty array
+        $this->assertSame([], Arr::duplicates([]));
+    }
+
     public function testExcept()
     {
         $array = ['name' => 'taylor', 'age' => 26];


### PR DESCRIPTION
## Summary

Adds `Arr::duplicates()` and `Arr::duplicatesStrict()` to retrieve duplicate items from an array, mirroring `Collection::duplicates()` and `Collection::duplicatesStrict()`.

## Usage

```php
// Scalar duplicates
Arr::duplicates(['a', 'b', 'a', 'c', 'b']);
// [2 => 'a', 4 => 'b']

// By array key
Arr::duplicates($users, 'role');

// By dot notation
Arr::duplicates($items, 'meta.type');

// By callback
Arr::duplicates($items, fn ($item) => $item['category']);

// Strict comparison (type-safe)
Arr::duplicatesStrict([1, '1', 1]);
// [2 => 1]
```