### PR TITLE
[12.x] Fix Number::pairs() infinite loop when $by is zero or negative

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -316,9 +316,11 @@ class Number
      */
     public static function pairs(int|float $to, int|float $by, int|float $start = 0, int|float $offset = 1)
     {
-        if ($by <= 0) {
-            throw new \InvalidArgumentException('The $by argument must be greater than 0.');
+        if ($by == 0) {
+            throw new \InvalidArgumentException('The $by argument must not be zero.');
         }
+
+        $by = abs($by);
 
         $output = [];
 

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -316,6 +316,10 @@ class Number
      */
     public static function pairs(int|float $to, int|float $by, int|float $start = 0, int|float $offset = 1)
     {
+        if ($by <= 0) {
+            throw new \InvalidArgumentException('The $by argument must be greater than 0.');
+        }
+
         $output = [];
 
         for ($lower = $start; $lower < $to; $lower += $by) {

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -331,18 +331,16 @@ class SupportNumberTest extends TestCase
         $this->assertSame([[0.5, 2.5], [3.0, 5.0], [5.5, 7.5], [8.0, 10.0]], Number::pairs(10, 2.5, 0.5, 0.5));
     }
 
-    public function testPairsThrowsOnNonPositiveBy()
+    public function testPairsThrowsWhenByIsZero()
     {
         $this->expectException(\InvalidArgumentException::class);
 
         Number::pairs(100, 0);
     }
 
-    public function testPairsThrowsOnNegativeBy()
+    public function testPairsWithNegativeByWorksLikePositive()
     {
-        $this->expectException(\InvalidArgumentException::class);
-
-        Number::pairs(100, -10);
+        $this->assertSame(Number::pairs(100, 10), Number::pairs(100, -10));
     }
 
     public function testTrim()

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -331,6 +331,20 @@ class SupportNumberTest extends TestCase
         $this->assertSame([[0.5, 2.5], [3.0, 5.0], [5.5, 7.5], [8.0, 10.0]], Number::pairs(10, 2.5, 0.5, 0.5));
     }
 
+    public function testPairsThrowsOnNonPositiveBy()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        Number::pairs(100, 0);
+    }
+
+    public function testPairsThrowsOnNegativeBy()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        Number::pairs(100, -10);
+    }
+
     public function testTrim()
     {
         $this->assertSame(12, Number::trim(12));


### PR DESCRIPTION
`Number::pairs()` enters an infinite loop when `$by` is `0` or negative because the `for` loop's increment `$lower += $by` never advances `$lower` past `$to`:

```php
Number::pairs(100, 0);   // infinite loop
Number::pairs(100, -10); // infinite loop
```
Throw an `InvalidArgumentException` at the start of the method when `$by <= 0`. A step size of zero or less is nonsensical for producing pairs, and this matches how other Laravel range utilities handle invalid input.