### PR TITLE
[13.x] Correct Repository::setStore @return to $this

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -941,7 +941,7 @@ class Repository implements ArrayAccess, CacheContract
      * Set the cache store implementation.
      *
      * @param  \Illuminate\Contracts\Cache\Store  $store
-     * @return static
+     * @return $this
      */
     public function setStore($store)
     {


### PR DESCRIPTION
`Cache\Repository::setStore` is documented `@return static` but the body returns `$this`, not a new instance. Tightening to `@return $this` so static analysis sees the actual instance.