### PR TITLE
[13.x] Prevent array expires parameter from bypassing signed URL expiry check

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -505,6 +505,10 @@ class UrlGenerator implements UrlGeneratorContract
     {
         $expires = $request->query('expires');
 
+        if ($expires !== null && ! is_string($expires)) {
+            return false;
+        }
+
         return ! ($expires && Carbon::now()->getTimestamp() > $expires);
     }
 

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -966,6 +966,23 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertTrue($url3->hasValidSignature($secondRequest));
     }
 
+    public function testSignedUrlWithArrayExpiresReturnsFalse()
+    {
+        $url = new UrlGenerator(
+            new RouteCollection,
+            Request::create('http://www.foo.com/')
+        );
+        $url->setKeyResolver(function () {
+            return 'secret';
+        });
+
+        // ?expires[]=99999999999 is truthy but comparing timestamp > array is always false,
+        // so without the guard the URL would never appear expired.
+        $request = Request::create('http://www.foo.com/foo?expires[]=99999999999');
+
+        $this->assertFalse($url->signatureHasNotExpired($request));
+    }
+
     public function testMissingNamedRouteResolution()
     {
         $url = new UrlGenerator(


### PR DESCRIPTION
`signatureHasNotExpired()` reads `$expires` from the query string but doesn't guard against it being an array. When `?expires[]=99999999999` is sent, PHP evaluates `Carbon::now()->getTimestamp() > ['99999999999']` as `false` (a scalar is never greater than an array), so the URL appears to never have expired regardless of the actual expiry time.

```php
// ?expires[]=1 — already expired, should return false
$url->signatureHasNotExpired($request); // returns true — bypass
```

Adding a non-string guard mirrors the same fix applied to the `signature` parameter in #59860 and returns false for any non-string expires value. Added a regression test alongside the existing signed URL tests.