### PR TITLE
[13.x] Fix false positives in LazyCollection::has() for duplicate keys

### DIFF
--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -592,6 +592,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
 
         foreach ($this as $key => $value) {
             unset($keys[$key]);
+
             if (empty($keys)) {
                 return true;
             }

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -589,10 +589,10 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     public function has($key)
     {
         $keys = array_flip(is_array($key) ? $key : func_get_args());
-        $count = count($keys);
 
         foreach ($this as $key => $value) {
-            if (array_key_exists($key, $keys) && --$count == 0) {
+            unset($keys[$key]);
+            if (empty($keys)) {
                 return true;
             }
         }

--- a/tests/Support/SupportLazyCollectionTest.php
+++ b/tests/Support/SupportLazyCollectionTest.php
@@ -531,4 +531,17 @@ class SupportLazyCollectionTest extends TestCase
             $this->assertContains($key, ['first', 'second', 'third']);
         }
     }
+
+    public function testHasDoesNotCountDuplicateKeys()
+    {
+        $collection = LazyCollection::make(function () {
+            yield 'a' => 1;
+            yield 'a' => 2;
+            yield 'c' => 3;
+        });
+
+        $this->assertFalse($collection->has('a', 'b'));
+        $this->assertFalse($collection->has(['a', 'b']));
+        $this->assertTrue($collection->has('a'));
+    }
 }


### PR DESCRIPTION
`LazyCollection::has()` can return `true` when the underlying iterator yields the same key more than once. 

The implementation decrements the counter every time a matching key is encountered. So the same key can be counted multiple times returning `true` even when another requested key was never found.

e.g.
```
$lazy = LazyCollection::make(function () {
	yield 'a' => 1;
	yield 'a' => 2;
	yield 'c' => 3;
});

$lazy->has('a', 'b'); // was true, should be false
```