### PR TITLE
[13.x] Optimize Worker queue pause check

### DIFF
--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -285,6 +285,24 @@ class QueueManager implements FactoryContract, MonitorContract
     }
 
     /**
+     * Determine which of the given queues are currently paused.
+     *
+     * @param  string  $connection
+     * @param  array  $queues
+     * @return array
+     */
+    public function getPausedQueues($connection, $queues)
+    {
+        $keys = array_map(fn ($queue) => "illuminate:queue:paused:{$connection}:{$queue}", $queues);
+
+        $states = $this->app['cache']->store()->many($keys);
+
+        return array_values(array_filter(
+            $queues, fn ($queue) => $states["illuminate:queue:paused:{$connection}:{$queue}"] ?? false
+        ));
+    }
+
+    /**
      * Indicate that queue workers should not poll for restart or pause signals.
      *
      * This prevents the workers from hitting the application cache to determine if they need to pause or restart.

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -418,8 +418,12 @@ class Worker
                 return $job;
             }
 
-            foreach (explode(',', $queue) as $index => $queue) {
-                if ($this->queuePaused($connection->getConnectionName(), $queue)) {
+            $queues = explode(',', $queue);
+
+            $paused = array_flip($this->getPausedQueues($connection->getConnectionName(), $queues));
+
+            foreach ($queues as $index => $queue) {
+                if (isset($paused[$queue])) {
                     continue;
                 }
 
@@ -439,19 +443,23 @@ class Worker
     }
 
     /**
-     * Determine if a given connection and queue is paused.
+     * Determine which of the given queues are currently paused.
      *
      * @param  string  $connectionName
-     * @param  string  $queue
-     * @return bool
+     * @param  array  $queues
+     * @return array
      */
-    protected function queuePaused($connectionName, $queue)
+    protected function getPausedQueues($connectionName, $queues)
     {
         if (! static::$pausable) {
-            return false;
+            return [];
         }
 
-        return $this->cache && $this->manager->isPaused($connectionName, $queue);
+        if ($this->cache === null) {
+            return [];
+        }
+
+        return $this->manager->getPausedQueues($connectionName, $queues);
     }
 
     /**

--- a/tests/Integration/Queue/WorkCommandTest.php
+++ b/tests/Integration/Queue/WorkCommandTest.php
@@ -195,7 +195,7 @@ class WorkCommandTest extends QueueTestCase
 
         $cache = m::mock(Repository::class);
         $cache->shouldNotReceive('get')->with('illuminate:queue:restart');
-        $cache->shouldReceive('get')->with(m::pattern('/^illuminate:queue:paused:/'), false);
+        $cache->shouldReceive('many')->andReturn([]);
 
         $cacheManager = m::mock(CacheManager::class);
         $cacheManager->shouldReceive('driver')->andReturn($cache);
@@ -225,7 +225,7 @@ class WorkCommandTest extends QueueTestCase
         $cache = m::mock(Repository::class);
 
         $cache->shouldReceive('get')->with('illuminate:queue:restart')->andReturn(null);
-        $cache->shouldNotReceive('get')->with(m::pattern('/^illuminate:queue:paused:/'), false);
+        $cache->shouldNotReceive('many');
 
         $cacheManager = m::mock(CacheManager::class);
         $cacheManager->shouldReceive('driver')->andReturn($cache);

--- a/tests/Queue/QueuePauseResumeTest.php
+++ b/tests/Queue/QueuePauseResumeTest.php
@@ -161,6 +161,19 @@ class QueuePauseResumeTest extends TestCase
         $this->assertSame('notifications', $dispatchedEvent->queue);
     }
 
+    public function testGetPausedQueues()
+    {
+        $this->assertSame([], $this->manager->getPausedQueues('redis', ['default', 'emails']));
+
+        $this->manager->pause('redis', 'emails');
+        $this->manager->pause('redis', 'notifications');
+
+        $this->assertSame(
+            ['emails', 'notifications'],
+            $this->manager->getPausedQueues('redis', ['default', 'emails', 'notifications'])
+        );
+    }
+
     public function testParsingQueueString()
     {
         $parser = new class()


### PR DESCRIPTION
As per your feedback [here](https://github.com/laravel/framework/pull/60084#issuecomment-4441804647) this is targetted at 13.x. 


### Why
 
If you have pausing enabled each queue you set will hit the cache 1x every single job, so if you have `queue:work --queue=high,default` both the high and default queue will have a cache hit every job, do one million jobs and thats 2 million cache hits.

Now, scale it up to 10 workers 2 queues each some even 4, and it can suddenly get crazy... (this is just a staging site)

<img width="879" height="61" alt="image" src="https://github.com/user-attachments/assets/ca0223fa-b9da-4416-9859-5d2135f1e4d3" />


### What this does

This changes the `getPausedQueues` method on the worker to `getPausedQueues` - this is a B/C but I couldnt see a better way - unless we deprecate the old method and add a new one 🤷🏻
 
 All this PR does is use `many()`, so we can do one round trip and attempt at making it more performant. This is even more helpful the more queues and workers you have.

This may need tweaking, and a bit of love so hash at it 

Secret message : SGVsbG8gTXIgT3R3ZWxs
