### PR TITLE
[13.x] Prevent array query params from bypassing signed URL validation

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -511,6 +511,10 @@ class UrlGenerator implements UrlGeneratorContract
     {
         $expires = $request->query('expires');
 
+        if ($expires !== null && ! is_string($expires)) {
+            return false;
+        }
+
         return ! ($expires && Carbon::now()->getTimestamp() > $expires);
     }
 

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -483,10 +483,16 @@ class UrlGenerator implements UrlGeneratorContract
 
         $keys = is_array($keys) ? $keys : [$keys];
 
+        $signature = $request->query('signature');
+
+        if (! is_string($signature)) {
+            return false;
+        }
+
         foreach ($keys as $key) {
             if (hash_equals(
                 hash_hmac('sha256', $original, $key),
-                (string) $request->query('signature', '')
+                $signature
             )) {
                 return true;
             }

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -996,6 +996,23 @@ class RoutingUrlGeneratorTest extends TestCase
         }
     }
 
+    public function testSignedUrlWithArrayExpiresReturnsFalse()
+    {
+        $url = new UrlGenerator(
+            new RouteCollection,
+            Request::create('http://www.foo.com/')
+        );
+        $url->setKeyResolver(function () {
+            return 'secret';
+        });
+
+        // ?expires[]=99999999999 is truthy but comparing timestamp > array is always
+        // false in PHP, so without the guard the URL would never appear expired.
+        $request = Request::create('http://www.foo.com/foo?expires[]=99999999999');
+
+        $this->assertFalse($url->signatureHasNotExpired($request));
+    }
+
     public function testMissingNamedRouteResolution()
     {
         $url = new UrlGenerator(

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -966,6 +966,36 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertTrue($url3->hasValidSignature($secondRequest));
     }
 
+    public function testSignedUrlWithArraySignatureReturnsFalseWithoutWarning()
+    {
+        $url = new UrlGenerator(
+            $routes = new RouteCollection,
+            Request::create('http://www.foo.com/')
+        );
+        $url->setKeyResolver(function () {
+            return 'secret';
+        });
+
+        $route = new Route(['GET'], 'foo', ['as' => 'foo', function () {
+            //
+        }]);
+        $routes->add($route);
+
+        // ?signature[]=foo&signature[]=bar previously raised an
+        // "Array to string conversion" warning.
+        $request = Request::create('http://www.foo.com/foo?signature[]=foo&signature[]=bar');
+
+        set_error_handler(static function (int $errno, string $errstr) {
+            throw new \ErrorException($errstr, 0, $errno);
+        }, E_WARNING);
+
+        try {
+            $this->assertFalse($url->hasValidSignature($request));
+        } finally {
+            restore_error_handler();
+        }
+    }
+
     public function testMissingNamedRouteResolution()
     {
         $url = new UrlGenerator(


### PR DESCRIPTION
When `signature` or `expires` query parameters are sent as arrays (e.g. `?signature[]=foo` or `?expires[]=99999999999`), the signed URL validation behaves incorrectly.

For `signature`: `(string) ['foo']` triggers an "Array to string conversion" warning.

For `expires`: a non-empty array is truthy, but `timestamp > array` is always `false` in PHP — so the URL appears to never have expired, bypassing the expiry check entirely.

```php
// ?signature[]=foo&signature[]=bar — warning + incorrect result
$url->hasCorrectSignature($request);

// ?expires[]=1 — already expired, should return false
$url->signatureHasNotExpired($request); // returns true without the guard
```

Both are fixed by extracting the param first and returning false when it isn't a string. The `signature` fix ports what was already applied to the `12.x` branch in #59778. Added regression tests alongside the existing signed URL tests.