### PR TITLE
[13.x] Exit worker after too many consecutive getNextJob() failures

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -102,6 +102,13 @@ class Worker
     public $lostConnection = false;
 
     /**
+     * The number of consecutive times the worker failed to retrieve a job.
+     *
+     * @var int
+     */
+    protected int $consecutiveGetNextJobFailures = 0;
+
+    /**
      * Indicates if the worker is paused.
      *
      * @var bool
@@ -400,6 +407,8 @@ class Worker
 
         $this->raiseBeforeJobPopEvent($connection->getConnectionName(), $queue);
 
+        $failed = false;
+
         try {
             if (isset(static::$popCallbacks[$this->name ?? ''])) {
                 if (! is_null($job = (static::$popCallbacks[$this->name ?? ''])($popJobCallback, $queue))) {
@@ -421,11 +430,21 @@ class Worker
                 }
             }
         } catch (Throwable $e) {
+            $failed = true;
+
             $this->exceptions->report($e);
 
             $this->stopWorkerIfLostConnection($e);
 
+            if (++$this->consecutiveGetNextJobFailures >= 100) {
+                $this->shouldQuit = true;
+            }
+
             $this->sleep(1);
+        } finally {
+            if (! $failed) {
+                $this->consecutiveGetNextJobFailures = 0;
+            }
         }
     }
 

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -172,6 +172,55 @@ class QueueWorkerTest extends TestCase
         $this->exceptionHandler->shouldHaveReceived('report')->with($e);
     }
 
+    public function testWorkerQuitsAfterTooManyConsecutiveGetNextJobFailures()
+    {
+        $worker = new InsomniacWorker(
+            new WorkerFakeManager('default', new BrokenQueueConnection('default', new RuntimeException)),
+            $this->events,
+            $this->exceptionHandler,
+            function () {
+                return false;
+            }
+        );
+
+        for ($i = 0; $i < 99; $i++) {
+            $worker->runNextJob('default', 'queue', $this->workerOptions());
+            $this->assertFalse($worker->shouldQuit);
+        }
+
+        $worker->runNextJob('default', 'queue', $this->workerOptions());
+        $this->assertTrue($worker->shouldQuit);
+    }
+
+    public function testConsecutiveGetNextJobFailureCounterResetsOnSuccess()
+    {
+        $brokenConnection = new BrokenQueueConnection('default', new RuntimeException);
+        $worker = new InsomniacWorker(
+            new WorkerFakeManager('default', $brokenConnection),
+            $this->events,
+            $this->exceptionHandler,
+            function () {
+                return false;
+            }
+        );
+
+        for ($i = 0; $i < 50; $i++) {
+            $worker->runNextJob('default', 'queue', $this->workerOptions());
+        }
+
+        $this->assertFalse($worker->shouldQuit);
+
+        // Switch to a working connection — counter should reset
+        $worker->getManager()->connections['default'] = new WorkerFakeConnection('default', ['queue' => []]);
+        $worker->runNextJob('default', 'queue', $this->workerOptions());
+
+        // Now go back to broken — counter starts fresh so still under threshold
+        $worker->getManager()->connections['default'] = $brokenConnection;
+        $worker->runNextJob('default', 'queue', $this->workerOptions());
+
+        $this->assertFalse($worker->shouldQuit);
+    }
+
     public function testWorkerSleepsWhenQueueIsEmpty()
     {
         $worker = $this->getWorker('default', ['queue' => []]);
@@ -599,6 +648,11 @@ class InsomniacWorker extends Worker
     public function memoryExceeded($memoryLimit)
     {
         return $this->stopOnMemoryExceeded;
+    }
+
+    public function getManager()
+    {
+        return $this->manager;
     }
 }
 


### PR DESCRIPTION
When `getNextJob()` throws a non-database exception (SQS SDK timeout, Redis auth failure, HTTP error, etc.), the catch block reports the error, calls `stopWorkerIfLostConnection()`, and sleeps 1 second — then the daemon loop retries immediately. Since `stopWorkerIfLostConnection()` only matches database-specific error strings, queue connection failures never set `shouldQuit`, and the worker loops forever reporting the same error.

In production this means a worker container stays "Up" in your process manager while processing zero messages, potentially for days.

The fix tracks consecutive `getNextJob()` failures. After 100 consecutive failures (~100 seconds of retrying), the worker sets `shouldQuit = true` and exits so the process manager can restart it. The counter resets to zero whenever `getNextJob()` completes without throwing, so transient errors (brief network blips) recover normally.

Fixes #59517.