### PR TITLE
[13.x] Ensure assertModelMissing and assertModelExists dont silently pass

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -33,7 +33,7 @@ trait InteractsWithDatabase
             return $this;
         }
 
-        if (count($data) > 0 && array_is_list($data) && array_all($data, fn ($row) => is_array($row))) {
+        if ($data !== [] && array_is_list($data) && array_all($data, fn ($row) => is_array($row))) {
             foreach ($data as $row) {
                 $this->assertDatabaseHas($table, $row, $connection);
             }
@@ -73,7 +73,7 @@ trait InteractsWithDatabase
             return $this;
         }
 
-        if (count($data) > 0 && array_is_list($data) && array_all($data, fn ($row) => is_array($row))) {
+        if ($data !== [] && array_is_list($data) && array_all($data, fn ($row) => is_array($row))) {
             foreach ($data as $row) {
                 $this->assertDatabaseMissing($table, $row, $connection);
             }

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -33,7 +33,7 @@ trait InteractsWithDatabase
             return $this;
         }
 
-        if (array_is_list($data) && array_all($data, fn ($row) => is_array($row))) {
+        if (count($data) > 0 && array_is_list($data) && array_all($data, fn ($row) => is_array($row))) {
             foreach ($data as $row) {
                 $this->assertDatabaseHas($table, $row, $connection);
             }
@@ -73,7 +73,7 @@ trait InteractsWithDatabase
             return $this;
         }
 
-        if (array_is_list($data) && array_all($data, fn ($row) => is_array($row))) {
+        if (count($data) > 0 && array_is_list($data) && array_all($data, fn ($row) => is_array($row))) {
             foreach ($data as $row) {
                 $this->assertDatabaseMissing($table, $row, $connection);
             }

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -234,6 +234,32 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->assertModelMissing(new ProductStub($this->data));
     }
 
+    public function testAssertModelMissingFailsWhenFindsModelResults()
+    {
+        $this->expectException(ExpectationFailedException::class);
+
+        $this->data = ['id' => 1];
+
+        $builder = $this->mockCountBuilder(true);
+
+        $builder->shouldReceive('get')->andReturn(collect([$this->data]));
+
+        $this->assertModelMissing(new ProductStub($this->data));
+    }
+
+    public function testAssertModelExistsFailsWhenDoesNotFindModelResults()
+    {
+        $this->expectException(ExpectationFailedException::class);
+
+        $this->data = ['id' => 1];
+
+        $builder = $this->mockCountBuilder(false);
+
+        $builder->shouldReceive('get')->andReturn(collect());
+
+        $this->assertModelExists(new ProductStub($this->data));
+    }
+
     public function testAssertSoftDeletedInDatabaseFindsResults()
     {
         $this->mockCountBuilder(true);


### PR DESCRIPTION
Noticed I missed checking its not an empty array because... https://3v4l.org/qKWot#v8.5.3 is true


```php
 // Currently this would pass, even tho it shouldnt :o 
 $user = User::factory()->create();                                                                                                                                                                      
 $this->assertModelMissing($user);
```

I've also added some tests to ensure it never catches a poor soul again. As these weren't tested afaik! 

![hyb](https://media.tenor.com/qunoIvPRzQQAAAAM/hell-yeah-brother-hulk-hogan.gif)
