### PR TITLE
[12.x] Apply eager load constraints to one-of-many subqueries

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -940,7 +940,66 @@ class Builder implements BuilderContract
 
         $relation->addEagerConstraints($models);
 
+        $query = null;
+        $originalWheres = [];
+        $originalWhereBindings = [];
+        $originalJoins = [];
+        $originalJoinBindings = [];
+
+        $isOneOfMany = method_exists($relation, 'isOneOfMany') && $relation->isOneOfMany();
+
+        if ($isOneOfMany) {
+            $query = $relation->getQuery()->getQuery();
+
+            $originalWheres = $query->wheres ?? [];
+            $originalWhereBindings = $query->bindings['where'] ?? [];
+            $originalJoins = $query->joins ?? [];
+            $originalJoinBindings = $query->bindings['join'] ?? [];
+        }
+
         $constraints($relation);
+
+        $subQueries = $isOneOfMany && method_exists($relation, 'getOneOfManySubQueries')
+        ? $relation->getOneOfManySubQueries()
+        : [];
+
+        if ($query && $subQueries) {
+            $currentWheres = $query->wheres ?? [];
+            $currentWhereBindings = $query->bindings['where'] ?? [];
+            $currentJoins = $query->joins ?? [];
+            $currentJoinBindings = $query->bindings['join'] ?? [];
+
+            $newJoins = array_slice($currentJoins, count($originalJoins));
+            $newJoinBindings = array_slice($currentJoinBindings, count($originalJoinBindings));
+            $newWheres = array_slice($currentWheres, count($originalWheres));
+            $newWhereBindings = array_slice($currentWhereBindings, count($originalWhereBindings));
+
+            foreach ($subQueries as $subQuery) {
+                if ($newJoins) {
+                    $subQuery->getQuery()->joins = array_merge(
+                        $subQuery->getQuery()->joins ?? [],
+                        $newJoins
+                    );
+
+                    $subQuery->getQuery()->bindings['join'] = array_merge(
+                        $subQuery->getQuery()->bindings['join'] ?? [],
+                        $newJoinBindings
+                    );
+                }
+
+                if ($newWheres) {
+                    $subQuery->getQuery()->wheres = array_merge(
+                        $subQuery->getQuery()->wheres ?? [],
+                        $newWheres
+                    );
+
+                    $subQuery->getQuery()->bindings['where'] = array_merge(
+                        $subQuery->getQuery()->bindings['where'] ?? [],
+                        $newWhereBindings
+                    );
+                }
+            }
+        }
 
         // Once we have the results, we just match those back up to their parent models
         // using the relationship instance. Then we just return the finished arrays

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/CanBeOneOfMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/CanBeOneOfMany.php
@@ -33,6 +33,13 @@ trait CanBeOneOfMany
     protected $oneOfManySubQuery;
 
     /**
+     * The one of many inner join subselect query builder instances.
+     *
+     * @var array<int, \Illuminate\Database\Eloquent\Builder<*>>
+     */
+    protected $oneOfManySubQueries = [];
+
+    /**
      * Add constraints for inner join subselect for one of many relationships.
      *
      * @param  \Illuminate\Database\Eloquent\Builder<*>  $query
@@ -70,6 +77,8 @@ trait CanBeOneOfMany
     public function ofMany($column = 'id', $aggregate = 'MAX', $relation = null)
     {
         $this->isOneOfMany = true;
+        $this->oneOfManySubQuery = null;
+        $this->oneOfManySubQueries = [];
 
         $this->relationName = $relation ?: $this->getDefaultOneOfManyJoinAlias(
             $this->guessRelationship()
@@ -100,6 +109,8 @@ trait CanBeOneOfMany
                 array_merge([$column], $previous['columns'] ?? []),
                 $aggregate,
             );
+
+            $this->oneOfManySubQueries[] = $subQuery;
 
             if (isset($previous)) {
                 $this->addOneOfManyJoinSubQuery(
@@ -276,6 +287,16 @@ trait CanBeOneOfMany
     public function getOneOfManySubQuery()
     {
         return $this->oneOfManySubQuery;
+    }
+
+    /**
+     * Get all of the one of many inner join subselect builder instances.
+     *
+     * @return array<int, \Illuminate\Database\Eloquent\Builder<*>>
+     */
+    public function getOneOfManySubQueries()
+    {
+        return $this->oneOfManySubQueries;
     }
 
     /**

--- a/tests/Database/DatabaseEloquentHasOneOfManyTest.php
+++ b/tests/Database/DatabaseEloquentHasOneOfManyTest.php
@@ -47,6 +47,7 @@ class DatabaseEloquentHasOneOfManyTest extends TestCase
             $table->string('state');
             $table->string('type');
             $table->foreignId('user_id');
+            $table->foreignId('login_id')->nullable();
             $table->timestamps();
         });
 
@@ -241,6 +242,75 @@ class DatabaseEloquentHasOneOfManyTest extends TestCase
 
         $this->assertTrue($user->relationLoaded('latest_login'));
         $this->assertSame($latestLogin->id, $user->latest_login->id);
+    }
+
+    public function testEagerLoadConstraintsAreAppliedToOneOfManySubQuery()
+    {
+        $user = HasOneOfManyTestUser::create();
+
+        $expectedLogin = $user->logins()->create();
+
+        $user->logins()->create();
+
+        $user = HasOneOfManyTestUser::with([
+            'latest_login' => function ($query) use ($expectedLogin) {
+                $query->whereKey($expectedLogin->getKey());
+            },
+        ])->first();
+
+        $this->assertTrue($user->relationLoaded('latest_login'));
+        $this->assertNotNull($user->latest_login);
+        $this->assertSame($expectedLogin->id, $user->latest_login->id);
+    }
+
+    public function testEagerLoadConstraintsAreAppliedToMultiColumnOneOfManySubQueries()
+    {
+        $user = HasOneOfManyTestUser::create();
+
+        $expectedPrice = $user->prices()->create([
+            'published_at' => '2021-05-01 00:00:00',
+        ]);
+
+        $user->prices()->create([
+            'published_at' => '2021-05-01 00:00:00',
+        ]);
+
+        $user = HasOneOfManyTestUser::with([
+            'price_with_shortcut' => function ($query) use ($expectedPrice) {
+                $query->whereKey($expectedPrice->getKey());
+            },
+        ])->first();
+
+        $this->assertTrue($user->relationLoaded('price_with_shortcut'));
+        $this->assertNotNull($user->price_with_shortcut);
+        $this->assertSame($expectedPrice->id, $user->price_with_shortcut->id);
+    }
+
+    public function testEagerLoadConstraintsWithJoinsAreAppliedToOneOfManySubQueries()
+    {
+        $user = HasOneOfManyTestUser::create();
+
+        $expectedLogin = $user->logins()->create();
+
+        $user->logins()->create();
+
+        $user->states()->create([
+            'type' => 'foo',
+            'state' => 'active',
+            'login_id' => $expectedLogin->id,
+        ]);
+
+        $user = HasOneOfManyTestUser::with([
+            'latest_login' => function ($query) {
+                $query
+                    ->join('states', 'states.login_id', '=', 'logins.id')
+                    ->where('states.type', 'foo');
+            },
+        ])->first();
+
+        $this->assertTrue($user->relationLoaded('latest_login'));
+        $this->assertNotNull($user->latest_login);
+        $this->assertSame($expectedLogin->id, $user->latest_login->id);
     }
 
     public function testItJoinsOtherTableInSubQuery()
@@ -690,7 +760,7 @@ class HasOneOfManyTestState extends Eloquent
     protected $table = 'states';
     protected $guarded = [];
     public $timestamps = true;
-    protected $fillable = ['type', 'state', 'updated_at'];
+    protected $fillable = ['type', 'state', 'updated_at', 'login_id'];
 }
 
 class HasOneOfManyTestPrice extends Eloquent


### PR DESCRIPTION
Fixes #59318.

## Problem

When eager loading a `latestOfMany` / `ofMany` relationship with a constraint closure, the constraint is currently only applied to the outer relation query.

For example:

```php
User::with([
    'latest_login' => fn ($query) => $query->whereKey($loginId),
])->get();
```

The one-of-many aggregate subquery still determines the latest related model from the unconstrained dataset. If the absolute latest related model does not match the eager-load constraint, the outer query filters it out and the relationship resolves to `null`, even though a matching related model exists.

This is unintuitive because eager-load constraints normally scope the relationship results. In this case, the constraint must also affect the aggregate subquery because that subquery determines which related model is the "one" model.

This also affects multi-column one-of-many relationships such as `latestOfMany(['published_at', 'id'])`, where later tie-breaker subqueries can still select from the unconstrained dataset.

## Solution

This change tracks all one-of-many aggregate subqueries created by the relation.

When eager-load constraints are applied to a one-of-many relation, newly added `join` and `where` constraints are also applied to each one-of-many aggregate subquery.

This allows the aggregate subqueries to select the related model from the constrained dataset instead of selecting the absolute latest related model and letting the outer query discard it.

This also keeps join-based eager-load constraints valid by applying the newly added joins together with their related where constraints.

## Why this should not break existing behavior

The change is scoped to eager loading one-of-many relationships.

It does not copy the full query state into the aggregate subqueries. It only forwards newly added eager-load `join` and `where` constraints, along with their bindings, to the one-of-many aggregate subqueries.

Existing one-of-many relationship definitions continue to behave the same. The outer query still receives the eager-load constraints as before; the aggregate subqueries now receive the same relevant constraints only where they are required to determine the correct aggregate row.

## Benefit to end users

This prevents silently incorrect relationship results. Developers can constrain eager-loaded `latestOfMany` / `ofMany` relationships and receive the latest related model within the constrained dataset.

Without this fix, applications may receive `null` for a relationship even when a matching related model exists.

## Tests

Added integration regression tests to `DatabaseEloquentHasOneOfManyTest` covering:

- single-column one-of-many eager-load constraints
- multi-column one-of-many eager-load constraints
- join-based eager-load constraints

The tests verify that eager-load constraints are applied to the aggregate subqueries used to determine the selected one-of-many record.

Before this fix, the single-column and multi-column cases could return `null` because the aggregate subquery selected an unconstrained record that was later discarded by the outer query. Join-based eager-load constraints could also produce invalid SQL when a copied where clause referenced a join that was not present in the aggregate subquery.

Ran:

```bash
php vendor/bin/phpunit tests/Database/DatabaseEloquentHasOneOfManyTest.php
php vendor/bin/phpunit tests/Database/DatabaseEloquentBuilderTest.php --filter testRelationshipEagerLoadProcess
php vendor/bin/phpunit tests/Database/DatabaseEloquentHasOneThroughOfManyTest.php
php vendor/bin/phpunit tests/Integration/Database/EloquentHasManyTest.php
php vendor/bin/phpunit tests/Integration/Database/EloquentMorphManyTest.php
```