### PR TITLE
[13.x] Throw ManagedQueueNotFoundException when a managed queue is missing

### DIFF
--- a/src/Illuminate/Foundation/Cloud/ManagedQueueNotFoundException.php
+++ b/src/Illuminate/Foundation/Cloud/ManagedQueueNotFoundException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Foundation\Cloud;
+
+use RuntimeException;
+
+class ManagedQueueNotFoundException extends RuntimeException
+{
+    //
+}

--- a/src/Illuminate/Foundation/Cloud/Queue.php
+++ b/src/Illuminate/Foundation/Cloud/Queue.php
@@ -359,7 +359,7 @@ class Queue implements QueueContract, ClearableQueue
      * @param  string|null  $queue
      * @return string
      */
-    protected function normalizeQueue($queue)
+    public function normalizeQueue($queue)
     {
         $prefix = $this->config['connection']['prefix'] ?? null;
         $suffix = $this->config['connection']['suffix'] ?? null;

--- a/src/Illuminate/Foundation/Cloud/QueueConnector.php
+++ b/src/Illuminate/Foundation/Cloud/QueueConnector.php
@@ -2,12 +2,17 @@
 
 namespace Illuminate\Foundation\Cloud;
 
+use Aws\CommandInterface;
+use Aws\Exception\AwsException;
+use Aws\Sqs\SqsClient;
 use Illuminate\Foundation\Application;
 use Illuminate\Queue\Connectors\ConnectorInterface;
 use Illuminate\Queue\Events\JobQueued;
 use Illuminate\Queue\Events\WorkerStopping;
+use Illuminate\Queue\SqsQueue;
 use Illuminate\Queue\Worker;
 use Illuminate\Queue\WorkerStopReason;
+use Psr\Http\Message\RequestInterface;
 
 class QueueConnector implements ConnectorInterface
 {
@@ -31,11 +36,17 @@ class QueueConnector implements ConnectorInterface
      */
     public function connect(array $config): Queue
     {
+        $underlying = $this->connector->connect($config['connection']);
+
         $queue = new Queue(
-            $this->connector->connect($config['connection']),
+            $underlying,
             $this->app[Events::class],
             $config,
         );
+
+        if ($underlying instanceof SqsQueue) {
+            $this->registerErrorHandling($underlying->getSqs(), $queue);
+        }
 
         $this->configureQueue($queue);
 
@@ -47,6 +58,30 @@ class QueueConnector implements ConnectorInterface
         $this->configureFailedJobProvider($queue);
 
         return $queue;
+    }
+
+    /**
+     * Register SQS client middleware that translates "queue does not exist"
+     * errors into a ManagedQueueNotFoundException with the queue name.
+     */
+    protected function registerErrorHandling(SqsClient $sqs, Queue $queue): void
+    {
+        $sqs->getHandlerList()->appendSign(function (callable $handler) use ($queue) {
+            return function (CommandInterface $command, RequestInterface $request) use ($handler, $queue) {
+                return $handler($command, $request)->otherwise(function ($reason) use ($command, $queue) {
+                    if ($reason instanceof AwsException &&
+                        $reason->getAwsErrorCode() === 'AWS.SimpleQueueService.NonExistentQueue') {
+                        $name = $queue->normalizeQueue($command['QueueUrl'] ?? null);
+
+                        throw new ManagedQueueNotFoundException(
+                            "A managed queue does not exist with name [{$name}].", 0, $reason,
+                        );
+                    }
+
+                    throw $reason;
+                });
+            };
+        }, 'managed-queue-not-found');
     }
 
     /**

--- a/src/Illuminate/Foundation/Cloud/QueueConnector.php
+++ b/src/Illuminate/Foundation/Cloud/QueueConnector.php
@@ -74,7 +74,7 @@ class QueueConnector implements ConnectorInterface
                         $name = $queue->normalizeQueue($command['QueueUrl'] ?? null);
 
                         throw new ManagedQueueNotFoundException(
-                            "A managed queue does not exist with name [{$name}].", 0, $reason,
+                            "Managed queue [{$name}] does not exist.", 0, $reason,
                         );
                     }
 

--- a/tests/Foundation/Cloud/QueueTest.php
+++ b/tests/Foundation/Cloud/QueueTest.php
@@ -929,13 +929,10 @@ class QueueTest extends TestCase
 
         $queue = $this->app['queue']->connection('cloud');
 
-        try {
-            $queue->push(new FakeJob, queue: 'missing-queue');
-            $this->fail('Expected ManagedQueueNotFoundException was not thrown.');
-        } catch (ManagedQueueNotFoundException $e) {
-            $this->assertSame('Managed queue [missing-queue] does not exist.', $e->getMessage());
-            $this->assertInstanceOf(AwsException::class, $e->getPrevious());
-        }
+        $this->expectException(ManagedQueueNotFoundException::class);
+        $this->expectExceptionMessage('Managed queue [missing-queue] does not exist.');
+
+        $queue->push(new FakeJob, queue: 'missing-queue');
     }
 
     public function testItUsesConfigValuesToNormalizeQueueName()

--- a/tests/Foundation/Cloud/QueueTest.php
+++ b/tests/Foundation/Cloud/QueueTest.php
@@ -2,12 +2,17 @@
 
 namespace Tests\Tests\Foundation;
 
+use Aws\CommandInterface;
+use Aws\Exception\AwsException;
+use Aws\HandlerList;
+use Aws\MockHandler;
 use Aws\Result;
 use Aws\Sqs\SqsClient;
 use Illuminate\Contracts\Encryption\DecryptException;
 use Illuminate\Foundation\Cloud;
 use Illuminate\Foundation\Cloud\Events;
 use Illuminate\Foundation\Cloud\FailedJobProvider;
+use Illuminate\Foundation\Cloud\ManagedQueueNotFoundException;
 use Illuminate\Foundation\Cloud\Queue;
 use Illuminate\Foundation\Cloud\QueueConnector;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
@@ -883,6 +888,56 @@ class QueueTest extends TestCase
         $this->assertEmpty($eventsFake->emitted);
     }
 
+    public function testItThrowsManagedQueueNotFoundExceptionWhenQueueDoesNotExist()
+    {
+        Cloud::configureManagedQueues($this->app);
+        Cloud::bootManagedQueues($this->app);
+        $this->fakeEvents();
+
+        $mock = new MockHandler();
+        $mock->append(fn (CommandInterface $cmd) => new AwsException('Queue does not exist.', $cmd, [
+            'code' => 'AWS.SimpleQueueService.NonExistentQueue',
+        ]));
+
+        $client = new SqsClient([
+            'region' => 'us-east-2',
+            'version' => 'latest',
+            'handler' => $mock,
+            'credentials' => false,
+        ]);
+
+        $this->app->instance(QueueConnector::class, new QueueConnector(new class($client) implements ConnectorInterface
+        {
+            public function __construct(private $client)
+            {
+            }
+
+            public function connect($config)
+            {
+                return new SqsQueue(
+                    $this->client,
+                    $config['queue'],
+                    $config['prefix'] ?? '',
+                    $config['suffix'] ?? '',
+                    $config['after_commit'] ?? null,
+                    $config['overflow'] ?? [],
+                );
+            }
+        }, $this->app));
+
+        $this->app['queue']->addConnector('cloud', $this->app->factory(QueueConnector::class));
+
+        $queue = $this->app['queue']->connection('cloud');
+
+        try {
+            $queue->push(new FakeJob, queue: 'missing-queue');
+            $this->fail('Expected ManagedQueueNotFoundException was not thrown.');
+        } catch (ManagedQueueNotFoundException $e) {
+            $this->assertSame('A managed queue does not exist with name [missing-queue].', $e->getMessage());
+            $this->assertInstanceOf(AwsException::class, $e->getPrevious());
+        }
+    }
+
     public function testItUsesConfigValuesToNormalizeQueueName()
     {
         Cloud::configureManagedQueues($this->app);
@@ -904,6 +959,7 @@ class QueueTest extends TestCase
     private function mockedQueue()
     {
         $client = $this->mock(SqsClient::class);
+        $client->shouldReceive('getHandlerList')->andReturn(new HandlerList());
 
         $this->app->instance(QueueConnector::class, new QueueConnector(new class($client) implements ConnectorInterface
         {

--- a/tests/Foundation/Cloud/QueueTest.php
+++ b/tests/Foundation/Cloud/QueueTest.php
@@ -933,7 +933,7 @@ class QueueTest extends TestCase
             $queue->push(new FakeJob, queue: 'missing-queue');
             $this->fail('Expected ManagedQueueNotFoundException was not thrown.');
         } catch (ManagedQueueNotFoundException $e) {
-            $this->assertSame('A managed queue does not exist with name [missing-queue].', $e->getMessage());
+            $this->assertSame('Managed queue [missing-queue] does not exist.', $e->getMessage());
             $this->assertInstanceOf(AwsException::class, $e->getPrevious());
         }
     }


### PR DESCRIPTION
When a managed queue doesn't exist, the underlying AWS SDK error is vague and doesn't include the queue name, making it hard to debug.

This PR registers an SQS client middleware (in `Foundation\Cloud\QueueConnector`) that intercepts `AWS.SimpleQueueService.NonExistentQueue` errors and rethrows them as a new `ManagedQueueNotFoundException` with a clear message:

> Managed queue [beep] does not exist.

The original `AwsException` is preserved as `$previous`. Because the middleware sits at the handler-stack level, every SQS operation (push, pop, size, clear, batch, etc.) is covered without wrapping individual queue methods.

Scoped to managed queues only — plain `SqsQueue` users are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)