### PR TITLE
[13.x] Add UnitEnum type support for $limiterName on RateLimitedWithRedis

### DIFF
--- a/src/Illuminate/Queue/Middleware/RateLimitedWithRedis.php
+++ b/src/Illuminate/Queue/Middleware/RateLimitedWithRedis.php
@@ -28,7 +28,7 @@ class RateLimitedWithRedis extends RateLimited
     /**
      * Create a new middleware instance.
      *
-     * @param  string  $limiterName
+     * @param  \UnitEnum|string  $limiterName
      */
     public function __construct($limiterName, ?string $connection = null)
     {


### PR DESCRIPTION
Add `UnitEnum` type support to the $limiterName PHPDoc in the `RateLimitedWithRedis` constructor to match the parent `RateLimited` implementation and improve consistency.

```php
/**
     * Create a new middleware instance.
     *
     * @param  \UnitEnum|string  $limiterName
     */
    public function __construct($limiterName)
    {
```