### PR TITLE
[13.x] Fix empty sparse fieldset handling in JSON:API resources

### DIFF
--- a/src/Illuminate/Http/Resources/JsonApi/Concerns/ResolvesJsonApiElements.php
+++ b/src/Illuminate/Http/Resources/JsonApi/Concerns/ResolvesJsonApiElements.php
@@ -143,16 +143,25 @@ trait ResolvesJsonApiElements
             $data = $data->jsonSerialize();
         }
 
-        $sparseFieldset = match ($this->usesRequestQueryString) {
-            true => $request->sparseFields($resourceType),
-            default => [],
-        };
+        $sparseFieldset = $this->usesRequestQueryString
+            ? $request->sparseFields($resourceType)
+            : null;
 
-        $data = (new Collection($data))
-            ->mapWithKeys(fn ($value, $key) => is_int($key) ? [$value => $this->resource->{$value}] : [$key => $value])
-            ->when(! empty($sparseFieldset), fn ($attributes) => $attributes->only($sparseFieldset))
-            ->transform(fn ($value) => value($value, $request))
-            ->all();
+        if ($sparseFieldset === []) {
+            // Client sent an empty sparse fieldset, so we return an empty attributes object.
+            $data = [];
+        } elseif (! empty($sparseFieldset)) {
+            // Client sent a sparse fieldset, so we filter the attributes to only those in the sparse fieldset.
+            $data = (new Collection($data))
+                ->only($sparseFieldset)
+                ->transform(fn ($value) => value($value, $request))
+                ->all();
+        } else {
+            // Client sent no sparse fieldset, so we return all attributes.
+            $data = (new Collection($data))
+                ->transform(fn ($value) => value($value, $request))
+                ->all();
+        }
 
         return $this->filter($data);
     }

--- a/src/Illuminate/Http/Resources/JsonApi/JsonApiRequest.php
+++ b/src/Illuminate/Http/Resources/JsonApi/JsonApiRequest.php
@@ -21,15 +21,27 @@ class JsonApiRequest extends Request
     /**
      * Get the request's included fields.
      */
