### PR TITLE
[13.x] Add unicode modifier to Console\Parser preg_split calls

### DIFF
--- a/src/Illuminate/Console/Parser.php
+++ b/src/Illuminate/Console/Parser.php
@@ -97,7 +97,7 @@ class Parser
     {
         [$token, $description] = static::extractDescription($token);
 
-        $matches = preg_split('/\s*\|\s*/', $token, 2);
+        $matches = preg_split('/\s*\|\s*/u', $token, 2);
 
         $shortcut = null;
 
@@ -123,7 +123,7 @@ class Parser
      */
     protected static function extractDescription(string $token)
     {
-        $parts = preg_split('/\s+:\s+/', trim($token), 2);
+        $parts = preg_split('/\s+:\s+/u', trim($token), 2);
 
         return count($parts) === 2 ? $parts : [$token, ''];
     }


### PR DESCRIPTION
Both `preg_split` calls in `Console\Parser` use `\s` to split command signature tokens — on the `|` shortcut separator and the `:` description separator. Without `/u`, `\s` only matches ASCII whitespace, so signatures that happen to contain Unicode whitespace (e.g. a non-breaking space pasted from a doc) won't split correctly. Same shape as #60056.