### PR TITLE
[13.x] Fix issue using custom aws credential providers

### DIFF
--- a/src/Illuminate/Queue/Connectors/SqsConnector.php
+++ b/src/Illuminate/Queue/Connectors/SqsConnector.php
@@ -55,7 +55,7 @@ class SqsConnector implements ConnectorInterface
 
         $provider = is_array($credentials) ? ($credentials['provider'] ?? null) : $credentials;
 
-        if (!is_string($provider)) {
+        if (! is_string($provider)) {
             return $provider;
         }
 

--- a/src/Illuminate/Queue/Connectors/SqsConnector.php
+++ b/src/Illuminate/Queue/Connectors/SqsConnector.php
@@ -53,7 +53,7 @@ class SqsConnector implements ConnectorInterface
     {
         $credentials = $config['credentials'] ?? null;
 
-        $provider = is_string($credentials) ? $credentials : ($credentials['provider'] ?? null);
+        $provider = is_array($credentials) ? ($credentials['provider'] ?? null) : $credentials;
 
         if (!is_string($provider)) {
             return $provider;

--- a/src/Illuminate/Queue/Connectors/SqsConnector.php
+++ b/src/Illuminate/Queue/Connectors/SqsConnector.php
@@ -55,8 +55,8 @@ class SqsConnector implements ConnectorInterface
 
         $provider = is_string($credentials) ? $credentials : ($credentials['provider'] ?? null);
 
-        if (is_null($provider)) {
-            return null;
+        if (!is_string($provider)) {
+            return $provider;
         }
 
         $options = is_array($credentials) ? Arr::except($credentials, ['provider']) : [];


### PR DESCRIPTION
# Why

https://github.com/laravel/framework/pull/59754 introduced a breaking change, although undocumented, when using credential providers.

The above PR changed sqs connections so that they can only use keys via config file, `ecs`, or `instance` credential providers, where as the aws sdk supports many other credential sources.

Previously this allowed supplying a credentials provider via the `credentials` key. (e.g `$config['credentials'] = CredentialProvider::ini()`

# Changes

Updated the credentials resolving code so that if the provider is not a string, then it will use that value.

This allows the use of the many other types of credential providers that aws supports, as well as custom implementations.