### PR TITLE
Add storage store

### DIFF
--- a/config/cache.php
+++ b/config/cache.php
@@ -27,8 +27,8 @@ return [
     | same cache driver to group types of items stored in your caches.
     |
     | Supported drivers: "array", "database", "file", "memcached",
-    |                    "redis", "dynamodb", "octane", "session",
-    |                    "failover", "null"
+    |                    "redis", "dynamodb", "storage", "octane",
+    |                    "session", "failover", "null"
     |
     */
 
@@ -56,6 +56,12 @@ return [
             'driver' => 'file',
             'path' => storage_path('framework/cache/data'),
             'lock_path' => storage_path('framework/cache/data'),
+        ],
+
+        'storage' => [
+            'driver' => 'storage',
+            'disk' => env('CACHE_STORAGE_DISK'),
+            'path' => env('CACHE_STORAGE_PATH', 'framework/cache/data'),
         ],
 
         'memcached' => [

--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -303,6 +303,22 @@ class CacheManager implements FactoryContract
     }
 
     /**
+     * Create an instance of the storage cache driver.
+     *
+     * @param  array  $config
+     * @return \Illuminate\Cache\Repository
+     */
+    protected function createStorageDriver(array $config)
+    {
+        return $this->repository(new StorageStore(
+            $this->app['filesystem']->disk($config['disk'] ?? null),
+            $config['path'] ?? '',
+            $this->getPrefix($config),
+            $this->getSerializableClasses($config),
+        ), $config);
+    }
+
+    /**
      * Create an instance of the Memcached cache driver.
      *
      * @param  array  $config

--- a/src/Illuminate/Cache/StorageStore.php
+++ b/src/Illuminate/Cache/StorageStore.php
@@ -1,0 +1,322 @@
+<?php
+
+namespace Illuminate\Cache;
+
+use Exception;
+use Illuminate\Contracts\Cache\Store;
+use Illuminate\Contracts\Filesystem\Filesystem;
+use Illuminate\Support\InteractsWithTime;
+
+class StorageStore implements Store
+{
+    use InteractsWithTime, RetrievesMultipleKeys;
+
+    /**
+     * The filesystem disk instance.
+     *
+     * @var \Illuminate\Contracts\Filesystem\Filesystem
+     */
+    protected $disk;
+
+    /**
+     * The storage path where cache files should be written.
+     *
+     * @var string
+     */
+    protected $directory;
+
+    /**
+     * A string that should be prepended to keys.
+     *
+     * @var string
+     */
+    protected $prefix;
+
+    /**
+     * The classes that should be allowed during unserialization.
+     *
+     * @var array|bool|null
+     */
+    protected $serializableClasses;
+
+    /**
+     * Create a new storage cache store instance.
+     *
+     * @param  \Illuminate\Contracts\Filesystem\Filesystem  $disk
+     * @param  string  $directory
+     * @param  string  $prefix
+     * @param  array|bool|null  $serializableClasses
+     */
+    public function __construct(Filesystem $disk, $directory = '', $prefix = '', $serializableClasses = null)
+    {
+        $this->disk = $disk;
+        $this->directory = trim($directory, '/');
+        $this->prefix = $prefix;
+        $this->serializableClasses = $serializableClasses;
+    }
+
+    /**
+     * Retrieve an item from the cache by key.
+     *
+     * @param  string  $key
+     * @return mixed
+     */
+    public function get($key)
+    {
+        return $this->getPayload($key)['data'] ?? null;
+    }
+
+    /**
+     * Store an item in the cache for a given number of seconds.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  int  $seconds
+     * @return bool
+     */
+    public function put($key, $value, $seconds)
+    {
+        return $this->disk->put(
+            $this->path($key), $this->expiration($seconds).serialize($value)
+        );
+    }
+
+    /**
+     * Store an item in the cache if the key doesn't exist.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  int  $seconds
+     * @return bool
+     */
+    public function add($key, $value, $seconds)
+    {
+        if (! is_null($this->get($key))) {
+            return false;
+        }
+
+        return $this->put($key, $value, $seconds);
+    }
+
+    /**
+     * Increment the value of an item in the cache.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return int
+     */
+    public function increment($key, $value = 1)
+    {
+        $raw = $this->getPayload($key);
+
+        return tap(((int) $raw['data']) + $value, function ($newValue) use ($key, $raw) {
+            $this->put($key, $newValue, $raw['time'] ?? 0);
+        });
+    }
+
+    /**
+     * Decrement the value of an item in the cache.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return int
+     */
+    public function decrement($key, $value = 1)
+    {
+        return $this->increment($key, $value * -1);
+    }
+
+    /**
+     * Store an item in the cache indefinitely.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function forever($key, $value)
+    {
+        return $this->put($key, $value, 0);
+    }
+
+    /**
+     * Adjust the expiration time of a cached item.
+     *
+     * @param  string  $key
+     * @param  int  $seconds
+     * @return bool
+     */
+    public function touch($key, $seconds)
+    {
+        $payload = $this->getPayload($key);
+
+        if (is_null($payload['data'])) {
+            return false;
+        }
+
+        return $this->put($key, $payload['data'], $seconds);
+    }
+
+    /**
+     * Remove an item from the cache.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function forget($key)
+    {
+        $forgotten = $this->disk->delete($this->path($key));
+
+        if ($forgotten) {
+            $this->disk->delete($this->path("illuminate:cache:flexible:created:{$key}"));
+        }
+
+        return $forgotten;
+    }
+
+    /**
+     * Remove all items from the cache.
+     *
+     * @return bool
+     */
+    public function flush()
+    {
+        if ($this->directory === '') {
+            $files = $this->disk->allFiles();
+
+            return $files === [] || $this->disk->delete($files);
+        }
+
+        return $this->disk->deleteDirectory($this->directory)
+            && $this->disk->makeDirectory($this->directory);
+    }
+
+    /**
+     * Retrieve an item and expiry time from the cache by key.
+     *
+     * @param  string  $key
+     * @return array
+     */
+    protected function getPayload($key)
+    {
+        $path = $this->path($key);
+
+        try {
+            if (is_null($contents = $this->disk->get($path))) {
+                return $this->emptyPayload();
+            }
+
+            $expire = substr($contents, 0, 10);
+        } catch (Exception) {
+            return $this->emptyPayload();
+        }
+        if ($this->currentTime() >= $expire) {
+            $this->forget($key);
+
+            return $this->emptyPayload();
+        }
+
+        try {
+            $data = $this->unserialize(substr($contents, 10));
+        } catch (Exception) {
+            $this->forget($key);
+
+            return $this->emptyPayload();
+        }
+
+        $time = $expire - $this->currentTime();
+
+        return compact('data', 'time');
+    }
+
+    /**
+     * Unserialize the given value.
+     *
+     * @param  string  $value
+     * @return mixed
+     */
+    protected function unserialize($value)
+    {
+        if ($this->serializableClasses !== null) {
+            return unserialize($value, ['allowed_classes' => $this->serializableClasses]);
+        }
+
+        return unserialize($value);
+    }
+
+    /**
+     * Get a default empty payload for the cache.
+     *
+     * @return array
+     */
+    protected function emptyPayload()
+    {
+        return ['data' => null, 'time' => null];
+    }
+
+    /**
+     * Get the full path for the given cache key.
+     *
+     * @param  string  $key
+     * @return string
+     */
+    public function path($key)
+    {
+        $parts = array_slice(str_split($hash = sha1($this->prefix.$key), 2), 0, 2);
+
+        return trim($this->directory.'/'.implode('/', $parts).'/'.$hash, '/');
+    }
+
+    /**
+     * Get the expiration time based on the given seconds.
+     *
+     * @param  int  $seconds
+     * @return int
+     */
+    protected function expiration($seconds)
+    {
+        $time = $this->availableAt($seconds);
+
+        return $seconds === 0 || $time > 9999999999 ? 9999999999 : $time;
+    }
+
+    /**
+     * Get the filesystem disk instance.
+     *
+     * @return \Illuminate\Contracts\Filesystem\Filesystem
+     */
+    public function getDisk()
+    {
+        return $this->disk;
+    }
+
+    /**
+     * Get the working directory of the cache.
+     *
+     * @return string
+     */
+    public function getDirectory()
+    {
+        return $this->directory;
+    }
+
+    /**
+     * Get the cache key prefix.
+     *
+     * @return string
+     */
+    public function getPrefix()
+    {
+        return $this->prefix;
+    }
+
+    /**
+     * Set the cache key prefix.
+     *
+     * @param  string  $prefix
+     * @return void
+     */
+    public function setPrefix($prefix)
+    {
+        $this->prefix = $prefix;
+    }
+}

