### PR TITLE
[13.x] Add AfterCommit queue attribute

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastEvent.php
+++ b/src/Illuminate/Broadcasting/BroadcastEvent.php
@@ -6,6 +6,7 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Broadcasting\Factory as BroadcastingFactory;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Queue\Attributes\AfterCommit;
 use Illuminate\Queue\Attributes\Backoff;
 use Illuminate\Queue\Attributes\DeleteWhenMissingModels;
 use Illuminate\Queue\Attributes\MaxExceptions;
@@ -74,7 +75,7 @@ class BroadcastEvent implements ShouldQueue
         $this->tries = $this->getAttributeValue($event, Tries::class, 'tries');
         $this->timeout = $this->getAttributeValue($event, Timeout::class, 'timeout');
         $this->backoff = $this->getAttributeValue($event, Backoff::class, 'backoff');
-        $this->afterCommit = property_exists($event, 'afterCommit') ? $event->afterCommit : null;
+        $this->afterCommit = $this->getAttributeValue($event, AfterCommit::class, 'afterCommit');
         $this->maxExceptions = $this->getAttributeValue($event, MaxExceptions::class, 'maxExceptions');
         $this->deleteWhenMissingModels = $this->getAttributeValue($event, DeleteWhenMissingModels::class, 'deleteWhenMissingModels');
     }

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -18,6 +18,7 @@ use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldBeUniqueUntilProcessing;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Contracts\Queue\ShouldQueueAfterCommit;
+use Illuminate\Queue\Attributes\AfterCommit;
 use Illuminate\Queue\Attributes\Backoff;
 use Illuminate\Queue\Attributes\Connection;
 use Illuminate\Queue\Attributes\Delay;
@@ -725,7 +726,7 @@ class Dispatcher implements DispatcherContract
             if ($listener instanceof ShouldQueueAfterCommit) {
                 $job->afterCommit = true;
             } else {
-                $job->afterCommit = property_exists($listener, 'afterCommit') ? $listener->afterCommit : null;
+                $job->afterCommit = $this->getAttributeValue($listener, AfterCommit::class, 'afterCommit');
             }
 
             $job->backoff = method_exists($listener, 'backoff') ? $listener->backoff(...$data) : $this->getAttributeValue($listener, Backoff::class, 'backoff');

--- a/src/Illuminate/Mail/SendQueuedMailable.php
+++ b/src/Illuminate/Mail/SendQueuedMailable.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Mail\Factory as MailFactory;
 use Illuminate\Contracts\Mail\Mailable as MailableContract;
 use Illuminate\Contracts\Queue\ShouldBeEncrypted;
 use Illuminate\Contracts\Queue\ShouldQueueAfterCommit;
+use Illuminate\Queue\Attributes\AfterCommit;
 use Illuminate\Queue\Attributes\Backoff;
 use Illuminate\Queue\Attributes\Connection;
 use Illuminate\Queue\Attributes\MaxExceptions;
@@ -67,7 +68,7 @@ class SendQueuedMailable
         if ($mailable instanceof ShouldQueueAfterCommit) {
             $this->afterCommit = true;
         } else {
-            $this->afterCommit = property_exists($mailable, 'afterCommit') ? $mailable->afterCommit : null;
+            $this->afterCommit = $this->getAttributeValue($mailable, AfterCommit::class, 'afterCommit');
         }
 
         $this->connection = $this->getAttributeValue($mailable, Connection::class, 'connection');

--- a/src/Illuminate/Notifications/SendQueuedNotifications.php
+++ b/src/Illuminate/Notifications/SendQueuedNotifications.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Contracts\Queue\ShouldQueueAfterCommit;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Queue\Attributes\AfterCommit;
 use Illuminate\Queue\Attributes\Backoff;
 use Illuminate\Queue\Attributes\DeleteWhenMissingModels;
 use Illuminate\Queue\Attributes\MaxExceptions;
@@ -96,7 +97,7 @@ class SendQueuedNotifications implements ShouldQueue
         if ($notification instanceof ShouldQueueAfterCommit) {
             $this->afterCommit = true;
         } else {
-            $this->afterCommit = property_exists($notification, 'afterCommit') ? $notification->afterCommit : null;
+            $this->afterCommit = $this->getAttributeValue($notification, AfterCommit::class, 'afterCommit');
         }
 
         $this->shouldBeEncrypted = $notification instanceof ShouldBeEncrypted;

--- a/src/Illuminate/Queue/Attributes/AfterCommit.php
+++ b/src/Illuminate/Queue/Attributes/AfterCommit.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Illuminate\Queue\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class AfterCommit
+{
+    //
+}

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -12,6 +12,7 @@ use Illuminate\Contracts\Encryption\Encrypter;
 use Illuminate\Contracts\Queue\ShouldBeEncrypted;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueueAfterCommit;
