### PR TITLE
[13.x] feat: add randomOrFactory and randomOrFactoryCreate methods

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/HasFactory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/HasFactory.php
@@ -2,10 +2,16 @@
 
 namespace Illuminate\Database\Eloquent\Factories;
 
+use Closure;
 use Illuminate\Database\Eloquent\Attributes\UseFactory;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
 
 /**
  * @template TFactory of \Illuminate\Database\Eloquent\Factories\Factory
+ *
+ * @phpstan-require-extends Model
  */
 trait HasFactory
 {
@@ -23,6 +29,52 @@ trait HasFactory
         return $factory
             ->count(is_numeric($count) ? $count : null)
             ->state(is_callable($count) || is_array($count) ? $count : $state);
+    }
+
+    /**
+     * Returns a random record from the database or the factory if there are no records.
+     *
+     * @param  (Closure(Builder<static>): mixed)|null  $query
+     * @param  (Closure(TFactory): TFactory)|null  $factory
+     * @return ($count is null ? static|TFactory : Collection<int, static>|TFactory)
+     *
+     * @phpstan-ignore method.childParameterType (parameters are not covariant)
+     */
+    public static function randomOrFactory(?Closure $query = null, ?Closure $factory = null, ?int $count = null): static|Collection|Factory
+    {
+        $factory ??= fn ($factory) => $factory;
+
+        return static::query()
+            ->inRandomOrder()
+            /** @phpstan-ignore argument.type (unknown builder) */
+            ->when($query, $query)
+            ->limit($count)
+            ->get()
+            ->whenNotEmpty(
+                fn ($m) => $count === null ? $m->first() : $m,
+                fn () => $factory(static::factory($count)),
+            );
+    }
+
+    /**
+     * Returns a random record from the database or create one with the factory if there are no records.
+     *
+     * @param  (Closure(Builder<static>): mixed)|null  $query
+     * @param  (Closure(TFactory): TFactory)|null  $factory
+     * @return ($count is null ? static : Collection<int, static>)
+     *
+     * @phpstan-ignore method.childParameterType (parameters are not covariant)
+     */
+    public static function randomOrFactoryCreate(?Closure $query = null, ?Closure $factory = null, ?int $count = null): static|Collection
+    {
+        $model = static::randomOrFactory($query, $factory, $count);
+
+        if (! $model instanceof Factory) {
+            return $model;
+        }
+
+        /** @phpstan-ignore return.type (returns static) */
+        return $count === null ? $model->createOne() : $model->createMany();
     }
 
     /**

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -1137,6 +1137,114 @@ class DatabaseEloquentFactoryTest extends TestCase
         }
     }
 
+    public function test_random_or_factory_returns_factory_instance_when_no_records_exist()
+    {
+        Factory::guessFactoryNamesUsing(function ($model) {
+            return $model.'Factory';
+        });
+        DB::table('users')->delete();
+        $result = FactoryTestUser::randomOrFactory();
+        $this->assertInstanceOf(FactoryTestUserFactory::class, $result);
+    }
+
+    public function test_random_or_factory_returns_random_model_when_records_exist()
+    {
+        Factory::guessFactoryNamesUsing(function ($model) {
+            return $model.'Factory';
+        });
+        DB::table('users')->delete();
+        $user = FactoryTestUserFactory::new()->create(['name' => 'Taylor']);
+        $result = FactoryTestUser::randomOrFactory();
+        $this->assertInstanceOf(FactoryTestUser::class, $result);
+        $this->assertSame($user->id, $result->id);
+    }
+
+    public function test_random_or_factory_returns_factory_when_no_records_with_count()
+    {
+        Factory::guessFactoryNamesUsing(function ($model) {
+            return $model.'Factory';
+        });
+        DB::table('users')->delete();
+        $result = FactoryTestUser::randomOrFactory(null, null, 3);
+        $this->assertInstanceOf(FactoryTestUserFactory::class, $result);
+        $models = $result->make();
+        $this->assertCount(3, $models);
+    }
+
+    public function test_random_or_factory_returns_collection_when_records_exist_with_count()
+    {
+        Factory::guessFactoryNamesUsing(function ($model) {
+            return $model.'Factory';
+        });
+        DB::table('users')->delete();
+        FactoryTestUserFactory::new()->count(2)->create();
+        $result = FactoryTestUser::randomOrFactory(null, null, 2);
+        $this->assertInstanceOf(Collection::class, $result);
+        $this->assertCount(2, $result);
+    }
+
+    public function test_random_or_factory_uses_query_closure_to_filter()
+    {
+        Factory::guessFactoryNamesUsing(function ($model) {
+            return $model.'Factory';
+        });
+        DB::table('users')->delete();
+        FactoryTestUserFactory::new()->create(['name' => 'foo']);
+        FactoryTestUserFactory::new()->create(['name' => 'bar']);
+        $result = FactoryTestUser::randomOrFactory(fn ($query) => $query->where('name', 'foo'));
+        $this->assertInstanceOf(FactoryTestUser::class, $result);
+        $this->assertSame('foo', $result->name);
+    }
+
+    public function test_random_or_factory_applies_factory_closure()
+    {
+        Factory::guessFactoryNamesUsing(function ($model) {
+            return $model.'Factory';
+        });
+        DB::table('users')->delete();
+        $result = FactoryTestUser::randomOrFactory(null, fn ($factory) => $factory->state(['name' => 'custom']));
+        $user = $result->create();
+        $this->assertSame('custom', $user->name);
+    }
+
+    public function test_random_or_factory_create_returns_model_and_creates_when_no_records()
+    {
+        Factory::guessFactoryNamesUsing(function ($model) {
+            return $model.'Factory';
+        });
+        DB::table('users')->delete();
+        $before = FactoryTestUser::count();
+        $result = FactoryTestUser::randomOrFactoryCreate();
+        $this->assertInstanceOf(FactoryTestUser::class, $result);
+        $this->assertSame($before + 1, FactoryTestUser::count());
+    }
+
+    public function test_random_or_factory_create_returns_existing_when_records_exist_without_creating()
+    {
+        Factory::guessFactoryNamesUsing(function ($model) {
+            return $model.'Factory';
+        });
+        DB::table('users')->delete();
+        $user = FactoryTestUserFactory::new()->create();
+        $before = FactoryTestUser::count();
+        $result = FactoryTestUser::randomOrFactoryCreate();
+        $this->assertInstanceOf(FactoryTestUser::class, $result);
+        $this->assertSame($user->id, $result->id);
+        $this->assertSame($before, FactoryTestUser::count());
+    }
+
+    public function test_random_or_factory_create_with_count_creates_many_when_no_records()
+    {
+        Factory::guessFactoryNamesUsing(function ($model) {
+            return $model.'Factory';
+        });
+        DB::table('users')->delete();
+        $result = FactoryTestUser::randomOrFactoryCreate(null, null, 2);
+        $this->assertInstanceOf(Collection::class, $result);
+        $this->assertCount(2, $result);
+        $this->assertSame(2, FactoryTestUser::count());
+    }
+
     /**
      * Get a database connection instance.
      *

--- a/types/Database/Eloquent/Factories/Factory.php
+++ b/types/Database/Eloquent/Factories/Factory.php
@@ -192,3 +192,28 @@ UserFactory::new()->has(
             return ['user_id' => $user?->getKey()];
         }),
 );
+
+class TypeTestUser extends \Illuminate\Database\Eloquent\Model
+{
+    /** @use \Illuminate\Database\Eloquent\Factories\HasFactory<TypeTestUserFactory> */
+    use \Illuminate\Database\Eloquent\Factories\HasFactory;
+}
+
+/** @extends Factory<TypeTestUser> */
+class TypeTestUserFactory extends Factory
+{
+    protected $model = TypeTestUser::class;
+
+    public function definition(): array
+    {
+        return [];
+    }
+}
+
+assertType('TypeTestUser|TypeTestUserFactory', TypeTestUser::randomOrFactory());
+assertType('TypeTestUser|TypeTestUserFactory', TypeTestUser::randomOrFactory(null, null, null));
+assertType('Illuminate\Database\Eloquent\Collection<int, TypeTestUser>|TypeTestUserFactory', TypeTestUser::randomOrFactory(null, null, 5));
+assertType('TypeTestUser', TypeTestUser::randomOrFactoryCreate());
+assertType('Illuminate\Database\Eloquent\Collection<int, TypeTestUser>', TypeTestUser::randomOrFactoryCreate(null, null, 3));
+assertType('TypeTestUser|TypeTestUserFactory', TypeTestUser::randomOrFactory(fn ($q) => $q->where('id', 1)));
+assertType('TypeTestUser', TypeTestUser::randomOrFactoryCreate(null, fn ($f) => $f->state([])));


