### PR TITLE
[13.x] Fix Number::trim() to handle INF and NAN without returning null

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -345,8 +345,12 @@ class Number
      * @param  int|float  $number
      * @return int|float
      */
-    public static function trim(int|float $number)
+    public static function trim(int|float $number): int|float
     {
+        if (is_nan($number) || is_infinite($number)) {
+            return $number;
+        }
+
         return json_decode(json_encode($number));
     }
 

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -347,6 +347,9 @@ class SupportNumberTest extends TestCase
         $this->assertSame(12.3, Number::trim(12.30));
         $this->assertSame(12.3456789, Number::trim(12.3456789));
         $this->assertSame(12.3456789, Number::trim(12.34567890000));
+        $this->assertSame(INF, Number::trim(INF));
+        $this->assertSame(-INF, Number::trim(-INF));
+        $this->assertNan(Number::trim(NAN));
     }
 
     #[RequiresPhpExtension('intl')]


### PR DESCRIPTION
[13.x] Fix Number::trim() to handle INF and NAN without returning null

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
