### PR TITLE
fix(routing): avoid appending request port when route domain already has one

### DIFF
--- a/src/Illuminate/Routing/RouteUrlGenerator.php
+++ b/src/Illuminate/Routing/RouteUrlGenerator.php
@@ -163,6 +163,10 @@ class RouteUrlGenerator
      */
     protected function addPortToDomain($domain)
     {
+        if (! is_null(parse_url($domain, PHP_URL_PORT))) {
+            return $domain;
+        }
+        
         $secure = $this->request->isSecure();
 
         $port = (int) $this->request->getPort();

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -499,6 +499,23 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertSame('http://sub.taylor.com:8080/foo/bar/otwell', $url->route('bar', ['taylor', 'otwell']));
     }
 
+    public function testRoutesWithDomainsAndExplicitDomainPorts()
+    {
+        $url = new UrlGenerator(
+            $routes = new RouteCollection,
+            Request::create('http://www.foo.com:8080/')
+        );
+
+        $route = new Route(['GET'], 'foo/bar', ['as' => 'foo', 'domain' => 'sub.foo.com:9090']);
+        $routes->add($route);
+
+        $route = new Route(['GET'], 'foo/bar/{baz}', ['as' => 'bar', 'domain' => 'sub.{foo}.com:9090']);
+        $routes->add($route);
+
+        $this->assertSame('http://sub.foo.com:9090/foo/bar', $url->route('foo'));
+        $this->assertSame('http://sub.taylor.com:9090/foo/bar/otwell', $url->route('bar', ['taylor', 'otwell']));
+    }
+
     public function testRoutesWithDomainsStripsProtocols()
     {
         // http:// Route


### PR DESCRIPTION
# fix(routing): avoid appending request port when route domain already has one

## Summary
- Prevent duplicate ports in generated route URLs when a route domain explicitly includes a port.
- Preserve explicit domain ports (for example, `9090`) instead of appending the current request port (for example, `8080`).
- Add regression coverage for both static and wildcard domains with explicit ports.

## Files Changed
- `src/Illuminate/Routing/RouteUrlGenerator.php`
- `tests/Routing/RoutingUrlGeneratorTest.php`

## Issue Examples Fixed

### 1. Explicit domain port duplicated
- Route domain: `sub.foo.com:9090`
- Current request: `http://www.foo.com:8080`
- Before: `http://sub.foo.com:9090:8080/foo/bar`
- After: `http://sub.foo.com:9090/foo/bar`

### 2. Wildcard domain port duplicated
- Route domain: `sub.{tenant}.com:9090`
- Parameters: `tenant=taylor`
- Current request: `http://www.foo.com:8080`
- Before: `http://sub.taylor.com:9090:8080/foo/bar/otwell`
- After: `http://sub.taylor.com:9090/foo/bar/otwell`

## Compatibility
- This change is backward-compatible for domains without explicit ports.



<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
