### PR TITLE
[13.x] Improve markdown formatting of copied exception report

### DIFF
--- a/src/Illuminate/Foundation/resources/exceptions/renderer/markdown.blade.php
+++ b/src/Illuminate/Foundation/resources/exceptions/renderer/markdown.blade.php
@@ -2,15 +2,17 @@
 
 {!! $exception->message() !!}
 
-PHP {{ PHP_VERSION }}
-Laravel {{ app()->version() }}
-{{ $exception->request()->httpHost() }}
+PHP `{{ PHP_VERSION }}`  
+Laravel `{{ app()->version() }}`  
+`{{ $exception->request()->httpHost() }}`
 
 ## Stack Trace
 
+```
 @foreach($exception->frames() as $index => $frame)
 {{ $index }} - {{ $frame->file() }}:{{ $frame->line() }}
 @endforeach
+```
 
 @if ($exception->previousExceptions()->isNotEmpty())
 ## Previous {{ \Illuminate\Support\Str::plural('exception', $exception->previousExceptions()->count()) }}
@@ -20,20 +22,22 @@ Laravel {{ app()->version() }}
 
 {!! $previous->message() !!}
 
+```
 @foreach($previous->frames() as $index => $frame)
 {{ $index }} - {{ $frame->file() }}:{{ $frame->line() }}
 @endforeach
+```
 @endforeach
 @endif
 
 ## Request
 
-{{ $exception->request()->method() }} {{ \Illuminate\Support\Str::start($exception->request()->path(), '/') }}
+`{{ $exception->request()->method() }} {{ \Illuminate\Support\Str::start($exception->request()->path(), '/') }}`
 
 ## Headers
 
 @forelse ($exception->requestHeaders() as $key => $value)
-* **{{ $key }}**: {!! $value !!}
+* **{{ $key }}**: `{!! $value !!}`
 @empty
 No header data available.
 @endforelse
@@ -41,7 +45,7 @@ No header data available.
 ## Route Context
 
 @forelse($exception->applicationRouteContext() as $name => $value)
-{{ $name }}: {!! $value !!}
+{{ \Illuminate\Support\Str::headline($name) }}: `{!! $value !!}`  
 @empty
 No routing data available.
 @endforelse
@@ -57,7 +61,9 @@ No route parameter data available.
 ## Database Queries
 
 @forelse ($exception->applicationQueries() as ['connectionName' => $connectionName, 'sql' => $sql, 'time' => $time])
-* {{ $connectionName }} - {!! $sql !!} ({{ $time }} ms)
+```sql
+{{ $connectionName }} - {!! $sql !!} ({{ $time }} ms)
+```
 @empty
 No database queries detected.
 @endforelse


### PR DESCRIPTION
This PR improves the markdown formatting of the copied exception report from exception page.

Here are screenshots of the markdown from a markdown viewer -

**Before**
<img width="1485" height="592" alt="image" src="https://github.com/user-attachments/assets/0c719e28-5ce5-4b25-9f49-f7e87fc57114" />

**After**
<img width="1485" height="601" alt="image" src="https://github.com/user-attachments/assets/f2b7083c-da2c-477e-b451-21e2e40d43d8" />
