### PR TITLE
Fix typo in Sleep::microsecond() PHPDoc comment

### DIFF
--- a/src/Illuminate/Support/Sleep.php
+++ b/src/Illuminate/Support/Sleep.php
@@ -239,7 +239,7 @@ class Sleep
     }
 
     /**
-     * Sleep for on microsecond.
+     * Sleep for one microsecond.
      *
      * @return $this
      */


### PR DESCRIPTION
## Summary
- Fixed typo in `Sleep::microsecond()` PHPDoc comment
- Changed "Sleep for **on** microsecond" to "Sleep for **one** microsecond"

## Why
The comment was inconsistent with similar methods:
- `minute()` → "Sleep for **one** minute."
- `second()` → "Sleep for **one** second."
- `millisecond()` → "Sleep for **one** millisecond."
- `microsecond()` → "Sleep for **on** microsecond." ❌

This fix improves documentation consistency.

## Change
- [x] Documentation only (no behavior change)
- [x] No tests required (PHPDoc comment)
