### PR TITLE
[13.x] Add unicode modifier to SeeInHtml normalize whitespace regex

### DIFF
--- a/src/Illuminate/Testing/Constraints/SeeInHtml.php
+++ b/src/Illuminate/Testing/Constraints/SeeInHtml.php
@@ -122,7 +122,7 @@ class SeeInHtml extends Constraint
         $value = strip_tags($value);
         $value = html_entity_decode($value, ENT_QUOTES, 'UTF-8');
         $value = trim($value);
-        $value = preg_replace('/\s+/', ' ', $value);
+        $value = preg_replace('/\s+/u', ' ', $value);
 
         return $value;
     }


### PR DESCRIPTION
`SeeInHtml::normalize()` is used by `assertSee()`-family assertions. The method explicitly decodes with `'UTF-8'` on the line above, but the trailing `preg_replace('/\\s+/', ' ', $value)` doesn't have the `/u` flag — so HTML containing Unicode whitespace (non-breaking space, ideographic space, etc.) gets left in place instead of collapsed, causing `assertSee()` matches to silently fail. Same shape as #60056.