### PR TITLE
[13.x] Prefer `match` operator over if-else chains

### DIFF
--- a/src/Illuminate/Auth/DatabaseUserProvider.php
+++ b/src/Illuminate/Auth/DatabaseUserProvider.php
@@ -115,13 +115,11 @@ class DatabaseUserProvider implements UserProvider
         $query = $this->connection->table($this->table);
 
         foreach ($credentials as $key => $value) {
-            if (is_array($value) || $value instanceof Arrayable) {
-                $query->whereIn($key, $value);
-            } elseif ($value instanceof Closure) {
-                $value($query);
-            } else {
-                $query->where($key, $value);
-            }
+            match (true) {
+                is_array($value) || $value instanceof Arrayable => $query->whereIn($key, $value),
+                $value instanceof Closure => $value($query),
+                default => $query->where($key, $value),
+            };
         }
 
         // Now we are ready to execute the query to see if we have a user matching

--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -126,13 +126,11 @@ class EloquentUserProvider implements UserProvider
         $query = $this->newModelQuery();
 
         foreach ($credentials as $key => $value) {
-            if (is_array($value) || $value instanceof Arrayable) {
-                $query->whereIn($key, $value);
-            } elseif ($value instanceof Closure) {
-                $value($query);
-            } else {
-                $query->where($key, $value);
-            }
+            match (true) {
+                is_array($value) || $value instanceof Arrayable => $query->whereIn($key, $value),
+                $value instanceof Closure => $value($query),
+                default => $query->where($key, $value),
+            };
         }
 
         return $query->first();

