### PR TITLE
[13.x] Refactor: use `value()`

### DIFF
--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -282,7 +282,7 @@ if (! function_exists('when')) {
      */
     function when($condition, $value, $default = null)
     {
-        $condition = $condition instanceof Closure ? $condition() : $condition;
+        $condition = value($condition);
 
         if ($condition) {
             return value($value, $condition);

--- a/src/Illuminate/Conditionable/Traits/Conditionable.php
+++ b/src/Illuminate/Conditionable/Traits/Conditionable.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Support\Traits;
 
-use Closure;
 use Illuminate\Support\HigherOrderWhenProxy;
 
 trait Conditionable

--- a/src/Illuminate/Conditionable/Traits/Conditionable.php
+++ b/src/Illuminate/Conditionable/Traits/Conditionable.php
@@ -20,7 +20,7 @@ trait Conditionable
      */
     public function when($value = null, ?callable $callback = null, ?callable $default = null)
     {
-        $value = $value instanceof Closure ? $value($this) : $value;
+        $value = value($value, $this);
 
         if (func_num_args() === 0) {
             return new HigherOrderWhenProxy($this);
@@ -52,7 +52,7 @@ trait Conditionable
      */
     public function unless($value = null, ?callable $callback = null, ?callable $default = null)
     {
-        $value = $value instanceof Closure ? $value($this) : $value;
+        $value = value($value, $this);
 
         if (func_num_args() === 0) {
             return (new HigherOrderWhenProxy($this))->negateConditionOnCapture();

--- a/src/Illuminate/Http/Client/ResponseSequence.php
+++ b/src/Illuminate/Http/Client/ResponseSequence.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Http\Client;
 
-use Closure;
 use Illuminate\Support\Traits\Macroable;
 use OutOfBoundsException;
 

--- a/src/Illuminate/Http/Client/ResponseSequence.php
+++ b/src/Illuminate/Http/Client/ResponseSequence.php
@@ -167,6 +167,6 @@ class ResponseSequence
 
         $response = array_shift($this->responses);
 
-        return $response instanceof Closure ? $response($request) : $response;
+        return value($response, $request);
     }
 }


### PR DESCRIPTION
**Use `value()` helper instead of manual Closure checks**

Replace inline `$x instanceof Closure ? $x(...) : $x` patterns with Laravel's built-in `value()` helper where applicable.

**Changes:**
- `Conditionable::when()` and `unless()` — use `value($value, $this)` for resolving the condition
- Global `when()` helper — use `value($condition)` instead of manual Closure check
- `ResponseSequence::__invoke()` — use `value($response, $request)` for the final response resolution

No behavior change — purely a readability improvement.