### PR TITLE
[13.x] Add JSON exception rendering helper for API routes

### DIFF
--- a/src/Illuminate/Foundation/Configuration/Exceptions.php
+++ b/src/Illuminate/Foundation/Configuration/Exceptions.php
@@ -202,6 +202,18 @@ class Exceptions
     }
 
     /**
+     * Register the callable that determines if the exception handler response should be JSON for API routes.
+     *
+     * @return $this
+     */
+    public function shouldRenderJsonForApiRoutes()
+    {
+        $this->handler->shouldRenderJsonForApiRoutes();
+
+        return $this;
+    }
+
+    /**
      * Indicate that the given exception class should not be ignored.
      *
      * @param  array<int, class-string<\Throwable>>|class-string<\Throwable>  $class

--- a/src/Illuminate/Foundation/Console/ApiInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/ApiInstallCommand.php
@@ -6,6 +6,7 @@ use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Process;
+use Illuminate\Support\Str;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 use function Illuminate\Support\artisan_binary;
@@ -66,6 +67,8 @@ class ApiInstallCommand extends Command
             $this->uncommentApiRoutesFile();
         }
 
+        $this->configureExceptionHandlerForApiRoutes();
+
         if ($this->option('passport')) {
             Process::run([
                 php_binary(),
@@ -113,6 +116,43 @@ class ApiInstallCommand extends Command
 
             return;
         }
+    }
+
+    /**
+     * Configure the exception handler to render JSON for API routes.
+     *
+     * @return void
+     */
+    protected function configureExceptionHandlerForApiRoutes()
+    {
+        $appBootstrapPath = $this->laravel->bootstrapPath('app.php');
+
+        $content = file_get_contents($appBootstrapPath);
+
+        if (str_contains($content, '$exceptions->shouldRenderJsonForApiRoutes();')) {
+            return;
+        }
+
+        $exceptionConfigurationClosures = [
+            '->withExceptions(function (Exceptions $exceptions): void {',
+            '->withExceptions(function (Exceptions $exceptions) {',
+            '->withExceptions(function (\Illuminate\Foundation\Configuration\Exceptions $exceptions): void {',
+            '->withExceptions(function (\Illuminate\Foundation\Configuration\Exceptions $exceptions) {',
+        ];
+
+        foreach ($exceptionConfigurationClosures as $closure) {
+            if (str_contains($content, $closure)) {
+                file_put_contents($appBootstrapPath, Str::replaceFirst(
+                    $closure,
+                    $closure.PHP_EOL.'        $exceptions->shouldRenderJsonForApiRoutes();',
+                    $content
+                ));
+
+                return;
+            }
+        }
+
+        $this->components->warn("Unable to automatically configure exception JSON rendering for API routes in [{$appBootstrapPath}]. Please add it manually.");
     }
 
     /**

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -871,6 +871,18 @@ class Handler implements ExceptionHandlerContract
     }
 
     /**
+     * Register the callable that determines if the exception handler response should be JSON for API routes.
+     *
+     * @return $this
+     */
+    public function shouldRenderJsonForApiRoutes()
+    {
+        return $this->shouldRenderJsonWhen(function ($request, $exception) {
+            return $request->is('api/*');
+        });
+    }
+
+    /**
      * Prepare a response for the given exception.
      *
      * @param  \Illuminate\Http\Request  $request

--- a/src/Illuminate/Support/Facades/Exceptions.php
+++ b/src/Illuminate/Support/Facades/Exceptions.php
@@ -26,6 +26,7 @@ use Illuminate\Support\Testing\Fakes\ExceptionHandlerFake;
  * @method static \Symfony\Component\HttpFoundation\Response render(\Illuminate\Http\Request $request, \Throwable $e)
  * @method static \Illuminate\Foundation\Exceptions\Handler respondUsing(callable $callback)
  * @method static \Illuminate\Foundation\Exceptions\Handler shouldRenderJsonWhen(callable $callback)
+ * @method static \Illuminate\Foundation\Exceptions\Handler shouldRenderJsonForApiRoutes()
  * @method static \Illuminate\Foundation\Exceptions\Handler dontReportDuplicates()
  * @method static \Illuminate\Contracts\Debug\ExceptionHandler handler()
  * @method static void assertReported(\Closure|string $exception)

--- a/tests/Foundation/Configuration/ExceptionsTest.php
+++ b/tests/Foundation/Configuration/ExceptionsTest.php
@@ -49,4 +49,17 @@ class ExceptionsTest extends TestCase
         $shouldReturnJson = (fn () => $this->shouldReturnJson(new Request, new Exception()))->call($exceptions->handler);
         $this->assertFalse($shouldReturnJson);
     }
+
+    public function testShouldRenderJsonForApiRoutes()
+    {
+        $exceptions = new Exceptions(new Handler(new Container));
+
+        $exceptions->shouldRenderJsonForApiRoutes();
+
+        $shouldReturnJson = (fn () => $this->shouldReturnJson(Request::create('/api/users'), new Exception()))->call($exceptions->handler);
+        $this->assertTrue($shouldReturnJson);
+
+        $shouldReturnJson = (fn () => $this->shouldReturnJson(Request::create('/users'), new Exception()))->call($exceptions->handler);
+        $this->assertFalse($shouldReturnJson);
+    }
 }

--- a/tests/Foundation/Console/ApiInstallCommandTest.php
+++ b/tests/Foundation/Console/ApiInstallCommandTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\Console;
+
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Foundation\Application;
+use Illuminate\Foundation\Console\ApiInstallCommand;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class ApiInstallCommandTest extends TestCase
+{
+    protected string $basePath;
+
+    protected Filesystem $files;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->files = new Filesystem;
+        $this->basePath = sys_get_temp_dir().'/laravel-framework-api-install-command-test-'.bin2hex(random_bytes(5));
+
+        $this->files->ensureDirectoryExists($this->basePath.'/bootstrap');
+        $this->files->ensureDirectoryExists($this->basePath.'/routes');
+
+        $this->files->put($this->basePath.'/routes/web.php', '<?php');
+        $this->files->put($this->basePath.'/routes/console.php', '<?php');
+
+        $this->files->put($this->basePath.'/bootstrap/app.php', <<<'PHP'
+<?php
+
+use Illuminate\Foundation\Application;
+use Illuminate\Foundation\Configuration\Exceptions;
+use Illuminate\Foundation\Configuration\Middleware;
+
+return Application::configure(basePath: dirname(__DIR__))
+    ->withRouting(
+        web: __DIR__.'/../routes/web.php',
+        // api: __DIR__.'/../routes/api.php',
+        commands: __DIR__.'/../routes/console.php',
+        health: '/up',
+    )
+    ->withMiddleware(function (Middleware $middleware): void {
+        //
+    })
+    ->withExceptions(function (Exceptions $exceptions): void {
+        //
+    })->create();
+PHP
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        $this->files->deleteDirectory($this->basePath);
+
+        parent::tearDown();
+    }
+
+    public function testItConfiguresJsonExceptionRenderingForApiRoutes()
+    {
+        $command = $this->newCommand();
+
+        $this->runCommand($command, ['--without-migration-prompt' => true]);
+
+        $content = file_get_contents($this->basePath.'/bootstrap/app.php');
+
+        $this->assertFileExists($this->basePath.'/routes/api.php');
+        $this->assertStringContainsString("api: __DIR__.'/../routes/api.php',", $content);
+        $this->assertStringContainsString('$exceptions->shouldRenderJsonForApiRoutes();', $content);
+    }
+
+    public function testItDoesNotDuplicateJsonExceptionConfigurationForApiRoutes()
+    {
+        $command = $this->newCommand();
+
+        $this->runCommand($command, ['--without-migration-prompt' => true]);
+        $this->runCommand($command, ['--without-migration-prompt' => true]);
+
+        $content = file_get_contents($this->basePath.'/bootstrap/app.php');
+
+        $this->assertSame(1, substr_count($content, '$exceptions->shouldRenderJsonForApiRoutes();'));
+    }
+
+    protected function newCommand(): ApiInstallCommand
+    {
+        $command = new class extends ApiInstallCommand
+        {
+            protected function installSanctum()
+            {
+                //
+            }
+
+            protected function installPassport()
+            {
+                //
+            }
+        };
+
+        $command->setLaravel(new Application($this->basePath));
+
+        return $command;
+    }
+
+    protected function runCommand(ApiInstallCommand $command, array $options = [])
+    {
+        return $command->run(new ArrayInput($options), new BufferedOutput);
+    }
+}

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -212,6 +212,25 @@ class FoundationExceptionsHandlerTest extends TestCase
         $this->assertSame(6, Assert::getCount());
     }
 
+    public function testShouldReturnJsonForApiRoutes()
+    {
+        $this->handler->shouldRenderJsonForApiRoutes();
+
+        $apiRequest = m::mock(stdClass::class);
+        $apiRequest->shouldReceive('expectsJson')->never();
+        $apiRequest->shouldReceive('is')->once()->with('api/*')->andReturn(true);
+
+        $shouldReturnJson = (fn () => $this->shouldReturnJson($apiRequest, new Exception()))->call($this->handler);
+        $this->assertTrue($shouldReturnJson);
+
+        $webRequest = m::mock(stdClass::class);
+        $webRequest->shouldReceive('expectsJson')->never();
+        $webRequest->shouldReceive('is')->once()->with('api/*')->andReturn(false);
+
+        $shouldReturnJson = (fn () => $this->shouldReturnJson($webRequest, new Exception()))->call($this->handler);
+        $this->assertFalse($shouldReturnJson);
+    }
+
     public function testReturnsJsonWithStackTraceWhenAjaxRequestAndDebugTrue()
     {
         $this->config->shouldReceive('get')->with('app.debug', null)->once()->andReturn(true);

--- a/types/Foundation/Configuration/Exceptions.php
+++ b/types/Foundation/Configuration/Exceptions.php
@@ -14,3 +14,4 @@ $exceptions = new Exceptions(
 
 $exceptions->stopIgnoring(HttpException::class);
 $exceptions->stopIgnoring([ModelNotFoundException::class]);
+$exceptions->shouldRenderJsonForApiRoutes();


### PR DESCRIPTION
This PR adds a small DX improvement for API-first Laravel applications.

It introduces a new convenience method:

```php
$exceptions->shouldRenderJsonForApiRoutes();
```

which internally configures exception rendering for `api/*` routes using the existing `shouldRenderJsonWhen(...)` API.

The `install:api` command/stubs have also been updated to automatically enable JSON exception rendering for API routes in newly generated applications.

This helps avoid a common source of confusion when testing API routes with tools such as Postman, Insomnia, or curl without manually sending the `Accept: application/json` header.

The implementation is intentionally minimal and does not mutate the incoming request or alter existing `expectsJson()` behavior.
