### PR TITLE
[13.x] Allow lifecycle and output callbacks on Schedule::group()

### DIFF
--- a/src/Illuminate/Console/Scheduling/PendingEventAttributes.php
+++ b/src/Illuminate/Console/Scheduling/PendingEventAttributes.php
@@ -10,7 +10,36 @@ class PendingEventAttributes
     use ManagesAttributes, ManagesFrequencies;
 
     /**
-     * The recorded macro calls to replay on each event.
+     * Event lifecycle and output methods that should be deferred and replayed on each event in the group.
+     *
+     * @var array<int, string>
+     */
+    protected const DEFERRED_EVENT_METHODS = [
+        'before',
+        'after',
+        'then',
+        'thenWithOutput',
+        'onSuccess',
+        'onSuccessWithOutput',
+        'onFailure',
+        'onFailureWithOutput',
+        'pingBefore',
+        'pingBeforeIf',
+        'thenPing',
+        'thenPingIf',
+        'pingOnSuccess',
+        'pingOnSuccessIf',
+        'pingOnFailure',
+        'pingOnFailureIf',
+        'sendOutputTo',
+        'appendOutputTo',
+        'emailOutputTo',
+        'emailWrittenOutputTo',
+        'emailOutputOnFailure',
+    ];
+
+    /**
+     * The recorded macro and deferred method calls to replay on each event.
      *
      * @var array<int, array{string, array}>
      */
@@ -106,7 +135,7 @@ class PendingEventAttributes
      */
     public function __call(string $method, array $parameters): mixed
     {
-        if (Event::hasMacro($method)) {
+        if (Event::hasMacro($method) || in_array($method, static::DEFERRED_EVENT_METHODS, true)) {
             $this->macros[] = [$method, $parameters];
 
             return $this;

--- a/tests/Integration/Console/Scheduling/ScheduleGroupTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleGroupTest.php
@@ -328,4 +328,144 @@ class ScheduleGroupTest extends TestCase
 
         Event::flushMacros();
     }
+
+    public function testGroupAppliesOnFailureCallbackToAllEvents()
+    {
+        $calls = [];
+
+        $schedule = new ScheduleClass;
+        $schedule->daily()
+            ->onFailure(function () use (&$calls) {
+                $calls[] = 'group-failure';
+            })
+            ->group(function ($schedule) {
+                $schedule->command('inspire');
+                $schedule->command('inspire');
+            });
+
+        $events = $schedule->events();
+        $this->assertCount(2, $events);
+
+        $events[0]->finish(app(), 1);
+        $events[1]->finish(app(), 1);
+
+        $this->assertSame(['group-failure', 'group-failure'], $calls);
+    }
+
+    public function testGroupOnFailureCallbackDoesNotRunOnSuccess()
+    {
+        $calls = [];
+
+        $schedule = new ScheduleClass;
+        $schedule->daily()
+            ->onFailure(function () use (&$calls) {
+                $calls[] = 'group-failure';
+            })
+            ->group(function ($schedule) {
+                $schedule->command('inspire');
+            });
+
+        $events = $schedule->events();
+        $events[0]->finish(app(), 0);
+
+        $this->assertSame([], $calls);
+    }
+
+    public function testGroupAppliesOnSuccessCallbackToAllEvents()
+    {
+        $calls = [];
+
+        $schedule = new ScheduleClass;
+        $schedule->daily()
+            ->onSuccess(function () use (&$calls) {
+                $calls[] = 'group-success';
+            })
+            ->group(function ($schedule) {
+                $schedule->command('inspire');
+                $schedule->command('inspire');
+            });
+
+        $events = $schedule->events();
+        $events[0]->finish(app(), 0);
+        $events[1]->finish(app(), 0);
+
+        $this->assertSame(['group-success', 'group-success'], $calls);
+    }
+
+    public function testGroupAppliesBeforeAndAfterCallbacksToAllEvents()
+    {
+        $calls = [];
+
+        $schedule = new ScheduleClass;
+        $schedule->daily()
+            ->before(function () use (&$calls) {
+                $calls[] = 'before';
+            })
+            ->after(function () use (&$calls) {
+                $calls[] = 'after';
+            })
+            ->then(function () use (&$calls) {
+                $calls[] = 'then';
+            })
+            ->group(function ($schedule) {
+                $schedule->command('inspire');
+            });
+
+        $events = $schedule->events();
+        $events[0]->callBeforeCallbacks(app());
+        $events[0]->finish(app(), 0);
+
+        $this->assertSame(['before', 'after', 'then'], $calls);
+    }
+
+    public function testGroupCallbacksCombineWithEventLevelCallbacks()
+    {
+        $calls = [];
+
+        $schedule = new ScheduleClass;
+        $schedule->daily()
+            ->onFailure(function () use (&$calls) {
+                $calls[] = 'group';
+            })
+            ->group(function ($schedule) use (&$calls) {
+                $schedule->command('inspire')->onFailure(function () use (&$calls) {
+                    $calls[] = 'event';
+                });
+            });
+
+        $events = $schedule->events();
+        $events[0]->finish(app(), 1);
+
+        $this->assertSame(['group', 'event'], $calls);
+    }
+
+    public function testNestedGroupInheritsLifecycleCallbacks()
+    {
+        $calls = [];
+
+        $schedule = new ScheduleClass;
+        $schedule->daily()
+            ->onFailure(function () use (&$calls) {
+                $calls[] = 'outer';
+            })
+            ->group(function ($schedule) use (&$calls) {
+                $schedule->command('inspire');
+                $schedule->weekly()
+                    ->onFailure(function () use (&$calls) {
+                        $calls[] = 'inner';
+                    })
+                    ->group(function ($schedule) {
+                        $schedule->command('inspire');
+                    });
+            });
+
+        $events = $schedule->events();
+        $this->assertCount(2, $events);
+
+        $events[0]->finish(app(), 1);
+        $this->assertSame(['outer'], $calls);
+
+        $events[1]->finish(app(), 1);
+        $this->assertSame(['outer', 'outer', 'inner'], $calls);
+    }
 }


### PR DESCRIPTION
We found out that several scheduled commands weren't running for over a month. It would be incredibly helpful to be able to set callbacks to execute for all jobs in a entire group, rather than adding them one-by-one.