--- a/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php
@@ -84,11 +84,11 @@ abstract class Broadcaster implements BroadcasterContract
      */
     public function channel($channel, $callback, $options = [])
     {
-        if ($channel instanceof HasBroadcastChannel) {
-            $channel = $channel->broadcastChannelRoute();
-        } elseif (is_string($channel) && class_exists($channel) && is_a($channel, HasBroadcastChannel::class, true)) {
-            $channel = (new $channel)->broadcastChannelRoute();
-        }
+        $channel = match (true) {
+            $channel instanceof HasBroadcastChannel => $channel->broadcastChannelRoute(),
+            is_string($channel) && class_exists($channel) && is_a($channel, HasBroadcastChannel::class, true) => (new $channel)->broadcastChannelRoute(),
+            default => $channel,
+        };
 
         $this->channels[$channel] = $callback;
 
@@ -158,13 +158,11 @@ abstract class Broadcaster implements BroadcasterContract
      */
     protected function extractParameters($callback)
     {
-        if (is_callable($callback)) {
-            return (new ReflectionFunction($callback))->getParameters();
-        } elseif (is_string($callback)) {
-            return $this->extractParametersFromClass($callback);
-        }
-
-        throw new Exception('Given channel handler is an unknown type.');
+        return match (true) {
+            is_callable($callback) => (new ReflectionFunction($callback))->getParameters(),
+            is_string($callback) => $this->extractParametersFromClass($callback),
+            default => throw new Exception('Given channel handler is an unknown type.'),
+        };
     }
 
     /**

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -406,11 +406,11 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
             return $this->newInstance($this->items);
         }
 
-        if ($keys instanceof Enumerable) {
-            $keys = $keys->all();
-        } elseif (! is_array($keys)) {
-            $keys = func_get_args();
-        }
+        $keys = match (true) {
+            $keys instanceof Enumerable => $keys->all(),
+            is_array($keys) => $keys,
+            default => func_get_args(),
+        };
 
         return $this->newInstance(Arr::except($this->items, $keys));
     }

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -46,17 +46,14 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      */
     public function __construct($source = null)
     {
-        if ($source instanceof Closure || $source instanceof self) {
-            $this->source = $source;
-        } elseif (is_null($source)) {
-            $this->source = static::empty();
-        } elseif ($source instanceof Generator) {
-            throw new InvalidArgumentException(
+        $this->source = match (true) {
+            $source instanceof Closure || $source instanceof self => $source,
+            $source === null => static::empty(),
+            $source instanceof Generator => throw new InvalidArgumentException(
                 'Generators should not be passed directly to LazyCollection. Instead, pass a generator function.'
-            );
-        } else {
-            $this->source = $this->getArrayableItems($source);
-        }
+            ),
+            default => $this->getArrayableItems($source),
+        };
     }
 
     /**
@@ -495,13 +492,11 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     {
         $instance = new static(function () use ($depth) {
             foreach ($this as $item) {
-                if (! is_array($item) && ! $item instanceof Enumerable) {
-                    yield $item;
-                } elseif ($depth === 1) {
-                    yield from $item;
-                } else {
-                    yield from (new static($item))->flatten($depth - 1);
-                }
+                yield from match (true) {
+                    ! is_array($item) && ! $item instanceof Enumerable => [$item],
+                    $depth === 1 => $item,
+                    default => (new static($item))->flatten($depth - 1),
+                };
             }
         });
 

--- a/src/Illuminate/Conditionable/Traits/Conditionable.php
+++ b/src/Illuminate/Conditionable/Traits/Conditionable.php
@@ -30,13 +30,11 @@ trait Conditionable
             return (new HigherOrderWhenProxy($this))->condition($value);
         }
 
-        if ($value) {
-            return $callback($this, $value) ?? $this;
-        } elseif ($default) {
-            return $default($this, $value) ?? $this;
-        }
-
-        return $this;
+        return match (true) {
+            (bool) $value => $callback($this, $value) ?? $this,
+            $default !== null => $default($this, $value) ?? $this,
+            default => $this,
+        };
     }
 
     /**
@@ -62,12 +60,10 @@ trait Conditionable
             return (new HigherOrderWhenProxy($this))->condition(! $value);
         }
 
-        if (! $value) {
-            return $callback($this, $value) ?? $this;
-        } elseif ($default) {
-            return $default($this, $value) ?? $this;
-        }
-
-        return $this;
+        return match (true) {
+            ! $value => $callback($this, $value) ?? $this,
+            $default !== null => $default($this, $value) ?? $this,
+            default => $this,
+        };
     }
 }

--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -436,13 +436,11 @@ trait InteractsWithIO
     {
         $level ??= '';
 
-        if (isset($this->verbosityMap[$level])) {
-            $level = $this->verbosityMap[$level];
-        } elseif (! is_int($level)) {
-            $level = $this->verbosity;
-        }
-
-        return $level;
+        return match (true) {
+            isset($this->verbosityMap[$level]) => $this->verbosityMap[$level],
+            is_int($level) => $level,
+            default => $this->verbosity,
+        };
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -379,21 +379,14 @@ class Schedule
      */
     public function compileArrayInput($key, $value)
     {
-        $value = (new Collection($value))->map(function ($value) {
-            return ProcessUtils::escapeArgument($value);
-        });
-
-        if (str_starts_with($key, '--')) {
-            $value = $value->map(function ($value) use ($key) {
-                return "{$key}={$value}";
-            });
-        } elseif (str_starts_with($key, '-')) {
-            $value = $value->map(function ($value) use ($key) {
-                return "{$key} {$value}";
-            });
-        }
-
-        return $value->implode(' ');
+        return (new Collection($value))
+            ->map(static fn ($subValue) => ProcessUtils::escapeArgument($subValue))
+            ->map(static fn ($subValue) => match (true) {
+                str_starts_with($key, '--') => "{$key}={$subValue}",
+                str_starts_with($key, '-') => "{$key} {$subValue}",
+                default => $subValue,
+            })
+            ->implode(' ');
     }
 
     /**

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -322,13 +322,11 @@ class Container implements ArrayAccess, ContainerContract
             return $this->checkedForSingletonOrScopedAttributes[$className] = null;
         }
 
-        $type = null;
-
-        if (! empty($reflection->getAttributes(Singleton::class))) {
-            $type = 'singleton';
-        } elseif (! empty($reflection->getAttributes(Scoped::class))) {
-            $type = 'scoped';
-        }
+        $type = match (true) {
+            $reflection->getAttributes(Singleton::class) !== [] => 'singleton',
+            $reflection->getAttributes(Scoped::class) !== [] => 'scoped',
+            default => null,
+        };
 
         return $this->checkedForSingletonOrScopedAttributes[$className] = $type;
     }

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -760,11 +760,11 @@ class Connection implements ConnectionInterface
             // We need to transform all instances of DateTimeInterface into the actual
             // date string. Each query grammar maintains its own date string format
             // so we'll just ask the grammar for the format to get from the date.
-            if ($value instanceof DateTimeInterface) {
-                $bindings[$key] = $value->format($grammar->getDateFormat());
-            } elseif (is_bool($value)) {
-                $bindings[$key] = (int) $value;
-            }
+            $bindings[$key] = match (true) {
+                $value instanceof DateTimeInterface => $value->format($grammar->getDateFormat()),
+                is_bool($value) => (int) $value,
+                default => $value,
+            };
         }
 
         return $bindings;

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -1149,17 +1149,7 @@ class Connection implements ConnectionInterface
      */
     public function escape($value, $binary = false)
     {
-        if ($value === null) {
-            return 'null';
-        } elseif ($binary) {
-            return $this->escapeBinary($value);
-        } elseif (is_int($value) || is_float($value)) {
-            return (string) $value;
-        } elseif (is_bool($value)) {
-            return $this->escapeBool($value);
-        } elseif (is_array($value)) {
-            throw new RuntimeException('The database connection does not support escaping arrays.');
-        } else {
+        $escapeString = function (string $value) {
             if (str_contains($value, "\00")) {
                 throw new RuntimeException('Strings with null bytes cannot be escaped. Use the binary escape option.');
             }
@@ -1169,7 +1159,16 @@ class Connection implements ConnectionInterface
             }
 
             return $this->escapeString($value);
-        }
+        };
+
+        return match (true) {
+            $value === null => 'null',
+            $binary => $this->escapeBinary($value),
+            is_int($value) || is_float($value) => (string) $value,
+            is_bool($value) => $this->escapeBool($value),
+            is_array($value) => throw new RuntimeException('The database connection does not support escaping arrays.'),
+            default => $escapeString($value),
+        };
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -887,13 +887,11 @@ class Collection extends BaseCollection implements QueueableCollection
 
         $relations = $this->map->getQueueableRelations()->all();
 
-        if (count($relations) === 0 || $relations === [[]]) {
-            return [];
-        } elseif (count($relations) === 1) {
-            return reset($relations);
-        } else {
-            return array_intersect(...array_values($relations));
-        }
+        return match (true) {
+            $relations === [] || $relations === [[]] => [],
+            count($relations) === 1 => reset($relations),
+            default => array_intersect(...array_values($relations)),
+        };
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -978,17 +978,13 @@ trait HasAttributes
             return static::$castTypeCache[$castType];
         }
 
