### PR TITLE
[13.x] Add generic result type to collection min/max methods

### DIFF
--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -808,7 +808,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * @template TMinResult = mixed
      *
      * @param  (callable(TValue): TMinResult)|string|null  $callback
-     * @return ?TMinResult
+     * @return ($callback is callable ? ?TMinResult : ($callback is null ? ?TValue : mixed))
      */
     public function min($callback = null);
 
@@ -818,7 +818,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * @template TMaxResult = mixed
      *
      * @param  (callable(TValue): TMaxResult)|string|null  $callback
-     * @return ?TMaxResult
+     * @return ($callback is callable ? ?TMaxResult : ($callback is null ? ?TValue : mixed))
      */
     public function max($callback = null);
 

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -805,16 +805,20 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Get the min value of a given key.
      *
-     * @param  (callable(TValue):mixed)|string|null  $callback
-     * @return mixed
+     * @template TMinResult = mixed
+     *
+     * @param  (callable(TValue): TMinResult)|string|null  $callback
+     * @return ?TMinResult
      */
     public function min($callback = null);
 
     /**
      * Get the max value of a given key.
      *
-     * @param  (callable(TValue):mixed)|string|null  $callback
-     * @return mixed
+     * @template TMaxResult = mixed
+     *
+     * @param  (callable(TValue): TMaxResult)|string|null  $callback
+     * @return ?TMaxResult
      */
     public function max($callback = null);
 

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -489,7 +489,7 @@ trait EnumeratesValues
      * @template TMinResult = mixed
      *
      * @param  (callable(TValue): TMinResult)|string|null  $callback
