### PR TITLE
[13.x] Add attributes to Scheduler

### DIFF
--- a/src/Illuminate/Console/Scheduling/ManagesAttributes.php
+++ b/src/Illuminate/Console/Scheduling/ManagesAttributes.php
@@ -112,6 +112,13 @@ trait ManagesAttributes
     public $description;
 
     /**
+     * The arbitrary attributes stored with the event.
+     *
+     * @var array<array-key, mixed>
+     */
+    public $attributes = [];
+
+    /**
      * Set which user the command should run as.
      *
      * @param  string  $user
@@ -257,6 +264,19 @@ trait ManagesAttributes
     public function description($description)
     {
         $this->description = $description;
+
+        return $this;
+    }
+
+    /**
+     * Set arbitrary attributes to store with the event.
+     *
+     * @param  array<array-key, mixed>  $attributes
+     * @return $this
+     */
+    public function withAttributes($attributes)
+    {
+        $this->attributes = array_merge_recursive($this->attributes, $attributes);
 
         return $this;
     }

--- a/src/Illuminate/Console/Scheduling/PendingEventAttributes.php
+++ b/src/Illuminate/Console/Scheduling/PendingEventAttributes.php
@@ -86,7 +86,7 @@ class PendingEventAttributes
         }
 
         if ($this->attributes !== []) {
-            $event->withAttributes($this->attributes);
+            $event->attributes = $this->attributes;
         }
 
         if ($this->timezone !== null) {

--- a/src/Illuminate/Console/Scheduling/PendingEventAttributes.php
+++ b/src/Illuminate/Console/Scheduling/PendingEventAttributes.php
@@ -85,6 +85,10 @@ class PendingEventAttributes
             $event->name($this->description);
         }
 
+        if ($this->attributes !== []) {
+            $event->withAttributes($this->attributes);
+        }
+
         if ($this->timezone !== null) {
             $event->timezone($this->timezone);
         }

--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -336,16 +336,18 @@ class Schedule
      */
     protected function mergePendingAttributes(Event $event)
     {
-        if (! empty($this->groupStack)) {
-            $group = array_last($this->groupStack);
-
-            $group->mergeAttributes($event);
-        }
-
         if (isset($this->attributes)) {
             $this->attributes->mergeAttributes($event);
 
             $this->attributes = null;
+
+            return;
+        }
+
+        if (! empty($this->groupStack)) {
+            $group = array_last($this->groupStack);
+
+            $group->mergeAttributes($event);
         }
     }
 

--- a/tests/Console/Scheduling/ScheduleTest.php
+++ b/tests/Console/Scheduling/ScheduleTest.php
@@ -89,4 +89,31 @@ final class ScheduleTest extends TestCase
         $this->assertSame([], $filteredEvents[2]->environments);
         $this->assertSame('0 * * * *', $filteredEvents[2]->expression);
     }
+
+    public function testItCanAddAttributesToEvents(): void
+    {
+        $schedule = new Schedule();
+
+        $event = $schedule->command('inspire')
+            ->withAttributes(['team' => 'platform'])
+            ->withAttributes(['labels' => ['maintenance']]);
+
+        $this->assertSame([
+            'team' => 'platform',
+            'labels' => ['maintenance'],
+        ], $event->attributes);
+    }
+
+    public function testItCanAddAttributesToPendingEvents(): void
+    {
+        $schedule = new Schedule();
+
+        $schedule->withAttributes(['team' => 'platform'])->command('inspire');
+        $schedule->command('queue:work');
+
+        $events = $schedule->events();
+
+        $this->assertSame(['team' => 'platform'], $events[0]->attributes);
+        $this->assertSame([], $events[1]->attributes);
+    }
 }

--- a/tests/Integration/Console/Scheduling/ScheduleGroupTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleGroupTest.php
@@ -99,6 +99,33 @@ class ScheduleGroupTest extends TestCase
         $this->assertSame(['team' => 'platform'], $events[0]->attributes);
     }
 
+    public function testGroupAttributesAreNotDuplicatedOnPendingSchedules()
+    {
+        Schedule::withAttributes(['team' => 'platform'])->group(function () {
+            Schedule::dailyAt('09:00')->command('inspire');
+        });
+
+        $events = Schedule::events();
+
+        $this->assertSame(['team' => 'platform'], $events[0]->attributes);
+        $this->assertSame('0 9 * * *', $events[0]->expression);
+    }
+
+    public function testGroupAttributesAreMergedWithPendingAttributes()
+    {
+        Schedule::withAttributes(['team' => 'platform'])->group(function () {
+            Schedule::withAttributes(['tagName' => 'import-premium-podcasts'])
+                ->command('audio:import-podcasts --only-premium');
+        });
+
+        $events = Schedule::events();
+
+        $this->assertSame([
+            'team' => 'platform',
+            'tagName' => 'import-premium-podcasts',
+        ], $events[0]->attributes);
+    }
+
     #[DataProvider('groupAttributes')]
     public function testGroupCanApplyAttributeToSchedules(string $property, mixed $value)
     {

--- a/tests/Integration/Console/Scheduling/ScheduleGroupTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleGroupTest.php
@@ -547,6 +547,31 @@ class ScheduleGroupTest extends TestCase
         $this->assertSame(['outer', 'outer', 'inner'], $calls);
     }
 
