### PR TITLE
[13.x] Add unit tests for the queue:listen command

### DIFF
--- a/tests/Queue/QueueListenCommandTest.php
+++ b/tests/Queue/QueueListenCommandTest.php
@@ -1,0 +1,204 @@
+<?php
+
+namespace Illuminate\Tests\Queue;
+
+use Illuminate\Config\Repository as ConfigRepository;
+use Illuminate\Foundation\Application;
+use Illuminate\Queue\Console\ListenCommand;
+use Illuminate\Queue\Listener;
+use Illuminate\Queue\ListenerOptions;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\NullOutput;
+
+class QueueListenCommandTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    protected function createApplication(array $queueConfig = []): Application
+    {
+        $app = new Application;
+        $app['config'] = new ConfigRepository([
+            'queue' => array_merge([
+                'default' => 'redis',
+                'connections' => [
+                    'redis' => ['driver' => 'redis', 'queue' => 'default'],
+                    'sqs' => ['driver' => 'sqs', 'queue' => 'sqs-queue'],
+                ],
+            ], $queueConfig),
+        ]);
+
+        return $app;
+    }
+
+    protected function makeListener(): Listener
+    {
+        $listener = m::mock(Listener::class);
+        $listener->shouldReceive('setOutputHandler')->once();
+
+        return $listener;
+    }
+
+    protected function runCommand(ListenCommand $command, array $input = [], $output = null): void
+    {
+        // The --env option is normally added by the Artisan console application globally.
+        $command->getDefinition()->addOption(
+            new InputOption('--env', null, InputOption::VALUE_OPTIONAL, 'The environment the command should run under')
+        );
+
+        $command->run(new ArrayInput($input), $output ?? new NullOutput);
+    }
+
+    public function testHandleCallsListenerWithExplicitConnection()
+    {
+        $listener = $this->makeListener();
+        $listener->shouldReceive('listen')
+            ->once()
+            ->with('redis', 'default', m::type(ListenerOptions::class));
+
+        $command = new ListenCommand($listener);
+        $command->setLaravel($this->createApplication());
+        $this->runCommand($command, ['connection' => 'redis']);
+    }
+
+    public function testHandleUsesDefaultConnectionFromConfigWhenNotSpecified()
+    {
+        $listener = $this->makeListener();
+        $listener->shouldReceive('listen')
+            ->once()
+            ->with(null, 'default', m::type(ListenerOptions::class));
+
+        $command = new ListenCommand($listener);
+        $command->setLaravel($this->createApplication());
+        $this->runCommand($command);
+    }
+
+    public function testHandleResolvesQueueFromConnectionConfig()
+    {
+        $listener = $this->makeListener();
+        $listener->shouldReceive('listen')
+            ->once()
+            ->with('sqs', 'sqs-queue', m::type(ListenerOptions::class));
+
+        $command = new ListenCommand($listener);
+        $command->setLaravel($this->createApplication());
+        $this->runCommand($command, ['connection' => 'sqs']);
+    }
+
+    public function testHandleUsesQueueOptionOverConnectionConfig()
+    {
+        $listener = $this->makeListener();
+        $listener->shouldReceive('listen')
+            ->once()
+            ->with('sqs', 'custom-queue', m::type(ListenerOptions::class));
+
+        $command = new ListenCommand($listener);
+        $command->setLaravel($this->createApplication());
+        $this->runCommand($command, ['connection' => 'sqs', '--queue' => 'custom-queue']);
+    }
+
+    public function testHandleDefaultsQueueToDefaultWhenNotInConnectionConfig()
+    {
+        $listener = $this->makeListener();
+        $listener->shouldReceive('listen')
+            ->once()
+            ->with('database', 'default', m::type(ListenerOptions::class));
+
+        $app = $this->createApplication([
+            'connections' => ['database' => ['driver' => 'database']],
+        ]);
+
+        $command = new ListenCommand($listener);
+        $command->setLaravel($app);
+        $this->runCommand($command, ['connection' => 'database']);
+    }
+
+    public function testGatherOptionsBuildsListenerOptionsWithCommandOptions()
+    {
+        $capturedOptions = null;
+
+        $listener = $this->makeListener();
+        $listener->shouldReceive('listen')
+            ->once()
+            ->with(m::any(), m::any(), m::on(function (ListenerOptions $options) use (&$capturedOptions) {
+                $capturedOptions = $options;
+
+                return true;
+            }));
+
+        $command = new ListenCommand($listener);
+        $command->setLaravel($this->createApplication());
+        $this->runCommand($command, [
+            '--name' => 'my-worker',
+            '--backoff' => '5',
+            '--memory' => '256',
+            '--timeout' => '120',
+            '--sleep' => '10',
+            '--tries' => '3',
+            '--rest' => '2',
+            '--force' => true,
+        ]);
+
+        $this->assertInstanceOf(ListenerOptions::class, $capturedOptions);
+        $this->assertSame('my-worker', $capturedOptions->name);
+        $this->assertSame('5', $capturedOptions->backoff);
+        $this->assertSame('256', $capturedOptions->memory);
+        $this->assertSame('120', $capturedOptions->timeout);
+        $this->assertSame('10', $capturedOptions->sleep);
+        $this->assertSame('3', $capturedOptions->maxTries);
+        $this->assertSame('2', $capturedOptions->rest);
+        $this->assertTrue($capturedOptions->force);
+    }
+
+    public function testGatherOptionsUsesBackoffWhenAvailable()
+    {
+        $capturedOptions = null;
+
+        $listener = $this->makeListener();
+        $listener->shouldReceive('listen')
+            ->once()
+            ->with(m::any(), m::any(), m::on(function (ListenerOptions $options) use (&$capturedOptions) {
+                $capturedOptions = $options;
+
+                return true;
+            }));
+
+        $command = new ListenCommand($listener);
+        $command->setLaravel($this->createApplication());
+        $this->runCommand($command, ['--backoff' => '7']);
+
+        $this->assertSame('7', $capturedOptions->backoff);
+    }
+
+    public function testOutputHandlerWritesToCommandOutput()
+    {
+        $capturedHandler = null;
+
+        $listener = m::mock(Listener::class);
+        $listener->shouldReceive('setOutputHandler')
+            ->once()
+            ->with(m::on(function (callable $handler) use (&$capturedHandler) {
+                $capturedHandler = $handler;
+
+                return true;
+            }));
+        $listener->shouldReceive('listen')->once();
+
+        $buffered = new BufferedOutput;
+
+        $command = new ListenCommand($listener);
+        $command->setLaravel($this->createApplication());
+        $this->runCommand($command, [], $buffered);
+
+        $this->assertIsCallable($capturedHandler);
+        $capturedHandler(null, 'hello from listener');
+
+        $this->assertStringContainsString('hello from listener', $buffered->fetch());
+    }
+}

