### PR TITLE
[13.x] Fix Response::json() ignoring default argument when key is null (#60029)

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -110,7 +110,7 @@ class Response implements ArrayAccess, Stringable
         }
 
         if (is_null($key)) {
-            return $this->decoded;
+            return $this->decoded ?? $default;
         }
 
         return data_get($this->decoded, $key, $default);


### PR DESCRIPTION
Fixes #60029

When calling `json()` without a key (e.g. `$response->json(default: [])`), the method returned `$this->decoded` directly instead of respecting the `$default` parameter, causing `null` to be returned for non-JSON responses instead of the provided default.

This change uses the null coalescing operator: `$this->decoded ?? $default`.