### PR TITLE
fix: fix isUniqueConstraintError to catch SQL Server error 2627

### DIFF
--- a/src/Illuminate/Database/SqlServerConnection.php
+++ b/src/Illuminate/Database/SqlServerConnection.php
@@ -81,9 +81,9 @@ class SqlServerConnection extends Connection
      * @param  \Exception  $exception
      * @return bool
      */
-    protected function isUniqueConstraintError(Exception $exception)
+    protected function isUniqueConstraintError(Exception $exception): bool
     {
-        return (bool) preg_match('#Cannot insert duplicate key row in object#i', $exception->getMessage());
+        return (bool) preg_match('#Cannot insert duplicate key(?: row)? in object#i', $exception->getMessage());
     }
 
     /**


### PR DESCRIPTION
Hi @taylorotwell, `SqlServerConnection::isUniqueConstraintError` only caught error 2601 but missed error 2627 because the regex required "row" in the message. Error 2601 says "Cannot insert duplicate key row in object" while 2627 says "Cannot insert duplicate key in object" (no "row"). This caused UNIQUE KEY and PRIMARY KEY constraint violations to throw a generic `QueryException` instead of `UniqueConstraintViolationException`. Fixed by making "row" optional.         


https://learn.microsoft.com/en-us/sql/relational-databases/errors-events/database-engine-events-and-errors-2000-to-2999