### PR TITLE
[13.x] Add missing return types to additional pagination methods

### DIFF
--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -179,7 +179,7 @@ abstract class AbstractPaginator implements CanBeEscapedWhenCastToString, Htmlab
      * @param  int  $page
      * @return string
      */
-    public function url($page)
+    public function url($page): string
     {
         if ($page <= 0) {
             $page = 1;

--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -108,7 +108,7 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
     /**
      * Get the paginator links as a collection (for JSON responses).
      *
-     * @return \Illuminate\Support\Collection
+     * @return \Illuminate\Support\Collection<int, array{url: string|null, label: string, active: bool, page?: int|null}>
      */
     public function linkCollection()
     {


### PR DESCRIPTION
## why

sans these new annotations, wayfinder's generated typescript yields `unknown` type for pagination URLs and `Record<string, unknown>` for pagination `links`, instead of emitting known types `string` and `{ url: string | null, label: string, active: bool, page?: int | null }[]`, respectively.

this is a docblock + return type change only.