### PR TITLE
[13.x] Add method to convert a Password instance to a passwordrules string

### DIFF
--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -432,6 +432,39 @@ class Password implements DataAwareRule, ImplicitRule, IteratorAggregate, Rule, 
     }
 
     /**
+     * Convert the password rule to a passwordrules HTML attribute string.
+     *
+     * @return string
+     *
+     * @see https://developer.apple.com/password-rules/
+     */
+    public function toPasswordRulesString()
+    {
+        $rules = ['minlength: '.$this->min];
+
+        if ($this->max) {
+            $rules[] = 'maxlength: '.$this->max;
+        }
+
+        if ($this->mixedCase) {
+            $rules[] = 'required: lower';
+            $rules[] = 'required: upper';
+        } elseif ($this->letters) {
+            $rules[] = 'required: lower';
+        }
+
+        if ($this->numbers) {
+            $rules[] = 'required: digit';
+        }
+
+        if ($this->symbols) {
+            $rules[] = 'required: special';
+        }
+
+        return implode('; ', $rules).';';
+    }
+
+    /**
      * Get an iterator for the password validation rules.
      *
      * @return \ArrayIterator<TKey, TValue>

--- a/tests/Validation/ValidationPasswordRuleTest.php
+++ b/tests/Validation/ValidationPasswordRuleTest.php
@@ -498,6 +498,26 @@ class ValidationPasswordRuleTest extends TestCase
         $this->assertSame(['sometimes', 'string', 'min:8'], [...Password::sometimes()]);
     }
 
+    public function testToPasswordRulesString()
+    {
+        $this->assertSame('minlength: 8;', Password::min(8)->toPasswordRulesString());
+
+        $this->assertSame('minlength: 8; maxlength: 64;', Password::min(8)->max(64)->toPasswordRulesString());
+
+        $this->assertSame('minlength: 8; required: lower; required: upper;', Password::min(8)->mixedCase()->toPasswordRulesString());
+
+        $this->assertSame('minlength: 8; required: lower;', Password::min(8)->letters()->toPasswordRulesString());
+
+        $this->assertSame('minlength: 8; required: digit;', Password::min(8)->numbers()->toPasswordRulesString());
+
+        $this->assertSame('minlength: 8; required: special;', Password::min(8)->symbols()->toPasswordRulesString());
+
+        $this->assertSame(
+            'minlength: 12; maxlength: 64; required: lower; required: upper; required: digit; required: special;',
+            Password::min(12)->max(64)->mixedCase()->numbers()->symbols()->toPasswordRulesString()
+        );
+    }
+
     protected function passes($rule, $values)
     {
         $this->assertValidationRules($rule, $values, true, []);


### PR DESCRIPTION
Introduces a new method which converts a Password rule instance into an HTML passwordrules attribute string per [Apple's documentation](https://developer.apple.com/password-rules/)

This lets password managers like 1Password and built-in browser ones read the app's password policy and automatically suggest a valid password when a user registers or changes their password, rather than the user having to trial-and-error a generated one against validation errors. It's an easy way to provide some hidden convenience to users.

Example output:

```php
Password::min(12)->max(64)->mixedCase()->numbers()->symbols()->toPasswordRulesString()
// 'minlength: 12; maxlength: 64; required: lower; required: upper; required: digit; required: special;',
```

Example usage in a password field:

```blade
<input
    type="password"
    autocomplete="new-password"
    passwordrules="{{ Password::defaults()->toPasswordRulesString() }}"
/>
```
