### PR TITLE
[13.x] Add filesystem driver option for SQS overflow storage

### DIFF
--- a/config/queue.php
+++ b/config/queue.php
@@ -64,7 +64,10 @@ return [
             'after_commit' => false,
             'overflow' => [
                 'enabled' => env('SQS_OVERFLOW_ENABLED', false),
+                'driver' => env('SQS_OVERFLOW_DRIVER', 'cache'),
                 'store' => env('SQS_OVERFLOW_STORE'),
+                'disk' => env('SQS_OVERFLOW_DISK'),
+                'prefix' => env('SQS_OVERFLOW_PREFIX'),
                 'always' => false,
                 'delete_after_processing' => true,
             ],

--- a/src/Illuminate/Queue/Jobs/SqsJob.php
+++ b/src/Illuminate/Queue/Jobs/SqsJob.php
@@ -89,7 +89,15 @@ class SqsJob extends Job implements JobContract
 
         if (Arr::get($this->overflowStorage, 'delete_after_processing') &&
             $pointer = $this->overflowPointer()) {
-            $this->overflowStore()->forget($pointer);
+            if ($this->overflowDriverIsFilesystem()) {
+                $this->container->make('filesystem')->disk(
+                    Arr::get($this->overflowStorage, 'disk')
+                )->delete($pointer);
+            } else {
+                $this->container->make('cache')->store(
+                    Arr::get($this->overflowStorage, 'store')
+                )->forget($pointer);
+            }
         }
     }
 
@@ -125,7 +133,9 @@ class SqsJob extends Job implements JobContract
         }
 
         if ($pointer = $this->overflowPointer()) {
-            return $this->cachedRawBody = $this->overflowStore()->get($pointer);
+            return $this->cachedRawBody = $this->overflowDriverIsFilesystem()
+                ? $this->container->make('filesystem')->disk(Arr::get($this->overflowStorage, 'disk'))->get($pointer)
+                : $this->container->make('cache')->store(Arr::get($this->overflowStorage, 'store'))->get($pointer);
         }
 
         return $this->job['Body'];
@@ -158,15 +168,13 @@ class SqsJob extends Job implements JobContract
     }
 
     /**
-     * Resolve the configured cache store for extended storage.
+     * Determine if the overflow driver is the filesystem driver.
      *
-     * @return \Illuminate\Contracts\Cache\Repository
+     * @return bool
      */
