### PR TITLE
[13.x] Pass WorkerOptions to Pausing/Resuming/Interrupted

### DIFF
--- a/src/Illuminate/Queue/Events/WorkerInterrupted.php
+++ b/src/Illuminate/Queue/Events/WorkerInterrupted.php
@@ -10,11 +10,13 @@ class WorkerInterrupted
      * @param  int  $signal  The signal that interrupted the worker.
      * @param  string|null  $connectionName
      * @param  string|null  $queue
+     * @param  \Illuminate\Queue\WorkerOptions|null  $workerOptions
      */
     public function __construct(
         public int $signal,
         public ?string $connectionName = null,
         public ?string $queue = null,
+        public $workerOptions = null,
     ) {
     }
 }

--- a/src/Illuminate/Queue/Events/WorkerInterrupted.php
+++ b/src/Illuminate/Queue/Events/WorkerInterrupted.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Queue\Events;
 
+use Illuminate\Queue\WorkerOptions;
+
 class WorkerInterrupted
 {
     /**
@@ -10,13 +12,13 @@ class WorkerInterrupted
      * @param  int  $signal  The signal that interrupted the worker.
      * @param  string|null  $connectionName
      * @param  string|null  $queue
-     * @param  \Illuminate\Queue\WorkerOptions|null  $workerOptions
+     * @param  WorkerOptions|null  $workerOptions
      */
     public function __construct(
         public int $signal,
         public ?string $connectionName = null,
         public ?string $queue = null,
-        public $workerOptions = null,
+        public ?WorkerOptions $workerOptions = null,
     ) {
     }
 }

--- a/src/Illuminate/Queue/Events/WorkerPausing.php
+++ b/src/Illuminate/Queue/Events/WorkerPausing.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Queue\Events;
 
+use Illuminate\Queue\WorkerOptions;
+
 class WorkerPausing
 {
     /**
@@ -9,12 +11,12 @@ class WorkerPausing
      *
      * @param  string|null  $connectionName
      * @param  string|null  $queue
-     * @param  \Illuminate\Queue\WorkerOptions|null  $workerOptions
+     * @param  WorkerOptions|null  $workerOptions
      */
     public function __construct(
         public ?string $connectionName = null,
         public ?string $queue = null,
-        public $workerOptions = null,
+        public ?WorkerOptions $workerOptions = null,
     ) {
     }
 }

--- a/src/Illuminate/Queue/Events/WorkerPausing.php
+++ b/src/Illuminate/Queue/Events/WorkerPausing.php
@@ -9,10 +9,12 @@ class WorkerPausing
      *
      * @param  string|null  $connectionName
      * @param  string|null  $queue
+     * @param  \Illuminate\Queue\WorkerOptions|null  $workerOptions
      */
     public function __construct(
         public ?string $connectionName = null,
         public ?string $queue = null,
+        public $workerOptions = null,
     ) {
     }
 }

--- a/src/Illuminate/Queue/Events/WorkerResuming.php
+++ b/src/Illuminate/Queue/Events/WorkerResuming.php
@@ -9,10 +9,12 @@ class WorkerResuming
      *
      * @param  string|null  $connectionName
      * @param  string|null  $queue
+     * @param  \Illuminate\Queue\WorkerOptions|null  $workerOptions
      */
     public function __construct(
         public ?string $connectionName = null,
         public ?string $queue = null,
+        public $workerOptions = null,
     ) {
     }
 }

--- a/src/Illuminate/Queue/Events/WorkerResuming.php
+++ b/src/Illuminate/Queue/Events/WorkerResuming.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Queue\Events;
 
+use Illuminate\Queue\WorkerOptions;
+
 class WorkerResuming
 {
     /**
@@ -9,12 +11,12 @@ class WorkerResuming
      *
      * @param  string|null  $connectionName
      * @param  string|null  $queue
-     * @param  \Illuminate\Queue\WorkerOptions|null  $workerOptions
+     * @param  WorkerOptions|null  $workerOptions
      */
     public function __construct(
         public ?string $connectionName = null,
         public ?string $queue = null,
-        public $workerOptions = null,
+        public ?WorkerOptions $workerOptions = null,
     ) {
     }
 }

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -186,7 +186,7 @@ class Worker
     public function daemon($connectionName, $queue, WorkerOptions $options)
     {
         if ($supportsAsyncSignals = $this->supportsAsyncSignals()) {
-            $this->listenForSignals($connectionName, $queue);
+            $this->listenForSignals($connectionName, $queue, $options);
         }
 
         $lastRestart = $this->getTimestampOfLastQueueRestart();
@@ -836,30 +836,30 @@ class Worker
      * @param  string|null  $queue
      * @return void
      */
-    protected function listenForSignals($connectionName = null, $queue = null)
+    protected function listenForSignals($connectionName = null, $queue = null, $options = null)
     {
         pcntl_async_signals(true);
 
         foreach ([SIGQUIT, SIGTERM, SIGINT] as $signal) {
-            pcntl_signal($signal, function (int $signal) use ($connectionName, $queue) {
+            pcntl_signal($signal, function (int $signal) use ($connectionName, $queue, $options) {
                 $this->shouldQuit = true;
 
-                $this->events->dispatch(new WorkerInterrupted($signal, $connectionName, $queue));
+                $this->events->dispatch(new WorkerInterrupted($signal, $connectionName, $queue, $options));
 
                 $this->notifyJobOfSignal($signal);
             });
         }
 
-        pcntl_signal(SIGUSR2, function () use ($queue, $connectionName) {
+        pcntl_signal(SIGUSR2, function () use ($queue, $connectionName, $options) {
             $this->paused = true;
 
-            $this->events->dispatch(new WorkerPausing($connectionName, $queue));
+            $this->events->dispatch(new WorkerPausing($connectionName, $queue, $options));
         });
 
-        pcntl_signal(SIGCONT, function () use ($connectionName, $queue) {
+        pcntl_signal(SIGCONT, function () use ($connectionName, $queue, $options) {
             $this->paused = false;
 
-            $this->events->dispatch(new WorkerResuming($connectionName, $queue));
+            $this->events->dispatch(new WorkerResuming($connectionName, $queue, $options));
         });
     }
 


### PR DESCRIPTION
Happy Friday!

This PR adds workerOptions to Pausing/Resuming/Interrupted events. It's typed, like the events.

I would like to see the `--name` of the worker that these events occur on which I can pull from the options.

This is very useful if queues are split over various workers .. this means I can pinpoint exactly what worker it was.

This also follows the WorkerStarting and Stopping events.. making them all align... slowly   cause right now we see WorkerPausing.. but the question is... which worker? :D 
