### PR TITLE
[13.x] Add explicit direction argument to sort functions

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -1123,26 +1123,34 @@ class Arr
      *
      * @param  array<TKey, TValue>  $array
      * @param  int-mask-of<SORT_REGULAR|SORT_NUMERIC|SORT_STRING|SORT_LOCALE_STRING|SORT_NATURAL|SORT_FLAG_CASE>  $options
-     * @param  SortDirection|bool  $descending
+     * @param  SortDirection|bool  $direction
+     * @param  bool  $descending
      * @return array<TKey, TValue>
      */
-    public static function sortRecursive($array, $options = SORT_REGULAR, $descending = false)
+    public static function sortRecursive($array, $options = SORT_REGULAR, $direction = SortDirection::Ascending, bool $descending = false)
     {
+        $direction = match (true) {
+            $descending => SortDirection::Descending,
+            $direction instanceof SortDirection => $direction,
+            $direction => SortDirection::Descending,
+            ! $direction => SortDirection::Ascending,
+        };
+
         foreach ($array as &$value) {
             if (is_array($value)) {
-                $value = static::sortRecursive($value, $options, $descending);
+                $value = static::sortRecursive($value, $options, $direction);
             }
         }
 
         if (! array_is_list($array)) {
-            match ($descending) {
-                false, SortDirection::Ascending => ksort($array, $options),
-                true, SortDirection::Descending => krsort($array, $options),
+            match ($direction) {
+                SortDirection::Ascending => ksort($array, $options),
+                SortDirection::Descending => krsort($array, $options),
             };
         } else {
-            match ($descending) {
-                false, SortDirection::Ascending => sort($array, $options),
-                true, SortDirection::Descending => rsort($array, $options),
+            match ($direction) {
+                SortDirection::Ascending => sort($array, $options),
+                SortDirection::Descending => rsort($array, $options),
             };
         }
 

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1578,14 +1578,22 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      *
      * @param  array<array-key, (callable(TValue, TValue): mixed)|(callable(TValue, TKey): mixed)|string|array{string, string}>|(callable(TValue, TKey): mixed)|string|int  $callback
      * @param  int  $options
-     * @param  SortDirection|bool  $descending
+     * @param  SortDirection|bool  $direction
+     * @param  bool  $descending
      * @return static
      */
-    public function sortBy($callback, $options = SORT_REGULAR, $descending = false)
+    public function sortBy($callback, $options = SORT_REGULAR, $direction = SortDirection::Ascending, bool $descending = false)
     {
         if (is_array($callback) && ! is_callable($callback)) {
             return $this->sortByMany($callback, $options);
         }
+
+        $direction = match (true) {
+            $descending => SortDirection::Descending,
+            $direction instanceof SortDirection => $direction,
+            $direction => SortDirection::Descending,
+            ! $direction => SortDirection::Ascending,
+        };
 
         $results = [];
 
@@ -1598,9 +1606,9 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
             $results[$key] = $callback($value, $key);
         }
 
-        match ($descending) {
-            false, SortDirection::Ascending => asort($results, $options),
-            true, SortDirection::Descending => arsort($results, $options),
+        match ($direction) {
+            SortDirection::Ascending => asort($results, $options),
+            SortDirection::Descending => arsort($results, $options),
         };
 
         // Once we have sorted all of the keys in the array, we will loop through them
@@ -1692,23 +1700,31 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
             }
         }
 
-        return $this->sortBy($callback, $options, true);
+        return $this->sortBy($callback, $options, SortDirection::Descending);
     }
 
     /**
      * Sort the collection keys.
      *
      * @param  int  $options
-     * @param  SortDirection|bool  $descending
+     * @param  SortDirection|bool  $direction
+     * @param  bool  $descending
      * @return static
      */
-    public function sortKeys($options = SORT_REGULAR, $descending = false)
+    public function sortKeys($options = SORT_REGULAR, $direction = SortDirection::Ascending, bool $descending = false)
     {
+        $direction = match (true) {
+            $descending => SortDirection::Descending,
+            $direction instanceof SortDirection => $direction,
+            $direction => SortDirection::Descending,
+            ! $direction => SortDirection::Ascending,
+        };
+
         $items = $this->items;
 
-        match ($descending) {
-            false, SortDirection::Ascending => ksort($items, $options),
-            true, SortDirection::Descending => krsort($items, $options),
+        match ($direction) {
+            SortDirection::Ascending => ksort($items, $options),
+            SortDirection::Descending => krsort($items, $options),
         };
 
         return $this->newInstance($items);

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -13,6 +13,7 @@ use Illuminate\Support\Traits\EnumeratesValues;
 use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
 use IteratorAggregate;
+use SortDirection;
 use stdClass;
 use Traversable;
 
@@ -1508,9 +1509,12 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
 
     /**
      * {@inheritDoc}
+     *
+     * @param  SortDirection|bool  $direction
+     * @param  bool  $descending
      */
     #[\Override]
-    public function sortBy($callback, $options = SORT_REGULAR, $descending = false)
+    public function sortBy($callback, $options = SORT_REGULAR, $direction = SortDirection::Ascending, bool $descending = false)
     {
         return $this->passthru(__FUNCTION__, func_get_args());
     }
@@ -1526,9 +1530,12 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
 
     /**
      * {@inheritDoc}
+     *
+     * @param  SortDirection|bool  $direction
+     * @param  bool  $descending
      */
     #[\Override]
-    public function sortKeys($options = SORT_REGULAR, $descending = false)
+    public function sortKeys($options = SORT_REGULAR, $direction = SortDirection::Ascending, bool $descending = false)
     {
         return $this->passthru(__FUNCTION__, func_get_args());
     }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -11,6 +11,7 @@ use Illuminate\Support\MultipleItemsFoundException;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
+use SortDirection;
 use stdClass;
 use WeakMap;
 
@@ -1521,6 +1522,19 @@ class SupportArrTest extends TestCase
         ];
 
         $this->assertEquals($expect, Arr::sortRecursive($array));
+
+        $array = [
+            10 => ['bar', 'foo'],
+            20 => [0, 1, 2],
+        ];
+
+        $expect = [
+            20 => [2, 1, 0],
+            10 => ['foo', 'bar'],
+        ];
+
+        $this->assertEquals($expect, Arr::sortRecursive($array, descending: true));
+        $this->assertEquals($expect, Arr::sortRecursive($array, direction: SortDirection::Descending));
     }
 
     public function testSortRecursiveDesc()

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2069,6 +2069,24 @@ class SupportCollectionTest extends TestCase
             function ($x) {
                 return $x;
             },
+            descending: true);
+
+        $this->assertEquals(['taylor', 'dayle'], array_values($data->all()));
+
+        $data = new $collection(['dayle', 'taylor']);
+        $data = $data->sortBy(
+            function ($x) {
+                return $x;
+            },
+            direction: SortDirection::Descending);
+
+        $this->assertEquals(['taylor', 'dayle'], array_values($data->all()));
+
+        $data = new $collection(['dayle', 'taylor']);
+        $data = $data->sortBy(
+            function ($x) {
+                return $x;
+            },
             SORT_REGULAR,
             SortDirection::Descending);
 
