### PR TITLE
[13.x] Add fluent debounceFor/maxDebounceWait to PendingDispatch and debounceFor() method support on job classes

### DIFF
--- a/src/Illuminate/Bus/DebounceLock.php
+++ b/src/Illuminate/Bus/DebounceLock.php
@@ -135,6 +135,10 @@ class DebounceLock
      */
     public function getDebounceDelay($job)
     {
+        if (method_exists($job, 'debounceFor')) {
+            return $job->debounceFor();
+        }
+
         return $this->getAttributeValue($job, DebounceFor::class, 'debounceFor');
     }
 

--- a/src/Illuminate/Foundation/Bus/PendingDispatch.php
+++ b/src/Illuminate/Foundation/Bus/PendingDispatch.php
@@ -33,6 +33,20 @@ class PendingDispatch
     protected $afterResponse = false;
 
     /**
+     * The number of seconds the job should be debounced for.
+     *
+     * @var int|null
+     */
+    protected $debounceFor = null;
+
+    /**
+     * The maximum number of seconds a debounced job may be deferred before it must run.
+     *
+     * @var int|null
+     */
+    protected $maxDebounceWait = null;
+
+    /**
      * Create a new pending job dispatch.
      *
      * @param  mixed  $job
@@ -187,6 +201,32 @@ class PendingDispatch
     }
 
     /**
+     * Debounce the job for the given number of seconds.
+     *
+     * @param  int  $seconds
+     * @return $this
+     */
+    public function debounceFor(int $seconds)
+    {
+        $this->debounceFor = $seconds;
+
+        return $this;
+    }
+
+    /**
+     * Set the maximum number of seconds a debounced job may be deferred before it must run.
+     *
+     * @param  int  $seconds
+     * @return $this
+     */
+    public function maxDebounceWait(int $seconds)
+    {
+        $this->maxDebounceWait = $seconds;
+
+        return $this;
+    }
+
+    /**
      * Indicate that the job should be dispatched after the response is sent to the browser.
      *
      * @param  bool  $afterResponse
@@ -223,20 +263,22 @@ class PendingDispatch
      */
     protected function acquireDebounceLock()
     {
-        $debounceFor = $this->getAttributeValue($this->job, DebounceFor::class, 'debounceFor');
+        $debounceFor = $this->debounceFor
+            ?? (method_exists($this->job, 'debounceFor') ? $this->job->debounceFor() : null)
+            ?? $this->getAttributeValue($this->job, DebounceFor::class, 'debounceFor');
 
         if ($debounceFor === null) {
             return;
         }
 
-        $lock = new DebounceLock(Container::getInstance()->make(Cache::class));
-
         if ($this->job instanceof ShouldBeUnique) {
             throw new LogicException('A debounced job cannot also implement ShouldBeUnique.');
         }
 
+        $lock = new DebounceLock(Container::getInstance()->make(Cache::class));
+
         $result = $lock->acquire(
-            $this->job, $debounceFor
+            $this->job, $debounceFor, $this->maxDebounceWait
         );
 
         $this->job->debounceOwner = $result['owner'];

--- a/tests/Integration/Queue/DebouncedJobTest.php
+++ b/tests/Integration/Queue/DebouncedJobTest.php
@@ -312,6 +312,62 @@ class DebouncedJobTest extends QueueTestCase
         $this->assertEquals(30, $job2->delay);
     }
 
