### PR TITLE
[13.x] Add enum key support to Arr::pluck() and LazyCollection::pluck()

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -1029,7 +1029,6 @@ class Arr
 
     /**
      * Push an item into an array using "dot" notation.
-     *
      */
     public static function push(ArrayAccess|array &$array, string|int|null $key, mixed ...$values): array
     {

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -643,7 +643,6 @@ class Arr
      *
      * An array is "associative" if it doesn't have sequential numerical keys beginning with zero.
      *
-     * @param  array  $array
      * @return ($array is list ? false : true)
      */
     public static function isAssoc(array $array)
@@ -799,7 +798,9 @@ class Arr
                     ? $key($item)
                     : data_get($item, $key);
 
-                if (is_object($itemKey) && method_exists($itemKey, '__toString')) {
+                if ($itemKey instanceof \UnitEnum) {
+                    $itemKey = enum_value($itemKey);
+                } elseif (is_object($itemKey) && method_exists($itemKey, '__toString')) {
                     $itemKey = (string) $itemKey;
                 }
 
@@ -829,8 +830,6 @@ class Arr
     /**
      * Run a map over each of the items in the array.
      *
-     * @param  array  $array
-     * @param  callable  $callback
      * @return array
      */
     public static function map(array $array, callable $callback)
@@ -1031,10 +1030,6 @@ class Arr
     /**
      * Push an item into an array using "dot" notation.
      *
-     * @param  \ArrayAccess|array  $array
-     * @param  string|int|null  $key
-     * @param  mixed  $values
-     * @return array
      */
     public static function push(ArrayAccess|array &$array, string|int|null $key, mixed ...$values): array
     {

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -691,7 +691,6 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * Determine if the collection contains a single item.
      *
      * @param  (callable(TValue, TKey): bool)|null  $callback
-     * @return bool
      *
      * @deprecated 12.49.0 Use the `hasSole()` method instead.
      */
@@ -703,7 +702,6 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     /**
      * Determine if the collection contains multiple items.
      *
-     * @return bool
      *
      * @deprecated 12.50.0 Use the `hasMany()` method instead.
      */
@@ -784,7 +782,9 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
                         ? $key($item)
                         : data_get($item, $key);
 
-                    if (is_object($itemKey) && method_exists($itemKey, '__toString')) {
+                    if ($itemKey instanceof \UnitEnum) {
+                        $itemKey = enum_value($itemKey);
+                    } elseif (is_object($itemKey) && method_exists($itemKey, '__toString')) {
                         $itemKey = (string) $itemKey;
                     }
 
@@ -861,7 +861,6 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     /**
      * Multiply the items in the collection by the multiplier.
      *
-     * @param  int  $multiplier
      * @return static
      */
     public function multiply(int $multiplier)
@@ -1350,7 +1349,6 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * @param  (callable(TValue, TKey): bool)|string|null  $key
      * @param  mixed  $operator
      * @param  mixed  $value
-     * @return bool
      */
     public function hasSole($key = null, $operator = null, $value = null): bool
     {
@@ -1619,7 +1617,6 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     /**
      * Take items in the collection until a given point in time, with an optional callback on timeout.
      *
-     * @param  \DateTimeInterface  $timeout
      * @param  callable(TValue|null, TKey|null): mixed|null  $callback
      * @return static<TKey, TValue>
      */
@@ -1863,7 +1860,6 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     /**
      * Count the number of items in the collection.
      *
-     * @return int
      */
     public function count(): int
     {

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1859,7 +1859,6 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
 
     /**
      * Count the number of items in the collection.
-     *
      */
     public function count(): int
     {

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1043,20 +1043,17 @@ class SupportArrTest extends TestCase
             ['status' => TestBackedEnum::A, 'name' => 'foo'],
             ['status' => TestBackedEnum::B, 'name' => 'bar'],
         ];
-
         $this->assertEquals([1 => 'foo', 2 => 'bar'], Arr::pluck($array, 'name', 'status'));
 
         $array = [
             ['status' => TestStringBackedEnum::A, 'name' => 'foo'],
             ['status' => TestStringBackedEnum::B, 'name' => 'bar'],
         ];
-
         $this->assertEquals(['A' => 'foo', 'B' => 'bar'], Arr::pluck($array, 'name', 'status'));
 
         $array = [
             ['status' => TestEnum::A, 'name' => 'foo'],
         ];
-
         $this->assertEquals(['A' => 'foo'], Arr::pluck($array, 'name', 'status'));
     }
 
@@ -1736,8 +1733,7 @@ class SupportArrTest extends TestCase
         $this->assertSame($subject, Arr::from($items));
 
         $items = new WeakMap;
-        $items[$temp = new class
-        {
+        $items[$temp = new class {
         }] = 'bar';
         $this->assertSame(['bar'], Arr::from($items));
 

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1037,6 +1037,29 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['2017-07-25 00:00:00' => '2017-07-30 00:00:00'], $array);
     }
 
+    public function testPluckWithEnumKeys()
+    {
+        $array = [
+            ['status' => TestBackedEnum::A, 'name' => 'foo'],
+            ['status' => TestBackedEnum::B, 'name' => 'bar'],
+        ];
+
+        $this->assertEquals([1 => 'foo', 2 => 'bar'], Arr::pluck($array, 'name', 'status'));
+
+        $array = [
+            ['status' => TestStringBackedEnum::A, 'name' => 'foo'],
+            ['status' => TestStringBackedEnum::B, 'name' => 'bar'],
+        ];
+
+        $this->assertEquals(['A' => 'foo', 'B' => 'bar'], Arr::pluck($array, 'name', 'status'));
+
+        $array = [
+            ['status' => TestEnum::A, 'name' => 'foo'],
+        ];
+
+        $this->assertEquals(['A' => 'foo'], Arr::pluck($array, 'name', 'status'));
+    }
+
     public function testArrayPluckWithArrayAndObjectValues()
     {
         $array = [(object) ['name' => 'taylor', 'email' => 'foo'], ['name' => 'dayle', 'email' => 'bar']];

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1736,7 +1736,8 @@ class SupportArrTest extends TestCase
         $this->assertSame($subject, Arr::from($items));
 
         $items = new WeakMap;
-        $items[$temp = new class {
+        $items[$temp = new class
+        {
         }] = 'bar';
         $this->assertSame(['bar'], Arr::from($items));
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2531,6 +2531,27 @@ class SupportCollectionTest extends TestCase
     }
 
     #[DataProvider('collectionClassProvider')]
+    public function testPluckWithEnumKeys($collection)
+    {
+        $data = new $collection([
+            ['status' => TestBackedEnum::A, 'name' => 'foo'],
+            ['status' => TestBackedEnum::B, 'name' => 'bar'],
+        ]);
+        $this->assertEquals([1 => 'foo', 2 => 'bar'], $data->pluck('name', 'status')->all());
+
+        $data = new $collection([
+            ['status' => TestStringBackedEnum::A, 'name' => 'foo'],
+            ['status' => TestStringBackedEnum::B, 'name' => 'bar'],
+        ]);
+        $this->assertEquals(['A' => 'foo', 'B' => 'bar'], $data->pluck('name', 'status')->all());
+
+        $data = new $collection([
+            ['status' => TestEnum::A, 'name' => 'foo'],
+        ]);
+        $this->assertEquals(['A' => 'foo'], $data->pluck('name', 'status')->all());
+    }
+
+    #[DataProvider('collectionClassProvider')]
     public function testHas($collection)
     {
         $data = new $collection(['id' => 1, 'first' => 'Hello', 'second' => 'World']);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2607,12 +2607,10 @@ class SupportCollectionTest extends TestCase
     #[DataProvider('collectionClassProvider')]
     public function testImplodeModels($collection)
     {
-        $model = new class extends Model
-        {
+        $model = new class extends Model {
         };
         $model->setAttribute('email', 'foo');
-        $modelTwo = new class extends Model
-        {
+        $modelTwo = new class extends Model {
         };
         $modelTwo->setAttribute('email', 'bar');
         $data = new $collection([$model, $modelTwo]);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2607,10 +2607,12 @@ class SupportCollectionTest extends TestCase
     #[DataProvider('collectionClassProvider')]
     public function testImplodeModels($collection)
     {
-        $model = new class extends Model {
+        $model = new class extends Model
+        {
         };
         $model->setAttribute('email', 'foo');
-        $modelTwo = new class extends Model {
+        $modelTwo = new class extends Model
+        {
         };
         $modelTwo->setAttribute('email', 'bar');
         $data = new $collection([$model, $modelTwo]);


### PR DESCRIPTION
## Summary

- `Arr::pluck()` and `LazyCollection::pluck()` now correctly handle enum instances used as keys, consistent with the enum support added to `Collection::keyBy()` and `Collection::groupBy()`.

## Problem

Both `Arr::pluck()` and `LazyCollection::pluck()` handle object keys with `__toString` but not enums. Since enums don't implement `__toString` by default, passing an enum as the pluck key results in the enum object being used directly as an array key, which is invalid in PHP and causes an error.

```php
// Before - throws error for int/string backed enums, fatal for unit enums
Arr::pluck($array, 'name', 'status'); // where 'status' resolves to an enum

// After - works correctly
[1 => 'foo', 2 => 'bar']   // BackedEnum: uses backing value
['A' => 'foo']             // UnitEnum: uses name
```

## Solution

Add an `instanceof \UnitEnum` check before the existing `__toString` check in both `Arr::pluck()` and `LazyCollection::pluck()`, using `enum_value()` to extract the value — the same pattern applied in #59809 for `Collection::keyBy()`.

## Test Plan

- [x] `SupportArrTest::testPluckWithEnumKeys` — int backed, string backed, and unit enums
- [x] `SupportCollectionTest::testPluckWithEnumKeys` — covers both `Collection` and `LazyCollection` via `collectionClassProvider`