### PR TITLE
[13.x] remove last `compact()` call

### DIFF
--- a/tests/Auth/AuthPasswordBrokerTest.php
+++ b/tests/Auth/AuthPasswordBrokerTest.php
@@ -95,7 +95,7 @@ class AuthPasswordBrokerTest extends TestCase
         $broker->shouldReceive('validateReset')->once()->andReturn($user = m::mock(CanResetPassword::class));
         $mocks['tokens']->shouldReceive('delete')->once()->with($user);
         $callback = function ($user, $password) {
-            $_SERVER['__password.reset.test'] = compact('user', 'password');
+            $_SERVER['__password.reset.test'] = ['user' => $user, 'password' => $password];
 
             return 'foo';
         };


### PR DESCRIPTION
this is a follow up to #60234, and removes the final use of `compact()` in the framework

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
