### PR TITLE
[13.x] Improve return type for `Illuminate\Cache\Lock::get()`

### DIFF
--- a/src/Illuminate/Cache/Lock.php
+++ b/src/Illuminate/Cache/Lock.php
@@ -83,8 +83,10 @@ abstract class Lock implements LockContract
     /**
      * Attempt to acquire the lock.
      *
-     * @param  callable|null  $callback
-     * @return mixed
+     * @template TReturn of mixed
+     *
+     * @param  (callable(): TReturn)|null  $callback
+     * @return ($callback is null ? bool : TReturn|false)
      */
     public function get($callback = null)
     {


### PR DESCRIPTION
This PR improves the return type of the `Lock::get()` method of the `Illuminate\Cache` namespace.

#### Before:
Always returned `mixed`.

#### After:
- `$lock->get()`:
  - lock acquired: `true`
  - lock not acquired: `false`

- `$lock->get(fn () => 42)`:
  - lock acquired: `int`
  - lock not acquired: `false`
