### PR TITLE
Correctly handle associative array keys in HTTP client multipart requests

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -1155,7 +1155,7 @@ class PendingRequest
     protected function parseMultipartBodyFormat(array $data)
     {
         return (new Collection($data))
-            ->flatMap(function ($value, $key) {
+            ->flatMap(function ($value, $rootKey) {
                 if (is_array($value)) {
                     // If the array has 'name' and 'contents' keys, it's already formatted for multipart...
                     if (isset($value['name'], $value['contents'])) {
@@ -1163,12 +1163,13 @@ class PendingRequest
                     }
 
                     // Otherwise, treat it as multiple values for the same field name...
-                    return (new Collection($value))->map(function ($item) use ($key) {
-                        return ['name' => $key.'[]', 'contents' => $item];
-                    });
+                    return (new Collection($value))
+                        ->mapWithKeys(function ($item, $key) use ($rootKey) {
+                            return ["{$rootKey}[$key]" => ['name' => "{$rootKey}[$key]", 'contents' => $item]];
+                        });
                 }
 
-                return [['name' => $key, 'contents' => $value]];
+                return [['name' => $rootKey, 'contents' => $value]];
             })
             ->values()
             ->all();

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -882,6 +882,25 @@ class HttpClientTest extends TestCase
         });
     }
 
+    public function testCanSendMultipartDataWithKeyedArrayValues()
+    {
+        $this->factory->fake();
+
+        $this->factory->asMultipart()->post('http://foo.com/multipart', [
+            'user' => ['name' => 'foo'],
+            'admin' => ['name' => 'bar'],
+        ]);
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://foo.com/multipart' &&
+                Str::startsWith($request->header('Content-Type')[0], 'multipart') &&
+                $request[0]['name'] === 'user[name]' &&
+                $request[0]['contents'] === 'foo' &&
+                $request[1]['name'] === 'admin[name]' &&
+                $request[1]['contents'] === 'bar';
+        });
+    }
+
     public function testItCanSendToken()
     {
         $this->factory->fake();

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -849,9 +849,9 @@ class HttpClientTest extends TestCase
                 Str::startsWith($request->header('Content-Type')[0], 'multipart') &&
                 $request[0]['name'] === 'name' &&
                 $request[0]['contents'] === 'Steve' &&
-                $request[1]['name'] === 'roles[]' &&
+                $request[1]['name'] === 'roles[0]' &&
                 $request[1]['contents'] === 'Network Administrator' &&
-                $request[2]['name'] === 'roles[]' &&
+                $request[2]['name'] === 'roles[1]' &&
                 $request[2]['contents'] === 'Janitor';
         });
     }
@@ -872,9 +872,9 @@ class HttpClientTest extends TestCase
                 Str::startsWith($request->header('Content-Type')[0], 'multipart') &&
                 $request[0]['name'] === 'name' &&
                 $request[0]['contents'] === 'Steve' &&
-                $request[1]['name'] === 'roles[]' &&
+                $request[1]['name'] === 'roles[0]' &&
                 $request[1]['contents'] === 'Network Administrator' &&
-                $request[2]['name'] === 'roles[]' &&
+                $request[2]['name'] === 'roles[1]' &&
                 $request[2]['contents'] === 'Janitor' &&
                 $request[3]['name'] === 'attachment' &&
                 $request[3]['contents'] === 'photo_content' &&


### PR DESCRIPTION
## Description

This PR fixes an issue where associative array keys may be lost when sending nested array values as multipart data through the HTTP client.

For example, the following payload:
```php
Http::asMultipart()->post('http://foo.com/multipart', [
  'user' => ['name' => 'foo'],
  'admin' => ['name' => 'bar'],
]);
```
should preserve the nested keys and generate multipart field names such as:
```
user[name]
admin[name]
```
Instead, the current Laravel-side multipart expansion may flatten these values using `[]`, which causes the original array keys to be lost. In some cases, when multiple nested arrays contain the same inner key, this can also result in data being overwritten or dropped.

Fixes #59992.

## Changes
This PR updates `parseMultipartBodyFormat` so that keyed array values are expanded using their associative keys instead of being converted to unkeyed array fields.

It also adds a regression test covering the case where two root fields contain the same nested key:
```php
[
  'user' => ['name' => 'foo'],
  'admin' => ['name' => 'bar'],
]
```
The expected multipart fields are now preserved as:
```
user[name] = foo
admin[name] = bar
```
## Note about the preferred fix

While this PR fixes the reported issue within Laravel's current multipart parsing logic, I still believe #59984 would be the better long-term solution.

The reason is that this PR adds more Laravel-side logic around multipart array expansion, even though this behavior is now handled directly by Guzzle's MultipartStream in guzzlehttp/psr7 ^2.9.

In other words, this PR demonstrates that the current Laravel implementation does not fully cover the same behavior as Guzzle. However, instead of continuing to duplicate and maintain multipart array expansion logic inside the framework, it would likely be cleaner and more robust to rely on Guzzle for this responsibility.

So although this PR fixes #59992 directly, I would personally prefer reconsidering #59984, which removes the duplicated framework logic and delegates nested multipart array expansion to the underlying HTTP library.