### PR TITLE
[12.x] Add --ignore-existing-tables and --mark-as-ran options to migrate command

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -36,7 +36,9 @@ class MigrateCommand extends BaseCommand implements Isolatable
                 {--seed : Indicates if the seed task should be re-run}
                 {--seeder= : The class name of the root seeder}
                 {--step : Force the migrations to be run so they can be rolled back individually}
-                {--graceful : Return a successful exit code even if an error occurs}';
+                {--graceful : Return a successful exit code even if an error occurs}
+                {--ignore-existing-tables : Skip migrations that fail because a table already exists}
+                {--mark-as-ran : Record pending migrations in the migrations table without running them}';
 
     /**
      * The console command description.
@@ -77,6 +79,8 @@ class MigrateCommand extends BaseCommand implements Isolatable
      * Execute the console command.
      *
      * @return int
+     *
+     * @throws \Throwable
      */
     public function handle()
     {
@@ -116,6 +120,8 @@ class MigrateCommand extends BaseCommand implements Isolatable
                 ->run($this->getMigrationPaths(), [
                     'pretend' => $this->option('pretend'),
                     'step' => $this->option('step'),
+                    'mark_as_ran' => $this->option('mark-as-ran'),
+                    'ignore_existing_tables' => $this->option('ignore-existing-tables'),
                 ]);
 
             // Finally, if the "seed" option has been given, we will re-run the database

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -9,6 +9,7 @@ use Illuminate\Console\View\Components\Task;
 use Illuminate\Console\View\Components\TwoColumnDetail;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
+use Illuminate\Database\QueryException;
 use Illuminate\Database\Events\MigrationEnded;
 use Illuminate\Database\Events\MigrationsEnded;
 use Illuminate\Database\Events\MigrationSkipped;
@@ -183,7 +184,7 @@ class Migrator
         // First we will just make sure that there are any migrations to run. If there
         // aren't, we will just make a note of it to the developer so they're aware
         // that all of the migrations have been run against this database system.
-        if (count($migrations) === 0) {
+        if ($migrations === []) {
             $this->fireMigrationEvent(new NoPendingMigrations('up'));
 
             $this->write(Info::class, 'Nothing to migrate');
@@ -200,15 +201,19 @@ class Migrator
 
         $step = $options['step'] ?? false;
 
+        $markAsRan = $options['mark_as_ran'] ?? false;
+
+        $ignoreExistingTables = $options['ignore_existing_tables'] ?? false;
+
         $this->fireMigrationEvent(new MigrationsStarted('up', $options));
 
-        $this->write(Info::class, 'Running migrations.');
+        $this->write(Info::class, $markAsRan ? 'Marking migrations as ran.' : 'Running migrations.');
 
         // Once we have the array of migrations, we will spin through them and run the
         // migrations "up" so the changes are made to the databases. We'll then log
         // that the migration was run so we don't repeat it next time we execute.
         foreach ($migrations as $file) {
-            $this->runUp($file, $batch, $pretend);
+            $this->runUp($file, $batch, $pretend, $markAsRan, $ignoreExistingTables);
 
             if ($step) {
                 $batch++;
@@ -226,9 +231,11 @@ class Migrator
      * @param  string  $file
      * @param  int  $batch
      * @param  bool  $pretend
+     * @param  bool  $markAsRan
+     * @param  bool  $ignoreExistingTables
      * @return void
      */
-    protected function runUp($file, $batch, $pretend)
+    protected function runUp($file, $batch, $pretend, $markAsRan = false, $ignoreExistingTables = false)
     {
         // First we will resolve a "real" instance of the migration class from this
         // migration file name. Once we have the instances we can run the actual
@@ -249,14 +256,47 @@ class Migrator
             $this->fireMigrationEvent(new MigrationSkipped($name));
 
             $this->write(Task::class, $name, fn () => MigrationResult::Skipped->value);
+        } elseif ($markAsRan) {
+            $this->write(Task::class, $name, fn () => MigrationResult::Success->value);
+
+            $this->repository->log($name, $batch);
         } else {
-            $this->write(Task::class, $name, fn () => $this->runMigration($migration, 'up'));
+            $this->write(Task::class, $name, function () use ($migration, $ignoreExistingTables) {
+                try {
+                    $this->runMigration($migration, 'up');
+                } catch (QueryException $e) {
+                    if ($ignoreExistingTables && $this->isTableAlreadyExistsException($e)) {
+                        return;
+                    }
+
+                    throw $e;
+                }
+            });
 
             // Once we have run a migrations class, we will log that it was run in this
             // repository so that we don't try to run it next time we do a migration
             // in the application. A migration repository keeps the migrate order.
             $this->repository->log($name, $batch);
         }
+    }
+
+    /**
+     * Determine if the given exception was caused by a table that already exists.
+     *
+     * @param  \Illuminate\Database\QueryException  $e
+     * @return bool
+     */
+    protected function isTableAlreadyExistsException(QueryException $e): bool
+    {
+        $sqlState = $e->getCode();
+
+        // MySQL/MariaDB: 42S01, PostgreSQL: 42P07
+        if (in_array($sqlState, ['42S01', '42P07'])) {
+            return true;
+        }
+
+        // SQLite uses a generic SQLSTATE; match on the message instead
+        return str_contains($e->getMessage(), 'already exists');
     }
 
     /**
@@ -290,7 +330,7 @@ class Migrator
      * Get the migrations for a rollback operation.
      *
      * @param  array<string, mixed>  $options
-     * @return array{id: int, migration: string, batch: int}[]
+     * @return object{id: int, migration: string, batch: int}[]
      */
     protected function getMigrationsForRollback(array $options)
     {
@@ -362,7 +402,7 @@ class Migrator
         // the database back into its "empty" state ready for the migrations.
         $migrations = array_reverse($this->repository->getRan());
 
-        if (count($migrations) === 0) {
+        if ($migrations === []) {
             $this->write(Info::class, 'Nothing to rollback.');
 
             return [];

--- a/tests/Database/DatabaseMigrationMigrateCommandTest.php
+++ b/tests/Database/DatabaseMigrationMigrateCommandTest.php
@@ -28,7 +28,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
             return $callback();
         });
         $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
-        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => false]);
+        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => false, 'mark_as_ran' => false, 'ignore_existing_tables' => false]);
         $migrator->shouldReceive('getNotes')->andReturn([]);
         $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
 
@@ -54,7 +54,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
         $schemaState->shouldReceive('load')->once()->with(__DIR__.'/stubs/schema.sql');
         $dispatcher->shouldReceive('dispatch')->once()->with(m::type(SchemaLoaded::class));
         $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
-        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => false]);
+        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => false, 'mark_as_ran' => false, 'ignore_existing_tables' => false]);
         $migrator->shouldReceive('getNotes')->andReturn([]);
         $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
 
