### PR TITLE
[14.x] Adds PHP Attribute helper [WIP]

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -10,6 +10,7 @@ use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Eloquent\Attributes\UsePolicy;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Attr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
@@ -701,11 +702,7 @@ class Gate implements GateContract
             return null;
         }
 
-        $attributes = (new ReflectionClass($class))->getAttributes(UsePolicy::class);
-
-        return $attributes !== []
-            ? $attributes[0]->newInstance()->class
-            : null;
+        return Attr::onClass($class)->instance(UsePolicy::class)->class;
     }
 
     /**

--- a/src/Illuminate/Collections/Traits/TransformsToResourceCollection.php
+++ b/src/Illuminate/Collections/Traits/TransformsToResourceCollection.php
@@ -6,8 +6,8 @@ use Illuminate\Database\Eloquent\Attributes\UseResource;
 use Illuminate\Database\Eloquent\Attributes\UseResourceCollection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Resources\Json\ResourceCollection;
+use Illuminate\Support\Attr;
 use LogicException;
-use ReflectionClass;
 
 trait TransformsToResourceCollection
 {
@@ -93,11 +93,7 @@ trait TransformsToResourceCollection
             return null;
         }
 
-        $attributes = (new ReflectionClass($class))->getAttributes(UseResource::class);
-
-        return $attributes !== []
-            ? $attributes[0]->newInstance()->class
-            : null;
+        return Attr::onClass($class)->instance(UseResource::class)?->class;
     }
 
     /**
@@ -112,10 +108,6 @@ trait TransformsToResourceCollection
             return null;
         }
 
-        $attributes = (new ReflectionClass($class))->getAttributes(UseResourceCollection::class);
-
-        return $attributes !== []
-            ? $attributes[0]->newInstance()->class
-            : null;
+        return Attr::onClass($class)->instance(UseResourceCollection::class)?->class;
     }
 }

--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -7,8 +7,8 @@ use Illuminate\Console\Events\ArtisanStarting;
 use Illuminate\Contracts\Console\Application as ApplicationContract;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Support\Attr;
 use Illuminate\Support\ProcessUtils;
-use ReflectionClass;
 use Symfony\Component\Console\Application as SymfonyApplication;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
@@ -255,11 +255,9 @@ class Application extends SymfonyApplication implements ApplicationContract
     public function resolve($command)
     {
         if (is_subclass_of($command, SymfonyCommand::class)) {
-            $attribute = (new ReflectionClass($command))->getAttributes(AsCommand::class);
+            $commandName = Attr::onClass($command)->instance(AsCommand::class)?->name;
 
-            $commandName = ! empty($attribute) ? $attribute[0]->newInstance()->name : null;
-
-            if (! is_null($commandName)) {
+            if ($commandName) {
                 foreach (explode('|', $commandName) as $name) {
                     $this->commandMap[$name] = $command;
                 }

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -6,8 +6,8 @@ use Illuminate\Console\Attributes\Description;
 use Illuminate\Console\Attributes\Signature;
 use Illuminate\Console\View\Components\Factory;
 use Illuminate\Contracts\Console\Isolatable;
+use Illuminate\Support\Attr;
 use Illuminate\Support\Traits\Macroable;
-use ReflectionClass;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -136,25 +136,12 @@ class Command extends SymfonyCommand
      */
     protected function configureFromAttributes()
     {
-        $reflection = new ReflectionClass($this);
+        $signature = Attr::onClass($this)->instance(Signature::class);
 
-        $signature = $reflection->getAttributes(Signature::class);
+        $this->signature = $signature?->signature;
+        $this->aliases = $signature?->aliases;
 
-        if (count($signature) > 0) {
-            $signatureInstance = $signature[0]->newInstance();
-
-            $this->signature = $signatureInstance->signature;
-
-            if ($signatureInstance->aliases !== null) {
-                $this->aliases = $signatureInstance->aliases;
-            }
-        }
-
-        $description = $reflection->getAttributes(Description::class);
-
-        if (count($description) > 0) {
-            $this->description = $description[0]->newInstance()->description;
-        }
+        $this->description = Attr::onClass($this)->instance(Description::class)->description ?? '';
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Events\NullDispatcher;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Attr;
 use Illuminate\Support\Collection;
 use InvalidArgumentException;
 use ReflectionClass;

--- a/src/Illuminate/Database/Eloquent/Concerns/TransformsToResource.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/TransformsToResource.php
@@ -4,9 +4,9 @@ namespace Illuminate\Database\Eloquent\Concerns;
 
 use Illuminate\Database\Eloquent\Attributes\UseResource;
 use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Attr;
 use Illuminate\Support\Str;
 use LogicException;
-use ReflectionClass;
 
 trait TransformsToResource
 {
@@ -90,10 +90,6 @@ trait TransformsToResource
             return null;
         }
 
-        $attributes = (new ReflectionClass($class))->getAttributes(UseResource::class);
-
-        return $attributes !== []
-            ? $attributes[0]->newInstance()->class
-            : null;
+        return Attr::onClass($class)->instance(UseResource::class)?->class;
     }
 }

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Factories\Attributes\UseModel;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Attr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Enumerable;
@@ -16,7 +17,6 @@ use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\ForwardsCalls;
 use Illuminate\Support\Traits\Macroable;
