### PR TITLE
[13.x] Add collation to processColumns and getColumns return shape

### DIFF
--- a/src/Illuminate/Database/Query/Processors/Processor.php
+++ b/src/Illuminate/Database/Query/Processors/Processor.php
@@ -113,7 +113,7 @@ class Processor
      * Process the results of a columns query.
      *
      * @param  list<array<string, mixed>>  $results
-     * @return list<array{name: string, type: string, type_name: string, nullable: bool, default: mixed, auto_increment: bool, comment: string|null, generation: array{type: string, expression: string|null}|null}>
+     * @return list<array{name: string, type: string, type_name: string, collation: string|null, nullable: bool, default: mixed, auto_increment: bool, comment: string|null, generation: array{type: string, expression: string|null}|null}>
      */
     public function processColumns($results)
     {

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -394,7 +394,7 @@ class Builder
      * Get the columns for a given table.
      *
      * @param  string  $table
-     * @return list<array{name: string, type: string, type_name: string, nullable: bool, default: mixed, auto_increment: bool, comment: string|null, generation: array{type: string, expression: string|null}|null}>
+     * @return list<array{name: string, type: string, type_name: string, collation: string|null, nullable: bool, default: mixed, auto_increment: bool, comment: string|null, generation: array{type: string, expression: string|null}|null}>
      */
     public function getColumns($table)
     {


### PR DESCRIPTION
The `Processor::processColumns()` and `Schema\Builder::getColumns()` `@return` shapes don't list `collation`, but every concrete `processColumns()` populates it: MySQL (`MySqlProcessor.php:52`), Postgres (`PostgresProcessor.php:89`), SQL Server (`SqlServerProcessor.php:75`), and SQLite (`SQLiteProcessor.php:37`). The value can be `null` (e.g. non-string columns on MySQL/Postgres/SqlServer, or no `COLLATE` clause on SQLite). Aligning the shape with what the processors actually return.