### PR TITLE
Fix/invalid pagination edge case

### DIFF
--- a/tests/Pagination/LengthAwarePaginatorTest.php
+++ b/tests/Pagination/LengthAwarePaginatorTest.php
@@ -58,6 +58,21 @@ class LengthAwarePaginatorTest extends TestCase
         $this->assertEmpty($paginator->items());
     }
 
+    public function testLengthAwarePaginatorRetainsRequestedPageWhenDatasetShrinks()
+    {
+        $beforeDatasetChange = new LengthAwarePaginator(['item16'], 16, 15, 2);
+
+        $this->assertSame(2, $beforeDatasetChange->currentPage());
+        $this->assertSame(2, $beforeDatasetChange->lastPage());
+        $this->assertCount(1, $beforeDatasetChange->items());
+
+        $afterDatasetChange = new LengthAwarePaginator([], 15, 15, 2);
+
+        $this->assertSame(2, $afterDatasetChange->currentPage());
+        $this->assertSame(1, $afterDatasetChange->lastPage());
+        $this->assertEmpty($afterDatasetChange->items());
+    }
+
     public function testLengthAwarePaginatorOnFirstAndLastPage()
     {
         $paginator = new LengthAwarePaginator(['1', '2', '3', '4'], 4, 2, 2);

--- a/tests/Pagination/LengthAwarePaginatorTest.php
+++ b/tests/Pagination/LengthAwarePaginatorTest.php
@@ -60,17 +60,29 @@ class LengthAwarePaginatorTest extends TestCase
 
     public function testLengthAwarePaginatorRetainsRequestedPageWhenDatasetShrinks()
     {
-        $beforeDatasetChange = new LengthAwarePaginator(['item16'], 16, 15, 2);
+        // Initial paginator state (valid dataset)
+        $before = new LengthAwarePaginator(
+            ['item16'],
+            16,
+            15,
+            2
+        );
 
-        $this->assertSame(2, $beforeDatasetChange->currentPage());
-        $this->assertSame(2, $beforeDatasetChange->lastPage());
-        $this->assertCount(1, $beforeDatasetChange->items());
+        $this->assertSame(2, $before->currentPage());
+        $this->assertSame(2, $before->lastPage());
+        $this->assertCount(1, $before->items());
 
-        $afterDatasetChange = new LengthAwarePaginator([], 15, 15, 2);
+        // New paginator instance with reduced dataset (separate request simulation)
+        $after = new LengthAwarePaginator(
+            [],
+            15,
+            15,
+            2
+        );
 
-        $this->assertSame(2, $afterDatasetChange->currentPage());
-        $this->assertSame(1, $afterDatasetChange->lastPage());
-        $this->assertEmpty($afterDatasetChange->items());
+        $this->assertSame(2, $after->currentPage());
+        $this->assertSame(1, $after->lastPage());
+        $this->assertEmpty($after->items());
     }
 
     public function testLengthAwarePaginatorOnFirstAndLastPage()

--- a/tests/Pagination/PaginatorTest.php
+++ b/tests/Pagination/PaginatorTest.php
@@ -35,17 +35,21 @@ class PaginatorTest extends TestCase
 
     public function testSimplePaginatorRetainsRequestedPageWhenDatasetShrinks()
     {
-        $beforeDatasetChange = new Paginator(['item16'], 15, 2);
+         // Initial paginator state
+    $paginator = new Paginator(['item16'], 15, 2);
 
-        $this->assertSame(2, $beforeDatasetChange->currentPage());
-        $this->assertSame(['item16'], $beforeDatasetChange->items());
-        $this->assertFalse($beforeDatasetChange->hasMorePages());
+    $this->assertSame(2, $paginator->currentPage());
+    $this->assertSame(['item16'], $paginator->items());
+    $this->assertFalse($paginator->hasMorePages());
+    $this->assertSame(15, $paginator->perPage());
 
-        $afterDatasetChange = new Paginator([], 15, 2);
+    // Simulated "new request" with empty dataset (not mutation, just new instance)
+    $paginatorAfter = new Paginator([], 15, 2);
 
-        $this->assertSame(2, $afterDatasetChange->currentPage());
-        $this->assertSame([], $afterDatasetChange->items());
-        $this->assertFalse($afterDatasetChange->hasMorePages());
+    $this->assertSame(2, $paginatorAfter->currentPage());
+    $this->assertSame([], $paginatorAfter->items());
+    $this->assertFalse($paginatorAfter->hasMorePages());
+    $this->assertSame(15, $paginatorAfter->perPage());
     }
 
     public function testPaginatorRemovesTrailingSlashes()

--- a/tests/Pagination/PaginatorTest.php
+++ b/tests/Pagination/PaginatorTest.php
@@ -35,21 +35,21 @@ class PaginatorTest extends TestCase
 
     public function testSimplePaginatorRetainsRequestedPageWhenDatasetShrinks()
     {
-         // Initial paginator state
-    $paginator = new Paginator(['item16'], 15, 2);
+        // Initial paginator state
+        $paginator = new Paginator(['item16'], 15, 2);
 
-    $this->assertSame(2, $paginator->currentPage());
-    $this->assertSame(['item16'], $paginator->items());
-    $this->assertFalse($paginator->hasMorePages());
-    $this->assertSame(15, $paginator->perPage());
+        $this->assertSame(2, $paginator->currentPage());
+        $this->assertSame(['item16'], $paginator->items());
+        $this->assertFalse($paginator->hasMorePages());
+        $this->assertSame(15, $paginator->perPage());
 
-    // Simulated "new request" with empty dataset (not mutation, just new instance)
-    $paginatorAfter = new Paginator([], 15, 2);
+        // Simulated "new request" with empty dataset (not mutation, just new instance)
+        $paginatorAfter = new Paginator([], 15, 2);
 
-    $this->assertSame(2, $paginatorAfter->currentPage());
-    $this->assertSame([], $paginatorAfter->items());
-    $this->assertFalse($paginatorAfter->hasMorePages());
-    $this->assertSame(15, $paginatorAfter->perPage());
+        $this->assertSame(2, $paginatorAfter->currentPage());
+        $this->assertSame([], $paginatorAfter->items());
+        $this->assertFalse($paginatorAfter->hasMorePages());
+        $this->assertSame(15, $paginatorAfter->perPage());
     }
 
     public function testPaginatorRemovesTrailingSlashes()

--- a/tests/Pagination/PaginatorTest.php
+++ b/tests/Pagination/PaginatorTest.php
@@ -33,6 +33,21 @@ class PaginatorTest extends TestCase
         $this->assertEquals($pageInfo, $p->toArray());
     }
 
