### PR TITLE
[13.x] Send a User-Agent header on Have I Been Pwned API requests

### DIFF
--- a/src/Illuminate/Validation/NotPwnedVerifier.php
+++ b/src/Illuminate/Validation/NotPwnedVerifier.php
@@ -4,6 +4,7 @@ namespace Illuminate\Validation;
 
 use Exception;
 use Illuminate\Contracts\Validation\UncompromisedVerifier;
+use Illuminate\Foundation\Application;
 use Illuminate\Support\Stringable;
 
 class NotPwnedVerifier implements UncompromisedVerifier
@@ -23,6 +24,13 @@ class NotPwnedVerifier implements UncompromisedVerifier
     protected $timeout;
 
     /**
+     * The User-Agent header sent with requests to the Have I Been Pwned API.
+     *
+     * @var string|null
+     */
+    protected $userAgent;
+
+    /**
      * Create a new uncompromised verifier.
      *
      * @param  \Illuminate\Http\Client\Factory  $factory
@@ -32,6 +40,19 @@ class NotPwnedVerifier implements UncompromisedVerifier
     {
         $this->factory = $factory;
         $this->timeout = $timeout ?? 30;
+    }
+
+    /**
+     * Set the User-Agent header sent with requests to the Have I Been Pwned API.
+     *
+     * @param  string  $userAgent
+     * @return $this
+     */
+    public function withUserAgent(string $userAgent)
+    {
+        $this->userAgent = $userAgent;
+
+        return $this;
     }
 
     /**
@@ -85,6 +106,7 @@ class NotPwnedVerifier implements UncompromisedVerifier
         try {
             $response = $this->factory->withHeaders([
                 'Add-Padding' => true,
+                'User-Agent' => $this->userAgent ?? $this->defaultUserAgent(),
             ])->timeout($this->timeout)->get(
                 'https://api.pwnedpasswords.com/range/'.$hashPrefix
             );
@@ -99,5 +121,20 @@ class NotPwnedVerifier implements UncompromisedVerifier
         return (new Stringable($body))->trim()->explode("\n")->filter(function ($line) {
             return str_contains($line, ':');
         });
+    }
+
+    /**
+     * Get the default User-Agent header sent with requests to the Have I Been Pwned API.
+     *
+     * @return string
+     */
+    protected function defaultUserAgent()
+    {
+        // App name intentionally omitted — leaking it to a third-party API requires explicit opt-in via withUserAgent().
+        if (class_exists(Application::class)) {
+            return 'Laravel/'.Application::VERSION;
+        }
+
+        return 'Laravel';
     }
 }

--- a/tests/Validation/ValidationNotPwnedVerifierTest.php
+++ b/tests/Validation/ValidationNotPwnedVerifierTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Validation;
 
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Debug\ExceptionHandler;
+use Illuminate\Foundation\Application;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\Factory as HttpFactory;
 use Illuminate\Http\Client\Response;
@@ -43,7 +44,7 @@ class ValidationNotPwnedVerifierTest extends TestCase
         $httpFactory
             ->shouldReceive('withHeaders')
             ->once()
-            ->with(['Add-Padding' => true])
+            ->with(['Add-Padding' => true, 'User-Agent' => 'Laravel/'.Application::VERSION])
             ->andReturn($httpFactory);
 
         $httpFactory
@@ -80,7 +81,7 @@ class ValidationNotPwnedVerifierTest extends TestCase
         $httpFactory
             ->shouldReceive('withHeaders')
             ->once()
-            ->with(['Add-Padding' => true])
+            ->with(['Add-Padding' => true, 'User-Agent' => 'Laravel/'.Application::VERSION])
             ->andReturn($httpFactory);
 
         $httpFactory
@@ -122,7 +123,7 @@ class ValidationNotPwnedVerifierTest extends TestCase
         $httpFactory
             ->shouldReceive('withHeaders')
             ->once()
-            ->with(['Add-Padding' => true])
+            ->with(['Add-Padding' => true, 'User-Agent' => 'Laravel/'.Application::VERSION])
             ->andReturn($httpFactory);
 
         $httpFactory
@@ -168,7 +169,7 @@ class ValidationNotPwnedVerifierTest extends TestCase
         $httpFactory
             ->shouldReceive('withHeaders')
             ->once()
-            ->with(['Add-Padding' => true])
+            ->with(['Add-Padding' => true, 'User-Agent' => 'Laravel/'.Application::VERSION])
             ->andReturn($httpFactory);
 
         $httpFactory
@@ -189,5 +190,64 @@ class ValidationNotPwnedVerifierTest extends TestCase
         ]));
 
         unset($container[ExceptionHandler::class]);
