### PR TITLE
[13.x] Add enum support to FilesystemManager purge and forgetDisk methods

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -413,6 +413,8 @@ class FilesystemManager implements FactoryContract
     public function forgetDisk($disk)
     {
         foreach ((array) $disk as $diskName) {
+            $diskName = enum_value($diskName);
+
             unset($this->disks[$diskName]);
         }
 
@@ -422,12 +424,12 @@ class FilesystemManager implements FactoryContract
     /**
      * Disconnect the given disk and remove from local cache.
      *
-     * @param  string|null  $name
+     * @param  \UnitEnum|string|null  $name
      * @return void
      */
     public function purge($name = null)
     {
-        $name ??= $this->getDefaultDriver();
+        $name = enum_value($name) ?: $this->getDefaultDriver();
 
         unset($this->disks[$name]);
     }

--- a/tests/Filesystem/FilesystemManagerTest.php
+++ b/tests/Filesystem/FilesystemManagerTest.php
@@ -290,7 +290,7 @@ class FilesystemManagerTest extends TestCase
     public function testPurgeAndForgetDiskAcceptsUnitEnum()
     {
         $app = new Application;
-        $app["config"] = [
+        $app['config'] = [
             'filesystems.default' => 'local',
             'filesystems.disks.local' => ['driver' => 'local', 'root' => __DIR__],
         ];

--- a/tests/Filesystem/FilesystemManagerTest.php
+++ b/tests/Filesystem/FilesystemManagerTest.php
@@ -287,6 +287,32 @@ class FilesystemManagerTest extends TestCase
     //         rmdir(__DIR__.'/../../to-be-scoped');
     //     }
     // }
+    public function testPurgeAndForgetDiskAcceptsUnitEnum()
+    {
+        $app = new Application;
+        $app["config"] = [
+            "filesystems.default" => "local",
+            "filesystems.disks.local" => ["driver" => "local", "root" => __DIR__],
+        ];
+
+        $manager = new FilesystemManager($app);
+
+        $manager->disk(FakeDiskName::Local);
+
+        $property = new \ReflectionProperty($manager, "disks");
+
+        $this->assertCount(1, $property->getValue($manager));
+
+        $manager->forgetDisk(FakeDiskName::Local);
+        $this->assertCount(0, $property->getValue($manager));
+
+        $manager->disk(FakeDiskName::Local);
+        $this->assertCount(1, $property->getValue($manager));
+
+        $manager->purge(FakeDiskName::Local);
+        $this->assertCount(0, $property->getValue($manager));
+    }
+
 }
 
 class CustomFilesystemDriver
@@ -299,4 +325,9 @@ class CustomFilesystemDriver
     {
         return $this->driver;
     }
+}
+
+enum FakeDiskName: string
+{
+    case Local = "local";
 }

--- a/tests/Filesystem/FilesystemManagerTest.php
+++ b/tests/Filesystem/FilesystemManagerTest.php
@@ -291,15 +291,15 @@ class FilesystemManagerTest extends TestCase
     {
         $app = new Application;
         $app["config"] = [
-            "filesystems.default" => "local",
-            "filesystems.disks.local" => ["driver" => "local", "root" => __DIR__],
+            'filesystems.default' => 'local',
+            'filesystems.disks.local' => ['driver' => 'local', 'root' => __DIR__],
         ];
 
         $manager = new FilesystemManager($app);
 
         $manager->disk(FakeDiskName::Local);
 
-        $property = new \ReflectionProperty($manager, "disks");
+        $property = new \ReflectionProperty($manager, 'disks');
 
         $this->assertCount(1, $property->getValue($manager));
 
@@ -329,5 +329,5 @@ class CustomFilesystemDriver
 
 enum FakeDiskName: string
 {
-    case Local = "local";
+    case Local = 'local';
 }

--- a/tests/Filesystem/FilesystemManagerTest.php
+++ b/tests/Filesystem/FilesystemManagerTest.php
@@ -312,7 +312,6 @@ class FilesystemManagerTest extends TestCase
         $manager->purge(FakeDiskName::Local);
         $this->assertCount(0, $property->getValue($manager));
     }
-
 }
 
 class CustomFilesystemDriver


### PR DESCRIPTION
The `purge()` and `forgetDisk()` methods in `FilesystemManager` did not support `UnitEnum` values, unlike `disk()` which already does. This inconsistency means calling `Storage::purge(MyEnum::Disk)` or `Storage::forgetDisk(MyEnum::Disk)` would fail to correctly identify the connection.

This change applies `enum_value()` to both methods, bringing them in line with the rest of the manager.