### PR TITLE
If non-existing custom env is requested, throw runtime exception

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
@@ -42,6 +42,7 @@ class LoadEnvironmentVariables
     {
         if ($app->runningInConsole() && ($input = new ArgvInput)->hasParameterOption('--env')) {                                           
             $envName = $input->getParameterOption('--env');
+
             $file = $app->environmentFile().'.'.$envName;                                    
                                                                        
             if ($this->setEnvironmentFilePath($app, $file)) {                                

--- a/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
@@ -40,11 +40,18 @@ class LoadEnvironmentVariables
      */
     protected function checkForSpecificEnvironmentFile($app)
     {
-        if ($app->runningInConsole() &&
-            ($input = new ArgvInput)->hasParameterOption('--env') &&
-            $this->setEnvironmentFilePath($app, $app->environmentFile().'.'.$input->getParameterOption('--env'))) {
-            return;
-        }
+        if ($app->runningInConsole() && ($input = new ArgvInput)->hasParameterOption('--env')) {                                           
+            $envName = $input->getParameterOption('--env');
+            $file = $app->environmentFile().'.'.$envName;                                    
+                                                                       
+            if ($this->setEnvironmentFilePath($app, $file)) {                                
+                return;
+            }                                                                                
+                                                                       
+            throw new RuntimeException(
+                "The environment file [{$file}] requested by --env={$envName} does not exist."                                                                              
+            ); 
+        }  
 
         $environment = Env::get('APP_ENV');
 


### PR DESCRIPTION
During a recent AI-assisted coding session with Claude, Claude ignored specific instructions to *not* run `migrate:fresh`. I wrote these instructions because in past sessions, it had done this without asking, leading to me being surprised that all of my local data was suddenly gone.

In this most recent session, however, it ignored my rules and ran `migrate:fresh`. It did so, however, by reasoning that it was running the migration against the test database—thinking that blowing away the test database was OK. And it should have been right to conclude that. 

It was wrong, however, to assume that the test database would live in an environment configuration called ".env.testing". All of my test configuration lives in phpunit.xml. So Claude executed `php artisan migrate:fresh --env=testing`, and Laravel, finding no `.env.testing`, simply failed silently to using `.env`.  From Claude's perspective, it had successfully run the migration against the correct environment. 

I have opened this pull request to suggest that the behavior of failing silently from specificity to generality should probably be changed, especially where environment configuration is concerned. I don't know if my conclusion is correct, and I don't know if my solution is correct, and I am open to both being wrong.

Thank you!