### PR TITLE
[13.x] Unused `$parameters` in `validate*case()`

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1452,10 +1452,9 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @param  array<int, int|string>  $parameters
      * @return bool
      */
-    public function validateLowercase($attribute, $value, $parameters)
+    public function validateLowercase($attribute, $value)
     {
         return is_string($value) && Str::lower($value) === $value;
     }
@@ -1465,10 +1464,9 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @param  array<int, int|string>  $parameters
      * @return bool
      */
-    public function validateUppercase($attribute, $value, $parameters)
+    public function validateUppercase($attribute, $value)
     {
         return is_string($value) && Str::upper($value) === $value;
     }


### PR DESCRIPTION
Poking around in here for a new validation rule idea, spotted these aren't used.

Confused me for a couple of seconds, since my first time in this area and started to wonder if some magic I needed to be aware of.
