### PR TITLE
[13.x] Fix inverted ratio comparison operators in image dimension validation

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -850,7 +850,9 @@ trait ValidatesAttributes
             [1, 1], array_filter(sscanf($parameters['min_ratio'], '%f/%d'))
         );
 
-        return ($width / $height) < ($minNumerator / $minDenominator);
+        $precision = 1 / (max(($width + $height) / 2, $height) + 1);
+
+        return ($minNumerator / $minDenominator) - ($width / $height) > $precision;
     }
 
     /**
@@ -871,7 +873,9 @@ trait ValidatesAttributes
             [1, 1], array_filter(sscanf($parameters['max_ratio'], '%f/%d'))
         );
 
-        return ($width / $height) > ($maxNumerator / $maxDenominator);
+        $precision = 1 / (max(($width + $height) / 2, $height) + 1);
+
+        return ($width / $height) - ($maxNumerator / $maxDenominator) > $precision;
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -850,7 +850,7 @@ trait ValidatesAttributes
             [1, 1], array_filter(sscanf($parameters['min_ratio'], '%f/%d'))
         );
 
-        return ($width / $height) > ($minNumerator / $minDenominator);
+        return ($width / $height) < ($minNumerator / $minDenominator);
     }
 
     /**
@@ -871,7 +871,7 @@ trait ValidatesAttributes
             [1, 1], array_filter(sscanf($parameters['max_ratio'], '%f/%d'))
         );
 
-        return ($width / $height) < ($maxNumerator / $maxDenominator);
+        return ($width / $height) > ($maxNumerator / $maxDenominator);
     }
 
     /**

--- a/tests/Validation/ValidationImageFileRuleTest.php
+++ b/tests/Validation/ValidationImageFileRuleTest.php
@@ -60,42 +60,43 @@ class ValidationImageFileRuleTest extends TestCase
 
     public function testDimensionWithTheMinRatioMethod()
     {
-        $this->fails(
-            File::image()->dimensions(Rule::dimensions()->minRatio(1 / 2)),
-            UploadedFile::fake()->image('foo.png', 100, 100),
-            ['validation.dimensions'],
-        );
-
         $this->passes(
             File::image()->dimensions(Rule::dimensions()->minRatio(1 / 2)),
-            UploadedFile::fake()->image('foo.png', 100, 200),
+            UploadedFile::fake()->image('foo.png', 100, 100),
+        );
+
+        $this->fails(
+            File::image()->dimensions(Rule::dimensions()->minRatio(1 / 2)),
+            UploadedFile::fake()->image('foo.png', 100, 300),
+            ['validation.dimensions'],
         );
     }
 
     public function testDimensionWithTheMaxRatioMethod()
     {
-        $this->fails(
+        $this->passes(
             File::image()->dimensions(Rule::dimensions()->maxRatio(1 / 2)),
             UploadedFile::fake()->image('foo.png', 100, 300),
             ['validation.dimensions'],
         );
 
-        $this->passes(
+        $this->fails(
             File::image()->dimensions(Rule::dimensions()->maxRatio(1 / 2)),
             UploadedFile::fake()->image('foo.png', 100, 100),
+            ['validation.dimensions'],
         );
     }
 
     public function testDimensionWithTheRatioBetweenMethod()
     {
         $this->fails(
-            File::image()->dimensions(Rule::dimensions()->ratioBetween(1 / 2, 1 / 3)),
+            File::image()->dimensions(Rule::dimensions()->ratioBetween(1 / 3, 1 / 2)),
             UploadedFile::fake()->image('foo.png', 100, 100),
             ['validation.dimensions'],
         );
 
         $this->passes(
-            File::image()->dimensions(Rule::dimensions()->ratioBetween(1 / 2, 1 / 3)),
+            File::image()->dimensions(Rule::dimensions()->ratioBetween(1 / 3, 1 / 2)),
             UploadedFile::fake()->image('foo.png', 100, 200),
         );
     }

--- a/tests/Validation/ValidationImageFileRuleTest.php
+++ b/tests/Validation/ValidationImageFileRuleTest.php
@@ -65,6 +65,11 @@ class ValidationImageFileRuleTest extends TestCase
             UploadedFile::fake()->image('foo.png', 100, 100),
         );
 
+        $this->passes(
+            File::image()->dimensions(Rule::dimensions()->minRatio(2 / 3)),
+            UploadedFile::fake()->image('foo.png', 200, 300),
+        );
+
         $this->fails(
             File::image()->dimensions(Rule::dimensions()->minRatio(1 / 2)),
             UploadedFile::fake()->image('foo.png', 100, 300),
@@ -78,6 +83,11 @@ class ValidationImageFileRuleTest extends TestCase
             File::image()->dimensions(Rule::dimensions()->maxRatio(1 / 2)),
             UploadedFile::fake()->image('foo.png', 100, 300),
             ['validation.dimensions'],
+        );
+
+        $this->passes(
+            File::image()->dimensions(Rule::dimensions()->maxRatio(1 / 3)),
+            UploadedFile::fake()->image('foo.png', 100, 300),
         );
 
         $this->fails(

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -5491,11 +5491,11 @@ class ValidationValidatorTest extends TestCase
 
         // for min_ratio
         $v = new Validator($trans, ['x' => $uploadedFile], ['x' => 'dimensions:min_ratio=1/2']);
-        $this->assertTrue($v->fails());
+        $this->assertTrue($v->passes());
 
         // for max_ratio
         $v = new Validator($trans, ['x' => $uploadedFile], ['x' => 'dimensions:max_ratio=2/5']);
-        $this->assertTrue($v->passes());
+        $this->assertTrue($v->fails());
 
         // Knowing that demo image2.png has width = 4 and height = 2
         $uploadedFile = new UploadedFile(__DIR__.'/fixtures/image2.png', '', null, null, true);
@@ -5556,11 +5556,11 @@ class ValidationValidatorTest extends TestCase
 
         // evaluates to (64 / 65) > (1 / 1.0) which is true/fails
         $v = new Validator($trans, ['x' => $uploadedFile], ['x' => 'dimensions:min_ratio=1']);
-        $this->assertFalse($v->fails());
+        $this->assertTrue($v->fails());
 
-        // evaluates to (64 / 65) < (1 / 1.0) which is false/passes
+        // evaluates to (64 / 65) > (1 / 1.0) which is false/passes
         $v = new Validator($trans, ['x' => $uploadedFile], ['x' => 'dimensions:max_ratio=1']);
-        $this->assertFalse($v->passes());
+        $this->assertTrue($v->passes());
 
         // Knowing that demo image5.png has width = 1366 and height = 768
         $uploadedFile = new UploadedFile(__DIR__.'/fixtures/image5.png', '', null, null, true);


### PR DESCRIPTION
The `failsMinRatioCheck` method used `>` instead of  `<` causing images that exceeded the minimum ratio to incorrectly fail the validation. Same for the `failsMaxRatioCheck`

I have updated the comparison operators and corrected the tests assertions that were written to match the inverted behavior.