### PR TITLE
[13.x] Add missing @param annotations to cache many() and putMany() methods

### DIFF
--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -122,6 +122,7 @@ class DatabaseStore implements CanFlushLocks, LockProvider, Store
      *
      * Items not found in the cache will have a null value.
      *
+     * @param  array  $keys
      * @return array
      */
     public function many(array $keys)

--- a/src/Illuminate/Cache/FailoverStore.php
+++ b/src/Illuminate/Cache/FailoverStore.php
@@ -46,6 +46,7 @@ class FailoverStore extends TaggableStore implements CanFlushLocks, LockProvider
      *
      * Items not found in the cache will have a null value.
      *
+     * @param  array  $keys
      * @return array
      */
     public function many(array $keys)
@@ -69,6 +70,7 @@ class FailoverStore extends TaggableStore implements CanFlushLocks, LockProvider
     /**
      * Store multiple items in the cache for a given number of seconds.
      *
+     * @param  array  $values
      * @param  int  $seconds
      * @return bool
      */

--- a/src/Illuminate/Cache/MemoizedStore.php
+++ b/src/Illuminate/Cache/MemoizedStore.php
@@ -51,6 +51,7 @@ class MemoizedStore implements CanFlushLocks, LockProvider, Store
      *
      * Items not found in the cache will have a null value.
      *
+     * @param  array  $keys
      * @return array
      */
     public function many(array $keys)
@@ -106,6 +107,7 @@ class MemoizedStore implements CanFlushLocks, LockProvider, Store
     /**
      * Store multiple items in the cache for a given number of seconds.
      *
+     * @param  array  $values
      * @param  int  $seconds
      * @return bool
      */

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -151,6 +151,7 @@ class Repository implements ArrayAccess, CacheContract
      *
      * Items not found in the cache will have a null value.
      *
+     * @param  array  $keys
      * @return array
      */
     public function many(array $keys)
@@ -393,6 +394,7 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Store multiple items in the cache for a given number of seconds.
      *
+     * @param  array  $values
      * @param  \DateTimeInterface|\DateInterval|int|null  $ttl
      * @return bool
      */


### PR DESCRIPTION
Several cache store classes are missing `@param` annotations on `many()` and `putMany()` methods, while other store implementations like `RedisStore`, `MemcachedStore`, `DynamoDbStore`, and `RetrievesMultipleKeys` already include them.

### Changes

**`many()` — added `@param  array  $keys`:**
- `Repository.php`
- `DatabaseStore.php`
- `FailoverStore.php`
- `MemoizedStore.php`

**`putMany()` — added `@param  array  $values`:**
- `Repository.php`
- `FailoverStore.php`
- `MemoizedStore.php`

This aligns the PHPDoc across all cache store implementations.