### PR TITLE
[13.x] Added `make:facade` command

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -514,6 +514,7 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
                     'Controller' => 'E.g. UserController',
                     'Event' => 'E.g. PodcastProcessed',
                     'Exception' => 'E.g. InvalidOrderException',
+                    'Facade' => 'E.g. Orders',
                     'Factory' => 'E.g. PostFactory',
                     'Job' => 'E.g. ProcessPodcast',
                     'Listener' => 'E.g. SendPodcastNotification',

--- a/src/Illuminate/Foundation/Console/FacadeMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/FacadeMakeCommand.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\GeneratorCommand;
+use Illuminate\Support\Str;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputOption;
+
+#[AsCommand(name: 'make:facade')]
+class FacadeMakeCommand extends GeneratorCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'make:facade';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new facade';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Facade';
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return $this->hasTargetClass()
+            ? $this->resolveStubPath('/stubs/facade.targeted.stub')
+            : $this->resolveStubPath('/stubs/facade.stub');
+    }
+
+    /**
+     * Gets the facade accessor.
+     *
+     * @return string
+     */
+    protected function getAccessor(): string
+    {
+        return $this->option('accessor')
+            ?: $this->getTargetClass()
+            ?: Str::slug($this->getNameInput());
+    }
+
+    /**
+     * Check if there is a class name target.
+     *
+     * @return bool
+     */
+    protected function hasTargetClass(): bool
+    {
+        return ($this->option('target') && class_exists($this->option('target')))
+            || ($this->option('accessor') && class_exists($this->option('accessor')))
+            || class_exists($this->getAccessor());
+    }
+
+    /**
+     * Gets the target class if there is one.
+     *
+     * @return string
+     */
+    protected function getTargetClass(): string
+    {
+        $name = str_replace('/', '\\', ltrim($this->getNameInput(), '\\/'));
+        $rootNamespace = trim($this->rootNamespace(), '\\');
+
+        return $this->option('target')
+            ?: array_first(array_filter([
+                $rootNamespace.'\\Services\\'.$name.'Service',
+                $rootNamespace.'\\Services\\'.$name,
+                $rootNamespace.'\\'.$name.'Service',
+            ], class_exists(...)))
+            ?: (class_exists($this->option('accessor') ?? 'dummy class') ? $this->option('accessor') : '');
+    }
+
+    /**
+     * Resolve the fully-qualified path to the stub.
+     *
+     * @param  string  $stub
+     * @return string
+     */
+    protected function resolveStubPath($stub)
+    {
+        return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
+            ? $customPath
+            : __DIR__.$stub;
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param  string  $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace): string
+    {
+        return $rootNamespace.'\Support\Facades';
+    }
+
+    /**
+     * Build the class with the given name.
+     *
+     * @param  string  $name
+     * @return string
+     *
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+     */
+    protected function buildClass($name)
+    {
+        $replace = $this->buildFacadeReplacements();
+
+        return str_replace(
+            array_keys($replace), array_values($replace), parent::buildClass($name)
+        );
+    }
+
+    /**
+     * Build the replacements for a factory.
+     *
+     * @return array<string, string>
+     */
+    protected function buildFacadeReplacements(): array
+    {
+        $accessor = $this->getAccessor();
+
+        $replacements = [
+            '{{ accessor }}' => class_exists($accessor) ? Str::wrap($accessor, '\\', '::class') : Str::wrap($accessor, '\''),
+        ];
+
+        if ($this->hasTargetClass()) {
+            $target = $this->getTargetClass();
+            $import = $target;
+            $alias = class_basename($target);
+            if ($alias === class_basename($this->getNameInput())) {
+                $alias = $alias.'Service';
+                $import .= ' as '.$alias;
+            }
+
+            $replacements['{{ accessor }}'] = is_a($accessor, $target, true) ? class_basename($alias).'::class' : $replacements['{{ accessor }}'];
+            $replacements['{{ qualifiedTarget }}'] = $import;
+            $replacements['{{ target }}'] = $alias;
+        }
+
+        return $replacements;
+    }
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['target', 't', InputOption::VALUE_REQUIRED, 'Set the target service class'],
+            ['accessor', 'a', InputOption::VALUE_REQUIRED, 'Set the facade accessor'],
+            ['force', 'f', InputOption::VALUE_NONE, 'Create the facade even if the class already exists'],
+        ];
+    }
+}

