### PR TITLE
[13.x] Switch force check in Worker

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -330,7 +330,7 @@ class Worker
      */
     protected function daemonShouldRun(WorkerOptions $options, $connectionName, $queue)
     {
-        return ! ((($this->isDownForMaintenance)() && ! $options->force) ||
+        return ! ((! $options->force && ($this->isDownForMaintenance)()) ||
             $this->paused ||
             $this->events->until(new Looping($connectionName, $queue)) === false);
     }


### PR DESCRIPTION
If you have `--force` on a worker it'll skip maintenance mode. 

Currently, the code checks its down via the maintenance driver (in most cases cache), and then checks if its forced, this means if you have `--force` its doing a cache check where it doesnt need to.

IE currently the cache lookup is wasted.. if you use `--force` this PR fixes that, and if you dont use it.. it'll still be as it was now :) 