### PR TITLE
[14.x] Update `Notification::fake()` to respect job middleware

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -360,9 +360,9 @@ class NotificationFake implements Fake, NotificationDispatcher, NotificationFact
     /**
      * Pipe the notifiction job through its middleware to determine if it would have been delivered.
      *
-     * @param object $notifiable
-     * @param Notification $notification
-     * @param string $channel
+     * @param  object  $notifiable
+     * @param  Notification  $notification
+     * @param  string  $channel
      * @return bool
      */
     protected function passesJobMiddleware(object $notifiable, Notification $notification, string $channel): bool
@@ -392,9 +392,9 @@ class NotificationFake implements Fake, NotificationDispatcher, NotificationFact
     /**
      * Gather the notification job's middleware.
      *
-     * @param object $notifiable
-     * @param Notification $notification
-     * @param string $channel
+     * @param  object  $notifiable
+     * @param  Notification  $notification
+     * @param  string  $channel
      * @return array
      */
     protected function gatherMiddleware(object $notifiable, Notification $notification, string $channel): array

--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -379,7 +379,7 @@ class NotificationFake implements Fake, NotificationDispatcher, NotificationFact
 
         $delivered = false;
 
-        new Pipeline(app())
+        (new Pipeline(app()))
             ->send(new SendQueuedNotifications($notifiable, $notification, [$channel]))
             ->through($middleware)
             ->then(function () use (&$delivered): void {

--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -9,6 +9,9 @@ use Illuminate\Contracts\Notifications\Factory as NotificationFactory;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Contracts\Translation\HasLocalePreference;
 use Illuminate\Notifications\AnonymousNotifiable;
+use Illuminate\Notifications\Notification;
+use Illuminate\Notifications\SendQueuedNotifications;
+use Illuminate\Pipeline\Pipeline;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
@@ -330,6 +333,15 @@ class NotificationFake implements Fake, NotificationDispatcher, NotificationFact
                 continue;
             }
 
+            $delivered = array_values(array_filter(
+                $notifiableChannels,
+                fn (string $channel): bool => $this->passesJobMiddleware($notifiable, $notification, $channel),
+            ));
+
+            if ($delivered === []) {
+                continue;
+            }
+
             $this->notifications[get_class($notifiable)][(string) $notifiable->getKey()][get_class($notification)][] = [
                 'notification' => $this->serializeAndRestore && $notification instanceof ShouldQueue
                     ? $this->serializeAndRestoreNotification($notification)
@@ -343,6 +355,60 @@ class NotificationFake implements Fake, NotificationDispatcher, NotificationFact
                 }),
             ];
         }
