### PR TITLE
[13.x] Make PendingDispatch conditionable

### DIFF
--- a/src/Illuminate/Foundation/Bus/PendingDispatch.php
+++ b/src/Illuminate/Foundation/Bus/PendingDispatch.php
@@ -12,12 +12,12 @@ use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Foundation\Queue\InteractsWithUniqueJobs;
 use Illuminate\Queue\Attributes\DebounceFor;
 use Illuminate\Queue\Attributes\ReadsQueueAttributes;
+use Illuminate\Support\Traits\Conditionable;
 use LogicException;
 
 class PendingDispatch
 {
-    use InteractsWithUniqueJobs;
-    use ReadsQueueAttributes;
+    use Conditionable, InteractsWithUniqueJobs, ReadsQueueAttributes;
 
     /**
      * The job.

--- a/tests/Bus/BusPendingDispatchTest.php
+++ b/tests/Bus/BusPendingDispatchTest.php
@@ -138,7 +138,7 @@ class BusPendingDispatchTest extends TestCase
 
     protected function tearDown(): void
     {
-       m::close();
-       parent::tearDown();                                                                                                                                                                                                                                                               
+        m::close();
+        parent::tearDown();                                                                                                                                                                                                                                                               
     }
 }

--- a/tests/Bus/BusPendingDispatchTest.php
+++ b/tests/Bus/BusPendingDispatchTest.php
@@ -139,6 +139,6 @@ class BusPendingDispatchTest extends TestCase
     protected function tearDown(): void
     {
         m::close();
-        parent::tearDown();                                                                                                                                                                                                                                                               
+        parent::tearDown();
     }
 }

--- a/tests/Bus/BusPendingDispatchTest.php
+++ b/tests/Bus/BusPendingDispatchTest.php
@@ -107,4 +107,40 @@ class BusPendingDispatchTest extends TestCase
         $this->job->shouldReceive('appendToChain')->once()->with($newJob);
         $this->pendingDispatch->appendToChain($newJob);
     }
+
+    public function testWhenMethodOfConditionableTraitWithTrue()
+    {   
+        $this->job->shouldReceive('delay')->once()->with(300);
+
+        $this->pendingDispatch->when(true, fn ($pendingDispatch) => $pendingDispatch->delay(300));
+    }
+
+    public function testWhenMethodOfConditionableTraitWithFalse()
+    {
+        
+        $this->job->shouldReceive('delay')->never();
+
+        $this->pendingDispatch->when(false, fn ($pendingDispatch) => $pendingDispatch->delay(300));
+    }
+
+    public function testUnlessMethodOfConditionableTraitWithTrue()
+    {   
+        $this->job->shouldReceive('delay')->never();
+
+        $this->pendingDispatch->unless(true, fn ($pendingDispatch) => $pendingDispatch->delay(300));
+    }
+
+    public function testUnlessMethodOfConditionableTraitWithFalse()
+    {
+        
+        $this->job->shouldReceive('delay')->once()->with(300);
+
+        $this->pendingDispatch->unless(false, fn ($pendingDispatch) => $pendingDispatch->delay(300));
+    }
+
+    protected function tearDown(): void
+    {
+       m::close();
+       parent::tearDown();                                                                                                                                                                                                                                                               
+    }
 }

--- a/tests/Bus/BusPendingDispatchTest.php
+++ b/tests/Bus/BusPendingDispatchTest.php
@@ -109,7 +109,7 @@ class BusPendingDispatchTest extends TestCase
     }
 
     public function testWhenMethodOfConditionableTraitWithTrue()
-    {   
+    {
         $this->job->shouldReceive('delay')->once()->with(300);
 
         $this->pendingDispatch->when(true, fn ($pendingDispatch) => $pendingDispatch->delay(300));
@@ -117,14 +117,13 @@ class BusPendingDispatchTest extends TestCase
 
     public function testWhenMethodOfConditionableTraitWithFalse()
     {
-        
         $this->job->shouldReceive('delay')->never();
 
         $this->pendingDispatch->when(false, fn ($pendingDispatch) => $pendingDispatch->delay(300));
     }
 
     public function testUnlessMethodOfConditionableTraitWithTrue()
-    {   
+    {
         $this->job->shouldReceive('delay')->never();
 
         $this->pendingDispatch->unless(true, fn ($pendingDispatch) => $pendingDispatch->delay(300));
@@ -132,7 +131,6 @@ class BusPendingDispatchTest extends TestCase
 
     public function testUnlessMethodOfConditionableTraitWithFalse()
     {
-        
         $this->job->shouldReceive('delay')->once()->with(300);
 
         $this->pendingDispatch->unless(false, fn ($pendingDispatch) => $pendingDispatch->delay(300));


### PR DESCRIPTION
It would be nice to configure queued jobs to be dispatch with some conditions.

I am working for a cryptocurrency company, we don't want to deal with fraudulent customers. At the same time, for better conversion, certain customers don't have to submit their personal details before payment is done.

```php
class Customer extends Model
{
    public function hasSufficientPersonalDetails(): bool
    {
        return $this->name
            && ($this->phone_number || $this->email)
            && $this->addresses->isNotEmpty();
    }
}

use App\Jobs\SendPersonalDetailsToFraudDetectionTool;

// After payment is done.
SendPersonalDetailsToFraudDetectionTool::dispatch($customer)
    ->when($customer->hasSufficientPersonalDetails(), fn ($job) => $job->withoutDelay());

// Or
SendPersonalDetailsToFraudDetectionTool::dispatch($customer)
    ->unless($customer->hasSufficientPersonalDetails(), fn ($job) => $job->delay(180));
```
This is important to us, the earlier our fraud tool got the data, the earlier it can assess and stop fraudulent customers. 