### PR TITLE
[13.x] Fix assertInsomniac() docblock and add missing @param to syncWithCarbon()

### DIFF
--- a/src/Illuminate/Support/Sleep.php
+++ b/src/Illuminate/Support/Sleep.php
@@ -476,7 +476,7 @@ class Sleep
     }
 
     /**
-     * Assert that no sleeping occurred.
+     * Assert that all sleeping that occurred had a duration of zero.
      *
      * @return void
      */
@@ -546,6 +546,7 @@ class Sleep
     /**
      * Indicate that Carbon's "now" should be kept in sync when sleeping.
      *
+     * @param  bool  $value
      * @return void
      */
     public static function syncWithCarbon($value = true)


### PR DESCRIPTION
## Changes

- Fix incorrect docblock description on `Sleep::assertInsomniac()` which was identical to `assertNeverSlept()` but these methods behave differently.
  - `assertNeverSlept()` asserts zero sleeps occurred
  - `assertInsomniac()` asserts all sleeps had zero duration
  
- Add missing `@param bool $value` annotation to `Sleep::syncWithCarbon()`