### PR TITLE
[13.x] Add JSON Schema composition helpers to Laravel’s `JsonSchema` builder.

### DIFF
--- a/src/Illuminate/Contracts/JsonSchema/JsonSchema.php
+++ b/src/Illuminate/Contracts/JsonSchema/JsonSchema.php
@@ -15,6 +15,37 @@ interface JsonSchema
     public function object(Closure|array $properties = []);
 
     /**
+     * Create a new oneOf composite schema instance.
+     *
+     * @param  (Closure(JsonSchema): array<int, \Illuminate\JsonSchema\Types\Type>)|array<int, \Illuminate\JsonSchema\Types\Type>  $schemas
+     * @return \Illuminate\JsonSchema\Types\CompositeType
+     */
+    public function oneOf(Closure|array $schemas);
+
+    /**
+     * Create a new anyOf composite schema instance.
+     *
+     * @param  (Closure(JsonSchema): array<int, \Illuminate\JsonSchema\Types\Type>)|array<int, \Illuminate\JsonSchema\Types\Type>  $schemas
+     * @return \Illuminate\JsonSchema\Types\CompositeType
+     */
+    public function anyOf(Closure|array $schemas);
+
+    /**
+     * Create a new allOf composite schema instance.
+     *
+     * @param  (Closure(JsonSchema): array<int, \Illuminate\JsonSchema\Types\Type>)|array<int, \Illuminate\JsonSchema\Types\Type>  $schemas
+     * @return \Illuminate\JsonSchema\Types\CompositeType
+     */
+    public function allOf(Closure|array $schemas);
+
+    /**
+     * Create a new const schema instance.
+     *
+     * @return \Illuminate\JsonSchema\Types\ConstType
+     */
+    public function const(mixed $value);
+
+    /**
      * Create a new array property instance.
      *
      * @return \Illuminate\JsonSchema\Types\ArrayType

--- a/src/Illuminate/JsonSchema/JsonSchema.php
+++ b/src/Illuminate/JsonSchema/JsonSchema.php
@@ -7,6 +7,10 @@ use Illuminate\JsonSchema\Types\Type;
 
 /**
  * @method static Types\ObjectType object(Closure|array<string, Types\Type> $properties = [])
+ * @method static Types\CompositeType oneOf(Closure|array<int, Types\Type> $schemas)
+ * @method static Types\CompositeType anyOf(Closure|array<int, Types\Type> $schemas)
+ * @method static Types\CompositeType allOf(Closure|array<int, Types\Type> $schemas)
+ * @method static Types\ConstType const(mixed $value)
  * @method static Types\IntegerType integer()
  * @method static Types\NumberType number()
  * @method static Types\StringType string()

--- a/src/Illuminate/JsonSchema/JsonSchemaTypeFactory.php
+++ b/src/Illuminate/JsonSchema/JsonSchemaTypeFactory.php
@@ -22,6 +22,44 @@ class JsonSchemaTypeFactory extends JsonSchema implements JsonSchemaContract
     }
 
     /**
+     * Create a new oneOf composite schema instance.
+     *
+     * @param  (Closure(JsonSchemaTypeFactory): array<int, Types\Type>)|array<int, Types\Type>  $schemas
+     */
+    public function oneOf(Closure|array $schemas): Types\CompositeType
+    {
+        return new Types\CompositeType(Types\CompositeType::ONE_OF, $this->resolveSchemas($schemas));
+    }
+
+    /**
+     * Create a new anyOf composite schema instance.
+     *
+     * @param  (Closure(JsonSchemaTypeFactory): array<int, Types\Type>)|array<int, Types\Type>  $schemas
+     */
+    public function anyOf(Closure|array $schemas): Types\CompositeType
+    {
+        return new Types\CompositeType(Types\CompositeType::ANY_OF, $this->resolveSchemas($schemas));
+    }
+
+    /**
+     * Create a new allOf composite schema instance.
+     *
+     * @param  (Closure(JsonSchemaTypeFactory): array<int, Types\Type>)|array<int, Types\Type>  $schemas
+     */
+    public function allOf(Closure|array $schemas): Types\CompositeType
+    {
+        return new Types\CompositeType(Types\CompositeType::ALL_OF, $this->resolveSchemas($schemas));
+    }
+
+    /**
+     * Create a new const schema instance.
+     */
+    public function const(mixed $value): Types\ConstType
+    {
+        return new Types\ConstType($value);
+    }
+
+    /**
      * Create a new array property instance.
      */
     public function array(): Types\ArrayType
