### PR TITLE
[13.x] Fix LazyCollection::get() ignoring default value for null keys

### DIFF
--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -534,7 +534,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     public function get($key, $default = null)
     {
         if (is_null($key)) {
-            return;
+            return value($default);
         }
 
         foreach ($this as $outerKey => $outerValue) {

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -5818,8 +5818,6 @@ class SupportCollectionTest extends TestCase
         }));
     }
 
-
-
     #[DataProvider('collectionClassProvider')]
     public function testGetWithDefaultValue($collection)
     {

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -5802,6 +5802,25 @@ class SupportCollectionTest extends TestCase
     }
 
     #[DataProvider('collectionClassProvider')]
+    public function testGetWithNullKeyAndDefaultValue($collection)
+    {
+        $data = new $collection([1, 2, 3]);
+        $this->assertSame('fallback', $data->get(null, 'fallback'));
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testGetWithNullKeyAndCallbackDefaultValue($collection)
+    {
+        $data = new $collection([1, 2, 3]);
+
+        $this->assertSame('fallback', $data->get(null, function () {
+            return 'fallback';
+        }));
+    }
+
+
+
+    #[DataProvider('collectionClassProvider')]
     public function testGetWithDefaultValue($collection)
     {
         $data = new $collection(['name' => 'taylor', 'framework' => 'laravel']);


### PR DESCRIPTION
This PR fixes an inconsistency between `Collection::get()` and `LazyCollection::get()` when the key is `null`.

Before the change `LazyCollection::get(null, $default)` returned `null` because the method exited early ignoring the provided default value. Now it returns the default value.