### PR TITLE
[13.x] use casting instead of `empty()` calls

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -300,9 +300,9 @@ class FormRequest extends Request implements ValidatesWhenResolved
         $url = $this->redirector->getUrlGenerator();
 
         return match (true) {
-            ! empty($this->redirect) => $url->to($this->redirect),
-            ! empty($this->redirectRoute) => $url->route($this->redirectRoute),
-            ! empty($this->redirectAction) => $url->action($this->redirectAction),
+            (bool) $this->redirect => $url->to($this->redirect),
+            (bool) $this->redirectRoute => $url->route($this->redirectRoute),
+            (bool) $this->redirectAction => $url->action($this->redirectAction),
             default => $url->previous(),
         };
     }


### PR DESCRIPTION
PR #59914 switched from an if/else chain to this `match` call. since `match` does strict equality, and because the old code was only checking for "truthy" values, the `empty()` calls were added to preserve identical functionality.

we can get this same behavior, without the overhead of function calls, by casting the values to booleans.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
