### PR TITLE
[12.x] Fix| Fallback to PDO::const when Mysql::const not available

### DIFF
--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -132,7 +132,7 @@ class MySqlSchemaState extends SchemaState
         }
 
         $sslVerifyConst = defined('Pdo\Mysql::ATTR_SSL_VERIFY_SERVER_CERT')
-            ? Pdo\Mysql::ATTR_SSL_VERIFY_SERVER_CERT
+            ? Mysql::ATTR_SSL_VERIFY_SERVER_CERT
             : PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT;
 
         if (($config['options'][$sslVerifyConst] ?? null) === false) {

--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -5,6 +5,7 @@ namespace Illuminate\Database\Schema;
 use Exception;
 use Illuminate\Database\Connection;
 use Illuminate\Support\Str;
+use PDO;
 use Pdo\Mysql;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
@@ -130,7 +131,11 @@ class MySqlSchemaState extends SchemaState
             $value .= ' --ssl-key="${:LARAVEL_LOAD_SSL_KEY}"';
         }
 
-        if (($config['options'][Mysql::ATTR_SSL_VERIFY_SERVER_CERT] ?? null) === false) {
+        $sslVerifyConst = defined('Pdo\Mysql::ATTR_SSL_VERIFY_SERVER_CERT')
+            ? Pdo\Mysql::ATTR_SSL_VERIFY_SERVER_CERT
+            : PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT;
+
+        if (($config['options'][$sslVerifyConst] ?? null) === false) {
             if (version_compare($versionInfo['version'], '5.7.11', '>=') && ! $versionInfo['isMariaDb']) {
                 $value .= ' --ssl-mode=DISABLED';
             } else {

--- a/tests/Database/DatabaseMariaDbSchemaStateTest.php
+++ b/tests/Database/DatabaseMariaDbSchemaStateTest.php
@@ -113,7 +113,7 @@ class DatabaseMariaDbSchemaStateTest extends TestCase
                 'username' => 'root',
                 'database' => 'forge',
                 'options' => [
-                    defined('Pdo\Mysql::ATTR_SSL_VERIFY_SERVER_CERT') ? Pdo\Mysql::ATTR_SSL_VERIFY_SERVER_CERT : PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => false,
+                    defined('Pdo\Mysql::ATTR_SSL_VERIFY_SERVER_CERT') ? Mysql::ATTR_SSL_VERIFY_SERVER_CERT : PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => false,
                 ],
             ],
         ];

--- a/tests/Database/DatabaseMariaDbSchemaStateTest.php
+++ b/tests/Database/DatabaseMariaDbSchemaStateTest.php
@@ -5,6 +5,7 @@ namespace Database;
 use Generator;
 use Illuminate\Database\MariaDbConnection;
 use Illuminate\Database\Schema\MariaDbSchemaState;
+use PDO;
 use Pdo\Mysql;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -112,7 +113,7 @@ class DatabaseMariaDbSchemaStateTest extends TestCase
                 'username' => 'root',
                 'database' => 'forge',
                 'options' => [
-                    Mysql::ATTR_SSL_VERIFY_SERVER_CERT => false,
+                    defined('Pdo\Mysql::ATTR_SSL_VERIFY_SERVER_CERT') ? Pdo\Mysql::ATTR_SSL_VERIFY_SERVER_CERT : PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => false,
                 ],
             ],
         ];

--- a/tests/Database/DatabaseMySqlSchemaStateTest.php
+++ b/tests/Database/DatabaseMySqlSchemaStateTest.php
@@ -116,7 +116,7 @@ class DatabaseMySqlSchemaStateTest extends TestCase
                 'database' => 'forge',
                 'options' => [
                     defined('Pdo\Mysql::ATTR_SSL_VERIFY_SERVER_CERT')
-                                ? Pdo\Mysql::ATTR_SSL_VERIFY_SERVER_CERT
+                                ? Mysql::ATTR_SSL_VERIFY_SERVER_CERT
                                 : PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => false,
                 ],
             ],

--- a/tests/Database/DatabaseMySqlSchemaStateTest.php
+++ b/tests/Database/DatabaseMySqlSchemaStateTest.php
@@ -6,6 +6,7 @@ use Exception;
 use Generator;
 use Illuminate\Database\MySqlConnection;
 use Illuminate\Database\Schema\MySqlSchemaState;
+use PDO;
 use Pdo\Mysql;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -114,7 +115,9 @@ class DatabaseMySqlSchemaStateTest extends TestCase
                 'username' => 'root',
                 'database' => 'forge',
                 'options' => [
-                    Mysql::ATTR_SSL_VERIFY_SERVER_CERT => false,
+                    defined('Pdo\Mysql::ATTR_SSL_VERIFY_SERVER_CERT')
+                                ? Pdo\Mysql::ATTR_SSL_VERIFY_SERVER_CERT
+                                : PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => false,
                 ],
             ],
         ];


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
## Issue
Laravel Framework 12.x references the [php 8.4 `Mysql::ATTR_SSL_VERIFY_SERVER_CERT` const](https://www.php.net/manual/en/class.pdo-mysql.php).
Yet, since  [symfony/polyfill-php84:v1.38.0](https://github.com/symfony/polyfill-php84/releases/tag/v1.38.0) it is no longer available _(```bug #590 PHP can be built without PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT ```)_

## Changes
- Check if the constant exists, if it does not we fallback to [php7.0 PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT](https://www.php.net/manual/en/ref.pdo-mysql.php). 

This seems to be the simplest fix for this issue

## Exception
```sh
[  Undefined constant Pdo\Mysql::ATTR_SSL_VERIFY_SERVER_CERT ]

vendor/laravel/framework/src/Illuminate/Database/Schema/MySqlSchemaState.php:133
    129▕         if (isset($config['options'][Mysql::ATTR_SSL_KEY])) ***
    130▕             $value .= ' --ssl-key="$***:LARAVEL_LOAD_SSL_KEY***"';
    131▕         ***
    132▕ 
  ➜ 133▕         if (($config['options'][Mysql::ATTR_SSL_VERIFY_SERVER_CERT] ?? null) === false) ***
    134▕             if (version_compare($versionInfo['version'], '5.7.11', '>=') && ! $versionInfo['isMariaDb']) ***
    135▕                 $value .= ' --ssl-mode=DISABLED';
    136▕             *** else ***
    137▕                 $value .= ' --ssl=off';
```

## How to reproduce 
- Setup a fresh laravel 12 project on php8.3
- Bump [symfony/polyfill-php84](https://github.com/symfony/polyfill-php84/) to the latest version


### Tests
- I added the same check in the tests where I found reference to `Pdo\Mysql::ATTR_SSL_VERIFY_SERVER_CERT`
