### PR TITLE
[13.x] Add Prefer header helpers to Request

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -93,6 +93,10 @@ trait InteractsWithInput
 
             $key = strtolower(trim($parts[0]));
 
+            if (array_key_exists($key, $preferences)) {
+                continue;
+            }
+
             if (! isset($parts[1])) {
                 $preferences[$key] = true;
 

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -83,7 +83,7 @@ trait InteractsWithInput
         $preferences = [];
 
         foreach (explode(',', $header) as $preference) {
-            $preference = trim($preference);
+            $preference = trim(explode(';', $preference, 2)[0]);
 
             if ($preference === '') {
                 continue;
@@ -91,7 +91,7 @@ trait InteractsWithInput
 
             $parts = explode('=', $preference, 2);
 
-            $key = strtolower(trim(explode(';', $parts[0], 2)[0]));
+            $key = strtolower(trim($parts[0]));
 
             if ($key === '' || array_key_exists($key, $preferences)) {
                 continue;
@@ -103,8 +103,7 @@ trait InteractsWithInput
                 continue;
             }
 
-            $value = trim(explode(';', $parts[1], 2)[0]);
-            $value = trim($value, '"\'');
+            $value = trim(trim($parts[1]), '"\'');
 
             $preferences[$key] = $value === '' ? true : $value;
         }

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -68,6 +68,67 @@ trait InteractsWithInput
     }
 
     /**
+     * Get all preferences from the Prefer header.
+     *
+     * @return array<string, string|bool>
+     */
+    public function preferences()
+    {
+        $header = $this->header('Prefer', '');
+
+        if ($header === '' || $header === null) {
+            return [];
+        }
+
+        $preferences = [];
+
+        foreach (explode(',', $header) as $preference) {
+            $preference = trim($preference);
+
+            if ($preference === '') {
+                continue;
+            }
+
+            $parts = explode('=', $preference, 2);
+
+            $key = strtolower(trim($parts[0]));
+
+            if (! isset($parts[1])) {
+                $preferences[$key] = true;
+
+                continue;
+            }
+
+            $preferences[$key] = trim(trim($parts[1]), '"\'');
+        }
+
+        return $preferences;
+    }
+
+    /**
+     * Get a preference from the Prefer header.
+     *
+     * @param  string  $key
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public function preference($key, $default = null)
+    {
+        return $this->preferences()[strtolower($key)] ?? $default;
+    }
+
+    /**
+     * Determine if the Prefer header contains the given preference.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function hasPreference($key)
+    {
+        return array_key_exists(strtolower($key), $this->preferences());
+    }
+
+    /**
      * Get the keys for all of the input and files.
      *
      * @return array

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -74,9 +74,9 @@ trait InteractsWithInput
      */
     public function preferences()
     {
-        $header = $this->header('Prefer', '');
+        $header = implode(',', $this->headers->all('Prefer'));
 
-        if ($header === '' || $header === null) {
+        if ($header === '') {
             return [];
         }
 

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -103,7 +103,9 @@ trait InteractsWithInput
                 continue;
             }
 
-            $preferences[$key] = trim(trim($parts[1]), '"\'');
+            $value = trim(trim($parts[1]), '"\'');
+
+            $preferences[$key] = $value === '' ? true : $value;
         }
 
         return $preferences;

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -91,9 +91,9 @@ trait InteractsWithInput
 
             $parts = explode('=', $preference, 2);
 
-            $key = strtolower(trim($parts[0]));
+            $key = strtolower(trim(explode(';', $parts[0], 2)[0]));
 
-            if (array_key_exists($key, $preferences)) {
+            if ($key === '' || array_key_exists($key, $preferences)) {
                 continue;
             }
 
@@ -103,7 +103,8 @@ trait InteractsWithInput
                 continue;
             }
 
-            $value = trim(trim($parts[1]), '"\'');
+            $value = trim(explode(';', $parts[1], 2)[0]);
+            $value = trim($value, '"\'');
 
             $preferences[$key] = $value === '' ? true : $value;
         }

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -1298,6 +1298,19 @@ class HttpRequestTest extends TestCase
         $this->assertNull($request->preference('respond-async'));
     }
 
