### PR TITLE
[13.x] Fix getMigrationBatches return type annotation

### DIFF
--- a/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
+++ b/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
@@ -99,7 +99,7 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
     /**
      * Get the completed migrations with their batch numbers.
      *
-     * @return array<int, string>[]
+     * @return array<string, int>
      */
     public function getMigrationBatches()
     {

--- a/src/Illuminate/Database/Migrations/MigrationRepositoryInterface.php
+++ b/src/Illuminate/Database/Migrations/MigrationRepositoryInterface.php
@@ -37,7 +37,7 @@ interface MigrationRepositoryInterface
     /**
      * Get the completed migrations with their batch numbers.
      *
-     * @return array<int, string>[]
+     * @return array<string, int>
      */
     public function getMigrationBatches();
 


### PR DESCRIPTION
## Summary

Fixes the `@return` type annotation for `getMigrationBatches()` in both `MigrationRepositoryInterface` and `DatabaseMigrationRepository`.

## Context

The method calls `pluck('batch', 'migration')->all()`, which returns an associative array keyed by migration name (string) with batch number (int) as the value.

The current annotation `array<int, string>[]` is incorrect in two ways:

1. The keys and values are swapped — migration names are the keys (string), batch numbers are the values (int)
2. The trailing `[]` is extraneous — the return is a flat associative array, not an array of arrays

## Changes

| File | Before | After |
|---|---|---|
| `MigrationRepositoryInterface.php` | `@return array<int, string>[]` | `@return array<string, int>` |
| `DatabaseMigrationRepository.php` | `@return array<int, string>[]` | `@return array<string, int>` |

## Impact

PHPDoc-only change. No behavioral change. This improves static analysis accuracy (PHPStan/Psalm) and IDE type inference.