### PR TITLE
[13.x] Stop suppressing non-unique constraint errors in DatabaseSessionHandler

### DIFF
--- a/src/Illuminate/Session/DatabaseSessionHandler.php
+++ b/src/Illuminate/Session/DatabaseSessionHandler.php
@@ -5,7 +5,7 @@ namespace Illuminate\Session;
 use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Database\ConnectionInterface;
-use Illuminate\Database\QueryException;
+use Illuminate\Database\UniqueConstraintViolationException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\InteractsWithTime;
@@ -155,7 +155,7 @@ class DatabaseSessionHandler implements ExistenceAwareInterface, SessionHandlerI
     {
         try {
             return $this->getQuery()->insert(Arr::set($payload, 'id', $sessionId));
-        } catch (QueryException) {
+        } catch (UniqueConstraintViolationException) {
             $this->performUpdate($sessionId, $payload);
         }
     }

--- a/tests/Integration/Session/DatabaseSessionHandlerTest.php
+++ b/tests/Integration/Session/DatabaseSessionHandlerTest.php
@@ -2,8 +2,10 @@
 
 namespace Illuminate\Tests\Integration\Session;
 
+use Illuminate\Database\QueryException;
 use Illuminate\Session\DatabaseSessionHandler;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 use Orchestra\Testbench\Attributes\WithMigration;
 
@@ -110,5 +112,19 @@ class DatabaseSessionHandlerTest extends DatabaseTestCase
         $this->assertNull($session->user_agent);
         $this->assertNull($session->ip_address);
         $this->assertNull($session->user_id);
+    }
+
+    public function test_write_does_not_swallow_non_unique_constraint_errors()
+    {
+        Schema::table('sessions', function ($table) {
+            $table->string('required_column');
+        });
+
+        $connection = $this->app['db']->connection();
+        $handler = new DatabaseSessionHandler($connection, 'sessions', 1);
+
+        $this->expectException(QueryException::class);
+
+        $handler->write('session_id', 'some data');
     }
 }


### PR DESCRIPTION
Fixes #57961.

`DatabaseSessionHandler::performInsert()` catches every `QueryException` and falls back to `performUpdate()`. The catch was added to handle a race where another process inserts the same session row between `read()` and `insert()` — but it currently swallows *any* SQL error during insert, including NOT NULL violations, missing-column errors, and disk/connection issues. The fallback `UPDATE WHERE id = ?` then matches zero rows, `write()` returns `true`, and the session silently fails to persist.

The user impact reported in #57961 is debugging-hostile: CSRF tokens stop working, login sessions vanish, and there's no error to trace.

This PR narrows the catch to `UniqueConstraintViolationException` (a `QueryException` subclass that the connection layer already throws for unique-key collisions across MySQL, PostgreSQL, SQLite, and SQL Server). The race-condition path is preserved — only legitimate unique-key collisions trigger the update fallback. Every other SQL error now propagates to the caller as `QueryException`.

## Test plan

Added `test_write_does_not_swallow_non_unique_constraint_errors` in `tests/Integration/Session/DatabaseSessionHandlerTest.php`. It adds a `NOT NULL` column to the `sessions` table at runtime, then calls `$handler->write()` and asserts a `QueryException` is thrown. Without this fix the test fails — `write()` returns `true` silently. With the fix, the exception propagates as expected.

```
vendor/bin/phpunit tests/Integration/Session/DatabaseSessionHandlerTest.php
OK (5 tests, 34 assertions)
```