### PR TITLE
[13.x] Add all* queue inspection methods

### DIFF
--- a/src/Illuminate/Queue/BeanstalkdQueue.php
+++ b/src/Illuminate/Queue/BeanstalkdQueue.php
@@ -146,6 +146,36 @@ class BeanstalkdQueue extends Queue implements QueueContract
     }
 
     /**
+     * Get all pending jobs across every queue.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function allPendingJobs(): Collection
+    {
+        return new Collection;
+    }
+
+    /**
+     * Get all delayed jobs across every queue.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function allDelayedJobs(): Collection
+    {
+        return new Collection;
+    }
+
+    /**
+     * Get all reserved jobs across every queue.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function allReservedJobs(): Collection
+    {
+        return new Collection;
+    }
+
+    /**
      * Get the creation timestamp of the oldest pending job, excluding delayed jobs.
      *
      * @param  string|null  $queue

--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -180,6 +180,47 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
     }
 
     /**
+     * Get all pending jobs across every queue.
+     *
+     * @return \Illuminate\Support\Collection<int, \Illuminate\Queue\Jobs\InspectedJob>
+     */
+    public function allPendingJobs(): Collection
+    {
+        return $this->database->table($this->table)
+            ->whereNull('reserved_at')
+            ->where('available_at', '<=', $this->currentTime())
+            ->get()
+            ->map(fn ($record) => InspectedJob::fromPayload($record->payload, $record->attempts));
+    }
+
+    /**
+     * Get all delayed jobs across every queue.
+     *
+     * @return \Illuminate\Support\Collection<int, \Illuminate\Queue\Jobs\InspectedJob>
+     */
+    public function allDelayedJobs(): Collection
+    {
+        return $this->database->table($this->table)
+            ->whereNull('reserved_at')
+            ->where('available_at', '>', $this->currentTime())
+            ->get()
+            ->map(fn ($record) => InspectedJob::fromPayload($record->payload, $record->attempts));
+    }
+
+    /**
+     * Get all reserved jobs across every queue.
+     *
+     * @return \Illuminate\Support\Collection<int, \Illuminate\Queue\Jobs\InspectedJob>
+     */
+    public function allReservedJobs(): Collection
+    {
+        return $this->database->table($this->table)
+            ->whereNotNull('reserved_at')
+            ->get()
+            ->map(fn ($record) => InspectedJob::fromPayload($record->payload, $record->attempts));
+    }
+
+    /**
      * Get the creation timestamp of the oldest pending job, excluding delayed jobs.
      *
      * @param  string|null  $queue

--- a/src/Illuminate/Queue/FailoverQueue.php
+++ b/src/Illuminate/Queue/FailoverQueue.php
@@ -106,6 +106,36 @@ class FailoverQueue extends Queue implements QueueContract
     }
 
     /**
+     * Get all pending jobs across every queue.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function allPendingJobs(): Collection
+    {
+        return $this->manager->connection($this->connections[0])->allPendingJobs();
+    }
+
+    /**
+     * Get all delayed jobs across every queue.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function allDelayedJobs(): Collection
+    {
+        return $this->manager->connection($this->connections[0])->allDelayedJobs();
+    }
+
+    /**
+     * Get all reserved jobs across every queue.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function allReservedJobs(): Collection
+    {
+        return $this->manager->connection($this->connections[0])->allReservedJobs();
+    }
+
+    /**
      * Get the creation timestamp of the oldest pending job, excluding delayed jobs.
      *
      * @param  string|null  $queue

--- a/src/Illuminate/Queue/NullQueue.php
+++ b/src/Illuminate/Queue/NullQueue.php
@@ -85,6 +85,36 @@ class NullQueue extends Queue implements QueueContract
     }
 
     /**
+     * Get all pending jobs across every queue.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function allPendingJobs(): Collection
+    {
+        return new Collection;
+    }
+
+    /**
+     * Get all delayed jobs across every queue.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function allDelayedJobs(): Collection
+    {
+        return new Collection;
+    }
+
+    /**
+     * Get all reserved jobs across every queue.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function allReservedJobs(): Collection
+    {
+        return new Collection;
+    }
+
+    /**
      * Get the creation timestamp of the oldest pending job, excluding delayed jobs.
      *
      * @param  string|null  $queue

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -195,6 +195,55 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
     }
 
     /**
+     * Get all pending jobs across every queue.
+     *
+     * @return \Illuminate\Support\Collection<int, \Illuminate\Queue\Jobs\InspectedJob>
+     */
+    public function allPendingJobs(): Collection
+    {
+        return $this->allQueueNames()
+            ->flatMap(fn ($name) => $this->getConnection()->lrange($this->getQueueRedisKey($name), 0, -1))
+            ->map(fn ($payload) => InspectedJob::fromPayload($payload));
+    }
+
+    /**
+     * Get all delayed jobs across every queue.
+     *
+     * @return \Illuminate\Support\Collection<int, \Illuminate\Queue\Jobs\InspectedJob>
+     */
+    public function allDelayedJobs(): Collection
+    {
+        return $this->allQueueNames()
+            ->flatMap(fn ($name) => $this->getConnection()->zrange($this->getQueueRedisKey($name).':delayed', 0, -1))
+            ->map(fn ($payload) => InspectedJob::fromPayload($payload));
+    }
+
+    /**
+     * Get all reserved jobs across every queue.
+     *
+     * @return \Illuminate\Support\Collection<int, \Illuminate\Queue\Jobs\InspectedJob>
+     */
+    public function allReservedJobs(): Collection
+    {
+        return $this->allQueueNames()
+            ->flatMap(fn ($name) => $this->getConnection()->zrange($this->getQueueRedisKey($name).':reserved', 0, -1))
+            ->map(fn ($payload) => InspectedJob::fromPayload($payload));
+    }
+
+    /**
+     * Get the unique queue names.
+     *
+     * @return \Illuminate\Support\Collection<int, string>
+     */
+    protected function allQueueNames(): Collection
+    {
+        return (new Collection($this->getConnection()->keys('queues:*')))
+            ->map(fn ($key) => Str::between($key, 'queues:', ':'))
+            ->unique()
+            ->values();
+    }
+
+    /**
      * Get the creation timestamp of the oldest pending job, excluding delayed jobs.
      *
      * @param  string|null  $queue

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -168,6 +168,36 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
     }
 
     /**
+     * Get all pending jobs across every queue.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function allPendingJobs(): Collection
+    {
+        return new Collection;
+    }
+
+    /**
+     * Get all delayed jobs across every queue.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function allDelayedJobs(): Collection
+    {
+        return new Collection;
+    }
+
+    /**
+     * Get all reserved jobs across every queue.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function allReservedJobs(): Collection
+    {
+        return new Collection;
+    }
+
+    /**
      * Get the creation timestamp of the oldest pending job, excluding delayed jobs.
      *
      * Not supported by SQS, returns null.

--- a/src/Illuminate/Queue/SyncQueue.php
+++ b/src/Illuminate/Queue/SyncQueue.php
@@ -106,6 +106,36 @@ class SyncQueue extends Queue implements QueueContract
     }
 
     /**
+     * Get all pending jobs across every queue.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function allPendingJobs(): Collection
+    {
+        return new Collection;
+    }
+
+    /**
+     * Get all delayed jobs across every queue.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function allDelayedJobs(): Collection
+    {
+        return new Collection;
+    }
+
+    /**
+     * Get all reserved jobs across every queue.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function allReservedJobs(): Collection
+    {
+        return new Collection;
+    }
+
+    /**
      * Get the creation timestamp of the oldest pending job, excluding delayed jobs.
      *
      * @param  string|null  $queue

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -461,7 +461,7 @@ class QueueFake extends QueueManager implements Fake, Queue
      * Get the pending jobs for the given queue.
      *
      * @param  string|null  $queue
-     * @return \Illuminate\Support\Collection<int, \Illuminate\Queue\Jobs\InspectedJob>
+     * @return \Illuminate\Support\Collection
      */
     public function pendingJobs($queue = null): Collection
     {
@@ -496,6 +496,45 @@ class QueueFake extends QueueManager implements Fake, Queue
      * @return \Illuminate\Support\Collection
      */
     public function reservedJobs($queue = null): Collection
+    {
+        return new Collection;
+    }
+
+    /**
+     * Get all pending jobs across every queue.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function allPendingJobs(): Collection
+    {
+        return (new Collection($this->jobs))
+            ->flatten(1)
+            ->map(fn ($data) => new InspectedJob(
+                uuid: null,
+                name: is_object($data['job'])
+                    ? (method_exists($data['job'], 'displayName') ? $data['job']->displayName() : get_class($data['job']))
+                    : $data['job'],
+                attempts: 0,
+                createdAt: null,
+            ));
+    }
+
+    /**
+     * Get all delayed jobs across every queue.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function allDelayedJobs(): Collection
+    {
+        return new Collection;
+    }
+
+    /**
+     * Get all reserved jobs across every queue.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function allReservedJobs(): Collection
     {
         return new Collection;
     }

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -461,7 +461,7 @@ class QueueFake extends QueueManager implements Fake, Queue
      * Get the pending jobs for the given queue.
      *
      * @param  string|null  $queue
-     * @return \Illuminate\Support\Collection
+     * @return \Illuminate\Support\Collection<int, \Illuminate\Queue\Jobs\InspectedJob>
      */
     public function pendingJobs($queue = null): Collection
     {
@@ -503,7 +503,7 @@ class QueueFake extends QueueManager implements Fake, Queue
     /**
      * Get all pending jobs across every queue.
      *
-     * @return \Illuminate\Support\Collection
+     * @return \Illuminate\Support\Collection<int, \Illuminate\Queue\Jobs\InspectedJob>
      */
     public function allPendingJobs(): Collection
     {

--- a/tests/Integration/Queue/RedisQueueTest.php
+++ b/tests/Integration/Queue/RedisQueueTest.php
@@ -668,6 +668,65 @@ class RedisQueueTest extends TestCase
         $this->assertNotNull($reserved->first()->uuid);
         $this->assertInstanceOf(Carbon::class, $reserved->first()->createdAt);
     }
+
+    #[DataProvider('redisDriverProvider')]
+    public function testAllPendingJobs($driver)
+    {
+        $default = config('queue.connections.redis.queue', 'default');
+        $this->setQueue($driver, $default);
+
+        $this->queue->push(new RedisQueueIntegrationTestJob(1));
+        $this->queue->pushOn('emails', new RedisQueueIntegrationTestJob(2));
+
+        $pending = $this->queue->allPendingJobs();
+
+        $this->assertCount(2, $pending);
+        $this->assertInstanceOf(InspectedJob::class, $pending->first());
+        $this->assertSame(RedisQueueIntegrationTestJob::class, $pending->first()->name);
+        $this->assertSame(0, $pending->first()->attempts);
+        $this->assertNotNull($pending->first()->uuid);
+        $this->assertInstanceOf(Carbon::class, $pending->first()->createdAt);
+    }
+
+    #[DataProvider('redisDriverProvider')]
+    public function testAllDelayedJobs($driver)
+    {
+        $default = config('queue.connections.redis.queue', 'default');
+        $this->setQueue($driver, $default);
+
+        $this->queue->later(60, new RedisQueueIntegrationTestJob(1));
+        $this->queue->laterOn('emails', 60, new RedisQueueIntegrationTestJob(2));
+
+        $delayed = $this->queue->allDelayedJobs();
+
+        $this->assertCount(2, $delayed);
+        $this->assertInstanceOf(InspectedJob::class, $delayed->first());
+        $this->assertSame(RedisQueueIntegrationTestJob::class, $delayed->first()->name);
+        $this->assertSame(0, $delayed->first()->attempts);
+        $this->assertNotNull($delayed->first()->uuid);
+        $this->assertInstanceOf(Carbon::class, $delayed->first()->createdAt);
+    }
+
+    #[DataProvider('redisDriverProvider')]
+    public function testAllReservedJobs($driver)
+    {
+        $default = config('queue.connections.redis.queue', 'default');
+        $this->setQueue($driver, $default);
+
+        $this->queue->push(new RedisQueueIntegrationTestJob(1));
+        $this->queue->pushOn('emails', new RedisQueueIntegrationTestJob(2));
+        $this->queue->pop();
+        $this->queue->pop('emails');
+
+        $reserved = $this->queue->allReservedJobs();
+
+        $this->assertCount(2, $reserved);
+        $this->assertInstanceOf(InspectedJob::class, $reserved->first());
+        $this->assertSame(RedisQueueIntegrationTestJob::class, $reserved->first()->name);
+        $this->assertSame(1, $reserved->first()->attempts);
+        $this->assertNotNull($reserved->first()->uuid);
+        $this->assertInstanceOf(Carbon::class, $reserved->first()->createdAt);
+    }
 }
 
 class RedisQueueIntegrationTestJob

--- a/tests/Queue/QueueDatabaseQueueUnitTest.php
+++ b/tests/Queue/QueueDatabaseQueueUnitTest.php
@@ -269,6 +269,93 @@ class QueueDatabaseQueueUnitTest extends TestCase
         $this->assertSame(1000000, $jobs->first()->createdAt->getTimestamp());
     }
 
