### PR TITLE
[13.x] Avoid debounce cache resolution for regular jobs

### DIFF
--- a/src/Illuminate/Foundation/Bus/PendingDispatch.php
+++ b/src/Illuminate/Foundation/Bus/PendingDispatch.php
@@ -9,11 +9,13 @@ use Illuminate\Contracts\Bus\Dispatcher;
 use Illuminate\Contracts\Cache\Repository as Cache;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Foundation\Queue\InteractsWithUniqueJobs;
+use Illuminate\Queue\Attributes\DebounceFor;
+use Illuminate\Queue\Attributes\ReadsQueueAttributes;
 use LogicException;
 
 class PendingDispatch
 {
-    use InteractsWithUniqueJobs;
+    use InteractsWithUniqueJobs, ReadsQueueAttributes;
 
     /**
      * The job.
@@ -220,13 +222,13 @@ class PendingDispatch
      */
     protected function acquireDebounceLock()
     {
-        $lock = new DebounceLock(Container::getInstance()->make(Cache::class));
-
-        $debounceFor = $lock->getDebounceDelay($this->job);
+        $debounceFor = $this->getAttributeValue($this->job, DebounceFor::class, 'debounceFor');
 
         if ($debounceFor === null) {
             return;
         }
+
+        $lock = new DebounceLock(Container::getInstance()->make(Cache::class));
 
         if ($this->job instanceof ShouldBeUnique) {
             throw new LogicException('A debounced job cannot also implement ShouldBeUnique.');


### PR DESCRIPTION
`PendingDispatch` was resolving the debounce cache repository before checking whether the job actually has debounce configuration.

That makes regular queued jobs depend on a cache binding even when they are not debounced. In lightweight queue test containers this currently fails with:

```text
Target [Illuminate\Contracts\Cache\Repository] is not instantiable.
```

This reads the debounce attribute value first, using the same queue attribute reader, and only resolves the cache repository once the job is actually debounced.

Tests:

```bash
php vendor/bin/phpunit tests/Queue/QueueSqsQueueTest.php
php vendor/bin/phpunit tests/Integration/Queue/DebouncedJobTest.php
php vendor/bin/pint --dirty
```