### PR TITLE
[13.x] Fix ShouldBeUniqueUntilProcessing lock leak when middleware releases the job

### DIFF
--- a/src/Illuminate/Bus/UniqueLock.php
+++ b/src/Illuminate/Bus/UniqueLock.php
@@ -11,6 +11,14 @@ class UniqueLock
     use ReadsQueueAttributes;
 
     /**
+     * Default TTL (seconds) for the per-dispatch "released" marker when a job
+     * does not declare a uniqueFor value. Long enough to cover any realistic
+     * retry chain; the marker is uuid-scoped so it cannot collide with future
+     * dispatches.
+     */
+    protected const DEFAULT_RELEASED_MARKER_TTL = 86400;
+
+    /**
      * The cache repository implementation.
      *
      * @var \Illuminate\Contracts\Cache\Repository
@@ -35,15 +43,9 @@ class UniqueLock
      */
     public function acquire($job)
     {
-        $uniqueFor = method_exists($job, 'uniqueFor')
-            ? $job->uniqueFor()
-            : ($this->getAttributeValue($job, UniqueFor::class, 'uniqueFor') ?? 0);
-
-        $cache = method_exists($job, 'uniqueVia')
-            ? ($job->uniqueVia() ?? $this->cache)
-            : $this->cache;
-
-        return (bool) $cache->lock(self::getKey($job), $uniqueFor)->get();
+        return (bool) $this->resolveCache($job)
+            ->lock(self::getKey($job), $this->resolveUniqueFor($job))
+            ->get();
     }
 
     /**
@@ -54,11 +56,77 @@ class UniqueLock
      */
     public function release($job)
     {
-        $cache = method_exists($job, 'uniqueVia')
+        $this->resolveCache($job)->lock(self::getKey($job))->forceRelease();
+    }
+
+    /**
+     * Record that the unique lock has been released by the given dispatch.
+     *
+     * Used to make subsequent attempts of the same dispatch idempotent so
+     * they do not force-release a lock that may now belong to a different
+     * dispatch.
+     *
+     * @param  mixed  $job
+     * @param  string  $owner
+     * @return void
+     */
+    public function recordReleasedBy($job, string $owner)
+    {
+        $this->resolveCache($job)->put(
+            self::getReleasedKey($job, $owner),
+            true,
+            $this->resolveUniqueFor($job) ?: self::DEFAULT_RELEASED_MARKER_TTL
+        );
+    }
+
+    /**
+     * Determine whether the unique lock was previously released by the given dispatch.
+     *
+     * @param  mixed  $job
+     * @param  string  $owner
+     * @return bool
+     */
+    public function wasReleasedBy($job, string $owner)
+    {
+        return (bool) $this->resolveCache($job)->get(self::getReleasedKey($job, $owner));
+    }
+
+    /**
+     * Forget the per-dispatch "released" marker for the given job.
+     *
+     * @param  mixed  $job
+     * @param  string  $owner
+     * @return void
+     */
+    public function forgetReleasedBy($job, string $owner)
+    {
+        $this->resolveCache($job)->forget(self::getReleasedKey($job, $owner));
+    }
+
+    /**
+     * Resolve the cache store for the given job.
+     *
+     * @param  mixed  $job
+     * @return \Illuminate\Contracts\Cache\Repository
+     */
+    protected function resolveCache($job)
+    {
+        return method_exists($job, 'uniqueVia')
             ? ($job->uniqueVia() ?? $this->cache)
             : $this->cache;
+    }
 
-        $cache->lock(self::getKey($job))->forceRelease();
+    /**
+     * Resolve the uniqueFor value (in seconds) for the given job.
+     *
+     * @param  mixed  $job
+     * @return int
+     */
+    protected function resolveUniqueFor($job)
+    {
+        return method_exists($job, 'uniqueFor')
+            ? $job->uniqueFor()
+            : ($this->getAttributeValue($job, UniqueFor::class, 'uniqueFor') ?? 0);
     }
 
     /**
@@ -78,5 +146,17 @@ class UniqueLock
             : get_class($job);
 
         return 'laravel_unique_job:'.$jobName.':'.$uniqueId;
+    }
+
+    /**
+     * Generate the per-dispatch "released" marker key for the given job.
+     *
+     * @param  mixed  $job
+     * @param  string  $owner
+     * @return string
+     */
+    public static function getReleasedKey($job, string $owner)
+    {
+        return self::getKey($job).':released:'.$owner;
     }
 }

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -86,8 +86,12 @@ class CallQueuedHandler
             $this->runningCommand = null;
         }
 
