### PR TITLE
[13.x] Add Azure Communication Services mail transport (acs)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -87,6 +87,7 @@
         "predis/predis": "^2.3 || ^3.0",
         "rector/rector": "^2.3",
         "resend/resend-php": "^1.0",
+        "symfony/azure-mailer": "^7.4.0 || ^8.0.0",
         "symfony/cache": "^7.4.0 || ^8.0.0",
         "symfony/http-client": "^7.4.0 || ^8.0.0",
         "symfony/psr-http-message-bridge": "^7.4.0 || ^8.0.0",
@@ -172,6 +173,7 @@
         "symfony/cache": "Required to PSR-6 cache bridge (^7.4 || ^8.0).",
         "symfony/filesystem": "Required to enable support for relative symbolic links (^7.4 || ^8.0).",
         "symfony/http-client": "Required to enable support for the Symfony API mail transports (^7.4 || ^8.0).",
+        "symfony/azure-mailer": "Required to enable support for the Azure mail transport (^7.4.0 || ^8.0.0).",
         "symfony/mailgun-mailer": "Required to enable support for the Mailgun mail transport (^7.4 || ^8.0).",
         "symfony/postmark-mailer": "Required to enable support for the Postmark mail transport (^7.4 || ^8.0).",
         "symfony/psr-http-message-bridge": "Required to use PSR-7 bridging features (^7.4 || ^8.0)."

