### PR TITLE
Fix Database lock Queryexception Sqlstate #60171

### DIFF
--- a/src/Illuminate/Cache/DatabaseLock.php
+++ b/src/Illuminate/Cache/DatabaseLock.php
@@ -77,7 +77,13 @@ class DatabaseLock extends Lock
             ]);
 
             $acquired = true;
-        } catch (QueryException) {
+        } catch (QueryException $e) {
+            $sqlState = (string) ($e->errorInfo[0] ?? $e->getCode());
+
+            if (! str_starts_with($sqlState, '23')) {
+                throw $e;
+            }
+
             $updated = $this->connection->table($this->table)
                 ->where('key', $this->name)
                 ->where(function ($query) {

--- a/tests/Integration/Database/DatabaseLockTest.php
+++ b/tests/Integration/Database/DatabaseLockTest.php
@@ -165,4 +165,64 @@ class DatabaseLockTest extends DatabaseTestCase
             $lock->release();
         }
     }
+
+    public function testAcquireRethrowsNonIntegrityConstraintQueryException()
+    {
+        $connection = m::mock(Connection::class);
+        $insertBuilder = m::mock(Builder::class);
+
+        $insertBuilder->shouldReceive('insert')->once()->andThrow(
+            $this->queryExceptionWithSqlState(
+                'insert into cache_locks (key, owner, expiration) values (?, ?, ?)',
+                ['foo', 'owner-123', 123],
+                'Data too long for column',
+                1406,
+                '22001'
+            )
+        );
+
+        $connection->shouldReceive('table')->with('cache_locks')->once()->andReturn($insertBuilder);
+
+        $lock = new DatabaseLock($connection, 'cache_locks', 'foo', 10, 'owner-123');
+
+        $this->expectException(QueryException::class);
+        $this->expectExceptionMessage('Data too long for column');
+
+        $lock->acquire();
+    }
+
+    public function testAcquireUsesUpdateFallbackForIntegrityConstraintViolation()
+    {
+        $connection = m::mock(Connection::class);
+        $insertBuilder = m::mock(Builder::class);
+        $updateBuilder = m::mock(Builder::class);
+
+        $insertBuilder->shouldReceive('insert')->once()->andThrow(
+            $this->queryExceptionWithSqlState(
+                'insert into cache_locks (key, owner, expiration) values (?, ?, ?)',
+                ['foo', 'owner-123', 123],
+                'Duplicate entry',
+                1062,
+                '23000'
+            )
+        );
+
+        $updateBuilder->shouldReceive('where')->with('key', 'foo')->once()->andReturnSelf();
+        $updateBuilder->shouldReceive('where')->with(m::type('Closure'))->once()->andReturnSelf();
+        $updateBuilder->shouldReceive('update')->once()->andReturn(1);
+
+        $connection->shouldReceive('table')->with('cache_locks')->andReturn($insertBuilder, $updateBuilder);
+
+        $lock = new DatabaseLock($connection, 'cache_locks', 'foo', 10, 'owner-123');
+
+        $this->assertTrue($lock->acquire());
+    }
+
+    protected function queryExceptionWithSqlState(string $sql, array $bindings, string $message, int $code, string $sqlState): QueryException
+    {
+        $previous = new PDOException($message, $code);
+        $previous->errorInfo = [$sqlState, $code, $message];
+
+        return new QueryException('mysql', $sql, $bindings, $previous);
+    }
 }


### PR DESCRIPTION
Fixes #60171 : `DatabaseLock::acquire()` with the database cache driver could swallow unrelated `QueryException` errors (for example SQLSTATE `22001`) and keep retrying until `block()` timed out.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
