### PR TITLE
Add whereHasCount and orWhereHasCount methods

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -233,6 +233,43 @@ trait QueriesRelationships
         return $this->doesntHave($relation, 'or', $callback);
     }
 
+
+
+
+
+
+        /**
+         * Add a relationship count condition to the query.
+         *
+         * @param  string  $relation
+         * @param  string  $operator
+         * @param  int  $count
+         * @param  \Closure|null  $callback
+         * @return $this
+         */
+        public function whereHasCount(string $relation, string $operator = '>=', int $count = 1, ?\Closure $callback = null): static
+        {
+            return $this->has($relation, $operator, $count, 'and', $callback);
+        }
+
+        /**
+         * Add an "or where has count" condition to the query.
+         *
+         * @param  string  $relation
+         * @param  string  $operator
+         * @param  int  $count
+         * @param  \Closure|null  $callback
+         * @return $this
+         */
+        public function orWhereHasCount(string $relation, string $operator = '>=', int $count = 1, ?\Closure $callback = null): static
+        {
+            return $this->has($relation, $operator, $count, 'or', $callback);
+        }
+
+
+
+
+
     /**
      * Add a polymorphic relationship count / exists condition to the query.
      *

--- a/tests/Integration/Database/EloquentWhereHasTest.php
+++ b/tests/Integration/Database/EloquentWhereHasTest.php
@@ -248,6 +248,51 @@ class EloquentWhereHasTest extends DatabaseTestCase
 
         $this->assertEquals([1], $users->pluck('id')->all());
     }
+
+
+
+    public function testWhereHasCount()
+    {
+        
+        $users = User::whereHasCount('posts', '>=', 1)->get();
+
+        $this->assertEquals([1, 2], $users->pluck('id')->all());
+    }
+
+    public function testWhereHasCountWithHigherCount()
+    {
+    
+        $users = User::whereHasCount('posts', '>=', 2)->get();
+
+        $this->assertEmpty($users);
+    }
+
+    public function testWhereHasCountWithCallback()
+    {
+
+        $users = User::whereHasCount('posts', '>=', 1, function ($query) {
+            $query->where('public', true);
+        })->get();
+
+        $this->assertEquals([1], $users->pluck('id')->all());
+    }
+
+    public function testOrWhereHasCount()
+    {
+
+        $users = User::whereHasCount('posts', '>=', 1, function ($query) {
+            $query->where('public', true);
+        })->orWhereHasCount('posts', '>=', 1, function ($query) {
+            $query->where('public', false);
+        })->get();
+
+        $this->assertEquals([1, 2], $users->pluck('id')->all());
+    }
+
+
+
+
+
 }
 
 class Comment extends Model


### PR DESCRIPTION
Adds `whereHasCount()` and `orWhereHasCount()` to the `QueriesRelationships` trait as a cleaner alternative to `has()` when querying relationships by count.

```php
User::whereHasCount('posts', '>=', 3)->get();
User::whereHasCount('posts', '>=', 1, fn($q) => $q->where('public', true))->get();
```

Tests included.