### PR TITLE
[14.x] Optimize Worker queue cache check

### DIFF
--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -284,6 +284,7 @@ class QueueManager implements FactoryContract, MonitorContract
 
     /**
      * Get the paused queues from the given queues.
+     *
      * @param  string  $connection
      * @param  array  $queues
      * @return array

--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -289,7 +289,7 @@ class QueueManager implements FactoryContract, MonitorContract
      * @param  array  $queues
      * @return array
      */
-    public function getPausedQueues($connection, array $queues)
+    public function getPausedQueues($connection, $queues)
     {
         $keys = array_map(fn ($queue) => "illuminate:queue:paused:{$connection}:{$queue}", $queues);
 

--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -283,6 +283,23 @@ class QueueManager implements FactoryContract, MonitorContract
     }
 
     /**
+     * Get the paused queues from the given queues.
+     * @param  string  $connection
+     * @param  array  $queues
+     * @return array
+     */
+    public function getPausedQueues($connection, array $queues)
+    {
+        $keys = array_map(fn ($queue) => "illuminate:queue:paused:{$connection}:{$queue}", $queues);
+
+        $states = $this->app['cache']->store()->many($keys);
+
+        return array_values(array_filter(
+            $queues, fn ($queue) => $states["illuminate:queue:paused:{$connection}:{$queue}"] ?? false
+        ));
+    }
+
+    /**
      * Indicate that queue workers should not poll for restart or pause signals.
      *
      * This prevents the workers from hitting the application cache to determine if they need to pause or restart.

--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -283,7 +283,7 @@ class QueueManager implements FactoryContract, MonitorContract
     }
 
     /**
-     * Get the paused queues from the given queues.
+     * Determine which of the given queues are currently paused.
      *
      * @param  string  $connection
      * @param  array  $queues

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -410,7 +410,7 @@ class Worker
     }
 
     /**
-     * Get the paused queues from the given queues.
+     * Determine which of the given queues are currently paused.
      *
      * @param  string  $connectionName
      * @param  array  $queues

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -416,7 +416,7 @@ class Worker
      * @param  array  $queues
      * @return array
      */
-    protected function getPausedQueues($connectionName, array $queues)
+    protected function getPausedQueues($connectionName, $queues)
     {
         if (! static::$pausable) {
             return [];

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -387,10 +387,10 @@ class Worker
 
             $queues = explode(',', $queue);
 
-            $paused = $this->getPausedQueues($connection->getConnectionName(), $queues);
+            $paused = array_flip($this->getPausedQueues($connection->getConnectionName(), $queues));
 
             foreach ($queues as $index => $queue) {
-                if (in_array($queue, $paused)) {
+                if (isset($paused[$queue])) {
                     continue;
                 }
 

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -385,8 +385,12 @@ class Worker
                 return $job;
             }
 
-            foreach (explode(',', $queue) as $index => $queue) {
-                if ($this->queuePaused($connection->getConnectionName(), $queue)) {
+            $queues = explode(',', $queue);
+
+            $paused = $this->getPausedQueues($connection->getConnectionName(), $queues);
+
+            foreach ($queues as $index => $queue) {
+                if (in_array($queue, $paused)) {
                     continue;
                 }
 
@@ -406,19 +410,22 @@ class Worker
     }
 
     /**
-     * Determine if a given connection and queue is paused.
-     *
+     * Get the paused queues from the given queues.
      * @param  string  $connectionName
-     * @param  string  $queue
-     * @return bool
+     * @param  array  $queues
+     * @return array
      */
-    protected function queuePaused($connectionName, $queue)
+    protected function getPausedQueues($connectionName, array $queues)
     {
         if (! static::$pausable) {
-            return false;
+            return [];
         }
 
-        return $this->cache && $this->manager->isPaused($connectionName, $queue);
+        if ($this->cache === null) {
+            return [];
+        }
+
+        return $this->manager->getPausedQueues($connectionName, $queues);
     }
 
     /**

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -411,6 +411,7 @@ class Worker
 
     /**
      * Get the paused queues from the given queues.
+     *
      * @param  string  $connectionName
      * @param  array  $queues
      * @return array

--- a/tests/Queue/QueuePauseResumeTest.php
+++ b/tests/Queue/QueuePauseResumeTest.php
@@ -161,6 +161,19 @@ class QueuePauseResumeTest extends TestCase
         $this->assertSame('notifications', $dispatchedEvent->queue);
     }
 
+    public function testGetPausedQueues()
+    {
+        $this->assertSame([], $this->manager->getPausedQueues('redis', ['default', 'emails']));
+
+        $this->manager->pause('redis', 'emails');
+        $this->manager->pause('redis', 'notifications');
+
+        $this->assertSame(
+            ['emails', 'notifications'],
+            $this->manager->getPausedQueues('redis', ['default', 'emails', 'notifications'])
+        );
+    }
+
     public function testParsingQueueString()
     {
         $parser = new class()


### PR DESCRIPTION
If you have pausing enabled each queue you set will hit the cache 1x every single job, so if you have `queue:work --queue=high,default` both the high and default queue will have a cache hit every job, do one million jobs and thats 2 million cache hits. 

Now, scale it up to 10 workers 2 queues each some even 4, and it can suddenly get crazy... (this is just a staging site)

<img width="879" height="61" alt="image" src="https://github.com/user-attachments/assets/c70cb3ba-ade3-4049-a300-7465374369d1" />


All this PR does is use `many()`, so we can do one round trip and attempt at making it more performant.  This is even more helpful the more queues and workers you have. 

I've targeted 14.x as it is somewhat a breaking change if someones extending the Worker and the queuePaused method. 
It can however be back-ported if you fancy it.. I wasnt 100% sure if to go for 13.x but ended up here.

I've tried to keep it dead simple, but apply your wizardry if you can see a nicer way.  

Happy to sit on this, but felt like a simple optimization to save the back and forth to Redis / DB


 
 
 Secret message: V29ya2luZyBvbiBsYXJhdmVsIGlzIGNvb2w=