### PR TITLE
Fix/stack push late component

### DIFF
--- a/src/Illuminate/View/Concerns/ManagesStacks.php
+++ b/src/Illuminate/View/Concerns/ManagesStacks.php
@@ -28,6 +28,13 @@ trait ManagesStacks
     protected $pushStack = [];
 
     /**
+     * All deferred stack placeholders awaiting resolution.
+     *
+     * @var array
+     */
+    protected $deferredStacks = [];
+
+    /**
      * Start injecting content into a push section.
      *
      * @param  string  $section
@@ -148,6 +155,25 @@ trait ManagesStacks
      */
     public function yieldPushContent($section, $default = '')
     {
+        if ($this->renderCount > 0) {
+            $placeholder = '@@stack::'.$section.'::'.uniqid().'@@';
+            $this->deferredStacks[$placeholder] = [$section, $default];
+
+            return $placeholder;
+        }
+
+        return $this->resolvePushContent($section, $default);
+    }
+
+    /**
+     * Resolve the push content for a given section.
+     *
+     * @param  string  $section
+     * @param  string  $default
+     * @return string
+     */
+    protected function resolvePushContent($section, $default = '')
+    {
         if ($this->isStackEmpty($section)) {
             return $default;
         }
@@ -161,6 +187,27 @@ trait ManagesStacks
         if (isset($this->pushes[$section])) {
             $output .= implode('', $this->pushes[$section]);
         }
+
+        return $output;
+    }
+
+    /**
+     * Resolve all deferred stack placeholders in the given output.
+     *
+     * @param  string  $output
+     * @return string
+     */
+    public function resolveDeferredStacks(string $output): string
+    {
+        foreach ($this->deferredStacks as $placeholder => [$section, $default]) {
+            $output = str_replace(
+                $placeholder,
+                $this->resolvePushContent($section, $default),
+                $output
+            );
+        }
+
+        $this->deferredStacks = [];
 
         return $output;
     }
@@ -183,5 +230,6 @@ trait ManagesStacks
         $this->pushes = [];
         $this->prepends = [];
         $this->pushStack = [];
+        $this->deferredStacks = [];
     }
 }

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -520,11 +520,14 @@ class Factory implements FactoryContract
      *
      * @return void
      */
-    public function flushStateIfDoneRendering()
+    public function flushStateIfDoneRendering(string $output = ''): string
     {
         if ($this->doneRendering()) {
+            $output = $this->resolveDeferredStacks($output);
             $this->flushState();
         }
+
+        return $output;
     }
 
     /**

--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -164,9 +164,15 @@ class View implements ArrayAccess, Htmlable, Stringable, ViewContract
             // Once we have the contents of the view, we will flush the sections if we are
             // done rendering all views so that there is nothing left hanging over when
             // another view gets rendered in the future by the application developer.
-            $this->factory->flushStateIfDoneRendering();
+            $contents = ! is_null($response) ? $response : $contents;
 
-            return ! is_null($response) ? $response : $contents;
+            if (is_string($contents)) {
+                $contents = $this->factory->flushStateIfDoneRendering($contents) ?: $contents;
+            } else {
+                $this->factory->flushStateIfDoneRendering();
+            }
+
+            return $contents;
         } catch (Throwable $e) {
             $this->factory->flushState();
 

--- a/tests/View/ViewStackTest.php
+++ b/tests/View/ViewStackTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Illuminate\Tests\View;
+
+use Illuminate\Events\Dispatcher;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\View\Engines\EngineResolver;
+use Illuminate\View\Engines\PhpEngine;
+use Illuminate\View\Factory;
+use Illuminate\View\FileViewFinder;
+use PHPUnit\Framework\TestCase;
+
+class ViewStackTest extends TestCase
+{
+    protected string $tmpDir;
+    protected Factory $factory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->tmpDir = sys_get_temp_dir().'/laravel_stack_test_'.uniqid();
+        mkdir($this->tmpDir);
+
+        $resolver = new EngineResolver;
+        $resolver->register('php', fn () => new PhpEngine(new Filesystem));
+
+        $finder = new FileViewFinder(new Filesystem, [$this->tmpDir]);
+        $finder->addExtension('php');
+
+        $this->factory = new Factory($resolver, $finder, new Dispatcher);
+    }
+
+    protected function tearDown(): void
+    {
+        array_map('unlink', glob($this->tmpDir.'/*.php'));
+        rmdir($this->tmpDir);
+        parent::tearDown();
+    }
+
+    protected function makeView(string $name, string $content): void
+    {
+        file_put_contents($this->tmpDir.'/'.$name.'.php', $content);
+    }
+
+    public function testPushFromLayoutComponentIsRenderedIntoStack(): void
+    {
+        $this->makeView('layout', <<<'PHP'
+<head><?php echo $__env->yieldPushContent('scripts'); ?></head>
+<body>
+<?php echo $slot; ?>
+<?php $__env->startPush('scripts'); ?>pushed from layout<?php $__env->stopPush(); ?>
+</body>
+PHP);
+
+        $this->makeView('welcome', <<<'PHP'
+<?php $__env->startPush('scripts'); ?>pushed from view<?php $__env->stopPush(); ?>
+<?php
+$slot = 'hello';
+echo $__env->make('layout', ['slot' => $slot])->render();
+?>
+PHP);
+
+        $output = $this->factory->make('welcome')->render();
+
+        $this->assertStringContainsString('pushed from view', $output);
+        $this->assertStringContainsString('pushed from layout', $output);
+
+        $headStart = strpos($output, '<head>');
+        $headEnd = strpos($output, '</head>');
+        $headContent = substr($output, $headStart, $headEnd - $headStart);
+
+        $this->assertStringContainsString('pushed from view', $headContent);
+        $this->assertStringContainsString('pushed from layout', $headContent);
+    }
+}


### PR DESCRIPTION
Fixes #60221

**Problem:** Components nested inside a layout body register their `@push` calls after `@stack` has already been yielded, so they arrive too late and are silently dropped.

**Fix:** `yieldPushContent` now returns a unique placeholder string instead of resolving immediately. Once the entire component tree finishes rendering, all placeholders are replaced with the real stack content via `resolveDeferredStacks()`, called inside `flushStateIfDoneRendering()`.

**Tests:** Added `ViewStackTest` to cover the case where a layout-level component pushes to a stack defined earlier in the layout.