@@ -59,5 +97,20 @@ class JsonSchemaTypeFactory extends JsonSchema implements JsonSchemaContract
     public function boolean(): Types\BooleanType
     {
         return new Types\BooleanType;
+    }
+
+    /**
+     * Resolve the given schemas.
+     *
+     * @param  (Closure(JsonSchemaTypeFactory): array<int, Types\Type>)|array<int, Types\Type>  $schemas
+     * @return array<int, Types\Type>
+     */
+    protected function resolveSchemas(Closure|array $schemas): array
+    {
+        if ($schemas instanceof Closure) {
+            $schemas = $schemas($this);
+        }
+
+        return array_values($schemas);
     }
 }

--- a/src/Illuminate/JsonSchema/Serializer.php
+++ b/src/Illuminate/JsonSchema/Serializer.php
@@ -11,7 +11,7 @@ class Serializer
      *
      * @var array<int, string>
      */
-    protected static array $ignore = ['required', 'nullable'];
+    protected static array $ignore = ['required', 'nullable', 'hasConst'];
 
     /**
      * Serialize the given property to an array.
@@ -25,21 +25,32 @@ class Serializer
         /** @var array<string, mixed> $attributes */
         $attributes = (fn () => get_object_vars($type))->call($type);
 
-        $attributes['type'] = match (get_class($type)) {
-            Types\ArrayType::class => 'array',
-            Types\BooleanType::class => 'boolean',
-            Types\IntegerType::class => 'integer',
-            Types\NumberType::class => 'number',
-            Types\ObjectType::class => 'object',
-            Types\StringType::class => 'string',
-            default => throw new RuntimeException('Unsupported ['.get_class($type).'] type.'),
-        };
+        if ($type instanceof Types\CompositeType) {
+            $attributes[$attributes['keyword']] = array_map(
+                static fn (Types\Type $schema) => static::serialize($schema),
+                $attributes['schemas'],
+            );
+
+            unset($attributes['keyword'], $attributes['schemas']);
+        } elseif (! $type instanceof Types\ConstType) {
+            $attributes['type'] = match (get_class($type)) {
+                Types\ArrayType::class => 'array',
+                Types\BooleanType::class => 'boolean',
+                Types\IntegerType::class => 'integer',
+                Types\NumberType::class => 'number',
+                Types\ObjectType::class => 'object',
+                Types\StringType::class => 'string',
+                default => throw new RuntimeException('Unsupported ['.get_class($type).'] type.'),
+            };
+        }
 
         $nullable = static::isNullable($type);
 