-        if ($this->isCustomDateTimeCast($castType)) {
-            $convertedCastType = 'custom_datetime';
-        } elseif ($this->isImmutableCustomDateTimeCast($castType)) {
-            $convertedCastType = 'immutable_custom_datetime';
-        } elseif ($this->isDecimalCast($castType)) {
-            $convertedCastType = 'decimal';
-        } elseif (class_exists($castType)) {
-            $convertedCastType = $castType;
-        } else {
-            $convertedCastType = trim(strtolower($castType));
-        }
+        $convertedCastType = match (true) {
+            $this->isCustomDateTimeCast($castType) => 'custom_datetime',
+            $this->isImmutableCustomDateTimeCast($castType) => 'immutable_custom_datetime',
+            $this->isDecimalCast($castType) => 'decimal',
+            class_exists($castType) => $castType,
+            default => trim(strtolower($castType)),
+        };
 
         return static::$castTypeCache[$castType] = $convertedCastType;
     }
@@ -1293,15 +1289,13 @@ trait HasAttributes
     {
         $enumClass = $this->getCasts()[$key];
 
-        if (! isset($value)) {
-            $this->attributes[$key] = null;
-        } elseif (is_object($value)) {
-            $this->attributes[$key] = $this->getStorableEnumValue($enumClass, $value);
-        } else {
-            $this->attributes[$key] = $this->getStorableEnumValue(
+        $this->attributes[$key] = match (true) {
+            ! isset($value) => null,
+            is_object($value) => $this->getStorableEnumValue($enumClass, $value),
+            default => $this->getStorableEnumValue(
                 $enumClass, $this->getEnumCaseFromValue($enumClass, $value)
-            );
-        }
+            ),
+        };
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasGlobalScopes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasGlobalScopes.php
@@ -62,17 +62,13 @@ trait HasGlobalScopes
      */
     public static function addGlobalScope($scope, $implementation = null)
     {
-        if (is_string($scope) && ($implementation instanceof Closure || $implementation instanceof Scope)) {
-            return static::$globalScopes[static::class][$scope] = $implementation;
-        } elseif ($scope instanceof Closure) {
-            return static::$globalScopes[static::class][spl_object_hash($scope)] = $scope;
-        } elseif ($scope instanceof Scope) {
-            return static::$globalScopes[static::class][get_class($scope)] = $scope;
-        } elseif (is_string($scope) && class_exists($scope) && is_subclass_of($scope, Scope::class)) {
-            return static::$globalScopes[static::class][$scope] = new $scope;
-        }
-
-        throw new InvalidArgumentException('Global scope must be an instance of Closure or Scope or be a class name of a class extending '.Scope::class);
+        return match (true) {
+            is_string($scope) && ($implementation instanceof Closure || $implementation instanceof Scope) => static::$globalScopes[static::class][$scope] = $implementation,
+            $scope instanceof Closure => static::$globalScopes[static::class][spl_object_hash($scope)] = $scope,
+            $scope instanceof Scope => static::$globalScopes[static::class][get_class($scope)] = $scope,
+            is_string($scope) && class_exists($scope) && is_subclass_of($scope, Scope::class) => static::$globalScopes[static::class][$scope] = new $scope,
+            default => throw new InvalidArgumentException('Global scope must be an instance of Closure or Scope or be a class name of a class extending '.Scope::class),
+        };
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
@@ -32,13 +32,12 @@ trait HasTimestamps
     #[Initialize]
     public function initializeHasTimestamps()
     {
-        if ($this->timestamps === true) {
-            if (static::resolveClassAttribute(WithoutTimestamps::class) !== null) {
-                $this->timestamps = false;
-            } elseif (($table = static::resolveClassAttribute(Table::class)) && $table->timestamps !== null) {
-                $this->timestamps = $table->timestamps;
-            }
-        }
+        $this->timestamps = match (true) {
+            $this->timestamps !== true => false,
+            static::resolveClassAttribute(WithoutTimestamps::class) !== null => false,
+            ($timestamps = static::resolveClassAttribute(Table::class)?->timestamps) !== null => $timestamps,
+            default => true,
+        };
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -581,20 +581,13 @@ abstract class Factory
     protected function expandAttributes(array $definition)
     {
         return (new Collection($definition))
-            ->map($evaluateRelations = function ($attribute, $key) {
-                if (! $this->expandRelationships && $attribute instanceof self) {
-                    $attribute = null;
-                } elseif ($attribute instanceof self &&
-                    array_intersect([$attribute->modelName(), $key], $this->excludeRelationships)) {
-                    $attribute = null;
-                } elseif ($attribute instanceof self) {
-                    $attribute = $this->getRandomRecycledModel($attribute->modelName())?->getKey()
-                        ?? $attribute->recycle($this->recycle)->create()->getKey();
-                } elseif ($attribute instanceof Model) {
-                    $attribute = $attribute->getKey();
-                }
-
-                return $attribute;
+            ->map($evaluateRelations = fn ($attribute, $key) => match (true) {
+                ! $this->expandRelationships && $attribute instanceof self => null,
+                $attribute instanceof self && array_intersect([$attribute->modelName(), $key], $this->excludeRelationships) => null,
+                $attribute instanceof self => $this->getRandomRecycledModel($attribute->modelName())?->getKey()
+                    ?? $attribute->recycle($this->recycle)->create()->getKey(),
+                $attribute instanceof Model => $attribute->getKey(),
+                default => $attribute,
             })
             ->map(function ($attribute, $key) use (&$definition, $evaluateRelations) {
                 if (is_callable($attribute) && ! is_string($attribute) && ! is_array($attribute)) {

--- a/src/Illuminate/Database/Eloquent/ModelInspector.php
+++ b/src/Illuminate/Database/Eloquent/ModelInspector.php
@@ -126,14 +126,10 @@ class ModelInspector
                     || $method->isAbstract()
                     || $method->getDeclaringClass()->getName() === Model::class
             )
-            ->mapWithKeys(function (ReflectionMethod $method) use ($model) {
-                if (preg_match('/^get(.+)Attribute$/', $method->getName(), $matches) === 1) {
-                    return [Str::snake($matches[1]) => 'accessor'];
-                } elseif ($model->hasAttributeMutator($method->getName())) {
-                    return [Str::snake($method->getName()) => 'attribute'];
-                } else {
-                    return [];
-                }
+            ->mapWithKeys(static fn (ReflectionMethod $method) => match (true) {
+                preg_match('/^get(.+)Attribute$/', $method->getName(), $matches) === 1 => [Str::snake($matches[1]) => 'accessor'],
+                $model->hasAttributeMutator($method->getName()) => [Str::snake($method->getName()) => 'attribute'],
+                default => [],
             })
             ->reject(fn ($cast, $name) => (new BaseCollection($columns))->contains('name', $name))
             ->map(fn ($cast, $name) => [

--- a/src/Illuminate/Database/Migrations/MigrationCreator.php
+++ b/src/Illuminate/Database/Migrations/MigrationCreator.php
@@ -111,19 +111,17 @@ class MigrationCreator
      */
     protected function getStub($table, $create)
     {
-        if (is_null($table)) {
-            $stub = $this->files->exists($customPath = $this->customStubPath.'/migration.stub')
+        $stub = match (true) {
+            $table === null => $this->files->exists($customPath = $this->customStubPath.'/migration.stub')
                 ? $customPath
-                : $this->stubPath().'/migration.stub';
-        } elseif ($create) {
-            $stub = $this->files->exists($customPath = $this->customStubPath.'/migration.create.stub')
+                : $this->stubPath().'/migration.stub',
+            $create => $this->files->exists($customPath = $this->customStubPath.'/migration.create.stub')
                 ? $customPath
-                : $this->stubPath().'/migration.create.stub';
-        } else {
-            $stub = $this->files->exists($customPath = $this->customStubPath.'/migration.update.stub')
+                : $this->stubPath().'/migration.create.stub',
+            default => $this->files->exists($customPath = $this->customStubPath.'/migration.update.stub')
                 ? $customPath
-                : $this->stubPath().'/migration.update.stub';
-        }
+                : $this->stubPath().'/migration.update.stub',
+        };
 
         return $this->files->get($stub);
     }

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1537,13 +1537,11 @@ class Blueprint
      */
     public function morphs($name, $indexName = null, $after = null)
     {
-        if (Builder::$defaultMorphKeyType === 'uuid') {
-            $this->uuidMorphs($name, $indexName, $after);
-        } elseif (Builder::$defaultMorphKeyType === 'ulid') {
-            $this->ulidMorphs($name, $indexName, $after);
-        } else {
-            $this->numericMorphs($name, $indexName, $after);
-        }
+        match (Builder::$defaultMorphKeyType) {
+            'uuid' => $this->uuidMorphs($name, $indexName, $after),
+            'ulid' => $this->ulidMorphs($name, $indexName, $after),
+            default => $this->numericMorphs($name, $indexName, $after),
+        };
     }
 
     /**
@@ -1556,13 +1554,11 @@ class Blueprint
      */
     public function nullableMorphs($name, $indexName = null, $after = null)
     {
-        if (Builder::$defaultMorphKeyType === 'uuid') {
-            $this->nullableUuidMorphs($name, $indexName, $after);
-        } elseif (Builder::$defaultMorphKeyType === 'ulid') {
-            $this->nullableUlidMorphs($name, $indexName, $after);
-        } else {
-            $this->nullableNumericMorphs($name, $indexName, $after);
-        }
+        match (Builder::$defaultMorphKeyType) {
+            'uuid' => $this->nullableUuidMorphs($name, $indexName, $after),
+            'ulid' => $this->nullableUlidMorphs($name, $indexName, $after),
+            default => $this->nullableNumericMorphs($name, $indexName, $after),
+        };
     }
 
     /**

--- a/src/Illuminate/Database/SqlServerConnection.php
+++ b/src/Illuminate/Database/SqlServerConnection.php
@@ -94,13 +94,12 @@ class SqlServerConnection extends Connection
      */
     protected function parseUniqueConstraintViolation(Exception $exception): array
     {
-        $index = null;
-
-        if (preg_match('#with unique index \'([^\']+)\'#i', $message = $exception->getMessage(), $matches)) {
-            $index = $matches[1];
-        } elseif (preg_match('#Violation of [A-Z ]+ constraint \'([^\']+)\'#i', $message, $matches)) {
-            $index = $matches[1];
-        }
+        $message = $exception->getMessage();
+        $index = match (true) {
+            preg_match('#with unique index \'([^\']+)\'#i', $message, $matches) === 1 => $matches[1],
+            preg_match('#Violation of [A-Z ]+ constraint \'([^\']+)\'#i', $message, $matches) === 1 => $matches[1],
+            default => null,
+        };
 
         return ['columns' => [], 'index' => $index];
     }

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -736,17 +736,13 @@ class FilesystemAdapter implements CloudFilesystemContract
 
         $adapter = $this->adapter;
 
-        if (method_exists($adapter, 'getUrl')) {
-            return $adapter->getUrl($path);
-        } elseif (method_exists($this->driver, 'getUrl')) {
-            return $this->driver->getUrl($path);
-        } elseif ($adapter instanceof FtpAdapter || $adapter instanceof SftpAdapter) {
-            return $this->getFtpUrl($path);
-        } elseif ($adapter instanceof LocalAdapter) {
-            return $this->getLocalUrl($path);
-        } else {
-            throw new RuntimeException('This driver does not support retrieving URLs.');
-        }
+        return match (true) {
+            method_exists($adapter, 'getUrl') => $adapter->getUrl($path),
+            method_exists($this->driver, 'getUrl') => $this->driver->getUrl($path),
+            $adapter instanceof FtpAdapter || $adapter instanceof SftpAdapter => $this->getFtpUrl($path),
+            $adapter instanceof LocalAdapter => $this->getLocalUrl($path),
+            default => throw new RuntimeException('This driver does not support retrieving URLs.'),
+        };
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -2130,17 +2130,13 @@ trait ValidatesAttributes
      */
     public function validateRequired($attribute, $value)
     {
-        if (is_null($value)) {
-            return false;
-        } elseif (is_string($value) && trim($value) === '') {
-            return false;
-        } elseif (is_countable($value) && count($value) < 1) {
-            return false;
-        } elseif ($value instanceof File) {
-            return (string) $value->getPath() !== '';
-        }
-
-        return true;
+        return match (true) {
+            $value === null => false,
+            is_string($value) => trim($value) !== '',
+            is_countable($value) => count($value) > 0,
+            $value instanceof File => (string) $value->getPath() !== '',
+            default => true,
+        };
     }
 
     /**
@@ -2781,15 +2777,12 @@ trait ValidatesAttributes
         // return the proper size accordingly. If it is a number, then number itself
         // is the size. If it is a file, we take kilobytes, and for a string the
         // entire length of the string will be considered the attribute size.
-        if (is_numeric($value) && $hasNumeric) {
-            return (string) $this->ensureExponentWithinAllowedRange($attribute, $this->trim($value));
-        } elseif (is_array($value)) {
-            return count($value);
-        } elseif ($value instanceof File) {
-            return (string) ($value->getSize() / 1024);
-        }
-
-        return mb_strlen($value ?? '');
+        return match (true) {
+            is_numeric($value) && $hasNumeric => (string) $this->ensureExponentWithinAllowedRange($attribute, $this->trim($value)),
+            is_array($value) => count($value),
+            $value instanceof File => (string) ($value->getSize() / 1024),
+            default => mb_strlen($value ?? ''),
+        };
     }
 
     /**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -527,13 +527,11 @@ class Validator implements ValidatorContract
      */
     public function whenPasses(callable $callback, ?callable $default = null)
     {
-        if ($this->passes()) {
-            return $callback($this) ?? $this;
-        } elseif ($default) {
-            return $default($this) ?? $this;
-        }
-
-        return $this;
+        return match (true) {
+            $this->passes() => $callback($this) ?? $this,
+            $default !== null => $default($this) ?? $this,
+            default => $this,
+        };
     }
 
     /**

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -369,16 +369,14 @@ class BladeCompiler extends Compiler implements CompilerInterface
 
         $view = value($component->resolveView(), $data);
 
-        if ($view instanceof View) {
-            return $view->with($data)->render();
-        } elseif ($view instanceof Htmlable) {
-            return $view->toHtml();
-        } else {
-            return Container::getInstance()
+        return match (true) {
+            $view instanceof View => $view->with($data)->render(),
+            $view instanceof Htmlable => $view->toHtml(),
+            default => Container::getInstance()
                 ->make(ViewFactory::class)
                 ->make($view, $data)
-                ->render();
-        }
+                ->render(),
+        };
     }
 
     /**

--- a/src/Illuminate/View/Concerns/ManagesComponents.php
+++ b/src/Illuminate/View/Concerns/ManagesComponents.php
@@ -95,13 +95,11 @@ trait ManagesComponents
         try {
             $view = value($view, $data);
 
-            if ($view instanceof View) {
-                return $view->with($data)->render();
-            } elseif ($view instanceof Htmlable) {
-                return $view->toHtml();
-            } else {
-                return $this->make($view, $data)->render();
-            }
+            return match (true) {
+                $view instanceof View => $view->with($data)->render(),
+                $view instanceof Htmlable => $view->toHtml(),
+                default => $this->make($view, $data)->render(),
+            };
         } finally {
             $this->currentComponentData = $previousComponentData;
         }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
To improve code readability, this MR changes various if-else chains to use a `match` operator instead, which allows for more consise syntax and more clearly illustrates the goal of the related code.