### PR TITLE
[12.x] backport #60101 to 12.x

### DIFF
--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -179,7 +179,7 @@ abstract class AbstractPaginator implements CanBeEscapedWhenCastToString, Htmlab
      * @param  int  $page
      * @return string
      */
-    public function url($page)
+    public function url($page): string
     {
         if ($page <= 0) {
             $page = 1;

--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -108,7 +108,7 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
     /**
      * Get the paginator links as a collection (for JSON responses).
      *
-     * @return \Illuminate\Support\Collection
+     * @return \Illuminate\Support\Collection<int, array{url: string|null, label: string, active: bool, page?: int|null}>
      */
     public function linkCollection()
     {


### PR DESCRIPTION
backport of https://github.com/laravel/framework/pull/60101 to 12.x

should be negligible backporting risk here, just a docblock change and a known return type annotation (see its preceding docblock)