### PR TITLE
Fix Password::required() and sometimes() mutating default rule instance

### DIFF
--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -179,7 +179,7 @@ class Password implements DataAwareRule, ImplicitRule, IteratorAggregate, Rule, 
      */
     public static function required()
     {
-        $password = static::default();
+        $password = clone static::default();
 
         $password->required = true;
 
@@ -193,7 +193,7 @@ class Password implements DataAwareRule, ImplicitRule, IteratorAggregate, Rule, 
      */
     public static function sometimes()
     {
-        $password = static::default();
+        $password = clone static::default();
 
         $password->sometimes = true;
 

--- a/tests/Validation/ValidationPasswordRuleTest.php
+++ b/tests/Validation/ValidationPasswordRuleTest.php
@@ -443,6 +443,32 @@ class ValidationPasswordRuleTest extends TestCase
         $this->passes([Password::sometimes()], ['Password123', 'password123']);
     }
 
+    public function testRequiredDoesNotMutateDefaultRuleInstance()
+    {
+        Password::defaults(Password::min(6)->letters());
+
+        $required = Password::required();
+        $this->assertContains('required', [...$required]);
+        $this->assertContains('min:6', [...$required]);
+
+        $default = Password::default();
+        $this->assertNotContains('required', [...$default]);
+        $this->assertContains('min:6', [...$default]);
+    }
+
+    public function testSometimesDoesNotMutateDefaultRuleInstance()
+    {
+        Password::defaults(Password::min(6)->letters());
+
+        $sometimes = Password::sometimes();
+        $this->assertContains('sometimes', [...$sometimes]);
+        $this->assertContains('min:6', [...$sometimes]);
+
+        $default = Password::default();
+        $this->assertNotContains('sometimes', [...$default]);
+        $this->assertContains('min:6', [...$default]);
+    }
+
     public function testRequiredWithMissingValue()
     {
         $v = new Validator(


### PR DESCRIPTION
## Problem

When applications configure default password rules using:

```php
Password::defaults(Password::min(8));
```

calling `Password::required()` or `Password::sometimes()`
mutates the shared default `Password` rule instance.

As a result, later calls to `Password::default()` may unexpectedly
retain the `required` or `sometimes` flags.

## Solution

Clone the configured default password rule instance before applying
mutations in `Password::required()` and `Password::sometimes()`.

This ensures the configured default rule behaves as an immutable
template and prevents state leakage between calls.

## Tests

Added regression tests covering:

- `Password::required()` does not mutate the configured default rule
- `Password::sometimes()` does not mutate the configured default rule