### PR TITLE
[13.x] Add UnitEnum support to Cache Repository touch method

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -662,12 +662,14 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Set the expiration of a cached item.
      *
-     * @param  string  $key
+     * @param  \UnitEnum|string  $key
      * @param  \DateTimeInterface|\DateInterval|int  $ttl
      * @return bool
      */
     public function touch($key, $ttl)
     {
+        $key = enum_value($key);
+
         return $this->store->touch($this->itemKey($key), $this->getSeconds($ttl));
     }
 

--- a/src/Illuminate/Support/Facades/Cache.php
+++ b/src/Illuminate/Support/Facades/Cache.php
@@ -42,7 +42,7 @@ use Mockery;
  * @method static mixed sear(\UnitEnum|string $key, \Closure $callback)
  * @method static mixed rememberForever(\UnitEnum|string $key, \Closure $callback)
  * @method static mixed flexible(\UnitEnum|string $key, array $ttl, callable $callback, array|null $lock = null, bool $alwaysDefer = false)
- * @method static bool touch(string $key, \DateTimeInterface|\DateInterval|int $ttl)
+ * @method static bool touch(\UnitEnum|string $key, \DateTimeInterface|\DateInterval|int $ttl)
  * @method static mixed withoutOverlapping(\UnitEnum|string $key, callable $callback, int $lockFor = 0, int $waitFor = 10, string|null $owner = null)
  * @method static \Illuminate\Cache\Limiters\ConcurrencyLimiterBuilder funnel(\UnitEnum|string $name)
  * @method static bool forget(\UnitEnum|array|string $key)

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -508,6 +508,15 @@ class CacheRepositoryTest extends TestCase
         $this->assertTrue($repo->touch($key, DateInterval::createFromDateString("$ttl seconds")));
     }
 
+    public function testTouchWorksWithEnumKey(): void
+    {
+        $ttl = 60;
+
+        $repo = $this->getRepository();
+        $repo->getStore()->shouldReceive('touch')->once()->with('foo', $ttl)->andReturn(true);
+        $this->assertTrue($repo->touch(TestCacheKey::FOO, $ttl));
+    }
+
     public function testAtomicExecutesCallbackAndReturnsResult()
     {
         $repo = new Repository(new ArrayStore);


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

While the `Illuminate\Contracts\Cache\Repository` interface already specifies that the `$key` can be a `\UnitEnum|string`, the actual implementation in `Illuminate\Cache\Repository` was missing the logic to convert the Enum instance into a raw value.

This PR updates the `touch` method in `Illuminate\Cache\Repository` to officially support `\UnitEnum` as the `$key` parameter.