### PR TITLE
[12.x] Add minProperties and maxProperties support to JsonSchema ObjectType

### DIFF
--- a/src/Illuminate/JsonSchema/Types/ObjectType.php
+++ b/src/Illuminate/JsonSchema/Types/ObjectType.php
@@ -5,6 +5,16 @@ namespace Illuminate\JsonSchema\Types;
 class ObjectType extends Type
 {
     /**
+     * The minimum number of properties (inclusive).
+     */
+    protected ?int $minProperties = null;
+
+    /**
+     * The maximum number of properties (inclusive).
+     */
+    protected ?int $maxProperties = null;
+
+    /**
      * Whether additional properties are allowed.
      */
     protected ?bool $additionalProperties = null;
@@ -17,6 +27,26 @@ class ObjectType extends Type
     public function __construct(protected array $properties = [])
     {
         //
+    }
+
+    /**
+     * Set the minimum number of properties (inclusive).
+     */
+    public function min(int $value): static
+    {
+        $this->minProperties = $value;
+
+        return $this;
+    }
+
+    /**
+     * Set the maximum number of properties (inclusive).
+     */
+    public function max(int $value): static
+    {
+        $this->maxProperties = $value;
+
+        return $this;
     }
 
     /**

--- a/tests/JsonSchema/ObjectTypeTest.php
+++ b/tests/JsonSchema/ObjectTypeTest.php
@@ -78,6 +78,37 @@ class ObjectTypeTest extends TestCase
         ], $type->toArray());
     }
 
+    public function test_it_may_have_a_minimum_number_of_properties(): void
+    {
+        $type = JsonSchema::object()->min(1);
+
+        $this->assertEquals([
+            'type' => 'object',
+            'minProperties' => 1,
+        ], $type->toArray());
+    }
+
+    public function test_it_may_have_a_maximum_number_of_properties(): void
+    {
+        $type = JsonSchema::object()->max(5);
+
+        $this->assertEquals([
+            'type' => 'object',
+            'maxProperties' => 5,
+        ], $type->toArray());
+    }
+
+    public function test_it_may_combine_min_and_max_properties(): void
+    {
+        $type = JsonSchema::object()->min(1)->max(5);
+
+        $this->assertEquals([
+            'type' => 'object',
+            'minProperties' => 1,
+            'maxProperties' => 5,
+        ], $type->toArray());
+    }
+
     public function test_it_may_disable_additional_properties(): void
     {
         $type = JsonSchema::object()->default(['age' => 1])->withoutAdditionalProperties();


### PR DESCRIPTION
`ArrayType` already supports `min()` and `max()` for item count
constraints (`minItems` / `maxItems`). This adds the same API to
`ObjectType` using the equivalent JSON Schema keywords
`minProperties` and `maxProperties`.

```php
JsonSchema::object()->min(1)->max(5);

// produces:
// { "type": "object", "minProperties": 1, "maxProperties": 5 }
```

This mirrors the existing min()/max() convention already used by
ArrayType, NumberType, IntegerType, and StringType.