@@ -74,7 +74,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
             return $callback();
         });
         $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
-        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => false]);
+        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => false, 'mark_as_ran' => false, 'ignore_existing_tables' => false]);
         $migrator->shouldReceive('repositoryExists')->once()->andReturn(false);
         $command->expects($this->once())->method('callSilent')->with($this->equalTo('migrate:install'), $this->equalTo([]));
 
@@ -93,7 +93,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
             return $callback();
         });
         $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
-        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => true, 'step' => false]);
+        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => true, 'step' => false, 'mark_as_ran' => false, 'ignore_existing_tables' => false]);
         $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
 
         $this->runCommand($command, ['--pretend' => true]);
@@ -111,7 +111,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
             return $callback();
         });
         $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
-        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => false]);
+        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => false, 'mark_as_ran' => false, 'ignore_existing_tables' => false]);
         $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
 
         $this->runCommand($command, ['--database' => 'foo']);
@@ -129,10 +129,46 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
             return $callback();
         });
         $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
-        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => true]);
+        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => true, 'mark_as_ran' => false, 'ignore_existing_tables' => false]);
         $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
 
         $this->runCommand($command, ['--step' => true]);
+    }
+
+    public function testMarkAsRanPassedToMigrator()
+    {
+        $command = new MigrateCommand($migrator = m::mock(Migrator::class), $dispatcher = m::mock(Dispatcher::class));
+        $app = new ApplicationDatabaseMigrationStub(['path.database' => __DIR__]);
+        $app->useDatabasePath(__DIR__);
+        $command->setLaravel($app);
+        $migrator->shouldReceive('paths')->once()->andReturn([]);
+        $migrator->shouldReceive('hasRunAnyMigrations')->andReturn(true);
+        $migrator->shouldReceive('usingConnection')->once()->andReturnUsing(function ($name, $callback) {
+            return $callback();
+        });
+        $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
+        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => false, 'mark_as_ran' => true, 'ignore_existing_tables' => false]);
+        $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
+
+        $this->runCommand($command, ['--mark-as-ran' => true]);
+    }
+
+    public function testIgnoreExistingTablesPassedToMigrator()
+    {
+        $command = new MigrateCommand($migrator = m::mock(Migrator::class), $dispatcher = m::mock(Dispatcher::class));
+        $app = new ApplicationDatabaseMigrationStub(['path.database' => __DIR__]);
+        $app->useDatabasePath(__DIR__);
+        $command->setLaravel($app);
+        $migrator->shouldReceive('paths')->once()->andReturn([]);
+        $migrator->shouldReceive('hasRunAnyMigrations')->andReturn(true);
+        $migrator->shouldReceive('usingConnection')->once()->andReturnUsing(function ($name, $callback) {
+            return $callback();
+        });
+        $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
+        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => false, 'mark_as_ran' => false, 'ignore_existing_tables' => true]);
+        $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
+
+        $this->runCommand($command, ['--ignore-existing-tables' => true]);
     }
 
     protected function runCommand($command, $input = [])


