### PR TITLE
[13.x] Allow JsonSchema fluent boolean flags to be unset

### DIFF
--- a/src/Illuminate/JsonSchema/Types/ArrayType.php
+++ b/src/Illuminate/JsonSchema/Types/ArrayType.php
@@ -59,9 +59,7 @@ class ArrayType extends Type
      */
     public function unique(bool $unique = true): static
     {
-        if ($unique) {
-            $this->uniqueItems = true;
-        }
+        $this->uniqueItems = $unique ?: null;
 
         return $this;
     }

--- a/src/Illuminate/JsonSchema/Types/Type.php
+++ b/src/Illuminate/JsonSchema/Types/Type.php
@@ -46,9 +46,7 @@ abstract class Type extends JsonSchema
      */
     public function required(bool $required = true): static
     {
-        if ($required) {
-            $this->required = true;
-        }
+        $this->required = $required ?: null;
 
         return $this;
     }
@@ -58,9 +56,7 @@ abstract class Type extends JsonSchema
      */
     public function nullable(bool $nullable = true): static
     {
-        if ($nullable) {
-            $this->nullable = true;
-        }
+        $this->nullable = $nullable ?: null;
 
         return $this;
     }

--- a/tests/JsonSchema/ArrayTypeTest.php
+++ b/tests/JsonSchema/ArrayTypeTest.php
@@ -67,6 +67,15 @@ class ArrayTypeTest extends TestCase
         ], $type->toArray());
     }
 
+    public function test_it_may_unset_unique_items(): void
+    {
+        $type = JsonSchema::array()->unique()->unique(false);
+
+        $this->assertEquals([
+            'type' => 'array',
+        ], $type->toArray());
+    }
+
     public function test_it_may_combine_unique_items_with_min_and_max(): void
     {
         $type = JsonSchema::array()->min(1)->max(5)->unique();

--- a/tests/JsonSchema/TypeTest.php
+++ b/tests/JsonSchema/TypeTest.php
@@ -107,6 +107,35 @@ class TypeTest extends TestCase
         $this->assertInstanceOf(JsonSchema::class, $schema);
     }
 
+    public function test_required_may_be_unset(): void
+    {
+        $schema = JsonSchema::object([
+            'name' => JsonSchema::string()->required()->required(false),
+        ]);
+
+        $this->assertEquals([
+            'type' => 'object',
+            'properties' => [
+                'name' => [
+                    'type' => 'string',
+                ],
+            ],
+        ], $schema->toArray());
+
+        $this->assertValidOnJsonSchema($schema, (object) []);
+    }
+
+    public function test_nullable_may_be_unset(): void
+    {
+        $schema = JsonSchema::string()->nullable()->nullable(false);
+
+        $this->assertEquals([
+            'type' => 'string',
+        ], $schema->toArray());
+
+        $this->assertNotValidOnJsonSchema($schema, null);
+    }
+
     public function test_throws_with_invalid_enum_string(): void
     {
         $this->expectException(InvalidArgumentException::class);


### PR DESCRIPTION
## Summary

This PR fixes the fluent boolean flag API in `JsonSchema` types so that
previously enabled flags may also be disabled.

Currently, methods such as:

```php
required(bool $required = true)
nullable(bool $nullable = true)
unique(bool $unique = true)
```

only apply changes when the given value is `true`.

This works for fresh instances:

```php
JsonSchema::string()->nullable(false)
```

because nothing is enabled yet.

However, it fails when composing schemas conditionally or attempting to
remove previously applied state:

```php
JsonSchema::string()->nullable()->nullable(false);

JsonSchema::string()->required()->required(false);

JsonSchema::array()->unique()->unique(false);
```

Before this change, passing `false` would not unset the existing flag.

## Changes

Updated the fluent flag setters to allow disabling previously enabled state.

In `src/Illuminate/JsonSchema/Types/Type.php`:

```php
$this->required = $required ?: null;

$this->nullable = $nullable ?: null;
```

In `src/Illuminate/JsonSchema/Types/ArrayType.php`:

```php
$this->uniqueItems = $unique ?: null;
```

This keeps the generated schema output clean while allowing conditional
schema composition.

## Tests

Added the following tests:

### `tests/JsonSchema/ArrayTypeTest.php`

- `test_it_may_unset_unique_items`

### `tests/JsonSchema/TypeTest.php`

- `test_required_may_be_unset`
- `test_nullable_may_be_unset`

These tests validate both:

- the serialized schema array output
- the actual validation behavior against the JSON Schema validator

## Files Changed

- `src/Illuminate/JsonSchema/Types/Type.php`
- `src/Illuminate/JsonSchema/Types/ArrayType.php`
- `tests/JsonSchema/ArrayTypeTest.php`
- `tests/JsonSchema/TypeTest.php`

## Validation

```bash
./vendor/bin/phpunit tests/JsonSchema/ArrayTypeTest.php tests/JsonSchema/TypeTest.php
```

Result:

```text
OK (170 tests, 178 assertions)
```

Linting was also run on the modified files:

```text
No linter errors found.
```