### PR TITLE
[13.x] Correct Log\Context\Repository::handleUnserializeExceptionsUsing @return to $this

### DIFF
--- a/src/Illuminate/Log/Context/Repository.php
+++ b/src/Illuminate/Log/Context/Repository.php
@@ -607,7 +607,7 @@ class Repository
      * Handle unserialize exceptions using the given callback.
      *
      * @param  callable|null  $callback
-     * @return static
+     * @return $this
      */
     public function handleUnserializeExceptionsUsing($callback)
     {


### PR DESCRIPTION
`Log\Context\Repository::handleUnserializeExceptionsUsing()` is annotated `@return static` but the body just does `return $this;`. The sibling `flush()` method right below it already correctly uses `@return $this`. Aligning.