### PR TITLE
[13.x] re-add docblock for `apply()` method

### DIFF
--- a/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
@@ -3,7 +3,8 @@
 namespace Illuminate\Database\Eloquent;
 
 /**
- * @implements \Illuminate\Database\Eloquent\Scope<\Illuminate\Database\Eloquent\Model>
+ * @template TModel of \Illuminate\Database\Eloquent\Model
+ * @implements \Illuminate\Database\Eloquent\Scope<TModel>
  */
 class SoftDeletingScope implements Scope
 {
@@ -14,6 +15,13 @@ class SoftDeletingScope implements Scope
      */
     protected $extensions = ['Restore', 'RestoreOrCreate', 'CreateOrRestore', 'WithTrashed', 'WithoutTrashed', 'OnlyTrashed'];
 
+    /**
+     * Apply the scope to a given Eloquent query builder.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder<TModel>  $builder
+     * @param  TModel  $model
+     * @return void
+     */
     public function apply(Builder $builder, Model $model)
     {
         $builder->whereNull($model->getQualifiedDeletedAtColumn());


### PR DESCRIPTION
this docblock was removed in #59675 when trying to refactor some of the generics.

we will add the docblock back, and define the `TModel` generic at the class level, so it can be passed to the interface, and also used in the `apply()` method.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
