### PR TITLE
[13.x] Remove obsolete @phpstan-ignore clauses

### DIFF
--- a/types/Support/Helpers.php
+++ b/types/Support/Helpers.php
@@ -44,7 +44,7 @@ assertType('Illuminate\Support\HigherOrderTapProxy', tap(new User()));
 function testThrowIf(float|int $foo, ?DateTime $bar = null): void
 {
     rescue(fn () => assertType('never', throw_if(true, Exception::class)));
-    assertType('false', throw_if(false, Exception::class)); // @phpstan-ignore deadCode.unreachable
+    assertType('false', throw_if(false, Exception::class));
     assertType('false', throw_if(empty($foo)));
     throw_if(is_float($foo));
     assertType('int', $foo);
@@ -63,7 +63,7 @@ function testThrowUnless(float|int $foo, ?DateTime $bar = null): void
 {
     assertType('true', throw_unless(true, Exception::class));
     rescue(fn () => assertType('never', throw_unless(false, Exception::class)));
-    assertType('true', throw_unless(empty($foo))); // @phpstan-ignore deadCode.unreachable
+    assertType('true', throw_unless(empty($foo)));
     throw_unless(is_int($foo));
     assertType('int', $foo);
     throw_unless($foo == false);


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Working on #60162 some static errors (newly) popped up in CI. I assume these were triggered by https://github.com/phpstan/phpstan/releases/tag/2.1.55. Removing the ignore clauses should fix this.

*Note:* this may be cherry-picked to 12.x if relevant.