### PR TITLE
[13.x] Boot managed queues before service providers boot

### DIFF
--- a/src/Illuminate/Foundation/Cloud.php
+++ b/src/Illuminate/Foundation/Cloud.php
@@ -20,7 +20,12 @@ class Cloud
      */
     public static function bootstrapperBootstrapping(Application $app, string $bootstrapper): void
     {
-        //
+        (match ($bootstrapper) {
+            BootProviders::class => function () use ($app) {
+                static::bootManagedQueues($app);
+            },
+            default => fn () => true,
+        })();
     }
 
     /**
@@ -37,9 +42,6 @@ class Cloud
             },
             HandleExceptions::class => function () use ($app) {
                 static::configureCloudLogging($app);
-            },
-            BootProviders::class => function () use ($app) {
-                static::bootManagedQueues($app);
             },
             default => fn () => true,
         })();
@@ -156,7 +158,7 @@ class Cloud
      */
     public static function bootManagedQueues(Application $app): void
     {
-        if (($_SERVER['LARAVEL_CLOUD_MANAGED_QUEUES'] ?? '0') !== '1') {
+        if ($app['config']->get('queue.connections.cloud.driver') !== 'cloud') {
             return;
         }
 

--- a/tests/Foundation/Cloud/QueueTest.php
+++ b/tests/Foundation/Cloud/QueueTest.php
@@ -50,7 +50,6 @@ class QueueTest extends TestCase
         Worker::$restartable = true;
         Worker::$pausable = true;
         $_SERVER['LARAVEL_CLOUD'] = '1';
-        $_SERVER['LARAVEL_CLOUD_MANAGED_QUEUES'] = '1';
         $_SERVER['LARAVEL_CLOUD_MANAGED_QUEUES_CONFIG'] = json_encode([
             'driver' => 'cloud',
             'connection' => [
@@ -71,7 +70,7 @@ class QueueTest extends TestCase
     {
         parent::tearDown();
 
-        unset($_SERVER['LARAVEL_CLOUD'], $_SERVER['LARAVEL_CLOUD_MANAGED_QUEUES'], $_SERVER['LARAVEL_CLOUD_MANAGED_QUEUES_CONFIG']);
+        unset($_SERVER['LARAVEL_CLOUD'], $_SERVER['LARAVEL_CLOUD_MANAGED_QUEUES_CONFIG']);
         Worker::$restartable = true;
         Worker::$pausable = true;
     }

--- a/tests/Foundation/Cloud/QueueTest.php
+++ b/tests/Foundation/Cloud/QueueTest.php
@@ -169,15 +169,26 @@ class QueueTest extends TestCase
         $this->assertInstanceOf(FailedJobProvider::class, $this->app['queue.failer']);
     }
 
-    public function testItDoesNotRegisterCloudConnectorWhenManagedQueuesIsInactive()
+    public function testItDoesNotRegisterCloudConnectorWhenCloudQueueConnectionIsNotConfigured()
     {
-        unset($_SERVER['LARAVEL_CLOUD_MANAGED_QUEUES']);
+        $this->app['config']->set('queue.connections.cloud', null);
 
         Cloud::bootManagedQueues($this->app);
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('No connector for [cloud]');
+        $this->expectExceptionMessage('The [cloud] queue connection has not been configured.');
         $this->app['queue']->connection('cloud');
+    }
+
+    public function testItDoesNotRegisterCloudConnectorWhenCloudQueueConnectionDriverIsNotCloud()
+    {
+        $this->app['config']->set('queue.connections.cloud.driver', 'sqs');
+        $originalFailer = $this->app['queue.failer'];
+
+        Cloud::bootManagedQueues($this->app);
+
+        $this->assertFalse($this->app->bound(Events::class));
+        $this->assertSame($originalFailer, $this->app['queue.failer']);
     }
 
     public function testItDoesNotEmitEventsWhilePoppingWhenNoJobsAreProcessingAndNoJobsAreAvailableToPop()


### PR DESCRIPTION
## Summary

`Cloud::bootManagedQueues()` registers the `cloud` queue connector (`$app['queue']->addConnector('cloud', ...)`) and rebinds `queue.failer`. It's currently hooked to the `bootstrapperBootstrapped: BootProviders::class` event, which fires **after** `BootProviders::bootstrap()` returns — i.e. after every service provider's `boot()` has already run.

Any application service provider whose `boot()` touches the queue manager via the facade blows up under `QUEUE_CONNECTION=cloud`. For example:

```php
class QueueServiceProvider extends ServiceProvider
{
    public function boot(): void
    {
        Queue::createPayloadUsing(function ($connection, $queue, $payload) {
            // ...
        });
    }
}
```

`Queue::createPayloadUsing(...)` proxies through `QueueManager::__call` → `$this->connection()` → resolves the default queue connection. With `QUEUE_CONNECTION=cloud`, that fails with `The [cloud] queue connection has not been configured` because the connector hasn't been registered yet.

Reproduction in a Cloud environment:

```
QUEUE_CONNECTION=cloud php artisan package:discover --ansi
```

## Fix

Move `bootManagedQueues()` from `bootstrapperBootstrapped: BootProviders::class` to `bootstrapperBootstrapping: BootProviders::class`. This places it after `RegisterProviders` finishes (so `queue` / `queue.failer` are bound) but before any user provider's `boot()` runs.

While here, refactor the early-return guard. The previous `$_SERVER['LARAVEL_CLOUD_MANAGED_QUEUES']` check overlapped with the env-driven config `configureManagedQueues()` already populates. Derive intent from observable state instead: only register the cloud connector when `queue.connections.cloud.driver === 'cloud'`. The outer `laravel_cloud()` gate in `Application::registerLaravelCloudServices()` already prevents these hooks from firing off-Cloud, so the duplicate environment check inside `bootManagedQueues` is redundant.

## Test plan

- [x] `tests/Foundation/Cloud/QueueTest.php` — 36/36 pass
- [x] Existing `testItDoesNotRegisterCloudConnectorWhenManagedQueuesIsInactive` reworked into two tests covering the new conditions: missing `queue.connections.cloud` block, and `driver !== 'cloud'`
- [x] Verified locally against a Laravel 13 app: `LARAVEL_CLOUD=1 LARAVEL_CLOUD_MANAGED_QUEUES=1 LARAVEL_CLOUD_MANAGED_QUEUES_CONFIG=... QUEUE_CONNECTION=cloud php artisan package:discover --ansi` now succeeds where it previously threw