### PR TITLE
[13.x] Add WorkerIdle event

### DIFF
--- a/src/Illuminate/Queue/Events/WorkerIdle.php
+++ b/src/Illuminate/Queue/Events/WorkerIdle.php
@@ -9,10 +9,12 @@ class WorkerIdle
      *
      * @param  string  $connectionName
      * @param  string  $queue
+     * @param  string|null  $name The name of the worker.
      */
     public function __construct(
         public $connectionName,
         public $queue,
+        public $name = null,
     ) {
     }
 }

--- a/src/Illuminate/Queue/Events/WorkerIdle.php
+++ b/src/Illuminate/Queue/Events/WorkerIdle.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\Queue\Events;
+
+class WorkerIdle
+{
+    /**
+     * Create a new event instance.
+     *
+     * @param  string  $connectionName
+     * @param  string  $queue
+     */
+    public function __construct(
+        public $connectionName,
+        public $queue,
+    ) {
+    }
+}

--- a/src/Illuminate/Queue/Events/WorkerIdle.php
+++ b/src/Illuminate/Queue/Events/WorkerIdle.php
@@ -9,12 +9,12 @@ class WorkerIdle
      *
      * @param  string  $connectionName
      * @param  string  $queue
-     * @param  string|null  $name The name of the worker.
+     * @param  \Illuminate\Queue\WorkerOptions  $workerOptions
      */
     public function __construct(
         public $connectionName,
         public $queue,
-        public $name = null,
+        public $workerOptions,
     ) {
     }
 }

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -237,7 +237,7 @@ class Worker
                     $this->sleep($options->rest);
                 }
             } else {
-                $this->events->dispatch(new WorkerIdle($connectionName, $queue));
+                $this->events->dispatch(new WorkerIdle($connectionName, $queue, $this->name));
 
                 $this->sleep($options->sleep);
             }

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -17,6 +17,7 @@ use Illuminate\Queue\Events\JobProcessing;
 use Illuminate\Queue\Events\JobReleasedAfterException;
 use Illuminate\Queue\Events\JobTimedOut;
 use Illuminate\Queue\Events\Looping;
+use Illuminate\Queue\Events\WorkerIdle;
 use Illuminate\Queue\Events\WorkerInterrupted;
 use Illuminate\Queue\Events\WorkerPausing;
 use Illuminate\Queue\Events\WorkerResuming;
@@ -236,6 +237,8 @@ class Worker
                     $this->sleep($options->rest);
                 }
             } else {
+                $this->events->dispatch(new WorkerIdle($connectionName, $queue));
+
                 $this->sleep($options->sleep);
             }
 

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -237,7 +237,7 @@ class Worker
                     $this->sleep($options->rest);
                 }
             } else {
-                $this->events->dispatch(new WorkerIdle($connectionName, $queue, $this->name));
+                $this->events->dispatch(new WorkerIdle($connectionName, $queue, $options));
 
                 $this->sleep($options->sleep);
             }

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -451,15 +451,14 @@ class QueueWorkerTest extends TestCase
         $workerOptions->stopWhenEmpty = true;
 
         $worker = $this->getWorker('default', ['queue' => []]);
-        $worker->setName('my-worker');
 
         $worker->daemon('default', 'queue', $workerOptions);
 
-        $this->events->shouldHaveReceived('dispatch')->with(m::on(function ($event) {
+        $this->events->shouldHaveReceived('dispatch')->with(m::on(function ($event) use ($workerOptions) {
             return $event instanceof WorkerIdle
                 && $event->connectionName === 'default'
                 && $event->queue === 'queue'
-                && $event->name === 'my-worker';
+                && $event->workerOptions === $workerOptions;
         }))->once();
     }
 

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -15,6 +15,7 @@ use Illuminate\Queue\Events\JobPopping;
 use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Queue\Events\JobProcessing;
 use Illuminate\Queue\Events\JobReleasedAfterException;
+use Illuminate\Queue\Events\WorkerIdle;
 use Illuminate\Queue\Events\WorkerStarting;
 use Illuminate\Queue\Events\WorkerStopping;
 use Illuminate\Queue\MaxAttemptsExceededException;
@@ -442,6 +443,22 @@ class QueueWorkerTest extends TestCase
         $this->assertTrue($secondJob->fired);
 
         $this->events->shouldHaveReceived('dispatch')->with(m::type(WorkerStarting::class))->once();
+    }
+
+    public function testWorkerIdleIsDispatched()
+    {
+        $workerOptions = new WorkerOptions();
+        $workerOptions->stopWhenEmpty = true;
+
+        $worker = $this->getWorker('default', ['queue' => []]);
+
+        $worker->daemon('default', 'queue', $workerOptions);
+
+        $this->events->shouldHaveReceived('dispatch')->with(m::on(function ($event) {
+            return $event instanceof WorkerIdle
+                && $event->connectionName === 'default'
+                && $event->queue === 'queue';
+        }))->once();
     }
 
     public function testWorkerStoppingIsDispatched()

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -451,13 +451,15 @@ class QueueWorkerTest extends TestCase
         $workerOptions->stopWhenEmpty = true;
 
         $worker = $this->getWorker('default', ['queue' => []]);
+        $worker->setName('my-worker');
 
         $worker->daemon('default', 'queue', $workerOptions);
 
         $this->events->shouldHaveReceived('dispatch')->with(m::on(function ($event) {
             return $event instanceof WorkerIdle
                 && $event->connectionName === 'default'
-                && $event->queue === 'queue';
+                && $event->queue === 'queue'
+                && $event->name === 'my-worker';
         }))->once();
     }
 


### PR DESCRIPTION
  So, I had a thought.. 
  
  I have all these workers, but, are they really being used to their full capacity? 
  
  I want to know if they're idling, `JobPopping` is OK, but you cant distinguish if it got a job, or didn't. 
  
  Look at the code... and you'll see if there's no job, it sleeps!
  
As the resident Queue man (lol),  

This PR adds a  `WorkerIdle` event.. now I can clearly see if a worker is doing nothing ie if I see 10000 idle events for my worker called `geoff` I know i need to do something  thanks to the options class which reveals the --name (biggest secret ever)

This just helps me to know if I can move queues onto other workers if they're never used etc.
