### PR TITLE
[13.x] Add enum support to LogManager forgetChannel

### DIFF
--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -617,12 +617,12 @@ class LogManager implements LoggerInterface
     /**
      * Unset the given channel instance.
      *
-     * @param  string|null  $driver
+     * @param  \UnitEnum|string|null  $driver
      * @return void
      */
     public function forgetChannel($driver = null)
     {
-        $driver = $this->parseDriver($driver);
+        $driver = $this->parseDriver(enum_value($driver));
 
         if (isset($this->channels[$driver])) {
             unset($this->channels[$driver]);

--- a/tests/Log/LogManagerTest.php
+++ b/tests/Log/LogManagerTest.php
@@ -792,6 +792,19 @@ class LogManagerTest extends TestCase
 
         $this->assertSame('single', $this->app['config']['logging.default']);
     }
+
+    public function testForgetChannelAcceptsBackedEnum()
+    {
+        $manager = new LogManager($this->app);
+
+        $manager->channel('single')->getLogger();
+
+        $this->assertCount(1, $manager->getChannels());
+
+        $manager->forgetChannel(LogChannelName::Single);
+
+        $this->assertEmpty($manager->getChannels());
+    }
 }
 
 class CustomizeFormatter


### PR DESCRIPTION
`LogManager::channel()`, `driver()` and `setDefaultDriver()` already accept `UnitEnum` values (added in #59391 and #59861), but `forgetChannel()` still type-documents `string|null` and forwards the raw value to `parseDriver()`. Because `parseDriver()` calls `trim()`, passing a backed enum results in:

```php
Log::channel(LogChannelName::Single);
Log::forgetChannel(LogChannelName::Single); // TypeError: trim(): Argument #1 ($string) must be of type string, LogChannelName given
```

This change converts the value via `enum_value()` before delegating to `parseDriver()` and updates the docblock to `\UnitEnum|string|null`, matching the rest of the manager. Added a regression test covering resolution-then-forget with a backed enum.