### PR TITLE
[12.x] Accept Symfony's new control-characters exception message in mailer test

### DIFF
--- a/tests/Mail/MailMailerTest.php
+++ b/tests/Mail/MailMailerTest.php
@@ -228,12 +228,18 @@ class MailMailerTest extends TestCase
         $view->shouldReceive('render')->once()->andReturn('rendered.view');
         $mailer = new Mailer('array', $view, new ArrayTransport);
 
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Email addresses may not contain line break characters.');
+        try {
+            $mailer->send('foo', ['data'], function (Message $message) {
+                $message->to(new Address("\"foo\r\nBcc: victim@example.com\"@example.com"))->from('hello@laravel.com');
+            });
 
-        $mailer->send('foo', ['data'], function (Message $message) {
-            $message->to(new Address("\"foo\r\nBcc: victim@example.com\"@example.com"))->from('hello@laravel.com');
-        });
+            $this->fail('Expected InvalidArgumentException was not thrown.');
+        } catch (InvalidArgumentException $e) {
+            $this->assertContains($e->getMessage(), [
+                'Email address contains control characters.',
+                'Email addresses may not contain line break characters.',
+            ]);
+        }
     }
 
     public function testGlobalFromIsRespectedOnAllMessages(): void


### PR DESCRIPTION
Backport of #60202 to 12.x.

## Summary

`symfony/mime` 7.4.12 added an early control-character guard in `Address::__construct` that throws `InvalidArgumentException('Email address contains control characters.')` before the older `RfcComplianceException('Email addresses may not contain line break characters.')` ever gets a chance to.

`testMailerRejectsSymfonyAddressesContainingLineBreaks` constructs `new Address("\"foo\r\nBcc: ...\"@example.com")` to trigger the rejection, so it now hits the new message instead of the old one and the test fails on CI:

```
1) Illuminate\Tests\Mail\MailMailerTest::testMailerRejectsSymfonyAddressesContainingLineBreaks
Failed asserting that exception message 'Email address contains control characters.' contains 'Email addresses may not contain line break characters.'.
```

## Fix

The composer constraint is `symfony/mime: "^7.4.0 || ^8.0.0"`, so both messages are legitimately reachable depending on installed patch version. Switch to a try/catch + `assertContains` pattern that accepts either message:

```php
try {
    \$mailer->send('foo', ['data'], function (Message \$message) {
        \$message->to(new Address("\"foo\r\nBcc: victim@example.com\"@example.com"))->from('hello@laravel.com');
    });

    \$this->fail('Expected InvalidArgumentException was not thrown.');
} catch (InvalidArgumentException \$e) {
    \$this->assertContains(\$e->getMessage(), [
        'Email address contains control characters.',
        'Email addresses may not contain line break characters.',
    ]);
}
```

Behavioural guarantees preserved: exception class still pinned (any other class propagates as an Error), no-throw regression still caught by `\$this->fail(...)`, message still an exact full-string match against a known allow-list.

This try/catch + `\$this->fail` shape is already used elsewhere in the test suite (e.g. `tests/Cache/CacheRepositoryTest.php:578`, `tests/Auth/AuthHandlesAuthorizationTest.php:66`).

11.x is unaffected — `testMailerRejectsSymfonyAddressesContainingLineBreaks` doesn't exist on that branch.

## Test plan

- [x] `vendor/bin/phpunit tests/Mail/MailMailerTest.php` — 16/16 pass on symfony/mime 7.4.12
- [x] `vendor/bin/pint` clean