### PR TITLE
fix: catch UniqueConstraintViolationException instead of QueryException in DatabaseLock

### DIFF
--- a/src/Illuminate/Cache/DatabaseLock.php
+++ b/src/Illuminate/Cache/DatabaseLock.php
@@ -4,7 +4,7 @@ namespace Illuminate\Cache;
 
 use Illuminate\Database\Connection;
 use Illuminate\Database\DetectsConcurrencyErrors;
-use Illuminate\Database\QueryException;
+use Illuminate\Database\UniqueConstraintViolationException;
 use Throwable;
 
 class DatabaseLock extends Lock
@@ -77,7 +77,7 @@ class DatabaseLock extends Lock
             ]);
 
             $acquired = true;
-        } catch (QueryException) {
+        } catch (UniqueConstraintViolationException) {
             $updated = $this->connection->table($this->table)
                 ->where('key', $this->name)
                 ->where(function ($query) {


### PR DESCRIPTION
Hi @taylorotwell, This fixes the DatabaseLock catch to use UniqueConstraintViolationException instead of QueryException. Most of the time, it works the same, but in some cases, like transient errors or permission errors, the broad catch was hiding the real failure instead of surfacing it. Existing tests cover this change.

Fixes #60171