### PR TITLE
[13.x] Allow Jobs to include context

### DIFF
--- a/src/Illuminate/Contracts/Queue/HasContext.php
+++ b/src/Illuminate/Contracts/Queue/HasContext.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Contracts\Queue;
+
+interface HasContext
+{
+    /**
+     * Get the context to include in the job payload.
+     *
+     * @return array
+     */
+    public function context(): array;
+}

--- a/src/Illuminate/Queue/Jobs/InspectedJob.php
+++ b/src/Illuminate/Queue/Jobs/InspectedJob.php
@@ -12,13 +12,15 @@ class InspectedJob
      * @param  string|null  $uuid  The unique identifier for the job.
      * @param  string|null  $name  The display name of the job.
      * @param  int  $attempts  The number of times the job has been attempted.
+     * @param  array|null  $context  The context provided by the job.
      * @param  \Illuminate\Support\Carbon|null  $createdAt  The date and time the job was created.
      */
     public function __construct(
         public readonly ?string $uuid,
         public readonly ?string $name,
         public readonly int $attempts,
-        public readonly ?Carbon $createdAt,
+        public readonly ?array $context = null,
+        public readonly ?Carbon $createdAt = null,
     ) {
     }
 
@@ -37,6 +39,7 @@ class InspectedJob
             uuid: $decoded['uuid'] ?? null,
             name: $decoded['displayName'] ?? null,
             attempts: $attempts ?? $decoded['attempts'] ?? 0,
+            context: $decoded['context'] ?? null,
             createdAt: isset($decoded['createdAt']) ? Carbon::createFromTimestamp($decoded['createdAt']) : null,
         );
     }

--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -89,6 +89,16 @@ abstract class Job
     }
 
     /**
+     * Get the job context.
+     *
+     * @return array|null
+     */
+    public function context()
+    {
+        return $this->payload()['context'] ?? null;
+    }
+
+    /**
      * Fire the job.
      *
      * @return void

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -9,6 +9,7 @@ use Illuminate\Bus\UniqueLock;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Cache\Repository as Cache;
 use Illuminate\Contracts\Encryption\Encrypter;
+use Illuminate\Contracts\Queue\HasContext;
 use Illuminate\Contracts\Queue\ShouldBeEncrypted;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueueAfterCommit;
@@ -185,6 +186,7 @@ abstract class Queue
                 'command' => $job,
                 'batchId' => $job->batchId ?? null,
             ],
+            'context' => $this->getJobContext($job),
             'createdAt' => Carbon::now()->getTimestamp(),
         ]);
 
@@ -206,6 +208,17 @@ abstract class Queue
                 'command' => $command,
             ]),
         ]);
+    }
+
+    /**
+     * Get the context for the given job.
+     *
+     * @param  object  $job
+     * @return array|null
+     */
+    protected function getJobContext($job)
+    {
+        return $job instanceof HasContext ? $job->context() : null;
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -6,6 +6,7 @@ use BadMethodCallException;
 use Closure;
 use Illuminate\Bus\UniqueLock;
 use Illuminate\Contracts\Cache\Repository as Cache;
+use Illuminate\Contracts\Queue\HasContext;
 use Illuminate\Contracts\Queue\Queue;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Events\CallQueuedListener;
@@ -493,6 +494,7 @@ class QueueFake extends QueueManager implements Fake, Queue
                     ? (method_exists($data['job'], 'displayName') ? $data['job']->displayName() : get_class($data['job']))
                     : $data['job'],
                 attempts: 0,
+                context: $data['job'] instanceof HasContext ? $data['job']->context() : null,
                 createdAt: null,
             ));
     }
@@ -534,6 +536,7 @@ class QueueFake extends QueueManager implements Fake, Queue
                     ? (method_exists($data['job'], 'displayName') ? $data['job']->displayName() : get_class($data['job']))
                     : $data['job'],
                 attempts: 0,
+                context: $data['job'] instanceof HasContext ? $data['job']->context() : null,
                 createdAt: null,
             ));
     }

--- a/tests/Integration/Queue/RedisQueueTest.php
+++ b/tests/Integration/Queue/RedisQueueTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Queue;
 
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Queue\HasContext;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
 use Illuminate\Queue\Events\JobQueued;
 use Illuminate\Queue\Events\JobQueueing;
@@ -726,6 +727,25 @@ class RedisQueueTest extends TestCase
         $this->assertSame(1, $reserved->first()->attempts);
         $this->assertNotNull($reserved->first()->uuid);
         $this->assertInstanceOf(Carbon::class, $reserved->first()->createdAt);
+    }
+
+    #[DataProvider('redisDriverProvider')]
+    public function testJobContext($driver)
+    {
+        $default = config('queue.connections.redis.queue', 'default');
+        $this->setQueue($driver, $default);
+
+        $this->queue->push(new RedisContextJob);
+
+        $this->assertSame(['task_id' => 42, 'type' => 'export'], $this->queue->pendingJobs()->first()->context);
+    }
+}
+
+class RedisContextJob implements HasContext
+{
+    public function context(): array
+    {
+        return ['task_id' => 42, 'type' => 'export'];
     }
 }
 

