### PR TITLE
[13.x] Fix PHPDoc typo in MigrationRepositoryInterface

### DIFF
--- a/src/Illuminate/Database/Migrations/MigrationRepositoryInterface.php
+++ b/src/Illuminate/Database/Migrations/MigrationRepositoryInterface.php
@@ -53,7 +53,7 @@ interface MigrationRepositoryInterface
     /**
      * Remove a migration from the log.
      *
-     * @param  objectt{id?: int, migration: string, batch?: int}  $migration
+     * @param  object{id?: int, migration: string, batch?: int}  $migration
      * @return void
      */
     public function delete($migration);


### PR DESCRIPTION
## Summary

Fixes a typo in the `@param` PHPDoc annotation for the `delete` method in `MigrationRepositoryInterface`.

## Changes

`objectt` → `object` in the `@param` type annotation on line 56.

## Impact

PHPDoc-only change. No behavioral change.