### PR TITLE
[13.x] Introduce WorkerInterrupted event

### DIFF
--- a/src/Illuminate/Queue/Events/WorkerInterrupted.php
+++ b/src/Illuminate/Queue/Events/WorkerInterrupted.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Illuminate\Queue\Events;
+
+class WorkerInterrupted
+{
+    /**
+     * Create a new event instance.
+     *
+     * @param  int  $signal  The signal that interrupted the worker.
+     * @param  string|null  $connectionName
+     * @param  string|null  $queue
+     */
+    public function __construct(
+        public int $signal,
+        public ?string $connectionName = null,
+        public ?string $queue = null,
+    ) {}
+}

--- a/src/Illuminate/Queue/Events/WorkerInterrupted.php
+++ b/src/Illuminate/Queue/Events/WorkerInterrupted.php
@@ -15,5 +15,6 @@ class WorkerInterrupted
         public int $signal,
         public ?string $connectionName = null,
         public ?string $queue = null,
-    ) {}
+    ) {
+    }
 }

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -17,6 +17,7 @@ use Illuminate\Queue\Events\JobProcessing;
 use Illuminate\Queue\Events\JobReleasedAfterException;
 use Illuminate\Queue\Events\JobTimedOut;
 use Illuminate\Queue\Events\Looping;
+use Illuminate\Queue\Events\WorkerInterrupted;
 use Illuminate\Queue\Events\WorkerStarting;
 use Illuminate\Queue\Events\WorkerStopping;
 use Illuminate\Support\Carbon;
@@ -176,7 +177,7 @@ class Worker
     public function daemon($connectionName, $queue, WorkerOptions $options)
     {
         if ($supportsAsyncSignals = $this->supportsAsyncSignals()) {
-            $this->listenForSignals();
+            $this->listenForSignals($connectionName, $queue);
         }
 
         $lastRestart = $this->getTimestampOfLastQueueRestart();
@@ -814,15 +815,19 @@ class Worker
     /**
      * Enable async signals for the process.
      *
+     * @param  string|null  $connectionName
+     * @param  string|null  $queue
      * @return void
      */
-    protected function listenForSignals()
+    protected function listenForSignals($connectionName = null, $queue = null)
     {
         pcntl_async_signals(true);
 
         foreach ([SIGQUIT, SIGTERM, SIGINT] as $signal) {
-            pcntl_signal($signal, function (int $signal) {
+            pcntl_signal($signal, function (int $signal) use ($connectionName, $queue) {
                 $this->shouldQuit = true;
+
+                $this->events->dispatch(new WorkerInterrupted($signal, $connectionName, $queue));
 
                 $this->notifyJobOfSignal($signal);
             });

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -15,6 +15,7 @@ use Illuminate\Queue\Events\JobPopping;
 use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Queue\Events\JobProcessing;
 use Illuminate\Queue\Events\JobReleasedAfterException;
+use Illuminate\Queue\Events\WorkerInterrupted;
 use Illuminate\Queue\Events\WorkerStarting;
 use Illuminate\Queue\Events\WorkerStopping;
 use Illuminate\Queue\MaxAttemptsExceededException;
@@ -509,6 +510,19 @@ class QueueWorkerTest extends TestCase
         }))->once();
     }
 
+    public function testWorkerInterruptedEventIsDispatchedOnSignal()
+    {
+        $worker = $this->getWorker('default', ['queue' => []]);
+        $worker->receiveSignal(15, 'default', 'default');
+
+        $this->events->shouldHaveReceived('dispatch')->with(m::on(function ($event) {
+            return $event instanceof WorkerInterrupted
+                && $event->signal === 15
+                && $event->connectionName === 'default'
+                && $event->queue === 'default';
+        }))->once();
+    }
+
     public function testInterruptibleJobIsNotifiedOnSignal()
     {
         $interruptible = new class implements Interruptible
@@ -579,6 +593,15 @@ class InsomniacWorker extends Worker
     public function sleep($seconds)
     {
         $this->sleptFor = $seconds;
+    }
+
+    public function receiveSignal(int $signal, ?string $connectionName = null, ?string $queue = null): void
+    {
+        $this->shouldQuit = true;
+
+        $this->events->dispatch(new WorkerInterrupted($signal, $connectionName, $queue));
+
+        $this->notifyJobOfSignal($signal);
     }
 
     public function notifyJobOfSignal(int $signal): void

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -15,7 +15,6 @@ use Illuminate\Queue\Events\JobPopping;
 use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Queue\Events\JobProcessing;
 use Illuminate\Queue\Events\JobReleasedAfterException;
-use Illuminate\Queue\Events\WorkerInterrupted;
 use Illuminate\Queue\Events\WorkerStarting;
 use Illuminate\Queue\Events\WorkerStopping;
 use Illuminate\Queue\MaxAttemptsExceededException;
@@ -510,19 +509,6 @@ class QueueWorkerTest extends TestCase
         }))->once();
     }
 
-    public function testWorkerInterruptedEventIsDispatchedOnSignal()
-    {
-        $worker = $this->getWorker('default', ['queue' => []]);
-        $worker->receiveSignal(15, 'default', 'default');
-
-        $this->events->shouldHaveReceived('dispatch')->with(m::on(function ($event) {
-            return $event instanceof WorkerInterrupted
-                && $event->signal === 15
-                && $event->connectionName === 'default'
-                && $event->queue === 'default';
-        }))->once();
-    }
-
     public function testInterruptibleJobIsNotifiedOnSignal()
     {
         $interruptible = new class implements Interruptible
@@ -595,14 +581,6 @@ class InsomniacWorker extends Worker
         $this->sleptFor = $seconds;
     }
 
-    public function receiveSignal(int $signal, ?string $connectionName = null, ?string $queue = null): void
-    {
-        $this->shouldQuit = true;
-
-        $this->events->dispatch(new WorkerInterrupted($signal, $connectionName, $queue));
-
-        $this->notifyJobOfSignal($signal);
-    }
 
     public function notifyJobOfSignal(int $signal): void
     {


### PR DESCRIPTION
When a signal arrives from infra, the worker finishes the current job before stopping cleanly so we rely on the `WorkerStopping` event.

But, a worker is **not guaranteed** to finish a job before it's killed from infra.  

So, my idea of a `WorkerInterrupted` event is born! 


This is basically nice from an observability view.
 
 
This complements the Interruptible job stuff, essentially. IE I want to know my workers are being signaled, but the jobs may not need to care. I can then log, call Slack etc when a signal arrives so its no longer guess work

Open to renaming it to WorkerSignaled or something if you prefer :) 

No test cause its signals.. but can do a fake test if you want?

I've just done it inline, same as WorkerStopping rather than making an executeX method

I think I've done it in a non-bc way, but also:

<img width="250" height="150" alt="image" src="https://github.com/user-attachments/assets/c87b8962-3e16-4d55-9b84-049324c166d9" /> 



So forgive me!
