### PR TITLE
[13.x] Allow schema path option on migrate:refresh

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
@@ -66,6 +66,7 @@ class RefreshCommand extends Command
             '--database' => $database,
             '--path' => $path,
             '--realpath' => $this->input->getOption('realpath'),
+            '--schema-path' => $this->input->getOption('schema-path'),
             '--force' => true,
         ]));
 
@@ -155,6 +156,7 @@ class RefreshCommand extends Command
             ['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production'],
             ['path', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'The path(s) to the migrations files to be executed'],
             ['realpath', null, InputOption::VALUE_NONE, 'Indicate any provided migration file paths are pre-resolved absolute paths'],
+            ['schema-path', null, InputOption::VALUE_OPTIONAL, 'The path to a schema dump file'],
             ['seed', null, InputOption::VALUE_NONE, 'Indicates if the seed task should be re-run'],
             ['seeder', null, InputOption::VALUE_OPTIONAL, 'The class name of the root seeder'],
             ['step', null, InputOption::VALUE_OPTIONAL, 'The number of migrations to be reverted & re-run'],

--- a/tests/Database/DatabaseMigrationRefreshCommandTest.php
+++ b/tests/Database/DatabaseMigrationRefreshCommandTest.php
@@ -74,6 +74,32 @@ class DatabaseMigrationRefreshCommandTest extends TestCase
         $this->runCommand($command, ['--step' => 2]);
     }
 
+    public function testRefreshCommandForwardsSchemaPathToMigrateCommand()
+    {
+        $command = new RefreshCommand;
+
+        $app = new ApplicationDatabaseRefreshStub(['path.database' => __DIR__]);
+        $dispatcher = $app->instance(Dispatcher::class, $events = m::mock());
+        $console = m::mock(ConsoleApplication::class)->makePartial();
+        $console->__construct();
+        $command->setLaravel($app);
+        $command->setApplication($console);
+
+        $resetCommand = m::mock(ResetCommand::class);
+        $migrateCommand = m::mock(MigrateCommand::class);
+
+        $console->shouldReceive('find')->with('migrate:reset')->andReturn($resetCommand);
+        $console->shouldReceive('find')->with('migrate')->andReturn($migrateCommand);
+        $dispatcher->shouldReceive('dispatch')->once()->with(m::type(DatabaseRefreshed::class));
+
+        $schemaPath = __DIR__.'/stubs/schema.sql';
+        $quote = DIRECTORY_SEPARATOR === '\\' ? '"' : "'";
+        $resetCommand->shouldReceive('run')->with(new InputMatcher("--force=1 {$quote}migrate:reset{$quote}"), m::any());
+        $migrateCommand->shouldReceive('run')->with(new InputMatcher("--schema-path={$quote}{$schemaPath}{$quote} --force=1 migrate"), m::any());
+
+        $this->runCommand($command, ['--schema-path' => $schemaPath]);
+    }
+
     public function testRefreshCommandExitsWhenProhibited()
     {
         $command = new RefreshCommand;


### PR DESCRIPTION
The `migrate:refresh` command resets migrations and then delegates to the base `migrate` command.

Since the base `migrate` command supports `--schema-path`, and `migrate:fresh` already accepts and forwards that option, this adds the same pass-through support to `migrate:refresh`.

This does not change rollback or reset behavior. The option is only forwarded to the internal `migrate` call.

Tests updated accordingly.