### PR TITLE
 [13.x] Expose new countColumns parameter to control the columns of `getCountForPagination`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1114,16 +1114,17 @@ class Builder implements BuilderContract
      * @param  array|string  $columns
      * @param  string  $pageName
      * @param  int|null  $page
-     * @param  \Closure|int|null  $total
+     * @param  int|null|\Closure  $total
+     * @param  array|string  $countColumns
      * @return \Illuminate\Pagination\LengthAwarePaginator<int, TModel>
      *
      * @throws \InvalidArgumentException
      */
-    public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null, $total = null)
+    public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null, $total = null, $countColumns = ['*'])
     {
         $page = $page ?: Paginator::resolveCurrentPage($pageName);
 
-        $total = value($total) ?? $this->toBase()->getCountForPagination();
+        $total = value($total) ?? $this->toBase()->getCountForPagination($countColumns);
 
         $perPage = value($perPage, $total) ?: $this->model->getPerPage();
 

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -989,13 +989,15 @@ class BelongsToMany extends Relation
      * @param  array  $columns
      * @param  string  $pageName
      * @param  int|null  $page
+     * @param  int|null|\Closure  $total
+     * @param  array  $countColumns
      * @return \Illuminate\Pagination\LengthAwarePaginator<int, TRelatedModel&object{pivot: TPivotModel}>
      */
-    public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null)
+    public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null, $total = null, $countColumns = ['*'])
     {
         $this->query->addSelect($this->shouldSelect($columns));
 
-        return tap($this->query->paginate($perPage, $columns, $pageName, $page), function ($paginator) {
+        return tap($this->query->paginate($perPage, $columns, $pageName, $page, $total, $countColumns), function ($paginator) {
             $this->hydratePivotRelation($paginator->items());
         });
     }

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrManyThrough.php
@@ -478,13 +478,15 @@ abstract class HasOneOrManyThrough extends Relation
      * @param  array  $columns
      * @param  string  $pageName
      * @param  int|null  $page
+     * @param  int|null|\Closure  $total
+     * @param  array  $countColumns
      * @return \Illuminate\Pagination\LengthAwarePaginator
      */
-    public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null)
+    public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null, $total = null, $countColumns = ['*'])
     {
         $this->query->addSelect($this->shouldSelect($columns));
 
-        return $this->query->paginate($perPage, $columns, $pageName, $page);
+        return $this->query->paginate($perPage, $columns, $pageName, $page, $total, $countColumns);
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3602,14 +3602,15 @@ class Builder implements BuilderContract
      * @param  string|\Illuminate\Contracts\Database\Query\Expression|array<string|\Illuminate\Contracts\Database\Query\Expression>  $columns
      * @param  string  $pageName
      * @param  int|null  $page
-     * @param  \Closure|int|null  $total
+     * @param  int|null|\Closure  $total
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression|array<string|\Illuminate\Contracts\Database\Query\Expression>  $countColumns
      * @return \Illuminate\Pagination\LengthAwarePaginator
      */
-    public function paginate($perPage = 15, $columns = ['*'], $pageName = 'page', $page = null, $total = null)
+    public function paginate($perPage = 15, $columns = ['*'], $pageName = 'page', $page = null, $total = null, $countColumns = ['*'])
     {
         $page = $page ?: Paginator::resolveCurrentPage($pageName);
 
-        $total = value($total) ?? $this->getCountForPagination();
+        $total = value($total) ?? $this->getCountForPagination($countColumns);
 
         $perPage = value($perPage, $total);
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -6148,6 +6148,7 @@ SQL;
         $columns = ['test'];
         $pageName = 'page-name';
         $page = 1;
+        $countColumns = ['test'];
         $builder = $this->getMockQueryBuilder();
         $path = 'http://foo.bar?page=3';
 
@@ -6161,7 +6162,7 @@ SQL;
             return $path;
         });
 
-        $result = $builder->paginate($perPage, $columns, $pageName, $page);
+        $result = $builder->paginate($perPage, $columns, $pageName, $page, countColumns: $countColumns);
 
         $this->assertEquals(new LengthAwarePaginator($results, 2, $perPage, $page, [
             'path' => $path,
@@ -6235,6 +6236,7 @@ SQL;
         $columns = ['id', 'name'];
         $pageName = 'page-name';
         $page = 1;
+        $countColumns = ['id'];
         $builder = $this->getMockQueryBuilder();
         $path = 'http://foo.bar?page=3';
 
@@ -6248,7 +6250,7 @@ SQL;
             return $path;
         });
 
-        $result = $builder->paginate($perPage, $columns, $pageName, $page);
+        $result = $builder->paginate($perPage, $columns, $pageName, $page, countColumns: $countColumns);
 
         $this->assertEquals(new LengthAwarePaginator($results, 2, $perPage, $page, [
             'path' => $path,
@@ -6262,6 +6264,7 @@ SQL;
         $columns = ['id', 'name'];
         $pageName = 'page-name';
         $page = 1;
+        $countColumns = ['id'];
         $builder = $this->getMockQueryBuilder();
         $path = 'http://foo.bar?page=3';
 
@@ -6275,7 +6278,7 @@ SQL;
             return $path;
         });
 
-        $result = $builder->paginate($perPage, $columns, $pageName, $page, 10);
+        $result = $builder->paginate($perPage, $columns, $pageName, $page, 10, $countColumns);
 
         $this->assertEquals(10, $result->total());
     }


### PR DESCRIPTION
### Summary

The idea behind this PR is to be able to control the fields used by the `getCountForPagination`/`runPaginationCountQuery` and have slightly better performant queries when the count is done on table with many fields