### PR TITLE
[13.x] Add prohibited to KeyGenerateCommand

### DIFF
--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -36,7 +36,7 @@ class KeyGenerateCommand extends Command
      */
     public function handle()
     {
-        if($this->isProhibited()){
+        if ($this->isProhibited()) {
             return;
         }
 

--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -4,13 +4,14 @@ namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Command;
 use Illuminate\Console\ConfirmableTrait;
+use Illuminate\Console\Prohibitable;
 use Illuminate\Encryption\Encrypter;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'key:generate')]
 class KeyGenerateCommand extends Command
 {
-    use ConfirmableTrait;
+    use ConfirmableTrait, Prohibitable;
 
     /**
      * The name and signature of the console command.
@@ -35,6 +36,10 @@ class KeyGenerateCommand extends Command
      */
     public function handle()
     {
+        if($his->isProhibited()){
+            return;
+        }
+
         $key = $this->generateRandomKey();
 
         if ($this->option('show')) {

--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -36,7 +36,7 @@ class KeyGenerateCommand extends Command
      */
     public function handle()
     {
-        if($his->isProhibited()){
+        if($this->isProhibited()){
             return;
         }
 


### PR DESCRIPTION
Trying to tighten my hosted envs from any accidents so going through any problematic commands

This allows us to do :
```php
        KeyGenerateCommand::prohibit($isHostedEnv);
```
 
Very useful if you have encrypted data etc.. non b/c


Thanks Taylor 🤝 