### PR TITLE
[13.x] Cloud queue metrics

### DIFF
--- a/src/Illuminate/Foundation/Cloud.php
+++ b/src/Illuminate/Foundation/Cloud.php
@@ -155,12 +155,13 @@ class Cloud
         }
 
         $app->singleton(Events::class, fn () => new Events(Cloud::socket()));
-
         $app->bind(QueueConnector::class, fn ($app) => new QueueConnector(new SqsConnector, $app));
+
         $app['queue']->addConnector('sqs', $app->factory(QueueConnector::class));
 
         $failer = $app['queue.failer'];
         unset($app['queue.failer']);
+
         $app->singleton('queue.failer', fn ($app) => new FailedJobProvider(
             $failer, $app[Events::class], $app['encrypter'],
         ));

--- a/src/Illuminate/Foundation/Cloud.php
+++ b/src/Illuminate/Foundation/Cloud.php
@@ -3,9 +3,13 @@
 namespace Illuminate\Foundation;
 
 use Illuminate\Database\Migrations\Migrator;
+use Illuminate\Foundation\Bootstrap\BootProviders;
 use Illuminate\Foundation\Bootstrap\HandleExceptions;
 use Illuminate\Foundation\Bootstrap\LoadConfiguration;
-use Illuminate\Queue\Worker;
+use Illuminate\Foundation\Cloud\Events;
+use Illuminate\Foundation\Cloud\FailedJobProvider;
+use Illuminate\Foundation\Cloud\QueueConnector;
+use Illuminate\Queue\Connectors\SqsConnector;
 use Monolog\Formatter\JsonFormatter;
 use Monolog\Handler\SocketHandler;
 use PDO;
@@ -34,6 +38,9 @@ class Cloud
             },
             HandleExceptions::class => function () use ($app) {
                 static::configureCloudLogging($app);
+            },
+            BootProviders::class => function () use ($app) {
+                static::bootManagedQueues($app);
             },
             default => fn () => true,
         })();
@@ -127,22 +134,36 @@ class Cloud
      */
     public static function configureManagedQueues(Application $app): void
     {
-        if ((int) ($_SERVER['LARAVEL_CLOUD_MANAGED_QUEUES'] ?? 0) === 1) {
-            Worker::$restartable = false;
-            Worker::$pausable = false;
-
-            $app['config']->set(
-                'queue.connections.sqs.credentials',
-                'ecs'
-            );
-
-            if (isset($_SERVER['LARAVEL_CLOUD_REGION'])) {
-                $app['config']->set(
-                    'queue.connections.sqs.region',
-                    $_SERVER['LARAVEL_CLOUD_REGION']
-                );
-            }
+        if (! Cloud::managedQueuesAreActive()) {
+            return;
         }
+
+        $app['config']->set('queue.connections.sqs.credentials', 'ecs');
+
+        if (isset($_SERVER['LARAVEL_CLOUD_REGION'])) {
+            $app['config']->set('queue.connections.sqs.region', $_SERVER['LARAVEL_CLOUD_REGION']);
+        }
+    }
+
+    /**
+     * Boot managed queues if applicable.
+     */
+    public static function bootManagedQueues(Application $app): void
+    {
+        if (! Cloud::managedQueuesAreActive()) {
+            return;
+        }
+
+        $app->singleton(Events::class, fn () => new Events(Cloud::socket()));
+
+        $app->bind(QueueConnector::class, fn ($app) => new QueueConnector(new SqsConnector, $app));
+        $app['queue']->addConnector('sqs', $app->factory(QueueConnector::class));
+
+        $failer = $app['queue.failer'];
+        unset($app['queue.failer']);
+        $app->singleton('queue.failer', fn ($app) => new FailedJobProvider(
+            $failer, $app[Events::class], $app['encrypter'],
+        ));
     }
 
     /**
@@ -163,11 +184,27 @@ class Cloud
                 'includeStacktraces' => true,
             ],
             'with' => [
-                'connectionString' => $_ENV['LARAVEL_CLOUD_LOG_SOCKET'] ??
-                                      $_SERVER['LARAVEL_CLOUD_LOG_SOCKET'] ??
-                                      'unix:///tmp/cloud-init.sock',
+                'connectionString' => Cloud::socket(),
                 'persistent' => true,
             ],
         ]);
+    }
+
+    /**
+     * The cloud socket address.
+     */
+    protected static function socket(): string
+    {
+        return $_ENV['LARAVEL_CLOUD_LOG_SOCKET'] ??
+            $_SERVER['LARAVEL_CLOUD_LOG_SOCKET'] ??
+                'unix:///tmp/cloud-init.sock';
+    }
+
+    /**
+     * Determine if managed queues are active.
+     */
+    protected static function managedQueuesAreActive(): bool
+    {
+        return ($_SERVER['LARAVEL_CLOUD_MANAGED_QUEUES'] ?? null) === '1';
     }
 }

