### PR TITLE
[13.x] Fix MigrationRepositoryInterface return type docblocks (object vs array)

### DIFF
--- a/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
+++ b/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
@@ -56,7 +56,7 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
      * Get the list of migrations.
      *
      * @param  int  $steps
-     * @return array{id: int, migration: string, batch: int}[]
+     * @return object{id: int, migration: string, batch: int}[]
      */
     public function getMigrations($steps)
     {
@@ -73,7 +73,7 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
      * Get the list of the migrations by batch number.
      *
      * @param  int  $batch
-     * @return array{id: int, migration: string, batch: int}[]
+     * @return object{id: int, migration: string, batch: int}[]
      */
     public function getMigrationsByBatch($batch)
     {
@@ -87,7 +87,7 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
     /**
      * Get the last migration batch.
      *
-     * @return array{id: int, migration: string, batch: int}[]
+     * @return object{id: int, migration: string, batch: int}[]
      */
     public function getLast()
     {

--- a/src/Illuminate/Database/Migrations/MigrationRepositoryInterface.php
+++ b/src/Illuminate/Database/Migrations/MigrationRepositoryInterface.php
@@ -15,7 +15,7 @@ interface MigrationRepositoryInterface
      * Get the list of migrations.
      *
      * @param  int  $steps
-     * @return array{id: int, migration: string, batch: int}[]
+     * @return object{id: int, migration: string, batch: int}[]
      */
     public function getMigrations($steps);
 
@@ -23,14 +23,14 @@ interface MigrationRepositoryInterface
      * Get the list of the migrations by batch.
      *
      * @param  int  $batch
-     * @return array{id: int, migration: string, batch: int}[]
+     * @return object{id: int, migration: string, batch: int}[]
      */
     public function getMigrationsByBatch($batch);
 
     /**
      * Get the last migration batch.
      *
-     * @return array{id: int, migration: string, batch: int}[]
+     * @return object{id: int, migration: string, batch: int}[]
      */
     public function getLast();
 

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -290,7 +290,7 @@ class Migrator
      * Get the migrations for a rollback operation.
      *
      * @param  array<string, mixed>  $options
-     * @return array{id: int, migration: string, batch: int}[]
+     * @return object{id: int, migration: string, batch: int}[]
      */
     protected function getMigrationsForRollback(array $options)
     {


### PR DESCRIPTION
Follow-up to #59875 / #59876, which corrected the `delete()` parameter shape and the `getMigrationBatches()` return type on `MigrationRepositoryInterface` and `DatabaseMigrationRepository`. Three sibling methods on the same pair of files (and one consumer in `Migrator`) were missed.

`getMigrations()`, `getMigrationsByBatch()`, and `getLast()` are documented as returning `array{id: int, migration: string, batch: int}[]`, but the implementations return query result rows from `$this->table()->...->get()->all()` — which the query builder produces as `stdClass` objects (FETCH_OBJ), not arrays. The same is reflected in `Migrator::rollbackMigrations()`, which uses `$migration->migration`, `$migration->id`, etc. — confirming the contract is objects.

This change updates the three return type annotations in:

- `src/Illuminate/Database/Migrations/MigrationRepositoryInterface.php`
- `src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php`
- `src/Illuminate/Database/Migrations/Migrator.php` — `getMigrationsForRollback()` matched its repository delegates

…from `array{...}[]` to `object{...}[]`, matching the `delete()` parameter shape established in #59875 and the property access already used in `Migrator`.

PHPDoc-only change. No behavioral change.