### PR TITLE
[13.x] Add timeoutUntil to process pending commands

### DIFF
--- a/src/Illuminate/Process/PendingProcess.php
+++ b/src/Illuminate/Process/PendingProcess.php
@@ -4,7 +4,9 @@ namespace Illuminate\Process;
 
 use Carbon\CarbonInterval;
 use Closure;
+use DateTimeInterface;
 use Illuminate\Process\Exceptions\ProcessTimedOutException;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Conditionable;
@@ -139,6 +141,19 @@ class PendingProcess
     public function timeout(CarbonInterval|int $timeout)
     {
         $this->timeout = $timeout instanceof CarbonInterval ? (int) $timeout->totalSeconds : $timeout;
+
+        return $this;
+    }
+
+    /**
+     * Specify the date and time at which the process should timeout.
+     *
+     * @param  \DateTimeInterface  $deadline
+     * @return $this
+     */
+    public function timeoutUntil(DateTimeInterface $deadline)
+    {
+        $this->timeout = max(0, (int) ceil(Carbon::now()->diffInSeconds($deadline, false)));
 
         return $this;
     }

--- a/src/Illuminate/Support/Facades/Process.php
+++ b/src/Illuminate/Support/Facades/Process.php
@@ -9,6 +9,7 @@ use Illuminate\Process\Factory;
  * @method static \Illuminate\Process\PendingProcess command(array|string $command)
  * @method static \Illuminate\Process\PendingProcess path(string $path)
  * @method static \Illuminate\Process\PendingProcess timeout(\Carbon\CarbonInterval|int $timeout)
+ * @method static \Illuminate\Process\PendingProcess timeoutUntil(\DateTimeInterface $deadline)
  * @method static \Illuminate\Process\PendingProcess idleTimeout(\Carbon\CarbonInterval|int $timeout)
  * @method static \Illuminate\Process\PendingProcess forever()
  * @method static \Illuminate\Process\PendingProcess env(array $environment)

--- a/tests/Process/ProcessTest.php
+++ b/tests/Process/ProcessTest.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Process\ProcessResult;
 use Illuminate\Process\Exceptions\ProcessFailedException;
 use Illuminate\Process\Exceptions\ProcessTimedOutException;
 use Illuminate\Process\Factory;
+use Illuminate\Support\Carbon;
 use OutOfBoundsException;
 use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 use PHPUnit\Framework\TestCase;
@@ -652,6 +653,44 @@ class ProcessTest extends TestCase
         $result = $factory->timeout($timeout)->path(__DIR__)->run('sleep 2; exit 1;');
 
         $result->throw();
+    }
+
+    public function testTimeoutCanBeSetUntilAGivenDeadline()
+    {
+        Carbon::setTestNow('2026-05-11 12:00:00');
+
+        try {
+            $factory = new Factory;
+
+            $factory->fake();
+
+            $factory->timeoutUntil(Carbon::now()->addSeconds(15))->run('ls -la');
+
+            $factory->assertRan(function ($process) {
+                return $process->command === 'ls -la' && $process->timeout === 15;
+            });
+        } finally {
+            Carbon::setTestNow();
+        }
+    }
+
+    public function testTimeoutUntilPastDeadlineTimesOutImmediately()
+    {
+        Carbon::setTestNow('2026-05-11 12:00:00');
+
+        try {
+            $factory = new Factory;
+
+            $factory->fake();
+
+            $factory->timeoutUntil(Carbon::now()->subSecond())->run('ls -la');
+
+            $factory->assertRan(function ($process) {
+                return $process->command === 'ls -la' && $process->timeout === 0;
+            });
+        } finally {
+            Carbon::setTestNow();
+        }
     }
 
     #[RequiresOperatingSystem('Linux|DAR')]


### PR DESCRIPTION
This PR adds a `timeoutUntil` method to pending process commands so a process timeout may be configured using an absolute deadline.

This is useful when a command needs to run within an existing time budget and the caller already has a deadline rather than a relative number of seconds.

Example:

```php
Process::timeoutUntil(now()->addMinutes(5))->run('php artisan report:generate');
```

The deadline is converted to the remaining number of seconds before the Symfony process is created, and past deadlines are treated as an immediate timeout.

Tests have been added for future and past deadlines.