### PR TITLE
Support enum in LazyCollection -> keyBy()

### DIFF
--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -567,6 +567,10 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
             foreach ($this as $key => $item) {
                 $resolvedKey = $keyBy($item, $key);
 
+                if ($resolvedKey instanceof \UnitEnum) {
+                    $resolvedKey = enum_value($resolvedKey);
+                }
+
                 if (is_object($resolvedKey)) {
                     $resolvedKey = (string) $resolvedKey;
                 }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3752,6 +3752,20 @@ class SupportCollectionTest extends TestCase
     }
 
     #[DataProvider('collectionClassProvider')]
+    public function testKeyByBackedEnum($collection)
+    {
+        $data = new $collection([
+            ['id' => 1, 'status' => TestStringBackedEnum::A],
+            ['id' => 2, 'status' => TestStringBackedEnum::B],
+        ]);
+
+        $this->assertEquals([
+            TestStringBackedEnum::A->value => ['id' => 1, 'status' => TestStringBackedEnum::A],
+            TestStringBackedEnum::B->value => ['id' => 2, 'status' => TestStringBackedEnum::B],
+        ], $data->keyBy('status')->all());
+    }
+
+    #[DataProvider('collectionClassProvider')]
     public function testKeyByClosure($collection)
     {
         $data = new $collection([


### PR DESCRIPTION
# Support ```BackedEnum``` in ```LazyCollection::keyBy()```

## Description

This is a mirror implementation of what has already been done in Collection, adding enum support to LazyCollection. (https://github.com/laravel/framework/pull/56786) and fixing same error that throws.

```Error: Object of class Illuminate\Tests\Support\TestStringBackedEnum could not be converted to string```