### PR TITLE
[13.x] Remove useless `fail-fast` option

### DIFF
--- a/.github/workflows/databases-nightly.yml
+++ b/.github/workflows/databases-nightly.yml
@@ -18,9 +18,6 @@ jobs:
           - 3306:3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
 
-    strategy:
-      fail-fast: true
-
     name: MySQL 9
 
     steps:
@@ -63,9 +60,6 @@ jobs:
         ports:
           - 3306:3306
         options: --health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=10s --health-timeout=5s --health-retries=3
-
-    strategy:
-      fail-fast: true
 
     name: MariaDB Very Latest
 

--- a/.github/workflows/databases.yml
+++ b/.github/workflows/databases.yml
@@ -22,9 +22,6 @@ jobs:
           - 3306:3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
 
-    strategy:
-      fail-fast: true
-
     name: MySQL 5.7
 
     steps:
@@ -69,9 +66,6 @@ jobs:
           - 3306:3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
 
-    strategy:
-      fail-fast: true
-
     name: MySQL 8
 
     steps:
@@ -114,9 +108,6 @@ jobs:
         ports:
           - 3306:3306
         options: --health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=10s --health-timeout=5s --health-retries=3
-
-    strategy:
-      fail-fast: true
 
     name: MariaDB 10
 
@@ -161,9 +152,6 @@ jobs:
         ports:
           - 5432:5432
         options: --health-cmd=pg_isready --health-interval=10s --health-timeout=5s --health-retries=3
-
-    strategy:
-      fail-fast: true
 
     name: PostgreSQL 18
 
@@ -211,9 +199,6 @@ jobs:
           - 5432:5432
         options: --health-cmd=pg_isready --health-interval=10s --health-timeout=5s --health-retries=3
 
-    strategy:
-      fail-fast: true
-
     name: PostgreSQL 14
 
     steps:
@@ -260,9 +245,6 @@ jobs:
           - 5432:5432
         options: --health-cmd=pg_isready --health-interval=10s --health-timeout=5s --health-retries=3
 
-    strategy:
-      fail-fast: true
-
     name: PostgreSQL 10
 
     steps:
@@ -306,9 +288,6 @@ jobs:
           SA_PASSWORD: Forge123
         ports:
           - 1433:1433
-
-    strategy:
-      fail-fast: true
 
     name: SQL Server 2019
 
@@ -355,9 +334,6 @@ jobs:
         ports:
           - 1433:1433
 
-    strategy:
-      fail-fast: true
-
     name: SQL Server 2017
 
     steps:
@@ -393,9 +369,6 @@ jobs:
   sqlite:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
-
-    strategy:
-      fail-fast: true
 
     name: SQLite
 

--- a/.github/workflows/facades.yml
+++ b/.github/workflows/facades.yml
@@ -14,9 +14,6 @@ jobs:
   update:
     runs-on: ubuntu-24.04
 
-    strategy:
-      fail-fast: true
-
     name: Facade DocBlocks
 
     steps:

--- a/.github/workflows/queues.yml
+++ b/.github/workflows/queues.yml
@@ -11,9 +11,6 @@ jobs:
   sync:
     runs-on: ubuntu-24.04
 
-    strategy:
-      fail-fast: true
-
     name: Sync Driver
 
     steps:
@@ -45,9 +42,6 @@ jobs:
 
   database:
     runs-on: ubuntu-24.04
-
-    strategy:
-      fail-fast: true
 
     name: Database Driver
 


### PR DESCRIPTION
Remove useless `fail-fast` option.
As this has only an effect with `matrix` as a sibling.