### PR TITLE
[13.x] Add password rule builder method to Rule

### DIFF
--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -20,6 +20,7 @@ use Illuminate\Validation\Rules\ImageFile;
 use Illuminate\Validation\Rules\In;
 use Illuminate\Validation\Rules\NotIn;
 use Illuminate\Validation\Rules\Numeric;
+use Illuminate\Validation\Rules\Password;
 use Illuminate\Validation\Rules\ProhibitedIf;
 use Illuminate\Validation\Rules\ProhibitedUnless;
 use Illuminate\Validation\Rules\RequiredIf;
@@ -237,6 +238,16 @@ class Rule
     public static function email()
     {
         return new Email;
+    }
+
+    /**
+     * Get a password rule builder instance.
+     *
+     * @return \Illuminate\Validation\Rules\Password
+     */
+    public static function password()
+    {
+        return Password::defaults();
     }
 
     /**

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -247,7 +247,7 @@ class Rule
      */
     public static function password()
     {
-        return Password::defaults();
+        return Password::default();
     }
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

## Description

Thank you for the Laravel framework!

But I believe there should be a `password` method on `\Illuminate\Validation\Rule` just like there is `email` and other builder rules. I have personally tried using it like that, but found out it is not supported, so I just added a macro in my application code to support just that.

Another benefit is that end users will not be forced to use an alias when they are using it in the same file where they are using the `Illuminate\Support\Facades\Password` facade, which is common in [Livewire](https://livewire.laravel.com) components or [Laravel Actions](https://www.laravelactions.com/) classes during password resets.

<img width="1511" height="817" alt="image" src="https://github.com/user-attachments/assets/d9cbd33e-4778-4d0e-bedf-6c2e2aea10ef" />

## Testing

I didn't write any other tests because there are already tests for the Password rule, and I can see the existing rules didn't have a dedicated one checking if the rules work through the Rule class.