### PR TITLE
[12.x] Disable pausing on managed queue workers

### DIFF
--- a/src/Illuminate/Foundation/Cloud.php
+++ b/src/Illuminate/Foundation/Cloud.php
@@ -121,6 +121,7 @@ class Cloud
     {
         if ((int) ($_SERVER['LARAVEL_CLOUD_MANAGED_QUEUES'] ?? 0) === 1) {
             Worker::$restartable = false;
+            Worker::$pausable = false;
 
             $app['config']->set(
                 'queue.connections.sqs.credentials',

--- a/tests/Integration/Foundation/CloudTest.php
+++ b/tests/Integration/Foundation/CloudTest.php
@@ -69,6 +69,21 @@ class CloudTest extends TestCase
         }
     }
 
+    public function test_it_disables_queue_pause_polling_for_managed_queues()
+    {
+        Worker::$pausable = true;
+        $_SERVER['LARAVEL_CLOUD_MANAGED_QUEUES'] = '1';
+
+        try {
+            Cloud::configureManagedQueues($this->app);
+
+            $this->assertFalse(Worker::$pausable);
+        } finally {
+            unset($_SERVER['LARAVEL_CLOUD_MANAGED_QUEUES']);
+            Worker::$pausable = true;
+        }
+    }
+
     #[WithConfig('queue.connections.sqs', ['driver' => 'sqs', 'region' => 'us-east-1', 'queue' => 'default'])]
     public function test_it_configures_managed_queue_credentials()
     {


### PR DESCRIPTION
Sets `Worker::\$pausable = false` alongside `Worker::\$restartable = false` in `Cloud::configureManagedQueues()` so cloud-managed workers ignore pause signals, matching the existing handling of restart signals.