### PR TITLE
Fix/jsonapi nested eager loaded leak

### DIFF
--- a/src/Illuminate/Database/Connectors/SQLiteConnector.php
+++ b/src/Illuminate/Database/Connectors/SQLiteConnector.php
@@ -51,7 +51,7 @@ class SQLiteConnector extends Connector implements ConnectorInterface
             return $path;
         }
 
-        $path = realpath($path) ?: realpath(base_path($path));
+        $path = realpath($path) ?: (function_exists('base_path') ? realpath(base_path($path)) : false);
 
         // Here we'll verify that the SQLite database exists before going any further
         // as the developer probably wants to know if the database exists and this

--- a/src/Illuminate/Http/Resources/JsonApi/Concerns/ResolvesJsonApiElements.php
+++ b/src/Illuminate/Http/Resources/JsonApi/Concerns/ResolvesJsonApiElements.php
@@ -35,9 +35,24 @@ trait ResolvesJsonApiElements
     protected bool $includesPreviouslyLoadedRelationships = false;
 
     /**
+     * The sparse included to use when resolving this resource as a sub-resource.
+     */
+    protected ?array $resolutionSparseIncluded = null;
+
+    /**
+     * Set the sparse included for resolving this resource as a sub-resource.
+     */
+    public function setResolutionSparseIncluded(?array $sparseIncluded): static
+    {
+        $this->resolutionSparseIncluded = $sparseIncluded;
+
+        return $this;
+    }
+
+    /**
      * Cached loaded relationships map.
      *
-     * @var array<int, array{0: \Illuminate\Http\Resources\JsonApi\JsonApiResource, 1: string, 2: string, 3: bool}|null
+     * @var array<int, array{0: \Illuminate\Http\Resources\JsonApi\JsonApiResource, 1: string, 2: string, 3: bool, 4: string, 5: array}|null
      */
     public $loadedRelationshipsMap;
 
@@ -112,7 +127,7 @@ trait ResolvesJsonApiElements
         }
 
         if (static::class !== JsonApiResource::class) {
-            return Str::of(static::class)->classBasename()->basename('Resource')->snake()->pluralStudly();
+            return (string) Str::of(static::class)->classBasename()->basename('Resource')->snake()->pluralStudly();
         }
 
         if (! $this->resource instanceof Model) {
@@ -123,7 +138,7 @@ trait ResolvesJsonApiElements
 
         $morphMap = Relation::getMorphAlias($modelClassName);
 
-        return Str::of(
+        return (string) Str::of(
             $morphMap !== $modelClassName ? $morphMap : class_basename($modelClassName)
         )->snake()->pluralStudly();
     }
@@ -188,10 +203,13 @@ trait ResolvesJsonApiElements
             return;
         }
 
-        $sparseIncluded = match (true) {
-            $this->includesPreviouslyLoadedRelationships => array_keys($this->resource->getRelations()),
-            default => $request->sparseIncluded(),
-        };
+        if ($this->resolutionSparseIncluded !== null) {
+            $sparseIncluded = $this->resolutionSparseIncluded;
+        } elseif ($this->includesPreviouslyLoadedRelationships) {
+            $sparseIncluded = array_keys($this->resource->getRelations());
+        } else {
+            $sparseIncluded = $request->sparseIncluded();
+        }
 
         $resourceRelationships = (new Collection($this->toRelationships($request)))
             ->transform(fn ($value, $key) => is_int($key) ? new RelationResolver($value) : new RelationResolver($key, $value))
@@ -214,11 +232,14 @@ trait ResolvesJsonApiElements
                     }
                 }
 
+                $subIncludes = $request->sparseIncluded($relationName) ?? [];
+
                 yield from $this->compileResourceRelationshipUsingResolver(
                     $request,
                     $this->resource,
                     $relationResolver,
                     $relatedModels,
+                    $subIncludes,
                 );
             }
         }))->all();
@@ -231,7 +252,8 @@ trait ResolvesJsonApiElements
         JsonApiRequest $request,
         mixed $resource,
         RelationResolver $relationResolver,
