### PR TITLE
[13.x] Restore grouped where semantics for list-style orWhere arrays

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -391,6 +391,12 @@ class Builder implements BuilderContract
      */
     public function orWhere($column, $operator = null, $value = null)
     {
+        if (is_array($column) && array_is_list($column)) {
+            $this->query->orWhere($column);
+
+            return $this;
+        }
+
         [$value, $operator] = $this->query->prepareValueAndOperator(
             $value, $operator, func_num_args() === 2
         );

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1034,12 +1034,12 @@ class Builder implements BuilderContract
      * @param  string  $method
      * @return $this
      */
-    protected function addArrayOfWheres($column, $boolean, $method = 'where')
+    protected function addArrayOfWheres($column, $boolean, $method = 'where', $nestedBoolean = null)
     {
-        return $this->whereNested(function ($query) use ($column, $method, $boolean) {
+        return $this->whereNested(function ($query) use ($column, $method, $boolean, $nestedBoolean) {
             foreach ($column as $key => $value) {
                 if (is_numeric($key) && is_array($value)) {
-                    $query->{$method}(...array_values($value), boolean: $boolean);
+                    $query->{$method}(...array_values($value), boolean: $nestedBoolean ?? $boolean);
                 } else {
                     $query->{$method}($key, '=', $value, $boolean);
                 }
@@ -1117,6 +1117,10 @@ class Builder implements BuilderContract
      */
     public function orWhere($column, $operator = null, $value = null)
     {
+        if (is_array($column) && array_is_list($column)) {
+            return $this->addArrayOfWheres($column, 'or', nestedBoolean: 'and');
+        }
+
         [$value, $operator] = $this->prepareValueAndOperator(
             $value, $operator, func_num_args() === 2
         );

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2807,7 +2807,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1, 1 => 'foo'], $builder->getBindings());
     }
 
-    public function testOrWheresHaveConsistentResults()
+    public function testOrWhereArrayConditionsUseTheExpectedBooleanGrouping()
     {
         $queries = [];
         $builder = $this->getBuilder();
@@ -2820,7 +2820,7 @@ class DatabaseQueryBuilderTest extends TestCase
 
         $this->assertSame([
             'select * from "users" where "xxxx" = ? or ("foo" = ? or "bar" = ?)',
-            'select * from "users" where "xxxx" = ? or ("foo" = ? or "bar" = ?)',
+            'select * from "users" where "xxxx" = ? or ("foo" = ? and "bar" = ?)',
         ], $queries);
 
         $queries = [];
@@ -3027,7 +3027,7 @@ class DatabaseQueryBuilderTest extends TestCase
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('xxxx', 'xxxx')->orWhere([['foo', 1], ['bar', 2]]);
-        $this->assertSame('select * from "users" where "xxxx" = ? or ("foo" = ? or "bar" = ?)', $builder->toSql());
+        $this->assertSame('select * from "users" where "xxxx" = ? or ("foo" = ? and "bar" = ?)', $builder->toSql());
         $this->assertEquals([0 => 'xxxx', 1 => 1, 2 => 2], $builder->getBindings());
 
         $builder = $this->getBuilder();
@@ -3039,7 +3039,7 @@ class DatabaseQueryBuilderTest extends TestCase
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('xxxx', 'xxxx')->orWhere([['foo', 1], ['bar', '<', 2]]);
-        $this->assertSame('select * from "users" where "xxxx" = ? or ("foo" = ? or "bar" < ?)', $builder->toSql());
+        $this->assertSame('select * from "users" where "xxxx" = ? or ("foo" = ? and "bar" < ?)', $builder->toSql());
         $this->assertEquals([0 => 'xxxx', 1 => 1, 2 => 2], $builder->getBindings());
 
         // where()->orWhereColumn(col1, col2)
@@ -3058,7 +3058,7 @@ class DatabaseQueryBuilderTest extends TestCase
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('xxxx', 'xxxx')->orWhere([['foo', 1], ['bar', '<', 2]]);
-        $this->assertSame('select * from "users" where "xxxx" = ? or ("foo" = ? or "bar" < ?)', $builder->toSql());
+        $this->assertSame('select * from "users" where "xxxx" = ? or ("foo" = ? and "bar" < ?)', $builder->toSql());
         $this->assertEquals([0 => 'xxxx', 1 => 1, 2 => 2], $builder->getBindings());
 
         // where()->orWhereNot(key, value)

--- a/tests/Integration/Database/EloquentWhereTest.php
+++ b/tests/Integration/Database/EloquentWhereTest.php
@@ -62,6 +62,18 @@ class EloquentWhereTest extends DatabaseTestCase
                     ->first()
             )
         );
+
+        $this->assertTrue(
+            $secondUser->is(
+                UserWhereTest::where([
+                    ['name', '=', 'wrong-name'],
+                    ['email', '=', 'test-email1'],
+                ])->orWhere([
+                    ['name', '=', 'test-name1'],
+                    ['address', '=', 'test-address1'],
+                ])->first()
+            )
+        );
     }
 
     public function testWhereNot()


### PR DESCRIPTION
This restores the grouped `and` semantics for list-style condition arrays passed to `orWhere`.

It keeps the boolean-respecting behavior introduced in #53147 for explicit `where([...], boolean: 'or')` calls, but preserves the historical `orWhere([...])` behavior that was reported in #59516.

Tests were added to cover both the query builder and Eloquent paths.
