### PR TITLE
[13.x] Document missing $health param on ApplicationBuilder::withRouting

### DIFF
--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -147,6 +147,7 @@ class ApplicationBuilder
      * @param  string|null  $commands
      * @param  string|null  $channels
      * @param  string|null  $pages
+     * @param  string|null  $health
      * @param  string  $apiPrefix
      * @param  callable|null  $then
      * @return $this


### PR DESCRIPTION
`ApplicationBuilder::withRouting()` accepts `?string $health = null` (line 160) but its docblock has no matching `@param`. Adding it between `$pages` and `$apiPrefix` to match the signature order.