### PR TITLE
[13.x] Fix ValidationImageFileRuleTest

### DIFF
--- a/tests/Validation/ValidationImageFileRuleTest.php
+++ b/tests/Validation/ValidationImageFileRuleTest.php
@@ -32,8 +32,8 @@ class ValidationImageFileRuleTest extends TestCase
 
     public function testDimensionsWithCustomImageSizeMethod()
     {
-        $handle = tmpfile(); // To prevent PHP from deleting the temp file early.
-        $path = stream_get_meta_data($handle)['uri'];
+        $stream = tmpfile(); // To prevent PHP from deleting the temp file early.
+        $path = stream_get_meta_data($stream)['uri'];
 
         $this->fails(
             File::image()->dimensions(Rule::dimensions()->width(100)->height(100)),

--- a/tests/Validation/ValidationImageFileRuleTest.php
+++ b/tests/Validation/ValidationImageFileRuleTest.php
@@ -32,15 +32,18 @@ class ValidationImageFileRuleTest extends TestCase
 
     public function testDimensionsWithCustomImageSizeMethod()
     {
+        $handle = tmpfile(); // To prevent PHP from deleting the temp file early.
+        $path = stream_get_meta_data($handle)['uri'];
+
         $this->fails(
             File::image()->dimensions(Rule::dimensions()->width(100)->height(100)),
-            new UploadedFileWithCustomImageSizeMethod(stream_get_meta_data(tmpfile())['uri'], 'foo.png'),
+            new UploadedFileWithCustomImageSizeMethod($path, 'foo.png'),
             ['validation.dimensions'],
         );
 
         $this->passes(
             File::image()->dimensions(Rule::dimensions()->width(200)->height(200)),
-            new UploadedFileWithCustomImageSizeMethod(stream_get_meta_data(tmpfile())['uri'], 'foo.png'),
+            new UploadedFileWithCustomImageSizeMethod($path, 'foo.png'),
         );
     }
 


### PR DESCRIPTION
Was surprised to see this failing via https://github.com/laravel/framework/actions/runs/26788085152/job/78968350449

It's because the vars it had were removed in https://github.com/laravel/framework/pull/60338 so now it's doomed to fail.


This PR basically makes it simpler... (I reckon) and adds a comment to ensure it's not changed again.