--- a/src/Illuminate/Foundation/Console/stubs/facade.stub
+++ b/src/Illuminate/Foundation/Console/stubs/facade.stub
@@ -1,0 +1,13 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Support\Facades\Facade;
+
+class {{ class }} extends Facade
+{
+    protected static function getFacadeAccessor(): string
+    {
+        return {{ accessor }};
+    }
+}

--- a/src/Illuminate/Foundation/Console/stubs/facade.targeted.stub
+++ b/src/Illuminate/Foundation/Console/stubs/facade.targeted.stub
@@ -1,0 +1,17 @@
+<?php
+
+namespace {{ namespace }};
+
+use {{ qualifiedTarget }};
+use Illuminate\Support\Facades\Facade;
+
+/**
+ * @mixin {{ target }}
+ */
+class {{ class }} extends Facade
+{
+    protected static function getFacadeAccessor(): string
+    {
+        return {{ accessor }};
+    }
+}

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -57,6 +57,7 @@ use Illuminate\Foundation\Console\EventGenerateCommand;
 use Illuminate\Foundation\Console\EventListCommand;
 use Illuminate\Foundation\Console\EventMakeCommand;
 use Illuminate\Foundation\Console\ExceptionMakeCommand;
+use Illuminate\Foundation\Console\FacadeMakeCommand;
 use Illuminate\Foundation\Console\InterfaceMakeCommand;
 use Illuminate\Foundation\Console\JobMakeCommand;
 use Illuminate\Foundation\Console\JobMiddlewareMakeCommand;
@@ -209,6 +210,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'EventGenerate' => EventGenerateCommand::class,
         'EventMake' => EventMakeCommand::class,
         'ExceptionMake' => ExceptionMakeCommand::class,
+        'FacadeMake' => FacadeMakeCommand::class,
         'FactoryMake' => FactoryMakeCommand::class,
         'InterfaceMake' => InterfaceMakeCommand::class,
         'JobMake' => JobMakeCommand::class,
