### PR TITLE
[13.x] Exclude expired locks in DatabaseLock::isLock

### DIFF
--- a/src/Illuminate/Cache/DatabaseLock.php
+++ b/src/Illuminate/Cache/DatabaseLock.php
@@ -118,24 +118,18 @@ class DatabaseLock extends Lock
      */
     public function release()
     {
-        if ($this->isOwnedByCurrentProcess()) {
-            try {
-                $this->connection->table($this->table)
-                    ->where('key', $this->name)
-                    ->where('owner', $this->owner)
-                    ->delete();
-
+        try {
+            return $this->connection->table($this->table)
+                ->where('key', $this->name)
+                ->where('owner', $this->owner)
+                ->delete() > 0;
+        } catch (Throwable $e) {
+            if ($this->causedByConcurrencyError($e)) {
                 return true;
-            } catch (Throwable $e) {
-                if ($this->causedByConcurrencyError($e)) {
-                    return true;
-                }
-
-                throw $e;
             }
-        }
 
-        return false;
+            throw $e;
+        }
     }
 
     /**

--- a/src/Illuminate/Cache/DatabaseLock.php
+++ b/src/Illuminate/Cache/DatabaseLock.php
@@ -177,7 +177,10 @@ class DatabaseLock extends Lock
      */
     protected function getCurrentOwner()
     {
-        return $this->connection->table($this->table)->where('key', $this->name)->first()?->owner;
+        return $this->connection->table($this->table)
+            ->where('key', $this->name)
+            ->where('expiration', '>', $this->currentTime())
+            ->first()?->owner;
     }
 
     /**

--- a/tests/Integration/Database/DatabaseLockTest.php
+++ b/tests/Integration/Database/DatabaseLockTest.php
@@ -138,14 +138,9 @@ class DatabaseLockTest extends DatabaseTestCase
     public function testReleaseIgnoresConcurrencyException(string $message, int $code, bool $hasConcurrencyError)
     {
         $connection = m::mock(Connection::class);
-        $selectBuilder = m::mock(Builder::class);
         $deleteBuilder = m::mock(Builder::class);
 
         $owner = 'owner-123';
-
-        $selectBuilder->shouldReceive('where')->with('key', 'foo')->once()->andReturnSelf();
-        $selectBuilder->shouldReceive('where')->with('expiration', '>', m::any())->once()->andReturnSelf();
-        $selectBuilder->shouldReceive('first')->once()->andReturn((object) ['owner' => $owner]);
 
         $deleteBuilder->shouldReceive('where')->with('key', 'foo')->once()->andReturnSelf();
         $deleteBuilder->shouldReceive('where')->with('owner', $owner)->once()->andReturnSelf();
@@ -158,7 +153,7 @@ class DatabaseLockTest extends DatabaseTestCase
             )
         );
 
-        $connection->shouldReceive('table')->with('cache_locks')->andReturn($selectBuilder, $deleteBuilder);
+        $connection->shouldReceive('table')->with('cache_locks')->andReturn($deleteBuilder);
 
         $lock = new DatabaseLock($connection, 'cache_locks', 'foo', 10, $owner); // same owner...
 

--- a/tests/Integration/Database/DatabaseLockTest.php
+++ b/tests/Integration/Database/DatabaseLockTest.php
@@ -77,6 +77,18 @@ class DatabaseLockTest extends DatabaseTestCase
         $this->assertFalse($lock->isLocked());
     }
 
+    public function testExpiredLockIsNotLocked()
+    {
+        $lock = Cache::driver('database')->lock('foo');
+        $this->assertFalse($lock->isLocked());
+
+        $lock->get();
+        $this->assertTrue($lock->isLocked());
+
+        DB::table('cache_locks')->update(['expiration' => Carbon::now()->subDay()->getTimestamp()]);
+        $this->assertFalse($lock->isLocked());
+    }
+
     public function testOtherOwnerDoesNotOwnLockAfterRestore()
     {
         $firstLock = Cache::store('database')->lock('foo');
@@ -132,6 +144,7 @@ class DatabaseLockTest extends DatabaseTestCase
         $owner = 'owner-123';
 
         $selectBuilder->shouldReceive('where')->with('key', 'foo')->once()->andReturnSelf();
+        $selectBuilder->shouldReceive('where')->with('expiration', '>', m::any())->once()->andReturnSelf();
         $selectBuilder->shouldReceive('first')->once()->andReturn((object) ['owner' => $owner]);
 
         $deleteBuilder->shouldReceive('where')->with('key', 'foo')->once()->andReturnSelf();


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR contains two related fixes for DatabaseLock:

1. Fix isLocked() incorrectly reporting expired locks as locked

Previously, DatabaseLock::getCurrentOwner() would return the owner of a lock even if it had expired. This caused isLocked() to incorrectly return true for expired locks.

This fix adds an expiration check to getCurrentOwner(), ensuring expired locks are no longer considered active.

2. Restore release() behavior to match 13.x branch

With the change to getCurrentOwner(), the release() method would now return false when releasing an expired lock (since isOwnedByCurrentProcess() relies on getCurrentOwner()).

This commit simplifies release() to send a single DELETE query and return whether any rows were affected, restoring the previous behavior where releasing an expired lock that you owned returns true.

Reference to Symfony's implementation:

`isLocked` [exists in Symfony](https://github.com/symfony/lock/blob/fc1b4bf2b3db438da5f23a285d78a92da2010052/Store/PdoStore.php#L219-L229) - checks expiration when determining if a lock exists

`release` [delete in Symfony](https://github.com/symfony/lock/blob/fc1b4bf2b3db438da5f23a285d78a92da2010052/Store/PdoStore.php#L209-L217) - deletes by key and token without checking expiration