+    public function testNestedGroupInheritsLifecycleCallbacksOnce()
+    {
+        $calls = [];
+
+        $schedule = new ScheduleClass;
+        $schedule
+            ->after(function () use (&$calls) {
+                $calls[] = 'outer';
+            })
+            ->group(function ($schedule) use (&$calls) {
+                $schedule
+                    ->after(function () use (&$calls) {
+                        $calls[] = 'inner';
+                    })
+                    ->group(function ($schedule) {
+                        $schedule->command('inspire');
+                    });
+            });
+
+        $events = $schedule->events();
+        $events[0]->finish(app(), 0);
+
+        $this->assertSame(['outer', 'inner'], $calls);
+    }
+
     public function testGroupCanStartWithLifecycleCallbackWithoutFrequency()
     {
         $calls = [];

--- a/tests/Integration/Console/Scheduling/ScheduleGroupTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleGroupTest.php
@@ -88,6 +88,17 @@ class ScheduleGroupTest extends TestCase
         $this->assertSame('Asia/Dhaka', $events[1]->timezone);
     }
 
+    public function testGroupCanApplyAttributesToSchedules()
+    {
+        Schedule::withAttributes(['team' => 'platform'])->group(function () {
+            Schedule::command('inspire');
+        });
+
+        $events = Schedule::events();
+
+        $this->assertSame(['team' => 'platform'], $events[0]->attributes);
+    }
+
     #[DataProvider('groupAttributes')]
     public function testGroupCanApplyAttributeToSchedules(string $property, mixed $value)
     {

--- a/tests/Integration/Console/Scheduling/ScheduleGroupTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleGroupTest.php
@@ -367,6 +367,26 @@ class ScheduleGroupTest extends TestCase
         Event::flushMacros();
     }
 
+    public function testGroupAppliesEventMacrosOnceToPendingSchedules()
+    {
+        Event::macro('sentryMonitor', function () {
+            $this->sentryMonitored = ($this->sentryMonitored ?? 0) + 1;
+
+            return $this;
+        });
+
+        $schedule = new ScheduleClass;
+        $schedule->daily()->sentryMonitor()->group(function ($schedule) {
+            $schedule->at('09:00')->command('inspire');
+        });
+
+        $events = $schedule->events();
+        $this->assertSame(1, $events[0]->sentryMonitored);
+        $this->assertSame('0 9 * * *', $events[0]->expression);
+
+        Event::flushMacros();
+    }
+
     public function testGroupAppliesOnFailureCallbackToAllEvents()
     {
         $calls = [];
@@ -454,6 +474,26 @@ class ScheduleGroupTest extends TestCase
         $events[0]->finish(app(), 0);
 
         $this->assertSame(['before', 'after', 'then'], $calls);
+    }
+
+    public function testGroupAppliesAfterCallbackOnceToPendingSchedules()
+    {
+        $calls = [];
+
+        $schedule = new ScheduleClass;
+        $schedule
+            ->after(function () use (&$calls) {
+                $calls[] = 'after';
+            })
+            ->group(function ($schedule) {
+                $schedule->at('09:00')->command('inspire');
+            });
+
+        $events = $schedule->events();
+        $events[0]->finish(app(), 0);
+
+        $this->assertSame(['after'], $calls);
+        $this->assertSame('0 9 * * *', $events[0]->expression);
     }
 
     public function testGroupCallbacksCombineWithEventLevelCallbacks()


### PR DESCRIPTION
Here's what I want to be able to do:

* Group commands together
* For each command, I want to add a metric tag identifier (eg: `['tagName' => 'import-premium-podcasts']`)
* I want to add an `after()` callback to the entire group. If the command exits successful, I want to emit a `scheduled-command.succeeded` metric with the tag representing the command name.

Something like this:

```php
Schedule::after(function(Event $event) {
    $tagName = $event->attributes['tagName'] ?? null;
    if (! $tagName) {
        return;
    }

    $metricName = $event->exitCode === 0 ? 'scheduled-command.succeeded' : 'scheduled-command.failed';
    Stats::increment($metricName, tags: ['command' => $tagName])
})->group(function ($schedule) {
    $schedule
        ->command('audio:import-podcasts --only-premium')
        ->withoutOverlapping(100)
        ->withAttributes(['tagName' => 'import-premium-podcasts']);
});
```

## Couldn't you do this instead by?

### From the `$command` attribute
Yes, but it gets kind of wonky. It ends up looking like `'/usr/local/bin/php' 'artisan' audio:import-podcasts --only-premium'. It would require stripping off the front part for every command and figuring out how the options/args should be parsed.

### From the `$description`
Sure, but what if I want a clean looking description that doesn't match the tag name? Like I want it to have colons in it or whatever.

### As a macro
Yes, I could create a class with a static `WeakMap` property or something.

# Semi-related change
I swapped the order in `mergePendingAttributes()` to avoid replaying before/after events twice.