### PR TITLE
Allow mail default driver to accept enums

### DIFF
--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -559,11 +559,13 @@ class MailManager implements FactoryContract
     /**
      * Set the default mail driver name.
      *
-     * @param  string  $name
+     * @param  \UnitEnum|string  $name
      * @return void
      */
-    public function setDefaultDriver(string $name)
+    public function setDefaultDriver($name)
     {
+        $name = enum_value($name);
+
         if ($this->app['config']['mail.driver']) {
             $this->app['config']['mail.driver'] = $name;
         }

--- a/tests/Mail/MailManagerTest.php
+++ b/tests/Mail/MailManagerTest.php
@@ -149,6 +149,17 @@ class MailManagerTest extends TestCase
         $this->assertSame($mailer1, $mailer2);
     }
 
+    public function testSetDefaultDriverAcceptsBackedEnum(): void
+    {
+        $this->app['config']->set('mail.mailers.array', [
+            'transport' => 'array',
+        ]);
+
+        $this->app['mail.manager']->setDefaultDriver(MailerName::ArrayMailer);
+
+        $this->assertSame('array', $this->app['config']->get('mail.default'));
+    }
+
     public function testPurgeAcceptsBackedEnum(): void
     {
         $this->app['config']->set('mail.mailers.array', [


### PR DESCRIPTION
This PR allows `MailManager::setDefaultDriver()` to accept backed enums, matching the existing enum support in `mailer()` and `driver()`.

Currently, mailers can be resolved using a backed enum, but setting the default mail driver still requires a string. This updates `setDefaultDriver()` to normalize enum values via `enum_value()` before writing the config value.