### PR TITLE
[13.x] Feat: add `$qualifiedKeyName` in `find()` and `orFind()`

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3457,11 +3457,12 @@ class Builder implements BuilderContract
      *
      * @param  int|string  $id
      * @param  string|\Illuminate\Contracts\Database\Query\Expression|array<string|\Illuminate\Contracts\Database\Query\Expression>  $columns
+     * @param  string  $qualifiedKeyName
      * @return \stdClass|null
      */
-    public function find($id, $columns = ['*'])
+    public function find($id, $columns = ['*'], $qualifiedKeyName = 'id')
     {
-        return $this->where('id', '=', $id)->first($columns);
+        return $this->where($qualifiedKeyName, '=', $id)->first($columns);
     }
 
     /**
@@ -3472,9 +3473,10 @@ class Builder implements BuilderContract
      * @param  mixed  $id
      * @param  (\Closure(): TValue)|string|\Illuminate\Contracts\Database\Query\Expression|array<string|\Illuminate\Contracts\Database\Query\Expression>  $columns
      * @param  (\Closure(): TValue)|null  $callback
+     * @param string $qualifiedKeyName
      * @return \stdClass|TValue
      */
-    public function findOr($id, $columns = ['*'], ?Closure $callback = null)
+    public function findOr($id, $columns = ['*'], ?Closure $callback = null, $qualifiedKeyName = 'id')
     {
         if ($columns instanceof Closure) {
             $callback = $columns;
@@ -3482,7 +3484,7 @@ class Builder implements BuilderContract
             $columns = ['*'];
         }
 
-        if (! is_null($data = $this->find($id, $columns))) {
+        if (! is_null($data = $this->find($id, $columns, $qualifiedKeyName))) {
             return $data;
         }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3473,7 +3473,7 @@ class Builder implements BuilderContract
      * @param  mixed  $id
      * @param  (\Closure(): TValue)|string|\Illuminate\Contracts\Database\Query\Expression|array<string|\Illuminate\Contracts\Database\Query\Expression>  $columns
      * @param  (\Closure(): TValue)|null  $callback
-     * @param string $qualifiedKeyName
+     * @param  string  $qualifiedKeyName
      * @return \stdClass|TValue
      */
     public function findOr($id, $columns = ['*'], ?Closure $callback = null, $qualifiedKeyName = 'id')

--- a/tests/Integration/Console/CommandSchedulingTest.php
+++ b/tests/Integration/Console/CommandSchedulingTest.php
@@ -83,7 +83,7 @@ class CommandSchedulingTest extends TestCase
 
         // We'll trigger the scheduler three times to simulate multiple servers
         $this->app->instance(Schedule::class, clone $schedule);
-        $this->artisan('schedule:run' );
+        $this->artisan('schedule:run');
         $this->app->instance(Schedule::class, clone $schedule);
         $this->artisan('schedule:run');
         $this->app->instance(Schedule::class, clone $schedule);

--- a/tests/Integration/Console/CommandSchedulingTest.php
+++ b/tests/Integration/Console/CommandSchedulingTest.php
@@ -83,7 +83,7 @@ class CommandSchedulingTest extends TestCase
 
         // We'll trigger the scheduler three times to simulate multiple servers
         $this->app->instance(Schedule::class, clone $schedule);
-        $this->artisan('schedule:run');
+        $this->artisan('schedule:run' );
         $this->app->instance(Schedule::class, clone $schedule);
         $this->artisan('schedule:run');
         $this->app->instance(Schedule::class, clone $schedule);


### PR DESCRIPTION
It is possible that when using the `find function`, the column name may be different from the `id`, for example, something like `uuid`. For this reason, the `$qualifiedKeyName` variable was added to the `function` input with a default value of `id`, which can be changed if the column name is different.