### PR TITLE
[13.x] Add circuit breaker to HTTP client

### DIFF
--- a/src/Illuminate/Http/Client/CircuitBreaker.php
+++ b/src/Illuminate/Http/Client/CircuitBreaker.php
@@ -24,21 +24,21 @@ class CircuitBreaker
     /**
      * The number of consecutive failures that will open the circuit.
      *
-     * @var int
+     * @var positive-int
      */
     protected $failureThreshold;
 
     /**
      * The number of seconds the circuit stays open before a probe is allowed.
      *
-     * @var int
+     * @var positive-int
      */
     protected $resetTimeout;
 
     /**
      * The number of seconds failure and state entries persist in the cache.
      *
-     * @var int
+     * @var positive-int
      */
     protected $cacheTtl;
 

--- a/src/Illuminate/Http/Client/CircuitBreaker.php
+++ b/src/Illuminate/Http/Client/CircuitBreaker.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace Illuminate\Http\Client;
+
+use Illuminate\Contracts\Cache\Repository;
+use Illuminate\Support\Carbon;
+
+class CircuitBreaker
+{
+    /**
+     * The cache repository used to persist circuit state.
+     *
+     * @var \Illuminate\Contracts\Cache\Repository
+     */
+    protected $cache;
+
+    /**
+     * The identifier used to namespace circuit state entries.
+     *
+     * @var string
+     */
+    protected $key;
+
+    /**
+     * The number of consecutive failures that will open the circuit.
+     *
+     * @var int
+     */
+    protected $failureThreshold;
+
+    /**
+     * The number of seconds the circuit stays open before a probe is allowed.
+     *
+     * @var int
+     */
+    protected $resetTimeout;
+
+    /**
+     * The number of seconds failure and state entries persist in the cache.
+     *
+     * @var int
+     */
+    protected $cacheTtl;
+
+    /**
+     * Create a new circuit breaker instance.
+     */
+    public function __construct(Repository $cache, string $key, int $failureThreshold = 5, int $resetTimeout = 30, ?int $cacheTtl = null)
+    {
+        $this->cache = $cache;
+        $this->key = $key;
+        $this->failureThreshold = max(1, $failureThreshold);
+        $this->resetTimeout = max(1, $resetTimeout);
+        $this->cacheTtl = $cacheTtl ?? max($resetTimeout * 10, 600);
+    }
+
+    /**
+     * Ensure the circuit is not open. Throw if it is and the half-open probe slot is taken.
+     *
+     * @throws \Illuminate\Http\Client\CircuitOpenException
+     */
+    public function guard(): void
+    {
+        $openedAt = $this->cache->get($this->openedAtKey());
+
+        if ($openedAt === null) {
+            return;
+        }
+
+        $elapsed = Carbon::now()->getTimestamp() - (int) $openedAt;
+
+        if ($elapsed < $this->resetTimeout) {
+            throw new CircuitOpenException($this->key, $this->resetTimeout - $elapsed);
+        }
+
+        if (! $this->cache->add($this->probeKey(), 1, $this->resetTimeout)) {
+            throw new CircuitOpenException($this->key, 1);
+        }
+    }
+
+    /**
+     * Record a successful request, closing the circuit if it was half-open.
+     */
+    public function recordSuccess(): void
+    {
+        $this->cache->forget($this->failuresKey());
+        $this->cache->forget($this->openedAtKey());
+        $this->cache->forget($this->probeKey());
+    }
+
+    /**
+     * Record a failed request, opening the circuit if the threshold is exceeded.
+     */
+    public function recordFailure(): void
+    {
+        $this->cache->forget($this->probeKey());
+
+        if ($this->cache->get($this->openedAtKey()) !== null) {
+            $this->cache->put($this->openedAtKey(), Carbon::now()->getTimestamp(), $this->cacheTtl);
+
+            return;
+        }
+
+        $failures = (int) $this->cache->increment($this->failuresKey());
+
+        if ($failures === 1) {
+            $this->cache->put($this->failuresKey(), 1, $this->cacheTtl);
+        }
+
+        if ($failures >= $this->failureThreshold) {
+            $this->cache->put($this->openedAtKey(), Carbon::now()->getTimestamp(), $this->cacheTtl);
+        }
+    }
+
+    /**
+     * Determine whether the circuit is currently open.
+     */
+    public function isOpen(): bool
+    {
+        $openedAt = $this->cache->get($this->openedAtKey());
+
+        if ($openedAt === null) {
+            return false;
+        }
+
+        return (Carbon::now()->getTimestamp() - (int) $openedAt) < $this->resetTimeout;
+    }
+
+    /**
+     * Get the identifier used for this circuit.
+     */
+    public function key(): string
+    {
+        return $this->key;
+    }
+
+    protected function failuresKey(): string
+    {
+        return "illuminate:http:circuit_breaker:failures:{$this->key}";
+    }
+
+    protected function openedAtKey(): string
+    {
+        return "illuminate:http:circuit_breaker:opened_at:{$this->key}";
+    }
+
+    protected function probeKey(): string
+    {
+        return "illuminate:http:circuit_breaker:probe:{$this->key}";
+    }
+}