+    }
+
+    /**
+     * Pipe the job through its middleware to determine if it would have been delivered.
+     *
+     * @param object $notifiable
+     * @param Notification $notification
+     * @param string $channel
+     * @return bool
+     */
+    protected function passesJobMiddleware(object $notifiable, Notification $notification, string $channel): bool
+    {
+        if (! $notification instanceof ShouldQueue) {
+            return true;
+        }
+
+        $middleware = $this->gatherMiddleware($notifiable, $notification, $channel);
+
+        if ($middleware === []) {
+            return true;
+        }
+
+        $delivered = false;
+
+        new Pipeline(app())
+            ->send(new SendQueuedNotifications($notifiable, $notification, [$channel]))
+            ->through($middleware)
+            ->then(function () use (&$delivered): void {
+                $delivered = true;
+            });
+
+        return $delivered;
+    }
+
+    /**
+     * Gather the job's middleware.
+     *
+     * @param object $notifiable
+     * @param Notification $notification
+     * @param string $channel
+     * @return array
+     */
+    protected function gatherMiddleware(object $notifiable, Notification $notification, string $channel): array
+    {
+        $middleware = $notification->middleware ?? [];
+
+        if (method_exists($notification, 'middleware')) {
+            $middleware = array_merge(
+                $notification->middleware($notifiable, $channel),
+                $middleware,
+            );
+        }
+
+        return $middleware;
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -346,7 +346,7 @@ class NotificationFake implements Fake, NotificationDispatcher, NotificationFact
                 'notification' => $this->serializeAndRestore && $notification instanceof ShouldQueue
                     ? $this->serializeAndRestoreNotification($notification)
                     : $notification,
-                'channels' => $notifiableChannels,
+                'channels' => $delivered,
                 'notifiable' => $notifiable,
                 'locale' => $notification->locale ?? $this->locale ?? value(function () use ($notifiable) {
                     if ($notifiable instanceof HasLocalePreference) {

--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -358,7 +358,7 @@ class NotificationFake implements Fake, NotificationDispatcher, NotificationFact
     }
 
     /**
-     * Pipe the job through its middleware to determine if it would have been delivered.
+     * Pipe the notifiction job through its middleware to determine if it would have been delivered.
      *
      * @param object $notifiable
      * @param Notification $notification
@@ -390,7 +390,7 @@ class NotificationFake implements Fake, NotificationDispatcher, NotificationFact
     }
 
     /**
-     * Gather the job's middleware.
+     * Gather the notification job's middleware.
      *
      * @param object $notifiable
      * @param Notification $notification

--- a/tests/Support/SupportTestingNotificationFakeTest.php
+++ b/tests/Support/SupportTestingNotificationFakeTest.php
@@ -224,6 +224,20 @@ class SupportTestingNotificationFakeTest extends TestCase
         $this->fake->assertNotSentTo($user, NotificationWithFalsyShouldSendStub::class);
     }
 
+    public function testAssertSentToWhenNotificationPassesJobMiddleware()
+    {
+        $this->fake->send($this->user, new NotificationWithMiddlewareStub(deliver: true));
+
+        $this->fake->assertSentTo($this->user, NotificationWithMiddlewareStub::class);
+    }
+
+    public function testAssertNotSentToWhenNotificationFailsJobMiddleware()
+    {
+        $this->fake->send($this->user, new NotificationWithMiddlewareStub(deliver: false));
+
+        $this->fake->assertNotSentTo($this->user, NotificationWithMiddlewareStub::class);
+    }
+
     public function testAssertItCanSerializeAndRestoreNotifications()
     {
         $this->fake->serializeAndRestore();
@@ -266,6 +280,34 @@ class LocalizedUserStub extends User implements HasLocalePreference
     public function preferredLocale()
     {
         return 'au';
+    }
+}
+
+class NotificationWithMiddlewareStub extends NotificationStub implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(protected bool $deliver = true)
+    {
+    }
+
+    public function middleware($notifiable, $channel)
+    {
+        return [new NotificationDeliveryMiddlewareStub($this->deliver)];
+    }
+}
+
+class NotificationDeliveryMiddlewareStub
+{
+    public function __construct(protected bool $deliver)
+    {
+    }
+
+    public function handle($job, $next)
+    {
+        if ($this->deliver) {
+            $next($job);
+        }
     }
 }
 

--- a/tests/Support/SupportTestingNotificationFakeTest.php
+++ b/tests/Support/SupportTestingNotificationFakeTest.php
@@ -238,6 +238,15 @@ class SupportTestingNotificationFakeTest extends TestCase
         $this->fake->assertNotSentTo($this->user, NotificationWithMiddlewareStub::class);
     }
 
+    public function testAssertSentToRecordsOnlyChannelsThatPassJobMiddleware()
+    {
+        $this->fake->send($this->user, new NotificationWithPerChannelMiddlewareStub);
+
+        $this->fake->assertSentTo($this->user, NotificationWithPerChannelMiddlewareStub::class, function ($notification, $channels) {
+            return $channels === ['database'];
+        });
+    }
+
     public function testAssertItCanSerializeAndRestoreNotifications()
     {
         $this->fake->serializeAndRestore();
@@ -294,6 +303,21 @@ class NotificationWithMiddlewareStub extends NotificationStub implements ShouldQ
     public function middleware($notifiable, $channel)
     {
         return [new NotificationDeliveryMiddlewareStub($this->deliver)];
+    }
+}
+
+class NotificationWithPerChannelMiddlewareStub extends NotificationStub implements ShouldQueue
+{
+    use Queueable;
+
+    public function via($notifiable)
+    {
+        return ['mail', 'database'];
+    }
+
+    public function middleware($notifiable, $channel)
+    {
+        return [new NotificationDeliveryMiddlewareStub($channel === 'database')];
     }
 }
 


### PR DESCRIPTION
I was writing some notifications tests today, and I got tripped up by `Notification::fake()`, as it doesn't respect any middleware on the notification job. 

I've adjusted `NotificationFake` so it now pipes the job through its middleware to determine if it would have been sent to the applicable channels.

Did this 14.x because technically it's a breaking change, but I think the current behaviour of having notification middleware ignored can be confusing.