### PR TITLE
[13.x] Add enum support to RateLimitedWithRedis connection

### DIFF
--- a/src/Illuminate/Queue/Middleware/RateLimitedWithRedis.php
+++ b/src/Illuminate/Queue/Middleware/RateLimitedWithRedis.php
@@ -7,6 +7,8 @@ use Illuminate\Contracts\Redis\Factory as Redis;
 use Illuminate\Redis\Limiters\DurationLimiter;
 use Illuminate\Support\InteractsWithTime;
 
+use function Illuminate\Support\enum_value;
+
 class RateLimitedWithRedis extends RateLimited
 {
     use InteractsWithTime;
@@ -29,12 +31,13 @@ class RateLimitedWithRedis extends RateLimited
      * Create a new middleware instance.
      *
      * @param  \UnitEnum|string  $limiterName
+     * @param  \UnitEnum|string|null  $connection
      */
-    public function __construct($limiterName, ?string $connection = null)
+    public function __construct($limiterName, $connection = null)
     {
         parent::__construct($limiterName);
 
-        $this->connectionName = $connection;
+        $this->connectionName = enum_value($connection);
     }
 
     /**
@@ -95,12 +98,12 @@ class RateLimitedWithRedis extends RateLimited
     /**
      * Specify the Redis connection that should be used.
      *
-     * @param  string  $name
+     * @param  \UnitEnum|string  $name
      * @return $this
      */
-    public function connection(string $name)
+    public function connection($name)
     {
-        $this->connectionName = $name;
+        $this->connectionName = enum_value($name);
 
         return $this;
     }

--- a/tests/Integration/Queue/RateLimitedWithRedisTest.php
+++ b/tests/Integration/Queue/RateLimitedWithRedisTest.php
@@ -129,6 +129,20 @@ class RateLimitedWithRedisTest extends TestCase
         // $this->assertInstanceOf(Connection::class, $fetch('redis'));
     }
 
+    public function testConnectionAcceptsBackedEnum()
+    {
+        $rateLimited = new RateLimitedWithRedis('limiterName', RedisRateLimitedConnection::Default);
+
+        $fetch = (function (string $name) {
+            return $this->{$name};
+        })->bindTo($rateLimited, RateLimitedWithRedis::class);
+
+        $this->assertSame('default', $fetch('connectionName'));
+
+        $rateLimited->connection(RedisRateLimitedConnection::Cache);
+        $this->assertSame('cache', $fetch('connectionName'));
+    }
+
     protected function assertJobRanSuccessfully($testJob)
     {
         $testJob::$handled = false;
@@ -233,4 +247,10 @@ class RedisRateLimitedDontReleaseTestJob extends RedisRateLimitedTestJob
     {
         return [(new RateLimitedWithRedis($this->key))->dontRelease()];
     }
+}
+
+enum RedisRateLimitedConnection: string
+{
+    case Default = 'default';
+    case Cache = 'cache';
 }


### PR DESCRIPTION
PR #59841 added `UnitEnum` support for the `\$limiterName` argument on `RateLimitedWithRedis`, but the constructor's `\$connection` parameter and the `connection()` setter were not updated. They still type-hint `?string` / `string`, so passing a backed enum to either fails with a `TypeError`:

```php
new RateLimitedWithRedis(LimiterName::Foo, RedisConnection::Default); // TypeError
RateLimited::for(LimiterName::Foo)->connection(RedisConnection::Cache); // TypeError
```

This is inconsistent with the underlying `Redis::connection()` (#59391, #59420 era) which already accepts `UnitEnum`, and with the `$limiterName` argument fixed in #59841.

The fix follows the same pattern used elsewhere in the framework: drop the narrow type hint, document `\UnitEnum|string` (`|null` for the optional constructor argument), and run `enum_value()` before storing the connection name. Stored state remains a string (matching the existing `@var string|null` annotation on `$connectionName`).

Added a regression test that covers both the constructor and the fluent setter — placed alongside the existing `testMiddlewareSerialization` since the test file already houses construction-shape coverage for this middleware.