### PR TITLE
[13.x] Add support for Lettermint

### DIFF
--- a/config/mail.php
+++ b/config/mail.php
@@ -65,6 +65,10 @@ return [
             'transport' => 'resend',
         ],
 
+        'lettermint' => [
+            'transport' => 'lettermint',
+        ],
+
         'sendmail' => [
             'transport' => 'sendmail',
             'path' => env('MAIL_SENDMAIL_PATH', '/usr/sbin/sendmail -bs -i'),

--- a/config/services.php
+++ b/config/services.php
@@ -22,6 +22,11 @@ return [
         'key' => env('RESEND_KEY'),
     ],
 
+    'lettermint' => [
+        'key' => env('LETTERMINT_TOKEN'),
+        'route' => env('LETTERMINT_ROUTE'),
+    ],
+
     'ses' => [
         'key' => env('AWS_ACCESS_KEY_ID'),
         'secret' => env('AWS_SECRET_ACCESS_KEY'),

--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Mail\Factory as FactoryContract;
 use Illuminate\Log\LogManager;
 use Illuminate\Mail\Transport\ArrayTransport;
 use Illuminate\Mail\Transport\CloudflareTransport;
+use Illuminate\Mail\Transport\LettermintTransport;
 use Illuminate\Mail\Transport\LogTransport;
 use Illuminate\Mail\Transport\ResendTransport;
 use Illuminate\Mail\Transport\SesTransport;
@@ -339,6 +340,25 @@ class MailManager implements FactoryContract
                 $config['key'] ??
                 $this->app['config']->get('services.cloudflare.token') ??
                 $this->app['config']->get('services.cloudflare.key'),
+            $this->getHttpClient($config),
+        );
+    }
+
+    /**
+     * Create an instance of the Lettermint transport driver.
+     *
+     * @param  array  $config
+     * @return \Illuminate\Mail\Transport\LettermintTransport
+     */
+    protected function createLettermintTransport(array $config)
+    {
+        return new LettermintTransport(
+            $config['token'] ??
+                $config['key'] ??
+                $this->app['config']->get('services.lettermint.token') ??
+                $this->app['config']->get('services.lettermint.key'),
+            $config['route'] ??
+                $this->app['config']->get('services.lettermint.route'),
             $this->getHttpClient($config),
         );
     }

