### PR TITLE
[13.x] Fix async HTTP retries when using array backoff values

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -1272,11 +1272,9 @@ class PendingRequest
      */
     protected function getMaximumAttempts()
     {
-        if (is_array($this->tries)) {
-            return count($this->tries) + 1;
-        }
-
-        return $this->tries ?? 1;
+        return is_array($this->tries)
+            ? count($this->tries) + 1
+            : ($this->tries ?? 1);
     }
 
     /**
@@ -1288,11 +1286,9 @@ class PendingRequest
      */
     protected function retryDelayInMilliseconds($attempt, $exception)
     {
-        if (is_array($this->tries)) {
-            return $this->tries[$attempt - 1] ?? 0;
-        }
-
-        return value($this->retryDelay ?? 100, $attempt, $exception);
+        return is_array($this->tries)
+            ? $this->tries[$attempt - 1] ?? 0
+            : value($this->retryDelay ?? 100, $attempt, $exception);
     }
 
     /**

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -1240,12 +1240,10 @@ class PendingRequest
             return $exception;
         }
 
-        if ($attempt < $this->tries && $shouldRetry) {
-            $options['delay'] = value(
-                $this->retryDelay,
-                $attempt,
-                $response instanceof Response ? $response->toException() : $response
-            );
+        $exception = $response instanceof Response ? $response->toException() : $response;
+
+        if ($attempt < $this->getMaximumAttempts() && $shouldRetry) {
+            $options['delay'] = $this->retryDelayInMilliseconds($attempt, $exception);
 
             return $this->makePromise($method, $url, $options, $attempt + 1);
         }
@@ -1260,11 +1258,41 @@ class PendingRequest
             }
         }
 
-        if ($this->tries > 1 && $this->retryThrow) {
+        if ($this->getMaximumAttempts() > 1 && $this->retryThrow) {
             return $response instanceof Response ? $response->toException() : $response;
         }
 
         return $response;
+    }
+
+    /**
+     * Get the maximum number of attempts for the request.
+     *
+     * @return int
+     */
+    protected function getMaximumAttempts()
+    {
+        if (is_array($this->tries)) {
+            return count($this->tries) + 1;
+        }
+
+        return $this->tries ?? 1;
+    }
+
+    /**
+     * Get the delay in milliseconds before the next retry attempt.
+     *
+     * @param  int  $attempt
+     * @param  mixed  $exception
+     * @return int|float
+     */
+    protected function retryDelayInMilliseconds($attempt, $exception)
+    {
+        if (is_array($this->tries)) {
+            return $this->tries[$attempt - 1] ?? 0;
+        }
+
+        return value($this->retryDelay ?? 100, $attempt, $exception);
     }
 
     /**

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -2282,6 +2282,40 @@ class HttpClientTest extends TestCase
         $this->factory->assertSentCount(3);
     }
 
+    public function testAsyncRequestRetriesWithBackoffArray()
+    {
+        $this->factory->fake([
+            '*' => $this->factory::response(['error'], 403),
+        ]);
+
+        $response = $this->factory
+            ->async()
+            ->retry([1, 2], throw: false)
+            ->get('http://foo.com/get')
+            ->wait();
+
+        $this->assertTrue($response->failed());
+
+        $this->factory->assertSentCount(3);
+    }
+
+    public function testAsyncRequestRetriesWithIntegerTries()
+    {
+        $this->factory->fake([
+            '*' => $this->factory::response(['error'], 403),
+        ]);
+
+        $response = $this->factory
+            ->async()
+            ->retry(2, 1000, null, false)
+            ->get('http://foo.com/get')
+            ->wait();
+
+        $this->assertTrue($response->failed());
+
+        $this->factory->assertSentCount(2);
+    }
+
     public function testRequestExceptionIsNotThrownWithoutRetriesIfRetryNotNecessary()
     {
         $this->factory->fake([


### PR DESCRIPTION
## Summary

This PR fixes async HTTP retry behavior when using array backoff values.

Currently, synchronous requests correctly support array-based retry delays through the global `retry()` helper:

```php
Http::retry([100, 200])->get(...);
```

However, the async flow:

```php
Http::async()->retry([100, 200])->get(...)->wait();
```

does not behave correctly because the retry logic compares the current attempt directly against `$this->tries`, which may be an array.

This causes async retries with array backoff values to stop prematurely.

---

## What Changed

### `PendingRequest.php`

Added internal helpers to normalize retry behavior between sync and async flows:

- `getMaximumAttempts()`
  - Returns:
    - `count($tries) + 1` when `$tries` is an array
    - the configured integer otherwise
    - defaults to `1`

- `retryDelayInMilliseconds()`
  - Uses array-based backoff values consistently with the global `retry()` helper
  - Keeps existing integer retry behavior unchanged

Updated async retry handling in `handlePromiseResponse()` to use these helpers instead of directly comparing against `$this->tries`.

---

## Tests

Added coverage for:

- async retries with array backoff values
- async retries with integer retry counts (regression coverage)

### Added tests

- `testAsyncRequestRetriesWithBackoffArray`
- `testAsyncRequestRetriesWithIntegerTries`

---

## Before

```php
Http::async()
    ->retry([1, 2])
    ->get(...)
    ->wait();
```

Would not retry correctly.

---

## After

Array-based retry delays now behave consistently between sync and async requests.

---

## Backward Compatibility

This change is fully backward compatible.

It only fixes inconsistent async retry behavior to match the existing synchronous implementation.