### PR TITLE
[13.x] Revert "Correct Factory::configure @return to $this (#59963)"

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -230,7 +230,7 @@ abstract class Factory
     /**
      * Configure the factory.
      *
-     * @return $this
+     * @return static
      */
     public function configure()
     {


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This reverts commit 4727569b831d0bb5596889f45ea273d91b2e67de (#59963).

This change reverts the strict `$this` return to `static`, as returning new static instances (rather than (re-)configuring the existing one) is a common pattern for factories. For example, the documentation on factory callbacks illustrating the usage of `configure` does this by calling `afterMaking` and `afterCreating`, which both return new static instances (rather than `$this`); see https://laravel.com/docs/13.x/eloquent-factories#factory-callbacks.

Although the base implementation does indeed return `$this`, imposing this on child implementations seems too restrictive to me given these considerations.

/cc @mosabbirrakib was there any reason in particular you needed the restricted type?