+    public function testFluentDebounceForOnPlainJob()
+    {
+        $this->markTestSkippedWhenUsingQueueDrivers(['beanstalkd']);
+
+        $job = new PlainDebounceableJob('entity-1');
+        $pending = dispatch($job)->debounceFor(30);
+        unset($pending);
+
+        $this->assertEquals(30, $job->delay);
+    }
+
+    public function testFluentDebounceForOverridesAttribute()
+    {
+        $this->markTestSkippedWhenUsingQueueDrivers(['beanstalkd']);
+
+        $job = new DebouncedTestJob('entity-1');
+        $pending = dispatch($job)->debounceFor(10);
+        unset($pending);
+
+        $this->assertEquals(10, $job->delay);
+    }
+
+    public function testJobDebounceForMethodOverridesAttribute()
+    {
+        $this->markTestSkippedWhenUsingQueueDrivers(['beanstalkd']);
+
+        $highPriorityJob = new DebouncedWithMethodJob('entity-1', 'high');
+        $pending = dispatch($highPriorityJob);
+        unset($pending);
+
+        $this->assertEquals(5, $highPriorityJob->delay);
+
+        $normalJob = new DebouncedWithMethodJob('entity-2', 'normal');
+        $pending = dispatch($normalJob);
+        unset($pending);
+
+        $this->assertEquals(30, $normalJob->delay);
+    }
+
+    public function testFluentMaxDebounceWaitOverridesAttribute()
+    {
+        $this->markTestSkippedWhenUsingQueueDrivers(['beanstalkd']);
+
+        $job = new PlainDebounceableJob('entity-1');
+        $pending = dispatch($job)->debounceFor(30)->maxDebounceWait(20);
+        unset($pending);
+
+        $this->travelTo(Carbon::now()->addSeconds(21));
+
+        $job2 = new PlainDebounceableJob('entity-1');
+        $pending2 = dispatch($job2)->debounceFor(30)->maxDebounceWait(20);
+        unset($pending2);
+
+        $this->assertEquals(0, $job2->delay);
+    }
+
     public function testChildDebouncedJobInheritsFromParent()
     {
         $this->markTestSkippedWhenUsingQueueDrivers(['sync', 'beanstalkd']);
@@ -464,6 +520,51 @@ class DebouncedWithMaxWaitJob implements ShouldQueue
     public function handle()
     {
         static::$handleCount++;
+    }
+}
+
+class PlainDebounceableJob implements ShouldQueue
+{
+    use InteractsWithQueue, Queueable, Dispatchable;
+
+    public static $handled = false;
+
+    public function __construct(public string $entityId)
+    {
+    }
+
+    public function debounceId(): string
+    {
+        return $this->entityId;
+    }
+
+    public function handle()
+    {
+        static::$handled = true;
+    }
+}
+
+#[DebounceFor(30)]
+class DebouncedWithMethodJob implements ShouldQueue
+{
+    use InteractsWithQueue, Queueable, Dispatchable;
+
+    public function __construct(public string $entityId, public string $priority = 'normal')
+    {
+    }
+
+    public function debounceId(): string
+    {
+        return $this->entityId;
+    }
+
+    public function debounceFor(): int
+    {
+        return $this->priority === 'high' ? 5 : 30;
+    }
+
+    public function handle()
+    {
     }
 }
 


### PR DESCRIPTION
## Summary

The original debounce implementation (#59507) documented but did not ship three features. This PR completes them.

### What was documented:
```php
// Debounce at the dispatch site (no attribute needed)
dispatch(new SyncExternalData($accountId))->debounceFor(30); 

// Override the attribute at dispatch time
dispatch(new RebuildSearchIndex($docId))->debounceFor(10);

// debounceFor() method takes precedence over the attribute
#[DebounceFor(30)]
class RebuildSearchIndex implements ShouldQueue
{
    public function debounceFor(): int
    {
        return $this->priority === 'high' ? 5 : 30;
    }
}
```

As far as I can see none of the above worked. `PendingDispatch` had no `debounceFor()` method; `__call` would have proxied to the job, and `DebounceLock::getDebounceDelay()` never checked for a `debounceFor()` method on the job.

## Changes

- Add `debounceFor(int $seconds)` and `maxDebounceWait(int $seconds)` fluent methods to `PendingDispatch`
- Update `acquireDebounceLock()` to resolve the debounce value using the intended priority chain
- Update `DebounceLock::getDebounceDelay(` to check for a `debounceFor()` method on the job before falling back to the attribute

Priority chain (highest to lowest):
1. Call-site `->debounceFor()` on `PendingDispatch`
2. `debounceFor()` method on the job class
3. `#[DebounceFor]` attribute / `$debounceFor` property