### PR TITLE
Add offset parameter to every-N-minutes scheduler methods

### DIFF
--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -178,71 +178,92 @@ trait ManagesFrequencies
     /**
      * Schedule the event to run every two minutes.
      *
+     * @param  int<0, 1>  $offset
      * @return $this
+     *
+     * @throws \InvalidArgumentException
      */
-    public function everyTwoMinutes()
+    public function everyTwoMinutes($offset = 0)
     {
-        return $this->spliceIntoPosition(1, '*/2');
+        return $this->minuteBasedSchedule($offset, 2);
     }
 
     /**
      * Schedule the event to run every three minutes.
      *
+     * @param  int<0, 2>  $offset
      * @return $this
+     *
+     * @throws \InvalidArgumentException
      */
-    public function everyThreeMinutes()
+    public function everyThreeMinutes($offset = 0)
     {
-        return $this->spliceIntoPosition(1, '*/3');
+        return $this->minuteBasedSchedule($offset, 3);
     }
 
     /**
      * Schedule the event to run every four minutes.
      *
+     * @param  int<0, 3>  $offset
      * @return $this
+     *
+     * @throws \InvalidArgumentException
      */
-    public function everyFourMinutes()
+    public function everyFourMinutes($offset = 0)
     {
-        return $this->spliceIntoPosition(1, '*/4');
+        return $this->minuteBasedSchedule($offset, 4);
     }
 
     /**
      * Schedule the event to run every five minutes.
      *
+     * @param  int<0, 4>  $offset
      * @return $this
+     *
+     * @throws \InvalidArgumentException
      */
-    public function everyFiveMinutes()
+    public function everyFiveMinutes($offset = 0)
     {
-        return $this->spliceIntoPosition(1, '*/5');
+        return $this->minuteBasedSchedule($offset, 5);
     }
 
     /**
      * Schedule the event to run every ten minutes.
      *
+     * @param  int<0, 9>  $offset
      * @return $this
+     *
+     * @throws \InvalidArgumentException
      */
-    public function everyTenMinutes()
+    public function everyTenMinutes($offset = 0)
     {
-        return $this->spliceIntoPosition(1, '*/10');
+        return $this->minuteBasedSchedule($offset, 10);
     }
 
     /**
      * Schedule the event to run every fifteen minutes.
      *
+     * @param  int<0, 14>  $offset
      * @return $this
+     *
+     * @throws \InvalidArgumentException
      */
-    public function everyFifteenMinutes()
+    public function everyFifteenMinutes($offset = 0)
     {
-        return $this->spliceIntoPosition(1, '*/15');
+        return $this->minuteBasedSchedule($offset, 15);
     }
 
     /**
      * Schedule the event to run every thirty minutes.
      *
+     * @param  int<0, 29>  $offset
      * @return $this
+     *
+     * @throws \InvalidArgumentException
      */
-    public function everyThirtyMinutes()
+    public function everyThirtyMinutes($offset = 0)
     {
-        return $this->spliceIntoPosition(1, '*/30');
+        return $this->minuteBasedSchedule($offset, 30);
     }
 
     /**
@@ -383,6 +404,28 @@ trait ManagesFrequencies
         $hours = $first.','.$second;
 
         return $this->hourBasedSchedule($offset, $hours);
+    }
+
+    /**
+     * Schedule the event to run every $step minutes, starting at the given offset.
+     *
+     * @param  int  $offset
+     * @param  int  $step
+     * @return $this
+     *
+     * @throws \InvalidArgumentException
+     */
+    protected function minuteBasedSchedule($offset, $step)
+    {
+        if ($offset < 0 || $offset >= $step) {
+            $max = $step - 1;
+
+            throw new InvalidArgumentException(
+                "Offset must be between 0 and {$max} for an every-{$step}-minutes schedule."
+            );
+        }
+
+        return $this->spliceIntoPosition(1, $offset === 0 ? "*/{$step}" : "{$offset}-59/{$step}");
     }
 
     /**

--- a/tests/Console/Scheduling/FrequencyTest.php
+++ b/tests/Console/Scheduling/FrequencyTest.php
@@ -38,6 +38,36 @@ class FrequencyTest extends TestCase
         $this->assertSame('*/30 * * * *', $this->event->everyThirtyMinutes()->getExpression());
     }
 
