### PR TITLE
[13.x] Align Mailable::cc @return with sibling fluent methods

### DIFF
--- a/src/Illuminate/Contracts/Mail/Mailable.php
+++ b/src/Illuminate/Contracts/Mail/Mailable.php
@@ -36,7 +36,7 @@ interface Mailable
      *
      * @param  object|array|string  $address
      * @param  string|null  $name
-     * @return self
+     * @return $this
      */
     public function cc($address, $name = null);
 


### PR DESCRIPTION
In `Illuminate\Contracts\Mail\Mailable`, every fluent setter documents `@return \$this` except `cc()`, which is the lone outlier with `@return self`:

```php
public function cc($address, $name = null);   // @return self
public function bcc($address, $name = null);  // @return $this
public function to($address, $name = null);   // @return $this
public function locale($locale);              // @return $this
public function mailer($mailer);              // @return $this
```

The actual implementation `Illuminate\Mail\Mailable::cc()` already documents `@return \$this` and returns `\$this` via `setAddress()`. Updates the contract to match, so static analysers see the more precise type for `\$mailable->cc(...)->bcc(...)` chains on a typed contract reference.

PHPDoc-only change; no behavioral or runtime impact.