### PR TITLE
[13.x] Add Batch::addOrFail() and use in PendingBatch::dispatch()

### DIFF
--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -145,6 +145,19 @@ class Batch implements Arrayable, JsonSerializable
     }
 
     /**
+     * Add additional jobs to the batch or throw if the batch no longer exists.
+     *
+     * @param  \Illuminate\Support\Enumerable|object|array  $jobs
+     * @return self
+     *
+     * @throws \Illuminate\Bus\BatchNotFoundException
+     */
+    public function addOrFail($jobs): self
+    {
+        return $this->add($jobs) ?? throw new BatchNotFoundException($this->id);
+    }
+
+    /**
      * Add additional jobs to the batch.
      *
      * @param  \Illuminate\Support\Enumerable|object|array  $jobs

--- a/src/Illuminate/Bus/BatchNotFoundException.php
+++ b/src/Illuminate/Bus/BatchNotFoundException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Bus;
+
+use RuntimeException;
+
+class BatchNotFoundException extends RuntimeException
+{
+    public function __construct(public readonly string $batchId)
+    {
+        parent::__construct("Batch [{$batchId}] was not found.");
+    }
+}

--- a/src/Illuminate/Bus/PendingBatch.php
+++ b/src/Illuminate/Bus/PendingBatch.php
@@ -373,7 +373,7 @@ class PendingBatch
         try {
             $batch = $this->store($repository);
 
-            $batch = $batch->add($this->jobs);
+            $batch = $batch->addOrFail($this->jobs);
         } catch (Throwable $e) {
             if (isset($batch)) {
                 $repository->delete($batch->id);
@@ -420,7 +420,7 @@ class PendingBatch
     protected function dispatchExistingBatch($batch)
     {
         try {
-            $batch = $batch->add($this->jobs);
+            $batch = $batch->addOrFail($this->jobs);
         } catch (Throwable $e) {
             $batch->delete();
 

--- a/tests/Bus/BusPendingBatchTest.php
+++ b/tests/Bus/BusPendingBatchTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Bus;
 
 use Illuminate\Bus\Batch;
 use Illuminate\Bus\Batchable;
+use Illuminate\Bus\BatchNotFoundException;
 use Illuminate\Bus\BatchRepository;
 use Illuminate\Bus\PendingBatch;
 use Illuminate\Container\Container;
@@ -53,7 +54,7 @@ class BusPendingBatchTest extends TestCase
 
         $repository = m::mock(BatchRepository::class);
         $repository->shouldReceive('store')->once()->with($pendingBatch)->andReturn($batch = m::mock(stdClass::class));
-        $batch->shouldReceive('add')->once()->with(m::type(Collection::class))->andReturn($batch = m::mock(Batch::class));
+        $batch->shouldReceive('addOrFail')->once()->with(m::type(Collection::class))->andReturn($batch = m::mock(Batch::class));
 
         $container->instance(BatchRepository::class, $repository);
 
@@ -77,9 +78,38 @@ class BusPendingBatchTest extends TestCase
 
         $batch->id = 'test-id';
 
-        $batch->shouldReceive('add')->once()->andReturnUsing(function () {
+        $batch->shouldReceive('addOrFail')->once()->andReturnUsing(function () {
             throw new RuntimeException('Failed to add jobs...');
         });
+
+        $repository->shouldReceive('delete')->once()->with('test-id');
+
+        $container->instance(BatchRepository::class, $repository);
+
+        $pendingBatch->dispatch();
+    }
+
+    public function test_batch_is_deleted_from_storage_if_add_returns_null()
+    {
+        $this->expectException(BatchNotFoundException::class);
+        $this->expectExceptionMessage('Batch [test-id] was not found.');
+
+        $container = new Container;
+
+        $job = new class
+        {
+            use Batchable;
+        };
+
+        $pendingBatch = new PendingBatch($container, new Collection([$job]));
+
+        $repository = m::mock(BatchRepository::class);
+
+        $repository->shouldReceive('store')->once()->with($pendingBatch)->andReturn($batch = m::mock(stdClass::class));
+
+        $batch->id = 'test-id';
+
+        $batch->shouldReceive('addOrFail')->once()->andThrow(new BatchNotFoundException('test-id'));
 
         $repository->shouldReceive('delete')->once()->with('test-id');
 
@@ -105,7 +135,7 @@ class BusPendingBatchTest extends TestCase
 
         $repository = m::mock(BatchRepository::class);
         $repository->shouldReceive('store')->once()->andReturn($batch = m::mock(stdClass::class));
-        $batch->shouldReceive('add')->once()->andReturn($batch = m::mock(Batch::class));
+        $batch->shouldReceive('addOrFail')->once()->andReturn($batch = m::mock(Batch::class));
 
         $container->instance(BatchRepository::class, $repository);
 
@@ -154,7 +184,7 @@ class BusPendingBatchTest extends TestCase
 
         $repository = m::mock(BatchRepository::class);
         $repository->shouldReceive('store')->once()->andReturn($batch = m::mock(stdClass::class));
-        $batch->shouldReceive('add')->once()->andReturn($batch = m::mock(Batch::class));
+        $batch->shouldReceive('addOrFail')->once()->andReturn($batch = m::mock(Batch::class));
 
         $container->instance(BatchRepository::class, $repository);
 
@@ -210,7 +240,7 @@ class BusPendingBatchTest extends TestCase
 
         $repository = m::mock(BatchRepository::class);
         $repository->shouldReceive('store')->once()->with($pendingBatch)->andReturn($batch = m::mock(stdClass::class));
-        $batch->shouldReceive('add')->once()->with(m::type(Collection::class))->andReturn($batch = m::mock(Batch::class));
+        $batch->shouldReceive('addOrFail')->once()->with(m::type(Collection::class))->andReturn($batch = m::mock(Batch::class));
 
         $container->instance(BatchRepository::class, $repository);
 

--- a/types/Bus/PendingBatch.php
+++ b/types/Bus/PendingBatch.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Bus\Batch;
+use Illuminate\Bus\PendingBatch;
+use Illuminate\Support\Facades\Bus;
+
+use function PHPStan\Testing\assertType;
+
+/** @var PendingBatch $pendingBatch */
+$pendingBatch = Bus::batch([]);
+
+assertType('Illuminate\Bus\PendingBatch', $pendingBatch);
+assertType('Illuminate\Bus\PendingBatch', $pendingBatch->onQueue('queue'));
+assertType('Illuminate\Bus\PendingBatch', $pendingBatch->name('batch-name'));
+assertType('Illuminate\Bus\PendingBatch', $pendingBatch->allowFailures());
+
+assertType('Illuminate\Bus\Batch', $pendingBatch->dispatch());
+assertType('Illuminate\Bus\Batch', $pendingBatch->dispatchAfterResponse());
+
+assertType('Illuminate\Bus\Batch|null', $pendingBatch->dispatchIf(true));
+assertType('Illuminate\Bus\Batch|null', $pendingBatch->dispatchUnless(false));
+
+/** @var Batch $batch */
+$batch = $pendingBatch->dispatch();
+
+assertType('Illuminate\Bus\Batch|null', $batch->fresh());
+assertType('Illuminate\Bus\Batch|null', $batch->add([]));
+assertType('Illuminate\Bus\Batch', $batch->addOrFail([]));
+
+assertType('Illuminate\Bus\Batch|null', Bus::findBatch('some-id'));


### PR DESCRIPTION
`Batch::add()` returns `$this->fresh()`, which can return null if the batch was concurrently deleted between `PendingBatch::dispatch()`'s `store()` and `add()`'s internal re-fetch. #59891 correctly annotated this as `@return self|null`.

When that null surfaces, `PendingBatch::dispatch()` — which forwards `$batch->add($jobs)` to `new BatchDispatched($batch)` (constructor signature: `public Batch $batch`, non-nullable) — fails with:

```
TypeError: Illuminate\Bus\Events\BatchDispatched::__construct():
Argument #1 ($batch) must be of type Illuminate\Bus\Batch, null given,
called in src/Illuminate/Bus/PendingBatch.php on line 388
```

This PR adds `Batch::addOrFail()` — mirroring the existing `find/findOrFail` and `first/firstOrFail` conventions — that throws a dedicated `BatchNotFoundException` instead of returning null. `PendingBatch::dispatch()` and `dispatchExistingBatch()` use it, restoring their `@return Batch` contract and producing a meaningful exception when the race occurs.

- `Batch::add()` signature is unchanged.
- No existing caller of `add()` needs to change.
- Regression test for `dispatch()` included; `types/Bus/PendingBatch.php` locks the contract.