### PR TITLE
[13.x] Fix `Response` class for Symfony 8.1 compatibility

### DIFF
--- a/src/Illuminate/Http/Response.php
+++ b/src/Illuminate/Http/Response.php
@@ -10,7 +10,6 @@ use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
 use JsonSerializable;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
-use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 
 class Response extends SymfonyResponse
 {
@@ -27,13 +26,11 @@ class Response extends SymfonyResponse
      *
      * @throws \InvalidArgumentException
      */
-    public function __construct($content = '', $status = 200, array $headers = [])
+    public function __construct($content = '', int $status = 200, array $headers = [])
     {
-        $this->headers = new ResponseHeaderBag($headers);
+        parent::__construct('', $status, $headers);
 
         $this->setContent($content);
-        $this->setStatusCode($status);
-        $this->setProtocolVersion('1.0');
     }
 
     /**
@@ -46,10 +43,11 @@ class Response extends SymfonyResponse
     }
 
     /**
-     * Set the content on the response.
+     * {@inheritDoc}
+     *
+     * Override to allow for a broader range of content types.
      *
      * @param  mixed  $content
-     * @return $this
      *
      * @throws \InvalidArgumentException
      */
@@ -78,9 +76,7 @@ class Response extends SymfonyResponse
             $content = $content->render();
         }
 
-        parent::setContent($content);
-
-        return $this;
+        return parent::setContent($content);
     }
 
     /**

--- a/src/Illuminate/Http/Response.php
+++ b/src/Illuminate/Http/Response.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
 use JsonSerializable;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 
 class Response extends SymfonyResponse
 {
@@ -26,9 +27,13 @@ class Response extends SymfonyResponse
      *
      * @throws \InvalidArgumentException
      */
-    public function __construct($content = '', int $status = 200, array $headers = [])
+    public function __construct($content = '', int $status = 200, array|ResponseHeaderBag $headers = [])
     {
-        parent::__construct('', $status, $headers);
+        parent::__construct(
+            '',
+            $status,
+            $headers instanceof ResponseHeaderBag ? $headers->all() : $headers,
+        );
 
         $this->setContent($content);
     }

--- a/tests/Http/HttpResponseTest.php
+++ b/tests/Http/HttpResponseTest.php
@@ -36,6 +36,9 @@ class HttpResponseTest extends TestCase
         $this->assertSame('{"foo":"bar"}', $response->getContent());
         $this->assertSame('application/json', $response->headers->get('Content-Type'));
 
+        $response = new Response(headers: new ResponseHeaderBag(['foo' => 'bar']));
+        $this->assertSame('bar', $response->headers->get('foo'));
+
         $response = new Response;
         $response->setContent(['foo' => 'bar']);
         $this->assertSame('{"foo":"bar"}', $response->getContent());


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Running tests with Symfony 8.1 RC results in errors due to deprecations of manually setting the `headers` property; see also https://github.com/symfony/symfony/pull/63541.

This PR refactors the corresponding logic by passing the headers via the constructor instead (suggested replacement). To achieve this, the constructor body is reworked to no longer entirely overwrite the parent definition, but rather call it and subsequently set the content (the only part of the parent we aim to 'extend' here).

To achieve some sort of parity with the parent constructor, we also allow directly passing a `ResponseHeaderBag` instance, but convert it back to an array to ensure compatibility with Symfony 7.4/8.0.