### PR TITLE
[13.x] Return 403 instead of 500 when broadcast channel binding fails for typed parameters

### DIFF
--- a/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php
@@ -248,17 +248,23 @@ abstract class Broadcaster implements BroadcasterContract
     protected function resolveImplicitBindingIfPossible($key, $value, $callbackParameters)
     {
         foreach ($callbackParameters as $parameter) {
-            if (! $this->isImplicitlyBindable($key, $parameter)) {
+            if ($parameter->getName() !== $key) {
                 continue;
             }
 
-            $className = Reflector::getParameterClassName($parameter);
+            if (Reflector::isParameterSubclassOf($parameter, UrlRoutable::class)) {
+                $className = Reflector::getParameterClassName($parameter);
 
-            if (is_null($model = (new $className)->resolveRouteBinding($value))) {
-                throw new AccessDeniedHttpException;
+                if (is_null($model = (new $className)->resolveRouteBinding($value))) {
+                    throw new AccessDeniedHttpException;
+                }
+
+                return $model;
             }
 
-            return $model;
+            if (Reflector::getParameterClassName($parameter) !== null) {
+                throw new AccessDeniedHttpException;
+            }
         }
 
         return $value;

--- a/tests/Broadcasting/BroadcasterTest.php
+++ b/tests/Broadcasting/BroadcasterTest.php
@@ -126,6 +126,16 @@ class BroadcasterTest extends TestCase
         $this->broadcaster->extractAuthParameters('asd.{model}', 'asd.1', $callback);
     }
 
+    public function testTypeHintedNonUrlRoutableParameterThrowsHttpException()
+    {
+        $this->expectException(HttpException::class);
+
+        $callback = function ($user, BroadcasterTestNonRoutableStub $model) {
+            //
+        };
+        $this->broadcaster->extractAuthParameters('asd.{model}', 'asd.1', $callback);
+    }
+
     public function testCanRegisterChannelsWithoutOptions()
     {
         $this->broadcaster->channel('somechannel', function () {
@@ -433,6 +443,11 @@ class BroadcasterTestEloquentModelNotFoundStub extends Model
     {
         //
     }
+}
+
+class BroadcasterTestNonRoutableStub
+{
+    //
 }
 
 class DummyBroadcastingChannel


### PR DESCRIPTION
Fixes #59951.

If a `Broadcast::channel` closure type-hints a parameter with a class that doesn't implement `UrlRoutable`, the broadcaster currently passes the raw string from the channel name to the closure, which then crashes with a `TypeError` (500).

```php
Broadcast::channel('Event.{event}', function (User $user, Event $event) {
    return true;
});
```

After this PR, that case throws `AccessDeniedHttpException` (403), matching what already happens when an `UrlRoutable` model isn't found.

Builtin types (`string`, `int`) and untyped parameters are unchanged.