### PR TITLE
Specify Translation Loader namespaces shape

### DIFF
--- a/src/Illuminate/Contracts/Translation/Loader.php
+++ b/src/Illuminate/Contracts/Translation/Loader.php
@@ -34,7 +34,7 @@ interface Loader
     /**
      * Get an array of all the registered namespaces.
      *
-     * @return array
+     * @return array<string, string>
      */
     public function namespaces();
 }

--- a/src/Illuminate/Translation/ArrayLoader.php
+++ b/src/Illuminate/Translation/ArrayLoader.php
@@ -72,7 +72,7 @@ class ArrayLoader implements Loader
     /**
      * Get an array of all the registered namespaces.
      *
-     * @return array
+     * @return array<string, string>
      */
     public function namespaces()
     {

--- a/src/Illuminate/Translation/FileLoader.php
+++ b/src/Illuminate/Translation/FileLoader.php
@@ -33,7 +33,7 @@ class FileLoader implements Loader
     /**
      * All of the namespace hints.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $hints = [];
 
@@ -174,7 +174,7 @@ class FileLoader implements Loader
     /**
      * Get an array of all the registered namespaces.
      *
-     * @return array
+     * @return array<string, string>
      */
     public function namespaces()
     {


### PR DESCRIPTION
The `Loader::namespaces()` contract is documented `@return array`, but the implementations always return an associative `[$namespace => $hint]` map. `FileLoader` returns `\$this->hints`, which is built up via `\$this->hints[\$namespace] = \$hint` in `addNamespace()` (both strings); `ArrayLoader` returns `[]`. Updating the contract, `FileLoader::\$hints` `@var`, and both `namespaces()` methods to `array<string, string>`.