### PR TITLE
[13.x] View\Factory::flushComponents() doesn't reset $slots / $slotStack

### DIFF
--- a/src/Illuminate/View/Concerns/ManagesComponents.php
+++ b/src/Illuminate/View/Concerns/ManagesComponents.php
@@ -217,5 +217,7 @@ trait ManagesComponents
         $this->componentStack = [];
         $this->componentData = [];
         $this->currentComponentData = [];
+        $this->slots = [];
+        $this->slotStack = [];
     }
 }

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -696,6 +696,20 @@ class ViewFactoryTest extends TestCase
         $this->assertSame('laravel.com', $contents);
     }
 
+    public function testFlushStateResetsSlots()
+    {
+        $factory = $this->getFactory();
+
+        $factory->slot('title');
+        echo 'laravel.com';
+        $factory->endSlot();
+
+        $factory->flushState();
+
+        $this->assertSame([], (fn () => $this->slots)->call($factory));
+        $this->assertSame([], (fn () => $this->slotStack)->call($factory));
+    }
+
     public function testTranslation()
     {
         $container = new Container;


### PR DESCRIPTION
Fixes #60278

`View\Factory::flushComponents()` only reset `$componentStack`, `$componentData` and `$currentComponentData`. It left `$slots` and `$slotStack` untouched, so any slot content captured during a request survived `flushState()`.

This is invisible under FPM (the Factory is rebuilt each request), but under Octane the Factory is a persistent singleton: a top-level slot such as `<x-slot:title>` leaked into the next render on the same worker that didn't declare its own slots.

Added a unit test to ensure it passes and will stay OK.

I only added some code so I think it will not break anything. Only fix the comportment with Octane.