### PR TITLE
[13.x] Add unicode modifier to ResolvesDumpSource compiled view path regex

### DIFF
--- a/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
+++ b/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
@@ -138,7 +138,7 @@ trait ResolvesDumpSource
      */
     protected function getOriginalFileForCompiledView($file)
     {
-        preg_match('/\/\*\*PATH\s(.*)\sENDPATH/', file_get_contents($file), $matches);
+        preg_match('/\/\*\*PATH\s(.*)\sENDPATH/u', file_get_contents($file), $matches);
 
         if (isset($matches[1])) {
             $file = $matches[1];


### PR DESCRIPTION
`ResolvesDumpSource::getOriginalFileForCompiledView()` extracts the source path from a compiled view header using `preg_match('/\\/\\*\\*PATH\\s(.*)\\sENDPATH/', ...)`. The pattern uses `\s` for the markers and `.` for the captured path — neither matches Unicode reliably without `/u`, so source paths containing multibyte chars (common on macOS/Linux) won't be extracted. Adding the `/u` flag, same shape as #60056.