### PR TITLE
[13.x] Add tests for SeeInHtml constraint covering unicode whitespace

### DIFF
--- a/tests/Testing/SeeInHtmlTest.php
+++ b/tests/Testing/SeeInHtmlTest.php
@@ -40,7 +40,7 @@ class SeeInHtmlTest extends TestCase
     {
         $constraint = new SeeInHtml('Hello World');
 
-        $this->assertTrue($constraint->matches(["<p>Hello   World</p>"]));
+        $this->assertTrue($constraint->matches(['<p>Hello   World</p>']));
         $this->assertTrue($constraint->matches(["<p>Hello\tWorld</p>"]));
         $this->assertTrue($constraint->matches(["<p>Hello\nWorld</p>"]));
         $this->assertTrue($constraint->matches(["<p>Hello \t\n World</p>"]));

--- a/tests/Testing/SeeInHtmlTest.php
+++ b/tests/Testing/SeeInHtmlTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Illuminate\Tests\Testing;
+
+use Illuminate\Testing\Constraints\SeeInHtml;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class SeeInHtmlTest extends TestCase
+{
+    public function testCollapsesUnicodeWhitespaceFromHtmlEntities()
+    {
+        $constraint = new SeeInHtml('Hello World');
+
+        $this->assertTrue($constraint->matches(['<p>Hello&nbsp;World</p>']));
+        $this->assertTrue($constraint->matches(['<p>Hello&#8195;World</p>']));
+        $this->assertTrue($constraint->matches(['<p>Hello&#12288;World</p>']));
+    }
+
+    #[DataProvider('unicodeWhitespaceCharacters')]
+    public function testCollapsesRawUnicodeWhitespace(string $whitespace)
+    {
+        $constraint = new SeeInHtml('Hello World');
+
+        $this->assertTrue($constraint->matches(["<p>Hello{$whitespace}World</p>"]));
+    }
+
+    public static function unicodeWhitespaceCharacters(): array
+    {
+        return [
+            'no-break space (U+00A0)' => ["\u{00A0}"],
+            'en space (U+2002)' => ["\u{2002}"],
+            'em space (U+2003)' => ["\u{2003}"],
+            'thin space (U+2009)' => ["\u{2009}"],
+            'ideographic space (U+3000)' => ["\u{3000}"],
+        ];
+    }
+
+    public function testCollapsesMultipleAsciiWhitespace()
+    {
+        $constraint = new SeeInHtml('Hello World');
+
+        $this->assertTrue($constraint->matches(["<p>Hello   World</p>"]));
+        $this->assertTrue($constraint->matches(["<p>Hello\tWorld</p>"]));
+        $this->assertTrue($constraint->matches(["<p>Hello\nWorld</p>"]));
+        $this->assertTrue($constraint->matches(["<p>Hello \t\n World</p>"]));
+    }
+
+    public function testFailsWhenValueIsAbsent()
+    {
+        $constraint = new SeeInHtml('Hello World');
+
+        $this->assertFalse($constraint->matches(['<p>Goodbye World</p>']));
+    }
+
+    public function testNegateInvertsTheAssertion()
+    {
+        $constraint = new SeeInHtml('Hello World', ordered: false, negate: true);
+
+        $this->assertTrue($constraint->matches(['<p>Goodbye World</p>']));
+        $this->assertFalse($constraint->matches(['<p>Hello&nbsp;World</p>']));
+    }
+
+    public function testOrderedRespectsSequenceAcrossUnicodeWhitespace()
+    {
+        $constraint = new SeeInHtml('Hello&nbsp;beautiful&#8195;World', ordered: true);
+
+        $this->assertTrue($constraint->matches(['Hello', 'beautiful', 'World']));
+        $this->assertFalse($constraint->matches(['World', 'Hello']));
+    }
+}


### PR DESCRIPTION
## Why
  
  `SeeInHtml::normalize()` had no test coverage. PR #60090 added the `/u` modifier to `preg_replace('/\s+/u', ' ', $value)` so HTML containing Unicode
  whitespace (non-breaking space, em space, ideographic space, etc.) collapses correctly before comparison — but the fix shipped without tests, so future
  regressions wouldn't be caught.
  
  ## What

  Adds `tests/Testing/SeeInHtmlTest.php` with 6 test methods covering:

  - Unicode whitespace via HTML entities (`&nbsp;`, `&#8195;`, `&#12288;`).
  - Raw UTF-8 whitespace via a data provider (U+00A0, U+2002, U+2003, U+2009, U+3000).
  - ASCII whitespace collapsing (regression for the pre-`/u` behavior).
  - `negate` mode inverting the assertion correctly.
  - `ordered` mode respecting sequence across unicode whitespace.