### PR TITLE
[13.x] Honor empty JSON:API sparse fieldsets

### DIFF
--- a/src/Illuminate/Http/Resources/JsonApi/Concerns/ResolvesJsonApiElements.php
+++ b/src/Illuminate/Http/Resources/JsonApi/Concerns/ResolvesJsonApiElements.php
@@ -143,14 +143,13 @@ trait ResolvesJsonApiElements
             $data = $data->jsonSerialize();
         }
 
-        $sparseFieldset = match ($this->usesRequestQueryString) {
-            true => $request->sparseFields($resourceType),
-            default => [],
-        };
+        $usesSparseFieldset = $this->usesRequestQueryString && $request->hasSparseFieldset($resourceType);
+
+        $sparseFieldset = $usesSparseFieldset ? $request->sparseFields($resourceType) : [];
 
         $data = (new Collection($data))
             ->mapWithKeys(fn ($value, $key) => is_int($key) ? [$value => $this->resource->{$value}] : [$key => $value])
-            ->when(! empty($sparseFieldset), fn ($attributes) => $attributes->only($sparseFieldset))
+            ->when($usesSparseFieldset, fn ($attributes) => $attributes->only($sparseFieldset))
             ->transform(fn ($value) => value($value, $request))
             ->all();
 

--- a/src/Illuminate/Http/Resources/JsonApi/JsonApiRequest.php
+++ b/src/Illuminate/Http/Resources/JsonApi/JsonApiRequest.php
@@ -33,6 +33,18 @@ class JsonApiRequest extends Request
     }
 
     /**
+     * Determine if a sparse fieldset was provided for the given resource type.
+     */
+    public function hasSparseFieldset(string $key): bool
+    {
+        if (is_null($this->cachedSparseFields)) {
+            $this->sparseFields($key);
+        }
+
+        return array_key_exists($key, $this->cachedSparseFields);
+    }
+
+    /**
      * Get the request's included relationships.
      */
     public function sparseIncluded(?string $key = null): ?array

--- a/tests/Integration/Http/Resources/JsonApi/JsonApiRequestTest.php
+++ b/tests/Integration/Http/Resources/JsonApi/JsonApiRequestTest.php
@@ -30,6 +30,18 @@ class JsonApiRequestTest extends TestCase
         $this->assertSame([], $request->sparseFields('posts'));
     }
 
+    public function testItCanDetermineIfSparseFieldsetWasProvided()
+    {
+        $request = JsonApiRequest::create(uri: '/?'.http_build_query([
+            'fields' => [
+                'users' => '',
+            ],
+        ]));
+
+        $this->assertTrue($request->hasSparseFieldset('users'));
+        $this->assertFalse($request->hasSparseFieldset('posts'));
+    }
+
     public function testItCanResolveSparseIncluded()
     {
         $request = JsonApiRequest::create(uri: '/?'.http_build_query([

--- a/tests/Integration/Http/Resources/JsonApi/JsonApiResourceTest.php
+++ b/tests/Integration/Http/Resources/JsonApi/JsonApiResourceTest.php
@@ -48,6 +48,21 @@ class JsonApiResourceTest extends TestCase
             ->assertJsonMissing(['jsonapi', 'included']);
     }
 
+    public function testItCanGenerateJsonApiResponseWithEmptySparseFieldsets()
+    {
+        $user = User::factory()->create();
+
+        $this->getJson("/users/{$user->getKey()}?".http_build_query(['fields' => ['users' => '']]))
+            ->assertHeader('Content-type', 'application/vnd.api+json')
+            ->assertExactJson([
+                'data' => [
+                    'id' => (string) $user->getKey(),
+                    'type' => 'users',
+                ],
+            ])
+            ->assertJsonMissing(['jsonapi', 'included']);
+    }
+
     public function testItCanGenerateJsonApiResponseWithEmptyRelationshipsUsingSparseIncluded()
     {
         $user = User::factory()->create();


### PR DESCRIPTION
Fixes #59812.

JSON:API sparse fieldsets currently treat a missing fieldset and an explicitly empty fieldset the same way because both resolve to an empty array.

This keeps the parsed field values as-is, but tracks whether a fieldset was actually provided before applying it to resource attributes. That lets `fields[users]=` return only the resource identifier members while leaving the no-fieldset case unchanged.