### PR TITLE
[13.x] Replace func_get_args() with variadic parameters in Stringable trim methods

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1060,9 +1060,9 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
      * @param  string|null  $characters
      * @return static
      */
-    public function trim($characters = null)
+    public function trim(...$args)
     {
-        return new static(Str::trim(...array_merge([$this->value], func_get_args())));
+        return new static(Str::trim($this->value, ...$args));
     }
 
     /**
@@ -1071,9 +1071,9 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
      * @param  string|null  $characters
      * @return static
      */
-    public function ltrim($characters = null)
+    public function ltrim(...$args)
     {
-        return new static(Str::ltrim(...array_merge([$this->value], func_get_args())));
+        return new static(Str::ltrim($this->value, ...$args));
     }
 
     /**
@@ -1082,9 +1082,9 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
      * @param  string|null  $characters
      * @return static
      */
-    public function rtrim($characters = null)
+    public function rtrim(...$args)
     {
-        return new static(Str::rtrim(...array_merge([$this->value], func_get_args())));
+        return new static(Str::rtrim($this->value, ...$args));
     }
 
     /**

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -162,16 +162,19 @@ class SupportStringableTest extends TestCase
     public function testTrim()
     {
         $this->assertSame('foo', (string) $this->stringable(' foo ')->trim());
+        $this->assertSame('hello', (string) $this->stringable('xxhelloxx')->trim('x'));
     }
 
     public function testLtrim()
     {
         $this->assertSame('foo ', (string) $this->stringable(' foo ')->ltrim());
+        $this->assertSame('helloxx', (string) $this->stringable('xxhelloxx')->ltrim('x'));
     }
 
     public function testRtrim()
     {
         $this->assertSame(' foo', (string) $this->stringable(' foo ')->rtrim());
+        $this->assertSame('xxhello', (string) $this->stringable('xxhelloxx')->rtrim('x'));
     }
 
     public function testCanBeLimitedByWords()


### PR DESCRIPTION
The trim, ltrim, and rtrim methods in `Illuminate\Support\Stringable` previously used the legacy `func_get_args()` pattern to forward arguments. This PR replaces them with native PHP variadic parameters `(...$args)`.

### Before
```php
public function trim($characters = null)
{
    return new static(Str::trim(...array_merge([$this->value], func_get_args())));
}
```

### After 
```php
public function trim(...$args)
{
    return new static(Str::trim($this->value, ...$args));
}
```