### PR TITLE
[13.] Add filter to `expectsDatabaseQueryCount()` assertion

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -263,7 +263,7 @@ trait InteractsWithDatabase
         $actual = 0;
 
         $connectionInstance->listen(function (QueryExecuted $event) use (&$actual, $connectionInstance, $connection, $filter) {
-            if (is_null($connection) || $connectionInstance === $event->connection || $filter === null || $filter($event)) {
+            if ((is_null($connection) || $connectionInstance === $event->connection) && ($filter === null || $filter($event))) {
                 $actual++;
             }
         });

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -253,16 +253,17 @@ trait InteractsWithDatabase
      *
      * @param  int  $expected
      * @param  string|null  $connection
+     * @param  (Closure(QueryEvent): bool)|null  $filter
      * @return $this
      */
-    public function expectsDatabaseQueryCount($expected, $connection = null)
+    public function expectsDatabaseQueryCount($expected, $connection = null, $filter = null)
     {
         $connectionInstance = $this->getConnection($connection);
 
         $actual = 0;
 
-        $connectionInstance->listen(function (QueryExecuted $event) use (&$actual, $connectionInstance, $connection) {
-            if (is_null($connection) || $connectionInstance === $event->connection) {
+        $connectionInstance->listen(function (QueryExecuted $event) use (&$actual, $connectionInstance, $connection, $filter) {
+            if (is_null($connection) || $connectionInstance === $event->connection || $filter === null || $filter($event)) {
                 $actual++;
             }
         });

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -563,6 +563,29 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $case->setUp();
         $case->testExpectsDatabaseQueryCount();
         $case->tearDown();
+
+        $case = new class('foo') extends TestingTestCase
+        {
+            use CreatesApplication;
+
+            public function testExpectsDatabaseQueryCount()
+            {
+                $this->expectsDatabaseQueryCount(4);
+                // Expect only non-write queries
+                $this->expectsDatabaseQueryCount(3, fn (QueryExecuted $event) => preg_match('/\bSELECT\b/', $event->sql) === 1);
+
+                DB::pretend(function ($db) {
+                    $db->table('foo')->count();
+                    $db->table('foo')->count();
+                    $db->table('foo')->count();
+                    $db->table('foo')->insert(['bar' => 'baz']);
+                });
+            }
+        };
+
+        $case->setUp();
+        $case->testExpectsDatabaseQueryCount();
+        $case->tearDown();
     }
 
     protected function mockCountBuilder($existsResult, $deletedAtColumn = 'deleted_at', $countResult = null)

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Foundation;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithDatabase;
 use Illuminate\Foundation\Testing\TestCase as TestingTestCase;


### PR DESCRIPTION
This addition allows us to do
```php
class MyFooTest extends TestCase
{
    use CreatesApplication;

    public function testExpectsDatabaseQueryCount()
    {
        $this->expectsDatabaseQueryCount(4);
        // Expect only non-write queries
        $this->expectsDatabaseQueryCount(3, fn (QueryExecuted $event) => preg_match('/\bSELECT\b/', $event->sql) === 1);

         DB::pretend(function ($db) {
            $db->table('foo')->count();
            $db->table('foo')->count();
            $db->table('foo')->count();
            $db->table('foo')->insert(['bar' => 'baz']);
         });
    }
};
```

# Alternatives considered
* **read/write connection**
    * This only allows filtering via connection, not other aspects of the query operation
    * A read/write connection doesn't necessarily guarantee that only read/write queries are possible/executed via this connection