### PR TITLE
Fix @params typo in Fluent and MessageBag toPrettyJson() docblocks

### DIFF
--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -206,8 +206,7 @@ class Fluent implements Arrayable, ArrayAccess, IteratorAggregate, Jsonable, Jso
     /**
      * Convert the fluent instance to pretty print formatted JSON.
      *
-     * @params int $options
-     *
+     * @param  int  $options
      * @return string
      */
     public function toPrettyJson(int $options = 0)

--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -434,8 +434,7 @@ class MessageBag implements Jsonable, JsonSerializable, MessageBagContract, Mess
     /**
      * Convert the object to pretty print formatted JSON.
      *
-     * @params int $options
-     *
+     * @param  int  $options
      * @return string
      */
     public function toPrettyJson(int $options = 0)


### PR DESCRIPTION
Both `Fluent::toPrettyJson()` and `MessageBag::toPrettyJson()` have an invalid `@params` tag (plural) in their docblocks where the standard `@param` (singular) is required:

```php
// Fluent.php:209
* @params int $options   ← invalid

// MessageBag.php:437
* @params int $options   ← invalid
```

PHPDoc parsers, IDEs, and static-analysis tools (PHPStan, Psalm) silently ignore unrecognised tags, so the type annotation on `$options` is effectively invisible — it won't appear in IDE tooltips and won't be picked up by static analysis.

The two methods are symmetric (both wrap `toJson()` with `JSON_PRETTY_PRINT`) and were likely copy-pasted from the same original block, carrying the typo across.