### PR TITLE
[13.x] battle harden when scheme is present in the config

### DIFF
--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -267,7 +267,13 @@ class PhpRedisConnector implements Connector
      */
     protected function formatHost(array $options)
     {
+        $hostScheme = parse_url($options['host'], PHP_URL_SCHEME);
+
         if (isset($options['scheme'])) {
+            if (is_string($hostScheme) && $hostScheme !== $options['scheme']) {
+                throw new InvalidArgumentException('The scheme configured in the Redis host option must match the scheme option.');
+            }
+
             return Str::start($options['host'], "{$options['scheme']}://");
         }
 

--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -267,17 +267,27 @@ class PhpRedisConnector implements Connector
      */
     protected function formatHost(array $options)
     {
-        $hostScheme = parse_url($options['host'], PHP_URL_SCHEME);
+        $host = $options['host'] ?? null;
 
-        if (isset($options['scheme'])) {
-            if (is_string($hostScheme) && $hostScheme !== $options['scheme']) {
-                throw new InvalidArgumentException('The scheme configured in the Redis host option must match the scheme option.');
-            }
-
-            return Str::start($options['host'], "{$options['scheme']}://");
+        if (! is_string($host) || $host === '') {
+            throw new InvalidArgumentException('Redis host must be a non-empty string.');
         }
 
-        return $options['host'];
+        $hostScheme = parse_url($host, PHP_URL_SCHEME);
+
+        if (isset($options['scheme'])) {
+            if (is_string($hostScheme)) {
+                if (strcasecmp($hostScheme, $options['scheme']) !== 0) {
+                    throw new InvalidArgumentException('The scheme configured in the Redis host option must match the scheme option.');
+                }
+
+                return $host;
+            }
+
+            return Str::start($host, "{$options['scheme']}://");
+        }
+
+        return $host;
     }
 
     /**

--- a/src/Illuminate/Redis/Connectors/PredisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PredisConnector.php
@@ -7,6 +7,7 @@ use Illuminate\Redis\Connections\PredisClusterConnection;
 use Illuminate\Redis\Connections\PredisConnection;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use InvalidArgumentException;
 use Predis\Client;
 
 class PredisConnector implements Connector
@@ -28,10 +29,7 @@ class PredisConnector implements Connector
             $formattedOptions['prefix'] = $config['prefix'];
         }
 
-        if (isset($config['host']) && str_starts_with($config['host'], 'tls://')) {
-            $config['scheme'] = 'tls';
-            $config['host'] = Str::after($config['host'], 'tls://');
-        }
+        $config = $this->formatHost($config);
 
         return new PredisConnection(new Client($config, $formattedOptions));
     }
@@ -52,8 +50,42 @@ class PredisConnector implements Connector
             $clusterSpecificOptions['prefix'] = $config['prefix'];
         }
 
-        return new PredisClusterConnection(new Client(array_values($config), array_merge(
+        $servers = array_map(function ($server) {
+            return is_array($server) ? $this->formatHost($server) : $server;
+        }, array_values($config));
+
+        return new PredisClusterConnection(new Client($servers, array_merge(
             $options, $clusterOptions, $clusterSpecificOptions
         )));
+    }
+
+    /**
+     * Format the host using the scheme if available.
+     *
+     * @param  array  $config
+     * @return array
+     */
+    protected function formatHost(array $config)
+    {
+        $host = $config['host'] ?? null;
+
+        if (! is_string($host) || $host === '') {
+            return $config;
+        }
+
+        $hostScheme = parse_url($host, PHP_URL_SCHEME);
+
+        if (! is_string($hostScheme)) {
+            return $config;
+        }
+
+        if (isset($config['scheme']) && strcasecmp($hostScheme, $config['scheme']) !== 0) {
+            throw new InvalidArgumentException('The scheme configured in the Redis host option must match the scheme option.');
+        }
+
+        $config['scheme'] = $config['scheme'] ?? $hostScheme;
+        $config['host'] = Str::after($host, "{$hostScheme}://");
+
+        return $config;
     }
 }

--- a/tests/Redis/PhpRedisConnectorTest.php
+++ b/tests/Redis/PhpRedisConnectorTest.php
@@ -226,6 +226,39 @@ class PhpRedisConnectorTest extends TestCase
 
         $connector->testParseBackoffAlgorithm('bogus');
     }
+
+    public function testFormatHostPrefixesConfiguredSchemeWhenHostHasNoScheme()
+    {
+        $connector = new TestablePhpRedisConnector;
+
+        $this->assertSame('tls://127.0.0.1', $connector->testFormatHost([
+            'host' => '127.0.0.1',
+            'scheme' => 'tls',
+        ]));
+    }
+
+    public function testFormatHostDoesNotDuplicateMatchingScheme()
+    {
+        $connector = new TestablePhpRedisConnector;
+
+        $this->assertSame('tls://127.0.0.1', $connector->testFormatHost([
+            'host' => 'tls://127.0.0.1',
+            'scheme' => 'tls',
+        ]));
+    }
+
+    public function testFormatHostThrowsOnConflictingScheme()
+    {
+        $connector = new TestablePhpRedisConnector;
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The scheme configured in the Redis host option must match the scheme option.');
+
+        $connector->testFormatHost([
+            'host' => 'tcp://127.0.0.1',
+            'scheme' => 'tls',
+        ]);
+    }
 }
 
 class TestablePhpRedisConnector extends PhpRedisConnector
