### PR TITLE
[13.x] Add enum support to ConcurrencyManager setDefaultInstance

### DIFF
--- a/src/Illuminate/Concurrency/ConcurrencyManager.php
+++ b/src/Illuminate/Concurrency/ConcurrencyManager.php
@@ -80,11 +80,13 @@ class ConcurrencyManager extends MultipleInstanceManager
     /**
      * Set the default instance name.
      *
-     * @param  string  $name
+     * @param  \UnitEnum|string  $name
      * @return void
      */
     public function setDefaultInstance($name)
     {
+        $name = enum_value($name);
+
         $this->app['config']['concurrency.default'] = $name;
         $this->app['config']['concurrency.driver'] = $name;
     }

--- a/tests/Integration/Concurrency/ConcurrencyTest.php
+++ b/tests/Integration/Concurrency/ConcurrencyTest.php
@@ -97,6 +97,14 @@ PHP);
         );
     }
 
+    public function testSetDefaultInstanceAcceptsBackedEnum()
+    {
+        Concurrency::setDefaultInstance(ConcurrencyDriverEnum::Sync);
+
+        $this->assertSame('sync', config('concurrency.default'));
+        $this->assertSame('sync', config('concurrency.driver'));
+    }
+
     public function testRunHandlerProcessErrorWithDefaultExceptionWithoutParam()
     {
         $this->expectException(Exception::class);


### PR DESCRIPTION
`ConcurrencyManager::driver()` already accepts `UnitEnum` values (added in #59801), but `setDefaultInstance()` still type-documents `string` and assigns the raw value to config. Passing a backed enum stores the enum object in `concurrency.default` and `concurrency.driver`, so the next `Concurrency::driver()` call (with no argument) tries to resolve the enum object as a driver name and fails.

```php
Concurrency::setDefaultInstance(ConcurrencyDriverEnum::Sync); // stores the enum object
Concurrency::run(...); // resolves default driver — fails because the stored value is not a string
```

This follows the same fix applied to `setDefaultDriver` in `AuthManager`, `BroadcastManager`, `CacheManager`, `PasswordBrokerManager`, and most recently `QueueManager`/`LogManager`/`SessionManager` (#59861) — document `\UnitEnum|string`, run `enum_value()` before storing. Both the `concurrency.default` key and the legacy `concurrency.driver` key now receive the resolved string.

Added a regression test alongside the existing `testDriverCanBeResolvedUsingBackedEnum`.