### PR TITLE
[13.x] Add Str::isEmpty() and Str::isNotEmpty() methods

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -550,6 +550,28 @@ class Str
     }
 
     /**
+     * Determine if the given string is empty.
+     *
+     * @param  string  $value
+     * @return bool
+     */
+    public static function isEmpty($value)
+    {
+        return $value === '';
+    }
+
+    /**
+     * Determine if the given string is not empty.
+     *
+     * @param  string  $value
+     * @return bool
+     */
+    public static function isNotEmpty($value)
+    {
+        return ! static::isEmpty($value);
+    }
+
+    /**
      * Determine if a given string is 7 bit ASCII.
      *
      * @param  string  $value

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -693,6 +693,22 @@ class SupportStrTest extends TestCase
         PATTERN, $multilineValue));
     }
 
+    public function testIsEmpty()
+    {
+        $this->assertTrue(Str::isEmpty(''));
+        $this->assertFalse(Str::isEmpty(' '));
+        $this->assertFalse(Str::isEmpty('a'));
+        $this->assertFalse(Str::isEmpty('0'));
+    }
+
+    public function testIsNotEmpty()
+    {
+        $this->assertFalse(Str::isNotEmpty(''));
+        $this->assertTrue(Str::isNotEmpty(' '));
+        $this->assertTrue(Str::isNotEmpty('a'));
+        $this->assertTrue(Str::isNotEmpty('0'));
+    }
+
     public function testIsUrl()
     {
         $this->assertTrue(Str::isUrl('https://laravel.com'));


### PR DESCRIPTION
## Summary

Adds `Str::isEmpty()` and `Str::isNotEmpty()` as static methods on `Illuminate\Support\Str`, mirroring the methods already available on `Illuminate\Support\Stringable`.

## Context

| Method | `Stringable` | `Str` static |
|---|---|---|
| `isEmpty()` | ✅ | ❌ |
| `isNotEmpty()` | ✅ | ❌ |

The `Stringable` class has had these since they were added, but the static `Str` counterparts are missing, creating an inconsistency.

## Example

```php
// Before — no static equivalent
Str::of('')->isEmpty();     // ✅ works via Stringable
Str::isEmpty('');           // ❌ does not exist

// After
Str::isEmpty('');           // true
Str::isEmpty('hello');      // false
Str::isNotEmpty('hello');   // true
Str::isNotEmpty('');        // false
```

## Changes

- `src/Illuminate/Support/Str.php` — adds `Str::isEmpty()` and `Str::isNotEmpty()`
- `tests/Support/SupportStrTest.php` — adds `testIsEmpty()` and `testIsNotEmpty()`