### PR TITLE
[13.x] Add Number::flushState() and reset in test teardown

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
@@ -38,6 +38,7 @@ use Illuminate\Support\EncodedHtmlString;
 use Illuminate\Support\Facades\Facade;
 use Illuminate\Support\Facades\ParallelTesting;
 use Illuminate\Support\Lottery;
+use Illuminate\Support\Number;
 use Illuminate\Support\Once;
 use Illuminate\Support\Sleep;
 use Illuminate\Support\Str;
@@ -195,6 +196,7 @@ trait InteractsWithTestCaseLifecycle
         Lottery::determineResultsNormally();
         Markdown::flushState();
         Migrator::withoutMigrations([]);
+        Number::flushState();
         Once::flush();
         PreventRequestsDuringMaintenance::flushState();
         Queue::createPayloadUsing(null);

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -437,6 +437,17 @@ class Number
     }
 
     /**
+     * Flush the state of the Number class.
+     *
+     * @return void
+     */
+    public static function flushState()
+    {
+        static::$locale = 'en';
+        static::$currency = 'USD';
+    }
+
+    /**
      * Ensure the "intl" PHP extension is installed.
      *
      * @return void

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -18,6 +18,20 @@ class SupportNumberTest extends TestCase
         $this->assertSame('USD', Number::defaultCurrency());
     }
 
+    public function testFlushState()
+    {
+        Number::useLocale('de');
+        Number::useCurrency('EUR');
+
+        $this->assertSame('de', Number::defaultLocale());
+        $this->assertSame('EUR', Number::defaultCurrency());
+
+        Number::flushState();
+
+        $this->assertSame('en', Number::defaultLocale());
+        $this->assertSame('USD', Number::defaultCurrency());
+    }
+
     #[RequiresPhpExtension('intl')]
     public function testFormat()
     {


### PR DESCRIPTION
`Number::useLocale()` and `Number::useCurrency()` set process-global state (`$locale`, `$currency`), but there's no reset hook — tests that change either leak into subsequent tests. The existing `testFormatWithAppLocale` in `SupportNumberTest` even resets manually via `Number::useLocale('en')` at the end, which would leak if the assertion above fails.

Adding `Number::flushState()` (mirroring `Markdown::flushState()`, `JsonResource::flushState()`, etc.) and calling it from `tearDownTheTestEnvironment()` alongside the existing `Lottery::determineResultsNormally()` added in #60083.