### PR TITLE
[13.x] Make docblock for Factory@configure more correct

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -230,7 +230,7 @@ abstract class Factory
     /**
      * Configure the factory.
      *
-     * @return static
+     * @return $this
      */
     public function configure()
     {


### PR DESCRIPTION
PHPStan on higher levels will complain about the return type of any overridden `configure` method in an Eloquent database factory class, including the out-of-the-box factory with the new starter kit's teams implementation.

```
 ------ 
  Line   database/factories/UserFactory.php                                                                                                                  
 ------ 
  :60    Method Database\Factories\UserFactory::configure() should return $this(Database\Factories\UserFactory) but returns static(Database\Factories\UserFactory).
         🪪  return.type                                                                                                                                     
 ------ 
```

Making the docblock more specific to return `$this` instead of `static` resolves this issue.