### PR TITLE
[13.x] Apply eager load constraints to one-of-many subqueries

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -944,14 +944,19 @@ class Builder implements BuilderContract
         $relation = $this->getRelation($name);
 
         $relation->addEagerConstraints($models);
+        $query = null;
+        $whereCount = 0;
+        $whereBindingsCount = 0;
 
-        $query = $relation->getQuery()->getQuery();
-        $whereCount = count($query->wheres ?? []);
-        $whereBindingsCount = count($query->getRawBindings()['where'] ?? []);
+        if (method_exists($relation, 'getOneOfManySubQuery')) {
+            $query = $relation->getQuery()->getQuery();
+            $whereCount = count($query->wheres ?? []);
+            $whereBindingsCount = count($query->getRawBindings()['where'] ?? []);
+        }
 
         $constraints($relation);
 
-        if (method_exists($relation, 'getOneOfManySubQuery') && ($subQuery = $relation->getOneOfManySubQuery()) !== null) {
+        if ($query !== null && ($subQuery = $relation->getOneOfManySubQuery()) !== null) {
             $wheres = array_slice($query->wheres ?? [], $whereCount);
             $whereBindings = array_slice($query->getRawBindings()['where'] ?? [], $whereBindingsCount);
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -945,7 +945,18 @@ class Builder implements BuilderContract
 
         $relation->addEagerConstraints($models);
 
+        $query = $relation->getQuery()->getQuery();
+        $whereCount = count($query->wheres ?? []);
+        $whereBindingsCount = count($query->getRawBindings()['where'] ?? []);
+
         $constraints($relation);
+
+        if (method_exists($relation, 'getOneOfManySubQuery') && ($subQuery = $relation->getOneOfManySubQuery()) !== null) {
+            $wheres = array_slice($query->wheres ?? [], $whereCount);
+            $whereBindings = array_slice($query->getRawBindings()['where'] ?? [], $whereBindingsCount);
+
+            $subQuery->getQuery()->mergeWheres($wheres, $whereBindings);
+        }
 
         // Once we have the results, we just match those back up to their parent models
         // using the relationship instance. Then we just return the finished arrays

--- a/tests/Integration/Database/EloquentHasOneOfManyTest.php
+++ b/tests/Integration/Database/EloquentHasOneOfManyTest.php
@@ -79,6 +79,21 @@ class EloquentHasOneOfManyTest extends DatabaseTestCase
         $this->assertSame($users[0]->latest_updated_state->id, $latestState->id);
         $this->assertSame($users[0]->latest_updated_latest_created_state->id, $latestState->id);
     }
+
+    public function testItAppliesEagerLoadConstraintsToTheInnerSubquery()
+    {
+        $user = User::create();
+        $user->latest_login()->create();
+        $expectedLogin = $user->latest_login()->create();
+        $user->latest_login()->create();
+
+        $result = User::with(['latest_login' => function ($query) use ($expectedLogin) {
+            $query->whereKey($expectedLogin->getKey());
+        }])->first();
+
+        $this->assertNotNull($result->latest_login);
+        $this->assertSame($expectedLogin->id, $result->latest_login->id);
+    }
 }
 
 class User extends Model


### PR DESCRIPTION
## Summary
Apply eager-load closure constraints to one-of-many inner subqueries.

## Problem
When eager loading an `ofMany` / `latestOfMany` relationship with a closure constraint, the constraint is only applied to the outer relation query. The inner subquery still selects the latest record from the unconstrained dataset, which can cause the relationship to resolve to `null` even when a matching record exists.

Issue: https://github.com/laravel/framework/issues/59318

## Solution
In `Eloquent\Builder::eagerLoadRelation()`, snapshot the relation query's `where` clauses and `where` bindings before the eager-load closure runs, then merge only the newly added `where` constraints into the one-of-many subquery when present.

This keeps the fix scoped to eager loading and avoids changing lazy-loaded relation behavior.

## Tests
- Added a regression test covering eager loading a `latestOfMany` relation with a `whereKey(...)` constraint.
- Ran the nearby Eloquent relationship suites around has-one / has-many / through / morph relation behavior.
