### PR TITLE
[13.x] Return FAILURE exit code when key:generate is prohibited

### DIFF
--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -50,7 +50,7 @@ class KeyGenerateCommand extends Command
         // automatically setup for this developer. This key gets generated using a
         // secure random byte generator and is later base64 encoded for storage.
         if (! $this->setKeyInEnvironmentFile($key)) {
-            return;
+            return Command::FAILURE;
         }
 
         $this->laravel['config']['app.key'] = $key;

--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -37,7 +37,7 @@ class KeyGenerateCommand extends Command
     public function handle()
     {
         if ($this->isProhibited()) {
-            return;
+            return Command::FAILURE;
         }
 
         $key = $this->generateRandomKey();

--- a/tests/Foundation/Console/KeyGenerateCommandTest.php
+++ b/tests/Foundation/Console/KeyGenerateCommandTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Foundation\Console;
 
+use Illuminate\Config\Repository;
 use Illuminate\Console\Command;
 use Illuminate\Console\OutputStyle;
 use Illuminate\Console\View\Components\Factory;
@@ -35,6 +36,39 @@ class KeyGenerateCommandTest extends TestCase
         KeyGenerateCommand::prohibit();
 
         Assert::assertSame(Command::FAILURE, $command->handle());
+    }
+
+    public function testReturnsFailureWhenEnvironmentFileCannotBeWritten()
+    {
+        $envFile = tempnam(sys_get_temp_dir(), 'env_');
+        file_put_contents($envFile, "FOO=bar\n");
+
+        $config = new Repository([
+            'app' => ['key' => '', 'cipher' => 'aes-256-cbc'],
+        ]);
+
+        $input = new ArrayInput([]);
+        $output = new NullOutput;
+        $outputStyle = new OutputStyle($input, $output);
+
+        $container = m::mock(Container::class);
+        $container->shouldReceive('call');
+        $container->shouldReceive('runningUnitTests')->andReturn(true);
+        $container->shouldReceive('make')->with(OutputStyle::class, m::any())->andReturn($outputStyle);
+        $container->shouldReceive('make')->with(Factory::class, m::any())->andReturn(new Factory($outputStyle));
+        $container->shouldReceive('offsetGet')->with('config')->andReturn($config);
+        $container->shouldReceive('environmentFilePath')->andReturn($envFile);
+
+        $command = new KeyGenerateCommand;
+        $command->setLaravel($container);
+
+        $command->run($input, $output);
+
+        try {
+            Assert::assertSame(Command::FAILURE, $command->handle());
+        } finally {
+            @unlink($envFile);
+        }
     }
 
     protected function tearDown(): void

--- a/tests/Foundation/Console/KeyGenerateCommandTest.php
+++ b/tests/Foundation/Console/KeyGenerateCommandTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Console\OutputStyle;
+use Illuminate\Console\View\Components\Factory;
+use Illuminate\Container\Container;
+use Illuminate\Foundation\Console\KeyGenerateCommand;
+use Illuminate\Testing\Assert;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+
+class KeyGenerateCommandTest extends TestCase
+{
+    public function testProhibitable()
+    {
+        $input = new ArrayInput([]);
+        $output = new NullOutput;
+        $outputStyle = new OutputStyle($input, $output);
+
+        $container = m::mock(Container::class);
+        $container->shouldReceive('call');
+        $container->shouldReceive('runningUnitTests')->andReturn(true);
+        $container->shouldReceive('make')->with(OutputStyle::class, m::any())->andReturn($outputStyle);
+        $container->shouldReceive('make')->with(Factory::class, m::any())->andReturn(new Factory($outputStyle));
+
+        $command = new KeyGenerateCommand;
+        $command->setLaravel($container);
+
+        $command->run($input, $output);
+
+        KeyGenerateCommand::prohibit();
+
+        Assert::assertSame(Command::FAILURE, $command->handle());
+    }
+
+    protected function tearDown(): void
+    {
+        KeyGenerateCommand::prohibit(false);
+
+        parent::tearDown();
+    }
+}


### PR DESCRIPTION
When `key:generate` is prohibited via `KeyGenerateCommand::prohibit()`, it currently returns nothing — so `handle()` yields `null`, which `Illuminate\Console\Command::execute()` casts to `0` (SUCCESS). CI/deploy scripts can't tell the command was blocked.

All other commands using `isProhibited()` (`SeedCommand`, `WipeCommand`, `DumpCommand`, the migration commands) return `Command::FAILURE`. This brings `KeyGenerateCommand` in line.