### PR TITLE
Add unicode modifier to Str::limit() regex for preserveWords

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -744,7 +744,7 @@ class Str
             return $trimmed.$end;
         }
 
-        return preg_replace("/(.*)\s.*/", '$1', $trimmed).$end;
+        return preg_replace("/(.*)\s.*/u", '$1', $trimmed).$end;
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -822,6 +822,10 @@ class SupportStrTest extends TestCase
         $this->assertSame('这是一...', Str::limit($nonAsciiString, 6, preserveWords: true));
         $this->assertSame('这是一', Str::limit($nonAsciiString, 6, ''));
         $this->assertSame('这是一', Str::limit($nonAsciiString, 6, '', true));
+
+        // Test with Unicode whitespace (non-breaking space) when preserveWords is true
+        $unicodeWhitespaceString = 'Laravel PHP Framework'; // Non-breaking spaces (U+00A0)
+        $this->assertSame('Laravel PHP...', Str::limit($unicodeWhitespaceString, 15, '...', true));
     }
 
     public function testLength()


### PR DESCRIPTION
## Summary
When using `Str::limit()` with `preserveWords: true`, the regex pattern `/(.*)\s.*/` did not have the `/u` modifier. This caused Unicode whitespace characters (like non-breaking space U+00A0) to not be recognized as word boundaries.

## Example
```php
// Before (incorrect):
Str::limit('Laravel PHP Framework', 15, '...', true);
// With non-breaking spaces, returned: 'Laravel PHP Fra...' (didn't find word boundary)

// After (correct):
Str::limit('Laravel PHP Framework', 15, '...', true);
// Returns: 'Laravel PHP...' (correctly finds Unicode space boundary)