### PR TITLE
[13.x] Add Worker::queueGroup method

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -118,11 +118,11 @@ class Worker
     protected static $popCallbacks = [];
 
     /**
-     * The registered queue groups.
+     * The registered queue name groups.
      *
      * @var array<string, array<int, string>>
      */
-    protected static $groups = [];
+    protected static $queueGroups = [];
 
     /**
      * The custom exit code to be used when memory is exceeded.
@@ -421,7 +421,7 @@ class Worker
             $queues = [];
 
             foreach (explode(',', $queue) as $name) {
-                $queues = array_merge($queues, static::resolveGroup($name));
+                $queues = array_merge($queues, static::resolveQueueGroup($name));
             }
 
             foreach ($queues as $index => $queue) {
@@ -1021,15 +1021,15 @@ class Worker
     }
 
     /**
-     * Register a queue group for the worker.
+     * Register a named group of queues for the worker.
      *
      * @param  string  $name
      * @param  array  $queues
      * @return void
      */
-    public static function group($name, array $queues)
+    public static function queueGroup($name, array $queues)
     {
-        static::$groups[$name] = $queues;
+        static::$queueGroups[$name] = $queues;
     }
 
     /**
@@ -1037,9 +1037,9 @@ class Worker
      *
      * @return void
      */
-    public static function flushGroups()
+    public static function flushQueueGroups()
     {
-        static::$groups = [];
+        static::$queueGroups = [];
     }
 
     /**
@@ -1048,9 +1048,9 @@ class Worker
      * @param  string  $name
      * @return array
      */
