### PR TITLE
[13.x] Fix `Illuminate\Http\Response` compatibility against Symfony 8.1

### DIFF
--- a/src/Illuminate/Http/Response.php
+++ b/src/Illuminate/Http/Response.php
@@ -29,7 +29,13 @@ class Response extends SymfonyResponse
      */
     public function __construct($content = '', $status = 200, array $headers = [])
     {
-        parent::__construct('', $status, new ResponseHeaderBag($headers));
+        if (method_exists($this, 'setHeaders')) {
+            parent::__construct('', $status, new ResponseHeaderBag($headers));
+        } else {
+            $this->headers = new ResponseHeaderBag($headers);
+            $this->setStatusCode($status);
+            $this->setProtocolVersion('1.0');
+        }
 
         $this->setContent($content);
     }

--- a/src/Illuminate/Http/Response.php
+++ b/src/Illuminate/Http/Response.php
@@ -29,11 +29,9 @@ class Response extends SymfonyResponse
      */
     public function __construct($content = '', $status = 200, array $headers = [])
     {
-        $this->headers = new ResponseHeaderBag($headers);
+        parent::__construct('', $status, new ResponseHeaderBag($headers));
 
         $this->setContent($content);
-        $this->setStatusCode($status);
-        $this->setProtocolVersion('1.0');
     }
 
     /**


### PR DESCRIPTION
This avoids `Symfony\Component\HttpFoundation\Response` from throwing a deprecation when we set `$headers` property value in the constructor.

Alternative to #60303 and avoid making public API changes in a patch release. We can consider making the property type change for Laravel 14.