### PR TITLE
[13.x] Add `normalize` parameter to `Str::studly()` and `Str::pascal()`

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1709,10 +1709,19 @@ class Str
      * Convert a value to studly caps case.
      *
      * @param  string  $value
+     * @param  bool  $normalize  When true, all-uppercase words (e.g. acronyms) are lowercased before conversion so "CBOR" becomes "Cbor" instead of "CBOR".
      * @return ($value is '' ? '' : string)
      */
-    public static function studly($value)
+    public static function studly($value, bool $normalize = false)
     {
+        if ($normalize) {
+            $value = preg_replace_callback(
+                '/(^|[-_ \s])([A-Z]+)(?=[-_ \s]|$)/u',
+                fn ($m) => $m[1].static::lower($m[2]),
+                $value
+            );
+        }
+
         $key = $value;
 
         if (isset(static::$studlyCache[$key])) {
@@ -1730,11 +1739,12 @@ class Str
      * Convert a value to Pascal case.
      *
      * @param  string  $value
+     * @param  bool  $normalize  When true, all-uppercase words (e.g. acronyms) are lowercased before conversion so "CBOR" becomes "Cbor" instead of "CBOR".
      * @return ($value is '' ? '' : string)
      */
-    public static function pascal($value)
+    public static function pascal($value, bool $normalize = false)
     {
-        return static::studly($value);
+        return static::studly($value, $normalize);
     }
 
     /**

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -983,21 +983,23 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     /**
      * Convert a value to studly caps case.
      *
+     * @param  bool  $normalize
      * @return static
      */
-    public function studly()
+    public function studly(bool $normalize = false)
     {
-        return new static(Str::studly($this->value));
+        return new static(Str::studly($this->value, $normalize));
     }
 
     /**
      * Convert the string to Pascal case.
      *
+     * @param  bool  $normalize
      * @return static
      */
-    public function pascal()
+    public function pascal(bool $normalize = false)
     {
-        return new static(Str::pascal($this->value));
+        return new static(Str::pascal($this->value, $normalize));
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1172,6 +1172,14 @@ class SupportStrTest extends TestCase
         $this->assertSame('❤MultiByte☆', Str::studly('❤ multi-byte☆'));
 
         $this->assertSame('LaravelRocks!', Str::studly('laravel rocks!'));
+
+        // normalize: true — all-uppercase words (acronyms) are treated as single words
+        $this->assertSame('Cbor', Str::studly('CBOR', normalize: true));
+        $this->assertSame('Fmls', Str::studly('FMLS', normalize: true));
+        $this->assertSame('AllCaps', Str::studly('ALL_CAPS', normalize: true));
+        $this->assertSame('AllJersey', Str::studly('AllJersey', normalize: true));
+        $this->assertSame('AllJersey', Str::studly('all_jersey', normalize: true));
+        $this->assertSame('FooBar', Str::studly('foo_bar', normalize: true));
     }
 
     public function testPascal()


### PR DESCRIPTION
### Problem

`Str::studly()` works correctly for `snake_case` and `camelCase` inputs, but all-uppercase strings — common as MLS abbreviations, env var names, or acronyms — are left unchanged:

```php
Str::studly('cbor')    // → 'Cbor'   ✓
Str::studly('CBOR')    // → 'CBOR'   ✗ (left unchanged)
Str::studly('ALL_CAPS') // → 'ALLCAPS' ✗
```

The root cause is that `ucfirst` on an already-uppercase word does nothing.

### Solution

Add an optional `normalize: true` parameter that lowercases any all-uppercase word segment before conversion, so acronym-style strings produce the expected StudlyCase output:

```php
Str::studly('CBOR', normalize: true)     // → 'Cbor'
Str::studly('FMLS', normalize: true)     // → 'Fmls'
Str::studly('ALL_CAPS', normalize: true) // → 'AllCaps'
Str::studly('AllJersey', normalize: true) // → 'AllJersey' (unchanged — already mixed case)
Str::studly('all_jersey', normalize: true) // → 'AllJersey' (unchanged behaviour)
```

The same parameter is threaded through to `Str::pascal()` and the `Stringable` fluent wrappers.

### Notes

- The default is `false`, so **existing behaviour is fully preserved**.
- The cache is keyed on the post-normalize value, so cache correctness is unaffected.
- Mixed-case words (`AllJersey`, `WestPenn`) are untouched because only segments where every letter is uppercase are lowercased.