### PR TITLE
[13.x] Add debounce assertions to BusFake

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -7,11 +7,13 @@ use Illuminate\Bus\BatchRepository;
 use Illuminate\Bus\ChainedBatch;
 use Illuminate\Bus\PendingBatch;
 use Illuminate\Contracts\Bus\QueueingDispatcher;
+use Illuminate\Queue\Attributes\DebounceFor;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\ReflectsClosures;
 use PHPUnit\Framework\Assert as PHPUnit;
+use ReflectionClass;
 use RuntimeException;
 
 class BusFake implements Fake, QueueingDispatcher
@@ -552,6 +554,64 @@ class BusFake implements Fake, QueueingDispatcher
     {
         $this->assertNothingDispatched();
         $this->assertNothingBatched();
+    }
+
+    /**
+     * Assert if a job was dispatched with the DebounceFor attribute.
+     *
+     * @param  string|\Closure  $command
+     * @param  callable|null  $callback
+     * @return void
+     */
+    public function assertDispatchedWithDebounce($command, $callback = null)
+    {
+        if ($command instanceof Closure) {
+            [$command, $callback] = [$this->firstClosureParameterType($command), $command];
+        }
+
+        PHPUnit::assertTrue(
+            $this->dispatchedWithDebounce($command, $callback)->count() > 0,
+            "The expected [{$command}] job was not dispatched with debounce."
+        );
+    }
+
+    /**
+     * Assert if a job was not dispatched with the DebounceFor attribute.
+     *
+     * @param  string|\Closure  $command
+     * @param  callable|null  $callback
+     * @return void
+     */
+    public function assertNotDispatchedWithDebounce($command, $callback = null)
+    {
+        if ($command instanceof Closure) {
+            [$command, $callback] = [$this->firstClosureParameterType($command), $command];
+        }
+
+        PHPUnit::assertFalse(
+            $this->dispatchedWithDebounce($command, $callback)->count() > 0,
+            "The unexpected [{$command}] job was dispatched with debounce."
+        );
+    }
+
+    /**
+     * Get all of the debounced jobs matching a truth-test callback.
+     *
+     * @param  string  $command
+     * @param  callable|null  $callback
+     * @return \Illuminate\Support\Collection
+     */
+    public function dispatchedWithDebounce(string $command, $callback = null)
+    {
+        if (! $this->hasDispatched($command)) {
+            return new Collection;
+        }
+
+        $callback = $callback ?: fn () => true;
+
+        return (new Collection($this->commands[$command]))->filter(function ($command) use ($callback) {
+            return ! empty((new ReflectionClass($command))->getAttributes(DebounceFor::class)) && $callback($command);
+        });
     }
 
     /**

--- a/tests/Support/SupportTestingBusFakeTest.php
+++ b/tests/Support/SupportTestingBusFakeTest.php
@@ -7,6 +7,7 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Bus\Dispatcher;
 use Illuminate\Contracts\Bus\QueueingDispatcher;
+use Illuminate\Queue\Attributes\DebounceFor;
 use Illuminate\Support\Testing\Fakes\BatchRepositoryFake;
 use Illuminate\Support\Testing\Fakes\BusFake;
 use Illuminate\Support\Testing\Fakes\PendingBatchFake;
@@ -1016,6 +1017,50 @@ class SupportTestingBusFakeTest extends TestCase
             $this->assertStringContainsString('The expected batch was not dispatched.', $e->getMessage());
         }
     }
+
+    public function testAssertDispatchedWithDebounce()
+    {
+        try {
+            $this->fake->assertDispatchedWithDebounce(DebouncedBusJobStub::class);
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringContainsString('The expected [Illuminate\Tests\Support\DebouncedBusJobStub] job was not dispatched with debounce.', $e->getMessage());
+        }
+
+        $this->fake->dispatch(new DebouncedBusJobStub);
+
+        $this->fake->assertDispatchedWithDebounce(DebouncedBusJobStub::class);
+    }
+
+    public function testAssertDispatchedWithDebounceWithClosure()
+    {
+        $this->fake->dispatch(new DebouncedBusJobStub);
+
+        $this->fake->assertDispatchedWithDebounce(function (DebouncedBusJobStub $job) {
+            return true;
+        });
+    }
+
+    public function testAssertNotDispatchedWithDebounce()
+    {
+        $this->fake->dispatch(new BusJobStub);
+
+        $this->fake->assertNotDispatchedWithDebounce(BusJobStub::class);
+
+        $this->fake->dispatch(new DebouncedBusJobStub);
+
+        try {
+            $this->fake->assertNotDispatchedWithDebounce(DebouncedBusJobStub::class);
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringContainsString('The unexpected [Illuminate\Tests\Support\DebouncedBusJobStub] job was dispatched with debounce.', $e->getMessage());
+        }
+    }
+
+    public function testAssertNotDispatchedWithDebounceWhenNothingDispatched()
+    {
+        $this->fake->assertNotDispatchedWithDebounce(DebouncedBusJobStub::class);
+    }
 }
 
 class BusJobStub
@@ -1067,4 +1112,10 @@ class BusFakeJobWithSerialization
     {
         $this->value = $data['value'].'-unserialized';
     }
+}
+
+#[DebounceFor(5)]
+class DebouncedBusJobStub
+{
+    use Queueable;
 }


### PR DESCRIPTION
Adds `assertDispatchedWithDebounce`, `assertNotDispatchedWithDebounce`, and `dispatchedWithDebounce` to `BusFake` to support testing jobs decorated with the `#[DebounceFor]` attribute introduced in #59507.