### PR TITLE
[11.x] Boot managed queues before service providers boot

### DIFF
--- a/src/Illuminate/Foundation/Cloud.php
+++ b/src/Illuminate/Foundation/Cloud.php
@@ -21,7 +21,12 @@ class Cloud
      */
     public static function bootstrapperBootstrapping(Application $app, string $bootstrapper): void
     {
-        //
+        (match ($bootstrapper) {
+            BootProviders::class => function () use ($app) {
+                static::bootManagedQueues($app);
+            },
+            default => fn () => true,
+        })();
     }
 
     /**
@@ -38,9 +43,6 @@ class Cloud
             },
             HandleExceptions::class => function () use ($app) {
                 static::configureCloudLogging($app);
-            },
-            BootProviders::class => function () use ($app) {
-                static::bootManagedQueues($app);
             },
             default => fn () => true,
         })();
@@ -149,7 +151,7 @@ class Cloud
      */
     public static function bootManagedQueues(Application $app): void
     {
-        if (($_SERVER['LARAVEL_CLOUD_MANAGED_QUEUES'] ?? '0') !== '1') {
+        if ($app['config']->get('queue.connections.cloud.driver') !== 'cloud') {
             return;
         }
 

--- a/tests/Foundation/Cloud/QueueTest.php
+++ b/tests/Foundation/Cloud/QueueTest.php
@@ -132,15 +132,26 @@ class QueueTest extends TestCase
         $this->assertInstanceOf(FailedJobProvider::class, $this->app['queue.failer']);
     }
 
-    public function testItDoesNotRegisterCloudConnectorWhenManagedQueuesIsInactive()
+    public function testItDoesNotRegisterCloudConnectorWhenCloudQueueConnectionIsNotConfigured()
     {
-        unset($_SERVER['LARAVEL_CLOUD_MANAGED_QUEUES']);
+        $this->app['config']->set('queue.connections.cloud', null);
 
         Cloud::bootManagedQueues($this->app);
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('No connector for [cloud]');
+        $this->expectExceptionMessage('The [cloud] queue connection has not been configured.');
         $this->app['queue']->connection('cloud');
+    }
+
+    public function testItDoesNotRegisterCloudConnectorWhenCloudQueueConnectionDriverIsNotCloud()
+    {
+        $this->app['config']->set('queue.connections.cloud.driver', 'sqs');
+        $originalFailer = $this->app['queue.failer'];
+
+        Cloud::bootManagedQueues($this->app);
+
+        $this->assertFalse($this->app->bound(Events::class));
+        $this->assertSame($originalFailer, $this->app['queue.failer']);
     }
 
     public function testItDoesNotEmitEventsWhilePoppingWhenNoJobsAreProcessingAndNoJobsAreAvailableToPop()

--- a/tests/Foundation/Cloud/QueueTest.php
+++ b/tests/Foundation/Cloud/QueueTest.php
@@ -47,7 +47,6 @@ class QueueTest extends TestCase
     protected function setUp(): void
     {
         $_SERVER['LARAVEL_CLOUD'] = '1';
-        $_SERVER['LARAVEL_CLOUD_MANAGED_QUEUES'] = '1';
         $_SERVER['LARAVEL_CLOUD_MANAGED_QUEUES_CONFIG'] = json_encode([
             'driver' => 'cloud',
             'connection' => [
@@ -68,7 +67,7 @@ class QueueTest extends TestCase
     {
         parent::tearDown();
 
-        unset($_SERVER['LARAVEL_CLOUD'], $_SERVER['LARAVEL_CLOUD_MANAGED_QUEUES'], $_SERVER['LARAVEL_CLOUD_MANAGED_QUEUES_CONFIG']);
+        unset($_SERVER['LARAVEL_CLOUD'], $_SERVER['LARAVEL_CLOUD_MANAGED_QUEUES_CONFIG']);
     }
 
     public function testItConfiguresCloudConnectionFromManagedQueuesConfig()


### PR DESCRIPTION
Backport of #60198 to 11.x.

## Summary

`Cloud::bootManagedQueues()` registers the `cloud` queue connector and rebinds `queue.failer`. It's currently hooked to `bootstrapperBootstrapped: BootProviders::class`, which fires **after** every service provider's `boot()` has already run.

Any application service provider whose `boot()` touches the queue manager via the facade blows up under `QUEUE_CONNECTION=cloud`. For example:

```php
public function boot(): void
{
    Queue::createPayloadUsing(fn ($connection, $queue, $payload) => /* … */);
}
```

`Queue::createPayloadUsing(...)` proxies through `QueueManager::__call` → `$this->connection()` → resolves the default connection. With `QUEUE_CONNECTION=cloud` that fails with `The [cloud] queue connection has not been configured` because the connector hasn't been registered yet.

Reproduction in a Cloud environment:

```
QUEUE_CONNECTION=cloud php artisan package:discover --ansi
```

## Fix

Move `bootManagedQueues()` from `bootstrapperBootstrapped: BootProviders::class` to `bootstrapperBootstrapping: BootProviders::class`. This places it after `RegisterProviders` (so `queue` / `queue.failer` are bound) but before any user provider's `boot()` runs.

While here, refactor the early-return guard. The previous `$_SERVER['LARAVEL_CLOUD_MANAGED_QUEUES']` check overlapped with the env-driven config `configureManagedQueues()` already populates. Derive intent from observable state instead: only register the cloud connector when `queue.connections.cloud.driver === 'cloud'`. The outer `laravel_cloud()` gate in `Application::registerLaravelCloudServices()` already prevents these hooks from firing off-Cloud, so the duplicate environment check is redundant.

A follow-up commit drops the now-unused `LARAVEL_CLOUD_MANAGED_QUEUES` env from the test setUp/tearDown.

## Test plan

- [x] `tests/Foundation/Cloud/QueueTest.php` — 34/34 pass
- [x] `vendor/bin/pint` clean on changed files
- [x] Existing `testItDoesNotRegisterCloudConnectorWhenManagedQueuesIsInactive` reworked into two tests covering the new conditions: missing `queue.connections.cloud` block, and `driver !== 'cloud'`