### PR TITLE
[13.x] Add fluent dump methods to Eloquent models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -29,6 +29,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Support\Str;
 use Illuminate\Support\Stringable as SupportStringable;
+use Illuminate\Support\Traits\Dumpable;
 use Illuminate\Support\Traits\ForwardsCalls;
 use JsonException;
 use JsonSerializable;
@@ -54,6 +55,10 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         ForwardsCalls;
     /** @use HasCollection<\Illuminate\Database\Eloquent\Collection<array-key, static & self>> */
     use HasCollection;
+    use Dumpable {
+        dump as protected;
+        dd as protected;
+    }
 
     /**
      * The connection name for the model.
@@ -2791,7 +2796,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function __call($method, $parameters)
     {
-        if (in_array($method, ['increment', 'decrement', 'incrementQuietly', 'decrementQuietly', 'incrementEach', 'decrementEach'])) {
+        if (in_array($method, ['increment', 'decrement', 'incrementQuietly', 'decrementQuietly', 'incrementEach', 'decrementEach', 'dd', 'dump'])) {
             return $this->$method(...$parameters);
         }
 
@@ -2816,7 +2821,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public static function __callStatic($method, $parameters)
     {
-        if (static::isScopeMethodWithAttribute($method)) {
+        if (in_array($method, ['dd', 'dump']) || static::isScopeMethodWithAttribute($method)) {
             return static::query()->$method(...$parameters);
         }
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -61,6 +61,7 @@ use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use stdClass;
 use Stringable as NativeStringable;
+use Symfony\Component\VarDumper\VarDumper;
 
 include_once 'Enums.php';
 
@@ -748,6 +749,36 @@ class DatabaseEloquentModelTest extends TestCase
     {
         $count = EloquentModelEmptyDestroyStub::destroy([]);
         $this->assertSame(0, $count);
+    }
+
+    public function testDumpMethodDumpsModelInstanceAndReturnsIt()
+    {
+        $log = new BaseCollection;
+
+        VarDumper::setHandler(function ($value) use ($log) {
+            $log->add($value);
+        });
+
+        try {
+            $model = new EloquentModelStub;
+
+            $result = $model->dump('one', 'two');
+
+            $this->assertSame($model, $result);
+            $this->assertSame([$model, 'one', 'two'], $log->all());
+        } finally {
+            VarDumper::setHandler(null);
+        }
+    }
+
+    public function testDumpMethodCallsQueryBuilderCorrectly()
+    {
+        EloquentModelDumpStub::$arguments = [];
+
+        $result = EloquentModelDumpStub::dump('one', 'two');
+
+        $this->assertSame('foo', $result);
+        $this->assertSame(['one', 'two'], EloquentModelDumpStub::$arguments);
     }
 
     public function testWithMethodCallsQueryBuilderCorrectly()
@@ -4133,6 +4164,24 @@ class EloquentModelWithStub extends Model
         $mock->shouldReceive('with')->once()->with(['foo', 'bar'])->andReturn('foo');
 
         return $mock;
+    }
+}
+
+class EloquentModelDumpStub extends Model
+{
+    public static $arguments = [];
+
+    public function newQuery()
+    {
+        return new class
+        {
+            public function dump(...$arguments)
+            {
+                EloquentModelDumpStub::$arguments = $arguments;
+
+                return 'foo';
+            }
+        };
     }
 }
 


### PR DESCRIPTION
### **Summary**

This PR introduces fluent `dump()` and `dd()` debugging methods directly to Eloquent models by leveraging the `Illuminate\Support\Traits\Dumpable` trait.

This change **leaves the static behavior entirely unchanged**: calling `User::dump()` or `User::dd()` will continue to be forwarded to the Query Builder as before.

### **Why this PR? (Fixing Unexpected Behavior)**

The main driver behind this PR is addressing an **unexpected behavior** in the developer experience when debugging hydrated models.

Currently, the Eloquent Query Builder is fully inspectable mid-chain. However, if a developer attempts to fluently call `->dump()` or `->dd()` on a **hydrated model instance**, the call is caught by the magic `__call()` method and forwarded down to a new Query Builder instance. Instead of inspecting the model's current state, the developer unexpectedly gets a dump of the Query Builder itself.

By adding the `Dumpable` trait directly to the `Model` class, we resolve this friction:

* **Fixes Developer Intuition:** Calling `->dump()` on an instantiated model now actually dumps that specific model instance (its attributes, relations, and mutated state) rather than routing back to the builder.
* **Preserves Fluent Chains:** Developers can safely inspect an instance mid-operation or within collection pipelines without breaking the execution flow or relying on temporary variables.

### **The Alias Trick (`dump as protected`)**

To achieve this without breaking backwards compatibility or creating conflicts with the magic `__call` routing, this PR utilizes an **aliasing trick** when importing the trait:

```php
use Dumpable {
    dump as protected;
    dd as protected;
}

```

By aliasing the trait's methods as `protected`, we prevent them from hiding or overriding the public static/magic behavior blindly. Instead, it allows us to intercept the calls explicitly inside `__call()` and `__callStatic()`. This ensures that:

1. **Dynamic calls** on a hydrated instance hit `__call()`, match the array check, and safely execute the protected trait method internally on `$this`.
2. **Static calls**: When called statically, the call hits `__callStatic()`. It is explicitly intercepted by the `in_array` check and safely forwarded to a new Query Builder instance (`static::query()->$method(...)`). This ensures that the static behavior remains completely untouched and backward-compatible.

### **Usage Example**

```php
// THE PROBLEM (Current unexpected behavior)
$user = User::find(1); 
$user->dd(); // Unexpectedly dumps a Query Builder instance, NOT the $user model!

// THE SOLUTION (With this PR)
User::find(1)
    ->dd()   // Correctly dumps the hydrated User instance
    ->update(['status' => 'active']);

// UNCHANGED (Static calls still forward to the Query Builder safely thanks to the alias trick)
User::dd();

```