+    public function testSimplePaginatorRetainsRequestedPageWhenDatasetShrinks()
+    {
+        $beforeDatasetChange = new Paginator(['item16'], 15, 2);
+
+        $this->assertSame(2, $beforeDatasetChange->currentPage());
+        $this->assertSame(['item16'], $beforeDatasetChange->items());
+        $this->assertFalse($beforeDatasetChange->hasMorePages());
+
+        $afterDatasetChange = new Paginator([], 15, 2);
+
+        $this->assertSame(2, $afterDatasetChange->currentPage());
+        $this->assertSame([], $afterDatasetChange->items());
+        $this->assertFalse($afterDatasetChange->hasMorePages());
+    }
+
     public function testPaginatorRemovesTrailingSlashes()
     {
         $p = new Paginator(['item1', 'item2', 'item3'], 2, 2, ['path' => 'http://website.com/test/']);


### PR DESCRIPTION
Adds focused regression coverage for paginator behavior when a requested page becomes effectively invalid after dataset shrink (for example, after deletes).
Confirms both LengthAwarePaginator and Paginator retain the requested page while returning an empty slice when that page no longer has items.
Includes a docblock typing improvement for LengthAwarePaginator::linkCollection() by specifying the returned collection item shape for stronger IDE/static-analysis inference.
No runtime pagination logic changes; this PR adds coverage and type clarity only.