-    public static function resolveGroup($name)
+    public static function resolveQueueGroup($name)
     {
-        return static::$groups[$name] ?? [$name];
+        return static::$queueGroups[$name] ?? [$name];
     }
 
     /**

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -118,6 +118,13 @@ class Worker
     protected static $popCallbacks = [];
 
     /**
+     * The registered queue groups.
+     *
+     * @var array<string, array<int, string>>
+     */
+    protected static $groups = [];
+
+    /**
      * The custom exit code to be used when memory is exceeded.
      *
      * @var int|null
@@ -411,7 +418,13 @@ class Worker
                 return $job;
             }
 
-            foreach (explode(',', $queue) as $index => $queue) {
+            $queues = [];
+
+            foreach (explode(',', $queue) as $name) {
+                $queues = array_merge($queues, static::resolveGroup($name));
+            }
+
+            foreach ($queues as $index => $queue) {
                 if ($this->queuePaused($connection->getConnectionName(), $queue)) {
                     continue;
                 }
@@ -1005,6 +1018,39 @@ class Worker
         } else {
             static::$popCallbacks[$workerName] = $callback;
         }
+    }
+
+    /**
+     * Register a queue group for the worker.
+     *
+     * @param  string  $name
+     * @param  array  $queues
+     * @return void
+     */
+    public static function group($name, array $queues)
+    {
+        static::$groups[$name] = $queues;
+    }
+
+    /**
+     * Flush all registered queue groups.
+     *
+     * @return void
+     */
+    public static function flushGroups()
+    {
+        static::$groups = [];
+    }
+
+    /**
+     * Resolve the queues registered under the given group name.
+     *
+     * @param  string  $name
+     * @return array
+     */
+    public static function resolveGroup($name)
+    {
+        return static::$groups[$name] ?? [$name];
     }
 
     /**

--- a/tests/Integration/Queue/WorkCommandTest.php
+++ b/tests/Integration/Queue/WorkCommandTest.php
@@ -279,9 +279,6 @@ class WorkCommandTest extends QueueTestCase
         $this->assertTrue(FirstJob::$ran);
         $this->assertTrue(SecondJob::$ran);
         $this->assertFalse(ThirdJob::$ran);
-        $this->assertSame(0, Queue::size('payments'));
-        $this->assertSame(0, Queue::size('notifications'));
-        $this->assertSame(1, Queue::size('ignore-me-pls'));
     }
 }
 

--- a/tests/Integration/Queue/WorkCommandTest.php
+++ b/tests/Integration/Queue/WorkCommandTest.php
@@ -30,6 +30,7 @@ class WorkCommandTest extends QueueTestCase
             FirstJob::$ran = false;
             SecondJob::$ran = false;
             ThirdJob::$ran = false;
+            Worker::flushGroups();
         });
 
         parent::setUp();
@@ -259,6 +260,28 @@ class WorkCommandTest extends QueueTestCase
         $this->withoutMockingConsoleOutput()->artisan('queue:work', ['--once' => true]);
         Exceptions::assertNotReported(UniqueConstraintViolationException::class);
         $this->assertSame(2, substr_count(Artisan::output(), JobWillFail::class));
+    }
+
+    public function testGroup()
+    {
+        Worker::group('critical', ['payments', 'notifications']);
+
+        Queue::push(new FirstJob, '', 'payments');
+        Queue::push(new SecondJob, '', 'notifications');
+        Queue::push(new ThirdJob, '', 'ignore-me-pls');
+
+        $this->artisan('queue:work', [
+            '--queue' => 'critical',
+            '--stop-when-empty' => true,
+            '--memory' => 1024,
+        ])->assertExitCode(0);
+
+        $this->assertTrue(FirstJob::$ran);
+        $this->assertTrue(SecondJob::$ran);
+        $this->assertFalse(ThirdJob::$ran);
+        $this->assertSame(0, Queue::size('payments'));
+        $this->assertSame(0, Queue::size('notifications'));
+        $this->assertSame(1, Queue::size('ignore-me-pls'));
     }
 }
 

--- a/tests/Integration/Queue/WorkCommandTest.php
+++ b/tests/Integration/Queue/WorkCommandTest.php
@@ -30,7 +30,7 @@ class WorkCommandTest extends QueueTestCase
             FirstJob::$ran = false;
             SecondJob::$ran = false;
             ThirdJob::$ran = false;
-            Worker::flushGroups();
+            Worker::flushQueueGroups();
         });
 
         parent::setUp();
@@ -262,9 +262,9 @@ class WorkCommandTest extends QueueTestCase
         $this->assertSame(2, substr_count(Artisan::output(), JobWillFail::class));
     }
 
-    public function testGroup()
+    public function testQueueGroup()
     {
-        Worker::group('critical', ['payments', 'notifications']);
+        Worker::queueGroup('critical', ['payments', 'notifications']);
 
         Queue::push(new FirstJob, '', 'payments');
         Queue::push(new SecondJob, '', 'notifications');

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -50,6 +50,8 @@ class QueueWorkerTest extends TestCase
 
         Container::setInstance();
 
+        Worker::flushGroups();
+
         parent::tearDown();
     }
 

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -50,8 +50,6 @@ class QueueWorkerTest extends TestCase
 
         Container::setInstance();
 
-        Worker::flushGroups();
-
         parent::tearDown();
     }
 


### PR DESCRIPTION
So, one thing that causes me pain is having to define all the separate queues on a worker, when features are changing the workers can drift. For context I have 10+ workers, all doing different things using the database driver, so I have to type all my workers manually.

IE imagine currently you have an "important" worker : `queue:work --queue=payments,refunds`

If we ship a new `chargeback` queue with a feature, someone may easily forget to change the existing worker as it goes through all the different environments when its time for release etc.  


This PR adds a Worker::queueGroup method so we can do: 
```php 
  // This would live in our app service provider
  Worker::queueGroup('important', ['payments', 'refunds', 'chargebacks']);


// Which unlocks cool stuff like..
  Worker::queueGroup('important', [
      'payments',                                                                                                                                                                                                                                             
      'refunds',                                            
      ...(Feature::active('chargebacks') ? ['chargebacks'] : []),
  ]);
  
// This means we can just do php artisan queue:work --queue=important
```

This means supervisor configs, Cloud, and local scripts - ie any infra all keep saying `--queue=important` forever so you don't have to write instructions, for when things ship, all the changes can stay in one PR.

No B/C, so all the events etc, still come through as the expected queue. 
 
I went with the static approach to avoid any new options. Also avoided the queue manager as didn't wanna go down a rabbit hole of all the different queue methods, size, resume/pause etc.  This is just a Worker thing in my head.

You might see a nicer way though, but thought I'd give it a go, no drama if you throw it away! 

Open to renaming etc, ofc 🫡 I went with group, then queueGroup, but maybe alias is better? Needs some thought as I'm overthinking it :D 
