### PR TITLE
[13.x] feat: add factory to pivot stub

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/model.pivot.stub
+++ b/src/Illuminate/Foundation/Console/stubs/model.pivot.stub
@@ -2,9 +2,10 @@
 
 namespace {{ namespace }};
 
+{{ factoryImport }}
 use Illuminate\Database\Eloquent\Relations\Pivot;
 
 class {{ class }} extends Pivot
 {
-    //
+    {{ factory }}
 }


### PR DESCRIPTION
## Changed

The stub `model.pivot.stub` doesn't include the template for factories but `php artisan make:model` allow the `-p` and `-f` flag to coexists

## Reasons

I think Pivot models are not excluded from having factories. There's also a DX inconsistency because, as mentioned above, the artisan command allows the two flags to be used together.

I've read the `ModelMakeCommand` this should be enough to allow pivots to include the factory scaffold, let me know if I'm missing something


<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
