### PR TITLE
[13.x] Mark generation type field nullable in processColumns @return shape

### DIFF
--- a/src/Illuminate/Database/Query/Processors/Processor.php
+++ b/src/Illuminate/Database/Query/Processors/Processor.php
@@ -113,7 +113,7 @@ class Processor
      * Process the results of a columns query.
      *
      * @param  list<array<string, mixed>>  $results
-     * @return list<array{name: string, type: string, type_name: string, collation: string|null, nullable: bool, default: mixed, auto_increment: bool, comment: string|null, generation: array{type: string, expression: string|null}|null}>
+     * @return list<array{name: string, type: string, type_name: string, collation: string|null, nullable: bool, default: mixed, auto_increment: bool, comment: string|null, generation: array{type: string|null, expression: string|null}|null}>
      */
     public function processColumns($results)
     {


### PR DESCRIPTION
The `processColumns` shape declares `generation: array{type: string, ...}`, but three of the four concrete implementations have a `default => null` arm in their type `match`:

- `MySqlProcessor` line 61: `default => null`
- `PostgresProcessor` line 98: `default => null`
- `SQLiteProcessor` line 46: `default => null`

So `generation.type` is genuinely nullable. Tightening the parent shape to `type: string|null` to match.