--- a/src/Illuminate/Mail/Transport/LettermintTransport.php
+++ b/src/Illuminate/Mail/Transport/LettermintTransport.php
@@ -1,0 +1,238 @@
+<?php
+
+namespace Illuminate\Mail\Transport;
+
+use Exception;
+use SensitiveParameter;
+use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Mailer\Envelope;
+use Symfony\Component\Mailer\Exception\TransportException;
+use Symfony\Component\Mailer\Header\MetadataHeader;
+use Symfony\Component\Mailer\Header\TagHeader;
+use Symfony\Component\Mailer\SentMessage;
+use Symfony\Component\Mailer\Transport\AbstractTransport;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\Email;
+use Symfony\Component\Mime\MessageConverter;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+class LettermintTransport extends AbstractTransport
+{
+    /**
+     * The HTTP client instance.
+     */
+    protected HttpClientInterface $client;
+
+    /**
+     * The headers that should not be forwarded as custom headers.
+     */
+    protected const BYPASS_HEADERS = [
+        'from',
+        'to',
+        'cc',
+        'bcc',
+        'reply-to',
+        'sender',
+        'subject',
+        'content-type',
+        'message-id',
+        'date',
+        'mime-version',
+        'x-lettermint-message-id',
+    ];
+
+    /**
+     * Create a new Lettermint transport instance.
+     */
+    public function __construct(
+        #[SensitiveParameter] protected string $token,
+        protected ?string $route = null,
+        ?HttpClientInterface $client = null,
+    ) {
+        parent::__construct();
+
+        $this->client = $client ?? HttpClient::create();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws TransportException
+     */
+    protected function doSend(SentMessage $message): void
+    {
+        try {
+            $response = $this->client->request('POST', 'https://api.lettermint.co/v1/send', [
+                'headers' => [
+                    'Accept' => 'application/json',
+                    'x-lettermint-token' => $this->token,
+                ],
+                'json' => $this->getPayload($message),
+            ]);
+
+            $result = $response->toArray(false);
+        } catch (Exception $exception) {
+            throw new TransportException(
+                sprintf('Request to Lettermint API failed. Reason: %s.', $exception->getMessage()),
+                is_int($exception->getCode()) ? $exception->getCode() : 0,
+                $exception,
+            );
+        }
+
+        throw_if(
+            $response->getStatusCode() !== Response::HTTP_ACCEPTED,
+            TransportException::class,
+            $this->getErrorMessage($result),
+            $response->getStatusCode(),
+        );
+
+        if ($messageId = $result['message_id'] ?? null) {
+            MessageConverter::toEmail($message->getOriginalMessage())
+                ->getHeaders()
+                ->addTextHeader('X-Lettermint-Message-ID', $messageId);
+        }
+    }
+
+    /**
+     * Get the Lettermint payload for the given message.
+     */
+    protected function getPayload(SentMessage $message): array
+    {
+        $email = MessageConverter::toEmail($message->getOriginalMessage());
+
+        $envelope = $message->getEnvelope();
+
+        return array_filter([
+            'from' => $envelope->getSender()->toString(),
+            'to' => $this->stringifyAddresses($this->getRecipients($email, $envelope)),
+            'cc' => $this->stringifyAddresses($email->getCc()),
+            'bcc' => $this->stringifyAddresses($email->getBcc()),
+            'reply_to' => $this->stringifyAddresses($email->getReplyTo()),
+            'subject' => $email->getSubject(),
+            'html' => $email->getHtmlBody(),
+            'text' => $email->getTextBody(),
+            'headers' => $this->getCustomHeaders($email),
+            'attachments' => $this->getAttachments($email),
+            'route' => $this->route,
+            'tag' => $this->getTag($email),
+            'metadata' => $this->getMetadata($email),
+        ], fn ($value) => $value !== null && $value !== [] && $value !== '');
+    }
+
+    /**
+     * Get the recipients without CC or BCC.
+     */
+    protected function getRecipients(Email $email, Envelope $envelope): array
+    {
+        return array_filter($envelope->getRecipients(), function (Address $address) use ($email) {
+            return in_array($address, array_merge($email->getCc(), $email->getBcc()), true) === false;
+        });
+    }
+
+    /**
+     * Get the custom headers for the email, excluding the standard ones.
+     */
+    protected function getCustomHeaders(Email $email): array
+    {
+        $headers = [];
+
+        foreach ($email->getHeaders()->all() as $name => $header) {
+            if ($header instanceof TagHeader || $header instanceof MetadataHeader) {
+                continue;
+            }
+
+            if (in_array($name, self::BYPASS_HEADERS, true)) {
+                continue;
+            }
+
+            $headers[$header->getName()] = $header->getBodyAsString();
+        }
+
+        return $headers;
+    }
+
+    /**
+     * Get the attachments formatted for the Lettermint API.
+     */
+    protected function getAttachments(Email $email): array
+    {
+        $attachments = [];
+
+        foreach ($email->getAttachments() as $attachment) {
+            $headers = $attachment->getPreparedHeaders();
+
+            $item = [
+                'content' => str_replace("\r\n", '', $attachment->bodyToString()),
+                'filename' => $headers->getHeaderParameter('Content-Disposition', 'filename'),
+                'content_type' => $headers->get('Content-Type')->getBody(),
+            ];
+
+            if ($attachment->hasContentId()) {
+                $item['content_id'] = $attachment->getContentId();
+            }
+
+            $attachments[] = $item;
+        }
+
+        return $attachments;
+    }
+
+    /**
+     * Get the email tag, if available.
+     */
+    protected function getTag(Email $email): ?string
+    {
+        $tag = null;
+
+        foreach ($email->getHeaders()->all() as $header) {
+            if ($header instanceof TagHeader) {
+                $tag = $header->getValue();
+            }
+        }
+
+        return $tag;
+    }
+
+    /**
+     * Get the email metadata, if available.
+     *
+     * @return array<string, string>
+     */
+    protected function getMetadata(Email $email): array
+    {
+        $metadata = [];
+
+        foreach ($email->getHeaders()->all() as $header) {
+            if ($header instanceof MetadataHeader) {
+                $metadata[$header->getKey()] = $header->getValue();
+            }
+        }
+
+        return $metadata;
+    }
+
+    /**
+     * Get multiple addresses formatted as strings for the Lettermint API.
+     */
+    protected function stringifyAddresses(array $addresses): array
+    {
+        return array_map(fn (Address $address) => $address->toString(), $addresses);
+    }
+
+    /**
+     * Get the error message from the Lettermint response.
+     */
+    protected function getErrorMessage(array $result): string
+    {
+        return $result['message'] ?? $result['error'] ?? 'Unknown error';
+    }
+
+    /**
+     * Get the string representation of the transport.
+     */
+    public function __toString(): string
+    {
+        return 'lettermint';
+    }
+}

--- a/tests/Mail/MailLettermintTransportTest.php
+++ b/tests/Mail/MailLettermintTransportTest.php
@@ -115,15 +115,15 @@ class MailLettermintTransportTest extends TestCase
 
             return new MockResponse(json_encode([
                 'message_id' => 'lettermint-message-id',
-                'status' => 'queued',
+                'status' => 'pending',
             ]), ['http_code' => 202]);
         });
 
         $transport = new LettermintTransport('test-token', 'broadcast', $client);
 
         $sender = new Address('sender@example.com', 'Taylor Otwell');
