### PR TITLE
[13.x] Fix factory hasAttached method pivot JSON attribute handling

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Factories\Attributes\UseModel;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Enumerable;
@@ -724,7 +725,7 @@ abstract class Factory
      */
     public function hasAttached($factory, $pivot = [], $relationship = null)
     {
-        if (is_array($pivot) && $pivot !== [] && array_all($pivot, fn ($p) => is_array($p))) {
+        if (is_array($pivot) && $pivot !== [] && !Arr::isAssoc($pivot) && array_all($pivot, fn ($p) => is_array($p))) {
             $factory = $factory instanceof Factory && $factory->count === null
                 ? $factory->count(count($pivot))
                 : $factory;

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -9,7 +9,6 @@ use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Factories\Attributes\UseModel;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Enumerable;
@@ -725,7 +724,7 @@ abstract class Factory
      */
     public function hasAttached($factory, $pivot = [], $relationship = null)
     {
-        if (is_array($pivot) && $pivot !== [] && !Arr::isAssoc($pivot) && array_all($pivot, fn ($p) => is_array($p))) {
+        if (is_array($pivot) && $pivot !== [] && array_is_list($pivot) && array_all($pivot, fn ($p) => is_array($p))) {
             $factory = $factory instanceof Factory && $factory->count === null
                 ? $factory->count(count($pivot))
                 : $factory;

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -15,6 +15,7 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Factories\Sequence;
 use Illuminate\Database\Eloquent\Model as Eloquent;
+use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
@@ -90,6 +91,7 @@ class DatabaseEloquentFactoryTest extends TestCase
             $table->foreignId('role_id');
             $table->foreignId('user_id');
             $table->string('admin')->default('N');
+            $table->json('meta')->nullable();
         });
     }
 
@@ -556,15 +558,26 @@ class DatabaseEloquentFactoryTest extends TestCase
         unset($_SERVER['__test.role.creating-role']);
     }
 
+    public function test_belongs_to_many_relationship_with_pivot_json_column()
+    {
+        $user = FactoryTestUserFactory::new()
+            ->hasAttached(FactoryTestRoleFactory::new(), ['meta' => ['foo' => 'bar']])
+            ->create();
+
+        $this->assertCount(1, $user->factoryTestRoles);
+        $this->assertSame(['foo' => 'bar'], $user->factoryTestRoles[0]->pivot->meta);
+    }
+
     public function test_belongs_to_many_relationship_with_pivot_arrays()
     {
         $user = FactoryTestUserFactory::new()
-            ->hasAttached(FactoryTestRoleFactory::new(), [['admin' => 'Y'], ['admin' => 'N']])
+            ->hasAttached(FactoryTestRoleFactory::new(), [['admin' => 'Y'], ['admin' => 'N', 'meta' => ['foo' => 'bar']]])
             ->create();
 
         $this->assertCount(2, $user->factoryTestRoles);
         $this->assertSame('Y', $user->factoryTestRoles[0]->pivot->admin);
         $this->assertSame('N', $user->factoryTestRoles[1]->pivot->admin);
+        $this->assertSame(['foo' => 'bar'], $user->factoryTestRoles[1]->pivot->meta);
     }
 
     public function test_sequences()
@@ -1194,7 +1207,7 @@ class FactoryTestUser extends Eloquent
 
     public function factoryTestRoles()
     {
-        return $this->belongsToMany(FactoryTestRole::class, 'role_user', 'user_id', 'role_id')->withPivot('admin');
+        return $this->belongsToMany(FactoryTestRole::class, 'role_user', 'user_id', 'role_id')->using(FactoryTestUserRolePivot::class)->withPivot(['admin', 'meta']);
     }
 }
 
@@ -1354,6 +1367,15 @@ class FactoryTestUserWithArray extends Eloquent
     {
         return ['options' => 'array'];
     }
+}
+
+class FactoryTestUserRolePivot extends Pivot
+{
+    protected $table = 'role_user';
+
+    public $timestamps = false;
+
+    protected $casts = ['meta' => 'array'];
 }
 
 class FactoryTestUserWithArrayFactory extends Factory


### PR DESCRIPTION
Hello !

Since #59723 was merged, it is no longer possible to set a JSON attribute on the pivot when using the factory `hasAttached` method. Doing so results in an exception being thrown.

```php                                    
  $user = User::factory()
    ->hasAttached(
        Role::factory(),
        ['meta' => ['foo' => 'bar']]
    )
    ->create(); // ErrorException: Undefined array key 0
```


This PR aims to restore the original behavior by checking whether the pivot attribute is an associative array. IMO, if an `['attribute' => 'value']` array is passed, we can safely assume the developer intends to set specific column values on the pivot rather than creating multiple relations.

I have also added tests to prevent future regressions, as this was previously untested behavior.

Thanks !