### PR TITLE
[13.x] Add canonical URL to string facade

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -634,6 +634,85 @@ class Str
     }
 
     /**
+     * Get a canonical form of the given URL suitable for equality comparison.
+     *
+     * Normalizes the scheme (defaults to https), lowercases the host, strips
+     * any leading "www." subdomain, drops the default port for the scheme
+     * (80/443), removes a trailing slash from the path, sorts query string
+     * parameters, and discards the fragment. The path is otherwise preserved
+     * verbatim, including case.
+     *
+     * @param  string  $url
+     * @return string
+     */
+    public static function canonicalUrl($url)
+    {
+        $url = trim($url);
+
+        if ($url === '') {
+            return '';
+        }
+
+        if (! preg_match('#^[a-z][a-z0-9+\-.]*://#i', $url)) {
+            $url = 'https://'.$url;
+        }
+
+        $parts = parse_url($url);
+
+        if ($parts === false || ! isset($parts['host'])) {
+            return $url;
+        }
+
+        $scheme = strtolower($parts['scheme'] ?? 'https');
+        $host = strtolower($parts['host']);
+
+        if (str_starts_with($host, 'www.')) {
+            $host = substr($host, 4);
+        }
+
+        $host = trim($host, '[]');
+
+        if (str_contains($host, ':')) {
+            $host = '['.$host.']';
+        }
+
+        $port = '';
+
+        if (isset($parts['port'])) {
+            $isDefaultPort = ($scheme === 'https' && $parts['port'] === 443)
+                || ($scheme === 'http' && $parts['port'] === 80);
+
+            if (! $isDefaultPort) {
+                $port = ':'.$parts['port'];
+            }
+        }
+
+        $userInfo = '';
+
+        if (isset($parts['user'])) {
+            $userInfo = $parts['user'].(isset($parts['pass']) ? ':'.$parts['pass'] : '').'@';
+        }
+
+        $path = $parts['path'] ?? '';
+
+        if ($path === '' || $path === '/') {
+            $path = '';
+        } else {
+            $path = rtrim($path, '/');
+        }
+
+        $query = '';
+
+        if (isset($parts['query']) && $parts['query'] !== '') {
+            $pairs = explode('&', $parts['query']);
+            sort($pairs);
+            $query = '?'.implode('&', $pairs);
+        }
+
+        return $scheme.'://'.$userInfo.$host.$port.$path.$query;
+    }
+
+    /**
      * Determine if a given value is a valid UUID.
      *
      * @param  mixed  $value

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -403,6 +403,16 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
+     * Get a canonical form of the URL suitable for equality comparison.
+     *
+     * @return static
+     */
+    public function canonicalUrl()
+    {
+        return new static(Str::canonicalUrl($this->value));
+    }
+
+    /**
      * Determine if a given string is a valid UUID.
      *
      * @param  int<0, 8>|'max'|null  $version

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -719,6 +719,69 @@ class SupportStrTest extends TestCase
         $this->assertFalse(Str::isUrl('http:///path'));
     }
 
+    public function testCanonicalUrl()
+    {
+        // Already canonical input is returned unchanged.
+        $this->assertSame('https://example.com', Str::canonicalUrl('https://example.com'));
+
+        // Whitespace is trimmed, empty input returns an empty string.
+        $this->assertSame('', Str::canonicalUrl(''));
+        $this->assertSame('', Str::canonicalUrl('   '));
+        $this->assertSame('https://example.com', Str::canonicalUrl('  https://example.com  '));
+
+        // Missing scheme defaults to https.
+        $this->assertSame('https://example.com', Str::canonicalUrl('example.com'));
+        $this->assertSame('https://example.com', Str::canonicalUrl('www.example.com'));
+
+        // Leading "www." is stripped from the host.
+        $this->assertSame('https://example.com', Str::canonicalUrl('https://www.example.com'));
+        $this->assertSame('http://example.com', Str::canonicalUrl('http://www.example.com'));
+
+        // Host is lowercased; scheme is lowercased.
+        $this->assertSame('https://example.com', Str::canonicalUrl('HTTPS://EXAMPLE.COM'));
+        $this->assertSame('https://example.com', Str::canonicalUrl('Https://Example.Com'));
+
+        // Trailing slash is removed from a root path.
+        $this->assertSame('https://example.com', Str::canonicalUrl('https://example.com/'));
+
+        // A non-root trailing slash is stripped, but the path is otherwise preserved (including case).
+        $this->assertSame('https://example.com/Path', Str::canonicalUrl('https://example.com/Path/'));
+        $this->assertSame('https://example.com/path/to/resource', Str::canonicalUrl('https://example.com/path/to/resource'));
+
+        // Query string is preserved and its parameters are sorted.
+        $this->assertSame('https://example.com?q=1', Str::canonicalUrl('https://example.com/?q=1'));
+        $this->assertSame('https://example.com/path?q=1&r=2', Str::canonicalUrl('https://example.com/path?q=1&r=2'));
+        $this->assertSame('https://example.com/path?a=1&b=2', Str::canonicalUrl('https://example.com/path?b=2&a=1'));
+        $this->assertSame('https://example.com?a=1&b=2&c=3', Str::canonicalUrl('https://example.com?c=3&a=1&b=2'));
+
+        // Fragments are dropped entirely.
+        $this->assertSame('https://example.com', Str::canonicalUrl('https://example.com/#section'));
+        $this->assertSame('https://example.com/path?q=1', Str::canonicalUrl('https://www.example.com/path/?q=1#frag'));
+
+        // Default ports for http/https are stripped; non-default ports are preserved.
+        $this->assertSame('https://example.com', Str::canonicalUrl('https://example.com:443'));
+        $this->assertSame('http://example.com', Str::canonicalUrl('http://example.com:80'));
+        $this->assertSame('https://example.com:8080/path', Str::canonicalUrl('https://example.com:8080/path/'));
+        $this->assertSame('http://example.com:8443', Str::canonicalUrl('http://example.com:8443'));
+
+        // User info is preserved.
+        $this->assertSame('https://user:pass@example.com', Str::canonicalUrl('https://user:pass@www.example.com/'));
+
+        // IPv6 hosts are wrapped in brackets on output.
+        $this->assertSame('https://[::1]:8080/path', Str::canonicalUrl('https://[::1]:8080/path/'));
+        $this->assertSame('https://[2001:db8::1]', Str::canonicalUrl('https://[2001:db8::1]/'));
+
+        // Two URLs that differ only by www/trailing-slash/port/fragment noise canonicalize to the same string.
+        $this->assertSame(
+            Str::canonicalUrl('https://www.example.com/'),
+            Str::canonicalUrl('https://example.com')
+        );
+        $this->assertSame(
+            Str::canonicalUrl('https://example.com:443/path?b=2&a=1#frag'),
+            Str::canonicalUrl('https://www.example.com/path/?a=1&b=2')
+        );
+    }
+
     #[DataProvider('validUuidList')]
     public function testIsUuidWithValidUuid($uuid)
     {

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -50,6 +50,21 @@ class SupportStringableTest extends TestCase
         $this->assertFalse($this->stringable('https://laravel.com')->isUrl(['http']));
     }
 
+    public function testCanonicalUrl()
+    {
+        $canonical = $this->stringable('https://www.example.com/')->canonicalUrl();
+
+        $this->assertInstanceOf(Stringable::class, $canonical);
+        $this->assertSame('https://example.com', (string) $canonical);
+
+        $this->assertSame('https://example.com', (string) $this->stringable('  HTTPS://EXAMPLE.COM/  ')->canonicalUrl());
+        $this->assertSame('https://example.com/path?q=1', (string) $this->stringable('https://www.example.com/path/?q=1#frag')->canonicalUrl());
+        $this->assertSame('https://example.com/path?a=1&b=2', (string) $this->stringable('https://example.com/path?b=2&a=1')->canonicalUrl());
+        $this->assertSame('https://example.com', (string) $this->stringable('https://example.com:443')->canonicalUrl());
+        $this->assertSame('https://example.com', (string) $this->stringable('example.com')->canonicalUrl());
+        $this->assertSame('', (string) $this->stringable('')->canonicalUrl());
+    }
+
     public function testIsUuid()
     {
         $this->assertTrue($this->stringable('2cdc7039-65a6-4ac7-8e5d-d554a98e7b15')->isUuid());


### PR DESCRIPTION
Adds `Str::canonicalUrl()` (and a `Stringable::canonicalUrl()` wrapper) which produces a deterministic, normalized form of a URL suitable for equality comparisons against multiple forms of a URL.

This came out of a real scenario at work, where we run a number of background jobs that scrape external websites. The queue keys for those jobs, along with the downstream models and cache results we attach the results to, are keyed off the URL itself in certain cases. The URLs come from user input and other integrations, which means the same logical site shows up in a handful of forms:

- example.com, https://example.com, https://www.example.com/
- HTTPS://EXAMPLE.COM:443
- https://example.com/?b=2&a=1 vs https://example.com/?a=1&b=2
- https://example.com/path/#section vs https://example.com/path

We initially wrote a small normalization helper in our own codebase to deduplicate these before hashing/keying, and figured it might be helpful in the framework for others who need to do similar things with user-facing/supplied URLs. Anyone wiring URLs into a domain model (scrapers, link shorteners, bookmark apps, SEO tooling, webhook subscription dedup, "have we seen this site before" caching) might hit the same problem we had.

**What it does**

`Str::canonicalUrl($url)` goes through a few normalization steps:

- Trims whitespace; returns `''` for empty input
- Defaults missing scheme to https://
- Lowercases scheme and host ([RFC 3986 §6.2.2.1](https://datatracker.ietf.org/doc/html/rfc3986#section-6.2.2.1))
- Strips a leading www. from the host
- Wraps IPv6 hosts in [...] on output
- Drops the default port for the scheme (:80 for http, :443 for https)
- Removes a trailing slash from the path (preserving path case, since paths are case-sensitive per RFC)
- Sorts query string parameters lexically so ?b=2&a=1 and ?a=1&b=2 collapse to the same form
- Discards the fragment
- Preserves user info (user:pass@) verbatim

A few examples:

```php
Str::canonicalUrl('https://www.Example.com:443/Path/?b=2&a=1#section'); // => "https://example.com/Path?a=1&b=2"
Str::canonicalUrl('example.com'); // => "https://example.com"
Str::canonicalUrl('https://[2001:db8::1]:8080/path/'); // => "https://[2001:db8::1]:8080/path"
```

Hopefully it helps someone that might be doing similar things!