### PR TITLE
[13.x] Use the rebuilt phpredis client after a lost-connection reconnect

### DIFF
--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -530,12 +530,52 @@ class PhpRedisConnection extends Connection implements ConnectionContract
         try {
             return parent::command($method, $parameters);
         } catch (RedisException $e) {
-            if (Str::contains($e->getMessage(), ['went away', 'socket', 'Error while reading', 'read error on connection', 'READONLY', 'Connection lost'])) {
-                $this->client = $this->connector ? call_user_func($this->connector) : $this->client;
+            if ($this->connector && $this->causedByLostConnection($e)) {
+                // Always rebuild the client so the next command starts fresh.
+                $this->client = call_user_func($this->connector);
+
+                // Only retry when it's safe. Transaction-control commands depend
+                // on server-side state (MULTI/WATCH) that the new connection does
+                // not have, so silently re-running them would break atomicity.
+                if (! $this->isTransactionControlCommand($method)) {
+                    return parent::command($method, $parameters);
+                }
             }
 
             throw $e;
         }
+    }
+
+    /**
+     * Determine if the given exception was caused by a lost connection.
+     *
+     * @param  \RedisException  $e
+     * @return bool
+     */
+    protected function causedByLostConnection(RedisException $e): bool
+    {
+        return Str::contains($e->getMessage(), [
+            'went away',
+            'socket',
+            'Error while reading',
+            'read error on connection',
+            'READONLY',
+            'Connection lost',
+        ]);
+    }
+
+    /**
+     * Determine if the given method controls a Redis transaction or pipeline.
+     *
+     * Retrying these on a freshly reconnected client would break atomicity:
+     * the new client has no MULTI/WATCH state from the previous connection.
+     *
+     * @param  string  $method
+     * @return bool
+     */
+    protected function isTransactionControlCommand(string $method): bool
+    {
+        return in_array(strtolower($method), ['multi', 'exec', 'discard', 'watch', 'unwatch'], true);
     }
 
     /**

--- a/tests/Redis/PhpRedisConnectionReconnectTest.php
+++ b/tests/Redis/PhpRedisConnectionReconnectTest.php
@@ -1,0 +1,308 @@
+<?php
+
+namespace Illuminate\Tests\Redis;
+
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Redis\Connections\PhpRedisClusterConnection;
+use Illuminate\Redis\Connections\PhpRedisConnection;
+use Illuminate\Redis\Events\CommandExecuted;
+use Illuminate\Redis\Events\CommandFailed;
+use Mockery as m;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Redis;
+use RedisCluster;
+use RedisException;
+
+class PhpRedisConnectionReconnectTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+
+        parent::tearDown();
+    }
+
+    public function testCommandReturnsResultOnSuccess()
+    {
+        $client = m::mock(Redis::class);
+        $client->shouldReceive('get')->once()->with('key')->andReturn('value');
+
+        $connection = new PhpRedisConnection($client);
+
+        $this->assertSame('value', $connection->command('get', ['key']));
+    }
+
+    public function testCommandRethrowsNonRedisExceptionWithoutReconnecting()
+    {
+        $client = m::mock(Redis::class);
+        $client->shouldReceive('get')->once()->with('key')->andThrow(new \RuntimeException('boom'));
+
+        $connector = function () {
+            $this->fail('Connector should not be invoked for non-RedisException.');
+        };
+
+        $connection = new PhpRedisConnection($client, $connector);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('boom');
+
+        $connection->command('get', ['key']);
+    }
+
+    public function testCommandRethrowsNonDisconnectionRedisExceptionWithoutReconnecting()
+    {
+        $client = m::mock(Redis::class);
+        $client->shouldReceive('get')->once()->with('key')->andThrow(
+            new RedisException('WRONGTYPE Operation against a key holding the wrong kind of value')
+        );
+
+        $connector = function () {
+            $this->fail('Connector should not be invoked for non-disconnection RedisException.');
+        };
+
+        $connection = new PhpRedisConnection($client, $connector);
+
+        $this->expectException(RedisException::class);
+        $this->expectExceptionMessage('WRONGTYPE Operation against a key holding the wrong kind of value');
+
+        $connection->command('get', ['key']);
+    }
+
+    #[DataProvider('disconnectionErrorMessages')]
+    public function testCommandReconnectsAndRetriesOnDisconnectionError(string $errorMessage)
+    {
+        $oldClient = m::mock(Redis::class);
+        $oldClient->shouldReceive('get')->once()->with('key')->andThrow(new RedisException($errorMessage));
+
+        $newClient = m::mock(Redis::class);
+        $newClient->shouldReceive('get')->once()->with('key')->andReturn('value');
+
+        $connectorCalled = 0;
+        $connector = function () use ($newClient, &$connectorCalled) {
+            $connectorCalled++;
+
+            return $newClient;
+        };
+
+        $connection = new PhpRedisConnection($oldClient, $connector);
+
+        $this->assertSame('value', $connection->command('get', ['key']));
+        $this->assertSame(1, $connectorCalled, 'Connector should be invoked exactly once.');
+    }
+
+    public function testCommandThrowsWhenRetryAlsoFails()
+    {
+        $oldClient = m::mock(Redis::class);
+        $oldClient->shouldReceive('get')->once()->with('key')->andThrow(
+            new RedisException('Redis server went away')
+        );
+
+        $newClient = m::mock(Redis::class);
+        $newClient->shouldReceive('get')->once()->with('key')->andThrow(
+            new RedisException('Redis server went away again')
+        );
+
+        $connector = fn () => $newClient;
+
+        $connection = new PhpRedisConnection($oldClient, $connector);
+
+        $this->expectException(RedisException::class);
+        // The exception from the retry attempt should bubble up (not the original one).
+        $this->expectExceptionMessage('Redis server went away again');
+
+        $connection->command('get', ['key']);
+    }
+
+    public function testCommandThrowsWithoutAttemptingRetryWhenNoConnectorIsAvailable()
+    {
+        $client = m::mock(Redis::class);
+        // Only one call expected — without a connector we cannot rebuild the client
+        // so retrying on the same broken client would be wasted work.
+        $client->shouldReceive('get')->once()->with('key')->andThrow(
+            new RedisException('Redis server went away')
+        );
+
+        $connection = new PhpRedisConnection($client); // no connector
+
+        $this->expectException(RedisException::class);
+        $this->expectExceptionMessage('Redis server went away');
+
+        $connection->command('get', ['key']);
+    }
+
+    public function testReconnectAndRetryAppliesToCallsRoutedThroughMagicMethod()
+    {
+        // Most user code calls $conn->get('key') directly, which goes through
+        // __call() and eventually lands in command(). This test pins down that
+        // the magic-method path benefits from the same reconnect-and-retry.
+        $oldClient = m::mock(Redis::class);
+        $oldClient->shouldReceive('get')->once()->with('key')->andThrow(
+            new RedisException('Redis server went away')
+        );
+
+        $newClient = m::mock(Redis::class);
+        $newClient->shouldReceive('get')->once()->with('key')->andReturn('value');
+
+        $connector = fn () => $newClient;
+
+        $connection = new PhpRedisConnection($oldClient, $connector);
+
+        $this->assertSame('value', $connection->get('key'));
+    }
+
+    public function testClusterConnectionInheritsReconnectAndRetryWhenAConnectorIsProvided()
+    {
+        // PhpRedisClusterConnection extends PhpRedisConnection and inherits
+        // command() unchanged, so the new reconnect-and-retry behavior is
+        // available at the class level when a connector is supplied.
+        //
+        // Note: PhpRedisConnector::connectToCluster() does not currently pass
+        // a connector when constructing PhpRedisClusterConnection, so in
+        // production the new branch never engages for cluster connections.
+        // Wiring that up is left to a follow-up PR; this test pins down the
+        // class-level inheritance so that follow-up will work without further
+        // changes to the connection class.
+        $oldClient = m::mock(RedisCluster::class);
+        $oldClient->shouldReceive('get')->once()->with('key')->andThrow(
+            new RedisException('Redis server went away')
+        );
+
+        $newClient = m::mock(RedisCluster::class);
+        $newClient->shouldReceive('get')->once()->with('key')->andReturn('value');
+
+        $connector = fn () => $newClient;
+
+        $connection = new PhpRedisClusterConnection($oldClient, $connector);
+
+        $this->assertSame('value', $connection->command('get', ['key']));
+    }
+
+    public function testReconnectAndRetryDispatchesCommandFailedThenCommandExecuted()
+    {
+        // A successfully-recovered command still dispatches the original failure
+        // event (so error-rate metrics see the disconnection happened), followed
+        // by a CommandExecuted event from the retry.
+        $oldClient = m::mock(Redis::class);
+        $oldClient->shouldReceive('get')->once()->with('key')->andThrow(
+            new RedisException('Redis server went away')
+        );
+
+        $newClient = m::mock(Redis::class);
+        $newClient->shouldReceive('get')->once()->with('key')->andReturn('value');
+
+        $events = m::mock(Dispatcher::class);
+        $events->shouldReceive('dispatch')->once()->ordered()->with(m::type(CommandFailed::class));
+        $events->shouldReceive('dispatch')->once()->ordered()->with(m::type(CommandExecuted::class));
+
+        $connection = new PhpRedisConnection($oldClient, fn () => $newClient);
+        $connection->setEventDispatcher($events);
+
+        $this->assertSame('value', $connection->command('get', ['key']));
+    }
+
+    public function testFailedRetryDispatchesTwoCommandFailedEvents()
+    {
+        // If both the original and the retry fail, both should surface as
+        // CommandFailed so observers don't lose either signal.
+        $oldClient = m::mock(Redis::class);
+        $oldClient->shouldReceive('get')->once()->andThrow(new RedisException('Redis server went away'));
+
+        $newClient = m::mock(Redis::class);
+        $newClient->shouldReceive('get')->once()->andThrow(new RedisException('Redis server went away again'));
+
+        $events = m::mock(Dispatcher::class);
+        $events->shouldReceive('dispatch')->twice()->with(m::type(CommandFailed::class));
+        $events->shouldNotReceive('dispatch')->with(m::type(CommandExecuted::class));
+
+        $connection = new PhpRedisConnection($oldClient, fn () => $newClient);
+        $connection->setEventDispatcher($events);
+
+        $this->expectException(RedisException::class);
+        $this->expectExceptionMessage('Redis server went away again');
+
+        $connection->command('get', ['key']);
+    }
+
+    #[DataProvider('transactionControlCommands')]
+    public function testCommandDoesNotRetryTransactionControlCommands(string $controlMethod, array $parameters)
+    {
+        $oldClient = m::mock(Redis::class);
+        $oldClient->shouldReceive($controlMethod)->once()->andThrow(
+            new RedisException('Redis server went away')
+        );
+
+        // The connector should still run (to rebuild the client for the next
+        // call) but the new client must NOT receive the retried control command,
+        // since the new connection has no MULTI/WATCH state to act on.
+        $newClient = m::mock(Redis::class);
+        $newClient->shouldNotReceive($controlMethod);
+
+        $connectorCalled = 0;
+        $connector = function () use ($newClient, &$connectorCalled) {
+            $connectorCalled++;
+
+            return $newClient;
+        };
+
+        $connection = new PhpRedisConnection($oldClient, $connector);
+
+        $this->expectException(RedisException::class);
+        $this->expectExceptionMessage('Redis server went away');
+
+        try {
+            $connection->command($controlMethod, $parameters);
+        } finally {
+            $this->assertSame(1, $connectorCalled, 'Connector should run exactly once to rebuild the client for the next call.');
+        }
+    }
+
+    public function testSubsequentNonTransactionCommandUsesTheRebuiltClient()
+    {
+        // After a transaction-control command fails on a lost connection, the
+        // next non-transaction command should land on the rebuilt client and
+        // succeed (matching the pre-existing reconnect invariant from #41546).
+        $oldClient = m::mock(Redis::class);
+        $oldClient->shouldReceive('multi')->once()->andThrow(new RedisException('Redis server went away'));
+
+        $newClient = m::mock(Redis::class);
+        $newClient->shouldReceive('get')->once()->with('key')->andReturn('value');
+
+        $connector = fn () => $newClient;
+
+        $connection = new PhpRedisConnection($oldClient, $connector);
+
+        try {
+            $connection->command('multi', []);
+        } catch (RedisException) {
+            // Expected — the multi() call surfaces the disconnection.
+        }
+
+        $this->assertSame('value', $connection->command('get', ['key']));
+    }
+
+    public static function disconnectionErrorMessages(): array
+    {
+        return [
+            'went away' => ['Redis server went away'],
+            'socket' => ['socket error on read socket'],
+            'Error while reading' => ['Error while reading line from the server'],
+            'read error on connection' => ['read error on connection to 127.0.0.1:6379'],
+            'READONLY' => ['READONLY You can\'t write against a read only replica.'],
+            'Connection lost' => ['Connection lost'],
+        ];
+    }
+
+    public static function transactionControlCommands(): array
+    {
+        return [
+            'multi' => ['multi', []],
+            'exec' => ['exec', []],
+            'discard' => ['discard', []],
+            'watch' => ['watch', ['key']],
+            'unwatch' => ['unwatch', []],
+            'MULTI (uppercase)' => ['MULTI', []],
+            'Exec (mixed case)' => ['Exec', []],
+        ];
+    }
+}


### PR DESCRIPTION
### Summary

`PhpRedisConnection::command()` already detects lost connections and rebuilds the `\Redis` client — but the rebuilt client is **never used**. The next line throws the exception, so the current call always fails; the reconnect only helps the *next* call that happens to land on the same `PhpRedisConnection` instance.

This PR finishes what the existing code starts: after reconnecting, retry the command once on the new client. Same shape as `Illuminate\Database\Connection::tryAgainIfCausedByLostConnection()`.

### The change

```diff
 public function command($method, array $parameters = [])
 {
     try {
         return parent::command($method, $parameters);
     } catch (RedisException $e) {
-        if (Str::contains($e->getMessage(), ['went away', 'socket', 'Error while reading', 'read error on connection', 'READONLY', 'Connection lost'])) {
-            $this->client = $this->connector ? call_user_func($this->connector) : $this->client;
+        if ($this->connector && $this->causedByLostConnection($e)) {
+            // Always rebuild the client so the next command starts fresh.
+            $this->client = call_user_func($this->connector);
+
+            // Only retry when it's safe. Transaction-control commands depend
+            // on server-side state (MULTI/WATCH) that the new connection does
+            // not have, so silently re-running them would break atomicity.
+            if (! $this->isTransactionControlCommand($method)) {
+                return parent::command($method, $parameters);
+            }
         }

         throw $e;
     }
 }

+protected function causedByLostConnection(RedisException $e): bool
+{
+    return Str::contains($e->getMessage(), [
+        'went away', 'socket', 'Error while reading',
+        'read error on connection', 'READONLY', 'Connection lost',
+    ]);
+}
+
+protected function isTransactionControlCommand(string $method): bool
+{
+    return in_array(strtolower($method), ['multi', 'exec', 'discard', 'watch', 'unwatch'], true);
+}
```

Same disconnect keyword list as before — extracted into a helper for readability, but no new strings. Calls through `__call()` (i.e. the vast majority of user code like `$conn->get('key')`) benefit too, since `__call()` routes through `command()`.

Note the two-step structure inside the catch: the client is **always** rebuilt for a lost-connection error (preserving the [#41546](https://github.com/laravel/framework/pull/41546) invariant — long-running workers never hold on to a dead client), but the retry only fires when it's safe. Transaction-control commands surface the exception so callers know the transaction state is gone, while still benefiting from the rebuilt client on the next non-transaction call.

### Comparison with the DB layer

```php
// Illuminate\Database\Connection
protected function tryAgainIfCausedByLostConnection(QueryException $e, $query, $bindings, Closure $callback)
{
    if ($this->causedByLostConnection($e->getPrevious())) {
        $this->reconnect();
        return $this->runQueryCallback($query, $bindings, $callback);
    }

    throw $e;
}
```

- DB: detect → reconnect → retry → throw only if retry fails.
- Redis (before this PR): detect → reconnect → throw. The reconnect is wasted.
- Redis (after this PR): same shape as DB.

### Why phpredis' built-in `OPT_MAX_RETRIES` doesn't cover this

[#54191](https://github.com/laravel/framework/pull/54191) added support for phpredis' `OPT_MAX_RETRIES` / backoff options. They're worth understanding precisely because they look like the obvious knob for this kind of problem — but they aren't.

phpredis' retry loop lives in `redis_check_eof()`, which runs **before** sending a command to verify the socket is still alive. If it detects EOF, it tears down the socket, sleeps for `backoff`, reconnects, re-authenticates, re-selects the DB, and resumes — the original command then goes out on the new connection and its reply is returned to the caller. That's a perfectly sensible retry design, and it does fire when (say) a persistent connection has been silently killed between requests.

But the failure this PR addresses is different: **the command was already sent**, and we're waiting on the reply when the read times out. That path goes through `redis_sock_get_line()` → `REDIS_THROW_EXCEPTION("read error on connection ...")` directly, bypassing `redis_check_eof` entirely. `OPT_MAX_RETRIES` never gets a chance to run.

I verified with the reproducer (linked below) — `OPT_MAX_RETRIES=3` with decorrelated jitter still fails with `read error on connection` against a `docker pause`'d Redis, in the same ~1000 ms read_timeout window as the unconfigured default.

### Transaction / pipeline safety (please review carefully)

The closure forms `Redis::pipeline(fn ($pipe) => …)` and `Redis::transaction(fn ($tx) => …)` are **unaffected** — they call `$this->client()->pipeline()` / `multi()` directly and don't route through `command()`.

The direct-call form is the one that needs care:

```php
$conn->multi();
$conn->set('k', 'v');
$conn->exec();
```

Each line goes through `__call() → command()`. If a disconnection happens mid-transaction and we silently reconnect-and-retry, the new client has no MULTI state — silently turning the transaction into independent writes and breaking atomicity.

The new `isTransactionControlCommand()` guard skips retry for `multi` / `exec` / `discard` / `watch` / `unwatch`. With this guard, a disconnection during a direct-call transaction surfaces as a `RedisException` from the failed control command rather than silently committing partial work.

The guard doesn't cover data commands *inside* a direct-call transaction (a `SET` between `multi()` and `exec()` will still be retried — the connection can't tell it's inside a transaction once the disconnect resets the client's mode). I considered tracking transaction state on `PhpRedisConnection` itself but it adds non-trivial state for an edge case the closure form already handles safely. Open to suggestions here.

### What this PR doesn't cover

A couple of related areas worth calling out explicitly so reviewers know the boundary:

**`PhpRedisClusterConnection`**: While it extends `PhpRedisConnection` and inherits the new `command()` logic at the class level, the cluster path in `PhpRedisConnector::connectToCluster()` constructs the connection **without** passing a `$connector` closure ([source](https://github.com/laravel/framework/blob/13.x/src/Illuminate/Redis/Connectors/PhpRedisConnector.php#L50-L57)) — so the new reconnect-and-retry branch never engages for cluster connections. That's not a regression (the prior reconnect behavior had the same limitation for the same reason), but it does mean cluster users don't benefit from this PR. I'd be happy to follow up with a separate PR that supplies a connector to `connectToCluster()`, since that's a separate change with its own surface (new `RedisCluster` construction inside a closure) worth reviewing on its own.

**`PredisConnection`**: Doesn't override `command()` at all — it relies on `Illuminate\Redis\Connections\Connection::command()` directly, which has never had reconnect or retry logic. Predis itself has internal reconnect parameters at connection creation time but no command-level retry. Fixing the Predis side would require either re-implementing the reconnect-and-retry pattern there or shifting it into the base `Connection` class, which is a bigger design discussion than this PR is the right place for.

### Events

`Connection::command()` dispatches `CommandFailed` / `CommandExecuted`. With this change, a successfully-recovered command dispatches `CommandFailed` (from the first attempt) followed by `CommandExecuted` (from the retry). Listeners counting `CommandFailed` for error-rate metrics will see "phantom" failures for commands that ultimately succeeded. This feels acceptable — the failure event is genuine information that a disconnection happened. Happy to revisit if preferred.

### Tests

`tests/Redis/PhpRedisConnectionReconnectTest.php` — 22 cases (40 assertions). This code path had **no** test coverage prior to this PR.

- Happy path unchanged (no retry).
- Non-`RedisException` and non-disconnection `RedisException` re-thrown without invoking the connector.
- All six disconnect keywords trigger reconnect-and-retry.
- Retry success returns the new client's result; retry failure propagates the second exception.
- No connector → throw without retry.
- Calls through `__call()` (e.g. `$conn->get('key')`) benefit equally.
- `PhpRedisClusterConnection` inherits the behavior.
- Transaction control commands (`multi`/`exec`/`discard`/`watch`/`unwatch`, including mixed-case) are never retried.
- Event dispatch: recovered call emits `CommandFailed` then `CommandExecuted`; failed retry emits two `CommandFailed`.

### Reproducer

Self-contained, Docker + phpredis: https://gist.github.com/MilesChou/46757c1ff49f20593e7fa87d536450a5

Current behavior — both configurations fail in the same ~1000 ms `read_timeout` window:

```
A. default (Laravel + connector):    ❌  read error on connection
B. OPT_MAX_RETRIES=3 + backoff:      ❌  read error on connection
```

After this PR — both recover transparently (~1600 ms = 1000 ms read_timeout + reconnect + retry):

```
A. default (Laravel + connector):    ✅  returns the value
B. OPT_MAX_RETRIES=3 + backoff:      ✅  returns the value
```

### Backward compatibility

Behavior changes in exactly one direction: callers that previously received a `RedisException` after a recoverable disconnection now receive a successful result. The exception type/shape is unchanged when retry isn't possible or fails. The 2022 reconnect invariant — that a disconnected client gets rebuilt before the next call — is preserved.

Targeting 13.x.

### History & related

The reconnect-without-retry behavior was introduced in [#41546](https://github.com/laravel/framework/pull/41546) (2022) as a minimal fix for [#41302](https://github.com/laravel/framework/issues/41302) — Queue Workers stuck in a stale-connection loop. For workers the next loop iteration uses the rebuilt client, so reconnect-without-retry was sufficient. For request/response paths (Cache, Session, long-running Octane) the failed request *is* the failed request. This PR closes that gap without changing worker behavior.

- [#41302](https://github.com/laravel/framework/issues/41302), [#41651](https://github.com/laravel/framework/issues/41651), [#55144](https://github.com/laravel/framework/issues/55144) — recurring reports of the same symptom
- [#41546](https://github.com/laravel/framework/pull/41546) — original half-implemented reconnect
- [#54191](https://github.com/laravel/framework/pull/54191) — phpredis built-in retry (doesn't cover this case)
- [#57685](https://github.com/laravel/framework/pull/57685) — added `READONLY` to the disconnect keywords
