### PR TITLE
[13.x] Add support for `SortDirection` enum to collections and Arr

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,6 +57,7 @@
         "symfony/mime": "^7.4.0 || ^8.0.0",
         "symfony/polyfill-php84": "^1.33",
         "symfony/polyfill-php85": "^1.33",
+        "symfony/polyfill-php86": "^1.36",
         "symfony/process": "^7.4.5 || ^8.0.5",
         "symfony/routing": "^7.4.0 || ^8.0.0",
         "symfony/uid": "^7.4.0 || ^8.0.0",

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
 use JsonSerializable;
 use Random\Randomizer;
+use SortDirection;
 use Traversable;
 use WeakMap;
 
@@ -1091,7 +1092,7 @@ class Arr
      * @template TValue
      *
      * @param  iterable<TKey, TValue>  $array
-     * @param  callable|string|null|array<int, (callable(TValue, TValue): -1|0|1)|array{string, 'asc'|'desc'}>  $callback
+     * @param  callable|string|null|array<int, (callable(TValue, TValue): -1|0|1)|array{string, SortDirection|'asc'|'desc'}>  $callback
      * @return array<TKey, TValue>
      */
     public static function sort($array, $callback = null)
@@ -1122,7 +1123,7 @@ class Arr
      *
      * @param  array<TKey, TValue>  $array
      * @param  int-mask-of<SORT_REGULAR|SORT_NUMERIC|SORT_STRING|SORT_LOCALE_STRING|SORT_NATURAL|SORT_FLAG_CASE>  $options
-     * @param  bool  $descending
+     * @param  SortDirection|bool  $descending
      * @return array<TKey, TValue>
      */
     public static function sortRecursive($array, $options = SORT_REGULAR, $descending = false)
@@ -1134,13 +1135,15 @@ class Arr
         }
 
         if (! array_is_list($array)) {
-            $descending
-                ? krsort($array, $options)
-                : ksort($array, $options);
+            match ($descending) {
+                false, SortDirection::Ascending => ksort($array, $options),
+                true, SortDirection::Descending => krsort($array, $options),
+            };
         } else {
-            $descending
-                ? rsort($array, $options)
-                : sort($array, $options);
+            match ($descending) {
+                false, SortDirection::Ascending => sort($array, $options),
+                true, SortDirection::Descending => rsort($array, $options),
+            };
         }
 
         return $array;
@@ -1158,7 +1161,7 @@ class Arr
      */
     public static function sortRecursiveDesc($array, $options = SORT_REGULAR)
     {
-        return static::sortRecursive($array, $options, true);
+        return static::sortRecursive($array, $options, SortDirection::Descending);
     }
 
     /**

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Traits\EnumeratesValues;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Support\Traits\TransformsToResourceCollection;
 use InvalidArgumentException;
+use SortDirection;
 use stdClass;
 use Traversable;
 
@@ -1577,7 +1578,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      *
      * @param  array<array-key, (callable(TValue, TValue): mixed)|(callable(TValue, TKey): mixed)|string|array{string, string}>|(callable(TValue, TKey): mixed)|string  $callback
      * @param  int  $options
-     * @param  bool  $descending
+     * @param  SortDirection|bool  $descending
      * @return static
      */
     public function sortBy($callback, $options = SORT_REGULAR, $descending = false)
@@ -1597,8 +1598,10 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
             $results[$key] = $callback($value, $key);
         }
 
-        $descending ? arsort($results, $options)
-            : asort($results, $options);
+        match ($descending) {
+            false, SortDirection::Ascending => asort($results, $options),
+            true, SortDirection::Descending => arsort($results, $options),
+        };
 
         // Once we have sorted all of the keys in the array, we will loop through them
         // and grab the corresponding model so we can set the underlying items list
@@ -1627,15 +1630,18 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
 
                 $prop = $comparison[0];
 
