### PR TITLE
[13.x] fix: Queue and Connection attributes in Mailable::queue() and later()

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -12,7 +12,9 @@ use Illuminate\Contracts\Queue\Factory as Queue;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Contracts\Translation\HasLocalePreference;
+use Illuminate\Queue\Attributes\Connection;
 use Illuminate\Queue\Attributes\Delay;
+use Illuminate\Queue\Attributes\Queue as QueueAttribute;
 use Illuminate\Support\Collection;
 use Illuminate\Support\EncodedHtmlString;
 use Illuminate\Support\HtmlString;
@@ -232,15 +234,13 @@ class Mailable implements MailableContract, Renderable
             return $this->later($delay, $queue);
         }
 
-        $connection = property_exists($this, 'connection') ? $this->connection : null;
+        $connection = $this->getAttributeValue($this, Connection::class, 'connection');
 
         if (is_null($connection) && method_exists($queue, 'resolveConnectionFromQueueRoute')) {
             $connection = $queue->resolveConnectionFromQueueRoute($this);
         }
 
-        $queueName = property_exists($this, 'queue')
-            ? $this->queue
-            : null;
+        $queueName = $this->getAttributeValue($this, QueueAttribute::class, 'queue');
 
         if (is_null($queueName) && method_exists($queue, 'resolveQueueFromQueueRoute')) {
             $queueName = $queue->resolveQueueFromQueueRoute($this);
@@ -260,11 +260,9 @@ class Mailable implements MailableContract, Renderable
      */
     public function later($delay, Queue $queue)
     {
-        $connection = property_exists($this, 'connection') ? $this->connection : null;
+        $connection = $this->getAttributeValue($this, Connection::class, 'connection');
 
-        $queueName = property_exists($this, 'queue')
-            ? $this->queue
-            : null;
+        $queueName = $this->getAttributeValue($this, QueueAttribute::class, 'queue');
 
         if (is_null($connection) && method_exists($queue, 'resolveConnectionFromQueueRoute')) {
             $connection = $queue->resolveConnectionFromQueueRoute($this);

--- a/tests/Mail/MailableQueuedTest.php
+++ b/tests/Mail/MailableQueuedTest.php
@@ -11,7 +11,9 @@ use Illuminate\Foundation\Application;
 use Illuminate\Mail\Mailable;
 use Illuminate\Mail\Mailer;
 use Illuminate\Mail\SendQueuedMailable;
+use Illuminate\Queue\Attributes\Connection;
 use Illuminate\Queue\Attributes\Delay;
+use Illuminate\Queue\Attributes\Queue as QueueAttribute;
 use Illuminate\Support\Testing\Fakes\QueueFake;
 use Laravel\SerializableClosure\SerializableClosure;
 use Mockery as m;
@@ -180,6 +182,45 @@ class MailableQueuedTest extends TestCase
         $this->assertEquals(60, $pushedJob->delay);
     }
 
+    public function testQueuedMailableRespectsQueueAndConnectionAttributes(): void
+    {
+        $queueFake = new MailableQueueFake(new Application);
+        $mailer = $this->getMockBuilder(Mailer::class)
+            ->setConstructorArgs($this->getMocks())
+            ->onlyMethods(['createMessage', 'to'])
+            ->getMock();
+        $mailer->setQueue($queueFake);
+        $mailable = new MailableQueueableStubWithQueueAndConnectionAttributes;
+        $queueFake->assertNothingPushed();
+        $mailer->send($mailable);
+        $queueFake->assertPushedOn('mail-queue', SendQueuedMailable::class);
+
+        $pushedJob = $queueFake->pushed(SendQueuedMailable::class)->first();
+        $this->assertSame('redis', $queueFake->connectionName);
+        $this->assertSame('mail-queue', $pushedJob->queue);
+        $this->assertSame('redis', $pushedJob->connection);
+    }
+
+    public function testDelayedQueuedMailableRespectsQueueAndConnectionAttributes(): void
+    {
+        $queueFake = new MailableQueueFake(new Application);
+        $mailer = $this->getMockBuilder(Mailer::class)
+            ->setConstructorArgs($this->getMocks())
+            ->onlyMethods(['createMessage', 'to'])
+            ->getMock();
+        $mailer->setQueue($queueFake);
+        $mailable = new MailableQueueableStubWithDelayQueueAndConnectionAttributes;
+        $queueFake->assertNothingPushed();
+        $mailer->send($mailable);
+        $queueFake->assertPushedOn('delayed-mail-queue', SendQueuedMailable::class);
+
+        $pushedJob = $queueFake->pushed(SendQueuedMailable::class)->first();
+        $this->assertSame('sqs', $queueFake->connectionName);
+        $this->assertSame('delayed-mail-queue', $pushedJob->queue);
+        $this->assertSame('sqs', $pushedJob->connection);
+        $this->assertEquals(30, $pushedJob->delay);
+    }
+
     public function testQueuedMailableForwardsDeduplicationIdMethodToQueueJob(): void
     {
         $queueFake = new QueueFake(new Application);
@@ -272,5 +313,32 @@ class MailableQueueableStubWithDeduplication extends Mailable implements ShouldQ
     public function deduplicationId($payload, $queue)
     {
         return hash('sha256', $payload);
+    }
+}
+
+#[Connection('redis')]
+#[QueueAttribute('mail-queue')]
+class MailableQueueableStubWithQueueAndConnectionAttributes extends MailableQueueableStub
+{
+    //
+}
+
+#[Connection('sqs')]
+#[Delay(30)]
+#[QueueAttribute('delayed-mail-queue')]
+class MailableQueueableStubWithDelayQueueAndConnectionAttributes extends MailableQueueableStub
+{
+    //
+}
+
+class MailableQueueFake extends QueueFake
+{
+    public $connectionName;
+
+    public function connection($value = null)
+    {
+        $this->connectionName = $value;
+
+        return parent::connection($value);
     }
 }


### PR DESCRIPTION

fix #60327 : Queue and Connection attributes in Mailable::queue() and later()
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
