### PR TITLE
test(Benchmark): add test coverage for dd()

### DIFF
--- a/tests/Support/SupportBenchmarkTest.php
+++ b/tests/Support/SupportBenchmarkTest.php
@@ -1,9 +1,24 @@
 <?php
 
-namespace Illuminate\Tests\Support;
+namespace Illuminate\Support {
+    function dd(mixed ...$vars): never
+    {
+        throw new \Illuminate\Tests\Support\BenchmarkDdCapturedException($vars[0]);
+    }
+}
+
+namespace Illuminate\Tests\Support {
 
 use Illuminate\Support\Benchmark;
 use PHPUnit\Framework\TestCase;
+
+class BenchmarkDdCapturedException extends \RuntimeException
+{
+    public function __construct(public readonly mixed $result)
+    {
+        parent::__construct();
+    }
+}
 
 class SupportBenchmarkTest extends TestCase
 {
@@ -28,10 +43,48 @@ class SupportBenchmarkTest extends TestCase
 
         $this->assertFalse(Benchmark::hasMacro($macroName));
 
-        // Register a macro to test
         Benchmark::macro($macroName, fn () => true);
 
         $this->assertTrue(Benchmark::hasMacro($macroName));
         $this->assertTrue(Benchmark::$macroName());
     }
+
+    public function testDdWithSingleClosure(): void
+    {
+        try {
+            Benchmark::dd(fn () => 1 + 1);
+            $this->fail('Expected BenchmarkDdCapturedException to be thrown');
+        } catch (BenchmarkDdCapturedException $e) {
+            $this->assertMatchesRegularExpression('/^\d+\.\d{3}ms$/', $e->result);
+        }
+    }
+
+    public function testDdWithArray(): void
+    {
+        try {
+            Benchmark::dd([
+                'first' => fn () => 1 + 1,
+                'second' => fn () => 2 + 2,
+            ]);
+            $this->fail('Expected BenchmarkDdCapturedException to be thrown');
+        } catch (BenchmarkDdCapturedException $e) {
+            $this->assertIsArray($e->result);
+            $this->assertArrayHasKey('first', $e->result);
+            $this->assertArrayHasKey('second', $e->result);
+            $this->assertMatchesRegularExpression('/^\d+\.\d{3}ms$/', $e->result['first']);
+            $this->assertMatchesRegularExpression('/^\d+\.\d{3}ms$/', $e->result['second']);
+        }
+    }
+
+    public function testDdWithIterations(): void
+    {
+        try {
+            Benchmark::dd(fn () => 1 + 1, iterations: 5);
+            $this->fail('Expected BenchmarkDdCapturedException to be thrown');
+        } catch (BenchmarkDdCapturedException $e) {
+            $this->assertMatchesRegularExpression('/^\d+\.\d{3}ms$/', $e->result);
+        }
+    }
+}
+
 }

