### PR TITLE
[12.x] Fix wasChanged() reporting stale changes after a save with no changes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1229,8 +1229,13 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         // that is already in this database using the current IDs in this "where"
         // clause to only update this model. Otherwise, we'll just insert them.
         if ($this->exists) {
-            $saved = $this->isDirty() ?
-                $this->performUpdate($query) : true;
+            if ($this->isDirty()) {
+                $saved = $this->performUpdate($query);
+            } else {
+                $this->syncChanges();
+
+                $saved = true;
+            }
         }
 
         // If the model is brand new, we'll insert it into our database and set the

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -1721,6 +1721,31 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals(1, EloquentTestPost::count());
     }
 
+    public function testWasChangedIsResetAfterSaveWithoutChanges()
+    {
+        $user = EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
+
+        $user->email = 'foo@gmail.com';
+        $user->save();
+
+        $this->assertTrue($user->wasChanged('email'));
+        $this->assertSame(['email' => 'foo@gmail.com'], $user->getChanges());
+
+        // Saving again without any modifications should reset the recorded changes.
+        $user->save();
+
+        $this->assertFalse($user->wasChanged());
+        $this->assertFalse($user->wasChanged('email'));
+        $this->assertSame([], $user->getChanges());
+
+        // Setting an attribute to its current value is not a change either.
+        $user->email = 'foo@gmail.com';
+        $user->save();
+
+        $this->assertFalse($user->wasChanged('email'));
+        $this->assertSame([], $user->getChanges());
+    }
+
     public function testSavingJSONFields()
     {
         $model = EloquentTestWithJSON::create(['json' => ['x' => 0]]);


### PR DESCRIPTION
### What's the problem?
After saving a model with no pending changes, `wasChanged()` and `getChanges()` still report the changes from the *previous* save — even though nothing actually changed this time:

```php
$user->email = 'foo@example.com';
$user->save();
$user->wasChanged('email'); // true 

$user->save();              // nothing changed
$user->wasChanged('email'); // true  - should be false
$user->getChanges();        // ['email' => 'foo@example.com'] - should be []
```

The docs say `wasChanged()` reflects changes from "when the model was last saved" — so a no-op save should clear it.

### Why does it happen?

`syncChanges()` — the method responsible for updating `$model->changes` — is only called inside `performUpdate()`. But `performUpdate()` only runs when the model is actually dirty. When you call `save()` on a clean model, Laravel short-circuits early with a `return true` and never refreshes `$model->changes`, leaving it with the stale values from the previous save.

### The fix

One line: call `syncChanges()` on that short-circuit branch so a no-op save correctly records an empty change set. The insert path and the normal dirty-update path are completely untouched.