### PR TITLE
[13.x] Prevent TypeError in AuthenticateSession when session value is not a string

### DIFF
--- a/src/Illuminate/Session/Middleware/AuthenticateSession.php
+++ b/src/Illuminate/Session/Middleware/AuthenticateSession.php
@@ -107,6 +107,10 @@ class AuthenticateSession implements AuthenticatesSessions
      */
     protected function validatePasswordHash($passwordHash, $storedValue)
     {
+        if (! is_string($passwordHash) || ! is_string($storedValue)) {
+            return false;
+        }
+
         try {
             // Try new HMAC format first, then fall back to raw password hash format for backward compatibility
             return hash_equals($this->guard()->hashPasswordForCookie($passwordHash), $storedValue)


### PR DESCRIPTION
#### Problem

In PHP 8+, calling `hash_equals()` with non-string arguments throws a `TypeError` instead of returning `false`.

Within `AuthenticateSession`, the `$storedValue` is retrieved from the session and may be `null` or another non-string type (e.g. array) if the session is missing, corrupted, or manipulated. In such cases, this leads to an unhandled exception and a 500 response instead of failing authentication gracefully.

#### Impact

* Unexpected 500 errors during authentication
* Potential denial of service if malformed session data is repeatedly triggered
* Breaks the expected behavior of safely invalidating the session

#### Solution

Added explicit `is_string()` checks for both `$passwordHash` and `$storedValue` before calling `hash_equals()`.

If either value is not a string, the comparison safely fails instead of throwing an exception.

#### Benefits for End Users

* Prevents unexpected server errors during authentication
* Ensures consistent and graceful logout behavior
* Improves application stability when dealing with invalid or corrupted session data

#### Backward Compatibility

This change is fully backward compatible:

* Only affects edge cases where invalid types are passed
* Normal authentication flow remains unchanged
* No changes to public APIs or expected return values

#### Tests

* Existing `AuthenticateSessionTest` suite passes without modification
* Behavior remains consistent for valid inputs

---

### Why this matters

This aligns with Laravel’s goal of providing a robust and fault-tolerant authentication system, especially under edge cases involving session state.
