### PR TITLE
Scope `@pushOnce` and `@prependOnce` IDs by stack name

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesStacks.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesStacks.php
@@ -41,7 +41,7 @@ trait CompilesStacks
         [$stack, $id] = [$parts[0], $parts[1] ?? ''];
 
         $id = trim($id) ?: "'".(string) Str::uuid()."'";
-        $id = "$stack:$id";
+        $id = $stack.':'.$id;
 
         return '<?php if (! $__env->hasRenderedOnce('.$id.')): $__env->markAsRenderedOnce('.$id.');
 $__env->startPush('.$stack.'); ?>';
@@ -91,7 +91,7 @@ $__env->startPush('.$stack.'); ?>';
         [$stack, $id] = [$parts[0], $parts[1] ?? ''];
 
         $id = trim($id) ?: "'".(string) Str::uuid()."'";
-        $id = "$stack:$id";
+        $id = $stack.':'.$id;
 
         return '<?php if (! $__env->hasRenderedOnce('.$id.')): $__env->markAsRenderedOnce('.$id.');
 $__env->startPrepend('.$stack.'); ?>';

--- a/src/Illuminate/View/Compilers/Concerns/CompilesStacks.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesStacks.php
@@ -41,6 +41,7 @@ trait CompilesStacks
         [$stack, $id] = [$parts[0], $parts[1] ?? ''];
 
         $id = trim($id) ?: "'".(string) Str::uuid()."'";
+        $id = "$stack:$id";
 
         return '<?php if (! $__env->hasRenderedOnce('.$id.')): $__env->markAsRenderedOnce('.$id.');
 $__env->startPush('.$stack.'); ?>';
@@ -90,6 +91,7 @@ $__env->startPush('.$stack.'); ?>';
         [$stack, $id] = [$parts[0], $parts[1] ?? ''];
 
         $id = trim($id) ?: "'".(string) Str::uuid()."'";
+        $id = "$stack:$id";
 
         return '<?php if (! $__env->hasRenderedOnce('.$id.')): $__env->markAsRenderedOnce('.$id.');
 $__env->startPrepend('.$stack.'); ?>';

--- a/tests/View/Blade/BladePrependTest.php
+++ b/tests/View/Blade/BladePrependTest.php
@@ -24,7 +24,7 @@ bar
 test
 @endPrependOnce';
 
-        $expected = '<?php if (! $__env->hasRenderedOnce(\'bar\')): $__env->markAsRenderedOnce(\'bar\');
+        $expected = '<?php if (! $__env->hasRenderedOnce(\'foo:bar\')): $__env->markAsRenderedOnce(\'foo:bar\');
 $__env->startPrepend(\'foo\'); ?>
 test
 <?php $__env->stopPrepend(); endif; ?>';
@@ -40,7 +40,7 @@ test
 test
 @endPrependOnce';
 
-        $expected = '<?php if (! $__env->hasRenderedOnce(\'e60e8f77-9ac3-4f71-9f8e-a044ef481d7f\')): $__env->markAsRenderedOnce(\'e60e8f77-9ac3-4f71-9f8e-a044ef481d7f\');
+        $expected = '<?php if (! $__env->hasRenderedOnce(\'foo:e60e8f77-9ac3-4f71-9f8e-a044ef481d7f\')): $__env->markAsRenderedOnce(\'foo:e60e8f77-9ac3-4f71-9f8e-a044ef481d7f\');
 $__env->startPrepend(\'foo\'); ?>
 test
 <?php $__env->stopPrepend(); endif; ?>';

--- a/tests/View/Blade/BladePushTest.php
+++ b/tests/View/Blade/BladePushTest.php
@@ -34,7 +34,7 @@ test
 test
 @endPushOnce';
 
-        $expected = '<?php if (! $__env->hasRenderedOnce(\'bar\')): $__env->markAsRenderedOnce(\'bar\');
+        $expected = '<?php if (! $__env->hasRenderedOnce(\'foo:bar\')): $__env->markAsRenderedOnce(\'foo:bar\');
 $__env->startPush(\'foo\'); ?>
 test
 <?php $__env->stopPush(); endif; ?>';
@@ -50,7 +50,7 @@ test
 test
 @endPushOnce';
 
-        $expected = '<?php if (! $__env->hasRenderedOnce(\'e60e8f77-9ac3-4f71-9f8e-a044ef481d7f\')): $__env->markAsRenderedOnce(\'e60e8f77-9ac3-4f71-9f8e-a044ef481d7f\');
+        $expected = '<?php if (! $__env->hasRenderedOnce(\'foo:e60e8f77-9ac3-4f71-9f8e-a044ef481d7f\')): $__env->markAsRenderedOnce(\'foo:e60e8f77-9ac3-4f71-9f8e-a044ef481d7f\');
 $__env->startPush(\'foo\'); ?>
 test
 <?php $__env->stopPush(); endif; ?>';


### PR DESCRIPTION
### Summary

This PR updates the Blade compiler logic for `@pushOnce` and `@prependOnce` so the rendered-once identifier is scoped by the stack name.

Previously, the optional `$id` passed to `@pushOnce` or `@prependOnce` was used as-is. This meant that using the same ID across different stacks could cause one stack entry to prevent another from rendering, even though they target different stacks.

With this change, the stack name is included as part of the rendered-once ID, making the ID unique per stack.

### Problem

Given two different stacks using the same once ID:

```blade
@pushOnce('scripts', 'datatable')
    <script src="/datatable.js"></script>
@endPushOnce

@pushOnce('styles', 'datatable')
    <link rel="stylesheet" href="/datatable.css">
@endPushOnce
```

Both directives use the same ID, `datatable`, but they push to different stacks.

Before this change, the first rendered directive could mark `datatable` as already rendered, causing the second directive to be skipped incorrectly.

### Solution

The compiled once ID now includes the stack name, so IDs are scoped to the stack they belong to.

For example:

```blade
@pushOnce('scripts', 'datatable')
@pushOnce('styles', 'datatable')
```

These are now treated as separate rendered-once entries because their effective IDs are tied to their stack names.

### Why this is useful

This prevents accidental collisions when reusable components, packages, or layouts use common once IDs across different stacks.

It also matches the expected behavior that `@pushOnce` and `@prependOnce` should only deduplicate content within the same target stack, not globally across all stacks.

### Changed behavior

* `@pushOnce` IDs are now scoped to the push stack.
* `@prependOnce` IDs are now scoped to the prepend stack.
* Auto-generated UUID behavior remains unchanged when no ID is provided.
* Existing usages with unique IDs continue to work as before.