### PR TITLE
[13.x] Add Stringable::whenDoesntContain()

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1166,6 +1166,19 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
+     * Execute the given callback if the string doesn't contain a given substring.
+     *
+     * @param  string|iterable<string>  $needles
+     * @param  callable  $callback
+     * @param  callable|null  $default
+     * @return static
+     */
+    public function whenDoesntContain($needles, $callback, $default = null)
+    {
+        return $this->when($this->doesntContain($needles), $callback, $default);
+    }
+
+    /**
      * Execute the given callback if the string is empty.
      *
      * @param  callable  $callback

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -242,6 +242,31 @@ class SupportStringableTest extends TestCase
         }));
     }
 
+    public function testWhenDoesntContain()
+    {
+        $this->assertSame('Tony Stark', (string) $this->stringable('stark')->whenDoesntContain('xxx', function ($stringable) {
+            return $stringable->prepend('Tony ')->title();
+        }, function ($stringable) {
+            return $stringable->prepend('Arno ')->title();
+        }));
+
+        $this->assertSame('stark', (string) $this->stringable('stark')->whenDoesntContain('tar', function ($stringable) {
+            return $stringable->prepend('Tony ')->title();
+        }));
+
+        $this->assertSame('Arno Stark', (string) $this->stringable('stark')->whenDoesntContain('tar', function ($stringable) {
+            return $stringable->prepend('Tony ')->title();
+        }, function ($stringable) {
+            return $stringable->prepend('Arno ')->title();
+        }));
+
+        $this->assertSame('Tony Stark', (string) $this->stringable('stark')->whenDoesntContain(['xxx', 'yyy'], function ($stringable) {
+            return $stringable->prepend('Tony ')->title();
+        }, function ($stringable) {
+            return $stringable->prepend('Arno ')->title();
+        }));
+    }
+
     public function testDedup()
     {
         $this->assertSame(' laravel php framework ', (string) $this->stringable(' laravel   php  framework ')->deduplicate());


### PR DESCRIPTION
The fluent string builder has \`whenDoesntEndWith()\` and \`whenDoesntStartWith()\` as negative counterparts to their positive forms, but \`whenContains()\` has no equivalent \`whenDoesntContain()\`. This adds it.