### PR TITLE
fix: Update handle method return type to bool|null in ModelMakeCommand

### DIFF
--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -43,7 +43,7 @@ class ModelMakeCommand extends GeneratorCommand
     /**
      * Execute the console command.
      *
-     * @return void
+     * @return bool|null
      */
     public function handle()
     {


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
The method `handle()` in the file `ModelMakeCommand` incorrectly marks the function return type as void, but in reality returns `bool|null`.

This causes errors in PHPStan such as [staticMethod.void](https://phpstan.org/error-identifiers/staticMethod.void) and IntelliSense problems when extending the class to generate more files (For example in my case, to also create Schema files when working with packages like [lighthouse](https://lighthouse-php.com/))

```php
    public function handle(): ?false
    {
        /**
         * The parent result actually returns a value sometimes.
         *
         * @var null|false $parentResult
         * @phpstan-ignore staticMethod.void
         */
        $parentResult = parent::handle();

        if ($parentResult === false) {
            return false;
        }

        if ($this->option('all')) {
            $this->input->setOption('schema', true);
        }

        if ($this->option('schema')) {
            $this->createGraphQLSchema();
        }

        return null;
    }
```

