### PR TITLE
[13.x] Allow additionalProperties to accept a subschema on ObjectType

### DIFF
--- a/src/Illuminate/JsonSchema/Serializer.php
+++ b/src/Illuminate/JsonSchema/Serializer.php
@@ -50,6 +50,10 @@ class Serializer
         }, ARRAY_FILTER_USE_BOTH);
 
         if ($type instanceof Types\ObjectType) {
+            if (isset($attributes['additionalProperties']) && $attributes['additionalProperties'] instanceof Types\Type) {
+                $attributes['additionalProperties'] = static::serialize($attributes['additionalProperties']);
+            }
+
             if (count($attributes['properties']) === 0) {
                 unset($attributes['properties']);
             } else {

--- a/src/Illuminate/JsonSchema/Types/ObjectType.php
+++ b/src/Illuminate/JsonSchema/Types/ObjectType.php
@@ -5,9 +5,9 @@ namespace Illuminate\JsonSchema\Types;
 class ObjectType extends Type
 {
     /**
-     * Whether additional properties are allowed.
+     * The additional properties constraint.
      */
-    protected ?bool $additionalProperties = null;
+    protected bool|Type|null $additionalProperties = null;
 
     /**
      * Create a new object type instance.
@@ -20,13 +20,21 @@ class ObjectType extends Type
     }
 
     /**
+     * Set the additional properties constraint.
+     */
+    public function additionalProperties(bool|Type $value = true): static
+    {
+        $this->additionalProperties = $value === true ? null : $value;
+
+        return $this;
+    }
+
+    /**
      * Disallow additional properties.
      */
     public function withoutAdditionalProperties(): static
     {
-        $this->additionalProperties = false;
-
-        return $this;
+        return $this->additionalProperties(false);
     }
 
     /**

--- a/tests/JsonSchema/ObjectTypeTest.php
+++ b/tests/JsonSchema/ObjectTypeTest.php
@@ -103,6 +103,57 @@ class ObjectTypeTest extends TestCase
         ], $type->toArray());
     }
 
+    public function test_it_may_explicitly_allow_additional_properties(): void
+    {
+        $type = JsonSchema::object()->additionalProperties(true);
+
+        $this->assertEquals([
+            'type' => 'object',
+        ], $type->toArray());
+    }
+
+    public function test_it_may_set_additional_properties_as_boolean_false(): void
+    {
+        $type = JsonSchema::object()->additionalProperties(false);
+
+        $this->assertEquals([
+            'type' => 'object',
+            'additionalProperties' => false,
+        ], $type->toArray());
+    }
+
+    public function test_it_may_set_additional_properties_as_schema(): void
+    {
+        $type = JsonSchema::object()->additionalProperties(JsonSchema::string());
+
+        $this->assertEquals([
+            'type' => 'object',
+            'additionalProperties' => [
+                'type' => 'string',
+            ],
+        ], $type->toArray());
+    }
+
+    public function test_it_may_set_additional_properties_schema_alongside_properties(): void
+    {
+        $type = JsonSchema::object([
+            'name' => JsonSchema::string()->required(),
+        ])->additionalProperties(JsonSchema::string());
+
+        $this->assertEquals([
+            'type' => 'object',
+            'properties' => [
+                'name' => [
+                    'type' => 'string',
+                ],
+            ],
+            'required' => ['name'],
+            'additionalProperties' => [
+                'type' => 'string',
+            ],
+        ], $type->toArray());
+    }
+
     public function test_it_may_set_enum(): void
     {
         $type = JsonSchema::object()->enum([

--- a/tests/JsonSchema/TypeTest.php
+++ b/tests/JsonSchema/TypeTest.php
@@ -300,6 +300,16 @@ class TypeTest extends TestCase
                 ]),
                 (object) ['age' => 0], // not nullable
             ],
+            [
+                JsonSchema::object([
+                    'name' => JsonSchema::string()->required(),
+                ])->additionalProperties(JsonSchema::string()),
+                (object) ['name' => 'Nuno', 'tag' => 'laravel'],
+            ],
+            [
+                JsonSchema::object()->additionalProperties(JsonSchema::integer()),
+                (object) ['count' => 1],
+            ],
 
             // ArrayType
             [JsonSchema::array(), []],
@@ -397,6 +407,20 @@ class TypeTest extends TestCase
             [JsonSchema::object(['name' => JsonSchema::string()->required()])->default(['name' => 'x']), (object) []], // default doesn't satisfy missing required
             [JsonSchema::object(['score' => JsonSchema::integer()->min(0)]), (object) ['score' => -1]], // below min
             [JsonSchema::object(['age' => JsonSchema::integer()->nullable(false)]), (object) ['age' => null]], // not nullable
+            [
+                JsonSchema::object([
+                    'name' => JsonSchema::string()->required(),
+                ])->additionalProperties(JsonSchema::string()),
+                (object) ['name' => 'Nuno', 'tag' => 1],
+            ],
+            [
+                JsonSchema::object()->additionalProperties(JsonSchema::integer()),
+                (object) ['count' => 'one'],
+            ],
+            [
+                JsonSchema::object()->additionalProperties(false),
+                (object) ['extra' => 'nope'],
+            ],
 
             // ArrayType
             [JsonSchema::array(), (object) []], // type mismatch


### PR DESCRIPTION
`ObjectType` only exposed `withoutAdditionalProperties()`, which maps to `additionalProperties: false`. JSON Schema also allows `additionalProperties` to be a schema for keys outside `properties`.

This adds `additionalProperties(bool|Type $value = true)`. `true` keeps the default (keyword omitted). `false` forbids extra keys. A `Type` constrains extra keys. `withoutAdditionalProperties()` still works and calls `additionalProperties(false)`.

`Serializer` recurses into `additionalProperties` when it is a `Type`, same as `items` on `ArrayType`.

```php
JsonSchema::object([
    'name' => JsonSchema::string()->required(),
])->additionalProperties(JsonSchema::string());
```

**Tests**

- `tests/JsonSchema/ObjectTypeTest.php` — `toArray()` output
- `tests/JsonSchema/TypeTest.php` — Opis validator accepts/rejects extra keys

```bash
./vendor/bin/phpunit tests/JsonSchema/
```