### PR TITLE
[13.x] default clear() queue driver param to null

### DIFF
--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -567,10 +567,10 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
     /**
      * Delete all of the jobs from the queue.
      *
-     * @param  string  $queue
+     * @param  string|null  $queue
      * @return int
      */
-    public function clear($queue)
+    public function clear($queue = null)
     {
         return $this->database->table($this->table)
             ->where('queue', $this->getQueue($queue))

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -511,10 +511,10 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
     /**
      * Delete all of the jobs from the queue.
      *
-     * @param  string  $queue
+     * @param  string|null  $queue
      * @return int
      */
-    public function clear($queue)
+    public function clear($queue = null)
     {
         $queue = $this->getQueueRedisKey($queue);
 

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -442,10 +442,10 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
     /**
      * Delete all of the jobs from the queue.
      *
-     * @param  string  $queue
+     * @param  string|null  $queue
      * @return int
      */
-    public function clear($queue)
+    public function clear($queue = null)
     {
         return tap($this->size($queue), function () use ($queue) {
             $this->sqs->purgeQueue([


### PR DESCRIPTION
Tried to do this locally after tinkering & testing and got an error: 

```php
> Queue::clear();                                                                                                                             

   ArgumentCountError  Too few arguments to function Illuminate\Queue\DatabaseQueue::clear(), 0 passed in vendor\laravel\framework\src\Illuminate\Queue\QueueManager.php on line 407 and exactly 1 expected.****
```

If we default it to null, it'll use the default queue so no error.  

This makes it the same as pop(), push(), size(), and every other method on the queue drivers already.

No B/C.. as it's just allowing null.

I was going to add this to all the drivers no op ie Sync etc, so its on the Facade as I think it would be useful, but not sure if you fancy that 😄 ... if you want that lmk, I'll do it!