### PR TITLE
[13.x] Allow passing scheduled `Event` in callbacks

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -282,9 +282,7 @@ class Event
 
         $eventParameterType = Arr::get($parameters, 'event');
 
-        if ($eventParameterType === null ||
-            ! is_a($eventParameterType, Event::class, true) ||
-            ! is_a($this, $eventParameterType)) {
+        if ($eventParameterType === null || ! is_a($this, $eventParameterType)) {
             return [];
         }
 

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -238,7 +238,7 @@ class Event
     public function callBeforeCallbacks(Container $container)
     {
         foreach ($this->beforeCallbacks as $callback) {
-            $container->call($callback);
+            $this->callEventCallback($container, $callback);
         }
     }
 
@@ -251,8 +251,44 @@ class Event
     public function callAfterCallbacks(Container $container)
     {
         foreach ($this->afterCallbacks as $callback) {
-            $container->call($callback);
+            $this->callEventCallback($container, $callback);
         }
+    }
+
+    /**
+     * Call the given event callback.
+     *
+     * @param  \Illuminate\Contracts\Container\Container  $container
+     * @param  \Closure  $callback
+     * @param  array  $parameters
+     * @return mixed
+     */
+    protected function callEventCallback(Container $container, Closure $callback, array $parameters = [])
+    {
+        return $container->call($callback, array_merge(
+            $this->eventParametersForCallback($callback), $parameters
+        ));
+    }
+
+    /**
+     * Get the event parameters for the given callback.
+     *
+     * @param  \Closure  $callback
+     * @return array
+     */
+    protected function eventParametersForCallback(Closure $callback)
+    {
+        $parameters = $this->closureParameterTypes($callback);
+
+        $eventParameterType = Arr::get($parameters, 'event');
+
+        if ($eventParameterType === null ||
+            ! is_a($eventParameterType, Event::class, true) ||
+            ! is_a($this, $eventParameterType)) {
+            return [];
+        }
+
+        return ['event' => $this];
     }
 
     /**
@@ -339,13 +375,13 @@ class Event
         $this->lastChecked = Date::now();
 
         foreach ($this->filters as $callback) {
-            if (! $app->call($callback)) {
+            if (! $this->callEventCallback($app, $callback)) {
                 return false;
             }
         }
 
         foreach ($this->rejects as $callback) {
-            if ($app->call($callback)) {
+            if ($this->callEventCallback($app, $callback)) {
                 return false;
             }
         }
@@ -690,7 +726,7 @@ class Event
 
         return $this->then(function (Container $container) use ($callback) {
             if ($this->exitCode === 0) {
-                $container->call($callback);
+                $this->callEventCallback($container, $callback);
             }
         });
     }
@@ -725,7 +761,7 @@ class Event
 
         return $this->then(function (Container $container) use ($callback) {
             if ($this->exitCode !== 0) {
-                $container->call($callback);
+                $this->callEventCallback($container, $callback);
             }
         });
     }
@@ -758,7 +794,7 @@ class Event
 
             return $onlyIfOutputExists && empty($output)
                 ? null
-                : $container->call($callback, ['output' => new Stringable($output)]);
+                : $this->callEventCallback($container, $callback, ['output' => new Stringable($output)]);
         };
     }
 

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -260,7 +260,7 @@ class Event
      *
      * @param  \Illuminate\Contracts\Container\Container  $container
      * @param  \Closure  $callback
-     * @param  array  $parameters
+     * @param  array<string, mixed>  $parameters
      * @return mixed
      */
     protected function callEventCallback(Container $container, Closure $callback, array $parameters = [])

--- a/tests/Console/Scheduling/EventTest.php
+++ b/tests/Console/Scheduling/EventTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Console\Scheduling;
 
 use Illuminate\Console\Scheduling\Event;
 use Illuminate\Console\Scheduling\EventMutex;
+use Illuminate\Container\Container;
 use Illuminate\Support\Str;
 use Mockery as m;
 use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
@@ -96,6 +97,52 @@ class EventTest extends TestCase
         });
 
         $this->assertSame('fancy-command-description', $event->mutexName());
