### PR TITLE
[13.x] Queue::group method

### DIFF
--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -39,6 +39,13 @@ class QueueManager implements FactoryContract, MonitorContract
     protected $connectors = [];
 
     /**
+     * The queue aliases that have been registered.
+     *
+     * @var array
+     */
+    protected $aliases = [];
+
+    /**
      * Create a new queue manager instance.
      *
      * @param  \Illuminate\Contracts\Foundation\Application  $app
@@ -123,6 +130,18 @@ class QueueManager implements FactoryContract, MonitorContract
     public function stopping($callback)
     {
         $this->app['events']->listen(Events\WorkerStopping::class, $callback);
+    }
+
+    /**
+     * Register a queue alias.
+     *
+     * @param  string  $alias
+     * @param  array|string  $queues
+     * @return void
+     */
+    public function alias($alias, $queues)
+    {
+        $this->aliases[$alias] = (array) $queues;
     }
 
     /**
@@ -224,13 +243,15 @@ class QueueManager implements FactoryContract, MonitorContract
      */
     public function pause($connection, $queue)
     {
-        $this->app['cache']
-            ->store()
-            ->forever("illuminate:queue:paused:{$connection}:{$queue}", true);
+        foreach ($this->resolveQueueAlias($queue) as $resolvedQueue) {
+            $this->app['cache']
+                ->store()
+                ->forever("illuminate:queue:paused:{$connection}:{$resolvedQueue}", true);
 
-        $this->app['events']->dispatch(
-            new Events\QueuePaused($connection, $queue)
-        );
+            $this->app['events']->dispatch(
+                new Events\QueuePaused($connection, $resolvedQueue)
+            );
+        }
     }
 
     /**
@@ -243,13 +264,15 @@ class QueueManager implements FactoryContract, MonitorContract
      */
     public function pauseFor($connection, $queue, $ttl)
     {
-        $this->app['cache']
-            ->store()
-            ->put("illuminate:queue:paused:{$connection}:{$queue}", true, $ttl);
+        foreach ($this->resolveQueueAlias($queue) as $resolvedQueue) {
+            $this->app['cache']
+                ->store()
+                ->put("illuminate:queue:paused:{$connection}:{$resolvedQueue}", true, $ttl);
 
-        $this->app['events']->dispatch(
-            new Events\QueuePaused($connection, $queue, $ttl)
-        );
+            $this->app['events']->dispatch(
+                new Events\QueuePaused($connection, $resolvedQueue, $ttl)
+            );
+        }
     }
 
     /**
@@ -261,13 +284,15 @@ class QueueManager implements FactoryContract, MonitorContract
      */
     public function resume($connection, $queue)
     {
-        $this->app['cache']
-            ->store()
-            ->forget("illuminate:queue:paused:{$connection}:{$queue}");
+        foreach ($this->resolveQueueAlias($queue) as $resolvedQueue) {
+            $this->app['cache']
+                ->store()
+                ->forget("illuminate:queue:paused:{$connection}:{$resolvedQueue}");
 
-        $this->app['events']->dispatch(
-            new Events\QueueResumed($connection, $queue)
-        );
+            $this->app['events']->dispatch(
+                new Events\QueueResumed($connection, $resolvedQueue)
+            );
+        }
     }
 
     /**
@@ -334,6 +359,17 @@ class QueueManager implements FactoryContract, MonitorContract
         }
 
         return ['driver' => 'null'];
+    }
+
+    /**
+     * Resolve a queue name from its alias.
+     *
+     * @param  string  $queue
+     * @return array
+     */
+    protected function resolveQueueAlias($queue)
+    {
+        return $this->aliases[$queue] ?? [$queue];
     }
 
     /**

--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -133,7 +133,7 @@ class QueueManager implements FactoryContract, MonitorContract
     }
 
     /**
-     * Register a queue alias.
+     * Register a queue group.
      *
      * @param  string  $group
      * @param  array|string  $queues
@@ -362,7 +362,7 @@ class QueueManager implements FactoryContract, MonitorContract
     }
 
     /**
-     * Resolve a queue name from its alias.
+     * Resolve a queue name from its group.
      *
      * @param  string  $queue
      * @return array

--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -39,11 +39,11 @@ class QueueManager implements FactoryContract, MonitorContract
     protected $connectors = [];
 
     /**
-     * The queue aliases that have been registered.
+     * The queue groups that have been registered.
      *
      * @var array
      */
-    protected $aliases = [];
+    protected $groups = [];
 
     /**
      * Create a new queue manager instance.
@@ -135,13 +135,13 @@ class QueueManager implements FactoryContract, MonitorContract
     /**
      * Register a queue alias.
      *
-     * @param  string  $alias
+     * @param  string  $group
      * @param  array|string  $queues
      * @return void
      */
