### PR TITLE
[13.x] Add Arr::sum() method

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -643,7 +643,6 @@ class Arr
      *
      * An array is "associative" if it doesn't have sequential numerical keys beginning with zero.
      *
-     * @param  array  $array
      * @return ($array is list ? false : true)
      */
     public static function isAssoc(array $array)
@@ -829,8 +828,6 @@ class Arr
     /**
      * Run a map over each of the items in the array.
      *
-     * @param  array  $array
-     * @param  callable  $callback
      * @return array
      */
     public static function map(array $array, callable $callback)
@@ -892,6 +889,26 @@ class Arr
 
             return $callback(...$chunk);
         });
+    }
+
+    /**
+     * Get the sum of the given values.
+     *
+     * @param  array  $array
+     * @param  (callable(mixed): mixed)|string|null  $callback
+     * @return int|float
+     */
+    public static function sum($array, $callback = null)
+    {
+        $callback = is_null($callback)
+            ? fn ($value) => $value
+            : (is_callable($callback) ? $callback : fn ($item) => data_get($item, $callback));
+
+        return array_reduce(
+            array_keys($array),
+            fn ($result, $key) => $result + $callback($array[$key], $key),
+            0
+        );
     }
 
     /**
@@ -1030,11 +1047,6 @@ class Arr
 
     /**
      * Push an item into an array using "dot" notation.
-     *
-     * @param  \ArrayAccess|array  $array
-     * @param  string|int|null  $key
-     * @param  mixed  $values
-     * @return array
      */
     public static function push(ArrayAccess|array &$array, string|int|null $key, mixed ...$values): array
     {

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1145,6 +1145,16 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['1-a-0', '2-b-1'], $result);
     }
 
+    public function testSum()
+    {
+        $this->assertEquals(6, Arr::sum([1, 2, 3]));
+        $this->assertEquals(0, Arr::sum([]));
+        $this->assertEquals(6, Arr::sum([['foo' => 1], ['foo' => 2], ['foo' => 3]], 'foo'));
+        $this->assertEquals(6, Arr::sum([1, 2, 3], fn ($v) => $v));
+        $this->assertEquals(12, Arr::sum([1, 2, 3], fn ($v) => $v * 2));
+        $this->assertEquals(3, Arr::sum([['item' => ['price' => 1]], ['item' => ['price' => 2]]], 'item.price'));
+    }
+
     #[IgnoreDeprecations]
     public function testPrepend()
     {


### PR DESCRIPTION
## Summary

Adds `Arr::sum($array, $callback = null)` to `Illuminate\Support\Arr`, mirroring the existing `Collection::sum()` behaviour for plain arrays.

## Context

| Feature | Exists in `Collection` | Exists in `Arr` |
|---|---|---|
| `sum()` | ✅ | ❌ |

While PHP has `array_sum()`, it does not support dot-notation key extraction or callable transforms on nested arrays.

## Example

```php
// Simple sum
Arr::sum([1, 2, 3]); // 6

// With a dot-notation key
Arr::sum([
    ['price' => 10],
    ['price' => 20],
    ['price' => 30],
], 'price'); // 60

// Nested dot-notation
Arr::sum($items, 'item.price');

// With a callback
Arr::sum($items, fn ($item) => $item['price'] * $item['qty']);
```

## Changes

- `src/Illuminate/Collections/Arr.php` — adds `Arr::sum()`
- `tests/Support/SupportArrTest.php` — adds `testSum()`

## Test Plan

- [x] Sum of simple integers
- [x] Empty array returns `0`
- [x] Dot-notation key extraction
- [x] Callable callback
- [x] Callback with multiplier
- [x] Nested dot-notation key