### PR TITLE
[13.x] Add cache serializable classes config

### DIFF
--- a/config/cache.php
+++ b/config/cache.php
@@ -108,6 +108,20 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Serializable Classes
+    |--------------------------------------------------------------------------
+    |
+    | This option controls which classes may be unserialized by cache stores
+    | that support restricted unserialization. Set this value to an array of
+    | class names to restrict which classes may be restored from cache. When
+    | null, PHP's default unserialization behavior will be used.
+    |
+    */
+
+    'serializable_classes' => null,
+
+    /*
+    |--------------------------------------------------------------------------
     | Cache Key Prefix
     |--------------------------------------------------------------------------
     |


### PR DESCRIPTION
This PR adds the existing `cache.serializable_classes` option to the default cache configuration file.

The cache manager already reads this value when creating stores that support restricted unserialization. Surfacing it in `config/cache.php` makes the option easier to discover for applications that intentionally restrict cached classes and need to allow specific cached object types.

The default remains `null`, so PHP's current unserialization behavior is unchanged unless an application opts in to a class list.

Tests:
- `php -l config/cache.php`
- `vendor/bin/pint --test config/cache.php`