### PR TITLE
[13.x] Add enum support to contextual attribute binding

### DIFF
--- a/src/Illuminate/Container/Attributes/Auth.php
+++ b/src/Illuminate/Container/Attributes/Auth.php
@@ -5,6 +5,7 @@ namespace Illuminate\Container\Attributes;
 use Attribute;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Container\ContextualAttribute;
+use UnitEnum;
 
 #[Attribute(Attribute::TARGET_PARAMETER)]
 class Auth implements ContextualAttribute
@@ -12,7 +13,7 @@ class Auth implements ContextualAttribute
     /**
      * Create a new class instance.
      */
-    public function __construct(public ?string $guard = null)
+    public function __construct(public UnitEnum|string|null $guard = null)
     {
     }
 

--- a/src/Illuminate/Container/Attributes/Authenticated.php
+++ b/src/Illuminate/Container/Attributes/Authenticated.php
@@ -5,6 +5,7 @@ namespace Illuminate\Container\Attributes;
 use Attribute;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Container\ContextualAttribute;
+use UnitEnum;
 
 #[Attribute(Attribute::TARGET_PARAMETER)]
 class Authenticated implements ContextualAttribute
@@ -12,7 +13,7 @@ class Authenticated implements ContextualAttribute
     /**
      * Create a new class instance.
      */
-    public function __construct(public ?string $guard = null)
+    public function __construct(public UnitEnum|string|null $guard = null)
     {
     }
 

--- a/src/Illuminate/Container/Attributes/Cache.php
+++ b/src/Illuminate/Container/Attributes/Cache.php
@@ -5,6 +5,7 @@ namespace Illuminate\Container\Attributes;
 use Attribute;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Container\ContextualAttribute;
+use UnitEnum;
 
 #[Attribute(Attribute::TARGET_PARAMETER)]
 class Cache implements ContextualAttribute
@@ -12,7 +13,7 @@ class Cache implements ContextualAttribute
     /**
      * Create a new class instance.
      */
-    public function __construct(public ?string $store = null)
+    public function __construct(public UnitEnum|string|null $store = null)
     {
     }
 

--- a/tests/Container/ContextualAttributeBindingTest.php
+++ b/tests/Container/ContextualAttributeBindingTest.php
@@ -145,6 +145,18 @@ class ContextualAttributeBindingTest extends TestCase
 
                 return $guard;
             });
+            $manager->shouldReceive('guard')->with(AuthGuardUnitEnum::unit)->andReturnUsing(function () {
+                $guard = m::mock(GuardContract::class);
+                $guard->shouldReceive('user')->andReturn(m:mock(AuthenticatableContract::class));
+
+                return $guard;
+            });
+            $manager->shouldReceive('guard')->with(AuthGuardBackedEnum::Backed)->andReturnUsing(function () {
+                $guard = m::mock(GuardContract::class);
+                $guard->shouldReceive('user')->andReturn(m:mock(AuthenticatableContract::class));
+
+                return $guard;
+            });
 
             return $manager;
         });
@@ -159,6 +171,8 @@ class ContextualAttributeBindingTest extends TestCase
             $manager = m::mock(CacheManager::class);
             $manager->shouldReceive('store')->with('foo')->andReturn(m::mock(CacheRepository::class));
             $manager->shouldReceive('store')->with('bar')->andReturn(m::mock(CacheRepository::class));
+            $manager->shouldReceive('store')->with(CacheStoreUnitEnum::unit)->andReturn(m::mock(CacheRepository::class));
+            $manager->shouldReceive('store')->with(CacheStoreBackedEnum::Backed)->andReturn(m::mock(CacheRepository::class));
 
             return $manager;
         });
@@ -201,6 +215,8 @@ class ContextualAttributeBindingTest extends TestCase
             $manager = m::mock(AuthManager::class);
             $manager->shouldReceive('guard')->with('foo')->andReturn(m::mock(GuardContract::class));
             $manager->shouldReceive('guard')->with('bar')->andReturn(m::mock(GuardContract::class));
+            $manager->shouldReceive('guard')->with(AuthGuardUnitEnum::unit)->andReturn(m::mock(GuardContract::class));
+            $manager->shouldReceive('guard')->with(AuthGuardBackedEnum::Backed)->andReturn(m::mock(GuardContract::class));
 
             return $manager;
         });
@@ -372,6 +388,26 @@ enum StorageDiskBackedEnum: string
     case Backed = 'backed';
 }
 
+enum AuthGuardUnitEnum
+{
+    case unit;
+}
+
+enum AuthGuardBackedEnum: string
+{
+    case Backed = 'backed';
+}
+
+enum CacheStoreUnitEnum
+{
+    case unit;
+}
+
+enum CacheStoreBackedEnum: string
+{
+    case Backed = 'backed';
+}
+
 interface ContainerTestContract
 {
 }
@@ -479,15 +515,23 @@ final class ComplexDependency implements ContainerTestContract
 
 final class AuthedTest
 {
-    public function __construct(#[Authenticated('foo')] AuthenticatableContract $foo, #[CurrentUser('bar')] AuthenticatableContract $bar)
-    {
+    public function __construct(
+        #[Authenticated('foo')] AuthenticatableContract $foo,
+        #[CurrentUser('bar')] AuthenticatableContract $bar,
+        #[Authenticated(AuthGuardUnitEnum::unit)] AuthenticatableContract $unit,
+        #[CurrentUser(AuthGuardBackedEnum::Backed)] AuthenticatableContract $backed,
+    ) {
     }
 }
 
 final class CacheTest
 {
-    public function __construct(#[Cache('foo')] CacheRepository $foo, #[Cache('bar')] CacheRepository $bar)
-    {
+    public function __construct(
+        #[Cache('foo')] CacheRepository $foo,
+        #[Cache('bar')] CacheRepository $bar,
+        #[Cache(CacheStoreUnitEnum::unit)] CacheRepository $unit,
+        #[Cache(CacheStoreBackedEnum::Backed)] CacheRepository $backed,
+    ) {
     }
 }
 
@@ -521,8 +565,12 @@ final class DatabaseTest
 
 final class GuardTest
 {
-    public function __construct(#[Auth('foo')] GuardContract $foo, #[Auth('bar')] GuardContract $bar)
-    {
+    public function __construct(
+        #[Auth('foo')] GuardContract $foo,
+        #[Auth('bar')] GuardContract $bar,
+        #[Auth(AuthGuardUnitEnum::unit)] GuardContract $unit,
+        #[Auth(AuthGuardBackedEnum::Backed)] GuardContract $backed,
+    ) {
     }
 }
 


### PR DESCRIPTION
This pull request introduces support for PHP enums (both `UnitEnum` and backed enums) in Container contextual attribute bindings, enhancing the flexibility of dependency injection configuration.

Support UnitEnum and backed enums in Container attribute bindings:
- Auth, Authenticated, and Cache attributes now accept enum values
- Updated parameter types to accept UnitEnum|string|null
- Added comprehensive tests for unit and backed enum bindings
- Tests cover AuthGuardUnitEnum, AuthGuardBackedEnum, CacheStoreUnitEnum, and CacheStoreBackedEnum

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
