### PR TITLE
[13.x] Use generic TModel in additional places in Factory class

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -366,7 +366,7 @@ abstract class Factory
     /**
      * Set the connection name on the results and store them.
      *
-     * @param  \Illuminate\Support\Collection<int, \Illuminate\Database\Eloquent\Model>  $results
+     * @param  \Illuminate\Support\Collection<int, TModel>  $results
      * @return void
      */
     protected function store(Collection $results)
@@ -391,7 +391,7 @@ abstract class Factory
     /**
      * Create the children for the given model.
      *
-     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  TModel  $model
      * @return void
      */
     protected function createChildren(Model $model)
@@ -514,7 +514,7 @@ abstract class Factory
      * Make an instance of the model with the given attributes.
      *
      * @param  \Illuminate\Database\Eloquent\Model|null  $parent
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return TModel
      */
     protected function makeInstance(?Model $parent)
     {


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
In some of my own overrides I was recently faced with static errors like `Parameter #1 $results of method Illuminate\Database\Eloquent\Factories\Factory<TModel of Illuminate\Database\Eloquent\Model>::store() expects Illuminate\Support\Collection<int, Illuminate\Database\Eloquent\Model>, Illuminate\Support\Collection<int, TModel of Illuminate\Database\Eloquent\Model> given.`. Given the `TModel` typehint is correct for these places AFAICS, I suggest adding them there.