### PR TITLE
[13.x] Use the invoked artisan path for console subprocesses

### DIFF
--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -136,7 +136,7 @@ class Kernel implements KernelContract
     public function __construct(Application $app, Dispatcher $events)
     {
         if (! defined('ARTISAN_BINARY')) {
-            define('ARTISAN_BINARY', 'artisan');
+            define('ARTISAN_BINARY', $_SERVER['argv'][0] ?? 'artisan');
         }
 
         $this->app = $app;

--- a/tests/Foundation/Console/KernelTest.php
+++ b/tests/Foundation/Console/KernelTest.php
@@ -6,11 +6,42 @@ use Illuminate\Events\Dispatcher;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Console\Kernel;
 use Illuminate\Foundation\Events\Terminating;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\StringInput;
 
+use function Illuminate\Support\artisan_binary;
+
 class KernelTest extends TestCase
 {
+    #[RunInSeparateProcess]
+    public function testItUsesTheInvokedArtisanScriptAsTheArtisanBinary()
+    {
+        $_SERVER['argv'][0] = '/home/laravel/artisan';
+
+        $app = new Application;
+        $events = new Dispatcher($app);
+        $app->instance('events', $events);
+
+        new Kernel($app, $events);
+
+        $this->assertSame('/home/laravel/artisan', artisan_binary());
+    }
+
+    #[RunInSeparateProcess]
+    public function testItFallsBackToArtisanWhenArgvIsUnavailable()
+    {
+        unset($_SERVER['argv']);
+
+        $app = new Application;
+        $events = new Dispatcher($app);
+        $app->instance('events', $events);
+
+        new Kernel($app, $events);
+
+        $this->assertSame('artisan', artisan_binary());
+    }
+
     public function testItDispatchesTerminatingEvent()
     {
         $called = [];


### PR DESCRIPTION
This ensures console subprocesses reuse the invoked Artisan script path instead of always defaulting to a bare `artisan` binary.

In particular, `schedule:work` shells out through `Application::formatCommandString('schedule:run')`, so running `/path/to/php /path/to/artisan schedule:work` from another working directory should continue to invoke the same Artisan script.

Tests were added around the console kernel's `ARTISAN_BINARY` initialization to cover both the invoked-path and fallback cases.

Closes #56390.
