### PR TITLE
Improve docblock wording in AurthorizationException

### DIFF
--- a/src/Illuminate/Auth/Access/AuthorizationException.php
+++ b/src/Illuminate/Auth/Access/AuthorizationException.php
@@ -8,7 +8,7 @@ use Throwable;
 class AuthorizationException extends Exception
 {
     /**
-     * The response from the gate.
+     * The authorization response returned by the gate.
      *
      * @var \Illuminate\Auth\Access\Response
      */


### PR DESCRIPTION
This PR improves the wording of a docblock in the AuthorizationException class for better clarity.

No functional changes have been made.