### PR TITLE
[13.x] Fix MariaDB < 10.2.5 schema introspection when information_schema.COLUMNS has no GENERATION_EXPRESSION 

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/MariaDbGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MariaDbGrammar.php
@@ -18,6 +18,31 @@ class MariaDbGrammar extends MySqlGrammar
     }
 
     /**
+     * Compile the query to determine the columns.
+     *
+     * @param  string|null  $schema
+     * @param  string  $table
+     * @return string
+     */
+    public function compileColumns($schema, $table)
+    {
+        if (version_compare($this->connection->getServerVersion(), '10.2.5', '<')) {
+            return sprintf(
+                'select column_name as `name`, data_type as `type_name`, column_type as `type`, '
+                .'collation_name as `collation`, is_nullable as `nullable`, '
+                .'column_default as `default`, column_comment as `comment`, '
+                .'null as `expression`, extra as `extra` '
+                .'from information_schema.columns where table_schema = %s and table_name = %s '
+                .'order by ordinal_position asc',
+                $schema ? $this->quoteString($schema) : 'schema()',
+                $this->quoteString($table)
+            );
+        }
+
+        return parent::compileColumns($schema, $table);
+    }
+
+    /**
      * Create the column definition for a uuid type.
      *
      * @param  \Illuminate\Support\Fluent  $column

--- a/tests/Database/DatabaseMariaDbSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMariaDbSchemaGrammarTest.php
@@ -1549,6 +1549,31 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
         $this->assertTrue($c);
     }
 
+    public function testCompileColumnsOmitsGenerationExpressionOnMariaDbBefore1025()
+    {
+        $connection = $this->getConnection();
+        $connection->shouldReceive('getServerVersion')->andReturn('10.2.4-MariaDB');
+
+        $sql = $this->getGrammar($connection)->compileColumns('mydb', 'users');
+
+        $this->assertStringNotContainsString('generation_expression', $sql);
+        $this->assertStringContainsString('null as `expression`', $sql);
+        $this->assertStringContainsString("table_schema = 'mydb'", $sql);
+        $this->assertStringContainsString("table_name = 'users'", $sql);
+    }
+
+    public function testCompileColumnsUsesGenerationExpressionOnMariaDb1025AndLater()
+    {
+        $connection = $this->getConnection();
+        $connection->shouldReceive('getServerVersion')->andReturn('10.2.5');
+
+        $sql = $this->getGrammar($connection)->compileColumns(null, 'users');
+
+        $this->assertStringContainsString('generation_expression as `expression`', $sql);
+        $this->assertStringContainsString('table_schema = schema()', $sql);
+        $this->assertStringContainsString("table_name = 'users'", $sql);
+    }
+
     protected function getConnection(
         ?MariaDbGrammar $grammar = null,
         ?MariaDbBuilder $builder = null,


### PR DESCRIPTION
### Problem

On MariaDB **before 10.2.5**, `information_schema.COLUMNS` does not include **`GENERATION_EXPRESSION`**. Laravel’s MySQL/MariaDB `compileColumns()` always selects:

`generation_expression as expression`

which causes the server to error:

SQLSTATE[42S22]: Column not found: 1054 Unknown column 'generation_expression' in 'field list'

Example reported query:
```sql
select column_name as `name`, data_type as `type_name`, column_type as `type`,
collation_name as `collation`, is_nullable as `nullable`, column_default as `default`,
column_comment as `comment`, generation_expression as `expression`, extra as `extra`
from information_schema.columns
where table_schema = schema() and table_name = '...'
order by ordinal_position asc
```

This surfaces during normal app usage whenever Schema::getColumns() / getColumnListing() runs—for example Eloquent Model::create() on a model with non-empty $guarded and empty $fillable, which triggers isGuardableColumn() and loads column names from the schema (see GuardsAttributes).

So the failure is not specific to one table; the stack trace may point at an innocuous insert because that is where the first schema introspection happens in the request.

Related framework history: generated column support in Schema::getColumns() was expanded in [#50329](https://github.com/laravel/framework/pull/50329).

References
[MDEV-9255](https://jira.mariadb.org/browse/MDEV-9255) — add generation_expression to information_schema.COLUMNS (fixed in 10.2.5).