+    public function testAllPendingJobs()
+    {
+        $queue = new DatabaseQueue($database = m::mock(Connection::class), 'table', 'default');
+        $queue->setContainer(m::spy(Container::class));
+
+        $payload1 = json_encode(['uuid' => 'uuid-1', 'displayName' => 'JobA', 'job' => 'foo', 'data' => [], 'createdAt' => 1000000]);
+        $payload2 = json_encode(['uuid' => 'uuid-2', 'displayName' => 'JobB', 'job' => 'foo', 'data' => [], 'createdAt' => 1000001]);
+
+        $database->shouldReceive('table')->with('table')->andReturn($query = m::mock(stdClass::class));
+        $query->shouldReceive('whereNull')->with('reserved_at')->andReturnSelf();
+        $query->shouldReceive('where')->with('available_at', '<=', m::any())->andReturnSelf();
+        $query->shouldReceive('get')->andReturn(collect([
+            (object) ['id' => 1, 'queue' => 'default', 'payload' => $payload1, 'attempts' => 0, 'reserved_at' => null],
+            (object) ['id' => 2, 'queue' => 'emails', 'payload' => $payload2, 'attempts' => 0, 'reserved_at' => null],
+        ]));
+
+        $jobs = $queue->allPendingJobs();
+
+        $this->assertCount(2, $jobs);
+        $this->assertInstanceOf(InspectedJob::class, $jobs->first());
+        $this->assertSame('JobA', $jobs->first()->name);
+        $this->assertSame('uuid-1', $jobs->first()->uuid);
+        $this->assertSame(0, $jobs->first()->attempts);
+        $this->assertInstanceOf(Carbon::class, $jobs->first()->createdAt);
+        $this->assertSame(1000000, $jobs->first()->createdAt->getTimestamp());
+        $this->assertSame('JobB', $jobs->last()->name);
+        $this->assertSame('uuid-2', $jobs->last()->uuid);
+    }
+
+    public function testAllDelayedJobs()
+    {
+        $queue = new DatabaseQueue($database = m::mock(Connection::class), 'table', 'default');
+        $queue->setContainer(m::spy(Container::class));
+
+        $payload1 = json_encode(['uuid' => 'uuid-1', 'displayName' => 'JobA', 'job' => 'foo', 'data' => [], 'createdAt' => 1000000]);
+        $payload2 = json_encode(['uuid' => 'uuid-2', 'displayName' => 'JobB', 'job' => 'foo', 'data' => [], 'createdAt' => 1000001]);
+
+        $database->shouldReceive('table')->with('table')->andReturn($query = m::mock(stdClass::class));
+        $query->shouldReceive('whereNull')->with('reserved_at')->andReturnSelf();
+        $query->shouldReceive('where')->with('available_at', '>', m::any())->andReturnSelf();
+        $query->shouldReceive('get')->andReturn(collect([
+            (object) ['id' => 1, 'queue' => 'default', 'payload' => $payload1, 'attempts' => 0, 'reserved_at' => null],
+            (object) ['id' => 2, 'queue' => 'emails', 'payload' => $payload2, 'attempts' => 0, 'reserved_at' => null],
+        ]));
+
+        $jobs = $queue->allDelayedJobs();
+
+        $this->assertCount(2, $jobs);
+        $this->assertInstanceOf(InspectedJob::class, $jobs->first());
+        $this->assertSame('JobA', $jobs->first()->name);
+        $this->assertSame('uuid-1', $jobs->first()->uuid);
+        $this->assertSame(0, $jobs->first()->attempts);
+        $this->assertInstanceOf(Carbon::class, $jobs->first()->createdAt);
+        $this->assertSame(1000000, $jobs->first()->createdAt->getTimestamp());
+        $this->assertSame('JobB', $jobs->last()->name);
+        $this->assertSame('uuid-2', $jobs->last()->uuid);
+    }
+
+    public function testAllReservedJobs()
+    {
+        $queue = new DatabaseQueue($database = m::mock(Connection::class), 'table', 'default');
+        $queue->setContainer(m::spy(Container::class));
+
+        $payload1 = json_encode(['uuid' => 'uuid-1', 'displayName' => 'JobA', 'job' => 'foo', 'data' => [], 'createdAt' => 1000000]);
+        $payload2 = json_encode(['uuid' => 'uuid-2', 'displayName' => 'JobB', 'job' => 'foo', 'data' => [], 'createdAt' => 1000001]);
+
+        $database->shouldReceive('table')->with('table')->andReturn($query = m::mock(stdClass::class));
+        $query->shouldReceive('whereNotNull')->with('reserved_at')->andReturnSelf();
+        $query->shouldReceive('get')->andReturn(collect([
+            (object) ['id' => 1, 'queue' => 'default', 'payload' => $payload1, 'attempts' => 1, 'reserved_at' => 1000005],
+            (object) ['id' => 2, 'queue' => 'emails', 'payload' => $payload2, 'attempts' => 2, 'reserved_at' => 1000006],
+        ]));
+
+        $jobs = $queue->allReservedJobs();
+
+        $this->assertCount(2, $jobs);
+        $this->assertInstanceOf(InspectedJob::class, $jobs->first());
+        $this->assertSame('JobA', $jobs->first()->name);
+        $this->assertSame('uuid-1', $jobs->first()->uuid);
+        $this->assertSame(1, $jobs->first()->attempts);
+        $this->assertInstanceOf(Carbon::class, $jobs->first()->createdAt);
+        $this->assertSame(1000000, $jobs->first()->createdAt->getTimestamp());
+        $this->assertSame('JobB', $jobs->last()->name);
+        $this->assertSame('uuid-2', $jobs->last()->uuid);
+        $this->assertSame(2, $jobs->last()->attempts);
+    }
+
     public function testGetLockForPoppingIsCached()
     {
         $database = m::mock(Connection::class);

--- a/tests/Support/SupportTestingQueueFakeTest.php
+++ b/tests/Support/SupportTestingQueueFakeTest.php
@@ -495,6 +495,19 @@ class SupportTestingQueueFakeTest extends TestCase
         $this->assertSame(0, $pending->first()->attempts);
     }
 