-        $recipient = new Address('to@example.com', 'Acme');
-        $replyTo = new Address('reply@example.com', 'Reply Person');
+        $recipient = new Address('me@example.com', 'Acme');
+        $replyTo = new Address('taylor@example.com', 'Taylor Otwell');
 
         $message = new Email();
         $message->subject('Test subject');
@@ -169,7 +169,7 @@ class MailLettermintTransportTest extends TestCase
 
             return new MockResponse(json_encode([
                 'message_id' => 'lettermint-message-id',
-                'status' => 'queued',
+                'status' => 'pending',
             ]), ['http_code' => 202]);
         });
 
@@ -179,7 +179,7 @@ class MailLettermintTransportTest extends TestCase
         $message->subject('With attachments');
         $message->text('See attached');
         $message->sender('sender@example.com');
-        $message->to('to@example.com');
+        $message->to('me@example.com');
         $message->attach('file contents', 'document.txt', 'text/plain');
         $message->addPart((new DataPart('image-bytes', 'logo.png', 'image/png'))->asInline()->setContentId('logo@example.com'));
 
@@ -212,7 +212,7 @@ class MailLettermintTransportTest extends TestCase
         $message->subject('Fail');
         $message->text('Body');
         $message->sender('sender@example.com');
-        $message->to('to@example.com');
+        $message->to('me@example.com');
 
         $this->expectException(TransportException::class);
         $this->expectExceptionMessage("The domain 'example.com' is not verified");
@@ -232,7 +232,7 @@ class MailLettermintTransportTest extends TestCase
         $message->subject('Fail');
         $message->text('Body');
         $message->sender('sender@example.com');
-        $message->to('to@example.com');
+        $message->to('me@example.com');
 
         $this->expectException(TransportException::class);
         $this->expectExceptionMessage('Connection refused');

