### PR TITLE
[13.x] Correct Batch fresh and add @return to self|null

### DIFF
--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -137,7 +137,7 @@ class Batch implements Arrayable, JsonSerializable
     /**
      * Get a fresh instance of the batch represented by this ID.
      *
-     * @return self
+     * @return self|null
      */
     public function fresh()
     {
@@ -148,7 +148,7 @@ class Batch implements Arrayable, JsonSerializable
      * Add additional jobs to the batch.
      *
      * @param  \Illuminate\Support\Enumerable|object|array  $jobs
-     * @return self
+     * @return self|null
      */
     public function add($jobs)
     {


### PR DESCRIPTION
`Batch::fresh()` and `Batch::add()` are documented as `@return self`, but both can return `null`.

`Batch::fresh()` delegates to `BatchRepository::find()`, whose contract documents `@return \Illuminate\Bus\Batch|null`:

https://github.com/laravel/framework/blob/13.x/src/Illuminate/Bus/BatchRepository.php#L18-L24

`Batch::add()` returns `\$this->fresh()`, inheriting the same nullability.

This PR updates both `@return` annotations to `self|null`. PHPDoc-only change; no behavioral or runtime impact. `BatchFake::fresh()` and `BatchFake::add()` keep `@return self` since they always return `\$this`.