### PR TITLE
[13.x] Fix PendingDispatch resolving Cache for every dispatched job

### DIFF
--- a/src/Illuminate/Foundation/Bus/PendingDispatch.php
+++ b/src/Illuminate/Foundation/Bus/PendingDispatch.php
@@ -9,11 +9,14 @@ use Illuminate\Contracts\Bus\Dispatcher;
 use Illuminate\Contracts\Cache\Repository as Cache;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Foundation\Queue\InteractsWithUniqueJobs;
+use Illuminate\Queue\Attributes\DebounceFor;
+use Illuminate\Queue\Attributes\ReadsQueueAttributes;
 use LogicException;
 
 class PendingDispatch
 {
     use InteractsWithUniqueJobs;
+    use ReadsQueueAttributes;
 
     /**
      * The job.
@@ -220,13 +223,13 @@ class PendingDispatch
      */
     protected function acquireDebounceLock()
     {
-        $lock = new DebounceLock(Container::getInstance()->make(Cache::class));
-
-        $debounceFor = $lock->getDebounceDelay($this->job);
+        $debounceFor = $this->getAttributeValue($this->job, DebounceFor::class, 'debounceFor');
 
         if ($debounceFor === null) {
             return;
         }
+
+        $lock = new DebounceLock(Container::getInstance()->make(Cache::class));
 
         if ($this->job instanceof ShouldBeUnique) {
             throw new LogicException('A debounced job cannot also implement ShouldBeUnique.');


### PR DESCRIPTION
## Summary

Fixes a regression where `PendingDispatch::acquireDebounceLock()` eagerly resolved `Cache::class` from the container for **every dispatched job**, even jobs that have no `#[DebounceFor]` attribute. This caused `BindingResolutionException: Target [Illuminate\Contracts\Cache\Repository] is not instantiable` in tests (and in any application context where cache is not bound before dispatch).

## Root Cause

The `acquireDebounceLock()` method instantiated `DebounceLock` (which requires a `Cache` binding) **before** checking whether the job actually needed debouncing:

```php
// Before — Cache resolved unconditionally
$lock = new DebounceLock(Container::getInstance()->make(Cache::class));
$debounceFor = $lock->getDebounceDelay($this->job);
if ($debounceFor === null) {
    return; // Cache was already resolved even though it wasn't needed
}
```

## Fix

Check for the `DebounceFor` attribute first (using the existing `ReadsQueueAttributes` trait — no cache needed), and only resolve `Cache` when the job actually requires debouncing:

```php
// After — Cache only resolved when debouncing is needed
$debounceFor = $this->getAttributeValue($this->job, DebounceFor::class, 'debounceFor');
if ($debounceFor === null) {
    return;
}
$lock = new DebounceLock(Container::getInstance()->make(Cache::class));
```

## Impact

- Fixes 7 failing `QueueSqsQueueTest` tests introduced by the debounce feature
- Fixes the `13.x` branch CI which started failing after the debounce feature was merged
- No behaviour change for jobs that do use `#[DebounceFor]`

## Test Plan

- [x] `QueueSqsQueueTest::testPendingDispatchProperlyPushesJobObjectOntoSqs` (and 6 similar) — now pass
- [x] Full `tests/Queue/` and `tests/Bus/` suites run cleanly