### PR TITLE
[12.x] Fix Number::trim() returning null for INF and NAN values

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -339,6 +339,10 @@ class Number
      */
     public static function trim(int|float $number)
     {
+        if (is_infinite($number) || is_nan($number)) {
+            return $number;
+        }
+
         return json_decode(json_encode($number));
     }
 

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -340,6 +340,9 @@ class SupportNumberTest extends TestCase
         $this->assertSame(12.3, Number::trim(12.30));
         $this->assertSame(12.3456789, Number::trim(12.3456789));
         $this->assertSame(12.3456789, Number::trim(12.34567890000));
+        $this->assertSame(INF, Number::trim(INF));
+        $this->assertSame(-INF, Number::trim(-INF));
+        $this->assertNan(Number::trim(NAN));
     }
 
     #[RequiresPhpExtension('intl')]


### PR DESCRIPTION
`Number::trim()` uses `json_decode(json_encode($number))` to strip trailing zeros. However, `json_encode(INF)` and `json_encode(NAN)` return `false` (PHP raises `JSON_ERROR_INF_OR_NAN`), so `json_decode(false)` returns `null` — a silent data loss.

```php
Number::trim(INF);  // returns null  ← bug
Number::trim(NAN);  // returns null  ← bug
```