### PR TITLE
[13.x] Tighten getCurrentSchemaListing @return in MySQL and SQLite builders

### DIFF
--- a/src/Illuminate/Database/Schema/MySqlBuilder.php
+++ b/src/Illuminate/Database/Schema/MySqlBuilder.php
@@ -49,7 +49,7 @@ class MySqlBuilder extends Builder
     /**
      * Get the names of current schemas for the connection.
      *
-     * @return string[]|null
+     * @return string[]
      */
     public function getCurrentSchemaListing()
     {

--- a/src/Illuminate/Database/Schema/SQLiteBuilder.php
+++ b/src/Illuminate/Database/Schema/SQLiteBuilder.php
@@ -164,7 +164,7 @@ class SQLiteBuilder extends Builder
     /**
      * Get the names of current schemas for the connection.
      *
-     * @return string[]|null
+     * @return string[]
      */
     public function getCurrentSchemaListing()
     {


### PR DESCRIPTION
Both `MySqlBuilder::getCurrentSchemaListing()` and `SQLiteBuilder::getCurrentSchemaListing()` always return a non-null array (`[$this->connection->getDatabaseName()]` and `['main']`), but their docblocks still say `@return string[]|null`. `PostgresBuilder` already declares `@return string[]`. Aligning the other two with the same.