### PR TITLE
Add support for UnitEnum in MailFake mailer and driver methods

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -16,6 +16,8 @@ use Illuminate\Support\Traits\ForwardsCalls;
 use Illuminate\Support\Traits\ReflectsClosures;
 use PHPUnit\Framework\Assert as PHPUnit;
 
+use function Illuminate\Support\enum_value;
+
 class MailFake implements Factory, Fake, Mailer, MailQueue
 {
     use ForwardsCalls, ReflectsClosures;
@@ -420,12 +422,12 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
     /**
      * Get a mailer instance by name.
      *
-     * @param  string|null  $name
+     * @param  \UnitEnum|string|null  $name
      * @return \Illuminate\Contracts\Mail\Mailer
      */
     public function mailer($name = null)
     {
-        $this->currentMailer = $name;
+        $this->currentMailer = enum_value($name);
 
         return $this;
     }
@@ -433,7 +435,7 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
     /**
      * Get a mailer driver instance.
      *
-     * @param  string|null  $driver
+     * @param  \UnitEnum|string|null  $driver
      * @return \Illuminate\Contracts\Mail\Mailer
      */
     public function driver($driver = null)

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -411,6 +411,15 @@ class SupportTestingMailFakeTest extends TestCase
         });
     }
 
+    public function testAssertMailerWithUnitEnum()
+    {
+        $this->fake->mailer(MailFakeMailer::Ses)->to('taylor@laravel.com')->send($this->mailable);
+
+        $this->fake->assertSent(MailableStub::class, function ($mail) {
+            return $mail->usesMailer('Ses');
+        });
+    }
+
     public function testDriverMethod()
     {
         $this->fake->driver('ses')->to('taylor@laravel.com')->send($this->mailable);
@@ -434,6 +443,21 @@ class SupportTestingMailFakeTest extends TestCase
                 $mail->usesMailer('mailjet');
         });
     }
+
+    public function testDriverMethodWithUnitEnum()
+    {
+        $this->fake->driver(MailFakeMailer::Mailjet)->to('taylor@laravel.com')->queue($this->mailable);
+
+        $this->fake->assertQueued(MailableStub::class, function ($mail) {
+            return $mail->usesMailer('Mailjet');
+        });
+    }
+}
+
+enum MailFakeMailer
+{
+    case Ses;
+    case Mailjet;
 }
 
 class MailableStub extends Mailable


### PR DESCRIPTION
Support UnitEnum mailers on MailFake

This PR updates `MailFake::mailer()` and `MailFake::driver()` documentation/behavior to match the real `MailManager`, which already accepts `UnitEnum|string|null` mailer names.

Before this change, passing a pure enum to `Mail::fake()->mailer(...)` stored the enum object as the current mailer. That meant fake mail assertions could behave differently from the real mail manager, which normalizes enums through `enum_value()`.

The change normalizes the fake mailer name with `enum_value()` and adds coverage for both `mailer()` and `driver()` when pure enums are used.