### PR TITLE
[13.x] Populate mailable recipients in mail notifications

### DIFF
--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -267,7 +267,9 @@ class MailChannel
             return $mailable;
         }
 
-        return $mailable->to($this->getRecipients($notifiable, $notification));
+        $recipients = $this->getRecipients($notifiable, $notification);
+
+        return $mailable->to(count($recipients) === 1 ? reset($recipients) : $recipients);
     }
 
     /**

--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -60,7 +60,8 @@ class MailChannel
         }
 
         if ($message instanceof Mailable) {
-            return $message->send($this->mailer);
+            return $this->populateMailableRecipients($message, $notifiable, $notification)
+                ->send($this->mailer);
         }
 
         return $this->mailer->mailer($message->mailer ?? null)->send(
@@ -213,7 +214,7 @@ class MailChannel
     {
         $this->addSender($mailMessage, $message);
 
-        $mailMessage->to($this->getRecipients($notifiable, $notification, $message));
+        $mailMessage->to($this->getRecipients($notifiable, $notification));
 
         if (! empty($message->cc)) {
             foreach ($message->cc as $cc) {
@@ -249,14 +250,34 @@ class MailChannel
     }
 
     /**
+     * Populate the mailable recipients using the notifiable's mail route.
+     *
+     * @param  \Illuminate\Contracts\Mail\Mailable  $mailable
+     * @param  mixed  $notifiable
+     * @param  \Illuminate\Notifications\Notification  $notification
+     * @return \Illuminate\Contracts\Mail\Mailable
+     */
+    protected function populateMailableRecipients($mailable, $notifiable, $notification)
+    {
+        if (! empty($mailable->to)) {
+            return $mailable;
+        }
+
+        if (method_exists($mailable, 'envelope') && ! empty($mailable->envelope()->to)) {
+            return $mailable;
+        }
+
+        return $mailable->to($this->getRecipients($notifiable, $notification));
+    }
+
+    /**
      * Get the recipients of the given message.
      *
      * @param  mixed  $notifiable
      * @param  \Illuminate\Notifications\Notification  $notification
-     * @param  \Illuminate\Notifications\Messages\MailMessage  $message
      * @return mixed
      */
-    protected function getRecipients($notifiable, $notification, $message)
+    protected function getRecipients($notifiable, $notification)
     {
         if (is_string($recipients = $notifiable->routeNotificationFor('mail', $notification))) {
             $recipients = [$recipients];

--- a/tests/Integration/Notifications/SendingMailNotificationsTest.php
+++ b/tests/Integration/Notifications/SendingMailNotificationsTest.php
@@ -448,6 +448,7 @@ class TestMailNotificationWithMailable extends Notification
         $mailable = m::mock(Mailable::class);
 
         $mailable->shouldReceive('send')->once();
+        $mailable->shouldReceive('to')->once()->with('taylor@laravel.com')->andReturnSelf();
 
         return $mailable;
     }

--- a/tests/Integration/Notifications/SendingNotificationsWithLocaleTest.php
+++ b/tests/Integration/Notifications/SendingNotificationsWithLocaleTest.php
@@ -116,6 +116,38 @@ class SendingNotificationsWithLocaleTest extends TestCase
         );
     }
 
+    public function testMailableWithoutToIsAddressedToNotifiable()
+    {
+        $user = NotifiableLocalizedUser::forceCreate([
+            'email' => 'taylor@laravel.com',
+        ]);
+
+        $user->notify(new GreetingMailNotificationWithMailableWithoutTo);
+
+        $message = app('mailer')->getSymfonyTransport()->messages()[0]->getOriginalMessage();
+
+        $this->assertSame(
+            'taylor@laravel.com',
+            $message->getTo()[0]->getAddress()
+        );
+    }
+
+    public function testMailableWithoutToIsAddressedToMultipleNotifiableRoutes()
+    {
+        $user = NotifiableLocalizedUserWithMultipleMailRoutes::forceCreate([
+            'email' => 'taylor@laravel.com',
+        ]);
+
+        $user->notify(new GreetingMailNotificationWithMailableWithoutTo);
+
+        $message = app('mailer')->getSymfonyTransport()->messages()[0]->getOriginalMessage();
+
+        $this->assertEqualsCanonicalizing(
+            ['foo_taylor@laravel.com', 'bar_taylor@laravel.com'],
+            array_map(fn ($address) => $address->getAddress(), $message->getTo())
+        );
+    }
+
     public function testMailIsSentWithLocaleUpdatedListenersCalled()
     {
         Carbon::setTestNow('2018-07-25');
@@ -247,6 +279,17 @@ class NotifiableEmailLocalePreferredUser extends Model implements HasLocalePrefe
     }
 }
 
+class NotifiableLocalizedUserWithMultipleMailRoutes extends NotifiableLocalizedUser
+{
+    public function routeNotificationForMail($notification)
+    {
+        return [
+            'foo_'.$this->email,
+            'bar_'.$this->email,
+        ];
+    }
+}
+
 class GreetingMailNotification extends Notification
 {
     public function via($notifiable)
@@ -273,6 +316,19 @@ class GreetingMailNotificationWithMailable extends Notification
     {
         return (new GreetingMailable)
             ->to($notifiable->email);
+    }
+}
+
+class GreetingMailNotificationWithMailableWithoutTo extends Notification
+{
+    public function via($notifiable)
+    {
+        return [MailChannel::class];
+    }
+
+    public function toMail($notifiable)
+    {
+        return new GreetingMailable;
     }
 }
 

