### PR TITLE
[13.x] Introduce Bus::bulk()

### DIFF
--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -256,17 +256,17 @@ class Dispatcher implements QueueingDispatcher
                 continue;
             }
 
-            $connectionName = $this->getAttributeValue($job, Connection::class, 'connection')
+            $connection = $this->getAttributeValue($job, Connection::class, 'connection')
                 ?? $this->resolveConnectionFromQueueRoute($job)
                 ?? null;
 
-            $queueName = $this->getAttributeValue($job, QueueAttribute::class, 'queue')
+            $queue = $this->getAttributeValue($job, QueueAttribute::class, 'queue')
                 ?? $this->resolveQueueFromQueueRoute($job)
                 ?? null;
 
-            $groups[$connectionName.':'.$queueName]['connection'] = $connectionName;
-            $groups[$connectionName.':'.$queueName]['queue'] = $queueName;
-            $groups[$connectionName.':'.$queueName]['jobs'][] = $job;
+            $groups[$connection.':'.$queue]['connection'] = $connection;
+            $groups[$connection.':'.$queue]['queue'] = $queue;
+            $groups[$connection.':'.$queue]['jobs'][] = $job;
         }
 
         foreach ($groups as $group) {

--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -240,7 +240,7 @@ class Dispatcher implements QueueingDispatcher
     }
 
     /**
-     * Dispatch multiple commands to their appropriate handlers on the queue.
+     * Dispatch multiple commands in bulk to their appropriate handlers on the queue.
      *
      * @param  iterable  $jobs
      * @return void

--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -240,6 +240,43 @@ class Dispatcher implements QueueingDispatcher
     }
 
     /**
+     * Dispatch multiple commands to their appropriate handlers on the queue.
+     *
+     * @param  iterable  $jobs
+     * @return void
+     */
+    public function dispatchBulk($jobs)
+    {
+        $groups = [];
+
+        foreach ($jobs as $job) {
+            if (! $this->queueResolver || ! $this->commandShouldBeQueued($job)) {
+                $this->dispatchNow($job);
+
+                continue;
+            }
+
+            $connectionName = $this->getAttributeValue($job, Connection::class, 'connection')
+                ?? $this->resolveConnectionFromQueueRoute($job)
+                ?? null;
+
+            $queueName = $this->getAttributeValue($job, QueueAttribute::class, 'queue')
+                ?? $this->resolveQueueFromQueueRoute($job)
+                ?? null;
+
+            $groups[$connectionName.':'.$queueName]['connection'] = $connectionName;
+            $groups[$connectionName.':'.$queueName]['queue'] = $queueName;
+            $groups[$connectionName.':'.$queueName]['jobs'][] = $job;
+        }
+
+        foreach ($groups as $group) {
+            ($this->queueResolver)($group['connection'])->bulk(
+                $group['jobs'], '', $group['queue']
+            );
+        }
+    }
+
+    /**
      * Push the command onto the given queue instance.
      *
      * @param  \Illuminate\Contracts\Queue\Queue  $queue

--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -141,6 +141,43 @@ class Dispatcher implements QueueingDispatcher
     }
 
     /**
+     * Dispatch multiple commands in bulk to their appropriate handlers on the queue.
+     *
+     * @param  iterable  $jobs
+     * @return void
+     */
+    public function bulk($jobs)
+    {
+        $groups = [];
+
+        foreach ($jobs as $job) {
+            if (! $this->queueResolver || ! $this->commandShouldBeQueued($job)) {
+                $this->dispatchNow($job);
+
+                continue;
+            }
+
+            $connection = $this->getAttributeValue($job, Connection::class, 'connection')
+                ?? $this->resolveConnectionFromQueueRoute($job)
+                ?? null;
+
+            $queue = $this->getAttributeValue($job, QueueAttribute::class, 'queue')
+                ?? $this->resolveQueueFromQueueRoute($job)
+                ?? null;
+
+            $groups[$connection.':'.$queue]['connection'] = $connection;
+            $groups[$connection.':'.$queue]['queue'] = $queue;
+            $groups[$connection.':'.$queue]['jobs'][] = $job;
+        }
+
+        foreach ($groups as $group) {
+            ($this->queueResolver)($group['connection'])->bulk(
+                $group['jobs'], '', $group['queue']
+            );
+        }
+    }
+
+    /**
      * Attempt to find the batch with the given ID.
      *
      * @return \Illuminate\Bus\Batch|null
@@ -237,43 +274,6 @@ class Dispatcher implements QueueingDispatcher
         }
 
         return $this->pushCommandToQueue($queue, $command);
-    }
-
-    /**
-     * Dispatch multiple commands in bulk to their appropriate handlers on the queue.
-     *
-     * @param  iterable  $jobs
-     * @return void
-     */
-    public function dispatchBulk($jobs)
-    {
-        $groups = [];
-
-        foreach ($jobs as $job) {
-            if (! $this->queueResolver || ! $this->commandShouldBeQueued($job)) {
-                $this->dispatchNow($job);
-
-                continue;
-            }
-
-            $connection = $this->getAttributeValue($job, Connection::class, 'connection')
-                ?? $this->resolveConnectionFromQueueRoute($job)
-                ?? null;
-
-            $queue = $this->getAttributeValue($job, QueueAttribute::class, 'queue')
-                ?? $this->resolveQueueFromQueueRoute($job)
-                ?? null;
-
-            $groups[$connection.':'.$queue]['connection'] = $connection;
-            $groups[$connection.':'.$queue]['queue'] = $queue;
-            $groups[$connection.':'.$queue]['jobs'][] = $job;
-        }
-
-        foreach ($groups as $group) {
-            ($this->queueResolver)($group['connection'])->bulk(
-                $group['jobs'], '', $group['queue']
-            );
-        }
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -721,19 +721,6 @@ class BusFake implements Fake, QueueingDispatcher
     }
 
     /**
-     * Dispatch multiple commands in bulk to their appropriate handlers on the queue.
-     *
-     * @param  iterable  $jobs
-     * @return void
-     */
-    public function dispatchBulk($jobs)
-    {
-        foreach ($jobs as $job) {
-            $this->dispatch($job);
-        }
-    }
-
-    /**
      * Dispatch a command to its appropriate handler after the current process.
      *
      * @param  mixed  $command
@@ -746,6 +733,19 @@ class BusFake implements Fake, QueueingDispatcher
             $this->commandsAfterResponse[get_class($command)][] = $this->getCommandRepresentation($command);
         } else {
             $this->dispatcher->dispatchAfterResponse($command, $handler);
+        }
+    }
+
+    /**
+     * Dispatch multiple commands in bulk to their appropriate handlers on the queue.
+     *
+     * @param  iterable  $jobs
+     * @return void
+     */
+    public function bulk($jobs)
+    {
+        foreach ($jobs as $job) {
+            $this->dispatch($job);
         }
     }
 

