### PR TITLE
[13.x] Enhance Cache attribute to support memoization

### DIFF
--- a/src/Illuminate/Container/Attributes/Cache.php
+++ b/src/Illuminate/Container/Attributes/Cache.php
@@ -15,7 +15,7 @@ class Cache implements ContextualAttribute
      */
     public function __construct(
         public UnitEnum|string|null $store = null,
-        public bool $memoized = false,
+        public bool $memo = false,
     ) {
     }
 
@@ -28,7 +28,7 @@ class Cache implements ContextualAttribute
      */
     public static function resolve(self $attribute, Container $container)
     {
-        return $attribute->memoized
+        return $attribute->memo
             ? $container->make('cache')->memo($attribute->store)
             : $container->make('cache')->store($attribute->store);
     }

--- a/src/Illuminate/Container/Attributes/Cache.php
+++ b/src/Illuminate/Container/Attributes/Cache.php
@@ -13,8 +13,10 @@ class Cache implements ContextualAttribute
     /**
      * Create a new class instance.
      */
-    public function __construct(public UnitEnum|string|null $store = null)
-    {
+    public function __construct(
+        public UnitEnum|string|null $store = null,
+        public bool $memoized = false,
+    ) {
     }
 
     /**
@@ -26,6 +28,8 @@ class Cache implements ContextualAttribute
      */
     public static function resolve(self $attribute, Container $container)
     {
-        return $container->make('cache')->store($attribute->store);
+        return $attribute->memoized
+            ? $container->make('cache')->memo($attribute->store)
+            : $container->make('cache')->store($attribute->store);
     }
 }

--- a/tests/Container/ContextualAttributeBindingTest.php
+++ b/tests/Container/ContextualAttributeBindingTest.php
@@ -173,6 +173,8 @@ class ContextualAttributeBindingTest extends TestCase
             $manager->shouldReceive('store')->with('bar')->andReturn(m::mock(CacheRepository::class));
             $manager->shouldReceive('store')->with(CacheStoreUnitEnum::unit)->andReturn(m::mock(CacheRepository::class));
             $manager->shouldReceive('store')->with(CacheStoreBackedEnum::Backed)->andReturn(m::mock(CacheRepository::class));
+            $manager->shouldReceive('memo')->with('foo')->andReturn(m::mock(CacheRepository::class));
+            $manager->shouldReceive('memo')->with('bar')->andReturn(m::mock(CacheRepository::class));
 
             return $manager;
         });
@@ -531,6 +533,8 @@ final class CacheTest
         #[Cache('bar')] CacheRepository $bar,
         #[Cache(CacheStoreUnitEnum::unit)] CacheRepository $unit,
         #[Cache(CacheStoreBackedEnum::Backed)] CacheRepository $backed,
+        #[Cache('foo', true)] CacheRepository $fooMemoized,
+        #[Cache('bar', true)] CacheRepository $barMemoized,
     ) {
     }
 }

--- a/tests/Container/ContextualAttributeBindingTest.php
+++ b/tests/Container/ContextualAttributeBindingTest.php
@@ -533,8 +533,8 @@ final class CacheTest
         #[Cache('bar')] CacheRepository $bar,
         #[Cache(CacheStoreUnitEnum::unit)] CacheRepository $unit,
         #[Cache(CacheStoreBackedEnum::Backed)] CacheRepository $backed,
-        #[Cache('foo', true)] CacheRepository $fooMemoized,
-        #[Cache('bar', true)] CacheRepository $barMemoized,
+        #[Cache('foo', memo: true)] CacheRepository $fooMemoized,
+        #[Cache('bar', memo: true)] CacheRepository $barMemoized,
     ) {
     }
 }


### PR DESCRIPTION
Laravel 12+ introduces [Cache Memoization](https://laravel.com/docs/13.x/cache#cache-memoization). This PR adds support to the `Cache` attribute for injecting a cache memo instance.