### PR TITLE
[12.x] Fix raw-block placeholder restoration when `@endphp` / `@endverbatim` immediately precedes a Blade echo

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -481,7 +481,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     protected function getRawPlaceholder($replace)
     {
-        return str_replace('#', $replace, '@__raw_block_#__@');
+        return str_replace('#', $replace, '@__raw_block_#__');
     }
 
     /**

--- a/tests/View/Blade/BladePhpStatementsTest.php
+++ b/tests/View/Blade/BladePhpStatementsTest.php
@@ -178,4 +178,32 @@ class BladePhpStatementsTest extends AbstractBladeTestCase
         $template = "<a @class(['k\' => ()])></a>";
         $this->assertEquals($template, $this->compiler->compileString($template));
     }
+
+    public function testPhpBlockFollowedImmediatelyByRegularEchoIsCompiled()
+    {
+        $string = '@php $x = 1; @endphp{{ $x }}';
+        $expected = '<?php $x = 1; ?><?php echo e($x); ?>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testPhpBlockFollowedImmediatelyByRawEchoIsCompiled()
+    {
+        $string = '@php $x = 1; @endphp{!! $x !!}';
+        $expected = '<?php $x = 1; ?><?php echo $x; ?>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testPhpBlockFollowedImmediatelyByLegacyEscapedEchoIsCompiled()
+    {
+        $string = '@php $x = 1; @endphp{{{ $x }}}';
+        $expected = '<?php $x = 1; ?><?php echo e($x); ?>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testAdjacentPhpBlocksAreCompiled()
+    {
+        $string = '@php $x = 1; @endphp@php $y = $x; @endphp';
+        $expected = '<?php $x = 1; ?><?php $y = $x; ?>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
 }

--- a/tests/View/Blade/BladeVerbatimTest.php
+++ b/tests/View/Blade/BladeVerbatimTest.php
@@ -101,4 +101,11 @@ class BladeVerbatimTest extends AbstractBladeTestCase
         $expected = "<?php echo e(1); ?>\n\nhello world\n";
         $this->assertSame($expected, $this->compiler->compileString($string));
     }
+
+    public function testVerbatimBlockFollowedImmediatelyByEchoIsCompiled()
+    {
+        $string = '@verbatim {{ literal }} @endverbatim{{ $value }}';
+        $expected = ' {{ literal }} <?php echo e($value); ?>';
+        $this->assertSame($expected, $this->compiler->compileString($string));
+    }
 }


### PR DESCRIPTION
When `@php ... @endphp` or `@verbatim ... @endverbatim` is followed immediately (no whitespace) by a Blade echo (`{{ ... }}`, `{!! ... !!}`, `{{{ ... }}}`), the raw-block placeholder leaks into the output and the trailing echo is emitted literally.

Reproducer:

```php
$c = new BladeCompiler(new Filesystem(), sys_get_temp_dir());
echo $c->compileString('@php $x = 1; @endphp{{ $x }}');
```

Before: `@__raw_block_0__{{ $x }}` (placeholder rendered to browser, `$x` undefined at runtime).
After: `<?php $x = 1; ?><?php echo e($x); ?>`.

### Root cause

`getRawPlaceholder()` produces `@__raw_block_N__@`. `compileEchos()` regex `/(@)?{{...}}/` matches the placeholder's trailing `@` as a Vue-style escape sigil, eats it, and emits the following `{{ ... }}` literally. `restoreRawContent()` then can't match the now-truncated placeholder.

### Fix

Drop the trailing `@` from the placeholder. The echo regex's `(@)?` group has nothing to consume.

### Notes for reviewers

* The leading `@` of the placeholder is incidentally matched by `compileStatements` and survives via the fallthrough `return $match[0]` when no directive of that name exists. That fallthrough is load-bearing for the placeholder mechanism. Anyone touching it should preserve this behavior.
* Realistic trigger is zero-whitespace concatenation in HTML-sensitive contexts: `@endphp{{ $currency }}`, `@endphp{{ $slug }}` inside a URL attribute, `@endverbatim{{ $delim }}` inside a JS string, etc.

### Tests

Five regression tests added in `BladePhpStatementsTest` and `BladeVerbatimTest` covering regular echo, raw echo, legacy escaped echo, adjacent `@php` blocks, and `@verbatim` followed by echo. All 450 `tests/View/` tests pass. The `@{{ vue }}` escape syntax remains intact.

### Backward compatibility

No public API changes. The placeholder is a transient internal token within a single `compileString()` call and never persisted to disk.
