### PR TITLE
[13.x] Skip delimiter filesystem tests on Windows 

### DIFF
--- a/tests/Integration/Filesystem/ReceiveFileTest.php
+++ b/tests/Integration/Filesystem/ReceiveFileTest.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Storage;
 use Orchestra\Testbench\Attributes\WithConfig;
 use Orchestra\Testbench\TestCase;
+use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 
 #[WithConfig('filesystems.disks.local.serve', true)]
 class ReceiveFileTest extends TestCase
@@ -77,6 +78,7 @@ class ReceiveFileTest extends TestCase
         $response->assertForbidden();
     }
 
+    #[RequiresOperatingSystem('Linux|Darwin')]
     public function testItCanReceiveAFileWithUriDelimitersInThePath()
     {
         $result = Storage::temporaryUploadUrl('receive-file-test.txt?pad=x', Carbon::now()->addMinute());
@@ -88,6 +90,7 @@ class ReceiveFileTest extends TestCase
         Storage::assertMissing('receive-file-test.txt');
     }
 
+    #[RequiresOperatingSystem('Linux|Darwin')]
     public function testUriDelimitersInThePathCannotHideAnExpiredUploadUrl()
     {
         $result = Storage::temporaryUploadUrl('receive-file-test.txt?pad=x', Carbon::now()->subMinute());

--- a/tests/Integration/Filesystem/ServeFileTest.php
+++ b/tests/Integration/Filesystem/ServeFileTest.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Storage;
 use Orchestra\Testbench\Attributes\WithConfig;
 use Orchestra\Testbench\TestCase;
+use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 
 #[WithConfig('filesystems.disks.local.serve', true)]
 class ServeFileTest extends TestCase
@@ -56,6 +57,7 @@ class ServeFileTest extends TestCase
         $response->assertForbidden();
     }
 
+    #[RequiresOperatingSystem('Linux|Darwin')]
     public function testItCanServeAFileWithUriDelimitersInThePath()
     {
         $url = Storage::temporaryUrl('serve-file-test.txt?pad=x', Carbon::now()->addMinute());
@@ -65,6 +67,7 @@ class ServeFileTest extends TestCase
         $this->assertSame('Hello Question', $response->streamedContent());
     }
 
+    #[RequiresOperatingSystem('Linux|Darwin')]
     public function testUriDelimitersInThePathCannotHideAnExpiredUrl()
     {
         $url = Storage::temporaryUrl('serve-file-test.txt?pad=x', Carbon::now()->subMinute());


### PR DESCRIPTION
Windows tests be failing https://github.com/laravel/framework/actions/runs/25948130095/job/76280415683 

which was caused by https://github.com/laravel/framework/pull/60137 (It was Taylor 😃! ) 

This is cause `?` on Windows is not a not a valid filename character  

<img width="793" height="159" alt="ApplicationFrameHost_ermfkA3TY5" src="https://github.com/user-attachments/assets/afbd4202-e3c1-4bbc-803d-4914f0efb6c2" />



I decided to just skip these cause its a bit of a rabbit hole... 