### PR TITLE
[13.x] Add cluster_aware Redis mode for managed single-endpoint providers

### DIFF
--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -5,9 +5,7 @@ namespace Illuminate\Cache;
 use Illuminate\Contracts\Cache\CanFlushLocks;
 use Illuminate\Contracts\Cache\LockProvider;
 use Illuminate\Contracts\Redis\Factory as Redis;
-use Illuminate\Redis\Connections\PhpRedisClusterConnection;
 use Illuminate\Redis\Connections\PhpRedisConnection;
-use Illuminate\Redis\Connections\PredisClusterConnection;
 use Illuminate\Redis\Connections\PredisConnection;
 use Illuminate\Support\LazyCollection;
 use Illuminate\Support\Str;
@@ -104,8 +102,7 @@ class RedisStore extends TaggableStore implements CanFlushLocks, LockProvider
 
         $connection = $this->connection();
 
-        // PredisClusterConnection does not support reading multiple values if the keys hash differently...
-        if ($connection instanceof PredisClusterConnection) {
+        if (! $connection->supportsMultiSlotMultiKeyCommands()) {
             return $this->manyAlias($keys);
         }
 
@@ -148,9 +145,7 @@ class RedisStore extends TaggableStore implements CanFlushLocks, LockProvider
     {
         $connection = $this->connection();
 
-        // Cluster connections do not support writing multiple values if the keys hash differently...
-        if ($connection instanceof PhpRedisClusterConnection ||
-            $connection instanceof PredisClusterConnection) {
+        if ($connection->isClusterAware()) {
             return $this->putManyAlias($values, $seconds);
         }
 

--- a/src/Illuminate/Cache/RedisTaggedCache.php
+++ b/src/Illuminate/Cache/RedisTaggedCache.php
@@ -4,9 +4,7 @@ namespace Illuminate\Cache;
 
 use Illuminate\Cache\Events\CacheFlushed;
 use Illuminate\Cache\Events\CacheFlushing;
-use Illuminate\Redis\Connections\PhpRedisClusterConnection;
 use Illuminate\Redis\Connections\PhpRedisConnection;
-use Illuminate\Redis\Connections\PredisClusterConnection;
 use Illuminate\Redis\Connections\PredisConnection;
 
 use function Illuminate\Support\enum_value;
@@ -124,8 +122,7 @@ class RedisTaggedCache extends TaggedCache
     {
         $connection = $this->store->connection();
 
-        if ($connection instanceof PredisClusterConnection ||
-            $connection instanceof PhpRedisClusterConnection) {
+        if ($connection->isClusterAware()) {
             return $this->flushClusteredConnection();
         }
 
@@ -206,7 +203,7 @@ class RedisTaggedCache extends TaggedCache
         $connection = $this->store->connection();
 
         foreach ($entries as $cacheKeys) {
-            if ($connection instanceof PredisClusterConnection) {
+            if (! $connection->supportsMultiSlotMultiKeyCommands()) {
                 $connection->pipeline(function ($connection) use ($cacheKeys) {
                     foreach ($cacheKeys as $cacheKey) {
                         $connection->del($cacheKey);

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -69,11 +69,11 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
     protected $secondaryQueueHadJob = false;
 
     /**
-     * Indicates if the connection is a Redis Cluster connection.
+     * Indicates if the connection should use cluster-safe key layouts.
      *
      * @var bool|null
      */
-    protected $isCluster = null;
+    protected $isClusterAware = null;
 
     /**
      * Create a new Redis queue instance.
@@ -506,7 +506,7 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
     {
         $queue = $queue ?: $this->default;
 
-        return $this->isClusterConnection() && ! Connection::hasHashTag($queue)
+        return $this->isClusterAwareConnection() && ! Connection::hasHashTag($queue)
             ? $this->getQueue('{'.$queue.'}')
             : $this->getQueue($queue);
     }
@@ -522,13 +522,13 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
     }
 
     /**
-     * Determine if the connection is a Redis Cluster connection.
+     * Determine if the connection should use cluster-safe key layouts.
      *
      * @return bool
      */
-    protected function isClusterConnection()
+    protected function isClusterAwareConnection()
     {
-        return $this->isCluster ??= $this->getConnection()->isCluster();
+        return $this->isClusterAware ??= $this->getConnection()->isClusterAware();
     }
 
     /**

--- a/src/Illuminate/Redis/Connections/Connection.php
+++ b/src/Illuminate/Redis/Connections/Connection.php
@@ -25,6 +25,13 @@ abstract class Connection
     protected $client;
 
     /**
+     * The connection configuration array.
+     *
+     * @var array
+     */
+    protected $config = [];
+
+    /**
      * The Redis connection name.
      *
      * @var string|null
@@ -183,13 +190,36 @@ abstract class Connection
     }
 
     /**
-     * Determine if the connection is a cluster connection.
+     * Determine if the underlying client is a Redis Cluster client.
      *
      * @return bool
      */
     public function isCluster()
     {
         return false;
+    }
+
+    /**
+     * Determine if the connection should use cluster-safe key layouts.
+     *
+     * True for real cluster clients and for standalone connections with
+     * `cluster_aware: true` (e.g. ElastiCache Serverless, Upstash, DMC proxy).
+     *
+     * @return bool
+     */
+    public function isClusterAware()
+    {
+        return $this->isCluster() || (bool) ($this->config['cluster_aware'] ?? false);
+    }
+
+    /**
+     * Determine if the client routes a single multi-key command across slots.
+     *
+     * @return bool
+     */
+    public function supportsMultiSlotMultiKeyCommands()
+    {
+        return ! $this->isClusterAware();
     }
 
     /**

--- a/src/Illuminate/Redis/Connections/PhpRedisClusterConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisClusterConnection.php
@@ -89,4 +89,15 @@ class PhpRedisClusterConnection extends PhpRedisConnection
     {
         return true;
     }
+
+    /**
+     * Determine if the client routes a single multi-key command across slots.
+     *
+     * @return bool
+     */
+    #[\Override]
+    public function supportsMultiSlotMultiKeyCommands()
+    {
+        return true;
+    }
 }

--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -23,13 +23,6 @@ class PhpRedisConnection extends Connection implements ConnectionContract
     protected $connector;
 
     /**
-     * The connection configuration array.
-     *
-     * @var array
-     */
-    protected $config;
-
-    /**
      * Create a new PhpRedis connection.
      *
      * @param  \Redis  $client

--- a/src/Illuminate/Redis/Connections/PredisConnection.php
+++ b/src/Illuminate/Redis/Connections/PredisConnection.php
@@ -23,10 +23,12 @@ class PredisConnection extends Connection implements ConnectionContract
      * Create a new Predis connection.
      *
      * @param  \Predis\Client  $client
+     * @param  array  $config
      */
-    public function __construct($client)
+    public function __construct($client, array $config = [])
     {
         $this->client = $client;
+        $this->config = $config;
     }
 
     /**

--- a/src/Illuminate/Redis/Connectors/PredisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PredisConnector.php
@@ -33,7 +33,7 @@ class PredisConnector implements Connector
             $config['host'] = Str::after($config['host'], 'tls://');
         }
 
-        return new PredisConnection(new Client($config, $formattedOptions));
+        return new PredisConnection(new Client($config, $formattedOptions), $config);
     }
 
     /**

--- a/src/Illuminate/Redis/Limiters/ConcurrencyLimiter.php
+++ b/src/Illuminate/Redis/Limiters/ConcurrencyLimiter.php
@@ -185,7 +185,7 @@ LUA;
     protected function getPrefix()
     {
         if (is_null($this->prefix)) {
-            $this->prefix = $this->redis->isCluster() && ! Connection::hasHashTag($this->name)
+            $this->prefix = $this->redis->isClusterAware() && ! Connection::hasHashTag($this->name)
                 ? '{'.$this->name.'}'
                 : $this->name;
         }

--- a/src/Illuminate/Support/Facades/Redis.php
+++ b/src/Illuminate/Support/Facades/Redis.php
@@ -21,6 +21,8 @@ namespace Illuminate\Support\Facades;
  * @method static void listen(\Closure $callback)
  * @method static void listenForFailures(\Closure $callback)
  * @method static bool isCluster()
+ * @method static bool isClusterAware()
+ * @method static bool supportsMultiSlotMultiKeyCommands()
  * @method static string|null getName()
  * @method static \Illuminate\Redis\Connections\Connection setName(string $name)
  * @method static \Illuminate\Contracts\Events\Dispatcher|null getEventDispatcher()

--- a/tests/Cache/CacheRedisStoreTest.php
+++ b/tests/Cache/CacheRedisStoreTest.php
@@ -29,6 +29,7 @@ class CacheRedisStoreTest extends TestCase
     {
         $redis = $this->getRedis();
         $redis->getRedis()->shouldReceive('connection')->once()->with('default')->andReturn($redis->getRedis());
+        $redis->getRedis()->shouldReceive('supportsMultiSlotMultiKeyCommands')->andReturn(true);
         $redis->getRedis()->shouldReceive('mget')->once()->with(['prefix:foo', 'prefix:fizz', 'prefix:norf', 'prefix:null'])
             ->andReturn([
                 serialize('bar'),
@@ -43,6 +44,21 @@ class CacheRedisStoreTest extends TestCase
         $this->assertSame('buzz', $results['fizz']);
         $this->assertSame('quz', $results['norf']);
         $this->assertNull($results['null']);
+    }
+
+    public function testManyFallsBackToPerKeyWhenMultiSlotMultiKeyUnsupported()
+    {
+        $redis = $this->getRedis();
+        $redis->getRedis()->shouldReceive('connection')->with('default')->andReturn($redis->getRedis());
+        $redis->getRedis()->shouldReceive('supportsMultiSlotMultiKeyCommands')->andReturn(false);
+        $redis->getRedis()->shouldNotReceive('mget');
+        $redis->getRedis()->shouldReceive('get')->once()->with('prefix:foo')->andReturn(serialize('bar'));
+        $redis->getRedis()->shouldReceive('get')->once()->with('prefix:baz')->andReturn(null);
+
+        $results = $redis->many(['foo', 'baz']);
+
+        $this->assertSame('bar', $results['foo']);
+        $this->assertNull($results['baz']);
     }
 
     public function testRedisValueIsReturnedForNumerics()
@@ -68,6 +84,7 @@ class CacheRedisStoreTest extends TestCase
         /** @var m\MockInterface $connection */
         $connection = $redis->getRedis();
         $connection->shouldReceive('connection')->with('default')->andReturn($redis->getRedis());
+        $connection->shouldReceive('isClusterAware')->andReturn(false);
         $connection->shouldReceive('multi')->once();
         $redis->getRedis()->shouldReceive('setex')->once()->with('prefix:foo', 60, serialize('bar'))->andReturn('OK');
         $redis->getRedis()->shouldReceive('setex')->once()->with('prefix:baz', 60, serialize('qux'))->andReturn('OK');
@@ -78,6 +95,24 @@ class CacheRedisStoreTest extends TestCase
             'foo' => 'bar',
             'baz' => 'qux',
             'bar' => 'norf',
+        ], 60);
+        $this->assertTrue($result);
+    }
+
+    public function testPutManyFallsBackToPerKeyOnClusterAwareStandalone()
+    {
+        $redis = $this->getRedis();
+        $connection = $redis->getRedis();
+        $connection->shouldReceive('connection')->with('default')->andReturn($redis->getRedis());
+        $connection->shouldReceive('isClusterAware')->andReturn(true);
+        $connection->shouldNotReceive('multi');
+        $connection->shouldNotReceive('exec');
+        $connection->shouldReceive('setex')->once()->with('prefix:foo', 60, serialize('bar'))->andReturn('OK');
+        $connection->shouldReceive('setex')->once()->with('prefix:baz', 60, serialize('qux'))->andReturn('OK');
+
+        $result = $redis->putMany([
+            'foo' => 'bar',
+            'baz' => 'qux',
         ], 60);
         $this->assertTrue($result);
     }

--- a/tests/Integration/Cache/RedisStoreTest.php
+++ b/tests/Integration/Cache/RedisStoreTest.php
@@ -245,8 +245,11 @@ class RedisStoreTest extends TestCase
 
     public function testPutManyCallsPutWhenClustered()
     {
+        $connection = m::mock(PhpRedisClusterConnection::class);
+        $connection->expects('isClusterAware')->andReturn(true);
+
         $store = m::mock(RedisStore::class)->makePartial();
-        $store->expects('connection')->andReturn(m::mock(PhpRedisClusterConnection::class));
+        $store->expects('connection')->andReturn($connection);
         $store->expects('put')
             ->twice()
             ->andReturn(true);

--- a/tests/Queue/QueueRedisQueueTest.php
+++ b/tests/Queue/QueueRedisQueueTest.php
@@ -31,7 +31,7 @@ class QueueRedisQueueTest extends TestCase
         $queue->expects($this->once())->method('getRandomId')->willReturn('foo');
         $queue->setContainer($container = m::spy(Container::class));
         $redis->shouldReceive('connection')->atLeast()->once()->andReturn($redis);
-        $redis->shouldReceive('isCluster')->andReturn(false);
+        $redis->shouldReceive('isClusterAware')->andReturn(false);
         $redis->shouldReceive('eval')->once()->with(LuaScripts::push(), 2, 'queues:default', 'queues:default:notify', json_encode(['uuid' => $uuid, 'displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'maxExceptions' => null, 'failOnTimeout' => false, 'backoff' => null, 'timeout' => null, 'data' => ['data'], 'createdAt' => $time->getTimestamp(), 'id' => 'foo', 'attempts' => 0, 'delay' => null]));
 
         $id = $queue->push('foo', ['data']);
@@ -57,7 +57,7 @@ class QueueRedisQueueTest extends TestCase
         $queue->expects($this->once())->method('getRandomId')->willReturn('foo');
         $queue->setContainer($container = m::spy(Container::class));
         $redis->shouldReceive('connection')->atLeast()->once()->andReturn($redis);
-        $redis->shouldReceive('isCluster')->andReturn(false);
+        $redis->shouldReceive('isClusterAware')->andReturn(false);
         $redis->shouldReceive('eval')->once()->with(LuaScripts::push(), 2, 'queues:default', 'queues:default:notify', json_encode(['uuid' => $uuid, 'displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'maxExceptions' => null, 'failOnTimeout' => false, 'backoff' => null, 'timeout' => null, 'data' => ['data'], 'createdAt' => $time->getTimestamp(), 'custom' => 'taylor', 'id' => 'foo', 'attempts' => 0, 'delay' => null]));
 
         Queue::createPayloadUsing(function ($connection, $queue, $payload) {
@@ -89,7 +89,7 @@ class QueueRedisQueueTest extends TestCase
         $queue->expects($this->once())->method('getRandomId')->willReturn('foo');
         $queue->setContainer($container = m::spy(Container::class));
         $redis->shouldReceive('connection')->atLeast()->once()->andReturn($redis);
-        $redis->shouldReceive('isCluster')->andReturn(false);
+        $redis->shouldReceive('isClusterAware')->andReturn(false);
         $redis->shouldReceive('eval')->once()->with(LuaScripts::push(), 2, 'queues:default', 'queues:default:notify', json_encode(['uuid' => $uuid, 'displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'maxExceptions' => null, 'failOnTimeout' => false, 'backoff' => null, 'timeout' => null, 'data' => ['data'], 'createdAt' => $time->getTimestamp(), 'custom' => 'taylor', 'bar' => 'foo', 'id' => 'foo', 'attempts' => 0, 'delay' => null]));
 
         Queue::createPayloadUsing(function ($connection, $queue, $payload) {
@@ -127,7 +127,7 @@ class QueueRedisQueueTest extends TestCase
         $queue->expects($this->once())->method('availableAt')->with(1)->willReturn(2);
 
         $redis->shouldReceive('connection')->atLeast()->once()->andReturn($redis);
-        $redis->shouldReceive('isCluster')->andReturn(false);
+        $redis->shouldReceive('isClusterAware')->andReturn(false);
         $redis->shouldReceive('eval')->once()->with(
             LuaScripts::later(),
             1,
@@ -160,7 +160,7 @@ class QueueRedisQueueTest extends TestCase
         $queue->expects($this->once())->method('availableAt')->with($date)->willReturn(5);
 
         $redis->shouldReceive('connection')->atLeast()->once()->andReturn($redis);
-        $redis->shouldReceive('isCluster')->andReturn(false);
+        $redis->shouldReceive('isClusterAware')->andReturn(false);
         $redis->shouldReceive('eval')->once()->with(
             LuaScripts::later(),
             1,
@@ -197,7 +197,7 @@ class QueueRedisQueueTest extends TestCase
     {
         $queue = new TestableRedisQueue($redis = m::mock(Factory::class), 'default');
         $connection = m::mock(\Illuminate\Redis\Connections\Connection::class);
-        $connection->shouldReceive('isCluster')->andReturn(false);
+        $connection->shouldReceive('isClusterAware')->andReturn(false);
         $redis->shouldReceive('connection')->andReturn($connection);
 
         $this->assertSame('queues:default', $queue->testGetQueueRedisKey(null));
@@ -208,7 +208,7 @@ class QueueRedisQueueTest extends TestCase
     {
         $queue = new TestableRedisQueue($redis = m::mock(Factory::class), 'default');
         $connection = m::mock(PhpRedisClusterConnection::class);
-        $connection->shouldReceive('isCluster')->andReturn(true);
+        $connection->shouldReceive('isClusterAware')->andReturn(true);
         $redis->shouldReceive('connection')->andReturn($connection);
 
         $this->assertSame('queues:{default}', $queue->testGetQueueRedisKey(null));
@@ -219,7 +219,7 @@ class QueueRedisQueueTest extends TestCase
     {
         $queue = new TestableRedisQueue($redis = m::mock(Factory::class), 'default');
         $connection = m::mock(PredisClusterConnection::class);
-        $connection->shouldReceive('isCluster')->andReturn(true);
+        $connection->shouldReceive('isClusterAware')->andReturn(true);
         $redis->shouldReceive('connection')->andReturn($connection);
 
         $this->assertSame('queues:{default}', $queue->testGetQueueRedisKey(null));
@@ -230,7 +230,7 @@ class QueueRedisQueueTest extends TestCase
     {
         $queue = new TestableRedisQueue($redis = m::mock(Factory::class), '{default}');
         $connection = m::mock(PhpRedisClusterConnection::class);
-        $connection->shouldReceive('isCluster')->andReturn(true);
+        $connection->shouldReceive('isClusterAware')->andReturn(true);
         $redis->shouldReceive('connection')->andReturn($connection);
 
         $this->assertSame('queues:{default}', $queue->testGetQueueRedisKey(null));
@@ -241,7 +241,7 @@ class QueueRedisQueueTest extends TestCase
     {
         $queue = new TestableRedisQueue($redis = m::mock(Factory::class), 'default');
         $connection = m::mock(PhpRedisClusterConnection::class);
-        $connection->shouldReceive('isCluster')->andReturn(true);
+        $connection->shouldReceive('isClusterAware')->andReturn(true);
         $redis->shouldReceive('connection')->andReturn($connection);
 
         // Queue name already contains hash tags — skip wrapping
@@ -252,7 +252,7 @@ class QueueRedisQueueTest extends TestCase
     {
         $queue = new TestableRedisQueue($redis = m::mock(Factory::class), 'default');
         $connection = m::mock(PhpRedisClusterConnection::class);
-        $connection->shouldReceive('isCluster')->andReturn(true);
+        $connection->shouldReceive('isClusterAware')->andReturn(true);
         $redis->shouldReceive('connection')->andReturn($connection);
 
         // Empty braces '{}' are not a valid hash tag — should still get wrapped
@@ -263,7 +263,7 @@ class QueueRedisQueueTest extends TestCase
     {
         $queue = new TestableRedisQueue($redis = m::mock(Factory::class), 'default');
         $connection = m::mock(PhpRedisClusterConnection::class);
-        $connection->shouldReceive('isCluster')->andReturn(true);
+        $connection->shouldReceive('isClusterAware')->andReturn(true);
         $redis->shouldReceive('connection')->andReturn($connection);
 
         // Unmatched '{' is not a valid hash tag — should still get wrapped
@@ -274,7 +274,7 @@ class QueueRedisQueueTest extends TestCase
     {
         $queue = new TestableRedisQueue($redis = m::mock(Factory::class), 'default');
         $connection = m::mock(PhpRedisClusterConnection::class);
-        $connection->shouldReceive('isCluster')->andReturn(true);
+        $connection->shouldReceive('isClusterAware')->andReturn(true);
         $redis->shouldReceive('connection')->andReturn($connection);
 
         // Unmatched '}' is not a valid hash tag — should still get wrapped
@@ -285,7 +285,7 @@ class QueueRedisQueueTest extends TestCase
     {
         $queue = new TestableRedisQueue($redis = m::mock(Factory::class), 'default');
         $connection = m::mock(PhpRedisClusterConnection::class);
-        $connection->shouldReceive('isCluster')->andReturn(true);
+        $connection->shouldReceive('isClusterAware')->andReturn(true);
         $redis->shouldReceive('connection')->andReturn($connection);
 
         // Redis spec: the first '{}' is an empty hash tag, so the whole key is hashed
@@ -309,7 +309,7 @@ class QueueRedisQueueTest extends TestCase
         $queue->setContainer($container = m::spy(Container::class));
 
         $clusterConnection = m::mock(PhpRedisClusterConnection::class)->shouldIgnoreMissing();
-        $clusterConnection->shouldReceive('isCluster')->andReturn(true);
+        $clusterConnection->shouldReceive('isClusterAware')->andReturn(true);
         $redis->shouldReceive('connection')->andReturn($clusterConnection);
 
         // command() is called by eval() — assert it receives hash-tagged keys
@@ -342,7 +342,7 @@ class QueueRedisQueueTest extends TestCase
         $queue->setContainer($container = m::spy(Container::class));
 
         $clusterConnection = m::mock(PhpRedisClusterConnection::class)->shouldIgnoreMissing();
-        $clusterConnection->shouldReceive('isCluster')->andReturn(true);
+        $clusterConnection->shouldReceive('isClusterAware')->andReturn(true);
         $redis->shouldReceive('connection')->andReturn($clusterConnection);
 
         $receivedQueue = null;
@@ -366,7 +366,7 @@ class QueueRedisQueueTest extends TestCase
     {
         $queue = new RedisQueue($redis = m::mock(Factory::class), 'default');
         $clusterConnection = m::mock(PhpRedisClusterConnection::class)->shouldIgnoreMissing();
-        $clusterConnection->shouldReceive('isCluster')->andReturn(true);
+        $clusterConnection->shouldReceive('isClusterAware')->andReturn(true);
         $redis->shouldReceive('connection')->andReturn($clusterConnection);
 
         $clusterConnection->shouldReceive('command')->once()->with('eval', m::on(function ($args) {
@@ -384,7 +384,7 @@ class QueueRedisQueueTest extends TestCase
     {
         $queue = new RedisQueue($redis = m::mock(Factory::class), 'default');
         $clusterConnection = m::mock(PhpRedisClusterConnection::class)->shouldIgnoreMissing();
-        $clusterConnection->shouldReceive('isCluster')->andReturn(true);
+        $clusterConnection->shouldReceive('isClusterAware')->andReturn(true);
         $redis->shouldReceive('connection')->andReturn($clusterConnection);
 
         $clusterConnection->shouldReceive('command')->once()->with('eval', m::on(function ($args) {
@@ -399,17 +399,17 @@ class QueueRedisQueueTest extends TestCase
         $this->assertSame(3, $queue->clear('default'));
     }
 
-    public function testIsClusterConnectionCachesResult()
+    public function testIsClusterAwareConnectionCachesResult()
     {
         $queue = new TestableRedisQueue($redis = m::mock(Factory::class), 'default');
         $connection = m::mock(PhpRedisClusterConnection::class);
-        $connection->shouldReceive('isCluster')->once()->andReturn(true);
+        $connection->shouldReceive('isClusterAware')->once()->andReturn(true);
         $redis->shouldReceive('connection')->once()->andReturn($connection);
 
         // Multiple calls should only trigger one connection() call
-        $this->assertTrue($queue->testIsClusterConnection());
-        $this->assertTrue($queue->testIsClusterConnection());
-        $this->assertTrue($queue->testIsClusterConnection());
+        $this->assertTrue($queue->testIsClusterAwareConnection());
+        $this->assertTrue($queue->testIsClusterAwareConnection());
+        $this->assertTrue($queue->testIsClusterAwareConnection());
     }
 }
 
@@ -420,8 +420,8 @@ class TestableRedisQueue extends RedisQueue
         return $this->getQueueRedisKey($queue);
     }
 
-    public function testIsClusterConnection()
+    public function testIsClusterAwareConnection()
     {
-        return $this->isClusterConnection();
+        return $this->isClusterAwareConnection();
     }
 }

--- a/tests/Redis/ConcurrencyLimiterTest.php
+++ b/tests/Redis/ConcurrencyLimiterTest.php
@@ -15,7 +15,7 @@ class ConcurrencyLimiterTest extends TestCase
     public function testAcquireUsesHashTagsOnPhpRedisClusterConnection()
     {
         $connection = m::mock(PhpRedisClusterConnection::class);
-        $connection->shouldReceive('isCluster')->andReturn(true);
+        $connection->shouldReceive('isClusterAware')->andReturn(true);
 
         // acquire() calls eval → command('eval', ...) with the lock script
         $connection->shouldReceive('command')->once()->with('eval', m::on(function ($args) {
@@ -44,7 +44,7 @@ class ConcurrencyLimiterTest extends TestCase
     public function testAcquireUsesPlainKeysOnNonClusterConnection()
     {
         $connection = m::mock(PhpRedisConnection::class);
-        $connection->shouldReceive('isCluster')->andReturn(false);
+        $connection->shouldReceive('isClusterAware')->andReturn(false);
 
         $connection->shouldReceive('command')->once()->with('eval', m::on(function ($args) {
             return str_contains($args[0], 'mget')
@@ -70,7 +70,7 @@ class ConcurrencyLimiterTest extends TestCase
     public function testAcquireUsesHashTagsOnPredisClusterConnection()
     {
         $connection = m::mock(PredisClusterConnection::class);
-        $connection->shouldReceive('isCluster')->andReturn(true);
+        $connection->shouldReceive('isClusterAware')->andReturn(true);
 
         $connection->shouldReceive('eval')->once()->with(
             m::on(fn ($s) => str_contains($s, 'mget')),
@@ -96,7 +96,7 @@ class ConcurrencyLimiterTest extends TestCase
     public function testReleaseKeyMatchesAcquireKeyOnCluster()
     {
         $connection = m::mock(PhpRedisClusterConnection::class);
-        $connection->shouldReceive('isCluster')->andReturn(true);
+        $connection->shouldReceive('isClusterAware')->andReturn(true);
 
         // Acquire returns the slot key
         $connection->shouldReceive('command')->once()->with('eval', m::on(function ($args) {
@@ -118,7 +118,7 @@ class ConcurrencyLimiterTest extends TestCase
     public function testAcquireDoesNotDoubleWrapPreExistingHashTags()
     {
         $connection = m::mock(PhpRedisClusterConnection::class);
-        $connection->shouldReceive('isCluster')->andReturn(true);
+        $connection->shouldReceive('isClusterAware')->andReturn(true);
 
         // Name already has hash tags — should NOT be double-wrapped
         $connection->shouldReceive('command')->once()->with('eval', m::on(function ($args) {
@@ -144,7 +144,7 @@ class ConcurrencyLimiterTest extends TestCase
     public function testAcquireWrapsUnmatchedBraceOnCluster()
     {
         $connection = m::mock(PhpRedisClusterConnection::class);
-        $connection->shouldReceive('isCluster')->andReturn(true);
+        $connection->shouldReceive('isClusterAware')->andReturn(true);
 
         // Name has '{' but no '}' — not a valid hash tag, should be wrapped
         $connection->shouldReceive('command')->once()->with('eval', m::on(function ($args) {
@@ -170,7 +170,7 @@ class ConcurrencyLimiterTest extends TestCase
     public function testAcquireWrapsEmptyBracesOnCluster()
     {
         $connection = m::mock(PhpRedisClusterConnection::class);
-        $connection->shouldReceive('isCluster')->andReturn(true);
+        $connection->shouldReceive('isClusterAware')->andReturn(true);
 
         // Name has '{}' but that's an empty hash tag — should be wrapped
         $connection->shouldReceive('command')->once()->with('eval', m::on(function ($args) {
@@ -196,7 +196,7 @@ class ConcurrencyLimiterTest extends TestCase
     public function testAcquireUsesPlainKeysOnPredisNonClusterConnection()
     {
         $connection = m::mock(PredisConnection::class);
-        $connection->shouldReceive('isCluster')->andReturn(false);
+        $connection->shouldReceive('isClusterAware')->andReturn(false);
 
         $connection->shouldReceive('eval')->once()->with(
             m::on(fn ($s) => str_contains($s, 'mget')),

--- a/tests/Redis/Connections/PhpRedisConnectionTest.php
+++ b/tests/Redis/Connections/PhpRedisConnectionTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Illuminate\Tests\Redis\Connections;
+
+use Illuminate\Redis\Connections\PhpRedisConnection;
+use Mockery as m;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+use PHPUnit\Framework\TestCase;
+
+#[RequiresPhpExtension('redis')]
+class PhpRedisConnectionTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+
+        parent::tearDown();
+    }
+
+    public function testIsClusterReturnsFalseForStandaloneConnection()
+    {
+        $connection = new PhpRedisConnection(m::mock(\Redis::class));
+
+        $this->assertFalse($connection->isCluster());
+    }
+
+    public function testIsClusterReturnsFalseEvenWhenClusterAwareFlagSet()
+    {
+        $connection = new PhpRedisConnection(
+            m::mock(\Redis::class),
+            null,
+            ['cluster_aware' => true],
+        );
+
+        // isCluster() is strictly about being a real cluster client,
+        // which a standalone connection never is regardless of config flags.
+        $this->assertFalse($connection->isCluster());
+    }
+
+    public function testIsClusterAwareReturnsFalseByDefault()
+    {
+        $connection = new PhpRedisConnection(m::mock(\Redis::class));
+
+        $this->assertFalse($connection->isClusterAware());
+    }
+
+    public function testIsClusterAwareReturnsFalseWhenFlagDisabled()
+    {
+        $connection = new PhpRedisConnection(
+            m::mock(\Redis::class),
+            null,
+            ['cluster_aware' => false],
+        );
+
+        $this->assertFalse($connection->isClusterAware());
+    }
+
+    public function testIsClusterAwareReturnsTrueWhenFlagSet()
+    {
+        $connection = new PhpRedisConnection(
+            m::mock(\Redis::class),
+            null,
+            ['cluster_aware' => true],
+        );
+
+        $this->assertTrue($connection->isClusterAware());
+    }
+
+    public function testIsClusterAwareTreatsTruthyFlagAsEnabled()
+    {
+        $connection = new PhpRedisConnection(
+            m::mock(\Redis::class),
+            null,
+            ['cluster_aware' => '1'],
+        );
+
+        $this->assertTrue($connection->isClusterAware());
+    }
+}

--- a/tests/Redis/Connections/PredisConnectionTest.php
+++ b/tests/Redis/Connections/PredisConnectionTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Illuminate\Tests\Redis\Connections;
+
+use Illuminate\Redis\Connections\PredisConnection;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Predis\Client;
+
+class PredisConnectionTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+
+        parent::tearDown();
+    }
+
+    public function testIsClusterReturnsFalseForStandaloneConnection()
+    {
+        $connection = new PredisConnection(m::mock(Client::class));
+
+        $this->assertFalse($connection->isCluster());
+    }
+
+    public function testIsClusterReturnsFalseEvenWhenClusterAwareFlagSet()
+    {
+        $connection = new PredisConnection(
+            m::mock(Client::class),
+            ['cluster_aware' => true],
+        );
+
+        $this->assertFalse($connection->isCluster());
+    }
+
+    public function testIsClusterAwareReturnsFalseByDefault()
+    {
+        $connection = new PredisConnection(m::mock(Client::class));
+
+        $this->assertFalse($connection->isClusterAware());
+    }
+
+    public function testIsClusterAwareReturnsFalseWhenFlagDisabled()
+    {
+        $connection = new PredisConnection(
+            m::mock(Client::class),
+            ['cluster_aware' => false],
+        );
+
+        $this->assertFalse($connection->isClusterAware());
+    }
+
+    public function testIsClusterAwareReturnsTrueWhenFlagSet()
+    {
+        $connection = new PredisConnection(
+            m::mock(Client::class),
+            ['cluster_aware' => true],
+        );
+
+        $this->assertTrue($connection->isClusterAware());
+    }
+}


### PR DESCRIPTION
Several managed Redis providers - AWS ElastiCache Serverless (Valkey), Upstash Redis, Redis Cloud with the DMC proxy - present a Redis Cluster behind a **single endpoint** while blocking the `CLUSTER` topology commands, so the client can't configure itself as a real cluster client. The endpoint still enforces slot semantics: multi-key commands return `CROSSSLOT` unless every key hashes to the same slot.

Laravel breaks out of the box on these providers. `Cache::many()`, `Cache::putMany()`, tagged cache `flush()`, and every queue `push` / `pop` / `later` / `migrate` script issue multi-key commands with no slot guarantee.

The existing hash-tag handling from #59533 only fires for real cluster clients - but here the client is standalone and only the server is clustered. There's no runtime signal to detect this, so the signal has to come from config.

This PR introduces a `cluster_aware` flag, opt-in per connection:

```php
// config/database.php
'redis' => [
    'default' => [
        // ...
        'cluster_aware' => true,
    ],
],
```

When set, queue and limiter keys get hash-tagged, and multi-key cache operations fall back to per-key paths.

### Changes

**Connection infrastructure**
- Added `isClusterAware()` - true for real cluster clients or standalone connections with `cluster_aware: true`.
- Added `supportsMultiSlotMultiKeyCommands()` - false when the client can't route a multi-key command across slots. Overridden to true on `PhpRedisClusterConnection`, which routes `MGET`/`DEL`/etc. per slot natively.
- `$config` moved to the base `Connection` so `PredisConnection` can read it; Predis constructor and connector updated accordingly (BC-safe default).

**RedisQueue & ConcurrencyLimiter**
- Keys are hash-tagged whenever `isClusterAware()` is true, not just for real cluster clients.

**RedisStore**
- `many()` falls back to per-key `get` when `! supportsMultiSlotMultiKeyCommands()`; phpredis cluster keeps the native `MGET` path.
- `putMany()` falls back to per-key `setex` when `isClusterAware()` - `MULTI`/`EXEC` can't span slots on any cluster-like endpoint.

**RedisTaggedCache**
- `flush()` uses the per-slot fallback when `isClusterAware()`.
- `flushValues()` uses pipelined per-key `DEL` when `! supportsMultiSlotMultiKeyCommands()`; phpredis cluster keeps the variadic `DEL` fast path.

### Backward Compatibility

- `cluster_aware` defaults to `false`. Zero behaviour change for any existing config.
- `isCluster()` semantics are unchanged - still true only for real cluster clients.
- Real cluster connections return true from `isClusterAware()` via the `isCluster()` branch, so every rewired call site takes the same path it did before for them.
- `PredisConnection::__construct($client)` still works; the new `$config` parameter is optional.