### PR TITLE
[13.x] Add initial value type to return of `reduce` and `reduceWithKeys`

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -844,7 +844,7 @@ trait EnumeratesValues
      *
      * @param  callable(TReduceInitial|TReduceReturnType, TValue, TKey): TReduceReturnType  $callback
      * @param  TReduceInitial  $initial
-     * @return TReduceReturnType
+     * @return TReduceInitial|TReduceReturnType
      */
     public function reduce(callable $callback, $initial = null)
     {
@@ -892,7 +892,7 @@ trait EnumeratesValues
      *
      * @param  callable(TReduceWithKeysInitial|TReduceWithKeysReturnType, TValue, TKey): TReduceWithKeysReturnType  $callback
      * @param  TReduceWithKeysInitial  $initial
-     * @return TReduceWithKeysReturnType
+     * @return TReduceWithKeysInitial|TReduceWithKeysReturnType
      */
     public function reduceWithKeys(callable $callback, $initial = null)
     {

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -706,21 +706,21 @@ assertType('Illuminate\Support\Collection<int, int|string>', $collection::make([
 assertType('Illuminate\Support\Collection<int, int>', $collection::make([1])->random(2));
 assertType('string', $collection::make(['string'])->random());
 
-assertType('1', $collection
+assertType('1|null', $collection
     ->reduce(function ($null, $user) {
         assertType('User', $user);
         assertType('1|null', $null);
 
         return 1;
     }));
-assertType('1', $collection
+assertType('0|1', $collection
     ->reduce(function ($int, $user) {
         assertType('User', $user);
         assertType('0|1', $int);
 
         return 1;
     }, 0));
-assertType('1', $collection
+assertType('0|1', $collection
     ->reduce(function ($int, $user, $key) {
         assertType('User', $user);
         assertType('0|1', $int);
@@ -729,21 +729,21 @@ assertType('1', $collection
         return 1;
     }, 0));
 
-assertType('1', $collection
+assertType('1|null', $collection
     ->reduceWithKeys(function ($null, $user) {
         assertType('User', $user);
         assertType('1|null', $null);
 
         return 1;
     }));
-assertType('1', $collection
+assertType('0|1', $collection
     ->reduceWithKeys(function ($int, $user) {
         assertType('User', $user);
         assertType('0|1', $int);
 
         return 1;
     }, 0));
-assertType('1', $collection
+assertType('0|1', $collection
     ->reduceWithKeys(function ($int, $user, $key) {
         assertType('User', $user);
         assertType('0|1', $int);
@@ -751,6 +751,7 @@ assertType('1', $collection
 
         return 1;
     }, 0));
+assertType("'bar'|'foo'", $collection::make([])->reduce(static fn (): string => 'foo', 'bar'));
 
 assertType('Illuminate\Support\Collection<int, int>', $collection::make([1])->replace([1]));
 assertType('Illuminate\Support\Collection<int, User>', $collection->replace([new User]));

--- a/types/Support/LazyCollection.php
+++ b/types/Support/LazyCollection.php
@@ -597,20 +597,52 @@ assertType('Illuminate\Support\LazyCollection<int, int|string>', $collection::ma
 assertType('Illuminate\Support\LazyCollection<int, int>|int', $collection::make([1])->random(2));
 assertType('Illuminate\Support\LazyCollection<int, string>|string', $collection::make(['string'])->random());
 
-assertType('1', $collection
+assertType('1|null', $collection
     ->reduce(function ($null, $user) {
         assertType('User', $user);
         assertType('1|null', $null);
 
         return 1;
     }));
-assertType('1', $collection
+assertType('0|1', $collection
     ->reduce(function ($int, $user) {
         assertType('User', $user);
         assertType('0|1', $int);
 
         return 1;
     }, 0));
+assertType('0|1', $collection
+    ->reduce(function ($int, $user, $key) {
+        assertType('User', $user);
+        assertType('0|1', $int);
+        assertType('int', $key);
+
+        return 1;
+    }, 0));
+
+assertType('1|null', $collection
+    ->reduceWithKeys(function ($null, $user) {
+        assertType('User', $user);
+        assertType('1|null', $null);
+
+        return 1;
+    }));
+assertType('0|1', $collection
+    ->reduceWithKeys(function ($int, $user) {
+        assertType('User', $user);
+        assertType('0|1', $int);
+
+        return 1;
+    }, 0));
+assertType('0|1', $collection
+    ->reduceWithKeys(function ($int, $user, $key) {
+        assertType('User', $user);
+        assertType('0|1', $int);
+        assertType('int', $key);
+
+        return 1;
+    }, 0));
+assertType("'bar'|'foo'", $collection::make([])->reduce(static fn (): string => 'foo', 'bar'));
 
 assertType('Illuminate\Support\LazyCollection<int, int>', $collection::make([1])->replace([1]));
 assertType('Illuminate\Support\LazyCollection<int, User>', $collection->replace([new User]));


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
On empty collections, the `reduce` and `reduceWithKeys` methods will simply return the initial value: 
```
> collect([])->reduce(static fn(): string => 'foo', 'bar');

= "bar"
``` 

Hence this should be part of the return typehint.

In real-world scenarios, this may appear when one does something like `$collection->filter(<function where nothing passes>)->reduce(...)` or `$model->emptyRelation->reduce(...)`.

Note that the `Enumerable` interface already (correctly) prescribes this:
https://github.com/laravel/framework/blob/fa071b5dc6b7b8653624a6f99768f5e56ddf7b49/src/Illuminate/Collections/Enumerable.php#L882-L892