--- a/src/Illuminate/Http/Client/CircuitBreaker.php
+++ b/src/Illuminate/Http/Client/CircuitBreaker.php
@@ -134,16 +134,25 @@ class CircuitBreaker
         return $this->key;
     }
 
+    /**
+     * Get the cache key used to track consecutive failures.
+     */
     protected function failuresKey(): string
     {
         return "illuminate:http:circuit_breaker:failures:{$this->key}";
     }
 
+    /**
+     * Get the cache key used to track when the circuit opened.
+     */
     protected function openedAtKey(): string
     {
         return "illuminate:http:circuit_breaker:opened_at:{$this->key}";
     }
 
+    /**
+     * Get the cache key used to reserve the half-open probe slot.
+     */
     protected function probeKey(): string
     {
         return "illuminate:http:circuit_breaker:probe:{$this->key}";

--- a/src/Illuminate/Http/Client/CircuitOpenException.php
+++ b/src/Illuminate/Http/Client/CircuitOpenException.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Illuminate\Http\Client;
+
+class CircuitOpenException extends HttpClientException
+{
+    /**
+     * The identifier of the open circuit.
+     *
+     * @var string
+     */
+    public $circuitKey;
+
+    /**
+     * The number of seconds until the circuit will allow a probe request.
+     *
+     * @var int
+     */
+    public $retryAfter;
+
+    /**
+     * Create a new circuit open exception instance.
+     */
+    public function __construct(string $circuitKey, int $retryAfter = 0)
+    {
+        parent::__construct("The circuit breaker for [{$circuitKey}] is open. Request was not dispatched.");
+
+        $this->circuitKey = $circuitKey;
+        $this->retryAfter = $retryAfter;
+    }
+}

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -164,14 +164,14 @@ class PendingRequest
      *
      * @var \Illuminate\Http\Client\CircuitBreaker|null
      */
-    protected $circuitBreaker = null;
+    protected $circuitBreaker;
 
     /**
      * The callback that decides whether a response should count as a circuit breaker failure.
      *
-     * @var (callable(\Illuminate\Http\Client\Response): bool)|null
+     * @var callable|null
      */
-    protected $circuitFailWhen = null;
+    protected $circuitFailWhen;
 
     /**
      * The callbacks that should execute before the request is sent.

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -1139,7 +1139,7 @@ class PendingRequest
 
             return $result;
         });
-        } catch (\Throwable $e) {
+        } catch (Throwable $e) {
             $this->circuitBreaker?->recordFailure();
 
             throw $e;

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -14,6 +14,7 @@ use GuzzleHttp\Middleware;
 use GuzzleHttp\Promise\EachPromise;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\UriTemplate\UriTemplate;
+use Illuminate\Container\Container;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Http\Client\Events\ConnectionFailed;
 use Illuminate\Http\Client\Events\RequestSending;
@@ -157,6 +158,20 @@ class PendingRequest
      * @var (callable(\Throwable, static, string|null): bool)|null
      */
     protected $retryWhenCallback = null;
+
+    /**
+     * The circuit breaker guarding the request.
+     *
+     * @var \Illuminate\Http\Client\CircuitBreaker|null
+     */
+    protected $circuitBreaker = null;
+
+    /**
+     * The callback that decides whether a response should count as a circuit breaker failure.
+     *
+     * @var (callable(\Illuminate\Http\Client\Response): bool)|null
+     */
+    protected $circuitFailWhen = null;
 
     /**
      * The callbacks that should execute before the request is sent.
@@ -667,6 +682,29 @@ class PendingRequest
     }
 
     /**
+     * Guard the request with a circuit breaker identified by the given key.
+     *
+     * @param  \Illuminate\Http\Client\CircuitBreaker|string  $key
+     * @param  int  $failureThreshold
+     * @param  int  $resetTimeout
+     * @param  (callable(\Illuminate\Http\Client\Response): bool)|null  $failWhen
+     * @return $this
+     */
+    public function circuitBreaker($key, int $failureThreshold = 5, int $resetTimeout = 30, ?callable $failWhen = null)
+    {
+        if ($key instanceof CircuitBreaker) {
+            $this->circuitBreaker = $key;
+        } else {
+            $cache = Container::getInstance()->make('cache')->store();
+            $this->circuitBreaker = new CircuitBreaker($cache, $key, $failureThreshold, $resetTimeout);
+        }
+
+        $this->circuitFailWhen = $failWhen;
+
+        return $this;
+    }
+
+    /**
      * Replace the specified options on the request.
      *
      * @param  array  $options
@@ -1036,9 +1074,12 @@ class PendingRequest
             );
         }
 
+        $this->circuitBreaker?->guard();
+
         $shouldRetry = null;
 
-        return retry($this->tries ?? 1, function ($attempt) use ($method, $url, $options, &$shouldRetry) {
+        try {
+            $response = retry($this->tries ?? 1, function ($attempt) use ($method, $url, $options, &$shouldRetry) {
             try {
                 return tap($this->newResponse($this->sendRequest($method, $url, $options)), function (&$response) use ($attempt, &$shouldRetry) {
                     $this->populateResponse($response);
@@ -1098,6 +1139,23 @@ class PendingRequest
 
             return $result;
         });
+        } catch (\Throwable $e) {
+            $this->circuitBreaker?->recordFailure();
+
+            throw $e;
+        }
+
+        if ($this->circuitBreaker) {
+            $isFailure = $this->circuitFailWhen
+                ? (bool) call_user_func($this->circuitFailWhen, $response)
+                : $response->serverError();
+
+            $isFailure
+                ? $this->circuitBreaker->recordFailure()
+                : $this->circuitBreaker->recordSuccess();
+        }
+
+        return $response;
     }
 
     /**

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -1080,65 +1080,65 @@ class PendingRequest
 
         try {
             $response = retry($this->tries ?? 1, function ($attempt) use ($method, $url, $options, &$shouldRetry) {
-            try {
-                return tap($this->newResponse($this->sendRequest($method, $url, $options)), function (&$response) use ($attempt, &$shouldRetry) {
-                    $this->populateResponse($response);
+                try {
+                    return tap($this->newResponse($this->sendRequest($method, $url, $options)), function (&$response) use ($attempt, &$shouldRetry) {
+                        $this->populateResponse($response);
 
-                    $this->dispatchResponseReceivedEvent($response);
-                    $response = $this->runAfterResponseCallbacks($response);
+                        $this->dispatchResponseReceivedEvent($response);
+                        $response = $this->runAfterResponseCallbacks($response);
 
-                    if ($response->successful()) {
-                        return;
+                        if ($response->successful()) {
+                            return;
+                        }
+
+                        try {
+                            $shouldRetry = $this->retryWhenCallback ? call_user_func($this->retryWhenCallback, $response->toException(), $this, $this->request->toPsrRequest()->getMethod()) : true;
+                        } catch (Exception $exception) {
+                            $shouldRetry = false;
+
+                            throw $exception;
+                        }
+
+                        if ($this->throwCallback &&
+                            ($this->throwIfCallback === null ||
+                             call_user_func($this->throwIfCallback, $response))) {
+                            $response->throw($this->throwCallback);
+                        }
+
+                        $potentialTries = is_array($this->tries)
+                            ? count($this->tries) + 1
+                            : $this->tries;
+
+                        if ($attempt < $potentialTries && $shouldRetry) {
+                            $response->throw();
+                        }
+
+                        if ($potentialTries > 1 && $this->retryThrow) {
+                            $response->throw();
+                        }
+                    });
+                } catch (TransferException $e) {
+                    if ($e instanceof ConnectException) {
+                        $this->marshalConnectionException($e);
                     }
 
-                    try {
-                        $shouldRetry = $this->retryWhenCallback ? call_user_func($this->retryWhenCallback, $response->toException(), $this, $this->request->toPsrRequest()->getMethod()) : true;
-                    } catch (Exception $exception) {
-                        $shouldRetry = false;
-
-                        throw $exception;
+                    if ($e instanceof RequestException && ! $e->hasResponse()) {
+                        $this->marshalRequestExceptionWithoutResponse($e);
                     }
 
-                    if ($this->throwCallback &&
-                        ($this->throwIfCallback === null ||
-                         call_user_func($this->throwIfCallback, $response))) {
-                        $response->throw($this->throwCallback);
+                    if ($e instanceof RequestException && $e->hasResponse()) {
+                        $this->marshalRequestExceptionWithResponse($e);
                     }
 
-                    $potentialTries = is_array($this->tries)
-                        ? count($this->tries) + 1
-                        : $this->tries;
-
-                    if ($attempt < $potentialTries && $shouldRetry) {
-                        $response->throw();
-                    }
-
-                    if ($potentialTries > 1 && $this->retryThrow) {
-                        $response->throw();
-                    }
-                });
-            } catch (TransferException $e) {
-                if ($e instanceof ConnectException) {
-                    $this->marshalConnectionException($e);
+                    throw $e;
                 }
+            }, $this->retryDelay ?? 100, function ($exception) use (&$shouldRetry) {
+                $result = $shouldRetry !== null ? $shouldRetry : ($this->retryWhenCallback ? call_user_func($this->retryWhenCallback, $exception, $this, $this->request?->toPsrRequest()->getMethod()) : true);
 
-                if ($e instanceof RequestException && ! $e->hasResponse()) {
-                    $this->marshalRequestExceptionWithoutResponse($e);
-                }
+                $shouldRetry = null;
 
-                if ($e instanceof RequestException && $e->hasResponse()) {
-                    $this->marshalRequestExceptionWithResponse($e);
-                }
-
-                throw $e;
-            }
-        }, $this->retryDelay ?? 100, function ($exception) use (&$shouldRetry) {
-            $result = $shouldRetry !== null ? $shouldRetry : ($this->retryWhenCallback ? call_user_func($this->retryWhenCallback, $exception, $this, $this->request?->toPsrRequest()->getMethod()) : true);
-
-            $shouldRetry = null;
-
-            return $result;
-        });
+                return $result;
+            });
         } catch (Throwable $e) {
             $this->circuitBreaker?->recordFailure();
 

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -4469,6 +4469,106 @@ class HttpClientTest extends TestCase
         $response->json();
         $this->assertSame(3, $response->bodyCallCount);
     }
+
+    public function testCircuitBreakerTripsAfterReachingFailureThreshold()
+    {
+        $this->factory->fake([
+            '*' => $this->factory::response(['error'], 500),
+        ]);
+
+        $breaker = new \Illuminate\Http\Client\CircuitBreaker($this->makeCircuitCache(), 'api', failureThreshold: 3, resetTimeout: 30);
+
+        for ($i = 0; $i < 3; $i++) {
+            $this->factory->circuitBreaker($breaker)->get('http://foo.com/get');
+        }
+
+        $this->assertTrue($breaker->isOpen());
+        $this->factory->assertSentCount(3);
+
+        try {
+            $this->factory->circuitBreaker($breaker)->get('http://foo.com/get');
+            $this->fail('Expected CircuitOpenException was not thrown.');
+        } catch (\Illuminate\Http\Client\CircuitOpenException $e) {
+            $this->assertSame('api', $e->circuitKey);
+            $this->assertGreaterThan(0, $e->retryAfter);
+        }
+
+        $this->factory->assertSentCount(3);
+    }
+
+    public function testCircuitBreakerResetsFailureCountAfterSuccess()
+    {
+        $this->factory->fakeSequence()
+            ->push(['error'], 500)
+            ->push(['error'], 500)
+            ->push(['ok'], 200)
+            ->push(['error'], 500)
+            ->push(['error'], 500);
+
+        $breaker = new \Illuminate\Http\Client\CircuitBreaker($this->makeCircuitCache(), 'api', failureThreshold: 3, resetTimeout: 30);
+
+        for ($i = 0; $i < 5; $i++) {
+            $this->factory->circuitBreaker($breaker)->get('http://foo.com/get');
+        }
+
+        $this->assertFalse($breaker->isOpen());
+    }
+
+    public function testCircuitBreakerTransitionsToHalfOpenAfterResetTimeout()
+    {
+        $this->factory->fakeSequence()
+            ->push(['error'], 500)
+            ->push(['error'], 500)
+            ->push(['ok'], 200);
+
+        $cache = $this->makeCircuitCache();
+        $breaker = new \Illuminate\Http\Client\CircuitBreaker($cache, 'api', failureThreshold: 2, resetTimeout: 30);
+
+        $this->factory->circuitBreaker($breaker)->get('http://foo.com/get');
+        $this->factory->circuitBreaker($breaker)->get('http://foo.com/get');
+
+        $this->assertTrue($breaker->isOpen());
+
+        $cache->put('illuminate:http:circuit_breaker:opened_at:api', \Illuminate\Support\Carbon::now()->getTimestamp() - 60, 600);
+
+        $response = $this->factory->circuitBreaker($breaker)->get('http://foo.com/get');
+
+        $this->assertTrue($response->ok());
+        $this->assertFalse($breaker->isOpen());
+    }
+
+    public function testCircuitBreakerHonorsCustomFailWhenCallback()
+    {
+        $this->factory->fake(['*' => $this->factory::response(['error'], 400)]);
+
+        $breaker = new \Illuminate\Http\Client\CircuitBreaker($this->makeCircuitCache(), 'api', failureThreshold: 2, resetTimeout: 30);
+
+        $failWhen = fn ($response) => $response->status() === 400;
+
+        $this->factory->circuitBreaker($breaker, failWhen: $failWhen)->get('http://foo.com/get');
+        $this->factory->circuitBreaker($breaker, failWhen: $failWhen)->get('http://foo.com/get');
+
+        $this->assertTrue($breaker->isOpen());
+    }
+
+    public function testCircuitBreakerDoesNotCountClientErrorsByDefault()
+    {
+        $this->factory->fake(['*' => $this->factory::response(['error'], 404)]);
+
+        $breaker = new \Illuminate\Http\Client\CircuitBreaker($this->makeCircuitCache(), 'api', failureThreshold: 2, resetTimeout: 30);
+
+        $this->factory->circuitBreaker($breaker)->get('http://foo.com/get');
+        $this->factory->circuitBreaker($breaker)->get('http://foo.com/get');
+        $this->factory->circuitBreaker($breaker)->get('http://foo.com/get');
+
+        $this->assertFalse($breaker->isOpen());
+        $this->factory->assertSentCount(3);
+    }
+
+    protected function makeCircuitCache(): \Illuminate\Contracts\Cache\Repository
+    {
+        return new \Illuminate\Cache\Repository(new \Illuminate\Cache\ArrayStore);
+    }
 }
 
 class CustomFactory extends Factory

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -15,10 +15,15 @@ use GuzzleHttp\Psr7\Request as GuzzleRequest;
 use GuzzleHttp\Psr7\Response as Psr7Response;
 use GuzzleHttp\Psr7\Utils;
 use GuzzleHttp\TransferStats;
+use Illuminate\Cache\ArrayStore;
+use Illuminate\Cache\Repository as CacheRepository;
+use Illuminate\Contracts\Cache\Repository as CacheRepositoryContract;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Http\Client\Batch;
 use Illuminate\Http\Client\BatchInProgressException;
+use Illuminate\Http\Client\CircuitBreaker;
+use Illuminate\Http\Client\CircuitOpenException;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\Events\RequestSending;
 use Illuminate\Http\Client\Events\ResponseReceived;
@@ -4476,7 +4481,7 @@ class HttpClientTest extends TestCase
             '*' => $this->factory::response(['error'], 500),
         ]);
 
-        $breaker = new \Illuminate\Http\Client\CircuitBreaker($this->makeCircuitCache(), 'api', failureThreshold: 3, resetTimeout: 30);
+        $breaker = new CircuitBreaker($this->makeCircuitCache(), 'api', failureThreshold: 3, resetTimeout: 30);
 
         for ($i = 0; $i < 3; $i++) {
             $this->factory->circuitBreaker($breaker)->get('http://foo.com/get');
@@ -4488,7 +4493,7 @@ class HttpClientTest extends TestCase
         try {
             $this->factory->circuitBreaker($breaker)->get('http://foo.com/get');
             $this->fail('Expected CircuitOpenException was not thrown.');
-        } catch (\Illuminate\Http\Client\CircuitOpenException $e) {
+        } catch (CircuitOpenException $e) {
             $this->assertSame('api', $e->circuitKey);
             $this->assertGreaterThan(0, $e->retryAfter);
         }
@@ -4505,7 +4510,7 @@ class HttpClientTest extends TestCase
             ->push(['error'], 500)
             ->push(['error'], 500);
 
-        $breaker = new \Illuminate\Http\Client\CircuitBreaker($this->makeCircuitCache(), 'api', failureThreshold: 3, resetTimeout: 30);
+        $breaker = new CircuitBreaker($this->makeCircuitCache(), 'api', failureThreshold: 3, resetTimeout: 30);
 
         for ($i = 0; $i < 5; $i++) {
             $this->factory->circuitBreaker($breaker)->get('http://foo.com/get');
@@ -4522,14 +4527,14 @@ class HttpClientTest extends TestCase
             ->push(['ok'], 200);
 
         $cache = $this->makeCircuitCache();
-        $breaker = new \Illuminate\Http\Client\CircuitBreaker($cache, 'api', failureThreshold: 2, resetTimeout: 30);
+        $breaker = new CircuitBreaker($cache, 'api', failureThreshold: 2, resetTimeout: 30);
 
         $this->factory->circuitBreaker($breaker)->get('http://foo.com/get');
         $this->factory->circuitBreaker($breaker)->get('http://foo.com/get');
 
         $this->assertTrue($breaker->isOpen());
 
-        $cache->put('illuminate:http:circuit_breaker:opened_at:api', \Illuminate\Support\Carbon::now()->getTimestamp() - 60, 600);
+        $cache->put('illuminate:http:circuit_breaker:opened_at:api', Carbon::now()->getTimestamp() - 60, 600);
 
         $response = $this->factory->circuitBreaker($breaker)->get('http://foo.com/get');
 
@@ -4541,7 +4546,7 @@ class HttpClientTest extends TestCase
     {
         $this->factory->fake(['*' => $this->factory::response(['error'], 400)]);
 
-        $breaker = new \Illuminate\Http\Client\CircuitBreaker($this->makeCircuitCache(), 'api', failureThreshold: 2, resetTimeout: 30);
+        $breaker = new CircuitBreaker($this->makeCircuitCache(), 'api', failureThreshold: 2, resetTimeout: 30);
 
         $failWhen = fn ($response) => $response->status() === 400;
 
@@ -4555,7 +4560,7 @@ class HttpClientTest extends TestCase
     {
         $this->factory->fake(['*' => $this->factory::response(['error'], 404)]);
 
-        $breaker = new \Illuminate\Http\Client\CircuitBreaker($this->makeCircuitCache(), 'api', failureThreshold: 2, resetTimeout: 30);
+        $breaker = new CircuitBreaker($this->makeCircuitCache(), 'api', failureThreshold: 2, resetTimeout: 30);
 
         $this->factory->circuitBreaker($breaker)->get('http://foo.com/get');
         $this->factory->circuitBreaker($breaker)->get('http://foo.com/get');
@@ -4565,9 +4570,9 @@ class HttpClientTest extends TestCase
         $this->factory->assertSentCount(3);
     }
 
-    protected function makeCircuitCache(): \Illuminate\Contracts\Cache\Repository
+    protected function makeCircuitCache(): CacheRepositoryContract
     {
-        return new \Illuminate\Cache\Repository(new \Illuminate\Cache\ArrayStore);
+        return new CacheRepository(new ArrayStore);
     }
 }
 


### PR DESCRIPTION
Adds `circuitBreaker()` to `PendingRequest` for failing fast while a
downstream service is degraded, instead of every request paying the
full retry budget.

    Http::circuitBreaker('stripe-api', failureThreshold: 5, resetTimeout: 30)
        ->retry(3, 100)
        ->get('https://api.stripe.com/v1/charges');

After 5 consecutive 5xx responses the breaker opens and throws
`CircuitOpenException` immediately for 30 seconds. A single probe
request is then allowed through — a success closes the circuit, a
failure re-opens it. State is persisted in the default cache store
so all workers share it.

Retry and circuit breaker are orthogonal: retry handles transient
failures within a single call, the breaker handles sustained outages
across calls. The default fail predicate only counts 5xx responses
(client errors shouldn't trip the breaker); passing a `failWhen`
closure lets callers customise that.