### PR TITLE
[12.x] feat: batch multiple ->change() calls into a single ALTER TABLE

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -203,6 +203,8 @@ class Blueprint
                 $this->commands
             );
 
+            $this->commands = $this->groupChangedColumns($this->commands);
+
             $this->addAlterCommands();
         }
     }
@@ -276,6 +278,40 @@ class Blueprint
                 $this->addCommand($commandName, compact('column'));
             }
         }
+    }
+
+    /**
+     * Group consecutive change commands into batch commands when the grammar supports it.
+     *
+     * @param  array  $commands
+     * @return array
+     */
+    protected function groupChangedColumns(array $commands)
+    {
+        if (! $this->grammar->supportsChangeBatching()) {
+            return $commands;
+        }
+
+        $result = [];
+        $batch = [];
+
+        foreach ($commands as $command) {
+            if ($command->name === 'change') {
+                $batch[] = $command->column;
+            } else {
+                if ($batch) {
+                    $result[] = $this->createCommand('change', ['columns' => $batch]);
+                    $batch = [];
+                }
+                $result[] = $command;
+            }
+        }
+
+        if ($batch) {
+            $result[] = $this->createCommand('change', ['columns' => $batch]);
+        }
+
+        return $result;
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -534,4 +534,14 @@ abstract class Grammar extends BaseGrammar
     {
         return $this->transactions;
     }
+
+    /**
+     * Check if this Grammar supports batching multiple column changes into one ALTER TABLE statement.
+     *
+     * @return bool
+     */
+    public function supportsChangeBatching()
+    {
+        return false;
+    }
 }

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -395,27 +395,64 @@ class MySqlGrammar extends Grammar
     /** @inheritDoc */
     public function compileChange(Blueprint $blueprint, Fluent $command)
     {
-        $column = $command->column;
+        // Columns with instant/lock carry table-level ALTER options that cannot be mixed
+        // into a multi-column statement, so they are flushed as their own ALTER TABLE.
+        $table = $this->wrapTable($blueprint);
+        $sql = [];
+        $batch = [];
 
-        $sql = sprintf('alter table %s %s %s%s %s',
-            $this->wrapTable($blueprint),
-            is_null($column->renameTo) ? 'modify' : 'change',
-            $this->wrap($column),
-            is_null($column->renameTo) ? '' : ' '.$this->wrap($column->renameTo),
-            $this->getType($column)
-        );
+        foreach ($command->columns as $column) {
+            if ($column->instant || $column->lock) {
+                if ($batch) {
+                    $sql[] = sprintf('alter table %s %s', $table, implode(', ', $batch));
+                    $batch = [];
+                }
 
-        $sql = $this->addModifiers($sql, $blueprint, $column);
+                $single = sprintf('alter table %s %s',
+                    $table,
+                    $this->compileChangeFragment($blueprint, $column));
 
-        if ($column->instant) {
-            $sql .= ', algorithm=instant';
+                if ($column->instant) {
+                    $single .= ', algorithm=instant';
+                }
+
+                if ($column->lock) {
+                    $single .= ', lock='.$column->lock;
+                }
+
+                $sql[] = $single;
+            } else {
+                $batch[] = $this->compileChangeFragment($blueprint, $column);
+            }
         }
 
-        if ($column->lock) {
-            $sql .= ', lock='.$column->lock;
+        if ($batch) {
+            $sql[] = sprintf('alter table %s %s', $table, implode(', ', $batch));
         }
 
         return $sql;
+    }
+
+    /**
+     * Compile the MODIFY / CHANGE fragment for a single column.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string
+     */
+    protected function compileChangeFragment(Blueprint $blueprint, Fluent $column)
+    {
+        if (is_null($column->renameTo)) {
+            $fragment = sprintf('modify %s %s', $this->wrap($column), $this->getType($column));
+        } else {
+            $fragment = sprintf('change %s %s %s',
+                $this->wrap($column),
+                $this->wrap($column->renameTo),
+                $this->getType($column)
+            );
+        }
+
+        return $this->addModifiers($fragment, $blueprint, $column);
     }
 
     /**
@@ -1418,6 +1455,12 @@ class MySqlGrammar extends Grammar
         }
 
         return $value;
+    }
+
+    /** @inheritDoc */
+    public function supportsChangeBatching()
+    {
+        return true;
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -279,30 +279,35 @@ class PostgresGrammar extends Grammar
     }
 
     /** @inheritDoc */
+    public function supportsChangeBatching()
+    {
+        return true;
+    }
+
+    /** @inheritDoc */
     public function compileChange(Blueprint $blueprint, Fluent $command)
     {
-        $column = $command->column;
+        $parts = [];
 
-        $changes = ['type '.$this->getType($column).$this->modifyCollate($blueprint, $column)];
+        foreach ($command->columns as $column) {
+            $changes = ['type '.$this->getType($column).$this->modifyCollate($blueprint, $column)];
 
-        foreach ($this->modifiers as $modifier) {
-            if ($modifier === 'Collate') {
-                continue;
-            }
+            foreach ($this->modifiers as $modifier) {
+                if ($modifier === 'Collate') {
+                    continue;
+                }
 
-            if (method_exists($this, $method = "modify{$modifier}")) {
-                $constraints = (array) $this->{$method}($blueprint, $column);
-
-                foreach ($constraints as $constraint) {
-                    $changes[] = $constraint;
+                if (method_exists($this, $method = "modify{$modifier}")) {
+                    foreach ((array) $this->{$method}($blueprint, $column) as $constraint) {
+                        $changes[] = $constraint;
+                    }
                 }
             }
+
+            array_push($parts, ...$this->prefixArray('alter column '.$this->wrap($column), $changes));
         }
 
-        return sprintf('alter table %s %s',
-            $this->wrapTable($blueprint),
-            implode(', ', $this->prefixArray('alter column '.$this->wrap($column), $changes))
-        );
+        return sprintf('alter table %s %s', $this->wrapTable($blueprint), implode(', ', $parts));
     }
 
     /**

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -1649,6 +1649,60 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertSame('alter table `users` modify `name` varchar(100) not null, lock=none', $statements[0]);
     }
 
+    public function testChangingMultipleColumnsProducesSingleAlterTableStatement()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'game_bets');
+        $blueprint->decimal('bet_amount', 16, 4)->change();
+        $blueprint->decimal('real_bet_amount', 16, 4)->default(0)->change();
+        $blueprint->decimal('win_amount', 16, 4)->default(0)->change();
+        $blueprint->decimal('odds', 10, 4)->change();
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame(
+            'alter table `game_bets` modify `bet_amount` decimal(16, 4) not null, modify `real_bet_amount` decimal(16, 4) not null default \'0\', modify `win_amount` decimal(16, 4) not null default \'0\', modify `odds` decimal(10, 4) not null',
+            $statements[0]
+        );
+    }
+
+    public function testChangingColumnsWithInstantAreNotBatched()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->string('name', 100)->change()->instant();
+        $blueprint->string('email', 200)->change();
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(2, $statements);
+        $this->assertSame('alter table `users` modify `name` varchar(100) not null, algorithm=instant', $statements[0]);
+        $this->assertSame('alter table `users` modify `email` varchar(200) not null', $statements[1]);
+    }
+
+    public function testChangingColumnsWithLockAreNotBatched()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->string('name', 100)->change()->lock('none');
+        $blueprint->string('email', 200)->change();
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(2, $statements);
+        $this->assertSame('alter table `users` modify `name` varchar(100) not null, lock=none', $statements[0]);
+        $this->assertSame('alter table `users` modify `email` varchar(200) not null', $statements[1]);
+    }
+
+    public function testInstantColumnInterruptsBatchAndBatchResumesAfter()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->string('before', 100)->change();
+        $blueprint->string('name', 100)->change()->instant();
+        $blueprint->string('after', 100)->change();
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(3, $statements);
+        $this->assertSame('alter table `users` modify `before` varchar(100) not null', $statements[0]);
+        $this->assertSame('alter table `users` modify `name` varchar(100) not null, algorithm=instant', $statements[1]);
+        $this->assertSame('alter table `users` modify `after` varchar(100) not null', $statements[2]);
+    }
+
     public function testDroppingColumnWithLock()
     {
         $blueprint = new Blueprint($this->getConnection(), 'users');

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -1407,6 +1407,21 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         return $result;
     }
 
+    public function testChangingMultipleColumnsProducesSingleAlterTableStatement()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'orders');
+        $blueprint->decimal('price', 16, 4)->change();
+        $blueprint->decimal('tax', 10, 4)->default(0)->change();
+        $statements = $blueprint->toSql();
+
+        // Both column alterations are batched into one ALTER TABLE statement;
+        // the remaining statements are per-column COMMENT updates (unavoidable in Postgres).
+        $alterStatements = array_values(array_filter($statements, fn ($s) => str_starts_with($s, 'alter table')));
+        $this->assertCount(1, $alterStatements);
+        $this->assertStringContainsString('alter column "price"', $alterStatements[0]);
+        $this->assertStringContainsString('alter column "tax"', $alterStatements[0]);
+    }
+
     public function testGrammarsAreMacroable()
     {
         // compileReplace macro.

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -289,12 +289,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
         });
 
         $this->assertEquals([
-            'alter table `users` modify `amount` double null invisible after `name`',
-            'alter table `users` modify `added_at` timestamp(4) not null default CURRENT_TIMESTAMP(4) on update CURRENT_TIMESTAMP(4)',
-            "alter table `users` modify `difficulty` enum('easy', 'hard') character set utf8mb4 collate 'unicode' not null default 'easy'",
-            'alter table `users` modify `positions` multipolygon srid 1234 as (expression) stored',
-            'alter table `users` change `old_name` `new_name` varchar(50) not null',
-            "alter table `users` modify `id` bigint unsigned not null auto_increment comment 'my comment' first",
+            "alter table `users` modify `amount` double null invisible after `name`, modify `added_at` timestamp(4) not null default CURRENT_TIMESTAMP(4) on update CURRENT_TIMESTAMP(4), modify `difficulty` enum('easy', 'hard') character set utf8mb4 collate 'unicode' not null default 'easy', modify `positions` multipolygon srid 1234 as (expression) stored, change `old_name` `new_name` varchar(50) not null, modify `id` bigint unsigned not null auto_increment comment 'my comment' first",
             'alter table `users` auto_increment = 10',
         ], $blueprint->toSql());
     }

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -117,10 +117,7 @@ class SchemaBuilderTest extends DatabaseTestCase
         });
 
         $expected = [
-            'alter table `test` modify `not_null_column_to_not_null` text not null',
-            'alter table `test` modify `not_null_column_to_nullable` text null',
-            'alter table `test` modify `nullable_column_to_nullable` text null',
-            'alter table `test` modify `nullable_column_to_not_null` text not null',
+            'alter table `test` modify `not_null_column_to_not_null` text not null, modify `not_null_column_to_nullable` text null, modify `nullable_column_to_nullable` text null, modify `nullable_column_to_not_null` text not null',
         ];
 
         $this->assertEquals($expected, $blueprint->toSql());


### PR DESCRIPTION
Previously each ->change() generated a separate ALTER TABLE statement, causing N full-table copies for N changed columns. This commit combines consecutive change commands into one statement on supported drivers.

- Add Grammar::supportsChangeBatching() (returns false); MySQL and Postgres override it to true; MariaDB inherits automatically
- Blueprint::groupChangedColumns() groups consecutive change commands into a single 'columns' command before compilation
- MySqlGrammar::compileChange() handles instant/lock columns internally by splitting them into separate ALTER TABLE statements when needed, keeping that MySQL-specific knowledge out of Blueprint
- MySqlGrammar::compileChangeFragment() extracts the MODIFY/CHANGE fragment per column
- SQLite is unaffected (full table rebuild via BlueprintState); SQL Server is unaffected (ALTER COLUMN is one-column-per-statement)

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
