### PR TITLE
Fix typo in docblock for listManagementOptions method in SesV2Transport

### DIFF
--- a/src/Illuminate/Mail/Transport/SesV2Transport.php
+++ b/src/Illuminate/Mail/Transport/SesV2Transport.php
@@ -100,7 +100,7 @@ class SesV2Transport extends AbstractTransport implements Stringable
     }
 
     /**
-     * Extract the SES list managenent options, if applicable.
+     * Extract the SES list management options, if applicable.
      *
      * @param  \Symfony\Component\Mailer\SentMessage  $message
      * @return array|null


### PR DESCRIPTION
Hello! 
This change is fixing a typo in the `\Illuminate\Mail\Transport\SesV2Transport::listManagementOptions()` docblock: 'managenent' which should be 'management'.
