### PR TITLE
[13.x] Report MultipleRecordsFoundException from sole()

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -17,7 +17,6 @@ use Illuminate\Contracts\Debug\ShouldntReport;
 use Illuminate\Contracts\Foundation\ExceptionRenderer;
 use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
-use Illuminate\Database\MultipleRecordsFoundException;
 use Illuminate\Database\RecordNotFoundException;
 use Illuminate\Database\RecordsNotFoundException;
 use Illuminate\Foundation\Exceptions\Renderer\Renderer;
@@ -161,7 +160,6 @@ class Handler implements ExceptionHandlerContract
         HttpException::class,
         HttpResponseException::class,
         ModelNotFoundException::class,
-        MultipleRecordsFoundException::class,
         OriginMismatchException::class,
         RecordNotFoundException::class,
         RecordsNotFoundException::class,

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -14,6 +14,7 @@ use Illuminate\Container\Container;
 use Illuminate\Contracts\Routing\ResponseFactory as ResponseFactoryContract;
 use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Contracts\View\Factory as ViewFactory;
+use Illuminate\Database\MultipleRecordsFoundException;
 use Illuminate\Database\RecordsNotFoundException;
 use Illuminate\Foundation\Exceptions\Handler;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithExceptionHandling;
@@ -391,6 +392,15 @@ class FoundationExceptionsHandlerTest extends TestCase
         $logger->shouldNotReceive('log');
 
         $this->handler->report(new RecordsNotFoundException);
+    }
+
+    public function testMultipleRecordsFoundIsReported()
+    {
+        $logger = m::mock(LoggerInterface::class);
+        $this->container->instance(LoggerInterface::class, $logger);
+        $logger->shouldReceive('error')->withArgs(['2 records were found.', m::hasKey('exception')])->once();
+
+        $this->handler->report(new MultipleRecordsFoundException(2));
     }
 
     public function testItReturnsSpecificErrorViewIfExists()


### PR DESCRIPTION
MultipleRecordsFoundException got added to $internalDontReport in #35908 alongside RecordsNotFoundException, but the two aren't really the same kind of error and shouldn't be treated the same way.

RecordsNotFoundException makes sense in that list — prepareException() maps it to a NotFoundHttpException, so it surfaces as a 404. Silencing it from the log is fine, it's the same as any other route model binding miss.

MultipleRecordsFoundException isn't mapped anywhere. It just falls through as an unhandled 500. And because it's in $internalDontReport, nothing gets logged either. So when ->sole() matches more than one row, the user sees a generic 500 and there's no trace of it in the logs, Nightwatch, anywhere.

That's the exact case you'd want to know about. If you called ->sole() you're asserting there's exactly one row — finding two means your data or your query is wrong, and that's a real bug worth reporting. Right now it's getting swallowed.

This PR just removes it from the ignore list. 0 rows still 404s silently via RecordsNotFoundException. 2+ rows now reports like any other uncaught RuntimeException.