### PR TITLE
[13.x] Respect $default in Response::json() when no key is passed

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -110,7 +110,7 @@ class Response implements ArrayAccess, Stringable
         }
 
         if (is_null($key)) {
-            return $this->decoded;
+            return $this->decoded ?? $default;
         }
 
         return data_get($this->decoded, $key, $default);

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -362,6 +362,18 @@ class HttpClientTest extends TestCase
         $this->assertSame(['foo' => 'bar'], $response['result']);
     }
 
+    public function testJsonDefaultIsRespectedWhenBodyIsEmpty()
+    {
+        $this->factory->fake([
+            '*' => Factory::response('', 200),
+        ]);
+
+        $response = $this->factory->get('http://foo.com/api');
+
+        $this->assertSame([], $response->json(default: []));
+        $this->assertSame('fallback', $response->json(default: 'fallback'));
+    }
+
     public function testResponseObjectAsArray()
     {
         $this->factory->fake([


### PR DESCRIPTION
When calling `json()` without a key argument, the `$default` parameter was silently ignored — `$this->decoded` was returned as-is even when it was `null`.

Passing a key correctly falls back to `$default` via `data_get()`, so this makes the no-key case consistent:

```php
// Before
$response->json(default: []);        // returns null when body is empty
$response->json('key', 'default');   // returns 'default' correctly

// After
$response->json(default: []);        // returns [] when body is empty
```

Fixes #60029.