### PR TITLE
[13.x] Fix flaky DynamoBatchTest timing assertions

### DIFF
--- a/tests/Integration/Queue/DynamoBatchTest.php
+++ b/tests/Integration/Queue/DynamoBatchTest.php
@@ -67,7 +67,7 @@ class DynamoBatchTest extends TestCase
         $retrieved = $repo->find($batch->id);
         $this->assertEquals(2, $retrieved->totalJobs);
         $this->assertEquals(0, $retrieved->failedJobs);
-        $this->assertTrue($retrieved->finishedAt->between(Carbon::now()->subSecond(), Carbon::now()));
+        $this->assertTrue($retrieved->finishedAt->between(Carbon::now()->subSeconds(3), Carbon::now()));
     }
 
     public function test_retrieve_non_existent_batch()
@@ -114,8 +114,8 @@ class DynamoBatchTest extends TestCase
         $retrieved = $repo->find($batch->id);
         $this->assertEquals(2, $retrieved->totalJobs);
         $this->assertEquals(1, $retrieved->failedJobs);
-        $this->assertTrue($retrieved->finishedAt->between(Carbon::now()->subSecond(), Carbon::now()));
-        $this->assertTrue($retrieved->cancelledAt->between(Carbon::now()->subSecond(), Carbon::now()));
+        $this->assertTrue($retrieved->finishedAt->between(Carbon::now()->subSeconds(3), Carbon::now()));
+        $this->assertTrue($retrieved->cancelledAt->between(Carbon::now()->subSeconds(3), Carbon::now()));
     }
 
     public function test_get_batches()


### PR DESCRIPTION
## Summary

Fixes intermittently failing `DynamoBatchTest` assertions caused by a timing race condition. The tests assert that `finishedAt` and `cancelledAt` fall within a 1-second window, but DynamoDB Local on CI can occasionally take longer than 1 second to process the batch, causing a false failure.

## Root Cause

```php
// Before — 1 second window is too tight on slow CI runners
$this->assertTrue($retrieved->finishedAt->between(Carbon::now()->subSecond(), Carbon::now()));
```

## Fix

Widen the window to 3 seconds, which is consistent with how other timing-sensitive tests in the framework handle CI latency:

```php
// After — 3 second window accommodates CI infrastructure latency
$this->assertTrue($retrieved->finishedAt->between(Carbon::now()->subSeconds(3), Carbon::now()));
```

## Affected assertions

- `test_retrieve_batch_by_id` — `finishedAt`
- `test_batch_with_failing_job` — `finishedAt` and `cancelledAt`