### PR TITLE
[13.x] Prevent TypeError in `encoding` rule when value is a non-Stringable object

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -984,6 +984,10 @@ trait ValidatesAttributes
             throw new InvalidArgumentException("Validation rule encoding parameter [{$parameters[0]}] is not a valid encoding.");
         }
 
+        if (is_object($value) && ! $value instanceof File && ! method_exists($value, '__toString')) {
+            return false;
+        }
+
         return mb_check_encoding($value instanceof File ? $value->getContent() : $value, $parameters[0]);
     }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3284,6 +3284,13 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
     }
 
+    public function testValidateEncodingDoesNotThrowOnNonStringableObject()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['x' => new \stdClass], ['x' => 'encoding:UTF-8']);
+        $this->assertFalse($v->passes());
+    }
+
     public function testValidateDoesntStartWith()
     {
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
`validateEncoding` passes `$value` straight to `mb_check_encoding()`, which accepts `array|string|null`. If the attribute value is an object that isn't `File` and doesn't implement `__toString`, the rule throws a `TypeError` instead of returning `false`.

```php
$v = new Validator($trans, ['x' => new stdClass], ['x' => 'encoding:UTF-8']);
$v->passes();
// TypeError: Argument #1 ($value) must be of type array|string|null, stdClass given
```

Added a guard matching the style used by `validateEmail` and `validateJson` so the rule cleanly reports a failure. Added one regression test in `tests/Validation/ValidationValidatorTest.php` alongside the existing `*DoesNotThrowOnNonStringValue` tests.