### PR TITLE
[13.x] Improve markdown formatting of copied exception report

### DIFF
--- a/src/Illuminate/Foundation/resources/exceptions/renderer/markdown.blade.php
+++ b/src/Illuminate/Foundation/resources/exceptions/renderer/markdown.blade.php
@@ -2,15 +2,17 @@
 
 {!! $exception->message() !!}
 
-PHP {{ PHP_VERSION }}
-Laravel {{ app()->version() }}
-{{ $exception->request()->httpHost() }}
+PHP `{{ PHP_VERSION }}`  
+Laravel `{{ app()->version() }}`  
+`{{ $exception->request()->httpHost() }}`
 
 ## Stack Trace
 
+```
 @foreach($exception->frames() as $index => $frame)
 {{ $index }} - {{ $frame->file() }}:{{ $frame->line() }}
 @endforeach
+```
 
 @if ($exception->previousExceptions()->isNotEmpty())
 ## Previous {{ \Illuminate\Support\Str::plural('exception', $exception->previousExceptions()->count()) }}
@@ -20,20 +22,22 @@ Laravel {{ app()->version() }}
 
 {!! $previous->message() !!}
 
+```
 @foreach($previous->frames() as $index => $frame)
 {{ $index }} - {{ $frame->file() }}:{{ $frame->line() }}
 @endforeach
+```
 @endforeach
 @endif
 
 ## Request
 
-{{ $exception->request()->method() }} {{ \Illuminate\Support\Str::start($exception->request()->path(), '/') }}
+`{{ $exception->request()->method() }} {{ \Illuminate\Support\Str::start($exception->request()->path(), '/') }}`
 
 ## Headers
 
 @forelse ($exception->requestHeaders() as $key => $value)
-* **{{ $key }}**: {!! $value !!}
+* **{{ $key }}**: `{!! $value !!}`
 @empty
 No header data available.
 @endforelse
@@ -41,7 +45,7 @@ No header data available.
 ## Route Context
 
 @forelse($exception->applicationRouteContext() as $name => $value)
-{{ $name }}: {!! $value !!}
+{{ \Illuminate\Support\Str::headline($name) }}: `{!! $value !!}`  
 @empty
 No routing data available.
 @endforelse
@@ -57,7 +61,9 @@ No route parameter data available.
 ## Database Queries
 
 @forelse ($exception->applicationQueries() as ['connectionName' => $connectionName, 'sql' => $sql, 'time' => $time])
-* {{ $connectionName }} - {!! $sql !!} ({{ $time }} ms)
+```sql
+{{ $connectionName }} - {!! $sql !!} ({{ $time }} ms)
+```
 @empty
 No database queries detected.
 @endforelse


### PR DESCRIPTION
# What?

Improves the formatting of the markdown output produced by the exception renderer's "Copy as Markdown" button
(`resources/exceptions/renderer/markdown.blade.php`) so the copied report renders cleanly in GitHub issues, pull requests, Slack, and other  
 markdown-aware surfaces.

# Why?

The previous output relied on plain text with no code fences or inline code spans, so stack traces, queries, URLs, and header values lost all formatting once pasted — long lines wrapped arbitrarily, paths were treated as links, and SQL was unreadable.

# Changes

- Wrap the PHP version, Laravel version, and request method/path in inline code spans, with markdown hard line breaks between the version lines.
- Wrap the main stack trace and each previous-exception stack trace in fenced code blocks.
- Wrap header values and route-context values in inline code spans for readability.
- Use `Str::headline()` on route-context keys (e.g. `controllerAction` → `Controller Action`).
- Switch the database queries from a bullet list to per-query ` ```sql ` fenced blocks so they get syntax highlighting when rendered.  


No behavior changes outside the template — this only affects the copied markdown representation of the exception page.
