### PR TITLE
[13.x] Add enum support for cache tags

### DIFF
--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -333,7 +333,7 @@ class RedisStore extends TaggableStore implements CanFlushLocks, LockProvider
     /**
      * Begin executing a new tags operation.
      *
-     * @param  mixed  $names
+     * @param  \UnitEnum|array|string  $names
      * @return \Illuminate\Cache\RedisTaggedCache
      */
     public function tags($names)

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -802,7 +802,7 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Begin executing a new tags operation if the store supports it.
      *
-     * @param  mixed  $names
+     * @param  \UnitEnum|array|string  $names
      * @return \Illuminate\Cache\TaggedCache
      *
      * @throws \BadMethodCallException

--- a/src/Illuminate/Cache/TagSet.php
+++ b/src/Illuminate/Cache/TagSet.php
@@ -4,6 +4,8 @@ namespace Illuminate\Cache;
 
 use Illuminate\Contracts\Cache\Store;
 
+use function Illuminate\Support\enum_value;
+
 class TagSet
 {
     /**
@@ -29,7 +31,7 @@ class TagSet
     public function __construct(Store $store, array $names = [])
     {
         $this->store = $store;
-        $this->names = $names;
+        $this->names = array_map(enum_value(...), $names);
     }
 
     /**

--- a/src/Illuminate/Cache/TaggableStore.php
+++ b/src/Illuminate/Cache/TaggableStore.php
@@ -9,7 +9,7 @@ abstract class TaggableStore implements Store
     /**
      * Begin executing a new tags operation.
      *
-     * @param  mixed  $names
+     * @param  \UnitEnum|array|string  $names
      * @return \Illuminate\Cache\TaggedCache
      */
     public function tags($names)

--- a/src/Illuminate/Support/Facades/Cache.php
+++ b/src/Illuminate/Support/Facades/Cache.php
@@ -50,7 +50,7 @@ use Mockery;
  * @method static bool deleteMultiple(iterable $keys)
  * @method static bool clear()
  * @method static bool flushLocks()
- * @method static \Illuminate\Cache\TaggedCache tags(mixed $names)
+ * @method static \Illuminate\Cache\TaggedCache tags(\UnitEnum|array|string $names)
  * @method static string|null getName()
  * @method static bool supportsTags()
  * @method static bool supportsFlushingLocks()

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -402,6 +402,18 @@ class CacheRepositoryTest extends TestCase
 
         $store = $repo->tags('r1', 'r2', 'r3');
         $this->assertEquals(['r1', 'r2', 'r3'], $store->getTags()->getNames());
+
+        $store = $repo->tags(TestCacheTag::User, TestUnitCacheTag::Admin);
+        $this->assertEquals(['user', 'Admin'], $store->getTags()->getNames());
+    }
+
+    public function testTaggedCacheWorksWithEnumTags()
+    {
+        $cache = new Repository(new ArrayStore());
+
+        $cache->tags(TestCacheTag::User)->put('profile', 'taylor', 10);
+
+        $this->assertSame('taylor', $cache->tags('user')->get('profile'));
     }
 
     public function testEventDispatcherIsPassedToStoreFromRepository()
@@ -795,4 +807,14 @@ class CacheRepositoryTest extends TestCase
 enum TestCacheKey: string
 {
     case FOO = 'foo';
+}
+
+enum TestCacheTag: string
+{
+    case User = 'user';
+}
+
+enum TestUnitCacheTag
+{
+    case Admin;
 }


### PR DESCRIPTION
This PR allows cache tag names to be provided as enums.

Cache keys already support enums, including on tagged cache instances. This extends the same normalization to tag names by resolving tags through `enum_value()` when the `TagSet` is created. Backed enums use their backing value, and unit enums use their case name.

The tag namespace is shared with the equivalent string value, so `Cache::tags(CacheTag::Users)` and `Cache::tags("users")` address the same tagged cache namespace.

Tests added for backed enum tags, unit enum tags, and string-equivalent tagged cache lookups.

Tests:
- `vendor/bin/phpunit tests/Cache/CacheRepositoryTest.php`
- `vendor/bin/pint --test src/Illuminate/Cache/Repository.php src/Illuminate/Cache/RedisStore.php src/Illuminate/Cache/TagSet.php src/Illuminate/Cache/TaggableStore.php src/Illuminate/Support/Facades/Cache.php tests/Cache/CacheRepositoryTest.php`