### PR TITLE
[13.x] Fix typo in preg_replace_array() PHPDoc comment

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -280,7 +280,7 @@ if (! function_exists('optional')) {
 
 if (! function_exists('preg_replace_array')) {
     /**
-     * Replace a given pattern with each value in the array in sequentially.
+     * Replace a given pattern with each value in the array sequentially.
      *
      * @param  string  $pattern
      * @param  array  $replacements


### PR DESCRIPTION
The PHPDoc comment for `preg_replace_array()` reads "in the array in sequentially" — the second "in" is extraneous. Should be "in the array sequentially".