### PR TITLE
[13.x] Ability to opt out of worker restart on lost connection

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -140,6 +140,13 @@ class Worker
     public static $reportJobExceptions = true;
 
     /**
+     * Indicates if the worker should stop when a lost connection is detected.
+     *
+     * @var bool
+     */
+    public static $stopOnLostConnection = true;
+
+    /**
      * Indicates if the worker should check for the restart signal in the cache.
      *
      * @var bool
@@ -509,7 +516,7 @@ class Worker
      */
     protected function stopWorkerIfLostConnection($e)
     {
-        if ($this->causedByLostConnection($e)) {
+        if (static::$stopOnLostConnection && $this->causedByLostConnection($e)) {
             $this->lostConnection = true;
         }
     }

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -558,6 +558,35 @@ class QueueWorkerTest extends TestCase
         }));
     }
 
+    public function testWorkerDoesNotStopOnLostConnectionWhenDisabled()
+    {
+        $workerOptions = new WorkerOptions();
+        $workerOptions->stopWhenEmpty = true;
+
+        $worker = $this->getWorker('default', ['queue' => [
+            $job = new WorkerFakeJob(function () {
+                throw new RuntimeException('server has gone away');
+            }),
+        ]]);
+
+        Worker::$stopOnLostConnection = false;
+
+        try {
+            $worker->daemon('default', 'queue', $workerOptions);
+        } finally {
+            Worker::$stopOnLostConnection = true;
+        }
+
+        $this->assertTrue($job->fired);
+
+        $this->events->shouldHaveReceived('dispatch')->with(m::on(function ($event) use ($workerOptions) {
+            return $event instanceof WorkerStopping
+                && $event->status === 0
+                && $event->workerOptions === $workerOptions
+                && $event->reason === WorkerStopReason::QueueEmpty;
+        }));
+    }
+
     public function testJobReleasedEvent()
     {
         $e = new RuntimeException;


### PR DESCRIPTION
I noticed this today... 

If a job has a lost connection, the whole worker restarts

Currently I have many jobs spread across databases ie replicas and main nodes

This PR allows you to do:

```php
Worker::stopOnLostConnection = false;
```

This is completely opt out, so no b/c.

Reasoning...
- If one of the replica wobbles, it causes the whole worker to restart
- Restarting doesn't prevent the underlying replica issue from recurring,  as the workers are usually on supervisors / watchdog etc anyway so it's just boot looping when it doesnt need to. 
- One of my providers manually interjects and restarts all the workers if theres one thats "down" and by it restarting it may show as down.

Essentially if there's a real database problem we'd just go into maintenance or pause the queues we need to, right now it'll just constantly restart anyway if there was a real problem which seems odd to me.

