### PR TITLE
[13.x] Skip allocation in mergeFillable/Appends/Hidden/Visible when input is empty

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
@@ -87,6 +87,10 @@ trait GuardsAttributes
      */
     public function mergeFillable(array $fillable)
     {
+        if ($fillable === []) {
+            return $this;
+        }
+
         $this->fillable = array_values(array_unique(array_merge($this->fillable, $fillable)));
 
         return $this;

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2484,6 +2484,10 @@ trait HasAttributes
      */
     public function mergeAppends(array $appends)
     {
+        if ($appends === []) {
+            return $this;
+        }
+
         $this->appends = array_values(array_unique(array_merge($this->appends, $appends)));
 
         return $this;

--- a/src/Illuminate/Database/Eloquent/Concerns/HidesAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HidesAttributes.php
@@ -65,6 +65,10 @@ trait HidesAttributes
      */
     public function mergeHidden(array $hidden)
     {
+        if ($hidden === []) {
+            return $this;
+        }
+
         $this->hidden = array_values(array_unique(array_merge($this->hidden, $hidden)));
 
         return $this;
@@ -101,6 +105,10 @@ trait HidesAttributes
      */
     public function mergeVisible(array $visible)
     {
+        if ($visible === []) {
+            return $this;
+        }
+
         $this->visible = array_values(array_unique(array_merge($this->visible, $visible)));
 
         return $this;

--- a/tests/Database/DatabaseEloquentModelAttributesTest.php
+++ b/tests/Database/DatabaseEloquentModelAttributesTest.php
@@ -347,6 +347,50 @@ class DatabaseEloquentModelAttributesTest extends TestCase
         $this->assertSame(['password', 'secret', 'api_key'], $model->getHidden());
     }
 
+    public function test_merge_fillable_with_empty_array_is_noop(): void
+    {
+        $model = new ModelWithFillableAttribute;
+        $original = $model->getFillable();
+
+        $result = $model->mergeFillable([]);
+
+        $this->assertSame($model, $result);
+        $this->assertSame($original, $model->getFillable());
+    }
+
+    public function test_merge_hidden_with_empty_array_is_noop(): void
+    {
+        $model = new ModelWithHiddenAttribute;
+        $original = $model->getHidden();
+
+        $result = $model->mergeHidden([]);
+
+        $this->assertSame($model, $result);
+        $this->assertSame($original, $model->getHidden());
+    }
+
+    public function test_merge_visible_with_empty_array_is_noop(): void
+    {
+        $model = new ModelWithVisibleAttribute;
+        $original = $model->getVisible();
+
+        $result = $model->mergeVisible([]);
+
+        $this->assertSame($model, $result);
+        $this->assertSame($original, $model->getVisible());
+    }
+
+    public function test_merge_appends_with_empty_array_is_noop(): void
+    {
+        $model = new ModelWithAppendsAttribute;
+        $original = $model->getAppends();
+
+        $result = $model->mergeAppends([]);
+
+        $this->assertSame($model, $result);
+        $this->assertSame($original, $model->getAppends());
+    }
+
     public function test_set_fillable_overrides_attribute(): void
     {
         $model = new ModelWithFillableAttribute;


### PR DESCRIPTION
## Problem

PR #59404 (released v13.3.0, fixing trait initializer collision) replaced `if (empty($this->fillable)) { $this->fillable = ... }` (and the analogous empty-checks for `appends`, `hidden`, `visible`) with calls to `$this->mergeFillable(...)` / `mergeAppends(...)` / `mergeHidden(...)` / `mergeVisible(...)`.

The collision fix is correct and necessary.

However, those `merge*` methods are now invoked on **every** model construction, including when the input array is empty (the common case — most models don't declare `#[Appends]`, so `static::resolveClassAttribute(Appends::class, 'columns') ?? []` evaluates to `[]`).

The current implementation:

```php
public function mergeFillable(array $fillable)
{
    $this->fillable = array_values(array_unique(array_merge($this->fillable, $fillable)));
    return $this;
}
```

For empty `$fillable`, this still allocates **three** transient arrays per call (`array_merge`, `array_unique`, `array_values`) — and the same for `mergeAppends`, `mergeHidden`, `mergeVisible`. At high construction rates the cumulative peak-memory cost is significant.

## Reproducible benchmark

[laravel-eloquent-bench](https://github.com/zenchef/laravel-eloquent-bench) — pinned point-release skeletons, identical synthetic 120-fillable / 13-cast / 50-relation / 4-trait model, N=100,000 constructions on PHP 8.4.14:

| Version | Peak memory | Δ vs v13.1.1 |
|---|---:|---:|
| v13.1.1 | 148 MB | — |
| v13.2.0 | 148 MB | 0 |
| **v13.3.0 (#59404 lands)** | **400 MB** | **+252 MB (+170%)** |
| v13.6.0 | 400 MB | +252 MB |

Memory recovers to the v13.1.1 baseline (148 MB) when the four `merge*` calls short-circuit on empty input. At scale on applications that hydrate many models per request, this delta is enough to exceed PHP's default `memory_limit`.

## Fix

Add an early return when the input is empty. Four guards:

```php
public function mergeFillable(array $fillable)
{
    if ($fillable === []) {
        return $this;
    }
    $this->fillable = array_values(array_unique(array_merge($this->fillable, $fillable)));
    return $this;
}
```

…and the same pattern for `mergeAppends`, `mergeHidden`, `mergeVisible`.

Behavior is preserved: `array_values(array_unique(array_merge($x, [])))` re-normalizes `$x`. Skipping that re-normalization when there's nothing to merge is a no-op for any developer-set `$fillable` / `$appends` / `$hidden` / `$visible` (which are conventionally already clean arrays). The trait-initializer-collision fix that motivated #59404 is preserved — it only matters when there's something to merge, which the guard explicitly skips.

## Tests

Added four `test_merge_*_with_empty_array_is_noop` cases in `tests/Database/DatabaseEloquentModelAttributesTest.php` asserting:

- Calling each `merge*` method with `[]` returns `$this`.
- The underlying property is unchanged (same array reference).

Existing tests for the trait-initializer-collision fix from #59404 continue to pass.

## References

- Regression introduced by: #59404 (v13.3.0)
- Original bug correctly fixed by #59404: #59381 (preserved)
- Benchmark: https://github.com/zenchef/laravel-eloquent-bench
- Sibling regressions in v13.x: #59284, #59701 (tracked separately)