-    protected function overflowStore()
+    protected function overflowDriverIsFilesystem()
     {
-        return $this->container->make('cache')->store(
-            Arr::get($this->overflowStorage, 'store')
-        );
+        return Arr::get($this->overflowStorage, 'driver', 'cache') === 'filesystem';
     }
 
     /**

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -445,10 +445,10 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
         $prefix = Arr::get($this->overflowStorage, 'prefix');
 
         if ($this->overflowDriverIsFilesystem()) {
-            return ltrim(($prefix ?: 'laravel/sqs-payloads') . '/' . $uuid . '.json', '/');
+            return ltrim(($prefix ?: 'laravel/sqs-payloads').'/'.$uuid.'.json', '/');
         }
 
-        return ($prefix ? rtrim($prefix, ':') . ':' : static::EXTENDED_PAYLOAD_CACHE_PREFIX) . $uuid;
+        return ($prefix ? rtrim($prefix, ':').':' : static::EXTENDED_PAYLOAD_CACHE_PREFIX).$uuid;
     }
 
     /**

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -380,7 +380,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
     }
 
     /**
-     * Determine if the payload should be stored in cache.
+     * Determine if the payload should be sent to overflow storage.
      *
      * @param  string  $payload
      * @return bool
@@ -396,7 +396,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
     }
 
     /**
-     * Store the payload in cache and return a pointer payload.
+     * Store the payload in overflow storage and return a pointer payload.
      *
      * @param  string  $payload
      * @return string
@@ -409,13 +409,46 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
             ? $decoded->uuid
             : (string) Str::uuid();
 
-        $this->container->make('cache')->store(
-            Arr::get($this->overflowStorage, 'store')
-        )->put(
-            $path = static::EXTENDED_PAYLOAD_CACHE_PREFIX.$uuid, $payload
-        );
+        $path = $this->overflowPath($uuid);
+
+        if ($this->overflowDriverIsFilesystem()) {
+            $this->container->make('filesystem')->disk(
+                Arr::get($this->overflowStorage, 'disk')
+            )->put($path, $payload);
+        } else {
+            $this->container->make('cache')->store(
+                Arr::get($this->overflowStorage, 'store')
+            )->put($path, $payload);
+        }
 
         return json_encode(['@pointer' => $path]);
+    }
+
+    /**
+     * Determine if the overflow driver is the filesystem driver.
+     *
+     * @return bool
+     */
+    protected function overflowDriverIsFilesystem()
+    {
+        return Arr::get($this->overflowStorage, 'driver', 'cache') === 'filesystem';
+    }
+
+    /**
+     * Build the overflow storage path or cache key for the given uuid.
+     *
+     * @param  string  $uuid
+     * @return string
+     */
+    protected function overflowPath($uuid)
+    {
+        $prefix = Arr::get($this->overflowStorage, 'prefix');
+
+        if ($this->overflowDriverIsFilesystem()) {
+            return ltrim(($prefix ?: 'laravel/sqs-payloads') . '/' . $uuid . '.json', '/');
+        }
+
+        return ($prefix ? rtrim($prefix, ':') . ':' : static::EXTENDED_PAYLOAD_CACHE_PREFIX) . $uuid;
     }
 
     /**
@@ -451,6 +484,14 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
             $this->sqs->purgeQueue([
                 'QueueUrl' => $this->getQueue($queue),
             ]);
+
+            if ($this->overflowDriverIsFilesystem() &&
+                Arr::get($this->overflowStorage, 'delete_after_processing') &&
+                $prefix = Arr::get($this->overflowStorage, 'prefix')) {
+                $this->container->make('filesystem')->disk(
+                    Arr::get($this->overflowStorage, 'disk')
+                )->deleteDirectory($prefix);
+            }
         });
     }
 

--- a/tests/Queue/QueueSqsJobTest.php
+++ b/tests/Queue/QueueSqsJobTest.php
@@ -6,6 +6,8 @@ use Aws\Sqs\SqsClient;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Cache\Factory as CacheFactory;
 use Illuminate\Contracts\Cache\Repository as CacheRepository;
+use Illuminate\Contracts\Filesystem\Factory as FilesystemFactory;
+use Illuminate\Contracts\Filesystem\Filesystem;
 use Illuminate\Queue\Jobs\SqsJob;
 use Illuminate\Queue\SqsQueue;
 use Mockery as m;
@@ -228,6 +230,115 @@ class QueueSqsJobTest extends TestCase
             'enabled' => true,
             'store' => 'database',
             'delete_after_processing' => true,
+        ]);
+
+        $job->delete();
+    }
+
+    public function testGetRawBodyResolvesPointerFromFilesystem()
+    {
+        $fullPayload = json_encode(['job' => 'foo', 'data' => ['key' => 'value']]);
+        $pointerPath = 'laravel/sqs-payloads/some-uuid.json';
+        $pointerBody = json_encode(['@pointer' => $pointerPath]);
+
+        $disk = m::mock(Filesystem::class);
+        $disk->shouldReceive('get')->once()->with($pointerPath)->andReturn($fullPayload);
+
+        $filesystem = m::mock(FilesystemFactory::class);
+        $filesystem->shouldReceive('disk')->with('s3')->andReturn($disk);
+
+        $container = m::mock(Container::class);
+        $container->shouldReceive('make')->with('filesystem')->andReturn($filesystem);
+
+        $jobData = $this->mockedJobData;
+        $jobData['Body'] = $pointerBody;
+
+        $job = new SqsJob($container, $this->mockedSqsClient, $jobData, 'connection-name', $this->queueUrl, [
+            'enabled' => true,
+            'driver' => 'filesystem',
+            'disk' => 's3',
+            'delete_after_processing' => true,
+        ]);
+
+        $this->assertEquals($fullPayload, $job->getRawBody());
+    }
+
+    public function testGetRawBodyCachesFilesystemResult()
+    {
+        $fullPayload = json_encode(['job' => 'foo', 'data' => ['key' => 'value']]);
+        $pointerPath = 'laravel/sqs-payloads/some-uuid.json';
+        $pointerBody = json_encode(['@pointer' => $pointerPath]);
+
+        $disk = m::mock(Filesystem::class);
+        $disk->shouldReceive('get')->once()->with($pointerPath)->andReturn($fullPayload);
+
+        $filesystem = m::mock(FilesystemFactory::class);
+        $filesystem->shouldReceive('disk')->with('s3')->andReturn($disk);
+
+        $container = m::mock(Container::class);
+        $container->shouldReceive('make')->with('filesystem')->andReturn($filesystem);
+
+        $jobData = $this->mockedJobData;
+        $jobData['Body'] = $pointerBody;
+
+        $job = new SqsJob($container, $this->mockedSqsClient, $jobData, 'connection-name', $this->queueUrl, [
+            'enabled' => true,
+            'driver' => 'filesystem',
+            'disk' => 's3',
+            'delete_after_processing' => true,
+        ]);
+
+        // Call twice; disk should only be hit once.
+        $job->getRawBody();
+        $this->assertEquals($fullPayload, $job->getRawBody());
+    }
+
+    public function testDeleteCleansUpFilesystemFileWhenCleanupEnabled()
+    {
+        $pointerPath = 'laravel/sqs-payloads/some-uuid.json';
+        $pointerBody = json_encode(['@pointer' => $pointerPath]);
+
+        $disk = m::mock(Filesystem::class);
+        $disk->shouldReceive('delete')->once()->with($pointerPath);
+
+        $filesystem = m::mock(FilesystemFactory::class);
+        $filesystem->shouldReceive('disk')->with('s3')->andReturn($disk);
+
+        $container = m::mock(Container::class);
+        $container->shouldReceive('make')->with('filesystem')->andReturn($filesystem);
+
+        $jobData = $this->mockedJobData;
+        $jobData['Body'] = $pointerBody;
+
+        $sqsClient = m::mock(SqsClient::class)->makePartial();
+        $sqsClient->shouldReceive('deleteMessage')->once();
+
+        $job = new SqsJob($container, $sqsClient, $jobData, 'connection-name', $this->queueUrl, [
+            'enabled' => true,
+            'driver' => 'filesystem',
+            'disk' => 's3',
+            'delete_after_processing' => true,
+        ]);
+
+        $job->delete();
+    }
+
+    public function testDeleteDoesNotCleanUpFilesystemWhenCleanupDisabled()
+    {
+        $pointerPath = 'laravel/sqs-payloads/some-uuid.json';
+        $pointerBody = json_encode(['@pointer' => $pointerPath]);
+
+        $jobData = $this->mockedJobData;
+        $jobData['Body'] = $pointerBody;
+
+        $sqsClient = m::mock(SqsClient::class)->makePartial();
+        $sqsClient->shouldReceive('deleteMessage')->once();
+
+        $job = new SqsJob($this->mockedContainer, $sqsClient, $jobData, 'connection-name', $this->queueUrl, [
+            'enabled' => true,
+            'driver' => 'filesystem',
+            'disk' => 's3',
+            'delete_after_processing' => false,
         ]);
 
         $job->delete();

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -9,6 +9,8 @@ use Illuminate\Container\Container;
 use Illuminate\Contracts\Bus\Dispatcher as DispatcherContract;
 use Illuminate\Contracts\Cache\Factory as CacheFactory;
 use Illuminate\Contracts\Cache\Repository as CacheRepository;
+use Illuminate\Contracts\Filesystem\Factory as FilesystemFactory;
+use Illuminate\Contracts\Filesystem\Filesystem;
 use Illuminate\Queue\Jobs\SqsJob;
 use Illuminate\Queue\QueueRoutes;
 use Illuminate\Queue\SqsQueue;
@@ -799,6 +801,200 @@ class QueueSqsQueueTest extends TestCase
         $overflowStorage = [
             'enabled' => true,
             'store' => 'database',
+            'always' => false,
+            'delete_after_processing' => true,
+        ];
+
+        $queue = $this->getMockBuilder(SqsQueue::class)
+            ->onlyMethods(['getQueue'])
+            ->setConstructorArgs([$this->sqs, $this->queueName, $this->account, '', false, $overflowStorage])
+            ->getMock();
+        $queue->setContainer(m::mock(Container::class));
+        $queue->expects($this->once())->method('getQueue')->with($this->queueName)->willReturn($this->queueUrl);
+
+        $this->sqs->shouldReceive('receiveMessage')->once()->andReturn($this->mockedReceiveMessageResponseModel);
+
+        $job = $queue->pop($this->queueName);
+
+        $this->assertInstanceOf(SqsJob::class, $job);
+    }
+
+    public function testPushRawStoresPayloadToFilesystemWhenExceedingThreshold()
+    {
+        $uuid = 'test-uuid-1234';
+        $largePayload = json_encode(['uuid' => $uuid, 'job' => 'App\\Jobs\\TestJob', 'data' => str_repeat('x', SqsQueue::MAX_SQS_PAYLOAD_SIZE)]);
+        $expectedPath = 'laravel/sqs-payloads/'.$uuid.'.json';
+        $expectedPointer = json_encode(['@pointer' => $expectedPath]);
+
+        $disk = m::mock(Filesystem::class);
+        $disk->shouldReceive('put')->once()->with($expectedPath, $largePayload);
+
+        $filesystem = m::mock(FilesystemFactory::class);
+        $filesystem->shouldReceive('disk')->with('s3')->andReturn($disk);
+
+        $container = m::mock(Container::class);
+        $container->shouldReceive('make')->with('filesystem')->andReturn($filesystem);
+
+        $queue = new SqsQueue($this->sqs, $this->queueName, $this->prefix, '', false, [
+            'enabled' => true,
+            'driver' => 'filesystem',
+            'disk' => 's3',
+            'always' => false,
+            'delete_after_processing' => true,
+        ]);
+        $queue->setContainer($container);
+
+        $this->sqs->shouldReceive('sendMessage')->once()->withArgs(function ($args) use ($expectedPointer) {
+            return $args['MessageBody'] === $expectedPointer;
+        })->andReturn($this->mockedSendMessageResponseModel);
+
+        $queue->pushRaw($largePayload, $this->queueName);
+    }
+
+    public function testPushRawAlwaysStoresToFilesystemWhenAlwaysIsTrue()
+    {
+        $uuid = 'test-uuid-always';
+        $smallPayload = json_encode(['uuid' => $uuid, 'job' => 'App\\Jobs\\TestJob', 'data' => 'small']);
+        $expectedPath = 'laravel/sqs-payloads/'.$uuid.'.json';
+        $expectedPointer = json_encode(['@pointer' => $expectedPath]);
+
+        $disk = m::mock(Filesystem::class);
+        $disk->shouldReceive('put')->once()->with($expectedPath, $smallPayload);
+
+        $filesystem = m::mock(FilesystemFactory::class);
+        $filesystem->shouldReceive('disk')->with('s3')->andReturn($disk);
+
+        $container = m::mock(Container::class);
+        $container->shouldReceive('make')->with('filesystem')->andReturn($filesystem);
+
+        $queue = new SqsQueue($this->sqs, $this->queueName, $this->prefix, '', false, [
+            'enabled' => true,
+            'driver' => 'filesystem',
+            'disk' => 's3',
+            'always' => true,
+            'delete_after_processing' => true,
+        ]);
+        $queue->setContainer($container);
+
+        $this->sqs->shouldReceive('sendMessage')->once()->withArgs(function ($args) use ($expectedPointer) {
+            return $args['MessageBody'] === $expectedPointer;
+        })->andReturn($this->mockedSendMessageResponseModel);
+
+        $queue->pushRaw($smallPayload, $this->queueName);
+    }
+
+    public function testPushRawHonorsCustomFilesystemPrefix()
+    {
+        $uuid = 'test-uuid-prefix';
+        $smallPayload = json_encode(['uuid' => $uuid, 'job' => 'App\\Jobs\\TestJob', 'data' => 'small']);
+        $expectedPath = 'custom/path/'.$uuid.'.json';
+        $expectedPointer = json_encode(['@pointer' => $expectedPath]);
+
+        $disk = m::mock(Filesystem::class);
+        $disk->shouldReceive('put')->once()->with($expectedPath, $smallPayload);
+
+        $filesystem = m::mock(FilesystemFactory::class);
+        $filesystem->shouldReceive('disk')->with('s3')->andReturn($disk);
+
+        $container = m::mock(Container::class);
+        $container->shouldReceive('make')->with('filesystem')->andReturn($filesystem);
+
+        $queue = new SqsQueue($this->sqs, $this->queueName, $this->prefix, '', false, [
+            'enabled' => true,
+            'driver' => 'filesystem',
+            'disk' => 's3',
+            'prefix' => 'custom/path',
+            'always' => true,
+            'delete_after_processing' => true,
+        ]);
+        $queue->setContainer($container);
+
+        $this->sqs->shouldReceive('sendMessage')->once()->withArgs(function ($args) use ($expectedPointer) {
+            return $args['MessageBody'] === $expectedPointer;
+        })->andReturn($this->mockedSendMessageResponseModel);
+
+        $queue->pushRaw($smallPayload, $this->queueName);
+    }
+
+    public function testPushRawDoesNotStoreToFilesystemWhenBelowThreshold()
+    {
+        $smallPayload = json_encode(['uuid' => 'test-uuid', 'job' => 'App\\Jobs\\TestJob', 'data' => 'small']);
+
+        $queue = new SqsQueue($this->sqs, $this->queueName, $this->prefix, '', false, [
+            'enabled' => true,
+            'driver' => 'filesystem',
+            'disk' => 's3',
+            'always' => false,
+            'delete_after_processing' => true,
+        ]);
+        $queue->setContainer(m::mock(Container::class));
+
+        $this->sqs->shouldReceive('sendMessage')->once()->withArgs(function ($args) use ($smallPayload) {
+            return $args['MessageBody'] === $smallPayload;
+        })->andReturn($this->mockedSendMessageResponseModel);
+
+        $queue->pushRaw($smallPayload, $this->queueName);
+    }
+
+    public function testClearDeletesOverflowDirectoryForFilesystemDriver()
+    {
+        $disk = m::mock(Filesystem::class);
+        $disk->shouldReceive('deleteDirectory')->once()->with('laravel/sqs-payloads');
+
+        $filesystem = m::mock(FilesystemFactory::class);
+        $filesystem->shouldReceive('disk')->with('s3')->andReturn($disk);
+
+        $container = m::mock(Container::class);
+        $container->shouldReceive('make')->with('filesystem')->andReturn($filesystem);
+
+        $queue = $this->getMockBuilder(SqsQueue::class)
+            ->onlyMethods(['getQueue', 'size'])
+            ->setConstructorArgs([$this->sqs, $this->queueName, $this->prefix, '', false, [
+                'enabled' => true,
+                'driver' => 'filesystem',
+                'disk' => 's3',
+                'prefix' => 'laravel/sqs-payloads',
+                'always' => false,
+                'delete_after_processing' => true,
+            ]])
+            ->getMock();
+        $queue->setContainer($container);
+        $queue->expects($this->once())->method('getQueue')->willReturn($this->queueUrl);
+        $queue->expects($this->once())->method('size')->willReturn(5);
+
+        $this->sqs->shouldReceive('purgeQueue')->once();
+
+        $queue->clear($this->queueName);
+    }
+
+    public function testClearDoesNotDeleteDirectoryForFilesystemWhenCleanupDisabled()
+    {
+        $queue = $this->getMockBuilder(SqsQueue::class)
+            ->onlyMethods(['getQueue', 'size'])
+            ->setConstructorArgs([$this->sqs, $this->queueName, $this->prefix, '', false, [
+                'enabled' => true,
+                'driver' => 'filesystem',
+                'disk' => 's3',
+                'prefix' => 'laravel/sqs-payloads',
+                'always' => false,
+                'delete_after_processing' => false,
+            ]])
+            ->getMock();
+        $queue->setContainer(m::mock(Container::class));
+        $queue->expects($this->once())->method('getQueue')->willReturn($this->queueUrl);
+        $queue->expects($this->once())->method('size')->willReturn(5);
+
+        $this->sqs->shouldReceive('purgeQueue')->once();
+
+        $queue->clear($this->queueName);
+    }
+
+    public function testPopPassesFilesystemOverflowStorageOptionsToJob()
+    {
+        $overflowStorage = [
+            'enabled' => true,
+            'driver' => 'filesystem',
+            'disk' => 's3',
             'always' => false,
             'delete_after_processing' => true,
         ];


### PR DESCRIPTION
Follow-up to #59734.

In the original PR I proposed offloading large SQS payloads to a filesystem disk (typically S3). Before merge that was changed over to cache stores. I asked in the PR comments whether you'd be open to making this configurable, and this is that PR. It adds a `driver` option under `overflow` so people can pick between `cache` (the current default) and `filesystem`.

A few reasons we want filesystem available:

- **AWS parity:** S3 is the storage AWS itself documents for this pattern. The Amazon SQS Extended Client Library for Java uses S3, and most engineers reaching for SQS overflow are coming from that pattern.
- **Persistence semantics:** Cache stores often have eviction or TTL behavior that doesn't suit job payloads which may sit on a queue for extended periods before a worker picks them up. Redis or Memcached behind a memory limit can drop the payload before the worker ever reads it. S3 and SQS, on the other hand, are both designed to hold data durably.
- **Compliance and audit:** For audited environments (SOC 2, ISO, HIPAA, etc.), putting job payloads on S3 is straightforward to document since it is an AWS-recommended standard. Putting them in a cache store adds audit surface and more work with auditors. At our scale that probably means we can't adopt the feature with cache as the only option.

The default stays `driver => 'cache'`, so nothing changes for anyone already using the feature as merged. (if that makes it out before and if this is merged)

## Config

```php
'overflow' => [
    'enabled' => env('SQS_OVERFLOW_ENABLED', false),
    'driver'  => env('SQS_OVERFLOW_DRIVER', 'cache'), // cache or filesystem
    'store'   => env('SQS_OVERFLOW_STORE'),           // when driver=cache
    'disk'    => env('SQS_OVERFLOW_DISK'),            // when driver=filesystem
    'prefix'  => env('SQS_OVERFLOW_PREFIX'),
    'always'  => false,
    'delete_after_processing' => true,
],
```

When `driver` is `filesystem`, the queue writes the payload to the configured disk at `{prefix}/{uuid}.json` and stores that path in the SQS message body as the pointer. Workers read the payload back from the same disk. `clear()` also removes the overflow directory when `delete_after_processing` is on.

When `driver` is `cache`, behavior is exactly what shipped in #59734.

## Tests

All existing cache-driver tests stay as-is. Filesystem mirrors added for:

- push at threshold
- `always => true`
- custom prefix
- below-threshold no-op
- `clear()` calls `deleteDirectory` when cleanup is on
- `clear()` skips it when cleanup is off
- `pop()` forwards filesystem config to the job
- pointer resolution and result caching on the job side
- file deletion on job completion (and the disabled case)
