### PR TITLE
Fix nested enum path generation for make:enum command

### DIFF
--- a/src/Illuminate/Foundation/Console/EnumMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/EnumMakeCommand.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\GeneratorCommand;
+use Illuminate\Support\Str;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -69,6 +70,18 @@ class EnumMakeCommand extends GeneratorCommand
      */
     protected function getDefaultNamespace($rootNamespace)
     {
+        if (is_dir(app_path('Enums')) && Str::startsWith($this->input->getArgument('name'), 'Enums/')) {
+            $this->argument['name'] = Str::after($this->input->getArgument('name'), 'Enums/');
+            
+            return $rootNamespace.'\\Enums';
+        }
+
+        if (is_dir(app_path('Enumerations')) && Str::startsWith($this->input->getArgument('name'), 'Enumerations/')) {
+            $this->argument['name'] = Str::after($this->input->getArgument('name'), 'Enumerations/');
+            
+            return $rootNamespace.'\\Enumerations';
+        }
+
         return match (true) {
             is_dir(app_path('Enums')) => $rootNamespace.'\\Enums',
             is_dir(app_path('Enumerations')) => $rootNamespace.'\\Enumerations',


### PR DESCRIPTION
When using `php artisan make:enum Enums/Profile/HairColor` and the Enums directory exists, the command would incorrectly generate the file at `app/Enums/Enums/Profile/HairColor.php` instead of `app/Enums/Profile/HairColor.php`.

This fix ensures that when the provided enum name starts with the directory name (Enums/ or Enumerations/) and that directory exists, we strip the prefix from the name before determining the namespace, preventing double nesting.

Fixes issue #60152