### PR TITLE
[13.x] Fix database cache driver staleness in parallel testing

### DIFF
--- a/src/Illuminate/Cache/RateLimiter.php
+++ b/src/Illuminate/Cache/RateLimiter.php
@@ -39,6 +39,19 @@ class RateLimiter
     }
 
     /**
+     * Set the cache store implementation.
+     *
+     * @param  \Illuminate\Contracts\Cache\Repository  $cache
+     * @return $this
+     */
+    public function setCache(Cache $cache)
+    {
+        $this->cache = $cache;
+
+        return $this;
+    }
+
+    /**
      * Register a named rate limiter configuration.
      *
      * @param  \UnitEnum|string  $name

--- a/src/Illuminate/Testing/Concerns/TestDatabases.php
+++ b/src/Illuminate/Testing/Concerns/TestDatabases.php
@@ -175,13 +175,13 @@ trait TestDatabases
     {
         DB::purge();
 
-        // Forget cached stores and resolved singletons holding references to
-        // the previous connection, which would otherwise reconnect against
-        // the new database config and silently swap the active PDO.
+        // Forget cached stores and refresh resolved singletons that hold a
+        // reference to the previous connection, which would otherwise reconnect
+        // against the new database config and silently swap the active PDO.
         Cache::forgetDriver();
 
         if (app()->resolved(RateLimiter::class)) {
-            app()->forgetInstance(RateLimiter::class);
+            app(RateLimiter::class)->setCache(Cache::driver());
         }
 
         $default = config('database.default');

--- a/src/Illuminate/Testing/Concerns/TestDatabases.php
+++ b/src/Illuminate/Testing/Concerns/TestDatabases.php
@@ -2,10 +2,12 @@
 
 namespace Illuminate\Testing\Concerns;
 
+use Illuminate\Cache\RateLimiter;
 use Illuminate\Database\QueryException;
 use Illuminate\Foundation\Testing;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\ParallelTesting;
 use Illuminate\Support\Facades\Schema;
@@ -172,6 +174,15 @@ trait TestDatabases
     protected function switchToDatabase($database)
     {
         DB::purge();
+
+        // Forget cached stores and resolved singletons holding references to
+        // the previous connection, which would otherwise reconnect against
+        // the new database config and silently swap the active PDO.
+        Cache::forgetDriver();
+
+        if (app()->resolved(RateLimiter::class)) {
+            app()->forgetInstance(RateLimiter::class);
+        }
 
         $default = config('database.default');
 

--- a/tests/Testing/Concerns/TestDatabasesTest.php
+++ b/tests/Testing/Concerns/TestDatabasesTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Testing\Concerns;
 use Illuminate\Cache\RateLimiter;
 use Illuminate\Config\Repository as Config;
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Cache\Repository;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Testing\Concerns\TestDatabases;
@@ -68,13 +69,16 @@ class TestDatabasesTest extends TestCase
         $this->switchToDatabase($testDatabase);
     }
 
-    public function testSwitchToDatabaseForgetsResolvedRateLimiterSingleton()
+    public function testSwitchToDatabaseRefreshesResolvedRateLimiterCache()
     {
         $container = Container::getInstance();
-        $container->instance(RateLimiter::class, m::mock(RateLimiter::class));
+        $rateLimiter = m::mock(RateLimiter::class);
+        $rateLimiter->shouldReceive('setCache')->once();
+        $container->instance(RateLimiter::class, $rateLimiter);
 
         DB::shouldReceive('purge')->once();
         Cache::shouldReceive('forgetDriver')->once();
+        Cache::shouldReceive('driver')->once()->andReturn(m::mock(Repository::class));
 
         config()->shouldReceive('get')
             ->once()
@@ -89,7 +93,34 @@ class TestDatabasesTest extends TestCase
 
         $this->switchToDatabase('my_database_test_1');
 
-        $this->assertFalse($container->resolved(RateLimiter::class));
+        $this->assertTrue($container->resolved(RateLimiter::class));
+    }
+
+    public function testSwitchToDatabasePreservesRegisteredRateLimiters()
+    {
+        $container = Container::getInstance();
+        $container->instance(RateLimiter::class, new RateLimiter(m::mock(Repository::class)));
+
+        $limiter = app(RateLimiter::class);
+        $limiter->for('login', fn () => null);
+
+        DB::shouldReceive('purge')->once();
+        Cache::shouldReceive('forgetDriver')->once();
+        Cache::shouldReceive('driver')->once()->andReturn(m::mock(Repository::class));
+
+        config()->shouldReceive('get')
+            ->once()
+            ->with('database.connections.mysql.url', false)
+            ->andReturn(false);
+
+        config()->shouldReceive('set')
+            ->once()
+            ->with('database.connections.mysql.database', 'my_database_test_1');
+
+        $this->switchToDatabase('my_database_test_1');
+
+        $this->assertSame($limiter, app(RateLimiter::class));
+        $this->assertNotNull(app(RateLimiter::class)->limiter('login'));
     }
 
     public function testSwitchToDatabaseDoesNotResolveRateLimiterIfUnresolved()

--- a/tests/Testing/Concerns/TestDatabasesTest.php
+++ b/tests/Testing/Concerns/TestDatabasesTest.php
@@ -2,8 +2,10 @@
 
 namespace Illuminate\Tests\Testing\Concerns;
 
+use Illuminate\Cache\RateLimiter;
 use Illuminate\Config\Repository as Config;
 use Illuminate\Container\Container;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Testing\Concerns\TestDatabases;
 use Mockery as m;
@@ -34,6 +36,7 @@ class TestDatabasesTest extends TestCase
     public function testSwitchToDatabaseWithoutUrl()
     {
         DB::shouldReceive('purge')->once();
+        Cache::shouldReceive('forgetDriver')->once();
 
         config()->shouldReceive('get')
             ->once()
@@ -51,6 +54,7 @@ class TestDatabasesTest extends TestCase
     public function testSwitchToDatabaseWithUrl($testDatabase, $url, $testUrl)
     {
         DB::shouldReceive('purge')->once();
+        Cache::shouldReceive('forgetDriver')->once();
 
         config()->shouldReceive('get')
             ->once()
@@ -62,6 +66,53 @@ class TestDatabasesTest extends TestCase
             ->with('database.connections.mysql.url', $testUrl);
 
         $this->switchToDatabase($testDatabase);
+    }
+
+    public function testSwitchToDatabaseForgetsResolvedRateLimiterSingleton()
+    {
+        $container = Container::getInstance();
+        $container->instance(RateLimiter::class, m::mock(RateLimiter::class));
+
+        DB::shouldReceive('purge')->once();
+        Cache::shouldReceive('forgetDriver')->once();
+
+        config()->shouldReceive('get')
+            ->once()
+            ->with('database.connections.mysql.url', false)
+            ->andReturn(false);
+
+        config()->shouldReceive('set')
+            ->once()
+            ->with('database.connections.mysql.database', 'my_database_test_1');
+
+        $this->assertTrue($container->resolved(RateLimiter::class));
+
+        $this->switchToDatabase('my_database_test_1');
+
+        $this->assertFalse($container->resolved(RateLimiter::class));
+    }
+
+    public function testSwitchToDatabaseDoesNotResolveRateLimiterIfUnresolved()
+    {
+        $container = Container::getInstance();
+
+        DB::shouldReceive('purge')->once();
+        Cache::shouldReceive('forgetDriver')->once();
+
+        config()->shouldReceive('get')
+            ->once()
+            ->with('database.connections.mysql.url', false)
+            ->andReturn(false);
+
+        config()->shouldReceive('set')
+            ->once()
+            ->with('database.connections.mysql.database', 'my_database_test_1');
+
+        $this->assertFalse($container->resolved(RateLimiter::class));
+
+        $this->switchToDatabase('my_database_test_1');
+
+        $this->assertFalse($container->resolved(RateLimiter::class));
     }
 
     public function switchToDatabase($database)
@@ -99,6 +150,8 @@ class TestDatabasesTest extends TestCase
     protected function tearDown(): void
     {
         Container::setInstance(null);
+        Cache::clearResolvedInstance('cache');
+        Cache::setFacadeApplication(null);
         DB::clearResolvedInstance();
         DB::setFacadeApplication(null);
 


### PR DESCRIPTION
Fixes #54716.
  
  ## Problem
  
  When using the `database` cache driver with `php artisan test --parallel`, the cache (and any singleton wrapping a cache `Repository` via constructor
  injection) holds a reference to the connection that existed before `TestDatabases::switchToDatabase()` was called. When that stale connection is later
  used, it reconnects against the new database config and silently swaps the active `DatabaseManager` PDO, causing tests to read from the wrong SQLite
  transaction context. The `users` table appears empty inside the test even though a row was just inserted.
  
  Full reproduction and root-cause trace: https://github.com/laravel/framework/issues/54716#issuecomment-4443453448
  
  ## Fix
  
  After `DB::purge()` in `switchToDatabase()`, forget the cached cache driver and the resolved `RateLimiter` singleton, so any subsequent resolution picks
  up the new connection:
  
  ```php
  DB::purge();
  
  Cache::forgetDriver();
  
  if (app()->resolved(RateLimiter::class)) {
      app()->forgetInstance(RateLimiter::class);
  } 
  
  Tests
  
  tests/Testing/Concerns/TestDatabasesTest.php gains:
  
  - An expectation that Cache::forgetDriver() is called during every switchToDatabase() invocation
  - A test confirming the resolved RateLimiter singleton is forgotten
  - A test confirming an unresolved RateLimiter is not eagerly resolved by the switch
  
  Full Testing suite still passes locally (396 tests, 1459 assertions).
  
  Known limitation
  
  Any other singleton that received a cache Repository via constructor injection from a third-party package (Fortify-style throttling wrapped in custom
  service providers, etc.) would still hold a stale connection. A more architectural fix (preconfiguring DB_DATABASE with TEST_TOKEN before the application
  boots, as suggested in the issue) would dissolve this at the root, but is significantly more invasive. This PR ships the incremental fix that covers the
  two paths exercised by Laravel's first-party components.