### PR TITLE
[13.x] Replace @return with @var on docblocks for properties in tests

### DIFF
--- a/tests/Foundation/FoundationAuthenticationTest.php
+++ b/tests/Foundation/FoundationAuthenticationTest.php
@@ -21,7 +21,7 @@ class FoundationAuthenticationTest extends TestCase
     protected $app;
 
     /**
-     * @return array
+     * @var array
      */
     protected $credentials = [
         'email' => 'someone@laravel.com',

--- a/tests/Integration/Database/DatabaseTestCase.php
+++ b/tests/Integration/Database/DatabaseTestCase.php
@@ -12,7 +12,7 @@ abstract class DatabaseTestCase extends TestCase
     /**
      * The current database driver.
      *
-     * @return string
+     * @var string
      */
     protected $driver;
 

--- a/tests/Integration/Database/EloquentTransactionWithAfterCommitUsingDatabaseTransactionsTest.php
+++ b/tests/Integration/Database/EloquentTransactionWithAfterCommitUsingDatabaseTransactionsTest.php
@@ -13,7 +13,7 @@ class EloquentTransactionWithAfterCommitUsingDatabaseTransactionsTest extends Te
     /**
      * The current database driver.
      *
-     * @return string
+     * @var string
      */
     protected $driver;
 

--- a/tests/Integration/Database/EloquentTransactionWithAfterCommitUsingRefreshDatabaseTest.php
+++ b/tests/Integration/Database/EloquentTransactionWithAfterCommitUsingRefreshDatabaseTest.php
@@ -13,7 +13,7 @@ class EloquentTransactionWithAfterCommitUsingRefreshDatabaseTest extends TestCas
     /**
      * The current database driver.
      *
-     * @return string
+     * @var string
      */
     protected $driver;
 

--- a/tests/Integration/Queue/QueueTestCase.php
+++ b/tests/Integration/Queue/QueueTestCase.php
@@ -13,7 +13,7 @@ abstract class QueueTestCase extends TestCase
     /**
      * The current database driver.
      *
-     * @return string
+     * @var string
      */
     protected $driver;
 


### PR DESCRIPTION
Continuation of #60087 which addressed src/Illuminate/. This applies the same fix to the remaining cases in tests/.

Properties were documented with @return when they should use @var per PSR-5.