### PR TITLE
[13.x] Add name to MigrationStarted/MigrationEnded events

### DIFF
--- a/src/Illuminate/Database/Events/MigrationEvent.php
+++ b/src/Illuminate/Database/Events/MigrationEvent.php
@@ -22,14 +22,23 @@ abstract class MigrationEvent implements MigrationEventContract
     public $method;
 
     /**
+     * The migration name.
+     *
+     * @var string|null
+     */
+    public $name;
+
+    /**
      * Create a new event instance.
      *
      * @param  \Illuminate\Database\Migrations\Migration  $migration
      * @param  string  $method
+     * @param  string|null  $name
      */
-    public function __construct(Migration $migration, $method)
+    public function __construct(Migration $migration, $method, $name = null)
     {
         $this->method = $method;
         $this->migration = $migration;
+        $this->name = $name;
     }
 }

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -250,7 +250,7 @@ class Migrator
 
             $this->write(Task::class, $name, fn () => MigrationResult::Skipped->value);
         } else {
-            $this->write(Task::class, $name, fn () => $this->runMigration($migration, 'up'));
+            $this->write(Task::class, $name, fn () => $this->runMigration($migration, 'up', $name));
 
             // Once we have run a migrations class, we will log that it was run in this
             // repository so that we don't try to run it next time we do a migration
@@ -414,7 +414,7 @@ class Migrator
             return $this->pretendToRun($instance, 'down');
         }
 
-        $this->write(Task::class, $name, fn () => $this->runMigration($instance, 'down'));
+        $this->write(Task::class, $name, fn () => $this->runMigration($instance, 'down', $name));
 
         // Once we have successfully run the migration "down" we will remove it from
         // the migration repository so it will be considered to have not been run
@@ -429,19 +429,19 @@ class Migrator
      * @param  string  $method
      * @return void
      */
-    protected function runMigration($migration, $method)
+    protected function runMigration($migration, $method, $name = null)
     {
         $connection = $this->resolveConnection(
             $migration->getConnection()
         );
 
-        $callback = function () use ($connection, $migration, $method) {
+        $callback = function () use ($connection, $migration, $method, $name) {
             if (method_exists($migration, $method)) {
-                $this->fireMigrationEvent(new MigrationStarted($migration, $method));
+                $this->fireMigrationEvent(new MigrationStarted($migration, $method, $name));
 
                 $this->runMethod($connection, $migration, $method);
 
-                $this->fireMigrationEvent(new MigrationEnded($migration, $method));
+                $this->fireMigrationEvent(new MigrationEnded($migration, $method, $name));
             }
         };
 

--- a/tests/Integration/Database/MigratorEventsTest.php
+++ b/tests/Integration/Database/MigratorEventsTest.php
@@ -112,16 +112,24 @@ class MigratorEventsTest extends TestCase
         });
 
         Event::assertDispatched(MigrationStarted::class, function ($event) {
-            return $event->method === 'up' && $event->migration instanceof Migration;
+            return $event->method === 'up'
+                && $event->migration instanceof Migration
+                && $event->name === '2014_10_12_000000_create_members_table';
         });
         Event::assertDispatched(MigrationStarted::class, function ($event) {
-            return $event->method === 'down' && $event->migration instanceof Migration;
+            return $event->method === 'down'
+                && $event->migration instanceof Migration
+                && $event->name === '2014_10_12_000000_create_members_table';
         });
         Event::assertDispatched(MigrationEnded::class, function ($event) {
-            return $event->method === 'up' && $event->migration instanceof Migration;
+            return $event->method === 'up'
+                && $event->migration instanceof Migration
+                && $event->name === '2014_10_12_000000_create_members_table';
         });
         Event::assertDispatched(MigrationEnded::class, function ($event) {
-            return $event->method === 'down' && $event->migration instanceof Migration;
+            return $event->method === 'down'
+                && $event->migration instanceof Migration
+                && $event->name === '2014_10_12_000000_create_members_table';
         });
     }
 


### PR DESCRIPTION
It would be nice to know the name of the migration in these events. 

It's great knowing a migration started/ended, but even more useful to know the name, this means we dont need to use Reflection in any listeners to pull this out.. and its nice observability wise as we rely on these as the migration output doesn't go to our Logging service.

The [`MigrationSkipped`](https://github.com/laravel/framework/blob/295448c0076aa817f39a346f058645a7834a566a/src/Illuminate/Database/Events/MigrationSkipped.php#L7) event already has the name available, as `$migrationName` but felt `$name` was fine here... and in 14.x I'll update the MigrationSkipped event to just be `name` to align the three, unless you're happy to roll with `migrationName`, but felt odd to me. 

Migration Started / Ended both extend the abstract class, but defaulted to null so no b/c...

Tests updated accordingly.

Thanks!