### PR TITLE
[13.x] Guard base_path() call in SQLiteConnector for standalone usage

### DIFF
--- a/src/Illuminate/Database/Connectors/SQLiteConnector.php
+++ b/src/Illuminate/Database/Connectors/SQLiteConnector.php
@@ -51,7 +51,7 @@ class SQLiteConnector extends Connector implements ConnectorInterface
             return $path;
         }
 
-        $path = realpath($path) ?: realpath(base_path($path));
+        $path = realpath($path) ?: (function_exists('base_path') ? realpath(base_path($path)) : false);
 
         // Here we'll verify that the SQLite database exists before going any further
         // as the developer probably wants to know if the database exists and this


### PR DESCRIPTION
When using `illuminate/database` as a standalone package (without the full Laravel framework), the `base_path()` helper function is not available because it is defined in `Illuminate\Support\helpers.php` which is only loaded with the full `framework` package.

This causes a fatal error when connecting to a SQLite database with a relative path:

```
Call to undefined function Illuminate\Database\Connectors\base_path()
```

Guard the call with `function_exists()` so the connector works standalone. When `base_path()` is unavailable, the path resolution falls through to the existing `SQLiteDatabaseDoesNotExistException`.

Fixes #60260