### PR TITLE
[12.x] Fix Number::fileSize() handling of negative byte values

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -209,7 +209,7 @@ class Number
 
         $unitCount = count($units);
 
-        for ($i = 0; ($bytes / 1024) > 0.9 && ($i < $unitCount - 1); $i++) {
+        for ($i = 0; (abs($bytes) / 1024) > 0.9 && ($i < $unitCount - 1); $i++) {
             $bytes /= 1024;
         }
 

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -186,6 +186,12 @@ class SupportNumberTest extends TestCase
         $this->assertSame('1 ZB', Number::fileSize(1024 ** 7));
         $this->assertSame('1 YB', Number::fileSize(1024 ** 8));
         $this->assertSame('1,024 YB', Number::fileSize(1024 ** 9));
+
+        $this->assertSame('-1 B', Number::fileSize(-1));
+        $this->assertSame('-2 KB', Number::fileSize(-2048));
+        $this->assertSame('-2.00 KB', Number::fileSize(-2048, precision: 2));
+        $this->assertSame('-1.23 KB', Number::fileSize(-1264, precision: 2));
+        $this->assertSame('-5 GB', Number::fileSize(-1024 * 1024 * 1024 * 5));
     }
 
     public function testClamp()


### PR DESCRIPTION
`Number::fileSize()` does not scale negative byte values to the
appropriate unit, while `Number::forHumans()` in the same class does.

The loop condition uses `($bytes / 1024) > 0.9`, which is never true
for a negative number, so the loop never runs and the value is always
returned in bytes:

```php
Number::fileSize(-2048);    // "-2,048 B"  expected "-2 KB"
Number::fileSize(-1536000); // "-1,536,000 B"  expected "-1 MB"
```
