### PR TITLE
Fix/issue 59828

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -661,7 +661,7 @@ class Router implements BindingRegistrar, RegistrarContract
             return $class;
         }
 
-        if (str_contains($class, '\\') && class_exists($class)) {
+        if (str_contains($class, '\\') && class_exists($class)){
             return $class;
         }
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -661,7 +661,7 @@ class Router implements BindingRegistrar, RegistrarContract
             return $class;
         }
 
-        if (class_exists($class)) {
+        if (str_contains($class, '\\') && class_exists($class)) {
             return $class;
         }
 


### PR DESCRIPTION
<!--
Thank you for the detailed report.

I was able to understand the scenario: when using Route::controller(...)->group(...) with the action defined only as a string, such as 'request', Laravel may end up treating this name as a class when it matches a globally aliased facade that has already been loaded. This seems to happen due to the class_exists($class) check in PHP, which is case-insensitive, so names like request can collide with Request depending on the loading order.

Based on your description, the behavior is real, although it is likely low impact since it depends on a very specific combination of method name + previously resolved global alias.

In the meantime, the safest workaround is to define routes using the explicit array syntax, for example:

Route::get('/', [ExampleController::class, 'request']);

instead of relying on the method name string alone within the group. This is also more aligned with the modern way of defining controller routes in Laravel.

If needed, I can open a PR with a test reproducing this case and a proposed fix to prevent method names from being resolved as classes when used as action strings within a controller group.
-->
