### PR TITLE
[13.x] Add assertJsonPathsCanonicalizing to TestResponse

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -890,6 +890,20 @@ class TestResponse implements ArrayAccess
     }
 
     /**
+     * Assert that the given paths in the response contain all of the expected values without looking at the order.
+     *
+     * @return $this
+     */
+    public function assertJsonPathsCanonicalizing(array $paths)
+    {
+        foreach ($paths as $path => $expected) {
+            $this->assertJsonPathCanonicalizing($path, $expected);
+        }
+
+        return $this;
+    }
+
+    /**
      * Assert that the given path in the response contains all of the expected values without looking at the order.
      *
      * @param  string  $path

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -1593,6 +1593,34 @@ EOT
         $response->assertJsonPathCanonicalizing('*.foo', ['foo 0', 'foo 2', 'foo 3']);
     }
 
+    public function testAssertJsonPathsCanonicalizing(): void
+    {
+        $response = TestResponse::fromBaseResponse(new Response([
+            'data' => [
+                ['id' => 10, 'name' => 'Taylor'],
+                ['id' => 20, 'name' => 'Mohamed'],
+                ['id' => 30, 'name' => 'Nuno'],
+            ],
+        ]));
+
+        $response->assertJsonPathsCanonicalizing([
+            'data.*.id' => [30, 10, 20],
+            'data.*.name' => ['Nuno', 'Taylor', 'Mohamed'],
+        ]);
+    }
+
+    public function testAssertJsonPathsCanonicalizingCanFail(): void
+    {
+        $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceStub));
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Failed asserting that two arrays are equal.');
+
+        $response->assertJsonPathsCanonicalizing([
+            '*.foo' => ['foo 0', 'foo 2', 'foo 3'],
+        ]);
+    }
+
     public function testAssertJsonPaths(): void
     {
         $response = TestResponse::fromBaseResponse(new Response([


### PR DESCRIPTION
Adds `TestResponse::assertJsonPathsCanonicalizing()` as the batch equivalent of `assertJsonPathCanonicalizing()`.

It allows multiple JSON paths to be asserted while ignoring value order, matching the existing `assertJsonPaths()` convenience API.