@@ -2268,6 +2286,14 @@ class SupportCollectionTest extends TestCase
         $data = new $collection(['b' => 'dayle', 'a' => 'taylor']);
 
         $this->assertSame(['a' => 'taylor', 'b' => 'dayle'], $data->sortKeys()->all());
+
+        $data = new $collection(['a' => 'taylor', 'b' => 'dayle']);
+
+        $this->assertSame(['b' => 'dayle', 'a' => 'taylor'], $data->sortKeys(descending: true)->all());
+
+        $data = new $collection(['a' => 'taylor', 'b' => 'dayle']);
+
+        $this->assertSame(['b' => 'dayle', 'a' => 'taylor'], $data->sortKeys(direction: SortDirection::Descending)->all());
     }
 
     #[DataProvider('collectionClassProvider')]


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
As per #59859 it is possible to use the new `SortDirection` enum in various array and collection sorters. This is however limited to a last parameter, with another optional parameter before it, so that one might prefer using named arguments to leverage this. However, the argument name is still `descending` to keep supporting legacy syntaxes. Thus this results in using `descending: SortDirection::Descending` as argument which looks a bit weird to me. Moreover, if one wants to explicitly define sort directions for style purposes, this would require `descending: SortDirection::Ascending` which looks even weirder.

This PR aims to rename the argument in a backwards compatible manner, to support new improved readable syntaxes. This also allows for more easily deprecating behaviors in the future, if migrating towards a single solution would be preferable at some point.

### Old valid syntaxes (unchanged)

```php
$collection->sortBy($callback, SORT_REGULAR, true);
$collection->sortBy($callback, descending: true);
$collection->sortBy($callback, descending: SortDirection::Descending);
```

### New valid syntax
```php
$collection->sortBy($callback, direction: SortDirection::Descending);
$collection->sortBy($callback, direction: SortDirection::Ascending);
```

### Notes

- This is very much a stylistic preference of my own, with some additional overhead, so that's a definite con.
- If booleans will remain supported forever, then the problem is much less of a problem, as one can just happily keep using `descending: true`.
- If code deduplication is much preferable, the "direction+descending" combining function could be extracted to some universal (internal) helper.