### PR TITLE
[12.x] Fix regex typo in Env::addVariableToEnvContents that prevented quotin…

### DIFF
--- a/src/Illuminate/Support/Env.php
+++ b/src/Illuminate/Support/Env.php
@@ -187,7 +187,7 @@ class Env
         $prefix = explode('_', $key)[0].'_';
         $lastPrefixIndex = -1;
 
-        $shouldQuote = preg_match('/^[a-zA-z0-9]+$/', $value) === 0;
+        $shouldQuote = preg_match('/^[a-zA-Z0-9]+$/', $value) === 0;
 
         $lineToAddVariations = [
             $key.'='.(is_string($value) ? self::prepareQuotedValue($value) : $value),

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -1524,6 +1524,23 @@ class SupportHelpersTest extends TestCase
         );
     }
 
+    public function testWriteVariableQuotesValuesWithSpecialCharacters()
+    {
+        $filesystem = new Filesystem;
+        $path = __DIR__.'/tmp/env-test-file';
+        $filesystem->put($path, 'APP_NAME=Laravel'.PHP_EOL);
+
+        Env::writeVariable('APP_BRACKET', 'pass[word', $path);
+        Env::writeVariable('APP_CARET', 'foo^bar', $path);
+        Env::writeVariable('APP_BACKTICK', 'foo`bar', $path);
+
+        $contents = $filesystem->get($path);
+
+        $this->assertStringContainsString('APP_BRACKET="pass[word"', $contents);
+        $this->assertStringContainsString('APP_CARET="foo^bar"', $contents);
+        $this->assertStringContainsString('APP_BACKTICK="foo`bar"', $contents);
+    }
+
     public function testWillThrowAnExceptionIfFileIsMissingWhenTryingToWriteVariables(): void
     {
         $this->expectExceptionObject(new RuntimeException('The file [missing-file] does not exist.'));


### PR DESCRIPTION
`Env::addVariableToEnvContents()` uses a regex to decide whether a value needs to be quoted before writing it to a `.env` file:

```php
// Before (line 190)
$shouldQuote = preg_match('/^[a-zA-z0-9]+$/', $value) === 0;
```

The character class `[a-zA-z]` contains a lowercase `z` instead of uppercase `Z`. Because the ASCII range `A–z` (65–122) includes the characters `[` (91), `\` (92), `]` (93), `^` (94), `_` (95), and `` ` `` (96), values containing any of those characters match the pattern and are written **unquoted** to the `.env` file, even though they require quoting to be parsed correctly.

**Example with the bug:**

```
// Value 'pass[word' matched the wrong regex → written as:
APP_BRACKET=pass[word should be "pass[word")

// Value 'foo^bar' matched the wrong regex → written as:
APP_CARET=foo^bar (should be "foo^bar")
```

## Fix

Change `z` → `Z` in the character class so only true alphanumeric values skip quoting:

```php
// After
$shouldQuote = preg_match('/^[a-zA-Z0-9]+$/', $value) === 0;
```