### PR DESCRIPTION
## Summary

Adds two new options to `php artisan migrate`:

- `--ignore-existing-tables`: Silently skips any migration that fails with a "table already exists" database error (SQLSTATE `42S01` on MySQL/MariaDB, `42P07` on PostgreSQL, or message-based match for SQLite). The migration is still recorded in the `migrations` table so it won't be attempted again.

- `--mark-as-ran`: Records pending migrations in the `migrations` table without executing any DDL against the database. Equivalent to Django's `migrate --fake`. Useful when tables already exist and you only need to align the migration state.

## Motivation

When restoring a database from a dump, or syncing an environment where tables were created manually, `php artisan migrate` fails with a `QueryException`. Developers are currently forced to manually insert rows into the `migrations` table or drop and recreate tables. These two options eliminate that friction safely.

## Changes

- `MigrateCommand`: two new options added to the signature; both forwarded as `mark_as_ran` / `ignore_existing_tables` in the options array passed to `Migrator::run()`.
- `Migrator::runPending()`: extracts and passes the new options to `runUp()`; adjusts the info message when `--mark-as-ran` is active.
- `Migrator::runUp()`: new `$markAsRan` branch logs without running; new `$ignoreExistingTables` branch wraps `runMigration()` in a try/catch and swallows table-exists exceptions.
- `Migrator::isTableAlreadyExistsException()`: new helper covering MySQL/MariaDB (`42S01`), PostgreSQL (`42P07`), and SQLite (message match).
- `DatabaseMigrationMigrateCommandTest`: existing expectations updated for the new options array keys; two new test cases added.

## Usage

```bash
# Tables already exist in DB but not recorded in the migrations table:
php artisan migrate --ignore-existing-tables

# Record all pending migrations as run without touching the schema:
php artisan migrate --mark-as-ran
```