### PR TITLE
[12.x] Remove stale PHPStan ignore comments from type tests

### DIFF
--- a/types/Support/Helpers.php
+++ b/types/Support/Helpers.php
@@ -44,7 +44,7 @@ assertType('Illuminate\Support\HigherOrderTapProxy', tap(new User()));
 function testThrowIf(float|int $foo, ?DateTime $bar = null): void
 {
     rescue(fn () => assertType('never', throw_if(true, Exception::class)));
-    assertType('false', throw_if(false, Exception::class)); // @phpstan-ignore deadCode.unreachable
+    assertType('false', throw_if(false, Exception::class));
     assertType('false', throw_if(empty($foo)));
     throw_if(is_float($foo));
     assertType('int', $foo);
@@ -63,7 +63,7 @@ function testThrowUnless(float|int $foo, ?DateTime $bar = null): void
 {
     assertType('true', throw_unless(true, Exception::class));
     rescue(fn () => assertType('never', throw_unless(false, Exception::class)));
-    assertType('true', throw_unless(empty($foo))); // @phpstan-ignore deadCode.unreachable
+    assertType('true', throw_unless(empty($foo)));
     throw_unless(is_int($foo));
     assertType('int', $foo);
     throw_unless($foo == false);


### PR DESCRIPTION
This removes two stale `@phpstan-ignore deadCode.unreachable` comments from `types/Support/Helpers.php` that are no longer reported by PHPStan 2.1.55, causing the static analysis workflow to fail.