### PR TITLE
[13.x] Allow scheduler to opt out of pause and interrupt cache checks

### DIFF
--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -53,7 +53,7 @@ class Schedule
     public static $pausable = true;
 
     /**
-     * Indicates if the schedule should check for the restart signal in the cache.
+     * Indicates if the schedule should check for the interrupt signal in the cache.
      *
      * @var bool
      */

--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -116,6 +116,19 @@ class Schedule
     protected array $groupStack = [];
 
     /**
+     * Indicate that the scheduler should not poll for pause or interrupt signals.
+     *
+     * This prevents the scheduler from hitting the application cache to determine if it needs to pause or interrupt.
+     *
+     * @return void
+     */
+    public static function withoutInterruptionPolling()
+    {
+        static::$pausable = false;
+        static::$interruptible = false;
+    }
+
+    /**
      * Create a new schedule instance.
      *
      * @param  \DateTimeZone|string|null  $timezone

--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -46,6 +46,20 @@ class Schedule
     const SATURDAY = 6;
 
     /**
+     * Indicates if the schedule should check for the paused signal in the cache.
+     *
+     * @var bool
+     */
+    public static $pausable = true;
+
+    /**
+     * Indicates if the schedule should check for the restart signal in the cache.
+     *
+     * @var bool
+     */
+    public static $interruptible = true;
+
+    /**
      * All of the events on the schedule.
      *
      * @var \Illuminate\Console\Scheduling\Event[]

--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -46,20 +46,6 @@ class Schedule
     const SATURDAY = 6;
 
     /**
-     * Indicates if the schedule should check for the paused signal in the cache.
-     *
-     * @var bool
-     */
-    public static $pausable = true;
-
-    /**
-     * Indicates if the schedule should check for the interrupt signal in the cache.
-     *
-     * @var bool
-     */
-    public static $interruptible = true;
-
-    /**
      * All of the events on the schedule.
      *
      * @var \Illuminate\Console\Scheduling\Event[]
@@ -116,17 +102,18 @@ class Schedule
     protected array $groupStack = [];
 
     /**
-     * Indicate that the scheduler should not poll for pause or interrupt signals.
+     * Indicates if the schedule should check for the paused signal in the cache.
      *
-     * This prevents the scheduler from hitting the application cache to determine if it needs to pause or interrupt.
-     *
-     * @return void
+     * @var bool
      */
-    public static function withoutInterruptionPolling()
-    {
-        static::$pausable = false;
-        static::$interruptible = false;
-    }
+    public static $pausable = true;
+
+    /**
+     * Indicates if the schedule should check for the interrupt signal in the cache.
+     *
+     * @var bool
+     */
+    public static $interruptible = true;
 
     /**
      * Create a new schedule instance.
@@ -512,6 +499,19 @@ class Schedule
         }
 
         return $this->dispatcher;
+    }
+
+    /**
+     * Indicate that the scheduler should not poll for pause or interrupt signals.
+     *
+     * This prevents the scheduler from hitting the application cache to determine if it needs to pause or interrupt.
+     *
+     * @return void
+     */
+    public static function withoutInterruptionPolling()
+    {
+        static::$pausable = false;
+        static::$interruptible = false;
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
@@ -296,6 +296,10 @@ class ScheduleRunCommand extends Command
      */
     protected function isPaused()
     {
+        if (! Schedule::$pausable) {
+            return false;
+        }
+
         return $this->cache->get('illuminate:schedule:paused', false);
     }
 
@@ -306,6 +310,10 @@ class ScheduleRunCommand extends Command
      */
     protected function shouldInterrupt()
     {
+        if (! Schedule::$interruptible) {
+            return false;
+        }
+
         return $this->cache->get('illuminate:schedule:interrupt', false);
     }
 


### PR DESCRIPTION
The Worker class allows you to opt out of the cache checks, this would also nice for the scheduler.   

This works for `schedule;work`, and `schedule:run` commands (work basically calls run)

This is particularly useful for`everyXSeconds` calls,  where you get a considerable amount of cache hits.. and even more useful the more servers you have.

This PR gives you the ability to turn them off independently, or as a whole: 

```php
// Independently
Schedule::$pausable  = false;
Schedule::$interruptible = false;


// Completely.
Schedule::withoutInterruptionPolling();
```

I went with the Schedule class cause it makes the most sense discoverability wise in my head.

I've tried to align it with the Worker, but feel free to jazz it up.

This is still useful in general even if you're not using the `Second` events to avoid the cache hit if you're not using the features.  

I haven't added tests cause I cant figure out a nice way / feels hard to test for the sake of two static flags

Thanks!