### PR TITLE
[13.x] Broaden test OS attributes to non-Windows

### DIFF
--- a/tests/Console/Scheduling/EventTest.php
+++ b/tests/Console/Scheduling/EventTest.php
@@ -14,7 +14,7 @@ use function Illuminate\Support\php_binary;
 
 class EventTest extends TestCase
 {
-    #[RequiresOperatingSystem('Linux|Darwin')]
+    #[RequiresOperatingSystem('(?!Windows)')]
     public function testBuildCommandUsingUnix()
     {
         $event = new Event(m::mock(EventMutex::class), 'php -i');
@@ -30,7 +30,7 @@ class EventTest extends TestCase
         $this->assertSame('php -i > "NUL" 2>&1', $event->buildCommand());
     }
 
-    #[RequiresOperatingSystem('Linux|Darwin')]
+    #[RequiresOperatingSystem('(?!Windows)')]
     public function testBuildCommandInBackgroundUsingUnix()
     {
         $event = new Event(m::mock(EventMutex::class), 'php -i');

--- a/tests/Filesystem/FilesystemManagerTest.php
+++ b/tests/Filesystem/FilesystemManagerTest.php
@@ -134,7 +134,7 @@ class FilesystemManagerTest extends TestCase
         }
     }
 
-    #[RequiresOperatingSystem('Linux|Darwin')]
+    #[RequiresOperatingSystem('(?!Windows)')]
     public function testCanBuildScopedDisksWithVisibility()
     {
         try {

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -106,7 +106,7 @@ class FilesystemTest extends TestCase
         $this->assertStringEqualsFile($tempFile, 'Hello Taylor');
     }
 
-    #[RequiresOperatingSystem('Linux|Darwin')]
+    #[RequiresOperatingSystem('(?!Windows)')]
     public function testReplaceWhenUnixSymlinkExists()
     {
         $tempFile = self::$tempDir.'/file.txt';
@@ -547,7 +547,7 @@ class FilesystemTest extends TestCase
         $this->assertFileExists(self::$tempDir.'/created');
     }
 
-    #[RequiresOperatingSystem('Linux|Darwin')]
+    #[RequiresOperatingSystem('(?!Windows)')]
     #[RequiresPhpExtension('pcntl')]
     public function testSharedGet()
     {

--- a/tests/Filesystem/JoinPathsHelperTest.php
+++ b/tests/Filesystem/JoinPathsHelperTest.php
@@ -10,7 +10,7 @@ use function Illuminate\Filesystem\join_paths;
 
 class JoinPathsHelperTest extends TestCase
 {
-    #[RequiresOperatingSystem('Linux|DAR')]
+    #[RequiresOperatingSystem('Linux|Darwin')]
     #[DataProvider('unixDataProvider')]
     public function testItCanMergePathsForUnix(string $expected, string $given)
     {

--- a/tests/Filesystem/JoinPathsHelperTest.php
+++ b/tests/Filesystem/JoinPathsHelperTest.php
@@ -10,7 +10,7 @@ use function Illuminate\Filesystem\join_paths;
 
 class JoinPathsHelperTest extends TestCase
 {
-    #[RequiresOperatingSystem('Linux|Darwin')]
+    #[RequiresOperatingSystem('(?!Windows)')]
     #[DataProvider('unixDataProvider')]
     public function testItCanMergePathsForUnix(string $expected, string $given)
     {

--- a/tests/Foundation/Exceptions/Renderer/FrameTest.php
+++ b/tests/Foundation/Exceptions/Renderer/FrameTest.php
@@ -11,7 +11,7 @@ use Symfony\Component\ErrorHandler\Exception\FlattenException;
 
 class FrameTest extends TestCase
 {
-    #[RequiresOperatingSystem('Linux|DAR')]
+    #[RequiresOperatingSystem('Linux|Darwin')]
     #[DataProvider('unixFileDataProvider')]
     public function test_it_normalizes_file_path_on_unix($frameData, $basePath, $expected)
     {
@@ -81,7 +81,7 @@ class FrameTest extends TestCase
         ];
     }
 
-    #[RequiresOperatingSystem('Linux|DAR')]
+    #[RequiresOperatingSystem('Linux|Darwin')]
     #[DataProvider('unixIsFromVendorDataProvider')]
     public function test_it_determines_if_frame_is_from_vendor_on_unix($frameData, $basePath, $expected)
     {

--- a/tests/Foundation/Exceptions/Renderer/FrameTest.php
+++ b/tests/Foundation/Exceptions/Renderer/FrameTest.php
@@ -11,7 +11,7 @@ use Symfony\Component\ErrorHandler\Exception\FlattenException;
 
 class FrameTest extends TestCase
 {
-    #[RequiresOperatingSystem('Linux|Darwin')]
+    #[RequiresOperatingSystem('(?!Windows)')]
     #[DataProvider('unixFileDataProvider')]
     public function test_it_normalizes_file_path_on_unix($frameData, $basePath, $expected)
     {
@@ -81,7 +81,7 @@ class FrameTest extends TestCase
         ];
     }
 
-    #[RequiresOperatingSystem('Linux|Darwin')]
+    #[RequiresOperatingSystem('(?!Windows)')]
     #[DataProvider('unixIsFromVendorDataProvider')]
     public function test_it_determines_if_frame_is_from_vendor_on_unix($frameData, $basePath, $expected)
     {

--- a/tests/Integration/Concurrency/ConcurrencyTest.php
+++ b/tests/Integration/Concurrency/ConcurrencyTest.php
@@ -12,7 +12,7 @@ use Orchestra\Testbench\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 
-#[RequiresOperatingSystem('Linux|Darwin')]
+#[RequiresOperatingSystem('(?!Windows)')]
 class ConcurrencyTest extends TestCase
 {
     protected function setUp(): void

--- a/tests/Integration/Concurrency/ConcurrencyTest.php
+++ b/tests/Integration/Concurrency/ConcurrencyTest.php
@@ -12,7 +12,7 @@ use Orchestra\Testbench\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 
-#[RequiresOperatingSystem('Linux|DAR')]
+#[RequiresOperatingSystem('Linux|Darwin')]
 class ConcurrencyTest extends TestCase
 {
     protected function setUp(): void

--- a/tests/Integration/Database/MariaDb/DatabaseEmulatePreparesMariaDbConnectionTest.php
+++ b/tests/Integration/Database/MariaDb/DatabaseEmulatePreparesMariaDbConnectionTest.php
@@ -6,7 +6,7 @@ use PDO;
 use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 
-#[RequiresOperatingSystem('Linux|Darwin')]
+#[RequiresOperatingSystem('(?!Windows)')]
 #[RequiresPhpExtension('pdo_mysql')]
 class DatabaseEmulatePreparesMariaDbConnectionTest extends DatabaseMariaDbConnectionTest
 {

--- a/tests/Integration/Database/MariaDb/DatabaseMariaDbConnectionTest.php
+++ b/tests/Integration/Database/MariaDb/DatabaseMariaDbConnectionTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 
-#[RequiresOperatingSystem('Linux|Darwin')]
+#[RequiresOperatingSystem('(?!Windows)')]
 #[RequiresPhpExtension('pdo_mysql')]
 class DatabaseMariaDbConnectionTest extends MariaDbTestCase
 {

--- a/tests/Integration/Database/MariaDb/DatabaseMariaDbSchemaBuilderAlterTableWithEnumTest.php
+++ b/tests/Integration/Database/MariaDb/DatabaseMariaDbSchemaBuilderAlterTableWithEnumTest.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Facades\Schema;
 use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 
-#[RequiresOperatingSystem('Linux|Darwin')]
+#[RequiresOperatingSystem('(?!Windows)')]
 #[RequiresPhpExtension('pdo_mysql')]
 class DatabaseMariaDbSchemaBuilderAlterTableWithEnumTest extends MariaDbTestCase
 {

--- a/tests/Integration/Database/MariaDb/DatabaseMariaDbSchemaBuilderTest.php
+++ b/tests/Integration/Database/MariaDb/DatabaseMariaDbSchemaBuilderTest.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Facades\Schema;
 use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 
-#[RequiresOperatingSystem('Linux|Darwin')]
+#[RequiresOperatingSystem('(?!Windows)')]
 #[RequiresPhpExtension('pdo_mysql')]
 class DatabaseMariaDbSchemaBuilderTest extends MariaDbTestCase
 {

--- a/tests/Integration/Database/MariaDb/EscapeTest.php
+++ b/tests/Integration/Database/MariaDb/EscapeTest.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use RuntimeException;
 
-#[RequiresOperatingSystem('Linux|Darwin')]
+#[RequiresOperatingSystem('(?!Windows)')]
 #[RequiresPhpExtension('pdo_mysql')]
 class EscapeTest extends MariaDbTestCase
 {

--- a/tests/Integration/Database/MariaDb/FulltextTest.php
+++ b/tests/Integration/Database/MariaDb/FulltextTest.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Facades\Schema;
 use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 
-#[RequiresOperatingSystem('Linux|Darwin')]
+#[RequiresOperatingSystem('(?!Windows)')]
 #[RequiresPhpExtension('pdo_mysql')]
 class FulltextTest extends MariaDbTestCase
 {

--- a/tests/Integration/Database/MariaDb/JsonLikeTest.php
+++ b/tests/Integration/Database/MariaDb/JsonLikeTest.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Facades\Schema;
 use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 
-#[RequiresOperatingSystem('Linux|Darwin')]
+#[RequiresOperatingSystem('(?!Windows)')]
 #[RequiresPhpExtension('pdo_mysql')]
 class JsonLikeTest extends MariaDbTestCase
 {

--- a/tests/Integration/Database/MySql/DatabaseEmulatePreparesMySqlConnectionTest.php
+++ b/tests/Integration/Database/MySql/DatabaseEmulatePreparesMySqlConnectionTest.php
@@ -6,7 +6,7 @@ use PDO;
 use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 
-#[RequiresOperatingSystem('Linux|Darwin')]
+#[RequiresOperatingSystem('(?!Windows)')]
 #[RequiresPhpExtension('pdo_mysql')]
 class DatabaseEmulatePreparesMySqlConnectionTest extends DatabaseMySqlConnectionTest
 {

--- a/tests/Integration/Database/MySql/DatabaseMySqlConnectionTest.php
+++ b/tests/Integration/Database/MySql/DatabaseMySqlConnectionTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 
-#[RequiresOperatingSystem('Linux|Darwin')]
+#[RequiresOperatingSystem('(?!Windows)')]
 #[RequiresPhpExtension('pdo_mysql')]
 class DatabaseMySqlConnectionTest extends MySqlTestCase
 {

--- a/tests/Integration/Database/MySql/DatabaseMySqlSchemaBuilderAlterTableWithEnumTest.php
+++ b/tests/Integration/Database/MySql/DatabaseMySqlSchemaBuilderAlterTableWithEnumTest.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Facades\Schema;
 use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 
-#[RequiresOperatingSystem('Linux|Darwin')]
+#[RequiresOperatingSystem('(?!Windows)')]
 #[RequiresPhpExtension('pdo_mysql')]
 class DatabaseMySqlSchemaBuilderAlterTableWithEnumTest extends MySqlTestCase
 {

--- a/tests/Integration/Database/MySql/DatabaseMySqlSchemaBuilderTest.php
+++ b/tests/Integration/Database/MySql/DatabaseMySqlSchemaBuilderTest.php
@@ -9,7 +9,7 @@ use Orchestra\Testbench\Attributes\RequiresDatabase;
 use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 
-#[RequiresOperatingSystem('Linux|Darwin')]
+#[RequiresOperatingSystem('(?!Windows)')]
 #[RequiresPhpExtension('pdo_mysql')]
 class DatabaseMySqlSchemaBuilderTest extends MySqlTestCase
 {

--- a/tests/Integration/Database/MySql/EscapeTest.php
+++ b/tests/Integration/Database/MySql/EscapeTest.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use RuntimeException;
 
-#[RequiresOperatingSystem('Linux|Darwin')]
+#[RequiresOperatingSystem('(?!Windows)')]
 #[RequiresPhpExtension('pdo_mysql')]
 class EscapeTest extends MySqlTestCase
 {

--- a/tests/Integration/Database/MySql/FulltextTest.php
+++ b/tests/Integration/Database/MySql/FulltextTest.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Facades\Schema;
 use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 
-#[RequiresOperatingSystem('Linux|Darwin')]
+#[RequiresOperatingSystem('(?!Windows)')]
 #[RequiresPhpExtension('pdo_mysql')]
 class FulltextTest extends MySqlTestCase
 {

--- a/tests/Integration/Database/MySql/JoinLateralTest.php
+++ b/tests/Integration/Database/MySql/JoinLateralTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 
 #[RequiresPhpExtension('pdo_mysql')]
-#[RequiresOperatingSystem('Linux|Darwin')]
+#[RequiresOperatingSystem('(?!Windows)')]
 class JoinLateralTest extends MySqlTestCase
 {
     protected function afterRefreshingDatabase()

--- a/tests/Integration/Database/MySql/JoinLateralTest.php
+++ b/tests/Integration/Database/MySql/JoinLateralTest.php
@@ -6,11 +6,11 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
-use PHPUnit\Framework\Attributes\RequiresOperatingSystemFamily;
+use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 
 #[RequiresPhpExtension('pdo_mysql')]
-#[RequiresOperatingSystemFamily('Linux|Darwin')]
+#[RequiresOperatingSystem('Linux|Darwin')]
 class JoinLateralTest extends MySqlTestCase
 {
     protected function afterRefreshingDatabase()

--- a/tests/Integration/Database/Postgres/DatabasePostgresConnectionTest.php
+++ b/tests/Integration/Database/Postgres/DatabasePostgresConnectionTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 
-#[RequiresOperatingSystem('Linux|Darwin')]
+#[RequiresOperatingSystem('(?!Windows)')]
 #[RequiresPhpExtension('pdo_pgsql')]
 class DatabasePostgresConnectionTest extends PostgresTestCase
 {

--- a/tests/Integration/Database/Postgres/EscapeTest.php
+++ b/tests/Integration/Database/Postgres/EscapeTest.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use RuntimeException;
 
-#[RequiresOperatingSystem('Linux|Darwin')]
+#[RequiresOperatingSystem('(?!Windows)')]
 #[RequiresPhpExtension('pdo_pgsql')]
 class EscapeTest extends PostgresTestCase
 {

--- a/tests/Integration/Database/Postgres/FulltextTest.php
+++ b/tests/Integration/Database/Postgres/FulltextTest.php
@@ -9,7 +9,7 @@ use Orchestra\Testbench\Attributes\RequiresDatabase;
 use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 
-#[RequiresOperatingSystem('Linux|Darwin')]
+#[RequiresOperatingSystem('(?!Windows)')]
 #[RequiresPhpExtension('pdo_pgsql')]
 class FulltextTest extends PostgresTestCase
 {

--- a/tests/Integration/Database/Postgres/JoinLateralTest.php
+++ b/tests/Integration/Database/Postgres/JoinLateralTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 
 #[RequiresPhpExtension('pdo_pgsql')]
-#[RequiresOperatingSystem('Linux|Darwin')]
+#[RequiresOperatingSystem('(?!Windows)')]
 class JoinLateralTest extends PostgresTestCase
 {
     protected function afterRefreshingDatabase()

--- a/tests/Integration/Database/Postgres/JoinLateralTest.php
+++ b/tests/Integration/Database/Postgres/JoinLateralTest.php
@@ -6,11 +6,11 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
-use PHPUnit\Framework\Attributes\RequiresOperatingSystemFamily;
+use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 
 #[RequiresPhpExtension('pdo_pgsql')]
-#[RequiresOperatingSystemFamily('Linux|Darwin')]
+#[RequiresOperatingSystem('Linux|Darwin')]
 class JoinLateralTest extends PostgresTestCase
 {
     protected function afterRefreshingDatabase()

--- a/tests/Integration/Database/Postgres/PostgresSchemaBuilderTest.php
+++ b/tests/Integration/Database/Postgres/PostgresSchemaBuilderTest.php
@@ -9,7 +9,7 @@ use Orchestra\Testbench\Attributes\RequiresDatabase;
 use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 
-#[RequiresOperatingSystem('Linux|Darwin')]
+#[RequiresOperatingSystem('(?!Windows)')]
 #[RequiresPhpExtension('pdo_pgsql')]
 class PostgresSchemaBuilderTest extends PostgresTestCase
 {

--- a/tests/Integration/Database/SqlServer/DatabaseSqlServerConnectionTest.php
+++ b/tests/Integration/Database/SqlServer/DatabaseSqlServerConnectionTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 
-#[RequiresOperatingSystem('Linux|Darwin')]
+#[RequiresOperatingSystem('(?!Windows)')]
 #[RequiresPhpExtension('pdo_sqlsrv')]
 class DatabaseSqlServerConnectionTest extends SqlServerTestCase
 {

--- a/tests/Integration/Database/Sqlite/SchemaStateTest.php
+++ b/tests/Integration/Database/Sqlite/SchemaStateTest.php
@@ -33,7 +33,7 @@ class SchemaStateTest extends TestCase
         parent::tearDown();
     }
 
-    #[RequiresOperatingSystem('Linux|Darwin')]
+    #[RequiresOperatingSystem('(?!Windows)')]
     public function testSchemaDumpOnSqlite()
     {
         if ($this->usesSqliteInMemoryDatabaseConnection()) {

--- a/tests/Integration/Filesystem/FilesystemTest.php
+++ b/tests/Integration/Filesystem/FilesystemTest.php
@@ -8,7 +8,7 @@ use Orchestra\Testbench\TestCase;
 use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 use Symfony\Component\Process\Process;
 
-#[RequiresOperatingSystem('Linux|Darwin')]
+#[RequiresOperatingSystem('(?!Windows)')]
 class FilesystemTest extends TestCase
 {
     protected $stubFile;

--- a/tests/Integration/Filesystem/ReceiveFileTest.php
+++ b/tests/Integration/Filesystem/ReceiveFileTest.php
@@ -78,7 +78,7 @@ class ReceiveFileTest extends TestCase
         $response->assertForbidden();
     }
 
-    #[RequiresOperatingSystem('Linux|Darwin')]
+    #[RequiresOperatingSystem('(?!Windows)')]
     public function testItCanReceiveAFileWithUriDelimitersInThePath()
     {
         $result = Storage::temporaryUploadUrl('receive-file-test.txt?pad=x', Carbon::now()->addMinute());
@@ -90,7 +90,7 @@ class ReceiveFileTest extends TestCase
         Storage::assertMissing('receive-file-test.txt');
     }
 
-    #[RequiresOperatingSystem('Linux|Darwin')]
+    #[RequiresOperatingSystem('(?!Windows)')]
     public function testUriDelimitersInThePathCannotHideAnExpiredUploadUrl()
     {
         $result = Storage::temporaryUploadUrl('receive-file-test.txt?pad=x', Carbon::now()->subMinute());

--- a/tests/Integration/Filesystem/ServeFileTest.php
+++ b/tests/Integration/Filesystem/ServeFileTest.php
@@ -57,7 +57,7 @@ class ServeFileTest extends TestCase
         $response->assertForbidden();
     }
 
-    #[RequiresOperatingSystem('Linux|Darwin')]
+    #[RequiresOperatingSystem('(?!Windows)')]
     public function testItCanServeAFileWithUriDelimitersInThePath()
     {
         $url = Storage::temporaryUrl('serve-file-test.txt?pad=x', Carbon::now()->addMinute());
@@ -67,7 +67,7 @@ class ServeFileTest extends TestCase
         $this->assertSame('Hello Question', $response->streamedContent());
     }
 
-    #[RequiresOperatingSystem('Linux|Darwin')]
+    #[RequiresOperatingSystem('(?!Windows)')]
     public function testUriDelimitersInThePathCannotHideAnExpiredUrl()
     {
         $url = Storage::temporaryUrl('serve-file-test.txt?pad=x', Carbon::now()->subMinute());

--- a/tests/Integration/Filesystem/StorageTest.php
+++ b/tests/Integration/Filesystem/StorageTest.php
@@ -8,7 +8,7 @@ use Orchestra\Testbench\TestCase;
 use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 use Symfony\Component\Process\Process;
 
-#[RequiresOperatingSystem('Linux|Darwin')]
+#[RequiresOperatingSystem('(?!Windows)')]
 class StorageTest extends TestCase
 {
     protected $stubFile;

--- a/tests/Integration/Queue/DynamoBatchTest.php
+++ b/tests/Integration/Queue/DynamoBatchTest.php
@@ -16,7 +16,7 @@ use Orchestra\Testbench\Attributes\RequiresEnv;
 use Orchestra\Testbench\TestCase;
 use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 
-#[RequiresOperatingSystem('Linux|Darwin')]
+#[RequiresOperatingSystem('(?!Windows)')]
 #[RequiresEnv('DYNAMODB_ENDPOINT')]
 class DynamoBatchTest extends TestCase
 {

--- a/tests/Integration/Queue/DynamoBatchTestWithTTL.php
+++ b/tests/Integration/Queue/DynamoBatchTestWithTTL.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Env;
 use Orchestra\Testbench\Attributes\RequiresEnv;
 use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 
-#[RequiresOperatingSystem('Linux|Darwin')]
+#[RequiresOperatingSystem('(?!Windows)')]
 #[RequiresEnv('DYNAMODB_ENDPOINT')]
 class DynamoBatchTestWithTTL extends DynamoBatchTest
 {

--- a/tests/Integration/Routing/SerializableClosureV1CacheRouteTest.php
+++ b/tests/Integration/Routing/SerializableClosureV1CacheRouteTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 
 use function Illuminate\Filesystem\join_paths;
 
-#[RequiresOperatingSystem('Linux|Darwin')]
+#[RequiresOperatingSystem('(?!Windows)')]
 #[WithConfig('app.key', 'AckfSECXIvnK5r28GVIWUAxmbBSjTsmF')]
 #[WithMigration]
 class SerializableClosureV1CacheRouteTest extends TestCase

--- a/tests/Integration/Routing/SerializableClosureV1CacheRouteTest.php
+++ b/tests/Integration/Routing/SerializableClosureV1CacheRouteTest.php
@@ -7,11 +7,11 @@ use Orchestra\Testbench\Attributes\WithConfig;
 use Orchestra\Testbench\Attributes\WithMigration;
 use Orchestra\Testbench\Factories\UserFactory;
 use Orchestra\Testbench\TestCase;
-use PHPUnit\Framework\Attributes\RequiresOperatingSystemFamily;
+use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 
 use function Illuminate\Filesystem\join_paths;
 
-#[RequiresOperatingSystemFamily('Linux|Darwin')]
+#[RequiresOperatingSystem('Linux|Darwin')]
 #[WithConfig('app.key', 'AckfSECXIvnK5r28GVIWUAxmbBSjTsmF')]
 #[WithMigration]
 class SerializableClosureV1CacheRouteTest extends TestCase

--- a/tests/Integration/Routing/SerializableClosureV1CacheRouteTest.php
+++ b/tests/Integration/Routing/SerializableClosureV1CacheRouteTest.php
@@ -41,6 +41,8 @@ class SerializableClosureV1CacheRouteTest extends TestCase
     protected function tearDown(): void
     {
         unset($_ENV['APP_ROUTES_CACHE']);
+
+        parent::tearDown();
     }
 
     public function testItCanUseCachedRouteFromSerializableClosureV1()

--- a/tests/Process/ProcessTest.php
+++ b/tests/Process/ProcessTest.php
@@ -496,7 +496,7 @@ class ProcessTest extends TestCase
         $this->assertTrue(true);
     }
 
-    #[RequiresOperatingSystem('Linux|DAR')]
+    #[RequiresOperatingSystem('Linux|Darwin')]
     public function testRealProcessesCanHaveErrorOutput()
     {
         $factory = new Factory;
@@ -524,7 +524,7 @@ class ProcessTest extends TestCase
         $result->throw();
     }
 
-    #[RequiresOperatingSystem('Linux|DAR')]
+    #[RequiresOperatingSystem('Linux|Darwin')]
     public function testRealProcessesCanThrowWithoutOutput()
     {
         $this->expectException(ProcessFailedException::class);
@@ -562,7 +562,7 @@ class ProcessTest extends TestCase
         $result->throw();
     }
 
-    #[RequiresOperatingSystem('Linux|DAR')]
+    #[RequiresOperatingSystem('Linux|Darwin')]
     public function testRealProcessesCanThrowWithErrorOutput()
     {
         $this->expectException(ProcessFailedException::class);
@@ -604,7 +604,7 @@ class ProcessTest extends TestCase
         $result->throw();
     }
 
-    #[RequiresOperatingSystem('Linux|DAR')]
+    #[RequiresOperatingSystem('Linux|Darwin')]
     public function testRealProcessesCanThrowWithOutput()
     {
         $this->expectException(ProcessFailedException::class);
@@ -625,7 +625,7 @@ class ProcessTest extends TestCase
         $result->throw();
     }
 
-    #[RequiresOperatingSystem('Linux|DAR')]
+    #[RequiresOperatingSystem('Linux|Darwin')]
     public function testRealProcessesCanTimeout()
     {
         $this->expectException(ProcessTimedOutException::class);
@@ -639,7 +639,7 @@ class ProcessTest extends TestCase
         $result->throw();
     }
 
-    #[RequiresOperatingSystem('Linux|DAR')]
+    #[RequiresOperatingSystem('Linux|Darwin')]
     public function testATimeoutCanBeSetWithACarbonInterval()
     {
         $this->expectException(ProcessTimedOutException::class);
@@ -654,7 +654,7 @@ class ProcessTest extends TestCase
         $result->throw();
     }
 
-    #[RequiresOperatingSystem('Linux|DAR')]
+    #[RequiresOperatingSystem('Linux|Darwin')]
     public function testRealProcessesCanThrowIfTrue()
     {
         $this->expectException(ProcessFailedException::class);
@@ -665,7 +665,7 @@ class ProcessTest extends TestCase
         $result->throwIf(true);
     }
 
-    #[RequiresOperatingSystem('Linux|DAR')]
+    #[RequiresOperatingSystem('Linux|Darwin')]
     public function testRealProcessesDoesntThrowIfFalse()
     {
         $factory = new Factory;
@@ -676,7 +676,7 @@ class ProcessTest extends TestCase
         $this->assertTrue(true);
     }
 
-    #[RequiresOperatingSystem('Linux|DAR')]
+    #[RequiresOperatingSystem('Linux|Darwin')]
     public function testRealProcessesCanUseStandardInput()
     {
         $factory = new Factory();
@@ -685,7 +685,7 @@ class ProcessTest extends TestCase
         $this->assertSame('foobar', $result->output());
     }
 
-    #[RequiresOperatingSystem('Linux|DAR')]
+    #[RequiresOperatingSystem('Linux|Darwin')]
     public function testProcessPipe()
     {
         $factory = new Factory;
@@ -701,7 +701,7 @@ class ProcessTest extends TestCase
         $this->assertSame("foo\n", $pipe->output());
     }
 
-    #[RequiresOperatingSystem('Linux|DAR')]
+    #[RequiresOperatingSystem('Linux|Darwin')]
     public function testProcessPipeFailed()
     {
         $factory = new Factory;
@@ -717,7 +717,7 @@ class ProcessTest extends TestCase
         $this->assertTrue($pipe->failed());
     }
 
-    #[RequiresOperatingSystem('Linux|DAR')]
+    #[RequiresOperatingSystem('Linux|Darwin')]
     public function testProcessSimplePipe()
     {
         $factory = new Factory;
@@ -733,7 +733,7 @@ class ProcessTest extends TestCase
         $this->assertSame("foo\n", $pipe->output());
     }
 
-    #[RequiresOperatingSystem('Linux|DAR')]
+    #[RequiresOperatingSystem('Linux|Darwin')]
     public function testProcessSimplePipeFailed()
     {
         $factory = new Factory;

--- a/tests/Process/ProcessTest.php
+++ b/tests/Process/ProcessTest.php
@@ -496,7 +496,7 @@ class ProcessTest extends TestCase
         $this->assertTrue(true);
     }
 
-    #[RequiresOperatingSystem('Linux|Darwin')]
+    #[RequiresOperatingSystem('(?!Windows)')]
     public function testRealProcessesCanHaveErrorOutput()
     {
         $factory = new Factory;
@@ -524,7 +524,7 @@ class ProcessTest extends TestCase
         $result->throw();
     }
 
-    #[RequiresOperatingSystem('Linux|Darwin')]
+    #[RequiresOperatingSystem('(?!Windows)')]
     public function testRealProcessesCanThrowWithoutOutput()
     {
         $this->expectException(ProcessFailedException::class);
@@ -562,7 +562,7 @@ class ProcessTest extends TestCase
         $result->throw();
     }
 
-    #[RequiresOperatingSystem('Linux|Darwin')]
+    #[RequiresOperatingSystem('(?!Windows)')]
     public function testRealProcessesCanThrowWithErrorOutput()
     {
         $this->expectException(ProcessFailedException::class);
@@ -604,7 +604,7 @@ class ProcessTest extends TestCase
         $result->throw();
     }
 
-    #[RequiresOperatingSystem('Linux|Darwin')]
+    #[RequiresOperatingSystem('(?!Windows)')]
     public function testRealProcessesCanThrowWithOutput()
     {
         $this->expectException(ProcessFailedException::class);
@@ -625,7 +625,7 @@ class ProcessTest extends TestCase
         $result->throw();
     }
 
-    #[RequiresOperatingSystem('Linux|Darwin')]
+    #[RequiresOperatingSystem('(?!Windows)')]
     public function testRealProcessesCanTimeout()
     {
         $this->expectException(ProcessTimedOutException::class);
@@ -639,7 +639,7 @@ class ProcessTest extends TestCase
         $result->throw();
     }
 
-    #[RequiresOperatingSystem('Linux|Darwin')]
+    #[RequiresOperatingSystem('(?!Windows)')]
     public function testATimeoutCanBeSetWithACarbonInterval()
     {
         $this->expectException(ProcessTimedOutException::class);
@@ -654,7 +654,7 @@ class ProcessTest extends TestCase
         $result->throw();
     }
 
-    #[RequiresOperatingSystem('Linux|Darwin')]
+    #[RequiresOperatingSystem('(?!Windows)')]
     public function testRealProcessesCanThrowIfTrue()
     {
         $this->expectException(ProcessFailedException::class);
@@ -665,7 +665,7 @@ class ProcessTest extends TestCase
         $result->throwIf(true);
     }
 
-    #[RequiresOperatingSystem('Linux|Darwin')]
+    #[RequiresOperatingSystem('(?!Windows)')]
     public function testRealProcessesDoesntThrowIfFalse()
     {
         $factory = new Factory;
@@ -676,7 +676,7 @@ class ProcessTest extends TestCase
         $this->assertTrue(true);
     }
 
-    #[RequiresOperatingSystem('Linux|Darwin')]
+    #[RequiresOperatingSystem('(?!Windows)')]
     public function testRealProcessesCanUseStandardInput()
     {
         $factory = new Factory();
@@ -685,7 +685,7 @@ class ProcessTest extends TestCase
         $this->assertSame('foobar', $result->output());
     }
 
-    #[RequiresOperatingSystem('Linux|Darwin')]
+    #[RequiresOperatingSystem('(?!Windows)')]
     public function testProcessPipe()
     {
         $factory = new Factory;
@@ -701,7 +701,7 @@ class ProcessTest extends TestCase
         $this->assertSame("foo\n", $pipe->output());
     }
 
-    #[RequiresOperatingSystem('Linux|Darwin')]
+    #[RequiresOperatingSystem('(?!Windows)')]
     public function testProcessPipeFailed()
     {
         $factory = new Factory;
@@ -717,7 +717,7 @@ class ProcessTest extends TestCase
         $this->assertTrue($pipe->failed());
     }
 
-    #[RequiresOperatingSystem('Linux|Darwin')]
+    #[RequiresOperatingSystem('(?!Windows)')]
     public function testProcessSimplePipe()
     {
         $factory = new Factory;
@@ -733,7 +733,7 @@ class ProcessTest extends TestCase
         $this->assertSame("foo\n", $pipe->output());
     }
 
-    #[RequiresOperatingSystem('Linux|Darwin')]
+    #[RequiresOperatingSystem('(?!Windows)')]
     public function testProcessSimplePipeFailed()
     {
         $factory = new Factory;


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
As a follow-up to #60162, this PR replace the "Linux|Darwin" matcher with a broader non-Windows regex, given all these tests are likely to work fine on any non-Windows machine and as such allow for easier testing on a broader variety of OS'es. Based on the values listed on https://www.php.net/manual/en/reserved.constants.php#constant.php-os-family, this seems to be quite a safe general assumption. Moreover, this will only influence local development environments on non-standard OS'es, where test now potentially might fail rather than be skipped.