### PR TITLE
int argument for Collection::sortBy()

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1575,7 +1575,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Sort the collection using the given callback.
      *
-     * @param  array<array-key, (callable(TValue, TValue): mixed)|(callable(TValue, TKey): mixed)|string|array{string, string}>|(callable(TValue, TKey): mixed)|string  $callback
+     * @param  array<array-key, (callable(TValue, TValue): mixed)|(callable(TValue, TKey): mixed)|string|array{string, string}>|(callable(TValue, TKey): mixed)|string|int  $callback
      * @param  int  $options
      * @param  bool  $descending
      * @return static


### PR DESCRIPTION
The `Collection::sortBy()` method may be used by passing the name of a key as an argument. In the current `@param` annotation, this is represented by the `string` type; in this PR, I'm adding the `int` type also, to cover the case of a collection of integer-indexed arrays.
