### PR TITLE
[13.x] reset Lottery on test case teardown

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
@@ -192,7 +192,7 @@ trait InteractsWithTestCaseLifecycle
         HandleExceptions::flushState($this);
         JsonApiResource::flushState();
         JsonResource::flushState();
-        Lottery::determineResultsNormally()
+        Lottery::determineResultsNormally();
         Markdown::flushState();
         Migrator::withoutMigrations([]);
         Once::flush();

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
@@ -37,6 +37,7 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\EncodedHtmlString;
 use Illuminate\Support\Facades\Facade;
 use Illuminate\Support\Facades\ParallelTesting;
+use Illuminate\Support\Lottery;
 use Illuminate\Support\Once;
 use Illuminate\Support\Sleep;
 use Illuminate\Support\Str;
@@ -191,6 +192,7 @@ trait InteractsWithTestCaseLifecycle
         HandleExceptions::flushState($this);
         JsonApiResource::flushState();
         JsonResource::flushState();
+        Lottery::determineResultsNormally()
         Markdown::flushState();
         Migrator::withoutMigrations([]);
         Once::flush();


### PR DESCRIPTION
Seems like a lot of weeping and gnashing of teeth could come about as a result of the Lottery not being reset between tests.

I am adding this today to my project's repo, so I figured it might be nice to become the Laravel default.