### PR TITLE
[13.x] do not try to import Echo into `bootstrap.js`

### DIFF
--- a/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
@@ -104,20 +104,8 @@ class BroadcastingInstallCommand extends Command
                 copy($stubPath, $echoScriptPath);
             }
 
-            // Only add the bootstrap import for the standard JS implementation...
-            if (file_exists($bootstrapScriptPath = $this->laravel->resourcePath('js/bootstrap.js'))) {
-                $bootstrapScript = file_get_contents(
-                    $bootstrapScriptPath
-                );
-
-                if (! str_contains($bootstrapScript, './echo')) {
-                    file_put_contents(
-                        $bootstrapScriptPath,
-                        trim($bootstrapScript.PHP_EOL.file_get_contents(__DIR__.'/stubs/echo-bootstrap-js.stub')).PHP_EOL,
-                    );
-                }
-            } elseif (file_exists($appScriptPath = $this->laravel->resourcePath('js/app.js'))) {
-                // If no bootstrap.js, try app.js...
+            // Import Echo in the main JavaScript file...
+            if (file_exists($appScriptPath = $this->laravel->resourcePath('js/app.js'))) {
                 $appScript = file_get_contents(
                     $appScriptPath
                 );


### PR DESCRIPTION
`bootstrap.js` was recently removed from `laravel/laravel` so it probably doesn't make sense to try and import Echo there anymore. going forward it will only try to import it into `app.js`.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
