### PR TITLE
[13.x] Add CSRF token and header name configuration support

### DIFF
--- a/config/session.php
+++ b/config/session.php
@@ -134,6 +134,32 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | CSRF Token Header Name
+    |--------------------------------------------------------------------------
+    |
+    | Here you may change the name of the CSRF Token Header that is used by
+    | the PreventRequestForgery class. Typically, you should not need
+    | to change this value, but if necessary you can change it.
+    |
+    */
+
+    'csrf_header_name' => 'X-CSRF-TOKEN',
+
+    /*
+    |--------------------------------------------------------------------------
+    | CSRF Token Name
+    |--------------------------------------------------------------------------
+    |
+    | Here you may change the name of the CSRF Token that is used by
+    | the PreventRequestForgery class. Typically, you should not need
+    | to change this value, but if necessary you can change it.
+    |
+    */
+
+    'csrf_token_name' => 'XSRF-TOKEN',
+
+    /*
+    |--------------------------------------------------------------------------
     | Session Cookie Path
     |--------------------------------------------------------------------------
     |

--- a/config/session.php
+++ b/config/session.php
@@ -143,7 +143,7 @@ return [
     |
     */
 
-    'csrf_header_name' => 'X-CSRF-TOKEN',
+    'csrf_header_name' => env('CSRF_HEADER_NAME', 'X-CSRF-TOKEN'),
 
     /*
     |--------------------------------------------------------------------------
@@ -156,7 +156,7 @@ return [
     |
     */
 
-    'csrf_token_name' => 'XSRF-TOKEN',
+    'csrf_token_name' => env('CSRF_TOKEN_NAME', 'XSRF-TOKEN'),
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Illuminate/Foundation/Http/Middleware/PreventRequestForgery.php
+++ b/src/Illuminate/Foundation/Http/Middleware/PreventRequestForgery.php
@@ -187,7 +187,7 @@ class PreventRequestForgery
 
         $tokenName = config('session.csrf_token_name', 'XSRF-TOKEN');
 
-        if (! $token && $header = $request->header('X-' . $tokenName)) {
+        if (! $token && $header = $request->header('X-'.$tokenName)) {
             try {
                 $token = CookieValuePrefix::remove($this->encrypter->decrypt($header, static::serialized()));
             } catch (DecryptException) {
@@ -308,6 +308,7 @@ class PreventRequestForgery
     public static function serialized()
     {
         $tokenName = config('session.csrf_token_name', 'XSRF-TOKEN');
+
         return EncryptCookies::serialized($tokenName);
     }
 

--- a/src/Illuminate/Foundation/Http/Middleware/PreventRequestForgery.php
+++ b/src/Illuminate/Foundation/Http/Middleware/PreventRequestForgery.php
@@ -182,9 +182,12 @@ class PreventRequestForgery
      */
     protected function getTokenFromRequest($request)
     {
-        $token = $request->input('_token') ?: $request->header('X-CSRF-TOKEN');
+        $csrfHeaderName = config('session.csrf_header_name', 'X-CSRF-TOKEN');
+        $token = $request->input('_token') ?: $request->header($csrfHeaderName);
 
-        if (! $token && $header = $request->header('X-XSRF-TOKEN')) {
+        $tokenName = config('session.csrf_token_name', 'XSRF-TOKEN');
+
+        if (! $token && $header = $request->header('X-' . $tokenName)) {
             try {
                 $token = CookieValuePrefix::remove($this->encrypter->decrypt($header, static::serialized()));
             } catch (DecryptException) {
@@ -239,7 +242,7 @@ class PreventRequestForgery
     protected function newCookie($request, $config)
     {
         return new Cookie(
-            'XSRF-TOKEN',
+            config('session.csrf_token_name', 'XSRF-TOKEN'),
             $request->session()->token(),
             $this->availableAt(60 * $config['lifetime']),
             $config['path'],
@@ -304,7 +307,8 @@ class PreventRequestForgery
      */
     public static function serialized()
     {
-        return EncryptCookies::serialized('XSRF-TOKEN');
+        $tokenName = config('session.csrf_token_name', 'XSRF-TOKEN');
+        return EncryptCookies::serialized($tokenName);
     }
 
     /**


### PR DESCRIPTION
### Details

In the `\Illuminate\Foundation\Http\Middleware\PreventRequestForgery` class, the tokens for XSRF and CSRF keys are hardcoded.

To support users in changing the key for getting or setting the token or header, this class now uses the key name from the session configuration file.

There are no breaking changes due to the default fallback keys for this class.

### The Issue

There were two applications running with inertia. One URL points to `laravel.app`, which is also a subdomain-supported domain like `abc.laravel.app` or something else (`[subdomain].laravel.app`).

The other application points to `another.laravel.app`, which is also a dynamic subdomain-supported domain like `abc.another.laravel.app` or something else (`[subdomain].another.laravel.app`).

Now, a conflict arises. The application works fine when a user tries to browse. However, it throws an error when the application receives a parent domain cookie in the child application.

### The Solution

To resolve this issue, users can change the CSRF/XSRF cookie name or header name from `session.php`. Additionally, they can set the HTTP keys in [inertia](https://inertiajs.com/docs/v3/security/csrf-protection).

Here’s how to do it:

```php
createInertiaApp({
  http: {
    xsrfCookieName: ‘MY-XSRF-TOKEN’,
    xsrfHeaderName: ‘X-MY-XSRF-TOKEN’,
  },
  // …
})
```

After making these changes, both applications work as expected.