### PR TITLE
add index for database performance

### DIFF
--- a/src/Illuminate/Queue/Console/stubs/failed_jobs.stub
+++ b/src/Illuminate/Queue/Console/stubs/failed_jobs.stub
@@ -14,11 +14,13 @@ return new class extends Migration
         Schema::create('{{table}}', function (Blueprint $table) {
             $table->id();
             $table->string('uuid')->unique();
-            $table->text('connection');
-            $table->text('queue');
+            $table->string('connection');
+            $table->string('queue');
             $table->longText('payload');
             $table->longText('exception');
             $table->timestamp('failed_at')->useCurrent();
+
+            $table->index(['connection', 'queue', 'failed_at']);
         });
     }
 

--- a/tests/Database/migrations/connection_configured/2022_02_21_000000_create_failed_jobs_table.php
+++ b/tests/Database/migrations/connection_configured/2022_02_21_000000_create_failed_jobs_table.php
@@ -22,11 +22,13 @@ return new class extends Migration
     {
         Schema::create('failed_jobs', function (Blueprint $table) {
             $table->id();
-            $table->text('connection');
-            $table->text('queue');
+            $table->string('connection');
+            $table->string('queue');
             $table->longText('payload');
             $table->longText('exception');
             $table->timestamp('failed_at')->useCurrent();
+
+            $table->index(['connection', 'queue', 'failed_at']);
         });
     }
 

--- a/tests/Integration/Generators/QueueFailedTableCommandTest.php
+++ b/tests/Integration/Generators/QueueFailedTableCommandTest.php
@@ -14,6 +14,9 @@ class QueueFailedTableCommandTest extends TestCase
             'use Illuminate\Database\Migrations\Migration;',
             'return new class extends Migration',
             'Schema::create(\'failed_jobs\', function (Blueprint $table) {',
+            '$table->string(\'connection\');',
+            '$table->string(\'queue\');',
+            '$table->index([\'connection\', \'queue\', \'failed_at\']);',
             'Schema::dropIfExists(\'failed_jobs\');',
         ], 'create_failed_jobs_table.php');
     }

--- a/tests/Queue/DatabaseFailedJobProviderTest.php
+++ b/tests/Queue/DatabaseFailedJobProviderTest.php
@@ -203,11 +203,13 @@ class DatabaseFailedJobProviderTest extends TestCase
 
         $this->db->getConnection()->getSchemaBuilder()->create('failed_jobs', function (Blueprint $table) {
             $table->id();
-            $table->text('connection');
-            $table->text('queue');
+            $table->string('connection');
+            $table->string('queue');
             $table->longText('payload');
             $table->longText('exception');
             $table->timestamp('failed_at')->useCurrent();
+
+            $table->index(['connection', 'queue', 'failed_at']);
         });
 
         return $this;

--- a/tests/Queue/DatabaseUuidFailedJobProviderTest.php
+++ b/tests/Queue/DatabaseUuidFailedJobProviderTest.php
@@ -187,11 +187,13 @@ class DatabaseUuidFailedJobProviderTest extends TestCase
         ]);
         $db->getConnection()->getSchemaBuilder()->create('failed_jobs', function (Blueprint $table) {
             $table->uuid();
-            $table->text('connection');
-            $table->text('queue');
+            $table->string('connection');
+            $table->string('queue');
             $table->longText('payload');
             $table->longText('exception');
             $table->timestamp('failed_at')->useCurrent();
+
+            $table->index(['connection', 'queue', 'failed_at']);
         });
 
         return new DatabaseUuidFailedJobProvider($db->getDatabaseManager(), $database, $table);


### PR DESCRIPTION
This adds back a compound index on the faild_jobs table that is supported on all database engines.