-    public function sparseFields(string $key): array
+    public function sparseFields(string $key): ?array
     {
         if (is_null($this->cachedSparseFields)) {
             $this->cachedSparseFields = (new Collection($this->array('fields')))
-                ->transform(fn ($fieldsets) => empty($fieldsets) ? [] : explode(',', $fieldsets))
+                ->map(function ($fieldsets) {
+                    // If the client sent no fields, return null.
+                    if ($fieldsets === null) {
+                        return null;
+                    }
+
+                    // If the client sent an empty string, return an empty array.
+                    if ($fieldsets === '' || (is_array($fieldsets) && empty($fieldsets))) {
+                        return [];
+                    }
+
+                    return explode(',', $fieldsets);
+                })
                 ->all();
         }
 
-        return $this->cachedSparseFields[$key] ?? [];
+        return $this->cachedSparseFields[$key] ?? null;
     }
 
     /**

--- a/tests/Integration/Http/Resources/JsonApi/JsonApiRequestTest.php
+++ b/tests/Integration/Http/Resources/JsonApi/JsonApiRequestTest.php
@@ -7,7 +7,41 @@ use Illuminate\Http\Resources\JsonApi\JsonApiResource;
 
 class JsonApiRequestTest extends TestCase
 {
-    public function testItCanResolveSparseFields()
+    /**
+     * Test that when no sparse fields are requested, the method returns null for any type.
+     *
+     * @return void
+     */
+    public function testItReturnsNullWhenNoSparseFieldsAreRequested(): void
+    {
+        $request = JsonApiRequest::create(uri: '/');
+
+        $this->assertNull($request->sparseFields('users'));
+        $this->assertNull($request->sparseFields('teams'));
+        $this->assertNull($request->sparseFields('posts'));
+    }
+
+    /**
+     * Test that when an empty sparse fieldset is requested, the method returns an empty array for that type.
+     *
+     * @return void
+     */
+    public function testItReturnsEmptyArrayWhenEmptySparseFieldsetIsRequested(): void
+    {
+        $request = JsonApiRequest::create(uri: '/?fields[users]=');
+
+        $this->assertSame([], $request->sparseFields('users'));
+        // Other types not present in query should return null
+        $this->assertNull($request->sparseFields('teams'));
+        $this->assertNull($request->sparseFields('posts'));
+    }
+
+    /**
+     * Test that when sparse fields are requested, the method returns an array of the requested fields for that type.
+     *
+     * @return void
+     */
+    public function testItReturnsFieldListWhenSparseFieldsAreRequested(): void
     {
         $request = JsonApiRequest::create(uri: '/?'.http_build_query([
             'fields' => [
@@ -18,19 +52,16 @@ class JsonApiRequestTest extends TestCase
 
         $this->assertSame(['name', 'email'], $request->sparseFields('users'));
         $this->assertSame(['name'], $request->sparseFields('teams'));
-        $this->assertSame([], $request->sparseFields('posts'));
+        $this->assertNull($request->sparseFields('posts'));
     }
 
-    public function testItCanResolveEmptySparseFields()
-    {
-        $request = JsonApiRequest::create(uri: '/');
-
-        $this->assertSame([], $request->sparseFields('users'));
-        $this->assertSame([], $request->sparseFields('teams'));
-        $this->assertSame([], $request->sparseFields('posts'));
-    }
-
-    public function testItCanResolveSparseIncluded()
+    /**
+     * Test that when sparse included relationships are requested,
+     * the method returns an array of the requested relationships for that type.
+     *
+     * @return void
+     */
+    public function testItCanResolveSparseIncluded(): void
     {
         $request = JsonApiRequest::create(uri: '/?'.http_build_query([
             'include' => 'teams,posts.author,posts.comments,profile.user.profile',
@@ -42,7 +73,14 @@ class JsonApiRequestTest extends TestCase
         $this->assertSame(['user.profile'], $request->sparseIncluded('profile'));
     }
 
-    public function testItCanREsolveSparseIncludedWithMaxRelationshipNesting()
+    /**
+     * Test that when sparse included relationships are requested with max relationship nesting,
+     * the method returns an array of the requested relationships for that type,
+     * but only up to the max relationship depth.
+     *
+     * @return void
+     */
+    public function testItCanResolveSparseIncludedWithMaxRelationshipNesting(): void
     {
         JsonApiResource::maxRelationshipDepth(2);
 
@@ -56,7 +94,12 @@ class JsonApiRequestTest extends TestCase
         $this->assertSame(['user'], $request->sparseIncluded('profile'));
     }
 
-    public function testItCanResolveEmptySparseIncluded()
+    /**
+     * Test that when no sparse included relationships are requested, the method returns an empty array.
+     *
+     * @return void
+     */
+    public function testItCanResolveEmptySparseIncluded(): void
     {
         $request = JsonApiRequest::create(uri: '/');
 


### PR DESCRIPTION
Currently, JSON:API resources treat a missing sparse fieldset and an explicitly empty sparse fieldset identically. Both cases make `JsonApiRequest::sparseFields()` return an empty array.

According to the JSON:API specification ([RFC 6901](https://jsonapi.org/format/#fetching-sparse-fieldsets)), when a client sends an empty fieldset like `?fields[users]=`, the server **MUST NOT** return any attributes for that resource type – only the resource identifier (`id` and `type`) should be present. Conversely, when the fieldset is omitted entirely, all attributes should be returned as normal.

### Current behavior

- `?fields[users]=` → returns all attributes (wrong)
- No `fields` query → returns all attributes (correct)

### Expected behavior

- `?fields[users]=` → returns **only** `{ "id": "...", "type": "users" }`
- No `fields` query → returns all attributes

### Changes made

1. **Modified `JsonApiRequest::sparseFields()`** to return `?array` instead of `array`:
   - Returns `null` when the fieldset was **not** specified for the given type.
   - Returns `[]` when the fieldset **was** specified but empty.
   - Returns the list of fields otherwise.

2. **Updated `ResolvesJsonApiElements::resolveResourceAttributes()`** to handle the new `?array` return value:
   - If `$sparseFieldset === []`, the `attributes` member is omitted from the resource object.
   - If `$sparseFieldset` is `null`, all attributes are included.
   - Otherwise, only the requested fields are included.

3. **Adjusted tests** to cover the three distinct cases (`null`, `[]`, non‑empty array).

### Related issue

Fixes #59812