### PR TITLE
[13.x] Dispatch `QueueBusy` from `queue:work`

### DIFF
--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -45,6 +45,7 @@ class WorkCommand extends Command
                             {--memory=128 : The memory limit in megabytes}
                             {--sleep=3 : The number of seconds to sleep when no job is available}
                             {--rest=0 : The number of seconds to rest between jobs}
+                            {--max-busy=0 : Dispatch QueueBusy if queue size exceeds this (0=disabled)}
                             {--timeout=60 : The number of seconds a child process can run}
                             {--tries=1 : The number of times to attempt a job before logging it failed}
                             {--json : Output the queue worker information as JSON}';
@@ -168,6 +169,7 @@ class WorkCommand extends Command
             $this->option('stop-when-empty'),
             $this->option('max-jobs'),
             $this->option('max-time'),
+            $this->option('max-busy'),
             $this->option('rest'),
         );
     }

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -17,6 +17,7 @@ use Illuminate\Queue\Events\JobProcessing;
 use Illuminate\Queue\Events\JobReleasedAfterException;
 use Illuminate\Queue\Events\JobTimedOut;
 use Illuminate\Queue\Events\Looping;
+use Illuminate\Queue\Events\QueueBusy;
 use Illuminate\Queue\Events\WorkerIdle;
 use Illuminate\Queue\Events\WorkerInterrupted;
 use Illuminate\Queue\Events\WorkerPausing;
@@ -154,6 +155,13 @@ class Worker
     public static $pausable = true;
 
     /**
+     * When the worker last checked whether to dispatch a QueueBusy event.
+     *
+     * @var bool
+     */
+    protected int $lastBusyCheck = 0;
+
+    /**
      * Create a new queue worker.
      *
      * @param  \Illuminate\Contracts\Queue\Factory  $manager
@@ -240,6 +248,17 @@ class Worker
                 $this->events->dispatch(new WorkerIdle($connectionName, $queue, $options));
 
                 $this->sleep($options->sleep);
+            }
+
+            // If a busy threshold has been defined, and it's been at
+            // least a minute (could be longer if the job is slow)
+            // check whether the queue size is considered busy.
+            if ($options->maxBusy > 0 && (time() - $this->lastBusyCheck) >= 60) {
+                $this->lastBusyCheck = time();
+
+                if (($size = $this->manager->connection($connectionName)->size($queue)) >= $options->maxBusy) {
+                    $this->events->dispatch(new QueueBusy($connectionName, $queue, $size));
+                }
             }
 
             if ($supportsAsyncSignals) {

--- a/src/Illuminate/Queue/WorkerOptions.php
+++ b/src/Illuminate/Queue/WorkerOptions.php
@@ -82,6 +82,11 @@ class WorkerOptions
     public $maxTime;
 
     /**
+     * The max queue size before dispatching QueueBusy.
+     */
+    public int $maxBusy = 0;
+
+    /**
      * Create a new worker options instance.
      *
      * @param  string  $name
@@ -94,6 +99,7 @@ class WorkerOptions
      * @param  bool  $stopWhenEmpty
      * @param  int  $maxJobs
      * @param  int  $maxTime
+     * @param  int  $maxBusy
      * @param  int  $rest
      */
     public function __construct(
@@ -107,6 +113,7 @@ class WorkerOptions
         $stopWhenEmpty = false,
         $maxJobs = 0,
         $maxTime = 0,
+        $maxBusy = 0,
         $rest = 0,
     ) {
         $this->name = $name;
@@ -120,5 +127,6 @@ class WorkerOptions
         $this->stopWhenEmpty = $stopWhenEmpty;
         $this->maxJobs = $maxJobs;
         $this->maxTime = $maxTime;
+        $this->maxBusy = $maxBusy;
     }
 }


### PR DESCRIPTION
Listening for `QueueBusy` events is useful.

- **Before**: we schedule `queue:monitor --max=100` every minute (along with a comment reminding us the [docs say this is how we get those precious events](https://laravel.com/docs/13.x/queues#monitoring-your-queues)) and (depending on setup perhaps?) see it noisily churning away every minute 🙈 

- **After**: we add `max-busy=100` to each `queue:work` we care about (maybe more than one!) and it just happens, plus it's super clear when listing background processes in the cluster what the thresholds are

Did wonder if dispatching from `queue:monitor` should be deprecated, but depends if this is merged 😆

If it is, I'll happily update the docs (you've seen me flapping around in Dusk docs, Taylor!) but may need help with tests, I'm but one man 😅 
