### PR TITLE
[13.x] Ensure Up/Down commands report exceptions

### DIFF
--- a/src/Illuminate/Foundation/Console/DownCommand.php
+++ b/src/Illuminate/Foundation/Console/DownCommand.php
@@ -67,6 +67,8 @@ class DownCommand extends Command
                 $this->components->info('You may bypass maintenance mode via ['.config('app.url')."/{$downFilePayload['secret']}].");
             }
         } catch (Exception $e) {
+            report($e);
+
             $this->components->error(sprintf(
                 'Failed to enter maintenance mode: %s.',
                 $e->getMessage(),

--- a/src/Illuminate/Foundation/Console/UpCommand.php
+++ b/src/Illuminate/Foundation/Console/UpCommand.php
@@ -48,6 +48,8 @@ class UpCommand extends Command
 
             $this->components->info('Application is now live.');
         } catch (Exception $e) {
+            report($e);
+
             $this->components->error(sprintf(
                 'Failed to disable maintenance mode: %s.',
                 $e->getMessage(),


### PR DESCRIPTION
Happy Friday y'all

I noticed this in our Laravel Cloud `Running deployment command` logs, 

One of the listeners we have the wrong class in the construct, so it was causing it to hit the catch() path. This means it logs out, but doesn't report the exception.  

It would be nice if this got reported properly as its just a log atm - extremely useful cause the box its running on just stdouts, rather than going to the loggin service

```
   ERROR  Failed to enter maintenance mode: Target class [App\Listeners\XXXXXX] does not exist..  
```