### PR TITLE
[13.x] Rector : Always convert `compact()` to variables

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Rector\CodeQuality\Rector\FuncCall\CompactToVariablesRector;
 use Rector\CodeQuality\Rector\FuncCall\SortCallLikeNamedArgsRector;
 use Rector\CodeQuality\Rector\Identical\StrlenZeroToIdenticalEmptyStringRector;
 use Rector\CodingStyle\Rector\ArrowFunction\ArrowFunctionDelegatingCallToFirstClassCallableRector;
@@ -123,6 +124,7 @@ return RectorConfig::configure()
     ])
     ->withRules([
         ...$testsuiteRules,
+        CompactToVariablesRector::class,
         CountArrayToEmptyArrayComparisonRector::class,
         SortCallLikeNamedArgsRector::class,
         StrlenZeroToIdenticalEmptyStringRector::class,


### PR DESCRIPTION
Rector : Always convert `compact()` to variables

---

Follow up for https://github.com/laravel/framework/pull/60235 and https://github.com/laravel/framework/pull/60234