### PR TITLE
Add support to scoped filesystem for Cloud

### DIFF
--- a/src/Illuminate/Foundation/Cloud.php
+++ b/src/Illuminate/Foundation/Cloud.php
@@ -51,18 +51,26 @@ class Cloud
         $disks = json_decode($_SERVER['LARAVEL_CLOUD_DISK_CONFIG'], true);
 
         foreach ($disks as $disk) {
-            $app['config']->set('filesystems.disks.'.$disk['disk'], [
-                'driver' => 's3',
-                'key' => $disk['access_key_id'],
-                'secret' => $disk['access_key_secret'],
-                'bucket' => $disk['bucket'],
-                'url' => $disk['url'],
-                'endpoint' => $disk['endpoint'],
-                'region' => 'auto',
-                'use_path_style_endpoint' => false,
-                'throw' => false,
-                'report' => false,
-            ]);
+            if ($disk['scoped_disk'] ?? false) {
+                $app['config']->set('filesystems.disks.'.$disk['disk'], [
+                    'driver' => 'scoped',
+                    'disk' => $disk['scoped_disk'],
+                    'prefix' => $disk['prefix'] ?? '',
+                ]);
+            } else {
+                $app['config']->set('filesystems.disks.'.$disk['disk'], [
+                    'driver' => 's3',
+                    'key' => $disk['access_key_id'],
+                    'secret' => $disk['access_key_secret'],
+                    'bucket' => $disk['bucket'],
+                    'url' => $disk['url'],
+                    'endpoint' => $disk['endpoint'],
+                    'region' => 'auto',
+                    'use_path_style_endpoint' => false,
+                    'throw' => false,
+                    'report' => false,
+                ]);
+            }
 
             if ($disk['is_default'] ?? false) {
                 $app['config']->set('filesystems.default', $disk['disk']);

--- a/tests/Integration/Foundation/CloudTest.php
+++ b/tests/Integration/Foundation/CloudTest.php
@@ -54,6 +54,35 @@ class CloudTest extends TestCase
         unset($_SERVER['LARAVEL_CLOUD_DISK_CONFIG']);
     }
 
+    public function test_it_can_configure_scoped_disks()
+    {
+        $_SERVER['LARAVEL_CLOUD_DISK_CONFIG'] = json_encode(
+            [
+                [
+                    'disk' => 'test-disk',
+                    'access_key_id' => 'test-access-key-id',
+                    'access_key_secret' => 'test-access-key-secret',
+                    'bucket' => 'test-bucket',
+                    'url' => 'test-url',
+                    'endpoint' => 'test-endpoint',
+                ],
+                [
+                    'disk' => 'test-disk-scoped',
+                    'scoped_disk' => 'test-disk',
+                    'prefix' => 'test/prefix/',
+                    'is_default' => true,
+                ],
+            ]
+        );
+
+        Cloud::configureDisks($this->app);
+
+        $this->assertSame('scoped', $this->app['config']->get('filesystems.disks.test-disk-scoped.driver'));
+        $this->assertSame('test-disk', $this->app['config']->get('filesystems.disks.test-disk-scoped.disk'));
+
+        unset($_SERVER['LARAVEL_CLOUD_DISK_CONFIG']);
+    }
+
     public function test_it_disables_queue_restart_polling_for_managed_queues()
     {
         Worker::$restartable = true;


### PR DESCRIPTION
This adds support for the Cloud::configureDisks to support scoped filesystems.

Passing a `scoped_disk` will swap the driver from `s3` to `scoped` and fill the config `disk` parameter with the value from `scoped_disk`.

Other parameters are irrelevant therefore skipped.

`is_default` mechanism still applies to both normal and scoped disks.