### PR TITLE
[13.x] Ability to override the Worker timeout exit code

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -125,6 +125,13 @@ class Worker
     public static $memoryExceededExitCode;
 
     /**
+     * The custom exit code to be used when a job times out.
+     *
+     * @var int|null
+     */
+    public static $timedOutExitCode;
+
+    /**
      * Indicates if the worker should report job exceptions.
      *
      * @var bool
@@ -280,7 +287,7 @@ class Worker
                 ));
             }
 
-            $this->kill(static::EXIT_ERROR, $options, WorkerStopReason::TimedOut);
+            $this->kill(static::$timedOutExitCode ?? static::EXIT_ERROR, $options, WorkerStopReason::TimedOut);
         }, true);
 
         pcntl_alarm(


### PR DESCRIPTION
We have environments on Cloud (which is perfect, put me on a podcast I'll advocate 🤣), and others on an alt provider...  The alt provider causes **all** workers to restart if a job times out 3 times, due to the exit code which is mad.

This PR allows us to override the timeout exit code. 

This is exactly the same as we have for the memory  exceeded status code which I did here https://github.com/laravel/framework/pull/57044 

There's no tests for this as it's within a signal.