### PR TITLE
[13.x] Add minProperties and maxProperties to JsonSchema ObjectType

### DIFF
--- a/src/Illuminate/JsonSchema/Types/ObjectType.php
+++ b/src/Illuminate/JsonSchema/Types/ObjectType.php
@@ -10,6 +10,16 @@ class ObjectType extends Type
     protected ?bool $additionalProperties = null;
 
     /**
+     * The minimum number of properties (inclusive).
+     */
+    protected ?int $minProperties = null;
+
+    /**
+     * The maximum number of properties (inclusive).
+     */
+    protected ?int $maxProperties = null;
+
+    /**
      * Create a new object type instance.
      *
      * @param  array<string, Type>  $properties
@@ -17,6 +27,26 @@ class ObjectType extends Type
     public function __construct(protected array $properties = [])
     {
         //
+    }
+
+    /**
+     * Set the minimum number of properties (inclusive).
+     */
+    public function min(int $value): static
+    {
+        $this->minProperties = $value;
+
+        return $this;
+    }
+
+    /**
+     * Set the maximum number of properties (inclusive).
+     */
+    public function max(int $value): static
+    {
+        $this->maxProperties = $value;
+
+        return $this;
     }
 
     /**

--- a/tests/JsonSchema/ObjectTypeTest.php
+++ b/tests/JsonSchema/ObjectTypeTest.php
@@ -103,6 +103,47 @@ class ObjectTypeTest extends TestCase
         ], $type->toArray());
     }
 
+    public function test_it_may_set_min_properties(): void
+    {
+        $type = JsonSchema::object()->title('Payload')->min(1);
+
+        $this->assertEquals([
+            'type' => 'object',
+            'title' => 'Payload',
+            'minProperties' => 1,
+        ], $type->toArray());
+    }
+
+    public function test_it_may_set_max_properties(): void
+    {
+        $type = JsonSchema::object()->description('A record')->max(5);
+
+        $this->assertEquals([
+            'type' => 'object',
+            'description' => 'A record',
+            'maxProperties' => 5,
+        ], $type->toArray());
+    }
+
+    public function test_it_may_combine_min_and_max_properties(): void
+    {
+        $type = JsonSchema::object([
+            'name' => JsonSchema::string()->required(),
+        ])->min(1)->max(3);
+
+        $this->assertEquals([
+            'type' => 'object',
+            'properties' => [
+                'name' => [
+                    'type' => 'string',
+                ],
+            ],
+            'required' => ['name'],
+            'minProperties' => 1,
+            'maxProperties' => 3,
+        ], $type->toArray());
+    }
+
     public function test_it_may_set_enum(): void
     {
         $type = JsonSchema::object()->enum([

--- a/tests/JsonSchema/TypeTest.php
+++ b/tests/JsonSchema/TypeTest.php
@@ -300,6 +300,9 @@ class TypeTest extends TestCase
                 ]),
                 (object) ['age' => 0], // not nullable
             ],
+            [JsonSchema::object()->min(1), (object) ['a' => 1]],
+            [JsonSchema::object()->max(2), (object) ['a' => 1, 'b' => 2]],
+            [JsonSchema::object()->min(1)->max(2), (object) ['a' => 1]],
 
             // ArrayType
             [JsonSchema::array(), []],
@@ -397,6 +400,8 @@ class TypeTest extends TestCase
             [JsonSchema::object(['name' => JsonSchema::string()->required()])->default(['name' => 'x']), (object) []], // default doesn't satisfy missing required
             [JsonSchema::object(['score' => JsonSchema::integer()->min(0)]), (object) ['score' => -1]], // below min
             [JsonSchema::object(['age' => JsonSchema::integer()->nullable(false)]), (object) ['age' => null]], // not nullable
+            [JsonSchema::object()->min(2), (object) ['a' => 1]], // too few properties
+            [JsonSchema::object()->max(1), (object) ['a' => 1, 'b' => 2]], // too many properties
 
             // ArrayType
             [JsonSchema::array(), (object) []], // type mismatch


### PR DESCRIPTION
ArrayType already has `min()` / `max()` for `minItems` and `maxItems`. ObjectType was missing the same for property counts.

Adds `min()` and `max()` on ObjectType, same pattern as ArrayType.