### PR TITLE
[13.x] update `rand()` to `mt_rand()`

### DIFF
--- a/tests/Integration/Console/Scheduling/ScheduleGroupTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleGroupTest.php
@@ -119,7 +119,7 @@ class ScheduleGroupTest extends TestCase
             'runInBackground' => ['runInBackground', true],
             'evenInMaintenanceMode' => ['evenInMaintenanceMode', true],
             'evenWhenPaused' => ['evenWhenPaused', true],
-            'withoutOverlapping' => ['withoutOverlapping', rand(1000, 1400)],
+            'withoutOverlapping' => ['withoutOverlapping', mt_rand(1000, 1400)],
         ];
     }
 

--- a/tests/Support/OnceTest.php
+++ b/tests/Support/OnceTest.php
@@ -21,7 +21,7 @@ class OnceTest extends TestCase
         {
             public function rand()
             {
-                return once(fn () => rand(1, PHP_INT_MAX));
+                return once(fn () => mt_rand(1, PHP_INT_MAX));
             }
         };
 
@@ -92,7 +92,7 @@ class OnceTest extends TestCase
             public function rand(string $letter)
             {
                 return once(function () use ($letter) {
-                    return $letter.rand(1, 10000000);
+                    return $letter.mt_rand(1, 10000000);
                 });
             }
         };
@@ -111,7 +111,7 @@ class OnceTest extends TestCase
         $letter = 'a';
 
         a:
-        $results[] = once(fn () => $letter.rand(1, 10000000));
+        $results[] = once(fn () => $letter.mt_rand(1, 10000000));
 
         if (count($results) < 2) {
             goto a;
@@ -205,7 +205,7 @@ class OnceTest extends TestCase
 
     public function testMemoizationWhenOnceIsWithinClosure()
     {
-        $resolver = fn () => once(fn () => rand(1, PHP_INT_MAX));
+        $resolver = fn () => once(fn () => mt_rand(1, PHP_INT_MAX));
 
         $first = $resolver();
         $second = $resolver();
@@ -273,15 +273,15 @@ class OnceTest extends TestCase
     {
         $this->markTestSkipped('This test shows a limitation of the current implementation.');
 
-        $result = [once(fn () => rand(1, PHP_INT_MAX)), once(fn () => rand(1, PHP_INT_MAX))];
+        $result = [once(fn () => mt_rand(1, PHP_INT_MAX)), once(fn () => mt_rand(1, PHP_INT_MAX))];
 
         $this->assertNotSame($result[0], $result[1]);
     }
 
     public function testResultIsDifferentWhenCalledFromDifferentClosures()
     {
-        $resolver = fn () => once(fn () => rand(1, PHP_INT_MAX));
-        $resolver2 = fn () => once(fn () => rand(1, PHP_INT_MAX));
+        $resolver = fn () => once(fn () => mt_rand(1, PHP_INT_MAX));
+        $resolver2 = fn () => once(fn () => mt_rand(1, PHP_INT_MAX));
 
         $first = $resolver();
         $second = $resolver2();
@@ -295,7 +295,7 @@ class OnceTest extends TestCase
         {
             public function rand()
             {
-                return once(fn () => rand(1, PHP_INT_MAX));
+                return once(fn () => mt_rand(1, PHP_INT_MAX));
             }
         };
 
@@ -303,7 +303,7 @@ class OnceTest extends TestCase
         {
             public function rand()
             {
-                return once(fn () => rand(1, PHP_INT_MAX));
+                return once(fn () => mt_rand(1, PHP_INT_MAX));
             }
         };
 
@@ -319,7 +319,7 @@ class OnceTest extends TestCase
         {
             public function rand()
             {
-                return once(fn () => once(fn () => rand(1, PHP_INT_MAX)));
+                return once(fn () => once(fn () => mt_rand(1, PHP_INT_MAX)));
             }
         };
 
@@ -375,24 +375,24 @@ class OnceTest extends TestCase
 
 $letter = 'a';
 
-$GLOBALS['onceable1'] = fn () => once(fn () => $letter.rand(1, PHP_INT_MAX));
-$GLOBALS['onceable2'] = fn () => once(fn () => $letter.rand(1, PHP_INT_MAX));
+$GLOBALS['onceable1'] = fn () => once(fn () => $letter.mt_rand(1, PHP_INT_MAX));
+$GLOBALS['onceable2'] = fn () => once(fn () => $letter.mt_rand(1, PHP_INT_MAX));
 
 function my_rand()
 {
-    return once(fn () => rand(1, PHP_INT_MAX));
+    return once(fn () => mt_rand(1, PHP_INT_MAX));
 }
 
 class MyClass
 {
     public function rand()
     {
-        return once(fn () => rand(1, PHP_INT_MAX));
+        return once(fn () => mt_rand(1, PHP_INT_MAX));
     }
 
     public static function staticRand()
     {
-        return once(fn () => rand(1, PHP_INT_MAX));
+        return once(fn () => mt_rand(1, PHP_INT_MAX));
     }
 
     public function callRand()

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -890,7 +890,7 @@ assertType('mixed', $collection::make([1])->sum('string'));
 assertType('int<1, 2>', $collection::make(['string'])->sum(function ($string) {
     assertType('string', $string);
 
-    return rand(1, 2);
+    return mt_rand(1, 2);
 }));
 
 assertType('Illuminate\Support\Collection<int, int>', $collection::make([1])->take(1));

--- a/types/Support/LazyCollection.php
+++ b/types/Support/LazyCollection.php
@@ -750,7 +750,7 @@ assertType('mixed', $collection::make([1])->sum('string'));
 assertType('int<1, 2>', $collection::make(['string'])->sum(function ($string) {
     assertType('string', $string);
 
-    return rand(1, 2);
+    return mt_rand(1, 2);
 }));
 
 assertType('Illuminate\Support\LazyCollection<int, int>', $collection::make([1])->take(1));


### PR DESCRIPTION
as of v7.1 `rand()` has been aliased to `mt_rand()`.

we get a present, but mostly insignificant, performance bump from switching, but the big benefit is consistency in the codebase.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
