### PR TITLE
[13.x] Improve `commandShouldBeDebounced` execution efficiency

### DIFF
--- a/src/Illuminate/Bus/DebounceLock.php
+++ b/src/Illuminate/Bus/DebounceLock.php
@@ -93,7 +93,7 @@ class DebounceLock
      */
     public function isCurrentOwner($job, string $owner)
     {
-        return $this->resolveCache($job)->get(static::getKey($job)) === $owner;
+        return $this->getCurrentOwner($job) === $owner;
     }
 
     /**
@@ -104,7 +104,18 @@ class DebounceLock
      */
     public function lockExists($job)
     {
-        return ! is_null($this->resolveCache($job)->get(static::getKey($job)));
+        return ! is_null($this->getCurrentOwner($job));
+    }
+
+    /**
+     * Get the current owner for the given debounce key.
+     *
+     * @param  mixed  $job
+     * @return ?string
+     */
+    public function getCurrentOwner($job)
+    {
+        return $this->resolveCache($job)->get(static::getKey($job));
     }
 
     /**

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -239,11 +239,11 @@ class CallQueuedHandler
         $lock = new DebounceLock($this->container->make(Cache::class));
 
         // Fail-open: if the lock no longer exists (cache eviction, TTL expiry), let the job execute...
-        if (! $lock->lockExists($command)) {
+        if (is_null($currentOwner = $lock->getCurrentOwner($command))) {
             return false;
         }
 
-        return ! $lock->isCurrentOwner($command, $owner);
+        return $currentOwner !== $owner;
     }
 
     /**

--- a/tests/Integration/Queue/DebouncedJobTest.php
+++ b/tests/Integration/Queue/DebouncedJobTest.php
@@ -311,6 +311,18 @@ class DebouncedJobTest extends QueueTestCase
 
         $this->assertEquals(30, $job2->delay);
     }
+
+    public function testGetCurrentOwner()
+    {
+        $cache = $this->app->get(Cache::class);
+        $lock = new DebounceLock($cache);
+
+        $job = new DebouncedTestJob('entity-1');
+
+        $owner = $lock->acquire($job)['owner'];
+
+        $this->assertEquals($lock->getCurrentOwner($job), $owner);
+    }
 }
 
 #[DebounceFor(30)]


### PR DESCRIPTION
## Summary

This PR improves performance by reducing the number of times the `commandShouldBeDebounced` method operates on the cache during execution.

To maintain backward compatibility, the `lockExists` and `isCurrentOwner` methods are retained.