### PR TITLE
Add --layout option for command view

### DIFF
--- a/src/Illuminate/Foundation/Console/ViewMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewMakeCommand.php
@@ -49,6 +49,14 @@ class ViewMakeCommand extends GeneratorCommand
     {
         $contents = parent::buildClass($name);
 
+        if ($layout = $this->option('layout')) {
+            $contents = str_replace(
+                '{{ layout }}',
+                $layout,
+                $contents,
+            );
+        }
+
         return str_replace(
             '{{ quote }}',
             Inspiring::quotes()->random(),
@@ -65,7 +73,7 @@ class ViewMakeCommand extends GeneratorCommand
     protected function getPath($name)
     {
         return $this->viewPath(
-            $this->getNameInput().'.'.$this->option('extension'),
+            $this->getNameInput() . '.' . $this->option('extension'),
         );
     }
 
@@ -105,7 +113,7 @@ class ViewMakeCommand extends GeneratorCommand
     {
         return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
             ? $customPath
-            : __DIR__.$stub;
+            : __DIR__ . $stub;
     }
 
     /**
@@ -182,21 +190,21 @@ class ViewMakeCommand extends GeneratorCommand
      */
     protected function testClassFullyQualifiedName()
     {
-        $name = Str::of(Str::lower($this->getNameInput()))->replace('.'.$this->option('extension'), '');
+        $name = Str::of(Str::lower($this->getNameInput()))->replace('.' . $this->option('extension'), '');
 
         $namespacedName = Str::of(
             (new Stringable($name))
                 ->replace('/', ' ')
                 ->explode(' ')
-                ->map(fn ($part) => (new Stringable($part))->ucfirst())
+                ->map(fn($part) => (new Stringable($part))->ucfirst())
                 ->implode('\\')
         )
             ->replace(['-', '_'], ' ')
             ->explode(' ')
-            ->map(fn ($part) => (new Stringable($part))->ucfirst())
+            ->map(fn($part) => (new Stringable($part))->ucfirst())
             ->implode('');
 
-        return 'Tests\\Feature\\View\\'.$namespacedName;
+        return 'Tests\\Feature\\View\\' . $namespacedName;
     }
 
     /**
@@ -206,11 +214,11 @@ class ViewMakeCommand extends GeneratorCommand
      */
     protected function getTestStub()
     {
-        $stubName = 'view.'.($this->usingPest() ? 'pest' : 'test').'.stub';
+        $stubName = 'view.' . ($this->usingPest() ? 'pest' : 'test') . '.stub';
 
         return file_exists($customPath = $this->laravel->basePath("stubs/$stubName"))
             ? $customPath
-            : __DIR__.'/stubs/'.$stubName;
+            : __DIR__ . '/stubs/' . $stubName;
     }
 
     /**
@@ -239,7 +247,7 @@ class ViewMakeCommand extends GeneratorCommand
 
         return $this->option('pest') ||
             (function_exists('\Pest\\version') &&
-             file_exists(base_path('tests').'/Pest.php'));
+                file_exists(base_path('tests') . '/Pest.php'));
     }
 
     /**
@@ -251,6 +259,7 @@ class ViewMakeCommand extends GeneratorCommand
     {
         return [
             ['extension', null, InputOption::VALUE_OPTIONAL, 'The extension of the generated view', 'blade.php'],
+            ['layout', null, InputOption::VALUE_OPTIONAL, 'The layout to extend in the generated view'],
             ['force', 'f', InputOption::VALUE_NONE, 'Create the view even if the view already exists'],
         ];
     }

--- a/src/Illuminate/Foundation/Console/ViewMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewMakeCommand.php
@@ -73,7 +73,7 @@ class ViewMakeCommand extends GeneratorCommand
     protected function getPath($name)
     {
         return $this->viewPath(
-            $this->getNameInput() . '.' . $this->option('extension'),
+            $this->getNameInput().'.'.$this->option('extension'),
         );
     }
 
@@ -113,7 +113,7 @@ class ViewMakeCommand extends GeneratorCommand
     {
         return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
             ? $customPath
-            : __DIR__ . $stub;
+            : __DIR__.$stub;
     }
 
     /**
@@ -190,21 +190,21 @@ class ViewMakeCommand extends GeneratorCommand
      */
     protected function testClassFullyQualifiedName()
     {
-        $name = Str::of(Str::lower($this->getNameInput()))->replace('.' . $this->option('extension'), '');
+        $name = Str::of(Str::lower($this->getNameInput()))->replace('.'.$this->option('extension'), '');
 
         $namespacedName = Str::of(
             (new Stringable($name))
                 ->replace('/', ' ')
                 ->explode(' ')
-                ->map(fn($part) => (new Stringable($part))->ucfirst())
+                ->map(fn ($part) => (new Stringable($part))->ucfirst())
                 ->implode('\\')
         )
             ->replace(['-', '_'], ' ')
             ->explode(' ')
-            ->map(fn($part) => (new Stringable($part))->ucfirst())
+            ->map(fn ($part) => (new Stringable($part))->ucfirst())
             ->implode('');
 
-        return 'Tests\\Feature\\View\\' . $namespacedName;
+        return 'Tests\\Feature\\View\\'.$namespacedName;
     }
 
     /**
@@ -214,11 +214,11 @@ class ViewMakeCommand extends GeneratorCommand
      */
     protected function getTestStub()
     {
-        $stubName = 'view.' . ($this->usingPest() ? 'pest' : 'test') . '.stub';
+        $stubName = 'view.'.($this->usingPest() ? 'pest' : 'test').'.stub';
 
         return file_exists($customPath = $this->laravel->basePath("stubs/$stubName"))
             ? $customPath
-            : __DIR__ . '/stubs/' . $stubName;
+            : __DIR__.'/stubs/'.$stubName;
     }
 
     /**
@@ -247,7 +247,7 @@ class ViewMakeCommand extends GeneratorCommand
 
         return $this->option('pest') ||
             (function_exists('\Pest\\version') &&
-                file_exists(base_path('tests') . '/Pest.php'));
+                file_exists(base_path('tests').'/Pest.php'));
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/stubs/view.stub
+++ b/src/Illuminate/Foundation/Console/stubs/view.stub
@@ -1,3 +1,13 @@
+@if('{{ layout }}')
+@extends('{{ layout }}')
+
+@section('content')
+    <div>
+        <!-- {{ quote }} -->
+    </div>
+@endsection
+@else
 <div>
     <!-- {{ quote }} -->
 </div>
+@endif

--- a/tests/Integration/Generators/ViewMakeCommandTest.php
+++ b/tests/Integration/Generators/ViewMakeCommandTest.php
@@ -6,7 +6,9 @@ class ViewMakeCommandTest extends TestCase
 {
     protected $files = [
         'resources/views/foo.blade.php',
+        'resources/views/bar.blade.php',
         'tests/Feature/View/FooTest.php',
+        'tests/Feature/View/BarTest.php',
     ];
 
     public function testItCanGenerateViewFile()
@@ -25,5 +27,28 @@ class ViewMakeCommandTest extends TestCase
 
         $this->assertFilenameExists('resources/views/foo.blade.php');
         $this->assertFilenameExists('tests/Feature/View/FooTest.php');
+    }
+
+    public function testItCanGenerateViewFileWithLayout()
+    {
+        $this->artisan('make:view', ['name' => 'foo', '--layout' => 'layouts.app'])
+            ->assertExitCode(0);
+
+        $this->assertFilenameExists('resources/views/foo.blade.php');
+
+        $content = file_get_contents($this->app->basePath('resources/views/foo.blade.php'));
+        $this->assertStringContainsString('@extends(\'layouts.app\')', $content);
+    }
+
+    public function testItCanGenerateViewFileWithLayoutAndTest()
+    {
+        $this->artisan('make:view', ['name' => 'bar', '--layout' => 'layouts.admin', '--test' => true])
+            ->assertExitCode(0);
+
+        $this->assertFilenameExists('resources/views/bar.blade.php');
+        $this->assertFilenameExists('tests/Feature/View/BarTest.php');
+
+        $content = file_get_contents($this->app->basePath('resources/views/bar.blade.php'));
+        $this->assertStringContainsString('@extends(\'layouts.admin\')', $content);
     }
 }


### PR DESCRIPTION
# Add --layout option to make:view command

## Description

This PR adds an optional `--layout` parameter to the `make:view` command, allowing developers to generate views that extend a specified layout without manual editing.

## Benefit to End Users

- **Faster Development**: Generate views with layouts in one command instead of creating the file and manually adding `@extends()`
- **Consistency**: Ensures all views follow the same layout structure from creation
- **DRY Principle**: No need to manually type the layout extension in every new view

## Usage

```bash
php artisan make:view pages/home --layout=layouts.app