--- a/tests/Mail/MailLettermintTransportTest.php
+++ b/tests/Mail/MailLettermintTransportTest.php
@@ -1,0 +1,242 @@
+<?php
+
+namespace Illuminate\Tests\Mail;
+
+use Illuminate\Config\Repository;
+use Illuminate\Container\Container;
+use Illuminate\Mail\MailManager;
+use Illuminate\Mail\Transport\LettermintTransport;
+use Illuminate\View\Factory;
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\Mailer\Exception\TransportException;
+use Symfony\Component\Mailer\Header\MetadataHeader;
+use Symfony\Component\Mailer\Header\TagHeader;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\Email;
+use Symfony\Component\Mime\Part\DataPart;
+
+class MailLettermintTransportTest extends TestCase
+{
+    public function testGetTransport(): void
+    {
+        $container = new Container;
+
+        $container->singleton('config', function () {
+            return new Repository([
+                'services' => [
+                    'lettermint' => [
+                        'token' => 'service-token',
+                        'route' => 'broadcast',
+                    ],
+                ],
+            ]);
+        });
+
+        $manager = new MailManager($container);
+
+        $transport = $manager->createSymfonyTransport(['transport' => 'lettermint']);
+
+        $this->assertInstanceOf(LettermintTransport::class, $transport);
+        $this->assertSame('lettermint', (string) $transport);
+        $this->assertSame('service-token', (new ReflectionProperty($transport, 'token'))->getValue($transport));
+        $this->assertSame('broadcast', (new ReflectionProperty($transport, 'route'))->getValue($transport));
+    }
+
+    public function testGetTransportUsesServiceKeyFallback(): void
+    {
+        $container = new Container;
+
+        $container->singleton('config', function () {
+            return new Repository([
+                'services' => [
+                    'lettermint' => [
+                        'key' => 'service-key',
+                    ],
+                ],
+            ]);
+        });
+
+        $manager = new MailManager($container);
+
+        $transport = $manager->createSymfonyTransport(['transport' => 'lettermint']);
+
+        $this->assertSame('service-key', (new ReflectionProperty($transport, 'token'))->getValue($transport));
+    }
+
+    public function testMailerConfigurationOverridesServiceConfiguration(): void
+    {
+        $container = new Container;
+
+        $container->singleton('config', function () {
+            return new Repository([
+                'mail' => [
+                    'default' => 'lettermint',
+                    'mailers' => [
+                        'lettermint' => [
+                            'transport' => 'lettermint',
+                            'token' => 'mailer-token',
+                            'route' => 'transactional',
+                        ],
+                    ],
+                ],
+                'services' => [
+                    'lettermint' => [
+                        'token' => 'service-token',
+                        'route' => 'broadcast',
+                    ],
+                ],
+            ]);
+        });
+
+        $container->instance('view', $this->createStub(Factory::class));
+        $container->singleton('events', fn () => null);
+
+        $manager = new MailManager($container);
+
+        $transport = $manager->mailer('lettermint')->getSymfonyTransport();
+
+        $this->assertSame('mailer-token', (new ReflectionProperty($transport, 'token'))->getValue($transport));
+        $this->assertSame('transactional', (new ReflectionProperty($transport, 'route'))->getValue($transport));
+    }
+
+    public function testSend(): void
+    {
+        $requestBody = null;
+        $requestUrl = null;
+        $requestHeaders = null;
+
+        $client = new MockHttpClient(function ($method, $url, $options) use (&$requestBody, &$requestUrl, &$requestHeaders) {
+            $requestUrl = $url;
+            $requestBody = json_decode($options['body'], true);
+            $requestHeaders = $options['normalized_headers'];
+
+            return new MockResponse(json_encode([
+                'message_id' => 'lettermint-message-id',
+                'status' => 'queued',
+            ]), ['http_code' => 202]);
+        });
+
+        $transport = new LettermintTransport('test-token', 'broadcast', $client);
+
+        $sender = new Address('sender@example.com', 'Taylor Otwell');
+        $recipient = new Address('to@example.com', 'Acme');
+        $replyTo = new Address('reply@example.com', 'Reply Person');
+
+        $message = new Email();
+        $message->subject('Test subject');
+        $message->html('<p>Hello</p>');
+        $message->text('Hello');
+        $message->sender($sender);
+        $message->to($recipient);
+        $message->cc('cc@example.com');
+        $message->bcc('bcc@example.com');
+        $message->replyTo($replyTo);
+        $message->getHeaders()->addTextHeader('X-Custom-Header', 'CustomValue');
+        $message->getHeaders()->add(new TagHeader('transactional'));
+        $message->getHeaders()->add(new MetadataHeader('campaign', 'welcome'));
+
+        $sentMessage = $transport->send($message);
+
+        $this->assertSame('https://api.lettermint.co/v1/send', $requestUrl);
+        $this->assertSame(['x-lettermint-token: test-token'], $requestHeaders['x-lettermint-token']);
+        $this->assertSame($sender->toString(), $requestBody['from']);
+        $this->assertSame([$recipient->toString()], $requestBody['to']);
+        $this->assertSame(['cc@example.com'], $requestBody['cc']);
+        $this->assertSame(['bcc@example.com'], $requestBody['bcc']);
+        $this->assertSame([$replyTo->toString()], $requestBody['reply_to']);
+        $this->assertSame('Test subject', $requestBody['subject']);
+        $this->assertSame('<p>Hello</p>', $requestBody['html']);
+        $this->assertSame('Hello', $requestBody['text']);
+        $this->assertSame('broadcast', $requestBody['route']);
+        $this->assertSame('transactional', $requestBody['tag']);
+        $this->assertSame(['campaign' => 'welcome'], $requestBody['metadata']);
+        $this->assertSame(['X-Custom-Header' => 'CustomValue'], $requestBody['headers']);
+        $this->assertSame(
+            'lettermint-message-id',
+            $sentMessage->getOriginalMessage()->getHeaders()->get('X-Lettermint-Message-ID')->getBodyAsString()
+        );
+    }
+
+    public function testSendWithAttachments(): void
+    {
+        $requestBody = null;
+
+        $client = new MockHttpClient(function ($method, $url, $options) use (&$requestBody) {
+            $requestBody = json_decode($options['body'], true);
+
+            return new MockResponse(json_encode([
+                'message_id' => 'lettermint-message-id',
+                'status' => 'queued',
+            ]), ['http_code' => 202]);
+        });
+
+        $transport = new LettermintTransport('test-token', null, $client);
+
+        $message = new Email();
+        $message->subject('With attachments');
+        $message->text('See attached');
+        $message->sender('sender@example.com');
+        $message->to('to@example.com');
+        $message->attach('file contents', 'document.txt', 'text/plain');
+        $message->addPart((new DataPart('image-bytes', 'logo.png', 'image/png'))->asInline()->setContentId('logo@example.com'));
+
+        $transport->send($message);
+
+        $this->assertCount(2, $requestBody['attachments']);
+        $this->assertSame('document.txt', $requestBody['attachments'][0]['filename']);
+        $this->assertSame('text/plain', $requestBody['attachments'][0]['content_type']);
+        $this->assertNotEmpty($requestBody['attachments'][0]['content']);
+        $this->assertSame('logo.png', $requestBody['attachments'][1]['filename']);
+        $this->assertSame('image/png', $requestBody['attachments'][1]['content_type']);
+        $this->assertNotEmpty($requestBody['attachments'][1]['content']);
+        $this->assertSame('logo@example.com', $requestBody['attachments'][1]['content_id']);
+    }
+
+    public function testSendThrowsOnApiFailure(): void
+    {
+        $client = new MockHttpClient(function () {
+            return new MockResponse(json_encode([
+                'message' => "The domain 'example.com' is not verified or does not belong to your account.",
+                'errors' => [
+                    'from' => ["The domain 'example.com' is not verified or does not belong to your account."],
+                ],
+            ]), ['http_code' => 422]);
+        });
+
+        $transport = new LettermintTransport('test-token', null, $client);
+
+        $message = new Email();
+        $message->subject('Fail');
+        $message->text('Body');
+        $message->sender('sender@example.com');
+        $message->to('to@example.com');
+
+        $this->expectException(TransportException::class);
+        $this->expectExceptionMessage("The domain 'example.com' is not verified");
+
+        $transport->send($message);
+    }
+
+    public function testSendThrowsOnRequestFailure(): void
+    {
+        $client = new MockHttpClient(function () {
+            throw new \RuntimeException('Connection refused');
+        });
+
+        $transport = new LettermintTransport('test-token', null, $client);
+
+        $message = new Email();
+        $message->subject('Fail');
+        $message->text('Body');
+        $message->sender('sender@example.com');
+        $message->to('to@example.com');
+
+        $this->expectException(TransportException::class);
+        $this->expectExceptionMessage('Connection refused');
+
+        $transport->send($message);
+    }
+}


### PR DESCRIPTION
This PR adds support for Lettermint as a first-party mail transport in Laravel.

Like the existing Resend and Cloudflare transports, this implementation sends directly to Lettermint's HTTP API and gives applications that prefer an EU-based provider a native option without additional packages.

Submitting this as we're seeing more adoption and endorsement from Laravel communities like Dutch Laravel Foundation and Swiss Laravel Association.

**Added:**
- a native `lettermint` mail transport
- support for attachments and inline attachments
- support for Laravel mail tags and metadata
- support for a default Lettermint route via `services.lettermint.route`
- support for per-mailer route overrides via `mail.mailers.*.route`

**Configuration**
```php
// config/services.php
'lettermint' => [
    'token' => env('LETTERMINT_TOKEN'),
    'route' => env('LETTERMINT_ROUTE'),
],
```

```php
// config/mail.php
'mailers' => [
    'lettermint' => [
        'transport' => 'lettermint',
    ],
],
```

If needed, the route may also be overridden per mailer:
```php
// config/mail.php
'mailers' => [
    'broadcast' => [
        'transport' => 'lettermint',
        'route' => env('LETTERMINT_BROADCAST_ROUTE'),
    ],
],
```

