### PR TITLE
[13.x] Add detailed @return shape to Schema\Builder::getForeignKeys

### DIFF
--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -469,7 +469,7 @@ class Builder
      * Get the foreign keys for a given table.
      *
      * @param  string  $table
-     * @return array
+     * @return list<array{name: string|null, columns: list<string>, foreign_schema: string|null, foreign_table: string, foreign_columns: list<string>, on_update: string|null, on_delete: string|null}>
      */
     public function getForeignKeys($table)
     {


### PR DESCRIPTION
`Schema\Builder::getForeignKeys()` is the only `get*` method in the file with a vague `@return array` docblock — every sibling (`getColumns`, `getIndexes`, `getTables`, `getViews`, `getTypes`, `getSchemas`) declares a detailed `list<array{...}>` shape.

The four `processForeignKeys()` implementations (`MySql`, `Postgres`, `SQLite`, `SqlServer`) all return the same consistent shape, so the docblock can describe it precisely:

```php
list<array{
    name: string|null,
    columns: list<string>,
    foreign_schema: string|null,
    foreign_table: string,
    foreign_columns: list<string>,
    on_update: string|null,
    on_delete: string|null,
}>
```

PHPDoc-only change. Improves static analysis and IDE inference; no behavioral change.