+    }
+
+    public function testBeforeAndAfterCallbacksCanReceiveEvent()
+    {
+        $container = new Container;
+        $beforeEvent = null;
+        $afterEvent = null;
+        $event = new Event(m::mock(EventMutex::class), 'php -i');
+
+        $event->before(function (Event $event) use (&$beforeEvent) {
+            $beforeEvent = $event;
+        });
+
+        $event->after(function (Event $event) use (&$afterEvent) {
+            $afterEvent = $event;
+        });
+
+        $event->callBeforeCallbacks($container);
+        $event->callAfterCallbacks($container);
+
+        $this->assertSame($event, $beforeEvent);
+        $this->assertSame($event, $afterEvent);
+    }
+
+    public function testFilterCallbacksCanReceiveEvent()
+    {
+        $container = new Container;
+        $filterEvent = null;
+        $rejectEvent = null;
+        $event = new Event(m::mock(EventMutex::class), 'php -i');
+
+        $event->when(function (Event $event) use (&$filterEvent) {
+            $filterEvent = $event;
+
+            return true;
+        });
+
+        $event->skip(function (Event $event) use (&$rejectEvent) {
+            $rejectEvent = $event;
+
+            return false;
+        });
+
+        $this->assertTrue($event->filtersPass($container));
+        $this->assertSame($event, $filterEvent);
+        $this->assertSame($event, $rejectEvent);
     }
 
     public function testDaysOfMonthMethod()

--- a/tests/Integration/Console/Scheduling/CallbackEventTest.php
+++ b/tests/Integration/Console/Scheduling/CallbackEventTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Integration\Console\Scheduling;
 use Exception;
 use Illuminate\Console\Scheduling\CallbackEvent;
 use Illuminate\Console\Scheduling\EventMutex;
+use Illuminate\Support\Stringable;
 use Mockery as m;
 use Orchestra\Testbench\TestCase;
 
@@ -72,5 +73,51 @@ class CallbackEventTest extends TestCase
         $this->expectException(Exception::class);
 
         $event->run($this->app);
+    }
+
+    public function testOnSuccessCallbackCanReceiveEvent()
+    {
+        $callbackEvent = null;
+
+        $event = (new CallbackEvent(m::mock(EventMutex::class), function () {
+        }))->onSuccess(function (CallbackEvent $event) use (&$callbackEvent) {
+            $callbackEvent = $event;
+        });
+
+        $event->run($this->app);
+
+        $this->assertSame($event, $callbackEvent);
+    }
+
+    public function testOnFailureCallbackCanReceiveEvent()
+    {
+        $callbackEvent = null;
+
+        $event = (new CallbackEvent(m::mock(EventMutex::class), function () {
+            return false;
+        }))->onFailure(function (CallbackEvent $event) use (&$callbackEvent) {
+            $callbackEvent = $event;
+        });
+
+        $event->run($this->app);
+
+        $this->assertSame($event, $callbackEvent);
+    }
+
+    public function testOutputCallbackCanReceiveEvent()
+    {
+        $callbackEvent = null;
+        $outputValue = null;
+
+        $event = (new CallbackEvent(m::mock(EventMutex::class), function () {
+        }))->onSuccess(function (Stringable $output, CallbackEvent $event) use (&$callbackEvent, &$outputValue) {
+            $callbackEvent = $event;
+            $outputValue = (string) $output;
+        });
+
+        $event->run($this->app);
+
+        $this->assertSame($event, $callbackEvent);
+        $this->assertSame('', $outputValue);
     }
 }


### PR DESCRIPTION
This would be a lovely pairing with https://github.com/laravel/framework/pull/60133. 

## Background

Our team realized this week that some of our critical scheduled commands were dying on the vine due to OOM. It would be helpful to have standardized logs write `"Command {$event->command} started|completed|failed"` in before and after hooks. Given that we have so many scheduled commands, it's a bit tedious to write the callbacks for all of them. Also... we have to _remember_ to do it going forward 🫠 

## What this does
Allows userland to typehint a callback with `Event $event` as a parameter, and pass `$this` to it.

## Example
```php
Schedule::command('delete-expired-invites')
    ->hourly()
    ->before(fn (Event $event) => Log::info("Starting {$event->command}")
    ->after(fn (Stringable $output, Event $event) => Log::info("Completed {$event->command} with output:\n$output"));
```