### PR TITLE
[13.x] Add seconds option to `queue:pause` command

### DIFF
--- a/src/Illuminate/Queue/Console/PauseCommand.php
+++ b/src/Illuminate/Queue/Console/PauseCommand.php
@@ -18,7 +18,9 @@ class PauseCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'queue:pause {queue : The name of the queue to pause}';
+    protected $signature = 'queue:pause
+                            {queue : The name of the queue to pause}
+                            {--seconds= : The time in seconds that you want to pause the queue}';
 
     /**
      * The console command description.
@@ -40,6 +42,24 @@ class PauseCommand extends Command
             $this->components->error('Queue pausing is currently disabled.');
 
             return 1;
+        }
+
+        $seconds = $this->option('seconds');
+
+        if ($seconds !== null && (filter_var($seconds, FILTER_VALIDATE_INT) === false || (int) $seconds < 1)) {
+            $this->components->error('The seconds option must be a positive integer.');
+
+            return 1;
+        }
+
+        if ($seconds !== null) {
+            $seconds = (int) $seconds;
+
+            $manager->pauseFor($connection, $queue, $seconds);
+
+            $this->components->info("Job processing on queue [{$connection}:{$queue}] has been paused for {$seconds} seconds.");
+
+            return 0;
         }
 
         $manager->pause($connection, $queue);

--- a/tests/Integration/Console/Scheduling/QueuePauseCommandTest.php
+++ b/tests/Integration/Console/Scheduling/QueuePauseCommandTest.php
@@ -4,15 +4,32 @@ namespace Illuminate\Tests\Integration\Console\Scheduling;
 
 use Illuminate\Queue\Events\QueuePaused;
 use Illuminate\Queue\Worker;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Queue;
 use Orchestra\Testbench\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class QueuePauseCommandTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Event::fake();
+    }
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+
+        Worker::$pausable = true;
+
+        parent::tearDown();
+    }
+
     public function testDispatchesEvent()
     {
-        Event::fake();
-
         $this->artisan('queue:pause default');
 
         Event::assertDispatched(QueuePaused::class);
@@ -20,8 +37,6 @@ class QueuePauseCommandTest extends TestCase
 
     public function testDisabledError()
     {
-        Event::fake();
-
         Worker::$pausable = false;
 
         $this->artisan('queue:pause default');
@@ -29,5 +44,52 @@ class QueuePauseCommandTest extends TestCase
         Event::assertNotDispatched(QueuePaused::class);
 
         Worker::$pausable = true;
+    }
+
+    public function testCanPauseQueueForSeconds()
+    {
+        Carbon::setTestNow($now = Carbon::now());
+
+        Event::fake();
+
+        $this->artisan('queue:pause', [
+            'queue' => 'default',
+            '--seconds' => 30,
+        ])->assertSuccessful();
+
+        $this->assertTrue(Queue::isPaused(config('queue.default'), 'default'));
+
+        Event::assertDispatched(QueuePaused::class, function ($event) {
+            return $event->connection === config('queue.default')
+                && $event->queue === 'default'
+                && $event->ttl === 30;
+        });
+
+        Carbon::setTestNow($now->copy()->addSeconds(31));
+
+        $this->assertFalse(Queue::isPaused(config('queue.default'), 'default'));
+    }
+
+    #[DataProvider('invalidSecondsOptions')]
+    public function testSecondsOptionMustBePositive($seconds)
+    {
+        Event::fake();
+
+        $this->artisan('queue:pause', [
+            'queue' => 'default',
+            '--seconds' => $seconds,
+        ])->assertFailed();
+
+        Event::assertNotDispatched(QueuePaused::class);
+    }
+
+    public static function invalidSecondsOptions()
+    {
+        return [
+            'zero' => [0],
+            'negative' => [-1],
+            'float' => ['1.5'],
+            'string' => ['invalid'],
+        ];
     }
 }


### PR DESCRIPTION
This PR adds a `--seconds` option to the `queue:pause` Artisan command, allowing a queue to be paused temporarily from the command line.

Laravel already supports temporarily pausing queues through `Queue::pauseFor(...)`, but the Artisan command only exposed indefinite pauses. With this change, users can run:

```bash
php artisan queue:pause default --seconds=300
```

This is useful for short maintenance windows, temporary third-party rate limits, deploy coordination, or incident response where a queue should resume automatically without requiring a later `queue:resume` command.

This change does not alter the existing `queue:pause` behavior. Calling `queue:pause` without `--seconds` still pauses the queue indefinitely. The new option is opt-in, validates that the provided value is a positive integer, and delegates to the existing `QueueManager::pauseFor` behavior.