### PR TITLE
[13.x] Add lineUnless and linesUnless to notification messages

### DIFF
--- a/src/Illuminate/Notifications/Messages/SimpleMessage.php
+++ b/src/Illuminate/Notifications/Messages/SimpleMessage.php
@@ -174,6 +174,18 @@ class SimpleMessage
     }
 
     /**
+     * Add a line of text to the notification unless the given condition is true.
+     *
+     * @param  bool  $boolean
+     * @param  mixed  $line
+     * @return $this
+     */
+    public function lineUnless($boolean, $line)
+    {
+        return $this->lineIf(! $boolean, $line);
+    }
+
+    /**
      * Add lines of text to the notification.
      *
      * @param  iterable  $lines
@@ -202,6 +214,18 @@ class SimpleMessage
         }
 
         return $this;
+    }
+
+    /**
+     * Add lines of text to the notification unless the given condition is true.
+     *
+     * @param  bool  $boolean
+     * @param  iterable  $lines
+     * @return $this
+     */
+    public function linesUnless($boolean, $lines)
+    {
+        return $this->linesIf(! $boolean, $lines);
     }
 
     /**

--- a/tests/Notifications/NotificationMailMessageTest.php
+++ b/tests/Notifications/NotificationMailMessageTest.php
@@ -185,6 +185,32 @@ class NotificationMailMessageTest extends TestCase
         $this->assertSame([$callback], $message->callbacks);
     }
 
+    public function testLineUnless()
+    {
+        $message = new MailMessage;
+        $message->lineUnless(false, 'Shown when condition is false');
+
+        $this->assertSame(['Shown when condition is false'], $message->introLines);
+
+        $message = new MailMessage;
+        $message->lineUnless(true, 'Hidden when condition is true');
+
+        $this->assertSame([], $message->introLines);
+    }
+
+    public function testLinesUnless()
+    {
+        $message = new MailMessage;
+        $message->linesUnless(false, ['First line', 'Second line']);
+
+        $this->assertSame(['First line', 'Second line'], $message->introLines);
+
+        $message = new MailMessage;
+        $message->linesUnless(true, ['First line', 'Second line']);
+
+        $this->assertSame([], $message->introLines);
+    }
+
     public function testWhenCallback()
     {
         $callback = function (MailMessage $mailMessage, $condition) {


### PR DESCRIPTION
## Summary

This PR adds `lineUnless` and `linesUnless` methods to notification messages via `SimpleMessage`.

These methods provide the inverse conditional behavior of the existing `lineIf` and `linesIf` helpers:

```php
$message->lineUnless($condition, '...');
$message->linesUnless($condition, [
    '...',
]);
```

This keeps the API consistent with Laravel's broader `when` / `unless` conventions and improves readability when the negative condition is the intended flow.

## Motivation

`SimpleMessage` already provides conditional helpers through `lineIf` and `linesIf`, but currently lacks their `unless` counterparts.

Without these methods, developers must negate conditions manually:

```php
$message->lineIf(! $condition, '...');
```

Adding dedicated `unless` variants improves expressiveness and keeps the notification API symmetrical and consistent with other framework patterns.

## Changes

- Added `lineUnless()` to `SimpleMessage`
- Added `linesUnless()` to `SimpleMessage`
- Added test coverage for both methods

## Tests

Added the following tests to `NotificationMailMessageTest`:

- `testLineUnless`
- `testLinesUnless`

Verified with:

```bash
./vendor/bin/phpunit tests/Notifications/NotificationMailMessageTest.php --filter Unless
```

## Backward Compatibility

This change is fully backward compatible and only introduces additional convenience methods without altering existing behavior.