### PR TITLE
[13.x] Indicate an event was skipped

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -92,7 +92,7 @@ class Event
     public $exitCode;
 
     /**
-     * Whether the execution was skipped due to the mutex already being reserved.
+     * Indicates whether the execution was skipped due to the mutex already being reserved.
      *
      * @var bool
      */

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -96,7 +96,7 @@ class Event
      *
      * @var bool
      */
-    public $skippedBecauseOverlapping;
+    public $skippedBecauseOverlapping = false;
 
     /**
      * Create a new event instance.
@@ -134,6 +134,8 @@ class Event
      */
     public function run(Container $container)
     {
+        $this->skippedBecauseOverlapping = false;
+
         if ($this->shouldSkipDueToOverlapping()) {
             $this->skippedBecauseOverlapping = true;
 

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -92,6 +92,13 @@ class Event
     public $exitCode;
 
     /**
+     * Whether the execution was skipped due to the mutex already being reserved.
+     *
+     * @var bool
+     */
+    public $skippedBecauseOverlapping;
+
+    /**
      * Create a new event instance.
      *
      * @param  \Illuminate\Console\Scheduling\EventMutex  $mutex
@@ -128,6 +135,8 @@ class Event
     public function run(Container $container)
     {
         if ($this->shouldSkipDueToOverlapping()) {
+            $this->skippedBecauseOverlapping = true;
+
             return;
         }
 

--- a/tests/Console/Scheduling/EventTest.php
+++ b/tests/Console/Scheduling/EventTest.php
@@ -222,6 +222,67 @@ class EventTest extends TestCase
         $this->assertSame(1, $reject->calls);
     }
 
+    public function testRunIndicatesWhenSkippedBecauseOverlapping()
+    {
+        $container = new Container;
+        $beforeCallbackCalled = false;
+        $mutex = m::mock(EventMutex::class);
+        $event = new class($mutex, 'php -i') extends Event
+        {
+            public $executed = false;
+
+            protected function execute($container)
+            {
+                $this->executed = true;
+
+                return 0;
+            }
+        };
+
+        $event->withoutOverlapping();
+        $event->before(function () use (&$beforeCallbackCalled) {
+            $beforeCallbackCalled = true;
+        });
+
+        $mutex->shouldReceive('create')->once()->with($event)->andReturn(false);
+
+        $event->run($container);
+
+        $this->assertTrue($event->skippedBecauseOverlapping);
+        $this->assertFalse($event->executed);
+        $this->assertFalse($beforeCallbackCalled);
+    }
+
+    public function testRunResetsSkippedBecauseOverlapping()
+    {
+        $container = new Container;
+        $mutex = m::mock(EventMutex::class);
+        $event = new class($mutex, 'php -i') extends Event
+        {
+            public $executions = 0;
+
+            protected function execute($container)
+            {
+                $this->executions++;
+
+                return 0;
+            }
+        };
+
+        $event->withoutOverlapping();
+
+        $mutex->shouldReceive('create')->twice()->with($event)->andReturn(false, true);
+        $mutex->shouldReceive('forget')->once()->with($event);
+
+        $event->run($container);
+        $this->assertTrue($event->skippedBecauseOverlapping);
+
+        $event->run($container);
+
+        $this->assertFalse($event->skippedBecauseOverlapping);
+        $this->assertSame(1, $event->executions);
+    }
+
     public function testDaysOfMonthMethod()
     {
         $event = new Event(m::mock(EventMutex::class), 'php -i');

--- a/tests/Integration/Console/Scheduling/ScheduleRunCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleRunCommandTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Integration\Console\Scheduling;
 use Illuminate\Console\Events\ScheduledTaskFailed;
 use Illuminate\Console\Events\ScheduledTaskFinished;
 use Illuminate\Console\Events\ScheduledTaskStarting;
+use Illuminate\Console\Scheduling\EventMutex;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Console\Scheduling\ScheduleRunCommand;
 use Illuminate\Contracts\Container\BindingResolutionException;
@@ -183,6 +184,51 @@ class ScheduleRunCommandTest extends TestCase
         Event::assertDispatched(ScheduledTaskStarting::class);
         Event::assertDispatched(ScheduledTaskFinished::class);
         Event::assertNotDispatched(ScheduledTaskFailed::class);
+    }
+
+    public function test_overlapping_task_finished_event_indicates_skipped()
+    {
+        Event::fake([
+            ScheduledTaskStarting::class,
+            ScheduledTaskFinished::class,
+            ScheduledTaskFailed::class,
+        ]);
+
+        $this->app->instance(EventMutex::class, new class implements EventMutex
+        {
+            public function create(\Illuminate\Console\Scheduling\Event $event)
+            {
+                return false;
+            }
+
+            public function exists(\Illuminate\Console\Scheduling\Event $event)
+            {
+                return false;
+            }
+
+            public function forget(\Illuminate\Console\Scheduling\Event $event)
+            {
+                //
+            }
+        });
+
+        $ran = false;
+        $schedule = $this->app->make(Schedule::class);
+        $task = $schedule->call(function () use (&$ran) {
+            $ran = true;
+        })->name('test')->withoutOverlapping()->everyMinute();
+
+        $this->artisan('schedule:run');
+
+        Event::assertDispatched(ScheduledTaskStarting::class, function ($event) use ($task) {
+            return $event->task === $task;
+        });
+        Event::assertDispatched(ScheduledTaskFinished::class, function ($event) use ($task) {
+            return $event->task === $task &&
+                   $event->task->skippedBecauseOverlapping === true;
+        });
+        Event::assertNotDispatched(ScheduledTaskFailed::class);
+        $this->assertFalse($ran);
     }
 
     /**


### PR DESCRIPTION
It's hard to ascertain that a job was skipped due to the mutex being reserved. This adds a property for that.