+use Illuminate\Queue\Attributes\AfterCommit;
 use Illuminate\Queue\Attributes\Backoff;
 use Illuminate\Queue\Attributes\DeleteWhenMissingModels;
 use Illuminate\Queue\Attributes\FailOnTimeout;
@@ -413,6 +414,10 @@ abstract class Queue
 
         if (! $job instanceof Closure && is_object($job) && isset($job->afterCommit)) {
             return $job->afterCommit;
+        }
+
+        if (! $job instanceof Closure && is_object($job) && $this->getAttributeValue($job, AfterCommit::class, 'afterCommit')) {
+            return true;
         }
 
         return $this->dispatchAfterCommit ?? false;

--- a/tests/Broadcasting/BroadcastEventTest.php
+++ b/tests/Broadcasting/BroadcastEventTest.php
@@ -7,6 +7,7 @@ use Illuminate\Broadcasting\BroadcastEvent;
 use Illuminate\Broadcasting\InteractsWithBroadcasting;
 use Illuminate\Contracts\Broadcasting\Broadcaster;
 use Illuminate\Contracts\Broadcasting\Factory as BroadcastingFactory;
+use Illuminate\Queue\Attributes\AfterCommit;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Throwable;
@@ -116,6 +117,13 @@ class BroadcastEventTest extends TestCase
 
         $job->failed($exception);
     }
+
+    public function testAfterCommitAttributeIsPropagated()
+    {
+        $job = new BroadcastEvent(new TestBroadcastEventWithAfterCommitAttribute);
+
+        $this->assertTrue($job->afterCommit);
+    }
 }
 
 class TestBroadcastEvent
@@ -142,6 +150,11 @@ class TestBroadcastEventWithManualData extends TestBroadcastEvent
     {
         return ['name' => 'Taylor'];
     }
+}
+
+#[AfterCommit]
+class TestBroadcastEventWithAfterCommitAttribute extends TestBroadcastEvent
+{
 }
 
 class TestBroadcastEventWithSpecificBroadcaster extends TestBroadcastEvent

--- a/tests/Events/QueuedEventsTest.php
+++ b/tests/Events/QueuedEventsTest.php
@@ -13,6 +13,7 @@ use Illuminate\Contracts\Queue\ShouldBeUniqueUntilProcessing;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Events\CallQueuedListener;
 use Illuminate\Events\Dispatcher;
+use Illuminate\Queue\Attributes\AfterCommit;
 use Illuminate\Queue\CallQueuedHandler;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\QueueManager;
@@ -225,6 +226,24 @@ class QueuedEventsTest extends TestCase
 
         $fakeQueue->assertPushed(CallQueuedListener::class, function ($job) {
             return $job->tries === 5;
+        });
+    }
+
+    public function testQueuePropagatesAfterCommitAttribute()
+    {
+        $d = new Dispatcher;
+
+        $fakeQueue = new QueueFake(new Container);
+
+        $d->setQueueResolver(function () use ($fakeQueue) {
+            return $fakeQueue;
+        });
+
+        $d->listen('some.event', TestDispatcherAfterCommitAttribute::class.'@handle');
+        $d->dispatch('some.event', ['foo', 'bar']);
+
+        $fakeQueue->assertPushed(CallQueuedListener::class, function ($job) {
+            return $job->afterCommit === true;
         });
     }
 
@@ -678,6 +697,15 @@ class TestDispatcherOptions implements ShouldQueue
         return 5;
     }
 
