### PR TITLE
[13.x] Add FormRequest::handleUnknownFieldsUsing() violation callback

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -87,6 +87,13 @@ class FormRequest extends Request implements ValidatesWhenResolved
     protected static bool $globalFailOnUnknownFields = false;
 
     /**
+     * The callback that is responsible for handling unknown fields violations.
+     *
+     * @var (callable(self, array<int, string>))|null
+     */
+    protected static $unknownFieldsViolationCallback;
+
+    /**
      * Get the validator instance for the request.
      *
      * @return \Illuminate\Contracts\Validation\Validator
@@ -233,12 +240,28 @@ class FormRequest extends Request implements ValidatesWhenResolved
 
         $input = $this->isJson() ? $this->json()->all() : $this->request->all();
 
+        $unknownFields = [];
+
         foreach (array_keys(Arr::dot($input)) as $inputKey) {
             if (! $this->isKnownField($inputKey, $allowedKeys)) {
-                $validator->errors()->add($inputKey, trans('validation.prohibited', [
-                    'attribute' => str_replace('_', ' ', $inputKey),
-                ]));
+                $unknownFields[] = $inputKey;
             }
+        }
+
+        if (empty($unknownFields)) {
+            return;
+        }
+
+        if (isset(static::$unknownFieldsViolationCallback)) {
+            call_user_func(static::$unknownFieldsViolationCallback, $this, $unknownFields);
+
+            return;
+        }
+
+        foreach ($unknownFields as $field) {
+            $validator->errors()->add($field, trans('validation.prohibited', [
+                'attribute' => str_replace('_', ' ', $field),
+            ]));
         }
     }
 
@@ -399,6 +422,17 @@ class FormRequest extends Request implements ValidatesWhenResolved
     }
 
     /**
+     * Register a callback that is responsible for handling unknown fields violations.
+     *
+     * @param  (callable(self, array<int, string>))|null  $callback
+     * @return void
+     */
+    public static function handleUnknownFieldsUsing(?callable $callback): void
+    {
+        static::$unknownFieldsViolationCallback = $callback;
+    }
+
+    /**
      * Set the Validator instance.
      *
      * @param  \Illuminate\Contracts\Validation\Validator  $validator
@@ -445,5 +479,6 @@ class FormRequest extends Request implements ValidatesWhenResolved
     public static function flushState(): void
     {
         static::$globalFailOnUnknownFields = false;
+        static::$unknownFieldsViolationCallback = null;
     }
 }

--- a/src/Illuminate/Foundation/Http/UnknownFieldsException.php
+++ b/src/Illuminate/Foundation/Http/UnknownFieldsException.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Illuminate\Foundation\Http;
+
+use RuntimeException;
+
+class UnknownFieldsException extends RuntimeException
+{
+    /**
+     * The class name of the form request.
+     */
+    public string $formRequest;
+
+    /**
+     * The unknown fields that were sent.
+     *
+     * @var array<int, string>
+     */
+    public array $fields;
+
+    /**
+     * Create a new exception instance.
+     *
+     * @param  array<int, string>  $fields
+     */
+    public function __construct(FormRequest $formRequest, array $fields)
+    {
+        $class = get_class($formRequest);
+
+        parent::__construct('Unknown fields ['.implode(', ', $fields)."] on form request [{$class}].");
+
+        $this->formRequest = $class;
+        $this->fields = $fields;
+    }
+}

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -12,6 +12,7 @@ use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Foundation\Http\Attributes\ErrorBag;
 use Illuminate\Foundation\Http\Attributes\FailOnUnknownFields;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Foundation\Http\UnknownFieldsException;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Routing\Redirector;
 use Illuminate\Routing\UrlGenerator;
@@ -29,6 +30,7 @@ class FoundationFormRequestTest extends TestCase
     protected function tearDown(): void
     {
         FormRequest::failOnUnknownFields(false);
+        FormRequest::handleUnknownFieldsUsing(null);
 
         Container::setInstance(null);
 
@@ -567,6 +569,63 @@ class FoundationFormRequestTest extends TestCase
 
     //     $this->assertTrue($exception->validator->errors()->has('password_confirmation'));
     // }
+
+    public function testHandleUnknownFieldsUsingCallbackIsInvokedInsteadOfAddingValidatorErrors()
+    {
+        FormRequest::failOnUnknownFields();
+
+        $callbackFields = null;
+        $callbackRequest = null;
+
+        FormRequest::handleUnknownFieldsUsing(function (FormRequest $formRequest, array $fields) use (&$callbackFields, &$callbackRequest) {
+            $callbackRequest = $formRequest;
+            $callbackFields = $fields;
+        });
+
+        $request = $this->createRequest(
+            ['name' => 'Taylor', 'unexpected' => 'value', 'also_unknown' => 'test'],
+            FoundationTestFormRequestStub::class,
+            'POST'
+        );
+
+        $request->validateResolved();
+
+        $this->assertInstanceOf(FormRequest::class, $callbackRequest);
+        $this->assertEquals(['unexpected', 'also_unknown'], $callbackFields);
+    }
+
+    public function testHandleUnknownFieldsUsingNullResetsToDefaultBehavior()
+    {
+        FormRequest::failOnUnknownFields();
+
+        FormRequest::handleUnknownFieldsUsing(function () {
+            // No-op.
+        });
+
+        FormRequest::handleUnknownFieldsUsing(null);
+
+        $request = $this->createRequest(
+            ['name' => 'Taylor', 'unexpected' => 'value'],
+            FoundationTestFormRequestStub::class,
+            'POST'
+        );
+
+        $exception = $this->catchException(ValidationException::class, function () use ($request) {
+            $request->validateResolved();
+        });
+
+        $this->assertTrue($exception->validator->errors()->has('unexpected'));
+    }
+
+    public function testUnknownFieldsExceptionContainsFormRequestAndFields()
+    {
+        $request = FoundationTestFormRequestStub::create('/', 'POST', ['name' => 'Taylor']);
+        $exception = new UnknownFieldsException($request, ['bogus', 'extra']);
+
+        $this->assertEquals(FoundationTestFormRequestStub::class, $exception->formRequest);
+        $this->assertEquals(['bogus', 'extra'], $exception->fields);
+        $this->assertStringContainsString('bogus, extra', $exception->getMessage());
+    }
 
     /**
      * Catch the given exception thrown from the executor, and return it.


### PR DESCRIPTION
For applications that enable `FormRequest::failOnUnknownFields()` globally, unknown fields currently fail validation with no way to customize the behavior — making it too brutal for production where you may want to report violations without rejecting requests. This PR adds a `handleUnknownFieldsUsing()` callback following the same pattern as `Model::handleLazyLoadingViolationUsing()`, along with an `UnknownFieldsException` for use in the callback.

```php
// AppServiceProvider::boot()
FormRequest::failOnUnknownFields();
if (app()->isProduction()) {
    FormRequest::handleUnknownFieldsUsing(function (FormRequest $formRequest, array $fields) {
        report(new UnknownFieldsException($formRequest, $fields));
    });
}
```