### PR TITLE
[13.x] Fix make:enum explicit namespace prefixes

### DIFF
--- a/src/Illuminate/Foundation/Console/EnumMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/EnumMakeCommand.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\GeneratorCommand;
+use Illuminate\Support\Str;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -74,6 +75,23 @@ class EnumMakeCommand extends GeneratorCommand
             is_dir(app_path('Enumerations')) => $rootNamespace.'\\Enumerations',
             default => $rootNamespace,
         };
+    }
+
+    /**
+     * Parse the class name and format according to the root namespace.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function qualifyClass($name)
+    {
+        $name = str_replace('/', '\\', ltrim($name, '\\/'));
+
+        if (Str::startsWith($name, ['Enums\\', 'Enumerations\\'])) {
+            return parent::qualifyClass($this->rootNamespace().$name);
+        }
+
+        return parent::qualifyClass($name);
     }
 
     /**

--- a/tests/Integration/Generators/EnumMakeCommandTest.php
+++ b/tests/Integration/Generators/EnumMakeCommandTest.php
@@ -11,6 +11,8 @@ class EnumMakeCommandTest extends TestCase
         'app/StatusEnum.php',
         'app/StringEnum.php',
         'app/*/OrderStatusEnum.php',
+        'app/Enums/Profile/HairColor.php',
+        'app/Enums/Profile/EyeColor.php',
     ];
 
     public function testItCanGenerateEnumFile()
@@ -84,5 +86,31 @@ class EnumMakeCommandTest extends TestCase
         ], 'app/Enumerations/OrderStatusEnum.php');
 
         $files->deleteDirectory($enumerationsFolderPath);
+    }
+
+    public function testItDoesNotDoublePrefixExplicitEnumNamespaceAfterFirstGeneration()
+    {
+        /** @var \Illuminate\Filesystem\Filesystem $files */
+        $files = $this->app['files'];
+
+        $this->artisan('make:enum', ['name' => 'Enums/Profile/HairColor'])
+            ->assertExitCode(0);
+
+        $this->artisan('make:enum', ['name' => 'Enums/Profile/EyeColor'])
+            ->assertExitCode(0);
+
+        $this->assertFileContains([
+            'namespace App\Enums\Profile;',
+            'enum HairColor',
+        ], 'app/Enums/Profile/HairColor.php');
+
+        $this->assertFileContains([
+            'namespace App\Enums\Profile;',
+            'enum EyeColor',
+        ], 'app/Enums/Profile/EyeColor.php');
+
+        $this->assertFileDoesNotExist(app_path('Enums/Enums/Profile/EyeColor.php'));
+
+        $files->deleteDirectory(app_path('Enums'));
     }
 }


### PR DESCRIPTION
Fixes #60152

When `make:enum` is called with an explicit enum path like `Enums/Profile/HairColor`, the first run creates the expected file. After that, since `app/Enums` now exists, a second call with another explicit `Enums/...` path can end up being prefixed again and generate the enum in the wrong place, such as `app/Enums/Enums/Profile/EyeColor.php`.

I kept this change scoped to `make:enum` only.

Tests:
- `vendor/bin/phpunit tests/Integration/Generators/EnumMakeCommandTest.php`
- `vendor/bin/pint --test src/Illuminate/Foundation/Console/EnumMakeCommand.php tests/Integration/Generators/EnumMakeCommandTest.php`
