### PR TITLE
Fix grammatical error in Lottery::alwaysLose() PHPDoc comment

### DIFF
--- a/src/Illuminate/Support/Lottery.php
+++ b/src/Illuminate/Support/Lottery.php
@@ -189,7 +189,7 @@ class Lottery
     }
 
     /**
-     * Force the lottery to always result in a lose.
+     * Force the lottery to always result in a loss.
      *
      * @param  callable|null  $callback
      * @return void


### PR DESCRIPTION
## Summary
- Fixed grammatical error in `Lottery::alwaysLose()` PHPDoc comment
- Changed "result in a **lose**" to "result in a **loss**"

## Why
The word "lose" is a verb (e.g., "I lose"), but the context requires a noun to match the corresponding `alwaysWin()` method:

- `alwaysWin()` → "result in a **win**" (noun) ✅
- `alwaysLose()` → "result in a **lose**" (verb) ❌ → "**loss**" (noun) ✅

## Change
- [x] Documentation only (no behavior change)
- [x] No tests required (PHPDoc comment)