@@ -248,5 +281,10 @@ class TestablePhpRedisConnector extends PhpRedisConnector
     public function testParseBackoffAlgorithm(mixed $algorithm): int
     {
         return $this->parseBackoffAlgorithm($algorithm);
+    }
+
+    public function testFormatHost(array $options): string
+    {
+        return $this->formatHost($options);
     }
 }

--- a/tests/Redis/PhpRedisConnectorTest.php
+++ b/tests/Redis/PhpRedisConnectorTest.php
@@ -259,6 +259,41 @@ class PhpRedisConnectorTest extends TestCase
             'scheme' => 'tls',
         ]);
     }
+
+    public function testFormatHostAllowsCaseInsensitiveMatchingScheme()
+    {
+        $connector = new TestablePhpRedisConnector;
+
+        $this->assertSame('TLS://127.0.0.1', $connector->testFormatHost([
+            'host' => 'TLS://127.0.0.1',
+            'scheme' => 'tls',
+        ]));
+    }
+
+    public function testFormatHostThrowsWhenHostIsMissing()
+    {
+        $connector = new TestablePhpRedisConnector;
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Redis host must be a non-empty string.');
+
+        $connector->testFormatHost([
+            'scheme' => 'tls',
+        ]);
+    }
+
+    public function testFormatHostThrowsWhenHostIsNull()
+    {
+        $connector = new TestablePhpRedisConnector;
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Redis host must be a non-empty string.');
+
+        $connector->testFormatHost([
+            'host' => null,
+            'scheme' => 'tls',
+        ]);
+    }
 }
 
 class TestablePhpRedisConnector extends PhpRedisConnector

--- a/tests/Redis/PredisConnectorTest.php
+++ b/tests/Redis/PredisConnectorTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Illuminate\Tests\Redis;
+
+use Illuminate\Redis\Connectors\PredisConnector;
+use PHPUnit\Framework\TestCase;
+
+class PredisConnectorTest extends TestCase
+{
+    public function testFormatHostLeavesConfigUnchangedWhenHostIsMissing()
+    {
+        $connector = new TestablePredisConnector;
+
+        $config = ['scheme' => 'tls'];
+
+        $this->assertSame($config, $connector->testFormatHost($config));
+    }
+
+    public function testFormatHostLeavesConfigUnchangedWhenHostHasNoScheme()
+    {
+        $connector = new TestablePredisConnector;
+
+        $config = ['host' => '127.0.0.1', 'scheme' => 'tls'];
+
+        $this->assertSame($config, $connector->testFormatHost($config));
+    }
+
+    public function testFormatHostUsesHostSchemeWhenSchemeNotConfigured()
+    {
+        $connector = new TestablePredisConnector;
+
+        $this->assertSame([
+            'host' => '127.0.0.1',
+            'scheme' => 'tls',
+        ], $connector->testFormatHost([
+            'host' => 'tls://127.0.0.1',
+        ]));
+    }
+
+    public function testFormatHostKeepsExplicitSchemeWhenMatchingHostScheme()
+    {
+        $connector = new TestablePredisConnector;
+
+        $this->assertSame([
+            'host' => '127.0.0.1',
+            'scheme' => 'tls',
+        ], $connector->testFormatHost([
+            'host' => 'tls://127.0.0.1',
+            'scheme' => 'tls',
+        ]));
+    }
+
+    public function testFormatHostAcceptsCaseInsensitiveMatchingScheme()
+    {
+        $connector = new TestablePredisConnector;
+
+        $this->assertSame([
+            'host' => '127.0.0.1',
+            'scheme' => 'TLS',
+        ], $connector->testFormatHost([
+            'host' => 'tls://127.0.0.1',
+            'scheme' => 'TLS',
+        ]));
+    }
+
+    public function testFormatHostThrowsOnConflictingScheme()
+    {
+        $connector = new TestablePredisConnector;
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The scheme configured in the Redis host option must match the scheme option.');
+
+        $connector->testFormatHost([
+            'host' => 'tcp://127.0.0.1',
+            'scheme' => 'tls',
+        ]);
+    }
+}
+
+class TestablePredisConnector extends PredisConnector
+{
+    public function testFormatHost(array $config): array
+    {
+        return $this->formatHost($config);
+    }
+}


### PR DESCRIPTION
Currently if the scheme key is set in the redis config it will be appended on to the host, regardless of whether the host includes a scheme or not.

This will ensure schemes match if they are present in both, instead of simply appending and breaking.