### PR TITLE
[13.x] Make HTTP client async promises immutable

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -1031,9 +1031,11 @@ class PendingRequest
         [$this->pendingBody, $this->pendingFiles] = [null, []];
 
         if ($this->async) {
-            return $this->promise = new LazyPromise(
+            return $this->promise = (new LazyPromise(
                 fn () => $this->makePromise($method, $url, $options)
-            );
+            ))->onChain(function (LazyPromise $chained) {
+                $this->promise = $chained;
+            });
         }
 
         $shouldRetry = null;

--- a/src/Illuminate/Http/Client/Promises/FluentPromise.php
+++ b/src/Illuminate/Http/Client/Promises/FluentPromise.php
@@ -74,7 +74,7 @@ class FluentPromise implements PromiseInterface
     }
 
     /**
-     * Proxy requests to the underlying promise interface and update the local promise.
+     * Proxy requests to the underlying promise interface, wrapping any returned promise.
      *
      * @param  string  $method
      * @param  array  $parameters
@@ -88,8 +88,10 @@ class FluentPromise implements PromiseInterface
             return $result;
         }
 
-        $this->guzzlePromise = $result;
+        if ($result === $this->guzzlePromise) {
+            return $this;
+        }
 
-        return $this;
+        return new static($result);
     }
 }

--- a/src/Illuminate/Http/Client/Promises/LazyPromise.php
+++ b/src/Illuminate/Http/Client/Promises/LazyPromise.php
@@ -4,23 +4,22 @@ namespace Illuminate\Http\Client\Promises;
 
 use Closure;
 use GuzzleHttp\Promise\PromiseInterface;
-use RuntimeException;
 
 class LazyPromise implements PromiseInterface
 {
-    /**
-     * The callbacks to execute after the Guzzle Promise has been built.
-     *
-     * @var list<callable>
-     */
-    protected array $pending = [];
-
     /**
      * The promise built by the creator.
      *
      * @var \GuzzleHttp\Promise\PromiseInterface
      */
     protected PromiseInterface $guzzlePromise;
+
+    /**
+     * Optional callback invoked with each new promise produced by chaining.
+     *
+     * @var (\Closure(\Illuminate\Http\Client\Promises\LazyPromise): void)|null
+     */
+    protected ?Closure $chainCallback = null;
 
     /**
      * Create a new lazy promise instance.
@@ -32,51 +31,62 @@ class LazyPromise implements PromiseInterface
     }
 
     /**
-     * Build the promise from the promise builder.
+     * Register a callback to be notified of chained promises produced from this instance.
+     *
+     * Used by PendingRequest so that fluent chains in pool builders are tracked.
+     *
+     * @param  (\Closure(\Illuminate\Http\Client\Promises\LazyPromise): void)|null  $callback
+     * @return $this
+     */
+    public function onChain(?Closure $callback): static
+    {
+        $this->chainCallback = $callback;
+
+        return $this;
+    }
+
+    /**
+     * Build the promise from the promise builder, or return the already-built promise.
      *
      * @return \GuzzleHttp\Promise\PromiseInterface
-     *
-     * @throws \RuntimeException If the promise has already been built
      */
     public function buildPromise(): PromiseInterface
     {
         if (! $this->promiseNeedsBuilt()) {
-            throw new RuntimeException('Promise already built');
+            return $this->guzzlePromise;
         }
 
-        $this->guzzlePromise = call_user_func($this->promiseBuilder);
-
-        foreach ($this->pending as $pendingCallback) {
-            $pendingCallback($this->guzzlePromise);
-        }
-
-        $this->pending = [];
-
-        return $this->guzzlePromise;
+        return $this->guzzlePromise = call_user_func($this->promiseBuilder);
     }
 
     #[\Override]
     public function then(?callable $onFulfilled = null, ?callable $onRejected = null): PromiseInterface
     {
-        if ($this->promiseNeedsBuilt()) {
-            $this->pending[] = static fn (PromiseInterface $promise) => $promise->then($onFulfilled, $onRejected);
-
-            return $this;
-        }
-
-        return $this->guzzlePromise->then($onFulfilled, $onRejected);
+        return $this->chain(fn () => $this->buildPromise()->then($onFulfilled, $onRejected));
     }
 
     #[\Override]
     public function otherwise(callable $onRejected): PromiseInterface
     {
-        if ($this->promiseNeedsBuilt()) {
-            $this->pending[] = static fn (PromiseInterface $promise) => $promise->otherwise($onRejected);
+        return $this->chain(fn () => $this->buildPromise()->otherwise($onRejected));
+    }
 
-            return $this;
+    /**
+     * Produce a new chained LazyPromise that propagates the chain callback.
+     *
+     * @param  \Closure  $builder
+     * @return static
+     */
+    protected function chain(Closure $builder): static
+    {
+        $chained = new static($builder);
+        $chained->chainCallback = $this->chainCallback;
+
+        if ($this->chainCallback !== null) {
+            ($this->chainCallback)($chained);
         }
 
-        return $this->guzzlePromise->otherwise($onRejected);
+        return $chained;
     }
 
     #[\Override]

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -1931,6 +1931,39 @@ class HttpClientTest extends TestCase
         $this->assertSame($promise, $request->getPromise());
     }
 
+    public function testAsyncPromisesAreImmutableWhenChained()
+    {
+        $this->factory->fake([
+            '*' => $this->factory::response('ok', 200),
+        ]);
+
+        $promise1 = $this->factory->async()->get('http://foo.com');
+        $promise2 = $promise1->then(fn () => ['one', 'two']);
+        $promise3 = $promise2->then(fn () => ['three', 'four']);
+
+        $this->assertNotSame($promise1, $promise2);
+        $this->assertNotSame($promise2, $promise3);
+
+        $this->assertSame(200, $promise1->wait()->status());
+        $this->assertSame(['one', 'two'], $promise2->wait());
+        $this->assertSame(['three', 'four'], $promise3->wait());
+    }
+
+    public function testAsyncPromisesAreImmutableWhenChainedInReverseWaitOrder()
+    {
+        $this->factory->fake([
+            '*' => $this->factory::response('ok', 200),
+        ]);
+
+        $promise1 = $this->factory->async()->get('http://foo.com');
+        $promise2 = $promise1->then(fn () => 'one');
+        $promise3 = $promise2->then(fn () => 'two');
+
+        $this->assertSame('two', $promise3->wait());
+        $this->assertSame('one', $promise2->wait());
+        $this->assertSame(200, $promise1->wait()->status());
+    }
+
     public function testClientCanBeSet()
     {
         $client = $this->factory->buildClient();


### PR DESCRIPTION
The HTTP client's async wrappers (FluentPromise, LazyPromise) violated the immutability contract of GuzzleHttp\Promise\PromiseInterface: calling then() mutated the same wrapper and returned $this, so a chain of then() calls collapsed all intermediate promises into one — every wait() in the chain returned the value of the last handler.

FluentPromise::__call now returns a new wrapper around the chained Guzzle promise instead of overwriting $this->guzzlePromise.

LazyPromise::then / ::otherwise now return a new LazyPromise whose builder chains off $this->buildPromise(). buildPromise() is now idempotent (returning the already-built promise on subsequent calls) which makes the new design safe regardless of which promise in the chain is waited on first.

Fixes #60196.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
