### PR TITLE
[13.x] Add exclusiveMinimum and exclusiveMaximum support to JsonSchema numeric types

### DIFF
--- a/src/Illuminate/JsonSchema/Types/IntegerType.php
+++ b/src/Illuminate/JsonSchema/Types/IntegerType.php
@@ -15,6 +15,16 @@ class IntegerType extends Type
     protected ?int $maximum = null;
 
     /**
+     * The exclusive minimum value.
+     */
+    protected ?int $exclusiveMinimum = null;
+
+    /**
+     * The exclusive maximum value.
+     */
+    protected ?int $exclusiveMaximum = null;
+
+    /**
      * The number the value must be a multiple of.
      */
     protected ?int $multipleOf = null;
@@ -35,6 +45,26 @@ class IntegerType extends Type
     public function max(int $value): static
     {
         $this->maximum = $value;
+
+        return $this;
+    }
+
+    /**
+     * Set the exclusive minimum value.
+     */
+    public function exclusiveMin(int $value): static
+    {
+        $this->exclusiveMinimum = $value;
+
+        return $this;
+    }
+
+    /**
+     * Set the exclusive maximum value.
+     */
+    public function exclusiveMax(int $value): static
+    {
+        $this->exclusiveMaximum = $value;
 
         return $this;
     }

--- a/src/Illuminate/JsonSchema/Types/NumberType.php
+++ b/src/Illuminate/JsonSchema/Types/NumberType.php
@@ -15,6 +15,16 @@ class NumberType extends Type
     protected int|float|null $maximum = null;
 
     /**
+     * The exclusive minimum value.
+     */
+    protected int|float|null $exclusiveMinimum = null;
+
+    /**
+     * The exclusive maximum value.
+     */
+    protected int|float|null $exclusiveMaximum = null;
+
+    /**
      * The number the value must be a multiple of.
      */
     protected int|float|null $multipleOf = null;
@@ -35,6 +45,26 @@ class NumberType extends Type
     public function max(int|float $value): static
     {
         $this->maximum = $value;
+
+        return $this;
+    }
+
+    /**
+     * Set the exclusive minimum value.
+     */
+    public function exclusiveMin(int|float $value): static
+    {
+        $this->exclusiveMinimum = $value;
+
+        return $this;
+    }
+
+    /**
+     * Set the exclusive maximum value.
+     */
+    public function exclusiveMax(int|float $value): static
+    {
+        $this->exclusiveMaximum = $value;
 
         return $this;
     }

--- a/tests/JsonSchema/IntegerTypeTest.php
+++ b/tests/JsonSchema/IntegerTypeTest.php
@@ -61,6 +61,39 @@ class IntegerTypeTest extends TestCase
         ], $type->toArray());
     }
 
+    public function test_it_may_set_exclusive_min_value(): void
+    {
+        $type = JsonSchema::integer()->title('Age')->exclusiveMin(5);
+
+        $this->assertEquals([
+            'type' => 'integer',
+            'title' => 'Age',
+            'exclusiveMinimum' => 5,
+        ], $type->toArray());
+    }
+
+    public function test_it_may_set_exclusive_max_value(): void
+    {
+        $type = JsonSchema::integer()->description('Max age')->exclusiveMax(10);
+
+        $this->assertEquals([
+            'type' => 'integer',
+            'description' => 'Max age',
+            'exclusiveMaximum' => 10,
+        ], $type->toArray());
+    }
+
+    public function test_it_may_combine_exclusive_min_and_exclusive_max(): void
+    {
+        $type = JsonSchema::integer()->exclusiveMin(0)->exclusiveMax(100);
+
+        $this->assertEquals([
+            'type' => 'integer',
+            'exclusiveMinimum' => 0,
+            'exclusiveMaximum' => 100,
+        ], $type->toArray());
+    }
+
     public function test_it_may_set_enum(): void
     {
         $type = JsonSchema::integer()->enum([1, 2, 3]);

--- a/tests/JsonSchema/NumberTypeTest.php
+++ b/tests/JsonSchema/NumberTypeTest.php
@@ -93,6 +93,61 @@ class NumberTypeTest extends TestCase
         ], $type->toArray());
     }
 
