### PR TITLE
[13.x] Fix typo in mergeAttributeFromCachedCasts() PHPDoc comment

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1931,7 +1931,7 @@ trait HasAttributes
     }
 
     /**
-     * Merge the a cast class and attribute cast attribute back into the model.
+     * Merge the cast class and attribute cast attribute back into the model.
      *
      * @return void
      */


### PR DESCRIPTION
The PHPDoc for `mergeAttributeFromCachedCasts()` reads "Merge the a cast class and attribute cast attribute back into the model." — the extra "a" before "cast class" is a copy-paste artifact. The sibling `mergeAttributesFromCachedCasts()` (plural, just above) has the correct phrasing without it.