### PR TITLE
[13.x] Fix NullStore::get() return type annotation

### DIFF
--- a/src/Illuminate/Cache/NullStore.php
+++ b/src/Illuminate/Cache/NullStore.php
@@ -13,7 +13,7 @@ class NullStore extends TaggableStore implements CanFlushLocks, LockProvider
      * Retrieve an item from the cache by key.
      *
      * @param  string  $key
-     * @return void
+     * @return mixed
      */
     public function get($key)
     {


### PR DESCRIPTION
The `get()` method in `NullStore` is documented as `@return void`, but every other cache store implementation (`FileStore`, `RedisStore`, `DatabaseStore`, `ArrayStore`, `MemcachedStore`, `ApcStore`, `DynamoDbStore`, `MemoizedStore`, `FailoverStore`, `SessionStore`) documents it as `@return mixed`, consistent with the `Store` contract.

### Before
```php
@return void
```

### After
```php
@return mixed
```