### PR TITLE
[13.x] add `Arr::jsonLines()`

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -478,7 +478,7 @@ class Arr
      * @param  string  $separator
      * @return string
      */
-    public static function toNdJson($array, int $options = 0, string $separator = "\n"): string
+    public static function jsonLines($array, int $options = 0, string $separator = "\n"): string
     {
         $lines = [];
 

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -480,10 +480,13 @@ class Arr
      */
     public static function jsonLines($array, int $options = 0, string $separator = "\n"): string
     {
-        $lines = [];
+        $result = '';
+        $firstLine = true;
 
         foreach ($array as $value) {
-            $lines[] = json_encode(match (true) {
+            $result .= $firstLine ? '' : $separator;
+            $firstLine = false;
+            $result .= json_encode(match (true) {
                 $value instanceof JsonSerializable => $value->jsonSerialize(),
                 $value instanceof Jsonable => json_decode($value->toJson(), true),
                 $value instanceof Arrayable => $value->toArray(),
@@ -491,7 +494,7 @@ class Arr
             }, $options);
         }
 
-        return implode($separator, $lines);
+        return $result;
     }
 
     /**

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -471,6 +471,30 @@ class Arr
     }
 
     /**
+     * Get the given array as newline-delimited JSON.
+     *
+     * @param  iterable  $array
+     * @param  int  $options
+     * @param  string  $separator
+     * @return string
+     */
+    public static function toNdJson($array, int $options = 0, string $separator = "\n"): string
+    {
+        $lines = [];
+
+        foreach ($array as $value) {
+            $lines[] = json_encode(match (true) {
+                $value instanceof JsonSerializable => $value->jsonSerialize(),
+                $value instanceof Jsonable => json_decode($value->toJson(), true),
+                $value instanceof Arrayable => $value->toArray(),
+                default => $value,
+            }, $options);
+        }
+
+        return implode($separator, $lines);
+    }
+
+    /**
      * Get an item from an array using "dot" notation.
      *
      * @param  \ArrayAccess|array  $array

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1723,13 +1723,13 @@ class SupportArrTest extends TestCase
         Arr::from(123);
     }
 
-    #[DataProvider('toNdJsonProvider')]
-    public function testToNdJson($array)
+    #[DataProvider('jsonLinesProvider')]
+    public function testJsonLines($array)
     {
-        $this->assertSame('{"name":"Taylor"}'."\n".'{"name":"Abigail"}', Arr::toNdJson($array));
+        $this->assertSame('{"name":"Taylor"}'."\n".'{"name":"Abigail"}', Arr::jsonLines($array));
     }
 
-    public static function toNdJsonProvider()
+    public static function jsonLinesProvider()
     {
         return [
             'array' => [[['name' => 'Taylor'], ['name' => 'Abigail']]],
@@ -1741,11 +1741,11 @@ class SupportArrTest extends TestCase
         ];
     }
 
-    public function testToNdJsonWithOptionsAndSeparator()
+    public function testJsonLinesWithOptionsAndSeparator()
     {
         $this->assertSame(
             '{"url":"https://laravel.com"}|{"url":"https://laravel.com/docs"}',
-            Arr::toNdJson([
+            Arr::jsonLines([
                 ['url' => 'https://laravel.com'],
                 ['url' => 'https://laravel.com/docs'],
             ], JSON_UNESCAPED_SLASHES, '|')

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\ItemNotFoundException;
 use Illuminate\Support\MultipleItemsFoundException;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use stdClass;
@@ -1720,6 +1721,35 @@ class SupportArrTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Items cannot be represented by a scalar value.');
         Arr::from(123);
+    }
+
+    #[DataProvider('toNdJsonProvider')]
+    public function testToNdJson($array)
+    {
+        $this->assertSame('{"name":"Taylor"}'."\n".'{"name":"Abigail"}', Arr::toNdJson($array));
+    }
+
+    public static function toNdJsonProvider()
+    {
+        return [
+            'array' => [[['name' => 'Taylor'], ['name' => 'Abigail']]],
+            'collection' => [new Collection([['name' => 'Taylor'], ['name' => 'Abigail']])],
+            'generator' => [(function () {
+                yield ['name' => 'Taylor'];
+                yield ['name' => 'Abigail'];
+            })()],
+        ];
+    }
+
+    public function testToNdJsonWithOptionsAndSeparator()
+    {
+        $this->assertSame(
+            '{"url":"https://laravel.com"}|{"url":"https://laravel.com/docs"}',
+            Arr::toNdJson([
+                ['url' => 'https://laravel.com'],
+                ['url' => 'https://laravel.com/docs'],
+            ], JSON_UNESCAPED_SLASHES, '|')
+        );
     }
 
     public function testWrap()


### PR DESCRIPTION
I noticed that Tim added a [method like this in his last PR](https://github.com/laravel/framework/pull/60074/changes#diff-bba22988da8fabdaba0bff567b9ca75113e449f3352f5e88f585fa61555c0641R105-R113). Would probably be cool to just make it a first class citizen of the framework.