### PR TITLE
[13.x] Fix @params typo in toPrettyJson docblocks

### DIFF
--- a/src/Illuminate/Pagination/CursorPaginator.php
+++ b/src/Illuminate/Pagination/CursorPaginator.php
@@ -184,7 +184,7 @@ class CursorPaginator extends AbstractCursorPaginator implements Arrayable, Arra
     /**
      * Convert the object to pretty print formatted JSON.
      *
-     * @params int $options
+     * @param  int  $options
      *
      * @return string
      */

--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -246,7 +246,7 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
     /**
      * Convert the object to pretty print formatted JSON.
      *
-     * @params int $options
+     * @param  int  $options
      *
      * @return string
      */

--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -189,7 +189,7 @@ class Paginator extends AbstractPaginator implements Arrayable, ArrayAccess, Cou
     /**
      * Convert the object to pretty print formatted JSON.
      *
-     * @params int $options
+     * @param  int  $options
      *
      * @return string
      */

--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -206,7 +206,7 @@ class Fluent implements Arrayable, ArrayAccess, IteratorAggregate, Jsonable, Jso
     /**
      * Convert the fluent instance to pretty print formatted JSON.
      *
-     * @params int $options
+     * @param  int  $options
      *
      * @return string
      */

--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -434,7 +434,7 @@ class MessageBag implements Jsonable, JsonSerializable, MessageBagContract, Mess
     /**
      * Convert the object to pretty print formatted JSON.
      *
-     * @params int $options
+     * @param  int  $options
      *
      * @return string
      */


### PR DESCRIPTION
Five `toPrettyJson()` methods have `@params` (invalid PHPDoc tag) instead of `@param` in their docblocks: `Paginator`, `CursorPaginator`, `LengthAwarePaginator`, `Support\Fluent`, `Support\MessageBag`. Static analyzers and IDEs don't recognize `@params`, so the parameter goes undocumented. One-character fix per file.