### PR TITLE
Allow merging #[Middleware] attributes with other controller middleware sources

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -1123,14 +1123,24 @@ class Route
         ];
 
         if (is_a($controllerClass, HasMiddleware::class, true)) {
-            return $this->staticallyProvidedControllerMiddleware(
-                $controllerClass, $controllerMethod
+            return array_merge(
+                $this->staticallyProvidedControllerMiddleware(
+                    $controllerClass, $controllerMethod
+                ),
+                $this->attributeProvidedControllerMiddleware(
+                    $controllerClass, $controllerMethod
+                ),
             );
         }
 
         if (method_exists($controllerClass, 'getMiddleware')) {
-            return $this->controllerDispatcher()->getMiddleware(
-                $this->getController(), $controllerMethod
+            return array_merge(
+                $this->controllerDispatcher()->getMiddleware(
+                    $this->getController(), $controllerMethod
+                ),
+                $this->attributeProvidedControllerMiddleware(
+                    $controllerClass, $controllerMethod
+                ),
             );
         }
 

--- a/tests/Integration/Routing/ControllerMiddlewareMergingTest.php
+++ b/tests/Integration/Routing/ControllerMiddlewareMergingTest.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Routing;
+
+use Illuminate\Routing\Attributes\Controllers\Middleware as MiddlewareAttribute;
+use Illuminate\Routing\Controller;
+use Illuminate\Routing\Controllers\HasMiddleware;
+use Illuminate\Routing\Controllers\Middleware;
+use Illuminate\Support\Facades\Route;
+use Orchestra\Testbench\TestCase;
+
+class ControllerMiddlewareMergingTest extends TestCase
+{
+    public function test_attribute_middleware_is_merged_with_has_middleware(): void
+    {
+        $route = Route::get('/', [HasMiddlewareWithAttributeController::class, 'index']);
+        $this->assertEquals([
+            'static-all',
+            'static-only-index',
+            'attribute-all',
+            'attribute-method-index',
+        ], $route->controllerMiddleware());
+
+        $route = Route::get('/', [HasMiddlewareWithAttributeController::class, 'show']);
+        $this->assertEquals([
+            'static-all',
+            'static-except-index',
+            'attribute-all',
+            'attribute-except-index',
+        ], $route->controllerMiddleware());
+    }
+
+    public function test_attribute_middleware_is_merged_with_legacy_controller(): void
+    {
+        $route = Route::get('/', [LegacyControllerWithAttributeController::class, 'index']);
+        $this->assertEquals([
+            'legacy',
+            'attribute-all',
+        ], $route->controllerMiddleware());
+    }
+
+    public function test_plain_attribute_controller_is_not_affected(): void
+    {
+        $route = Route::get('/', [PlainAttributeOnlyController::class, 'index']);
+        $this->assertEquals([
+            'attribute-all',
+            'attribute-method-index',
+        ], $route->controllerMiddleware());
+
+        $route = Route::get('/', [PlainAttributeOnlyController::class, 'show']);
+        $this->assertEquals([
+            'attribute-all',
+        ], $route->controllerMiddleware());
+    }
+
+    public function test_attribute_middleware_ordering_follows_primary_source(): void
+    {
+        $route = Route::get('/', [HasMiddlewareWithAttributeController::class, 'index']);
+        $middleware = $route->controllerMiddleware();
+
+        $this->assertLessThan(
+            array_search('attribute-all', $middleware),
+            array_search('static-all', $middleware),
+        );
+    }
+
+    public function test_duplicate_middleware_is_deduplicated_via_gather(): void
+    {
+        $route = Route::get('/', [DuplicateMiddlewareController::class, 'index']);
+        $gathered = $route->gatherMiddleware();
+
+        $this->assertSame(array_values(array_unique($gathered)), array_values($gathered));
+    }
+}
+
+#[MiddlewareAttribute('attribute-all')]
+#[MiddlewareAttribute('attribute-except-index', except: ['index'])]
+class HasMiddlewareWithAttributeController implements HasMiddleware
+{
+    public static function middleware(): array
+    {
+        return [
+            new Middleware('static-all'),
+            (new Middleware('static-only-index'))->only('index'),
+            (new Middleware('static-except-index'))->except('index'),
+        ];
+    }
+
+    #[MiddlewareAttribute('attribute-method-index')]
+    public function index(): void
+    {
+        //
+    }
+
+    public function show(): void
+    {
+        //
+    }
+}
+
+#[MiddlewareAttribute('attribute-all')]
+class LegacyControllerWithAttributeController extends Controller
+{
+    public function __construct()
+    {
+        $this->middleware('legacy');
+    }
+
+    public function index(): void
+    {
+        //
+    }
+}
+
+#[MiddlewareAttribute('attribute-all')]
+class PlainAttributeOnlyController
+{
+    #[MiddlewareAttribute('attribute-method-index')]
+    public function index(): void
+    {
+        //
+    }
+
+    public function show(): void
+    {
+        //
+    }
+}
+
+#[MiddlewareAttribute('shared')]
+class DuplicateMiddlewareController implements HasMiddleware
+{
+    public static function middleware(): array
+    {
+        return [
+            new Middleware('shared'),
+        ];
+    }
+
+    public function index(): void
+    {
+        //
+    }
+}


### PR DESCRIPTION
The Problem
Currently, the #[Middleware] attribute introduced in Laravel 13 is mutually exclusive with existing middleware definitions (HasMiddleware interface or legacy $this->middleware() method).

As noted in issue #59803, if a developer uses both an attribute and the HasMiddleware interface, the attribute-based middleware is completely discarded. This leads to confusion and limits the flexibility of mixing constant-expression attributes with dynamic middleware definitions.

The Solution
This PR modifies the routing logic to ensure that middleware defined via PHP attributes is gathered and merged alongside existing sources, rather than being ignored when a higher-priority source is found.

Key Changes
Updated src/Illuminate/Routing/Route.php (or relevant controller middleware collector) to collect attribute-based middleware even if HasMiddleware or legacy stacks are present.

Ensured that attribute-based middleware is appended to the middleware stack, maintaining a predictable order.

Added a reproduction test case in tests/Integration/Routing/ControllerMiddlewareMergingTest.php to verify that all sources are correctly merged.

Fixes: #59803 