### PR TITLE
[13.x] Allow jobs to react to worker signals

### DIFF
--- a/src/Illuminate/Contracts/Queue/Interruptible.php
+++ b/src/Illuminate/Contracts/Queue/Interruptible.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Contracts\Queue;
+
+interface Interruptible
+{
+    public function interrupted(int $signal): void;
+}

--- a/src/Illuminate/Contracts/Queue/Interruptible.php
+++ b/src/Illuminate/Contracts/Queue/Interruptible.php
@@ -4,5 +4,11 @@ namespace Illuminate\Contracts\Queue;
 
 interface Interruptible
 {
+    /**
+     * Handle a signal received by the queue worker.
+     *
+     * @param  int  $signal
+     * @return void
+     */
     public function interrupted(int $signal): void;
 }

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -80,9 +80,11 @@ class CallQueuedHandler
 
         $this->runningCommand = $command;
 
-        $this->dispatchThroughMiddleware($job, $command);
-
-        $this->runningCommand = null;
+        try {
+            $this->dispatchThroughMiddleware($job, $command);
+        } finally {
+            $this->runningCommand = null;
+        }
 
         if (! $job->isReleased() && ! $this->commandShouldBeUniqueUntilProcessing($command)) {
             $this->ensureUniqueJobLockIsReleased($command);

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -39,6 +39,13 @@ class CallQueuedHandler
     protected $container;
 
     /**
+     * The command currently being processed.
+     *
+     * @var mixed
+     */
+    protected $runningCommand;
+
+    /**
      * Create a new handler instance.
      *
      * @param  \Illuminate\Contracts\Bus\Dispatcher  $dispatcher
@@ -71,7 +78,11 @@ class CallQueuedHandler
             return $this->deleteDebouncedJob($job, $command);
         }
 
+        $this->runningCommand = $command;
+
         $this->dispatchThroughMiddleware($job, $command);
+
+        $this->runningCommand = null;
 
         if (! $job->isReleased() && ! $this->commandShouldBeUniqueUntilProcessing($command)) {
             $this->ensureUniqueJobLockIsReleased($command);
@@ -106,6 +117,16 @@ class CallQueuedHandler
         }
 
         throw new RuntimeException('Unable to extract job payload.');
+    }
+
+    /**
+     * Get the command currently being processed.
+     *
+     * @return mixed
+     */
+    public function getRunningCommand()
+    {
+        return $this->runningCommand;
     }
 
     /**

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -122,16 +122,6 @@ class CallQueuedHandler
     }
 
     /**
-     * Get the command currently being processed.
-     *
-     * @return mixed
-     */
-    public function getRunningCommand()
-    {
-        return $this->runningCommand;
-    }
-
-    /**
      * Dispatch the given job / command through its specified middleware.
      *
      * @param  \Illuminate\Contracts\Queue\Job  $job
@@ -450,5 +440,15 @@ class CallQueuedHandler
         if (method_exists($command, 'invokeChainCatchCallbacks')) {
             $command->invokeChainCatchCallbacks($e);
         }
+    }
+
+    /**
+     * Get the command currently being processed.
+     *
+     * @return mixed
+     */
+    public function getRunningCommand()
+    {
+        return $this->runningCommand;
     }
 }

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -80,18 +80,18 @@ class Worker
     protected $resetScope;
 
     /**
-     * Indicates if the worker should exit.
-     *
-     * @var bool
-     */
-    public $shouldQuit = false;
-
-    /**
      * The job currently being processed.
      *
      * @var \Illuminate\Contracts\Queue\Job|null
      */
     public $currentJob = null;
+
+    /**
+     * Indicates if the worker should exit.
+     *
+     * @var bool
+     */
+    public $shouldQuit = false;
 
     /**
      * Indicates if the worker lost its connection.

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Cache\Repository as CacheContract;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Queue\Factory as QueueManager;
+use Illuminate\Contracts\Queue\Interruptible;
 use Illuminate\Database\DetectsLostConnections;
 use Illuminate\Queue\Events\JobAttempted;
 use Illuminate\Queue\Events\JobExceptionOccurred;
@@ -84,6 +85,13 @@ class Worker
      * @var bool
      */
     public $shouldQuit = false;
+
+    /**
+     * The job currently being processed.
+     *
+     * @var \Illuminate\Contracts\Queue\Job|null
+     */
+    public $currentJob = null;
 
     /**
      * Indicates if the worker lost its connection.
@@ -446,6 +454,8 @@ class Worker
      */
     protected function runJob($job, $connectionName, WorkerOptions $options)
     {
+        $this->currentJob = $job;
+
         try {
             return $this->process($connectionName, $job, $options);
         } catch (Throwable $e) {
@@ -454,6 +464,8 @@ class Worker
             }
 
             $this->stopWorkerIfLostConnection($e);
+        } finally {
+            $this->currentJob = null;
         }
     }
 
