### PR TITLE
[13.x] Use native `clamp` function

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -5,6 +5,7 @@ namespace Illuminate\Support;
 use Illuminate\Support\Traits\Macroable;
 use NumberFormatter;
 use RuntimeException;
+use ValueError;
 
 class Number
 {
@@ -310,7 +311,13 @@ class Number
      */
     public static function clamp(int|float $number, int|float $min, int|float $max)
     {
-        return clamp($number, $min, $max);
+        try {
+            return clamp($number, $min, $max);
+        } catch (ValueError $e) {
+            trigger_error($e->getMessage(), E_USER_DEPRECATED);
+
+            return $max;
+        }
     }
 
     /**

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -310,7 +310,7 @@ class Number
      */
     public static function clamp(int|float $number, int|float $min, int|float $max)
     {
-        return min(max($number, $min), $max);
+        return clamp($number, $min, $max);
     }
 
     /**

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -26,6 +26,7 @@
         "illuminate/reflection": "^13.0",
         "nesbot/carbon": "^3.8.4",
         "symfony/polyfill-php85": "^1.33",
+        "symfony/polyfill-php86": "^1.36",
         "voku/portable-ascii": "^2.0.2"
     },
     "replace": {

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -195,6 +195,10 @@ class SupportNumberTest extends TestCase
         $this->assertSame(5, Number::clamp(5, 1, 10));
         $this->assertSame(4.5, Number::clamp(4.5, 1, 10));
         $this->assertSame(1, Number::clamp(-10, 1, 5));
+        // Incorrect bounds always return 'max'
+        $this->assertSame(1, Number::clamp(-10, 5, 1));
+        $this->assertSame(1, Number::clamp(4, 5, 1));
+        $this->assertSame(1, Number::clamp(10, 5, 1));
     }
 
     public function testToHuman()

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Support;
 
 use Illuminate\Support\Number;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\TestCase;
 
@@ -195,9 +196,17 @@ class SupportNumberTest extends TestCase
         $this->assertSame(5, Number::clamp(5, 1, 10));
         $this->assertSame(4.5, Number::clamp(4.5, 1, 10));
         $this->assertSame(1, Number::clamp(-10, 1, 5));
+    }
+
+    #[IgnoreDeprecations]
+    public function testClampIncorrectBounds()
+    {
         // Incorrect bounds always return 'max'
+        $this->expectUserDeprecationMessage('clamp(): Argument #2 ($min) must be smaller than or equal to argument #3 ($max)');
         $this->assertSame(1, Number::clamp(-10, 5, 1));
+        $this->expectUserDeprecationMessage('clamp(): Argument #2 ($min) must be smaller than or equal to argument #3 ($max)');
         $this->assertSame(1, Number::clamp(4, 5, 1));
+        $this->expectUserDeprecationMessage('clamp(): Argument #2 ($min) must be smaller than or equal to argument #3 ($max)');
         $this->assertSame(1, Number::clamp(10, 5, 1));
     }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This replaces the manual `Number::clamp` implementation with the PHP native `clamp`, which is new in PHP 8.6 (unreleased). See also:
- https://wiki.php.net/rfc/clamp_v2
- https://github.com/php/php-src/pull/19434
- https://github.com/symfony/polyfill/pull/554

In doing so, it also introduces some tests for 'incorrect' behavior on providing reversed bounds, which currently leads to the incorrect and potentially unexpected outcome of always returning the 'max' value. By adding a deprecation now, this functionality can later be dropped to throw the `ValueError` and match the new default behavior.