### PR TITLE
[13.x] Fix multipart array index loss in HTTP client

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -1154,24 +1154,60 @@ class PendingRequest
      */
     protected function parseMultipartBodyFormat(array $data)
     {
-        return (new Collection($data))
-            ->flatMap(function ($value, $key) {
-                if (is_array($value)) {
-                    // If the array has 'name' and 'contents' keys, it's already formatted for multipart...
-                    if (isset($value['name'], $value['contents'])) {
-                        return [$value];
-                    }
+        $result = [];
 
-                    // Otherwise, treat it as multiple values for the same field name...
-                    return (new Collection($value))->map(function ($item) use ($key) {
-                        return ['name' => $key.'[]', 'contents' => $item];
-                    });
+        foreach ($data as $key => $value) {
+            if (is_array($value)) {
+                // If the array has 'name' and 'contents' keys, it's already formatted for multipart...
+                if (isset($value['name'], $value['contents'])) {
+                    $result[] = $value;
+                    continue;
                 }
 
-                return [['name' => $key, 'contents' => $value]];
-            })
-            ->values()
-            ->all();
+                // Otherwise, recursively expand nested arrays using bracket notation...
+                foreach ($this->expandMultipartArrayValue($key, $value) as $entry) {
+                    $result[] = $entry;
+                }
+                continue;
+            }
+
+            $result[] = ['name' => $key, 'contents' => $value];
+        }
+
+        return $result;
+    }
+
+    /**
+     * Recursively expand a multipart array value into a flat list using bracket notation.
+     *
+     * @param  string|int  $name
+     * @param  array  $value
+     * @return array[]
+     */
+    protected function expandMultipartArrayValue($name, array $value)
+    {
+        $result = [];
+
+        foreach ($value as $key => $item) {
+            $fieldName = is_int($key) ? $name.'[]' : $name.'['.$key.']';
+
+            if (is_array($item)) {
+                // Preserve passthrough for already-formatted multipart entries...
+                if (isset($item['name'], $item['contents'])) {
+                    $result[] = $item;
+                    continue;
+                }
+
+                foreach ($this->expandMultipartArrayValue($fieldName, $item) as $entry) {
+                    $result[] = $entry;
+                }
+                continue;
+            }
+
+            $result[] = ['name' => $fieldName, 'contents' => $item];
+        }
+
+        return $result;
     }
 
     /**

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -882,6 +882,69 @@ class HttpClientTest extends TestCase
         });
     }
 
+    public function testCanSendMultipartDataWithNestedArrayValues()
+    {
+        $this->factory->fake();
+
+        $this->factory->asMultipart()->post('http://foo.com/multipart', [
+            'user' => [
+                'name' => 'foo',
+                'email' => 'bar@baz.com',
+            ],
+        ]);
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://foo.com/multipart' &&
+                Str::startsWith($request->header('Content-Type')[0], 'multipart') &&
+                $request[0]['name'] === 'user[name]' &&
+                $request[0]['contents'] === 'foo' &&
+                $request[1]['name'] === 'user[email]' &&
+                $request[1]['contents'] === 'bar@baz.com';
+        });
+    }
+
+    public function testCanSendMultipartDataWithMultipleNestedArraysWithoutKeyCollision()
+    {
+        $this->factory->fake();
+
+        $this->factory->asMultipart()->post('http://foo.com/multipart', [
+            'users' => ['a' => 3, 'b' => 7],
+            'admins' => ['b' => 5, 'c' => 6],
+        ]);
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://foo.com/multipart' &&
+                Str::startsWith($request->header('Content-Type')[0], 'multipart') &&
+                $request[0]['name'] === 'users[a]' && $request[0]['contents'] === 3 &&
+                $request[1]['name'] === 'users[b]' && $request[1]['contents'] === 7 &&
+                $request[2]['name'] === 'admins[b]' && $request[2]['contents'] === 5 &&
+                $request[3]['name'] === 'admins[c]' && $request[3]['contents'] === 6;
+        });
+    }
+
+    public function testCanSendMultipartDataWithDeeplyNestedArrayValues()
+    {
+        $this->factory->fake();
+
+        $this->factory->asMultipart()->post('http://foo.com/multipart', [
+            'user' => [
+                'address' => [
+                    'city' => 'NYC',
+                    'zip' => '10001',
+                ],
+            ],
+        ]);
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://foo.com/multipart' &&
+                Str::startsWith($request->header('Content-Type')[0], 'multipart') &&
+                $request[0]['name'] === 'user[address][city]' &&
+                $request[0]['contents'] === 'NYC' &&
+                $request[1]['name'] === 'user[address][zip]' &&
+                $request[1]['contents'] === '10001';
+        });
+    }
+
     public function testItCanSendToken()
     {
         $this->factory->fake();


### PR DESCRIPTION
Fixes #59992.                                                                                                                                                                             
                                                                                                                                                                                            
  `PendingRequest::parseMultipartBodyFormat()` had two bugs when handling nested array values:                                                                                              
                                                                                                                                                                                            
  1. **Inner string keys were dropped.** `'user' => ['name' => 'foo', 'email' => 'bar']` produced two `user[]` parts instead of `user[name]` and `user[email]`.                             
  2. **Inner key collision between fields.** `Collection::flatMap` preserves string keys when merging child collections, so when two top-level fields shared an inner key (e.g. `'users' =>
  ['b' => 7]` + `'admins' => ['b' => 5]`), the colliding entry was silently overwritten and the trailing `->values()` masked the loss.                                                      
                                                            
  This PR replaces the `flatMap` with a `foreach` accumulator and adds a small recursive helper `expandMultipartArrayValue()` that emits bracket notation:                                  
                                                            
  - Integer-indexed values keep producing `name[]` (existing behavior preserved).                                                                                                           
  - String-keyed and deeply nested values now produce `name[key]`, `name[a][b]`, etc.
  - Entries already shaped as `['name' => ..., 'contents' => ...]` still pass through untouched at any depth.                                                                               
                                                                                                                                                                                            
  All existing multipart tests continue to pass; three new tests cover the scenarios reported in the issue.                                                                                 
