### PR TITLE
URL Encode Paths

### DIFF
--- a/src/Illuminate/Filesystem/LocalFilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/LocalFilesystemAdapter.php
@@ -82,7 +82,7 @@ class LocalFilesystemAdapter extends FilesystemAdapter
         return $url->to($url->temporarySignedRoute(
             'storage.'.$this->disk,
             $expiration,
-            ['path' => $path],
+            ['path' => rawurlencode($path)],
             absolute: false
         ));
     }
@@ -115,7 +115,7 @@ class LocalFilesystemAdapter extends FilesystemAdapter
             'url' => $url->to($url->temporarySignedRoute(
                 'storage.'.$this->disk.'.upload',
                 $expiration,
-                ['path' => $path, 'upload' => true],
+                ['path' => rawurlencode($path), 'upload' => true],
                 absolute: false
             )),
             'headers' => [],

--- a/tests/Integration/Filesystem/ReceiveFileTest.php
+++ b/tests/Integration/Filesystem/ReceiveFileTest.php
@@ -13,7 +13,10 @@ class ReceiveFileTest extends TestCase
     protected function setUp(): void
     {
         $this->beforeApplicationDestroyed(function () {
-            Storage::delete('receive-file-test.txt');
+            Storage::delete([
+                'receive-file-test.txt',
+                'receive-file-test.txt?pad=x',
+            ]);
         });
 
         parent::setUp();
@@ -72,5 +75,27 @@ class ReceiveFileTest extends TestCase
         $response = $this->get($uploadUrl['url']);
 
         $response->assertForbidden();
+    }
+
+    public function testItCanReceiveAFileWithUriDelimitersInThePath()
+    {
+        $result = Storage::temporaryUploadUrl('receive-file-test.txt?pad=x', Carbon::now()->addMinute());
+
+        $response = $this->call('PUT', $result['url'], [], [], [], [], 'Hello Question');
+
+        $response->assertNoContent();
+        Storage::assertExists('receive-file-test.txt?pad=x', 'Hello Question');
+        Storage::assertMissing('receive-file-test.txt');
+    }
+
+    public function testUriDelimitersInThePathCannotHideAnExpiredUploadUrl()
+    {
+        $result = Storage::temporaryUploadUrl('receive-file-test.txt?pad=x', Carbon::now()->subMinute());
+
+        $response = $this->call('PUT', $result['url'], [], [], [], [], 'Hello Question');
+
+        $response->assertForbidden();
+        Storage::assertMissing('receive-file-test.txt');
+        Storage::assertMissing('receive-file-test.txt?pad=x');
     }
 }

--- a/tests/Integration/Filesystem/ServeFileTest.php
+++ b/tests/Integration/Filesystem/ServeFileTest.php
@@ -14,10 +14,14 @@ class ServeFileTest extends TestCase
     {
         $this->afterApplicationCreated(function () {
             Storage::put('serve-file-test.txt', 'Hello World');
+            Storage::put('serve-file-test.txt?pad=x', 'Hello Question');
         });
 
         $this->beforeApplicationDestroyed(function () {
-            Storage::delete('serve-file-test.txt');
+            Storage::delete([
+                'serve-file-test.txt',
+                'serve-file-test.txt?pad=x',
+            ]);
         });
 
         parent::setUp();
@@ -46,6 +50,24 @@ class ServeFileTest extends TestCase
         $url = Storage::temporaryUrl('serve-file-test.txt', Carbon::now()->addMinute());
 
         $url = $url.'c';
+
+        $response = $this->get($url);
+
+        $response->assertForbidden();
+    }
+
+    public function testItCanServeAFileWithUriDelimitersInThePath()
+    {
+        $url = Storage::temporaryUrl('serve-file-test.txt?pad=x', Carbon::now()->addMinute());
+
+        $response = $this->get($url);
+
+        $this->assertSame('Hello Question', $response->streamedContent());
+    }
+
+    public function testUriDelimitersInThePathCannotHideAnExpiredUrl()
+    {
+        $url = Storage::temporaryUrl('serve-file-test.txt?pad=x', Carbon::now()->subMinute());
 
         $response = $this->get($url);
 


### PR DESCRIPTION
This change fixes local filesystem temporary signed URLs by URL-encoding the storage path before placing it into the signed route path segment, preventing URI delimiter characters such as ?, &, and # from being interpreted as query strings or fragments. This ensures the signed URL always resolves to the intended storage key and that reserved signed-route parameters like expires remain standalone query parameters, so expiration and signature validation are enforced correctly for both temporaryUrl() and temporaryUploadUrl().