### PR TITLE
[13.x] Correct PSR HTTP message suggestion

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -166,7 +166,7 @@
         "php-http/discovery": "Required to use PSR-7 bridging features (^1.15).",
         "phpunit/phpunit": "Required to use assertions and run tests (^11.5.50 || ^12.5.8 || ^13.0.3).",
         "predis/predis": "Required to use the predis connector (^2.3 || ^3.0).",
-        "psr/http-message": "Required to allow Storage::put to accept a StreamInterface (^1.0).",
+        "psr/http-message": "Required to allow Storage::put to accept a StreamInterface (^1.0 || ^2.0).",
         "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (^6.0 || ^7.0).",
         "resend/resend-php": "Required to enable support for the Resend mail transport (^0.10.0 || ^1.0).",
         "spatie/fork": "Required to use the 'fork' concurrency driver (^1.2).",

--- a/src/Illuminate/Filesystem/composer.json
+++ b/src/Illuminate/Filesystem/composer.json
@@ -30,7 +30,7 @@
         "league/flysystem-aws-s3-v3": "Required to use the Flysystem S3 driver (^3.25.1).",
         "league/flysystem-ftp": "Required to use the Flysystem FTP driver (^3.25.1).",
         "league/flysystem-sftp-v3": "Required to use the Flysystem SFTP driver (^3.25.1).",
-        "psr/http-message": "Required to allow Storage::put to accept a StreamInterface (^1.0).",
+        "psr/http-message": "Required to allow Storage::put to accept a StreamInterface (^1.0 || ^2.0).",
         "symfony/filesystem": "Required to enable support for relative symbolic links (^7.4 || ^8.0).",
         "symfony/mime": "Required to enable support for guessing extensions (^7.4 || ^8.0)."
     },


### PR DESCRIPTION
This updates the optional `psr/http-message` suggestion for filesystem stream support to mention both supported major versions. The code only requires the `StreamInterface` contract, so the package suggestion should allow `psr/http-message` 2.x as well as 1.x.