### PR TITLE
Fix/arr get or put method add

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -932,6 +932,27 @@ class Arr
     }
 
     /**
+     * Get an item from an array or set the default value.
+     *
+     * @param  array  $array
+     * @param  string|int  $key
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public static function getOrPut(&$array, $key, $default = null)
+    {
+        if (static::has($array, $key)) {
+            return static::get($array, $key);
+        }
+
+        $value = value($default);
+
+        static::set($array, $key, $value);
+
+        return $value;
+    }
+
+    /**
      * Convert the array into a query string.
      *
      * @param  array  $array

--- a/tests/Pagination/LengthAwarePaginatorTest.php
+++ b/tests/Pagination/LengthAwarePaginatorTest.php
@@ -58,6 +58,21 @@ class LengthAwarePaginatorTest extends TestCase
         $this->assertEmpty($paginator->items());
     }
 
+    public function testLengthAwarePaginatorRetainsRequestedPageWhenDatasetShrinks()
+    {
+        $beforeDatasetChange = new LengthAwarePaginator(['item16'], 16, 15, 2);
+
+        $this->assertSame(2, $beforeDatasetChange->currentPage());
+        $this->assertSame(2, $beforeDatasetChange->lastPage());
+        $this->assertCount(1, $beforeDatasetChange->items());
+
+        $afterDatasetChange = new LengthAwarePaginator([], 15, 15, 2);
+
+        $this->assertSame(2, $afterDatasetChange->currentPage());
+        $this->assertSame(1, $afterDatasetChange->lastPage());
+        $this->assertEmpty($afterDatasetChange->items());
+    }
+
     public function testLengthAwarePaginatorOnFirstAndLastPage()
     {
         $paginator = new LengthAwarePaginator(['1', '2', '3', '4'], 4, 2, 2);

--- a/tests/Pagination/LengthAwarePaginatorTest.php
+++ b/tests/Pagination/LengthAwarePaginatorTest.php
@@ -60,17 +60,29 @@ class LengthAwarePaginatorTest extends TestCase
 
     public function testLengthAwarePaginatorRetainsRequestedPageWhenDatasetShrinks()
     {
-        $beforeDatasetChange = new LengthAwarePaginator(['item16'], 16, 15, 2);
+        // Initial paginator state (valid dataset)
+        $before = new LengthAwarePaginator(
+            ['item16'],
+            16,
+            15,
+            2
+        );
 
-        $this->assertSame(2, $beforeDatasetChange->currentPage());
-        $this->assertSame(2, $beforeDatasetChange->lastPage());
-        $this->assertCount(1, $beforeDatasetChange->items());
+        $this->assertSame(2, $before->currentPage());
+        $this->assertSame(2, $before->lastPage());
+        $this->assertCount(1, $before->items());
 
-        $afterDatasetChange = new LengthAwarePaginator([], 15, 15, 2);
+        // New paginator instance with reduced dataset (separate request simulation)
+        $after = new LengthAwarePaginator(
+            [],
+            15,
+            15,
+            2
+        );
 
-        $this->assertSame(2, $afterDatasetChange->currentPage());
-        $this->assertSame(1, $afterDatasetChange->lastPage());
-        $this->assertEmpty($afterDatasetChange->items());
+        $this->assertSame(2, $after->currentPage());
+        $this->assertSame(1, $after->lastPage());
+        $this->assertEmpty($after->items());
     }
 
     public function testLengthAwarePaginatorOnFirstAndLastPage()

--- a/tests/Pagination/PaginatorTest.php
+++ b/tests/Pagination/PaginatorTest.php
@@ -35,17 +35,21 @@ class PaginatorTest extends TestCase
 
     public function testSimplePaginatorRetainsRequestedPageWhenDatasetShrinks()
     {
-        $beforeDatasetChange = new Paginator(['item16'], 15, 2);
+         // Initial paginator state
+    $paginator = new Paginator(['item16'], 15, 2);
 
-        $this->assertSame(2, $beforeDatasetChange->currentPage());
-        $this->assertSame(['item16'], $beforeDatasetChange->items());
-        $this->assertFalse($beforeDatasetChange->hasMorePages());
+    $this->assertSame(2, $paginator->currentPage());
+    $this->assertSame(['item16'], $paginator->items());
+    $this->assertFalse($paginator->hasMorePages());
+    $this->assertSame(15, $paginator->perPage());
 
-        $afterDatasetChange = new Paginator([], 15, 2);
+    // Simulated "new request" with empty dataset (not mutation, just new instance)
+    $paginatorAfter = new Paginator([], 15, 2);
 
-        $this->assertSame(2, $afterDatasetChange->currentPage());
-        $this->assertSame([], $afterDatasetChange->items());
-        $this->assertFalse($afterDatasetChange->hasMorePages());
+    $this->assertSame(2, $paginatorAfter->currentPage());
+    $this->assertSame([], $paginatorAfter->items());
+    $this->assertFalse($paginatorAfter->hasMorePages());
+    $this->assertSame(15, $paginatorAfter->perPage());
     }
 
     public function testPaginatorRemovesTrailingSlashes()

--- a/tests/Pagination/PaginatorTest.php
+++ b/tests/Pagination/PaginatorTest.php
@@ -35,21 +35,21 @@ class PaginatorTest extends TestCase
 
     public function testSimplePaginatorRetainsRequestedPageWhenDatasetShrinks()
     {
-         // Initial paginator state
-    $paginator = new Paginator(['item16'], 15, 2);
+        // Initial paginator state
+        $paginator = new Paginator(['item16'], 15, 2);
 
-    $this->assertSame(2, $paginator->currentPage());
-    $this->assertSame(['item16'], $paginator->items());
-    $this->assertFalse($paginator->hasMorePages());
-    $this->assertSame(15, $paginator->perPage());
+        $this->assertSame(2, $paginator->currentPage());
+        $this->assertSame(['item16'], $paginator->items());
+        $this->assertFalse($paginator->hasMorePages());
+        $this->assertSame(15, $paginator->perPage());
 
-    // Simulated "new request" with empty dataset (not mutation, just new instance)
-    $paginatorAfter = new Paginator([], 15, 2);
+        // Simulated "new request" with empty dataset (not mutation, just new instance)
+        $paginatorAfter = new Paginator([], 15, 2);
 
-    $this->assertSame(2, $paginatorAfter->currentPage());
-    $this->assertSame([], $paginatorAfter->items());
-    $this->assertFalse($paginatorAfter->hasMorePages());
-    $this->assertSame(15, $paginatorAfter->perPage());
+        $this->assertSame(2, $paginatorAfter->currentPage());
+        $this->assertSame([], $paginatorAfter->items());
+        $this->assertFalse($paginatorAfter->hasMorePages());
+        $this->assertSame(15, $paginatorAfter->perPage());
     }
 
     public function testPaginatorRemovesTrailingSlashes()

--- a/tests/Pagination/PaginatorTest.php
+++ b/tests/Pagination/PaginatorTest.php
@@ -33,6 +33,21 @@ class PaginatorTest extends TestCase
         $this->assertEquals($pageInfo, $p->toArray());
     }
 
+    public function testSimplePaginatorRetainsRequestedPageWhenDatasetShrinks()
+    {
+        $beforeDatasetChange = new Paginator(['item16'], 15, 2);
+
+        $this->assertSame(2, $beforeDatasetChange->currentPage());
+        $this->assertSame(['item16'], $beforeDatasetChange->items());
+        $this->assertFalse($beforeDatasetChange->hasMorePages());
+
+        $afterDatasetChange = new Paginator([], 15, 2);
+
+        $this->assertSame(2, $afterDatasetChange->currentPage());
+        $this->assertSame([], $afterDatasetChange->items());
+        $this->assertFalse($afterDatasetChange->hasMorePages());
+    }
+
     public function testPaginatorRemovesTrailingSlashes()
     {
         $p = new Paginator(['item1', 'item2', 'item3'], 2, 2, ['path' => 'http://website.com/test/']);

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1214,6 +1214,33 @@ class SupportArrTest extends TestCase
         $this->assertSame([1 => 'Second'], $array);
     }
 
+    public function testGetOrPut()
+    {
+        $array = ['name' => 'Desk', 'meta' => ['count' => null]];
+
+        $this->assertSame('Desk', Arr::getOrPut($array, 'name', 'Table'));
+        $this->assertSame('Desk', $array['name']);
+
+        $this->assertNull(Arr::getOrPut($array, 'meta.count', 100));
+        $this->assertNull($array['meta']['count']);
+
+        $this->assertSame(100, Arr::getOrPut($array, 'price', 100));
+        $this->assertSame(100, $array['price']);
+
+        $this->assertSame('dark', Arr::getOrPut($array, 'settings.theme', fn () => 'dark'));
+        $this->assertSame('dark', $array['settings']['theme']);
+
+        $called = false;
+        Arr::getOrPut($array, 'price', function () use (&$called) {
+            $called = true;
+
+            return 200;
+        });
+
+        $this->assertFalse($called);
+        $this->assertSame(100, $array['price']);
+    }
+
     public function testQuery()
     {
         $this->assertSame('', Arr::query([]));


### PR DESCRIPTION
✨ Overview

This PR introduces a new helper method Arr::getOrPut which retrieves a value from an array using dot notation, and if the key does not exist, sets and returns a default value.

This provides a fluent and reusable alternative to the common pattern of checking existence before assigning a default value.

🚀 Motivation

In Laravel applications, developers frequently write patterns like:

if (! Arr::has($array, 'key')) {
    Arr::set($array, 'key', 'default');
}

or

$array['key'] = $array['key'] ?? 'default';

This introduces repetition when working with deeply nested arrays and dot notation.

💡 Proposed Solution

Introduce:

Arr::getOrPut($array, 'settings.theme', 'dark');

Which:

Returns existing value if present
Sets and returns default if missing
Supports dot notation
Supports lazy evaluation via Closure
⚙️ Behavior
Uses Arr::has() to determine existence
Uses Arr::get() for retrieval
Uses Arr::set() for assignment
Does NOT overwrite existing values (including null values)
Supports nested dot notation keys