### PR TITLE
[13.x] Fix incorrect @return types in Number::spell(), ordinal(), and spellOrdinal()

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -96,7 +96,7 @@ class Number
      * @param  string|null  $locale
      * @param  int|null  $after
      * @param  int|null  $until
-     * @return string
+     * @return string|false
      */
     public static function spell(int|float $number, ?string $locale = null, ?int $after = null, ?int $until = null)
     {

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -120,7 +120,7 @@ class Number
      *
      * @param  int|float  $number
      * @param  string|null  $locale
-     * @return string
+     * @return string|false
      */
     public static function ordinal(int|float $number, ?string $locale = null)
     {

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -136,7 +136,7 @@ class Number
      *
      * @param  int|float  $number
      * @param  string|null  $locale
-     * @return string
+     * @return string|false
      */
     public static function spellOrdinal(int|float $number, ?string $locale = null)
     {


### PR DESCRIPTION
## Changes

Fix incorrect `@return` type annotations on three methods in the `Number` class.

According to the [PHP documentation](https://www.php.net/manual/en/numberformatter.format.php),
`NumberFormatter::format()` returns `string|false` — it returns `false` on failure.

The following methods call `NumberFormatter::format()` internally but their
docblocks incorrectly promised only `string`:

- `Number::spell()` — when `$number <= $after` or `$number >= $until`, it falls
  through to `static::format()` which can return `false`
- `Number::ordinal()` — calls `$formatter->format($number)` directly
- `Number::spellOrdinal()` — calls `$formatter->format($number)` directly

This causes incorrect static analysis results (PHPStan/Psalm) when these return
values are used as strings without null/false checks.