### PR TITLE
Support enum notification channels

### DIFF
--- a/src/Illuminate/Notifications/AnonymousNotifiable.php
+++ b/src/Illuminate/Notifications/AnonymousNotifiable.php
@@ -5,6 +5,8 @@ namespace Illuminate\Notifications;
 use Illuminate\Contracts\Notifications\Dispatcher;
 use InvalidArgumentException;
 
+use function Illuminate\Support\enum_value;
+
 class AnonymousNotifiable
 {
     /**
@@ -17,7 +19,7 @@ class AnonymousNotifiable
     /**
      * Add routing information to the target.
      *
-     * @param  string  $channel
+     * @param  \UnitEnum|string  $channel
      * @param  mixed  $route
      * @return $this
      *
@@ -25,6 +27,8 @@ class AnonymousNotifiable
      */
     public function route($channel, $route)
     {
+        $channel = enum_value($channel);
+
         if ($channel === 'database') {
             throw new InvalidArgumentException('The database channel does not support on-demand notifications.');
         }
@@ -59,11 +63,13 @@ class AnonymousNotifiable
     /**
      * Get the notification routing information for the given driver.
      *
-     * @param  string  $driver
+     * @param  \UnitEnum|string  $driver
      * @return mixed
      */
     public function routeNotificationFor($driver)
     {
+        $driver = enum_value($driver);
+
         return $this->routes[$driver] ?? null;
     }
 

--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -20,6 +20,8 @@ use Symfony\Component\Mailer\Exception\HttpTransportException;
 use Symfony\Component\Mailer\Exception\TransportException;
 use Throwable;
 
+use function Illuminate\Support\enum_value;
+
 class NotificationSender
 {
     use Localizable, ReadsQueueAttributes;
@@ -111,6 +113,8 @@ class NotificationSender
             if (empty($viaChannels = $channels ?: $original->via($notifiable))) {
                 continue;
             }
+
+            $viaChannels = $this->formatChannels($viaChannels);
 
             $this->withLocale($this->preferredLocale($notifiable, $original), function () use ($viaChannels, $notifiable, $original) {
                 $notificationId = (string) Str::uuid();
@@ -224,7 +228,7 @@ class NotificationSender
         foreach ($notifiables as $notifiable) {
             $notificationId = (string) Str::uuid();
 
-            foreach ((array) $original->via($notifiable) as $channel) {
+            foreach ($this->formatChannels($original->via($notifiable)) as $channel) {
                 $notification = clone $original;
 
                 if (! $notification->id) {
@@ -308,5 +312,16 @@ class NotificationSender
         }
 
         return $notifiables;
+    }
+
+    /**
+     * Format the channels into scalar channel names.
+     *
+     * @param  mixed  $channels
+     * @return array
+     */
+    protected function formatChannels($channels)
+    {
+        return array_map(enum_value(...), is_array($channels) ? $channels : [$channels]);
     }
 }

--- a/src/Illuminate/Notifications/RoutesNotifications.php
+++ b/src/Illuminate/Notifications/RoutesNotifications.php
@@ -5,6 +5,8 @@ namespace Illuminate\Notifications;
 use Illuminate\Contracts\Notifications\Dispatcher;
 use Illuminate\Support\Str;
 
+use function Illuminate\Support\enum_value;
+
 trait RoutesNotifications
 {
     /**
@@ -33,12 +35,14 @@ trait RoutesNotifications
     /**
      * Get the notification routing information for the given driver.
      *
-     * @param  string  $driver
+     * @param  \UnitEnum|string  $driver
      * @param  \Illuminate\Notifications\Notification|null  $notification
      * @return mixed
      */
     public function routeNotificationFor($driver, $notification = null)
     {
+        $driver = enum_value($driver);
+
         if (method_exists($this, $method = 'routeNotificationFor'.Str::studly($driver))) {
             return $this->{$method}($notification);
         }

--- a/src/Illuminate/Support/Facades/Notification.php
+++ b/src/Illuminate/Support/Facades/Notification.php
@@ -77,7 +77,7 @@ class Notification extends Facade
     /**
      * Begin sending a notification to an anonymous notifiable.
      *
-     * @param  string  $channel
+     * @param  \UnitEnum|string  $channel
      * @param  mixed  $route
      * @return \Illuminate\Notifications\AnonymousNotifiable
      */

--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -15,6 +15,8 @@ use Illuminate\Support\Traits\Macroable;
 use Illuminate\Support\Traits\ReflectsClosures;
 use PHPUnit\Framework\Assert as PHPUnit;
 
+use function Illuminate\Support\enum_value;
+
 class NotificationFake implements Fake, NotificationDispatcher, NotificationFactory
 {
     use Macroable, ReflectsClosures;
@@ -318,6 +320,15 @@ class NotificationFake implements Fake, NotificationDispatcher, NotificationFact
             }
 
             $notifiableChannels = $channels ?: $notification->via($notifiable);
+
+            if (empty($notifiableChannels)) {
+                continue;
+            }
+
+            $notifiableChannels = array_map(
+                enum_value(...),
+                is_array($notifiableChannels) ? $notifiableChannels : [$notifiableChannels]
+            );
 
             if (method_exists($notification, 'shouldSend')) {
                 $notifiableChannels = array_filter(

--- a/tests/Notifications/NotificationRoutesNotificationsTest.php
+++ b/tests/Notifications/NotificationRoutesNotificationsTest.php
@@ -53,6 +53,21 @@ class NotificationRoutesNotificationsTest extends TestCase
         $this->assertSame('taylor@laravel.com', $instance->routeNotificationFor('mail'));
     }
 
+    public function testNotificationOptionRoutingWithUnitEnum()
+    {
+        $instance = new RoutesNotificationsTestInstance;
+        $this->assertSame('bar', $instance->routeNotificationFor(RoutesNotificationsChannel::Foo));
+        $this->assertSame('taylor@laravel.com', $instance->routeNotificationFor(RoutesNotificationsChannel::Mail));
+    }
+
+    public function testOnDemandNotificationsCanRouteWithUnitEnum()
+    {
+        $notifiable = Notification::route(RoutesNotificationsChannel::Foo, 'bar');
+
+        $this->assertSame('bar', $notifiable->routeNotificationFor('foo'));
+        $this->assertSame('bar', $notifiable->routeNotificationFor(RoutesNotificationsChannel::Foo));
+    }
+
     public function testOnDemandNotificationsCannotUseDatabaseChannel()
     {
         $this->expectExceptionObject(
@@ -60,6 +75,15 @@ class NotificationRoutesNotificationsTest extends TestCase
         );
 
         Notification::route('database', 'foo');
+    }
+
+    public function testOnDemandNotificationsCannotUseDatabaseChannelWithUnitEnum()
+    {
+        $this->expectExceptionObject(
+            new InvalidArgumentException('The database channel does not support on-demand notifications.')
+        );
+
+        Notification::route(RoutesNotificationsChannel::Database, 'foo');
     }
 }
 
@@ -73,4 +97,11 @@ class RoutesNotificationsTestInstance
     {
         return 'bar';
     }
+}
+
+enum RoutesNotificationsChannel: string
+{
+    case Foo = 'foo';
+    case Mail = 'mail';
+    case Database = 'database';
 }

--- a/tests/Notifications/NotificationSenderTest.php
+++ b/tests/Notifications/NotificationSenderTest.php
@@ -64,6 +64,50 @@ class NotificationSenderTest extends TestCase
         $sender->send($notifiable, new DummyQueuedNotificationWithArrayVia);
     }
 
+    public function test_it_can_send_queued_notifications_with_unit_enum_via()
+    {
+        $notifiable = m::mock(Notifiable::class);
+        $manager = m::mock(ChannelManager::class);
+        $manager->shouldReceive('getContainer')->andReturn(app());
+        $manager->shouldReceive('resolveQueueFromQueueRoute')->andReturn(null);
+        $manager->shouldReceive('resolveConnectionFromQueueRoute')->andReturn(null);
+        $bus = m::mock(BusDispatcher::class);
+        $bus->shouldReceive('dispatch')
+            ->once()
+            ->withArgs(function ($job) {
+                return $job->queue === 'admin_notifications' && $job->channels === ['mail'] && $job->connection === 'redis';
+            });
+        $bus->shouldReceive('dispatch')
+            ->once()
+            ->withArgs(function ($job) {
+                return $job->queue === 'dummy' && $job->channels === ['database'] && $job->connection === 'sync';
+            });
+
+        $events = m::mock(EventDispatcher::class);
+        $events->shouldReceive('listen')->once();
+
+        $sender = new NotificationSender($manager, $bus, $events);
+
+        $sender->send($notifiable, new DummyQueuedNotificationWithUnitEnumVia);
+    }
+
+    public function test_it_can_send_notifications_with_unit_enum_channels()
+    {
+        $notifiable = new AnonymousNotifiable;
+        $manager = m::mock(ChannelManager::class);
+        $manager->shouldReceive('driver')->once()->with('mail')->andReturn($driver = m::mock());
+        $driver->shouldReceive('send')->once();
+        $bus = m::mock(BusDispatcher::class);
+        $events = m::mock(EventDispatcher::class);
+        $events->shouldReceive('listen')->once();
+        $events->shouldReceive('until')->with(m::type(NotificationSending::class))->andReturn(true);
+        $events->shouldReceive('dispatch')->once();
+
+        $sender = new NotificationSender($manager, $bus, $events);
+
+        $sender->sendNow($notifiable, new DummyNotificationWithEmptyStringVia, [NotificationSenderChannel::Mail]);
+    }
+
     public function test_it_can_send_notifications_with_an_empty_string_via()
     {
         $notifiable = new AnonymousNotifiable;
@@ -91,6 +135,21 @@ class NotificationSenderTest extends TestCase
         $sender = new NotificationSender($manager, $bus, $events);
 
         $sender->sendNow($notifiable, new DummyNotificationWithDatabaseVia);
+    }
+
+    public function test_it_cannot_send_notifications_via_database_unit_enum_for_anonymous_notifiables()
+    {
+        $notifiable = new AnonymousNotifiable;
+        $manager = m::mock(ChannelManager::class);
+        $manager->shouldNotReceive('driver');
+        $bus = m::mock(BusDispatcher::class);
+        $bus->shouldNotReceive('dispatch');
+        $events = m::mock(EventDispatcher::class);
+        $events->shouldReceive('listen')->once();
+
+        $sender = new NotificationSender($manager, $bus, $events);
+
+        $sender->sendNow($notifiable, new DummyNotificationWithDatabaseUnitEnumVia);
     }
 
     public function test_it_can_send_queued_notifications_through_middleware()
@@ -405,6 +464,36 @@ class DummyQueuedNotificationWithArrayVia extends Notification implements Should
     }
 }
 
+class DummyQueuedNotificationWithUnitEnumVia extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct()
+    {
+        $this->connection = 'redis';
+        $this->queue = 'dummy';
+    }
+
+    public function via($notifiable)
+    {
+        return [NotificationSenderChannel::Mail, NotificationSenderChannel::Database];
+    }
+
+    public function viaConnections()
+    {
+        return [
+            'database' => 'sync',
+        ];
+    }
+
+    public function viaQueues()
+    {
+        return [
+            'mail' => 'admin_notifications',
+        ];
+    }
+}
+
 class DummyNotificationWithEmptyStringVia extends Notification
 {
     use Queueable;
@@ -434,6 +523,16 @@ class DummyNotificationWithDatabaseVia extends Notification
     public function via($notifiable)
     {
         return 'database';
+    }
+}
+
+class DummyNotificationWithDatabaseUnitEnumVia extends Notification
+{
+    use Queueable;
+
+    public function via($notifiable)
+    {
+        return NotificationSenderChannel::Database;
     }
 }
 
@@ -557,4 +656,10 @@ class DummyNotificationWithViaMutation extends Notification
 
         return 'mail';
     }
+}
+
+enum NotificationSenderChannel: string
+{
+    case Mail = 'mail';
+    case Database = 'database';
 }

--- a/tests/Support/SupportTestingNotificationFakeTest.php
+++ b/tests/Support/SupportTestingNotificationFakeTest.php
@@ -224,6 +224,17 @@ class SupportTestingNotificationFakeTest extends TestCase
         $this->fake->assertNotSentTo($user, NotificationWithFalsyShouldSendStub::class);
     }
 
