### PR TITLE
[13.x] Allow Http Client to be used as PSR Client

### DIFF
--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -259,7 +259,7 @@ class Factory
                     $response = $response($request, $options);
                 }
 
-                if ($response instanceof PromiseInterface) {
+                if ($response instanceof PromiseInterface && ($options['on_stats'] ?? null) instanceof Closure) {
                     $options['on_stats'](new TransferStats(
                         $request->toPsrRequest(),
                         $response->wait(),

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -1499,7 +1499,7 @@ class PendingRequest
                 return $promise->then(function ($response) use ($request, $options) {
                     $this->factory?->recordRequestResponsePair(
                         (new Request($request))
-                            ->withData($options['laravel_data'])
+                            ->withData($options['laravel_data'] ?? [])
                             ->setRequestAttributes($this->attributes),
                         $this->newResponse($response)
                     );
@@ -1525,7 +1525,7 @@ class PendingRequest
                     ->map
                     ->__invoke(
                         (new Request($request))
-                            ->withData($options['laravel_data'])
+                            ->withData($options['laravel_data'] ?? [])
                             ->setRequestAttributes($this->attributes),
                         $options
                     )
@@ -1589,7 +1589,7 @@ class PendingRequest
                 $callbackResult = call_user_func(
                     $callback,
                     (new Request($request))
-                        ->withData($options['laravel_data'])
+                        ->withData($options['laravel_data'] ?? [])
                         ->setRequestAttributes($this->attributes),
                     $options,
                     $this

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Http;
 
 use Exception;
+use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException as GuzzleRequestException;
 use GuzzleHttp\Exception\TooManyRedirectsException;
@@ -1955,6 +1956,30 @@ class HttpClientTest extends TestCase
         $request->setClient($client);
 
         $this->assertSame($client, $request->buildClient());
+    }
+
+    public function testClientCanBeUsedExternally()
+    {
+        $this->factory->fake([
+            '200.com' => $this->factory::response('hello', 200),
+        ]);
+
+        $apiClient = new class ($this->factory->buildClient())
+        {
+            public function __construct(
+                private GuzzleClient $client,
+            ) {
+            }
+
+            public function sendGetRequest()
+            {
+                return $this->client->sendRequest(new GuzzleRequest('GET', '200.com'));
+            }
+        };
+
+        $response = $apiClient->sendGetRequest();
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('hello', $response->getBody()->getContents());
     }
 
     public function testRequestsCanReplaceOptions()


### PR DESCRIPTION
This makes some options used internally by the Http client optional so that the client returned by `buildClient` can be used anywhere that an instance of `\Psr\Http\Client\ClientInterface` is required. This allows the middleware and the handler stack to be used on all requests made using the client, which means things like request logging will also apply.

For example, say your application uses a package that allows address geocoding and has different drivers available for different map providers. The service class in this package must be instantiated with an instance of `\Psr\Http\Client\ClientInterface`, which it then uses to make API requests to the corresponding map providers. By passing the Laravel Http client, all requests and responses from these APIs can then be logged alongside all the other Http requests being made directly by application code.

```php
$geocoder = new GeocodingService(Http::buildClient());
```