### PR TITLE
[13.x] Improve macro closure binding

### DIFF
--- a/src/Illuminate/Macroable/Traits/Macroable.php
+++ b/src/Illuminate/Macroable/Traits/Macroable.php
@@ -4,13 +4,16 @@ namespace Illuminate\Support\Traits;
 
 use BadMethodCallException;
 use Closure;
+use Illuminate\Support\RebindsCallbacksToSelf;
 use ReflectionClass;
+use ReflectionException;
 use ReflectionMethod;
 use RuntimeException;
-use Throwable;
 
 trait Macroable
 {
+    use RebindsCallbacksToSelf;
+
     /**
      * The registered string macros.
      *
@@ -123,9 +126,9 @@ trait Macroable
 
         if ($macro instanceof Closure) {
             try {
-                $macro = $macro->bindTo($this, static::class) ?? throw new RuntimeException;
-            } catch (Throwable) {
-                $macro = $macro->bindTo(null, static::class);
+                $macro = $this->bindCallbackToSelf($macro) ?? throw new RuntimeException('Unable to bind macro');
+            } catch (ReflectionException $e) {
+                throw new RuntimeException('Unable to bind macro', previous: $e);
             }
         }
 


### PR DESCRIPTION
> [!NOTE]
> - This is a follow-up PR to #59414.

This PR simplifies macro closure binding by using the new [`RebindsCallbacksToSelf`](https://github.com/laravel/framework/blob/13.x/src/Illuminate/Support/RebindsCallbacksToSelf.php) trait introduced in #59614.

A concern raised in #59393 was the potential overhead of using reflection on every macro call[^1]. In practice, this does not appear to be an issue, as reflection metadata is internally cached by PHP.

I also created a small benchmark comparing the previous `try/catch` approach against the new `ReflectionFunction`-based implementation:

- Previous `try/catch` approach: ~830 ms for 1,000,000 calls
  https://3v4l.org/hCN8r/perf
- **New** `ReflectionFunction` approach: ~200 ms for 1,000,000 calls
  https://3v4l.org/hC73H/perf

In this benchmark, the reflection-based implementation is roughly 4x faster than blindly attempting `->bindTo()` and handling failures via exceptions.

[^1]: https://github.com/laravel/framework/pull/59393#issuecomment-4144143127