### PR TITLE
[13.x] Support enum queue names in QueueFake

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -428,11 +428,13 @@ class QueueFake extends QueueManager implements Fake, Queue
     /**
      * Get the size of the queue.
      *
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return int
      */
     public function size($queue = null)
     {
+        $queue = enum_value($queue);
+
         return (new Collection($this->jobs))
             ->flatten(1)
             ->filter(fn ($job) => $job['queue'] === $queue)
@@ -442,7 +444,7 @@ class QueueFake extends QueueManager implements Fake, Queue
     /**
      * Get the number of pending jobs.
      *
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return int
      */
     public function pendingSize($queue = null)
@@ -453,7 +455,7 @@ class QueueFake extends QueueManager implements Fake, Queue
     /**
      * Get the number of delayed jobs.
      *
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return int
      */
     public function delayedSize($queue = null)
@@ -464,7 +466,7 @@ class QueueFake extends QueueManager implements Fake, Queue
     /**
      * Get the number of reserved jobs.
      *
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return int
      */
     public function reservedSize($queue = null)
@@ -475,11 +477,13 @@ class QueueFake extends QueueManager implements Fake, Queue
     /**
      * Get the pending jobs for the given queue.
      *
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return \Illuminate\Support\Collection<int, \Illuminate\Queue\Jobs\InspectedJob>
      */
     public function pendingJobs($queue = null): Collection
     {
+        $queue = enum_value($queue);
+
         return (new Collection($this->jobs))
             ->flatten(1)
             ->filter(fn ($job) => $job['queue'] === $queue)
@@ -496,7 +500,7 @@ class QueueFake extends QueueManager implements Fake, Queue
     /**
      * Get the delayed jobs for the given queue.
      *
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return \Illuminate\Support\Collection
      */
     public function delayedJobs($queue = null): Collection
@@ -507,7 +511,7 @@ class QueueFake extends QueueManager implements Fake, Queue
     /**
      * Get the reserved jobs for the given queue.
      *
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return \Illuminate\Support\Collection
      */
     public function reservedJobs($queue = null): Collection
@@ -557,7 +561,7 @@ class QueueFake extends QueueManager implements Fake, Queue
     /**
      * Get the creation timestamp of the oldest pending job, excluding delayed jobs.
      *
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return int|null
      */
     public function creationTimeOfOldestPendingJob($queue = null)
@@ -570,11 +574,13 @@ class QueueFake extends QueueManager implements Fake, Queue
      *
      * @param  string|object  $job
      * @param  mixed  $data
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return mixed
      */
     public function push($job, $data = '', $queue = null)
     {
+        $queue = enum_value($queue);
+
         if ($this->shouldFakeJob($job)) {
             if ($job instanceof Closure) {
                 $job = CallQueuedClosure::create($job);
@@ -638,12 +644,14 @@ class QueueFake extends QueueManager implements Fake, Queue
      * Push a raw payload onto the queue.
      *
      * @param  string  $payload
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @param  array  $options
      * @return mixed
      */
     public function pushRaw($payload, $queue = null, array $options = [])
     {
+        $queue = enum_value($queue);
+
         $this->rawPushes[] = [
             'payload' => $payload,
             'queue' => $queue,
@@ -657,7 +665,7 @@ class QueueFake extends QueueManager implements Fake, Queue
      * @param  \DateTimeInterface|\DateInterval|int  $delay
      * @param  string|object  $job
      * @param  mixed  $data
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return mixed
      */
     public function later($delay, $job, $data = '', $queue = null)
@@ -668,7 +676,7 @@ class QueueFake extends QueueManager implements Fake, Queue
     /**
      * Push a new job onto the queue.
      *
-     * @param  string  $queue
+     * @param  \UnitEnum|string  $queue
      * @param  string|object  $job
      * @param  mixed  $data
      * @return mixed
@@ -681,7 +689,7 @@ class QueueFake extends QueueManager implements Fake, Queue
     /**
      * Push a new job onto a specific queue after (n) seconds.
      *
-     * @param  string  $queue
+     * @param  \UnitEnum|string  $queue
      * @param  \DateTimeInterface|\DateInterval|int  $delay
      * @param  string|object  $job
      * @param  mixed  $data
@@ -695,7 +703,7 @@ class QueueFake extends QueueManager implements Fake, Queue
     /**
      * Pop the next job off of the queue.
      *
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return \Illuminate\Contracts\Queue\Job|null
      */
     public function pop($queue = null)
@@ -708,7 +716,7 @@ class QueueFake extends QueueManager implements Fake, Queue
      *
      * @param  array  $jobs
      * @param  mixed  $data
-     * @param  string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return mixed
      */
     public function bulk($jobs, $data = '', $queue = null)

--- a/tests/Support/SupportTestingQueueFakeTest.php
+++ b/tests/Support/SupportTestingQueueFakeTest.php
@@ -96,6 +96,15 @@ class SupportTestingQueueFakeTest extends TestCase
         $this->assertEquals(1, $this->fake->size());
     }
 
+    public function testQueueSizeAcceptsUnitEnums()
+    {
+        $this->fake->push($this->job, '', QueueNameEnumStub::Foo);
+
+        $this->assertEquals(1, $this->fake->size('foo'));
+        $this->assertEquals(1, $this->fake->size(QueueNameEnumStub::Foo));
+        $this->assertEquals(0, $this->fake->size(QueueNameEnumStub::Bar));
+    }
+
     public function testAssertNotPushed()
     {
         $this->fake->push($this->job);
@@ -209,14 +218,24 @@ class SupportTestingQueueFakeTest extends TestCase
     {
         $this->fake->assertNothingPushed();
 
-        $queue = 'my-test-queue';
+        $queue = QueueNameEnumStub::Foo;
         $this->fake->bulk([
             $this->job,
             new JobStub,
         ], null, $queue);
 
+        $this->fake->assertPushedOn('foo', JobStub::class);
         $this->fake->assertPushedOn($queue, JobStub::class);
         $this->fake->assertPushed(JobStub::class, 2);
+    }
+
+    public function testPushOnAndLaterOnAcceptUnitEnums()
+    {
+        $this->fake->pushOn(QueueNameEnumStub::Foo, $this->job);
+        $this->fake->laterOn(QueueNameEnumStub::Bar, 10, new JobToFakeStub);
+
+        $this->fake->assertPushedOn('foo', JobStub::class);
+        $this->fake->assertPushedOn('bar', JobToFakeStub::class);
     }
 
     public function testAssertPushedWithChainUsingClassesOrObjectsArray()
@@ -497,6 +516,17 @@ class SupportTestingQueueFakeTest extends TestCase
         $this->assertSame(0, $pending->first()->attempts);
     }
 
+    public function testPendingJobsAcceptsUnitEnums()
+    {
+        $this->fake->push($this->job, '', QueueNameEnumStub::Foo);
+        $this->fake->push(new JobToFakeStub, '', QueueNameEnumStub::Bar);
+
+        $pending = $this->fake->pendingJobs(QueueNameEnumStub::Foo);
+
+        $this->assertCount(1, $pending);
+        $this->assertSame(JobStub::class, $pending->first()->name);
+    }
+
     public function testAllPendingJobs()
     {
         $this->fake->push($this->job, '', 'foo');
@@ -521,6 +551,23 @@ class SupportTestingQueueFakeTest extends TestCase
             ['payload' => 'some-payload', 'queue' => null, 'options' => ['options' => 'yeah']],
             ['payload' => 'some-other-payload', 'queue' => 'my-queue', 'options' => ['options' => 'also yeah']],
         ], $actualPushedRaw);
+    }
+
+    public function testRawPushesAcceptUnitEnums()
+    {
+        $this->fake->pushRaw('some-payload', QueueNameEnumStub::Foo, ['options' => 'yeah']);
+
+        $this->assertEqualsCanonicalizing([
+            ['payload' => 'some-payload', 'queue' => 'foo', 'options' => ['options' => 'yeah']],
+        ], $this->fake->rawPushes());
+
+        $pushedRaw = $this->fake->pushedRaw(
+            fn ($payload, $queue, $options) => $payload === 'some-payload'
+                && $queue === 'foo'
+                && $options['options'] === 'yeah'
+        );
+
+        $this->assertCount(1, $pushedRaw);
     }
 
     public function testPushedRaw()


### PR DESCRIPTION
Queue names passed as `UnitEnum` values are now normalized before being stored or queried, so fake queue assertions and inspection APIs behave consistently with string queue names.

## Changes

- Normalize queue names with `enum_value()` in `QueueFake::push()`, `pushRaw()`, `size()`, and `pendingJobs()`.
- Update queue-related docblocks to accept `UnitEnum|string|null`.
- Add coverage for enum queue names with `size`, `pendingJobs`, `bulk`, `pushOn`, `laterOn`, and raw pushes.