### PR TITLE
[11.x] Fix FIFO queue name normalization in Cloud managed queues

### DIFF
--- a/src/Illuminate/Foundation/Cloud/Queue.php
+++ b/src/Illuminate/Foundation/Cloud/Queue.php
@@ -366,7 +366,9 @@ class Queue implements QueueContract, ClearableQueue
 
         return Str::of($this->queue->getQueue($queue))
             ->when($prefix, fn ($str) => $str->chopStart($prefix.'/'))
-            ->when($suffix, fn ($str) => $str->chopEnd($suffix))
+            ->when($suffix, fn ($str) => $str->endsWith('.fifo')
+                ? $str->chopEnd('.fifo')->chopEnd($suffix)->append('.fifo')
+                : $str->chopEnd($suffix))
             ->toString();
     }
 

--- a/tests/Foundation/Cloud/QueueTest.php
+++ b/tests/Foundation/Cloud/QueueTest.php
@@ -923,6 +923,22 @@ class QueueTest extends TestCase
         $this->assertSame('my-queue', $eventsFake->emitted[0]['queue']);
     }
 
+    public function testItNormalizesFifoQueueNamesWithoutLeakingTheSuffix()
+    {
+        Cloud::configureManagedQueues($this->app);
+        Cloud::bootManagedQueues($this->app);
+        $eventsFake = $this->fakeEvents();
+        [$queue, $client] = $this->mockedQueue();
+        $client->shouldReceive('sendMessage')->times(1)->andReturn(new Result());
+
+        $queue->push(new FakeJob, queue: 'orders.fifo');
+
+        // The suffix is injected before the ".fifo" extension on the real SQS
+        // queue name, so the normalized name must strip it back out and keep
+        // the ".fifo" terminal rather than reporting "orders-env-....fifo".
+        $this->assertSame('orders.fifo', $eventsFake->emitted[0]['queue']);
+    }
+
     /**
      * @return array{Queue, MockInterface<SqsClient>}
      */


### PR DESCRIPTION
`Foundation\Cloud\Queue::normalizeQueue()` stripped the environment suffix with `chopEnd($suffix)`, but for FIFO queues the suffix sits *before* the `.fifo` terminal (e.g. `orders-{uuid}.fifo`), so the chop was a no-op and Cloud queue events reported `orders-{uuid}.fifo` instead of `orders.fifo` — leaking the per-environment UUID and breaking per-queue grouping/metrics.

This makes `normalizeQueue()` FIFO-aware, mirroring `SqsQueue::suffixQueue()` in reverse. Standard queues are unaffected. Added a regression test.

Backport of #60315.

🤖 Generated with [Claude Code](https://claude.com/claude-code)