### PR TITLE
[13.x] Replace @return with @var on property docblocks

### DIFF
--- a/src/Illuminate/Mail/SendQueuedMailable.php
+++ b/src/Illuminate/Mail/SendQueuedMailable.php
@@ -44,7 +44,7 @@ class SendQueuedMailable
     /**
      * The maximum number of unhandled exceptions to allow before failing.
      *
-     * @return int|null
+     * @var int|null
      */
     public $maxExceptions;
 

--- a/src/Illuminate/Pagination/CursorPaginator.php
+++ b/src/Illuminate/Pagination/CursorPaginator.php
@@ -28,7 +28,7 @@ class CursorPaginator extends AbstractCursorPaginator implements Arrayable, Arra
     /**
      * Indicates whether there are more items in the data source.
      *
-     * @return bool
+     * @var bool
      */
     protected $hasMore;
 

--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -26,9 +26,9 @@ use JsonSerializable;
 class Paginator extends AbstractPaginator implements Arrayable, ArrayAccess, Countable, IteratorAggregate, Jsonable, JsonSerializable, PaginatorContract
 {
     /**
-     * Determine if there are more items in the data source.
+     * Indicates if there are more items in the data source.
      *
-     * @return bool
+     * @var bool
      */
     protected $hasMore;
 


### PR DESCRIPTION
Three property docblocks were tagged `@return` instead of `@var`: `Pagination\Paginator::$hasMore`, `Pagination\CursorPaginator::$hasMore`, and `Mail\SendQueuedMailable::$maxExceptions`. `@return` is for method return values; static analyzers and IDEs don't pick up the type on properties tagged this way. Fixing all three, plus correcting `Paginator::$hasMore`'s description from method-style ("Determine if...") to property-style ("Indicates if...").