### PR TITLE
[12.x] Backport #60000 to 12.x

### DIFF
--- a/src/Illuminate/Queue/Connectors/SqsConnector.php
+++ b/src/Illuminate/Queue/Connectors/SqsConnector.php
@@ -53,10 +53,10 @@ class SqsConnector implements ConnectorInterface
     {
         $credentials = $config['credentials'] ?? null;
 
-        $provider = is_string($credentials) ? $credentials : ($credentials['provider'] ?? null);
+        $provider = is_array($credentials) ? ($credentials['provider'] ?? null) : $credentials;
 
-        if (is_null($provider)) {
-            return null;
+        if (! is_string($provider)) {
+            return $provider;
         }
 
         $options = is_array($credentials) ? Arr::except($credentials, ['provider']) : [];


### PR DESCRIPTION
Backport of #60000 to 12.x


https://github.com/laravel/framework/pull/59754 was the backport of the breaking change for sqs connectors to 12.x