### PR TITLE
[13.x] Fix nested enum path duplication in make:enum

### DIFF
--- a/src/Illuminate/Foundation/Console/EnumMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/EnumMakeCommand.php
@@ -69,6 +69,16 @@ class EnumMakeCommand extends GeneratorCommand
      */
     protected function getDefaultNamespace($rootNamespace)
     {
+        $name = $this->getNameInput();
+
+        if (str_starts_with($name, 'Enums/') || str_starts_with($name, 'Enums\\')) {
+            return $rootNamespace;
+        }
+
+        if (str_starts_with($name, 'Enumerations/') || str_starts_with($name, 'Enumerations\\')) {
+            return $rootNamespace;
+        }
+
         return match (true) {
             is_dir(app_path('Enums')) => $rootNamespace.'\\Enums',
             is_dir(app_path('Enumerations')) => $rootNamespace.'\\Enumerations',

--- a/tests/Integration/Generators/EnumMakeCommandTest.php
+++ b/tests/Integration/Generators/EnumMakeCommandTest.php
@@ -11,6 +11,8 @@ class EnumMakeCommandTest extends TestCase
         'app/StatusEnum.php',
         'app/StringEnum.php',
         'app/*/OrderStatusEnum.php',
+        'app/Enums/Profile/HairColor.php',
+        'app/Enums/Profile/EyeColor.php',
     ];
 
     public function testItCanGenerateEnumFile()
@@ -84,5 +86,33 @@ class EnumMakeCommandTest extends TestCase
         ], 'app/Enumerations/OrderStatusEnum.php');
 
         $files->deleteDirectory($enumerationsFolderPath);
+    }
+
+    public function testItCanGenerateNestedEnumsWithoutPathDuplication()
+    {
+        /** @var \Illuminate\Filesystem\Filesystem $files */
+        $files = $this->app['files'];
+
+        $enumsFolderPath = app_path('Enums');
+
+        $files->ensureDirectoryExists($enumsFolderPath);
+
+        $this->artisan('make:enum', ['name' => 'Enums/Profile/HairColor'])
+            ->assertExitCode(0);
+
+        $this->artisan('make:enum', ['name' => 'Enums/Profile/EyeColor'])
+            ->assertExitCode(0);
+
+        $this->assertFileContains([
+            'namespace App\Enums\Profile;',
+            'enum HairColor',
+        ], 'app/Enums/Profile/HairColor.php');
+
+        $this->assertFileContains([
+            'namespace App\Enums\Profile;',
+            'enum EyeColor',
+        ], 'app/Enums/Profile/EyeColor.php');
+
+        $files->deleteDirectory($enumsFolderPath);
     }
 }


### PR DESCRIPTION
## Summary

Fixes #60152 — `make:enum` produces incorrect nested paths when `app/Enums` directory exists.

### The Bug

```bash
php artisan make:enum Enums/Profile/HairColor   # ✅ app/Enums/Profile/HairColor.php
php artisan make:enum Enums/Profile/EyeColor     # ❌ app/Enums/Enums/Profile/EyeColor.php
```

The first command creates the `app/Enums` directory. On the second command, `getDefaultNamespace()` detects the now-existing directory and prepends `Enums\` to the namespace, doubling it with the user-provided `Enums/` prefix.

### The Fix

`EnumMakeCommand::getDefaultNamespace()` now checks whether the name input already starts with `Enums/`, `Enums\`, `Enumerations/`, or `Enumerations\`. When it does, the method returns the root namespace directly instead of prepending the directory-based sub-namespace.

### Test Added

- `testItCanGenerateNestedEnumsWithoutPathDuplication` — creates two nested enums sequentially and asserts both land in the correct directory without path duplication.

Closes #60152