--- a/src/Illuminate/Foundation/Cloud/Events.php
+++ b/src/Illuminate/Foundation/Cloud/Events.php
@@ -1,0 +1,217 @@
+<?php
+
+namespace Illuminate\Foundation\Cloud;
+
+use Illuminate\Foundation\Cloud;
+use RuntimeException;
+use Throwable;
+
+class Events
+{
+    /**
+     * The cloud socket.
+     *
+     * @var resource|null
+     */
+    protected $socket = null;
+
+    /**
+     * Create a new instance.
+     */
+    public function __construct(protected string $address)
+    {
+        //
+    }
+
+    /**
+     * Emit an event.
+     *
+     * @param  array<string, mixed>  $payload
+     */
+    public function emit(array $payload): void
+    {
+        $this->emitMany([$payload]);
+    }
+
+    /**
+     * Emit many events.
+     *
+     * @param  list<array<string, mixed>>  $payloads
+     */
+    public function emitMany(array $payloads): void
+    {
+        if ($payloads === []) {
+            return;
+        }
+
+        try {
+            $this->ensureConnected();
+
+            $this->write($this->format($payloads));
+        } catch (Throwable) {
+            //
+        }
+    }
+
+    /**
+     * Write the payload to the socket.
+     *
+     * @param  list<array<string, mixed>>  $payloads
+     */
+    protected function write(string $payload): void
+    {
+        $originalPayloadLength = strlen($payload);
+        $written = 0;
+        $zeroLengthWrites = 0;
+
+        while (true) {
+            $thisWrite = @fwrite($this->socket, $payload);
+
+            if ($thisWrite === false) {
+                $e = new RuntimeException($this->withSocketMetaData('Unable to write to socket'));
+
+                $this->disconnect();
+
+                throw $e;
+            }
+
+            $written += $thisWrite;
+
+            if ($written >= $originalPayloadLength) {
+                return;
+            }
+
+            if ($thisWrite === 0) {
+                $zeroLengthWrites++;
+            }
+
+            if ($zeroLengthWrites >= 5) {
+                $e = new RuntimeException($this->withSocketMetaData('Unable to write bytes to socket'));
+
+                $this->disconnect();
+
+                throw $e;
+            }
+
+            $payload = substr($payload, $thisWrite);
+        }
+    }
+
+    /**
+     * Format the payload.
+     *
+     * @param  list<array<string, mixed>>  $payloads
+     */
+    protected function format(array $payloads): string
+    {
+        return array_reduce($payloads, function (string $carry, array $line) {
+            if ($carry !== '') {
+                $carry .= "\n";
+            }
+
+            return $carry .= json_encode($line, flags: JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRESERVE_ZERO_FRACTION | JSON_INVALID_UTF8_SUBSTITUTE);
+        }, '')."\n";
+    }
+
+    /**
+     * Ensure the socket is connected.
+     */
+    protected function ensureConnected(): void
+    {
+        if (! $this->connected()) {
+            $this->connect();
+        }
+    }
+
+    /**
+     * Connect the socket.
+     */
+    protected function connect(): void
+    {
+        $socket = stream_socket_client(
+            address: $this->address,
+            error_code: $errorCode,
+            error_message: $errorMessage,
+            timeout: 2,
+            flags: STREAM_CLIENT_CONNECT | STREAM_CLIENT_PERSISTENT,
+        );
+
+        if ($socket === false) {
+            throw new RuntimeException("Failed connecting to the socket: {$errorMessage} [{$errorCode}]");
+        }
+
+        if (! stream_set_timeout($socket, 2)) {
+            $e = new RuntimeException($this->withSocketMetaData('Failed configuring socket timeout'));
+
+            $this->disconnect();
+
+            throw $e;
+        }
+
+        $this->socket = $socket;
+    }
+
+    /**
+     * Determine if the socket is connected.
+     */
+    protected function connected(): bool
+    {
+        if (gettype($this->socket) !== 'resource') {
+            return false;
+        }
+
+        if (feof($this->socket)) {
+            $this->disconnect();
+
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Disconnect the socket.
+     */
+    protected function disconnect(): void
+    {
+        if (gettype($this->socket) !== 'resource') {
+            $this->socket = null;
+
+            return;
+        }
+
+        try {
+            fclose($this->socket);
+        } catch (Throwable) {
+            //
+        }
+
+        $this->socket = null;
+    }
+
+    /**
+     * Decorate the message with the socket's meta data.
+     */
+    protected function withSocketMetaData(string $message): string
+    {
+        $prefix = "{$message}\n---\n";
+
+        if (! $this->connected()) {
+            return "{$prefix}closed: true";
+        }
+
+        $meta = stream_get_meta_data($this->socket);
+
+        return $prefix.array_reduce(array_keys($meta), function ($carry, $key) use ($meta) {
+            try {
+                return $carry.$key.': '.match ($meta[$key]) {
+                    true => 'true',
+                    false => 'false',
+                    default => $meta[$key],
+                }."\n";
+            } catch (Throwable) {
+                return $carry;
+            }
+        }, '');
+    }
+}

--- a/src/Illuminate/Foundation/Cloud/FailedJobProvider.php
+++ b/src/Illuminate/Foundation/Cloud/FailedJobProvider.php
@@ -1,0 +1,202 @@
+<?php
+
+namespace Illuminate\Foundation\Cloud;
+
+use Carbon\CarbonImmutable;
+use DateTimeInterface;
+use Illuminate\Contracts\Encryption\StringEncrypter;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Queue\Failed\CountableFailedJobProvider;
+use Illuminate\Queue\Failed\FailedJobProviderInterface;
+use Illuminate\Queue\Failed\PrunableFailedJobProvider;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
+use RuntimeException;
+
+class FailedJobProvider implements FailedJobProviderInterface, CountableFailedJobProvider, PrunableFailedJobProvider
+{
+    /**
+     * The connected queue instance.
+     *
+     * @var ?\Illuminate\Foundation\Cloud\Queue
+     */
+    protected $queue = null;
+
+    /**
+     * The loaded failed jobs keyed by ID.
+     *
+     * @var array<string, object>
+     */
+    protected $loadedFailedJobs = [];
+
+    /**
+     * Create a new instance.
+     */
+    public function __construct(
+        protected FailedJobProviderInterface $failer,
+        protected Events $events,
+        protected StringEncrypter $encrypter,
+    ) {
+        //
+    }
+
+    /**
+     * Log a failed job into storage.
+     *
+     * @param  string  $connection
+     * @param  string  $queue
+     * @param  string  $payload
+     * @param  \Throwable  $exception
+     * @return string|null
+     */
+    public function log($connection, $queue, $payload, $exception)
+    {
+        if ($connection !== 'sqs') {
+            return $this->failer->log(...func_get_args());
+        }
+
+        if ($this->queue === null) {
+            throw new RuntimeException('The failed job provider does not have a configured queue');
+        }
+
+        $timestamp = CarbonImmutable::now('UTC');
+        $processingJobDetails = $this->queue->processingJobDetails();
+
+        $this->events->emit([
+            '_cloud_event' => 'failed_job',
+            'id' => $id = Str::uuid7($timestamp)->toString(),
+            'queue' => $processingJobDetails['queue'],
+            'started_at' => $processingJobDetails['started_at']->toDateTimeString('microsecond'),
+            'attempts' => $processingJobDetails['attempts'],
+            'payload' => $payload,
+            'exception' => (string) mb_convert_encoding($exception, 'UTF-8'),
+        ]);
+
+        $this->queue->finishProcessingJob(timestamp: $timestamp);
+
+        return $id;
+    }
+
+    /**
+     * Get the IDs of all of the failed jobs.
+     *
+     * @param  string|null  $queue
+     * @return array
+     */
+    public function ids($queue = null)
+    {
+        return $this->failer->ids(...func_get_args());
+    }
+
+    /**
+     * Get a list of all of the failed jobs.
+     *
+     * @return array
+     */
+    public function all()
+    {
+        return $this->failer->all(...func_get_args());
+    }
+
+    /**
+     * Get a single failed job.
+     *
+     * @param  mixed  $id
+     * @return object|null
+     */
+    public function find($id)
+    {
+        if (! str_starts_with($id, 'https://')) {
+            return $this->failer->find($id);
+        }
+
+        $response = Http::connectTimeout(10)
+            ->timeout(10)
+            ->retry(3, 1000, fn ($exception) => $exception instanceof ConnectionException)
+            ->throw()
+            ->get($id);
+
+        return $this->loadedFailedJobs[$id] = json_decode($this->encrypter->decryptString($response->body()), flags: JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * Delete a single failed job from storage.
+     *
+     * @param  mixed  $id
+     * @return bool
+     */
+    public function forget($id)
+    {
+        if (! str_starts_with($id, 'https://')) {
+            return $this->failer->forget($id);
+        }
+
+        if (is_null($job = $this->loadedFailedJobs[$id] ?? null)) {
+            return false;
+        }
+
+        $this->events->emit([
+            '_cloud_event' => 'failed_job',
+            'id' => $job->id,
+            'queue' => $job->queue,
+            'retried_at' => CarbonImmutable::now('UTC')->toDateTimeString('microsecond'),
+        ]);
+
+        return true;
+    }
+
+    /**
+     * Flush all of the failed jobs from storage.
+     *
+     * @param  int|null  $hours
+     * @return void
+     */
+    public function flush($hours = null)
+    {
+        $this->failer->flush(...func_get_args());
+    }
+
+    /**
+     * Count the failed jobs.
+     *
+     * @param  string|null  $connection
+     * @param  string|null  $queue
+     * @return int
+     */
+    public function count($connection = null, $queue = null)
+    {
+        if (! $this->failer instanceof CountableFailedJobProvider) {
+            return 0;
+        }
+
+        return $this->failer->count(...func_get_args());
+    }
+
+    /**
+     * Prune all of the entries older than the given date.
+     *
+     * @param  \DateTimeInterface  $before
+     * @return int
+     */
+    public function prune(DateTimeInterface $before)
+    {
+        if (! $this->failer instanceof PrunableFailedJobProvider) {
+            return 0;
+        }
+
+        return $this->failer->prune(...func_get_args());
+    }
+
+    /**
+     * Set the connected queue instance.
+     *
+     * @param  \Illuminate\Foundation\Cloud\Queue  $queue
+     * @return $this
+     */
+    public function setQueue($queue)
+    {
+        $this->queue = $queue;
+
+        return $this;
+    }
+}

--- a/src/Illuminate/Foundation/Cloud/Queue.php
+++ b/src/Illuminate/Foundation/Cloud/Queue.php
@@ -302,6 +302,13 @@ class Queue implements QueueContract, ClearableQueue
         return $this->queue->getQueueableOptions(...func_get_args());
     }
 
+    /**
+     * Finish processing the current job and emit a queue event.
+     *
+     * @param  string  $default
+     * @param  \Carbon\CarbonImmutable|null  $timestamp
+     * @return void
+     */
     public function finishProcessingJob($default = 'processed', $timestamp = null)
     {
         if (! $this->processingJob) {

--- a/src/Illuminate/Foundation/Cloud/Queue.php
+++ b/src/Illuminate/Foundation/Cloud/Queue.php
@@ -1,0 +1,434 @@
+<?php
+
+namespace Illuminate\Foundation\Cloud;
+
+use Carbon\CarbonImmutable;
+use Illuminate\Contracts\Queue\ClearableQueue;
+use Illuminate\Contracts\Queue\Queue as QueueContract;
+use Illuminate\Support\Str;
+use Illuminate\Support\Traits\ForwardsCalls;
+
+class Queue implements QueueContract, ClearableQueue
+{
+    use ForwardsCalls;
+
+    /**
+     * The currently processing job.
+     *
+     * @var \Illuminate\Contracts\Queue\Job|null
+     */
+    protected $processingJob = null;
+
+    /**
+     * The queue for the currently processing job.
+     *
+     * @var string|null
+     */
+    protected $processingQueue = null;
+
+    /**
+     * The date the last job was pushed.
+     *
+     * @var \Carbon\CarbonImmutable|null
+     */
+    protected $lastJobPushedAt = null;
+
+    /**
+     * The date the last job started processing.
+     *
+     * @var \Carbon\CarbonImmutable
+     */
+    protected $processingJobStartedAt = null;
+
+    /**
+     * Create a new Queue instance.
+     */
+    public function __construct(
+        protected QueueContract $queue,
+        protected Events $events,
+    ) {
+        //
+    }
+
+    /**
+     * Get the size of the queue.
+     *
+     * @param  string|null  $queue
+     * @return int
+     */
+    public function size($queue = null)
+    {
+        return $this->queue->size(...func_get_args());
+    }
+
+    /**
+     * Get the number of pending jobs.
+     *
+     * @param  string|null  $queue
+     * @return int
+     */
+    public function pendingSize($queue = null)
+    {
+        return $this->queue->pendingSize(...func_get_args());
+    }
+
+    /**
+     * Get the number of delayed jobs.
+     *
+     * @param  string|null  $queue
+     * @return int
+     */
+    public function delayedSize($queue = null)
+    {
+        return $this->queue->delayedSize(...func_get_args());
+    }
+
+    /**
+     * Get the number of reserved jobs.
+     *
+     * @param  string|null  $queue
+     * @return int
+     */
+    public function reservedSize($queue = null)
+    {
+        return $this->queue->reservedSize(...func_get_args());
+    }
+
+    /**
+     * Get the creation timestamp of the oldest pending job, excluding delayed jobs.
+     *
+     * @param  string|null  $queue
+     * @return int|null
+     */
+    public function creationTimeOfOldestPendingJob($queue = null)
+    {
+        return $this->queue->creationTimeOfOldestPendingJob(...func_get_args());
+    }
+
+    /**
+     * Push a new job onto the queue.
+     *
+     * @param  string|object  $job
+     * @param  mixed  $data
+     * @param  string|null  $queue
+     * @return mixed
+     */
+    public function push($job, $data = '', $queue = null)
+    {
+        $this->beforeJobPushed();
+
+        $result = $this->queue->push(...func_get_args());
+
+        $this->afterJobPushed($queue);
+
+        return $result;
+    }
+
+    /**
+     * Push a new job onto the queue.
+     *
+     * @param  string  $queue
+     * @param  string|object  $job
+     * @param  mixed  $data
+     * @return mixed
+     */
+    public function pushOn($queue, $job, $data = '')
+    {
+        $this->beforeJobPushed();
+
+        $result = $this->queue->pushOn(...func_get_args());
+
+        $this->afterJobPushed($queue);
+
+        return $result;
+    }
+
+    /**
+     * Push a raw payload onto the queue.
+     *
+     * @param  string  $payload
+     * @param  string|null  $queue
+     * @return mixed
+     */
+    public function pushRaw($payload, $queue = null, array $options = [])
+    {
+        $this->beforeJobPushed();
+
+        $result = $this->queue->pushRaw(...func_get_args());
+
+        $this->afterJobPushed($queue);
+
+        return $result;
+    }
+
+    /**
+     * Push a new job onto the queue after (n) seconds.
+     *
+     * @param  \DateTimeInterface|\DateInterval|int  $delay
+     * @param  string|object  $job
+     * @param  mixed  $data
+     * @param  string|null  $queue
+     * @return mixed
+     */
+    public function later($delay, $job, $data = '', $queue = null)
+    {
+        $this->beforeJobPushed();
+
+        $result = $this->queue->later(...func_get_args());
+
+        $this->afterJobPushed($queue);
+
+        return $result;
+    }
+
+    /**
+     * Push a new job onto a specific queue after (n) seconds.
+     *
+     * @param  string  $queue
+     * @param  \DateTimeInterface|\DateInterval|int  $delay
+     * @param  string|object  $job
+     * @param  mixed  $data
+     * @return mixed
+     */
+    public function laterOn($queue, $delay, $job, $data = '')
+    {
+        $this->beforeJobPushed();
+
+        $result = $this->queue->laterOn(...func_get_args());
+
+        $this->afterJobPushed($queue);
+
+        return $result;
+    }
+
+    /**
+     * Push an array of jobs onto the queue.
+     *
+     * @param  array  $jobs
+     * @param  mixed  $data
+     * @param  string|null  $queue
+     * @return mixed
+     */
+    public function bulk($jobs, $data = '', $queue = null)
+    {
+        $this->beforeJobPushed();
+
+        $result = $this->queue->bulk(...func_get_args());
+
+        $this->afterJobsPushed(count($jobs), $queue);
+
+        return $result;
+    }
+
+    /**
+     * Pop the next job off of the queue.
+     *
+     * @param  string|null  $queue
+     * @return \Illuminate\Contracts\Queue\Job|null
+     */
+    public function pop($queue = null)
+    {
+        $this->finishProcessingJob();
+
+        $job = $this->queue->pop(...func_get_args());
+
+        $this->startProcessingJob($queue, $job);
+
+        return $job;
+    }
+
+    /**
+     * Delete all of the jobs from the queue.
+     *
+     * @param  string  $queue
+     * @return int
+     */
+    public function clear($queue)
+    {
+        return $this->queue->clear(...func_get_args());
+    }
+
+    /**
+     * Get the connection name for the queue.
+     *
+     * @return string
+     */
+    public function getConnectionName()
+    {
+        return $this->queue->getConnectionName();
+    }
+
+    /**
+     * Set the connection name for the queue.
+     *
+     * @param  string  $name
+     * @return $this
+     */
+    public function setConnectionName($name)
+    {
+        $this->queue->setConnectionName(...func_get_args());
+
+        return $this;
+    }
+
+    /**
+     * Set the queue configuration array.
+     *
+     * @param  array  $config
+     * @return $this
+     */
+    public function setConfig($config)
+    {
+        $this->queue->setConfig(...func_get_args());
+
+        return $this;
+    }
+
+    /**
+     * Get the queueable options from the job.
+     *
+     * @param  mixed  $job
+     * @param  string|null  $queue
+     * @param  string  $payload
+     * @param  \DateTimeInterface|\DateInterval|int|null  $delay
+     * @return array{DelaySeconds?: int, MessageGroupId?: string, MessageDeduplicationId?: string}
+     */
+    public function getQueueableOptions($job, $queue, $payload, $delay = null): array
+    {
+        if (! method_exists($this->queue, 'getQueueableOptions')) {
+            return [];
+        }
+
+        return $this->queue->getQueueableOptions(...func_get_args());
+    }
+
+    public function finishProcessingJob($default = 'processed', $timestamp = null)
+    {
+        if (! $this->processingJob) {
+            return;
+        }
+
+        $timestamp ??= CarbonImmutable::now('UTC');
+
+        $this->events->emit([
+            '_cloud_event' => 'queue',
+            'timestamp' => $timestamp->toDateTimeString('microsecond'),
+            'type' => match (true) {
+                $this->processingJob->hasFailed() => 'failed',
+                $this->processingJob->isReleased() => 'released',
+                default => $default,
+            },
+            'queue' => $this->processingQueue,
+            'duration_ms' => (int) $this->processingJobStartedAt->diffInMilliseconds($timestamp),
+        ]);
+
+        $this->processingQueue
+            = $this->processingJob
+            = $this->processingJobStartedAt
+            = null;
+    }
+
+    /**
+     * Last job details resolver.
+     *
+     * @return array{queue: string, attempts: int, started_at: CarbonImmutable}
+     */
+    public function processingJobDetails()
+    {
+        return [
+            'queue' => $this->processingQueue,
+            'attempts' => $this->processingJob->attempts(),
+            'started_at' => $this->processingJobStartedAt,
+        ];
+    }
+
+    /**
+     * Handle before a job is pushed.
+     *
+     * @return void
+     */
+    protected function beforeJobPushed()
+    {
+        $this->lastJobPushedAt = CarbonImmutable::now('UTC');
+    }
+
+    /**
+     * Handle after a job is pushed.
+     *
+     * @param  string|null  $queue
+     * @return void
+     */
+    protected function afterJobPushed($queue)
+    {
+        $this->afterJobsPushed(1, $queue);
+    }
+
+    /**
+     * Handle jobs being pushed.
+     *
+     * @param  int  $count
+     * @param  string|null  $queue
+     */
+    protected function afterJobsPushed($count, $queue)
+    {
+        $this->events->emitMany(array_fill(0, $count, [
+            '_cloud_event' => 'queue',
+            'timestamp' => $this->lastJobPushedAt->toDateTimeString('microsecond'),
+            'type' => 'queued',
+            'queue' => $this->normalizeQueue($queue),
+        ]));
+
+        $this->lastJobPushedAt = null;
+    }
+
+    /**
+     * Handle a job being popped.
+     *
+     * @param  string|null  $queue
+     * @param  \Illuminate\Contracts\Queue\Job|null  $job
+     * @return void
+     */
+    protected function startProcessingJob($queue, $job)
+    {
+        if (! $job) {
+            return;
+        }
+
+        $this->processingJob = $job;
+        $this->processingQueue = $this->normalizeQueue($queue);
+        $this->processingJobStartedAt = CarbonImmutable::now('UTC');
+
+        $this->events->emit([
+            '_cloud_event' => 'queue',
+            'timestamp' => $this->processingJobStartedAt->toDateTimeString('microsecond'),
+            'type' => 'started',
+            'queue' => $this->processingQueue,
+        ]);
+    }
+
+    /**
+     * Normalize the queue name.
+     *
+     * @param  string|null  $queue
+     * @return string
+     */
+    protected function normalizeQueue($queue)
+    {
+        return Str::of($this->queue->getQueue($queue))
+            ->chopStart($_SERVER['SQS_PREFIX'].'/')
+            ->chopEnd($_SERVER['SQS_SUFFIX'])
+            ->toString();
+    }
+
+    /**
+     * Dynamically pass method calls to the underlying queue.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return mixed
+     */
+    public function __call($method, $parameters)
+    {
+        return $this->forwardDecoratedCallTo($this->queue, $method, $parameters);
+    }
+}

--- a/src/Illuminate/Foundation/Cloud/QueueConnector.php
+++ b/src/Illuminate/Foundation/Cloud/QueueConnector.php
@@ -56,6 +56,7 @@ class QueueConnector implements ConnectorInterface
         });
 
         static::$reservedMemory = str_repeat('x', 32768);
+
         register_shutdown_function(function () use ($queue) {
             static::$reservedMemory = null;
 

--- a/src/Illuminate/Foundation/Cloud/QueueConnector.php
+++ b/src/Illuminate/Foundation/Cloud/QueueConnector.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Illuminate\Foundation\Cloud;
+
+use Illuminate\Foundation\Application;
+use Illuminate\Queue\Connectors\ConnectorInterface;
+use Illuminate\Queue\Events\WorkerStopping;
+use Illuminate\Queue\Worker;
+use Illuminate\Queue\WorkerStopReason;
+
+class QueueConnector implements ConnectorInterface
+{
+    /**
+     * Reserved memory so that errors can emit events correctly on memory exhaustion.
+     */
+    private static ?string $reservedMemory = null;
+
+    /**
+     * Create a new instance.
+     */
+    public function __construct(
+        protected ConnectorInterface $connector,
+        protected Application $app,
+    ) {
+        //
+    }
+
+    /**
+     * Establish a queue connection.
+     */
+    public function connect(array $config): Queue
+    {
+        $queue = new Queue($this->connector->connect($config), $this->app[Events::class]);
+
+        if (! $this->app->runningConsoleCommand('queue:work')) {
+            return $queue;
+        }
+
+        $this->configureWorker($queue);
+        $this->configureFailedJobProvider($queue);
+
+        return $queue;
+    }
+
+    /**
+     * Configure the queue worker.
+     */
+    protected function configureWorker(Queue $queue): void
+    {
+        Worker::$restartable = false;
+        Worker::$pausable = false;
+
+        $this->app['events']->listen(fn (WorkerStopping $event) => match ($event->reason) {
+            WorkerStopReason::TimedOut => $queue->finishProcessingJob(default: 'released'),
+            default => $queue->finishProcessingJob(),
+        });
+
+        static::$reservedMemory = str_repeat('x', 32768);
+        register_shutdown_function(function () use ($queue) {
+            static::$reservedMemory = null;
+
+            if (! is_null($error = error_get_last()) && in_array($error['type'], [E_COMPILE_ERROR, E_CORE_ERROR, E_ERROR, E_PARSE])) {
+                $queue->finishProcessingJob(default: 'released');
+            }
+        });
+    }
+
+    /**
+     * Configure the failed job provider.
+     */
+    protected function configureFailedJobProvider(Queue $queue): void
+    {
+        $this->app['queue.failer']->setQueue($queue);
+    }
+}

--- a/tests/Foundation/Cloud/QueueTest.php
+++ b/tests/Foundation/Cloud/QueueTest.php
@@ -7,7 +7,9 @@ use Illuminate\Foundation\Cloud;
 use Illuminate\Foundation\Cloud\Events;
 use Illuminate\Foundation\Cloud\FailedJobProvider;
 use Illuminate\Foundation\Cloud\Queue;
+use Illuminate\Foundation\Cloud\QueueConnector;
 use Illuminate\Http\Client\RequestException;
+use Illuminate\Queue\Connectors\SqsConnector;
 use Illuminate\Queue\Failed\FileFailedJobProvider;
 use Illuminate\Queue\Jobs\FakeJob;
 use Illuminate\Queue\SqsQueue;
@@ -135,6 +137,14 @@ class QueueTest extends TestCase
         Cloud::configureManagedQueues($this->app);
 
         $this->assertSame('eu-central-1', Config::get('queue.connections.sqs.region'));
+    }
+
+    public function testItBindsQueueConnectorAndNewsUpSqsConnector()
+    {
+        $this->app->bind(SqsConnector::class, fn () => throw new RuntimeException('Should not be resolved'));
+        Cloud::bootManagedQueues($this->app);
+
+        $this->app[QueueConnector::class];
     }
 
     public function testItBindsCloudQueue()

--- a/tests/Foundation/Cloud/QueueTest.php
+++ b/tests/Foundation/Cloud/QueueTest.php
@@ -1,0 +1,652 @@
+<?php
+
+namespace Tests\Tests\Foundation;
+
+use Illuminate\Contracts\Encryption\DecryptException;
+use Illuminate\Foundation\Cloud;
+use Illuminate\Foundation\Cloud\Events;
+use Illuminate\Foundation\Cloud\FailedJobProvider;
+use Illuminate\Foundation\Cloud\Queue;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Queue\Failed\FileFailedJobProvider;
+use Illuminate\Queue\Jobs\FakeJob;
+use Illuminate\Queue\SqsQueue;
+use Illuminate\Queue\Worker;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
+use Illuminate\Support\Testing\Fakes\QueueFake;
+use Orchestra\Testbench\Attributes\WithConfig;
+use Orchestra\Testbench\TestCase;
+use Ramsey\Uuid\Uuid;
+use RuntimeException;
+use Throwable;
+
+class QueueTest extends TestCase
+{
+    protected function defineEnvironment($app)
+    {
+        $app['config']->set('app.key', Str::random(32));
+    }
+
+    protected function setUp(): void
+    {
+        Worker::$restartable = true;
+        Worker::$pausable = true;
+        $_SERVER['LARAVEL_CLOUD'] = $_SERVER['LARAVEL_CLOUD_MANAGED_QUEUES'] = '1';
+        $_SERVER['SQS_PREFIX'] = 'https://sqs.us-east-2.amazonaws.com/1234567';
+        $_SERVER['SQS_SUFFIX'] = '-env-8280cf2c-2081-47e8-a1f1-9cdfcba8618f';
+
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        unset($_SERVER['LARAVEL_CLOUD'], $_SERVER['LARAVEL_CLOUD_MANAGED_QUEUES'], $_SERVER['SQS_PREFIX'], $_SERVER['SQS_SUFFIX'], $_SERVER['LARAVEL_CLOUD_REGION']);
+        Worker::$restartable = true;
+        Worker::$pausable = true;
+    }
+
+    public function testItDisablesQueueRestartPollingForManagedQueues()
+    {
+        $argv = $_SERVER['argv'];
+        $_SERVER['argv'] = ['artisan', 'queue:work'];
+
+        try {
+            Cloud::bootManagedQueues($this->app);
+            $this->assertTrue(Worker::$restartable);
+
+            $this->app['queue']->connection('sqs');
+            $this->assertFalse(Worker::$restartable);
+        } finally {
+            $_SERVER['argv'] = $argv;
+        }
+    }
+
+    public function testItDisablesQueuePausePollingForManagedQueues()
+    {
+        $argv = $_SERVER['argv'];
+        $_SERVER['argv'] = ['artisan', 'queue:work'];
+
+        try {
+            Cloud::bootManagedQueues($this->app);
+            $this->assertTrue(Worker::$pausable);
+
+            $this->app['queue']->connection('sqs');
+            $this->assertFalse(Worker::$pausable);
+        } finally {
+            $_SERVER['argv'] = $argv;
+        }
+    }
+
+    #[WithConfig('queue.connections.sqs', ['driver' => 'sqs', 'region' => 'us-east-1', 'queue' => 'default'])]
+    public function testItConfiguresManagedQueueCredentials()
+    {
+        Cloud::configureManagedQueues($this->app);
+
+        $this->assertEquals('ecs', $this->app['config']->get('queue.connections.sqs.credentials'));
+    }
+
+    #[WithConfig('queue.connections.sqs', ['driver' => 'sqs', 'region' => 'us-east-1', 'queue' => 'default'])]
+    public function testItDoesNotConfigureManagedQueuesWhenNotEnabled()
+    {
+        unset($_SERVER['LARAVEL_CLOUD_MANAGED_QUEUES']);
+        Cloud::configureManagedQueues($this->app);
+
+        $this->assertNull($this->app['config']->get('queue.connections.sqs.credentials'));
+    }
+
+    #[WithConfig('queue.connections.sqs', ['driver' => 'sqs', 'region' => 'us-east-1', 'queue' => 'default'])]
+    public function testItConfiguresManagedQueueRegion()
+    {
+        $_SERVER['LARAVEL_CLOUD_MANAGED_QUEUES'] = '1';
+        $_SERVER['LARAVEL_CLOUD_REGION'] = 'us-west-2';
+
+        try {
+            Cloud::configureManagedQueues($this->app);
+
+            $this->assertEquals('us-west-2', $this->app['config']->get('queue.connections.sqs.region'));
+        } finally {
+            unset($_SERVER['LARAVEL_CLOUD_MANAGED_QUEUES'], $_SERVER['LARAVEL_CLOUD_REGION']);
+        }
+    }
+
+    public function testItSetSqsCredentialsToEcs()
+    {
+        $this->assertSame(null, Config::get('queue.connections.sqs.credentials'));
+
+        Cloud::configureManagedQueues($this->app);
+
+        $this->assertSame('ecs', Config::get('queue.connections.sqs.credentials'));
+    }
+
+    public function testItSetsTheSqsRegion()
+    {
+        $this->assertSame('us-east-1', Config::get('queue.connections.sqs.region'));
+
+        Cloud::configureManagedQueues($this->app);
+        $this->assertSame('us-east-1', Config::get('queue.connections.sqs.region'));
+
+        $_SERVER['LARAVEL_CLOUD_REGION'] = 'eu-central-1';
+        Cloud::configureManagedQueues($this->app);
+
+        $this->assertSame('eu-central-1', Config::get('queue.connections.sqs.region'));
+    }
+
+    public function testItBindsCloudQueue()
+    {
+        Cloud::bootManagedQueues($this->app);
+
+        $this->assertInstanceOf(Queue::class, $this->app['queue']->connection('sqs'));
+    }
+
+    public function testItBindsCloudEventsAsSingleton()
+    {
+        Cloud::bootManagedQueues($this->app);
+
+        $this->assertFalse($this->app->resolved(Events::class));
+        $this->assertSame($this->app[Events::class], $this->app[Events::class]);
+    }
+
+    public function testItBindsTheQueueFailer()
+    {
+        Cloud::bootManagedQueues($this->app);
+
+        $this->assertInstanceOf(FailedJobProvider::class, $this->app['queue.failer']);
+    }
+
+    public function testItDoesNotBindCloudQueueWhenManagedQueuesIsInactive()
+    {
+        unset($_SERVER['LARAVEL_CLOUD_MANAGED_QUEUES']);
+
+        Cloud::bootManagedQueues($this->app);
+
+        $this->assertInstanceOf(SqsQueue::class, $this->app['queue']->connection('sqs'));
+    }
+
+    public function testItDoesNotEmitEventsWhilePoppingWhenNoJobsAreProcessingAndNoJobsAreAvailableToPop()
+    {
+        $eventsFake = $this->fakeEvents();
+        $queueFake = $this->fakeQueue();
+        $queue = new Queue($queueFake, $eventsFake);
+
+        $queue->pop();
+
+        $this->assertSame([], $eventsFake->emitted);
+    }
+
+    public function testItEmitsStartedEventWhenJobIsSuccessfullyPopped()
+    {
+        $this->travelTo('2000-01-02 03:04:05.060708');
+        $eventsFake = $this->fakeEvents();
+        $queueFake = $this->fakeQueue();
+        $queue = new Queue($queueFake, $eventsFake);
+
+        $queueFake->jobsToPop[] = new FakeJob;
+        $queue->pop();
+
+        $this->assertSame([[
+            '_cloud_event' => 'queue',
+            'timestamp' => '2000-01-02 03:04:05.060708',
+            'type' => 'started',
+            'queue' => 'default',
+        ]], $eventsFake->emitted);
+    }
+
+    public function testItEmitsProcessedEventWhenNextJobIsAboutToPop()
+    {
+        $this->travelTo('2000-01-02 03:04:05.060708');
+        $eventsFake = $this->fakeEvents();
+        $queueFake = $this->fakeQueue();
+        $queue = new Queue($queueFake, $eventsFake);
+
+        $queueFake->jobsToPop[] = new FakeJob;
+        $queue->pop();
+        $this->travel(1)->second();
+        $queue->pop();
+
+        $this->assertSame([
+            [
+                '_cloud_event' => 'queue',
+                'timestamp' => '2000-01-02 03:04:05.060708',
+                'type' => 'started',
+                'queue' => 'default',
+            ],
+            [
+                '_cloud_event' => 'queue',
+                'timestamp' => '2000-01-02 03:04:06.060708',
+                'type' => 'processed',
+                'queue' => 'default',
+                'duration_ms' => 1000,
+            ],
+        ], $eventsFake->emitted);
+    }
+
+    public function testItDoesNotEmitEventsForTheSameJobAfterItHasBeenProcessed()
+    {
+        $this->travelTo('2000-01-02 03:04:05.060708');
+        $eventsFake = $this->fakeEvents();
+        $queueFake = $this->fakeQueue();
+        $queue = new Queue($queueFake, $eventsFake);
+
+        $queueFake->jobsToPop[] = new FakeJob;
+        $queue->pop();
+        $queue->pop();
+        $queue->pop();
+        $queue->pop();
+
+        $this->assertCount(2, $eventsFake->emitted);
+    }
+
+    public function testItRemembersTheQueueForTheProcessedEvent()
+    {
+        $this->travelTo('2000-01-02 03:04:05.060708');
+        $eventsFake = $this->fakeEvents();
+        $queueFake = $this->fakeQueue();
+        $queue = new Queue($queueFake, $eventsFake);
+
+        $queueFake->jobsToPop = [new FakeJob, new FakeJob];
+        $queue->pop('first');
+        $queue->pop('second');
+        $queue->pop('third');
+
+        $this->assertSame([
+            [
+                '_cloud_event' => 'queue',
+                'timestamp' => '2000-01-02 03:04:05.060708',
+                'type' => 'started',
+                'queue' => 'first',
+            ],
+            [
+                '_cloud_event' => 'queue',
+                'timestamp' => '2000-01-02 03:04:05.060708',
+                'type' => 'processed',
+                'queue' => 'first',
+                'duration_ms' => 0,
+            ], [
+                '_cloud_event' => 'queue',
+                'timestamp' => '2000-01-02 03:04:05.060708',
+                'type' => 'started',
+                'queue' => 'second',
+            ],
+            [
+                '_cloud_event' => 'queue',
+                'timestamp' => '2000-01-02 03:04:05.060708',
+                'type' => 'processed',
+                'queue' => 'second',
+                'duration_ms' => 0,
+            ],
+        ], $eventsFake->emitted);
+    }
+
+    public function testItEmitsFailedJobEvents()
+    {
+        $this->travelTo('2000-01-02 03:04:05.060708');
+        $eventsFake = $this->fakeEvents();
+        $queueFake = $this->fakeQueue();
+        $queue = new Queue($queueFake, $eventsFake);
+        $failerFake = $this->fakeFailer();
+        $failedJobProvider = new FailedJobProvider($failerFake, $eventsFake, $this->app['encrypter']);
+        $failedJobProvider->setQueue($queue);
+        $this->app[FailedJobProvider::class] = $failedJobProvider;
+
+        $queueFake->jobsToPop[] = $jobFake = new FakeJob;
+        $queue->pop();
+        $jobFake->fail();
+        Str::createUuidsUsingSequence([Uuid::fromString('00dc709e-90c4-70c2-87c8-9b7127d20e8f')]);
+        $failedJobProvider->log('sqs', 'default', ['payload' => 'here'], new RuntimeException('Whoops!'));
+        Str::createUuidsNormally();
+        $queue->pop();
+
+        unset($eventsFake->emitted[1]['exception']);
+        $this->assertSame([
+            [
+                '_cloud_event' => 'queue',
+                'timestamp' => '2000-01-02 03:04:05.060708',
+                'type' => 'started',
+                'queue' => 'default',
+            ],
+            [
+                '_cloud_event' => 'failed_job',
+                'id' => '00dc709e-90c4-70c2-87c8-9b7127d20e8f',
+                'queue' => 'default',
+                'started_at' => '2000-01-02 03:04:05.060708',
+                'attempts' => 1,
+                'payload' => [
+                    'payload' => 'here',
+                ],
+            ],
+            [
+                '_cloud_event' => 'queue',
+                'timestamp' => '2000-01-02 03:04:05.060708',
+                'type' => 'failed',
+                'queue' => 'default',
+                'duration_ms' => 0,
+            ],
+        ], $eventsFake->emitted);
+    }
+
+    public function testItEmitsReleasedJobEvents()
+    {
+        $this->travelTo('2000-01-02 03:04:05.060708');
+        $eventsFake = $this->fakeEvents();
+        $queueFake = $this->fakeQueue();
+        $queue = new Queue($queueFake, $eventsFake);
+
+        $queueFake->jobsToPop[] = $jobFake = new FakeJob;
+        $queue->pop();
+        $jobFake->release();
+        $queue->pop();
+
+        $this->assertSame([
+            [
+                '_cloud_event' => 'queue',
+                'timestamp' => '2000-01-02 03:04:05.060708',
+                'type' => 'started',
+                'queue' => 'default',
+            ],
+            [
+                '_cloud_event' => 'queue',
+                'timestamp' => '2000-01-02 03:04:05.060708',
+                'type' => 'released',
+                'queue' => 'default',
+                'duration_ms' => 0,
+            ],
+        ], $eventsFake->emitted);
+    }
+
+    public function testItEmitsJobQueuedEvent()
+    {
+        $this->travelTo('2000-01-02 03:04:05.060708');
+        $eventsFake = $this->fakeEvents();
+        $queueFake = $this->fakeQueue();
+        $queue = new Queue($queueFake, $eventsFake);
+
+        $queue->push(new FakeJob, queue: '1');
+        $queue->pushOn('2', new FakeJob);
+        $queue->pushRaw('', queue: '3');
+        $queue->later(1, new FakeJob, queue: '4');
+        $queue->laterOn('5', 1, new FakeJob);
+        $queue->bulk([new FakeJob, new FakeJob], queue: '6');
+
+        $this->assertSame([
+            [
+                '_cloud_event' => 'queue',
+                'timestamp' => '2000-01-02 03:04:05.060708',
+                'type' => 'queued',
+                'queue' => '1',
+            ],
+            [
+                '_cloud_event' => 'queue',
+                'timestamp' => '2000-01-02 03:04:05.060708',
+                'type' => 'queued',
+                'queue' => '2',
+            ],
+            [
+                '_cloud_event' => 'queue',
+                'timestamp' => '2000-01-02 03:04:05.060708',
+                'type' => 'queued',
+                'queue' => '3',
+            ],
+            [
+                '_cloud_event' => 'queue',
+                'timestamp' => '2000-01-02 03:04:05.060708',
+                'type' => 'queued',
+                'queue' => '4',
+            ],
+            [
+                '_cloud_event' => 'queue',
+                'timestamp' => '2000-01-02 03:04:05.060708',
+                'type' => 'queued',
+                'queue' => '5',
+            ],
+            [
+                '_cloud_event' => 'queue',
+                'timestamp' => '2000-01-02 03:04:05.060708',
+                'type' => 'queued',
+                'queue' => '6',
+            ],
+            [
+                '_cloud_event' => 'queue',
+                'timestamp' => '2000-01-02 03:04:05.060708',
+                'type' => 'queued',
+                'queue' => '6',
+            ],
+        ], $eventsFake->emitted);
+    }
+
+    public function testTimestampsAreTheSameForBulkPush()
+    {
+        $eventsFake = $this->fakeEvents();
+        $queueFake = $this->fakeQueue();
+        $queue = new Queue($queueFake, $eventsFake);
+
+        $queue->bulk([new FakeJob, new FakeJob]);
+
+        $this->assertCount(2, $eventsFake->emitted);
+        // IMPORTANT: Do not freeze time to fix this test.
+        $this->assertSame($eventsFake->emitted[0]['timestamp'], $eventsFake->emitted[1]['timestamp']);
+    }
+
+    public function testItCapturesDurationForMultipleJobs()
+    {
+        $this->travelTo('2000-01-02 03:04:05.060708');
+        $eventsFake = $this->fakeEvents();
+        $queueFake = $this->fakeQueue();
+        $queue = new Queue($queueFake, $eventsFake);
+
+        $queueFake->jobsToPop = [new FakeJob, new FakeJob];
+        $queue->pop();
+        $this->travel(1)->second();
+        $queue->pop();
+        $this->travel(0.5)->second();
+        $queue->pop();
+
+        $this->assertSame(1000, $eventsFake->emitted[1]['duration_ms']);
+        $this->assertSame(500, $eventsFake->emitted[3]['duration_ms']);
+    }
+
+    public function testItCapturesUtcTime()
+    {
+        date_default_timezone_set('Australia/Melbourne');
+        $this->travelTo(Carbon::parse('2000-01-02 03:04:05.060708', 'Australia/Melbourne'));
+        $eventsFake = $this->fakeEvents();
+        $queueFake = $this->fakeQueue();
+        $queue = new Queue($queueFake, $eventsFake);
+
+        $queueFake->jobsToPop[] = new FakeJob;
+        $queue->pop();
+        $this->travel(1)->second();
+        $queue->pop();
+
+        $this->assertSame([
+            [
+                '_cloud_event' => 'queue',
+                'timestamp' => '2000-01-01 16:04:05.060708',
+                'type' => 'started',
+                'queue' => 'default',
+            ],
+            [
+                '_cloud_event' => 'queue',
+                'timestamp' => '2000-01-01 16:04:06.060708',
+                'type' => 'processed',
+                'queue' => 'default',
+                'duration_ms' => 1000,
+            ],
+        ], $eventsFake->emitted);
+    }
+
+    public function testFindProxiesToFailerForNonUrls()
+    {
+        $eventsFake = $this->fakeEvents();
+        $failer = $this->fakeFailer();
+        $provider = new FailedJobProvider($failer, $eventsFake, $this->app['encrypter']);
+
+        $job = $provider->find('not-a-url');
+
+        $this->assertNull($job);
+    }
+
+    public function testFindGetsUrlAndDecryptsResponse()
+    {
+        $eventsFake = $this->fakeEvents();
+        $failer = $this->fakeFailer();
+        $provider = new FailedJobProvider($failer, $eventsFake, $this->app['encrypter']);
+
+        $payload = ['id' => 'test-job-id', 'connection' => 'sqs', 'queue' => 'default', 'payload' => '{"job":"App\\\\Jobs\\\\TestJob"}'];
+        $encrypted = Crypt::encryptString(json_encode($payload));
+
+        Http::fake([
+            'https://cloud.laravel.com/*' => Http::response($encrypted),
+        ]);
+
+        $result = $provider->find('https://cloud.laravel.com/api/jobs/test-job-id?signature=abc');
+
+        $this->assertIsObject($result);
+        $this->assertSame('test-job-id', $result->id);
+        $this->assertSame('sqs', $result->connection);
+        $this->assertSame('default', $result->queue);
+        $this->assertSame('{"job":"App\\\\Jobs\\\\TestJob"}', $result->payload);
+        Http::assertSent(fn ($request) => $request->url() === 'https://cloud.laravel.com/api/jobs/test-job-id?signature=abc');
+    }
+
+    public function testFindReturnsNullWhenDecryptionFails()
+    {
+        $eventsFake = $this->fakeEvents();
+        $failer = $this->fakeFailer();
+        $provider = new FailedJobProvider($failer, $eventsFake, $this->app['encrypter']);
+
+        Http::fake([
+            'https://cloud.laravel.com/*' => Http::response('not-valid-encrypted-data'),
+        ]);
+
+        try {
+            $provider->find('https://cloud.laravel.com/api/jobs/test-job-id?signature=abc');
+            $this->fail();
+        } catch (Throwable $e) {
+            $this->assertInstanceOf(DecryptException::class, $e);
+        }
+    }
+
+    public function testFindReturnsNullWhenHttpRequestFails()
+    {
+        $eventsFake = $this->fakeEvents();
+        $failer = $this->fakeFailer();
+        $provider = new FailedJobProvider($failer, $eventsFake, $this->app['encrypter']);
+
+        Http::fake([
+            'https://cloud.laravel.com/*' => Http::response('Server Error', 500),
+        ]);
+
+        try {
+            $provider->find('https://cloud.laravel.com/api/jobs/test-job-id?signature=abc');
+            $this->fail();
+        } catch (Throwable $e) {
+            $this->assertInstanceOf(RequestException::class, $e);
+        }
+    }
+
+    public function testForgetProxiesToFailerForNonUrls()
+    {
+        $eventsFake = $this->fakeEvents();
+        $failer = $this->fakeFailer();
+        $provider = new FailedJobProvider($failer, $eventsFake, $this->app['encrypter']);
+
+        // First log a job to the failer with a UUID
+        $uuid = (string) Str::uuid();
+        $failer->log('database', 'default', json_encode(['uuid' => $uuid]), new \Exception('test'));
+        $jobId = $failer->ids()[0];
+
+        // Forget should delegate to the underlying failer
+        $result = $provider->forget($jobId);
+
+        $this->assertTrue($result);
+        $this->assertEmpty($failer->ids());
+    }
+
+    public function testForgetEmitsEventAfterFind()
+    {
+        $this->travelTo('2000-01-02 03:04:05.060708');
+        $eventsFake = $this->fakeEvents();
+        $failer = $this->fakeFailer();
+        $provider = new FailedJobProvider($failer, $eventsFake, $this->app['encrypter']);
+
+        $payload = ['id' => 'forget-test-id', 'connection' => 'sqs', 'queue' => 'default', 'payload' => '{}'];
+        $encrypted = Crypt::encryptString(json_encode($payload));
+
+        Http::fake([
+            'https://cloud.laravel.com/*' => Http::response($encrypted),
+        ]);
+
+        $url = 'https://cloud.laravel.com/api/jobs/forget-test-id?signature=abc';
+        $provider->find($url);
+        $result = $provider->forget($url);
+
+        $this->assertTrue($result);
+        $this->assertSame([
+            [
+                '_cloud_event' => 'failed_job',
+                'id' => 'forget-test-id',
+                'queue' => 'default',
+                'retried_at' => '2000-01-02 03:04:05.060708',
+            ],
+        ], $eventsFake->emitted);
+    }
+
+    public function testForgetReturnsFalseWithoutPriorFind()
+    {
+        $eventsFake = $this->fakeEvents();
+        $failer = $this->fakeFailer();
+        $provider = new FailedJobProvider($failer, $eventsFake, $this->app['encrypter']);
+
+        $result = $provider->forget('https://cloud.laravel.com/api/jobs/some-id?signature=abc');
+
+        $this->assertFalse($result);
+        $this->assertEmpty($eventsFake->emitted);
+    }
+
+    private function fakeEvents()
+    {
+        return new class('test-socket') extends Events
+        {
+            public array $emitted = [];
+
+            public function emitMany(array $payloads): void
+            {
+                $this->emitted = [
+                    ...$this->emitted,
+                    ...$payloads,
+                ];
+            }
+        };
+    }
+
+    private function fakeQueue()
+    {
+        return new class($this->app, [], null) extends QueueFake
+        {
+            public array $jobsToPop = [];
+
+            public function pop($queue = null)
+            {
+                return array_shift($this->jobsToPop);
+            }
+
+            public function getQueue($queue)
+            {
+                $queue ??= 'default';
+
+                return $_SERVER['SQS_PREFIX'].'/'.$queue.$_SERVER['SQS_SUFFIX'];
+            }
+        };
+    }
+
+    private function fakeFailer()
+    {
+        return new FileFailedJobProvider(tempnam(sys_get_temp_dir(), 'cloud_failed_job_test_'));
+    }
+}

--- a/tests/Foundation/FoundationAliasLoaderTest.php
+++ b/tests/Foundation/FoundationAliasLoaderTest.php
@@ -7,6 +7,14 @@ use PHPUnit\Framework\TestCase;
 
 class FoundationAliasLoaderTest extends TestCase
 {
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        AliasLoader::setInstance(null);
+        AliasLoader::setFacadeNamespace('Facades\\');
+    }
+
     public function testLoaderCanBeCreatedAndRegisteredOnce()
     {
         $loader = AliasLoader::getInstance(['foo' => 'bar']);

--- a/tests/Integration/Foundation/CloudTest.php
+++ b/tests/Integration/Foundation/CloudTest.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Tests\Integration\Foundation;
 
 use Illuminate\Foundation\Cloud;
-use Illuminate\Queue\Worker;
 use Orchestra\Testbench\Attributes\WithConfig;
 use Orchestra\Testbench\TestCase;
 
@@ -81,73 +80,6 @@ class CloudTest extends TestCase
         $this->assertSame('test-disk', $this->app['config']->get('filesystems.disks.test-disk-scoped.disk'));
 
         unset($_SERVER['LARAVEL_CLOUD_DISK_CONFIG']);
-    }
-
-    public function test_it_disables_queue_restart_polling_for_managed_queues()
-    {
-        Worker::$restartable = true;
-        $_SERVER['LARAVEL_CLOUD_MANAGED_QUEUES'] = '1';
-
-        try {
-            Cloud::configureManagedQueues($this->app);
-
-            $this->assertFalse(Worker::$restartable);
-        } finally {
-            unset($_SERVER['LARAVEL_CLOUD_MANAGED_QUEUES']);
-            Worker::$restartable = true;
-        }
-    }
-
-    public function test_it_disables_queue_pause_polling_for_managed_queues()
-    {
-        Worker::$pausable = true;
-        $_SERVER['LARAVEL_CLOUD_MANAGED_QUEUES'] = '1';
-
-        try {
-            Cloud::configureManagedQueues($this->app);
-
-            $this->assertFalse(Worker::$pausable);
-        } finally {
-            unset($_SERVER['LARAVEL_CLOUD_MANAGED_QUEUES']);
-            Worker::$pausable = true;
-        }
-    }
-
-    #[WithConfig('queue.connections.sqs', ['driver' => 'sqs', 'region' => 'us-east-1', 'queue' => 'default'])]
-    public function test_it_configures_managed_queue_credentials()
-    {
-        $_SERVER['LARAVEL_CLOUD_MANAGED_QUEUES'] = '1';
-
-        try {
-            Cloud::configureManagedQueues($this->app);
-
-            $this->assertEquals('ecs', $this->app['config']->get('queue.connections.sqs.credentials'));
-        } finally {
-            unset($_SERVER['LARAVEL_CLOUD_MANAGED_QUEUES']);
-        }
-    }
-
-    #[WithConfig('queue.connections.sqs', ['driver' => 'sqs', 'region' => 'us-east-1', 'queue' => 'default'])]
-    public function test_it_does_not_configure_managed_queues_when_not_enabled()
-    {
-        Cloud::configureManagedQueues($this->app);
-
-        $this->assertNull($this->app['config']->get('queue.connections.sqs.credentials'));
-    }
-
-    #[WithConfig('queue.connections.sqs', ['driver' => 'sqs', 'region' => 'us-east-1', 'queue' => 'default'])]
-    public function test_it_configures_managed_queue_region()
-    {
-        $_SERVER['LARAVEL_CLOUD_MANAGED_QUEUES'] = '1';
-        $_SERVER['LARAVEL_CLOUD_REGION'] = 'us-west-2';
-
-        try {
-            Cloud::configureManagedQueues($this->app);
-
-            $this->assertEquals('us-west-2', $this->app['config']->get('queue.connections.sqs.region'));
-        } finally {
-            unset($_SERVER['LARAVEL_CLOUD_MANAGED_QUEUES'], $_SERVER['LARAVEL_CLOUD_REGION']);
-        }
     }
 
     public function test_it_respects_log_levels()


### PR DESCRIPTION
This PR adds support for Cloud queue metrics.

The classes introduced have intentionally been restricted to the new `Illuminate/Foundation/Cloud` namespace, to avoid littering sub-package namespaces with Cloud specifics.

The implementation has also take a decorator approach to avoid shotgun surgery with cloud specific conditionals or modifications.

Will backport once we are happy with the PR and it is merged.