--- a/tests/Cache/CacheManagerTest.php
+++ b/tests/Cache/CacheManagerTest.php
@@ -5,10 +5,12 @@ namespace Illuminate\Tests\Cache;
 use Illuminate\Cache\ArrayStore;
 use Illuminate\Cache\CacheManager;
 use Illuminate\Cache\NullStore;
+use Illuminate\Cache\StorageStore;
 use Illuminate\Config\Repository;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Events\Dispatcher as Event;
+use Illuminate\Tests\Cache\Fixtures\ArrayFilesystem;
 use InvalidArgumentException;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -101,6 +103,36 @@ class CacheManagerTest extends TestCase
 
         $this->assertInstanceOf(ArrayStore::class, $arrayCache->getStore());
         $this->assertInstanceOf(NullStore::class, $nullCache->getStore());
+    }
+
+    public function testItCanCreateStorageDriver()
+    {
+        $disk = new ArrayFilesystem;
+
+        $filesystem = m::mock();
+        $filesystem->shouldReceive('disk')->with('s3')->once()->andReturn($disk);
+
+        $app = $this->getApp([
+            'cache' => [
+                'prefix' => 'cache:',
+                'stores' => [
+                    'storage' => [
+                        'driver' => 'storage',
+                        'disk' => 's3',
+                        'path' => 'cache',
+                    ],
+                ],
+            ],
+        ]);
+        $app->instance('filesystem', $filesystem);
+
+        $cacheManager = new CacheManager($app);
+        $store = $cacheManager->store('storage')->getStore();
+
+        $this->assertInstanceOf(StorageStore::class, $store);
+        $this->assertSame($disk, $store->getDisk());
+        $this->assertSame('cache', $store->getDirectory());
+        $this->assertSame('cache:', $store->getPrefix());
     }
 
     public function testItMakesRepositoryWhenContainerHasNoDispatcher()

