### PR TITLE
[13.x] Fix path separator encoding in temporaryUrl on local disk

### DIFF
--- a/src/Illuminate/Filesystem/LocalFilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/LocalFilesystemAdapter.php
@@ -82,7 +82,7 @@ class LocalFilesystemAdapter extends FilesystemAdapter
         return $url->to($url->temporarySignedRoute(
             'storage.'.$this->disk,
             $expiration,
-            ['path' => rawurlencode($path)],
+            ['path' => strtr(rawurlencode($path), ['%2F' => '/'])],
             absolute: false
         ));
     }

--- a/tests/Integration/Filesystem/ServeFileTest.php
+++ b/tests/Integration/Filesystem/ServeFileTest.php
@@ -16,12 +16,14 @@ class ServeFileTest extends TestCase
         $this->afterApplicationCreated(function () {
             Storage::put('serve-file-test.txt', 'Hello World');
             Storage::put('serve-file-test.txt?pad=x', 'Hello Question');
+            Storage::put('nested/folder/serve-file-test.txt', 'Hello Nested');
         });
 
         $this->beforeApplicationDestroyed(function () {
             Storage::delete([
                 'serve-file-test.txt',
                 'serve-file-test.txt?pad=x',
+                'nested/folder/serve-file-test.txt',
             ]);
         });
 
@@ -65,6 +67,18 @@ class ServeFileTest extends TestCase
         $response = $this->get($url);
 
         $this->assertSame('Hello Question', $response->streamedContent());
+    }
+
+    #[RequiresOperatingSystem('Linux|Darwin')]
+    public function testTemporaryUrlPreservesPathSeparatorsInNestedPaths()
+    {
+        $url = Storage::temporaryUrl('nested/folder/serve-file-test.txt', Carbon::now()->addMinute());
+
+        $this->assertStringContainsString('nested/folder/serve-file-test.txt', $url);
+
+        $response = $this->get($url);
+
+        $this->assertSame('Hello Nested', $response->streamedContent());
     }
 
     #[RequiresOperatingSystem('Linux|Darwin')]


### PR DESCRIPTION
Follows up on #60194, which fixed the encoding in `temporaryUploadUrl` but missed the identical pattern in `temporaryUrl` introduced by #60137.

## Background

#60137 added `rawurlencode($path)` to both `temporaryUrl` and `temporaryUploadUrl` so reserved URI characters (`?`, `&`, `#`) in storage keys couldn't escape the path segment of a signed URL.

`rawurlencode` also encodes `/` as `%2F`, so nested storage keys produced URLs that no longer matched the storage serve/upload routes. #60194 fixed this in `temporaryUploadUrl` with `strtr(rawurlencode($path), ['%2F' => '/'])`, but the sibling call site two methods up in `temporaryUrl` was left with the bare `rawurlencode($path)`.

## Reproduction

```php
$url = Storage::temporaryUrl('nested/folder/photo.jpg', now()->addMinute());
// http://localhost/storage/.../nested%2Ffolder%2Fphoto.jpg?expires=...&signature=...
```

A `GET` against that URL hits the storage serve route with an encoded key the route can't resolve, so users see a 404 / 403 instead of the file.

PHPUnit output before the fix:

```
Failed asserting that 'http://localhost/storage/nested%2Ffolder%2Fserve-file-test.txt?expires=...&signature=...'
contains "nested/folder/serve-file-test.txt".
```

## Fix

Mirror #60194 — apply the same `strtr` decode step in `temporaryUrl` so `?`, `&`, `#` stay escaped while `/` is preserved.

## After

```php
$url = Storage::temporaryUrl('nested/folder/photo.jpg', now()->addMinute());
// http://localhost/storage/.../nested/folder/photo.jpg?expires=...&signature=...
```

