### PR TITLE
[13.x] enhance assertDispatchedOnce to support callbacks and closures

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/EventFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/EventFake.php
@@ -150,12 +150,25 @@ class EventFake implements Dispatcher, Fake
     /**
      * Assert if an event was dispatched exactly once.
      *
-     * @param  string  $event
+     * @param  string|\Closure  $event
+     * @param  callable|null  $callback
      * @return void
      */
-    public function assertDispatchedOnce($event)
+    public function assertDispatchedOnce($event, $callback = null)
     {
-        $this->assertDispatchedTimes($event, 1);
+        if ($event instanceof Closure) {
+            [$event, $callback] = [$this->firstClosureParameterType($event), $event];
+        }
+
+        $count = $this->dispatched($event, $callback)->count();
+
+        PHPUnit::assertSame(
+            1, $count,
+            sprintf(
+                "The expected [{$event}] event was dispatched {$count} %s instead of 1 time.",
+                Str::plural('time', $count)
+            )
+        );
     }
 
     /**

--- a/tests/Support/SupportTestingEventFakeTest.php
+++ b/tests/Support/SupportTestingEventFakeTest.php
@@ -85,6 +85,41 @@ class SupportTestingEventFakeTest extends TestCase
         $this->fake->assertDispatchedTimes(EventStub::class, 2);
     }
 
+    public function testAssertDispatchedOnceWithCallback()
+    {
+        $this->fake->dispatch(new EventStub('first'));
+        $this->fake->dispatch(new EventStub('second'));
+
+        $this->fake->assertDispatchedOnce(EventStub::class, function (EventStub $event) {
+            return $event->name === 'first';
+        });
+    }
+
+    public function testAssertDispatchedOnceWithClosure()
+    {
+        $this->fake->dispatch(new EventStub('first'));
+        $this->fake->dispatch(new EventStub('second'));
+
+        $this->fake->assertDispatchedOnce(function (EventStub $event) {
+            return $event->name === 'first';
+        });
+    }
+
+    public function testAssertDispatchedOnceWithCallbackFailure()
+    {
+        $this->fake->dispatch(new EventStub('first'));
+        $this->fake->dispatch(new EventStub('second'));
+
+        try {
+            $this->fake->assertDispatchedOnce(EventStub::class, function (EventStub $event) {
+                return in_array($event->name, ['first', 'second']);
+            });
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringContainsString('The expected [Illuminate\Tests\Support\EventStub] event was dispatched 2 times instead of 1 time.', $e->getMessage());
+        }
+    }
+
     public function testAssertDispatchedTimes()
     {
         $this->fake->dispatch(EventStub::class);
@@ -167,7 +202,10 @@ class SupportTestingEventFakeTest extends TestCase
 
 class EventStub
 {
-    //
+    public function __construct(public ?string $name = null)
+    {
+        //
+    }
 }
 
 class ListenerStub


### PR DESCRIPTION
adds callback support to `EventFake::assertDispatchedOnce()`.

`EventFake::assertDispatched()` already supports filtering dispatched events with a callback, but `assertDispatchedOnce()` only checked the total dispatch count for the event class. This makes the “exactly once” assertion consistent with callback-based event assertions.

## Example

```php
Event::assertDispatchedOnce(OrderCreated::class, function (OrderCreated $event) {
    return $event->orderId === 123;
});
``` 
It also supports the typed closure style:

```php
Event::assertDispatchedOnce(function (OrderCreated $event) {
    return $event->orderId === 123;
});
```
## Changes

- Allow EventFake::assertDispatchedOnce() to accept a callback.
- Support typed closure inference, matching assertDispatched().
- Add tests for class + callback, typed closure, and callback failure behavior.