### PR TITLE
[13.x] Correct Attribute caching toggles @return to $this

### DIFF
--- a/src/Illuminate/Database/Eloquent/Casts/Attribute.php
+++ b/src/Illuminate/Database/Eloquent/Casts/Attribute.php
@@ -81,7 +81,7 @@ class Attribute
     /**
      * Disable object caching for the attribute.
      *
-     * @return static
+     * @return $this
      */
     public function withoutObjectCaching()
     {
@@ -93,7 +93,7 @@ class Attribute
     /**
      * Enable caching for the attribute.
      *
-     * @return static
+     * @return $this
      */
     public function shouldCache()
     {


### PR DESCRIPTION
`Eloquent\Casts\Attribute::withoutObjectCaching()` and `shouldCache()` are both annotated `@return static` but each just does `return $this;`. Tightening to `@return $this` so the fluent type matches the runtime instance.