+    public function testEmptyPreferenceValueIsTreatedAsToken()
+    {
+        $request = Request::create('/', 'GET', [], [], [], [
+            'HTTP_PREFER' => 'foo=, bar="", baz',
+        ]);
+
+        $this->assertSame([
+            'foo' => true,
+            'bar' => true,
+            'baz' => true,
+        ], $request->preferences());
+    }
+
     public function testDuplicatePreferencesUseTheFirstValue()
     {
         $request = Request::create('/', 'GET', [], [], [], [

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -1235,6 +1235,69 @@ class HttpRequestTest extends TestCase
         $this->assertNull($request->bearerToken());
     }
 
+    public function testCanRetrievePreferencesFromPreferHeader()
+    {
+        $request = Request::create('/', 'GET', [], [], [], [
+            'HTTP_PREFER' => 'respond-async, return=representation, timezone="America/Los_Angeles"',
+        ]);
+
+        $this->assertSame([
+            'respond-async' => true,
+            'return' => 'representation',
+            'timezone' => 'America/Los_Angeles',
+        ], $request->preferences());
+    }
+
+    public function testCanRetrieveSinglePreferenceFromPreferHeader()
+    {
+        $request = Request::create('/', 'GET', [], [], [], [
+            'HTTP_PREFER' => 'return=representation, timezone="America/Los_Angeles"',
+        ]);
+
+        $this->assertSame('America/Los_Angeles', $request->preference('timezone'));
+        $this->assertSame('representation', $request->preference('return'));
+    }
+
+    public function testCanDetermineIfPreferHeaderHasPreference()
+    {
+        $request = Request::create('/', 'GET', [], [], [], [
+            'HTTP_PREFER' => 'respond-async, return=representation',
+        ]);
+
+        $this->assertTrue($request->hasPreference('respond-async'));
+        $this->assertTrue($request->hasPreference('return'));
+        $this->assertFalse($request->hasPreference('missing'));
+    }
+
+    public function testPreferHeaderPreferenceLookupIsCaseInsensitive()
+    {
+        $request = Request::create('/', 'GET', [], [], [], [
+            'HTTP_PREFER' => 'Return=representation',
+        ]);
+
+        $this->assertSame('representation', $request->preference('RETURN'));
+        $this->assertTrue($request->hasPreference('RETURN'));
+    }
+
+    public function testPreferenceReturnsDefaultWhenMissing()
+    {
+        $request = Request::create('/', 'GET', [], [], [], [
+            'HTTP_PREFER' => 'respond-async',
+        ]);
+
+        $this->assertNull($request->preference('missing'));
+        $this->assertSame('fallback', $request->preference('missing', 'fallback'));
+    }
+
+    public function testMissingPreferHeaderReturnsEmptyPreferences()
+    {
+        $request = Request::create('/', 'GET');
+
+        $this->assertSame([], $request->preferences());
+        $this->assertFalse($request->hasPreference('respond-async'));
+        $this->assertNull($request->preference('respond-async'));
+    }
+
     public function testJSONMethod()
     {
         $payload = ['name' => 'taylor'];

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -1298,6 +1298,18 @@ class HttpRequestTest extends TestCase
         $this->assertNull($request->preference('respond-async'));
     }
 
+    public function testMultiplePreferHeadersAreCombined()
+    {
+        $request = Request::create('/', 'GET');
+        $request->headers->set('Prefer', ['respond-async, wait=100', 'handling=lenient']);
+
+        $this->assertSame([
+            'respond-async' => true,
+            'wait' => '100',
+            'handling' => 'lenient',
+        ], $request->preferences());
+    }
+
     public function testPreferenceParametersAreIgnored()
     {
         $request = Request::create('/', 'GET', [], [], [], [

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -1298,6 +1298,15 @@ class HttpRequestTest extends TestCase
         $this->assertNull($request->preference('respond-async'));
     }
 
+    public function testDuplicatePreferencesUseTheFirstValue()
+    {
+        $request = Request::create('/', 'GET', [], [], [], [
+            'HTTP_PREFER' => 'return=minimal, return=representation',
+        ]);
+
+        $this->assertSame('minimal', $request->preference('return'));
+    }
+
     public function testJSONMethod()
     {
         $payload = ['name' => 'taylor'];

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -1298,6 +1298,18 @@ class HttpRequestTest extends TestCase
         $this->assertNull($request->preference('respond-async'));
     }
 
+    public function testPreferenceParametersAreIgnored()
+    {
+        $request = Request::create('/', 'GET', [], [], [], [
+            'HTTP_PREFER' => 'return=minimal; foo="some parameter", respond-async; priority=5',
+        ]);
+
+        $this->assertSame([
+            'return' => 'minimal',
+            'respond-async' => true,
+        ], $request->preferences());
+    }
+
     public function testEmptyPreferenceValueIsTreatedAsToken()
     {
         $request = Request::create('/', 'GET', [], [], [], [


### PR DESCRIPTION
Adds helpers for reading values from the RFC 7240 `Prefer` request header.

```php
$request->preferences();
$request->preference('timezone');
$request->preference('timezone', config('app.timezone'));
$request->hasPreference('respond-async');
```

Given the header:

```
Prefer: respond-async, return=representation, timezone="America/Los_Angeles"
```

`preferences()` returns:

```php
[
    'respond-async' => true,
    'return' => 'representation',
    'timezone' => 'America/Los_Angeles',
]
```

Parsing follows RFC 7240:

- Token preferences (no `=`) are stored as `true`.
- Value preferences are trimmed and surrounding single/double quotes stripped.
- Empty values (`foo=""`, `foo=`) are treated the same as token preferences.
- Preference names are lowercased so lookups are case-insensitive; values keep their case.
- If the same preference appears more than once, the first one wins.
- Multiple `Prefer:` headers on the same request are combined.

Symfony already has `Request::preferSafeContent()` for the safe preference; this exposes generic access to the rest of the header.