### PR TITLE
Implement new collection method $collection->flipGrouped()

### DIFF
--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -506,6 +506,13 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public function flip();
 
     /**
+     * Group the collection's keys by their values.
+     *
+     * @return static<TValue, static<int, TKey>>
+     */
+    public function flipGrouped();
+
+    /**
      * Get an item from the collection by key.
      *
      * @template TGetDefault

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -428,6 +428,16 @@ trait EnumeratesValues
     }
 
     /**
+     * Group the collection's keys by their values.
+     *
+     * @return static<TValue, static<int, TKey>>
+     */
+    public function flipGrouped()
+    {
+        return $this->mapToGroups(fn ($value, $key) => [$value => $key]);
+    }
+
+    /**
      * Map a collection and flatten the result by a single level.
      *
      * @template TFlatMapKey of array-key

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2117,6 +2117,18 @@ class SupportCollectionTest extends TestCase
     }
 
     #[DataProvider('collectionClassProvider')]
+    public function testFlipGrouped($collection)
+    {
+        $data = new $collection([1, 2, 3, 2, 1]);
+
+        $groups = $data->flipGrouped();
+
+        $this->assertInstanceOf($collection, $groups);
+        $this->assertEquals([1 => [0, 4], 2 => [1, 3], 3 => [2]], $groups->toArray());
+        $this->assertEquals([1, 2, 3, 2, 1], $data->all());
+    }
+
+    #[DataProvider('collectionClassProvider')]
     public function testChunk($collection)
     {
         $data = new $collection([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -524,6 +524,9 @@ assertType("'string'|User", $collection->value('string', fn () => 'string'));
 
 assertType('Illuminate\Support\Collection<string, int>', $collection::make(['string'])->flip());
 
+assertType('Illuminate\Support\Collection<string, Illuminate\Support\Collection<int, int>>', $collection::make(['string', 'string'])
+    ->flipGrouped());
+
 assertType('Illuminate\Support\Collection<(int|string), Illuminate\Support\Collection<int, User>>', $collection->groupBy('name'));
 assertType('Illuminate\Support\Collection<(int|string), Illuminate\Support\Collection<int, User>>', $collection->groupBy('name', true));
 assertType('Illuminate\Support\Collection<string, Illuminate\Support\Collection<int, User>>', $collection->groupBy(function ($user, $int) {

--- a/types/Support/LazyCollection.php
+++ b/types/Support/LazyCollection.php
@@ -417,6 +417,9 @@ assertType('User|null', $collection->firstWhere('string', 'string', 'string'));
 
 assertType('Illuminate\Support\LazyCollection<string, int>', $collection::make(['string'])->flip());
 
+assertType('Illuminate\Support\LazyCollection<string, Illuminate\Support\LazyCollection<int, int>>', $collection::make(['string', 'string'])
+    ->flipGrouped());
+
 assertType('Illuminate\Support\LazyCollection<(int|string), Illuminate\Support\LazyCollection<int, User>>', $collection->groupBy('name'));
 assertType('Illuminate\Support\LazyCollection<(int|string), Illuminate\Support\LazyCollection<int, User>>', $collection->groupBy('name', true));
 assertType('Illuminate\Support\LazyCollection<string, Illuminate\Support\LazyCollection<int, User>>', $collection->groupBy(function ($user, $int) {


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

## Summary

Adds a `flipGrouped()` method to Laravel collections. It groups a collection's keys by their values — the grouped counterpart to `flip()`.

## Motivation

`flip()` swaps keys and values one-to-one, but breaks down when values are duplicated. The common workaround is:

```php
$collection->mapToGroups(fn ($value, $key) => [$value => $key]);
```

`flipGrouped()` wraps that pattern in a named, discoverable method.

## Example
```php
collect([1, 2, 3, 2, 1])->flipGrouped();
// [
//     1 => [0, 4],
//     2 => [1, 3],
//     3 => [2],
// ]
```

Each unique value becomes a group key, and the group contains the original keys that held that value.