### PR TITLE
[13.x] Fix QueueSqsQueueTest

### DIFF
--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -7,6 +7,7 @@ use Aws\Sqs\SqsClient;
 use Illuminate\Bus\Dispatcher;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Bus\Dispatcher as DispatcherContract;
+use Illuminate\Contracts\Cache\Repository as Cache;
 use Illuminate\Queue\Jobs\SqsJob;
 use Illuminate\Queue\QueueRoutes;
 use Illuminate\Queue\SqsQueue;
@@ -42,8 +43,18 @@ class QueueSqsQueueTest extends TestCase
     protected $mockedReceiveEmptyMessageResponseModel;
     protected $mockedQueueAttributesResponseModel;
 
+    protected function tearDown(): void
+    {
+        Container::setInstance();
+
+        parent::tearDown();
+    }
+
     protected function setUp(): void
     {
+        Container::setInstance($container = new Container);
+        $container->instance(Cache::class, m::mock(Cache::class));
+
         // Use Mockery to mock the SqsClient
         $this->sqs = m::mock(SqsClient::class);
 


### PR DESCRIPTION
Seeing loads of jobs flaking re: 
https://github.com/laravel/framework/actions/runs/24798867423/job/72575829745
https://github.com/laravel/framework/actions/runs/24800162932/job/72580338564 

Etc etc etc.. this was cause the Debounce changes.

Was gonna use the container and check the instance in the Debounce logic, but went with just adjusting the test for now to save that rabbit hole 😎 