### PR TITLE
[13.x] Remove unused variables from tests

### DIFF
--- a/tests/Integration/Routing/CompiledRouteCollectionTest.php
+++ b/tests/Integration/Routing/CompiledRouteCollectionTest.php
@@ -146,7 +146,7 @@ class CompiledRouteCollectionTest extends TestCase
 
     public function testRouteCollectionCanGetIteratorWhenRoutesAreAdded()
     {
-        $this->routeCollection->add($routeIndex = $this->newRoute('GET', 'foo/index', [
+        $this->routeCollection->add($this->newRoute('GET', 'foo/index', [
             'uses' => 'FooController@index',
             'as' => 'foo_index',
         ]));
@@ -155,7 +155,7 @@ class CompiledRouteCollectionTest extends TestCase
 
         $this->assertCount(1, $routes);
 
-        $this->routeCollection->add($routeShow = $this->newRoute('GET', 'bar/show', [
+        $this->routeCollection->add($this->newRoute('GET', 'bar/show', [
             'uses' => 'BarController@show',
             'as' => 'bar_show',
         ]));

--- a/tests/Validation/ValidationImageFileRuleTest.php
+++ b/tests/Validation/ValidationImageFileRuleTest.php
@@ -34,13 +34,13 @@ class ValidationImageFileRuleTest extends TestCase
     {
         $this->fails(
             File::image()->dimensions(Rule::dimensions()->width(100)->height(100)),
-            new UploadedFileWithCustomImageSizeMethod(stream_get_meta_data($tmpFile = tmpfile())['uri'], 'foo.png'),
+            new UploadedFileWithCustomImageSizeMethod(stream_get_meta_data(tmpfile())['uri'], 'foo.png'),
             ['validation.dimensions'],
         );
 
         $this->passes(
             File::image()->dimensions(Rule::dimensions()->width(200)->height(200)),
-            new UploadedFileWithCustomImageSizeMethod(stream_get_meta_data($tmpFile = tmpfile())['uri'], 'foo.png'),
+            new UploadedFileWithCustomImageSizeMethod(stream_get_meta_data(tmpfile())['uri'], 'foo.png'),
         );
     }
 


### PR DESCRIPTION
There are some unused variables in CompiledRouteCollectionTest and ValidationImageFileRuleTest. Therefore, I removed them.