### PR TITLE
[13.x] Support enum model arguments in authorize middleware definitions

### DIFF
--- a/src/Illuminate/Auth/Middleware/Authorize.php
+++ b/src/Illuminate/Auth/Middleware/Authorize.php
@@ -32,12 +32,12 @@ class Authorize
      * Specify the ability and models for the middleware.
      *
      * @param  \UnitEnum|string  $ability
-     * @param  string  ...$models
+     * @param  \UnitEnum|string  ...$models
      * @return string
      */
     public static function using($ability, ...$models)
     {
-        return static::class.':'.implode(',', [enum_value($ability), ...$models]);
+        return static::class.':'.implode(',', [enum_value($ability), ...array_map(enum_value(...), $models)]);
     }
 
     /**

--- a/src/Illuminate/Routing/Attributes/Controllers/Authorize.php
+++ b/src/Illuminate/Routing/Attributes/Controllers/Authorize.php
@@ -11,11 +11,11 @@ use UnitEnum;
 class Authorize extends Middleware
 {
     /**
-     * @param  array<string>|string|null  $models
+     * @param  array<\UnitEnum|string>|\UnitEnum|string|null  $models
      */
     public function __construct(
         UnitEnum|string $ability,
-        array|string|null $models = null,
+        array|UnitEnum|string|null $models = null,
         ?array $only = null,
         ?array $except = null,
     ) {

--- a/tests/Auth/AuthorizeMiddlewareTest.php
+++ b/tests/Auth/AuthorizeMiddlewareTest.php
@@ -65,6 +65,9 @@ class AuthorizeMiddlewareTest extends TestCase
 
         $signature = Authorize::using('ability', 'model', \App\Models\Comment::class);
         $this->assertSame('Illuminate\Auth\Middleware\Authorize:ability,model,App\Models\Comment', $signature);
+
+        $signature = Authorize::using(AbilitiesEnum::UPDATE, ModelsEnum::POST, ModelsEnum::COMMENT);
+        $this->assertSame('Illuminate\Auth\Middleware\Authorize:update,post,App\Models\Comment', $signature);
     }
 
     public function testSimpleAbilityUnauthorized()

--- a/tests/Auth/Enums.php
+++ b/tests/Auth/Enums.php
@@ -7,3 +7,9 @@ enum AbilitiesEnum: string
     case VIEW_DASHBOARD = 'view-dashboard';
     case UPDATE = 'update';
 }
+
+enum ModelsEnum: string
+{
+    case POST = 'post';
+    case COMMENT = 'App\Models\Comment';
+}

--- a/tests/Integration/Routing/AuthorizeMiddlewareAttributeTest.php
+++ b/tests/Integration/Routing/AuthorizeMiddlewareAttributeTest.php
@@ -21,6 +21,7 @@ class AuthorizeMiddlewareAttributeTest extends TestCase
         $this->assertEquals([
             'Illuminate\Auth\Middleware\Authorize:all',
             'Illuminate\Auth\Middleware\Authorize:except-index,a,b',
+            'Illuminate\Auth\Middleware\Authorize:view-related,post,comment',
         ], $route->controllerMiddleware());
     }
 }
@@ -28,6 +29,7 @@ class AuthorizeMiddlewareAttributeTest extends TestCase
 #[Authorize('all')]
 #[Authorize('only-index', 'a', only: ['index'])]
 #[Authorize('except-index', ['a', 'b'], except: ['index'])]
+#[Authorize(AuthorizeMiddlewareAttributeAbility::ViewRelated, [AuthorizeMiddlewareAttributeModel::Post, AuthorizeMiddlewareAttributeModel::Comment], except: ['index'])]
 class AuthorizeMiddlewareAttributeController
 {
     #[Authorize('also-index')]
@@ -40,4 +42,15 @@ class AuthorizeMiddlewareAttributeController
     {
         // ...
     }
+}
+
+enum AuthorizeMiddlewareAttributeAbility: string
+{
+    case ViewRelated = 'view-related';
+}
+
+enum AuthorizeMiddlewareAttributeModel: string
+{
+    case Post = 'post';
+    case Comment = 'comment';
 }


### PR DESCRIPTION
Allows enum values to be used for model arguments when generating authorize middleware definitions.

`Authorize::using()` already supports enum values for the ability name. This change extends the same normalization to the model arguments, allowing code such as controller `#[Authorize]` attributes to pass enum-backed route parameter names or model references consistently.

The controller `Authorize` attribute type declaration has also been updated so `models` may be provided as a `UnitEnum`, string, array, or null.