### PR TITLE
[13.x] Fix duplicated socket value in Redis broadcast payload

### DIFF
--- a/src/Illuminate/Broadcasting/Broadcasters/RedisBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/RedisBroadcaster.php
@@ -122,10 +122,12 @@ class RedisBroadcaster extends Broadcaster
 
         $connection = $this->redis->connection($this->connection);
 
+        $socket = Arr::pull($payload, 'socket');
+
         $payload = json_encode([
             'event' => $event,
             'data' => $payload,
-            'socket' => Arr::pull($payload, 'socket'),
+            'socket' => $socket,
         ]);
 
         try {

--- a/tests/Broadcasting/RedisBroadcasterTest.php
+++ b/tests/Broadcasting/RedisBroadcasterTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Broadcasting;
 use Illuminate\Broadcasting\Broadcasters\RedisBroadcaster;
 use Illuminate\Config\Repository as Config;
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Redis\Factory as Redis;
 use Illuminate\Http\Request;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -139,6 +140,31 @@ class RedisBroadcasterTest extends TestCase
                 'c' => 'd',
             ])
         );
+    }
+
+    public function testBroadcastDoesNotIncludeSocketInPayloadData()
+    {
+        $redis = m::mock(Redis::class);
+        $connection = m::mock('stdClass');
+
+        $redis->shouldReceive('connection')->once()->with(null)->andReturn($connection);
+
+        $connection->shouldReceive('eval')->once()->withArgs(function ($script, $numberOfKeys, $payload, $channel) {
+            $payload = json_decode($payload, true);
+
+            $this->assertSame(0, $numberOfKeys);
+            $this->assertSame('orders', $channel);
+            $this->assertSame('OrderUpdated', $payload['event']);
+            $this->assertSame('123.456', $payload['socket']);
+            $this->assertSame(['id' => 1], $payload['data']);
+
+            return true;
+        });
+
+        (new RedisBroadcaster($redis))->broadcast(['orders'], 'OrderUpdated', [
+            'id' => 1,
+            'socket' => '123.456',
+        ]);
     }
 
     /**


### PR DESCRIPTION
## Summary

This PR fixes an inconsistency in `RedisBroadcaster` where the `socket`
value was being included twice in Redis broadcast payloads.

Previously, the payload was constructed like this:

```php
'data' => $payload,
'socket' => Arr::pull($payload, 'socket'),
```

Because the socket was only removed after assigning `$payload` to `data`,
the resulting payload could contain the socket in both places:

```php
[
    'data' => [
        'id' => 1,
        'socket' => '123.456',
    ],
    'socket' => '123.456',
]
```

This behavior diverged from `PusherBroadcaster`, which removes the socket
from the payload data before broadcasting.

## Changes

Updated `RedisBroadcaster` to remove the socket before building the final payload:

```php
$socket = Arr::pull($payload, 'socket');

$payload = json_encode([
    'event' => $event,
    'data' => $payload,
    'socket' => $socket,
]);
```

## Tests

Added `testBroadcastDoesNotIncludeSocketInPayloadData` to verify that:

- the socket remains available at the top level of the payload
- the socket is not included inside `data`
- the expected channel, event, and payload are sent to Redis

## Files Changed

- `src/Illuminate/Broadcasting/Broadcasters/RedisBroadcaster.php`
- `tests/Broadcasting/RedisBroadcasterTest.php`

## Validation

```bash
./vendor/bin/phpunit tests/Broadcasting/RedisBroadcasterTest.php tests/Broadcasting
```

Result:

```text
OK (172 tests, 167 assertions)
```