### PR TITLE
[13.x] Fix chunkById infinite loop when query has root-level orWhere conditions

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -172,6 +172,25 @@ trait BuildsQueries
         do {
             $clone = clone $this;
 
+            // If the query has OR conditions at the root level, wrap them in a nested
+            // group to prevent SQL operator precedence issues when the cursor condition
+            // (AND id > $lastId) is appended by forPageAfterId / forPageBeforeId.
+            //
+            // Without this, a query like:
+            //   ->where('a')->orWhere('b')->chunkById(...)
+            // generates: WHERE a OR b AND id > X
+            // which MySQL evaluates as: WHERE a OR (b AND id > X)  ← wrong
+            // instead of: WHERE (a OR b) AND id > X  ← intended
+            $baseQuery = method_exists($clone, 'getQuery') ? $clone->getQuery() : $clone;
+
+            if (collect($baseQuery->wheres)->pluck('boolean')->contains(fn ($b) => str_contains($b, 'or'))) {
+                $nested = $baseQuery->forNestedWhere();
+                $nested->wheres = $baseQuery->wheres;
+                $baseQuery->wheres = [['type' => 'Nested', 'query' => $nested, 'boolean' => 'and']];
+                // Bindings intentionally stay on $baseQuery — Laravel always resolves
+                // bindings from the top-level query, not from nested query objects.
+            }
+
             if ($skip && $page > 1) {
                 $clone->offset(0);
             }

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -965,6 +965,58 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals(2, $i);
     }
 
+    public function testChunkByIdWithOrWhere()
+    {
+        EloquentTestUser::insert([
+            ['id' => 1, 'name' => 'First', 'email' => 'first@example.com'],
+            ['id' => 2, 'name' => 'Second', 'email' => 'second@example.com'],
+            ['id' => 3, 'name' => 'Third', 'email' => 'third@example.com'],
+            ['id' => 4, 'name' => 'Fourth', 'email' => 'fourth@example.com'],
+            ['id' => 5, 'name' => 'Fifth', 'email' => 'fifth@example.com'],
+        ]);
+
+        // Without the fix, the generated SQL was:
+        //   WHERE id = 1 OR id = 5 AND id > $lastId
+        // MySQL evaluated this as:
+        //   WHERE id = 1 OR (id = 5 AND id > $lastId)
+        // The first condition (id = 1) always matched regardless of $lastId,
+        // causing chunkById to loop infinitely on the same first chunk.
+        $collected = [];
+
+        EloquentTestUser::where('id', 1)
+            ->orWhere('id', 5)
+            ->chunkById(1, function (Collection $users) use (&$collected) {
+                foreach ($users as $user) {
+                    $collected[] = $user->id;
+                }
+            });
+
+        $this->assertSame([1, 5], $collected);
+    }
+
+    public function testChunkByIdDescWithOrWhere()
+    {
+        EloquentTestUser::insert([
+            ['id' => 1, 'name' => 'First', 'email' => 'first@example.com'],
+            ['id' => 2, 'name' => 'Second', 'email' => 'second@example.com'],
+            ['id' => 3, 'name' => 'Third', 'email' => 'third@example.com'],
+            ['id' => 4, 'name' => 'Fourth', 'email' => 'fourth@example.com'],
+            ['id' => 5, 'name' => 'Fifth', 'email' => 'fifth@example.com'],
+        ]);
+
+        $collected = [];
+
+        EloquentTestUser::where('id', 1)
+            ->orWhere('id', 5)
+            ->chunkByIdDesc(1, function (Collection $users) use (&$collected) {
+                foreach ($users as $user) {
+                    $collected[] = $user->id;
+                }
+            });
+
+        $this->assertSame([5, 1], $collected);
+    }
+
     public function testEachByIdWithNonIncrementingKey()
     {
         EloquentTestNonIncrementingSecond::insert([

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -6142,6 +6142,31 @@ SQL;
         }, 'someIdField');
     }
 
+    public function testChunkByIdWrapsOrWhereToPreventSqlPrecedenceIssue()
+    {
+        $capturedSqls = [];
+
+        $builder = $this->getBuilder()->from('users')->where('id', 1)->orWhere('id', 5);
+        $builder->getConnection()->shouldReceive('select')->andReturnUsing(function ($sql, $bindings) use (&$capturedSqls) {
+            $capturedSqls[] = $sql;
+
+            return [];
+        });
+        $builder->getProcessor()->shouldReceive('processSelect')->andReturn([]);
+
+        $builder->chunkById(2, function () {
+        });
+
+        // Without the fix, the SQL was:
+        //   WHERE "id" = ? or "id" = ? and "id" > ?
+        // which MySQL evaluates as:
+        //   WHERE "id" = ? or ("id" = ? and "id" > ?)  ← AND binds tighter than OR
+        // With the fix, the OR conditions are wrapped in a nested group:
+        //   WHERE ("id" = ? or "id" = ?) and "id" > ?
+        $this->assertStringContainsString('("id" = ? or "id" = ?)', $capturedSqls[0]);
+        $this->assertStringNotContainsString('"id" = ? or "id" = ? and', $capturedSqls[0]);
+    }
+
     public function testPaginate()
     {
         $perPage = 16;


### PR DESCRIPTION
## Problem

When `chunkById()` (or `chunkByIdDesc()`) is used on a query that contains root-level `orWhere` conditions, the cursor never advances and the method loops infinitely.

### Root cause

`orderedChunkById` clones the query and calls `forPageAfterId` / `forPageBeforeId`, which appends `AND id > $lastId` to the existing conditions. When the existing conditions include a root-level `OR`, SQL operator precedence causes MySQL (and other engines) to evaluate the `AND` before the `OR`:

```sql
-- What is generated
WHERE a = ? OR b = ? AND id > ?

-- How MySQL evaluates it (AND binds tighter than OR)
WHERE a = ? OR (b = ? AND id > ?)
```

The first branch (`a = ?`) always matches regardless of the cursor value, so the same first chunk is returned on every iteration → **infinite loop**.

This was raised in #29655 and a fix was proposed in #29721. That PR modified `forPageBeforeId` / `forPageAfterId` directly, which Taylor rejected because those are low-level methods where the developer is expected to control query construction.

However, as noted in that PR's discussion (but never addressed), `chunkById` is different: it is a **terminal iteration method** that users would never intentionally place between `where` / `orWhere` calls. The cursor condition it appends is an internal implementation detail, invisible to the caller. It is therefore reasonable to protect `chunkById` specifically.

## Fix

In `orderedChunkById`, before calling `forPageAfterId` / `forPageBeforeId`, detect any root-level `OR` conditions and wrap the existing `WHERE` clauses in a nested group:

```sql
-- After fix
WHERE (a = ? OR b = ?) AND id > ?
```

The implementation mirrors the approach already used by `Eloquent\Builder::groupWhereSliceForScope` when applying scopes — wrapping the existing wheres into a `Nested` entry without touching the outer query's bindings (which Laravel always resolves from the top-level builder).

## Tests

- **Unit test** (`DatabaseQueryBuilderTest`): verifies the generated SQL wraps OR conditions correctly.
- **Integration tests** (`DatabaseEloquentIntegrationTest`): `testChunkByIdWithOrWhere` and `testChunkByIdDescWithOrWhere` verify that all matching records are returned when using `orWhere` with both ascending and descending chunk iteration.