### PR TITLE
[13.x] feat: support cross database eloquent existence checking withWhereHas, whereHas

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -1088,7 +1088,7 @@ trait QueriesRelationships
             throw new RuntimeException(sprintf(
                 'Cross-connection aggregate function [%s] is not supported. '
                 .'Supported functions: count, exists, min, max, sum, avg.',
-                $function ?? 'null',
+                is_string($function) ? $function : 'null',
             ));
         }
 
@@ -1538,7 +1538,7 @@ trait QueriesRelationships
      *                        ? '='
      *                        : TOperator
      *                    )
-     *                ) 
+     *                )
      *            )
      *        )
      *     )

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -1499,7 +1499,28 @@ trait QueriesRelationships
      * @param  mixed  $count
      * @return bool
      *
-     * @phpstan ($count is numeric ? bool : false)
+     * @phpstan-return ($count is numeric
+     *    ? ($operator is '>='
+     *         ? ($count is non-positive-int ? true : false)
+     *         : ($operator is '>'
+     *            ? ($count is negative-int ? true : false)
+     *            : ($operator is '='|'==' ?
+     *                ? ($count is non-zero-int ? false : true)
+     *                : ($operator is '<=' ?
+     *                    ? ($count is non-negative-int ? true : false)
+     *                    : ($operator is '<'
+     *                        ? ($count is positive-int ? true : false)
+     *                        : ($operator is '!='|'<>'
+     *                            ? ($count is non-zero-int ? true : false)
+     *                            : false
+     *                        )
+     *                    )
+     *                )
+     *            )
+     *         )
+     *     )
+     *     : false
+     * )
      */
     protected function zeroCountSatisfiesCrossConnectionOperator($operator, $count)
     {

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -1359,7 +1359,8 @@ trait QueriesRelationships
      * @param  string  $boolean
      * @param  \Closure(array{self}&array<array-key, mixed>)|null  $callback
      * @return $this
-     * 
+     *
+     *
      * @phpstan-return ($operator is '>='|'<'
      *     ? ($count is 1
      *         ? $this

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -1426,7 +1426,7 @@ trait QueriesRelationships
      * "doesntHave" with no related rows ⇒ all parents qualify (force it to true).
      *
      * @param  bool  $not
-     * @param  string  $boolean
+     * @param  'and'|'or'  $boolean
      * @return $this
      */
     protected function addEmptyCrossConnectionConstraint($not, $boolean)

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -1139,7 +1139,7 @@ trait QueriesRelationships
      * @param  \Illuminate\Database\Eloquent\Relations\Relation<*, *, *>  $relation
      * @param  string  $relatedKey
      * @param  string  $localKey
-     * @param  \Closure|null  $constraints
+     * @param  \Closure(array{self}&array<array-key, mixed>)|null  $constraints
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
      * @param  string  $function
      * @return TResult

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -1520,8 +1520,29 @@ trait QueriesRelationships
     /**
      * Return the logical complement of a count comparison operator.
      *
-     * @param  string  $operator
+     * @template TOperator of string
+     *
+     * @param  TOperator  $operator
      * @return string
+     * @phpstan-return ($operator is '>='
+     *     ? '<'
+     *     : ($operator is '>'
+     *        ? '<='
+     *        : ($operator is '='|'==' ?
+     *            ? '!='
+     *            : ($operator is '<=' ?
+     *                ? '>'
+     *                : ($operator is '<'
+     *                    ? '>='
+     *                    : ($operator is '!='|'<>'
+     *                        ? '='
+     *                        : TOperator
+     *                    )
+     *                ) 
+     *            )
+     *        )
+     *     )
+     * )
      */
     protected function complementCrossConnectionCountOperator($operator)
     {

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -1359,8 +1359,6 @@ trait QueriesRelationships
      * @param  string  $boolean
      * @param  \Closure(array{self}&array<array-key, mixed>)|null  $callback
      * @return $this
-     *
-     *
      * @phpstan-return ($operator is '>='|'<'
      *     ? ($count is 1
      *         ? $this

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -1064,7 +1064,7 @@ trait QueriesRelationships
      * to each hydrated model as the requested attribute alias.
      *
      * @param  string  $name
-     * @param  \Illuminate\Database\Eloquent\Relations\Relation<*, *, *>  $relation
+     * @param  \Illuminate\Database\Eloquent\Relations\HasOneOrMany<*, *, *> |\Illuminate\Database\Eloquent\Relations\BelongsTo<*, *, *>  $relation
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
      * @param  'count'|'exists'|'min'|'max'|'sum'|'avg'|null  $function
      * @param  \Closure(array{self}&array<array-key, mixed>)|null  $constraints

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -1451,6 +1451,7 @@ trait QueriesRelationships
      *
      * @param  \Illuminate\Database\Eloquent\Relations\Relation<*, *, *>  $relation
      * @return array{0: string, 1: string}
+     * @phpstan-return ($relation is \Illuminate\Database\Eloquent\Relations\BelongsTo|\Illuminate\Database\Eloquent\Relations\HasOneOrMany ? array{0: string, 1: string} : never)
      *
      * @throws \RuntimeException
      */

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -1141,7 +1141,7 @@ trait QueriesRelationships
      * @param  string  $localKey
      * @param  \Closure(array{self}&array<array-key, mixed>)|null  $constraints
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
-     * @param  string  $function
+     * @param  'count'|'exists'|'min'|'max'|'sum'|'avg'  $function
      * @return TResult
      */
     protected function loadCrossConnectionAggregateValues($result, $alias, Relation $relation, $relatedKey, $localKey, $constraints, $column, $function)

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -1357,7 +1357,7 @@ trait QueriesRelationships
      * @param  string  $operator
      * @param  \Illuminate\Contracts\Database\Query\Expression|int  $count
      * @param  string  $boolean
-     * @param  \Closure|null  $callback
+     * @param  \Closure(array{self}&array<array-key, mixed>)|null  $callback
      * @return $this
      */
     protected function addCrossConnectionHasWhere(Relation $relation, $operator, $count, $boolean, ?Closure $callback)

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -1359,6 +1359,19 @@ trait QueriesRelationships
      * @param  string  $boolean
      * @param  \Closure(array{self}&array<array-key, mixed>)|null  $callback
      * @return $this
+     * 
+     * @phpstan-return ($operator is '>='|'<'
+     *     ? ($count is 1
+     *         ? $this
+     *         : ($count is \Illuminate\Contracts\Database\Query\Expression
+     *             ? never
+     *             : $this
+     *         )
+     *     : ($count is \Illuminate\Contracts\Database\Query\Expression
+     *         ? never
+     *         : $this
+     *     )
+     * )
      */
     protected function addCrossConnectionHasWhere(Relation $relation, $operator, $count, $boolean, ?Closure $callback)
     {

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -6,9 +6,12 @@ use BadMethodCallException;
 use Closure;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\RelationNotFoundException;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasOneOrMany;
+use Illuminate\Database\Eloquent\Relations\MorphOneOrMany;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Query\Builder as QueryBuilder;
@@ -16,6 +19,7 @@ use Illuminate\Database\Query\Expression;
 use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
+use RuntimeException;
 
 use function Illuminate\Support\enum_value;
 
@@ -50,6 +54,14 @@ trait QueriesRelationships
             return $this->hasMorph($relation, ['*'], $operator, $count, $boolean, $callback);
         }
 
+        $strategy = $this->relationCrossConnectionStrategy($relation);
+
+        if ($strategy === 'resolve') {
+            return $this->addCrossConnectionHasWhere(
+                $relation, $operator, $count, $boolean, $callback
+            );
+        }
+
         // If we only need to check for the existence of the relation, then we can optimize
         // the subquery to only run a "where exists" clause instead of this full "count"
         // clause. This will make these queries run much faster compared with a count.
@@ -60,6 +72,10 @@ trait QueriesRelationships
         $hasQuery = $relation->{$method}(
             $relation->getRelated()->newQueryWithoutRelationships(), $this
         );
+
+        if ($strategy === 'prefix') {
+            $this->applyCrossDatabasePrefixToHasQuery($hasQuery, $relation);
+        }
 
         // Next we will call any given callback as an "anonymous" scope so they can get the
         // proper logical grouping of the where clauses if needed by this Eloquent query
@@ -873,6 +889,18 @@ trait QueriesRelationships
 
             $relation = $this->getRelationWithoutConstraints($name);
 
+            // When the related model lives on a connection that cannot share a single
+            // SQL statement with the parent's connection, fall back to resolving the
+            // aggregate as a separate query and attaching the values to each model
+            // after the parent query has been executed.
+            if ($this->relationCrossConnectionStrategy($relation) === 'resolve') {
+                $this->addCrossConnectionAggregate(
+                    $name, $relation, $column, $function, $constraints, $alias ?? null
+                );
+
+                continue;
+            }
+
             if ($function) {
                 if ($this->getQuery()->getGrammar()->isExpression($column)) {
                     $aggregateColumn = $this->getQuery()->getGrammar()->getValue($column);
@@ -1024,6 +1052,484 @@ trait QueriesRelationships
     public function withExists($relation)
     {
         return $this->withAggregate($relation, '*', 'exists');
+    }
+
+    /**
+     * Register a deferred aggregate computation for a relation that lives on a
+     * different database connection than the parent.
+     *
+     * The aggregate is resolved after the parent query has been executed by
+     * running a single grouped query against the related connection, keyed
+     * by the parent's foreign key, and then attaching the resulting value
+     * to each hydrated model as the requested attribute alias.
+     *
+     * @param  string  $name
+     * @param  \Illuminate\Database\Eloquent\Relations\Relation<*, *, *>  $relation
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  string|null  $function
+     * @param  \Closure|null  $constraints
+     * @param  string|null  $alias
+     * @return void
+     *
+     * @throws \RuntimeException
+     */
+    protected function addCrossConnectionAggregate($name, Relation $relation, $column, $function, $constraints, $alias)
+    {
+        if (! ($relation instanceof HasOneOrMany || $relation instanceof BelongsTo)) {
+            throw new RuntimeException(sprintf(
+                'Cross-connection aggregate queries are not supported for the [%s] relation (type: [%s]). '
+                .'Supported relation types: HasOne, HasMany, MorphOne, MorphMany, BelongsTo.',
+                $name,
+                $relation::class,
+            ));
+        }
+
+        if (! in_array($function, ['count', 'exists', 'min', 'max', 'sum', 'avg'], true)) {
+            throw new RuntimeException(sprintf(
+                'Cross-connection aggregate function [%s] is not supported. '
+                .'Supported functions: count, exists, min, max, sum, avg.',
+                $function ?? 'null',
+            ));
+        }
+
+        if ($alias === null) {
+            $alias = Str::snake(preg_replace(
+                '/[^[:alnum:][:space:]_]/u',
+                '',
+                sprintf(
+                    '%s %s %s',
+                    $name,
+                    $function,
+                    strtolower($this->getQuery()->getGrammar()->getValue($column))
+                )
+            ));
+        }
+
+        if (is_null($this->query->columns)) {
+            $this->query->select([$this->query->from.'.*']);
+        }
+
+        $localKey = $relation instanceof BelongsTo
+            ? $relation->getForeignKeyName()
+            : $relation->getLocalKeyName();
+
+        $relatedKey = $relation instanceof BelongsTo
+            ? $relation->getOwnerKeyName()
+            : $relation->getForeignKeyName();
+
+        if ($function === 'exists') {
+            $this->withCasts([$alias => 'bool']);
+        }
+
+        $this->afterQuery(function ($result) use ($alias, $relation, $relatedKey, $localKey, $constraints, $column, $function) {
+            return $this->loadCrossConnectionAggregateValues(
+                $result, $alias, $relation, $relatedKey, $localKey, $constraints, $column, $function
+            );
+        });
+    }
+
+    /**
+     * Resolve aggregate values from the related connection and attach them to each parent model.
+     *
+     * @param  mixed  $result
+     * @param  string  $alias
+     * @param  \Illuminate\Database\Eloquent\Relations\Relation<*, *, *>  $relation
+     * @param  string  $relatedKey
+     * @param  string  $localKey
+     * @param  \Closure|null  $constraints
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  string  $function
+     * @return mixed
+     */
+    protected function loadCrossConnectionAggregateValues($result, $alias, Relation $relation, $relatedKey, $localKey, $constraints, $column, $function)
+    {
+        $models = $this->collectModelsForAfterQuery($result);
+
+        if ($models === null) {
+            return $result;
+        }
+
+        $defaultValue = match ($function) {
+            'count' => 0,
+            'exists' => false,
+            default => null,
+        };
+
+        if ($models->isEmpty()) {
+            return $result;
+        }
+
+        $keys = (new BaseCollection($models))
+            ->map(fn ($model) => $model->getAttribute($localKey))
+            ->filter(fn ($value) => $value !== null)
+            ->unique()
+            ->values()
+            ->all();
+
+        if (empty($keys)) {
+            foreach ($models as $model) {
+                $model->setAttribute($alias, $defaultValue);
+            }
+
+            return $result;
+        }
+
+        $relatedQuery = $relation->getRelated()->newQueryWithoutRelationships();
+
+        if ($relation instanceof MorphOneOrMany) {
+            $relatedQuery->where(
+                $relation->getMorphType(),
+                '=',
+                $this->getModel()->getMorphClass()
+            );
+        }
+
+        if ($constraints instanceof Closure) {
+            $relatedQuery->callScope($constraints);
+        }
+
+        $relatedQuery->whereIn($relatedKey, $keys);
+
+        if ($function === 'exists') {
+            $matched = array_fill_keys(array_map(
+                'strval',
+                $relatedQuery->select($relatedKey)->distinct()->pluck($relatedKey)->all()
+            ), true);
+
+            foreach ($models as $model) {
+                $key = $model->getAttribute($localKey);
+
+                $model->setAttribute(
+                    $alias,
+                    $key !== null && isset($matched[(string) $key])
+                );
+            }
+
+            return $result;
+        }
+
+        $grammar = $relatedQuery->getQuery()->getGrammar();
+
+        if ($function === 'count') {
+            $aggregateSql = 'count(*)';
+        } elseif ($grammar->isExpression($column)) {
+            $aggregateSql = sprintf('%s(%s)', $function, $grammar->getValue($column));
+        } else {
+            $aggregateSql = sprintf('%s(%s)', $function, $grammar->wrap($column));
+        }
+
+        $rows = $relatedQuery
+            ->select($relatedKey)
+            ->selectRaw($aggregateSql.' as aggregate_value')
+            ->groupBy($relatedKey)
+            ->toBase()
+            ->get();
+
+        $map = [];
+
+        foreach ($rows as $row) {
+            $map[(string) $row->{$relatedKey}] = $row->aggregate_value;
+        }
+
+        foreach ($models as $model) {
+            $key = $model->getAttribute($localKey);
+
+            $model->setAttribute(
+                $alias,
+                $key !== null && array_key_exists((string) $key, $map)
+                    ? $map[(string) $key]
+                    : $defaultValue
+            );
+        }
+
+        return $result;
+    }
+
+    /**
+     * Normalize an after-query result into an EloquentCollection of models, or
+     * null when the result does not contain models we can attach values to.
+     *
+     * Single Model results are wrapped in a fresh collection. The wrapping
+     * collection is discarded after the callback runs, but mutations to the
+     * model itself are preserved by reference.
+     *
+     * @param  mixed  $result
+     * @return \Illuminate\Database\Eloquent\Collection<int, \Illuminate\Database\Eloquent\Model>|null
+     */
+    protected function collectModelsForAfterQuery($result)
+    {
+        if ($result instanceof EloquentCollection) {
+            return $result;
+        }
+
+        if ($result instanceof Model) {
+            return $result->newCollection([$result]);
+        }
+
+        return null;
+    }
+
+    /**
+     * Determine the cross-connection strategy to use for a relation.
+     *
+     * Returns one of:
+     *  - "same":    parent and related share the same connection (no special handling).
+     *  - "prefix":  related lives on a different database but the same server, so
+     *               the existence subquery can stay on a single PDO connection by
+     *               qualifying the table with its database name.
+     *  - "resolve": related lives on a different server or driver; the existence
+     *               subquery must be resolved as a separate query and converted
+     *               into a "where in" / "where not in" clause on the parent.
+     *
+     * @param  \Illuminate\Database\Eloquent\Relations\Relation<*, *, *>  $relation
+     * @return string
+     */
+    protected function relationCrossConnectionStrategy(Relation $relation)
+    {
+        $outer = $this->getModel()->getConnection();
+        $inner = $relation->getRelated()->getConnection();
+
+        if ($outer === $inner || $outer->getName() === $inner->getName()) {
+            return 'same';
+        }
+
+        if (! method_exists($outer, 'getDriverName') || ! method_exists($inner, 'getDriverName')) {
+            return 'resolve';
+        }
+
+        if ($outer->getDriverName() !== $inner->getDriverName()) {
+            return 'resolve';
+        }
+
+        if ($outer->getDriverName() === 'sqlite') {
+            return 'resolve';
+        }
+
+        $outerConfig = method_exists($outer, 'getConfig') ? $outer->getConfig() : [];
+        $innerConfig = method_exists($inner, 'getConfig') ? $inner->getConfig() : [];
+
+        $sameHost = ($outerConfig['host'] ?? null) === ($innerConfig['host'] ?? null);
+        $samePort = ($outerConfig['port'] ?? null) === ($innerConfig['port'] ?? null);
+
+        return ($sameHost && $samePort) ? 'prefix' : 'resolve';
+    }
+
+    /**
+     * Prefix the existence subquery's table with the related connection's database name.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder<*>  $hasQuery
+     * @param  \Illuminate\Database\Eloquent\Relations\Relation<*, *, *>  $relation
+     * @return void
+     */
+    protected function applyCrossDatabasePrefixToHasQuery(Builder $hasQuery, Relation $relation)
+    {
+        $base = $hasQuery->getQuery();
+
+        if (! is_string($base->from)) {
+            return;
+        }
+
+        $databaseName = $relation->getRelated()->getConnection()->getDatabaseName();
+
+        if ($databaseName === null || $databaseName === '') {
+            return;
+        }
+
+        if (str_starts_with($base->from, $databaseName.'.') || str_contains($base->from, '.')) {
+            return;
+        }
+
+        $base->from($databaseName.'.'.$base->from);
+    }
+
+    /**
+     * Add a "has" condition for a relation whose related model is on a foreign connection.
+     *
+     * Executes the inner query against the related connection, collects the matching
+     * parent keys, and applies them as a "where in" / "where not in" clause on the
+     * outer query. This mirrors what Laravel already does for eager loads via "with",
+     * applied to relationship-existence checks.
+     *
+     * @param  \Illuminate\Database\Eloquent\Relations\Relation<*, *, *>  $relation
+     * @param  string  $operator
+     * @param  \Illuminate\Contracts\Database\Query\Expression|int  $count
+     * @param  string  $boolean
+     * @param  \Closure|null  $callback
+     * @return $this
+     */
+    protected function addCrossConnectionHasWhere(Relation $relation, $operator, $count, $boolean, ?Closure $callback)
+    {
+        [$relatedKey, $parentColumn] = $this->resolveCrossConnectionKeyPair($relation);
+
+        $relatedQuery = $relation->getRelated()->newQueryWithoutRelationships();
+
+        if ($relation instanceof MorphOneOrMany) {
+            $relatedQuery->where(
+                $relation->getMorphType(),
+                '=',
+                $this->getModel()->getMorphClass()
+            );
+        }
+
+        if ($callback) {
+            $relatedQuery->callScope($callback);
+        }
+
+        $useExists = $this->canUseExistsForExistenceCheck($operator, $count);
+        $not = false;
+
+        if ($useExists) {
+            $not = ($operator === '<' && $count === 1);
+
+            $ids = $relatedQuery->distinct()->pluck($relatedKey)->all();
+        } else {
+            if ($count instanceof Expression) {
+                throw new RuntimeException(
+                    'Cross-connection relationship existence queries do not support '
+                    .'Expression count values. Use a literal integer count, or move the '
+                    .'relationship to a single connection.'
+                );
+            }
+
+            $zeroSatisfies = $this->zeroCountSatisfiesCrossConnectionOperator($operator, $count);
+            $effectiveOperator = $zeroSatisfies
+                ? $this->complementCrossConnectionCountOperator($operator)
+                : $operator;
+
+            $ids = $relatedQuery
+                ->select($relatedKey)
+                ->groupBy($relatedKey)
+                ->havingRaw('count(*) '.$effectiveOperator.' ?', [$count])
+                ->pluck($relatedKey)
+                ->all();
+
+            if ($zeroSatisfies) {
+                $not = true;
+            }
+        }
+
+        if (empty($ids)) {
+            return $this->addEmptyCrossConnectionConstraint($not, $boolean);
+        }
+
+        return $this->whereIn($parentColumn, $ids, $boolean, $not);
+    }
+
+    /**
+     * Apply the correct empty-result constraint when a cross-connection resolution
+     * returns no matching parent keys.
+     *
+     * "has" with no related rows ⇒ no parents qualify (force the clause to false).
+     * "doesntHave" with no related rows ⇒ all parents qualify (force it to true).
+     *
+     * @param  bool  $not
+     * @param  string  $boolean
+     * @return $this
+     */
+    protected function addEmptyCrossConnectionConstraint($not, $boolean)
+    {
+        if ($not) {
+            return $boolean === 'or'
+                ? $this->orWhereRaw('1 = 1')
+                : $this;
+        }
+
+        return $boolean === 'or'
+            ? $this->orWhereRaw('0 = 1')
+            : $this->whereRaw('0 = 1');
+    }
+
+    /**
+     * Resolve the [related column, parent column] pair used by cross-connection
+     * relationship existence queries.
+     *
+     * Cross-connection support currently covers HasOne, HasMany, MorphOne,
+     * MorphMany, and BelongsTo relations — the most common relationship types
+     * that span database boundaries in practice. Other relation types throw a
+     * descriptive exception so the developer can restructure their query or
+     * move the relationship to a single connection.
+     *
+     * @param  \Illuminate\Database\Eloquent\Relations\Relation<*, *, *>  $relation
+     * @return array{0: string, 1: string}
+     *
+     * @throws \RuntimeException
+     */
+    protected function resolveCrossConnectionKeyPair(Relation $relation)
+    {
+        if ($relation instanceof BelongsTo) {
+            return [
+                $relation->getOwnerKeyName(),
+                $relation->getQualifiedForeignKeyName(),
+            ];
+        }
+
+        if ($relation instanceof HasOneOrMany) {
+            return [
+                $relation->getForeignKeyName(),
+                $relation->getQualifiedParentKeyName(),
+            ];
+        }
+
+        throw new RuntimeException(sprintf(
+            'Cross-connection relationship existence queries are not supported for [%s] '
+            .'(parent connection [%s], related connection [%s]). Supported relation types: '
+            .'HasOne, HasMany, MorphOne, MorphMany, BelongsTo. Move the relationship to a '
+            .'single connection, or use a connection that can address both databases.',
+            $relation::class,
+            $this->getModel()->getConnection()->getName(),
+            $relation->getRelated()->getConnection()->getName(),
+        ));
+    }
+
+    /**
+     * Determine whether a parent row with zero matching related rows satisfies
+     * the given count constraint.
+     *
+     * This is the signal we use to flip the cross-connection resolution from
+     * "select parents that match" (whereIn) to "select parents that do NOT
+     * match the complementary condition" (whereNotIn), so that parents with
+     * no related rows are included where the operator allows them to be.
+     *
+     * @param  string  $operator
+     * @param  mixed  $count
+     * @return bool
+     */
+    protected function zeroCountSatisfiesCrossConnectionOperator($operator, $count)
+    {
+        if (! is_numeric($count)) {
+            return false;
+        }
+
+        $count = (int) $count;
+
+        return match ($operator) {
+            '>=' => $count <= 0,
+            '>' => $count < 0,
+            '=', '==' => $count === 0,
+            '<=' => $count >= 0,
+            '<' => $count > 0,
+            '!=', '<>' => $count !== 0,
+            default => false,
+        };
+    }
+
+    /**
+     * Return the logical complement of a count comparison operator.
+     *
+     * @param  string  $operator
+     * @return string
+     */
+    protected function complementCrossConnectionCountOperator($operator)
+    {
+        return match ($operator) {
+            '>=' => '<',
+            '>' => '<=',
+            '=', '==' => '!=',
+            '<=' => '>',
+            '<' => '>=',
+            '!=', '<>' => '=',
+            default => $operator,
+        };
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -1496,6 +1496,7 @@ trait QueriesRelationships
      * @param  string  $operator
      * @param  mixed  $count
      * @return bool
+     * @phpstan ($count is numeric ? bool : false)
      */
     protected function zeroCountSatisfiesCrossConnectionOperator($operator, $count)
     {

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -1066,7 +1066,7 @@ trait QueriesRelationships
      * @param  string  $name
      * @param  \Illuminate\Database\Eloquent\Relations\Relation<*, *, *>  $relation
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
-     * @param  string|null  $function
+     * @param  'count'|'exists'|'min'|'max'|'sum'|'avg'|null  $function
      * @param  \Closure(array{self}&array<array-key, mixed>)|null  $constraints
      * @param  string|null  $alias
      * @return void

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -1260,6 +1260,7 @@ trait QueriesRelationships
      *
      * @param  TResult  $result
      * @return \Illuminate\Database\Eloquent\Collection<int, \Illuminate\Database\Eloquent\Model>|null
+     *
      * @phpstan-return ($result is \Illuminate\Database\Eloquent\Collection ? TResult : ($result is \Illuminate\Database\Eloquent\Model ? \Illuminate\Database\Eloquent\Collection<int, TResult> : null))
      */
     protected function collectModelsForAfterQuery($result)

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -1284,7 +1284,7 @@ trait QueriesRelationships
      *               into a "where in" / "where not in" clause on the parent.
      *
      * @param  \Illuminate\Database\Eloquent\Relations\Relation<*, *, *>  $relation
-     * @return string
+     * @return 'same'|'prefix'|'resolve'
      */
     protected function relationCrossConnectionStrategy(Relation $relation)
     {

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -1359,6 +1359,7 @@ trait QueriesRelationships
      * @param  string  $boolean
      * @param  \Closure(array{self}&array<array-key, mixed>)|null  $callback
      * @return $this
+     *
      * @phpstan-return ($operator is '>='|'<'
      *     ? ($count is 1
      *         ? $this

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -1067,7 +1067,7 @@ trait QueriesRelationships
      * @param  \Illuminate\Database\Eloquent\Relations\Relation<*, *, *>  $relation
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
      * @param  string|null  $function
-     * @param  \Closure|null  $constraints
+     * @param  \Closure(array{self}&array<array-key, mixed>)|null  $constraints
      * @param  string|null  $alias
      * @return void
      *

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -1149,15 +1149,15 @@ trait QueriesRelationships
             return $result;
         }
 
+        if ($models->isEmpty()) {
+            return $result;
+        }
+
         $defaultValue = match ($function) {
             'count' => 0,
             'exists' => false,
             default => null,
         };
-
-        if ($models->isEmpty()) {
-            return $result;
-        }
 
         $keys = (new BaseCollection($models))
             ->map(fn ($model) => $model->getAttribute($localKey))

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -1131,7 +1131,9 @@ trait QueriesRelationships
     /**
      * Resolve aggregate values from the related connection and attach them to each parent model.
      *
-     * @param  mixed  $result
+     * @template TResult
+     *
+     * @param  TResult  $result
      * @param  string  $alias
      * @param  \Illuminate\Database\Eloquent\Relations\Relation<*, *, *>  $relation
      * @param  string  $relatedKey
@@ -1139,7 +1141,7 @@ trait QueriesRelationships
      * @param  \Closure|null  $constraints
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
      * @param  string  $function
-     * @return mixed
+     * @return TResult
      */
     protected function loadCrossConnectionAggregateValues($result, $alias, Relation $relation, $relatedKey, $localKey, $constraints, $column, $function)
     {

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -1195,7 +1195,7 @@ trait QueriesRelationships
 
         if ($function === 'exists') {
             $matched = array_fill_keys(array_map(
-                'strval',
+                strval(...),
                 $relatedQuery->select($relatedKey)->distinct()->pluck($relatedKey)->all()
             ), true);
 

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -6,6 +6,7 @@ use BadMethodCallException;
 use Closure;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Database\Eloquent\CrossConnectionStrategy;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\RelationNotFoundException;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -56,7 +57,7 @@ trait QueriesRelationships
 
         $strategy = $this->relationCrossConnectionStrategy($relation);
 
-        if ($strategy === 'resolve') {
+        if ($strategy === CrossConnectionStrategy::Resolve) {
             return $this->addCrossConnectionHasWhere(
                 $relation, $operator, $count, $boolean, $callback
             );
@@ -73,7 +74,7 @@ trait QueriesRelationships
             $relation->getRelated()->newQueryWithoutRelationships(), $this
         );
 
-        if ($strategy === 'prefix') {
+        if ($strategy === CrossConnectionStrategy::Prefix) {
             $this->applyCrossDatabasePrefixToHasQuery($hasQuery, $relation);
         }
 
@@ -893,7 +894,7 @@ trait QueriesRelationships
             // SQL statement with the parent's connection, fall back to resolving the
             // aggregate as a separate query and attaching the values to each model
             // after the parent query has been executed.
-            if ($this->relationCrossConnectionStrategy($relation) === 'resolve') {
+            if ($this->relationCrossConnectionStrategy($relation) === CrossConnectionStrategy::Resolve) {
                 $this->addCrossConnectionAggregate(
                     $name, $relation, $column, $function, $constraints, $alias ?? null
                 );
@@ -1274,17 +1275,11 @@ trait QueriesRelationships
     /**
      * Determine the cross-connection strategy to use for a relation.
      *
-     * Returns one of:
-     *  - "same":    parent and related share the same connection (no special handling).
-     *  - "prefix":  related lives on a different database but the same server, so
-     *               the existence subquery can stay on a single PDO connection by
-     *               qualifying the table with its database name.
-     *  - "resolve": related lives on a different server or driver; the existence
-     *               subquery must be resolved as a separate query and converted
-     *               into a "where in" / "where not in" clause on the parent.
+     * See {@see \Illuminate\Database\Eloquent\CrossConnectionStrategy} for the
+     * meaning of each strategy case.
      *
      * @param  \Illuminate\Database\Eloquent\Relations\Relation<*, *, *>  $relation
-     * @return 'same'|'prefix'|'resolve'
+     * @return \Illuminate\Database\Eloquent\CrossConnectionStrategy
      */
     protected function relationCrossConnectionStrategy(Relation $relation)
     {
@@ -1292,19 +1287,19 @@ trait QueriesRelationships
         $inner = $relation->getRelated()->getConnection();
 
         if ($outer === $inner || $outer->getName() === $inner->getName()) {
-            return 'same';
+            return CrossConnectionStrategy::Same;
         }
 
         if (! method_exists($outer, 'getDriverName') || ! method_exists($inner, 'getDriverName')) {
-            return 'resolve';
+            return CrossConnectionStrategy::Resolve;
         }
 
         if ($outer->getDriverName() !== $inner->getDriverName()) {
-            return 'resolve';
+            return CrossConnectionStrategy::Resolve;
         }
 
         if ($outer->getDriverName() === 'sqlite') {
-            return 'resolve';
+            return CrossConnectionStrategy::Resolve;
         }
 
         $outerConfig = method_exists($outer, 'getConfig') ? $outer->getConfig() : [];
@@ -1313,7 +1308,9 @@ trait QueriesRelationships
         $sameHost = ($outerConfig['host'] ?? null) === ($innerConfig['host'] ?? null);
         $samePort = ($outerConfig['port'] ?? null) === ($innerConfig['port'] ?? null);
 
-        return ($sameHost && $samePort) ? 'prefix' : 'resolve';
+        return ($sameHost && $samePort)
+            ? CrossConnectionStrategy::Prefix
+            : CrossConnectionStrategy::Resolve;
     }
 
     /**
@@ -1453,6 +1450,7 @@ trait QueriesRelationships
      *
      * @param  \Illuminate\Database\Eloquent\Relations\Relation<*, *, *>  $relation
      * @return array{0: string, 1: string}
+     *
      * @phpstan-return ($relation is \Illuminate\Database\Eloquent\Relations\BelongsTo|\Illuminate\Database\Eloquent\Relations\HasOneOrMany ? array{0: string, 1: string} : never)
      *
      * @throws \RuntimeException
@@ -1524,6 +1522,7 @@ trait QueriesRelationships
      *
      * @param  TOperator  $operator
      * @return string
+     *
      * @phpstan-return ($operator is '>='
      *     ? '<'
      *     : ($operator is '>'

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -1494,6 +1494,7 @@ trait QueriesRelationships
      * @param  string  $operator
      * @param  mixed  $count
      * @return bool
+     *
      * @phpstan ($count is numeric ? bool : false)
      */
     protected function zeroCountSatisfiesCrossConnectionOperator($operator, $count)

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -1256,8 +1256,11 @@ trait QueriesRelationships
      * collection is discarded after the callback runs, but mutations to the
      * model itself are preserved by reference.
      *
-     * @param  mixed  $result
+     * @template TResult
+     *
+     * @param  TResult  $result
      * @return \Illuminate\Database\Eloquent\Collection<int, \Illuminate\Database\Eloquent\Model>|null
+     * @phpstan-return ($result is \Illuminate\Database\Eloquent\Collection ? TResult : ($result is \Illuminate\Database\Eloquent\Model ? \Illuminate\Database\Eloquent\Collection<int, TResult> : null))
      */
     protected function collectModelsForAfterQuery($result)
     {

--- a/src/Illuminate/Database/Eloquent/CrossConnectionStrategy.php
+++ b/src/Illuminate/Database/Eloquent/CrossConnectionStrategy.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Illuminate\Database\Eloquent;
+
+/**
+ * Strategy used by Eloquent to resolve relationship existence queries when the
+ * parent and related models live on different database connections.
+ */
+enum CrossConnectionStrategy: string
+{
+    /**
+     * Parent and related share the same connection. No cross-connection
+     * handling is required and the existing correlated subquery is used.
+     */
+    case Same = 'same';
+
+    /**
+     * Related lives on a different database but on the same server (same
+     * driver, host, and port). The existence subquery can stay on a single
+     * PDO connection by qualifying the related table with its database name.
+     */
+    case Prefix = 'prefix';
+
+    /**
+     * Related lives on a different server or driver. The existence subquery
+     * must be resolved by executing a separate query against the related
+     * connection, then converting the result into a "where in" or "where not
+     * in" clause on the parent.
+     */
+    case Resolve = 'resolve';
+}

--- a/tests/Database/DatabaseEloquentCrossDatabaseRelationshipTest.php
+++ b/tests/Database/DatabaseEloquentCrossDatabaseRelationshipTest.php
@@ -1,0 +1,410 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Model as Eloquent;
+use Illuminate\Database\Query\Expression;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class DatabaseEloquentCrossDatabaseRelationshipTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $db = new DB;
+
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ], 'primary');
+
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ], 'reporting');
+
+        $db->bootEloquent();
+        $db->setAsGlobal();
+
+        $this->createSchema();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->schema('primary')->drop('cross_db_posts');
+        $this->schema('reporting')->drop('cross_db_comments');
+        $this->schema('reporting')->drop('cross_db_likes');
+
+        Eloquent::unsetConnectionResolver();
+    }
+
+    /**
+     * Tier 1: same connection — generated SQL must remain a correlated EXISTS
+     * subquery, with no whereIn rewriting. Guards against regressions on the
+     * default code path.
+     */
+    public function testSameConnectionStillUsesExistsSubquery()
+    {
+        $sql = strtolower(SameConnectionPost::whereHas('localComments')->toSql());
+
+        $this->assertStringContainsString('exists', $sql);
+        $this->assertStringNotContainsString(' in (', $sql);
+    }
+
+    public function testHasReturnsPostsWithAtLeastOneRelatedRow()
+    {
+        $this->seedData();
+
+        $ids = CrossDbPost::has('comments')->orderBy('id')->pluck('id')->all();
+
+        $this->assertEquals([1, 2, 3], $ids);
+    }
+
+    public function testWhereHasAppliesCallbackFilter()
+    {
+        $this->seedData();
+
+        $ids = CrossDbPost::whereHas('comments', function ($query) {
+            $query->where('content', 'like', 'code%');
+        })->orderBy('id')->pluck('id')->all();
+
+        $this->assertEquals([1, 2], $ids);
+    }
+
+    public function testWhereHasWithGreaterThanCountConstraint()
+    {
+        $this->seedData();
+
+        $ids = CrossDbPost::whereHas('comments', null, '>=', 2)
+            ->orderBy('id')->pluck('id')->all();
+
+        $this->assertEquals([1], $ids);
+    }
+
+    public function testWhereHasWithLessThanOrEqualCountConstraintIncludesZeroCountParents()
+    {
+        $this->seedData();
+
+        // <= 1 should match posts with 0 or 1 comments. Posts 2, 3 each have 1.
+        // Post 4 has 0. Post 1 has 3 (excluded). This exercises the
+        // complement-flip logic for operators where a zero count satisfies
+        // the constraint.
+        $ids = CrossDbPost::whereHas('comments', null, '<=', 1)
+            ->orderBy('id')->pluck('id')->all();
+
+        $this->assertEquals([2, 3, 4], $ids);
+    }
+
+    public function testWhereHasWithEqualsZeroIsEquivalentToDoesntHave()
+    {
+        $this->seedData();
+
+        $ids = CrossDbPost::whereHas('comments', null, '=', 0)
+            ->orderBy('id')->pluck('id')->all();
+
+        $this->assertEquals([4], $ids);
+    }
+
+    public function testDoesntHaveReturnsParentsWithNoRelatedRows()
+    {
+        $this->seedData();
+
+        $ids = CrossDbPost::doesntHave('comments')->orderBy('id')->pluck('id')->all();
+
+        $this->assertEquals([4], $ids);
+    }
+
+    public function testWhereDoesntHaveWithFilter()
+    {
+        $this->seedData();
+
+        // Post 3's only comment is "other"; post 4 has no comments. Both qualify.
+        $ids = CrossDbPost::whereDoesntHave('comments', function ($query) {
+            $query->where('content', 'like', 'code%');
+        })->orderBy('id')->pluck('id')->all();
+
+        $this->assertEquals([3, 4], $ids);
+    }
+
+    public function testWhereDoesntHaveWithFilterThatMatchesNothingReturnsAllParents()
+    {
+        $this->seedData();
+
+        $ids = CrossDbPost::whereDoesntHave('comments', function ($query) {
+            $query->where('content', 'this-string-matches-nothing');
+        })->orderBy('id')->pluck('id')->all();
+
+        $this->assertEquals([1, 2, 3, 4], $ids);
+    }
+
+    public function testWhereHasWithFilterThatMatchesNothingReturnsNoParents()
+    {
+        $this->seedData();
+
+        $rows = CrossDbPost::whereHas('comments', function ($query) {
+            $query->where('content', 'this-string-matches-nothing');
+        })->get();
+
+        $this->assertCount(0, $rows);
+    }
+
+    public function testOrWhereHasCombinesWithExistingWhereClause()
+    {
+        $this->seedData();
+
+        $ids = CrossDbPost::where('title', 'D')
+            ->orWhereHas('comments', function ($query) {
+                $query->where('content', 'like', 'code%');
+            })
+            ->orderBy('id')
+            ->pluck('id')->all();
+
+        // Post 4 matches by title; posts 1 and 2 match via the comment filter.
+        $this->assertEquals([1, 2, 4], $ids);
+    }
+
+    public function testBelongsToCrossConnection()
+    {
+        $this->seedData();
+
+        $ids = CrossDbComment::whereHas('post', function ($query) {
+            $query->where('title', 'A');
+        })->orderBy('id')->pluck('id')->all();
+
+        $this->assertEquals([1, 2, 3], $ids);
+    }
+
+    public function testWithCountAttachesPerModelCount()
+    {
+        $this->seedData();
+
+        $posts = CrossDbPost::withCount('comments')->orderBy('id')->get();
+
+        $this->assertEquals(3, $posts->firstWhere('id', 1)->comments_count);
+        $this->assertEquals(1, $posts->firstWhere('id', 2)->comments_count);
+        $this->assertEquals(1, $posts->firstWhere('id', 3)->comments_count);
+        $this->assertEquals(0, $posts->firstWhere('id', 4)->comments_count);
+    }
+
+    public function testWithCountRespectsConstraintClosureAndAlias()
+    {
+        $this->seedData();
+
+        $posts = CrossDbPost::withCount([
+            'comments as code_count' => function ($query) {
+                $query->where('content', 'like', 'code%');
+            },
+        ])->orderBy('id')->get();
+
+        $this->assertEquals(2, $posts->firstWhere('id', 1)->code_count);
+        $this->assertEquals(1, $posts->firstWhere('id', 2)->code_count);
+        $this->assertEquals(0, $posts->firstWhere('id', 3)->code_count);
+        $this->assertEquals(0, $posts->firstWhere('id', 4)->code_count);
+    }
+
+    public function testWithCountOnFirstResultStampsCount()
+    {
+        $this->seedData();
+
+        $post = CrossDbPost::withCount('comments')->where('id', 1)->first();
+
+        $this->assertEquals(3, $post->comments_count);
+    }
+
+    public function testWithExistsAttachesBooleanFlag()
+    {
+        $this->seedData();
+
+        $posts = CrossDbPost::withExists('comments')->orderBy('id')->get();
+
+        $this->assertTrue($posts->firstWhere('id', 1)->comments_exists);
+        $this->assertTrue($posts->firstWhere('id', 2)->comments_exists);
+        $this->assertTrue($posts->firstWhere('id', 3)->comments_exists);
+        $this->assertFalse($posts->firstWhere('id', 4)->comments_exists);
+    }
+
+    public function testWithMaxOnRelatedNumericColumn()
+    {
+        $this->seedData();
+
+        $posts = CrossDbPost::withMax('comments', 'id')->orderBy('id')->get();
+
+        $this->assertEquals(3, $posts->firstWhere('id', 1)->comments_max_id);
+        $this->assertEquals(4, $posts->firstWhere('id', 2)->comments_max_id);
+        $this->assertEquals(5, $posts->firstWhere('id', 3)->comments_max_id);
+        $this->assertNull($posts->firstWhere('id', 4)->comments_max_id);
+    }
+
+    public function testWithWhereHasFiltersAndEagerLoadsRelation()
+    {
+        $this->seedData();
+
+        $posts = CrossDbPost::withWhereHas('comments', function ($query) {
+            $query->where('content', 'like', 'code%');
+        })->orderBy('id')->get();
+
+        $this->assertEquals([1, 2], $posts->pluck('id')->all());
+        $this->assertCount(2, $posts->firstWhere('id', 1)->comments);
+        $this->assertCount(1, $posts->firstWhere('id', 2)->comments);
+    }
+
+    public function testMorphManyRelationsAreResolvedAcrossConnections()
+    {
+        $this->seedData();
+        $this->seedLikes();
+
+        $ids = CrossDbPost::has('likes')->orderBy('id')->pluck('id')->all();
+
+        $this->assertEquals([1, 3], $ids);
+    }
+
+    public function testUnsupportedRelationTypeRaisesDescriptiveException()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Cross-connection relationship existence queries are not supported');
+
+        // BelongsToMany is intentionally out of scope for the first iteration.
+        CrossDbPost::has('taggedComments')->get();
+    }
+
+    public function testExpressionCountIsRejectedOnCrossConnectionPath()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Expression count values');
+
+        CrossDbPost::whereHas('comments', null, '>=', new Expression('2'))->get();
+    }
+
+    /**
+     * Schema setup.
+     */
+    protected function createSchema(): void
+    {
+        $this->schema('primary')->create('cross_db_posts', function ($table) {
+            $table->increments('id');
+            $table->string('title');
+        });
+
+        $this->schema('reporting')->create('cross_db_comments', function ($table) {
+            $table->increments('id');
+            $table->integer('post_id');
+            $table->string('content');
+        });
+
+        $this->schema('reporting')->create('cross_db_likes', function ($table) {
+            $table->increments('id');
+            $table->integer('likeable_id');
+            $table->string('likeable_type');
+        });
+    }
+
+    /**
+     * Seed canonical post/comment fixtures.
+     *
+     * Post 1: 3 comments (2 with "code", 1 "other").
+     * Post 2: 1 comment (with "code").
+     * Post 3: 1 comment ("other").
+     * Post 4: 0 comments.
+     */
+    protected function seedData(): void
+    {
+        CrossDbPost::create(['id' => 1, 'title' => 'A']);
+        CrossDbPost::create(['id' => 2, 'title' => 'B']);
+        CrossDbPost::create(['id' => 3, 'title' => 'C']);
+        CrossDbPost::create(['id' => 4, 'title' => 'D']);
+
+        CrossDbComment::create(['id' => 1, 'post_id' => 1, 'content' => 'code one']);
+        CrossDbComment::create(['id' => 2, 'post_id' => 1, 'content' => 'code two']);
+        CrossDbComment::create(['id' => 3, 'post_id' => 1, 'content' => 'other comment']);
+        CrossDbComment::create(['id' => 4, 'post_id' => 2, 'content' => 'code three']);
+        CrossDbComment::create(['id' => 5, 'post_id' => 3, 'content' => 'other comment']);
+    }
+
+    /**
+     * Seed morph-many likes on a subset of posts.
+     */
+    protected function seedLikes(): void
+    {
+        CrossDbLike::create(['likeable_id' => 1, 'likeable_type' => CrossDbPost::class]);
+        CrossDbLike::create(['likeable_id' => 1, 'likeable_type' => CrossDbPost::class]);
+        CrossDbLike::create(['likeable_id' => 3, 'likeable_type' => CrossDbPost::class]);
+    }
+
+    protected function schema($connection)
+    {
+        return DB::connection($connection)->getSchemaBuilder();
+    }
+}
+
+class CrossDbPost extends Eloquent
+{
+    protected $connection = 'primary';
+    protected $table = 'cross_db_posts';
+    protected $guarded = [];
+    public $timestamps = false;
+
+    public function comments()
+    {
+        return $this->hasMany(CrossDbComment::class, 'post_id');
+    }
+
+    public function likes()
+    {
+        return $this->morphMany(CrossDbLike::class, 'likeable');
+    }
+
+    public function taggedComments()
+    {
+        // BelongsToMany — intentionally exercises the unsupported-relation
+        // branch for cross-connection resolution.
+        return $this->belongsToMany(CrossDbComment::class, 'post_tag_pivot');
+    }
+}
+
+class CrossDbComment extends Eloquent
+{
+    protected $connection = 'reporting';
+    protected $table = 'cross_db_comments';
+    protected $guarded = [];
+    public $timestamps = false;
+
+    public function post()
+    {
+        return $this->belongsTo(CrossDbPost::class, 'post_id');
+    }
+}
+
+class CrossDbLike extends Eloquent
+{
+    protected $connection = 'reporting';
+    protected $table = 'cross_db_likes';
+    protected $guarded = [];
+    public $timestamps = false;
+}
+
+/**
+ * Used by the tier 1 same-connection guard test. Both this model and its
+ * related model live on the "primary" connection, so the existing EXISTS
+ * subquery path must be preserved exactly.
+ */
+class SameConnectionPost extends Eloquent
+{
+    protected $connection = 'primary';
+    protected $table = 'cross_db_posts';
+    protected $guarded = [];
+    public $timestamps = false;
+
+    public function localComments()
+    {
+        return $this->hasMany(SameConnectionComment::class, 'post_id');
+    }
+}
+
+class SameConnectionComment extends Eloquent
+{
+    protected $connection = 'primary';
+    protected $table = 'same_connection_comments';
+    protected $guarded = [];
+    public $timestamps = false;
+}


### PR DESCRIPTION
:wave: Hi,

This PR adds long awaited support for querying relationship existence across databases that's fully backwards compatible.

The framework has support for basic eloquent joins using `with` but currently does not support existence checking.

<img width="703" height="534" alt="Screenshot 2026-05-19 at 14 54 02" src="https://github.com/user-attachments/assets/5e8bc2f4-afd4-4f37-9f39-bd7f3eaa7ba4" />

People have discussed this previously: https://github.com/laravel/framework/issues/40823, https://github.com/laravel/framework/issues/35414, https://github.com/laravel/framework/issues/33402 and https://github.com/laravel/framework/issues/23042

And most recently, a discussion: https://github.com/laravel/framework/discussions/60173

The basic idea is to be able to achieve the following whereby:

- Post model is in MySQL
- Comment model is in Postgres

```php
$posts = Post::withWhereHas('comments', function (Builder $query) {
    $query->where('content', 'like', 'code%');
})->get();
```

Or...

```php
$posts = Post::whereHas('comments', function (Builder $query) {
    $query->where('content', 'like', 'code%');
}, '>=', 10)->get();
```

I hope this can be merged as more and more people are building Laravel apps that require multiple database connections, even if (in their scenario) performance is slightly comprimised.

There aren't any breaking changes here.

Much love ❤️ 