### PR TITLE
[13.x] Add enum support to MailManager setDefaultDriver

### DIFF
--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -559,11 +559,13 @@ class MailManager implements FactoryContract
     /**
      * Set the default mail driver name.
      *
-     * @param  string  $name
+     * @param  \UnitEnum|string  $name
      * @return void
      */
-    public function setDefaultDriver(string $name)
+    public function setDefaultDriver($name)
     {
+        $name = enum_value($name);
+
         if ($this->app['config']['mail.driver']) {
             $this->app['config']['mail.driver'] = $name;
         }

--- a/tests/Mail/MailManagerTest.php
+++ b/tests/Mail/MailManagerTest.php
@@ -164,6 +164,23 @@ class MailManagerTest extends TestCase
         $this->assertNotSame($mailer1, $mailer2);
     }
 
+    public function testSetDefaultDriverAcceptsBackedEnum(): void
+    {
+        $this->app['mail.manager']->setDefaultDriver(MailerName::ArrayMailer);
+
+        $this->assertSame('array', $this->app['config']['mail.default']);
+    }
+
+    public function testSetDefaultDriverWithLegacyDriverConfigKeyAcceptsBackedEnum(): void
+    {
+        $this->app['config']->set('mail.driver', 'smtp');
+
+        $this->app['mail.manager']->setDefaultDriver(MailerName::ArrayMailer);
+
+        $this->assertSame('array', $this->app['config']['mail.driver']);
+        $this->assertSame('array', $this->app['config']['mail.default']);
+    }
+
     public static function emptyTransportConfigDataProvider()
     {
         return [


### PR DESCRIPTION
`MailManager::mailer()`, `driver()` and `purge()` already accept `UnitEnum` values (added in #59645). However `MailManager::setDefaultDriver()` still type-hints `string $name` and assigns the raw value to config, so passing a backed enum throws a `TypeError` (and would store the enum object rather than its value if the type hint were merely loose).

```php
Mail::setDefaultDriver(MailerName::Smtp); // TypeError before this change
Mail::mailer(); // would otherwise resolve the enum object as a name
```

This follows the same fix applied to `AuthManager`, `BroadcastManager`, `CacheManager`, `PasswordBrokerManager`, `QueueManager`, `LogManager` and `SessionManager` (the last three in #59861) — drop the `string` type hint, document `\UnitEnum|string`, and run `enum_value()` before assigning. Both the modern `mail.default` key and the legacy `mail.driver` key now receive the resolved string.

Added two regression tests covering the modern config key and the legacy `mail.driver` shim path.