### PR TITLE
[13.x] Allow PHPStan to infer the pivot type when passing the pivot model directly

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -678,15 +678,17 @@ trait HasRelationships
      * Define a many-to-many relationship.
      *
      * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+     * @template TPivotModel of \Illuminate\Database\Eloquent\Relations\Pivot = \Illuminate\Database\Eloquent\Relations\Pivot
+     * @template TPivotTable of string|null
      *
      * @param  class-string<TRelatedModel>  $related
-     * @param  string|class-string<\Illuminate\Database\Eloquent\Model>|null  $table
+     * @param  class-string<TPivotModel>|TPivotTable  $table
      * @param  string|null  $foreignPivotKey
      * @param  string|null  $relatedPivotKey
      * @param  string|null  $parentKey
      * @param  string|null  $relatedKey
      * @param  string|null  $relation
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany<TRelatedModel, $this, \Illuminate\Database\Eloquent\Relations\Pivot>
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany<TRelatedModel, $this, TPivotModel>
      */
     public function belongsToMany(
         $related,

--- a/types/Database/Eloquent/Relations.php
+++ b/types/Database/Eloquent/Relations.php
@@ -13,6 +13,7 @@ use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
+use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Database\Eloquent\Relations\Relation;
 
 use function PHPStan\Testing\assertType;
@@ -162,6 +163,18 @@ class User extends Model
     {
         $belongsToMany = $this->belongsToMany(Role::class);
         assertType('Illuminate\Database\Eloquent\Relations\BelongsToMany<Illuminate\Types\Relations\Role, $this(Illuminate\Types\Relations\User), Illuminate\Database\Eloquent\Relations\Pivot, \'pivot\'>', $belongsToMany);
+
+        return $belongsToMany;
+    }
+
+    /** @return BelongsToMany<Role, $this, Tenant> */
+    public function tenantRoles(): BelongsToMany
+    {
+        $belongsToMany = $this->belongsToMany(Role::class)->using(Tenant::class);
+        assertType('Illuminate\Database\Eloquent\Relations\BelongsToMany<Illuminate\Types\Relations\Role, $this(Illuminate\Types\Relations\User), Illuminate\Types\Relations\Tenant, \'pivot\'>', $belongsToMany);
+
+        $belongsToManyShorthand = $this->belongsToMany(Role::class, Tenant::class);
+        assertType('Illuminate\Database\Eloquent\Relations\BelongsToMany<Illuminate\Types\Relations\Role, $this(Illuminate\Types\Relations\User), Illuminate\Types\Relations\Tenant, \'pivot\'>', $belongsToManyShorthand);
 
         return $belongsToMany;
     }
@@ -350,6 +363,9 @@ class Address extends Model
 {
 }
 class Role extends Model
+{
+}
+class Tenant extends Pivot
 {
 }
 class Car extends Model


### PR DESCRIPTION
This PR improves PHPStan type inference for belongs to many relations where the pivot class is passed as an argument, previously for this to work you would have to call the `->using()` method as well (which doesn't set the pivot table, just the model).

I've also added a type test for `BelongsToMany::using()` which seemed to be missing.