### PR TITLE
[13.x] Correct Factory::configure @return to $this

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -230,7 +230,7 @@ abstract class Factory
     /**
      * Configure the factory.
      *
-     * @return static
+     * @return $this
      */
     public function configure()
     {


### PR DESCRIPTION
`Eloquent\Factories\Factory::configure()` is documented `@return static` but the body is just `return $this;`. The method is the user-overridable hook called from the constructor; subclasses normally override it without instantiating anything new. Tightening to `@return $this`.