### PR TITLE
[13.x] Fix incorrect type hint in EncodedHtmlString::convert() docblock

### DIFF
--- a/src/Illuminate/Support/EncodedHtmlString.php
+++ b/src/Illuminate/Support/EncodedHtmlString.php
@@ -39,7 +39,7 @@ class EncodedHtmlString extends HtmlString
      * @internal
      *
      * @param  string|null  $value
-     * @param  int  $withQuote
+     * @param  bool  $withQuote
      * @param  bool  $doubleEncode
      * @return string
      */


### PR DESCRIPTION
## Summary

Fixed a type mismatch in the `EncodedHtmlString::convert()` method's docblock.

## Problem

The docblock annotated `$withQuote` as `int` but the actual parameter is `bool $withQuote = true`.

## Solution

Changed the docblock annotation from `@param int $withQuote` to `@param bool $withQuote`.

## Impact

- No behavior changes
- Documentation now matches implementation
- Improves static analysis accuracy
