### PR TITLE
[13.x] Allow arrays for assertSoftDeleted & assertNotSoftDeleted

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -158,6 +158,14 @@ trait InteractsWithDatabase
             );
         }
 
+        if (array_is_list($data) && array_all($data, fn ($row) => is_array($row))) {
+            foreach ($data as $row) {
+                $this->assertSoftDeleted($table, $row, $connection, $deletedAtColumn);
+            }
+
+            return $this;
+        }
+
         $this->assertThat(
             $this->getTable($table),
             new SoftDeletedInDatabase(
@@ -196,6 +204,14 @@ trait InteractsWithDatabase
                 $table->getConnectionName(),
                 $table->getDeletedAtColumn()
             );
+        }
+
+        if (array_is_list($data) && array_all($data, fn ($row) => is_array($row))) {
+            foreach ($data as $row) {
+                $this->assertNotSoftDeleted($table, $row, $connection, $deletedAtColumn);
+            }
+
+            return $this;
         }
 
         $this->assertThat(

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -158,7 +158,7 @@ trait InteractsWithDatabase
             );
         }
 
-        if (array_is_list($data) && array_all($data, fn ($row) => is_array($row))) {
+        if ($data !== [] && array_is_list($data) && array_all($data, fn ($row) => is_array($row))) {
             foreach ($data as $row) {
                 $this->assertSoftDeleted($table, $row, $connection, $deletedAtColumn);
             }
@@ -206,7 +206,7 @@ trait InteractsWithDatabase
             );
         }
 
-        if (array_is_list($data) && array_all($data, fn ($row) => is_array($row))) {
+        if ($data !== [] && array_is_list($data) && array_all($data, fn ($row) => is_array($row))) {
             foreach ($data as $row) {
                 $this->assertNotSoftDeleted($table, $row, $connection, $deletedAtColumn);
             }

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -205,6 +205,38 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->assertDatabaseCount($this->table, 3);
     }
 
+    public function testAssertSoftDeletedSupportsArrays()
+    {
+        $builder = m::mock(Builder::class);
+        $builder->shouldReceive('where')->with(['title' => 'Spark', 'name' => 'Laravel'])->once()->andReturnSelf();
+        $builder->shouldReceive('where')->with(['title' => 'Forge', 'name' => 'Laravel'])->once()->andReturnSelf();
+        $builder->shouldReceive('whereNotNull')->with('deleted_at')->twice()->andReturnSelf();
+        $builder->shouldReceive('exists')->twice()->andReturn(true);
+
+        $this->connection->shouldReceive('table')->with($this->table)->andReturn($builder);
+
+        $this->assertSoftDeleted($this->table, [
+            ['title' => 'Spark', 'name' => 'Laravel'],
+            ['title' => 'Forge', 'name' => 'Laravel'],
+        ]);
+    }
+
+    public function testAssertNotSoftDeletedSupportsArrays()
+    {
+        $builder = m::mock(Builder::class);
+        $builder->shouldReceive('where')->with(['title' => 'Spark', 'name' => 'Laravel'])->once()->andReturnSelf();
+        $builder->shouldReceive('where')->with(['title' => 'Forge', 'name' => 'Laravel'])->once()->andReturnSelf();
+        $builder->shouldReceive('whereNull')->with('deleted_at')->twice()->andReturnSelf();
+        $builder->shouldReceive('exists')->twice()->andReturn(true);
+
+        $this->connection->shouldReceive('table')->with($this->table)->andReturn($builder);
+
+        $this->assertNotSoftDeleted($this->table, [
+            ['title' => 'Spark', 'name' => 'Laravel'],
+            ['title' => 'Forge', 'name' => 'Laravel'],
+        ]);
+    }
+
     public function testAssertDatabaseMissingPassesWhenDoesNotFindResults()
     {
         $this->mockCountBuilder(false);


### PR DESCRIPTION
Good day Taylor!

Following on from https://github.com/laravel/framework/pull/59752

This allows an array of arrays, for `assertSoftDeleted` and `assertNotSoftDeleted` which means we can now do things like: 

```php
  $this->assertSoftDeleted(User::class, [                                                                                                      
      ['id' => 1, 'email' => 'taylor@laravel.com'],                                                                                            
      ['id' => 2, 'email' => 'jack@laravel.com'],
  ]);
  
    $this->assertNotSoftDeleted(User::class, [                                                                                                      
      ['id' => 1, 'email' => 'drake@laravel.com'],                                                                                            
      ['id' => 2, 'email' => 'skepta@laravel.com'],
  ]);
```

This means all the assert methods now allow it, completing the full set which is what I and my team use locally:
  - assertDatabaseHas                                                                                                                          
  - assertDatabaseMissing                                                                                                                      
  - assertSoftDeleted                                                                                                                          
  - assertNotSoftDeleted   
  

  (Last of my testing PRs! I promise)
