### PR TITLE
[13.x] fix: prevent double-prefix in make:enum, make:trait, and make:…

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -215,9 +215,19 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
             return $name;
         }
 
-        return $this->qualifyClass(
-            $this->getDefaultNamespace(trim($rootNamespace, '\\')).'\\'.$name
-        );
+        $defaultNamespace = $this->getDefaultNamespace(trim($rootNamespace, '\\'));
+
+        // Prevent double-prefixing when the default namespace adds a sub-namespace
+        // and the name already starts with that sub-namespace. This can happen when
+        // the sub-namespace directory is created by a prior make command invocation
+        // and the user explicitly includes the prefix in the name (e.g. Enums/Foo).
+        $subNamespace = ltrim(Str::after($defaultNamespace, trim($rootNamespace, '\\')), '\\');
+
+        if ($subNamespace !== '' && Str::startsWith($name, $subNamespace.'\\')) {
+            return $this->qualifyClass($rootNamespace.$name);
+        }
+
+        return $this->qualifyClass($defaultNamespace.'\\'.$name);
     }
 
     /**

--- a/tests/Integration/Generators/EnumMakeCommandTest.php
+++ b/tests/Integration/Generators/EnumMakeCommandTest.php
@@ -11,6 +11,9 @@ class EnumMakeCommandTest extends TestCase
         'app/StatusEnum.php',
         'app/StringEnum.php',
         'app/*/OrderStatusEnum.php',
+        'app/Enums/Profile/HairColor.php',
+        'app/Enums/Profile/EyeColor.php',
+        'app/Enums/Profile/Admin/Author.php',
     ];
 
     public function testItCanGenerateEnumFile()
@@ -84,5 +87,51 @@ class EnumMakeCommandTest extends TestCase
         ], 'app/Enumerations/OrderStatusEnum.php');
 
         $files->deleteDirectory($enumerationsFolderPath);
+    }
+
+    public function testItDoesNotDoublePrefixWhenEnumsDirExistsAndNameIncludesPrefix()
+    {
+        /** @var \Illuminate\Filesystem\Filesystem $files */
+        $files = $this->app['files'];
+
+        // First call creates app/Enums/Profile/HairColor.php and the app/Enums directory.
+        $this->artisan('make:enum', ['name' => 'Enums/Profile/HairColor'])
+            ->assertExitCode(0);
+
+        $this->assertFileContains([
+            'namespace App\Enums\Profile;',
+            'enum HairColor',
+        ], 'app/Enums/Profile/HairColor.php');
+
+        // Second call: app/Enums/ now exists. Without the fix, the path would become
+        // app/Enums/Enums/Profile/EyeColor.php (double-prefixed).
+        $this->artisan('make:enum', ['name' => 'Enums/Profile/EyeColor'])
+            ->assertExitCode(0);
+
+        $this->assertFileContains([
+            'namespace App\Enums\Profile;',
+            'enum EyeColor',
+        ], 'app/Enums/Profile/EyeColor.php');
+
+        $files->deleteDirectory(app_path('Enums'));
+    }
+
+    public function testItHandlesDeeplyNestedPathWithExistingEnumsDir()
+    {
+        /** @var \Illuminate\Filesystem\Filesystem $files */
+        $files = $this->app['files'];
+
+        // Simulate app/Enums/ already existing (e.g. created by a prior make:enum run).
+        $files->ensureDirectoryExists(app_path('Enums'));
+
+        $this->artisan('make:enum', ['name' => 'Enums/Profile/Admin/Author'])
+            ->assertExitCode(0);
+
+        $this->assertFileContains([
+            'namespace App\Enums\Profile\Admin;',
+            'enum Author',
+        ], 'app/Enums/Profile/Admin/Author.php');
+
+        $files->deleteDirectory(app_path('Enums'));
     }
 }


### PR DESCRIPTION
# fix: prevent double-prefix in `make:enum`, `make:trait`, and `make:interface` for nested paths

Fixes #60152

When using a namespace prefix in an artisan generator command (e.g. `make:enum Enums/Profile/HairColor`), the first invocation works correctly and creates `app/Enums/Profile/HairColor.php` — but as a side-effect it also creates the `app/Enums/` directory. Every subsequent call (e.g. `make:enum Enums/Profile/EyeColor`) then finds `app/Enums/` already exists, causing `getDefaultNamespace()` to return `App\Enums`. This gets prepended to the already-prefixed name `Enums\Profile\EyeColor`, producing the double-prefixed path `app/Enums/Enums/Profile/EyeColor.php`.

The same defect affects:

make:enum — detects app/Enums/ or app/Enumerations/
make:trait — detects app/Concerns/ or app/Traits/
make:interface — detects app/Contracts/ or app/Interfaces/

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
