### PR TITLE
[13.x] Fix time-sensitive flaky test in NotificationDatabaseChannelTest

### DIFF
--- a/tests/Notifications/NotificationDatabaseChannelTest.php
+++ b/tests/Notifications/NotificationDatabaseChannelTest.php
@@ -11,6 +11,20 @@ use PHPUnit\Framework\TestCase;
 
 class NotificationDatabaseChannelTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Carbon::setTestNow(Carbon::now());
+    }
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+
+        parent::tearDown();
+    }
+
     public function testDatabaseChannelCreatesDatabaseRecordWithProperData()
     {
         $notification = new NotificationDatabaseChannelTestNotification;


### PR DESCRIPTION
`testCustomizeTypeIsSentToDatabase` checks the `read_at` value a notification
writes to the database. The expectation and the sent value each call
`Carbon::now()`, so the test fails when the two calls land on different seconds.
Freezing time in `setUp()` keeps them aligned.

Seen on a scheduled run on my fork:
https://github.com/KentarouTakeda/laravel-framework/actions/runs/26611769748/job/78419022756

Happy to open the same fix against 12.x as well if preferred.
