### PR TITLE
[13.x] Mark `Scope@apply` builder parameter as having covariant template

### DIFF
--- a/src/Illuminate/Database/Eloquent/Scope.php
+++ b/src/Illuminate/Database/Eloquent/Scope.php
@@ -10,7 +10,7 @@ interface Scope
     /**
      * Apply the scope to a given Eloquent query builder.
      *
-     * @param  \Illuminate\Database\Eloquent\Builder<TModel>  $builder
+     * @param  \Illuminate\Database\Eloquent\Builder<covariant TModel>  $builder
      * @param  TModel  $model
      * @return void
      */

--- a/types/Database/Eloquent/Scope.php
+++ b/types/Database/Eloquent/Scope.php
@@ -38,5 +38,5 @@ class User extends Model
 
 $user = new User();
 $query = User::query();
-new UserScope()->apply($query, $user);
-new GenericScope()->apply($query, $user);
+(new UserScope())->apply($query, $user);
+(new GenericScope())->apply($query, $user);

--- a/types/Database/Eloquent/Scope.php
+++ b/types/Database/Eloquent/Scope.php
@@ -35,3 +35,8 @@ class GenericScope implements Scope
 class User extends Model
 {
 }
+
+$user = new User();
+$query = User::query();
+new UserScope()->apply($query, $user);
+new GenericScope()->apply($query, $user);

--- a/types/Database/Eloquent/Scope.php
+++ b/types/Database/Eloquent/Scope.php
@@ -15,7 +15,7 @@ class UserScope implements Scope
 {
     public function apply(Builder $builder, Model $model): void
     {
-        assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Types\Scope\User>', $builder);
+        assertType('Illuminate\Database\Eloquent\Builder<covariant Illuminate\Types\Scope\User>', $builder);
         assertType('Illuminate\Types\Scope\User', $model);
     }
 }
@@ -27,7 +27,7 @@ class GenericScope implements Scope
 {
     public function apply(Builder $builder, Model $model): void
     {
-        assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Database\Eloquent\Model>', $builder);
+        assertType('Illuminate\Database\Eloquent\Builder<covariant Illuminate\Database\Eloquent\Model>', $builder);
         assertType('Illuminate\Database\Eloquent\Model', $model);
     }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Due to the changes in #59675, if one now passes a 'specific' builder as parameter to the `apply` method of a (broader) 'generic' scope, one is faced with a message like:
```
 ------ ---------------------------------------------------------------------------------------------------------------
  Line   Database\Eloquent\Scope.php
 ------ ---------------------------------------------------------------------------------------------------------------
  42     Parameter #1 $builder of method Illuminate\Types\Scope\GenericScope::apply() expects
         Illuminate\Database\Eloquent\Builder<Illuminate\Database\Eloquent\Model>, Illuminate\Database\Eloquent\Builde
         r<Illuminate\Types\Scope\User> given.
         🪪  argument.type
         💡  Template type TModel on class Illuminate\Database\Eloquent\Builder is not covariant. Learn more: https://p
         hpstan.org/blog/whats-up-with-template-covariant
 ------ ---------------------------------------------------------------------------------------------------------------
```

This is illustrated by the first commit of this PR, which will err without the subsequent fix.

See also https://phpstan.org/blog/whats-up-with-template-covariant#call-site-variance.