### PR TITLE
[13.x] Add enum support to RedisManager purge method

### DIFF
--- a/src/Illuminate/Redis/RedisManager.php
+++ b/src/Illuminate/Redis/RedisManager.php
@@ -242,12 +242,12 @@ class RedisManager implements Factory
     /**
      * Disconnect the given connection and remove from local cache.
      *
-     * @param  string|null  $name
+     * @param  \UnitEnum|string|null  $name
      * @return void
      */
     public function purge($name = null)
     {
-        $name = $name ?: 'default';
+        $name = enum_value($name) ?: 'default';
 
         unset($this->connections[$name]);
     }

--- a/tests/Redis/RedisManagerExtensionTest.php
+++ b/tests/Redis/RedisManagerExtensionTest.php
@@ -87,17 +87,17 @@ class RedisManagerExtensionTest extends TestCase
 
     public function testPurgeAcceptsUnitEnum()
     {
-        $redis = new RedisManager(new Application, "my_custom_driver", [
+        $redis = new RedisManager(new Application, 'my_custom_driver', [
             "default" => [
-                "host" => "some-host",
-                "port" => "some-port",
-                "database" => 5,
-                "timeout" => 0.5,
+                'host' => 'some-host',
+                'port' => 'some-port',
+                'database' => 5,
+                'timeout' => 0.5,
             ],
         ]);
 
-        $property = new \ReflectionProperty($redis, "connections");
-        $property->setValue($redis, ["default" => "fake-connection"]);
+        $property = new \ReflectionProperty($redis, 'connections');
+        $property->setValue($redis, ["default" => 'fake-connection']);
 
         $this->assertCount(1, $redis->connections());
 

--- a/tests/Redis/RedisManagerExtensionTest.php
+++ b/tests/Redis/RedisManagerExtensionTest.php
@@ -84,6 +84,26 @@ class RedisManagerExtensionTest extends TestCase
 
         $redis->resolve($name);
     }
+
+    public function testPurgeAcceptsUnitEnum()
+    {
+        $redis = new RedisManager(new Application, "my_custom_driver", [
+            "default" => [
+                "host" => "some-host",
+                "port" => "some-port",
+                "database" => 5,
+                "timeout" => 0.5,
+            ],
+        ]);
+
+        $property = new \ReflectionProperty($redis, "connections");
+        $property->setValue($redis, ["default" => "fake-connection"]);
+
+        $this->assertCount(1, $redis->connections());
+
+        $redis->purge(FakeRedisConnectionName::Default);
+        $this->assertCount(0, $redis->connections());
+    }
 }
 
 class FakeRedisConnector implements Connector
@@ -112,4 +132,9 @@ class FakeRedisConnector implements Connector
     {
         return 'my-redis-cluster-connection';
     }
+}
+
+enum FakeRedisConnectionName: string
+{
+    case Default = 'default';
 }

--- a/tests/Redis/RedisManagerExtensionTest.php
+++ b/tests/Redis/RedisManagerExtensionTest.php
@@ -88,7 +88,7 @@ class RedisManagerExtensionTest extends TestCase
     public function testPurgeAcceptsUnitEnum()
     {
         $redis = new RedisManager(new Application, 'my_custom_driver', [
-            "default" => [
+            'default' => [
                 'host' => 'some-host',
                 'port' => 'some-port',
                 'database' => 5,
@@ -97,7 +97,7 @@ class RedisManagerExtensionTest extends TestCase
         ]);
 
         $property = new \ReflectionProperty($redis, 'connections');
-        $property->setValue($redis, ["default" => 'fake-connection']);
+        $property->setValue($redis, ['default' => 'fake-connection']);
 
         $this->assertCount(1, $redis->connections());
 


### PR DESCRIPTION
The [purge()](cci:1://file:///var/www/laravel-framework-contrib/src/Illuminate/Database/DatabaseManager.php:297:4-308:5) method in [RedisManager](cci:2://file:///var/www/laravel-framework-contrib/src/Illuminate/Redis/RedisManager.php:21:0-289:1) did not support [UnitEnum](cci:1://file:///var/www/laravel-framework-contrib/tests/Redis/RedisManagerExtensionTest.php:89:4-109:5) values, unlike [connection()](cci:1://file:///var/www/laravel-framework-contrib/src/Illuminate/Redis/RedisManager.php:81:4-95:5) which already does. This inconsistency means calling `Redis::purge(MyEnum::Connection)` would silently purge the wrong connection.

This change applies `enum_value()` to `purge()`, bringing it in line with the rest of the manager.