### PR TITLE
[13.x] Allow passing a Closure to `ThrottlesExceptions` middleware

### DIFF
--- a/src/Illuminate/Queue/Middleware/ThrottlesExceptions.php
+++ b/src/Illuminate/Queue/Middleware/ThrottlesExceptions.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Queue\Middleware;
 
+use Closure;
 use Illuminate\Cache\RateLimiter;
 use Illuminate\Container\Container;
 use Throwable;
@@ -39,7 +40,7 @@ class ThrottlesExceptions
     /**
      * The number of minutes to wait before retrying the job after an exception.
      *
-     * @var int
+     * @var int|(\Closure(\Throwable): int)
      */
     protected $retryAfterMinutes = 0;
 
@@ -137,7 +138,7 @@ class ThrottlesExceptions
 
             $this->limiter->hit($jobKey, $this->decaySeconds);
 
-            return $job->release($this->retryAfterMinutes * 60);
+            return $job->release($this->getTimeUntilNextRetryAfterException($throwable));
         }
     }
 
@@ -234,7 +235,7 @@ class ThrottlesExceptions
     /**
      * Specify the number of minutes a job should be delayed when it is released (before it has reached its max exceptions).
      *
-     * @param  int  $backoff
+     * @param  int|(\Closure(\Throwable): int)  $backoff
      * @return $this
      */
     public function backoff($backoff)
@@ -242,6 +243,21 @@ class ThrottlesExceptions
         $this->retryAfterMinutes = $backoff;
 
         return $this;
+    }
+
+    /**
+     * Get the number of seconds that should elapse before the job is retried after an exception.
+     *
+     * @param  \Throwable  $throwable
+     * @return int
+     */
+    protected function getTimeUntilNextRetryAfterException(Throwable $throwable)
+    {
+        $backoff = $this->retryAfterMinutes instanceof Closure
+            ? call_user_func($this->retryAfterMinutes, $throwable)
+            : $this->retryAfterMinutes;
+
+        return $backoff * 60;
     }
 
     /**

--- a/src/Illuminate/Queue/Middleware/ThrottlesExceptionsWithRedis.php
+++ b/src/Illuminate/Queue/Middleware/ThrottlesExceptionsWithRedis.php
@@ -80,7 +80,7 @@ class ThrottlesExceptionsWithRedis extends ThrottlesExceptions
 
             $this->limiter->acquire();
 
-            return $job->release($this->retryAfterMinutes * 60);
+            return $job->release($this->getTimeUntilNextRetryAfterException($throwable));
         }
     }
 

--- a/tests/Integration/Queue/ThrottlesExceptionsTest.php
+++ b/tests/Integration/Queue/ThrottlesExceptionsTest.php
@@ -317,6 +317,38 @@ class ThrottlesExceptionsTest extends TestCase
         $this->assertTrue($job->handled);
     }
 
+    public function testItCanBackoffUsingException()
+    {
+        $job = new class
+        {
+            public $releasedAfter;
+
+            public function release($delay)
+            {
+                $this->releasedAfter = $delay;
+
+                return $this;
+            }
+        };
+        $expectedException = new RuntimeException('Whoops!');
+        $receivedException = null;
+        $next = function () use ($expectedException) {
+            throw $expectedException;
+        };
+
+        $middleware = (new ThrottlesExceptions())->backoff(function ($throwable) use (&$receivedException) {
+            $receivedException = $throwable;
+
+            return 5;
+        });
+
+        $result = $middleware->handle($job, $next);
+
+        $this->assertSame($job, $result);
+        $this->assertSame($expectedException, $receivedException);
+        $this->assertSame(300, $job->releasedAfter);
+    }
+
     public function testReportingExceptions()
     {
         $this->spy(ExceptionHandler::class)

--- a/tests/Integration/Queue/ThrottlesExceptionsWithRedisTest.php
+++ b/tests/Integration/Queue/ThrottlesExceptionsWithRedisTest.php
@@ -150,6 +150,38 @@ class ThrottlesExceptionsWithRedisTest extends TestCase
         $middleware->report(fn () => false);
         $middleware->handle($job, $next);
     }
+
+    public function testItCanBackoffUsingException()
+    {
+        $job = new class
+        {
+            public $releasedAfter;
+
+            public function release($delay)
+            {
+                $this->releasedAfter = $delay;
+
+                return $this;
+            }
+        };
+        $expectedException = new RuntimeException('Whoops!');
+        $receivedException = null;
+        $next = function () use ($expectedException) {
+            throw $expectedException;
+        };
+
+        $middleware = (new ThrottlesExceptionsWithRedis())->backoff(function ($throwable) use (&$receivedException) {
+            $receivedException = $throwable;
+
+            return 5;
+        });
+
+        $result = $middleware->handle($job, $next);
+
+        $this->assertSame($job, $result);
+        $this->assertSame($expectedException, $receivedException);
+        $this->assertSame(300, $job->releasedAfter);
+    }
 }
 
 class CircuitBreakerWithRedisTestJob


### PR DESCRIPTION
I noticed a clanker put up some code today like this:

```php

public function middleware(): array
{
    return [
        (new ThrottlesExceptions(maxAttempts: 10, decaySeconds: 300))
            ->byJob()
            ->when(
                fn (Throwable $throwable): bool => $throwable instanceof ExternalAPIException 
                    && $throwable->isRateLimited()
            )
            ->backoff(2),
    ];
}
```

The `ExternalAPIException` has a property for reading the Retry-After header, and it would be great to be able to employ that, like so:

```php
    return [
        (new ThrottlesExceptions(maxAttempts: 10, decaySeconds: 300))
            ->byJob()
            ->when(
                fn (Throwable $throwable): bool => $throwable instanceof ExternalAPIException 
                    && $throwable->isRateLimited()
            )
            ->backoff(fn (Throwable $throwable) => $throwable instanceof ExternalAPIException 
                ? $throwable->retryAfter() / 60
                : 2
            ),
    ];
```