### PR TITLE
feat: add the 'ShouldBeDiscovered' attribute

### DIFF
--- a/src/Illuminate/Events/Attributes/ShouldBeDiscovered.php
+++ b/src/Illuminate/Events/Attributes/ShouldBeDiscovered.php
@@ -10,7 +10,7 @@ class ShouldBeDiscovered
     /**
      * Create a new attribute instance.
      *
-     * @param bool $shouldBeDiscovered
+     * @param  bool  $shouldBeDiscovered
      */
     public function __construct(public bool $shouldBeDiscovered = true)
     {

--- a/src/Illuminate/Events/Attributes/ShouldBeDiscovered.php
+++ b/src/Illuminate/Events/Attributes/ShouldBeDiscovered.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Illuminate\Events\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class ShouldBeDiscovered
+{
+    /**
+     * Create a new attribute instance.
+     *
+     * @param bool $shouldBeDiscovered
+     */
+    public function __construct(public bool $shouldBeDiscovered = true)
+    {
+        //
+    }
+}

--- a/src/Illuminate/Foundation/Events/DiscoverEvents.php
+++ b/src/Illuminate/Foundation/Events/DiscoverEvents.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Events;
 
 use Illuminate\Contracts\Events\ShouldBeDiscovered;
+use Illuminate\Events\Attributes\ShouldBeDiscovered as ShouldBeDiscoveredAttribute;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Reflector;
@@ -106,7 +107,7 @@ class DiscoverEvents
     public static function resolveDiscoveringFromAttribute(ReflectionClass $reflection)
     {
         do {
-            $attributes = $reflection->getAttributes(\Illuminate\Events\Attributes\ShouldBeDiscovered::class);
+            $attributes = $reflection->getAttributes(ShouldBeDiscoveredAttribute::class);
 
             if (isset($attributes[0], $attributes[0]->getArguments()[0])) {
                 return $attributes[0]->getArguments()[0];

--- a/src/Illuminate/Foundation/Events/DiscoverEvents.php
+++ b/src/Illuminate/Foundation/Events/DiscoverEvents.php
@@ -99,7 +99,7 @@ class DiscoverEvents
     }
 
     /**
-     * Resolve the collection class name from the CollectedBy attribute.
+     * Resolve if the listener should be discovered from its ShouldBeDiscovered attribute.
      *
      * @return bool
      */

--- a/src/Illuminate/Foundation/Events/DiscoverEvents.php
+++ b/src/Illuminate/Foundation/Events/DiscoverEvents.php
@@ -78,8 +78,9 @@ class DiscoverEvents
                 continue;
             }
 
-            if ($listener->implementsInterface(ShouldBeDiscovered::class) &&
-                $listener->getName()::shouldBeDiscovered() === false) {
+            if (self::resolveDiscoveringFromAttribute($listener) === false ||
+                ($listener->implementsInterface(ShouldBeDiscovered::class) &&
+                    $listener->getName()::shouldBeDiscovered() === false)) {
                 continue;
             }
 
@@ -95,6 +96,24 @@ class DiscoverEvents
         }
 
         return array_filter($listenerEvents);
+    }
+
+    /**
+     * Resolve the collection class name from the CollectedBy attribute.
+     *
+     * @return bool
+     */
+    public static function resolveDiscoveringFromAttribute(ReflectionClass $reflection)
+    {
+        do {
+            $attributes = $reflection->getAttributes(\Illuminate\Events\Attributes\ShouldBeDiscovered::class);
+
+            if (isset($attributes[0], $attributes[0]->getArguments()[0])) {
+                return $attributes[0]->getArguments()[0];
+            }
+        } while ($reflection = $reflection->getParentClass());
+
+        return true;
     }
 
     /**

--- a/tests/Integration/Foundation/DiscoverEventsTest.php
+++ b/tests/Integration/Foundation/DiscoverEventsTest.php
@@ -9,7 +9,9 @@ use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\Events\Event
 use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\Listeners\AbstractListener;
 use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\Listeners\Listener;
 use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\Listeners\ListenerInterface;
+use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\ShouldBeDiscoveredListeners\RegisteredByAttributeListener;
 use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\ShouldBeDiscoveredListeners\RegisteredListener;
+use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\ShouldBeDiscoveredListeners\SkippedByAttributeListener;
 use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\ShouldBeDiscoveredListeners\SkippedListener;
 use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\UnionListeners\UnionListener;
 use Orchestra\Testbench\TestCase;
@@ -81,13 +83,16 @@ class DiscoverEventsTest extends TestCase
 
     public function testListenersCanOptOutOfDiscovery()
     {
+        class_alias(RegisteredByAttributeListener::class, 'Tests\Integration\Foundation\Fixtures\EventDiscovery\ShouldBeDiscoveredListeners\RegisteredByAttributeListener');
         class_alias(RegisteredListener::class, 'Tests\Integration\Foundation\Fixtures\EventDiscovery\ShouldBeDiscoveredListeners\RegisteredListener');
+        class_alias(SkippedByAttributeListener::class, 'Tests\Integration\Foundation\Fixtures\EventDiscovery\ShouldBeDiscoveredListeners\SkippedByAttributeListener');
         class_alias(SkippedListener::class, 'Tests\Integration\Foundation\Fixtures\EventDiscovery\ShouldBeDiscoveredListeners\SkippedListener');
 
         $events = DiscoverEvents::within(__DIR__.'/Fixtures/EventDiscovery/ShouldBeDiscoveredListeners', getcwd());
 
         $this->assertEquals([
             EventOne::class => [
+                RegisteredByAttributeListener::class.'@handle',
                 RegisteredListener::class.'@handle',
             ],
         ], $events);

--- a/tests/Integration/Foundation/DiscoverEventsTest.php
+++ b/tests/Integration/Foundation/DiscoverEventsTest.php
@@ -90,12 +90,9 @@ class DiscoverEventsTest extends TestCase
 
         $events = DiscoverEvents::within(__DIR__.'/Fixtures/EventDiscovery/ShouldBeDiscoveredListeners', getcwd());
 
-        $this->assertEquals([
-            EventOne::class => [
-                RegisteredByAttributeListener::class.'@handle',
-                RegisteredListener::class.'@handle',
-            ],
-        ], $events);
+        $this->assertArrayHasKey(EventOne::class, $events);
+        $this->assertContains(RegisteredByAttributeListener::class.'@handle', $events[EventOne::class]);
+        $this->assertContains(RegisteredListener::class.'@handle', $events[EventOne::class]);
     }
 
     public function testNoExceptionForEmptyDirectories(): void

--- a/tests/Integration/Foundation/Fixtures/EventDiscovery/ShouldBeDiscoveredListeners/RegisteredByAttributeListener.php
+++ b/tests/Integration/Foundation/Fixtures/EventDiscovery/ShouldBeDiscoveredListeners/RegisteredByAttributeListener.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\ShouldBeDiscoveredListeners;
+
+use Illuminate\Events\Attributes\ShouldBeDiscovered;
+use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\Events\EventOne;
+
+#[ShouldBeDiscovered]
+class RegisteredByAttributeListener
+{
+    public function handle(EventOne $event)
+    {
+        //
+    }
+}

--- a/tests/Integration/Foundation/Fixtures/EventDiscovery/ShouldBeDiscoveredListeners/SkippedByAttributeListener.php
+++ b/tests/Integration/Foundation/Fixtures/EventDiscovery/ShouldBeDiscoveredListeners/SkippedByAttributeListener.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\ShouldBeDiscoveredListeners;
+
+use Illuminate\Events\Attributes\ShouldBeDiscovered;
+use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\Events\EventOne;
+
+#[ShouldBeDiscovered(false)]
+class SkippedByAttributeListener
+{
+    public function handle(EventOne $event)
+    {
+        //
+    }
+}


### PR DESCRIPTION
Hi,
Like #60209, this PR allows listeners to decide themselves if they should be registered during discovery... but with an Attribute (`ShouldBeDiscovered`), instead of  an interface.

Of course, I'm not creating any BC.
