### PR TITLE
[13.x] Stringify properties keys in JsonSchema Serializer

### DIFF
--- a/src/Illuminate/JsonSchema/Serializer.php
+++ b/src/Illuminate/JsonSchema/Serializer.php
@@ -69,6 +69,10 @@ class Serializer
                     static fn (Types\Type $property) => static::serialize($property),
                     $attributes['properties'],
                 );
+
+                if (array_is_list($attributes['properties'])) {
+                    $attributes['properties'] = (object) $attributes['properties'];
+                }
             }
         }
 

--- a/tests/JsonSchema/ObjectTypeTest.php
+++ b/tests/JsonSchema/ObjectTypeTest.php
@@ -92,6 +92,20 @@ class ObjectTypeTest extends TestCase
         $this->assertIsString($array['required'][1]);
     }
 
+    public function test_numeric_string_property_names_serialize_as_object(): void
+    {
+        $type = JsonSchema::object([
+            '0' => JsonSchema::string()->required(),
+            '1' => JsonSchema::string()->required(),
+            '2' => JsonSchema::string()->required(),
+        ]);
+
+        $json = json_encode($type->toArray());
+
+        $this->assertStringContainsString('"properties":{"0":', $json);
+        $this->assertStringNotContainsString('"properties":[', $json);
+    }
+
     public function test_it_may_disable_additional_properties(): void
     {
         $type = JsonSchema::object()->default(['age' => 1])->withoutAdditionalProperties();


### PR DESCRIPTION
I am building a small EdTech app where teachers can create multiple choice quizes and an AI grades the student submissions. I use Laravel JsonSchema to describe what a valid answer payload looks like, then I run it through opis/json-schema before sending the answer to the AI grader.

The quiz has answer slots A, B, C, D. In the payload the slots are indexed by position so slot A is `"0"`, slot B is `"1"`, etc. When I tried to publish my first quiz the validator kept saying my schema is invalid and every submisison was getting rejected

Here is what I had:

```php
$slots = [];
for ($i = 0; $i < 4; $i++) {
    $slots[(string) $i] = JsonSchema::boolean()->required();
}

$schema = JsonSchema::object([
    'question_id' => JsonSchema::integer()->required(),
    'selected_slots' => JsonSchema::object($slots)->required(),
])->toArray();
```

When I encode this to JSON, the `selected_slots.properties` field comes out as an array, not an object:

```json
"selected_slots": {
  "properties": [
    {"type":"boolean"},
    {"type":"boolean"},
    {"type":"boolean"},
    {"type":"boolean"}
  ],
  "type": "object",
  "required": ["0","1","2","3"]
}
```

opis throws `properties must be an object`. The JSON Schema spec (Draft 2020-12, the section about the `properties` keyword) also says it must be an object, so this output is not valid https://json-schema.org/understanding-json-schema/reference/object#properties

PR #60149 was merged last week and it handles the same coercion issue for the `required` array. But the same logic was not applied to `properties` itself. The test in that PR uses keys `"1"` and `"4"` which PHP coerces to int 1 and 4. Those are not list shaped so json_encode still emits an object and the bug stays hidden. With keys like `"0", "1", "2"` the array becomes a php list starting from 0 and json_encode emits an array instead.

### Fix

PHP coerces numeric string keys to int and there is no way to keep them as strings in an array. The cleanest way I found to make json_encode emit an object is to cast the array to `stdClass`, but only when it would otherwise be encoded as a list. For all normal cases (string keys like `'name'`, `'email'`) nothing changes and the existing tests pass without modification.

### Test

I added a test next to the one from #60149 that asserts the JSON output keeps `properties` as an object when the keys are `"0", "1", "2"`.

Thanks!