### PR TITLE
[13.x] Allow custom on delete/update

### DIFF
--- a/src/Illuminate/Database/Schema/ForeignKeyDefinition.php
+++ b/src/Illuminate/Database/Schema/ForeignKeyDefinition.php
@@ -9,8 +9,8 @@ use Illuminate\Support\Fluent;
  * @method ForeignKeyDefinition initiallyImmediate(bool $value = true) Set the default time to check the constraint (PostgreSQL)
  * @method ForeignKeyDefinition lock(('none'|'shared'|'default'|'exclusive') $value) Specify the DDL lock mode for the foreign key operation (MySQL)
  * @method ForeignKeyDefinition on(string $table) Specify the referenced table
- * @method ForeignKeyDefinition onDelete(('cascade'|'restrict'|'set null'|'no action') $action) Add an ON DELETE action
- * @method ForeignKeyDefinition onUpdate(('cascade'|'restrict'|'set null'|'no action') $action) Add an ON UPDATE action
+ * @method ForeignKeyDefinition onDelete(string $action) Add an ON DELETE action
+ * @method ForeignKeyDefinition onUpdate(string $action) Add an ON UPDATE action
  * @method ForeignKeyDefinition references(string|string[] $columns) Specify the referenced column(s)
  */
 class ForeignKeyDefinition extends Fluent


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

phpstan was complaining on the following:
```php
$table->foreign(['document_id', 'client_id'])
    ->references(['id', 'client_id'])
    ->on('documents')
    ->onDelete('set null (document_id)'); // ❌  phpstan: Parameter #1 $action of method Illuminate\Database\Schema\ForeignKeyDefinition::onDelete() expects 'cascade'|'no action'|'restrict'|'set null', 'set null (document…' given.
```

However this is valid SQL in postgres. In their docs they show the following example: 

FOREIGN KEY (tenant_id, author_id) REFERENCES users **ON DELETE SET NULL (author_id)** - https://www.postgresql.org/docs/current/ddl-constraints.html