### PR TITLE
[13.x] Align Enumerable::sum @return with EnumeratesValues template

### DIFF
--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -1121,8 +1121,10 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Get the sum of the given values.
      *
-     * @param  (callable(TValue, TKey): mixed)|string|null  $callback
-     * @return mixed
+     * @template TReturnType
+     *
+     * @param  (callable(TValue, TKey): TReturnType)|string|null  $callback
+     * @return ($callback is callable ? TReturnType : mixed)
      */
     public function sum($callback = null);
 


### PR DESCRIPTION
`EnumeratesValues::sum()` already declares `@template TReturnType` and a conditional `@return ($callback is callable ? TReturnType : mixed)` — but the `Enumerable` interface still has plain `@return mixed`. Bringing the interface in line so consumers who type-hint `Enumerable` get the same inferred return type that `Collection` / `LazyCollection` consumers already get. Mirrors #59991 (min/max generic types).