### PR TITLE
[13.x] Make ClearCommand prohibitable

### DIFF
--- a/src/Illuminate/Queue/Console/ClearCommand.php
+++ b/src/Illuminate/Queue/Console/ClearCommand.php
@@ -4,6 +4,7 @@ namespace Illuminate\Queue\Console;
 
 use Illuminate\Console\Command;
 use Illuminate\Console\ConfirmableTrait;
+use Illuminate\Console\Prohibitable;
 use Illuminate\Contracts\Queue\ClearableQueue;
 use Illuminate\Support\Str;
 use ReflectionClass;
@@ -14,7 +15,7 @@ use Symfony\Component\Console\Input\InputOption;
 #[AsCommand(name: 'queue:clear')]
 class ClearCommand extends Command
 {
-    use ConfirmableTrait;
+    use ConfirmableTrait, Prohibitable;
 
     /**
      * The console command name.
@@ -37,7 +38,8 @@ class ClearCommand extends Command
      */
     public function handle()
     {
-        if (! $this->confirmToProceed()) {
+        if ($this->isProhibited() ||
+            ! $this->confirmToProceed()) {
             return 1;
         }
 


### PR DESCRIPTION
I have many live environments, some that aren't set as production, ie `Jupiter` I want to be able to set this as prohibitable as there's important job etc, people shouldn't be clearing it.

I want to be able to do 

```php
ClearCommand::prohibit($inHostedEnvironments);
```

No B/C as it's opt in - this matches the FreshCommand etc. 

Arguably this could be put into `prohibitDestructiveCommands` but also not worth the pain of breaking someones flow.

Thanks Taylor