+    public function handle()
+    {
+        //
+    }
+}
+
+#[AfterCommit]
+class TestDispatcherAfterCommitAttribute implements ShouldQueue
+{
     public function handle()
     {
         //

--- a/tests/Mail/MailableQueuedTest.php
+++ b/tests/Mail/MailableQueuedTest.php
@@ -11,6 +11,7 @@ use Illuminate\Foundation\Application;
 use Illuminate\Mail\Mailable;
 use Illuminate\Mail\Mailer;
 use Illuminate\Mail\SendQueuedMailable;
+use Illuminate\Queue\Attributes\AfterCommit;
 use Illuminate\Queue\Attributes\Delay;
 use Illuminate\Support\Testing\Fakes\QueueFake;
 use Laravel\SerializableClosure\SerializableClosure;
@@ -180,6 +181,22 @@ class MailableQueuedTest extends TestCase
         $this->assertEquals(60, $pushedJob->delay);
     }
 
+    public function testQueuedMailableRespectsAfterCommitAttribute(): void
+    {
+        $job = new SendQueuedMailable(new MailableQueueableStubWithAfterCommitAttribute);
+
+        $this->assertTrue($job->afterCommit);
+    }
+
+    public function testQueuedMailableAfterCommitPropertyOverridesAttribute(): void
+    {
+        $mailable = (new MailableQueueableStubWithAfterCommitAttribute)->beforeCommit();
+
+        $job = new SendQueuedMailable($mailable);
+
+        $this->assertFalse($job->afterCommit);
+    }
+
     public function testQueuedMailableForwardsDeduplicationIdMethodToQueueJob(): void
     {
         $queueFake = new QueueFake(new Application);
@@ -241,6 +258,22 @@ class MailableQueueableStubWithMessageGroup extends Mailable implements ShouldQu
 
 #[Delay(30)]
 class MailableQueueableStubWithDelayAttribute extends Mailable implements ShouldQueue
+{
+    use Queueable;
+
+    public function build(): self
+    {
+        $this
+            ->subject('lorem ipsum')
+            ->html('foo bar baz')
+            ->to('foo@example.tld');
+
+        return $this;
+    }
+}
+
+#[AfterCommit]
+class MailableQueueableStubWithAfterCommitAttribute extends Mailable implements ShouldQueue
 {
     use Queueable;
 

--- a/tests/Notifications/NotificationSendQueuedNotificationTest.php
+++ b/tests/Notifications/NotificationSendQueuedNotificationTest.php
@@ -9,6 +9,7 @@ use Illuminate\Notifications\ChannelManager;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Notifications\Notification;
 use Illuminate\Notifications\SendQueuedNotifications;
+use Illuminate\Queue\Attributes\AfterCommit;
 use Illuminate\Support\Collection;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -62,6 +63,13 @@ class NotificationSendQueuedNotificationTest extends TestCase
 
         $this->assertEquals(23, $job->maxExceptions);
     }
+
+    public function testNotificationCanSetAfterCommitUsingAttribute()
+    {
+        $job = new SendQueuedNotifications(new NotifiableUser, new AfterCommitNotification);
+
+        $this->assertTrue($job->afterCommit);
+    }
 }
 
 class NotifiableUser extends Model
@@ -73,5 +81,10 @@ class NotifiableUser extends Model
 }
 
 class TestNotification extends Notification
+{
+}
+
+#[AfterCommit]
+class AfterCommitNotification extends Notification
 {
 }

--- a/tests/Queue/QueueSyncQueueTest.php
+++ b/tests/Queue/QueueSyncQueueTest.php
@@ -10,6 +10,7 @@ use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Contracts\Queue\ShouldQueueAfterCommit;
 use Illuminate\Database\DatabaseTransactionsManager;
+use Illuminate\Queue\Attributes\AfterCommit;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\Jobs\SyncJob;
 use Illuminate\Queue\SyncQueue;
@@ -131,6 +132,20 @@ class QueueSyncQueueTest extends TestCase
         $sync->push(new SyncQueueAfterCommitInterfaceJob());
     }
 
+    public function testItAddsATransactionCallbackForAttributeBasedAfterCommitJobs()
+    {
+        $sync = new SyncQueue;
+        $container = new Container;
+        $container->bind(\Illuminate\Contracts\Container\Container::class, \Illuminate\Container\Container::class);
+        $transactionManager = m::mock(DatabaseTransactionsManager::class);
+        $transactionManager->shouldReceive('addCallback')->once()->andReturn(null);
+        $transactionManager->shouldNotReceive('addCallbackForRollback');
+        $container->instance('db.transactions', $transactionManager);
+
+        $sync->setContainer($container);
+        $sync->push(new SyncQueueAfterCommitAttributeJob());
+    }
+
     public function testItAddsATransactionCallbackForAfterCommitUniqueJobs()
     {
         $sync = new SyncQueue;
@@ -245,6 +260,16 @@ class SyncQueueAfterCommitJob
 }
 
 class SyncQueueAfterCommitInterfaceJob implements ShouldQueueAfterCommit
+{
+    use InteractsWithQueue;
+
+    public function handle()
+    {
+    }
+}
+
+#[AfterCommit]
+class SyncQueueAfterCommitAttributeJob
 {
     use InteractsWithQueue;
 


### PR DESCRIPTION
This PR adds a new `Illuminate\Queue\Attributes\AfterCommit` attribute.

Laravel already supports queue configuration through class attributes for options like connection, queue, delay, tries, timeout, backoff, max exceptions, and missing model handling. This change adds the same declarative style for after-commit dispatching.

With this, jobs, queued listeners, mailables, notifications, and broadcast events can opt into after-commit dispatching using:

```php
use Illuminate\Queue\Attributes\AfterCommit;

#[AfterCommit]
class SendInvoiceNotification
{
    //
}
```

The existing behavior remains supported: `ShouldQueueAfterCommit` and the `$afterCommit` property continue to work, while the attribute provides a more consistent API alongside the other queue attributes.