### PR TITLE
[13.x] update `make:provider` command to use unqualified classes

### DIFF
--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -600,15 +600,21 @@ abstract class ServiceProvider
             ->merge([$provider])
             ->unique()
             ->sort()
-            ->values()
-            ->map(fn ($p) => '    '.$p.'::class,')
-            ->implode(PHP_EOL);
+            ->values();
 
-        $content = '<?php
+        $content = '<?php'.PHP_EOL.PHP_EOL;
 
-return [
-'.$providers.'
-];';
+        foreach ($providers as $provider) {
+            $content .= 'use '.$provider.';'.PHP_EOL;
+        }
+
+        $content .= PHP_EOL.'return ['.PHP_EOL;
+
+        foreach ($providers as $provider) {
+            $content .= '    '.class_basename($provider).'::class,'.PHP_EOL;
+        }
+
+        $content .= '];';
 
         file_put_contents($path, $content.PHP_EOL);
 


### PR DESCRIPTION
Laravel recently switched to using imports _everywhere_, as seen in #6760.  the `make:provider` command was still generating output with FQNs.  this commit switches the output to use imports.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
