### PR TITLE
[13.x] Add hours() and hour() methods to Sleep

### DIFF
--- a/src/Illuminate/Support/Sleep.php
+++ b/src/Illuminate/Support/Sleep.php
@@ -142,7 +142,7 @@ class Sleep
      */
     protected function duration($duration)
     {
-        if (! $duration instanceof DateInterval) {
+        if (!$duration instanceof DateInterval) {
             $this->duration = CarbonInterval::microsecond(0);
 
             $this->pending = $duration;
@@ -203,7 +203,6 @@ class Sleep
     {
         return $this->minutes();
     }
-
 
     /**
      * Sleep for the given number of seconds.
@@ -331,7 +330,7 @@ class Sleep
      */
     protected function goodnight()
     {
-        if ($this->alreadySlept || ! $this->shouldSleep) {
+        if ($this->alreadySlept || !$this->shouldSleep) {
             return;
         }
 
@@ -552,7 +551,7 @@ class Sleep
      */
     public function unless($condition)
     {
-        return $this->when(! value($condition, $this));
+        return $this->when(!value($condition, $this));
     }
 
     /**

--- a/src/Illuminate/Support/Sleep.php
+++ b/src/Illuminate/Support/Sleep.php
@@ -142,7 +142,7 @@ class Sleep
      */
     protected function duration($duration)
     {
-        if (!$duration instanceof DateInterval) {
+        if (! $duration instanceof DateInterval) {
             $this->duration = CarbonInterval::microsecond(0);
 
             $this->pending = $duration;
@@ -330,7 +330,7 @@ class Sleep
      */
     protected function goodnight()
     {
-        if ($this->alreadySlept || !$this->shouldSleep) {
+        if ($this->alreadySlept || ! $this->shouldSleep) {
             return;
         }
 
@@ -551,7 +551,7 @@ class Sleep
      */
     public function unless($condition)
     {
-        return $this->when(!value($condition, $this));
+        return $this->when(! value($condition, $this));
     }
 
     /**

--- a/src/Illuminate/Support/Sleep.php
+++ b/src/Illuminate/Support/Sleep.php
@@ -161,6 +161,28 @@ class Sleep
     }
 
     /**
+     * Sleep for the given number of hours.
+     *
+     * @return $this
+     */
+    public function hours()
+    {
+        $this->duration->add('hours', $this->pullPending());
+
+        return $this;
+    }
+
+    /**
+     * Sleep for one hour.
+     *
+     * @return $this
+     */
+    public function hour()
+    {
+        return $this->hours();
+    }
+
+    /**
      * Sleep for the given number of minutes.
      *
      * @return $this
@@ -181,6 +203,7 @@ class Sleep
     {
         return $this->minutes();
     }
+
 
     /**
      * Sleep for the given number of seconds.

--- a/tests/Support/SleepTest.php
+++ b/tests/Support/SleepTest.php
@@ -74,6 +74,24 @@ class SleepTest extends TestCase
         $this->assertEqualsWithDelta(0, $end - $start, 0.03);
     }
 
+    public function testItCanSpecifyHours()
+    {
+        Sleep::fake();
+
+        $sleep = Sleep::for(1.5)->hours();
+
+        $this->assertSame(5_400_000_000.0, (float) $sleep->duration->totalMicroseconds);
+    }
+
+    public function testItCanSpecifyHour()
+    {
+        Sleep::fake();
+
+        $sleep = Sleep::for(1)->hour();
+
+        $this->assertSame(3_600_000_000.0, (float) $sleep->duration->totalMicroseconds);
+    }
+
     public function testItCanSpecifyMinutes()
     {
         Sleep::fake();


### PR DESCRIPTION
## Changes

The `Sleep` class currently supports `minutes()`, `seconds()`, `milliseconds()`, and `microseconds()`  but is missing `hours()` and `hour()`.

This PR adds both methods, completing the time unit API and allowing more expressive sleep durations:

```php
// Before — required an awkward conversion:
Sleep::for(2 * 60)->minutes();

// After — clean and consistent with the existing API:
Sleep::for(2)->hours();
Sleep::for(1)->hour();