### PR TITLE
[13.x] Extract exception context in `JsonFormatter` when `ExceptionHandler` is not bound

### DIFF
--- a/src/Illuminate/Contracts/Debug/ExceptionHandler.php
+++ b/src/Illuminate/Contracts/Debug/ExceptionHandler.php
@@ -4,6 +4,10 @@ namespace Illuminate\Contracts\Debug;
 
 use Throwable;
 
+/**
+ * @method bool isReporting(\Throwable $e)
+ * @method array buildContextForException()
+ */
 interface ExceptionHandler
 {
     /**

--- a/src/Illuminate/Log/Formatters/JsonFormatter.php
+++ b/src/Illuminate/Log/Formatters/JsonFormatter.php
@@ -17,7 +17,7 @@ class JsonFormatter extends MonologJsonFormatter
         try {
             $handler = Container::getInstance()->make(ExceptionHandler::class);
         } catch (Throwable) {
-            return $response;
+            return array_merge($this->getExceptionContext($e, $depth), $response);
         }
 
         if ((! method_exists($handler, 'isReporting')) || ! $handler->isReporting($e)) {
@@ -29,17 +29,26 @@ class JsonFormatter extends MonologJsonFormatter
                     $response
                 );
             } elseif (method_exists($e, 'context')) {
-                $exceptionContext = $this->normalize($e->context(), $depth + 1);
-
-                if (is_array($exceptionContext)) {
-                    $response = array_merge(
-                        $exceptionContext,
-                        $response
-                    );
-                }
+                $response = array_merge($this->getExceptionContext($e, $depth), $response);
             }
         }
 
         return $response;
+    }
+
+    /**
+     * Extract the context from the exception if available.
+     *
+     * @return array<array-key, mixed>
+     */
+    protected function getExceptionContext(Throwable $e, int $depth): array
+    {
+        if (! method_exists($e, 'context')) {
+            return [];
+        }
+
+        $exceptionContext = $this->normalize($e->context(), $depth + 1);
+
+        return is_array($exceptionContext) ? $exceptionContext : [];
     }
 }

--- a/src/Illuminate/Log/Formatters/JsonFormatter.php
+++ b/src/Illuminate/Log/Formatters/JsonFormatter.php
@@ -47,7 +47,11 @@ class JsonFormatter extends MonologJsonFormatter
             return [];
         }
 
-        $exceptionContext = $this->normalize($e->context(), $depth + 1);
+        try {
+            $exceptionContext = $this->normalize($e->context(), $depth + 1);
+        } catch (Throwable) {
+            return [];
+        }
 
         return is_array($exceptionContext) ? $exceptionContext : [];
     }

--- a/tests/Log/JsonFormatterTest.php
+++ b/tests/Log/JsonFormatterTest.php
@@ -182,26 +182,6 @@ final class JsonFormatterTest extends TestCase
         $this->assertSame('callback_value', $exceptionData['callback_key']);
     }
 
-    public function testGracefulFallbackWhenContainerCannotResolveHandler()
-    {
-        Container::setInstance(new Container());
-
-        $handler = new TestHandler();
-        $monolog = new Monolog('test', [$handler]);
-        $handler->setFormatter(new JsonFormatter());
-
-        $exception = new ContextProvidingException('No handler bound');
-
-        $monolog->error('fail', ['exception' => $exception]);
-
-        $formatted = $this->getFormattedJson($handler);
-        $exceptionData = $formatted['context']['exception'];
-
-        $this->assertSame(ContextProvidingException::class, $exceptionData['class']);
-        $this->assertSame('No handler bound', $exceptionData['message']);
-        $this->assertArrayNotHasKey('foo', $exceptionData);
-    }
-
     public function testNonScalarContextValuesAreNormalized()
     {
         $exception = new ObjectContextException('Has objects in context');
@@ -290,6 +270,20 @@ final class JsonFormatterTest extends TestCase
         $this->assertArrayHasKey('previous', $exceptionData);
         $this->assertArrayNotHasKey('foo', $exceptionData['previous']);
         $this->assertSame(ContextProvidingException::class, $exceptionData['previous']['class']);
+    }
+
+    public function testNoHandlerSet_mergesExceptionContext()
+    {
+        $this->app->bind(ExceptionHandlerContract::class, function () {
+            throw new Exception('this never works');
+        });
+        Log::warning('fail', ['exception' => new ContextProvidingException('Oh no!')]);
+
+        $formatted = $this->getFormattedJson();
+
+        $exceptionData = $formatted['context']['exception'];
+        $this->assertSame('bar', $exceptionData['foo']);
+        $this->assertSame(ContextProvidingException::class, $exceptionData['class']);
     }
 
     private function getFormattedJson(?TestHandler $handler = null): array


### PR DESCRIPTION
If the container cannot resolve the `ExceptionHandler`, we still attempt to extract context from the Exception's `context()` method if it exists.

Also document the new methods on the interface via a docblock.