### PR TITLE
[13.x] Fix async promise chain mutability

### DIFF
--- a/src/Illuminate/Http/Client/Promises/FluentPromise.php
+++ b/src/Illuminate/Http/Client/Promises/FluentPromise.php
@@ -84,12 +84,10 @@ class FluentPromise implements PromiseInterface
     {
         $result = $this->forwardCallTo($this->guzzlePromise, $method, $parameters);
 
-        if (! $result instanceof PromiseInterface) {
-            return $result;
+        if ($result instanceof PromiseInterface) {
+            return new static($result);
         }
 
-        $this->guzzlePromise = $result;
-
-        return $this;
+        return $result;
     }
 }

--- a/src/Illuminate/Http/Client/Promises/LazyPromise.php
+++ b/src/Illuminate/Http/Client/Promises/LazyPromise.php
@@ -9,13 +9,6 @@ use RuntimeException;
 class LazyPromise implements PromiseInterface
 {
     /**
-     * The callbacks to execute after the Guzzle Promise has been built.
-     *
-     * @var list<callable>
-     */
-    protected array $pending = [];
-
-    /**
      * The promise built by the creator.
      *
      * @var \GuzzleHttp\Promise\PromiseInterface
@@ -35,22 +28,14 @@ class LazyPromise implements PromiseInterface
      * Build the promise from the promise builder.
      *
      * @return \GuzzleHttp\Promise\PromiseInterface
-     *
-     * @throws \RuntimeException If the promise has already been built
      */
     public function buildPromise(): PromiseInterface
     {
-        if (! $this->promiseNeedsBuilt()) {
-            throw new RuntimeException('Promise already built');
+        if (isset($this->guzzlePromise)) {
+            return $this->guzzlePromise;
         }
 
         $this->guzzlePromise = call_user_func($this->promiseBuilder);
-
-        foreach ($this->pending as $pendingCallback) {
-            $pendingCallback($this->guzzlePromise);
-        }
-
-        $this->pending = [];
 
         return $this->guzzlePromise;
     }
@@ -58,25 +43,13 @@ class LazyPromise implements PromiseInterface
     #[\Override]
     public function then(?callable $onFulfilled = null, ?callable $onRejected = null): PromiseInterface
     {
-        if ($this->promiseNeedsBuilt()) {
-            $this->pending[] = static fn (PromiseInterface $promise) => $promise->then($onFulfilled, $onRejected);
-
-            return $this;
-        }
-
-        return $this->guzzlePromise->then($onFulfilled, $onRejected);
+        return $this->__call('then', [$onFulfilled, $onRejected]);
     }
 
     #[\Override]
     public function otherwise(callable $onRejected): PromiseInterface
     {
-        if ($this->promiseNeedsBuilt()) {
-            $this->pending[] = static fn (PromiseInterface $promise) => $promise->otherwise($onRejected);
-
-            return $this;
-        }
-
-        return $this->guzzlePromise->otherwise($onRejected);
+        return $this->__call('otherwise', [$onRejected]);
     }
 
     #[\Override]
@@ -115,6 +88,22 @@ class LazyPromise implements PromiseInterface
         }
 
         return $this->guzzlePromise->wait($unwrap);
+    }
+
+    /**
+     * Proxy deferred promise calls through a new lazy promise.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return \GuzzleHttp\Promise\PromiseInterface
+     */
+    public function __call($method, $parameters)
+    {
+        if (! isset($this->guzzlePromise)) {
+            return new static(fn () => $this->buildPromise()->$method(...$parameters));
+        }
+
+        return $this->guzzlePromise->$method(...$parameters);
     }
 
     /**

--- a/src/Illuminate/Http/Client/Promises/LazyPromise.php
+++ b/src/Illuminate/Http/Client/Promises/LazyPromise.php
@@ -4,7 +4,6 @@ namespace Illuminate\Http\Client\Promises;
 
 use Closure;
 use GuzzleHttp\Promise\PromiseInterface;
-use RuntimeException;
 
 class LazyPromise implements PromiseInterface
 {


### PR DESCRIPTION
When chaining `then()` or `otherwise()` on async promises, each call should return a new promise instance as required by the `PromiseInterface` contract. Currently, both `FluentPromise` and `LazyPromise` mutate their internal state and return `$this`, breaking the chain:

```php
$promise1 = Http::async()->get(`/foo`)->then(fn (Response $r) => $r->status());
$promise2 = $promise1->then(fn ($status) => `one`);
$promise3 = $promise2->then(fn ($str) => `two`);

$result1 = $promise1->wait(); // `two` (WRONG, should be the status code)
$result2 = $promise2->wait(); // `two` (WRONG, should be `one`)
$result3 = $promise3->wait(); // `two` (CORRECT)
```

**Changes:**

1. **FluentPromise::__call()** — Return `new static($result)` instead of mutating `$this->guzzlePromise` and returning `$this`.

2. **LazyPromise::then() and otherwise()** — Proxy through a new `__call()` method that either returns a new `LazyPromise` (when deferred) or delegates to the underlying promise (when already built). Removed the `$pending` callback queue, replaced with proper deferred chaining.

**After the fix:**

```php
$result1 = $promise1->wait(); // status code
$result2 = $promise2->wait(); // `one`
$result3 = $promise3->wait(); // `two`
```