### PR TITLE
[13.x] Add unicode modifier to preg_split

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1448,7 +1448,7 @@ class Str
      */
     public static function headline($value)
     {
-        $parts = preg_split('/\s+/', $value, -1, PREG_SPLIT_NO_EMPTY);
+        $parts = preg_split('/\s+/u', $value, -1, PREG_SPLIT_NO_EMPTY);
 
         $parts = count($parts) > 1
             ? array_map(static::title(...), $parts)
@@ -1468,7 +1468,7 @@ class Str
      */
     public static function initials($value, $capitalize = false)
     {
-        $parts = preg_split('/\s+/', $value, -1, PREG_SPLIT_NO_EMPTY);
+        $parts = preg_split('/\s+/u', $value, -1, PREG_SPLIT_NO_EMPTY);
 
         $parts = array_map(fn ($part) => mb_substr($part, 0, 1), $parts);
 
@@ -1499,7 +1499,7 @@ class Str
 
         $endPunctuation = ['.', '!', '?', ':', '—', ','];
 
-        $words = preg_split('/\s+/', $value, -1, PREG_SPLIT_NO_EMPTY);
+        $words = preg_split('/\s+/u', $value, -1, PREG_SPLIT_NO_EMPTY);
         $wordCount = count($words);
 
         for ($i = 0; $i < $wordCount; $i++) {
@@ -1719,7 +1719,7 @@ class Str
             return static::$studlyCache[$key];
         }
 
-        $words = preg_split('/\s+/', static::replace(['-', '_'], ' ', $value), -1, PREG_SPLIT_NO_EMPTY);
+        $words = preg_split('/\s+/u', static::replace(['-', '_'], ' ', $value), -1, PREG_SPLIT_NO_EMPTY);
 
         $studlyWords = array_map(fn ($word) => static::ucfirst($word), $words);
 

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -90,6 +90,8 @@ class SupportStrTest extends TestCase
         $this->assertSame('Orwell 1984', Str::headline('orwell   1984'));
         $this->assertSame('Orwell 1984', Str::headline('-orwell-1984 -'));
         $this->assertSame('Orwell 1984', Str::headline(' orwell_- 1984 '));
+
+        $this->assertSame('Laravel Rocks!', Str::headline('laravel rocks!'));
     }
 
     public function testStringInitials()
@@ -105,6 +107,9 @@ class SupportStrTest extends TestCase
         $this->assertSame('JBLL', Str::initials('james bond loves laravel', true));
 
         $this->assertSame('❤M☆', Str::initials('❤ MULTIByte ☆'));
+
+        $this->assertSame('lr', Str::initials('laravel rocks!'));
+        $this->assertSame('LR', Str::initials('laravel rocks!', true));
     }
 
     public function testStringApa()
@@ -150,6 +155,10 @@ class SupportStrTest extends TestCase
         $this->assertSame('Устное Слово – Не Воробей. Как Только Он Вылетит, Его Не Поймаешь.', Str::apa('УСТНОЕ СЛОВО – НЕ ВОРОБЕЙ. КАК ТОЛЬКО ОН ВЫЛЕТИТ, ЕГО НЕ ПОЙМАЕШЬ.'));
 
         $this->assertSame('❤ Multibyte ☆', Str::apa('❤ MULTIByte ☆'));
+
+        $this->assertSame('Laravel Rocks!', Str::apa('Laravel Rocks!'));
+        $this->assertSame('Laravel Rocks!', Str::apa('Laravel rocks!'));
+        $this->assertSame('Laravel Rocks!', Str::apa('LARAVEL ROCKS!'));
 
         $this->assertSame('', Str::apa(''));
         $this->assertSame('   ', Str::apa('   '));
@@ -1161,6 +1170,8 @@ class SupportStrTest extends TestCase
 
         $this->assertSame('ÖffentlicheÜberraschungen', Str::studly('öffentliche-überraschungen'));
         $this->assertSame('❤MultiByte☆', Str::studly('❤ multi-byte☆'));
+
+        $this->assertSame('LaravelRocks!', Str::studly('laravel rocks!'));
     }
 
     public function testPascal()


### PR DESCRIPTION
PR #60012 changed `mb_split()` calls with `preg_split()` calls in the `Illuminate\Support\Str` class in advance of the `mb_split` deprecation on PHP 8.6 and removal on PHP 9.0.

But this change didn't include the Unicode modifier into the regular expressions passed to `preg_split()` (`/.../u`).

That would make the changed methods behave differently from the `mb_split()` implementation for strings that contain, for example, a non-breaking space (`\u{00A0}`), which is covered by several other `Illuminate\Support\Str` methods, like `Str::squish()`.

**This PR**

- Adds the Unicode modifier to the methods changed by PR #60012 
- Adds assertions to the affected methods' test cases, which would pass with the `mb_split()` implementation and would fail without these PR changes
