### PR TITLE
[13.x] Allowing `DebounceFor` attribute to be inherited

### DIFF
--- a/src/Illuminate/Bus/DebounceLock.php
+++ b/src/Illuminate/Bus/DebounceLock.php
@@ -7,7 +7,6 @@ use Illuminate\Queue\Attributes\DebounceFor;
 use Illuminate\Queue\Attributes\ReadsQueueAttributes;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
-use ReflectionClass;
 
 class DebounceLock
 {
@@ -147,11 +146,7 @@ class DebounceLock
      */
     public function getMaxDebounceWait($job)
     {
-        $attributes = (new ReflectionClass($job))->getAttributes(DebounceFor::class);
-
-        return count($attributes) > 0
-            ? $attributes[0]->newInstance()->maxWait
-            : null;
+        return $this->getAttributeInstance($job, DebounceFor::class)?->maxWait ?? null;
     }
 
     /**

--- a/src/Illuminate/Foundation/Bus/PendingDispatch.php
+++ b/src/Illuminate/Foundation/Bus/PendingDispatch.php
@@ -9,9 +9,7 @@ use Illuminate\Contracts\Bus\Dispatcher;
 use Illuminate\Contracts\Cache\Repository as Cache;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Foundation\Queue\InteractsWithUniqueJobs;
-use Illuminate\Queue\Attributes\DebounceFor;
 use LogicException;
-use ReflectionClass;
 
 class PendingDispatch
 {
@@ -218,11 +216,15 @@ class PendingDispatch
      *
      * @return void
      *
-     * @throws \LogicException
+     * @throws LogicException
      */
     protected function acquireDebounceLock()
     {
-        if (empty((new ReflectionClass($this->job))->getAttributes(DebounceFor::class))) {
+        $lock = new DebounceLock(Container::getInstance()->make(Cache::class));
+
+        $debounceFor = $lock->getDebounceDelay($this->job);
+
+        if ($debounceFor === null) {
             return;
         }
 
@@ -230,10 +232,8 @@ class PendingDispatch
             throw new LogicException('A debounced job cannot also implement ShouldBeUnique.');
         }
 
-        $lock = new DebounceLock(Container::getInstance()->make(Cache::class));
-
         $result = $lock->acquire(
-            $this->job, $debounceFor = $lock->getDebounceDelay($this->job)
+            $this->job, $debounceFor
         );
 
         $this->job->debounceOwner = $result['owner'];

--- a/src/Illuminate/Support/Traits/ReadsClassAttributes.php
+++ b/src/Illuminate/Support/Traits/ReadsClassAttributes.php
@@ -26,16 +26,8 @@ trait ReadsClassAttributes
             return $target->{$property};
         }
 
-        try {
-            do {
-                $attributes = $reflection->getAttributes($attributeClass);
-
-                if (count($attributes) > 0) {
-                    return $this->extractAttributeValue($attributes[0]->newInstance());
-                }
-            } while ($reflection = $reflection->getParentClass());
-        } catch (Exception) {
-            //
+        if ($instance = $this->getAttributeInstance($target, $attributeClass)) {
+            return $this->extractAttributeValue($instance);
         }
 
         return $target->{$property} ?? $default;
@@ -52,5 +44,31 @@ trait ReadsClassAttributes
         $properties = get_object_vars($instance);
 
         return $properties === [] ? true : reset($properties);
+    }
+
+    /**
+     * Get an instance of the given attribute class from the target class or its parents.
+     *
+     * @param object $target
+     * @param class-string $attributeClass
+     * @return object|null
+     */
+    protected function getAttributeInstance($target, string $attributeClass)
+    {
+        $reflection = new ReflectionClass($target);
+
+        try {
+            do {
+                $attributes = $reflection->getAttributes($attributeClass);
+
+                if (count($attributes) > 0) {
+                    return $attributes[0]->newInstance();
+                }
+            } while ($reflection = $reflection->getParentClass());
+        } catch (Exception) {
+            //
+        }
+
+        return null;
     }
 }

--- a/src/Illuminate/Support/Traits/ReadsClassAttributes.php
+++ b/src/Illuminate/Support/Traits/ReadsClassAttributes.php
@@ -49,8 +49,8 @@ trait ReadsClassAttributes
     /**
      * Get an instance of the given attribute class from the target class or its parents.
      *
-     * @param object $target
-     * @param class-string $attributeClass
+     * @param  object  $target
+     * @param  class-string  $attributeClass
      * @return object|null
      */
     protected function getAttributeInstance($target, string $attributeClass)

--- a/tests/Integration/Queue/DebouncedJobTest.php
+++ b/tests/Integration/Queue/DebouncedJobTest.php
@@ -314,7 +314,6 @@ class DebouncedJobTest extends QueueTestCase
 
     public function testChildDebouncedJobInheritsFromParent()
     {
-
         $this->markTestSkippedWhenUsingQueueDrivers(['sync', 'beanstalkd']);
 
         ChildOfDebouncedTestJob::$handleCount = 0;

--- a/tests/Integration/Queue/DebouncedJobTest.php
+++ b/tests/Integration/Queue/DebouncedJobTest.php
@@ -311,6 +311,28 @@ class DebouncedJobTest extends QueueTestCase
 
         $this->assertEquals(30, $job2->delay);
     }
+
+    public function testChildDebouncedJobInheritsFromParent()
+    {
+
+        $this->markTestSkippedWhenUsingQueueDrivers(['sync', 'beanstalkd']);
+
+        ChildOfDebouncedTestJob::$handleCount = 0;
+
+        // Dispatch two jobs with the same debounce identity.
+        // The second dispatch supersedes the first.
+        dispatch(new ChildOfDebouncedTestJob('entity-1'));
+        dispatch(new ChildOfDebouncedTestJob('entity-1'));
+
+        // Advance time past the debounce window so jobs become available.
+        $this->travelTo(Carbon::now()->addSeconds(31));
+
+        // Process both jobs from the queue.
+        $this->runQueueWorkerCommand(['--once' => true], 2);
+
+        // Only the second (latest) dispatch should have executed.
+        $this->assertEquals(1, ChildOfDebouncedTestJob::$handleCount);
+    }
 }
 
 #[DebounceFor(30)]
@@ -426,6 +448,27 @@ class DebouncedWithCustomCacheJob implements ShouldQueue
 
 #[DebounceFor(30, maxWait: 60)]
 class DebouncedWithMaxWaitJob implements ShouldQueue
+{
+    use InteractsWithQueue, Queueable, Dispatchable;
+
+    public static $handleCount = 0;
+
+    public function __construct(public string $entityId)
+    {
+    }
+
+    public function debounceId(): string
+    {
+        return $this->entityId;
+    }
+
+    public function handle()
+    {
+        static::$handleCount++;
+    }
+}
+
+class ChildOfDebouncedTestJob extends DebouncedTestJob implements ShouldQueue
 {
     use InteractsWithQueue, Queueable, Dispatchable;
 


### PR DESCRIPTION
This PR allows the `DebounceFor` attribute to be inherited by children job classes. Currently, children job classes cannot inherit the `DebounceFor` attribute and will not be debounced.

Side note:
Debounced jobs are almost the inverse of Unique jobs. Unique jobs handle this via the `ShouldBeUnique` interface and requiring all child jobs to implement that contract to be eligible for unique locks. If the contract exists, the accompanying attribute or property or method is scanned for and used. Debounced jobs should follow a similar pattern, but `ShouldBeDebounced` does not exist, and requiring it now after just releasing it is not ideal.
