### PR TITLE
[12.x] Fix Str::limit() dropping a whole word when preserveWords is e…

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -744,7 +744,7 @@ class Str
 
         $trimmed = rtrim(mb_strimwidth($value, 0, $limit, '', 'UTF-8'));
 
-        if (mb_substr($value, $limit, 1, 'UTF-8') === ' ') {
+        if (mb_substr($value, mb_strlen($trimmed), 1, 'UTF-8') === ' ') {
             return $trimmed.$end;
         }
 

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -789,6 +789,9 @@ class SupportStrTest extends TestCase
         $this->assertSame('The PHP framework for web artisans.', Str::limit($string, 100, preserveWords: true));
         $this->assertSame('The PHP framework...', Str::limit($string, 20, preserveWords: true));
 
+        $this->assertSame('The quick...', Str::limit('The quick brown fox', 10, preserveWords: true));
+        $this->assertSame('The quick brown...', Str::limit('The quick brown fox', 16, preserveWords: true));
+
         $nonAsciiString = '这是一段中文';
         $this->assertSame('这是一...', Str::limit($nonAsciiString, 6));
         $this->assertSame('这是一...', Str::limit($nonAsciiString, 6, preserveWords: true));


### PR DESCRIPTION
### What's the problem?

When using `Str::limit()` with `preserveWords: true`, the last word that should've been kept gets silently dropped:

```php
Str::limit('The quick brown fox', 10, preserveWords: true);
// returns "The..."    expected "The quick..."

Str::limit('The quick brown fox', 16, preserveWords: true);
// returns "The quick..."    expected "The quick brown..."
```

### Why does it happen?

`mb_strimwidth()` sometimes returns a string with a trailing space, which `rtrim()` then removes — so `$trimmed` already lands exactly on a word boundary. The original code then checks whether the character at index `$limit` in the original string is a space, to figure out if the cut was clean:

```php
if (mb_substr($value, $limit, 1, 'UTF-8') === ' ') {
```

But after `rtrim()` removes the trailing space, this index is off by one — it points to the first character of the *next* word rather than the boundary space. The clean-cut check fails, the fallback `preg_replace()` fires, and the last word gets chopped off.

### The fix

Instead of checking at `$limit`, we check the character right after `$trimmed`:

```php
if (mb_substr($value, mb_strlen($trimmed), 1, 'UTF-8') === ' ') {
```

This correctly detects the word boundary regardless of whether a trailing space was trimmed.

### Testing

All existing `testLimit` assertions (including non-ASCII cases) and the full `Stringable` test suite pass without changes. Regression tests for the buggy cases are added.