### PR TITLE
[13.x] Pass worker options to Looping

### DIFF
--- a/src/Illuminate/Queue/Events/Looping.php
+++ b/src/Illuminate/Queue/Events/Looping.php
@@ -9,10 +9,12 @@ class Looping
      *
      * @param  string  $connectionName  The connection name.
      * @param  string  $queue  The queue name.
+     * @param  \Illuminate\Queue\WorkerOptions|null  $workerOptions  The worker options.
      */
     public function __construct(
         public $connectionName,
         public $queue,
+        public $workerOptions = null,
     ) {
     }
 }

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -332,7 +332,7 @@ class Worker
     {
         return ! ((! $options->force && ($this->isDownForMaintenance)()) ||
             $this->paused ||
-            $this->events->until(new Looping($connectionName, $queue)) === false);
+            $this->events->until(new Looping($connectionName, $queue, $options)) === false);
     }
 
     /**


### PR DESCRIPTION
Konnichiwa ... am I too early? 

The `Looping` event may return false  to stop the loop, which is a cool feature

But, if you want to target certain workers you end up doing it against the queues assigned like: 

```php 
// This worker targets queues we want to pause, depending on app logic...
if ($event->queue === 'some-queue,some-queue-2,default' && someAppLogic()) {
  return false;
}
``` 

This is difficult to explain to devs as it needs you to know how Laravel's internals work, at least to some degree ie the queue isnt the specific queue, its --queue option including commas.

Its also painful if you adjust the queues so pretty fragile

By adding the worker options, we can target it by name... so its much easier to understand, and becomes: 

```php
if ($event->workerOptions->name === 'Bilbo-Bagginzzzz' && someAppLogic()) {
  return false;
}
``` 

This then means it's easier to target... and gives you the ability to use the other options, if for some reason you want to! 

Defaulted to null... just incase. 

We could probably add this to all the job events, but I dont have a real use case for it... so left it.