### PR TITLE
[12.x] Fix infinite recursion when middleware group referencing itself

### DIFF
--- a/src/Illuminate/Routing/MiddlewareNameResolver.php
+++ b/src/Illuminate/Routing/MiddlewareNameResolver.php
@@ -63,7 +63,7 @@ class MiddlewareNameResolver
             // merge its middleware into the results. This allows groups to conveniently
             // reference other groups without needing to repeat all their middlewares.
             if (isset($middlewareGroups[$middleware])) {
-                throw_if($name === $middleware, new LogicException("[$name] middleware group is referencing itself."));
+                throw_if($name === $middleware, fn () => new LogicException("[$name] middleware group is referencing itself."));
 
                 $results = array_merge($results, static::parseMiddlewareGroup(
                     $middleware, $map, $middlewareGroups

--- a/src/Illuminate/Routing/MiddlewareNameResolver.php
+++ b/src/Illuminate/Routing/MiddlewareNameResolver.php
@@ -64,6 +64,7 @@ class MiddlewareNameResolver
             // reference other groups without needing to repeat all their middlewares.
             if (isset($middlewareGroups[$middleware])) {
                 throw_if($name === $middleware, new LogicException("[$name] middleware group is referencing itself."));
+
                 $results = array_merge($results, static::parseMiddlewareGroup(
                     $middleware, $map, $middlewareGroups
                 ));

--- a/src/Illuminate/Routing/MiddlewareNameResolver.php
+++ b/src/Illuminate/Routing/MiddlewareNameResolver.php
@@ -48,10 +48,10 @@ class MiddlewareNameResolver
      * Parse the middleware group and format it for usage.
      *
      * @param  string  $name
-     * @param  array   $map
-     * @param  array   $middlewareGroups
-     *
+     * @param  array  $map
+     * @param  array  $middlewareGroups
      * @return array
+     *
      * @throws Throwable
      */
     protected static function parseMiddlewareGroup($name, $map, $middlewareGroups)

--- a/src/Illuminate/Routing/MiddlewareNameResolver.php
+++ b/src/Illuminate/Routing/MiddlewareNameResolver.php
@@ -3,6 +3,8 @@
 namespace Illuminate\Routing;
 
 use Closure;
+use LogicException;
+use Throwable;
 
 class MiddlewareNameResolver
 {
@@ -46,9 +48,11 @@ class MiddlewareNameResolver
      * Parse the middleware group and format it for usage.
      *
      * @param  string  $name
-     * @param  array  $map
-     * @param  array  $middlewareGroups
+     * @param  array   $map
+     * @param  array   $middlewareGroups
+     *
      * @return array
+     * @throws Throwable
      */
     protected static function parseMiddlewareGroup($name, $map, $middlewareGroups)
     {
@@ -59,6 +63,7 @@ class MiddlewareNameResolver
             // merge its middleware into the results. This allows groups to conveniently
             // reference other groups without needing to repeat all their middlewares.
             if (isset($middlewareGroups[$middleware])) {
+                throw_if($name === $middleware, new LogicException("[$name] middleware group is referencing itself."));
                 $results = array_merge($results, static::parseMiddlewareGroup(
                     $middleware, $map, $middlewareGroups
                 ));

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -11,7 +11,6 @@ use Illuminate\Auth\Middleware\Authorize;
 use Illuminate\Config\Repository;
 use Illuminate\Container\Attributes\Config;
 use Illuminate\Container\Container;
-use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Routing\Registrar;
 use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Database\Eloquent\Model;

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -11,6 +11,7 @@ use Illuminate\Auth\Middleware\Authorize;
 use Illuminate\Config\Repository;
 use Illuminate\Container\Attributes\Config;
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Routing\Registrar;
 use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Database\Eloquent\Model;
@@ -384,6 +385,21 @@ class RoutingRouteTest extends TestCase
         $this->assertTrue($_SERVER['__middleware.group']);
 
         unset($_SERVER['__middleware.group']);
+    }
+
+    public function testMiddlewareGroupsCannotReferenceItself()
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('[web] middleware group is referencing itself.');
+
+        $router = $this->getRouter();
+        $router->get('foo/bar', ['middleware' => 'web', function () {
+            return 'hello';
+        }]);
+
+        $router->middlewareGroup('web', ['web']);
+
+        $router->dispatch(Request::create('foo/bar', 'GET'));
     }
 
     public function testFluentRouteNamingWithinAGroup()


### PR DESCRIPTION
When defining app in : `bootstrap/app.php`

If we try for example to **use web group** **in the web group**.

```php
    ->withMiddleware(function (Middleware $middleware): void {
        $middleware->web('web');
    })
```

It was crashing as infinite recursion occurred.

This is for sure a `LogicException`.