--- a/tests/Notifications/MailChannelTest.php
+++ b/tests/Notifications/MailChannelTest.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace Illuminate\Tests\Notifications;
+
+use Illuminate\Contracts\Mail\Factory as MailFactory;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Markdown;
+use Illuminate\Notifications\Channels\MailChannel;
+use Illuminate\Notifications\Notification;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class MailChannelTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+
+        parent::tearDown();
+    }
+
+    public function testItPopulatesMailableRecipientsWhenToIsEmpty()
+    {
+        $mailable = new MailChannelTestMailable;
+
+        $mailable = $this->channel()->populateMailableRecipients(
+            $mailable,
+            new MailChannelNotifiable('taylor@laravel.com'),
+            new MailChannelTestNotification,
+        );
+
+        $this->assertSame('taylor@laravel.com', $mailable->to[0]['address']);
+    }
+
+    public function testItDoesNotOverrideExistingMailableRecipients()
+    {
+        $mailable = (new MailChannelTestMailable)->to('other@laravel.com');
+
+        $mailable = $this->channel()->populateMailableRecipients(
+            $mailable,
+            new MailChannelNotifiable('taylor@laravel.com'),
+            new MailChannelTestNotification,
+        );
+
+        $this->assertSame('other@laravel.com', $mailable->to[0]['address']);
+    }
+
+    public function testItDoesNotOverrideMailableRecipientsDefinedOnEnvelope()
+    {
+        $mailable = new MailChannelTestMailableWithEnvelopeRecipient;
+
+        $mailable = $this->channel()->populateMailableRecipients(
+            $mailable,
+            new MailChannelNotifiable('taylor@laravel.com'),
+            new MailChannelTestNotification,
+        );
+
+        $this->assertSame([], $mailable->to);
+    }
+
+    public function testItPopulatesMultipleMailableRecipientsFromRoute()
+    {
+        $mailable = new MailChannelTestMailable;
+
+        $mailable = $this->channel()->populateMailableRecipients(
+            $mailable,
+            new MailChannelNotifiableWithMultipleRoutes('taylor@laravel.com'),
+            new MailChannelTestNotification,
+        );
+
+        $this->assertEqualsCanonicalizing(
+            ['foo_taylor@laravel.com', 'bar_taylor@laravel.com'],
+            array_column($mailable->to, 'address')
+        );
+    }
+
+    protected function channel(): MailChannelForTesting
+    {
+        return new MailChannelForTesting(
+            m::mock(MailFactory::class),
+            m::mock(Markdown::class),
+        );
+    }
+}
+
+class MailChannelForTesting extends MailChannel
+{
+    public function populateMailableRecipients($mailable, $notifiable, $notification)
+    {
+        return parent::populateMailableRecipients($mailable, $notifiable, $notification);
+    }
+}
+
+class MailChannelNotifiable
+{
+    public function __construct(public string $email)
+    {
+    }
+
+    public function routeNotificationFor($driver, $notification = null)
+    {
+        return $driver === 'mail'
+            ? $this->routeNotificationForMail($notification)
+            : null;
+    }
+
+    public function routeNotificationForMail($notification)
+    {
+        return $this->email;
+    }
+}
+
+class MailChannelNotifiableWithMultipleRoutes extends MailChannelNotifiable
+{
+    public function routeNotificationForMail($notification)
+    {
+        return [
+            'foo_'.$this->email,
+            'bar_'.$this->email,
+        ];
+    }
+}
+
+class MailChannelTestMailable extends Mailable
+{
+    public function build()
+    {
+        return $this->html('Test');
+    }
+}
+
+class MailChannelTestMailableWithEnvelopeRecipient extends Mailable
+{
+    public function envelope()
+    {
+        return new \Illuminate\Mail\Mailables\Envelope(
+            to: [new \Illuminate\Mail\Mailables\Address('envelope@laravel.com')],
+            subject: 'Test',
+        );
+    }
+
+    public function content()
+    {
+        return new \Illuminate\Mail\Mailables\Content(
+            htmlString: 'Test',
+        );
+    }
+}
+
+class MailChannelTestNotification extends Notification
+{
+    //
+}


### PR DESCRIPTION
## Summary

When a notification `toMail()` method returns a `Mailable` instance without recipients, the `MailChannel` currently sends the message without automatically using the notifiable mail route.

This differs from the existing `MailMessage` behavior, where recipients are automatically resolved from the notifiable.

This PR aligns both behaviors by automatically populating recipients for `Mailable` notifications only when no recipients were explicitly defined.

## Changes

* Populate recipients from the notifiable mail route when:

  * the returned `Mailable` has no `to` recipients
  * and the `Mailable` `envelope()` does not define recipients

* Preserve existing behavior when:

  * recipients were explicitly defined using `->to()`
  * recipients were defined via `envelope()->to`

* Remove the unused `$message` parameter from `getRecipients()`

## Motivation

`MailMessage` notifications already resolve recipients automatically from the notifiable.

Returning a `Mailable` from `toMail()` should behave consistently and avoid requiring users to manually duplicate recipient resolution logic for the most common notification flow.

This also improves developer experience and reduces subtle delivery mistakes when converting notifications from `MailMessage` to `Mailable`.

## Backward Compatibility

This change is fully backward compatible.

Existing applications that already define recipients explicitly on the `Mailable` are unaffected because the channel only populates recipients when none are present.

## Tests

Added `tests/Notifications/MailChannelTest.php` covering:

* populates recipients from the notifiable
* does not override explicit `->to()`
* respects `envelope()->to`
* supports multiple addresses returned by `routeNotificationForMail()`

Additional integration coverage was added to `SendingNotificationsWithLocaleTest.php`.
