### PR TITLE
[13.x] Add enum support to ConcurrencyManager driver method

### DIFF
--- a/src/Illuminate/Concurrency/ConcurrencyManager.php
+++ b/src/Illuminate/Concurrency/ConcurrencyManager.php
@@ -7,6 +7,8 @@ use Illuminate\Support\MultipleInstanceManager;
 use RuntimeException;
 use Spatie\Fork\Fork;
 
+use function Illuminate\Support\enum_value;
+
 /**
  * @mixin \Illuminate\Contracts\Concurrency\Driver
  */
@@ -15,12 +17,12 @@ class ConcurrencyManager extends MultipleInstanceManager
     /**
      * Get a driver instance by name.
      *
-     * @param  string|null  $name
+     * @param  \UnitEnum|string|null  $name
      * @return mixed
      */
     public function driver($name = null)
     {
-        return $this->instance($name);
+        return $this->instance(enum_value($name));
     }
 
     /**

--- a/tests/Integration/Concurrency/ConcurrencyTest.php
+++ b/tests/Integration/Concurrency/ConcurrencyTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Integration\Concurrency;
 
 use Exception;
 use Illuminate\Concurrency\ProcessDriver;
+use Illuminate\Concurrency\SyncDriver;
 use Illuminate\Foundation\Application;
 use Illuminate\Process\Factory as ProcessFactory;
 use Illuminate\Support\Facades\Concurrency;
@@ -88,6 +89,14 @@ PHP);
         // $this->assertEquals(4, $forkOutput['second']);
     }
 
+    public function testDriverCanBeResolvedUsingBackedEnum()
+    {
+        $this->assertInstanceOf(
+            SyncDriver::class,
+            Concurrency::driver(ConcurrencyDriverEnum::Sync),
+        );
+    }
+
     public function testRunHandlerProcessErrorWithDefaultExceptionWithoutParam()
     {
         $this->expectException(Exception::class);
@@ -158,6 +167,11 @@ PHP);
         $this->assertSame('second', $second);
         $this->assertSame('third', $third);
     }
+}
+
+enum ConcurrencyDriverEnum: string
+{
+    case Sync = 'sync';
 }
 
 class ExceptionWithoutParam extends Exception


### PR DESCRIPTION
`ConcurrencyManager::driver()` delegates to `MultipleInstanceManager::instance()`, which uses the given name directly as an array key. Passing a `UnitEnum` throws a `TypeError` because the enum is never converted to its scalar value:

```php
Concurrency::driver(ConcurrencyDriver::Sync);
// TypeError: Cannot access offset of type ConcurrencyDriver on array
```

Converted the name via `enum_value()` before delegating, matching how `Support\Manager::driver()` already handles enums. Added a regression test in `tests/Integration/Concurrency/ConcurrencyTest.php` using the sync driver.