### PR TITLE
add generic return types to `Builder` paginate methods

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1115,7 +1115,7 @@ class Builder implements BuilderContract
      * @param  string  $pageName
      * @param  int|null  $page
      * @param  \Closure|int|null  $total
-     * @return \Illuminate\Pagination\LengthAwarePaginator
+     * @return \Illuminate\Pagination\LengthAwarePaginator<int, TModel>
      *
      * @throws \InvalidArgumentException
      */
@@ -1144,7 +1144,7 @@ class Builder implements BuilderContract
      * @param  array|string  $columns
      * @param  string  $pageName
      * @param  int|null  $page
-     * @return \Illuminate\Contracts\Pagination\Paginator
+     * @return \Illuminate\Pagination\Paginator<int, TModel>
      */
     public function simplePaginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null)
     {
@@ -1170,7 +1170,7 @@ class Builder implements BuilderContract
      * @param  array|string  $columns
      * @param  string  $cursorName
      * @param  \Illuminate\Pagination\Cursor|string|null  $cursor
-     * @return \Illuminate\Contracts\Pagination\CursorPaginator
+     * @return \Illuminate\Pagination\CursorPaginator<int, TModel>
      */
     public function cursorPaginate($perPage = null, $columns = ['*'], $cursorName = 'cursor', $cursor = null)
     {


### PR DESCRIPTION
## summary

`Illuminate\Database\Eloquent\Builder` already declares `@template TModel of \Illuminate\Database\Eloquent\Model` at the class level, and the three paginator classes (`LengthAwarePaginator`, `Paginator`, `CursorPaginator`) already declare `@template TKey of array-key` and `@template-covariant TValue`. this change threads the two together by adding generic return type annotations to the three paginate methods on `Builder`.

**before:**
```php
/** @return \Illuminate\Pagination\LengthAwarePaginator */
public function paginate(...) { ... }

/** @return \Illuminate\Contracts\Pagination\Paginator */
public function simplePaginate(...) { ... }

/** @return \Illuminate\Contracts\Pagination\CursorPaginator */
public function cursorPaginate(...) { ... }
```

**after:**
```php
/** @return \Illuminate\Pagination\LengthAwarePaginator<int, TModel> */
public function paginate(...) { ... }

/** @return \Illuminate\Pagination\Paginator<int, TModel> */
public function simplePaginate(...) { ... }

/** @return \Illuminate\Pagination\CursorPaginator<int, TModel> */
public function cursorPaginate(...) { ... }
```

## why

without these annotations, static analysis tools have no way to carry the model type through a paginator. a call like `Product::paginate(5)` resolves to an untyped `LengthAwarePaginator`, so tools that inspect the return shape (eg. for Inertia type generation) fall back to `data: Record<string, unknown>` instead of emitting `data: Product[]`.

this is a docblock-only change; no runtime behavior is affected.

## related

- https://github.com/laravel/surveyor/pull/39
- https://github.com/laravel/wayfinder/pull/249

## merge order

`this` -> `laravel/surveyor` -> `laravel/wayfinder`