### PR TITLE
[13.x] Simplify the make:event command.

### DIFF
--- a/src/Illuminate/Foundation/Console/EventMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/EventMakeCommand.php
@@ -49,6 +49,10 @@ class EventMakeCommand extends GeneratorCommand
      */
     protected function getStub()
     {
+        if ($this->option('broadcast')) {
+            return $this->resolveStubPath('/stubs/broadcast-event.stub');
+        }
+
         return $this->resolveStubPath('/stubs/event.stub');
     }
 
@@ -85,6 +89,7 @@ class EventMakeCommand extends GeneratorCommand
     {
         return [
             ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the event already exists'],
+            ['broadcast', 'b', InputOption::VALUE_NONE, 'Create a new event class for broadcasting'],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/stubs/broadcast-event.stub
+++ b/src/Illuminate/Foundation/Console/stubs/broadcast-event.stub
@@ -1,0 +1,36 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class {{ class }} implements ShouldBroadcast
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return array<int, Channel>
+     */
+    public function broadcastOn(): array
+    {
+        return [
+            new PrivateChannel('channel-name'),
+        ];
+    }
+}

--- a/src/Illuminate/Foundation/Console/stubs/event.stub
+++ b/src/Illuminate/Foundation/Console/stubs/event.stub
@@ -2,17 +2,12 @@
 
 namespace {{ namespace }};
 
-use Illuminate\Broadcasting\Channel;
-use Illuminate\Broadcasting\InteractsWithSockets;
-use Illuminate\Broadcasting\PresenceChannel;
-use Illuminate\Broadcasting\PrivateChannel;
-use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 
 class {{ class }}
 {
-    use Dispatchable, InteractsWithSockets, SerializesModels;
+    use Dispatchable, SerializesModels;
 
     /**
      * Create a new event instance.
@@ -20,17 +15,5 @@ class {{ class }}
     public function __construct()
     {
         //
-    }
-
-    /**
-     * Get the channels the event should broadcast on.
-     *
-     * @return array<int, Channel>
-     */
-    public function broadcastOn(): array
-    {
-        return [
-            new PrivateChannel('channel-name'),
-        ];
     }
 }

--- a/tests/Integration/Generators/EventMakeCommandTest.php
+++ b/tests/Integration/Generators/EventMakeCommandTest.php
@@ -8,7 +8,7 @@ class EventMakeCommandTest extends TestCase
         'app/Events/FooCreated.php',
     ];
 
-    public function testItCanGenerateEventFile()
+    public function testItCanGenerateBareMinimumEventFile()
     {
         $this->artisan('make:event', ['name' => 'FooCreated'])
             ->assertExitCode(0);
@@ -16,6 +16,24 @@ class EventMakeCommandTest extends TestCase
         $this->assertFileContains([
             'namespace App\Events;',
             'class FooCreated',
+            'use Dispatchable, SerializesModels;',
+        ], 'app/Events/FooCreated.php');
+    }
+
+    public function testItCanGenerateBroadcastEventFile()
+    {
+        $this->artisan('make:event', ['name' => 'FooCreated', '--broadcast' => true])
+            ->assertExitCode(0);
+
+        $this->assertFileContains([
+            'namespace App\Events;',
+            'use Illuminate\Broadcasting\Channel;',
+            'use Illuminate\Broadcasting\InteractsWithSockets;',
+            'use Illuminate\Broadcasting\PresenceChannel;',
+            'use Illuminate\Broadcasting\PrivateChannel;',
+            'use Illuminate\Contracts\Broadcasting\ShouldBroadcast;',
+            'class FooCreated implements ShouldBroadcast',
+            'use Dispatchable, InteractsWithSockets, SerializesModels;',
         ], 'app/Events/FooCreated.php');
     }
 }


### PR DESCRIPTION
Whenever I create a new event, I always have a bunch of references to classes used for broadcasting and the `broadcastOn` method by default.

99% of the time I don't use events for broadcasting. I believe that the generated event should be bare minimum by default.

If we want events for broadcasting, lets use the new `--broadcast` option.