### PR TITLE
[13.x] Rely on guzzlehttp/psr7 for nested multipart array expansion - Fix #59992

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,7 @@
         "ably/ably-php": "^1.0",
         "aws/aws-sdk-php": "^3.322.9",
         "fakerphp/faker": "^1.24",
-        "guzzlehttp/psr7": "^2.4",
+        "guzzlehttp/psr7": "^2.9",
         "laravel/pint": "^1.18",
         "league/flysystem-aws-s3-v3": "^3.25.1",
         "league/flysystem-ftp": "^3.25.1",

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -1155,20 +1155,13 @@ class PendingRequest
     protected function parseMultipartBodyFormat(array $data)
     {
         return (new Collection($data))
-            ->flatMap(function ($value, $key) {
-                if (is_array($value)) {
-                    // If the array has 'name' and 'contents' keys, it's already formatted for multipart...
-                    if (isset($value['name'], $value['contents'])) {
-                        return [$value];
-                    }
-
-                    // Otherwise, treat it as multiple values for the same field name...
-                    return (new Collection($value))->map(function ($item) use ($key) {
-                        return ['name' => $key.'[]', 'contents' => $item];
-                    });
+            ->map(function ($value, $key) {
+                // If the array has 'name' and 'contents' keys, it's already formatted for multipart...
+                if (is_array($value) && isset($value['name'], $value['contents'])) {
+                    return $value;
                 }
 
-                return [['name' => $key, 'contents' => $value]];
+                return ['name' => $key, 'contents' => $value];
             })
             ->values()
             ->all();

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -849,10 +849,8 @@ class HttpClientTest extends TestCase
                 Str::startsWith($request->header('Content-Type')[0], 'multipart') &&
                 $request[0]['name'] === 'name' &&
                 $request[0]['contents'] === 'Steve' &&
-                $request[1]['name'] === 'roles[]' &&
-                $request[1]['contents'] === 'Network Administrator' &&
-                $request[2]['name'] === 'roles[]' &&
-                $request[2]['contents'] === 'Janitor';
+                $request[1]['name'] === 'roles' &&
+                $request[1]['contents'] === ['Network Administrator', 'Janitor'];
         });
     }
 
@@ -872,13 +870,11 @@ class HttpClientTest extends TestCase
                 Str::startsWith($request->header('Content-Type')[0], 'multipart') &&
                 $request[0]['name'] === 'name' &&
                 $request[0]['contents'] === 'Steve' &&
-                $request[1]['name'] === 'roles[]' &&
-                $request[1]['contents'] === 'Network Administrator' &&
-                $request[2]['name'] === 'roles[]' &&
-                $request[2]['contents'] === 'Janitor' &&
-                $request[3]['name'] === 'attachment' &&
-                $request[3]['contents'] === 'photo_content' &&
-                $request[3]['filename'] === 'photo.jpg';
+                $request[1]['name'] === 'roles' &&
+                $request[1]['contents'] === ['Network Administrator', 'Janitor'] &&
+                $request[2]['name'] === 'attachment' &&
+                $request[2]['contents'] === 'photo_content' &&
+                $request[2]['filename'] === 'photo.jpg';
         });
     }
 


### PR DESCRIPTION
## Description

This PR updates `guzzlehttp/psr7` to `^2.9` and removes Laravel's custom multipart array expansion logic.

Nested array values in multipart requests are now supported directly by Guzzle's `MultipartStream`, added in guzzle/psr7#638. Because of that, Laravel no longer needs to expand array values itself before passing multipart options to Guzzle.

## Context

This was originally discussed in laravel/framework#53028, where the feedback was that the behavior should be handled in Guzzle.

Support was later added to Guzzle through guzzle/psr7#638, based on the work started in guzzle/psr7#616.

Laravel currently also handles this case through laravel/framework#56302, but that logic now duplicates behavior available in `guzzlehttp/psr7`.

## Changes

- Bump `guzzlehttp/psr7` to `^2.9`
- Let Guzzle handle nested multipart array expansion
- Remove Laravel-side array expansion in `parseMultipartBodyFormat`
- Update the related HTTP client tests

## Related

- laravel/framework#53028
- guzzle/psr7#616
- guzzle/psr7#638
- laravel/framework#56302