### PR TITLE
[13.x] Display error in `queue:pause` when `Worker` isn't pausable

### DIFF
--- a/src/Illuminate/Queue/Console/PauseCommand.php
+++ b/src/Illuminate/Queue/Console/PauseCommand.php
@@ -37,7 +37,7 @@ class PauseCommand extends Command
         [$connection, $queue] = $this->parseQueue($this->argument('queue'));
 
         if (! Worker::$pausable) {
-            $this->components->error('Queue pausing is disabled by withoutInterruptionPolling().');
+            $this->components->error('Queue pausing is currently disabled.');
 
             return 1;
         }

--- a/src/Illuminate/Queue/Console/PauseCommand.php
+++ b/src/Illuminate/Queue/Console/PauseCommand.php
@@ -36,7 +36,7 @@ class PauseCommand extends Command
     {
         [$connection, $queue] = $this->parseQueue($this->argument('queue'));
 
-        if (!Worker::$pausable) {
+        if (! Worker::$pausable) {
             $this->components->error('Queue pausing is disabled by withoutInterruptionPolling().');
 
             return 1;

--- a/src/Illuminate/Queue/Console/PauseCommand.php
+++ b/src/Illuminate/Queue/Console/PauseCommand.php
@@ -5,6 +5,7 @@ namespace Illuminate\Queue\Console;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Queue\Factory as QueueManager;
 use Illuminate\Queue\Console\Concerns\ParsesQueue;
+use Illuminate\Queue\Worker;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'queue:pause')]
@@ -34,6 +35,12 @@ class PauseCommand extends Command
     public function handle(QueueManager $manager)
     {
         [$connection, $queue] = $this->parseQueue($this->argument('queue'));
+
+        if (!Worker::$pausable) {
+            $this->components->error('Queue pausing is disabled by withoutInterruptionPolling().');
+
+            return 1;
+        }
 
         $manager->pause($connection, $queue);
 

--- a/tests/Integration/Console/Scheduling/QueuePauseCommandTest.php
+++ b/tests/Integration/Console/Scheduling/QueuePauseCommandTest.php
@@ -13,7 +13,7 @@ class QueuePauseCommandTest extends TestCase
     {
         Event::fake();
 
-        $this->artisan('queue:pause');
+        $this->artisan('queue:pause default');
 
         Event::assertDispatched(QueuePaused::class);
     }
@@ -24,7 +24,7 @@ class QueuePauseCommandTest extends TestCase
 
         Worker::$pausable = false;
 
-        $this->artisan('queue:pause');
+        $this->artisan('queue:pause default');
 
         Event::assertNotDispatched(QueuePaused::class);
 

--- a/tests/Integration/Console/Scheduling/QueuePauseCommandTest.php
+++ b/tests/Integration/Console/Scheduling/QueuePauseCommandTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Console\Scheduling;
+
+use Illuminate\Queue\Events\QueuePaused;
+use Illuminate\Queue\Worker;
+use Illuminate\Support\Facades\Event;
+use Orchestra\Testbench\TestCase;
+
+class QueuePauseCommandTest extends TestCase
+{
+    public function testDispatchesEvent()
+    {
+        Event::fake();
+
+        $this->artisan('queue:pause');
+
+        Event::assertDispatched(QueuePaused::class);
+    }
+
+    public function testDisabledError()
+    {
+        Event::fake();
+
+        Worker::$pausable = false;
+
+        $this->artisan('queue:pause');
+
+        Event::assertNotDispatched(QueuePaused::class);
+
+        Worker::$pausable = true;
+    }
+}


### PR DESCRIPTION
Hey Taylor, @jackbayliss is on vacation this week (allegedly) so you've got me for a change :bowtie:

- We didn't used to pause our queues, so called `withoutInterruptionPolling()` in our `AppServiceProvider`
- Now we've modernised, we're leaning on pause, but forgot we'd done this and `queue:pause` gives no clue
- Queue(!) much swearing by another dev in our team 🥁 

We'll likely stop calling `withoutInterruptionPolling()` of course, so feel free to throw this PR in the sea. Just thought it'd avoid other souls scratching their heads.
