### PR TITLE
[13.x] Fix numeric property names being cast to integers in JsonSchema requi…

### DIFF
--- a/src/Illuminate/JsonSchema/Serializer.php
+++ b/src/Illuminate/JsonSchema/Serializer.php
@@ -53,10 +53,13 @@ class Serializer
             if (count($attributes['properties']) === 0) {
                 unset($attributes['properties']);
             } else {
-                $required = array_keys(array_filter(
-                    $attributes['properties'],
-                    static fn (Types\Type $property) => static::isRequired($property),
-                ));
+                $required = array_map(
+                    'strval',
+                    array_keys(array_filter(
+                        $attributes['properties'],
+                        static fn (Types\Type $property) => static::isRequired($property),
+                    ))
+                );
 
                 if ($required !== []) {
                     $attributes['required'] = $required;

--- a/tests/JsonSchema/ObjectTypeTest.php
+++ b/tests/JsonSchema/ObjectTypeTest.php
@@ -78,6 +78,20 @@ class ObjectTypeTest extends TestCase
         ], $type->toArray());
     }
 
+    public function test_numeric_string_property_names_remain_strings_in_required_array(): void
+    {
+        $type = JsonSchema::object([
+            '1' => JsonSchema::string()->required(),
+            '4' => JsonSchema::string()->required(),
+        ]);
+
+        $array = $type->toArray();
+
+        $this->assertSame(['1', '4'], $array['required']);
+        $this->assertIsString($array['required'][0]);
+        $this->assertIsString($array['required'][1]);
+    }
+
     public function test_it_may_disable_additional_properties(): void
     {
         $type = JsonSchema::object()->default(['age' => 1])->withoutAdditionalProperties();


### PR DESCRIPTION
JsonSchema ->toArray() renders numeric property names as integer in the "required" array #60146

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
