### PR TITLE
Fix route registration for domain-scoped routes

### DIFF
--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -15,11 +15,25 @@ class RouteCollection extends AbstractRouteCollection
     protected $routes = [];
 
     /**
+     * Domain routes keyed by method, used to maintain domain-first ordering.
+     *
+     * @var array
+     */
+    protected $domainRoutes = [];
+
+    /**
      * A flattened array of all of the routes.
      *
      * @var \Illuminate\Routing\Route[]
      */
     protected $allRoutes = [];
+
+    /**
+     * Domain routes in the flattened array, used to maintain domain-first ordering.
+     *
+     * @var \Illuminate\Routing\Route[]
+     */
+    protected $allDomainRoutes = [];
 
     /**
      * A look-up table of routes by their names.
@@ -60,23 +74,20 @@ class RouteCollection extends AbstractRouteCollection
     {
         $methods = $route->methods();
         $domainAndUri = $route->getDomain().$route->uri();
-
-        foreach ($methods as $method) {
-            if ($route->getDomain()) {
-                $domainRoutes = array_filter($this->routes[$method] ?? [], fn ($route) => $route->getDomain() !== null);
-
-                $this->routes[$method] = $domainRoutes + [$domainAndUri => $route] + ($this->routes[$method] ?? []);
-            } else {
-                $this->routes[$method][$domainAndUri] = $route;
-            }
-        }
+        $allRoutesKey = implode('|', $methods).$domainAndUri;
 
         if ($route->getDomain()) {
-            $domainRoutes = array_filter($this->allRoutes, fn ($route) => $route->getDomain() !== null);
+            foreach ($methods as $method) {
+                $this->domainRoutes[$method][$domainAndUri] = $route;
+            }
 
-            $this->allRoutes = $domainRoutes + [implode('|', $methods).$domainAndUri => $route] + $this->allRoutes;
+            $this->allDomainRoutes[$allRoutesKey] = $route;
         } else {
-            $this->allRoutes[implode('|', $methods).$domainAndUri] = $route;
+            foreach ($methods as $method) {
+                $this->routes[$method][$domainAndUri] = $route;
+            }
+
+            $this->allRoutes[$allRoutesKey] = $route;
         }
     }
 
@@ -150,7 +161,7 @@ class RouteCollection extends AbstractRouteCollection
     {
         $this->nameList = [];
 
-        foreach ($this->allRoutes as $route) {
+        foreach ($this->allDomainRoutes + $this->allRoutes as $route) {
             if (($name = $route->getName()) && ! $this->inNameLookup($name)) {
                 $this->nameList[$name] = $route;
             }
@@ -168,7 +179,7 @@ class RouteCollection extends AbstractRouteCollection
     {
         $this->actionList = [];
 
-        foreach ($this->allRoutes as $route) {
+        foreach ($this->allDomainRoutes + $this->allRoutes as $route) {
             if (($controller = $route->getAction()['controller'] ?? null) && ! $this->inActionLookup($controller)) {
                 $this->addToActionList($route->getAction(), $route);
             }
@@ -204,7 +215,9 @@ class RouteCollection extends AbstractRouteCollection
      */
     public function get($method = null)
     {
-        return is_null($method) ? $this->getRoutes() : ($this->routes[$method] ?? []);
+        return is_null($method)
+            ? $this->getRoutes()
+            : ($this->domainRoutes[$method] ?? []) + ($this->routes[$method] ?? []);
     }
 
     /**
@@ -247,7 +260,7 @@ class RouteCollection extends AbstractRouteCollection
      */
     public function getRoutes()
     {
-        return array_values($this->allRoutes);
+        return array_values($this->allDomainRoutes + $this->allRoutes);
     }
 
     /**
@@ -257,7 +270,13 @@ class RouteCollection extends AbstractRouteCollection
      */
     public function getRoutesByMethod()
     {
-        return $this->routes;
+        $result = $this->domainRoutes;
+
+        foreach ($this->routes as $method => $routes) {
+            $result[$method] = ($result[$method] ?? []) + $routes;
+        }
+
+        return $result;
     }
 
     /**

--- a/tests/Routing/RouteCollectionTest.php
+++ b/tests/Routing/RouteCollectionTest.php
@@ -419,4 +419,19 @@ class RouteCollectionTest extends TestCase
             ],
         ], $this->routeCollection->getRoutesByMethod());
     }
+
+    public function testDomainRoutesAreMatchedBeforeNonDomainRoutes()
+    {
+        $this->routeCollection->add(
+            (new Route('GET', 'users', ['uses' => 'NoDomainController@index']))->name('no-domain')
+        );
+
+        $this->routeCollection->add(
+            (new Route('GET', 'users', ['uses' => 'DomainController@index']))->domain('api.test')->name('with-domain')
+        );
+
+        $request = Request::create('http://api.test/users', 'GET');
+
+        $this->assertSame('with-domain', $this->routeCollection->match($request)->getName());
+    }
 }


### PR DESCRIPTION
We noticed significantly slower local development response time after upgrading to Laravel 13. 

Profiling traced it to `addToCollections()`.  PR #55921 introduced `array_filter` + array union (`+`) in `addToCollections()` to ensure domain routes are ordered before non-domain routes. With ~500 domain-scoped routes in our app, this rebuilds the entire array on each insert.

This PR splits domain and non-domain routes into separate buckets during registration. Same ordering behavior.

Interestingly, [Taylor flagged this exact concern](https://github.com/laravel/framework/pull/55921#discussion_r2126838212) during review 

## Benchmark

`RouteCollection::addToCollections`

| Routes | Before (ms) | After (ms) |
|--------|-------------|------------|
| 100    | 0.7         | 0.3        |
| 200    | 1.9         | 0.4        |
| 400    | 7.0         | 0.8        |
| 600    | 15.0        | 1.1        |
| 854    | 29.5        | 1.6        |