-        if ($nullable) {
+        if ($nullable && isset($attributes['type'])) {
             $attributes['type'] = [$attributes['type'], 'null'];
         }
+
+        $hasConst = $attributes['hasConst'];
 
         $attributes = array_filter($attributes, static function (mixed $value, string $key) {
             if (in_array($key, static::$ignore, true)) {
@@ -48,6 +59,10 @@ class Serializer
 
             return $value !== null;
         }, ARRAY_FILTER_USE_BOTH);
+
+        if ($hasConst) {
+            $attributes['const'] = (fn () => get_object_vars($type))->call($type)['const'];
+        }
 
         if ($type instanceof Types\ObjectType) {
             if (count($attributes['properties']) === 0) {

--- a/src/Illuminate/JsonSchema/Types/CompositeType.php
+++ b/src/Illuminate/JsonSchema/Types/CompositeType.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Illuminate\JsonSchema\Types;
+
+use InvalidArgumentException;
+
+class CompositeType extends Type
+{
+    public const ALL_OF = 'allOf';
+
+    public const ANY_OF = 'anyOf';
+
+    public const ONE_OF = 'oneOf';
+
+    /**
+     * Create a new composite type instance.
+     *
+     * @param  'allOf'|'anyOf'|'oneOf'  $keyword
+     * @param  array<int, Type>  $schemas
+     */
+    public function __construct(protected string $keyword, protected array $schemas)
+    {
+        if (! in_array($keyword, [self::ALL_OF, self::ANY_OF, self::ONE_OF], true)) {
+            throw new InvalidArgumentException("Unsupported [{$keyword}] composite keyword.");
+        }
+
+        $this->schemas = array_values($schemas);
+    }
+
+    /**
+     * Get the composite keyword.
+     */
+    public function keyword(): string
+    {
+        return $this->keyword;
+    }
+
+    /**
+     * Get the composite schemas.
+     *
+     * @return array<int, Type>
+     */
+    public function schemas(): array
+    {
+        return $this->schemas;
+    }
+}

--- a/src/Illuminate/JsonSchema/Types/ConstType.php
+++ b/src/Illuminate/JsonSchema/Types/ConstType.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Illuminate\JsonSchema\Types;
+
+class ConstType extends Type
+{
+    /**
+     * Create a new const type instance.
+     */
+    public function __construct(mixed $value)
+    {
+        $this->const($value);
+    }
+}

--- a/src/Illuminate/JsonSchema/Types/Type.php
+++ b/src/Illuminate/JsonSchema/Types/Type.php
@@ -37,6 +37,16 @@ abstract class Type extends JsonSchema
     protected ?array $enum = null;
 
     /**
+     * The constant value for the type.
+     */
+    protected mixed $const = null;
+
+    /**
+     * Indicates if the constant value has been set.
+     */
+    protected bool $hasConst = false;
+
+    /**
      * Indicates if the type is nullable.
      */
     protected ?bool $nullable = null;
@@ -104,6 +114,17 @@ abstract class Type extends JsonSchema
 
         // Keep order and allow complex values (arrays / objects) without forcing uniqueness...
         $this->enum = array_values($values);
+
+        return $this;
+    }
+
+    /**
+     * Restrict the value to the provided constant value.
+     */
+    public function const(mixed $value): static
+    {
+        $this->const = $value;
+        $this->hasConst = true;
 
         return $this;
     }

--- a/tests/JsonSchema/CompositeTypeTest.php
+++ b/tests/JsonSchema/CompositeTypeTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Illuminate\Tests\JsonSchema;
+
+use Illuminate\JsonSchema\JsonSchema;
+use PHPUnit\Framework\TestCase;
+
+class CompositeTypeTest extends TestCase
+{
+    public function testOneOf()
+    {
+        $type = JsonSchema::oneOf([
+            JsonSchema::string(),
+            JsonSchema::integer(),
+        ])->title('Identifier');
+
+        $this->assertEquals([
+            'title' => 'Identifier',
+            'oneOf' => [
+                ['type' => 'string'],
+                ['type' => 'integer'],
+            ],
+        ], $type->toArray());
+    }
+
+    public function testOneOfAcceptsAClosure()
+    {
+        $type = JsonSchema::oneOf(fn ($schema) => [
+            $schema->string(),
+            $schema->integer(),
+        ]);
+
+        $this->assertEquals([
+            'oneOf' => [
+                ['type' => 'string'],
+                ['type' => 'integer'],
+            ],
+        ], $type->toArray());
+    }
+
+    public function testAnyOf()
+    {
+        $type = JsonSchema::anyOf([
+            JsonSchema::string()->min(3),
+            JsonSchema::integer()->min(100),
+        ]);
+
+        $this->assertEquals([
+            'anyOf' => [
+                [
+                    'minLength' => 3,
+                    'type' => 'string',
+                ],
+                [
+                    'minimum' => 100,
+                    'type' => 'integer',
+                ],
+            ],
+        ], $type->toArray());
+    }
+
+    public function testAllOf()
+    {
+        $type = JsonSchema::allOf([
+            JsonSchema::string()->min(3),
+            JsonSchema::string()->max(10),
+        ]);
+
+        $this->assertEquals([
+            'allOf' => [
+                [
+                    'minLength' => 3,
+                    'type' => 'string',
+                ],
+                [
+                    'maxLength' => 10,
+                    'type' => 'string',
+                ],
+            ],
+        ], $type->toArray());
+    }
+
+    public function testConst()
+    {
+        $type = JsonSchema::const('active');
+
+        $this->assertEquals([
+            'const' => 'active',
+        ], $type->toArray());
+    }
+
+    public function testConstOnTypedSchemas()
+    {
+        $type = JsonSchema::string()->const('active');
+
+        $this->assertEquals([
+            'const' => 'active',
+            'type' => 'string',
+        ], $type->toArray());
+    }
+
+    public function testNullConst()
+    {
+        $type = JsonSchema::const(null);
+
+        $this->assertEquals([
+            'const' => null,
+        ], $type->toArray());
+    }
+}

--- a/tests/JsonSchema/TypeTest.php
+++ b/tests/JsonSchema/TypeTest.php
@@ -290,6 +290,17 @@ class TypeTest extends TestCase
             [JsonSchema::array()->enum([[]]), []],
             [JsonSchema::array()->nullable(), null],
             [JsonSchema::array()->nullable(false), []],
+
+            // Composite types
+            [JsonSchema::oneOf([JsonSchema::string(), JsonSchema::integer()]), 'hello'],
+            [JsonSchema::oneOf([JsonSchema::string(), JsonSchema::integer()]), 10],
+            [JsonSchema::anyOf([JsonSchema::string()->min(3), JsonSchema::integer()->min(100)]), 'hello'],
+            [JsonSchema::anyOf([JsonSchema::string()->min(3), JsonSchema::integer()->min(100)]), 100],
+            [JsonSchema::allOf([JsonSchema::string()->min(3), JsonSchema::string()->max(5)]), 'hello'],
+            [JsonSchema::const('active'), 'active'],
+            [JsonSchema::const(null), null],
+            [JsonSchema::string()->const('active'), 'active'],
+            [JsonSchema::string()->nullable()->const(null), null],
         ];
     }
 
@@ -384,6 +395,15 @@ class TypeTest extends TestCase
             [JsonSchema::array()->enum([['a'], ['b']]), ['a', 'b']], // not equal to any enum member
             [JsonSchema::array()->items(JsonSchema::string()->max(1)), ['ab']], // item too long
             [JsonSchema::array()->nullable(false), null], // not nullable
+
+            // Composite types
+            [JsonSchema::oneOf([JsonSchema::string(), JsonSchema::integer()]), true],
+            [JsonSchema::anyOf([JsonSchema::string()->min(3), JsonSchema::integer()->min(100)]), 99],
+            [JsonSchema::allOf([JsonSchema::string()->min(3), JsonSchema::string()->max(5)]), 'too long'],
+            [JsonSchema::const('active'), 'inactive'],
+            [JsonSchema::const(null), 'active'],
+            [JsonSchema::string()->const('active'), 'inactive'],
+            [JsonSchema::string()->nullable()->const(null), 'active'],
         ];
     }
 


### PR DESCRIPTION
The existing builder already supports primitive and object/array schema definitions. This expands it with standard JSON Schema keywords for describing polymorphic or exact-value payloads:


- Add `JsonSchema::oneOf(...)`
- Add `JsonSchema::anyOf(...)`
- Add `JsonSchema::allOf(...)`
- Add `JsonSchema::const($value)`
- Add fluent `->const($value)` support on existing schema types
- Add serialization support for composite and const schemas
- Add contract definitions for the new helpers
- Add tests for array serialization and real JSON Schema validation behavior


These helpers make it easier to describe common real-world API payloads such as webhooks, discriminated objects, structured JSON responses, and dynamic configuration shapes.

## Example

```php
$schema = JsonSchema::oneOf([
    JsonSchema::object([
        'type' => JsonSchema::const('card')->required(),
        'last4' => JsonSchema::string()->min(4)->max(4)->required(),
    ]),

    JsonSchema::object([
        'type' => JsonSchema::const('bank_account')->required(),
        'iban' => JsonSchema::string()->required(),
    ]),
]);
```
