### PR TITLE
[13.x] Narrow attachment url scheme

### DIFF
--- a/src/Illuminate/Mail/Attachment.php
+++ b/src/Illuminate/Mail/Attachment.php
@@ -7,7 +7,9 @@ use Illuminate\Container\Container;
 use Illuminate\Contracts\Filesystem\Factory as FilesystemFactory;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
+use InvalidArgumentException;
 use RuntimeException;
 
 class Attachment
@@ -64,6 +66,10 @@ class Attachment
      */
     public static function fromUrl($url)
     {
+        if (! Str::isUrl($url, ['http', 'https'])) {
+            throw new InvalidArgumentException('Attachment URLs must use the http or https scheme.');
+        }
+
         return static::fromPath($url);
     }
 


### PR DESCRIPTION
Restricts `Attachment::fromUrl()` to http and https URLs. This keeps URL attachments aligned with their intended remote URL use case while rejecting unsupported schemes.