### PR TITLE
[13.x] Mark processViews schema field nullable in @return shape

### DIFF
--- a/src/Illuminate/Database/Query/Processors/Processor.php
+++ b/src/Illuminate/Database/Query/Processors/Processor.php
@@ -82,7 +82,7 @@ class Processor
      * Process the results of a views query.
      *
      * @param  list<array<string, mixed>>  $results
-     * @return list<array{name: string, schema: string, schema_qualified_name: string, definition: string}>
+     * @return list<array{name: string, schema: string|null, schema_qualified_name: string, definition: string}>
      */
     public function processViews($results)
     {


### PR DESCRIPTION
`Processor::processViews()` declares `schema: string` in its array shape, but the body returns `'schema' => $result->schema ?? null` (line 94), so the field is null whenever the underlying query has no `schema` column (e.g. SQLite). Updating the shape to `schema: string|null` to match.