### PR TITLE
[13.x] Add attachFromStorage helpers to notification MailMessage

### DIFF
--- a/src/Illuminate/Notifications/Messages/MailMessage.php
+++ b/src/Illuminate/Notifications/Messages/MailMessage.php
@@ -313,6 +313,43 @@ class MailMessage extends SimpleMessage implements Renderable
     }
 
     /**
+     * Attach a file to the message from storage.
+     *
+     * @param  string  $path
+     * @param  string|null  $name
+     * @param  array  $options
+     * @return $this
+     */
+    public function attachFromStorage($path, $name = null, array $options = [])
+    {
+        return $this->attachFromStorageDisk(null, $path, $name, $options);
+    }
+
+    /**
+     * Attach a file to the message from storage.
+     *
+     * @param  string|null  $disk
+     * @param  string  $path
+     * @param  string|null  $name
+     * @param  array  $options
+     * @return $this
+     */
+    public function attachFromStorageDisk($disk, $path, $name = null, array $options = [])
+    {
+        $attachment = Attachment::fromStorageDisk($disk, $path);
+
+        if (! is_null($name)) {
+            $attachment->as($name);
+        }
+
+        if (isset($options['mime'])) {
+            $attachment->withMime($options['mime']);
+        }
+
+        return $this->attach($attachment);
+    }
+
+    /**
      * Add a tag header to the message when supported by the underlying transport.
      *
      * @param  string  $value

--- a/tests/Notifications/NotificationMailMessageTest.php
+++ b/tests/Notifications/NotificationMailMessageTest.php
@@ -2,13 +2,29 @@
 
 namespace Illuminate\Tests\Notifications;
 
+use Illuminate\Config\Repository as ConfigRepository;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Filesystem\Factory as FilesystemFactory;
 use Illuminate\Contracts\Mail\Attachable;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Filesystem\FilesystemManager;
 use Illuminate\Mail\Attachment;
 use Illuminate\Notifications\Messages\MailMessage;
 use PHPUnit\Framework\TestCase;
 
 class NotificationMailMessageTest extends TestCase
 {
+    protected ?string $filesystemRoot = null;
+
+    protected function tearDown(): void
+    {
+        if ($this->filesystemRoot !== null) {
+            $this->deleteDirectory($this->filesystemRoot);
+            $this->filesystemRoot = null;
+        }
+
+        parent::tearDown();
+    }
     public function testTemplate()
     {
         $message = new MailMessage;
@@ -303,6 +319,37 @@ class NotificationMailMessageTest extends TestCase
         $this->assertSame([['truthy@example.com', null]], $message->cc);
     }
 
+    public function testItAttachesFilesFromStorage()
+    {
+        $this->bootstrapFilesystem();
+
+        file_put_contents($this->filesystemRoot.'/invoices/1.pdf', 'pdf content');
+
+        $message = new MailMessage;
+        $message->attachFromStorage('invoices/1.pdf', 'invoice.pdf');
+
+        $this->assertCount(1, $message->rawAttachments);
+        $this->assertSame('invoice.pdf', $message->rawAttachments[0]['name']);
+        $this->assertSame('pdf content', $message->rawAttachments[0]['data']);
+    }
+
+    public function testItAttachesFilesFromStorageDisk()
+    {
+        $this->bootstrapFilesystem();
+
+        file_put_contents($this->filesystemRoot.'/reports/report.txt', 'report content');
+
+        $message = new MailMessage;
+        $message->attachFromStorageDisk('s3', 'reports/report.txt', 'monthly-report.txt', [
+            'mime' => 'text/plain',
+        ]);
+
+        $this->assertCount(1, $message->rawAttachments);
+        $this->assertSame('monthly-report.txt', $message->rawAttachments[0]['name']);
+        $this->assertSame('report content', $message->rawAttachments[0]['data']);
+        $this->assertSame('text/plain', $message->rawAttachments[0]['options']['mime']);
+    }
+
     public function testItAttachesFilesViaAttachableContractFromPath()
     {
         $message = new MailMessage;
@@ -388,5 +435,58 @@ class NotificationMailMessageTest extends TestCase
                 ],
             ],
         ], $mailMessage->attachments);
+    }
+
+    protected function bootstrapFilesystem(): void
+    {
+        $this->filesystemRoot = sys_get_temp_dir().'/laravel-notification-mail-message-'.uniqid();
+
+        mkdir($this->filesystemRoot.'/invoices', 0777, true);
+        mkdir($this->filesystemRoot.'/reports', 0777, true);
+
+        $container = Container::getInstance() ?? new Container;
+
+        Container::setInstance($container);
+
+        $container->instance('config', new ConfigRepository([
+            'filesystems' => [
+                'default' => 'local',
+                'disks' => [
+                    'local' => [
+                        'driver' => 'local',
+                        'root' => $this->filesystemRoot,
+                    ],
+                    's3' => [
+                        'driver' => 'local',
+                        'root' => $this->filesystemRoot,
+                    ],
+                ],
+            ],
+        ]));
+
+        $container->instance('files', new Filesystem);
+
+        $container->singleton('filesystem', fn ($container) => new FilesystemManager($container));
+
+        $container->alias('filesystem', FilesystemFactory::class);
+    }
+
+    protected function deleteDirectory(string $directory): void
+    {
+        if (! is_dir($directory)) {
+            return;
+        }
+
+        foreach (scandir($directory) as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+
+            $path = $directory.'/'.$item;
+
+            is_dir($path) ? $this->deleteDirectory($path) : unlink($path);
+        }
+
+        rmdir($directory);
     }
 }


### PR DESCRIPTION
## Summary

This PR adds `attachFromStorage` and `attachFromStorageDisk` helpers to notification `MailMessage`.

These methods mirror the storage attachment API available on mailables and delegate to `Attachment::fromStorageDisk()` before attaching the generated attachment to the message.

## Motivation

After #58201, mailables support attaching files directly from storage using dedicated helpers.

Notification mail messages can already attach `Attachment` instances, but they do not provide the same convenience methods for storage-backed attachments. This creates a small API inconsistency between `Mailable` and notification `MailMessage`.

Adding these helpers improves parity and makes notification mail attachments more ergonomic.

## Changes

- Added `attachFromStorage()` to `MailMessage`
- Added `attachFromStorageDisk()` to `MailMessage`
- Delegates storage attachment creation to `Attachment::fromStorageDisk()`
- Applies custom attachment name and MIME options when provided
- Added test coverage for local and disk-specific storage attachments

## Example

```php
MailMessage::make()
    ->attachFromStorage('invoices/1.pdf')
    ->attachFromStorageDisk('s3', 'invoices/1.pdf', 'invoice.pdf', [
        'mime' => 'application/pdf',
    ]);
```

## Tests

Added coverage in `NotificationMailMessageTest`:

- `testItAttachesFilesFromStorage`
- `testItAttachesFilesFromStorageDisk`

Verified with:

```bash
./vendor/bin/phpunit tests/Notifications/NotificationMailMessageTest.php
./vendor/bin/pint
```

## Backward Compatibility

This change is fully backward compatible.

It only adds new convenience methods to notification `MailMessage` and does not alter existing attachment behavior.