-        Collection|Model|null $relatedModels
+        Collection|Model|null $relatedModels,
+        array $subIncludes = []
     ): Generator {
         $relationName = $relationResolver->relationName;
         $resourceClass = $relationResolver->resourceClass();
@@ -250,15 +272,15 @@ trait ResolvesJsonApiElements
 
             $isUnique = ! $relationship instanceof BelongsToMany;
 
-            yield $relationName => ['data' => $relatedModels->map(function ($relatedModel) use ($request, $resourceClass, $isUnique) {
+            yield $relationName => ['data' => $relatedModels->map(function ($relatedModel) use ($request, $resourceClass, $relationName, $isUnique, $subIncludes) {
                 $relatedResource = rescue(fn () => $relatedModel->toResource($resourceClass), new JsonApiResource($relatedModel));
 
                 return transform(
                     [$relatedResource->resolveResourceType($request), $relatedResource->resolveResourceIdentifier($request)],
-                    function ($uniqueKey) use ($request, $relatedModel, $relatedResource, $isUnique) {
-                        $this->loadedRelationshipsMap[] = [$relatedResource, ...$uniqueKey, $isUnique];
+                    function ($uniqueKey) use ($request, $relatedModel, $relatedResource, $relationName, $isUnique, $subIncludes) {
+                        $this->loadedRelationshipsMap[] = [$relatedResource, ...$uniqueKey, $isUnique, $relationName, $subIncludes];
 
-                        $this->compileIncludedNestedRelationshipsMap($request, $relatedModel, $relatedResource);
+                        $this->compileIncludedNestedRelationshipsMap($request, $relatedModel, $relatedResource, $relationName, $subIncludes);
 
                         return [
                             'id' => $uniqueKey[1],
@@ -289,10 +311,10 @@ trait ResolvesJsonApiElements
 
         yield $relationName => ['data' => transform(
             [$relatedResource->resolveResourceType($request), $relatedResource->resolveResourceIdentifier($request)],
-            function ($uniqueKey) use ($relatedModel, $relatedResource, $request) {
-                $this->loadedRelationshipsMap[] = [$relatedResource, ...$uniqueKey, true];
+            function ($uniqueKey) use ($relatedModel, $relatedResource, $request, $relationName, $subIncludes) {
+                $this->loadedRelationshipsMap[] = [$relatedResource, ...$uniqueKey, true, $relationName, $subIncludes];
 
-                $this->compileIncludedNestedRelationshipsMap($request, $relatedModel, $relatedResource);
+                $this->compileIncludedNestedRelationshipsMap($request, $relatedModel, $relatedResource, $relationName, $subIncludes);
 
                 return [
                     'id' => $uniqueKey[1],
@@ -305,15 +327,59 @@ trait ResolvesJsonApiElements
     /**
      * Compile included relationships map.
      */
-    protected function compileIncludedNestedRelationshipsMap(JsonApiRequest $request, Model $relation, JsonApiResource $resource): void
+    protected function compileIncludedNestedRelationshipsMap(JsonApiRequest $request, Model $relation, JsonApiResource $resource, ?string $parentRelationName = null, array $nestedIncludes = []): void
     {
-        (new Collection($resource->toRelationships($request)))
-            ->transform(fn ($value, $key) => is_int($key) ? new RelationResolver($value) : new RelationResolver($key, $value))
-            ->mapWithKeys(fn ($relationResolver) => [$relationResolver->relationName => $relationResolver])
-            ->filter(fn ($value, $key) => in_array($key, array_keys($relation->getRelations())))
-            ->each(function ($relationResolver, $key) use ($relation, $request) {
-                $this->compileResourceRelationshipUsingResolver($request, $relation, $relationResolver, $relation->getRelation($key));
-            });
+        if (empty($nestedIncludes) && $parentRelationName !== null) {
+            $nestedIncludes = $request->sparseIncluded($parentRelationName) ?? [];
+        }
+
+        foreach ($resource->toRelationships($request) as $key => $value) {
+            $relationResolver = is_int($key)
+                ? new RelationResolver($value)
+                : new RelationResolver($key, $value);
+
+            $subIncludes = $this->extractSubIncludes($relationResolver->relationName, $nestedIncludes);
+
+            if (empty($subIncludes)) {
+                continue;
+            }
+
+            foreach ($this->compileResourceRelationshipUsingResolver(
+                $request, $relation, $relationResolver, $relation->getRelation($relationResolver->relationName), $subIncludes
+            ) as $_);
+        }
+    }
+
+    /**
+     * Extract sub-includes for a specific relation from the nested includes list.
+     */
+    protected function extractSubIncludes(string $relationName, array $nestedIncludes): array
+    {
+        $subIncludes = [];
+
+        foreach ($nestedIncludes as $include) {
+            if ($include === $relationName) {
+                $subIncludes[] = $include;
+            } elseif (str_starts_with($include, $relationName.'.')) {
+                $subIncludes[] = substr($include, strlen($relationName) + 1);
+            }
+        }
+
+        return $subIncludes;
+    }
+
+    /**
+     * Determine if the given relation name is included in the sparse included list.
+     */
+    protected function relationInSparseIncluded(string $relationName, array $sparseIncluded): bool
+    {
+        foreach ($sparseIncluded as $include) {
+            if ($include === $relationName || str_starts_with($include, $relationName.'.')) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**
@@ -341,7 +407,13 @@ trait ResolvesJsonApiElements
         ];
 
         while ($index < count($this->loadedRelationshipsMap)) {
-            [$resourceInstance, $type, $id, $isUnique] = $this->loadedRelationshipsMap[$index];
+            $entry = $this->loadedRelationshipsMap[$index];
+            $resourceInstance = $entry[0];
+            $type = $entry[1];
+            $id = $entry[2];
+            $isUnique = $entry[3];
+            $relationName = $entry[4] ?? null;
+            $subIncludes = $entry[5] ?? [];
 
             $underlyingResource = $resourceInstance->resource;
 
@@ -360,11 +432,30 @@ trait ResolvesJsonApiElements
                 $resourceInstance = new JsonApiResource($resourceInstance->resource);
             }
 
+            // Set resolution sparse included to scope which relations the sub-resource
+            // should process based on the include query
+            $firstLevelIncludes = [];
+            foreach ($subIncludes as $include) {
+                $parts = explode('.', $include);
+                $firstLevelIncludes[] = $parts[0];
+            }
+            $resourceInstance->setResolutionSparseIncluded(
+                ! empty($firstLevelIncludes) ? array_unique($firstLevelIncludes) : []
+            );
+
             $relationsData = $resourceInstance
-                ->includePreviouslyLoadedRelationships()
                 ->resolve($request);
 
-            array_push($this->loadedRelationshipsMap, ...($resourceInstance->loadedRelationshipsMap ?? []));
+            // Only propagate entries that were actually requested via include
+            $filteredMap = [];
+            foreach ($resourceInstance->loadedRelationshipsMap ?? [] as $subEntry) {
+                $subRelationName = $subEntry[4] ?? null;
+                $subSubIncludes = $subEntry[5] ?? [];
+                if ($subRelationName !== null && $this->relationInSparseIncluded($subRelationName, $subIncludes)) {
+                    $filteredMap[] = $subEntry;
+                }
+            }
+            array_push($this->loadedRelationshipsMap, ...$filteredMap);
 
             $relations->push(array_filter([
                 'id' => $id,

--- a/tests/Integration/Http/Resources/JsonApi/JsonApiResourceTest.php
+++ b/tests/Integration/Http/Resources/JsonApi/JsonApiResourceTest.php
@@ -421,6 +421,58 @@ class JsonApiResourceTest extends TestCase
             ->assertJsonMissing(['jsonapi']);
     }
 
+    public function testItDoesNotIncludeNestedEagerLoadedRelationshipsWhenNotRequested()
+    {
+        $now = $this->freezeSecond();
+
+        $user = User::factory()->create();
+
+        $profile = Profile::factory()->create([
+            'user_id' => $user->getKey(),
+            'date_of_birth' => '2011-06-09',
+            'timezone' => 'America/Chicago',
+        ]);
+
+        [$post1, $post2] = Post::factory()->times(2)->create([
+            'user_id' => $user->getKey(),
+        ]);
+
+        $comment = Comment::factory()->create([
+            'post_id' => $post1->getKey(),
+            'user_id' => $user->getKey(),
+        ]);
+
+        $this->getJson("/posts/{$post1->getKey()}/with-nested-eager-loading?".http_build_query(['include' => 'comments']))
+            ->assertHeader('Content-type', 'application/vnd.api+json')
+            ->assertExactJson([
+                'data' => [
+                    'attributes' => [
+                        'content' => $post1->content,
+                        'title' => $post1->title,
+                    ],
+                    'type' => 'posts',
+                    'id' => (string) $post1->getKey(),
+                    'relationships' => [
+                        'comments' => [
+                            'data' => [
+                                ['id' => (string) $comment->getKey(), 'type' => 'comments'],
+                            ],
+                        ],
+                    ],
+                ],
+                'included' => [
+                    [
+                        'attributes' => [
+                            'content' => $comment->content,
+                        ],
+                        'id' => (string) $comment->getKey(),
+                        'type' => 'comments',
+                    ],
+                ],
+            ])
+            ->assertJsonMissing(['jsonapi']);
+    }
+
     public function testItCanResolveRelationshipWithRecursiveNestedRelationship()
     {
         $now = $this->freezeSecond();
@@ -632,9 +684,6 @@ class JsonApiResourceTest extends TestCase
         // to automatically set the inverse 'author' relationship on each Post,
         // creating circular object references (User -> Post -> User same instance).
         // Without the fix, this would hang forever due to infinite loop.
-        // The same User model appears twice in included: once as "posts" (the Post)
-        // and once as "authors" (Post's author via chaperone) - this is correct
-        // because different resource types should not be deduplicated.
         $this->getJson("/users/{$user->getKey()}/with-chaperone-posts?".http_build_query(['include' => 'chaperonePosts']))
             ->assertHeader('Content-type', 'application/vnd.api+json')
             ->assertJsonPath('data.id', (string) $user->getKey())
@@ -642,8 +691,7 @@ class JsonApiResourceTest extends TestCase
             ->assertJsonPath('data.relationships.chaperonePosts.data.0.type', 'posts')
             ->assertJsonPath('data.relationships.chaperonePosts.data.0.id', (string) $post->getKey())
             ->assertJsonPath('included.0.type', 'posts')
-            ->assertJsonPath('included.1.type', 'authors')
-            ->assertJsonCount(2, 'included');
+            ->assertJsonCount(1, 'included');
     }
 
     public function testIncludedResourcesCanBeArrayBackedCustomResources()

--- a/tests/Integration/Http/Resources/JsonApi/TestCase.php
+++ b/tests/Integration/Http/Resources/JsonApi/TestCase.php
@@ -51,6 +51,10 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
             return Post::find($postId)->toResource();
         });
 
+        $router->get('posts/{postId}/with-nested-eager-loading', function ($postId) {
+            return Post::with('comments.commenter')->find($postId)->toResource();
+        });
+
         $router->get('things/{id}', function ($id) {
             return new ArrayBackedJsonApiResource(['id' => (int) $id, 'name' => 'test']);
         });


### PR DESCRIPTION
Prevent unrequested nested eager-loaded relationships from appearing in the `included` section of JSON:API resource responses.

Fixes #60126

**Bug**: When a resource is loaded with nested eager-loading like `Post::with('comments.commenter')->find($id)` and only `include=comments` is requested, the `commenter` relation leaks into `included`. This happens because `compileIncludedNestedRelationshipsMap` pre-populates ALL loaded model relations, and `array_push` in `resolveIncludedResourceObjects` propagates them regardless of the include query.

**Changes**:
- Thread sub-include paths through the compile chain so each sub-resource knows which relations were actually requested via the `include` query.
- Rewrite `compileIncludedNestedRelationshipsMap` to check against the parsed include query instead of all loaded model relations.
- Scope sub-resource resolution via a `resolutionSparseIncluded` property to prevent `includePreviouslyLoadedRelationships` from compiling unrequested eager-loaded relations.
- Remove `array_push` in `resolveIncludedResourceObjects` since all intended nested entries are pre-populated during the initial compile.
- Fix `resolveResourceType` Stringable return type.
- Update chaperone test: inverse relations set by `chaperone()` are no longer automatically included unless explicitly in the `include` query.
- Add test verifying that `include=comments` does not leak `comments.commenter` into `included`.