### PR TITLE
[13.x] Match processInsertGetId @return to int|string

### DIFF
--- a/src/Illuminate/Database/Query/Processors/MySqlProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/MySqlProcessor.php
@@ -28,7 +28,7 @@ class MySqlProcessor extends Processor
      * @param  string  $sql
      * @param  array  $values
      * @param  string|null  $sequence
-     * @return int
+     * @return int|string
      */
     public function processInsertGetId(Builder $query, $sql, $values, $sequence = null)
     {

--- a/src/Illuminate/Database/Query/Processors/PostgresProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/PostgresProcessor.php
@@ -13,7 +13,7 @@ class PostgresProcessor extends Processor
      * @param  string  $sql
      * @param  array  $values
      * @param  string|null  $sequence
-     * @return int
+     * @return int|string
      */
     public function processInsertGetId(Builder $query, $sql, $values, $sequence = null)
     {

--- a/src/Illuminate/Database/Query/Processors/Processor.php
+++ b/src/Illuminate/Database/Query/Processors/Processor.php
@@ -25,7 +25,7 @@ class Processor
      * @param  string  $sql
      * @param  array  $values
      * @param  string|null  $sequence
-     * @return int
+     * @return int|string
      */
     public function processInsertGetId(Builder $query, $sql, $values, $sequence = null)
     {

--- a/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
@@ -15,7 +15,7 @@ class SqlServerProcessor extends Processor
      * @param  string  $sql
      * @param  array  $values
      * @param  string|null  $sequence
-     * @return int
+     * @return int|string
      */
     public function processInsertGetId(Builder $query, $sql, $values, $sequence = null)
     {


### PR DESCRIPTION
All four `processInsertGetId()` implementations end with `return is_numeric($id) ? (int) $id : $id;`, so a non-numeric id (e.g. UUID, snowflake) is returned as `string`. The base `Processor` and the MySQL, Postgres, and SQL Server overrides all annotate `@return int`, which is too narrow. Aligning with what the implementations actually return.