### PR TITLE
[13.x] Add whenIsUrl(), whenIsJson(), and whenIsMatch() to Stringable

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1291,6 +1291,43 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
+     * Execute the given callback if the string is a valid URL.
+     *
+     * @param  callable  $callback
+     * @param  callable|null  $default
+     * @return static
+     */
+    public function whenIsUrl($callback, $default = null)
+    {
+        return $this->when($this->isUrl(), $callback, $default);
+    }
+
+    /**
+     * Execute the given callback if the string is valid JSON.
+     *
+     * @param  callable  $callback
+     * @param  callable|null  $default
+     * @return static
+     */
+    public function whenIsJson($callback, $default = null)
+    {
+        return $this->when($this->isJson(), $callback, $default);
+    }
+
+    /**
+     * Execute the given callback if the string matches the given regex pattern.
+     *
+     * @param  string|iterable<string>  $pattern
+     * @param  callable  $callback
+     * @param  callable|null  $default
+     * @return static
+     */
+    public function whenIsMatch($pattern, $callback, $default = null)
+    {
+        return $this->when($this->isMatch($pattern), $callback, $default);
+    }
+
+    /**
      * Execute the given callback if the string starts with a given substring.
      *
      * @param  string|iterable<string>  $needles

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -436,6 +436,63 @@ class SupportStringableTest extends TestCase
         }));
     }
 
+    public function testWhenIsUrl()
+    {
+        $this->assertSame('Url: https://laravel.com', (string) $this->stringable('https://laravel.com')->whenIsUrl(function ($stringable) {
+            return $stringable->prepend('Url: ');
+        }, function ($stringable) {
+            return $stringable->prepend('Not Url: ');
+        }));
+
+        $this->assertSame('not-a-url', (string) $this->stringable('not-a-url')->whenIsUrl(function ($stringable) {
+            return $stringable->prepend('Url: ');
+        }));
+
+        $this->assertSame('Not Url: not-a-url', (string) $this->stringable('not-a-url')->whenIsUrl(function ($stringable) {
+            return $stringable->prepend('Url: ');
+        }, function ($stringable) {
+            return $stringable->prepend('Not Url: ');
+        }));
+    }
+
+    public function testWhenIsJson()
+    {
+        $this->assertSame('Json: {"foo":"bar"}', (string) $this->stringable('{"foo":"bar"}')->whenIsJson(function ($stringable) {
+            return $stringable->prepend('Json: ');
+        }, function ($stringable) {
+            return $stringable->prepend('Not Json: ');
+        }));
+
+        $this->assertSame('not-json', (string) $this->stringable('not-json')->whenIsJson(function ($stringable) {
+            return $stringable->prepend('Json: ');
+        }));
+
+        $this->assertSame('Not Json: not-json', (string) $this->stringable('not-json')->whenIsJson(function ($stringable) {
+            return $stringable->prepend('Json: ');
+        }, function ($stringable) {
+            return $stringable->prepend('Not Json: ');
+        }));
+    }
+
+    public function testWhenIsMatch()
+    {
+        $this->assertSame('Match: foo123', (string) $this->stringable('foo123')->whenIsMatch('/foo\d+/', function ($stringable) {
+            return $stringable->prepend('Match: ');
+        }, function ($stringable) {
+            return $stringable->prepend('No Match: ');
+        }));
+
+        $this->assertSame('bar', (string) $this->stringable('bar')->whenIsMatch('/foo\d+/', function ($stringable) {
+            return $stringable->prepend('Match: ');
+        }));
+
+        $this->assertSame('No Match: bar', (string) $this->stringable('bar')->whenIsMatch('/foo\d+/', function ($stringable) {
+            return $stringable->prepend('Match: ');
+        }, function ($stringable) {
+            return $stringable->prepend('No Match: ');
+        }));
+    }
+
     public function testWhenTest()
     {
         $this->assertSame('Winner: foo bar', (string) $this->stringable('foo bar')->whenTest('/bar/', function ($stringable) {


### PR DESCRIPTION
## Summary

`Stringable` already provides conditional `when*` callbacks for `isAscii()`, `isUuid()`, and
`isUlid()`, but three of its sibling `is*` methods — `isUrl()`, `isJson()`, and `isMatch()` —
have no `when*` counterparts. This PR fills that gap.

---

## Before / After

**Before** — required a manual boolean check via the generic `when()`:

```php
Str::of($url)->when(Str::isUrl($url), fn ($s) => $s->prepend('Valid: '));
```

**After** — fluent and self-descriptive:

```php
Str::of($url)->whenIsUrl(fn ($s) => $s->prepend('Valid: '));

Str::of($payload)->whenIsJson(fn ($s) => $s->prepend('Parsed: '));

Str::of($input)->whenIsMatch('/^\d{4}$/', fn ($s) => $s->prepend('Year: '));
```

---

## Real-World Example

Normalising incoming webhook field values that can arrive as a URL, JSON blob,
date string, or plain text — without a tangle of `if/else` checks:

```php
function normalise(string $value): string
{
    return (string) Str::of($value)
        ->whenIsUrl(
            fn ($s) => $s->replaceFirst('https://', '')->rtrim('/')
        )
        ->whenIsJson(
            fn ($s) => Str::of(json_decode($s)->label ?? $s)
        )
        ->whenIsMatch('/^\d{4}-\d{2}-\d{2}$/',
            fn ($s) => Str::of(date('j M Y', strtotime($s)))
        );
}
```

| Input | Output |
|---|---|
| `https://laravel.com/docs` | `laravel.com/docs` |
| `{"label":"Pro Plan","price":99}` | `Pro Plan` |
| `2025-05-16` | `16 May 2025` |
| `Just a plain note` | `Just a plain note` |

> Each `when*` method is a no-op when its condition is not met, so the value passes through cleanly without extra guards.

---

## Changes

- Added `whenIsUrl()`, `whenIsJson()`, and `whenIsMatch()` to `Illuminate\Support\Stringable`
- Added tests for all three methods following the same pattern as `testWhenIsUuid()` and `testWhenIsUlid()`
