### PR TITLE
[13.x] Add Worker Pausing/Resuming events

### DIFF
--- a/src/Illuminate/Queue/Events/WorkerPausing.php
+++ b/src/Illuminate/Queue/Events/WorkerPausing.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\Queue\Events;
+
+class WorkerPausing
+{
+    /**
+     * Create a new event instance.
+     *
+     * @param  string|null  $connectionName
+     * @param  string|null  $queue
+     */
+    public function __construct(
+        public ?string $connectionName = null,
+        public ?string $queue = null,
+    ) {
+    }
+}

--- a/src/Illuminate/Queue/Events/WorkerResuming.php
+++ b/src/Illuminate/Queue/Events/WorkerResuming.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\Queue\Events;
+
+class WorkerResuming
+{
+    /**
+     * Create a new event instance.
+     *
+     * @param  string|null  $connectionName
+     * @param  string|null  $queue
+     */
+    public function __construct(
+        public ?string $connectionName = null,
+        public ?string $queue = null,
+    ) {
+    }
+}

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -18,6 +18,8 @@ use Illuminate\Queue\Events\JobReleasedAfterException;
 use Illuminate\Queue\Events\JobTimedOut;
 use Illuminate\Queue\Events\Looping;
 use Illuminate\Queue\Events\WorkerInterrupted;
+use Illuminate\Queue\Events\WorkerPausing;
+use Illuminate\Queue\Events\WorkerResuming;
 use Illuminate\Queue\Events\WorkerStarting;
 use Illuminate\Queue\Events\WorkerStopping;
 use Illuminate\Support\Carbon;
@@ -833,8 +835,17 @@ class Worker
             });
         }
 
-        pcntl_signal(SIGUSR2, fn () => $this->paused = true);
-        pcntl_signal(SIGCONT, fn () => $this->paused = false);
+        pcntl_signal(SIGUSR2, function () {
+            $this->paused = true;
+
+            $this->events->dispatch(new WorkerPausing($connectionName, $queue));
+        });
+
+        pcntl_signal(SIGCONT, function () {
+            $this->paused = false;
+
+            $this->events->dispatch(new WorkerResuming($connectionName, $queue));
+        });
     }
 
     /**

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -835,13 +835,13 @@ class Worker
             });
         }
 
-        pcntl_signal(SIGUSR2, function () {
+        pcntl_signal(SIGUSR2, function () use ($queue, $connectionName) {
             $this->paused = true;
 
             $this->events->dispatch(new WorkerPausing($connectionName, $queue));
         });
 
-        pcntl_signal(SIGCONT, function () {
+        pcntl_signal(SIGCONT, function () use ($connectionName, $queue) {
             $this->paused = false;
 
             $this->events->dispatch(new WorkerResuming($connectionName, $queue));


### PR DESCRIPTION
I saw this doing the interruptible bits, currently if we get a SIGUSR2, or SIGCONT from infra,  there's no way to know what's occurring userland.

These events just mean we can tap into it so we get the full picture of what's occurring. 

No tests, cause signals!