### PR TITLE
[13.x] Add batch job `interrupted()` callback

### DIFF
--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -501,7 +501,13 @@ class Batch implements Arrayable, JsonSerializable
         $batch = $this->fresh();
 
         foreach ($this->options['interrupted'] as $handler) {
-            $handler($batch, $signal);
+            try {
+                $handler($batch, $signal);
+            } catch (Throwable $e) {
+                if (function_exists('report')) {
+                    report($e);
+                }
+            }
         }
     }
 

--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -431,6 +431,16 @@ class Batch implements Arrayable, JsonSerializable
     }
 
     /**
+     * Determine if the batch has "interrupted" callbacks.
+     *
+     * @return bool
+     */
+    public function hasInterruptedCallbacks()
+    {
+        return isset($this->options['interrupted']) && ! empty($this->options['interrupted']);
+    }
+
+    /**
      * Cancel the batch.
      *
      * @param  \Throwable|null  $exception
@@ -475,6 +485,24 @@ class Batch implements Arrayable, JsonSerializable
     public function delete()
     {
         $this->repository->delete($this->id);
+    }
+
+    /**
+     * Handle the batch being interrupted.
+     * 
+     * @return void
+     */
+    public function interrupted(int $signal): void
+    {
+        if (! $this->hasInterruptedCallbacks()) {
+            return;
+        }
+
+        $batch = $this->fresh();
+
+        foreach ($this->options['interrupted'] as $handler) {
+            $handler($batch, $signal);
+        }
     }
 
     /**

--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -489,18 +489,14 @@ class Batch implements Arrayable, JsonSerializable
 
     /**
      * Handle the batch being interrupted.
-     * 
+     *
      * @return void
      */
     public function interrupted(int $signal): void
     {
-        if (! $this->hasInterruptedCallbacks()) {
-            return;
-        }
-
         $batch = $this->fresh();
 
-        foreach ($this->options['interrupted'] as $handler) {
+        foreach ($this->options['interrupted'] ?? [] as $handler) {
             try {
                 $handler($batch, $signal);
             } catch (Throwable $e) {

--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -431,16 +431,6 @@ class Batch implements Arrayable, JsonSerializable
     }
 
     /**
-     * Determine if the batch has "interrupted" callbacks.
-     *
-     * @return bool
-     */
-    public function hasInterruptedCallbacks()
-    {
-        return isset($this->options['interrupted']) && ! empty($this->options['interrupted']);
-    }
-
-    /**
      * Cancel the batch.
      *
      * @param  \Throwable|null  $exception

--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -484,8 +484,6 @@ class Batch implements Arrayable, JsonSerializable
      */
     public function interrupted(int $signal): void
     {
-        $batch = $this->fresh();
-
         foreach ($this->options['interrupted'] ?? [] as $handler) {
             try {
                 $handler($batch, $signal);

--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -486,7 +486,7 @@ class Batch implements Arrayable, JsonSerializable
     {
         foreach ($this->options['interrupted'] ?? [] as $handler) {
             try {
-                $handler($batch, $signal);
+                $handler($this, $signal);
             } catch (Throwable $e) {
                 if (function_exists('report')) {
                     report($e);

--- a/src/Illuminate/Bus/PendingBatch.php
+++ b/src/Illuminate/Bus/PendingBatch.php
@@ -161,6 +161,29 @@ class PendingBatch
     }
 
     /**
+     * Add a callback to be executed if any job in the batch is interrupted.
+     *
+     * @param  callable  $callback
+     * @return $this
+     */
+    public function interrupted($callback)
+    {
+        $this->registerCallback('interrupted', $callback);
+
+        return $this;
+    }
+
+    /**
+     * Get the "interrupted" callbacks that have been registered with the pending batch.
+     *
+     * @return array
+     */
+    public function interruptedCallbacks()
+    {
+        return $this->options['interrupted'] ?? [];
+    }
+
+    /**
      * Add a callback to be executed after all jobs in the batch have executed successfully.
      *
      * @param  callable  $callback

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Queue;
 
+use Illuminate\Bus\Batchable;
 use Illuminate\Contracts\Cache\Repository as CacheContract;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Events\Dispatcher;
@@ -870,6 +871,10 @@ class Worker
 
         if ($job instanceof Interruptible) {
             $job->interrupted($signal);
+        }
+
+        if (isset(class_uses_recursive($job)[Batchable::class])) {
+            $job->batch()?->interrupted($signal);
         }
     }
 

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -636,11 +636,6 @@ class BusBatchTest extends TestCase
         $batch->options['then'] = [1];
         $this->assertTrue($batch->hasThenCallbacks());
 
-        $batch->options['interrupted'] = [];
-        $this->assertFalse($batch->hasInterruptedCallbacks());
-        $batch->options['interrupted'] = [1];
-        $this->assertTrue($batch->hasInterruptedCallbacks());
-
         $this->assertFalse($batch->allowsFailures());
         $batch->options['allowFailures'] = true;
         $this->assertTrue($batch->allowsFailures());

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -520,6 +520,58 @@ class BusBatchTest extends TestCase
         $this->assertEquals(2, $_SERVER['__failure3.param_count']);
     }
 
+    public function test_interrupted_callbacks_execute_correctly(): void
+    {
+        $queue = m::mock(Factory::class);
+
+        $repository = new DatabaseBatchRepository(new BatchFactory($queue), DB::connection(), 'job_batches');
+
+        $pendingBatch = (new PendingBatch(new Container, collect()))
+            ->interrupted(static fn (Batch $batch, int $signal): true => $_SERVER['__interrupted1.invoked'] = true)
+            ->interrupted(function (Batch $batch, int $signal) {
+                $_SERVER['__interrupted2.invoked'] = true;
+            })
+            ->interrupted(function (Batch $batch, int $signal) {
+                $_SERVER['__interrupted3.batch'] = $batch;
+                $_SERVER['__interrupted3.signal'] = $signal;
+                $_SERVER['__interrupted3.batch_id'] = $batch->id;
+                $_SERVER['__interrupted3.batch_class'] = get_class($batch);
+                $_SERVER['__interrupted3.param_count'] = func_num_args();
+            })
+            ->onConnection('test-connection')
+            ->onQueue('test-queue');
+
+        $batch = $repository->store($pendingBatch);
+
+        $job = new class
+        {
+            use Batchable;
+        };
+
+        $queue->shouldReceive('connection')->once()
+            ->with('test-connection')
+            ->andReturn($connection = m::mock(stdClass::class));
+
+        $connection->shouldReceive('bulk')->once();
+
+        $batch = $batch->add([$job]);
+
+        $_SERVER['__interrupted1.invoked'] = false;
+        $_SERVER['__interrupted2.invoked'] = false;
+        $_SERVER['__interrupted3.batch'] = null;
+        $_SERVER['__interrupted3.signal'] = null;
+
+        $batch->interrupted(15);
+
+        $this->assertTrue($_SERVER['__interrupted1.invoked']);
+        $this->assertTrue($_SERVER['__interrupted2.invoked']);
+        $this->assertInstanceOf(Batch::class, $_SERVER['__interrupted3.batch']);
+        $this->assertSame(15, $_SERVER['__interrupted3.signal']);
+        $this->assertSame($batch->id, $_SERVER['__interrupted3.batch_id']);
+        $this->assertSame(Batch::class, $_SERVER['__interrupted3.batch_class']);
+        $this->assertEquals(2, $_SERVER['__interrupted3.param_count']);
+    }
+
     public function test_batch_can_be_cancelled()
     {
         $queue = m::mock(Factory::class);
@@ -583,6 +635,11 @@ class BusBatchTest extends TestCase
         $this->assertFalse($batch->hasThenCallbacks());
         $batch->options['then'] = [1];
         $this->assertTrue($batch->hasThenCallbacks());
+
+        $batch->options['interrupted'] = [];
+        $this->assertFalse($batch->hasInterruptedCallbacks());
+        $batch->options['interrupted'] = [1];
+        $this->assertTrue($batch->hasInterruptedCallbacks());
 
         $this->assertFalse($batch->allowsFailures());
         $batch->options['allowFailures'] = true;

--- a/tests/Bus/BusPendingBatchTest.php
+++ b/tests/Bus/BusPendingBatchTest.php
@@ -40,6 +40,8 @@ class BusPendingBatchTest extends TestCase
             //
         })->catch(function () {
             //
+        })->interrupted(function () {
+            //
         })->allowFailures()->onConnection('test-connection')->onQueue('test-queue')->withOption('extra-option', 123);
 
         $this->assertSame('test-connection', $pendingBatch->connection());
@@ -48,6 +50,7 @@ class BusPendingBatchTest extends TestCase
         $this->assertCount(1, $pendingBatch->progressCallbacks());
         $this->assertCount(1, $pendingBatch->thenCallbacks());
         $this->assertCount(1, $pendingBatch->catchCallbacks());
+        $this->assertCount(1, $pendingBatch->interruptedCallbacks());
         $this->assertArrayHasKey('extra-option', $pendingBatch->options);
         $this->assertSame(123, $pendingBatch->options['extra-option']);
 

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -3,10 +3,10 @@
 namespace Illuminate\Tests\Queue;
 
 use Exception;
+use Illuminate\Bus\Batchable;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Events\Dispatcher;
-use Illuminate\Bus\Batchable;
 use Illuminate\Contracts\Queue\Interruptible;
 use Illuminate\Contracts\Queue\Job as QueueJobContract;
 use Illuminate\Queue\CallQueuedHandler;

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -535,7 +535,7 @@ class QueueWorkerTest extends TestCase
         $this->assertSame(15, $interruptible->receivedSignal);
     }
 
-    public function testBatchableJobBatchIsNotifiedOnSignal()
+    public function testBatchIsNotifiedOnSignal()
     {
         $batchable = new class
         {

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -6,6 +6,7 @@ use Exception;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Bus\Batchable;
 use Illuminate\Contracts\Queue\Interruptible;
 use Illuminate\Contracts\Queue\Job as QueueJobContract;
 use Illuminate\Queue\CallQueuedHandler;
@@ -532,6 +533,32 @@ class QueueWorkerTest extends TestCase
         $worker->notifyJobOfSignal(15);
 
         $this->assertSame(15, $interruptible->receivedSignal);
+    }
+
+    public function testBatchableJobBatchIsNotifiedOnSignal()
+    {
+        $batchable = new class
+        {
+            use Batchable;
+        };
+
+        [$batchable, $fakeBatch] = $batchable->withFakeBatch(options: [
+            'interrupted' => [function ($batch, $signal) use (&$receivedSignal) {
+                $receivedSignal = $signal;
+            }],
+        ]);
+
+        $handler = m::mock(CallQueuedHandler::class);
+        $handler->shouldReceive('getRunningCommand')->andReturn($batchable);
+
+        $worker = $this->getWorker('default', ['queue' => []]);
+        $job = new WorkerFakeJob;
+        $job->resolvedJob = $handler;
+
+        $worker->currentJob = $job;
+        $worker->notifyJobOfSignal(15);
+
+        $this->assertSame(15, $receivedSignal);
     }
 
     /**


### PR DESCRIPTION
This builds on the ability to interrupt jobs and extends it to batches via a new `interrupted()` method on the `PendingBatch`, so they can also react to those signals.