### PR TITLE
Align Enumerable all, times and range @return with implementations

### DIFF
--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -34,9 +34,11 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Create a new instance by invoking the callback a given amount of times.
      *
+     * @template TTimesValue
+     *
      * @param  int  $number
-     * @param  callable|null  $callback
-     * @return static
+     * @param  (callable(int): TTimesValue)|null  $callback
+     * @return static<int, TTimesValue>
      */
     public static function times($number, ?callable $callback = null);
 
@@ -46,7 +48,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * @param  int  $from
      * @param  int  $to
      * @param  int  $step
-     * @return static
+     * @return static<int, int>
      */
     public static function range($from, $to, $step = 1);
 
@@ -81,7 +83,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Get all items in the enumerable.
      *
-     * @return array
+     * @return array<TKey, TValue>
      */
     public function all();
 


### PR DESCRIPTION
Three more `Enumerable` annotations that are vaguer than what `Collection` and `LazyCollection` actually return.

`all()` is `@return array` on the contract, but both implementations declare `@return array<TKey, TValue>`.

`range()` is `@return static`, but `Collection::range()` returns `static<int, int>` and `LazyCollection::range()` returns `($step is zero ? never : static<int, int>)`.

`times()` is `@return static` with `@param callable|null $callback`. The shared `EnumeratesValues::times` trait method already carries `@template TTimesValue`, `@param (callable(int): TTimesValue)|null $callback`, `@return static<int, TTimesValue>` — moving that template up to the contract so callers see the value type without going through the trait.