--- a/tests/Queue/QueueListenCommandTest.php
+++ b/tests/Queue/QueueListenCommandTest.php
@@ -45,6 +45,14 @@ class QueueListenCommandTest extends TestCase
         return $listener;
     }
 
+    protected function createCommand(Listener $listener, array $queueConfig = []): ListenCommand
+    {
+        $command = new ListenCommand($listener);
+        $command->setLaravel($this->createApplication($queueConfig));
+
+        return $command;
+    }
+
     protected function runCommand(ListenCommand $command, array $input = [], $output = null): void
     {
         // The --env option is normally added by the Artisan console application globally.
@@ -62,9 +70,7 @@ class QueueListenCommandTest extends TestCase
             ->once()
             ->with('redis', 'default', m::type(ListenerOptions::class));
 
-        $command = new ListenCommand($listener);
-        $command->setLaravel($this->createApplication());
-        $this->runCommand($command, ['connection' => 'redis']);
+        $this->runCommand($this->createCommand($listener), ['connection' => 'redis']);
     }
 
     public function testHandleUsesDefaultConnectionFromConfigWhenNotSpecified()
@@ -74,9 +80,7 @@ class QueueListenCommandTest extends TestCase
             ->once()
             ->with(null, 'default', m::type(ListenerOptions::class));
 
-        $command = new ListenCommand($listener);
-        $command->setLaravel($this->createApplication());
-        $this->runCommand($command);
+        $this->runCommand($this->createCommand($listener));
     }
 
     public function testHandleResolvesQueueFromConnectionConfig()
@@ -86,9 +90,7 @@ class QueueListenCommandTest extends TestCase
             ->once()
             ->with('sqs', 'sqs-queue', m::type(ListenerOptions::class));
 
