### PR TITLE
fix: Add content_id to inline attachment handling in CloudflareTransport

### DIFF
--- a/src/Illuminate/Mail/Transport/CloudflareTransport.php
+++ b/src/Illuminate/Mail/Transport/CloudflareTransport.php
@@ -131,13 +131,21 @@ class CloudflareTransport extends AbstractTransport
 
         foreach ($email->getAttachments() as $attachment) {
             $headers = $attachment->getPreparedHeaders();
+            $disposition = $headers->getHeaderBody('Content-Disposition') ?: 'attachment';
+            $filename = $headers->getHeaderParameter('Content-Disposition', 'filename');
 
-            $attachments[] = [
+            $item = [
                 'content' => str_replace("\r\n", '', $attachment->bodyToString()),
-                'filename' => $headers->getHeaderParameter('Content-Disposition', 'filename'),
+                'filename' => $filename,
                 'type' => $headers->get('Content-Type')->getBody(),
-                'disposition' => $headers->getHeaderBody('Content-Disposition') ?: 'attachment',
+                'disposition' => $disposition,
             ];
+
+            if ($disposition === 'inline') {
+                $item['content_id'] = $attachment->hasContentId() ? $attachment->getContentId() : $filename;
+            }
+
+            $attachments[] = $item;
         }
 
         return $attachments;

--- a/tests/Mail/MailCloudflareTransportTest.php
+++ b/tests/Mail/MailCloudflareTransportTest.php
@@ -164,6 +164,40 @@ class MailCloudflareTransportTest extends TestCase
         $this->assertNotEmpty($requestBody['attachments'][0]['content']);
     }
 
+    public function testSendWithInlineAttachment(): void
+    {
+        $requestBody = null;
+
+        $client = new MockHttpClient(function ($method, $url, $options) use (&$requestBody) {
+            $requestBody = json_decode($options['body'], true);
+
+            return new MockResponse(json_encode([
+                'success' => true,
+                'errors' => [],
+                'messages' => [],
+                'result' => ['delivered' => ['me@example.com'], 'permanent_bounces' => [], 'queued' => []],
+            ]), ['http_code' => 200]);
+        });
+
+        $transport = new CloudflareTransport('test-account-id', 'test-key', $client);
+
+        $message = new Email();
+        $message->subject('With inline attachment');
+        $message->text('See image');
+        $message->sender('sender@example.com');
+        $message->to('me@example.com');
+        $message->embed('file contents', 'image.png', 'image/png');
+
+        $transport->send($message);
+
+        $this->assertCount(1, $requestBody['attachments']);
+        $this->assertSame('image.png', $requestBody['attachments'][0]['filename']);
+        $this->assertSame('image/png', $requestBody['attachments'][0]['type']);
+        $this->assertSame('inline', $requestBody['attachments'][0]['disposition']);
+        $this->assertSame('image.png', $requestBody['attachments'][0]['content_id']);
+        $this->assertNotEmpty($requestBody['attachments'][0]['content']);
+    }
+
     public function testSendThrowsOnApiFailure(): void
     {
         $client = new MockHttpClient(function () {


### PR DESCRIPTION
CloudFlare requires the `content_id` key to be set for inline attachments. See docs: https://developers.cloudflare.com/api/resources/email_sending/methods/send/

If missing, it fails with `Symfony\Component\Mailer\Exception\TransportException: email.sending.error.invalid_request_schema`

This solution uses the same idea as src/Illuminate/Mail/Transport/ResendTransport.php:94 which also requires `content_id`.

Besides the test, I have also manually sent an email with an inline image and confirmed the image is shown in the email I received.