### PR TITLE
Align Enumerable search and flatten @return with implementations

### DIFF
--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -494,7 +494,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Get a flattened array of the items in the collection.
      *
      * @param  int  $depth
-     * @return static
+     * @return static<int, mixed>
      */
     public function flatten($depth = INF);
 
@@ -924,7 +924,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      *
      * @param  TValue|callable(TValue,TKey): bool  $value
      * @param  bool  $strict
-     * @return TKey|bool
+     * @return TKey|false
      */
     public function search($value, $strict = false);
 


### PR DESCRIPTION
Two `@return` annotations on the `Enumerable` interface drift from what `Collection` and `LazyCollection` actually return.

`Enumerable::search()` is documented as `@return TKey|bool`, but `Collection::search()` returns `array_search(...) ?? false` and `LazyCollection::search()` is annotated `@return TKey|false`. `true` is never returned by either, so the contract should be `TKey|false`.

`Enumerable::flatten()` is documented as `@return static`, but both implementations declare `@return static<int, mixed>` since `array_flatten` rekeys to integers and value type is lost. Tightening the contract to match.