### PR TITLE
[13.x] Add payload() method to Factory for HTTP testing

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -160,6 +160,13 @@ abstract class Factory
     protected static $cachedModelAttributes = [];
 
     /**
+     * The model attributes that should be included in HTTP payloads.
+     *
+     * @var array<int, string>
+     */
+    protected $payloadAttributes = [];
+
+    /**
      * Create a new factory instance.
      *
      * @param  int|null  $count
@@ -1118,6 +1125,27 @@ abstract class Factory
         static::$factoryNameResolver = null;
         static::$namespace = 'Database\\Factories\\';
         static::$expandRelationshipsByDefault = true;
+    }
+
+    /**
+     * Get an HTTP payload array for the model.
+     *
+     * @param  array<string, mixed>  $overrides
+     * @param  \Illuminate\Database\Eloquent\Model|null  $parent
+     * @return array<string, mixed>
+     */
+    public function payload(array $overrides = [], ?Model $parent = null)
+    {
+        if (empty($this->payloadAttributes)) {
+            return $overrides;
+        }
+
+        $filtered = array_intersect_key(
+            $this->count(null)->raw([], $parent),
+            array_flip($this->payloadAttributes)
+        );
+
+        return array_merge($filtered, $overrides);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -235,6 +235,61 @@ class DatabaseEloquentFactoryTest extends TestCase
         $this->assertSame('Taylor Otwell', $user['name']);
     }
 
+    public function test_payload_returns_empty_when_payload_attributes_not_declared()
+    {
+        $payload = FactoryTestUserFactory::new()->payload();
+
+        $this->assertSame([], $payload);
+    }
+
+    public function test_payload_returns_only_overrides_when_payload_attributes_not_declared()
+    {
+        $payload = FactoryTestUserFactory::new()->payload(['foo' => 'bar']);
+
+        $this->assertSame(['foo' => 'bar'], $payload);
+    }
+
+    public function test_payload_filters_raw_attributes_by_whitelist()
+    {
+        $payload = FactoryTestUserWithPayloadFactory::new()->payload();
+
+        $this->assertArrayHasKey('name', $payload);
+        $this->assertArrayNotHasKey('options', $payload);
+    }
+
+    public function test_payload_overrides_merge_with_filtered_attributes()
+    {
+        $payload = FactoryTestUserWithPayloadFactory::new()->payload(['name' => 'Taylor Otwell']);
+
+        $this->assertSame('Taylor Otwell', $payload['name']);
+    }
+
+    public function test_payload_overrides_bypass_whitelist()
+    {
+        $payload = FactoryTestUserWithPayloadFactory::new()->payload(['password_confirmation' => 'secret']);
+
+        $this->assertArrayHasKey('name', $payload);
+        $this->assertSame('secret', $payload['password_confirmation']);
+        $this->assertArrayNotHasKey('options', $payload);
+    }
+
+    public function test_payload_returns_single_array_even_with_count()
+    {
+        $payload = FactoryTestUserWithPayloadFactory::new()->count(3)->payload();
+
+        $this->assertArrayHasKey('name', $payload);
+        $this->assertIsString($payload['name']);
+    }
+
+    public function test_payload_works_with_state()
+    {
+        $payload = FactoryTestUserWithPayloadFactory::new()
+            ->state(['name' => 'Taylor'])
+            ->payload();
+
+        $this->assertSame('Taylor', $payload['name']);
+    }
+
     public function test_expanded_model_attributes_can_be_created()
     {
         $post = FactoryTestPostFactory::new()->raw();
@@ -1154,6 +1209,21 @@ class FactoryTestUserFactory extends Factory
         return [
             'name' => $this->faker->name(),
             'options' => null,
+        ];
+    }
+}
+
+class FactoryTestUserWithPayloadFactory extends Factory
+{
+    protected $model = FactoryTestUser::class;
+
+    protected $payloadAttributes = ['name'];
+
+    public function definition()
+    {
+        return [
+            'name' => $this->faker->name(),
+            'options' => 'secret-value',
         ];
     }
 }


### PR DESCRIPTION
This PR adds a `payload()` method to the base `Factory` class, allowing factories to generate HTTP request payloads for testing without needing to persist a model or manually construct arrays in every test.

## Motivation

When writing feature tests for HTTP endpoints, developers frequently need to generate request payloads that match the shape the endpoint expects. Today, this is done either by manually building arrays or using `raw()` and filtering/transforming the result:

```php
// Manual construction — repetitive across tests
$response = $this->postJson(route('register.store'), [
    'name' => fake()->name(),
    'email' => fake()->unique()->freeEmail(),
    'password' => $password,
    'password_confirmation' => $password,
]);
```

The `raw()` method alone doesn't solve this cleanly: it returns the full `definition()` (including hashed passwords, timestamps, and other persistence-only fields), which doesn't match what a typical HTTP endpoint expects.

## Proposed solution

Factories can declare a whitelist of attributes that should appear in HTTP payloads:

```php
class UserFactory extends Factory
{
    protected $payloadAttributes = ['name', 'email'];

    public function definition(): array
    {
        return [
            'name' => fake()->name(),
            'email' => fake()->unique()->safeEmail(),
            'email_verified_at' => now(),
            'password' => Hash::make('password'),
            'remember_token' => Str::random(10),
        ];
    }
}
```

And generate clean HTTP payloads in tests:

```php
$response = $this->postJson(route('register.store'), User::factory()->payload([
    'password' => $password,
    'password_confirmation' => $password,
]));
```

## Behavior

- `$payloadAttributes` empty (default) → `payload()` returns only the overrides (fully backward compatible — no existing factory is affected)
- `$payloadAttributes` declared → filters `raw()` by the whitelist, then merges overrides
- Overrides always pass through, even if not in the whitelist (useful for fields like `password_confirmation` that aren't in `definition()`)
- `count()` doesn't affect `payload()` — always returns a single array

## Tests

7 new tests in `DatabaseEloquentFactoryTest` covering:
- Empty whitelist returns empty array / overrides only
- Whitelist filters `raw()` correctly
- Overrides merge with filtered attributes
- Overrides bypass whitelist (e.g., `password_confirmation`)
- `count()` doesn't affect output
- Works with `state()`

All 73 existing tests continue to pass.

## Not a breaking change

Factories that don't declare `$payloadAttributes` get an empty array by default. No existing factory or test behavior changes.