### PR TITLE
[13.x] Support Concurrency Run Timeouts

### DIFF
--- a/src/Illuminate/Concurrency/ForkDriver.php
+++ b/src/Illuminate/Concurrency/ForkDriver.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Concurrency;
 
+use Carbon\CarbonInterval;
 use Closure;
 use Illuminate\Contracts\Concurrency\Driver;
 use Illuminate\Support\Arr;
@@ -15,7 +16,7 @@ class ForkDriver implements Driver
     /**
      * Run the given tasks concurrently and return an array containing the results.
      */
-    public function run(Closure|array $tasks): array
+    public function run(Closure|array $tasks, CarbonInterval|int|null $timeout = null): array
     {
         $tasks = Arr::wrap($tasks);
 

--- a/src/Illuminate/Concurrency/ProcessDriver.php
+++ b/src/Illuminate/Concurrency/ProcessDriver.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Concurrency;
 
+use Carbon\CarbonInterval;
 use Closure;
 use Exception;
 use Illuminate\Console\Application;
@@ -29,17 +30,21 @@ class ProcessDriver implements Driver
      *
      * @throws \Throwable
      */
-    public function run(Closure|array $tasks): array
+    public function run(Closure|array $tasks, CarbonInterval|int|null $timeout = null): array
     {
         $command = Application::formatCommandString('invoke-serialized-closure');
 
-        $results = $this->processFactory->pool(function (Pool $pool) use ($tasks, $command) {
+        $results = $this->processFactory->pool(function (Pool $pool) use ($tasks, $command, $timeout) {
             foreach (Arr::wrap($tasks) as $key => $task) {
-                $pool->as($key)->path(base_path())->env([
+                $process = $pool->as($key)->path(base_path())->env([
                     'LARAVEL_INVOKABLE_CLOSURE' => base64_encode(
                         serialize(new SerializableClosure($task))
                     ),
                 ])->command($command);
+
+                if (! is_null($timeout)) {
+                    $process->timeout($timeout);
+                }
             }
         })->start()->wait();
 

--- a/src/Illuminate/Concurrency/SyncDriver.php
+++ b/src/Illuminate/Concurrency/SyncDriver.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Concurrency;
 
+use Carbon\CarbonInterval;
 use Closure;
 use Illuminate\Contracts\Concurrency\Driver;
 use Illuminate\Support\Collection;
@@ -14,7 +15,7 @@ class SyncDriver implements Driver
     /**
      * Run the given tasks concurrently and return an array containing the results.
      */
-    public function run(Closure|array $tasks): array
+    public function run(Closure|array $tasks, CarbonInterval|int|null $timeout = null): array
     {
         return Collection::wrap($tasks)->map(
             fn ($task) => $task()

--- a/src/Illuminate/Contracts/Concurrency/Driver.php
+++ b/src/Illuminate/Contracts/Concurrency/Driver.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Contracts\Concurrency;
 
+use Carbon\CarbonInterval;
 use Closure;
 use Illuminate\Support\Defer\DeferredCallback;
 
@@ -10,7 +11,7 @@ interface Driver
     /**
      * Run the given tasks concurrently and return an array containing the results.
      */
-    public function run(Closure|array $tasks): array;
+    public function run(Closure|array $tasks, CarbonInterval|int|null $timeout = null): array;
 
     /**
      * Defer the execution of the given tasks.

--- a/src/Illuminate/Support/Facades/Concurrency.php
+++ b/src/Illuminate/Support/Facades/Concurrency.php
@@ -17,7 +17,7 @@ use Illuminate\Concurrency\ConcurrencyManager;
  * @method static void purge(string|null $name = null)
  * @method static \Illuminate\Concurrency\ConcurrencyManager extend(string $name, \Closure $callback)
  * @method static \Illuminate\Concurrency\ConcurrencyManager setApplication(\Illuminate\Contracts\Foundation\Application $app)
- * @method static array run(\Closure|array $tasks)
+ * @method static array run(\Closure|array $tasks, \Carbon\CarbonInterval|int|null $timeout = null)
  * @method static \Illuminate\Support\Defer\DeferredCallback defer(\Closure|array $tasks)
  *
  * @see \Illuminate\Concurrency\ConcurrencyManager

--- a/tests/Integration/Concurrency/ConcurrencyTest.php
+++ b/tests/Integration/Concurrency/ConcurrencyTest.php
@@ -89,6 +89,26 @@ PHP);
         // $this->assertEquals(4, $forkOutput['second']);
     }
 
+    public function testProcessDriverRunMayUseCustomTimeout()
+    {
+        $factory = $this->app->make(ProcessFactory::class);
+
+        $factory->fake(fn () => $factory->result(json_encode([
+            'successful' => true,
+            'result' => serialize('result'),
+        ])));
+
+        $result = (new ProcessDriver($factory))->run([
+            fn () => 'result',
+        ], timeout: 120);
+
+        $this->assertSame(['result'], $result);
+
+        $factory->assertRan(function ($process) {
+            return $process->timeout === 120;
+        });
+    }
+
     public function testDriverCanBeResolvedUsingBackedEnum()
     {
         $this->assertInstanceOf(


### PR DESCRIPTION
`Concurrency::run()` currently uses the process driver by default, where each task is executed through Laravel’s process layer. That process layer has a **default 60-second timeou**t, but `Concurrency::run()` did not expose a way to customize it.

This PR adds support for passing a custom timeout when using the process driver:

```php
Concurrency::run([
    fn () => longRunningTask(),
], timeout: 300);
```

The fork driver is left unchanged because `spatie/fork` does not support task timeouts. The sync driver also keeps its existing behavior, since it runs tasks inline and a process timeout would not apply.