### PR TITLE
[12.x] Rename X-Request-ID header to Cloud-Request-ID

### DIFF
--- a/src/Illuminate/Foundation/LaravelCloudJsonFormatter.php
+++ b/src/Illuminate/Foundation/LaravelCloudJsonFormatter.php
@@ -18,7 +18,7 @@ class LaravelCloudJsonFormatter extends JsonFormatter
         $app = Container::getInstance();
 
         if ($app->bound('request')) {
-            $requestId = $app->make('request')->header('X-Request-ID');
+            $requestId = $app->make('request')->header('Cloud-Request-ID');
 
             if ($requestId !== null) {
                 $normalized['cloud_request_id'] = $requestId;

--- a/tests/Foundation/LaravelCloudJsonFormatterTest.php
+++ b/tests/Foundation/LaravelCloudJsonFormatterTest.php
@@ -39,7 +39,7 @@ class LaravelCloudJsonFormatterTest extends TestCase
     {
         $app = Container::getInstance();
         $request = Request::create('/');
-        $request->headers->set('X-Request-ID', '550e8400-e29b-41d4-a716-446655440000');
+        $request->headers->set('Cloud-Request-ID', '550e8400-e29b-41d4-a716-446655440000');
         $app->instance('request', $request);
 
         $formatter = new LaravelCloudJsonFormatter;
@@ -75,7 +75,7 @@ class LaravelCloudJsonFormatterTest extends TestCase
     {
         $app = Container::getInstance();
         $request = Request::create('/');
-        $request->headers->set('X-Request-ID', '6ba7b810-9dad-11d1-80b4-00c04fd430c8');
+        $request->headers->set('Cloud-Request-ID', '6ba7b810-9dad-11d1-80b4-00c04fd430c8');
         $app->instance('request', $request);
 
         $record = new LogRecord(


### PR DESCRIPTION
Renames the header read by `LaravelCloudJsonFormatter` from `X-Request-ID` to `Cloud-Request-ID` to match the header Laravel Cloud actually sends. Tests updated accordingly.