--- a/config/mail.php
+++ b/config/mail.php
@@ -30,7 +30,7 @@ return [
     | your mailers below. You may also add additional mailers if needed.
     |
     | Supported: "smtp", "sendmail", "mailgun", "ses", "ses-v2",
-    |            "postmark", "resend", "log", "array",
+    |            "postmark", "resend", "acs", "log", "array",
     |            "failover", "roundrobin"
     |
     */
@@ -63,6 +63,10 @@ return [
 
         'resend' => [
             'transport' => 'resend',
+        ],
+
+        'acs' => [
+            'transport' => 'acs',
         ],
 
         'sendmail' => [

--- a/config/services.php
+++ b/config/services.php
@@ -14,6 +14,11 @@ return [
     |
     */
 
+    'acs' => [
+        'endpoint' => env('AZURE_COMMUNICATION_ENDPOINT'),
+        'key' => env('AZURE_COMMUNICATION_KEY'),
+    ],
+
     'postmark' => [
         'token' => env('POSTMARK_TOKEN'),
     ],

--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -8,6 +8,7 @@ use Closure;
 use Illuminate\Contracts\Mail\Factory as FactoryContract;
 use Illuminate\Log\LogManager;
 use Illuminate\Mail\Transport\ArrayTransport;
+use Illuminate\Mail\Transport\AzureTransport;
 use Illuminate\Mail\Transport\CloudflareTransport;
 use Illuminate\Mail\Transport\LogTransport;
 use Illuminate\Mail\Transport\ResendTransport;
@@ -321,6 +322,23 @@ class MailManager implements FactoryContract
     {
         return new ResendTransport(
             Resend::client($config['key'] ?? $this->app['config']->get('services.resend.key')),
+        );
+    }
+
+    /**
+     * Create an instance of the Azure Communication Services Transport driver.
+     *
+     * @param  array  $config
+     * @return \Illuminate\Mail\Transport\AzureTransport
+     */
+    protected function createAcsTransport(array $config)
+    {
+        return new AzureTransport(
+            $config['key'] ?? $this->app['config']->get('services.acs.key'),
+            $config['endpoint'] ?? $this->app['config']->get('services.acs.endpoint'),
+            $config['disable_tracking'] ?? false,
+            $config['api_version'] ?? '2023-03-31',
+            $this->getHttpClient($config),
         );
     }
 

--- a/src/Illuminate/Mail/Transport/AzureTransport.php
+++ b/src/Illuminate/Mail/Transport/AzureTransport.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Illuminate\Mail\Transport;
+
+use SensitiveParameter;
+use Symfony\Component\Mailer\Bridge\Azure\Transport\AzureApiTransport;
+use Symfony\Component\Mailer\SentMessage;
+use Symfony\Component\Mailer\Transport\AbstractTransport;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+class AzureTransport extends AbstractTransport
+{
+    /**
+     * The underlying Azure API transport instance.
+     */
+    protected AzureApiTransport $azure;
+
+    /**
+     * Create a new Azure transport instance.
+     */
+    public function __construct(
+        #[SensitiveParameter] protected string $key,
+        protected string $endpoint,
+        protected bool $disableTracking = false,
+        protected string $apiVersion = '2023-03-31',
+        ?HttpClientInterface $client = null,
+    ) {
+        parent::__construct();
+
+        $host = $this->parseHost($this->endpoint);
+
+        $this->azure = (new AzureApiTransport(
+            $this->key,
+            'default',
+            $this->disableTracking,
+            $this->apiVersion,
+            $client,
+        ))->setHost($host);
+    }
+
+    /**
+     * @throws \Symfony\Component\Mailer\Exception\TransportException
+     */
+    protected function doSend(SentMessage $message): void
+    {
+        $sent = $this->azure->send(
+            $message->getOriginalMessage(),
+            $message->getEnvelope(),
+        );
+
+        if ($sent !== null) {
+            $message->setMessageId($sent->getMessageId());
+        }
+    }
+
+    /**
+     * Extract the hostname from the endpoint URL, stripping the protocol and trailing slash.
+     */
+    protected function parseHost(string $endpoint): string
+    {
+        $endpoint = rtrim($endpoint, '/');
+
+        return parse_url($endpoint, PHP_URL_HOST) ?? $endpoint;
+    }
+
+    /**
+     * Get the string representation of the transport.
+     */
+    public function __toString(): string
+    {
+        return 'acs';
+    }
+}

--- a/tests/Mail/MailAzureTransportTest.php
+++ b/tests/Mail/MailAzureTransportTest.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Illuminate\Tests\Mail;
+
+use Illuminate\Config\Repository;
+use Illuminate\Container\Container;
+use Illuminate\Mail\MailManager;
+use Illuminate\Mail\Transport\AzureTransport;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\Mailer\Exception\HttpTransportException;
+use Symfony\Component\Mime\Email;
+
+class MailAzureTransportTest extends TestCase
+{
+    public function testGetTransport(): void
+    {
+        $container = new Container;
+
+        $container->singleton('config', function () {
+            return new Repository([
+                'services' => [
+                    'acs' => [
+                        'key' => 'dGVzdC1rZXk=',
+                        'endpoint' => 'https://test-resource.communication.azure.com',
+                    ],
+                ],
+            ]);
+        });
+
+        $manager = new MailManager($container);
+
+        $transport = $manager->createSymfonyTransport(['transport' => 'acs']);
+
+        $this->assertInstanceOf(AzureTransport::class, $transport);
+        $this->assertSame('acs', (string) $transport);
+    }
+
+    public function testSend(): void
+    {
+        $requestUrl = null;
+        $requestBody = null;
+
+        $client = new MockHttpClient(function ($method, $url, $options) use (&$requestUrl, &$requestBody) {
+            $requestUrl = $url;
+            $requestBody = json_decode($options['body'], true);
+
+            return new MockResponse(
+                json_encode(['id' => 'test-operation-id']),
+                ['http_code' => 202],
+            );
+        });
+
+        $transport = new AzureTransport('dGVzdC1rZXk=', 'https://test-resource.unitedstates.communication.azure.com', false, '2023-03-31', $client);
+
+        $message = new Email();
+        $message->subject('Test subject');
+        $message->html('<p>Hello</p>');
+        $message->text('Hello');
+        $message->sender('sender@example.com');
+        $message->to('to@example.com');
+        $message->cc('cc@example.com');
+        $message->bcc('bcc@example.com');
+        $message->replyTo('reply@example.com');
+        $message->getHeaders()->addTextHeader('X-Custom-Header', 'CustomValue');
+
+        $sent = $transport->send($message);
+
+        $this->assertStringContainsString('test-resource.unitedstates.communication.azure.com', $requestUrl);
+        $this->assertStringContainsString('/emails:send', $requestUrl);
+        $this->assertSame('sender@example.com', $requestBody['senderAddress']);
+        $this->assertSame([['address' => 'to@example.com']], $requestBody['recipients']['to']);
+        $this->assertSame([['address' => 'cc@example.com']], $requestBody['recipients']['cc']);
+        $this->assertSame([['address' => 'bcc@example.com']], $requestBody['recipients']['bcc']);
+        $this->assertSame([['address' => 'reply@example.com']], $requestBody['replyTo']);
+        $this->assertSame('Test subject', $requestBody['content']['subject']);
+        $this->assertSame('<p>Hello</p>', $requestBody['content']['html']);
+        $this->assertSame('Hello', $requestBody['content']['plainText']);
+        $this->assertSame('CustomValue', $requestBody['headers']['X-Custom-Header']);
+        $this->assertSame('test-operation-id', $sent->getMessageId());
+    }
+
+    public function testSendWithTrailingSlashInEndpoint(): void
+    {
+        $requestUrl = null;
+
+        $client = new MockHttpClient(function ($method, $url, $options) use (&$requestUrl) {
+            $requestUrl = $url;
+
+            return new MockResponse(
+                json_encode(['id' => 'test-operation-id']),
+                ['http_code' => 202],
+            );
+        });
+
+        $transport = new AzureTransport('dGVzdC1rZXk=', 'https://test-resource.unitedstates.communication.azure.com/', false, '2023-03-31', $client);
+
+        $message = new Email();
+        $message->subject('Test');
+        $message->text('Body');
+        $message->sender('sender@example.com');
+        $message->to('to@example.com');
+
+        $transport->send($message);
+
+        $this->assertStringContainsString('test-resource.unitedstates.communication.azure.com', $requestUrl);
+    }
+
+    public function testSendThrowsOnApiFailure(): void
+    {
+        $client = new MockHttpClient(function () {
+            return new MockResponse(
+                json_encode([
+                    'error' => [
+                        'code' => 'InvalidRequest',
+                        'message' => 'The request is invalid.',
+                    ],
+                ]),
+                ['http_code' => 400],
+            );
+        });
+
+        $transport = new AzureTransport('dGVzdC1rZXk=', 'https://test-resource.unitedstates.communication.azure.com', false, '2023-03-31', $client);
+
+        $message = new Email();
+        $message->subject('Fail');
+        $message->text('Body');
+        $message->sender('sender@example.com');
+        $message->to('to@example.com');
+
+        $this->expectException(HttpTransportException::class);
+        $this->expectExceptionMessage('InvalidRequest');
+
+        $transport->send($message);
+    }
+}


### PR DESCRIPTION
This adds a new transport for [Azure Communication Services](https://learn.microsoft.com/en-us/azure/communication-services/concepts/email/email-overview) (ACS) Email. Following the recent addition of the Cloudflare transport, I thought ACS was worth considering for similar reasons: it is an even more cost-effective option, it costs roughly half of what Cloudflare Email charges per message, with no base cost at all (pure pay-as-you-go). Beyond pricing, ACS has strong synergy with Office 365 setups, where the sender domain and DNS configuration may already be in place, making it a near-zero-friction addition for teams already in the Microsoft ecosystem. I myself wasn't even aware about the service until this week.

This driver wraps Symfony's own [`symfony/azure-mailer`](https://github.com/symfony/azure-mailer) bridge. My suggestion is to register the transport as `acs` to avoid ambiguity — `azure` alone is too broad given the breadth of Azure services, and `acs` maps directly to the product name in the same way `ses` does for Amazon's offering.

---

A suggested addition to the [Mail documentation](https://laravel.com/docs/13.x/mail#driver-prerequisites) similar to the Resend driver.:

#### Azure Communication Services Driver

To use the [Azure Communication Services](https://learn.microsoft.com/en-us/azure/communication-services/concepts/email/email-overview) driver, install Symfony's Azure Mailer bridge via Composer:

```shell
composer require symfony/azure-mailer symfony/http-client
```

Next, set the `default` option in your application's `config/mail.php` configuration file to `acs`. After configuring your application's default mailer, ensure that your `config/services.php` configuration file contains the following options:

```php
'acs' => [
    'endpoint' => env('AZURE_COMMUNICATION_ENDPOINT'),
    'key' => env('AZURE_COMMUNICATION_KEY'),
],
```

The `endpoint` should be the full URL of your Azure Communication Services resource, for example `https://my-resource.unitedstates.communication.azure.com`.
