### PR TITLE
[13.x] Correct Translator::handleMissingKeysUsing @return to $this

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -386,7 +386,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      * Register a callback that is responsible for handling missing translation keys.
      *
      * @param  callable|null  $callback
-     * @return static
+     * @return $this
      */
     public function handleMissingKeysUsing(?callable $callback)
     {


### PR DESCRIPTION
`Translator::handleMissingKeysUsing()` is annotated `@return static` but the body is a fluent setter ending in `return $this;`. Tightening to `@return $this`.