### PR TITLE
[13.x] Optionally flush the SQS overflow store on queue:clear

### DIFF
--- a/config/queue.php
+++ b/config/queue.php
@@ -67,6 +67,7 @@ return [
                 'store' => env('SQS_OVERFLOW_STORE'),
                 'always' => false,
                 'delete_after_processing' => true,
+                'flush_on_clear' => env('SQS_OVERFLOW_FLUSH_ON_CLEAR', false),
             ],
         ],
 

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -451,6 +451,13 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
             $this->sqs->purgeQueue([
                 'QueueUrl' => $this->getQueue($queue),
             ]);
+
+            if (Arr::get($this->overflowStorage, 'enabled')
+                && Arr::get($this->overflowStorage, 'flush_on_clear')) {
+                $this->container->make('cache')->store(
+                    Arr::get($this->overflowStorage, 'store')
+                )->flush();
+            }
         });
     }
 

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -774,8 +774,17 @@ class QueueSqsQueueTest extends TestCase
         $queue->pushRaw($largePayload, $this->queueName);
     }
 
-    public function testClearDoesNotFlushCacheStore()
+    public function testClearFlushesOverflowStoreWhenFlushOnClearEnabled()
     {
+        $store = m::mock(CacheRepository::class);
+        $store->shouldReceive('flush')->once();
+
+        $cache = m::mock(CacheFactory::class);
+        $cache->shouldReceive('store')->once()->with('database')->andReturn($store);
+
+        $container = m::mock(Container::class);
+        $container->shouldReceive('make')->once()->with('cache')->andReturn($cache);
+
         $queue = $this->getMockBuilder(SqsQueue::class)
             ->onlyMethods(['getQueue', 'size'])
             ->setConstructorArgs([$this->sqs, $this->queueName, $this->prefix, '', false, [
@@ -783,9 +792,88 @@ class QueueSqsQueueTest extends TestCase
                 'store' => 'database',
                 'always' => false,
                 'delete_after_processing' => true,
+                'flush_on_clear' => true,
             ]])
             ->getMock();
-        $queue->setContainer(m::mock(Container::class));
+        $queue->setContainer($container);
+        $queue->expects($this->once())->method('getQueue')->willReturn($this->queueUrl);
+        $queue->expects($this->once())->method('size')->willReturn(5);
+
+        $this->sqs->shouldReceive('purgeQueue')->once();
+
+        $queue->clear($this->queueName);
+    }
+
+    public function testClearDoesNotFlushOverflowStoreWhenFlushOnClearDisabled()
+    {
+        $container = m::mock(Container::class);
+        $container->shouldNotReceive('make');
+
+        $queue = $this->getMockBuilder(SqsQueue::class)
+            ->onlyMethods(['getQueue', 'size'])
+            ->setConstructorArgs([$this->sqs, $this->queueName, $this->prefix, '', false, [
+                'enabled' => true,
+                'store' => 'database',
+                'always' => false,
+                'delete_after_processing' => true,
+                'flush_on_clear' => false,
+            ]])
+            ->getMock();
+        $queue->setContainer($container);
+        $queue->expects($this->once())->method('getQueue')->willReturn($this->queueUrl);
+        $queue->expects($this->once())->method('size')->willReturn(5);
+
+        $this->sqs->shouldReceive('purgeQueue')->once();
+
+        $queue->clear($this->queueName);
+    }
+
+    public function testClearDoesNotFlushOverflowStoreWhenOverflowDisabled()
+    {
+        $container = m::mock(Container::class);
+        $container->shouldNotReceive('make');
+
+        $queue = $this->getMockBuilder(SqsQueue::class)
+            ->onlyMethods(['getQueue', 'size'])
+            ->setConstructorArgs([$this->sqs, $this->queueName, $this->prefix, '', false, [
+                'enabled' => false,
+                'store' => 'database',
+                'always' => false,
+                'delete_after_processing' => true,
+                'flush_on_clear' => true,
+            ]])
+            ->getMock();
+        $queue->setContainer($container);
+        $queue->expects($this->once())->method('getQueue')->willReturn($this->queueUrl);
+        $queue->expects($this->once())->method('size')->willReturn(5);
+
+        $this->sqs->shouldReceive('purgeQueue')->once();
+
+        $queue->clear($this->queueName);
+    }
+
+    public function testClearForwardsConfiguredStoreNameToFactory()
+    {
+        $store = m::mock(CacheRepository::class);
+        $store->shouldReceive('flush')->once();
+
+        $cache = m::mock(CacheFactory::class);
+        $cache->shouldReceive('store')->once()->with('redis')->andReturn($store);
+
+        $container = m::mock(Container::class);
+        $container->shouldReceive('make')->once()->with('cache')->andReturn($cache);
+
+        $queue = $this->getMockBuilder(SqsQueue::class)
+            ->onlyMethods(['getQueue', 'size'])
+            ->setConstructorArgs([$this->sqs, $this->queueName, $this->prefix, '', false, [
+                'enabled' => true,
+                'store' => 'redis',
+                'always' => false,
+                'delete_after_processing' => true,
+                'flush_on_clear' => true,
+            ]])
+            ->getMock();
+        $queue->setContainer($container);
         $queue->expects($this->once())->method('getQueue')->willReturn($this->queueUrl);
         $queue->expects($this->once())->method('size')->willReturn(5);
 


### PR DESCRIPTION
Right now, `queue:clear` purges SQS but leaves the offloaded payloads sitting in the cache store. Even if a TTL got added later, when someone clears the queue, they may want the storage reclaimed now rather than waiting for expiration (matters especially on S3, where leftover objects keep costing money or persistence of payloads with sensitive data could be an issue).

Adds an opt-in `flush_on_clear` flag under the `overflow` config. When on, `SqsQueue::clear()` calls `flush()` on the configured cache store after purging SQS. Defaults to off.

Worth flagging: for most cache stores `flush()` wipes the whole store, not just the overflow entries. I considered some options to narrow its scope. Like tags or maybe a manifest file/entry pattern. Tags didn't seem right (though maybe that is still an option), and a manifest adds per-push overhead and concurrency issues that felt heavier than the feature needs. So this is opt-in and separate from `delete_after_processing`, with the recommendation to point `overflow.store` at a dedicated cache store (the new `storage` driver with its own disk and/or path is a clean fit).

Tests cover flush runs when enabled, don't run when disabled or when overflow is off, and forward the configured store name.

Has any user-facing documentation been written for the overflow feature yet? Happy to put together a docs PR if not.
