### PR TITLE
[13.x] Wait for Redis nodes to be ready before creating cluster

### DIFF
--- a/.github/workflows/redis.yml
+++ b/.github/workflows/redis.yml
@@ -101,6 +101,9 @@ jobs:
           redis-server --daemonize yes --port 7000 --appendonly yes --cluster-enabled yes --cluster-config-file nodes-7000.conf
           redis-server --daemonize yes --port 7001 --appendonly yes --cluster-enabled yes --cluster-config-file nodes-7001.conf
           redis-server --daemonize yes --port 7002 --appendonly yes --cluster-enabled yes --cluster-config-file nodes-7002.conf
+          until redis-cli -p 7000 ping 2>/dev/null | grep -q PONG; do sleep 0.1; done
+          until redis-cli -p 7001 ping 2>/dev/null | grep -q PONG; do sleep 0.1; done
+          until redis-cli -p 7002 ping 2>/dev/null | grep -q PONG; do sleep 0.1; done
           redis-cli --cluster create 127.0.0.1:7000 127.0.0.1:7001 127.0.0.1:7002 --cluster-replicas 0 --cluster-yes
 
       - name: Check Redis Cluster is ready


### PR DESCRIPTION
## Summary

Adds readiness checks between starting the Redis server processes and running `redis-cli --cluster create`, preventing the flaky `[ERR] Node 127.0.0.1:7000 is not configured as a cluster node` error in CI.

## Problem

The "Create Redis Cluster" workflow step starts three Redis nodes with `--daemonize yes` and immediately calls `redis-cli --cluster create`. Since the processes daemonize in the background, they may not yet be accepting connections when the `create` command runs, causing a race condition that fails the job intermittently.

## Solution

Poll each node with `redis-cli ping` until it responds with `PONG` before proceeding to cluster creation. Each loop sleeps 100ms between attempts, adding negligible overhead in the normal case while reliably eliminating the race.

```yaml
until redis-cli -p 7000 ping 2>/dev/null | grep -q PONG; do sleep 0.1; done
until redis-cli -p 7001 ping 2>/dev/null | grep -q PONG; do sleep 0.1; done
until redis-cli -p 7002 ping 2>/dev/null | grep -q PONG; do sleep 0.1; done
redis-cli --cluster create ...
```