+    }
+
+    public function testSendsDefaultUserAgentHeader()
+    {
+        $httpFactory = m::mock(HttpFactory::class);
+        $response = m::mock(Response::class);
+
+        $httpFactory
+            ->shouldReceive('withHeaders')
+            ->once()
+            ->with(['Add-Padding' => true, 'User-Agent' => 'Laravel/'.Application::VERSION])
+            ->andReturn($httpFactory);
+
+        $httpFactory
+            ->shouldReceive('timeout')
+            ->once()
+            ->with(30)
+            ->andReturn($httpFactory);
+
+        $httpFactory->shouldReceive('get')->once()->andReturn($response);
+        $response->shouldReceive('successful')->once()->andReturn(true);
+        $response->shouldReceive('body')->once()->andReturn('');
+
+        $verifier = new NotPwnedVerifier($httpFactory);
+
+        $this->assertTrue($verifier->verify([
+            'value' => 123123123,
+            'threshold' => 0,
+        ]));
+    }
+
+    public function testWithUserAgentOverridesDefault()
+    {
+        $httpFactory = m::mock(HttpFactory::class);
+        $response = m::mock(Response::class);
+
+        $httpFactory
+            ->shouldReceive('withHeaders')
+            ->once()
+            ->with(['Add-Padding' => true, 'User-Agent' => 'MyApp/1.0 (security@example.com)'])
+            ->andReturn($httpFactory);
+
+        $httpFactory
+            ->shouldReceive('timeout')
+            ->once()
+            ->with(30)
+            ->andReturn($httpFactory);
+
+        $httpFactory->shouldReceive('get')->once()->andReturn($response);
+        $response->shouldReceive('successful')->once()->andReturn(true);
+        $response->shouldReceive('body')->once()->andReturn('');
+
+        $verifier = (new NotPwnedVerifier($httpFactory))
+            ->withUserAgent('MyApp/1.0 (security@example.com)');
+
+        $this->assertTrue($verifier->verify([
+            'value' => 123123123,
+            'threshold' => 0,
+        ]));
     }
 }


### PR DESCRIPTION
## Summary

The `NotPwnedVerifier` (the default `UncompromisedVerifier` used by the `Password::uncompromised()` validation rule) currently sends only an `Add-Padding` header on its request to `api.pwnedpasswords.com`. Laravel's HTTP client does not inject a User-Agent, so the outgoing request identifies itself as `GuzzleHttp/7`.

[HIBP's API documentation](https://haveibeenpwned.com/API/v3) states in its overview section:

> The user agent should accurately describe the nature of the API consumer such that it can be clearly identified in the request. Not doing so may result in the request being blocked.

The range endpoint at `api.pwnedpasswords.com` does not enforce a user-agent today, but `GuzzleHttp/7` is the literal default for any PHP application using Guzzle — it does not describe the consumer at all, and it is indistinguishable from arbitrary scraping traffic. The endpoint is fronted by Cloudflare, whose bot mitigation tooling can flag generic library user-agents with no prior notice; that risk is independent of any policy change on HIBP's side.

If the request is ever blocked, the verifier returns `true` (the catch block leaves `$response` unset, the search yields an empty collection, and `verify()` reports "not pwned"). That means every Laravel app using `Password::uncompromised()` would silently stop performing the check — a security regression that would be difficult to detect from the application side.

This PR is in the same spirit as the existing `Add-Padding` header that is already sent on the same request: a small, conservative alignment with HIBP's published guidance.

## Changes

- A `User-Agent` header is now sent on every request to `api.pwnedpasswords.com/range/{prefix}`.
- Default value is `Laravel/{version}`, sourced from `Illuminate\Foundation\Application::VERSION`.
- A new `withUserAgent(string $userAgent)` setter lets applications override the default. This is useful for high-RPM consumers who want HIBP (or Cloudflare) to be able to identify and reach them:

```php
public function register(): void
{
    $this->app->extend(UncompromisedVerifier::class, function ($verifier) {
        return $verifier->withUserAgent('MyApp/1.0 (security@example.com)');
    });
}
```

- `config('app.name')` is intentionally not read by default — sending product identifiers to a third-party API should require explicit developer consent. Happy to revisit (e.g. an opt-in flag) if reviewers prefer the other direction.

## Benefit to end users

Every Laravel app using `Password::uncompromised()` becomes resilient to either HIBP enforcing its documented user-agent guidance or Cloudflare's bot mitigation flagging generic Guzzle traffic. Without this change, either event would silently turn the rule into a no-op.

## Backwards compatibility

- The `UncompromisedVerifier` contract is unchanged.
- `NotPwnedVerifier`'s constructor signature is unchanged.
- The new `withUserAgent()` method is purely additive.
- The endpoint, request method, body parsing, and existing failure behavior are all unchanged. The only wire-level difference is the additional header.

## Out of scope

Deliberately keeping this PR single-purpose. Not touched: caching, exception handling, the request timeout, or the framework-wide Guzzle user-agent.

## Tests

Two new tests in `ValidationNotPwnedVerifierTest` cover the default UA and the override path. The existing tests in that file have their `withHeaders` expectations updated to include the new header.

Wire-level verification via Guzzle request middleware (not committed to the test suite):

| Case | `User-Agent` actually sent|
|-----------------------------------------------|-----------------------------------------|
| Pre-PR (no UA set)                            | `GuzzleHttp/7`                          |
| Post-PR default                               | `Laravel/13.11.2`                       |
| Post-PR `withUserAgent('MyApp/1.0 (...)`      | `MyApp/1.0 (security@example.com)`      |

HIBP returned 200 in all three cases — none of these UA values trip current rejection logic.