### PR TITLE
[13.x] Add NotificationFake::assertNotSentOnDemand

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -123,6 +123,20 @@ class NotificationFake implements Fake, NotificationDispatcher, NotificationFact
     }
 
     /**
+     * Assert if a notification was not sent on-demand based on a truth-test callback.
+     *
+     * @param  string|\Closure  $notification
+     * @param  callable|null  $callback
+     * @return void
+     *
+     * @throws \Exception
+     */
+    public function assertNotSentOnDemand($notification, $callback = null)
+    {
+        $this->assertNotSentTo(new AnonymousNotifiable, $notification, $callback);
+    }
+
+    /**
      * Determine if a notification was sent based on a truth-test callback.
      *
      * @param  mixed  $notifiable

--- a/tests/Support/SupportTestingNotificationFakeTest.php
+++ b/tests/Support/SupportTestingNotificationFakeTest.php
@@ -107,6 +107,20 @@ class SupportTestingNotificationFakeTest extends TestCase
         }
     }
 
+    public function testAssertNotSentOnDemand()
+    {
+        $this->fake->assertNotSentOnDemand(NotificationStub::class);
+
+        $this->fake->send(new AnonymousNotifiable, new NotificationStub);
+
+        try {
+            $this->fake->assertNotSentOnDemand(NotificationStub::class);
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringContainsString('The unexpected [Illuminate\Tests\Support\NotificationStub] notification was sent.', $e->getMessage());
+        }
+    }
+
     public function testAssertNothingSent()
     {
         $this->fake->assertNothingSent();


### PR DESCRIPTION
`NotificationFake` already has `assertSentOnDemand` and `assertSentOnDemandTimes` for the positive on-demand assertions, plus `assertNotSentTo` for the regular-notifiable inverse — but no negative complement for on-demand. Adding `assertNotSentOnDemand` so a test can assert no on-demand notification was dispatched without falling back to `assertNotSentTo(new AnonymousNotifiable, ...)`.