### PR TITLE
[13.x] Normalize HTTP client header values

### DIFF
--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -12,7 +12,9 @@ use GuzzleHttp\TransferStats;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use Illuminate\Support\Stringable;
 use Illuminate\Support\Traits\Macroable;
+use InvalidArgumentException;
 use PHPUnit\Framework\Assert as PHPUnit;
 
 /**
@@ -182,7 +184,46 @@ class Factory
             $headers['Content-Type'] = 'application/json';
         }
 
-        return new Psr7Response($status, $headers, $body);
+        return new Psr7Response($status, static::normalizeResponseHeaders($headers), $body);
+    }
+
+    /**
+     * Normalize the given fake response headers.
+     *
+     * @param  array  $headers
+     * @return array
+     */
+    protected static function normalizeResponseHeaders(array $headers): array
+    {
+        foreach ($headers as $name => $value) {
+            if (is_array($value)) {
+                if ($value === []) {
+                    $headers[$name] = '';
+
+                    continue;
+                }
+
+                foreach ($value as $key => $item) {
+                    $value[$key] = match (true) {
+                        is_scalar($item) => (string) $item,
+                        $item instanceof Stringable => $item->toString(),
+                        default => throw new InvalidArgumentException('HTTP fake response header values must be scalar, Laravel Stringable, or arrays of scalar or Laravel Stringable values.'),
+                    };
+                }
+
+                $headers[$name] = $value;
+
+                continue;
+            }
+
+            $headers[$name] = match (true) {
+                is_scalar($value) => (string) $value,
+                $value instanceof Stringable => $value->toString(),
+                default => throw new InvalidArgumentException('HTTP fake response header values must be scalar, Laravel Stringable, or arrays of scalar or Laravel Stringable values.'),
+            };
+        }
+
+        return $headers;
     }
 
     /**

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -26,6 +26,7 @@ use Illuminate\Support\Str;
 use Illuminate\Support\Stringable;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
+use InvalidArgumentException;
 use JsonSerializable;
 use Psr\Http\Message\MessageInterface;
 use Psr\Http\Message\RequestInterface;
@@ -1361,6 +1362,10 @@ class PendingRequest
             $laravelData = $laravelData->jsonSerialize();
         }
 
+        if (is_array($laravelData) && $this->bodyFormat === 'multipart') {
+            return $this->normalizeMultipartOption($laravelData);
+        }
+
         return is_array($laravelData) ? $laravelData : [];
     }
 
@@ -1373,14 +1378,136 @@ class PendingRequest
     protected function normalizeRequestOptions(array $options)
     {
         foreach ($options as $key => $value) {
-            $options[$key] = match (true) {
-                is_array($value) => $this->normalizeRequestOptions($value),
-                $value instanceof Stringable => $value->toString(),
-                default => $value,
-            };
+            if ($key === 'headers' && is_array($value)) {
+                $options[$key] = $this->normalizeHeaderValues($value);
+
+                continue;
+            }
+
+            if ($key === 'multipart' && is_array($value)) {
+                $options[$key] = $this->normalizeMultipartOption($value);
+
+                continue;
+            }
+
+            $options[$key] = $this->normalizeRequestOptionValue($value);
         }
 
         return $options;
+    }
+
+    /**
+     * Normalize the given header values.
+     *
+     * @param  array  $headers
+     * @return array
+     */
+    protected function normalizeHeaderValues(array $headers): array
+    {
+        foreach ($headers as $name => $value) {
+            $headers[$name] = $this->normalizeHeaderValue($value);
+        }
+
+        return $headers;
+    }
+
+    /**
+     * Normalize the given header value.
+     *
+     * @param  mixed  $value
+     * @return string|array
+     */
+    protected function normalizeHeaderValue($value): string|array
+    {
+        if (is_array($value)) {
+            if ($value === []) {
+                return '';
+            }
+
+            foreach ($value as $key => $item) {
+                $value[$key] = match (true) {
+                    is_scalar($item) => (string) $item,
+                    $item instanceof Stringable => $item->toString(),
+                    default => throw new InvalidArgumentException('HTTP header values must be scalar, Laravel Stringable, or arrays of scalar or Laravel Stringable values.'),
+                };
+            }
+
+            return $value;
+        }
+
+        return match (true) {
+            is_scalar($value) => (string) $value,
+            $value instanceof Stringable => $value->toString(),
+            default => throw new InvalidArgumentException('HTTP header values must be scalar, Laravel Stringable, or arrays of scalar or Laravel Stringable values.'),
+        };
+    }
+
+    /**
+     * Normalize the given multipart option.
+     *
+     * @param  array  $multipart
+     * @return array
+     */
+    protected function normalizeMultipartOption(array $multipart): array
+    {
+        foreach ($multipart as $index => $part) {
+            if (! is_array($part)) {
+                $multipart[$index] = $this->normalizeRequestOptionValue($part);
+
+                continue;
+            }
+
+            foreach ($part as $key => $value) {
+                if ($key === 'headers' && is_array($value)) {
+                    continue;
+                }
+
+                $part[$key] = $this->normalizeRequestOptionValue($value);
+            }
+
+            $multipart[$index] = $part;
+        }
+
+        return $this->normalizeMultipartHeaders($multipart);
+    }
+
+    /**
+     * Normalize the given multipart headers.
+     *
+     * @param  array  $multipart
+     * @return array
+     */
+    protected function normalizeMultipartHeaders(array $multipart): array
+    {
+        foreach ($multipart as $index => $part) {
+            if (is_array($part) && isset($part['headers']) && is_array($part['headers'])) {
+                foreach ($part['headers'] as $name => $value) {
+                    $multipart[$index]['headers'][$name] = match (true) {
+                        $value === [] => '',
+                        is_scalar($value) => (string) $value,
+                        $value instanceof Stringable => $value->toString(),
+                        default => throw new InvalidArgumentException('Multipart header values must be scalar or Laravel Stringable.'),
+                    };
+                }
+            }
+        }
+
+        return $multipart;
+    }
+
+    /**
+     * Normalize the given request option value.
+     *
+     * @param  mixed  $value
+     * @return mixed
+     */
+    protected function normalizeRequestOptionValue($value)
+    {
+        return match (true) {
+            is_array($value) => array_map(fn ($item) => $this->normalizeRequestOptionValue($item), $value),
+            $value instanceof Stringable => $value->toString(),
+            default => $value,
+        };
     }
 
     /**

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -40,6 +40,7 @@ use Illuminate\Support\Sleep;
 use Illuminate\Support\Str;
 use Illuminate\Support\Stringable;
 use Illuminate\Support\Uri;
+use InvalidArgumentException;
 use JsonSerializable;
 use Mockery as m;
 use OutOfBoundsException;
@@ -50,6 +51,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use RuntimeException;
+use stdClass;
 use Symfony\Component\VarDumper\VarDumper;
 use Throwable;
 
@@ -95,6 +97,32 @@ class HttpClientTest extends TestCase
 
         $response = $this->factory->post('http://forge.laravel.com');
         $this->assertFalse($response->created());
+    }
+
+    public function testFakeResponseHeaderValuesAreSerialized()
+    {
+        $response = $this->factory::response('OK', 200, [
+            'X-Int' => 123,
+            'X-False' => false,
+            'X-Empty' => [],
+            'X-Laravel-Stringable' => new Stringable('laravel stringable'),
+            'X-Multiple' => ['first', 123, true, false],
+        ])->wait();
+
+        $this->assertSame(['123'], $response->getHeader('X-Int'));
+        $this->assertSame([''], $response->getHeader('X-False'));
+        $this->assertSame([''], $response->getHeader('X-Empty'));
+        $this->assertSame(['laravel stringable'], $response->getHeader('X-Laravel-Stringable'));
+        $this->assertSame(['first', '123', '1', ''], $response->getHeader('X-Multiple'));
+    }
+
+    #[DataProvider('invalidFakeResponseHeaderValuesProvider')]
+    public function testInvalidFakeResponseHeaderValuesAreRejected($value)
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('HTTP fake response header values must be scalar, Laravel Stringable, or arrays of scalar or Laravel Stringable values.');
+
+        $this->factory::response('OK', 200, ['X-Test' => $value]);
     }
 
     public function testStatusCodeShorthand()
@@ -675,6 +703,55 @@ class HttpClientTest extends TestCase
         });
     }
 
+    public function testHeaderValuesAreSerialized()
+    {
+        $this->factory->fake();
+
+        $this->factory->withHeaders([
+            'X-Int' => 123,
+            'X-Float' => 1.5,
+            'X-True' => true,
+            'X-False' => false,
+            'X-Laravel-Stringable' => new Stringable('laravel stringable'),
+            'X-Multiple' => ['first', 123, true, false],
+            'X-Empty' => [],
+        ])->post('http://foo.com/json');
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->hasHeader('X-Int', '123')
+                && $request->hasHeader('X-Float', '1.5')
+                && $request->hasHeader('X-True', '1')
+                && $request->hasHeader('X-False', '')
+                && $request->hasHeader('X-Laravel-Stringable', 'laravel stringable')
+                && $request->hasHeader('X-Multiple', ['first', '123', '1', ''])
+                && $request->hasHeader('X-Empty', '');
+        });
+    }
+
+    #[DataProvider('invalidHeaderValuesProvider')]
+    public function testInvalidHeaderValuesAreRejected($value)
+    {
+        $this->factory->fake();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('HTTP header values must be scalar, Laravel Stringable, or arrays of scalar or Laravel Stringable values.');
+
+        $this->factory->withHeaders(['X-Test' => $value])->post('http://foo.com/json');
+    }
+
+    public function testHeaderValuesProvidedThroughOptionsAreSerialized()
+    {
+        $this->factory->fake();
+
+        $this->factory->withOptions([
+            'headers' => ['X-Test' => 123],
+        ])->post('http://foo.com/json');
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->hasHeader('X-Test', '123');
+        });
+    }
+
     public function testCanSendFormDataWithStringable()
     {
         $this->factory->fake();
@@ -794,6 +871,57 @@ class HttpClientTest extends TestCase
                    $request[0]['name'] === 'foo' &&
                    $request->hasFile('foo', 'data', 'file.txt');
         });
+    }
+
+    public function testAttachHeaderValuesAreSerialized()
+    {
+        $this->factory->fake();
+
+        $this->factory->attach('file', 'data', 'file.txt', ['X-Part' => 123])->post('http://foo.com/file');
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request[0]['headers']['X-Part'] === '123';
+        });
+    }
+
+    public function testMultipartHeaderValuesAreSerialized()
+    {
+        $this->factory->fake();
+
+        $this->factory->asMultipart()->post('http://foo.com/multipart', [
+            [
+                'name' => 'file',
+                'contents' => 'data',
+                'headers' => [
+                    'X-Part' => 123,
+                    'X-Empty' => [],
+                    'X-Laravel-Stringable' => new Stringable('laravel stringable'),
+                ],
+            ],
+        ]);
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request[0]['headers']['X-Part'] === '123'
+                && $request[0]['headers']['X-Empty'] === ''
+                && $request[0]['headers']['X-Laravel-Stringable'] === 'laravel stringable';
+        });
+    }
+
+    #[DataProvider('invalidMultipartHeaderValuesProvider')]
+    public function testInvalidMultipartHeaderValuesAreRejected($value)
+    {
+        $this->factory->fake();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Multipart header values must be scalar or Laravel Stringable.');
+
+        $this->factory->asMultipart()->post('http://foo.com/multipart', [
+            [
+                'name' => 'file',
+                'contents' => 'data',
+                'headers' => ['X-Part' => $value],
+            ],
+        ]);
     }
 
     public function testCanSendMultipartDataWithSimplifiedParameters()
@@ -4392,6 +4520,42 @@ class HttpClientTest extends TestCase
             'put' => ['put'],
             'post' => ['post'],
             'delete' => ['delete'],
+        ];
+    }
+
+    public static function invalidHeaderValuesProvider()
+    {
+        return [
+            'null' => [null],
+            'object' => [new stdClass],
+            'resource' => [fopen('php://temp', 'r')],
+            'array with null' => [['valid', null]],
+            'array with object' => [['valid', new stdClass]],
+            'array with resource' => [['valid', fopen('php://temp', 'r')]],
+            'array with nested array' => [['valid', ['nested']]],
+        ];
+    }
+
+    public static function invalidMultipartHeaderValuesProvider()
+    {
+        return [
+            'null' => [null],
+            'array' => [['nested']],
+            'object' => [new stdClass],
+            'resource' => [fopen('php://temp', 'r')],
+        ];
+    }
+
+    public static function invalidFakeResponseHeaderValuesProvider()
+    {
+        return [
+            'null' => [null],
+            'object' => [new stdClass],
+            'resource' => [fopen('php://temp', 'r')],
+            'array with null' => [['valid', null]],
+            'array with object' => [['valid', new stdClass]],
+            'array with resource' => [['valid', fopen('php://temp', 'r')]],
+            'array with nested array' => [['valid', ['nested']]],
         ];
     }
 


### PR DESCRIPTION
This is needed because Laravel's HTTP client can receive numeric, boolean, existing `Illuminate\Support\Stringable`, and empty-array header values from its own fluent API before those values reach Guzzle's PSR-7 implementation. Before `guzzlehttp/psr7` 2.11, scalar and null header values were accepted and cast to strings, and empty arrays were accepted without an immediate failure. In `guzzlehttp/psr7` 2.11, those compatibility cases started emitting deprecations because `guzzlehttp/psr7` 3.0 requires header values to already be strings or arrays of strings and rejects empty header arrays.

This change keeps that transition explicit at Laravel's boundary by serializing supported scalar request header values and preserving Laravel's existing `Illuminate\Support\Stringable` normalization before values are passed to Guzzle, serializing empty header arrays to an empty string for compatibility, and rejecting unsupported header values before lower-level PSR-7 validation sees them. It also applies the same supported header-value normalization to fake response headers before constructing `GuzzleHttp\Psr7\Response` instances. It does not add native PHP `Stringable` header support because `guzzlehttp/psr7` did not previously accept those objects as header values, and it opens up the ability for a future PR to more easily co-support Guzzle 7, which uses `guzzlehttp/psr7` 2.x, and Guzzle 8, which uses `guzzlehttp/psr7` 3.x.

---

There is a similar PR recently merged into the AWS PHP SDK: https://github.com/aws/aws-sdk-php/pull/3289.