### PR TITLE
[13.x] Add an environment filter to the `schedule:list` command

### DIFF
--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -430,6 +430,28 @@ class Schedule
     }
 
     /**
+     * Get all of the events on the schedule which run on the provided environments.
+     *
+     * @param  list<string>  $environments
+     * @return \Illuminate\Console\Scheduling\Event[]
+     */
+    public function eventsForEnvironments(array $environments): array
+    {
+        return array_values(array_filter(
+            $this->events(),
+            function (Event $event) use ($environments) {
+                foreach ($environments as $environment) {
+                    if ($event->runsInEnvironment($environment)) {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+        ));
+    }
+
+    /**
      * Specify the cache store that should be used to store mutexes.
      *
      * @param  \UnitEnum|string  $store

--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -439,15 +439,7 @@ class Schedule
     {
         return array_values(array_filter(
             $this->events(),
-            function (Event $event) use ($environments) {
-                foreach ($environments as $environment) {
-                    if ($event->runsInEnvironment($environment)) {
-                        return true;
-                    }
-                }
-
-                return false;
-            }
+            static fn (Event $event) => array_any($environments, $event->runsInEnvironment(...))
         ));
     }
 

--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -430,7 +430,7 @@ class Schedule
     }
 
     /**
-     * Get all of the events on the schedule which run on the provided environments.
+     * Get all of the events on the schedule which run on any of the provided environments.
      *
      * @param  list<string>  $environments
      * @return \Illuminate\Console\Scheduling\Event[]

--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -6,6 +6,7 @@ use Closure;
 use Cron\CronExpression;
 use DateTimeZone;
 use Illuminate\Console\Command;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use ReflectionClass;
@@ -23,6 +24,7 @@ class ScheduleListCommand extends Command
      */
     protected $signature = 'schedule:list
         {--timezone= : The timezone that times should be displayed in}
+        {--environment=* : Display the tasks scheduled to run on this environment}
         {--next : Sort the listed tasks by their next due date}
         {--json : Output the scheduled tasks as JSON}
     ';
@@ -52,6 +54,19 @@ class ScheduleListCommand extends Command
     public function handle(Schedule $schedule)
     {
         $events = new Collection($schedule->events());
+
+        $environments = Arr::wrap($this->option('environment'));
+        if (! empty($environments)) {
+            $events = $events->filter(function (Event $event) use ($environments) {
+                foreach ($environments as $environment) {
+                    if ($event->runsInEnvironment($environment)) {
+                        return true;
+                    }
+                }
+
+                return false;
+            });
+        }
 
         if ($events->isEmpty()) {
             if ($this->option('json')) {

--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -53,20 +53,13 @@ class ScheduleListCommand extends Command
      */
     public function handle(Schedule $schedule)
     {
-        $events = new Collection($schedule->events());
-
         $environments = Arr::wrap($this->option('environment'));
-        if (! empty($environments)) {
-            $events = $events->filter(function (Event $event) use ($environments) {
-                foreach ($environments as $environment) {
-                    if ($event->runsInEnvironment($environment)) {
-                        return true;
-                    }
-                }
 
-                return false;
-            });
-        }
+        $events = new Collection(
+            empty($environments)
+                ? $schedule->events()
+                : $schedule->eventsForEnvironments($environments)
+        );
 
         if ($events->isEmpty()) {
             if ($this->option('json')) {

--- a/src/Illuminate/Console/composer.json
+++ b/src/Illuminate/Console/composer.json
@@ -24,6 +24,7 @@
         "laravel/prompts": "^0.3.0",
         "nunomaduro/termwind": "^2.0",
         "symfony/console": "^7.4.0 || ^8.0.0",
+        "symfony/polyfill-php84": "^1.37",
         "symfony/process": "^7.4.5 || ^8.0.5"
     },
     "suggest": {

--- a/tests/Console/Scheduling/ScheduleTest.php
+++ b/tests/Console/Scheduling/ScheduleTest.php
@@ -81,11 +81,11 @@ final class ScheduleTest extends TestCase
         $this->assertSame(['production'], $filteredEvents[0]->environments);
         $this->assertSame('0 0 * * *', $filteredEvents[0]->expression);
 
-        $this->assertStringEndsWith("'artisan' inspire", $filteredEvents[1]->command);
+        $this->assertMatchesRegularExpression('/artisan.*inspire$/', $filteredEvents[1]->command);
         $this->assertSame(['staging', 'production'], $filteredEvents[1]->environments);
         $this->assertSame('* * * * *', $filteredEvents[1]->expression);
 
-        $this->assertStringEndsWith("'artisan' foobar", $filteredEvents[2]->command);
+        $this->assertMatchesRegularExpression('/artisan.*foobar$/', $filteredEvents[2]->command);
         $this->assertSame([], $filteredEvents[2]->environments);
         $this->assertSame('0 * * * *', $filteredEvents[2]->expression);
     }

--- a/tests/Console/Scheduling/ScheduleTest.php
+++ b/tests/Console/Scheduling/ScheduleTest.php
@@ -64,4 +64,29 @@ final class ScheduleTest extends TestCase
         $this->assertSame(JobToTestWithSchedule::class, $scheduledJob->description);
         $this->assertFalse($this->container->resolved(JobToTestWithSchedule::class));
     }
+
+    public function testItCanFilterEventsByEnvironments(): void
+    {
+        $schedule = new Schedule();
+        $schedule->job(JobToTestWithSchedule::class)->environments('production')->daily();
+        $schedule->command('inspire')->environments(['staging', 'production'])->everyMinute();
+        $schedule->command('foobar', ['a' => 'b'])->environments(['local', 'uat'])->everyMinute();
+        $schedule->command('foobar')->hourly();
+
+        $filteredEvents = $schedule->eventsForEnvironments(['production', 'staging']);
+
+        $this->assertCount(3, $filteredEvents);
+
+        $this->assertSame(JobToTestWithSchedule::class, $filteredEvents[0]->description);
+        $this->assertSame(['production'], $filteredEvents[0]->environments);
+        $this->assertSame('0 0 * * *', $filteredEvents[0]->expression);
+
+        $this->assertStringEndsWith("'artisan' inspire", $filteredEvents[1]->command);
+        $this->assertSame(['staging', 'production'], $filteredEvents[1]->environments);
+        $this->assertSame('* * * * *', $filteredEvents[1]->expression);
+
+        $this->assertStringEndsWith("'artisan' foobar", $filteredEvents[2]->command);
+        $this->assertSame([], $filteredEvents[2]->environments);
+        $this->assertSame('0 * * * *', $filteredEvents[2]->expression);
+    }
 }

--- a/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
@@ -169,6 +169,65 @@ class ScheduleListCommandTest extends TestCase
         $this->assertSame('php artisan foo:command', $data[2]['command']);
     }
 
+    public function testDisplayScheduleWithEnvironmentAsJson()
+    {
+        $this->schedule->command(FooCommand::class)->environments('production')->everyMinute();
+        $this->schedule->command('inspire')->environments('local')->everyTwoMinutes();
+        $this->schedule->job(FooJob::class)->everyFiveMinutes();
+
+        $this->withoutMockingConsoleOutput()->artisan(ScheduleListCommand::class, [
+            '--environment' => 'production',
+            '--json' => true,
+        ]);
+
+        $output = Artisan::output();
+
+        $this->assertJson($output);
+        $data = json_decode($output, true);
+
+        $this->assertIsArray($data);
+        $this->assertCount(2, $data);
+
+        $this->assertSame('* * * * *', $data[0]['expression']);
+        $this->assertSame('php artisan foo:command', $data[0]['command']);
+        $this->assertSame(['production'], $data[0]['environments']);
+
+        $this->assertSame('*/5 * * * *', $data[1]['expression']);
+        $this->assertSame('Illuminate\Tests\Integration\Console\Scheduling\FooJob', $data[1]['command']);
+        $this->assertSame([], $data[1]['environments']);
+    }
+
+    public function testDisplayScheduleWithMultipleEnvironmentAsJson()
+    {
+        $this->schedule->command(FooCommand::class)->environments('production')->everyMinute();
+        $this->schedule->command('foobar', ['a' => 'b'])->environments(['staging', 'local'])->everyTwoMinutes();
+        $this->schedule->command('inspire')->environments('local')->everyFiveMinutes();
+        $this->schedule->job(FooJob::class)->everyTenMinutes();
+
+        $this->withoutMockingConsoleOutput()
+            ->artisan('schedule:list --environment=staging --environment=local --json');
+
+        $output = Artisan::output();
+
+        $this->assertJson($output);
+        $data = json_decode($output, true);
+
+        $this->assertIsArray($data);
+        $this->assertCount(3, $data);
+
+        $this->assertSame('*/2 * * * *', $data[0]['expression']);
+        $this->assertSame('php artisan foobar a='.ProcessUtils::escapeArgument('b'), $data[0]['command']);
+        $this->assertSame(['staging', 'local'], $data[0]['environments']);
+
+        $this->assertSame('*/5 * * * *', $data[1]['expression']);
+        $this->assertSame('php artisan inspire', $data[1]['command']);
+        $this->assertSame(['local'], $data[1]['environments']);
+
+        $this->assertSame('*/10 * * * *', $data[2]['expression']);
+        $this->assertSame('Illuminate\Tests\Integration\Console\Scheduling\FooJob', $data[2]['command']);
+        $this->assertSame([], $data[2]['environments']);
+    }
+
     public function testDisplayScheduleAsJsonWithTimezone()
     {
         $this->schedule->command('inspire')->daily();

--- a/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
@@ -120,7 +120,7 @@ class ScheduleListCommandTest extends TestCase
         $this->assertStringContainsString('ScheduleListCommandTest.php', $data[8]['command']);
     }
 
-    public function testDisplayScheduleAsJsonWithSpecificEnvironment()
+    public function testDisplayScheduleAsJsonWithEnvironmentData()
     {
         $environment = 'production';
         $this->schedule->command(FooCommand::class)->quarterly()->environments($environment);
@@ -136,6 +136,65 @@ class ScheduleListCommandTest extends TestCase
         $this->assertIsArray($data[0]['environments']);
         $this->assertNotEmpty($data[0]['environments']);
         $this->assertContains($environment, $data[0]['environments']);
+    }
+
+    public function testDisplayScheduleWithEnvironmentFilterAsJson()
+    {
+        $this->schedule->command(FooCommand::class)->environments('production')->everyMinute();
+        $this->schedule->command('inspire')->environments('local')->everyTwoMinutes();
+        $this->schedule->job(FooJob::class)->everyFiveMinutes();
+
+        $this->withoutMockingConsoleOutput()->artisan(ScheduleListCommand::class, [
+            '--environment' => 'production',
+            '--json' => true,
+        ]);
+
+        $output = Artisan::output();
+
+        $this->assertJson($output);
+        $data = json_decode($output, true);
+
+        $this->assertIsArray($data);
+        $this->assertCount(2, $data);
+
+        $this->assertSame('* * * * *', $data[0]['expression']);
+        $this->assertSame('php artisan foo:command', $data[0]['command']);
+        $this->assertSame(['production'], $data[0]['environments']);
+
+        $this->assertSame('*/5 * * * *', $data[1]['expression']);
+        $this->assertSame('Illuminate\Tests\Integration\Console\Scheduling\FooJob', $data[1]['command']);
+        $this->assertSame([], $data[1]['environments']);
+    }
+
+    public function testDisplayScheduleWithMultipleEnvironmentFilterAsJson()
+    {
+        $this->schedule->command(FooCommand::class)->environments('production')->everyMinute();
+        $this->schedule->command('foobar', ['a' => 'b'])->environments(['staging', 'local'])->everyTwoMinutes();
+        $this->schedule->command('inspire')->environments('local')->everyFiveMinutes();
+        $this->schedule->job(FooJob::class)->everyTenMinutes();
+
+        $this->withoutMockingConsoleOutput()
+            ->artisan('schedule:list --environment=staging --environment=local --json');
+
+        $output = Artisan::output();
+
+        $this->assertJson($output);
+        $data = json_decode($output, true);
+
+        $this->assertIsArray($data);
+        $this->assertCount(3, $data);
+
+        $this->assertSame('*/2 * * * *', $data[0]['expression']);
+        $this->assertSame('php artisan foobar a='.ProcessUtils::escapeArgument('b'), $data[0]['command']);
+        $this->assertSame(['staging', 'local'], $data[0]['environments']);
+
+        $this->assertSame('*/5 * * * *', $data[1]['expression']);
+        $this->assertSame('php artisan inspire', $data[1]['command']);
+        $this->assertSame(['local'], $data[1]['environments']);
+
+        $this->assertSame('*/10 * * * *', $data[2]['expression']);
+        $this->assertSame('Illuminate\Tests\Integration\Console\Scheduling\FooJob', $data[2]['command']);
+        $this->assertSame([], $data[2]['environments']);
     }
 
     public function testDisplayScheduleWithSortAsJson()
@@ -167,65 +226,6 @@ class ScheduleListCommandTest extends TestCase
         $this->assertSame('0 0 1 1-12/3 *', $data[2]['expression']);
         $this->assertSame('3 months from now', $data[2]['next_due_date_human']);
         $this->assertSame('php artisan foo:command', $data[2]['command']);
-    }
-
-    public function testDisplayScheduleWithEnvironmentAsJson()
-    {
-        $this->schedule->command(FooCommand::class)->environments('production')->everyMinute();
-        $this->schedule->command('inspire')->environments('local')->everyTwoMinutes();
-        $this->schedule->job(FooJob::class)->everyFiveMinutes();
-
-        $this->withoutMockingConsoleOutput()->artisan(ScheduleListCommand::class, [
-            '--environment' => 'production',
-            '--json' => true,
-        ]);
-
-        $output = Artisan::output();
-
-        $this->assertJson($output);
-        $data = json_decode($output, true);
-
-        $this->assertIsArray($data);
-        $this->assertCount(2, $data);
-
-        $this->assertSame('* * * * *', $data[0]['expression']);
-        $this->assertSame('php artisan foo:command', $data[0]['command']);
-        $this->assertSame(['production'], $data[0]['environments']);
-
-        $this->assertSame('*/5 * * * *', $data[1]['expression']);
-        $this->assertSame('Illuminate\Tests\Integration\Console\Scheduling\FooJob', $data[1]['command']);
-        $this->assertSame([], $data[1]['environments']);
-    }
-
-    public function testDisplayScheduleWithMultipleEnvironmentAsJson()
-    {
-        $this->schedule->command(FooCommand::class)->environments('production')->everyMinute();
-        $this->schedule->command('foobar', ['a' => 'b'])->environments(['staging', 'local'])->everyTwoMinutes();
-        $this->schedule->command('inspire')->environments('local')->everyFiveMinutes();
-        $this->schedule->job(FooJob::class)->everyTenMinutes();
-
-        $this->withoutMockingConsoleOutput()
-            ->artisan('schedule:list --environment=staging --environment=local --json');
-
-        $output = Artisan::output();
-
-        $this->assertJson($output);
-        $data = json_decode($output, true);
-
-        $this->assertIsArray($data);
-        $this->assertCount(3, $data);
-
-        $this->assertSame('*/2 * * * *', $data[0]['expression']);
-        $this->assertSame('php artisan foobar a='.ProcessUtils::escapeArgument('b'), $data[0]['command']);
-        $this->assertSame(['staging', 'local'], $data[0]['environments']);
-
-        $this->assertSame('*/5 * * * *', $data[1]['expression']);
-        $this->assertSame('php artisan inspire', $data[1]['command']);
-        $this->assertSame(['local'], $data[1]['environments']);
-
-        $this->assertSame('*/10 * * * *', $data[2]['expression']);
-        $this->assertSame('Illuminate\Tests\Integration\Console\Scheduling\FooJob', $data[2]['command']);
-        $this->assertSame([], $data[2]['environments']);
     }
 
     public function testDisplayScheduleAsJsonWithTimezone()


### PR DESCRIPTION
Adds an `--environment` array option to the `schedule:list` command, returning only events that run in the specified environments.

E.g. `php artisan schedule:list --environment=production`

Had a mini heart attack when I ran `schedule:list` on production and saw something like  `MyLocalEnvironmentOnlyCommand` scheduled to run in X minutes.

Perhaps in 14.x it could default to the current application env, rather than showing all? Didn't do it here as it would be a breaking change (though minor)
