### PR TITLE
[13.x] Add `Client\Request::uri()`

### DIFF
--- a/src/Illuminate/Http/Client/Request.php
+++ b/src/Illuminate/Http/Client/Request.php
@@ -6,6 +6,7 @@ use ArrayAccess;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Traits\Macroable;
+use Illuminate\Support\Uri;
 use LogicException;
 
 class Request implements ArrayAccess
@@ -61,6 +62,16 @@ class Request implements ArrayAccess
     public function url()
     {
         return (string) $this->request->getUri();
+    }
+
+    /**
+     * Get the request URI as a URI instance.
+     *
+     * @return \Illuminate\Support\Uri
+     */
+    public function uri()
+    {
+        return Uri::of($this->url());
     }
 
     /**

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -38,6 +38,7 @@ use Illuminate\Support\Defer\DeferredCallback;
 use Illuminate\Support\Fluent;
 use Illuminate\Support\Sleep;
 use Illuminate\Support\Str;
+use Illuminate\Support\Uri;
 use Illuminate\Support\Stringable;
 use JsonSerializable;
 use Mockery as m;
@@ -1129,6 +1130,18 @@ class HttpClientTest extends TestCase
         $this->factory->assertSent(function (Request $request) {
             return $request->url() === 'http://foo.com/get?foo=bar'
                 && $request['foo'] === 'bar';
+        });
+    }
+
+    public function testRequestUriMethod()
+    {
+        $this->factory->fake();
+
+        $this->factory->get('http://foo.com/get?foo=bar&page=1');
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->uri() instanceof Uri
+                && (string) $request->uri() === 'http://foo.com/get?foo=bar&page=1';
         });
     }
 


### PR DESCRIPTION
**Description**:

This PR adds `uri()` method to `Illuminate\Http\Client\Request` to return an `Illuminate\Support\Uri` instance, matching the method available on `Illuminate\Http\Request`.

**Example:**

```php
Http::fake();

Http::get('https://example.com/api/users?page=2');

Http::assertSent(function (Request $request) {
    return $request->uri()->path() === '/api/users'
        && $request->uri()->query()->integer('page') === 2;
});
```