-     * @return ?TMinResult
+     * @return ($callback is callable ? ?TMinResult : ($callback is null ? ?TValue : mixed))
      */
     public function min($callback = null)
     {
@@ -506,7 +506,7 @@ trait EnumeratesValues
      * @template TMaxResult = mixed
      *
      * @param  (callable(TValue): TMaxResult)|string|null  $callback
-     * @return ?TMaxResult
+     * @return ($callback is callable ? ?TMaxResult : ($callback is null ? ?TValue : mixed))
      */
     public function max($callback = null)
     {

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -486,8 +486,10 @@ trait EnumeratesValues
     /**
      * Get the min value of a given key.
      *
-     * @param  (callable(TValue):mixed)|string|null  $callback
-     * @return mixed
+     * @template TMinResult = mixed
+     *
+     * @param  (callable(TValue): TMinResult)|string|null  $callback
+     * @return ?TMinResult
      */
     public function min($callback = null)
     {
@@ -501,8 +503,10 @@ trait EnumeratesValues
     /**
      * Get the max value of a given key.
      *
-     * @param  (callable(TValue):mixed)|string|null  $callback
-     * @return mixed
+     * @template TMaxResult = mixed
+     *
+     * @param  (callable(TValue): TMaxResult)|string|null  $callback
+     * @return ?TMaxResult
      */
     public function max($callback = null)
     {

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -663,20 +663,20 @@ assertType('null', $collection::make()->min());
 assertType('int|null', $collection::make([1])->min());
 assertType('mixed', $collection::make([1])->min('string'));
 assertType('mixed', $collection::make(['string' => 1])->min('string'));
-assertType('int|null', $collection::make([1])->min(function ($int) {
+assertType("'foo'|null", $collection::make([1])->min(function ($int) {
     assertType('int', $int);
 
-    return $int;
+    return 'foo';
 }));
 assertType('mixed', $collection::make([new User])->min('id'));
 
 assertType('null', $collection::make()->max());
 assertType('int|null', $collection::make([1])->max());
 assertType('mixed', $collection::make([1])->max('string'));
-assertType('int|null', $collection::make([1])->max(function ($int) {
+assertType("'foo'|null", $collection::make([1])->max(function ($int) {
     assertType('int', $int);
 
-    return $int;
+    return 'foo';
 }));
 assertType('mixed', $collection::make([new User])->max('id'));
 

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -659,8 +659,8 @@ assertType('Illuminate\Support\Collection<string, string>', $collection::make(['
 assertType('Illuminate\Support\Collection<int, int>', $collection::make([1])->union([1]));
 assertType('Illuminate\Support\Collection<string, string>', $collection::make(['string' => 'string'])->union(['string' => 'string']));
 
-assertType('mixed', $collection::make()->min());
-assertType('mixed', $collection::make([1])->min());
+assertType('null', $collection::make()->min());
+assertType('int|null', $collection::make([1])->min());
 assertType('mixed', $collection::make([1])->min('string'));
 assertType('mixed', $collection::make(['string' => 1])->min('string'));
 assertType('int|null', $collection::make([1])->min(function ($int) {
@@ -670,8 +670,8 @@ assertType('int|null', $collection::make([1])->min(function ($int) {
 }));
 assertType('mixed', $collection::make([new User])->min('id'));
 
-assertType('mixed', $collection::make()->max());
-assertType('mixed', $collection::make([1])->max());
+assertType('null', $collection::make()->max());
+assertType('int|null', $collection::make([1])->max());
 assertType('mixed', $collection::make([1])->max('string'));
 assertType('int|null', $collection::make([1])->max(function ($int) {
     assertType('int', $int);

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -663,20 +663,20 @@ assertType('mixed', $collection::make()->min());
 assertType('mixed', $collection::make([1])->min());
 assertType('mixed', $collection::make([1])->min('string'));
 assertType('mixed', $collection::make(['string' => 1])->min('string'));
-assertType('mixed', $collection::make([1])->min(function ($int) {
+assertType('int|null', $collection::make([1])->min(function ($int) {
     assertType('int', $int);
 
-    return 1;
+    return $int;
 }));
 assertType('mixed', $collection::make([new User])->min('id'));
 
 assertType('mixed', $collection::make()->max());
 assertType('mixed', $collection::make([1])->max());
 assertType('mixed', $collection::make([1])->max('string'));
-assertType('mixed', $collection::make([1])->max(function ($int) {
+assertType('int|null', $collection::make([1])->max(function ($int) {
     assertType('int', $int);
 
-    return 1;
+    return $int;
 }));
 assertType('mixed', $collection::make([new User])->max('id'));
 

--- a/types/Support/LazyCollection.php
+++ b/types/Support/LazyCollection.php
@@ -554,20 +554,20 @@ assertType('Illuminate\Support\LazyCollection<string, string>', $collection::mak
 assertType('null', $collection::make()->min());
 assertType('int|null', $collection::make([1])->min());
 assertType('mixed', $collection::make([1])->min('string'));
-assertType('int|null', $collection::make([1])->min(function ($int) {
+assertType("'foo'|null", $collection::make([1])->min(function ($int) {
     assertType('int', $int);
 
-    return $int;
+    return 'foo';
 }));
 assertType('mixed', $collection::make([new User])->min('id'));
 
 assertType('null', $collection::make()->max());
 assertType('int|null', $collection::make([1])->max());
 assertType('mixed', $collection::make([1])->max('string'));
-assertType('int|null', $collection::make([1])->max(function ($int) {
+assertType("'foo'|null", $collection::make([1])->max(function ($int) {
     assertType('int', $int);
 
-    return $int;
+    return 'foo';
 }));
 assertType('mixed', $collection::make([new User])->max('id'));
 

--- a/types/Support/LazyCollection.php
+++ b/types/Support/LazyCollection.php
@@ -554,20 +554,20 @@ assertType('Illuminate\Support\LazyCollection<string, string>', $collection::mak
 assertType('mixed', $collection::make()->min());
 assertType('mixed', $collection::make([1])->min());
 assertType('mixed', $collection::make([1])->min('string'));
-assertType('mixed', $collection::make([1])->min(function ($int) {
+assertType('int|null', $collection::make([1])->min(function ($int) {
     assertType('int', $int);
 
-    return 1;
+    return $int;
 }));
 assertType('mixed', $collection::make([new User])->min('id'));
 
 assertType('mixed', $collection::make()->max());
 assertType('mixed', $collection::make([1])->max());
 assertType('mixed', $collection::make([1])->max('string'));
-assertType('mixed', $collection::make([1])->max(function ($int) {
+assertType('int|null', $collection::make([1])->max(function ($int) {
     assertType('int', $int);
 
-    return 1;
+    return $int;
 }));
 assertType('mixed', $collection::make([new User])->max('id'));
 

--- a/types/Support/LazyCollection.php
+++ b/types/Support/LazyCollection.php
@@ -551,8 +551,8 @@ assertType('Illuminate\Support\LazyCollection<int, int>', $collection::make([1])
 assertType('Illuminate\Support\LazyCollection<int, int>', $collection::make([1])->union([1]));
 assertType('Illuminate\Support\LazyCollection<string, string>', $collection::make(['string' => 'string'])->union(['string' => 'string']));
 
-assertType('mixed', $collection::make()->min());
-assertType('mixed', $collection::make([1])->min());
+assertType('null', $collection::make()->min());
+assertType('int|null', $collection::make([1])->min());
 assertType('mixed', $collection::make([1])->min('string'));
 assertType('int|null', $collection::make([1])->min(function ($int) {
     assertType('int', $int);
@@ -561,8 +561,8 @@ assertType('int|null', $collection::make([1])->min(function ($int) {
 }));
 assertType('mixed', $collection::make([new User])->min('id'));
 
-assertType('mixed', $collection::make()->max());
-assertType('mixed', $collection::make([1])->max());
+assertType('null', $collection::make()->max());
+assertType('int|null', $collection::make([1])->max());
 assertType('mixed', $collection::make([1])->max('string'));
 assertType('int|null', $collection::make([1])->max(function ($int) {
     assertType('int', $int);


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
When provided with a callback, the return type from a `min` or `max` call can be inferred from the provided callback return type. Note that `null` is always a possible return as the collection may be empty and we start from `null`.