### PR TITLE
[13.x] `schedule:pause` command should error when its disabled

### DIFF
--- a/src/Illuminate/Console/Scheduling/SchedulePauseCommand.php
+++ b/src/Illuminate/Console/Scheduling/SchedulePauseCommand.php
@@ -25,6 +25,12 @@ class SchedulePauseCommand extends Command
      */
     public function handle(Cache $cache, Dispatcher $dispatcher)
     {
+        if (! Schedule::$pausable) {
+            $this->components->error('Schedule pausing is currently disabled.');
+
+            return 1;
+        }
+
         $cache->forever('illuminate:schedule:paused', true);
 
         $dispatcher->dispatch(new SchedulePaused);

--- a/tests/Integration/Console/Scheduling/SchedulePauseCommandTest.php
+++ b/tests/Integration/Console/Scheduling/SchedulePauseCommandTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Integration\Console\Scheduling;
 
 use Illuminate\Console\Events\SchedulePaused;
+use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Support\Facades\Event;
 use Orchestra\Testbench\TestCase;
 
@@ -15,5 +16,18 @@ class SchedulePauseCommandTest extends TestCase
         $this->artisan('schedule:pause');
 
         Event::assertDispatched(SchedulePaused::class);
+    }
+
+    public function testFailsWhenPausingIsDisabled()
+    {
+        Event::fake();
+
+        Schedule::$pausable = false;
+
+        $this->artisan('schedule:pause')->assertFailed();
+
+        Event::assertNotDispatched(SchedulePaused::class);
+
+        Schedule::$pausable = true;
     }
 }


### PR DESCRIPTION
This will save many future generations trying to resume it in my app when its disabled, which saves them reading my AppServiceProvider hieroglyphics

This follows the exact same behaviour as the queue `PauseCommand` https://github.com/laravel/framework/blob/42b494e1ed2bc80511bca064c8a395b776ff1516/src/Illuminate/Queue/Console/PauseCommand.php#L40 

TLDR, think of the juniors man :bowtie: 