### PR TITLE
[12.x] Memoize credentials in SqsConnector

### DIFF
--- a/src/Illuminate/Queue/Connectors/SqsConnector.php
+++ b/src/Illuminate/Queue/Connectors/SqsConnector.php
@@ -61,13 +61,15 @@ class SqsConnector implements ConnectorInterface
 
         $options = is_array($credentials) ? Arr::except($credentials, ['provider']) : [];
 
-        return match ($provider) {
+        $resolved = match ($provider) {
             'ecs' => CredentialProvider::ecsCredentials($options),
             'instance' => CredentialProvider::instanceProfile($options),
             default => throw new InvalidArgumentException(
                 "Invalid credential provider [{$provider}]."
             ),
         };
+
+        return CredentialProvider::memoize($resolved);
     }
 
     /**


### PR DESCRIPTION
## Summary

Backport of [#59866](https://github.com/laravel/framework/pull/59866) to 12.x. `SqsConnector.php` is identical between 12.x and 13.x, so this is a straight cherry-pick.

When a queue config sets `credentials.provider = ecs` (or `instance`) — as Laravel Cloud does for managed queue workers via `Illuminate\Foundation\Cloud::configureManagedQueues()` — `SqsConnector::resolveCredentialProvider()` returned a raw `Aws\Credentials\EcsCredentialProvider` / `Aws\Credentials\InstanceProfileProvider` instance.

The AWS SDK's `Aws\ClientResolver::_apply_credentials()` short-circuits any callable passed as `credentials` (the SDK only auto-wraps in `memoize()` for its own internal `defaultProvider()` path), and the signer middleware (`Aws\Middleware::signer`) invokes the credentials provider on **every** signed request. Combined with the fact that `EcsCredentialProvider` / `InstanceProfileProvider` issue a fresh HTTP GET to the EKS Pod Identity Agent / EC2 metadata endpoint on every `__invoke()`, the result is that **every single SQS API call** triggers an HTTP fetch to the credentials endpoint, saturating the agent's built-in rate limiter under steady-state load.

## What this PR does

Wraps the resolved provider in `Aws\Credentials\CredentialProvider::memoize()` so credentials are cached in-process for the lifetime of the worker, with the SDK's standard 60-second pre-expiry refresh window. This matches what the SDK's own `CredentialProvider::defaultProvider()` does for the auto-discovered chain (which also wraps `ecsCredentials()` in `memoize()`).

```php
$resolved = match ($provider) {
    'ecs' => CredentialProvider::ecsCredentials($options),
    'instance' => CredentialProvider::instanceProfile($options),
    default => throw new InvalidArgumentException(
        \"Invalid credential provider [{$provider}].\"
    ),
};

return CredentialProvider::memoize($resolved);
```

## Benefit to end users

- Queue workers using ECS / EKS Pod Identity credentials make **one** credentials fetch per worker per ~6 hours instead of one per signed SQS request.
- Drastically reduces request volume to the Pod Identity Agent, eliminating 429 throttling under steady-state load.
- Same fix applies to the `instance` (EC2 IMDS) branch.
- No config change required.

## Backwards compatibility

- No public API change. Return type of `resolveCredentialProvider()` remains `callable|null`.
- `CredentialProvider::memoize()` is part of the AWS SDK's public, documented API.
- Per-process scope: each worker has its own cache (PHP scopes `static` per `Closure` instance). No cross-worker state.

## Test plan

- `tests/Queue/` suite passes locally (177 tests, 480 assertions).

> Generated by AI tools (Claude), and reviewed by Kieran Brown.