-                $ascending = Arr::get($comparison, 1, true) === true ||
-                             Arr::get($comparison, 1, true) === 'asc';
+                $direction = match (Arr::get($comparison, 1, true)) {
+                    true, 'asc', SortDirection::Ascending => SortDirection::Ascending,
+                    false, 'desc', SortDirection::Descending => SortDirection::Descending,
+                    default => SortDirection::Descending, // for backwards compatibility
+                };
 
                 if (! is_string($prop) && is_callable($prop)) {
                     $result = $prop($a, $b);
                 } else {
                     $values = [data_get($a, $prop), data_get($b, $prop)];
 
-                    if (! $ascending) {
+                    if ($direction === SortDirection::Descending) {
                         $values = array_reverse($values);
                     }
 
@@ -1680,7 +1686,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
             foreach ($callback as $index => $key) {
                 $comparison = Arr::wrap($key);
 
-                $comparison[1] = 'desc';
+                $comparison[1] = SortDirection::Descending;
 
                 $callback[$index] = $comparison;
             }
@@ -1693,14 +1699,17 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * Sort the collection keys.
      *
      * @param  int  $options
-     * @param  bool  $descending
+     * @param  SortDirection|bool  $descending
      * @return static
      */
     public function sortKeys($options = SORT_REGULAR, $descending = false)
     {
         $items = $this->items;
 
-        $descending ? krsort($items, $options) : ksort($items, $options);
+        match ($descending) {
+            false, SortDirection::Ascending => ksort($items, $options),
+            true, SortDirection::Descending => krsort($items, $options),
+        };
 
         return $this->newInstance($items);
     }
@@ -1713,7 +1722,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      */
     public function sortKeysDesc($options = SORT_REGULAR)
     {
-        return $this->sortKeys($options, true);
+        return $this->sortKeys($options, SortDirection::Descending);
     }
 
     /**

--- a/src/Illuminate/Collections/composer.json
+++ b/src/Illuminate/Collections/composer.json
@@ -19,7 +19,8 @@
         "illuminate/contracts": "^13.0",
         "illuminate/macroable": "^13.0",
         "symfony/polyfill-php84": "^1.33",
-        "symfony/polyfill-php85": "^1.33"
+        "symfony/polyfill-php85": "^1.33",
+        "symfony/polyfill-php86": "^1.36"
     },
     "suggest": {
         "illuminate/http": "Required to convert collections to API resources (^13.0).",

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -23,6 +23,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
+use SortDirection;
 use stdClass;
 use Symfony\Component\VarDumper\VarDumper;
 use UnexpectedValueException;
@@ -2064,6 +2065,16 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['dayle', 'taylor'], array_values($data->all()));
 
         $data = new $collection(['dayle', 'taylor']);
+        $data = $data->sortBy(
+            function ($x) {
+                return $x;
+            },
+            SORT_REGULAR,
+            SortDirection::Descending);
+
+        $this->assertEquals(['taylor', 'dayle'], array_values($data->all()));
+
+        $data = new $collection(['dayle', 'taylor']);
         $data = $data->sortByDesc(function ($x) {
             return $x;
         });
@@ -2151,6 +2162,14 @@ class SupportCollectionTest extends TestCase
 
         rsort($expected);
         $data = $data->sortBy([['item', 'desc']]);
+        $this->assertEquals($data->pluck('item')->toArray(), $expected);
+
+        rsort($expected);
+        $data = $data->sortBy([['item', false]]);
+        $this->assertEquals($data->pluck('item')->toArray(), $expected);
+
+        rsort($expected);
+        $data = $data->sortBy([['item', SortDirection::Descending]]);
         $this->assertEquals($data->pluck('item')->toArray(), $expected);
 
         sort($expected, SORT_STRING);


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This allows one to use the native PHP `SortDirection` enum (introduced in 8.6, unreleased) in collection and Arr methods, to allow for improved code readability and potential interoperability with other sources using this.

See also:
- https://wiki.php.net/rfc/sort_direction_enum
- https://github.com/symfony/polyfill/pull/569

The `descending` parameter has intentionally not be renamed anywhere, given that although referencing to parameters by names is not considered stable under semver, it is likely to be somewhat widespread and therefore probably not something to do on a whim. It may be worth doing a renaming in a future major.

Note I intend to follow-up with a similar PR for queries, but this is slightly more involved.