### PR TITLE
[13.x] Add foreignUuidFor schema helper

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1072,6 +1072,24 @@ class Blueprint
     }
 
     /**
+     * Create a foreign UUID column for the given model.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model|string  $model
+     * @param  string|null  $column
+     * @return \Illuminate\Database\Schema\ForeignIdColumnDefinition
+     */
+    public function foreignUuidFor($model, $column = null)
+    {
+        if (is_string($model)) {
+            $model = new $model;
+        }
+
+        return $this->foreignUuid($column ?: $model->getForeignKey())
+            ->table($model->getTable())
+            ->referencesModelColumn($model->getKeyName());
+    }
+
+    /**
      * Create a new float column on the table.
      *
      * @param  string  $column

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -453,6 +453,19 @@ class DatabaseSchemaBlueprintTest extends TestCase
         ], $getSql('MySql'));
     }
 
+    public function testGenerateUuidRelationshipColumnWithUuidModel()
+    {
+        $getSql = function ($grammar) {
+            return $this->getBlueprint($grammar, 'posts', function ($table) {
+                $table->foreignUuidFor(Fixtures\Models\EloquentModelUsingUuid::class);
+            })->toSql();
+        };
+
+        $this->assertEquals([
+            'alter table `posts` add `model_using_uuid_id` char(36) not null',
+        ], $getSql('MySql'));
+    }
+
     public function testGenerateRelationshipColumnWithUlidModel()
     {
         $getSql = function ($grammar) {
@@ -481,6 +494,20 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $this->assertEquals([
             'alter table `posts` add `user_id` bigint unsigned not null',
             'alter table `posts` add constraint `posts_user_id_foreign` foreign key (`user_id`) references `users` (`id`)',
+        ], $getSql('MySql'));
+    }
+
+    public function testGenerateUuidRelationshipConstrainedColumn()
+    {
+        $getSql = function ($grammar) {
+            return $this->getBlueprint($grammar, 'posts', function ($table) {
+                $table->foreignUuidFor(Fixtures\Models\EloquentModelUsingUuid::class)->constrained();
+            })->toSql();
+        };
+
+        $this->assertEquals([
+            'alter table `posts` add `model_using_uuid_id` char(36) not null',
+            'alter table `posts` add constraint `posts_model_using_uuid_id_foreign` foreign key (`model_using_uuid_id`) references `model` (`id`)',
         ], $getSql('MySql'));
     }
 


### PR DESCRIPTION
This PR adds a `foreignUuidFor` helper to schema blueprints.

While `foreignIdFor` already supports UUID-backed Eloquent models by detecting the model key type, this new helper provides an explicit API for migrations that intentionally want a UUID foreign key column:

```php
$table->foreignUuidFor(User::class)->constrained();
```

The helper mirrors the model-aware behavior of `foreignIdFor` by inferring:

- the foreign key column name from the model
- the related table name
- the referenced primary key column