### PR TITLE
[13.x] Correct Limit::none() @return type to Unlimited

### DIFF
--- a/src/Illuminate/Cache/RateLimiting/Limit.php
+++ b/src/Illuminate/Cache/RateLimiting/Limit.php
@@ -116,7 +116,7 @@ class Limit
     /**
      * Create a new unlimited rate limit.
      *
-     * @return static
+     * @return \Illuminate\Cache\RateLimiting\Unlimited
      */
     public static function none()
     {


### PR DESCRIPTION
`Limit::none()` is annotated `@return static` but always returns a concrete `new Unlimited`, never an instance of the calling class. The sibling factories (`perMinute`, `perHour`, `perDay`, etc.) correctly use `new static(...)` so `@return static` is right for them — only `none()` needed correcting.