### PR TITLE
[13.x] Fix DatabaseLock::acquire() catching unrelated QueryExceptions (#60171)

### DIFF
--- a/src/Illuminate/Cache/DatabaseLock.php
+++ b/src/Illuminate/Cache/DatabaseLock.php
@@ -77,7 +77,13 @@ class DatabaseLock extends Lock
             ]);
 
             $acquired = true;
-        } catch (QueryException) {
+        } catch (QueryException $e) {
+            $sqlState = $e->errorInfo[0] ?? null;
+
+            if ($sqlState === null || ! str_starts_with($sqlState, '23')) {
+                throw $e;
+            }
+
             $updated = $this->connection->table($this->table)
                 ->where('key', $this->name)
                 ->where(function ($query) {

--- a/tests/Integration/Database/DatabaseLockTest.php
+++ b/tests/Integration/Database/DatabaseLockTest.php
@@ -133,6 +133,56 @@ class DatabaseLockTest extends DatabaseTestCase
         }
     }
 
+    public function testAcquireRethrowsNonIntegrityConstraintException()
+    {
+        $connection = m::mock(Connection::class);
+        $insertBuilder = m::mock(Builder::class);
+
+        $qe = new QueryException(
+            'mysql',
+            'insert into cache_locks (key, owner, expiration) values (?, ?, ?)',
+            ['foo', 'owner', 1234567890],
+            new PDOException('SQLSTATE[22001]: String data, right truncated', 22001)
+        );
+        $qe->errorInfo = ['22001', 1406, 'String data, right truncated'];
+
+        $insertBuilder->shouldReceive('insert')->once()->andThrow($qe);
+
+        $connection->shouldReceive('table')->with('cache_locks')->andReturn($insertBuilder);
+
+        $lock = new DatabaseLock($connection, 'cache_locks', 'foo', 10);
+
+        $this->expectException(QueryException::class);
+        $lock->acquire();
+    }
+
+    public function testAcquireCatchesIntegrityConstraintException()
+    {
+        $connection = m::mock(Connection::class);
+        $insertBuilder = m::mock(Builder::class);
+        $updateBuilder = m::mock(Builder::class);
+
+        $qe = new QueryException(
+            'mysql',
+            'insert into cache_locks (key, owner, expiration) values (?, ?, ?)',
+            ['foo', 'owner', 1234567890],
+            new PDOException('SQLSTATE[23000]: Integrity constraint violation', 23000)
+        );
+        $qe->errorInfo = ['23000', 1062, 'Duplicate entry'];
+
+        $insertBuilder->shouldReceive('insert')->once()->andThrow($qe);
+
+        $updateBuilder->shouldReceive('where')->with('key', 'foo')->once()->andReturnSelf();
+        $updateBuilder->shouldReceive('where')->with(m::type('Closure'))->once()->andReturnSelf();
+        $updateBuilder->shouldReceive('update')->with(m::type('array'))->once()->andReturn(0);
+
+        $connection->shouldReceive('table')->with('cache_locks')->andReturn($insertBuilder, $updateBuilder);
+
+        $lock = new DatabaseLock($connection, 'cache_locks', 'foo', 10);
+
+        $this->assertFalse($lock->acquire());
+    }
+
     #[TestWith(['Serialization failure: 1213 Deadlock', 40001, true])]
     #[TestWith(['Table does not exist', 1146, false])]
     public function testReleaseIgnoresConcurrencyException(string $message, int $code, bool $hasConcurrencyError)


### PR DESCRIPTION
Fixes #60171

When acquire() fails on INSERT with a QueryException, it assumed the error was always a duplicate key violation and fell through to an UPDATE retry. Non-integrity-constraint errors (e.g. SQLSTATE 22001 for data truncation) were silently swallowed, causing block() to retry until timeout instead of propagating the real failure.

This fix checks the SQLSTATE from errorInfo, re-throwing the exception if it does not start with 23 (the SQL standard prefix for integrity constraint violations).