### PR TITLE
[13.x] Restore base_path() guard in SQLiteConnector lost during merge race

### DIFF
--- a/src/Illuminate/Database/Connectors/SQLiteConnector.php
+++ b/src/Illuminate/Database/Connectors/SQLiteConnector.php
@@ -51,7 +51,7 @@ class SQLiteConnector extends Connector implements ConnectorInterface
             return $path;
         }
 
-        $path = realpath($path) ?: realpath(base_path($path));
+        $path = realpath($path) ?: (function_exists('base_path') ? realpath(base_path($path)) : false);
 
         // Here we'll verify that the SQLite database exists before going any further
         // as the developer probably wants to know if the database exists and this


### PR DESCRIPTION
Restores the `function_exists('base_path')` guard from #60266 which was silently dropped when #60261 was merged.

## Background

Two PRs were merged ~2 minutes apart, both targeting issue #60260:

- #60266 merged 2026-05-25 23:02:48 UTC — guarded `base_path()` with `function_exists()` for standalone `illuminate/database` usage
- #60261 merged 2026-05-25 23:05:07 UTC — added `file:` URI prefix support

#60261 was opened against the pre-#60266 file, and its merge silently overwrote #60266's one-line guard. Current `13.x` HEAD has the original unguarded code:

```php
$path = realpath($path) ?: realpath(base_path($path));
```

This re-introduces the exact fatal error from #60260:

```
Call to undefined function Illuminate\Database\Connectors\base_path()
```

when `illuminate/database` is used standalone (without `illuminate/support`'s `helpers.php` loaded).

## Fix

Re-applies #60266 verbatim:

```php
$path = realpath($path) ?: (function_exists('base_path') ? realpath(base_path($path)) : false);
```

When `base_path()` is unavailable, path resolution falls through to the existing `SQLiteDatabaseDoesNotExistException` instead of fataling.

## Verification

- `./vendor/bin/phpunit tests/Database/DatabaseConnectorTest.php` → 33/33 pass
- `./vendor/bin/pint --test` → passed
- No behavior change for full-framework users (guard is zero-cost when `base_path()` exists)