-use ReflectionClass;
 use Throwable;
 use UnitEnum;
 
@@ -945,11 +945,8 @@ abstract class Factory
     public function modelName()
     {
         if (! array_key_exists(static::class, static::$cachedModelAttributes)) {
-            $attribute = (new ReflectionClass($this))->getAttributes(UseModel::class);
-
-            static::$cachedModelAttributes[static::class] = count($attribute) > 0
-                ? $attribute[0]->newInstance()->class
-                : false;
+            static::$cachedModelAttributes[static::class] = Attr::onClass($this)
+                ->instance(UseModel::class)?->class ?? false;
         }
 
         if (static::$cachedModelAttributes[static::class]) {

--- a/src/Illuminate/Database/Eloquent/Factories/HasFactory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/HasFactory.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Eloquent\Factories;
 
 use Illuminate\Database\Eloquent\Attributes\UseFactory;
+use Illuminate\Support\Attr;
 
 /**
  * @template TFactory of \Illuminate\Database\Eloquent\Factories\Factory
@@ -42,17 +43,14 @@ trait HasFactory
     /**
      * Get the factory from the UseFactory class attribute.
      *
-     * @return TFactory|null
+     * @return TFactory|void
      */
     protected static function getUseFactoryAttribute()
     {
-        $attributes = (new \ReflectionClass(static::class))
-            ->getAttributes(UseFactory::class);
+        $factoryClass = Attr::onClass(static::class)->instance(UseFactory::class)?->factoryClass;
 
-        if ($attributes !== []) {
-            $useFactory = $attributes[0]->newInstance();
-
-            $factory = $useFactory->factoryClass::new();
+        if ($factoryClass) {
+            $factory = $factoryClass::new();
 
             $factory->guessModelNamesUsing(fn () => static::class);
 

--- a/src/Illuminate/Database/Eloquent/HasCollection.php
+++ b/src/Illuminate/Database/Eloquent/HasCollection.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Database\Eloquent;
 
 use Illuminate\Database\Eloquent\Attributes\CollectedBy;
-use ReflectionClass;
+use Illuminate\Support\Attr;
 
 /**
  * @template TCollection of \Illuminate\Database\Eloquent\Collection
@@ -43,14 +43,6 @@ trait HasCollection
      */
     public function resolveCollectionFromAttribute()
     {
-        $reflectionClass = new ReflectionClass(static::class);
-
-        $attributes = $reflectionClass->getAttributes(CollectedBy::class);
-
-        if (! isset($attributes[0]) || ! isset($attributes[0]->getArguments()[0])) {
-            return;
-        }
-
-        return $attributes[0]->getArguments()[0];
+        return Attr::onClass(static::class)->instance(CollectedBy::class)?->collectionClass;
     }
 }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -25,6 +25,7 @@ use Illuminate\Database\Eloquent\Relations\Concerns\AsPivot;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Attr;
 use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Support\Str;
 use Illuminate\Support\Stringable as SupportStringable;
@@ -33,7 +34,6 @@ use JsonException;
 use JsonSerializable;
 use LogicException;
 use ReflectionClass;
-use ReflectionMethod;
 use Stringable;
 
 use function Illuminate\Support\enum_value;
@@ -1836,12 +1836,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     protected function resolveCustomBuilderClass()
     {
-        $attributes = (new ReflectionClass($this))
-            ->getAttributes(UseEloquentBuilder::class);
-
-        return ! empty($attributes)
-            ? $attributes[0]->newInstance()->builderClass
-            : false;
+        return Attr::onClass($this)->instance(UseEloquentBuilder::class)?->builderClass ?? false;
     }
 
     /**
@@ -1906,9 +1901,8 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     protected static function isScopeMethodWithAttribute(string $method)
     {
-        return method_exists(static::class, $method) &&
-            (new ReflectionMethod(static::class, $method))
-                ->getAttributes(LocalScope::class) !== [];
+        return method_exists(static::class, $method)
+            && Attr::onMethod(static::class, $method)->has(LocalScope::class);
     }
 
     /**
@@ -2574,17 +2568,11 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         }
 
         try {
-            $reflection = new ReflectionClass($class);
+            $instance = Attr::onClass($class)->instance($attributeClass, true);
 
-            do {
-                $attributes = $reflection->getAttributes($attributeClass);
-
-                if (count($attributes) > 0) {
-                    $instance = $attributes[0]->newInstance();
-
-                    return static::$classAttributes[$cacheKey] = $property ? $instance->{$property} : $instance;
-                }
-            } while ($reflection = $reflection->getParentClass());
+            if ($instance) {
+                return static::$classAttributes[$cacheKey] = $property ? $instance->{$property} : $instance;
+            }
         } catch (Exception) {
             //
         }

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -14,8 +14,8 @@ use Illuminate\Foundation\Http\Attributes\RedirectToRoute;
 use Illuminate\Foundation\Http\Attributes\StopOnFirstFailure;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Redirector;
+use Illuminate\Support\Attr;
 use Illuminate\Validation\ValidatesWhenResolvedTrait;
-use ReflectionClass;
 
 class FormRequest extends Request implements ValidatesWhenResolved
 {
@@ -121,29 +121,15 @@ class FormRequest extends Request implements ValidatesWhenResolved
      */
     protected function configureFromAttributes()
     {
-        $reflection = new ReflectionClass($this);
+        $attr = Attr::onClass($this);
 
-        if (count($reflection->getAttributes(StopOnFirstFailure::class)) > 0) {
-            $this->stopOnFirstFailure = true;
-        }
+        $this->stopOnFirstFailure = $attr->has(StopOnFirstFailure::class);
 
-        $redirectTo = $reflection->getAttributes(RedirectTo::class);
+        $this->redirect = $attr->instance(RedirectTo::class)?->url;
 
-        if (count($redirectTo) > 0) {
-            $this->redirect = $redirectTo[0]->newInstance()->url;
-        }
+        $this->redirectRoute = $attr->instance(RedirectToRoute::class)?->route;
 
-        $redirectToRoute = $reflection->getAttributes(RedirectToRoute::class);
-
-        if (count($redirectToRoute) > 0) {
-            $this->redirectRoute = $redirectToRoute[0]->newInstance()->route;
-        }
-
-        $errorBag = $reflection->getAttributes(ErrorBag::class);
-
-        if (count($errorBag) > 0) {
-            $this->errorBag = $errorBag[0]->newInstance()->name;
-        }
+        $this->errorBag = $attr->instance(ErrorBag::class)?->name ?? $this->errorBag;
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/Traits/CanConfigureMigrationCommands.php
+++ b/src/Illuminate/Foundation/Testing/Traits/CanConfigureMigrationCommands.php
@@ -4,7 +4,7 @@ namespace Illuminate\Foundation\Testing\Traits;
 
 use Illuminate\Foundation\Testing\Attributes\Seed;
 use Illuminate\Foundation\Testing\Attributes\Seeder;
-use ReflectionClass;
+use Illuminate\Support\Attr;
 
 trait CanConfigureMigrationCommands
 {
@@ -53,13 +53,9 @@ trait CanConfigureMigrationCommands
      */
     protected function shouldSeed()
     {
-        $class = new ReflectionClass($this);
-
-        do {
-            if (count($class->getAttributes(Seed::class)) > 0) {
-                return true;
-            }
-        } while ($class = $class->getParentClass());
+        if (Attr::onClass($this)->has(Seed::class, true)) {
+            return true;
+        }
 
         return property_exists($this, 'seed') ? $this->seed : false;
     }
@@ -71,15 +67,11 @@ trait CanConfigureMigrationCommands
      */
     protected function seeder()
     {
-        $class = new ReflectionClass($this);
+        $seeder = Attr::onClass($this)->recursive()->instance(Seeder::class)?->class;
 
-        do {
-            $seeder = $class->getAttributes(Seeder::class);
-
-            if (count($seeder) > 0) {
-                return $seeder[0]->newInstance()->class;
-            }
-        } while ($class = $class->getParentClass());
+        if ($seeder) {
+            return $seeder;
+        }
 
         return property_exists($this, 'seeder') ? $this->seeder : false;
     }

--- a/src/Illuminate/Http/Resources/CollectsResources.php
+++ b/src/Illuminate/Http/Resources/CollectsResources.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Resources\Attributes\Collects;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Pagination\AbstractCursorPaginator;
 use Illuminate\Pagination\AbstractPaginator;
+use Illuminate\Support\Attr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use LogicException;
@@ -60,11 +61,8 @@ trait CollectsResources
         $collects = null;
 
         if (! array_key_exists(static::class, static::$cachedCollectsAttributes)) {
-            $attribute = (new ReflectionClass($this))->getAttributes(Collects::class);
-
-            static::$cachedCollectsAttributes[static::class] = count($attribute) > 0
-                ? $attribute[0]->newInstance()->class
-                : false;
+            static::$cachedCollectsAttributes[static::class] = Attr::onClass($this)->instance(Collects::class)?->class
+                ?? false;
         }
 
         if (static::$cachedCollectsAttributes[static::class]) {

--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -4,8 +4,8 @@ namespace Illuminate\Http\Resources;
 
 use Illuminate\Http\Resources\Attributes\PreserveKeys;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Attr;
 use Illuminate\Support\Stringable;
-use ReflectionClass;
 
 trait ConditionallyLoadsAttributes
 {
@@ -95,9 +95,7 @@ trait ConditionallyLoadsAttributes
         }
 
         if (! array_key_exists(static::class, static::$cachedPreserveKeysAttributes)) {
-            static::$cachedPreserveKeysAttributes[static::class] = count(
-                (new ReflectionClass($this))->getAttributes(PreserveKeys::class)
-            ) > 0;
+            static::$cachedPreserveKeysAttributes[static::class] = Attr::onClass($this)->has(PreserveKeys::class);
         }
 
         if (static::$cachedPreserveKeysAttributes[static::class]) {

--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -13,9 +13,9 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Attributes\PreserveKeys;
 use Illuminate\Http\Resources\ConditionallyLoadsAttributes;
 use Illuminate\Http\Resources\DelegatesToResource;
+use Illuminate\Support\Attr;
 use JsonException;
 use JsonSerializable;
-use ReflectionClass;
 
 class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRoutable
 {
@@ -89,9 +89,8 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
     {
         return tap(static::newCollection($resource), function ($collection) {
             if (! array_key_exists(static::class, static::$cachedPreserveKeysAttributes)) {
-                static::$cachedPreserveKeysAttributes[static::class] = count(
-                    (new ReflectionClass(static::class))->getAttributes(PreserveKeys::class)
-                ) > 0;
+                static::$cachedPreserveKeysAttributes[static::class] = Attr::onClass(static::class)
+                    ->has(PreserveKeys::class);
             }
 
             if (static::$cachedPreserveKeysAttributes[static::class]) {

--- a/src/Illuminate/Queue/Attributes/ReadsQueueAttributes.php
+++ b/src/Illuminate/Queue/Attributes/ReadsQueueAttributes.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Queue\Attributes;
 
 use Exception;
-use ReflectionClass;
+use Illuminate\Support\Attr;
 
 trait ReadsQueueAttributes
 {
@@ -19,15 +19,11 @@ trait ReadsQueueAttributes
     protected function getAttributeValue($job, string $attributeClass, ?string $property = null, $default = null)
     {
         try {
-            $reflection = new ReflectionClass($job);
+            $instance = Attr::onClass($job)->recursive()->instance($attributeClass);
 
-            do {
-                $attributes = $reflection->getAttributes($attributeClass);
-
-                if (count($attributes) > 0) {
-                    return $this->extractAttributeValue($attributes[0]->newInstance());
-                }
-            } while ($reflection = $reflection->getParentClass());
+            if ($instance) {
+                return $instance;
+            }
         } catch (Exception) {
             //
         }

--- a/src/Illuminate/Support/Attr.php
+++ b/src/Illuminate/Support/Attr.php
@@ -1,0 +1,248 @@
+<?php
+
+namespace Illuminate\Support;
+
+use ReflectionAttribute;
+use ReflectionClass;
+use ReflectionMethod;
+use ReflectionObject;
+use ReflectionProperty;
+
+class Attr
+{
+    /**
+     * Create a new Attr instance.
+     *
+     * @param  \ReflectionClass|\ReflectionObject|\ReflectionMethod|\ReflectionProperty  $reflection
+     * @param  int  $flags
+     * @param  bool $isRecursive
+     * @param  bool $isFindingAll
+     */
+    public function __construct(
+        protected $reflection,
+        protected $flags = 0,
+        protected $isRecursive = false,
+        protected $isFindingAll = false
+    ) {
+        //
+    }
+
+    /**
+     * Include descendants of the attribute to filter.
+     *
+     * @return $this
+     */
+    public function instancesOf()
+    {
+        $this->flags |= ReflectionAttribute::IS_INSTANCEOF;
+
+        return $this;
+    }
+
+    /**
+     * Recursively find all classes until the last parent.
+     *
+     * @param  bool  $findAll
+     * @return $this
+     */
+    public function recursive($findAll = false)
+    {
+        $this->isRecursive = true;
+        $this->isFindingAll = $findAll;
+
+        return $this;
+    }
+
+    /**
+     * Retrieve all the attribute reflections of the target.
+     *
+     * @template TAttribute of object
+     *
+     * @param  class-string<TAttribute>  $attribute
+     * @return \ReflectionAttribute<TAttribute>[]
+     */
+    public function all($attribute)
+    {
+        // When the developer asks for recursive discovery, we will also check if the reflection
+        // supports recursion. As we search all the matching attributes, we will stop only when
+        // there are attributes found, or we reach the deepest parent class possible from all.
+        $shouldFindParents = $this->isRecursive && (
+            $this->reflection instanceof ReflectionClass ||
+            $this->reflection instanceof ReflectionMethod ||
+            $this->reflection instanceof ReflectionProperty
+        );
+
+        $parent = $this->reflection;
+
+        $reflections = [];
+
+        do {
+            $reflections = array_merge($reflections, $parent->getAttributes($attribute, $this->flags));
+        } while (
+            (empty($reflections) || $this->isFindingAll) &&
+            // When the developer has for a recursive search on methods or properties, we will
+            // find the declaring parent class, check if the method or property exists in it,
+            // and give the respective reflection. This way we can keep the recursion logic.
+            $parent = $shouldFindParents ? $this->getParent($parent) : null
+        );
+
+        return $reflections;
+    }
+
+    /**
+     * Retrieves the parent class of the class, object, property, or method.
+     *
+     * @param \ReflectionClass|\ReflectionMethod|\ReflectionProperty  $reflection
+     * @return \ReflectionClass|\ReflectionMethod|\ReflectionProperty|null
+     */
+    protected function getParent($reflection)
+    {
+        if ($reflection instanceof ReflectionClass) {
+            return $reflection->getParentClass() ?: null;
+        }
+
+        if ($reflection instanceof ReflectionMethod) {
+            $parent = $reflection->getDeclaringClass()->getParentClass();
+
+            if ($parent && $parent->hasMethod($reflection->getName())) {
+                return $parent->getMethod($reflection->getName());
+            }
+
+            return null;
+        }
+
+        if ($reflection instanceof ReflectionProperty) {
+            $parent = $reflection->getDeclaringClass()->getParentClass();
+
+            if ($parent && $parent->hasProperty($reflection->getName())) {
+                return $parent->getProperty($reflection->getName());
+            }
+
+            return null;
+        }
+    }
+
+    /**
+     * Returns all the attributes as their respective object instances.
+     *
+     * @template TAttribute of object
+     *
+     * @param  class-string<TAttribute>  $attribute
+     * @return TAttribute[]
+     */
+    public function instances($attribute)
+    {
+        return array_map(fn($attribute) => $attribute->newInstance(), $this->all($attribute));
+    }
+
+    /**
+     * Return all the instances of the attribute as a collection.
+     *
+     * @template TAttribute of object
+     *
+     * @param  class-string<TAttribute>  $attribute
+     * @return \Illuminate\Support\Collection<TAttribute>
+     */
+    public function collect($attribute)
+    {
+        return new Collection($this->instances($attribute));
+    }
+
+    /**
+     * Retrieve the first Reflection Attribute instance of the target.
+     *
+     * @template TAttribute of object
+     *
+     * @param  class-string<TAttribute>  $attribute
+     * @return \ReflectionAttribute<TAttribute>|null
+     */
+    public function first($attribute)
+    {
+        return $this->all($attribute)[0] ?? null;
+    }
+
+    /**
+     * Retrieve the first attribute instance of the target.
+     *
+     * @template TAttribute of object
+     *
+     * @param  class-string<TAttribute>  $attribute
+     * @return TAttribute|null
+     */
+    public function instance($attribute)
+    {
+        return $this->first($attribute)?->newInstance();
+    }
+
+    /**
+     * Check if a given attribute class exists on the target.
+     *
+     * @template TAttribute of object
+     *
+     * @param  class-string<TAttribute>  $attribute
+     * @return bool
+     */
+    public function has($attribute)
+    {
+        return !empty($this->all($attribute));
+    }
+
+    /**
+     * Check if a given attribute class does not exist on the target.
+     *
+     * @template TAttribute of object
+     *
+     * @param  class-string<TAttribute>  $attribute
+     * @return bool
+     */
+    public function missing($attribute)
+    {
+        return !$this->has($attribute);
+    }
+
+    /**
+     * Retrieve all the attributes from the given target.
+     *
+     * @param  class-string|object  $class
+     * @return static
+     */
+    public static function onClass($class)
+    {
+        return new static(new ReflectionClass($class));
+    }
+
+    /**
+     * Retrieve all the attributes from the given object.
+     *
+     * @param  object  $object
+     * @return static
+     */
+    public static function onObject($object)
+    {
+        return new static(new ReflectionObject($object));
+    }
+
+    /**
+     * Retrieve all the attributes from the given method.
+     *
+     * @param  object|string  $target
+     * @param  string  $method
+     * @return static
+     */
+    public static function onMethod($target, $method)
+    {
+        return new static(new ReflectionMethod($target, $method));
+    }
+
+    /**
+     * Retrieve all the attributes from the given property.
+     *
+     * @param  object|string  $target
+     * @param  string  $property
+     * @return static
+     */
+    public static function onProperty($target, $property)
+    {
+        return new static(new ReflectionProperty($target, $property));
+    }
+}

--- a/tests/Support/SupportAttrTest.php
+++ b/tests/Support/SupportAttrTest.php
@@ -1,0 +1,297 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use Attribute;
+use Illuminate\Support\Attr;
+use Illuminate\Support\Collection;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use ReflectionAttribute;
+
+class SupportAttrTest extends TestCase
+{
+    protected function attr(callable $factory, bool $instancesOf, ?bool $recursiveAll): Attr
+    {
+        $attr = $factory();
+
+        if ($instancesOf) {
+            $attr->instancesOf();
+        }
+
+        if ($recursiveAll !== null) {
+            $attr->recursive($recursiveAll);
+        }
+
+        return $attr;
+    }
+
+    protected function attributeValues(array $attributes): array
+    {
+        return array_map(fn (ReflectionAttribute $attribute) => $attribute->newInstance()->value, $attributes);
+    }
+
+    protected function instanceValues(array $instances): array
+    {
+        return array_map(fn (SupportAttrTestBaseAttribute $instance) => $instance->value, $instances);
+    }
+
+    public static function allTargetsProvider(): array
+    {
+        return [
+            'class exact' => [fn () => Attr::onClass(SupportAttrTestChildClass::class), false, null, ['child-base']],
+            'class instances of' => [fn () => Attr::onClass(SupportAttrTestChildClass::class), true, null, ['child-base', 'child-child']],
+            'class recursive first exact' => [fn () => Attr::onClass(SupportAttrTestChildClass::class), false, false, ['child-base']],
+            'class recursive first instances of' => [fn () => Attr::onClass(SupportAttrTestChildClass::class), true, false, ['child-base', 'child-child']],
+            'class recursive all exact' => [fn () => Attr::onClass(SupportAttrTestChildClass::class), false, true, ['child-base', 'parent-base']],
+            'class recursive all instances of' => [fn () => Attr::onClass(SupportAttrTestChildClass::class), true, true, ['child-base', 'child-child', 'parent-base', 'parent-child']],
+            'class recursive first finds parent exact' => [fn () => Attr::onClass(SupportAttrTestChildClassWithoutAttributes::class), false, false, ['parent-base']],
+            'class recursive first finds parent instances of' => [fn () => Attr::onClass(SupportAttrTestChildClassWithoutAttributes::class), true, false, ['parent-base', 'parent-child']],
+            'object exact' => [fn () => Attr::onObject(new SupportAttrTestChildClass), false, null, ['child-base']],
+            'object instances of' => [fn () => Attr::onObject(new SupportAttrTestChildClass), true, null, ['child-base', 'child-child']],
+            'object recursive all exact' => [fn () => Attr::onObject(new SupportAttrTestChildClass), false, true, ['child-base', 'parent-base']],
+            'object recursive all instances of' => [fn () => Attr::onObject(new SupportAttrTestChildClass), true, true, ['child-base', 'child-child', 'parent-base', 'parent-child']],
+            'class from object instances of' => [fn () => Attr::onClass(new SupportAttrTestChildClass), true, null, ['child-base', 'child-child']],
+            'method exact' => [fn () => Attr::onMethod(SupportAttrTestTarget::class, 'method'), false, null, ['method-base']],
+            'method instances of' => [fn () => Attr::onMethod(SupportAttrTestTarget::class, 'method'), true, null, ['method-base', 'method-child']],
+            'method recursive exact' => [fn () => Attr::onMethod(SupportAttrTestTarget::class, 'method'), false, false, ['method-base']],
+            'method recursive instances of' => [fn () => Attr::onMethod(SupportAttrTestTarget::class, 'method'), true, false, ['method-base', 'method-child']],
+            'method recursive all exact' => [fn () => Attr::onMethod(SupportAttrTestTarget::class, 'method'), false, true, ['method-base', 'parent-method-base']],
+            'method recursive all instances of' => [fn () => Attr::onMethod(SupportAttrTestTarget::class, 'method'), true, true, ['method-base', 'method-child', 'parent-method-base', 'parent-method-child']],
+            'method recursive first finds parent exact' => [fn () => Attr::onMethod(SupportAttrTestChildTargetWithoutAttributes::class, 'method'), false, false, ['parent-method-base']],
+            'method recursive first finds parent instances of' => [fn () => Attr::onMethod(SupportAttrTestChildTargetWithoutAttributes::class, 'method'), true, false, ['parent-method-base', 'parent-method-child']],
+            'method from object instances of' => [fn () => Attr::onMethod(new SupportAttrTestTarget, 'method'), true, null, ['method-base', 'method-child']],
+            'property exact' => [fn () => Attr::onProperty(SupportAttrTestTarget::class, 'property'), false, null, ['property-base']],
+            'property instances of' => [fn () => Attr::onProperty(SupportAttrTestTarget::class, 'property'), true, null, ['property-base', 'property-child']],
+            'property recursive exact' => [fn () => Attr::onProperty(SupportAttrTestTarget::class, 'property'), false, false, ['property-base']],
+            'property recursive instances of' => [fn () => Attr::onProperty(SupportAttrTestTarget::class, 'property'), true, false, ['property-base', 'property-child']],
+            'property recursive all exact' => [fn () => Attr::onProperty(SupportAttrTestTarget::class, 'property'), false, true, ['property-base', 'parent-property-base']],
+            'property recursive all instances of' => [fn () => Attr::onProperty(SupportAttrTestTarget::class, 'property'), true, true, ['property-base', 'property-child', 'parent-property-base', 'parent-property-child']],
+            'property recursive first finds parent exact' => [fn () => Attr::onProperty(SupportAttrTestChildTargetWithoutAttributes::class, 'property'), false, false, ['parent-property-base']],
+            'property recursive first finds parent instances of' => [fn () => Attr::onProperty(SupportAttrTestChildTargetWithoutAttributes::class, 'property'), true, false, ['parent-property-base', 'parent-property-child']],
+            'property from object instances of' => [fn () => Attr::onProperty(new SupportAttrTestTarget, 'property'), true, null, ['property-base', 'property-child']],
+        ];
+    }
+
+    public static function missingQueryModifiersProvider(): array
+    {
+        return [
+            'class exact' => [fn () => Attr::onClass(SupportAttrTestChildClass::class), false, null],
+            'class instances of' => [fn () => Attr::onClass(SupportAttrTestChildClass::class), true, null],
+            'class recursive first' => [fn () => Attr::onClass(SupportAttrTestChildClass::class), false, false],
+            'class recursive all instances of' => [fn () => Attr::onClass(SupportAttrTestChildClass::class), true, true],
+            'object recursive all instances of' => [fn () => Attr::onObject(new SupportAttrTestChildClass), true, true],
+            'method recursive all instances of' => [fn () => Attr::onMethod(SupportAttrTestTarget::class, 'method'), true, true],
+            'property recursive all instances of' => [fn () => Attr::onProperty(SupportAttrTestTarget::class, 'property'), true, true],
+        ];
+    }
+
+    #[DataProvider('allTargetsProvider')]
+    public function test_all_retrieves_attribute_reflections_for_target(callable $factory, bool $instancesOf, ?bool $recursiveAll, array $expected): void
+    {
+        $attributes = $this->attr($factory, $instancesOf, $recursiveAll)->all(SupportAttrTestBaseAttribute::class);
+
+        $this->assertContainsOnlyInstancesOf(ReflectionAttribute::class, $attributes);
+        $this->assertSame($expected, $this->attributeValues($attributes));
+    }
+
+    #[DataProvider('allTargetsProvider')]
+    public function test_instances_returns_attribute_instances(callable $factory, bool $instancesOf, ?bool $recursiveAll, array $expected): void
+    {
+        $instances = $this->attr($factory, $instancesOf, $recursiveAll)
+            ->instances(SupportAttrTestBaseAttribute::class);
+
+        $this->assertContainsOnlyInstancesOf(SupportAttrTestBaseAttribute::class, $instances);
+        $this->assertSame($expected, $this->instanceValues($instances));
+    }
+
+    #[DataProvider('allTargetsProvider')]
+    public function test_collect_returns_attribute_instances_in_collection(callable $factory, bool $instancesOf, ?bool $recursiveAll, array $expected): void
+    {
+        $collection = $this->attr($factory, $instancesOf, $recursiveAll)
+            ->collect(SupportAttrTestBaseAttribute::class);
+
+        $this->assertInstanceOf(Collection::class, $collection);
+        $this->assertContainsOnlyInstancesOf(SupportAttrTestBaseAttribute::class, $collection);
+        $this->assertSame($expected, $collection->map->value->all());
+    }
+
+    #[DataProvider('allTargetsProvider')]
+    public function test_first_returns_first_attribute_reflection(callable $factory, bool $instancesOf, ?bool $recursiveAll, array $expected): void
+    {
+        $attribute = $this->attr($factory, $instancesOf, $recursiveAll)
+            ->first(SupportAttrTestBaseAttribute::class);
+
+        $this->assertInstanceOf(ReflectionAttribute::class, $attribute);
+        $this->assertSame($expected[0], $attribute->newInstance()->value);
+    }
+
+    #[DataProvider('allTargetsProvider')]
+    public function test_instance_returns_first_attribute_instance(callable $factory, bool $instancesOf, ?bool $recursiveAll, array $expected): void
+    {
+        $instance = $this->attr($factory, $instancesOf, $recursiveAll)
+            ->instance(SupportAttrTestBaseAttribute::class);
+
+        $this->assertInstanceOf(SupportAttrTestBaseAttribute::class, $instance);
+        $this->assertSame($expected[0], $instance->value);
+    }
+
+    #[DataProvider('allTargetsProvider')]
+    public function test_has_returns_true_when_attribute_exists(callable $factory, bool $instancesOf, ?bool $recursiveAll, array $expected): void
+    {
+        $this->assertTrue(
+            $this->attr($factory, $instancesOf, $recursiveAll)
+                ->has(SupportAttrTestBaseAttribute::class)
+        );
+    }
+
+    #[DataProvider('allTargetsProvider')]
+    public function test_missing_returns_false_when_attribute_exists(callable $factory, bool $instancesOf, ?bool $recursiveAll, array $expected): void
+    {
+        $this->assertFalse(
+            $this->attr($factory, $instancesOf, $recursiveAll)
+                ->missing(SupportAttrTestBaseAttribute::class)
+        );
+    }
+
+    #[DataProvider('missingQueryModifiersProvider')]
+    public function test_all_returns_empty_when_attribute_is_missing(callable $factory, bool $instancesOf, ?bool $recursiveAll): void
+    {
+        $this->assertSame(
+            [],
+            $this->attr($factory, $instancesOf, $recursiveAll)->all(SupportAttrTestMissingAttribute::class)
+        );
+    }
+
+    #[DataProvider('missingQueryModifiersProvider')]
+    public function test_instances_returns_empty_when_attribute_is_missing(callable $factory, bool $instancesOf, ?bool $recursiveAll): void
+    {
+        $this->assertSame(
+            [],
+            $this->attr($factory, $instancesOf, $recursiveAll)->instances(SupportAttrTestMissingAttribute::class)
+        );
+    }
+
+    #[DataProvider('missingQueryModifiersProvider')]
+    public function test_collect_returns_empty_when_attribute_is_missing(callable $factory, bool $instancesOf, ?bool $recursiveAll): void
+    {
+        $this->assertTrue(
+            $this->attr($factory, $instancesOf, $recursiveAll)->collect(SupportAttrTestMissingAttribute::class)->isEmpty()
+        );
+    }
+
+    #[DataProvider('missingQueryModifiersProvider')]
+    public function test_first_returns_null_when_attribute_is_missing(callable $factory, bool $instancesOf, ?bool $recursiveAll): void
+    {
+        $this->assertNull(
+            $this->attr($factory, $instancesOf, $recursiveAll)->first(SupportAttrTestMissingAttribute::class)
+        );
+    }
+
+    #[DataProvider('missingQueryModifiersProvider')]
+    public function test_instance_returns_null_when_attribute_is_missing(callable $factory, bool $instancesOf, ?bool $recursiveAll): void
+    {
+        $this->assertNull(
+            $this->attr($factory, $instancesOf, $recursiveAll)->instance(SupportAttrTestMissingAttribute::class)
+        );
+    }
+
+    #[DataProvider('missingQueryModifiersProvider')]
+    public function test_has_returns_false_when_attribute_is_missing(callable $factory, bool $instancesOf, ?bool $recursiveAll): void
+    {
+        $this->assertFalse(
+            $this->attr($factory, $instancesOf, $recursiveAll)->has(SupportAttrTestMissingAttribute::class)
+        );
+    }
+
+    #[DataProvider('missingQueryModifiersProvider')]
+    public function test_missing_returns_true_when_attribute_is_missing(callable $factory, bool $instancesOf, ?bool $recursiveAll): void
+    {
+        $this->assertTrue(
+            $this->attr($factory, $instancesOf, $recursiveAll)->missing(SupportAttrTestMissingAttribute::class)
+        );
+    }
+
+    public function test_instances_of_returns_same_attr_instance(): void
+    {
+        $attr = Attr::onClass(SupportAttrTestChildClass::class);
+
+        $this->assertSame($attr, $attr->instancesOf());
+    }
+
+    public function test_recursive_returns_same_attr_instance(): void
+    {
+        $attr = Attr::onClass(SupportAttrTestChildClass::class);
+
+        $this->assertSame($attr, $attr->recursive());
+    }
+}
+
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD | Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
+class SupportAttrTestBaseAttribute
+{
+    public function __construct(public string $value)
+    {
+    }
+}
+
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD | Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
+class SupportAttrTestChildAttribute extends SupportAttrTestBaseAttribute
+{
+}
+
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD | Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
+class SupportAttrTestMissingAttribute
+{
+}
+
+#[SupportAttrTestBaseAttribute('parent-base')]
+#[SupportAttrTestChildAttribute('parent-child')]
+class SupportAttrTestParentClass
+{
+}
+
+#[SupportAttrTestBaseAttribute('child-base')]
+#[SupportAttrTestChildAttribute('child-child')]
+class SupportAttrTestChildClass extends SupportAttrTestParentClass
+{
+}
+
+class SupportAttrTestChildClassWithoutAttributes extends SupportAttrTestParentClass
+{
+}
+
+class SupportAttrTestParentTarget
+{
+    #[SupportAttrTestBaseAttribute('parent-property-base')]
+    #[SupportAttrTestChildAttribute('parent-property-child')]
+    public $property;
+
+    #[SupportAttrTestBaseAttribute('parent-method-base')]
+    #[SupportAttrTestChildAttribute('parent-method-child')]
+    public function method(): void
+    {
+    }
+}
+
+class SupportAttrTestTarget extends SupportAttrTestParentTarget
+{
+    #[SupportAttrTestBaseAttribute('property-base')]
+    #[SupportAttrTestChildAttribute('property-child')]
+    public $property;
+
+    #[SupportAttrTestBaseAttribute('method-base')]
+    #[SupportAttrTestChildAttribute('method-child')]
+    public function method(): void
+    {
+    }
+}
+
+class SupportAttrTestChildTargetWithoutAttributes extends SupportAttrTestParentTarget
+{
+    public $property;
+
+    public function method(): void
+    {
+    }
+}


### PR DESCRIPTION
## What?

This PR introduces the `Attr` helper to retrieve attributes instances from any target (Classes/Objects, Methods or Properties) in one line.

There are three intentions behind this PR:

- Remove _verbosy_ attribute retrieval (Reflection → getAttributes() → → check → newInstance() → check).
- Avoid do-while loops in recursive attribute retrieval.
- Allow third-party packages to do the same.

```php
use App\Models\Article;
use ReflectionClass;
use Illuminate\Database\Eloquent\Attributes\Table;
use Illuminate\Support\Attr;

// Before
$attributes = (new ReflectionClass(Article::class))->getAttributes(Table::class);

if (isset($attributes[0])) {
    return $attributes[0]->newInstance()->name;
}

// After
return Attr::onClass(Article::class)->instance(Table::class)->name;
```

...and that was just the simplest offender.

## Usages

There are three main usages that I've found across the framework:

1. **Attribute presence:** Simple _Does this class has this attribute?_.
2. **Retrieving an Attribute value:** Because the `getAttributes()` return an array, additional checks must be done to check is not empty, and then instance the first attribute to retrieve the value correctly.
3. **Retrieving all Attributes recursively:** Using a `do-while` loop to get all the attributes including ancestors.

In light of that, I made the helper with the intention of simplify these tasks, and centralise the attribute retrieval.

## Conveniences

This helper _may_ look like over-engineering attribute retrieval, but in reality is just simply offering an expressive way to retrieve an Attribute instance or value, without bringing the kitchen sink. Of course, this only works on the sections of the framework that require `illuminate/support`.

Here are some examples.

* **Check if a class has the given attribute**

```php
use App\Models\Article;
use Illuminate\Database\Eloquent\Attributes\Table;
use Illuminate\Support\Attr;

Attr::onClass(Article::class)->has(Table::class);
```

* **Get the first instance**

```php
use App\Models\Article;
use App\Attributes\StrTransform;
use Illuminate\Support\Attr;

Attr::onMethod(Article::class, 'title')->instance(StrTransform::class)?->call;
```

* **Return ALL the attributes until the last parent as a Collection**

```php
use App\Models\Article;
use Illuminate\Auth\Attributes\Authorize;
use Illuminate\Support\Attr;

$article = Article::find(251);

Attr::onMethod($article, 'publish')->recursive(true)->collect(Authorize::class);
```

## Integration

I took the liberty to use `Attr` on all framework parts that require `illuminate/support` (almost all of them). I left some places of the framework as-is because adding the helper would add little to an overall _verbosy_ code block.