--- a/tests/Cache/CacheStorageStoreTest.php
+++ b/tests/Cache/CacheStorageStoreTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Illuminate\Tests\Cache;
+
+use Illuminate\Cache\StorageStore;
+use Illuminate\Support\Carbon;
+use Illuminate\Tests\Cache\Fixtures\ArrayFilesystem;
+use PHPUnit\Framework\TestCase;
+
+class CacheStorageStoreTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+
+        parent::tearDown();
+    }
+
+    public function testValuesCanBeStoredAndRetrieved()
+    {
+        $disk = new ArrayFilesystem;
+        $store = new StorageStore($disk, 'cache', 'prefix:');
+
+        $this->assertTrue($store->put('foo', 'bar', 60));
+        $this->assertSame('bar', $store->get('foo'));
+        $this->assertStringStartsWith('cache/', $store->path('foo'));
+    }
+
+    public function testExpiredItemsReturnNullAndGetDeleted()
+    {
+        Carbon::setTestNow(Carbon::now());
+
+        $disk = new ArrayFilesystem;
+        $store = new StorageStore($disk, 'cache');
+
+        $store->put('foo', 'bar', 1);
+
+        Carbon::setTestNow(Carbon::now()->addSeconds(2));
+
+        $this->assertNull($store->get('foo'));
+        $this->assertFalse($disk->exists($store->path('foo')));
+    }
+
+    public function testAddDoesNotOverwriteExistingValues()
+    {
+        $store = new StorageStore(new ArrayFilesystem, 'cache');
+
+        $this->assertTrue($store->add('foo', 'bar', 60));
+        $this->assertFalse($store->add('foo', 'baz', 60));
+        $this->assertSame('bar', $store->get('foo'));
+    }
+
+    public function testIncrementAndDecrementRetainExpiration()
+    {
+        Carbon::setTestNow(Carbon::now());
+
+        $store = new StorageStore(new ArrayFilesystem, 'cache');
+        $store->put('foo', 5, 60);
+
+        $this->assertSame(7, $store->increment('foo', 2));
+        $this->assertSame(4, $store->decrement('foo', 3));
+
+        Carbon::setTestNow(Carbon::now()->addSeconds(61));
+
+        $this->assertNull($store->get('foo'));
+    }
+
+    public function testTouchUpdatesExpiration()
+    {
+        Carbon::setTestNow(Carbon::now());
+
+        $store = new StorageStore(new ArrayFilesystem, 'cache');
+        $store->put('foo', 'bar', 2);
+
+        Carbon::setTestNow(Carbon::now()->addSecond());
+
+        $this->assertTrue($store->touch('foo', 60));
+
+        Carbon::setTestNow(Carbon::now()->addSecond());
+
+        $this->assertSame('bar', $store->get('foo'));
+    }
+
+    public function testForgetRemovesFlexibleCreatedKeyOnlyWhenParentIsForgotten()
+    {
+        $disk = new ArrayFilesystem;
+        $store = new StorageStore($disk, 'cache');
+
+        $store->put('illuminate:cache:flexible:created:foo', true, 60);
+
+        $this->assertFalse($store->forget('foo'));
+        $this->assertTrue($disk->exists($store->path('illuminate:cache:flexible:created:foo')));
+
+        $store->put('foo', 'bar', 60);
+
+        $this->assertTrue($store->forget('foo'));
+        $this->assertFalse($disk->exists($store->path('foo')));
+        $this->assertFalse($disk->exists($store->path('illuminate:cache:flexible:created:foo')));
+    }
+
+    public function testFlushRemovesScopedDirectory()
+    {
+        $disk = new ArrayFilesystem;
+        $store = new StorageStore($disk, 'cache');
+
+        $store->put('foo', 'bar', 60);
+        $disk->put('other/file', 'value');
+
+        $this->assertTrue($store->flush());
+        $this->assertNull($store->get('foo'));
+        $this->assertTrue($disk->exists('other/file'));
+    }
+}

