### PR TITLE
[12.x] Prevent array to string conversion in signature validation

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -475,10 +475,16 @@ class UrlGenerator implements UrlGeneratorContract
 
         $keys = is_array($keys) ? $keys : [$keys];
 
+        $signature = $request->query('signature');
+
+        if (! is_string($signature)) {
+            return false;
+        }
+
         foreach ($keys as $key) {
             if (hash_equals(
                 hash_hmac('sha256', $original, $key),
-                (string) $request->query('signature', '')
+                $signature
             )) {
                 return true;
             }

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -776,6 +776,36 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertTrue($url->hasValidSignature($request, ignoreQuery: fn ($parameter) => $parameter === 'tampered'));
     }
 
+    public function testSignedUrlWithArraySignatureReturnsFalseWithoutWarning()
+    {
+        $url = new UrlGenerator(
+            $routes = new RouteCollection,
+            Request::create('http://www.foo.com/')
+        );
+        $url->setKeyResolver(function () {
+            return 'secret';
+        });
+
+        $route = new Route(['GET'], 'foo', ['as' => 'foo', function () {
+            //
+        }]);
+        $routes->add($route);
+
+        // ?signature[]=foo&signature[]=bar previously raised an
+        // "Array to string conversion" warning.
+        $request = Request::create('http://www.foo.com/foo?signature[]=foo&signature[]=bar');
+
+        set_error_handler(static function (int $errno, string $errstr) {
+            throw new \ErrorException($errstr, 0, $errno);
+        }, E_WARNING);
+
+        try {
+            $this->assertFalse($url->hasValidSignature($request));
+        } finally {
+            restore_error_handler();
+        }
+    }
+
     public function testSignedUrlImplicitModelBinding()
     {
         $url = new UrlGenerator(


### PR DESCRIPTION
When a request reaches a signed-URL route with array-style query parameters (e.g. `?signature[]=foo&signature[]=bar`), `$request->query('signature', '')` returns an array. The `(string)` cast on that array then raises an `Array to string conversion` warning, which surfaces as a critical-level error in error trackers (Bugsnag, Sentry, etc.).

This affects every signed-URL route in any Laravel app and is trivial to trigger by bots, fuzzers, or buggy clients. The request can never validate anyway, so the only effect is unwanted noise in production error logs.

## Fix

Validate the signature is a string before entering the verification loop, returning `false` early for any non-string value (an array signature can never validate anyway).

## Reproduction

```php
$response = $this->get('/some-signed-route?signature[]=x&signature[]=y');
// Before: PHP warning "Array to string conversion"
// After:  clean 403 response, no warning
```