### PR TITLE
Add `assertSessionMissingInput`

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1643,6 +1643,30 @@ class TestResponse implements ArrayAccess
     }
 
     /**
+     * Assert that the session is missing a given key in the flashed input array.
+     *
+     * @param  string|array  $key
+     * @return $this
+     */
+    public function assertSessionMissingInput($key)
+    {
+        if (is_array($key)) {
+            foreach ($key as $k) {
+                $this->assertSessionMissingInput($k);
+            }
+
+            return $this;
+        }
+
+        PHPUnit::withResponse($this)->assertFalse(
+            $this->session()->hasOldInput($key),
+            "Session has unexpected key [{$key}]."
+        );
+
+        return $this;
+    }
+
+    /**
      * Assert that the session has the given errors.
      *
      * @param  string|array  $keys

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -3138,6 +3138,20 @@ EOT
         });
     }
 
+    public function testAssertSessionMissingInput(): void
+    {
+        app()->instance('session.store', $store = new Store('test-session', new ArraySessionHandler(1)));
+
+        $store->put('_old_input', [
+            'foo' => 'value',
+        ]);
+
+        $response = TestResponse::fromBaseResponse(new Response());
+
+        $response->assertSessionMissingInput('bar');
+        $response->assertSessionMissingInput(['bar', 'baz']);
+    }
+
     public function testGetEncryptedCookie(): void
     {
         $container = Container::getInstance();


### PR DESCRIPTION
This adds `assertSessionMissingInput` - the counterpart to `assertSessionHasInput` added way back in https://github.com/laravel/framework/pull/29327.

It accepts a single field name or array of field names.

```php
$response->assertSessionMissingInput('name');
$response->assertSessionMissingInput(['connection_id', 'repository', 'source_branch']);
```