--- a/tests/Support/SupportBenchmarkTest.php
+++ b/tests/Support/SupportBenchmarkTest.php
@@ -8,83 +8,81 @@ namespace Illuminate\Support {
 }
 
 namespace Illuminate\Tests\Support {
+    use Illuminate\Support\Benchmark;
+    use PHPUnit\Framework\TestCase;
 
-use Illuminate\Support\Benchmark;
-use PHPUnit\Framework\TestCase;
-
-class BenchmarkDdCapturedException extends \RuntimeException
-{
-    public function __construct(public readonly mixed $result)
+    class BenchmarkDdCapturedException extends \RuntimeException
     {
-        parent::__construct();
-    }
-}
-
-class SupportBenchmarkTest extends TestCase
-{
-    public function testMeasure(): void
-    {
-        $this->assertIsNumeric(Benchmark::measure(fn () => 1 + 1));
-
-        $this->assertIsArray(Benchmark::measure([
-            'first' => fn () => 1 + 1,
-            'second' => fn () => 2 + 2,
-        ], 3));
-    }
-
-    public function testValue(): void
-    {
-        $this->assertIsArray(Benchmark::value(fn () => 1 + 1));
-    }
-
-    public function testMacroable(): void
-    {
-        $macroName = __FUNCTION__;
-
-        $this->assertFalse(Benchmark::hasMacro($macroName));
-
-        Benchmark::macro($macroName, fn () => true);
-
-        $this->assertTrue(Benchmark::hasMacro($macroName));
-        $this->assertTrue(Benchmark::$macroName());
-    }
-
-    public function testDdWithSingleClosure(): void
-    {
-        try {
-            Benchmark::dd(fn () => 1 + 1);
-            $this->fail('Expected BenchmarkDdCapturedException to be thrown');
-        } catch (BenchmarkDdCapturedException $e) {
-            $this->assertMatchesRegularExpression('/^\d+\.\d{3}ms$/', $e->result);
+        public function __construct(public readonly mixed $result)
+        {
+            parent::__construct();
         }
     }
 
-    public function testDdWithArray(): void
+    class SupportBenchmarkTest extends TestCase
     {
-        try {
-            Benchmark::dd([
+        public function testMeasure(): void
+        {
+            $this->assertIsNumeric(Benchmark::measure(fn () => 1 + 1));
+
+            $this->assertIsArray(Benchmark::measure([
                 'first' => fn () => 1 + 1,
                 'second' => fn () => 2 + 2,
-            ]);
-            $this->fail('Expected BenchmarkDdCapturedException to be thrown');
-        } catch (BenchmarkDdCapturedException $e) {
-            $this->assertIsArray($e->result);
-            $this->assertArrayHasKey('first', $e->result);
-            $this->assertArrayHasKey('second', $e->result);
-            $this->assertMatchesRegularExpression('/^\d+\.\d{3}ms$/', $e->result['first']);
-            $this->assertMatchesRegularExpression('/^\d+\.\d{3}ms$/', $e->result['second']);
+            ], 3));
+        }
+
+        public function testValue(): void
+        {
+            $this->assertIsArray(Benchmark::value(fn () => 1 + 1));
+        }
+
+        public function testMacroable(): void
+        {
+            $macroName = __FUNCTION__;
+
+            $this->assertFalse(Benchmark::hasMacro($macroName));
+
+            Benchmark::macro($macroName, fn () => true);
+
+            $this->assertTrue(Benchmark::hasMacro($macroName));
+            $this->assertTrue(Benchmark::$macroName());
+        }
+
+        public function testDdWithSingleClosure(): void
+        {
+            try {
+                Benchmark::dd(fn () => 1 + 1);
+                $this->fail('Expected BenchmarkDdCapturedException to be thrown');
+            } catch (BenchmarkDdCapturedException $e) {
+                $this->assertMatchesRegularExpression('/^\d+\.\d{3}ms$/', $e->result);
+            }
+        }
+
+        public function testDdWithArray(): void
+        {
+            try {
+                Benchmark::dd([
+                    'first' => fn () => 1 + 1,
+                    'second' => fn () => 2 + 2,
+                ]);
+                $this->fail('Expected BenchmarkDdCapturedException to be thrown');
+            } catch (BenchmarkDdCapturedException $e) {
+                $this->assertIsArray($e->result);
+                $this->assertArrayHasKey('first', $e->result);
+                $this->assertArrayHasKey('second', $e->result);
+                $this->assertMatchesRegularExpression('/^\d+\.\d{3}ms$/', $e->result['first']);
+                $this->assertMatchesRegularExpression('/^\d+\.\d{3}ms$/', $e->result['second']);
+            }
+        }
+
+        public function testDdWithIterations(): void
+        {
+            try {
+                Benchmark::dd(fn () => 1 + 1, iterations: 5);
+                $this->fail('Expected BenchmarkDdCapturedException to be thrown');
+            } catch (BenchmarkDdCapturedException $e) {
+                $this->assertMatchesRegularExpression('/^\d+\.\d{3}ms$/', $e->result);
+            }
         }
     }
-
-    public function testDdWithIterations(): void
-    {
-        try {
-            Benchmark::dd(fn () => 1 + 1, iterations: 5);
-            $this->fail('Expected BenchmarkDdCapturedException to be thrown');
-        } catch (BenchmarkDdCapturedException $e) {
-            $this->assertMatchesRegularExpression('/^\d+\.\d{3}ms$/', $e->result);
-        }
-    }
-}
-
 }


### PR DESCRIPTION
`Benchmark::dd()` had no test coverage. It formats benchmark results as `X.XXXms` strings and dumps them, but neither the formatting logic nor the single-closure vs. array branching was verified.

`Benchmark::dd()` calls `dd()` without a leading `\`, so PHP resolves it in the `Illuminate\Support` namespace first. The test file defines `Illuminate\Support\dd()` to throw a `BenchmarkDdCapturedException` instead of calling `exit()`, allowing the formatted result to be inspected in the test.