### PR TITLE
[13.x] Add internalServerError() and serviceUnavailable() to DeterminesStatusCode

### DIFF
--- a/src/Illuminate/Http/Client/Concerns/DeterminesStatusCode.php
+++ b/src/Illuminate/Http/Client/Concerns/DeterminesStatusCode.php
@@ -174,4 +174,24 @@ trait DeterminesStatusCode
     {
         return $this->status() === 429;
     }
+
+    /**
+     * Determine if the response was a 500 "Internal Server Error" response.
+     *
+     * @return bool
+     */
+    public function internalServerError()
+    {
+        return $this->status() === 500;
+    }
+
+    /**
+     * Determine if the response was a 503 "Service Unavailable" response.
+     *
+     * @return bool
+     */
+    public function serviceUnavailable()
+    {
+        return $this->status() === 503;
+    }
 }

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -311,6 +311,34 @@ class HttpClientTest extends TestCase
         $this->assertFalse($response->tooManyRequests());
     }
 
+    public function testInternalServerErrorResponse()
+    {
+        $this->factory->fake([
+            'vapor.laravel.com' => $this->factory::response('', 500),
+            'forge.laravel.com' => $this->factory::response('', 200),
+        ]);
+
+        $response = $this->factory->post('http://vapor.laravel.com');
+        $this->assertTrue($response->internalServerError());
+
+        $response = $this->factory->post('http://forge.laravel.com');
+        $this->assertFalse($response->internalServerError());
+    }
+
+    public function testServiceUnavailableResponse()
+    {
+        $this->factory->fake([
+            'vapor.laravel.com' => $this->factory::response('', 503),
+            'forge.laravel.com' => $this->factory::response('', 200),
+        ]);
+
+        $response = $this->factory->post('http://vapor.laravel.com');
+        $this->assertTrue($response->serviceUnavailable());
+
+        $response = $this->factory->post('http://forge.laravel.com');
+        $this->assertFalse($response->serviceUnavailable());
+    }
+
     public function testUnauthorizedRequest()
     {
         $this->factory->fake([


### PR DESCRIPTION
## Summary

Adds `internalServerError()` (500) and `serviceUnavailable()` (503) helper methods to the `DeterminesStatusCode` trait, completing the most commonly needed HTTP status code helpers.

## Context

The `DeterminesStatusCode` trait used by `Illuminate\Http\Client\Response` covers 4xx errors well but has no 5xx helpers at all. `500` and `503` are the two most frequently encountered server-side status codes when working with HTTP clients.

| Method | Status Code | Before |
|---|---|---|
| `internalServerError()` | 500 | ❌ Missing |
| `serviceUnavailable()` | 503 | ❌ Missing |

All existing helpers follow the same pattern — this simply extends it for the missing codes.

## Test Plan

- [x] `HttpClientTest::testInternalServerErrorResponse`
- [x] `HttpClientTest::testServiceUnavailableResponse`