### PR TITLE
[13.x] Fix callable usage in `Event@callEventCallback()`

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -766,14 +766,18 @@ class Event
      * Call the given event callback.
      *
      * @param  \Illuminate\Contracts\Container\Container  $container
-     * @param  \Closure  $callback
+     * @param  callable  $callback
      * @param  array<string, mixed>  $parameters
      * @return mixed
      */
-    protected function callEventCallback(Container $container, Closure $callback, array $parameters = [])
+    protected function callEventCallback(Container $container, callable $callback, array $parameters = [])
     {
+        $eventParameters = $callback instanceof Closure
+            ? $this->eventParametersForCallback($callback)
+            : [];
+
         return $container->call($callback, array_merge(
-            $this->eventParametersForCallback($callback), $parameters
+            $eventParameters, $parameters
         ));
     }
 

--- a/tests/Console/Scheduling/EventTest.php
+++ b/tests/Console/Scheduling/EventTest.php
@@ -145,6 +145,41 @@ class EventTest extends TestCase
         $this->assertSame($event, $rejectEvent);
     }
 
+    public function testFilterCallbacksMayBeInvokableObjects()
+    {
+        $container = new Container;
+        $filter = new class
+        {
+            public int $calls = 0;
+
+            public function __invoke(): bool
+            {
+                $this->calls++;
+
+                return true;
+            }
+        };
+        $reject = new class
+        {
+            public int $calls = 0;
+
+            public function __invoke(): bool
+            {
+                $this->calls++;
+
+                return false;
+            }
+        };
+        $event = new Event(m::mock(EventMutex::class), 'php -i');
+
+        $event->when($filter);
+        $event->skip($reject);
+
+        $this->assertTrue($event->filtersPass($container));
+        $this->assertSame(1, $filter->calls);
+        $this->assertSame(1, $reject->calls);
+    }
+
     public function testDaysOfMonthMethod()
     {
         $event = new Event(m::mock(EventMutex::class), 'php -i');


### PR DESCRIPTION
This allows userland to continue passing non-Closures to the lifecycle/filter functions.