### PR TITLE
Add whenRelation to Eloquent relations

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Database\MultipleRecordsFoundException;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Support\Collection as BaseCollection;
+use Illuminate\Support\HigherOrderWhenProxy;
 use Illuminate\Support\Traits\ForwardsCalls;
 use Illuminate\Support\Traits\Macroable;
 
@@ -210,6 +211,38 @@ abstract class Relation implements BuilderContract
     public function get($columns = ['*'])
     {
         return $this->query->get($columns);
+    }
+
+    /**
+     * Apply the callback if the given "value" is (or resolves to) truthy.
+     *
+     * @template TWhenParameter
+     * @template TWhenReturnType
+     *
+     * @param  (\Closure($this): TWhenParameter)|TWhenParameter|null  $value
+     * @param  (callable($this, TWhenParameter): TWhenReturnType)|null  $callback
+     * @param  (callable($this, TWhenParameter): TWhenReturnType)|null  $default
+     * @return $this|TWhenReturnType
+     */
+    public function whenRelation($value = null, ?callable $callback = null, ?callable $default = null)
+    {
+        $value = $value instanceof Closure ? $value($this) : $value;
+
+        if (func_num_args() === 0) {
+            return new HigherOrderWhenProxy($this);
+        }
+
+        if (func_num_args() === 1) {
+            return (new HigherOrderWhenProxy($this))->condition($value);
+        }
+
+        if ($value) {
+            return $callback($this, $value) ?? $this;
+        } elseif ($default) {
+            return $default($this, $value) ?? $this;
+        }
+
+        return $this;
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBelongsToManyChunkByIdTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyChunkByIdTest.php
@@ -3,8 +3,10 @@
 namespace Illuminate\Tests\Database;
 
 use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model as Eloquent;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use PHPUnit\Framework\TestCase;
 
 class DatabaseEloquentBelongsToManyChunkByIdTest extends TestCase
@@ -78,6 +80,59 @@ class DatabaseEloquentBelongsToManyChunkByIdTest extends TestCase
         });
 
         $this->assertSame(3, $i);
+    }
+
+    public function testWhenRelationReceivesRelationInstance()
+    {
+        $this->seedData();
+
+        $user = BelongsToManyChunkByIdTestTestUser::query()->first();
+
+        $articles = $user->articles()
+            ->whenRelation(true, function (BelongsToMany $relation, $value) {
+                $this->assertTrue($value);
+
+                return $relation->wherePivotIn('article_id', [1, 3]);
+            })
+            ->get();
+
+        $this->assertSame([1, 3], $articles->pluck('id')->all());
+    }
+
+    public function testWhenCallbackStillReceivesQueryBuilder()
+    {
+        $this->seedData();
+
+        $user = BelongsToManyChunkByIdTestTestUser::query()->first();
+
+        $articles = $user->articles()
+            ->when(true, function (Builder $query, $value) {
+                $this->assertTrue($value);
+
+                return $query->whereKey([1, 3]);
+            })
+            ->get();
+
+        $this->assertSame([1, 3], $articles->pluck('id')->all());
+    }
+
+    public function testWhenRelationDefaultReceivesRelationInstance()
+    {
+        $this->seedData();
+
+        $user = BelongsToManyChunkByIdTestTestUser::query()->first();
+
+        $articles = $user->articles()
+            ->whenRelation(false, function () {
+                $this->fail('The truthy callback should not be executed.');
+            }, function (BelongsToMany $relation, $value) {
+                $this->assertFalse($value);
+
+                return $relation->wherePivotIn('article_id', [2]);
+            })
+            ->get();
+
+        $this->assertSame([2], $articles->pluck('id')->all());
     }
 
     /**


### PR DESCRIPTION
## Summary

This adds `whenRelation()` to Eloquent relations.

This addresses #53292, where calling `when()` on a relationship forwards the call
to the underlying Eloquent builder instead of passing the relationship instance
to the callback.

```php
$user->posts()
    ->whenRelation($condition, function (BelongsToMany $relation) {
        return $relation->wherePivotIn('post_id', [1, 2]);
    });
```

The existing `when()` behavior is left unchanged so callbacks typed as
`Illuminate\Database\Eloquent\Builder` continue to work.

Fixes #53292.

## Tests

- Added coverage for `whenRelation()` callbacks receiving the relation instance.
- Added coverage that `when()` continues to receive the underlying builder.