### PR TITLE
[13.x] Correct Password::min @return to static

### DIFF
--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -230,7 +230,7 @@ class Password implements DataAwareRule, ImplicitRule, IteratorAggregate, Rule, 
      * Set the minimum size of the password.
      *
      * @param  int  $size
-     * @return $this
+     * @return static
      */
     public static function min($size)
     {


### PR DESCRIPTION
`Validation\Rules\Password::min()` is a `public static` method, but its docblock says `@return $this` — `$this` is undefined in static context. The body does `return new static($size);`. The four sibling static factories in the same file (`default`, `required`, `sometimes`, `defaults`) all correctly use `@return static`. Aligning.