### PR TITLE
[13.x] Fix lifecycle deferred event methods

### DIFF
--- a/src/Illuminate/Console/Scheduling/PendingEventAttributes.php
+++ b/src/Illuminate/Console/Scheduling/PendingEventAttributes.php
@@ -14,7 +14,7 @@ class PendingEventAttributes
      *
      * @var array<int, string>
      */
-    protected const DEFERRED_EVENT_METHODS = [
+    public const DEFERRED_EVENT_METHODS = [
         'before',
         'after',
         'then',

--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -502,7 +502,9 @@ class Schedule
             return $this->macroCall($method, $parameters);
         }
 
-        if (method_exists(PendingEventAttributes::class, $method) || Event::hasMacro($method)) {
+        if (method_exists(PendingEventAttributes::class, $method)
+            || in_array($method, PendingEventAttributes::DEFERRED_EVENT_METHODS, true)
+            || Event::hasMacro($method)) {
             $this->attributes ??= $this->groupStack ? clone array_last($this->groupStack) : new PendingEventAttributes($this);
 
             return $this->attributes->$method(...$parameters);

--- a/tests/Integration/Console/Scheduling/ScheduleGroupTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleGroupTest.php
@@ -468,4 +468,59 @@ class ScheduleGroupTest extends TestCase
         $events[1]->finish(app(), 1);
         $this->assertSame(['outer', 'outer', 'inner'], $calls);
     }
+
+    public function testGroupCanStartWithLifecycleCallbackWithoutFrequency()
+    {
+        $calls = [];
+
+        $schedule = new ScheduleClass;
+        $schedule
+            ->before(function () use (&$calls) {
+                $calls[] = 'before';
+            })
+            ->onSuccess(function () use (&$calls) {
+                $calls[] = 'success';
+            })
+            ->onFailure(function () use (&$calls) {
+                $calls[] = 'failure';
+            })
+            ->group(function ($schedule) {
+                $schedule->command('inspire')->daily();
+                $schedule->command('inspire')->weekly();
+            });
+
+        $events = $schedule->events();
+        $this->assertCount(2, $events);
+        $this->assertSame('0 0 * * *', $events[0]->expression);
+        $this->assertSame('0 0 * * 0', $events[1]->expression);
+
+        $events[0]->callBeforeCallbacks(app());
+        $events[0]->finish(app(), 0);
+        $events[1]->callBeforeCallbacks(app());
+        $events[1]->finish(app(), 1);
+
+        $this->assertSame(['before', 'success', 'before', 'failure'], $calls);
+    }
+
+    public function testGroupCanStartWithOutputCallbackWithoutFrequency()
+    {
+        $calls = [];
+
+        $schedule = new ScheduleClass;
+        $schedule
+            ->onFailureWithOutput(function (Event $event, \Illuminate\Support\Stringable $output) use (&$calls) {
+                $calls[] = 'failure:'.$output;
+            })
+            ->group(function ($schedule) {
+                $schedule->command('inspire')->daily();
+            });
+
+        $events = $schedule->events();
+        $this->assertCount(1, $events);
+        $this->assertSame('0 0 * * *', $events[0]->expression);
+
+        $events[0]->finish(app(), 1);
+
+        $this->assertCount(1, $calls);
+    }
 }


### PR DESCRIPTION
I did not realize that calls to PendingEventAttributes were intercepted by `Schedule`.

This should now allow for:

```php
Schedule::before(function (Event $event) {
    \Log::info("Starting command: {$event->command}");
})->group(function (Schedule $schedule) {
    $schedule->command('inspire')->onOneServer();
});
```