### PR TITLE
[13.x] Remove redundant Mockery::close from cache store tests

### DIFF
--- a/tests/Cache/CacheFailoverStoreTest.php
+++ b/tests/Cache/CacheFailoverStoreTest.php
@@ -13,11 +13,6 @@ use PHPUnit\Framework\TestCase;
 
 class CacheFailoverStoreTest extends TestCase
 {
-    protected function tearDown(): void
-    {
-        m::close();
-    }
-
     public function testImplementsCanFlushLocks()
     {
         $store = $this->makeFailoverStore([]);

--- a/tests/Cache/CacheMemoizedStoreTest.php
+++ b/tests/Cache/CacheMemoizedStoreTest.php
@@ -42,11 +42,6 @@ class CacheMemoizedStoreTest extends TestCase
         (new MemoizedStore('test', new Repository($stub)))->flushLocks();
     }
 
-    protected function tearDown(): void
-    {
-        m::close();
-    }
-
     public function testHasSeparateLockStoreDelegatestoUnderlyingStore(): void
     {
         $withSeparate = new MemoizedStore('test', new Repository(new ArrayStore));


### PR DESCRIPTION
Follow-up to #59730. The framework's PHPUnit subscriber `Illuminate\Tests\AfterEachTestSubscriber::notify` already calls `Mockery::close()` after every test method (registered globally via `tests/AfterEachTestExtension.php`), so manual `m::close()` calls in `tearDown()` are redundant.

#59730 cleaned up `AuthPasswordBrokerManagerTest`, `QueueRedisQueueTest`, and `ConcurrencyLimiterTest`. `CacheFailoverStoreTest` and `CacheMemoizedStoreTest` had the same pattern and were missed.

Diff is delete-only — both test files keep passing (`vendor/bin/phpunit tests/Cache/CacheFailoverStoreTest.php tests/Cache/CacheMemoizedStoreTest.php` → 7 tests, 10 assertions).