### PR TITLE
Fix $connection property type annotation in migration classes

### DIFF
--- a/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
+++ b/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
@@ -23,7 +23,7 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
     /**
      * The name of the database connection to use.
      *
-     * @var string
+     * @var string|null
      */
     protected $connection;
 

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -62,7 +62,7 @@ class Migrator
     /**
      * The name of the default connection.
      *
-     * @var string
+     * @var string|null
      */
     protected $connection;
 


### PR DESCRIPTION
The `$connection` property in `DatabaseMigrationRepository` and `Migrator` is documented as `@var string`, but it is never initialized in the constructor and defaults to `null`.

The `setSource()` method on `DatabaseMigrationRepository` and the `setConnection()` method on `Migrator` are the only ways to assign a value to this property, meaning it remains `null` until explicitly set.

### Changes

| File | Before | After |
|---|---|---|
| `DatabaseMigrationRepository.php` | `@var string` | `@var string\|null` |
| `Migrator.php` | `@var string` | `@var string\|null` |

This aligns the documentation with the actual runtime behavior of the property.