### PR TITLE
[13.x] Impement ValidationRule for Password rule

### DIFF
--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -3,11 +3,13 @@
 namespace Illuminate\Validation\Rules;
 
 use ArrayIterator;
+use Closure;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Validation\DataAwareRule;
 use Illuminate\Contracts\Validation\ImplicitRule;
 use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Contracts\Validation\UncompromisedVerifier;
+use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Contracts\Validation\ValidatorAwareRule;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Validator;
@@ -16,9 +18,20 @@ use InvalidArgumentException;
 use IteratorAggregate;
 use Traversable;
 
-class Password implements DataAwareRule, ImplicitRule, IteratorAggregate, Rule, ValidatorAwareRule
+class Password implements DataAwareRule, ImplicitRule, IteratorAggregate, Rule, ValidationRule, ValidatorAwareRule
 {
     use Conditionable;
+
+    /**
+     * Indicates the rule runs even when the attribute is missing.
+     *
+     * Paired with implementing ValidationRule — this is the non-deprecated
+     * equivalent of the (deprecated) ImplicitRule interface, which is kept
+     * in the implements list only for backwards compatibility.
+     *
+     * @var bool
+     */
+    public $implicit = true;
 
     /**
      * The validator performing the validation.
@@ -327,11 +340,33 @@ class Password implements DataAwareRule, ImplicitRule, IteratorAggregate, Rule, 
     }
 
     /**
+     * Run the validation rule.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  \Closure(string, ?string=): \Illuminate\Translation\PotentiallyTranslatedString  $fail
+     * @return void
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if ($this->passes($attribute, $value)) {
+            return;
+        }
+
+        foreach ($this->messages as $message) {
+            $fail($message);
+        }
+    }
+
+    /**
      * Determine if the validation rule passes.
      *
      * @param  string  $attribute
      * @param  mixed  $value
      * @return bool
+     *
+     * @deprecated Implement Illuminate\Contracts\Validation\ValidationRule
+     *             via the validate() method instead.
      */
     public function passes($attribute, $value)
     {

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -918,10 +918,12 @@ class Validator implements ValidatorContract
     {
         $originalAttribute = $this->replacePlaceholderInString($attribute);
 
+        $invokable = $rule instanceof InvokableValidationRule ? $rule->invokable() : $rule;
+
         $attribute = match (true) {
-            $rule instanceof Rules\Email => $attribute,
-            $rule instanceof Rules\File => $attribute,
-            $rule instanceof Rules\Password => $attribute,
+            $invokable instanceof Rules\Email => $attribute,
+            $invokable instanceof Rules\File => $attribute,
+            $invokable instanceof Rules\Password => $attribute,
             default => $originalAttribute,
         };
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

I noticed on a project using one of the starter kits `Illuminate\Validation\Rules\Password` does not yet implement `Illuminate\Contracts\Validation\ValidationRule`, which is the replacement for `Illuminate\Contracts\Validation\Rule`. 

It was due to this change: https://github.com/laravel/maestro/pull/76

I also properly implemented the replacement for `Illuminate\Contracts\Validation\ImplicitRule`. This change should make phpstan happy, while keeping backwards compatibility from a type perspective.

Here was the output from phpstan before the fix:

```

 ------ ------------------------------------------------------------------------------------------------------------------ 
  Line   app/Concerns/PasswordValidationRules.php (in context of class App\Actions\Fortify\CreateNewUser)                  
 ------ ------------------------------------------------------------------------------------------------------------------ 
  :20    Method App\Actions\Fortify\CreateNewUser::passwordRules() should return array<int, array<mixed>|Illuminate\Contracts\Validation\ValidationRule|string> but returns array<int, Illuminate\Validation\Rules\Password|string>.       
         🪪  return.type                                                                                                   
 ------ ------------------------------------------------------------------------------------------------------------------ 

 ------ ------------------------------------------------------------------------------------------------------------------ 
  Line   app/Concerns/PasswordValidationRules.php (in context of class App\Actions\Fortify\ResetUserPassword)              
 ------ ------------------------------------------------------------------------------------------------------------------ 
  :20    Method App\Actions\Fortify\ResetUserPassword::passwordRules() should return array<int, array<mixed>|Illuminate\Contracts\Validation\ValidationRule|string> but returns array<int, Illuminate\Validation\Rules\Password|string>.   
         🪪  return.type                                                                                                   
 ------ ------------------------------------------------------------------------------------------------------------------ 

 ------ ------------------------------------------------------------------------------------------------------------------ 
  Line   app/Concerns/PasswordValidationRules.php (in context of class App\Http\Requests\Settings\PasswordUpdateRequest)   
 ------ ------------------------------------------------------------------------------------------------------------------ 
  :20    Method App\Http\Requests\Settings\PasswordUpdateRequest::passwordRules() should return array<int, array<mixed>|Illuminate\Contracts\Validation\ValidationRule|string> but returns array<int, Illuminate\Validation\Rules\Password|string>.                                                                                                        
         🪪  return.type                                                                                                   
 ------ ------------------------------------------------------------------------------------------------------------------ 

 ------ ------------------------------------------------------------------------------------------------------------------ 
  Line   app/Concerns/PasswordValidationRules.php (in context of class App\Http\Requests\Settings\ProfileDeleteRequest)    
 ------ ------------------------------------------------------------------------------------------------------------------ 
  :20    Method App\Http\Requests\Settings\ProfileDeleteRequest::passwordRules() should return array<int, array<mixed>|Il  
         luminate\Contracts\Validation\ValidationRule|string> but returns array<int, Illuminate\Validation\Rules\Password  
         |string>.                                                                                                         
         🪪  return.type                                                                                                   
 ------ ------------------------------------------------------------------------------------------------------------------ 
```

If you like this pattern, I can finish updating the remaining rules to adopt ValidationRule properly, but keep backwards compatibility.
