### PR TITLE
[13.x] Flush the Vite CSP nonce

### DIFF
--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -1245,5 +1245,7 @@ class Vite implements Htmlable
         $this->fonts?->flush();
 
         $this->fonts = null;
+
+        $this->nonce = null;
     }
 }


### PR DESCRIPTION
Octane workers can hold onto the `$nonce` between requests