### PR TITLE
[13.x] Correct Lock getCurrentOwner @return type to string|null

### DIFF
--- a/src/Illuminate/Cache/Lock.php
+++ b/src/Illuminate/Cache/Lock.php
@@ -76,7 +76,7 @@ abstract class Lock implements LockContract
     /**
      * Returns the owner value written into the driver for this lock.
      *
-     * @return string
+     * @return string|null
      */
     abstract protected function getCurrentOwner();
 

--- a/src/Illuminate/Cache/RedisLock.php
+++ b/src/Illuminate/Cache/RedisLock.php
@@ -63,7 +63,7 @@ class RedisLock extends Lock
     /**
      * Returns the owner value written into the driver for this lock.
      *
-     * @return string
+     * @return string|null
      */
     protected function getCurrentOwner()
     {


### PR DESCRIPTION
The abstract `Lock::getCurrentOwner()` is documented as `@return string`, but it can — and routinely does — return `null` when the lock has not been acquired. The base class itself relies on this:

https://github.com/laravel/framework/blob/13.x/src/Illuminate/Cache/Lock.php#L155-L158

```php
public function isLocked(): bool
{
    return $this->getCurrentOwner() !== null;
}
```

The two implementations whose authors thought about this most carefully already document `string|null`:

- `ArrayLock::getCurrentOwner()` — returns `null` when `! $this->exists()`.
- `DatabaseLock::getCurrentOwner()` — returns `null` via `?->owner` when no row exists.

`RedisLock::getCurrentOwner()` returns `$this->redis->get($this->name)`, which returns `null` when the key has no value. It also incorrectly documented `@return string`.

This PR fixes the two incorrect `@return` annotations to `string|null`. PHPDoc-only change; no behavioral or runtime impact.