### PR TITLE
[13.x] Add test for `Fluent::toPrettyJson()` options parameter

### DIFF
--- a/tests/Support/SupportFluentTest.php
+++ b/tests/Support/SupportFluentTest.php
@@ -145,6 +145,22 @@ class SupportFluentTest extends TestCase
         $this->assertStringContainsString('    ', $results);
     }
 
+    public function testToPrettyJsonWithOptions()
+    {
+        $fluent = new Fluent(['baz' => '123']);
+
+        $results = $fluent->toPrettyJson();
+        $this->assertStringContainsString("\n", $results);
+        $this->assertStringContainsString('    ', $results);
+        $this->assertStringContainsString('"123"', $results);
+
+        $results = $fluent->toPrettyJson(JSON_NUMERIC_CHECK);
+        $this->assertStringContainsString("\n", $results);
+        $this->assertStringContainsString('    ', $results);
+        $this->assertStringContainsString('123', $results);
+        $this->assertStringNotContainsString('"123"', $results);
+    }
+
     public function testScope()
     {
         $fluent = new Fluent(['user' => ['name' => 'taylor']]);


### PR DESCRIPTION
 `Fluent::toPrettyJson(int $options = 0)` accepts an optional bitmask that is OR'd with `JSON_PRETTY_PRINT`, but the parameter was never covered by a test.

  This adds `testToPrettyJsonWithOptions()` to `SupportFluentTest`, mirroring the existing `testMessageBagReturnsExpectedPrettyJson` test in `SupportMessageBagTest` which already verifies the same pattern
   on the parallel `MessageBag` class.