### PR TITLE
Refactor parseVerbosity to use match

### DIFF
--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -436,13 +436,11 @@ trait InteractsWithIO
     {
         $level ??= '';
 
-        if (isset($this->verbosityMap[$level])) {
-            $level = $this->verbosityMap[$level];
-        } elseif (! is_int($level)) {
-            $level = $this->verbosity;
-        }
-
-        return $level;
+        return match (true) {
+            isset($this->verbosityMap[$level]) => $this->verbosityMap[$level],
+            ! is_int($level) => $this->verbosity,
+            default => $level,
+        };
     }
 
     /**


### PR DESCRIPTION
Same flavor as #59914. The `if/elseif` block in `InteractsWithIO::parseVerbosity()` reads cleaner as a `match` since each branch just produces the resolved level.