### PR TITLE
Add tests for Blueprint::foreignUuidFor() with model instance and custom column

### DIFF
--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -511,6 +511,32 @@ class DatabaseSchemaBlueprintTest extends TestCase
         ], $getSql('MySql'));
     }
 
+    public function testGenerateUuidRelationshipColumnAcceptsModelInstance()
+    {
+        $getSql = function ($grammar) {
+            return $this->getBlueprint($grammar, 'posts', function ($table) {
+                $table->foreignUuidFor(new Fixtures\Models\EloquentModelUsingUuid);
+            })->toSql();
+        };
+
+        $this->assertEquals([
+            'alter table `posts` add `model_using_uuid_id` char(36) not null',
+        ], $getSql('MySql'));
+    }
+
+    public function testGenerateUuidRelationshipColumnWithCustomColumnName()
+    {
+        $getSql = function ($grammar) {
+            return $this->getBlueprint($grammar, 'posts', function ($table) {
+                $table->foreignUuidFor(Fixtures\Models\EloquentModelUsingUuid::class, 'uuid_col');
+            })->toSql();
+        };
+
+        $this->assertEquals([
+            'alter table `posts` add `uuid_col` char(36) not null',
+        ], $getSql('MySql'));
+    }
+
     public function testGenerateRelationshipForModelWithNonStandardPrimaryKeyName()
     {
         $getSql = function ($grammar) {


### PR DESCRIPTION
`foreignUuidFor()` was added in #60091 but the two paths through the method were left without test coverage:

- Passing a model **instance** instead of a class string (the `if (is_string($model))` branch)
- Passing a **custom column name** as the second argument

This adds a test for each, following the same structure as the existing `foreignUuidFor` tests.