### PR TITLE
[13.x] Fix failed job providers crashing on corrupted payload (#59635)

### DIFF
--- a/src/Illuminate/Queue/Failed/DatabaseUuidFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseUuidFailedJobProvider.php
@@ -55,7 +55,7 @@ class DatabaseUuidFailedJobProvider implements CountableFailedJobProvider, Faile
     public function log($connection, $queue, $payload, $exception)
     {
         $this->getTable()->insert([
-            'uuid' => $uuid = json_decode($payload, true)['uuid'],
+            'uuid' => $uuid = (json_decode($payload, true) ?? [])['uuid'] ?? null,
             'connection' => $connection,
             'queue' => $queue,
             'payload' => $payload,

--- a/src/Illuminate/Queue/Failed/DynamoDbFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DynamoDbFailedJobProvider.php
@@ -57,7 +57,9 @@ class DynamoDbFailedJobProvider implements FailedJobProviderInterface
      */
     public function log($connection, $queue, $payload, $exception)
     {
-        $id = json_decode($payload, true)['uuid'];
+        $payloadData = json_decode($payload, true);
+
+        $id = $payloadData['uuid'] ?? null;
 
         $failedAt = Date::now();
 

--- a/src/Illuminate/Queue/Failed/FileFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/FileFailedJobProvider.php
@@ -56,7 +56,9 @@ class FileFailedJobProvider implements CountableFailedJobProvider, FailedJobProv
     public function log($connection, $queue, $payload, $exception)
     {
         return $this->lock(function () use ($connection, $queue, $payload, $exception) {
-            $id = json_decode($payload, true)['uuid'];
+            $payloadData = json_decode($payload, true);
+
+            $id = $payloadData['uuid'] ?? null;
 
             $jobs = $this->read();
 


### PR DESCRIPTION
Fixes #59635

Three UUID-based failed job providers (FileFailedJobProvider, DatabaseUuidFailedJobProvider, DynamoDbFailedJobProvider) accessed `json_decode($payload, true)['uuid']` without checking if `json_decode` returned null. If the queue backend delivers a corrupted payload, the provider crashes and the failed job record is permanently lost.

This fix safely extracts the UUID with a null-coalescing fallback, so non-JSON payloads are still recorded rather than crashing the failer.