### PR TITLE
Remove "can" attribute from route group

### DIFF
--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -19,7 +19,6 @@ use InvalidArgumentException;
  * @method \Illuminate\Routing\Route post(string $uri, \Closure|array|string|null $action = null)
  * @method \Illuminate\Routing\Route put(string $uri, \Closure|array|string|null $action = null)
  * @method \Illuminate\Routing\RouteRegistrar as(string $value)
- * @method \Illuminate\Routing\RouteRegistrar can(\UnitEnum|string  $ability, array|string $models = [])
  * @method \Illuminate\Routing\RouteRegistrar controller(string $controller)
  * @method \Illuminate\Routing\RouteRegistrar domain(\BackedEnum|string $value)
  * @method \Illuminate\Routing\RouteRegistrar middleware(array|string|null $middleware)
@@ -69,7 +68,6 @@ class RouteRegistrar
      */
     protected $allowedAttributes = [
         'as',
-        'can',
         'controller',
         'domain',
         'middleware',

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -912,36 +912,33 @@ class RouteRegistrarTest extends TestCase
         $this->seeMiddleware(RouteRegistrarMiddlewareStub::class);
     }
 
-    public function testCanSetMiddlewareCanOnGroups()
+    public function testCannotSetMiddlewareCanOnGroups()
     {
+        $this->expectException(\Exception::class);
+
         $this->router->can('test')->group(function ($router) {
             $router->get('/');
         });
-
-        $this->seeMiddleware('can:test');
     }
 
-    public function testCanSetMiddlewareCanWithModelsOnGroups()
+    public function testCannotSetMiddlewareCanWithModelsOnGroups()
     {
+        $this->expectException(\Exception::class);
+
         $this->router->can('view', 'post')->group(function ($router) {
             $router->get('/post/{post}');
         });
-
-        $this->seeMiddleware('can:view,post');
     }
 
-    public function testCanSetMiddlewareCanNestedOnGroups()
+    public function testCannotSetMiddlewareCanNestedOnGroups()
     {
+        $this->expectException(\Exception::class);
+
         $this->router->can('access-admin')->group(function ($router) {
             $router->can('edit', 'post')->group(function ($router) {
                 $router->get('/post/{post}/edit');
             });
         });
-
-        $this->assertEquals([
-            'can:access-admin',
-            'can:edit,post',
-        ], $this->getRoute()->middleware());
     }
 
     public function testCanSetMiddlewareForSpecifiedMethodsOnRegisteredResource()


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Issue: https://github.com/laravel/framework/issues/55114

Based on the rejection of previous PRs, I judged that there were no plans to add `can` attribute to route groups. Because the [documentation](https://laravel.com/docs/13.x/authorization) only states it can be used on individual routes, I concluded that it was best to revert the commit that causes it to autocomplete for route groups on IDEs like PhpStorm.

I've tested that it still works on individual routes.

See my comments starting from: https://github.com/laravel/framework/issues/55114#issuecomment-4300946070