-        if (! $job->isReleased() && ! $this->commandShouldBeUniqueUntilProcessing($command)) {
-            $this->ensureUniqueJobLockIsReleased($command);
+        if (! $job->isReleased()) {
+            if ($this->commandShouldBeUniqueUntilProcessing($command)) {
+                $this->forgetUniqueUntilProcessingReleasedMarker($command, $job->uuid());
+            } else {
+                $this->ensureUniqueJobLockIsReleased($command);
+            }
         }
 
         if (! $job->hasFailed() && ! $job->isReleased()) {
@@ -138,14 +142,18 @@ class CallQueuedHandler
 
         return (new Pipeline($this->container))->send($command)
             ->through(array_merge(method_exists($command, 'middleware') ? $command->middleware() : [], $command->middleware ?? []))
-            ->finally(function ($command) use (&$lockReleased) {
-                if (! $lockReleased && $this->commandShouldBeUniqueUntilProcessing($command) && ! $command->job->isReleased() && $command->job->attempts() <= 1) {
-                    $this->ensureUniqueJobLockIsReleased($command);
+            ->finally(function ($command) use ($job, &$lockReleased) {
+                if (! $lockReleased
+                    && $this->commandShouldBeUniqueUntilProcessing($command)
+                    && ! $command->job->isReleased()
+                    && ! $this->uniqueUntilProcessingLockAlreadyReleased($command, $job->uuid())) {
+                    $this->releaseUniqueUntilProcessingLock($command, $job->uuid());
                 }
             })
             ->then(function ($command) use ($job, &$lockReleased) {
-                if ($this->commandShouldBeUniqueUntilProcessing($command) && $job->attempts() <= 1) {
-                    $this->ensureUniqueJobLockIsReleased($command);
+                if ($this->commandShouldBeUniqueUntilProcessing($command)
+                    && ! $this->uniqueUntilProcessingLockAlreadyReleased($command, $job->uuid())) {
+                    $this->releaseUniqueUntilProcessingLock($command, $job->uuid());
 
                     $lockReleased = true;
                 }
@@ -233,6 +241,62 @@ class CallQueuedHandler
         if ($this->commandShouldBeUnique($command)) {
             (new UniqueLock($this->container->make(Cache::class)))->release($command);
         }
+    }
+
+    /**
+     * Release the unique-until-processing lock and record that this dispatch
+     * released it so retries are idempotent.
+     *
+     * @param  mixed  $command
+     * @param  string  $uuid
+     * @return void
+     */
+    protected function releaseUniqueUntilProcessingLock($command, string $uuid)
+    {
+        if (! $this->commandShouldBeUnique($command)) {
+            return;
+        }
+
+        $lock = new UniqueLock($this->container->make(Cache::class));
+        $lock->release($command);
+        $lock->recordReleasedBy($command, $uuid);
+    }
+
+    /**
+     * Determine whether this dispatch already released the unique-until-processing
+     * lock on a prior attempt. Prevents a retry from force-releasing a lock that
+     * may now belong to a different dispatch.
+     *
+     * @param  mixed  $command
+     * @param  string  $uuid
+     * @return bool
+     */
+    protected function uniqueUntilProcessingLockAlreadyReleased($command, string $uuid)
+    {
+        if (! $this->commandShouldBeUnique($command)) {
+            return false;
+        }
+
+        return (new UniqueLock($this->container->make(Cache::class)))
+            ->wasReleasedBy($command, $uuid);
+    }
+
+    /**
+     * Forget the per-dispatch released marker. Called after the job is fully
+     * resolved so the marker does not linger in the cache.
+     *
+     * @param  mixed  $command
+     * @param  string  $uuid
+     * @return void
+     */
+    protected function forgetUniqueUntilProcessingReleasedMarker($command, string $uuid)
+    {
+        if (! $this->commandShouldBeUnique($command)) {
+            return;
+        }
+
+        (new UniqueLock($this->container->make(Cache::class)))
+            ->forgetReleasedBy($command, $uuid);
     }
 
     /**
@@ -392,7 +456,9 @@ class CallQueuedHandler
             $command = $this->setJobInstanceIfNecessary($job, $command);
         }
 
-        if (! $this->commandShouldBeUniqueUntilProcessing($command)) {
+        if ($this->commandShouldBeUniqueUntilProcessing($command)) {
+            $this->forgetUniqueUntilProcessingReleasedMarker($command, $uuid);
+        } else {
             $this->ensureUniqueJobLockIsReleased($command);
         }
 

--- a/tests/Events/QueuedEventsTest.php
+++ b/tests/Events/QueuedEventsTest.php
@@ -576,18 +576,23 @@ class QueuedEventsTest extends TestCase
         $listener->uniqueId = 'until-processing-id';
 
         $expectedKey = 'laravel_unique_job:'.hash('xxh128', TestDispatcherShouldBeUniqueUntilProcessing::class).':until-processing-id';
+        $jobUuid = 'job-uuid-1';
+        $releasedMarkerKey = $expectedKey.':released:'.$jobUuid;
 
         $cache->shouldReceive('lock')
             ->with($expectedKey)
             ->andReturn($lock);
         $lock->shouldReceive('forceRelease')->once();
+        $cache->shouldReceive('get')->with($releasedMarkerKey)->andReturn(null);
+        $cache->shouldReceive('put')->with($releasedMarkerKey, true, m::any())->once();
+        $cache->shouldReceive('forget')->with($releasedMarkerKey)->once();
 
         $job = m::mock(Job::class);
         $job->shouldReceive('hasFailed')->andReturn(false);
         $job->shouldReceive('isDeleted')->andReturn(false);
         $job->shouldReceive('isReleased')->andReturn(false);
         $job->shouldReceive('isDeletedOrReleased')->andReturn(false);
-        $job->shouldReceive('attempts')->andReturn(1);
+        $job->shouldReceive('uuid')->andReturn($jobUuid);
         $job->shouldReceive('delete')->once();
 
         $handler = new CallQueuedHandler(new BusDispatcher($container), $container);

--- a/tests/Integration/Queue/UniqueJobTest.php
+++ b/tests/Integration/Queue/UniqueJobTest.php
@@ -14,6 +14,7 @@ use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Auth\User;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\Middleware\WithoutOverlapping;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Queue;
@@ -168,6 +169,48 @@ class UniqueJobTest extends QueueTestCase
 
         $this->assertTrue($job::$handled);
         $this->assertFalse($this->app->get(Cache::class)->lock($this->getLockKey($job), 10)->get());
+    }
+
+    public function testUniqueUntilProcessingLockIsReleasedAfterMiddlewareReleasedRetry()
+    {
+        $this->markTestSkippedWhenUsingSyncQueueDriver();
+
+        UniqueUntilProcessingWithoutOverlapJob::$handled = 0;
+
+        $cache = $this->app->get(Cache::class);
+
+        // Pre-acquire the WithoutOverlapping lock so attempt 1 will be released by
+        // the middleware before reaching handle(). This simulates the original
+        // user-reported scenario where another instance of the job is already
+        // processing while this one is dequeued.
+        $overlapKey = 'laravel-queue-overlap:'.UniqueUntilProcessingWithoutOverlapJob::class.':';
+        $overlapLock = $cache->lock($overlapKey, 60);
+        $this->assertTrue($overlapLock->get());
+
+        dispatch($job = new UniqueUntilProcessingWithoutOverlapJob);
+
+        // SBUUP lock acquired at dispatch time.
+        $this->assertFalse($cache->lock($this->getLockKey($job), 10)->get());
+
+        // Attempt 1: WithoutOverlapping releases the job because the overlap lock
+        // is already held. handle() must not run, and the SBUUP lock must remain
+        // held for the upcoming retry.
+        $this->runQueueWorkerCommand(['--once' => true]);
+
+        $this->assertSame(0, UniqueUntilProcessingWithoutOverlapJob::$handled);
+        $this->assertFalse($cache->lock($this->getLockKey($job), 10)->get());
+
+        // Free the overlap lock so attempt 2 can run handle().
+        $overlapLock->release();
+
+        $this->runQueueWorkerCommand(['--once' => true]);
+
+        $this->assertSame(1, UniqueUntilProcessingWithoutOverlapJob::$handled);
+
+        // Regression: the SBUUP lock must be released after the successful
+        // attempt 2, even though attempts() > 1. Otherwise future dispatches for
+        // the same key are silently dropped forever.
+        $this->assertTrue($cache->lock($this->getLockKey($job), 10)->get());
     }
 
     public function testLockIsReleasedOnModelNotFoundException()
@@ -342,6 +385,25 @@ class UniqueUntilProcessingRetryJob implements ShouldQueue, ShouldBeUniqueUntilP
         if ($this->attempts() === 1) {
             throw new Exception('First attempt failure.');
         }
+    }
+}
+
+class UniqueUntilProcessingWithoutOverlapJob implements ShouldQueue, ShouldBeUniqueUntilProcessing
+{
+    use InteractsWithQueue, Queueable, Dispatchable;
+
+    public $tries = 3;
+
+    public static int $handled = 0;
+
+    public function middleware()
+    {
+        return [new WithoutOverlapping];
+    }
+
+    public function handle()
+    {
+        static::$handled++;
     }
 }
 


### PR DESCRIPTION
# Introduction

In Laravel, you can mark a queued job with two safety features:

- `ShouldBeUniqueUntilProcessing` says "don't let two copies of this job sit in the queue at the same time." It uses a cache lock to remember "a copy of this job is already waiting." When the queue worker picks up the job and is about to start running it, the lock is released so a new copy can be queued while this one runs.

- `WithoutOverlapping` middleware says "don't let two copies of this job run at the same time." If a worker picks up the job while another worker is still running a copy, it puts this one back on the queue to try again in a moment.

It's reasonable to combine the two features together: "I've changed something. Dispatch a recompute job. If a recompute job is already sitting in the queue, drop the new one; the existing one will pick up my changes when it runs. If a recompute job is already running, wait until it's done before starting another." This means there will be at most 2 jobs in-flight for a job class + unique identifier, 0..1 sitting in the queue and 0..1 running.

# The Bug

https://github.com/laravel/framework/issues/60042

In 13.5, a bug fix to `ShouldBeUniqueUntilProcessing` (https://github.com/laravel/framework/pull/59567) changed the way locks are managed and introduced a different bug that causes jobs that use both features to occasionally get lost. You can see the bug when a job that uses both features gets returned to the queue by the `WithoutOverlapping` middleware and then succeeds on retry:

1. You dispatch the job. It sits in the queue. The "no duplicate in queue" lock is held.

2. A worker picks it up, but another job with the same unique ID is already running, so `WithoutOverlapping` says "not yet" and puts it back on the queue for a retry. **However, it does this without releasing the "no duplicate in queue" lock (which is _correct behavior_).**

3. Moments later, the other job finishes. A worker picks up our job again. This time it runs cleanly. **However, because of the change in https://github.com/laravel/framework/pull/59567, it still doesn't release the lock, because this isn't the first attempt.**

4. The job completes. As far as you can tell, everything is fine. However, the lock is never released, and now sits in the cache until its TTL (or forever, the default). From that point on, every future dispatch of the job until its TTL is silently dropped, because Laravel sees the lock and assumes a job is already queued even when there isn't one.

tl;dr The earlier bug fix to `ShouldBeUniqueUntilProcessing` (https://github.com/laravel/framework/pull/59567) said, in effect, "only release the lock on the first attempt; don't release on retries." That works fine when the first attempt actually started running and released the lock itself before failing. But if the first attempt gets returned to the queue before it ever started running (which is what `WithoutOverlapping` does), then the lock never got released the first time, and the rule says it can't be released on retries. The lock is stuck forever.

# The Fix

Instead of using "is this a retry?" as the question, use "did this specific dispatch already release its lock?"

Each queued job has a unique ID (UUID) that stays the same across retries. Leave a record in the cache when we release the lock, tagged with that UUID: "dispatch X already released its lock." When a later attempt of the same
dispatch is about to release the lock, it checks for the record:

- If the record doesn't exist, it means we still own the lock and we should release it. (Fixes the bug.)

- If the record exists, it means we already released the lock on a previous attempt, and some other dispatch may have grabbed it since then (i.e. we shouldn't release it). (Preserves the earlier fix.)

The new record expires automatically and is also cleaned up explicitly when the job finishes. Because it's tagged with the dispatch's UUID, two different dispatches of the same job class can never confuse each other.

# Tests

I've added one new test (`testUniqueUntilProcessingLockIsReleasedAfterMiddlewareReleasedRetry`) covering this scenario.

I've also confirmed my repro (https://github.com/nmbrcolin/repro-stale) passes with 13.4, fails with 13.5, and passes with 13.5 + these changes.