### PR TITLE
[13.x] Add JSON output option to ListFailedCommand and corresponding tests

### DIFF
--- a/src/Illuminate/Queue/Console/ListFailedCommand.php
+++ b/src/Illuminate/Queue/Console/ListFailedCommand.php
@@ -15,7 +15,8 @@ class ListFailedCommand extends Command
      *
      * @var string
      */
-    protected $name = 'queue:failed';
+    protected $signature = 'queue:failed
+                            {--json : Output the failed jobs as JSON}';
 
     /**
      * The console command description.
@@ -38,7 +39,13 @@ class ListFailedCommand extends Command
      */
     public function handle()
     {
-        if (count($jobs = $this->getFailedJobs()) === 0) {
+        $jobs = $this->getFailedJobs();
+
+        if ($this->option('json')) {
+            return $this->displayFailedJobsAsJson($jobs);
+        }
+
+        if (count($jobs) === 0) {
             return $this->components->info('No failed jobs found.');
         }
 
@@ -121,5 +128,22 @@ class ListFailedCommand extends Command
                 sprintf('<fg=gray>%s@%s</> %s', $job[1], $job[2], $job[3])
             ),
         );
+    }
+
+    /**
+     * Display the failed jobs as JSON.
+     *
+     * @param  array  $jobs
+     * @return void
+     */
+    protected function displayFailedJobsAsJson(array $jobs)
+    {
+        $this->output->writeln((new Collection($jobs))->values()->map(fn ($job) => [
+            'id' => $job[0],
+            'connection' => $job[1],
+            'queue' => $job[2],
+            'class' => $job[3],
+            'failed_at' => $job[4],
+        ])->toJson());
     }
 }

--- a/tests/Queue/ListFailedCommandTest.php
+++ b/tests/Queue/ListFailedCommandTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Illuminate\Tests\Queue;
+
+use Illuminate\Foundation\Application;
+use Illuminate\Queue\Console\ListFailedCommand;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class ListFailedCommandTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+
+        parent::tearDown();
+    }
+
+    public function testItDisplaysEmptyFailedJobsAsJson()
+    {
+        $output = $this->runCommandWithFailedJobs([], ['--json' => true]);
+
+        $this->assertJson($output);
+        $this->assertJsonStringEqualsJsonString('[]', $output);
+    }
+
+    public function testItDisplaysFailedJobsAsJson()
+    {
+        $output = $this->runCommandWithFailedJobs([
+            (object) [
+                'id' => 'failed-job-id',
+                'connection' => 'redis',
+                'queue' => 'default',
+                'payload' => json_encode([
+                    'job' => 'Illuminate\Queue\CallQueuedHandler@call',
+                    'data' => [
+                        'command' => 'O:32:"Illuminate\Tests\Queue\ExampleJob":0:{}',
+                    ],
+                ]),
+                'exception' => 'Exception stack trace',
+                'failed_at' => '2026-05-18 12:00:00',
+            ],
+        ], ['--json' => true]);
+
+        $this->assertJson($output);
+        $this->assertJsonStringEqualsJsonString(json_encode([
+            [
+                'id' => 'failed-job-id',
+                'connection' => 'redis',
+                'queue' => 'default',
+                'class' => 'Illuminate\Tests\Queue\ExampleJob',
+                'failed_at' => '2026-05-18 12:00:00',
+            ],
+        ]), $output);
+    }
+
+    protected function runCommandWithFailedJobs(array $failedJobs, array $arguments = []): string
+    {
+        $container = new Application;
+        $container->instance('queue.failer', $failer = m::mock());
+
+        $failer->shouldReceive('all')->once()->andReturn($failedJobs);
+
+        $command = new ListFailedCommand;
+        $command->setLaravel($container);
+
+        $output = new BufferedOutput;
+
+        $command->run(new ArrayInput($arguments), $output);
+
+        return $output->fetch();
+    }
+}


### PR DESCRIPTION
Adds JSON output support to the `queue:failed` Artisan command.

This makes failed queue jobs easier to consume from CI, scripts, dashboards, and other tooling, matching the existing `--json` support available on commands like `route:list`, `event:list`, `db:show`, `db:table`, `queue:monitor`, and `queue:work`.

## Changes

- Add a `--json` option to `queue:failed`.
- Return `[]` when no failed jobs are available.
- Output failed jobs with `id`, `connection`, `queue`, `class`, and `failed_at`.
- Add tests for empty and populated JSON output.
