### PR TITLE
[13.x] Fix: typo

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -56,7 +56,7 @@ trait HasRelationships
     protected $relationAutoloadContext = null;
 
     /**
-     * The many to many relationship methods.
+     * The many-to-many relationship methods.
      *
      * @var string[]
      */

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
@@ -53,7 +53,7 @@ trait AsPivot
 
         // The pivot model is a "dynamic" model since we will set the tables dynamically
         // for the instance. This allows it work for any intermediate tables for the
-        // many to many relationship that are defined by this developer's classes.
+        // many-to-many relationship that are defined by this developer's classes.
         $instance->setConnection($parent->getConnectionName())
             ->setTable($table)
             ->forceFill($attributes)


### PR DESCRIPTION
Fix typo: many to many → many-to-many in `HasRelationships`

One inconsistent spelling was corrected to match the existing convention used throughout the file.