### PR TITLE
[13.x] Add Arr::avg() method

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -643,7 +643,6 @@ class Arr
      *
      * An array is "associative" if it doesn't have sequential numerical keys beginning with zero.
      *
-     * @param  array  $array
      * @return ($array is list ? false : true)
      */
     public static function isAssoc(array $array)
@@ -829,8 +828,6 @@ class Arr
     /**
      * Run a map over each of the items in the array.
      *
-     * @param  array  $array
-     * @param  callable  $callback
      * @return array
      */
     public static function map(array $array, callable $callback)
@@ -892,6 +889,32 @@ class Arr
 
             return $callback(...$chunk);
         });
+    }
+
+    /**
+     * Get the average value of a given key.
+     *
+     * @param  array  $array
+     * @param  (callable(mixed): mixed)|string|null  $callback
+     * @return float|int|null
+     */
+    public static function avg($array, $callback = null)
+    {
+        $count = 0;
+        $total = 0;
+
+        $callback = is_null($callback)
+            ? fn ($value) => $value
+            : (is_callable($callback) ? $callback : fn ($item) => data_get($item, $callback));
+
+        foreach ($array as $key => $value) {
+            if (! is_null($resolved = $callback($value, $key))) {
+                $total += $resolved;
+                $count++;
+            }
+        }
+
+        return $count ? $total / $count : null;
     }
 
     /**
@@ -1030,11 +1053,6 @@ class Arr
 
     /**
      * Push an item into an array using "dot" notation.
-     *
-     * @param  \ArrayAccess|array  $array
-     * @param  string|int|null  $key
-     * @param  mixed  $values
-     * @return array
      */
     public static function push(ArrayAccess|array &$array, string|int|null $key, mixed ...$values): array
     {

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1145,6 +1145,18 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['1-a-0', '2-b-1'], $result);
     }
 
+    public function testAvg()
+    {
+        $this->assertEquals(2, Arr::avg([1, 2, 3]));
+        $this->assertSame(1.5, Arr::avg([1, 2]));
+        $this->assertNull(Arr::avg([]));
+        $this->assertNull(Arr::avg([null, null]));
+        $this->assertEquals(2, Arr::avg([1, null, 3]));
+        $this->assertEquals(2, Arr::avg([['foo' => 1], ['foo' => 2], ['foo' => 3]], 'foo'));
+        $this->assertEquals(2, Arr::avg([['foo' => 1], ['foo' => null], ['foo' => 3]], 'foo'));
+        $this->assertEquals(2, Arr::avg([1, 2, 3], fn ($v) => $v));
+    }
+
     #[IgnoreDeprecations]
     public function testPrepend()
     {


### PR DESCRIPTION
## Summary

Adds `Arr::avg($array, $callback = null)` to `Illuminate\Support\Arr`, mirroring the existing `Collection::avg()` behaviour for plain arrays.

## Context

| Feature | Exists in `Collection` | Exists in `Arr` |
|---|---|---|
| `avg()` | ✅ | ❌ |

## Solution

- Null values are excluded from the average (consistent with `Collection::avg()`)
- `$callback` accepts a callable, a dot-notation string key, or `null` to average the values directly
- Returns `null` for empty arrays or arrays containing only nulls

## Example

```php
Arr::avg([1, 2, 3]);                               // 2
Arr::avg([1, null, 3]);                            // 2  (null excluded)
Arr::avg([['score' => 10], ['score' => 20]], 'score'); // 15
Arr::avg($items, fn ($item) => $item['price'] * 0.9);
```

## Changes

- `src/Illuminate/Collections/Arr.php` — adds `Arr::avg()`
- `tests/Support/SupportArrTest.php` — adds `testAvg()`

## Test Plan

- [x] Basic average of integers
- [x] Average of two values returns float
- [x] Empty array returns `null`
- [x] All-null array returns `null`
- [x] Null values excluded from average
- [x] Dot-notation key extraction
- [x] Null key values excluded
- [x] Callable callback