### PR TITLE
[13.x] Use native `clamp` function

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,6 +57,7 @@
         "symfony/mime": "^7.4.0 || ^8.0.0",
         "symfony/polyfill-php84": "^1.33",
         "symfony/polyfill-php85": "^1.33",
+        "symfony/polyfill-php86": "^1.36",
         "symfony/process": "^7.4.5 || ^8.0.5",
         "symfony/routing": "^7.4.0 || ^8.0.0",
         "symfony/uid": "^7.4.0 || ^8.0.0",

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -310,7 +310,7 @@ class Number
      */
     public static function clamp(int|float $number, int|float $min, int|float $max)
     {
-        return min(max($number, $min), $max);
+        return clamp($number, $min, $max);
     }
 
     /**

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -26,6 +26,7 @@
         "illuminate/reflection": "^13.0",
         "nesbot/carbon": "^3.8.4",
         "symfony/polyfill-php85": "^1.33",
+        "symfony/polyfill-php86": "^1.36",
         "voku/portable-ascii": "^2.0.2"
     },
     "replace": {


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This replaces the manual `Number::clamp` implementation with the PHP native `clamp`, which is new in PHP 8.6 (unreleased). See also:
- https://wiki.php.net/rfc/clamp_v2
- https://github.com/php/php-src/pull/19434
- https://github.com/symfony/polyfill/pull/554