### PR TITLE
[13.x] Cast to string before preg_match in digits and digits_between rules

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -725,7 +725,7 @@ trait ValidatesAttributes
         $this->requireParameterCount(1, $parameters, 'digits');
 
         return (is_numeric($value) || is_string($value)) &&
-            ! preg_match('/[^0-9]/', $value) &&
+            ! preg_match('/[^0-9]/', (string) $value) &&
             strlen((string) $value) == $parameters[0];
     }
 
@@ -747,7 +747,7 @@ trait ValidatesAttributes
 
         $length = strlen((string) $value);
 
-        return ! preg_match('/[^0-9]/', $value)
+        return ! preg_match('/[^0-9]/', (string) $value)
                     && $length >= $parameters[0] && $length <= $parameters[1];
     }
 


### PR DESCRIPTION
The `validateMaxDigits` and `validateMinDigits` methods already cast `$value` to string before passing to `preg_match` (added in #59739), but `validateDigits` and `validateDigitsBetween` do not.

When a numeric (non-string) value such as an integer is passed, it reaches `preg_match` without an explicit string cast. While PHP coerces it implicitly, this is inconsistent with the sibling methods and could lead to unexpected behavior with certain value types.

This PR adds the same defensive `(string)` cast for consistency across all digit-related validation rules.