### PR TITLE
[13.x] Allow auto discovered listeners to opt out of discovery

### DIFF
--- a/src/Illuminate/Contracts/Events/ShouldBeDiscovered.php
+++ b/src/Illuminate/Contracts/Events/ShouldBeDiscovered.php
@@ -7,5 +7,5 @@ interface ShouldBeDiscovered
     /**
      * Determine if the listener should be registered during event discovery.
      */
-    public function shouldBeDiscovered(): bool;
+    public static function shouldBeDiscovered(): bool;
 }

--- a/src/Illuminate/Contracts/Events/ShouldBeDiscovered.php
+++ b/src/Illuminate/Contracts/Events/ShouldBeDiscovered.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Illuminate\Contracts\Events;
+
+interface ShouldBeDiscovered
+{
+    /**
+     * Determine if the listener should be registered during event discovery.
+     */
+    public function shouldBeDiscovered(): bool;
+}

--- a/src/Illuminate/Foundation/Events/DiscoverEvents.php
+++ b/src/Illuminate/Foundation/Events/DiscoverEvents.php
@@ -79,7 +79,7 @@ class DiscoverEvents
             }
 
             if ($listener->implementsInterface(ShouldBeDiscovered::class) &&
-                $listener->newInstanceWithoutConstructor()->shouldBeDiscovered() === false) {
+                $listener->getName()::shouldBeDiscovered() === false) {
                 continue;
             }
 

--- a/src/Illuminate/Foundation/Events/DiscoverEvents.php
+++ b/src/Illuminate/Foundation/Events/DiscoverEvents.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Events;
 
+use Illuminate\Contracts\Events\ShouldBeDiscovered;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Reflector;
@@ -74,6 +75,11 @@ class DiscoverEvents
             }
 
             if (! $listener->isInstantiable()) {
+                continue;
+            }
+
+            if ($listener->implementsInterface(ShouldBeDiscovered::class) &&
+                $listener->newInstanceWithoutConstructor()->shouldBeDiscovered() === false) {
                 continue;
             }
 

--- a/tests/Integration/Foundation/DiscoverEventsTest.php
+++ b/tests/Integration/Foundation/DiscoverEventsTest.php
@@ -9,6 +9,8 @@ use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\Events\Event
 use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\Listeners\AbstractListener;
 use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\Listeners\Listener;
 use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\Listeners\ListenerInterface;
+use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\ShouldBeDiscoveredListeners\RegisteredListener;
+use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\ShouldBeDiscoveredListeners\SkippedListener;
 use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\UnionListeners\UnionListener;
 use Orchestra\Testbench\TestCase;
 use SplFileInfo;
@@ -73,6 +75,20 @@ class DiscoverEventsTest extends TestCase
             EventTwo::class => [
                 Listener::class.'@handleEventTwo',
                 UnionListener::class.'@handle',
+            ],
+        ], $events);
+    }
+
+    public function testListenersImplementingShouldBeDiscoveredCanOptOut()
+    {
+        class_alias(RegisteredListener::class, 'Tests\Integration\Foundation\Fixtures\EventDiscovery\ShouldBeDiscoveredListeners\RegisteredListener');
+        class_alias(SkippedListener::class, 'Tests\Integration\Foundation\Fixtures\EventDiscovery\ShouldBeDiscoveredListeners\SkippedListener');
+
+        $events = DiscoverEvents::within(__DIR__.'/Fixtures/EventDiscovery/ShouldBeDiscoveredListeners', getcwd());
+
+        $this->assertEquals([
+            EventOne::class => [
+                RegisteredListener::class.'@handle',
             ],
         ], $events);
     }

--- a/tests/Integration/Foundation/DiscoverEventsTest.php
+++ b/tests/Integration/Foundation/DiscoverEventsTest.php
@@ -79,7 +79,7 @@ class DiscoverEventsTest extends TestCase
         ], $events);
     }
 
