### PR TITLE
[13.x] Consistent test OS attributes

### DIFF
--- a/tests/Filesystem/JoinPathsHelperTest.php
+++ b/tests/Filesystem/JoinPathsHelperTest.php
@@ -10,7 +10,7 @@ use function Illuminate\Filesystem\join_paths;
 
 class JoinPathsHelperTest extends TestCase
 {
-    #[RequiresOperatingSystem('Linux|DAR')]
+    #[RequiresOperatingSystem('Linux|Darwin')]
     #[DataProvider('unixDataProvider')]
     public function testItCanMergePathsForUnix(string $expected, string $given)
     {

--- a/tests/Foundation/Exceptions/Renderer/FrameTest.php
+++ b/tests/Foundation/Exceptions/Renderer/FrameTest.php
@@ -11,7 +11,7 @@ use Symfony\Component\ErrorHandler\Exception\FlattenException;
 
 class FrameTest extends TestCase
 {
-    #[RequiresOperatingSystem('Linux|DAR')]
+    #[RequiresOperatingSystem('Linux|Darwin')]
     #[DataProvider('unixFileDataProvider')]
     public function test_it_normalizes_file_path_on_unix($frameData, $basePath, $expected)
     {
@@ -81,7 +81,7 @@ class FrameTest extends TestCase
         ];
     }
 
-    #[RequiresOperatingSystem('Linux|DAR')]
+    #[RequiresOperatingSystem('Linux|Darwin')]
     #[DataProvider('unixIsFromVendorDataProvider')]
     public function test_it_determines_if_frame_is_from_vendor_on_unix($frameData, $basePath, $expected)
     {

--- a/tests/Integration/Concurrency/ConcurrencyTest.php
+++ b/tests/Integration/Concurrency/ConcurrencyTest.php
@@ -12,7 +12,7 @@ use Orchestra\Testbench\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 
-#[RequiresOperatingSystem('Linux|DAR')]
+#[RequiresOperatingSystem('Linux|Darwin')]
 class ConcurrencyTest extends TestCase
 {
     protected function setUp(): void

--- a/tests/Integration/Database/MySql/JoinLateralTest.php
+++ b/tests/Integration/Database/MySql/JoinLateralTest.php
@@ -6,11 +6,11 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
-use PHPUnit\Framework\Attributes\RequiresOperatingSystemFamily;
+use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 
 #[RequiresPhpExtension('pdo_mysql')]
-#[RequiresOperatingSystemFamily('Linux|Darwin')]
+#[RequiresOperatingSystem('Linux|Darwin')]
 class JoinLateralTest extends MySqlTestCase
 {
     protected function afterRefreshingDatabase()

--- a/tests/Integration/Database/Postgres/JoinLateralTest.php
+++ b/tests/Integration/Database/Postgres/JoinLateralTest.php
@@ -6,11 +6,11 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
-use PHPUnit\Framework\Attributes\RequiresOperatingSystemFamily;
+use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 
 #[RequiresPhpExtension('pdo_pgsql')]
-#[RequiresOperatingSystemFamily('Linux|Darwin')]
+#[RequiresOperatingSystem('Linux|Darwin')]
 class JoinLateralTest extends PostgresTestCase
 {
     protected function afterRefreshingDatabase()

--- a/tests/Integration/Routing/SerializableClosureV1CacheRouteTest.php
+++ b/tests/Integration/Routing/SerializableClosureV1CacheRouteTest.php
@@ -7,11 +7,11 @@ use Orchestra\Testbench\Attributes\WithConfig;
 use Orchestra\Testbench\Attributes\WithMigration;
 use Orchestra\Testbench\Factories\UserFactory;
 use Orchestra\Testbench\TestCase;
-use PHPUnit\Framework\Attributes\RequiresOperatingSystemFamily;
+use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 
 use function Illuminate\Filesystem\join_paths;
 
-#[RequiresOperatingSystemFamily('Linux|Darwin')]
+#[RequiresOperatingSystem('Linux|Darwin')]
 #[WithConfig('app.key', 'AckfSECXIvnK5r28GVIWUAxmbBSjTsmF')]
 #[WithMigration]
 class SerializableClosureV1CacheRouteTest extends TestCase

--- a/tests/Integration/Routing/SerializableClosureV1CacheRouteTest.php
+++ b/tests/Integration/Routing/SerializableClosureV1CacheRouteTest.php
@@ -40,6 +40,8 @@ class SerializableClosureV1CacheRouteTest extends TestCase
     #[\Override]
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         unset($_ENV['APP_ROUTES_CACHE']);
     }
 

--- a/tests/Process/ProcessTest.php
+++ b/tests/Process/ProcessTest.php
@@ -496,7 +496,7 @@ class ProcessTest extends TestCase
         $this->assertTrue(true);
     }
 
-    #[RequiresOperatingSystem('Linux|DAR')]
+    #[RequiresOperatingSystem('Linux|Darwin')]
     public function testRealProcessesCanHaveErrorOutput()
     {
         $factory = new Factory;
@@ -524,7 +524,7 @@ class ProcessTest extends TestCase
         $result->throw();
     }
 
-    #[RequiresOperatingSystem('Linux|DAR')]
+    #[RequiresOperatingSystem('Linux|Darwin')]
     public function testRealProcessesCanThrowWithoutOutput()
     {
         $this->expectException(ProcessFailedException::class);
@@ -562,7 +562,7 @@ class ProcessTest extends TestCase
         $result->throw();
     }
 
-    #[RequiresOperatingSystem('Linux|DAR')]
+    #[RequiresOperatingSystem('Linux|Darwin')]
     public function testRealProcessesCanThrowWithErrorOutput()
     {
         $this->expectException(ProcessFailedException::class);
@@ -604,7 +604,7 @@ class ProcessTest extends TestCase
         $result->throw();
     }
 
-    #[RequiresOperatingSystem('Linux|DAR')]
+    #[RequiresOperatingSystem('Linux|Darwin')]
     public function testRealProcessesCanThrowWithOutput()
     {
         $this->expectException(ProcessFailedException::class);
@@ -625,7 +625,7 @@ class ProcessTest extends TestCase
         $result->throw();
     }
 
-    #[RequiresOperatingSystem('Linux|DAR')]
+    #[RequiresOperatingSystem('Linux|Darwin')]
     public function testRealProcessesCanTimeout()
     {
         $this->expectException(ProcessTimedOutException::class);
@@ -639,7 +639,7 @@ class ProcessTest extends TestCase
         $result->throw();
     }
 
-    #[RequiresOperatingSystem('Linux|DAR')]
+    #[RequiresOperatingSystem('Linux|Darwin')]
     public function testATimeoutCanBeSetWithACarbonInterval()
     {
         $this->expectException(ProcessTimedOutException::class);
@@ -654,7 +654,7 @@ class ProcessTest extends TestCase
         $result->throw();
     }
 
-    #[RequiresOperatingSystem('Linux|DAR')]
+    #[RequiresOperatingSystem('Linux|Darwin')]
     public function testRealProcessesCanThrowIfTrue()
     {
         $this->expectException(ProcessFailedException::class);
@@ -665,7 +665,7 @@ class ProcessTest extends TestCase
         $result->throwIf(true);
     }
 
-    #[RequiresOperatingSystem('Linux|DAR')]
+    #[RequiresOperatingSystem('Linux|Darwin')]
     public function testRealProcessesDoesntThrowIfFalse()
     {
         $factory = new Factory;
@@ -676,7 +676,7 @@ class ProcessTest extends TestCase
         $this->assertTrue(true);
     }
 
-    #[RequiresOperatingSystem('Linux|DAR')]
+    #[RequiresOperatingSystem('Linux|Darwin')]
     public function testRealProcessesCanUseStandardInput()
     {
         $factory = new Factory();
@@ -685,7 +685,7 @@ class ProcessTest extends TestCase
         $this->assertSame('foobar', $result->output());
     }
 
-    #[RequiresOperatingSystem('Linux|DAR')]
+    #[RequiresOperatingSystem('Linux|Darwin')]
     public function testProcessPipe()
     {
         $factory = new Factory;
@@ -701,7 +701,7 @@ class ProcessTest extends TestCase
         $this->assertSame("foo\n", $pipe->output());
     }
 
-    #[RequiresOperatingSystem('Linux|DAR')]
+    #[RequiresOperatingSystem('Linux|Darwin')]
     public function testProcessPipeFailed()
     {
         $factory = new Factory;
@@ -717,7 +717,7 @@ class ProcessTest extends TestCase
         $this->assertTrue($pipe->failed());
     }
 
-    #[RequiresOperatingSystem('Linux|DAR')]
+    #[RequiresOperatingSystem('Linux|Darwin')]
     public function testProcessSimplePipe()
     {
         $factory = new Factory;
@@ -733,7 +733,7 @@ class ProcessTest extends TestCase
         $this->assertSame("foo\n", $pipe->output());
     }
 
-    #[RequiresOperatingSystem('Linux|DAR')]
+    #[RequiresOperatingSystem('Linux|Darwin')]
     public function testProcessSimplePipeFailed()
     {
         $factory = new Factory;


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This PR fixes two issues:
1. Usage of the `RequiresOperatingSystemFamily` attribute is replaced with `RequiresOperatingSystem`, as the former will do exact string matching, with the latter doing a regex match. Given that this was used with the regex argument `Linux|Darwin`, some tests were effectively always skipped.
2. Consistently use `Linux|Darwin` as argument, rather than `Linux|DAR`. The latter likely works fine, as I suspect a case-insensitive regex match is done, but looks somewhat confusing and inconsistent. Darwin is correct per https://www.php.net/manual/en/reserved.constants.php#constant.php-os-family.

After applying the fixes, the `SerializableClosureV1CacheRouteTest` was shown to not properly clean up, hence a `parent::tearDown` was added.