@@ -808,11 +820,41 @@ class Worker
     {
         pcntl_async_signals(true);
 
-        pcntl_signal(SIGQUIT, fn () => $this->shouldQuit = true);
-        pcntl_signal(SIGTERM, fn () => $this->shouldQuit = true);
-        pcntl_signal(SIGINT, fn () => $this->shouldQuit = true);
+        foreach ([SIGQUIT, SIGTERM, SIGINT] as $signal) {
+            pcntl_signal($signal, function (int $signal) {
+                $this->shouldQuit = true;
+
+                $this->notifyJobOfSignal($signal);
+            });
+        }
+
         pcntl_signal(SIGUSR2, fn () => $this->paused = true);
         pcntl_signal(SIGCONT, fn () => $this->paused = false);
+    }
+
+    /**
+     * Passes the signal to the running job.
+     *
+     * @param  int  $signal
+     * @return void
+     */
+    protected function notifyJobOfSignal(int $signal): void
+    {
+        if (! $this->currentJob) {
+            return;
+        }
+
+        $handler = $this->currentJob->getResolvedJob();
+
+        if (! $handler instanceof CallQueuedHandler) {
+            return;
+        }
+
+        $job = $handler->getRunningCommand();
+
+        if ($job instanceof Interruptible) {
+            $job->interrupted($signal);
+        }
     }
 
     /**

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -6,7 +6,9 @@ use Exception;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Queue\Interruptible;
 use Illuminate\Contracts\Queue\Job as QueueJobContract;
+use Illuminate\Queue\CallQueuedHandler;
 use Illuminate\Queue\Events\JobExceptionOccurred;
 use Illuminate\Queue\Events\JobPopped;
 use Illuminate\Queue\Events\JobPopping;
@@ -507,6 +509,31 @@ class QueueWorkerTest extends TestCase
         }))->once();
     }
 
+    public function testInterruptibleJobIsNotifiedOnSignal()
+    {
+        $interruptible = new class implements Interruptible
+        {
+            public ?int $receivedSignal = null;
+
+            public function interrupted(int $signal): void
+            {
+                $this->receivedSignal = $signal;
+            }
+        };
+
+        $handler = m::mock(CallQueuedHandler::class);
+        $handler->shouldReceive('getRunningCommand')->andReturn($interruptible);
+
+        $worker = $this->getWorker('default', ['queue' => []]);
+        $job = new WorkerFakeJob;
+        $job->resolvedJob = $handler;
+
+        $worker->currentJob = $job;
+        $worker->notifyJobOfSignal(15);
+
+        $this->assertSame(15, $interruptible->receivedSignal);
+    }
+
     /**
      * Helpers...
      */
@@ -552,6 +579,11 @@ class InsomniacWorker extends Worker
     public function sleep($seconds)
     {
         $this->sleptFor = $seconds;
+    }
+
+    public function notifyJobOfSignal(int $signal): void
+    {
+        parent::notifyJobOfSignal($signal);
     }
 
     public function stop($status = 0, $options = null, $reason = null)
@@ -649,6 +681,7 @@ class WorkerFakeJob implements QueueJobContract
     public $connectionName = '';
     public $queue = '';
     public $rawBody = '';
+    public $resolvedJob = null;
 
     public function __construct($callback = null)
     {
@@ -787,6 +820,11 @@ class WorkerFakeJob implements QueueJobContract
     public function resolveQueuedJobClass()
     {
         return 'WorkerFakeJob';
+    }
+
+    public function getResolvedJob()
+    {
+        return $this->resolvedJob;
     }
 }
 


### PR DESCRIPTION
When a worker retrieves a signal like SIGTERM,  you can have a set amount of time before it gets killed.  

In managed infrastructure, this is usually 10 seconds to 1 minute. (I can set it)

But, right now, the Job is oblivious its going be killed... so the worker knows, but the job doesnt.

So, I thought it would be nice to be able to react from inside the job, if this does happen. 


See a basic example video here (audio on) (I changed the method name since): 

<details> 

https://github.com/user-attachments/assets/4f620936-1bd6-4a8b-ba0c-432b37a51f8e

</details>

TLDR is you implement the Interruptible interface on the job, and put your logic in the interrupted method  which looks something like:

<details>

```php

namespace App\Jobs;

use Illuminate\Contracts\Queue\Interruptible;
use Illuminate\Contracts\Queue\ShouldQueue;
use Illuminate\Foundation\Queue\Queueable;

class SignalJob implements ShouldQueue, Interruptible // MUST IMPLEMENT THIS
{
    use Queueable;

    protected bool $stop = false;

    /**
     * Execute the job.
     */
    public function handle(): void
    {
        while(!$this->stop) {
            sleep(1);
            echo "I am running doing something kinda important...\n";
        }
    }

    public function interrupted(int $signal): void // MUST HAVE A METHOD WITH THE LOGIC
    {
        $this->stop = true;
        echo "I have been told to stop!\n";
        echo $signal;
    }
}


```

</details> 


Granted, this may not be something you want to maintain, or you may see a nicer way of passing the signal in, but I thought I'd give it a go! Could probably use some love, but no drama if you dont dig it.

This may need some additional thought and poking as I'm not super 100% knowledge on the queue logic.