+    public function testEveryXMinutesAcceptsOffset()
+    {
+        $this->assertSame('1-59/2 * * * *', $this->event->everyTwoMinutes(1)->getExpression());
+        $this->assertSame('2-59/3 * * * *', $this->event->everyThreeMinutes(2)->getExpression());
+        $this->assertSame('3-59/4 * * * *', $this->event->everyFourMinutes(3)->getExpression());
+        $this->assertSame('2-59/5 * * * *', $this->event->everyFiveMinutes(2)->getExpression());
+        $this->assertSame('7-59/10 * * * *', $this->event->everyTenMinutes(7)->getExpression());
+        $this->assertSame('5-59/15 * * * *', $this->event->everyFifteenMinutes(5)->getExpression());
+        $this->assertSame('15-59/30 * * * *', $this->event->everyThirtyMinutes(15)->getExpression());
+    }
+
+    public function testEveryFiveMinutesRejectsOffsetOutOfRange()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->event->everyFiveMinutes(5);
+    }
+
+    public function testEveryFiveMinutesRejectsNegativeOffset()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->event->everyFiveMinutes(-1);
+    }
+
+    public function testEveryThirtyMinutesRejectsOffsetEqualToStep()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Offset must be between 0 and 29 for an every-30-minutes schedule.');
+        $this->event->everyThirtyMinutes(30);
+    }
+
     public function testDaily()
     {
         $this->assertSame('0 0 * * *', $this->event->daily()->getExpression());


### PR DESCRIPTION
## Summary

Adds an optional `$offset` parameter to the minute-based scheduler frequency methods so jobs can be staggered without dropping to raw `->cron(...)` expressions.

```php
// Before — collides at :00/:05/:10 with any other every-five-minutes job
Schedule::command('reports:generate')->everyFiveMinutes();

// After — fires at :02/:07/:12...
Schedule::command('reports:generate')->everyFiveMinutes(2);
```

## Why

The hour-based frequency methods already accept an offset (`hourlyAt($offset)`, `everyOddHour($offset = 0)`, `everyTwoHours($offset = 0)`, ...). The minute-based ones do not, which forces users with multiple every-N-minutes jobs to bypass the fluent API entirely.

A concrete example from one of my own codebases — two related per-tenant fan-out jobs that need to be spread across the cycle so they don't pile on top of each other:

Before — the second job has to drop to raw cron just to offset by 2 minutes, and a comment is needed to explain why the two scheduling methods don't match.
```php
Schedule::command('tenants:artisan "ail:online-lines"')->everyFiveMinutes()->withoutOverlapping();
// Offset 2 minutes from ail:online-lines to spread the per-tenant fan-out load;
// everyFiveMinutes() has no offset modifier.
Schedule::command('tenants:artisan "ail:dispatch-due-order-reminders"')->cron('2-59/5 * * * *')->withoutOverlapping();
```


After — both jobs use the same fluent API, the offset is self-documenting, and the explanatory comment can go away.
```php
Schedule::command('tenants:artisan "ail:online-lines"')->everyFiveMinutes()->withoutOverlapping();
Schedule::command('tenants:artisan "ail:dispatch-due-order-reminders"')->everyFiveMinutes(2)->withoutOverlapping();
```

This PR closes that inconsistency. It does not add any new named methods — it adds one parameter to seven existing methods, so the API surface grows by parameters, not by names. Internally, the seven methods now delegate to a single new protected helper (`minuteBasedSchedule`), mirroring the existing `hourBasedSchedule`.

## Prior art

I'm aware of #35724 (closed) and #36616 (closed). Their feedback was that named "odd/even" variants weren't worth the surface area when raw cron syntax already covers the case. This PR is meaningfully different: it doesn't add new named methods — it brings the minute methods into parity with the hour methods that already shipped with offset support.

## Behaviour

- Calling without arguments produces a byte-identical cron expression to the current implementation (no behaviour change for existing callers — verified in tests).
- Calling with `$offset` produces `{offset}-59/{step}` in the minute slot.
- Out-of-range offsets (`< 0` or `>= step`) throw `InvalidArgumentException` at definition time, so misconfigured schedules fail loudly during deploy rather than silently never running. Validation lives in a single shared helper, not duplicated across the seven public methods.

## Tests

Added cases in `tests/Console/Scheduling/FrequencyTest.php`:

- Existing no-arg assertions retained — proof the change is byte-compatible.
- New offset-positive assertions for all seven methods.
- Three failure-mode tests covering out-of-range, negative, and step-boundary offsets (the last asserts the exception message wording, which locks in the `$step - 1` arithmetic).

`vendor/bin/phpunit tests/Console/Scheduling` passes locally.
