### PR TITLE
[13.x] Return null from failed job providers when payload cannot be decoded

### DIFF
--- a/src/Illuminate/Queue/Failed/DatabaseUuidFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseUuidFailedJobProvider.php
@@ -54,8 +54,14 @@ class DatabaseUuidFailedJobProvider implements CountableFailedJobProvider, Faile
      */
     public function log($connection, $queue, $payload, $exception)
     {
+        $uuid = json_decode($payload, true)['uuid'] ?? null;
+
+        if ($uuid === null) {
+            return null;
+        }
+
         $this->getTable()->insert([
-            'uuid' => $uuid = json_decode($payload, true)['uuid'],
+            'uuid' => $uuid,
             'connection' => $connection,
             'queue' => $queue,
             'payload' => $payload,

--- a/src/Illuminate/Queue/Failed/DynamoDbFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DynamoDbFailedJobProvider.php
@@ -57,7 +57,11 @@ class DynamoDbFailedJobProvider implements FailedJobProviderInterface
      */
     public function log($connection, $queue, $payload, $exception)
     {
-        $id = json_decode($payload, true)['uuid'];
+        $id = json_decode($payload, true)['uuid'] ?? null;
+
+        if ($id === null) {
+            return null;
+        }
 
         $failedAt = Date::now();
 

--- a/src/Illuminate/Queue/Failed/FileFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/FileFailedJobProvider.php
@@ -56,7 +56,11 @@ class FileFailedJobProvider implements CountableFailedJobProvider, FailedJobProv
     public function log($connection, $queue, $payload, $exception)
     {
         return $this->lock(function () use ($connection, $queue, $payload, $exception) {
-            $id = json_decode($payload, true)['uuid'];
+            $id = json_decode($payload, true)['uuid'] ?? null;
+
+            if ($id === null) {
+                return null;
+            }
 
             $jobs = $this->read();
 

--- a/tests/Queue/DatabaseUuidFailedJobProviderTest.php
+++ b/tests/Queue/DatabaseUuidFailedJobProviderTest.php
@@ -178,6 +178,15 @@ class DatabaseUuidFailedJobProviderTest extends TestCase
         $this->assertSame(2, $provider->count('connection-2', 'queue-1'));
     }
 
+    public function testCorruptedPayloadReturnsNull()
+    {
+        $provider = $this->getFailedJobProvider();
+
+        $result = $provider->log('database', 'queue', 'not-valid-json', new RuntimeException('Something went wrong.'));
+
+        $this->assertNull($result);
+    }
+
     protected function getFailedJobProvider(string $database = 'default', string $table = 'failed_jobs')
     {
         $db = new DB;

--- a/tests/Queue/DynamoDbFailedJobProviderTest.php
+++ b/tests/Queue/DynamoDbFailedJobProviderTest.php
@@ -170,4 +170,15 @@ class DynamoDbFailedJobProviderTest extends TestCase
 
         $provider->forget('id');
     }
+
+    public function testCorruptedPayloadReturnsNull()
+    {
+        $dynamoDbClient = m::mock(DynamoDbClient::class);
+
+        $provider = new DynamoDbFailedJobProvider($dynamoDbClient, 'application', 'table');
+
+        $result = $provider->log('connection', 'queue', 'not-valid-json', new Exception('Something went wrong.'));
+
+        $this->assertNull($result);
+    }
 }

--- a/tests/Queue/FileFailedJobProviderTest.php
+++ b/tests/Queue/FileFailedJobProviderTest.php
@@ -157,6 +157,14 @@ class FileFailedJobProviderTest extends TestCase
         $this->assertCount(2, $failedJobs);
     }
 
+    public function testCorruptedPayloadReturnsNull()
+    {
+        $result = $this->provider->log('connection', 'queue', 'not-valid-json', new Exception('Something went wrong.'));
+
+        $this->assertNull($result);
+        $this->assertEmpty($this->provider->all());
+    }
+
     public function testEmptyFailedJobsByDefault()
     {
         $failedJobs = $this->provider->all();


### PR DESCRIPTION
If a job's payload is corrupted (truncated, invalid JSON, etc.), `json_decode()` returns `null`. All three UUID-based failed job providers then do `null['uuid']`, which PHP 8 handles as a warning and returns null — but the code then tries to store a null UUID into the database, invoke DynamoDB with a null key, or write the job to the file with a null id. The failure record ends up lost or broken.

The fix is the same in all three providers: extract the UUID first with a null-safe fallback, and return `null` early if the payload can't be decoded. The non-UUID `DatabaseFailedJobProvider` is not affected since it stores the raw payload without parsing.

Fixes #59635.