### PR TITLE
[12.x] Fix infinite recursion when defining model scope with attribute as private

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1768,7 +1768,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         if (method_exists(static::class, $method)) {
             $reflectionClass = new ReflectionMethod(static::class, $method);
 
-            return !$reflectionClass->isPrivate() && $reflectionClass->getAttributes(LocalScope::class) !== [];
+            return ! $reflectionClass->isPrivate() && $reflectionClass->getAttributes(LocalScope::class) !== [];
         }
 
         return false;

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1765,9 +1765,13 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     protected static function isScopeMethodWithAttribute(string $method)
     {
-        return method_exists(static::class, $method) &&
-            (new ReflectionMethod(static::class, $method))
-                ->getAttributes(LocalScope::class) !== [];
+        if (method_exists(static::class, $method)) {
+            $reflectionClass = new ReflectionMethod(static::class, $method);
+
+            return !$reflectionClass->isPrivate() && $reflectionClass->getAttributes(LocalScope::class) !== [];
+        }
+
+        return false;
     }
 
     /**

--- a/tests/Integration/Database/EloquentModelScopeTest.php
+++ b/tests/Integration/Database/EloquentModelScopeTest.php
@@ -28,6 +28,13 @@ class EloquentModelScopeTest extends DatabaseTestCase
 
         $this->assertTrue($model->hasNamedScope('existsAsWell'));
     }
+
+    public function testModelDoesNotHaveScopeWhenPrivateVisibility()
+    {
+        $model = new TestScopeModel1;
+
+        $this->assertFalse($model->hasNamedScope('existsAsPrivate'));
+    }
 }
 
 class TestScopeModel1 extends Model
@@ -39,6 +46,12 @@ class TestScopeModel1 extends Model
 
     #[Scope]
     protected function existsAsWell(Builder $builder)
+    {
+        return $builder;
+    }
+
+    #[Scope]
+    private function existsAsPrivate(Builder $builder)
     {
         return $builder;
     }


### PR DESCRIPTION
The following code was crashing due to an infinite recursion :

```php
class DummyModel extends Model
{

    #[Scope]
    private function myScope(Builder $builder)
    {
        return $builder;
    }

}

DummyModel::query()->myScope();

```

It was recursively going to resolve the scope through the `___call` model method.

As the scope is private it was detected through reflection but each time trying to call it we fallback into `__call` again.