### PR TITLE
[13.x] Resolve scheduled event callback parameter by type rather than name

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -791,13 +791,13 @@ class Event
     {
         $parameters = $this->closureParameterTypes($callback);
 
-        $eventParameterType = Arr::get($parameters, 'event');
-
-        if ($eventParameterType === null || ! is_a($this, $eventParameterType)) {
-            return [];
+        foreach ($parameters as $name => $type) {
+            if ($type !== null && is_a($this, $type)) {
+                return [$name => $this];
+            }
         }
 
-        return ['event' => $this];
+        return [];
     }
 
     /**

--- a/tests/Console/Scheduling/EventTest.php
+++ b/tests/Console/Scheduling/EventTest.php
@@ -6,6 +6,7 @@ use Illuminate\Console\Scheduling\Event;
 use Illuminate\Console\Scheduling\EventMutex;
 use Illuminate\Container\Container;
 use Illuminate\Support\Str;
+use Illuminate\Support\Stringable;
 use Mockery as m;
 use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 use PHPUnit\Framework\TestCase;
@@ -167,6 +168,23 @@ class EventTest extends TestCase
 
         $this->assertSame($event, $beforeEvent);
         $this->assertSame($event, $filterEvent);
+    }
+
+    public function testEventCallbackDoesNotInjectIntoUnrelatedTypedParameters()
+    {
+        $container = new Container;
+        $stringValue = null;
+        $event = new Event(m::mock(EventMutex::class), 'php -i');
+
+        $container->instance(Stringable::class, Str::of('injected-string'));
+
+        $event->before(function (Stringable $value) use (&$stringValue) {
+            $stringValue = (string) $value;
+        });
+
+        $event->callBeforeCallbacks($container);
+
+        $this->assertSame('injected-string', $stringValue);
     }
 
     public function testFilterCallbacksMayBeInvokableObjects()

--- a/tests/Console/Scheduling/EventTest.php
+++ b/tests/Console/Scheduling/EventTest.php
@@ -145,6 +145,30 @@ class EventTest extends TestCase
         $this->assertSame($event, $rejectEvent);
     }
 
+    public function testEventCallbackResolvesByTypeRegardlessOfParameterName()
+    {
+        $container = new Container;
+        $beforeEvent = null;
+        $filterEvent = null;
+        $event = new Event(m::mock(EventMutex::class), 'php -i');
+
+        $event->before(function (Event $scheduledEvent) use (&$beforeEvent) {
+            $beforeEvent = $scheduledEvent;
+        });
+
+        $event->when(function (Event $scheduledEvent) use (&$filterEvent) {
+            $filterEvent = $scheduledEvent;
+
+            return true;
+        });
+
+        $event->callBeforeCallbacks($container);
+        $this->assertTrue($event->filtersPass($container));
+
+        $this->assertSame($event, $beforeEvent);
+        $this->assertSame($event, $filterEvent);
+    }
+
     public function testFilterCallbacksMayBeInvokableObjects()
     {
         $container = new Container;


### PR DESCRIPTION
Fixes a name-based parameter resolution issue introduced in #60144.

## Background

#60144 made it possible to pass the scheduled `Event` into lifecycle callbacks, and the PR description promises that you can "typehint a callback with `Event $event` as a parameter". However, the implementation only injects the event when the closure parameter is literally named `$event`. The `is_a($this, $eventParameterType)` check in the same method shows the intent was type-based, but the lookup is name-based — these contradict each other.

All tests added by #60144 happen to use the parameter name `$event`, so the working contract (typehint-based) was never exercised.

## Reproduction

```php
Schedule::command('inspire')
    ->before(function (Event $scheduledEvent) {
        Log::info("Starting {$scheduledEvent->command}");
    });
```

This throws `BindingResolutionException`: the parameter lookup misses on the name `'event'`, no value is injected, and the container falls back to autowiring a new `Event` — which fails because `EventMutex` isn't instantiable.

## Fix

Iterate the closure parameters and inject `$this` into the first parameter whose type is a class that `$this` is an instance of. This matches how Laravel container DI works elsewhere — by type, not by name.

## After

```php
Schedule::command('inspire')
    ->before(function (Event $scheduledEvent) {  // works
        Log::info("Starting {$scheduledEvent->command}");
    });

Schedule::command('inspire')
    ->before(function (Event $event) {  // still works
        Log::info("Starting {$event->command}");
    });
```