### PR TITLE
[13.x] Reduce default trusted proxy headers to prevent host header injection

### DIFF
--- a/src/Illuminate/Http/Middleware/TrustProxies.php
+++ b/src/Illuminate/Http/Middleware/TrustProxies.php
@@ -20,10 +20,6 @@ class TrustProxies
      * @var int
      */
     protected $headers = Request::HEADER_X_FORWARDED_FOR |
-        Request::HEADER_X_FORWARDED_HOST |
-        Request::HEADER_X_FORWARDED_PORT |
-        Request::HEADER_X_FORWARDED_PROTO |
-        Request::HEADER_X_FORWARDED_PREFIX |
         Request::HEADER_X_FORWARDED_AWS_ELB;
 
     /**
@@ -143,7 +139,7 @@ class TrustProxies
             'HEADER_X_FORWARDED_PORT' => Request::HEADER_X_FORWARDED_PORT,
             'HEADER_X_FORWARDED_PROTO' => Request::HEADER_X_FORWARDED_PROTO,
             'HEADER_X_FORWARDED_PREFIX' => Request::HEADER_X_FORWARDED_PREFIX,
-            default => Request::HEADER_X_FORWARDED_FOR | Request::HEADER_X_FORWARDED_HOST | Request::HEADER_X_FORWARDED_PORT | Request::HEADER_X_FORWARDED_PROTO | Request::HEADER_X_FORWARDED_PREFIX | Request::HEADER_X_FORWARDED_AWS_ELB,
+            default => Request::HEADER_X_FORWARDED_FOR | Request::HEADER_X_FORWARDED_AWS_ELB,
         };
     }
 

--- a/tests/Foundation/Configuration/MiddlewareTest.php
+++ b/tests/Foundation/Configuration/MiddlewareTest.php
@@ -177,10 +177,6 @@ class MiddlewareTest extends TestCase
         $property = $reflection->getProperty('headers');
 
         $this->assertEquals(Request::HEADER_X_FORWARDED_FOR |
-            Request::HEADER_X_FORWARDED_HOST |
-            Request::HEADER_X_FORWARDED_PORT |
-            Request::HEADER_X_FORWARDED_PROTO |
-            Request::HEADER_X_FORWARDED_PREFIX |
             Request::HEADER_X_FORWARDED_AWS_ELB, $method->invoke($middleware));
 
         $property->setValue($middleware, Request::HEADER_X_FORWARDED_AWS_ELB);

--- a/tests/Http/Middleware/TrustProxiesTest.php
+++ b/tests/Http/Middleware/TrustProxiesTest.php
@@ -340,11 +340,12 @@ class TrustProxiesTest extends TestCase
     {
         $request = $this->createProxiedRequest();
 
-        // trust *all* "X-Forwarded-*" headers
+        // unrecognized header strings fall back to the secure default headers
         $trustedProxy = $this->createTrustedProxy('HEADER_X_FORWARDED_ALL', '192.168.1.1, 192.168.1.2');
         $trustedProxy->handle($request, function (Request $request) {
-            $this->assertEquals($request->getTrustedHeaderSet(), $this->headerAll,
-                'Assert trusted proxy used all "X-Forwarded-*" header');
+            $this->assertEquals($request->getTrustedHeaderSet(),
+                Request::HEADER_X_FORWARDED_FOR | Request::HEADER_X_FORWARDED_AWS_ELB,
+                'Assert unrecognized header string falls back to secure default headers');
 
             $this->assertEquals(['192.168.1.1', '192.168.1.2'], $request->getTrustedProxies(),
                 'Assert trusted proxy using proxies as string separated by comma.');


### PR DESCRIPTION
## Problem

The default for `$headers` in `TrustProxies` trusted a broad set of
forwarded headers out of the box:

```php
protected $headers = Request::HEADER_X_FORWARDED_FOR
    | Request::HEADER_X_FORWARDED_HOST
    | Request::HEADER_X_FORWARDED_PORT
    | Request::HEADER_X_FORWARDED_PROTO
    | Request::HEADER_X_FORWARDED_PREFIX
    | Request::HEADER_X_FORWARDED_AWS_ELB;
```

When combined with a wildcard proxy (`trustProxies(at: '*')`), this allowed an attacker to poison the host used to generate asset URLs.

Because `asset()` ultimately resolves the hostname through the Symfony request object, which honours trusted proxy headers, an attacker who can send an arbitrary `X-Forwarded-Host` header (combined with `_PROTO`, `_PORT`, and `_PREFIX`) can redirect all asset URLs to a host they control. For example, with the old defaults and `proxies = '*'`, a manipulative request carrying:

```
X-Forwarded-Host: attacker.com
```

would cause `asset('cat.jpg')` to resolve to `https://attacker.com/cat.jpg` instead of `https://my-app.com/cat.jpg`.

This enables asset injection attacks (substituting legitimate assets with malicious ones) without the application developer doing anything obviously wrong. The root cause is that `X-Forwarded-Host` was trusted by default. Whether `*` proxies were allowed on purpose or by mistake, in this scenario, it's not expected to affect asset URLs.

This effect is magnified if the application caches the asset URLs. If asset URLs are cached, a single poisoned request can serve malicious assets to every subsequent visitor until the cache is cleared. There could be other side effects of this current default behaviour.

## Solution

The default is narrowed to the headers that do not have this side effect (might be better to remove all default headers at this point though):

```php
protected $headers = Request::HEADER_X_FORWARDED_FOR
    | Request::HEADER_X_FORWARDED_AWS_ELB;
```

The `default` branch of `getTrustedHeaderNames()` (which handles unrecognised string-based header configurations) is updated to match.

## Opting back in

Applications that legitimately need the removed headers can add them explicitly:

```php
// bootstrap/app.php

$middleware->trustProxies(
    at: '*',
    headers: Request::HEADER_X_FORWARDED_FOR
        | Request::HEADER_X_FORWARDED_HOST
        | Request::HEADER_X_FORWARDED_PORT
        | Request::HEADER_X_FORWARDED_PROTO
        | Request::HEADER_X_FORWARDED_PREFIX
        | Request::HEADER_X_FORWARDED_AWS_ELB
);
```