+    public function testAssertSentToWithUnitEnumChannels()
+    {
+        $notification = new NotificationWithUnitEnumChannelStub;
+
+        $this->fake->send($this->user, $notification);
+
+        $this->fake->assertSentTo($this->user, NotificationWithUnitEnumChannelStub::class, function ($notification, $channels) {
+            return $channels === ['mail'] && $notification->channel === 'mail';
+        });
+    }
+
     public function testAssertItCanSerializeAndRestoreNotifications()
     {
         $this->fake->serializeAndRestore();
@@ -254,6 +265,28 @@ class NotificationWithFalsyShouldSendStub extends Notification
     {
         return false;
     }
+}
+
+class NotificationWithUnitEnumChannelStub extends Notification
+{
+    public $channel;
+
+    public function via($notifiable)
+    {
+        return [NotificationFakeChannel::Mail];
+    }
+
+    public function shouldSend($notifiable, $channel)
+    {
+        $this->channel = $channel;
+
+        return true;
+    }
+}
+
+enum NotificationFakeChannel: string
+{
+    case Mail = 'mail';
 }
 
 class UserStub extends User


### PR DESCRIPTION
This PR allows notification channels to be provided as enums across the notification pipeline.

`ChannelManager::channel()` and `ChannelManager::driver()` already accept `UnitEnum|string|null`, but channels returned from `via()`, passed to `sendNow()`, or used for anonymous notification routing were still treated as raw strings in several places.

This change normalizes enum channels before routing, queueing, and faking notifications so enum-backed channel names behave consistently with string channel names.

Covered paths:
- immediate notification sending
- queued notification dispatch
- `viaConnections()` / `viaQueues()` channel lookup
- anonymous notification routing
- `RoutesNotifications::routeNotificationFor()`
- `NotificationFake`