### PR TITLE
[13.x] Add enum support to setDefaultDriver in QueueManager, LogManager, and SessionManager

### DIFF
--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -583,12 +583,12 @@ class LogManager implements LoggerInterface
     /**
      * Set the default log driver name.
      *
-     * @param  string  $name
+     * @param  \UnitEnum|string  $name
      * @return void
      */
     public function setDefaultDriver($name)
     {
-        $this->app['config']['logging.default'] = $name;
+        $this->app['config']['logging.default'] = enum_value($name);
     }
 
     /**

--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -349,12 +349,12 @@ class QueueManager implements FactoryContract, MonitorContract
     /**
      * Set the name of the default queue connection.
      *
-     * @param  string  $name
+     * @param  \UnitEnum|string  $name
      * @return void
      */
     public function setDefaultDriver($name)
     {
-        $this->app['config']['queue.default'] = $name;
+        $this->app['config']['queue.default'] = enum_value($name);
     }
 
     /**

--- a/src/Illuminate/Session/SessionManager.php
+++ b/src/Illuminate/Session/SessionManager.php
@@ -4,6 +4,8 @@ namespace Illuminate\Session;
 
 use Illuminate\Support\Manager;
 
+use function Illuminate\Support\enum_value;
+
 /**
  * @mixin \Illuminate\Session\Store
  */
@@ -279,11 +281,11 @@ class SessionManager extends Manager
     /**
      * Set the default session driver name.
      *
-     * @param  string  $name
+     * @param  \UnitEnum|string  $name
      * @return void
      */
     public function setDefaultDriver($name)
     {
-        $this->config->set('session.driver', $name);
+        $this->config->set('session.driver', enum_value($name));
     }
 }

--- a/tests/Log/LogManagerTest.php
+++ b/tests/Log/LogManagerTest.php
@@ -784,6 +784,14 @@ class LogManagerTest extends TestCase
 
         $this->assertSame($logger1, $logger2);
     }
+
+    public function testSetDefaultDriverAcceptsBackedEnum()
+    {
+        $manager = new LogManager($this->app);
+        $manager->setDefaultDriver(LogChannelName::Single);
+
+        $this->assertSame('single', $this->app['config']['logging.default']);
+    }
 }
 
 class CustomizeFormatter

--- a/tests/Queue/QueueManagerTest.php
+++ b/tests/Queue/QueueManagerTest.php
@@ -125,6 +125,21 @@ class QueueManagerTest extends TestCase
         $manager->connection(QueueConnectionName::Sync);
         $this->assertTrue($manager->connected(QueueConnectionName::Sync));
     }
+
+    public function testSetDefaultDriverAcceptsBackedEnum()
+    {
+        $app = [
+            'config' => [
+                'queue.default' => 'sync',
+                'queue.connections.sync' => ['driver' => 'sync'],
+            ],
+        ];
+
+        $manager = new QueueManager($app);
+        $manager->setDefaultDriver(QueueConnectionName::Sync);
+
+        $this->assertSame('sync', $app['config']['queue.default']);
+    }
 }
 
 enum QueueConnectionName: string

--- a/tests/Session/SessionManagerTest.php
+++ b/tests/Session/SessionManagerTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Illuminate\Tests\Session;
+
+use Illuminate\Config\Repository as Config;
+use Illuminate\Container\Container;
+use Illuminate\Session\SessionManager;
+use PHPUnit\Framework\TestCase;
+
+class SessionManagerTest extends TestCase
+{
+    public function testSetDefaultDriverAcceptsBackedEnum()
+    {
+        $app = new Container;
+        $app->singleton('config', fn () => new Config(['session' => ['driver' => 'array']]));
+
+        $manager = new SessionManager($app);
+        $manager->setDefaultDriver(SessionDriverName::Array);
+
+        $this->assertSame('array', $app['config']['session.driver']);
+    }
+}
+
+enum SessionDriverName: string
+{
+    case Array = 'array';
+}


### PR DESCRIPTION
`QueueManager`, `LogManager`, and `SessionManager` all accept enums in their resolution methods (`connection()`, `channel()`, `driver()`) but their `setDefaultDriver()` methods assign `$name` directly to config without calling `enum_value()`. This means passing a backed enum to `setDefaultDriver()` stores the enum object in config rather than its string value, causing a mismatch when the stored default is later resolved.

```php
Queue::setDefaultDriver(QueueConnection::Redis); // stores the enum object, not 'redis'
Queue::connection(); // tries to resolve the enum object as a string name — fails
```

This follows the same fix applied to `AuthManager`, `CacheManager`, `BroadcastManager`, and `PasswordBrokerManager`, which already call `enum_value()` in `setDefaultDriver()`. Added a regression test to each.