--- a/tests/Cache/Fixtures/ArrayFilesystem.php
+++ b/tests/Cache/Fixtures/ArrayFilesystem.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Illuminate\Tests\Cache\Fixtures;
+
+use Illuminate\Contracts\Filesystem\Filesystem;
+
+class ArrayFilesystem implements Filesystem
+{
+    public array $files = [];
+
+    public function path($path)
+    {
+        return $path;
+    }
+
+    public function exists($path)
+    {
+        return array_key_exists($path, $this->files) || $this->files($path) !== [];
+    }
+
+    public function get($path)
+    {
+        return $this->files[$path] ?? null;
+    }
+
+    public function readStream($path)
+    {
+        return null;
+    }
+
+    public function put($path, $contents, $options = [])
+    {
+        $this->files[$path] = $contents;
+
+        return true;
+    }
+
+    public function putFile($path, $file = null, $options = [])
+    {
+        return false;
+    }
+
+    public function putFileAs($path, $file, $name = null, $options = [])
+    {
+        return false;
+    }
+
+    public function writeStream($path, $resource, array $options = [])
+    {
+        return false;
+    }
+
+    public function getVisibility($path)
+    {
+        return Filesystem::VISIBILITY_PRIVATE;
+    }
+
+    public function setVisibility($path, $visibility)
+    {
+        return true;
+    }
+
+    public function prepend($path, $data)
+    {
+        return false;
+    }
+
+    public function append($path, $data)
+    {
+        return false;
+    }
+
+    public function delete($paths)
+    {
+        $deleted = false;
+
+        foreach ((array) $paths as $path) {
+            if (array_key_exists($path, $this->files)) {
+                unset($this->files[$path]);
+
+                $deleted = true;
+            }
+        }
+
+        return $deleted;
+    }
+
+    public function copy($from, $to)
+    {
+        return false;
+    }
+
+    public function move($from, $to)
+    {
+        return false;
+    }
+
+    public function size($path)
+    {
+        return strlen($this->files[$path] ?? '');
+    }
+
+    public function lastModified($path)
+    {
+        return 0;
+    }
+
+    public function files($directory = null, $recursive = false)
+    {
+        $directory = trim((string) $directory, '/');
+
+        return array_values(array_filter(array_keys($this->files), function ($path) use ($directory) {
+            return $directory === '' || str_starts_with($path, $directory.'/');
+        }));
+    }
+
+    public function allFiles($directory = null)
+    {
+        return $this->files($directory, true);
+    }
+
+    public function directories($directory = null, $recursive = false)
+    {
+        return [];
+    }
+
+    public function allDirectories($directory = null)
+    {
+        return [];
+    }
+
+    public function makeDirectory($path)
+    {
+        return true;
+    }
+
+    public function deleteDirectory($directory)
+    {
+        $deleted = false;
+
+        foreach ($this->allFiles($directory) as $path) {
+            unset($this->files[$path]);
+
+            $deleted = true;
+        }
+
+        return $deleted;
+    }
+}


### PR DESCRIPTION
Adds a `storage` cache driver that utilizes Laravel's filesystem / `Storage` services to cache data - primarily useful for leveraging an existing S3 disk as a key / value cache.