### PR TITLE
[13.x] Implement CanFlushLocks on NullStore and MemoizedStore

### DIFF
--- a/src/Illuminate/Cache/MemoizedStore.php
+++ b/src/Illuminate/Cache/MemoizedStore.php
@@ -3,10 +3,11 @@
 namespace Illuminate\Cache;
 
 use BadMethodCallException;
+use Illuminate\Contracts\Cache\CanFlushLocks;
 use Illuminate\Contracts\Cache\LockProvider;
 use Illuminate\Contracts\Cache\Store;
 
-class MemoizedStore implements LockProvider, Store
+class MemoizedStore implements CanFlushLocks, LockProvider, Store
 {
     /**
      * The memoized cache values.
@@ -195,6 +196,36 @@ class MemoizedStore implements LockProvider, Store
         }
 
         return $this->repository->getStore()->restoreLock(...func_get_args());
+    }
+
+    /**
+     * Flush all locks managed by the store.
+     *
+     * @return bool
+     *
+     * @throws \BadMethodCallException
+     */
+    public function flushLocks(): bool
+    {
+        $store = $this->repository->getStore();
+
+        if (! $store instanceof CanFlushLocks) {
+            throw new BadMethodCallException('This cache store does not support flushing locks.');
+        }
+
+        return $store->flushLocks();
+    }
+
+    /**
+     * Determine if the lock store is separate from the cache store.
+     *
+     * @return bool
+     */
+    public function hasSeparateLockStore(): bool
+    {
+        $store = $this->repository->getStore();
+
+        return $store instanceof CanFlushLocks && $store->hasSeparateLockStore();
     }
 
     /**

--- a/src/Illuminate/Cache/MemoizedStore.php
+++ b/src/Illuminate/Cache/MemoizedStore.php
@@ -106,7 +106,6 @@ class MemoizedStore implements CanFlushLocks, LockProvider, Store
     /**
      * Store multiple items in the cache for a given number of seconds.
      *
-     * @param  array  $values
      * @param  int  $seconds
      * @return bool
      */
@@ -201,8 +200,6 @@ class MemoizedStore implements CanFlushLocks, LockProvider, Store
     /**
      * Flush all locks managed by the store.
      *
-     * @return bool
-     *
      * @throws \BadMethodCallException
      */
     public function flushLocks(): bool
@@ -218,8 +215,6 @@ class MemoizedStore implements CanFlushLocks, LockProvider, Store
 
     /**
      * Determine if the lock store is separate from the cache store.
-     *
-     * @return bool
      */
     public function hasSeparateLockStore(): bool
     {

--- a/src/Illuminate/Cache/NullStore.php
+++ b/src/Illuminate/Cache/NullStore.php
@@ -2,9 +2,10 @@
 
 namespace Illuminate\Cache;
 
+use Illuminate\Contracts\Cache\CanFlushLocks;
 use Illuminate\Contracts\Cache\LockProvider;
 
-class NullStore extends TaggableStore implements LockProvider
+class NullStore extends TaggableStore implements CanFlushLocks, LockProvider
 {
     use RetrievesMultipleKeys;
 
@@ -91,6 +92,26 @@ class NullStore extends TaggableStore implements LockProvider
     public function restoreLock($name, $owner)
     {
         return $this->lock($name, 0, $owner);
+    }
+
+    /**
+     * Flush all locks managed by the store.
+     *
+     * @return bool
+     */
+    public function flushLocks(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Determine if the lock store is separate from the cache store.
+     *
+     * @return bool
+     */
+    public function hasSeparateLockStore(): bool
+    {
+        return false;
     }
 
     /**

--- a/src/Illuminate/Cache/NullStore.php
+++ b/src/Illuminate/Cache/NullStore.php
@@ -96,8 +96,6 @@ class NullStore extends TaggableStore implements CanFlushLocks, LockProvider
 
     /**
      * Flush all locks managed by the store.
-     *
-     * @return bool
      */
     public function flushLocks(): bool
     {
@@ -106,8 +104,6 @@ class NullStore extends TaggableStore implements CanFlushLocks, LockProvider
 
     /**
      * Determine if the lock store is separate from the cache store.
-     *
-     * @return bool
      */
     public function hasSeparateLockStore(): bool
     {

--- a/tests/Cache/CacheMemoizedStoreTest.php
+++ b/tests/Cache/CacheMemoizedStoreTest.php
@@ -7,7 +7,9 @@ use Illuminate\Cache\ArrayStore;
 use Illuminate\Cache\MemoizedStore;
 use Illuminate\Cache\NullStore;
 use Illuminate\Cache\Repository;
+use Illuminate\Contracts\Cache\Store;
 use Illuminate\Support\Carbon;
+use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
 class CacheMemoizedStoreTest extends TestCase
@@ -36,63 +38,13 @@ class CacheMemoizedStoreTest extends TestCase
     {
         $this->expectException(BadMethodCallException::class);
 
-        $stub = new class implements \Illuminate\Contracts\Cache\LockProvider, \Illuminate\Contracts\Cache\Store
-        {
-            public function get($key)
-            {
-            return null;
-            }
-            public function many(array $keys)
-            {
-            return [];
-            }
-            public function put($key, $value, $seconds)
-            {
-            return true;
-            }
-            public function putMany(array $values, $seconds)
-            {
-            return true;
-            }
-            public function increment($key, $value = 1)
-            {
-            return false;
-            }
-            public function decrement($key, $value = 1)
-            {
-            return false;
-            }
-            public function forever($key, $value)
-            {
-            return true;
-            }
-            public function forget($key)
-            {
-            return true;
-            }
-            public function flush()
-            {
-            return true;
-            }
-            public function touch($key, $seconds)
-            {
-            return true;
-            }
-            public function getPrefix()
-            {
-            return '';
-            }
-            public function lock($name, $seconds = 0, $owner = null)
-            {
-            return new \Illuminate\Cache\NoLock($name, $seconds, $owner);
-            }
-            public function restoreLock($name, $owner)
-            {
-            return $this->lock($name, 0, $owner);
-            }
-        };
-
+        $stub = m::mock(Store::class);
         (new MemoizedStore('test', new Repository($stub)))->flushLocks();
+    }
+
+    protected function tearDown(): void
+    {
+        m::close();
     }
 
     public function testHasSeparateLockStoreDelegatestoUnderlyingStore(): void

--- a/tests/Cache/CacheMemoizedStoreTest.php
+++ b/tests/Cache/CacheMemoizedStoreTest.php
@@ -36,20 +36,60 @@ class CacheMemoizedStoreTest extends TestCase
     {
         $this->expectException(BadMethodCallException::class);
 
-        $stub = new class implements \Illuminate\Contracts\Cache\LockProvider, \Illuminate\Contracts\Cache\Store {
-            public function get($key) { return null; }
-            public function many(array $keys) { return []; }
-            public function put($key, $value, $seconds) { return true; }
-            public function putMany(array $values, $seconds) { return true; }
-            public function increment($key, $value = 1) { return false; }
-            public function decrement($key, $value = 1) { return false; }
-            public function forever($key, $value) { return true; }
-            public function forget($key) { return true; }
-            public function flush() { return true; }
-            public function touch($key, $seconds) { return true; }
-            public function getPrefix() { return ''; }
-            public function lock($name, $seconds = 0, $owner = null) { return new \Illuminate\Cache\NoLock($name, $seconds, $owner); }
-            public function restoreLock($name, $owner) { return $this->lock($name, 0, $owner); }
+        $stub = new class implements \Illuminate\Contracts\Cache\LockProvider, \Illuminate\Contracts\Cache\Store
+        {
+            public function get($key)
+            {
+            return null;
+            }
+            public function many(array $keys)
+            {
+            return [];
+            }
+            public function put($key, $value, $seconds)
+            {
+            return true;
+            }
+            public function putMany(array $values, $seconds)
+            {
+            return true;
+            }
+            public function increment($key, $value = 1)
+            {
+            return false;
+            }
+            public function decrement($key, $value = 1)
+            {
+            return false;
+            }
+            public function forever($key, $value)
+            {
+            return true;
+            }
+            public function forget($key)
+            {
+            return true;
+            }
+            public function flush()
+            {
+            return true;
+            }
+            public function touch($key, $seconds)
+            {
+            return true;
+            }
+            public function getPrefix()
+            {
+            return '';
+            }
+            public function lock($name, $seconds = 0, $owner = null)
+            {
+            return new \Illuminate\Cache\NoLock($name, $seconds, $owner);
+            }
+            public function restoreLock($name, $owner)
+            {
+            return $this->lock($name, 0, $owner);
+            }
         };
 
         (new MemoizedStore('test', new Repository($stub)))->flushLocks();

--- a/tests/Cache/CacheMemoizedStoreTest.php
+++ b/tests/Cache/CacheMemoizedStoreTest.php
@@ -2,8 +2,10 @@
 
 namespace Illuminate\Tests\Cache;
 
+use BadMethodCallException;
 use Illuminate\Cache\ArrayStore;
 use Illuminate\Cache\MemoizedStore;
+use Illuminate\Cache\NullStore;
 use Illuminate\Cache\Repository;
 use Illuminate\Support\Carbon;
 use PHPUnit\Framework\TestCase;
@@ -22,5 +24,43 @@ class CacheMemoizedStoreTest extends TestCase
         Carbon::setTestNow($now->addSeconds(45));
 
         $this->assertSame('bar', $store->get('foo'));
+    }
+
+    public function testLocksCanBeFlushedWhenUnderlyingStoreSupportsIt(): void
+    {
+        $store = new MemoizedStore('test', new Repository(new ArrayStore));
+        $this->assertTrue($store->flushLocks());
+    }
+
+    public function testFlushLocksThrowsWhenUnderlyingStoreDoesNotSupportIt(): void
+    {
+        $this->expectException(BadMethodCallException::class);
+
+        $stub = new class implements \Illuminate\Contracts\Cache\LockProvider, \Illuminate\Contracts\Cache\Store {
+            public function get($key) { return null; }
+            public function many(array $keys) { return []; }
+            public function put($key, $value, $seconds) { return true; }
+            public function putMany(array $values, $seconds) { return true; }
+            public function increment($key, $value = 1) { return false; }
+            public function decrement($key, $value = 1) { return false; }
+            public function forever($key, $value) { return true; }
+            public function forget($key) { return true; }
+            public function flush() { return true; }
+            public function touch($key, $seconds) { return true; }
+            public function getPrefix() { return ''; }
+            public function lock($name, $seconds = 0, $owner = null) { return new \Illuminate\Cache\NoLock($name, $seconds, $owner); }
+            public function restoreLock($name, $owner) { return $this->lock($name, 0, $owner); }
+        };
+
+        (new MemoizedStore('test', new Repository($stub)))->flushLocks();
+    }
+
+    public function testHasSeparateLockStoreDelegatestoUnderlyingStore(): void
+    {
+        $withSeparate = new MemoizedStore('test', new Repository(new ArrayStore));
+        $this->assertTrue($withSeparate->hasSeparateLockStore());
+
+        $withoutSeparate = new MemoizedStore('test', new Repository(new NullStore));
+        $this->assertFalse($withoutSeparate->hasSeparateLockStore());
     }
 }

--- a/tests/Cache/CacheNullStoreTest.php
+++ b/tests/Cache/CacheNullStoreTest.php
@@ -38,4 +38,16 @@ class CacheNullStoreTest extends TestCase
     {
         $this->assertFalse((new NullStore)->touch('foo', 30));
     }
+
+    public function testLocksCanBeFlushed(): void
+    {
+        $store = new NullStore;
+        $this->assertTrue($store->flushLocks());
+    }
+
+    public function testHasSeparateLockStore(): void
+    {
+        $store = new NullStore;
+        $this->assertFalse($store->hasSeparateLockStore());
+    }
 }


### PR DESCRIPTION
## Summary

- Implement `CanFlushLocks` on `NullStore` and `MemoizedStore`, completing the interface consistency across all `LockProvider` cache stores.

## Context

`RedisStore`, `FileStore`, `ArrayStore`, `DatabaseStore`, and `FailoverStore` (added in #59738) all implement both `LockProvider` and `CanFlushLocks`. `NullStore` and `MemoizedStore` implement `LockProvider` but were missing `CanFlushLocks`, meaning `Cache::supportsFlushingLocks()` returned `false` for these stores.

| Store | Before | After |
|---|---|---|
| `NullStore` | `LockProvider` only | `CanFlushLocks`, `LockProvider` |
| `MemoizedStore` | `LockProvider` only | `CanFlushLocks`, `LockProvider` |

## Implementation

**`NullStore`** — `NoLock` is stateless and never stores anything, so `flushLocks()` is a no-op that returns `true`. `hasSeparateLockStore()` returns `false` since there is no lock store.

**`MemoizedStore`** — Delegates to the underlying store. `flushLocks()` calls through to the underlying store if it implements `CanFlushLocks`, otherwise throws `BadMethodCallException` (consistent with how `lock()` and `restoreLock()` handle unsupported stores).

## Test Plan

- [x] `CacheNullStoreTest::testLocksCanBeFlushed`
- [x] `CacheNullStoreTest::testHasSeparateLockStore`
- [x] `CacheMemoizedStoreTest::testLocksCanBeFlushedWhenUnderlyingStoreSupportsIt`
- [x] `CacheMemoizedStoreTest::testFlushLocksThrowsWhenUnderlyingStoreDoesNotSupportIt`
- [x] `CacheMemoizedStoreTest::testHasSeparateLockStoreDelegatestoUnderlyingStore`