### PR TITLE
[13.x] Fix path separator being encoded for LocalFilesystemAdapter

### DIFF
--- a/src/Illuminate/Filesystem/LocalFilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/LocalFilesystemAdapter.php
@@ -115,7 +115,7 @@ class LocalFilesystemAdapter extends FilesystemAdapter
             'url' => $url->to($url->temporarySignedRoute(
                 'storage.'.$this->disk.'.upload',
                 $expiration,
-                ['path' => rawurlencode($path), 'upload' => true],
+                ['path' => strtr(rawurlencode($path), ['%2F' => '/']), 'upload' => true],
                 absolute: false
             )),
             'headers' => [],

--- a/tests/Integration/Filesystem/ReceiveFileTest.php
+++ b/tests/Integration/Filesystem/ReceiveFileTest.php
@@ -17,6 +17,7 @@ class ReceiveFileTest extends TestCase
             Storage::delete([
                 'receive-file-test.txt',
                 'receive-file-test.txt?pad=x',
+                'nested/folder/receive-file-test.txt',
             ]);
         });
 
@@ -88,6 +89,14 @@ class ReceiveFileTest extends TestCase
         $response->assertNoContent();
         Storage::assertExists('receive-file-test.txt?pad=x', 'Hello Question');
         Storage::assertMissing('receive-file-test.txt');
+    }
+
+    #[RequiresOperatingSystem('Linux|Darwin')]
+    public function testTemporaryUploadUrlPreservesPathSeparatorsInNestedPaths()
+    {
+        $result = Storage::temporaryUploadUrl('nested/folder/receive-file-test.txt', Carbon::now()->addMinute());
+
+        $this->assertStringContainsString('nested/folder/receive-file-test.txt', $result['url']);
     }
 
     #[RequiresOperatingSystem('Linux|Darwin')]


### PR DESCRIPTION
https://github.com/laravel/framework/pull/60137 used `rawurlencode`

But, when using nested folders `/` gets transformed to `%2F` 

When you use `temporaryUploadUrl` and do a PUT request to that url  via JS ie `fetch(downloadUrl)` you get a 404 rather than a 204 essentially cause a signature mismatch.
<img width="163" height="48" alt="Screenshot 2026-05-20 at 08 59 41" src="https://github.com/user-attachments/assets/f1c66cda-5f8c-49c7-bddc-5869f8e099e2" />

I can work around this by doing a replace in JS, but feels odd.. and this will probs catch others out too.

Noticed this as our tests are suddenly failing. 

Added a test the best I can, hard to replicate without using Dusk or JS 😆 

Alternative is to potentially revert, but didn't wanna do that... so this felt simple enough.