### PR TITLE
[14.x] Adjust MigrationSkipped `migrationName` to `name`

### DIFF
--- a/src/Illuminate/Database/Events/MigrationSkipped.php
+++ b/src/Illuminate/Database/Events/MigrationSkipped.php
@@ -9,10 +9,10 @@ class MigrationSkipped implements MigrationEvent
     /**
      * Create a new event instance.
      *
-     * @param  string  $migrationName  The name of the migration that was skipped.
+     * @param  string  $name  The name of the migration that was skipped.
      */
     public function __construct(
-        public $migrationName,
+        public $name,
     ) {
     }
 }

--- a/tests/Integration/Database/MigratorEventsTest.php
+++ b/tests/Integration/Database/MigratorEventsTest.php
@@ -150,7 +150,7 @@ class MigratorEventsTest extends TestCase
         ]);
 
         Event::assertDispatched(MigrationSkipped::class, function ($event) {
-            return $event->migrationName === '2014_10_13_000000_skipped_migration';
+            return $event->name === '2014_10_13_000000_skipped_migration';
         });
     }
 }


### PR DESCRIPTION
This will align all the migration events as per https://github.com/laravel/framework/pull/60059#issuecomment-4415694666

Targets master, so 14.x due to the breaking change.

I have a life I swear, just thought I'd get it done 😎 