### PR TITLE
[13.x] Add Cache::collection() to match Config::collection()

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -340,6 +340,20 @@ class Repository implements ArrayAccess, CacheContract
     }
 
     /**
+     * Retrieve a collection of items from the cache.
+     *
+     * @param  \UnitEnum|string  $key
+     * @param  (\Closure():(array<array-key, mixed>|null))|array<array-key, mixed>|null  $default
+     * @return \Illuminate\Support\Collection<array-key, mixed>
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function collection($key, $default = null): Collection
+    {
+        return new Collection($this->array($key, $default));
+    }
+
+    /**
      * Store an item in the cache.
      *
      * @param  \UnitEnum|array|string  $key

--- a/src/Illuminate/Support/Facades/Cache.php
+++ b/src/Illuminate/Support/Facades/Cache.php
@@ -30,6 +30,7 @@ use Mockery;
  * @method static float float(\UnitEnum|string $key, \Closure|float|null $default = null)
  * @method static bool boolean(\UnitEnum|string $key, \Closure|bool|null $default = null)
  * @method static array array(\UnitEnum|string $key, \Closure|array|null $default = null)
+ * @method static \Illuminate\Support\Collection collection(\UnitEnum|string $key, \Closure|array|null $default = null)
  * @method static bool put(\UnitEnum|array|string $key, mixed $value, \DateTimeInterface|\DateInterval|int|null $ttl = null)
  * @method static bool set(\UnitEnum|array|string $key, mixed $value, \DateTimeInterface|\DateInterval|int|null $ttl = null)
  * @method static bool putMany(array $values, \DateTimeInterface|\DateInterval|int|null $ttl = null)

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -790,6 +790,30 @@ class CacheRepositoryTest extends TestCase
         $repo->getStore()->shouldReceive('get')->once()->with('foo')->andReturn('bar');
         $repo->array('foo');
     }
+
+    public function testItGetsAsCollection()
+    {
+        $repo = $this->getRepository();
+        $repo->getStore()->shouldReceive('get')->once()->with('foo')->andReturn(['bar', 'baz']);
+        $this->assertEquals(collect(['bar', 'baz']), $repo->collection('foo'));
+    }
+
+    public function testItGetsAsCollectionWithDefault()
+    {
+        $repo = $this->getRepository();
+        $repo->getStore()->shouldReceive('get')->once()->with('foo')->andReturn(null);
+        $this->assertEquals(collect(['default']), $repo->collection('foo', ['default']));
+    }
+
+    public function testItThrowsExceptionWhenGettingNonArrayAsCollection()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cache value for key [foo] must be an array, string given.');
+
+        $repo = $this->getRepository();
+        $repo->getStore()->shouldReceive('get')->once()->with('foo')->andReturn('bar');
+        $repo->collection('foo');
+    }
 }
 
 enum TestCacheKey: string


### PR DESCRIPTION
\`Config::collection()\` has existed for a while, but \`Cache\` only has \`array()\` with no collection counterpart. This adds \`Cache::collection()\` which wraps the existing \`array()\` method, keeping the same validation and default handling.