### PR TITLE
[13.x] Add enum support for notification routes

### DIFF
--- a/src/Illuminate/Notifications/AnonymousNotifiable.php
+++ b/src/Illuminate/Notifications/AnonymousNotifiable.php
@@ -5,6 +5,8 @@ namespace Illuminate\Notifications;
 use Illuminate\Contracts\Notifications\Dispatcher;
 use InvalidArgumentException;
 
+use function Illuminate\Support\enum_value;
+
 class AnonymousNotifiable
 {
     /**
@@ -17,7 +19,7 @@ class AnonymousNotifiable
     /**
      * Add routing information to the target.
      *
-     * @param  string  $channel
+     * @param  \UnitEnum|string  $channel
      * @param  mixed  $route
      * @return $this
      *
@@ -25,6 +27,8 @@ class AnonymousNotifiable
      */
     public function route($channel, $route)
     {
+        $channel = enum_value($channel);
+
         if ($channel === 'database') {
             throw new InvalidArgumentException('The database channel does not support on-demand notifications.');
         }
@@ -59,11 +63,13 @@ class AnonymousNotifiable
     /**
      * Get the notification routing information for the given driver.
      *
-     * @param  string  $driver
+     * @param  \UnitEnum|string  $driver
      * @return mixed
      */
     public function routeNotificationFor($driver)
     {
+        $driver = enum_value($driver);
+
         return $this->routes[$driver] ?? null;
     }
 

--- a/src/Illuminate/Support/Facades/Notification.php
+++ b/src/Illuminate/Support/Facades/Notification.php
@@ -77,7 +77,7 @@ class Notification extends Facade
     /**
      * Begin sending a notification to an anonymous notifiable.
      *
-     * @param  string  $channel
+     * @param  \UnitEnum|string  $channel
      * @param  mixed  $route
      * @return \Illuminate\Notifications\AnonymousNotifiable
      */

--- a/tests/Notifications/NotificationRoutesNotificationsTest.php
+++ b/tests/Notifications/NotificationRoutesNotificationsTest.php
@@ -61,6 +61,37 @@ class NotificationRoutesNotificationsTest extends TestCase
 
         Notification::route('database', 'foo');
     }
+
+    public function testOnDemandNotificationsCanUseEnumChannels()
+    {
+        $notifiable = Notification::route(NotificationRouteChannel::Mail, 'taylor@laravel.com')
+            ->route(UnitEnumNotificationRouteChannel::Slack, '#general');
+
+        $this->assertSame('taylor@laravel.com', $notifiable->routeNotificationFor('mail'));
+        $this->assertSame('taylor@laravel.com', $notifiable->routeNotificationFor(NotificationRouteChannel::Mail));
+        $this->assertSame('#general', $notifiable->routeNotificationFor('Slack'));
+        $this->assertSame('#general', $notifiable->routeNotificationFor(UnitEnumNotificationRouteChannel::Slack));
+    }
+
+    public function testOnDemandNotificationsCannotUseDatabaseEnumChannel()
+    {
+        $this->expectExceptionObject(
+            new InvalidArgumentException('The database channel does not support on-demand notifications.')
+        );
+
+        Notification::route(NotificationRouteChannel::Database, 'foo');
+    }
+}
+
+enum NotificationRouteChannel: string
+{
+    case Mail = 'mail';
+    case Database = 'database';
+}
+
+enum UnitEnumNotificationRouteChannel
+{
+    case Slack;
 }
 
 class RoutesNotificationsTestInstance


### PR DESCRIPTION
This PR allows on-demand notification route channel names to be provided as enums.

`Notification::route()` now resolves the channel through `enum_value()` before storing it on the anonymous notifiable. The lookup path also resolves enum drivers, so backed enum channels share the same route as their string equivalent, while unit enum channels use their case name.

The existing database channel guard is preserved after normalization, so a backed enum with value `database` still throws the existing exception.

Tests:
- `vendor/bin/phpunit tests/Notifications/NotificationRoutesNotificationsTest.php`
- `vendor/bin/pint --test src/Illuminate/Notifications/AnonymousNotifiable.php src/Illuminate/Support/Facades/Notification.php tests/Notifications/NotificationRoutesNotificationsTest.php`