### PR TITLE
[13.x] Unserialise and decrypt `InspectedJob` payload

### DIFF
--- a/src/Illuminate/Queue/Jobs/InspectedJob.php
+++ b/src/Illuminate/Queue/Jobs/InspectedJob.php
@@ -2,6 +2,9 @@
 
 namespace Illuminate\Queue\Jobs;
 
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Encryption\Encrypter;
+use Illuminate\Contracts\Queue\ShouldBeEncrypted;
 use Illuminate\Support\Carbon;
 
 class InspectedJob
@@ -34,6 +37,12 @@ class InspectedJob
     public static function fromPayload(string $payload, ?int $attempts = null): static
     {
         $decoded = json_decode($payload, true);
+
+        if (isset($decoded['data']['command'])) {
+            $decoded['data']['command'] = is_subclass_of($decoded['data']['commandName'] ?? '', ShouldBeEncrypted::class) && Container::getInstance()->bound(Encrypter::class)
+                ? unserialize(Container::getInstance()[Encrypter::class]->decrypt($decoded['data']['command']))
+                : unserialize($decoded['data']['command']);
+        }
 
         return new static(
             uuid: $decoded['uuid'] ?? null,

--- a/src/Illuminate/Queue/Jobs/InspectedJob.php
+++ b/src/Illuminate/Queue/Jobs/InspectedJob.php
@@ -38,11 +38,14 @@ class InspectedJob
     {
         $decoded = json_decode($payload, true);
 
-        if (isset($decoded['data']['commandName'], $decoded['data']['command'])) {
-            if (str_starts_with($decoded['data']['command'], 'O:')) {
-                $decoded['data']['command'] = unserialize($decoded['data']['command']);
-            } elseif (is_subclass_of($decoded['data']['commandName'], ShouldBeEncrypted::class) && Container::getInstance()->bound(Encrypter::class)) {
-                $decoded['data']['command'] = unserialize(Container::getInstance()[Encrypter::class]->decrypt($decoded['data']['command']));
+        $commandName = $decoded['data']['commandName'] ?? null;
+        $command = $decoded['data']['command'] ?? null;
+
+        if ($commandName && $command) {
+            if (str_starts_with($command, 'O:')) {
+                $decoded['data']['command'] = unserialize($command);
+            } elseif (is_subclass_of($commandName, ShouldBeEncrypted::class) && Container::getInstance()->bound(Encrypter::class)) {
+                $decoded['data']['command'] = unserialize(Container::getInstance()[Encrypter::class]->decrypt($command));
             }
         }
 

--- a/src/Illuminate/Queue/Jobs/InspectedJob.php
+++ b/src/Illuminate/Queue/Jobs/InspectedJob.php
@@ -38,10 +38,12 @@ class InspectedJob
     {
         $decoded = json_decode($payload, true);
 
-        if (isset($decoded['data']['command'])) {
-            $decoded['data']['command'] = is_subclass_of($decoded['data']['commandName'] ?? '', ShouldBeEncrypted::class) && Container::getInstance()->bound(Encrypter::class)
-                ? unserialize(Container::getInstance()[Encrypter::class]->decrypt($decoded['data']['command']))
-                : unserialize($decoded['data']['command']);
+        if (isset($decoded['data']['commandName'], $decoded['data']['command'])) {
+            if (str_starts_with($decoded['data']['command'], 'O:')) {
+                $decoded['data']['command'] = unserialize($decoded['data']['command']);
+            } elseif (is_subclass_of($decoded['data']['commandName'], ShouldBeEncrypted::class) && Container::getInstance()->bound(Encrypter::class)) {
+                $decoded['data']['command'] = unserialize(Container::getInstance()[Encrypter::class]->decrypt($decoded['data']['command']));
+            }
         }
 
         return new static(

--- a/tests/Queue/QueueDatabaseQueueIntegrationTest.php
+++ b/tests/Queue/QueueDatabaseQueueIntegrationTest.php
@@ -3,9 +3,12 @@
 namespace Illuminate\Tests\Queue;
 
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Encryption\Encrypter as EncrypterContract;
+use Illuminate\Contracts\Queue\ShouldBeEncrypted;
 use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Encryption\Encrypter;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Queue\DatabaseQueue;
 use Illuminate\Queue\Events\JobQueued;
@@ -105,6 +108,8 @@ class QueueDatabaseQueueIntegrationTest extends TestCase
     protected function tearDown(): void
     {
         $this->schema()->drop('jobs');
+
+        Container::setInstance(null);
 
         parent::tearDown();
     }
@@ -266,6 +271,30 @@ class QueueDatabaseQueueIntegrationTest extends TestCase
         Queue::createPayloadUsing(null);
     }
 
+    public function testCommandIsUnserialisedOnInspectedJob()
+    {
+        $this->queue->push(new DatabaseQueueInspectedJob('hello'));
+
+        $job = $this->queue->pendingJobs()->first();
+
+        $this->assertInstanceOf(DatabaseQueueInspectedJob::class, $job->payload['data']['command']);
+        $this->assertSame('hello', $job->payload['data']['command']->data);
+    }
+
+    public function testEncryptedCommandIsDecryptedOnInspectedJob()
+    {
+        $this->container->instance(EncrypterContract::class, new Encrypter(str_repeat('a', 16)));
+
+        Container::setInstance($this->container);
+
+        $this->queue->push(new DatabaseQueueEncryptedInspectedJob('secret'));
+
+        $job = $this->queue->pendingJobs()->first();
+
+        $this->assertInstanceOf(DatabaseQueueEncryptedInspectedJob::class, $job->payload['data']['command']);
+        $this->assertSame('secret', $job->payload['data']['command']->data);
+    }
+
     public function testJobPayloadIsAvailableOnEvents()
     {
         $jobQueueingEvent = null;
@@ -289,5 +318,19 @@ class QueueDatabaseQueueIntegrationTest extends TestCase
 
         $this->assertIsArray($jobQueuedEvent->payload());
         $this->assertSame('expected-job-uuid', $jobQueuedEvent->payload()['uuid']);
+    }
+}
+
+class DatabaseQueueInspectedJob
+{
+    public function __construct(public string $data)
+    {
+    }
+}
+
+class DatabaseQueueEncryptedInspectedJob implements ShouldBeEncrypted
+{
+    public function __construct(public string $data)
+    {
     }
 }


### PR DESCRIPTION
This PR adjusts the `InspectedJob` payload decoding so the part containing data passed to the job is automatically unserialised and decrypted, allowing you filter jobs with specific data (useful for deployment time checks).