### PR TITLE
[13.x] Route console components to stderr via withErrorOutput()

### DIFF
--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -464,4 +464,17 @@ trait InteractsWithIO
     {
         return $this->components;
     }
+
+    /**
+     * Get the console component factory bound to the error output.
+     *
+     * Useful when the command's primary output is being piped or redirected,
+     * and auxiliary output (progress, tasks, prompts) should go to stderr.
+     *
+     * @return \Illuminate\Console\View\Components\Factory
+     */
+    public function errorComponents(): \Illuminate\Console\View\Components\Factory
+    {
+        return $this->components->withErrorOutput();
+    }
 }

--- a/src/Illuminate/Console/View/Components/Factory.php
+++ b/src/Illuminate/Console/View/Components/Factory.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Console\View\Components;
 
 use InvalidArgumentException;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
  * @method void alert(string $string, int $verbosity = \Symfony\Component\Console\Output\OutputInterface::VERBOSITY_NORMAL)
@@ -37,6 +38,20 @@ class Factory
     public function __construct($output)
     {
         $this->output = $output;
+    }
+
+    /**
+     * Get a factory instance that writes to the error output.
+     *
+     * @return static
+     */
+    public function withErrorOutput(): static
+    {
+        $errorOutput = $this->output instanceof SymfonyStyle
+            ? $this->output->getErrorStyle()
+            : $this->output;
+
+        return new static($errorOutput);
     }
 
     /**


### PR DESCRIPTION
Console components (`task`, `info`, `warn`, etc.) always write to stdout. This makes it impossible to build commands whose primary output is piped or redirected without the component output contaminating it.

A common example is a command with a `--json` flag:

```php
public function handle(): int
{
    // task() writes to stdout — breaks JSON output when piped
    $this->components->task('Fetching data', fn () => ...);

    if ($this->option('json')) {
        $this->line(json_encode($result));
    }
    return 0;
}
```

```bash
php artisan some:command --json > output.json
# output.json is now corrupted with task() output
```

This PR adds `Factory::withErrorOutput()` which returns a new factory instance backed by the error output stream, and exposes `errorComponents()` on `InteractsWithIO` for convenience:

```php
$this->errorComponents()->task('Fetching data', fn () => ...);
// or
$this->components->withErrorOutput()->task('Fetching data', fn () => ...);
```

```bash
php artisan some:command --json > output.json
# task() output appears in terminal, output.json contains only JSON
```

Falls back to the standard output when the underlying output does not support a separate error stream (e.g. in tests).

Closes #56602.