-        $command = new ListenCommand($listener);
-        $command->setLaravel($this->createApplication());
-        $this->runCommand($command, ['connection' => 'sqs']);
+        $this->runCommand($this->createCommand($listener), ['connection' => 'sqs']);
     }
 
     public function testHandleUsesQueueOptionOverConnectionConfig()
@@ -98,9 +100,7 @@ class QueueListenCommandTest extends TestCase
             ->once()
             ->with('sqs', 'custom-queue', m::type(ListenerOptions::class));
 
-        $command = new ListenCommand($listener);
-        $command->setLaravel($this->createApplication());
-        $this->runCommand($command, ['connection' => 'sqs', '--queue' => 'custom-queue']);
+        $this->runCommand($this->createCommand($listener), ['connection' => 'sqs', '--queue' => 'custom-queue']);
     }
 
     public function testHandleDefaultsQueueToDefaultWhenNotInConnectionConfig()
@@ -110,13 +110,10 @@ class QueueListenCommandTest extends TestCase
             ->once()
             ->with('database', 'default', m::type(ListenerOptions::class));
 
-        $app = $this->createApplication([
-            'connections' => ['database' => ['driver' => 'database']],
-        ]);
-
-        $command = new ListenCommand($listener);
-        $command->setLaravel($app);
-        $this->runCommand($command, ['connection' => 'database']);
+        $this->runCommand(
+            $this->createCommand($listener, ['connections' => ['database' => ['driver' => 'database']]]),
+            ['connection' => 'database']
+        );
     }
 
     public function testGatherOptionsBuildsListenerOptionsWithCommandOptions()
@@ -132,9 +129,7 @@ class QueueListenCommandTest extends TestCase
                 return true;
             }));
 
-        $command = new ListenCommand($listener);
-        $command->setLaravel($this->createApplication());
-        $this->runCommand($command, [
+        $this->runCommand($this->createCommand($listener), [
             '--name' => 'my-worker',
             '--backoff' => '5',
             '--memory' => '256',
@@ -169,9 +164,7 @@ class QueueListenCommandTest extends TestCase
                 return true;
             }));
 
-        $command = new ListenCommand($listener);
-        $command->setLaravel($this->createApplication());
-        $this->runCommand($command, ['--backoff' => '7']);
+        $this->runCommand($this->createCommand($listener), ['--backoff' => '7']);
 
         $this->assertSame('7', $capturedOptions->backoff);
     }
@@ -192,9 +185,7 @@ class QueueListenCommandTest extends TestCase
 
         $buffered = new BufferedOutput;
 
-        $command = new ListenCommand($listener);
-        $command->setLaravel($this->createApplication());
-        $this->runCommand($command, [], $buffered);
+        $this->runCommand($this->createCommand($listener), [], $buffered);
 
         $this->assertIsCallable($capturedHandler);
         $capturedHandler(null, 'hello from listener');


### PR DESCRIPTION
I generate and refactor the unit tests for the `queue:listen` command using Claude Sonnet 4.5.

The hero of this command is the `Illuminate\Queue\Listener`. Those unit tests make sure correct configurations are passes down to the listener.

| Test | What it verifies   |
| -------- | -------- |
| `testHandleCallsListenerWithExplicitConnection` | `listener->listen()` is called with the given connection and its configured queue |
| `testHandleUsesDefaultConnectionFromConfigWhenNotSpecified` | No connection arg falls back to `queue.default` config |
| `testHandleResolvesQueueFromConnectionConfig` | Queue name is resolved from `queue.connections.{connection}.queue` |
| `testHandleUsesQueueOptionOverConnectionConfig` | `--queue` option overrides the connection's configured queue |
| `testHandleDefaultsQueueToDefaultWhenNotInConnectionConfig` | Falls back to `default` when the connection has no queue in config |
| `testGatherOptionsBuildsListenerOptionsWithCommandOptions` | All CLI options (`--name`, `--backoff`, `--memory`, `--timeout`, `--sleep`, `--tries`, `--rest`, `--force`) map correctly into ListenerOptions |
| `testGatherOptionsUsesBackoffWhenAvailable` | The `--backoff` option is used when present |
| `testOutputHandlerWritesToCommandOutput` | The output handler set on the Listener correctly writes through to the command's output |