### PR TITLE
Refactor getQueueableRelations to use match

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -887,13 +887,11 @@ class Collection extends BaseCollection implements QueueableCollection
 
         $relations = $this->map->getQueueableRelations()->all();
 
-        if (count($relations) === 0 || $relations === [[]]) {
-            return [];
-        } elseif (count($relations) === 1) {
-            return reset($relations);
-        } else {
-            return array_intersect(...array_values($relations));
-        }
+        return match (true) {
+            count($relations) === 0 || $relations === [[]] => [],
+            count($relations) === 1 => reset($relations),
+            default => array_intersect(...array_values($relations)),
+        };
     }
 
     /**


### PR DESCRIPTION
Following #59914, the `if/elseif/else` chain in `Eloquent\Collection::getQueueableRelations()` is a clean fit for `match`. Same logic, just expressed as an expression.