### PR TITLE
[13.x] Add stan ignore for MySqlSchemaState

### DIFF
--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -130,6 +130,7 @@ class MySqlSchemaState extends SchemaState
             $value .= ' --ssl-key="${:LARAVEL_LOAD_SSL_KEY}"';
         }
 
+        /** @phpstan-ignore classConstant.notFound */
         if (($config['options'][Mysql::ATTR_SSL_VERIFY_SERVER_CERT] ?? null) === false) {
             if (version_compare($versionInfo['version'], '5.7.11', '>=') && ! $versionInfo['isMariaDb']) {
                 $value .= ' --ssl-mode=DISABLED';


### PR DESCRIPTION
Konnichiwa Mr Otwell!

Noticed this is flaking in a bunch of tests 
https://github.com/laravel/framework/actions/runs/26481118206
https://github.com/laravel/framework/actions/runs/26481061200
... and more


So thought I'd just PR a fix so all the tests don't go crazy and confuse ppl