-    public function testListenersImplementingShouldBeDiscoveredCanOptOut()
+    public function testListenersCanOptOutOfDiscovery()
     {
         class_alias(RegisteredListener::class, 'Tests\Integration\Foundation\Fixtures\EventDiscovery\ShouldBeDiscoveredListeners\RegisteredListener');
         class_alias(SkippedListener::class, 'Tests\Integration\Foundation\Fixtures\EventDiscovery\ShouldBeDiscoveredListeners\SkippedListener');

--- a/tests/Integration/Foundation/Fixtures/EventDiscovery/ShouldBeDiscoveredListeners/RegisteredListener.php
+++ b/tests/Integration/Foundation/Fixtures/EventDiscovery/ShouldBeDiscoveredListeners/RegisteredListener.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\ShouldBeDiscoveredListeners;
+
+use Illuminate\Contracts\Events\ShouldBeDiscovered;
+use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\Events\EventOne;
+
+class RegisteredListener implements ShouldBeDiscovered
+{
+    public function shouldBeDiscovered(): bool
+    {
+        return true;
+    }
+
+    public function handle(EventOne $event)
+    {
+        //
+    }
+}

--- a/tests/Integration/Foundation/Fixtures/EventDiscovery/ShouldBeDiscoveredListeners/RegisteredListener.php
+++ b/tests/Integration/Foundation/Fixtures/EventDiscovery/ShouldBeDiscoveredListeners/RegisteredListener.php
@@ -7,7 +7,7 @@ use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\Events\Event
 
 class RegisteredListener implements ShouldBeDiscovered
 {
-    public function shouldBeDiscovered(): bool
+    public static function shouldBeDiscovered(): bool
     {
         return true;
     }

--- a/tests/Integration/Foundation/Fixtures/EventDiscovery/ShouldBeDiscoveredListeners/SkippedListener.php
+++ b/tests/Integration/Foundation/Fixtures/EventDiscovery/ShouldBeDiscoveredListeners/SkippedListener.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\ShouldBeDiscoveredListeners;
+
+use Illuminate\Contracts\Events\ShouldBeDiscovered;
+use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\Events\EventOne;
+
+class SkippedListener implements ShouldBeDiscovered
+{
+    public function shouldBeDiscovered(): bool
+    {
+        return false;
+    }
+
+    public function handle(EventOne $event)
+    {
+        //
+    }
+}

--- a/tests/Integration/Foundation/Fixtures/EventDiscovery/ShouldBeDiscoveredListeners/SkippedListener.php
+++ b/tests/Integration/Foundation/Fixtures/EventDiscovery/ShouldBeDiscoveredListeners/SkippedListener.php
@@ -7,7 +7,7 @@ use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\Events\Event
 
 class SkippedListener implements ShouldBeDiscovered
 {
-    public function shouldBeDiscovered(): bool
+    public static function shouldBeDiscovered(): bool
     {
         return false;
     }


### PR DESCRIPTION
Good day!

This PR adds a `ShouldBeDiscovered` interface that lets listeners decide themselves if they should be registered during discovery... used an interface so I'm not causing any B/C. 

I want auto discovery, cause it's easy, but I want to purposefully not register some events in certain environments, I can do it in the handle, but it felt repetitive so thought this could be nice... as avoids discovery completely 

This is especially helpful for listeners that implement ShouldQueue, as it's not completely obvious the logic in the handle will still get queued. 


Code example:
<details>


Idea being it just stops it being discovered at all.., no need to think about shouldQueue, we just dont want it for this env..

```php
  use Illuminate\Contracts\Events\ShouldBeDiscovered;
  use Illuminate\Contracts\Queue\ShouldQueue;

  class CustomerRegisteredListener implements ShouldBeDiscovered, ShouldQueue
  {
      public static function shouldBeDiscovered(): bool
      {
          return app()->environment('production');
      }

      // Before the check would be in the handle, but still sent it to the queue.
      public function handle(CustomerRegistered $event): void
      {
          Http::post(config('services.salesforce.webhook'), [
              'email' => $event->customer->email,
          ]);
      }
  }

```

</details>

 
Why not just use a subscriber? ... Cause generally you use it to subscribe for multiple events, if you only have one, it feels (at least to me) a bit overcomplicated.  I wanna let the auto discover handle it.

Also don't really wanna Event:forget as that too feels a bit.. meh

I just want a way to say "Dont listen to this.. due to XYZ" - ie a environment, feature etc. This provides a lightweight alternative essentially.  The method is purposefully static to not rely on state.

Note- you can still manually Event::listen, but this is about automagic discovery! This also works with optimize etc

Open to renaming, a better way,  or throwing this away I am but one man from England with ideas!  


