### PR TITLE
[13.x] Add Str::singularStudly and Str::singularPascal

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1043,6 +1043,32 @@ class Str
     }
 
     /**
+     * Singularize the last word of an English, studly caps case string.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    public static function singularStudly($value)
+    {
+        $parts = preg_split('/(.)(?=[A-Z])/u', $value, -1, PREG_SPLIT_DELIM_CAPTURE);
+
+        $lastWord = array_pop($parts);
+
+        return implode('', $parts).self::singular($lastWord);
+    }
+
+    /**
+     * Singularize the last word of an English, Pascal caps case string.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    public static function singularPascal($value)
+    {
+        return static::singularStudly($value);
+    }
+
+    /**
      * Generate a random, secure password.
      *
      * @param  int  $length

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -2011,4 +2011,20 @@ class SupportStrTest extends TestCase
 
         $this->assertSame('UserGroups', Str::pluralPascal('UserGroup', $countable));
     }
+
+    public function testSingularStudly(): void
+    {
+        $this->assertSame('UserGroup', Str::singularStudly('UserGroups'));
+        $this->assertSame('ProductCategory', Str::singularStudly('ProductCategories'));
+        $this->assertSame('Person', Str::singularStudly('People'));
+        $this->assertSame('Child', Str::singularStudly('Children'));
+        $this->assertSame('User', Str::singularStudly('User'));
+    }
+
+    public function testSingularPascal(): void
+    {
+        $this->assertSame('UserGroup', Str::singularPascal('UserGroups'));
+        $this->assertSame('ProductCategory', Str::singularPascal('ProductCategories'));
+        $this->assertSame('Person', Str::singularPascal('People'));
+    }
 }


### PR DESCRIPTION
Mirrors the existing `pluralStudly` / `pluralPascal`. Splits the input on capital-letter boundaries and runs `singular()` on the last word — so `Str::singularStudly('UserGroups')` returns `'UserGroup'` and `Str::singularStudly('ProductCategories')` returns `'ProductCategory'`. Useful when you have a StudlyCase plural (e.g. a model's class basename) and want the singular form without chaining `Str::studly(Str::singular(...))`.