### PR TITLE
[13.x] Merge attribute-provided middleware with existing middleware

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -1122,21 +1122,19 @@ class Route
             $this->getControllerMethod(),
         ];
 
-        if (is_a($controllerClass, HasMiddleware::class, true)) {
-            return $this->staticallyProvidedControllerMiddleware(
-                $controllerClass, $controllerMethod
-            );
-        }
+        $attributeMiddleware = $this->attributeProvidedControllerMiddleware($controllerClass, $controllerMethod);
 
-        if (method_exists($controllerClass, 'getMiddleware')) {
-            return $this->controllerDispatcher()->getMiddleware(
-                $this->getController(), $controllerMethod
-            );
-        }
-
-        return $this->attributeProvidedControllerMiddleware(
-            $controllerClass, $controllerMethod
-        );
+        return match (true) {
+            is_a($controllerClass, HasMiddleware::class, true) => array_merge(
+                $this->staticallyProvidedControllerMiddleware($controllerClass, $controllerMethod),
+                $attributeMiddleware,
+            ),
+            method_exists($controllerClass, 'getMiddleware') => array_merge(
+                $this->controllerDispatcher()->getMiddleware($this->getController(), $controllerMethod),
+                $attributeMiddleware,
+            ),
+            default => $attributeMiddleware,
+        };
     }
 
     /**

--- a/tests/Routing/RoutingControllerAttributeTest.php
+++ b/tests/Routing/RoutingControllerAttributeTest.php
@@ -4,7 +4,10 @@ namespace Illuminate\Tests\Routing;
 
 use Illuminate\Container\Container;
 use Illuminate\Routing\Attributes\Controllers\Middleware;
+use Illuminate\Routing\Controller as RoutingController;
+use Illuminate\Routing\Controllers\HasMiddleware;
 use Illuminate\Routing\Route;
+use Override;
 use PHPUnit\Framework\TestCase;
 
 class RoutingControllerAttributeTest extends TestCase
@@ -23,6 +26,19 @@ class RoutingControllerAttributeTest extends TestCase
         $route->setContainer(new Container);
 
         $this->assertEquals(['middleware1', 'middleware2', 'middleware3'], $route->gatherMiddleware());
+    }
+
+    public function testControllerMiddlewareMergesWithAttributeMiddleware()
+    {
+        $route = new Route('GET', 'foo', ['uses' => StaticMiddlewareController::class.'@index']);
+        $route->setContainer(new Container);
+
+        $this->assertEquals(['static-middleware', 'attribute-middleware-1', 'attribute-middleware-2'], $route->gatherMiddleware());
+
+        $route = new Route('GET', 'bar', ['uses' => DynamicMiddlewareController::class.'@index']);
+        $route->setContainer(new Container);
+
+        $this->assertEquals(['dynamic-middleware', 'attribute-middleware-1', 'attribute-middleware-2'], $route->gatherMiddleware());
     }
 }
 
@@ -56,6 +72,37 @@ abstract class BaseMiddlewareDeclarationOrderController extends Controller
 #[Middleware('middleware3')]
 class InheritMiddlewareDeclarationOrderController extends BaseMiddlewareDeclarationOrderController
 {
+    public function index()
+    {
+        //
+    }
+}
+
+#[Middleware('attribute-middleware-1')]
+class StaticMiddlewareController implements HasMiddleware
+{
+    #[Override]
+    public static function middleware(): array
+    {
+        return ['static-middleware'];
+    }
+
+    #[Middleware('attribute-middleware-2')]
+    public function index()
+    {
+        //
+    }
+}
+
+#[Middleware('attribute-middleware-1')]
+class DynamicMiddlewareController extends RoutingController
+{
+    public function __construct()
+    {
+        $this->middleware('dynamic-middleware');
+    }
+
+    #[Middleware('attribute-middleware-2')]
     public function index()
     {
         //


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
(This is effectively #59808 redone).

This MR aims to resolve #59803 by merging the middleware originating from attributes with middleware provided by other sources. 

Per discussion there and on #59808 this is technically a breaking behavioral change, however after careful consideration I'd argue this is fine to merge as it would only 'break' developer expectations if:
- the developer uses a controller that has middleware through a method (either static or dynamic)
- the developer has actively put a `Middleware` attribute on this controller class or one or more of its methods
- the expected outcome of the developer was that this attribute would be entirely disregarded

Given that this seems very unlikely, in particular due to the recent introduction of the attribute and the unlikelihood of anyone adding attributes for the sole purpose of them doing nothing at all, I think this improvement is fine or could even be called a bugfix at that.

If still unwanted as such, let me know, then I'll just retarget this for v14.

*Edit:* if open to the idea, another way to introduce this would be a static feature flag on the `Route` class, that defaults to `false` on v13 and will be removed on v14, which could be overridden by developers at application boot time.