### PR TITLE
[13.x] Add `assertPushedOnce()`

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -149,6 +149,17 @@ class QueueFake extends QueueManager implements Fake, Queue
     }
 
     /**
+     * Assert if a job was pushed exactly once.
+     *
+     * @param  string  $job
+     * @return void
+     */
+    public function assertPushedOnce($job)
+    {
+        $this->assertPushedTimes($job, 1);
+    }
+
+    /**
      * Assert if a job was pushed based on a truth-test callback.
      *
      * @param  \UnitEnum|string  $queue


### PR DESCRIPTION
PhpStorm flaps about parameters matching default values:

```diff
- Queue::assertPushedTimes(JobsComingOutOurEarsJob::class, 1);
+ Queue::assertPushedTimes(JobsComingOutOurEarsJob::class);
```

But that reads weird. This reads nicer and silences the IDE:

```diff
- Queue::assertPushedTimes(JobsComingOutOurEarsJob::class, 1);
+ Queue::assertPushedOnce(JobsComingOutOurEarsJob::class);
```
