### PR TITLE
[13.x] Align Enumerable::mapSpread @return with EnumeratesValues template

### DIFF
--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -699,8 +699,10 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Run a map over each nested chunk of items.
      *
-     * @param  callable  $callback
-     * @return static
+     * @template TMapSpreadValue
+     *
+     * @param  callable(mixed...): TMapSpreadValue  $callback
+     * @return static<TKey, TMapSpreadValue>
      */
     public function mapSpread(callable $callback);
 


### PR DESCRIPTION
`EnumeratesValues::mapSpread()` declares `@template TMapSpreadValue`, a typed callback signature, and a parameterized return — but the `Enumerable` interface has just `@param callable $callback` / `@return static`. Bringing the interface in line with the trait so `Enumerable`-typed consumers get the same inference. Same flavor as #59991 and #60036.