+    public function testAllPendingJobs()
+    {
+        $this->fake->push($this->job, '', 'foo');
+        $this->fake->push(new JobToFakeStub, '', 'bar');
+
+        $pending = $this->fake->allPendingJobs();
+
+        $this->assertCount(2, $pending);
+        $this->assertInstanceOf(InspectedJob::class, $pending->first());
+        $this->assertTrue($pending->contains(fn ($job) => $job->name === JobStub::class));
+        $this->assertTrue($pending->contains(fn ($job) => $job->name === JobToFakeStub::class));
+    }
+
     public function testGetRawPushes()
     {
         $this->fake->pushRaw('some-payload', null, ['options' => 'yeah']);


### PR DESCRIPTION
The `Queue::reservedJobs()` etc methods are great, but, a pain and inefficient when you have many queues you need to check.

During deployment in Laravel Cloud and other infra, we need to be sure there's no reserved jobs, as we dont want to kill the workers if they're working a job, This currently ends up looking like: 

``` php
Queue::reservedJobs('queue1') // this is a query
->merge(Queue::reservedJobs('queue2')) // this is a query ... etc
->merge(Queue::reservedJobs('queue3'))
->merge(Queue::reservedJobs('queue4')) // If we add a new queue, we need to remember to add it... :( 
``` 

So, we end up reaching for the `DB::table('jobs')` way, which means manually json decoding the payload, as the above is a bit nasty.

This PR adds `allReservedJobs`, `allDelayedJobs` and `allPendingJobs`  so we can just do: 

```php
Queue::allReservedJobs(); // We just need to know if something is reserved
  // Illuminate\Queue\Jobs\InspectedJob {#7549                                                                                                                                                                                                         
  //   +uuid: "1cde062a-8c6a-4d67-8125-e83f585c18cb",                                                                                                                                                                                                  
  //   +name: "App\\Jobs\\TestJob",
  //   +attempts: 0,                                                                                                                                                                                                                                   
  //   +createdAt: Illuminate\Support\Carbon @1777973529 {#7543
  //     date: 2026-05-05 09:32:09.0 +00:00,
  //   },
  // },
  // Illuminate\Queue\Jobs\InspectedJob {#7548
  //   +uuid: "7c029c59-e7da-4165-a50b-112c5dfc9bbe",
  //   +name: "App\\Jobs\\OtherJob",
  //   +attempts: 0,
  //   +createdAt: Illuminate\Support\Carbon @1777973529 {#7541
  //     date: 2026-05-05 09:32:09.0 +00:00,
  //   },
  // },
``` 

This only works for the database, Redis and fake driver same as `reservedJobs` etc. 

Added a allQueueNames method to the redis queue so we can figure out the queue names, which I think is fine? as felt this needed to work on both drivers to stand a chance of being merged.

Purely additive methods, so no B/C! 

Currently on holiday so responses may be a bit slower than normal if you have any questions, but feel free to change as you see fit 🫡