### PR TITLE
Fix duplicate type key in getTypes/processTypes return shape

### DIFF
--- a/src/Illuminate/Database/Query/Processors/Processor.php
+++ b/src/Illuminate/Database/Query/Processors/Processor.php
@@ -102,7 +102,7 @@ class Processor
      * Process the results of a types query.
      *
      * @param  list<array<string, mixed>>  $results
-     * @return list<array{name: string, schema: string, type: string, type: string, category: string, implicit: bool}>
+     * @return list<array{name: string, schema: string, schema_qualified_name: string, type: string, category: string, implicit: bool}>
      */
     public function processTypes($results)
     {

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -251,7 +251,7 @@ class Builder
      * Get the user-defined types that belong to the connection.
      *
      * @param  string|string[]|null  $schema
-     * @return list<array{name: string, schema: string, type: string, type: string, category: string, implicit: bool}>
+     * @return list<array{name: string, schema: string, schema_qualified_name: string, type: string, category: string, implicit: bool}>
      */
     public function getTypes($schema = null)
     {


### PR DESCRIPTION
The `@return` shape on `Schema\Builder::getTypes()` and `Query\Processors\Processor::processTypes()` lists `type: string` twice and is missing `schema_qualified_name`. `PostgresProcessor::processTypes()` actually returns `name`, `schema`, `schema_qualified_name`, `implicit`, `type`, `category` — so the second `type: string` slot is meant to be `schema_qualified_name: string`.