### PR TITLE
Match processForeignKeys return shape to Builder::getForeignKeys

### DIFF
--- a/src/Illuminate/Database/Query/Processors/Processor.php
+++ b/src/Illuminate/Database/Query/Processors/Processor.php
@@ -135,7 +135,7 @@ class Processor
      * Process the results of a foreign keys query.
      *
      * @param  list<array<string, mixed>>  $results
-     * @return list<array{name: string, columns: list<string>, foreign_schema: string, foreign_table: string, foreign_columns: list<string>, on_update: string, on_delete: string}>
+     * @return list<array{name: string|null, columns: list<string>, foreign_schema: string|null, foreign_table: string, foreign_columns: list<string>, on_update: string|null, on_delete: string|null}>
      */
     public function processForeignKeys($results)
     {


### PR DESCRIPTION
`Schema\Builder::getForeignKeys()` now declares `name`, `foreign_schema`, `on_update` and `on_delete` as `string|null` after #59903. The `Processor::processForeignKeys()` annotation it ultimately delegates to still has them as `string`, but the implementations actually produce `null` in real cases — `SQLiteProcessor` literally returns `'name' => null`, and `PostgresProcessor` falls through to `default => null` for `on_update`/`on_delete`. Aligning the docblock with what the processors return.