### PR TITLE
[13.x] Cast to string before preg_match in alpha_dash, alpha_num, digits, digits_between, regex, and not_regex rules

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -378,10 +378,10 @@ trait ValidatesAttributes
         }
 
         if (isset($parameters[0]) && $parameters[0] === 'ascii') {
-            return preg_match('/\A[a-zA-Z0-9_-]+\z/u', $value) > 0;
+            return preg_match('/\A[a-zA-Z0-9_-]+\z/u', (string) $value) > 0;
         }
 
-        return preg_match('/\A[\pL\pM\pN_-]+\z/u', $value) > 0;
+        return preg_match('/\A[\pL\pM\pN_-]+\z/u', (string) $value) > 0;
     }
 
     /**
@@ -400,10 +400,10 @@ trait ValidatesAttributes
         }
 
         if (isset($parameters[0]) && $parameters[0] === 'ascii') {
-            return preg_match('/\A[a-zA-Z0-9]+\z/u', $value) > 0;
+            return preg_match('/\A[a-zA-Z0-9]+\z/u', (string) $value) > 0;
         }
 
-        return preg_match('/\A[\pL\pM\pN]+\z/u', $value) > 0;
+        return preg_match('/\A[\pL\pM\pN]+\z/u', (string) $value) > 0;
     }
 
     /**
@@ -725,7 +725,7 @@ trait ValidatesAttributes
         $this->requireParameterCount(1, $parameters, 'digits');
 
         return (is_numeric($value) || is_string($value)) &&
-            ! preg_match('/[^0-9]/', $value) &&
+            ! preg_match('/[^0-9]/', (string) $value) &&
             strlen((string) $value) == $parameters[0];
     }
 
@@ -747,7 +747,7 @@ trait ValidatesAttributes
 
         $length = strlen((string) $value);
 
-        return ! preg_match('/[^0-9]/', $value)
+        return ! preg_match('/[^0-9]/', (string) $value)
                     && $length >= $parameters[0] && $length <= $parameters[1];
     }
 
@@ -2099,7 +2099,7 @@ trait ValidatesAttributes
 
         $this->requireParameterCount(1, $parameters, 'regex');
 
-        return preg_match($parameters[0], $value) > 0;
+        return preg_match($parameters[0], (string) $value) > 0;
     }
 
     /**
@@ -2118,7 +2118,7 @@ trait ValidatesAttributes
 
         $this->requireParameterCount(1, $parameters, 'not_regex');
 
-        return preg_match($parameters[0], $value) < 1;
+        return preg_match($parameters[0], (string) $value) < 1;
     }
 
     /**


### PR DESCRIPTION
## Summary

Adds explicit `(string)` casts before `preg_match()` calls in six validation rules that accept both string and numeric values.

## Context

These rules guard with `is_string($value) || is_numeric($value)` but then pass `$value` directly to `preg_match()` without casting. When `$value` is numeric (int or float), PHP auto-coerces it — but this is implicit and mirrors the same issue fixed in #59739 for `decimal`, `max_digits`, and `min_digits`.

| Rule | Location |
|---|---|
| `alpha_dash` | `validateAlphaDash()` lines 381, 384 |
| `alpha_num` | `validateAlphaNum()` lines 403, 406 |
| `digits` | `validateDigits()` line 728 |
| `digits_between` | `validateDigitsBetween()` line 750 |
| `regex` | `validateRegex()` line 2102 |
| `not_regex` | `validateNotRegex()` line 2121 |

## Solution

Add `(string)` cast at the `preg_match()` call site, consistent with how other rules in the same file already handle this (e.g. line 676: `preg_match('/^[+-]?\d*\.?(\d*)$/', (string) $value, $matches)`).

## Test Plan

- [x] Existing `tests/Validation/ValidationValidatorTest.php` alpha, digit, and regex tests pass