-    public function alias($alias, $queues)
+    public function group($group, $queues)
     {
-        $this->aliases[$alias] = (array) $queues;
+        $this->groups[$group] = (array) $queues;
     }
 
     /**
@@ -243,7 +243,7 @@ class QueueManager implements FactoryContract, MonitorContract
      */
     public function pause($connection, $queue)
     {
-        foreach ($this->resolveQueueAlias($queue) as $resolvedQueue) {
+        foreach ($this->resolveQueueGroups($queue) as $resolvedQueue) {
             $this->app['cache']
                 ->store()
                 ->forever("illuminate:queue:paused:{$connection}:{$resolvedQueue}", true);
@@ -264,7 +264,7 @@ class QueueManager implements FactoryContract, MonitorContract
      */
     public function pauseFor($connection, $queue, $ttl)
     {
-        foreach ($this->resolveQueueAlias($queue) as $resolvedQueue) {
+        foreach ($this->resolveQueueGroups($queue) as $resolvedQueue) {
             $this->app['cache']
                 ->store()
                 ->put("illuminate:queue:paused:{$connection}:{$resolvedQueue}", true, $ttl);
@@ -284,7 +284,7 @@ class QueueManager implements FactoryContract, MonitorContract
      */
     public function resume($connection, $queue)
     {
-        foreach ($this->resolveQueueAlias($queue) as $resolvedQueue) {
+        foreach ($this->resolveQueueGroups($queue) as $resolvedQueue) {
             $this->app['cache']
                 ->store()
                 ->forget("illuminate:queue:paused:{$connection}:{$resolvedQueue}");
@@ -367,9 +367,9 @@ class QueueManager implements FactoryContract, MonitorContract
      * @param  string  $queue
      * @return array
      */
-    protected function resolveQueueAlias($queue)
+    protected function resolveQueueGroups($queue)
     {
-        return $this->aliases[$queue] ?? [$queue];
+        return $this->groups[$queue] ?? [$queue];
     }
 
     /**

--- a/tests/Queue/QueuePauseResumeTest.php
+++ b/tests/Queue/QueuePauseResumeTest.php
@@ -161,9 +161,9 @@ class QueuePauseResumeTest extends TestCase
         $this->assertSame('notifications', $dispatchedEvent->queue);
     }
 
-    public function testAliasesPauseAndResume()
+    public function testGroupsPauseAndResume()
     {
-        $this->manager->alias('mail', ['mail-high', 'mail-low']);
+        $this->manager->group('mail', ['mail-high', 'mail-low']);
 
         $this->manager->pause('redis', 'mail');
 
@@ -176,11 +176,11 @@ class QueuePauseResumeTest extends TestCase
         $this->assertFalse($this->manager->isPaused('redis', 'mail-low'));
     }
 
-    public function testAliasesPauseFor()
+    public function testGroupsPauseFor()
     {
         Carbon::setTestNow();
 
-        $this->manager->alias('mail', ['mail-high', 'mail-low']);
+        $this->manager->group('mail', ['mail-high', 'mail-low']);
 
         $this->manager->pauseFor('redis', 'mail', 30);
 
@@ -191,9 +191,9 @@ class QueuePauseResumeTest extends TestCase
         $this->assertFalse($this->manager->isPaused('redis', 'mail-high'));
     }
 
-    public function testAliasesEventsFire()
+    public function testGroupsEventsFire()
     {
-        $this->manager->alias('mail', ['mail-high', 'mail-low']);
+        $this->manager->group('mail', ['mail-high', 'mail-low']);
 
         $paused = [];
         $this->manager->getApplication()['events']->listen(QueuePaused::class, function ($event) use (&$paused) {

--- a/tests/Queue/QueuePauseResumeTest.php
+++ b/tests/Queue/QueuePauseResumeTest.php
@@ -161,6 +161,50 @@ class QueuePauseResumeTest extends TestCase
         $this->assertSame('notifications', $dispatchedEvent->queue);
     }
 
+    public function testAliasesResolves()
+    {
+        $this->manager->alias('mail', ['mail-high', 'mail-low']);
+
+        $this->manager->pause('redis', 'mail');
+
+        $this->assertTrue($this->manager->isPaused('redis', 'mail-high'));
+        $this->assertTrue($this->manager->isPaused('redis', 'mail-low'));
+
+        $this->manager->resume('redis', 'mail');
+
+        $this->assertFalse($this->manager->isPaused('redis', 'mail-high'));
+        $this->assertFalse($this->manager->isPaused('redis', 'mail-low'));
+    }
+
+    public function testAliasesQueuesExpireWithPauseFor()
+    {
+        Carbon::setTestNow();
+
+        $this->manager->alias('mail', ['mail-high', 'mail-low']);
+
+        $this->manager->pauseFor('redis', 'mail', 30);
+
+        $this->assertTrue($this->manager->isPaused('redis', 'mail-high'));
+
+        Carbon::setTestNow(Carbon::now()->addMinute());
+
+        $this->assertFalse($this->manager->isPaused('redis', 'mail-high'));
+    }
+
+    public function testAliasesEventsFire()
+    {
+        $this->manager->alias('mail', ['mail-high', 'mail-low']);
+
+        $paused = [];
+        $this->manager->getApplication()['events']->listen(QueuePaused::class, function ($event) use (&$paused) {
+            $paused[] = $event->queue;
+        });
+
+        $this->manager->pause('redis', 'mail');
+
+        $this->assertSame(['mail-high', 'mail-low'], $paused);
+    }
+
     public function testParsingQueueString()
     {
         $parser = new class()

--- a/tests/Queue/QueuePauseResumeTest.php
+++ b/tests/Queue/QueuePauseResumeTest.php
@@ -161,6 +161,50 @@ class QueuePauseResumeTest extends TestCase
         $this->assertSame('notifications', $dispatchedEvent->queue);
     }
 
+    public function testAliasesPauseAndResume()
+    {
+        $this->manager->alias('mail', ['mail-high', 'mail-low']);
+
+        $this->manager->pause('redis', 'mail');
+
+        $this->assertTrue($this->manager->isPaused('redis', 'mail-high'));
+        $this->assertTrue($this->manager->isPaused('redis', 'mail-low'));
+
+        $this->manager->resume('redis', 'mail');
+
+        $this->assertFalse($this->manager->isPaused('redis', 'mail-high'));
+        $this->assertFalse($this->manager->isPaused('redis', 'mail-low'));
+    }
+
+    public function testAliasesPauseFor()
+    {
+        Carbon::setTestNow();
+
+        $this->manager->alias('mail', ['mail-high', 'mail-low']);
+
+        $this->manager->pauseFor('redis', 'mail', 30);
+
+        $this->assertTrue($this->manager->isPaused('redis', 'mail-high'));
+
+        Carbon::setTestNow(Carbon::now()->addMinute());
+
+        $this->assertFalse($this->manager->isPaused('redis', 'mail-high'));
+    }
+
+    public function testAliasesEventsFire()
+    {
+        $this->manager->alias('mail', ['mail-high', 'mail-low']);
+
+        $paused = [];
+        $this->manager->getApplication()['events']->listen(QueuePaused::class, function ($event) use (&$paused) {
+            $paused[] = $event->queue;
+        });
+
+        $this->manager->pause('redis', 'mail');
+
+        $this->assertSame(['mail-high', 'mail-low'], $paused);
+    }
+
     public function testParsingQueueString()
     {
         $parser = new class()

--- a/tests/Queue/QueuePauseResumeTest.php
+++ b/tests/Queue/QueuePauseResumeTest.php
@@ -161,7 +161,7 @@ class QueuePauseResumeTest extends TestCase
         $this->assertSame('notifications', $dispatchedEvent->queue);
     }
 
-    public function testAliasesResolves()
+    public function testAliasesPauseAndResume()
     {
         $this->manager->alias('mail', ['mail-high', 'mail-low']);
 
@@ -176,7 +176,7 @@ class QueuePauseResumeTest extends TestCase
         $this->assertFalse($this->manager->isPaused('redis', 'mail-low'));
     }
 
-    public function testAliasesQueuesExpireWithPauseFor()
+    public function testAliasesPauseFor()
     {
         Carbon::setTestNow();
 


### PR DESCRIPTION
In large applications,  it's common to split work across multiple queues, and workers, meaning you could have a bunch of queues that operate together across workers,  ie payments-high, payments-low, payments-refunds

Currently, to pause and resume queues you have to input the name of each queue individually.

This becomes tedious when you have many queues all similarly named, that all work together, especially in a disaster scenario:

```
// OMG payment provider is down
// lets pause the queues.. wait, what queues are linked again?!

  php artisan queue:pause payments-high                                                                                                                                                                                                                                                                                                                                                                                         
  php artisan queue:pause payments-low
  php artisan queue:pause payments-refunds        
 ```                                                                                                                                                                                                                                                                                                                                                                        
                                                            
This PR introduces `Queue::group()`, allowing you to group queues under a single name, which allow you to pause / resume them easier which should be used ideally in a service provider:

```php
  // Group easily...
  Queue::group('payments', ['payments-high', 'payments-low', 'payments-refunds']);
``` 

```
  // simple
  php artisan queue:pause payments
  php artisan queue:resume payments
```

This also works for the queue manager pause and resume methods:

```php
Queue::pause('payments'); // etc..
```

This literally is just using a foreach under the hood, so nothing ground breaking, there should be no B/C as it defaults to `[$queue];
  
My intention is to bring this to the Worker potentially in a separate PR,  for short hand convenience so you no longer have to declare each queue ie `--queue=a,b,c,d,default` which is tedious too, but leaving that out for now to keep this focused. 

I didn't put this in a trait, as it feels niche enough to the QueueManager imo, but happy to take criticism if you want anything changed, or if this sucks that's OK too 😆 


