### PR TITLE
[13.x] Fix EloquentModelDecimalCastingTest assertion across brick/math versions

### DIFF
--- a/tests/Integration/Database/EloquentModelDecimalCastingTest.php
+++ b/tests/Integration/Database/EloquentModelDecimalCastingTest.php
@@ -71,7 +71,7 @@ class EloquentModelDecimalCastingTest extends DatabaseTestCase
         } catch (MathException $e) {
             $this->assertSame('Unable to cast value to a decimal.', $e->getMessage());
             $this->assertInstanceOf(NumberFormatException::class, $e->getPrevious());
-            $this->assertSame('The given value "foo" does not represent a valid number.', $e->getPrevious()->getMessage());
+            $this->assertStringContainsString('"foo" does not represent a valid number.', $e->getPrevious()->getMessage());
         }
     }
 


### PR DESCRIPTION
`composer.json` permits `brick/math: ^0.14.2 || ^0.15 || ^0.16 || ^0.17`, but `EloquentModelDecimalCastingTest::testItWrapsThrownExceptions` hard-codes the exception message format from `0.14.x`:

```
'The given value "foo" does not represent a valid number.'  // brick/math <= 0.14
'Value "foo" does not represent a valid number.'            // brick/math >= 0.15
```

`brick/math 0.15.0` shortened it to `'Value "%s" does not represent a valid number.'`, which causes `prefer-stable` CI runs (resolving `0.17.x`) to fail across every job today. Switched the assertion to `assertStringContainsString` against the substring both versions share.