### PR DESCRIPTION
Hello!

These are some factory helpers that I've been using for years in factories/seeders/tests and it was suggested that I upstream them.

There's many times that I want to grab a *random* model instead of always creating creating a new factory instance, but I don't want the code to fail if no records exist, some common use-cases:
- having fewer "wide" parent models that are used across a variety of relations vs. having a ton of "narrow" parent models that are only used for one relationship
- grabbing a random record from pre-seeded db in tests is generally faster than generating a new one and writing to db (could also have more expensive afterMaking/afterCreating logic that's avoided)
- etc.

### Examples

```diff
final class CronLogFactory extends Factory
{
    public function definition(): array
    {
        return [
-            'cron_id' => fn () => Cron::inRandomOrder()->first() ?? Cron::factory(),
+            'cron_id' => fn () => Cron::randomOrFactory(),
            // ...
        ];
    }
}
```

It also allow customizing the query or factory:

```diff
public function configure(): static
{
    return $this->afterMaking(function (Contact $contact): void {
-        $contact->customer_id ??= Customer::query()
-            ->inRandomOrder()
-            ->engineering()
-            ->first()?->id
-            ?? Customer::factory()
-                ->engineering()
-                ->create()->id
+        $contact->customer_id ??= Customer::randomOrFactoryCreate(
+            fn ($q) => $q->whereEngineering(),
+            fn ($f) => $f->engineering(),
+        )->id;
    });
}
```

Thanks!