@@ -480,6 +482,18 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
     {
         $this->app->singleton(ExceptionMakeCommand::class, function ($app) {
             return new ExceptionMakeCommand($app['files']);
+        });
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerFacadeMakeCommand()
+    {
+        $this->app->singleton(FacadeMakeCommand::class, function ($app) {
+            return new FacadeMakeCommand($app['files']);
         });
     }
 

--- a/tests/Integration/Generators/FacadeMakeCommandTest.php
+++ b/tests/Integration/Generators/FacadeMakeCommandTest.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Generators;
+
+class FacadeMakeCommandTest extends TestCase
+{
+    protected $files = [
+        'app/Support/Facades/Audio.php',
+        'app/Support/Facades/Commerce/Customers.php',
+        'app/Support/Facades/Commerce/Orders.php',
+        'app/Support/Facades/Music.php',
+        'app/Support/Facades/Podcasts.php',
+        'app/Support/Facades/Stringable.php',
+        'app/Support/Facades/Strings.php',
+    ];
+
+    public function testItCanGenerateFacadeFile()
+    {
+        $this->artisan('make:facade', ['name' => 'Podcasts'])
+            ->assertExitCode(0);
+
+        $this->assertFileContains([
+            'namespace App\Support\Facades;',
+            'use Illuminate\Support\Facades\Facade;',
+            'class Podcasts extends Facade',
+            "return 'podcasts';",
+        ], 'app/Support/Facades/Podcasts.php');
+    }
+
+    public function testItCanGenerateFacadeWithAliasAccessor()
+    {
+        $this->artisan('make:facade', ['name' => 'Commerce/Customers', '--accessor' => 'commerce.customers'])
+            ->assertExitCode(0);
+
+        $this->assertFileContains([
+            'namespace App\Support\Facades\Commerce;',
+            'use Illuminate\Support\Facades\Facade;',
+            'class Customers extends Facade',
+            "return 'commerce.customers';",
+        ], 'app/Support/Facades/Commerce/Customers.php');
+    }
+
+    public function testItCanGenerateFacadeWithClassAccessor()
+    {
+        $this->artisan('make:facade', ['name' => 'Audio', '--accessor' => 'App\\Services\\AudioService'])
+            ->assertExitCode(0);
+
+        $this->assertFileContains([
+            'namespace App\Support\Facades;',
+            'use App\Services\AudioService;',
+            'use Illuminate\Support\Facades\Facade;',
+            '@mixin AudioService',
+            'class Audio extends Facade',
+            'return AudioService::class;',
+        ], 'app/Support/Facades/Audio.php');
+    }
+
+    public function testItCanGenerateFacadeFileWithTargetOption()
+    {
+        $this->artisan('make:facade', [
+            'name' => 'Strings',
+            '--target' => 'Illuminate\Support\Stringable',
+        ])->assertExitCode(0);
+
+        $this->assertFileContains([
+            'namespace App\Support\Facades;',
+            'use Illuminate\Support\Stringable;',
+            'use Illuminate\Support\Facades\Facade;',
+            '@mixin Stringable',
+            'class Strings extends Facade',
+            'return Stringable::class;',
+        ], 'app/Support/Facades/Strings.php');
+    }
+
+    public function testItCanGenerateFacadeWithClassAccessorAndTarget()
+    {
+        $this->artisan('make:facade', [
+            'name' => 'Customers',
+            '--accessor' => 'commerce.customers',
+            '--target' => 'App\\Services\\Commerce\\CustomerService',
+        ])
+            ->assertExitCode(0);
+
+        $this->assertFileContains([
+            'namespace App\Support\Facades;',
+            'use App\Services\Commerce\CustomerService;',
+            'use Illuminate\Support\Facades\Facade;',
+            '@mixin CustomerService',
+            'class Customers extends Facade',
+            "return 'commerce.customers';",
+        ], 'app/Support/Facades/Customers.php');
+    }
+
+    public function testItCanDetectServiceForFacade()
+    {
+        $this->artisan('make:facade', ['name' => 'Commerce/Orders'])
+            ->assertExitCode(0);
+
+        $this->assertFileContains([
+            'namespace App\Support\Facades\Commerce;',
+            'use App\Services\Commerce\OrdersService;',
+            'use Illuminate\Support\Facades\Facade;',
+            '@mixin OrdersService',
+            'class Orders extends Facade',
+            'return OrdersService::class;',
+        ], 'app/Support/Facades/Commerce/Orders.php');
+    }
+
+    public function testItCanAliasDetectedServiceForFacade()
+    {
+        $this->artisan('make:facade', ['name' => 'Music'])
+            ->assertExitCode(0);
+
+        $this->assertFileContains([
+            'namespace App\Support\Facades;',
+            'use App\Services\Music as MusicService;',
+            'use Illuminate\Support\Facades\Facade;',
+            '@mixin MusicService',
+            'class Music extends Facade',
+            'return MusicService::class;',
+        ], 'app/Support/Facades/Music.php');
+    }
+
+    public function testItCanAliasExplicitServiceForFacade()
+    {
+        $this->artisan('make:facade', [
+            'name' => 'Stringable',
+            '--target' => 'Illuminate\Support\Stringable',
+        ])
+            ->assertExitCode(0);
+
+        $this->assertFileContains([
+            'namespace App\Support\Facades;',
+            'use Illuminate\Support\Stringable as StringableService;',
+            'use Illuminate\Support\Facades\Facade;',
+            '@mixin StringableService',
+            'class Stringable extends Facade',
+            'return StringableService::class;',
+        ], 'app/Support/Facades/Stringable.php');
+    }
+
+    public function testItCanAliasExplicitServiceForFacadeWithAccessor()
+    {
+        $this->artisan('make:facade', [
+            'name' => 'Stringable',
+            '--accessor' => 'stringable',
+            '--target' => 'Illuminate\Support\Stringable',
+        ])
+            ->assertExitCode(0);
+
+        $this->assertFileContains([
+            'namespace App\Support\Facades;',
+            'use Illuminate\Support\Stringable as StringableService;',
+            'use Illuminate\Support\Facades\Facade;',
+            '@mixin StringableService',
+            'class Stringable extends Facade',
+            "return 'stringable';",
+        ], 'app/Support/Facades/Stringable.php');
+    }
+}
+
+namespace App\Services;
+
+class AudioService
+{
+}
+class Music
+{
+}
+
+namespace App\Services\Commerce;
+
+class CustomerService
+{
+}
+class OrdersService
+{
+}


### PR DESCRIPTION
This fills a minor gap in Laravel's `make` commands, which will make application-level facades easier to generate.

## Why I'd like to add this

Simply put - facades are great. But using them in my own projects is always just that one step more difficult than it needs to be, because there's no standard way to make them, or standard place to put them. This command solves those problems, and gives a clean, consistent way to access your own application services.

## Usage

Usage is fairly simple. You can create a facade with `make:facade`, and it will... make a facade in the `App\Support\Facades` namespace (this can easily be changed if `App\Facades` is more consistent, but most of the framework seems to keep facades under a `*\Support\Facades` namespace, so it seemed right to me).

```bash
php artisan make:facade Foo

   INFO  Facade [app/Support/Facades/Foo.php] created successfully
```

By default it will try to discover a matching service in the `App\Services` namespace, either as `Foo` or `FooService`

```php
namespace App\Support\Facades;

use App\Services\FooService;
// OR
use App\Services\Foo as FooService;
use Illuminate\Support\Facades\Facade;

/**
 * @mixin FooService
 */
class Foo extends Facade
{
    protected static function getFacadeAccessor(): string
    {
        return FooService::class;
    }
}
```

Failing that, it will just use a slug of the facade name as the facade accessor:

```php
namespace App\Support\Facades;

use Illuminate\Support\Facades\Facade;

class Foo extends Facade
{
    protected static function getFacadeAccessor(): string
    {
        return 'foo';
    }
}
```

You can also pass it the explicit accessor that you want to use:  `make:facade Foo --accessor=some.service`

```php
namespace App\Support\Facades;

use Illuminate\Support\Facades\Facade;

class Foo extends Facade
{
    protected static function getFacadeAccessor(): string
    {
        return 'some.service';
    }
}
```

Or give it a class name  as either `make:facade Foo --accessor=App\Services\FooBarService` or `make:facade Foo --target=App\Services\FooBarService`

```php
namespace App\Support\Facades;

use App\Services\FooBarService;
use Illuminate\Support\Facades\Facade;

/**
 * @mixin FooBarService
 */
class Foo extends Facade
{
    protected static function getFacadeAccessor(): string
    {
        return FooBarService::class;
    }
}
```

Or you can even set the accessor alias and still pass the target class: `make:facade Foo --accessor=some.service --target=App\Services\FooBarService`

```php
namespace App\Support\Facades;

use App\Services\FooBarService;
use Illuminate\Support\Facades\Facade;

/**
 * @mixin FooBarService
 */
class Foo extends Facade
{
    protected static function getFacadeAccessor(): string
    {
        return 'some.service';
    }
}
```