+    public function test_it_may_set_exclusive_min_value_as_float(): void
+    {
+        $type = JsonSchema::number()->title('Price')->exclusiveMin(5.5);
+
+        $this->assertEquals([
+            'type' => 'number',
+            'title' => 'Price',
+            'exclusiveMinimum' => 5.5,
+        ], $type->toArray());
+    }
+
+    public function test_it_may_set_exclusive_min_value_as_int(): void
+    {
+        $type = JsonSchema::number()->title('Price')->exclusiveMin(5);
+
+        $this->assertEquals([
+            'type' => 'number',
+            'title' => 'Price',
+            'exclusiveMinimum' => 5,
+        ], $type->toArray());
+    }
+
+    public function test_it_may_set_exclusive_max_value_as_float(): void
+    {
+        $type = JsonSchema::number()->description('Max price')->exclusiveMax(10.75);
+
+        $this->assertEquals([
+            'type' => 'number',
+            'description' => 'Max price',
+            'exclusiveMaximum' => 10.75,
+        ], $type->toArray());
+    }
+
+    public function test_it_may_set_exclusive_max_value_as_int(): void
+    {
+        $type = JsonSchema::number()->description('Max price')->exclusiveMax(10);
+
+        $this->assertEquals([
+            'type' => 'number',
+            'description' => 'Max price',
+            'exclusiveMaximum' => 10,
+        ], $type->toArray());
+    }
+
+    public function test_it_may_combine_exclusive_min_and_exclusive_max(): void
+    {
+        $type = JsonSchema::number()->exclusiveMin(0.0)->exclusiveMax(10.0);
+
+        $this->assertEquals([
+            'type' => 'number',
+            'exclusiveMinimum' => 0.0,
+            'exclusiveMaximum' => 10.0,
+        ], $type->toArray());
+    }
+
     public function test_it_may_set_enum(): void
     {
         $type = JsonSchema::number()->enum([1, 2.5, 3]);

--- a/tests/JsonSchema/TypeTest.php
+++ b/tests/JsonSchema/TypeTest.php
@@ -192,6 +192,9 @@ class TypeTest extends TestCase
             [JsonSchema::integer()->multipleOf(5), 10],
             [JsonSchema::integer()->multipleOf(3), 9],
             [JsonSchema::integer()->multipleOf(7), 0],
+            [JsonSchema::integer()->exclusiveMin(0), 1],
+            [JsonSchema::integer()->exclusiveMax(10), 9],
+            [JsonSchema::integer()->exclusiveMin(0)->exclusiveMax(10), 5],
             // additional IntegerType cases
             [JsonSchema::integer()->min(-5), -5], // negative boundary
             [JsonSchema::integer()->max(10), 9], // below max
@@ -211,6 +214,9 @@ class TypeTest extends TestCase
             [JsonSchema::number()->multipleOf(0.5), 2.5],
             [JsonSchema::number()->multipleOf(3), 9],
             [JsonSchema::number()->multipleOf(0.1), 0.3],
+            [JsonSchema::number()->exclusiveMin(0.0), 0.1],
+            [JsonSchema::number()->exclusiveMax(10.5), 10.4],
+            [JsonSchema::number()->exclusiveMin(0.0)->exclusiveMax(1.0), 0.5],
             // additional NumberType cases
             [JsonSchema::number()->min(-10.5), -10.5], // negative boundary
             [JsonSchema::number()->min(0)->max(1), 1.0], // boundary at max
@@ -352,6 +358,10 @@ class TypeTest extends TestCase
             // additional IntegerType cases
             [JsonSchema::integer()->min(0), -1], // below min boundary
             [JsonSchema::integer()->max(0), 1], // above max boundary
+            [JsonSchema::integer()->exclusiveMin(5), 5], // exactly at exclusiveMin boundary
+            [JsonSchema::integer()->exclusiveMin(5), 4], // below exclusiveMin
+            [JsonSchema::integer()->exclusiveMax(10), 10], // exactly at exclusiveMax boundary
+            [JsonSchema::integer()->exclusiveMax(10), 11], // above exclusiveMax
             [JsonSchema::integer(), 3.14], // not an integer
             [JsonSchema::integer()->enum([1, 2]), 2.5], // not in enum and not an integer
             [JsonSchema::integer()->enum(IntBackedEnum::class), 3], // integer backed enum cases mismatch
@@ -362,6 +372,10 @@ class TypeTest extends TestCase
             [JsonSchema::number(), '3.14'], // type mismatch
             [JsonSchema::number()->min(0.5), 0.4], // below min
             [JsonSchema::number()->max(1.5), 1.6], // above max
+            [JsonSchema::number()->exclusiveMin(0.0), 0.0], // exactly at exclusiveMin
+            [JsonSchema::number()->exclusiveMin(0.5), 0.49], // below exclusiveMin
+            [JsonSchema::number()->exclusiveMax(10.5), 10.5], // exactly at exclusiveMax
+            [JsonSchema::number()->exclusiveMax(10.5), 10.51], // above exclusiveMax
             [JsonSchema::number()->default(1.1), '1.1'], // wrong type
             [JsonSchema::number()->enum([1, 2.5, 3]), 4], // not in enum
             [JsonSchema::number()->multipleOf(0.5), 1.3], // not a multiple


### PR DESCRIPTION
## Summary

Currently, the `IntegerType` and `NumberType` classes in the JsonSchema component only support `minimum` and `maximum` constraints. JSON Schema draft-07 also defines `exclusiveMinimum` and `exclusiveMaximum` as numeric keywords for strict range validation, where the boundary value itself is excluded.

This PR adds fluent `exclusiveMin()` and `exclusiveMax()` methods to both types, making the API consistent with the existing `min()`/`max()` pattern.

## Changes

- **`IntegerType`**: Added `exclusiveMinimum` and `exclusiveMaximum` properties with `exclusiveMin()` and `exclusiveMax()` fluent methods
- **`NumberType`**: Same additions for float/number validation
- **Tests**: Unit tests for both types and integration tests validating the constraints against a real JSON Schema validator

## Example Usage

```php
// Integer: value must be > 0 and < 100 (exclusive boundaries)
Schema::integer()->exclusiveMin(0)->exclusiveMax(100);

// Number: value must be > 0.0
Schema::number()->exclusiveMin(0.0);
```

## Tests

All existing tests pass. New tests cover:
- Setting exclusive boundaries independently and in combination
- Validation integration: values at the boundary are rejected, values just inside are accepted