### PR TITLE
[13.x] Fix incorrect type hint in Optional::offsetUnset() docblock

### DIFF
--- a/src/Illuminate/Support/Optional.php
+++ b/src/Illuminate/Support/Optional.php
@@ -100,7 +100,7 @@ class Optional implements ArrayAccess
     /**
      * Unset the item at a given offset.
      *
-     * @param  string  $offset
+     * @param  mixed  $offset
      * @return void
      */
     public function offsetUnset($offset): void


### PR DESCRIPTION
## Summary

Fixed a type mismatch in the `Optional::offsetUnset()` method's docblock.

## Problem

The docblock annotated `$offset` as `string` but:
- The ArrayAccess interface defines `offsetUnset(mixed $offset)`
- The actual signature is `offsetUnset($offset): void`
- Other ArrayAccess methods in the same class use `@param mixed`

## Solution

Changed `@param string $offset` to `@param mixed $offset` for consistency.

## Impact

- No behavior changes
- Documentation now matches the PHP ArrayAccess interface contract
- Improves static analysis accuracy
