### PR TITLE
Add eager loading support for pivot classes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -145,6 +145,13 @@ class BelongsToMany extends Relation
     protected $accessor = 'pivot';
 
     /**
+     * The pivot relationships that should be eager loaded.
+     *
+     * @var array
+     */
+    protected $pivotEagerLoad = [];
+
+    /**
      * Create a new belongs to many relationship instance.
      *
      * @param  \Illuminate\Database\Eloquent\Builder<TRelatedModel>  $query
@@ -919,6 +926,28 @@ class BelongsToMany extends Relation
             : $this->related->newCollection();
     }
 
+    /**
+     * Specify pivot relationships that should be eager loaded.
+     *
+     * @param  array<array-key, array|(\Closure(\Illuminate\Database\Eloquent\Relations\Relation<*,*,*>): mixed)|string>|string  $relations
+     * @param  (\Closure(\Illuminate\Database\Eloquent\Relations\Relation<*,*,*>): mixed)|string|null  $callback
+     * @return $this
+     */
+    public function eagerPivot($relations, $callback = null)
+    {
+        $query = $this->newExistingPivot()->newQueryWithoutRelationships();
+
+        if ($callback instanceof Closure) {
+            $query->with($relations, $callback);
+        } else {
+            $query->with(is_string($relations) ? func_get_args() : $relations);
+        }
+
+        $this->pivotEagerLoad = array_merge($this->pivotEagerLoad, $query->getEagerLoads());
+
+        return $this;
+    }
+
     /** @inheritDoc */
     public function get($columns = ['*'])
     {
@@ -1243,6 +1272,26 @@ class BelongsToMany extends Relation
                 $this->migratePivotAttributes($model)
             ));
         }
+
+        $this->eagerLoadPivotRelations($models);
+    }
+
+    /**
+     * Eager load relationships on the pivot models.
+     *
+     * @param  array<int, TRelatedModel>  $models
+     * @return void
+     */
+    protected function eagerLoadPivotRelations(array $models)
+    {
+        if ($this->pivotEagerLoad === [] || $models === []) {
+            return;
+        }
+
+        (new EloquentCollection(array_map(
+            fn ($model) => $model->getRelation($this->accessor),
+            $models,
+        )))->load($this->pivotEagerLoad);
     }
 
     /**

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Integration\Database\EloquentBelongsToManyTest;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Database\RecordsNotFoundException;
 use Illuminate\Database\Schema\Blueprint;
@@ -165,6 +166,48 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $this->assertEquals(1, PostTagPivot::count());
         $this->assertEquals(1, PostTagPivot::first()->post_id);
         $this->assertEquals(2, PostTagPivot::first()->tag_id);
+    }
+
+    public function testPivotRelationsCanBeEagerLoadedOnBelongsToManyRelation()
+    {
+        $user = User::create(['name' => Str::random()]);
+        $matchingPost = Post::create(['title' => 'A title']);
+        $mismatchingPost = Post::create(['title' => 'Another title']);
+
+        $user->postsWithCustomPivot()->attach($matchingPost);
+        $user->postsWithCustomPivot()->attach($mismatchingPost);
+
+        $user = User::query()->with([
+            'postsWithCustomPivot' => function ($query) {
+                $query->eagerPivot([
+                    'user',
+                    'post' => function (BelongsTo $query) {
+                        $query->where('title', 'A title');
+                    },
+                ]);
+            },
+        ])->first();
+
+        DB::enableQueryLog();
+
+        $pivots = $user->postsWithCustomPivot->pluck('pivot');
+
+        $this->assertTrue($pivots->every->relationLoaded('user'));
+        $this->assertTrue($pivots->every->relationLoaded('post'));
+        $this->assertTrue($pivots->every(fn ($pivot) => $pivot->user->is($user)));
+        $this->assertSame(
+            [$matchingPost->id],
+            $pivots->pluck('post')->filter()->pluck('id')->all()
+        );
+
+        $pivots->each(function ($pivot) {
+            $pivot->user;
+            $pivot->post;
+        });
+
+        $this->assertEmpty(DB::getQueryLog());
+
+        DB::disableQueryLog();
     }
 
     public function testCustomPivotClassUsingSync()
@@ -1643,6 +1686,16 @@ class TagWithCustomPivot extends Model
 class UserPostPivot extends Pivot
 {
     protected $table = 'users_posts';
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'user_uuid', 'uuid');
+    }
+
+    public function post(): BelongsTo
+    {
+        return $this->belongsTo(Post::class, 'post_uuid', 'uuid');
+    }
 }
 
 class PostTagPivot extends Pivot


### PR DESCRIPTION
I don't often work with pivot classes but when I do it's usually because I need other relations on it. That and its two parent relations. But there's never been an easy way to eager load these.
What I did most of the times was pluck them, wrap them in a new eloquent collection and load it on there, but there are places you don't have that flexibility. Some packages (Nova for example) only allow you to define the query, and all other logic is on the model level, not collection

I'm not 100% sure on the naming tho, `withPivot` came to mind first, but that's already taken.
I'm also not sure if I'm missing a scenario where this might not work. Please point them out if you do.
In the meanwhile just looking to see if this gains any interest.