### PR TITLE
[13.x] Mark processIndexes type field nullable in @return shape

### DIFF
--- a/src/Illuminate/Database/Query/Processors/Processor.php
+++ b/src/Illuminate/Database/Query/Processors/Processor.php
@@ -124,7 +124,7 @@ class Processor
      * Process the results of an indexes query.
      *
      * @param  list<array<string, mixed>>  $results
-     * @return list<array{name: string, columns: list<string>, type: string, unique: bool, primary: bool}>
+     * @return list<array{name: string, columns: list<string>, type: string|null, unique: bool, primary: bool}>
      */
     public function processIndexes($results)
     {


### PR DESCRIPTION
`SQLiteProcessor::processIndexes` always returns `'type' => null` (line 69) since SQLite indexes don't expose a type. The parent shape still declares `type: string`. Tightening to `type: string|null` to match.