### PR TITLE
[13.x] Ensure TestResponse assertSee methods don't silently pass on empty arrays

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -707,6 +707,8 @@ class TestResponse implements ArrayAccess
 
         $values = $escape ? array_map(e(...), $value) : $value;
 
+        $this->ensureValuesAreNotEmpty($values);
+
         foreach ($values as $value) {
             PHPUnit::withResponse($this)->assertStringContainsString((string) $value, $this->getContent());
         }
@@ -735,6 +737,8 @@ class TestResponse implements ArrayAccess
     public function assertSeeInOrder(array $values, $escape = true)
     {
         $values = $escape ? array_map(e(...), $values) : $values;
+
+        $this->ensureValuesAreNotEmpty($values);
 
         PHPUnit::withResponse($this)->assertThat($values, new SeeInOrder($this->getContent()));
 
@@ -765,6 +769,8 @@ class TestResponse implements ArrayAccess
 
         $values = $escape ? array_map(e(...), $value) : $value;
 
+        $this->ensureValuesAreNotEmpty($values);
+
         PHPUnit::withResponse($this)->assertThat($values, new SeeInHtml($this->getContent()));
 
         return $this;
@@ -780,6 +786,8 @@ class TestResponse implements ArrayAccess
     public function assertSeeTextInOrder(array $values, $escape = true)
     {
         $values = $escape ? array_map(e(...), $values) : $values;
+
+        $this->ensureValuesAreNotEmpty($values);
 
         PHPUnit::withResponse($this)->assertThat($values, new SeeInHtml($this->getContent(), true));
 
@@ -798,6 +806,8 @@ class TestResponse implements ArrayAccess
         $value = Arr::wrap($value);
 
         $values = $escape ? array_map(e(...), $value) : $value;
+
+        $this->ensureValuesAreNotEmpty($values);
 
         foreach ($values as $value) {
             PHPUnit::withResponse($this)->assertStringNotContainsString((string) $value, $this->getContent());
@@ -829,6 +839,8 @@ class TestResponse implements ArrayAccess
         $value = Arr::wrap($value);
 
         $values = $escape ? array_map(e(...), $value) : $value;
+
+        $this->ensureValuesAreNotEmpty($values);
 
         PHPUnit::withResponse($this)->assertThat($values, new SeeInHtml($this->getContent(), negate: true));
 
@@ -1406,6 +1418,19 @@ class TestResponse implements ArrayAccess
         }
 
         return $this;
+    }
+
+    /**
+     * Ensure the given values are not empty before asserting against them.
+     *
+     * @param  array  $values
+     * @return void
+     */
+    protected function ensureValuesAreNotEmpty(array $values)
+    {
+        PHPUnit::withResponse($this)->assertNotEmpty(
+            $values, 'No values were provided to assert against.'
+        );
     }
 
     /**

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -697,6 +697,24 @@ EOT
         $response->assertSeeTextInOrder(['foobar', 'qux', 'baz']);
     }
 
+    #[TestWith(['assertSee'])]
+    #[TestWith(['assertSeeText'])]
+    #[TestWith(['assertSeeInOrder'])]
+    #[TestWith(['assertSeeTextInOrder'])]
+    #[TestWith(['assertDontSee'])]
+    #[TestWith(['assertDontSeeText'])]
+    public function testAssertSeeMethodsFailWhenGivenEmptyArray(string $method): void
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('No values were provided to assert against.');
+
+        $response = $this->makeMockResponse([
+            'render' => '<ul><li>foo</li><li>bar</li></ul>',
+        ]);
+
+        $response->{$method}([]);
+    }
+
     public function testAssertDontSee(): void
     {
         $response = $this->makeMockResponse([


### PR DESCRIPTION
`TestResponse::assertSee()` and its sibling methods (`assertSeeText`, `assertSeeInOrder`, `assertSeeTextInOrder`, `assertDontSee`, `assertDontSeeText`) silently pass when given an empty array. The `foreach`/constraint loop iterates zero times and the assertion succeeds without verifying anything against the response.

```php
$response = TestResponse::fromBaseResponse(new Response('hello world'));

$response->assertSee([]);       // passes — nothing was actually asserted
$response->assertDontSee([]);   // same
```

Added a small `ensureValuesAreNotEmpty()` helper (mirroring the existing `ensureResponseHasView()` pattern in the same file) and called it from each of the six methods so an empty input fails loudly with a clear message instead. Added a `#[TestWith]` regression test covering all six methods alongside the existing `*CanFail` tests.