### PR TITLE
[13.x] Accept Symfony's new control-characters exception message in mailer test

### DIFF
--- a/tests/Mail/MailMailerTest.php
+++ b/tests/Mail/MailMailerTest.php
@@ -228,12 +228,18 @@ class MailMailerTest extends TestCase
         $view->shouldReceive('render')->once()->andReturn('rendered.view');
         $mailer = new Mailer('array', $view, new ArrayTransport);
 
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Email addresses may not contain line break characters.');
+        try {
+            $mailer->send('foo', ['data'], function (Message $message) {
+                $message->to(new Address("\"foo\r\nBcc: victim@example.com\"@example.com"))->from('hello@laravel.com');
+            });
 
-        $mailer->send('foo', ['data'], function (Message $message) {
-            $message->to(new Address("\"foo\r\nBcc: victim@example.com\"@example.com"))->from('hello@laravel.com');
-        });
+            $this->fail('Expected InvalidArgumentException was not thrown.');
+        } catch (InvalidArgumentException $e) {
+            $this->assertContains($e->getMessage(), [
+                'Email address contains control characters.',
+                'Email addresses may not contain line break characters.',
+            ]);
+        }
     }
 
     public function testGlobalFromIsRespectedOnAllMessages(): void


### PR DESCRIPTION
## Summary

`symfony/mime` 7.4.12 added an early control-character guard in `Address::__construct`:

```php
if (preg_match('/[\x00-\x1F\x7F]/', \$this->address)) {
    throw new InvalidArgumentException('Email address contains control characters.');
}
```

This fires **before** the older `RfcComplianceException('Email addresses may not contain line break characters.')` ever gets a chance to. `testMailerRejectsSymfonyAddressesContainingLineBreaks` constructs `new Address("\"foo\r\nBcc: ...\"@example.com")` to trigger the rejection, so it now hits the new message instead of the old one and the test fails on CI.

Reproduction:

```
There was 1 failure:

1) Illuminate\Tests\Mail\MailMailerTest::testMailerRejectsSymfonyAddressesContainingLineBreaks
Failed asserting that exception message 'Email address contains control characters.' contains 'Email addresses may not contain line break characters.'.
```

Last 13.x nightly CI ran at 2026-05-20 01:12 UTC and passed; symfony/mime 7.4.12 was published into Packagist between then and the next PR run.

## Fix

The composer constraint is `symfony/mime: "^7.4.0 || ^8.0.0"`, so both messages are legitimately reachable depending on which patch version a user has installed (older 7.4.x throws the line-break message; 7.4.12+ throws the control-chars message).

Switch the test to a try/catch + `assertContains` pattern so it accepts either Symfony message as a valid outcome:

```php
try {
    \$mailer->send('foo', ['data'], function (Message \$message) {
        \$message->to(new Address("\"foo\r\nBcc: victim@example.com\"@example.com"))->from('hello@laravel.com');
    });

    \$this->fail('Expected InvalidArgumentException was not thrown.');
} catch (InvalidArgumentException \$e) {
    \$this->assertContains(\$e->getMessage(), [
        'Email address contains control characters.',
        'Email addresses may not contain line break characters.',
    ]);
}
```

The behavioural guarantees are preserved:

- **Exception class** still pinned via the `catch` type — any other exception class propagates and fails the test (PHPUnit reports it as an Error, with the real exception class + message + stack trace).
- **No-throw regression** still caught by `\$this->fail(...)`.
- **Message** is an exact full-string match against a known list — a Symfony typo/reword would fail loudly until the allowed list is updated.

This try/catch + `\$this->fail` + `assertContains` shape is already used elsewhere in the test suite, e.g. `tests/Cache/CacheRepositoryTest.php:578` and `tests/Auth/AuthHandlesAuthorizationTest.php:66`.

## Test plan

- [x] `vendor/bin/phpunit tests/Mail/MailMailerTest.php` — 16/16 pass on symfony/mime 7.4.12
- [x] `vendor/bin/pint` clean
- [x] Sibling test `testMailerRejectsAddressesContainingLineBreaks` (string input, hits Laravel's own check rather than Symfony's `Address::__construct`) is unaffected and left untouched
- [ ] 12.x backport: #LINK_TO_BE_FILLED