### PR TITLE
[13.x] Add assertNotDownload method to TestResponse

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -486,6 +486,24 @@ class TestResponse implements ArrayAccess
     }
 
     /**
+     * Assert that the response does not offer a file download.
+     *
+     * @return $this
+     */
+    public function assertNotDownload()
+    {
+        $contentDisposition = explode(';', $this->headers->get('content-disposition', ''));
+
+        PHPUnit::withResponse($this)->assertNotSame(
+            'attachment',
+            trim($contentDisposition[0]),
+            'Response offers unexpected file download.'
+        );
+
+        return $this;
+    }
+
+    /**
      * Asserts that the response contains the given cookie and equals the optional value.
      *
      * @param  string  $cookieName

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -2625,6 +2625,33 @@ EOT
         $files->deleteDirectory($tempDir);
     }
 
+    public function testAssertNotDownload(): void
+    {
+        $testResponse = TestResponse::fromBaseResponse(new Response(
+            'Hello World', 200, [
+                'Content-Disposition' => 'inline',
+            ]
+        ));
+        $testResponse->assertNotDownload();
+    }
+
+    public function testAssertNotDownloadWithNoContentDispositionHeader(): void
+    {
+        $testResponse = TestResponse::fromBaseResponse(new Response('Hello World'));
+        $testResponse->assertNotDownload();
+    }
+
+    public function testAssertNotDownloadFailsWhenResponseIsDownload(): void
+    {
+        $this->expectException(AssertionFailedError::class);
+        $testResponse = TestResponse::fromBaseResponse(new Response(
+            'Hello World', 200, [
+                'Content-Disposition' => 'attachment; filename=file.txt',
+            ]
+        ));
+        $testResponse->assertNotDownload();
+    }
+
     public function testMacroable(): void
     {
         TestResponse::macro('foo', function () {


### PR DESCRIPTION
**Add assertNotDownload method to TestResponse**
This PR adds an assertNotDownload() method as the inverse counterpart to the existing assertDownload().

**Why**
When writing tests, it's useful to explicitly assert that a response is not a file download — for example, verifying that a route returns a normal view or JSON response instead of triggering a download. Previously, there was no clean way to express this intent in tests.
This follows the same pattern already established in the codebase (e.g., assertStreamed / assertNotStreamed, assertSessionHasInput / assertSessionMissingInput).

**Usage**
`$response->assertNotDownload();`
The assertion passes when the Content-Disposition header is absent or set to anything other than attachment.