### PR TITLE
[13.x] remove `mt_srand()` deprecated "mode" argument

### DIFF
--- a/tests/Integration/Foundation/FoundationHelpersTest.php
+++ b/tests/Integration/Foundation/FoundationHelpersTest.php
@@ -127,7 +127,7 @@ class FoundationHelpersTest extends TestCase
         mt_srand(12345);
 
         // Should fallback to en_US
-        $this->assertSame('Arkansas', fake()->state());
+        $this->assertSame('New Jersey', fake()->state());
         $this->assertContains(fake('de_DE')->state(), [
             'Baden-Württemberg', 'Bayern', 'Berlin', 'Brandenburg', 'Bremen', 'Hamburg', 'Hessen', 'Mecklenburg-Vorpommern', 'Niedersachsen', 'Nordrhein-Westfalen', 'Rheinland-Pfalz', 'Saarland', 'Sachsen', 'Sachsen-Anhalt', 'Schleswig-Holstein', 'Thüringen',
         ]);
@@ -141,7 +141,7 @@ class FoundationHelpersTest extends TestCase
         mt_srand(4);
 
         // Should fallback to en_US
-        $this->assertSame('Australian Capital Territory', fake()->state());
+        $this->assertSame('Northern Territory', fake()->state());
     }
 
     protected function makeManifest($directory = '')

--- a/tests/Integration/Foundation/FoundationHelpersTest.php
+++ b/tests/Integration/Foundation/FoundationHelpersTest.php
@@ -124,7 +124,7 @@ class FoundationHelpersTest extends TestCase
 
     public function testFakeUsesLocale()
     {
-        mt_srand(12345, MT_RAND_PHP);
+        mt_srand(12345);
 
         // Should fallback to en_US
         $this->assertSame('Arkansas', fake()->state());
@@ -138,7 +138,7 @@ class FoundationHelpersTest extends TestCase
         ]);
 
         config(['app.faker_locale' => 'en_AU']);
-        mt_srand(4, MT_RAND_PHP);
+        mt_srand(4);
 
         // Should fallback to en_US
         $this->assertSame('Australian Capital Territory', fake()->state());


### PR DESCRIPTION
The "MT_RAND_PHP" mode uses an incorrect Mersenne Twister implementation which was used as the default up till PHP 7.1.0. This mode is only available for backward compatibility.  It has also been deprecated in 8.3.

This commit removes the deprecated mode, and falls back to the default mode of "MT_RAND_MT19937".

https://www.php.net/manual/en/function.mt-srand.php

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
