### PR TITLE
[13.x] Only handle unique constraint violations when acquiring database locks

### DIFF
--- a/src/Illuminate/Cache/DatabaseLock.php
+++ b/src/Illuminate/Cache/DatabaseLock.php
@@ -4,7 +4,7 @@ namespace Illuminate\Cache;
 
 use Illuminate\Database\Connection;
 use Illuminate\Database\DetectsConcurrencyErrors;
-use Illuminate\Database\QueryException;
+use Illuminate\Database\UniqueConstraintViolationException;
 use Throwable;
 
 class DatabaseLock extends Lock
@@ -77,7 +77,7 @@ class DatabaseLock extends Lock
             ]);
 
             $acquired = true;
-        } catch (QueryException) {
+        } catch (UniqueConstraintViolationException) {
             $updated = $this->connection->table($this->table)
                 ->where('key', $this->name)
                 ->where(function ($query) {

--- a/tests/Integration/Database/DatabaseLockTest.php
+++ b/tests/Integration/Database/DatabaseLockTest.php
@@ -6,6 +6,7 @@ use Illuminate\Cache\DatabaseLock;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Database\QueryException;
+use Illuminate\Database\UniqueConstraintViolationException;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
@@ -99,6 +100,56 @@ class DatabaseLockTest extends DatabaseTestCase
         $secondLock = Cache::store('database')->restoreLock('foo', 'other_owner');
         $this->assertTrue($secondLock->isOwnedBy($firstLock->owner()));
         $this->assertFalse($secondLock->isOwnedByCurrentProcess());
+    }
+
+    public function testAcquireRethrowsInsertQueryExceptionsThatAreNotUniqueConstraintViolations()
+    {
+        $connection = m::mock(Connection::class);
+        $insertBuilder = m::mock(Builder::class);
+
+        $insertBuilder->shouldReceive('insert')->once()->andThrow(
+            new QueryException(
+                'mysql',
+                'insert into cache_locks (`key`, `owner`, `expiration`) values (?, ?, ?)',
+                ['foo', 'owner-123', 1],
+                new PDOException('Table does not exist', 1146)
+            )
+        );
+
+        $connection->shouldReceive('table')->with('cache_locks')->once()->andReturn($insertBuilder);
+
+        $lock = new DatabaseLock($connection, 'cache_locks', 'foo', 10, 'owner-123', lottery: null);
+
+        $this->expectException(QueryException::class);
+        $this->expectExceptionMessage('Table does not exist');
+
+        $lock->acquire();
+    }
+
+    public function testAcquireFallsBackToUpdatingExistingLockAfterUniqueConstraintViolation()
+    {
+        $connection = m::mock(Connection::class);
+        $insertBuilder = m::mock(Builder::class);
+        $updateBuilder = m::mock(Builder::class);
+
+        $insertBuilder->shouldReceive('insert')->once()->andThrow(
+            new UniqueConstraintViolationException(
+                'mysql',
+                'insert into cache_locks (`key`, `owner`, `expiration`) values (?, ?, ?)',
+                ['foo', 'owner-123', 1],
+                new PDOException('Duplicate entry', 1062)
+            )
+        );
+
+        $updateBuilder->shouldReceive('where')->with('key', 'foo')->once()->andReturnSelf();
+        $updateBuilder->shouldReceive('where')->with(m::type('Closure'))->once()->andReturnSelf();
+        $updateBuilder->shouldReceive('update')->once()->andReturn(1);
+
+        $connection->shouldReceive('table')->with('cache_locks')->andReturn($insertBuilder, $updateBuilder);
+
+        $lock = new DatabaseLock($connection, 'cache_locks', 'foo', 10, 'owner-123', lottery: null);
+
+        $this->assertTrue($lock->acquire());
     }
 
     #[TestWith(['Deadlock found when trying to get lock', 1213, true])]


### PR DESCRIPTION
## Description

This pull request updates `DatabaseLock::acquire()` so it only falls back to updating an existing lock when the insert fails due to a unique constraint violation.

Previously, the method caught any `QueryException`, which could hide unrelated database errors such as missing tables, invalid SQL, permission issues, or connection problems. Those errors should be surfaced to the developer instead of being treated as a lock contention case.

This PR also adds regression coverage for both paths:

- non-unique insert query exceptions are rethrown
- unique constraint violations still fall back to updating the existing lock

Fixes #60171.