--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -721,6 +721,19 @@ class BusFake implements Fake, QueueingDispatcher
     }
 
     /**
+     * Dispatch multiple commands to their appropriate handlers on the queue.
+     *
+     * @param  iterable  $jobs
+     * @return void
+     */
+    public function dispatchBulk($jobs)
+    {
+        foreach ($jobs as $job) {
+            $this->dispatch($job);
+        }
+    }
+
+    /**
      * Dispatch a command to its appropriate handler after the current process.
      *
      * @param  mixed  $command

--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -721,7 +721,7 @@ class BusFake implements Fake, QueueingDispatcher
     }
 
     /**
-     * Dispatch multiple commands to their appropriate handlers on the queue.
+     * Dispatch multiple commands in bulk to their appropriate handlers on the queue.
      *
      * @param  iterable  $jobs
      * @return void

--- a/tests/Bus/BusDispatcherTest.php
+++ b/tests/Bus/BusDispatcherTest.php
@@ -164,7 +164,7 @@ class BusDispatcherTest extends TestCase
 
         $dispatcher = new Dispatcher($container, fn () => $mock);
 
-        $dispatcher->dispatchBulk([
+        $dispatcher->bulk([
             new BusDispatcherQueueable,
             new BusDispatcherQueueable,
             new BusDispatcherTestSpecificQueueCommand,

--- a/tests/Bus/BusDispatcherTest.php
+++ b/tests/Bus/BusDispatcherTest.php
@@ -210,8 +210,6 @@ class BusDispatcherTestSpecificQueueAndDelayCommand implements ShouldQueue
 
 class BusDispatcherTestSpecificQueueCommand implements ShouldQueue
 {
-    use Queueable;
-
     public $queue = 'high';
 }
 

--- a/tests/Bus/BusDispatcherTest.php
+++ b/tests/Bus/BusDispatcherTest.php
@@ -149,6 +149,29 @@ class BusDispatcherTest extends TestCase
 
         Container::setInstance(null);
     }
+
+    public function testDispatchBulk()
+    {
+        $container = new Container;
+        $container->instance('queue.routes', $queueRoutes = m::mock());
+        $queueRoutes->shouldReceive('getQueue')->andReturn(null);
+        $queueRoutes->shouldReceive('getConnection')->andReturn(null);
+        Container::setInstance($container);
+
+        $mock = m::mock(Queue::class);
+        $mock->shouldReceive('bulk')->once()->with(m::on(fn ($jobs) => count($jobs) === 2), '', null);
+        $mock->shouldReceive('bulk')->once()->with(m::on(fn ($jobs) => count($jobs) === 1), '', 'high');
+
+        $dispatcher = new Dispatcher($container, fn () => $mock);
+
+        $dispatcher->dispatchBulk([
+            new BusDispatcherQueueable,
+            new BusDispatcherQueueable,
+            new BusDispatcherTestSpecificQueueCommand,
+        ]);
+
+        Container::setInstance(null);
+    }
 }
 
 class BusInjectionStub
@@ -183,6 +206,13 @@ class BusDispatcherTestSpecificQueueAndDelayCommand implements ShouldQueue
 {
     public $queue = 'foo';
     public $delay = 10;
+}
+
+class BusDispatcherTestSpecificQueueCommand implements ShouldQueue
+{
+    use Queueable;
+
+    public $queue = 'high';
 }
 
 class BusDispatcherQueueable implements ShouldQueue


### PR DESCRIPTION
> [!TIP]
> This is purely for the most optimized way of getting jobs into a queue, it does not check for uniqueness, debounce etc.. ie the same as Bus::batch, but without the increment.


When you need to dispatch multiple jobs at once, ie when a user has done a mass import, export etc.. the only option today (at least to my knowledge 🌚) is: 
-  looping over `dispatch()` 
- `Bus::batch`, 
- `Queue::bulk` (if you know the internals)


Having to squeeze every bit of resources I can, one thing I've noticed is:

- Doing a `dispatch()` in a foreach is very resource intensive on the driver, as its 1x insert, if you have a lot of other operations going on (jobs etc) .. do this 80k times it adds up
- `Bus::batch` is great if we care about the tracking of the batch/jobs, but it also writes to the database on every job completion to track progress meaning 1x insert so similar to the above tbh

So, to counter this currently we end up doing something like (I have done this, Im sorry): 

```php
Queue::bulk(
      array_map(fn (User $user) => new ProcessUser($user), $users),
      '',
      'some-queue'
  ); 
  
  // Similar logic below for other queues.
``` 

The Queue::bulk way above works, but it doesn't feel the best as we have to handle different queues, etc and the signature seems a bit odd. 

All we want to do is basically put the jobs on the queue in the most efficient way possible, if they fail that's fine they'll go to failed_jobs.

 SO this PR adds `Bus::bulk` to just let us do:

```php
  Bus::bulk(array_map(fn (User $user) => new ProcessUser($user), $users));
``` 

The method groups by queues and connections automatically, so you dont have to handle it in userland, with the added efficiency of calling bulk() underneath and a nicer DX.

This is extremely useful as it avoids the one dispatch per job  and is completely safe cause the `bulk` method is needed by the Queue interface 😎  

This is the same as Bus::batch in the sense it just sends the jobs to the queue, just without the incrementing.

This made sense in my head rather than adding a flag like withoutIncrementing() on Bus::batch, but open to your guidance as I'm just shootin my shot to try make this more obvious, feel free to adjust 🫡 