--- a/tests/Queue/QueueDatabaseQueueUnitTest.php
+++ b/tests/Queue/QueueDatabaseQueueUnitTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Queue;
 
 use Illuminate\Bus\Batchable;
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Queue\HasContext;
 use Illuminate\Database\Connection;
 use Illuminate\Queue\DatabaseQueue;
 use Illuminate\Queue\Jobs\InspectedJob;
@@ -356,6 +357,20 @@ class QueueDatabaseQueueUnitTest extends TestCase
         $this->assertSame(2, $jobs->last()->attempts);
     }
 
+    public function testJobContext()
+    {
+        $queue = new DatabaseQueue($database = m::mock(Connection::class), 'table', 'default');
+        $queue->setContainer(m::spy(Container::class));
+
+        $database->shouldReceive('table')->with('table')->andReturn($query = m::mock(stdClass::class));
+        $query->shouldReceive('insertGetId')->once()->andReturnUsing(function ($array) {
+            $payload = json_decode($array['payload'], true);
+            $this->assertSame(['task_id' => 42, 'type' => 'export'], $payload['context']);
+        });
+
+        $queue->push(new ContextJob);
+    }
+
     public function testGetLockForPoppingIsCached()
     {
         $database = m::mock(Connection::class);
@@ -389,4 +404,12 @@ class MyTestJob
 class MyBatchableJob
 {
     use Batchable;
+}
+
+class ContextJob implements HasContext
+{
+    public function context(): array
+    {
+        return ['task_id' => 42, 'type' => 'export'];
+    }
 }

--- a/tests/Support/SupportTestingQueueFakeTest.php
+++ b/tests/Support/SupportTestingQueueFakeTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Support;
 
 use BadMethodCallException;
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\HasContext;
 use Illuminate\Foundation\Application;
 use Illuminate\Queue\CallQueuedClosure;
 use Illuminate\Queue\Jobs\InspectedJob;
@@ -540,6 +541,13 @@ class SupportTestingQueueFakeTest extends TestCase
         $this->assertTrue($pending->contains(fn ($job) => $job->name === JobToFakeStub::class));
     }
 
+    public function testContextIsIncluded()
+    {
+        $this->fake->push(new JobWithContextStub, '', 'foo');
+
+        $this->assertSame(['task_id' => 42, 'type' => 'export'], $this->fake->allPendingJobs()->first()->context);
+    }
+
     public function testGetRawPushes()
     {
         $this->fake->pushRaw('some-payload', null, ['options' => 'yeah']);
@@ -615,6 +623,19 @@ class JobToFakeStub
     public function handle()
     {
         //
+    }
+}
+
+class JobWithContextStub implements HasContext
+{
+    public function handle()
+    {
+        //
+    }
+
+    public function context(): array
+    {
+        return ['task_id' => 42, 'type' => 'export'];
     }
 }
 


### PR DESCRIPTION
When inspecting queued jobs or handling job events, you often just want a bit more **context** , especially during deployments. This is different from global "world" `illuminate:log:context` and more about the job context itself the job doesn't have to run for us to have this context just be dispatched.
 
 <details>

<summary> 
 I made a video to also cover this... (audio on, bit boring)

</summary>
 

https://github.com/user-attachments/assets/327134ef-f7f1-4dfe-9509-4fef0669cf49


 
 </details>
  
This PR adds a `HasContext` interface, which adds context into the job payload, implement it on your job and return whatever is useful:
  
  ```php
  class AgentJob implements ShouldQueue, HasContext
  {
      public function context(): array
      {
          return [
              'provider' => $this->provider,
              'model'    => $this->model,
          ];
      }
  }
```
Then when inspecting the queue we can access it:
```php
  Queue::reservedJobs()->first()->context
```
  Or in a listener access the context we need... no need to dig in the payload
```php
  public function handle(JobProcessing $event): void
  {
      Log::error('Processing Job', [
          'job' => $event->job->resolveName(),
          ...$event->job->context() ?? [],
      ]);
  }
```
                                                                                                                                                                                                                                                                                                                                                                                                                           
The context is completely controlled in userland, and completely opt in.

Used an interface cause I can't think of a nicer non b/c way , perhaps in 14.x we could method_exists if you don't like it, but I thought it was ok for now.
 
This is my eyes would also be **very cool** to surface to monitoring services too such as Telescope, etc.

This means we can go logging from reservedJobs from:

```
[11:50:11] Deployment waiting for App\Jobs\AgentJob
```
To

```
[11:50:11] Deployment waiting for App\Jobs\AgentJob {"provider":"anthropic","model":"claude-sonnet-4-20250514"}
```   

Specific to the job, and all contained within that job...                                                                                       
                                                                                                                                                                                                                                                                                                                     
Any adjustments, have at it, or let me know where to tweak ...  happy to rename too maybe metadata is more fitting?