### PR TITLE
[13.x] encode path in local filesystem temporary URLs

### DIFF
--- a/src/Illuminate/Filesystem/LocalFilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/LocalFilesystemAdapter.php
@@ -82,7 +82,7 @@ class LocalFilesystemAdapter extends FilesystemAdapter
         return $url->to($url->temporarySignedRoute(
             'storage.'.$this->disk,
             $expiration,
-            ['path' => $path],
+            ['path' => rawurlencode($path)],
             absolute: false
         ));
     }
@@ -115,7 +115,7 @@ class LocalFilesystemAdapter extends FilesystemAdapter
             'url' => $url->to($url->temporarySignedRoute(
                 'storage.'.$this->disk.'.upload',
                 $expiration,
-                ['path' => $path, 'upload' => true],
+                ['path' => rawurlencode($path), 'upload' => true],
                 absolute: false
             )),
             'headers' => [],

--- a/tests/Integration/Filesystem/ReceiveFileTest.php
+++ b/tests/Integration/Filesystem/ReceiveFileTest.php
@@ -14,6 +14,7 @@ class ReceiveFileTest extends TestCase
     {
         $this->beforeApplicationDestroyed(function () {
             Storage::delete('receive-file-test.txt');
+            Storage::delete('receive file test.txt');
         });
 
         parent::setUp();
@@ -72,5 +73,15 @@ class ReceiveFileTest extends TestCase
         $response = $this->get($uploadUrl['url']);
 
         $response->assertForbidden();
+    }
+
+    public function testItCanReceiveAFileWithSpecialCharacters()
+    {
+        $result = Storage::temporaryUploadUrl('receive file test.txt', Carbon::now()->addMinute());
+
+        $response = $this->call('PUT', $result['url'], [], [], [], [], 'Hello World');
+
+        $response->assertNoContent();
+        Storage::assertExists('receive file test.txt', 'Hello World');
     }
 }

--- a/tests/Integration/Filesystem/ServeFileTest.php
+++ b/tests/Integration/Filesystem/ServeFileTest.php
@@ -51,4 +51,17 @@ class ServeFileTest extends TestCase
 
         $response->assertForbidden();
     }
+
+    public function testItCanServeAFileWithSpecialCharacters()
+    {
+        Storage::put('serve file test.txt', 'Hello World');
+
+        $url = Storage::temporaryUrl('serve file test.txt', Carbon::now()->addMinute());
+
+        $response = $this->get($url);
+
+        $this->assertSame('Hello World', $response->streamedContent());
+
+        Storage::delete('serve file test.txt');
+    }
 }


### PR DESCRIPTION
Paths with special characters like `#` or `%` in the filename break the signature validation for temporary URLs on the local filesystem driver.

  For example, a file named `file#1.txt` would fail because `#` gets interpreted as a URL fragment, breaking both the URL and the signature.

  This simply wraps the path in `rawurlencode()` before passing it to `temporarySignedRoute`.
