### PR TITLE
[12.x] Ensure path seperators aren't encoded in LocalFilesystemAdapter

### DIFF
--- a/src/Illuminate/Filesystem/LocalFilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/LocalFilesystemAdapter.php
@@ -80,7 +80,8 @@ class LocalFilesystemAdapter extends FilesystemAdapter
         return $url->to($url->temporarySignedRoute(
             'storage.'.$this->disk,
             $expiration,
-            ['path' => strtr(rawurlencode($path), ['%2F' => '/'])]
+            ['path' => strtr(rawurlencode($path), ['%2F' => '/'])],
+            absolute: false
         ));
     }
 

--- a/src/Illuminate/Filesystem/LocalFilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/LocalFilesystemAdapter.php
@@ -80,8 +80,7 @@ class LocalFilesystemAdapter extends FilesystemAdapter
         return $url->to($url->temporarySignedRoute(
             'storage.'.$this->disk,
             $expiration,
-            ['path' => rawurldecode($path)],
-            absolute: false
+            ['path' => strtr(rawurlencode($path), ['%2F' => '/'])]
         ));
     }
 

--- a/src/Illuminate/Filesystem/LocalFilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/LocalFilesystemAdapter.php
@@ -111,7 +111,7 @@ class LocalFilesystemAdapter extends FilesystemAdapter
             'url' => $url->to($url->temporarySignedRoute(
                 'storage.'.$this->disk.'.upload',
                 $expiration,
-                ['path' => rawurlencode($path), 'upload' => true],
+                ['path' => strtr(rawurlencode($path), ['%2F' => '/']), 'upload' => true],
                 absolute: false
             )),
             'headers' => [],

--- a/tests/Integration/Filesystem/ReceiveFileTest.php
+++ b/tests/Integration/Filesystem/ReceiveFileTest.php
@@ -12,7 +12,11 @@ class ReceiveFileTest extends TestCase
     protected function setUp(): void
     {
         $this->beforeApplicationDestroyed(function () {
-            Storage::delete('receive-file-test.txt');
+            Storage::delete([
+                'receive-file-test.txt',
+                'receive-file-test.txt?pad=x',
+                'nested/folder/receive-file-test.txt',
+            ]);
         });
 
         parent::setUp();
@@ -71,5 +75,37 @@ class ReceiveFileTest extends TestCase
         $response = $this->get($uploadUrl['url']);
 
         $response->assertForbidden();
+    }
+
+    #[RequiresOperatingSystem('Linux|Darwin')]
+    public function testItCanReceiveAFileWithUriDelimitersInThePath()
+    {
+        $result = Storage::temporaryUploadUrl('receive-file-test.txt?pad=x', Carbon::now()->addMinute());
+
+        $response = $this->call('PUT', $result['url'], [], [], [], [], 'Hello Question');
+
+        $response->assertNoContent();
+        Storage::assertExists('receive-file-test.txt?pad=x', 'Hello Question');
+        Storage::assertMissing('receive-file-test.txt');
+    }
+
+    #[RequiresOperatingSystem('Linux|Darwin')]
+    public function testTemporaryUploadUrlPreservesPathSeparatorsInNestedPaths()
+    {
+        $result = Storage::temporaryUploadUrl('nested/folder/receive-file-test.txt', Carbon::now()->addMinute());
+
+        $this->assertStringContainsString('nested/folder/receive-file-test.txt', $result['url']);
+    }
+
+    #[RequiresOperatingSystem('Linux|Darwin')]
+    public function testUriDelimitersInThePathCannotHideAnExpiredUploadUrl()
+    {
+        $result = Storage::temporaryUploadUrl('receive-file-test.txt?pad=x', Carbon::now()->subMinute());
+
+        $response = $this->call('PUT', $result['url'], [], [], [], [], 'Hello Question');
+
+        $response->assertForbidden();
+        Storage::assertMissing('receive-file-test.txt');
+        Storage::assertMissing('receive-file-test.txt?pad=x');
     }
 }

--- a/tests/Integration/Filesystem/ReceiveFileTest.php
+++ b/tests/Integration/Filesystem/ReceiveFileTest.php
@@ -2,9 +2,11 @@
 
 namespace Illuminate\Tests\Integration\Filesystem;
 
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Storage;
 use Orchestra\Testbench\Attributes\WithConfig;
 use Orchestra\Testbench\TestCase;
+use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 
 #[WithConfig('filesystems.disks.local.serve', true)]
 class ReceiveFileTest extends TestCase

--- a/tests/Integration/Filesystem/ServeFileTest.php
+++ b/tests/Integration/Filesystem/ServeFileTest.php
@@ -27,7 +27,6 @@ class ServeFileTest extends TestCase
             ]);
         });
 
-
         parent::setUp();
     }
 

--- a/tests/Integration/Filesystem/ServeFileTest.php
+++ b/tests/Integration/Filesystem/ServeFileTest.php
@@ -2,9 +2,11 @@
 
 namespace Illuminate\Tests\Integration\Filesystem;
 
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Storage;
 use Orchestra\Testbench\Attributes\WithConfig;
 use Orchestra\Testbench\TestCase;
+use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 
 #[WithConfig('filesystems.disks.local.serve', true)]
 class ServeFileTest extends TestCase
@@ -17,6 +19,16 @@ class ServeFileTest extends TestCase
 
         $this->beforeApplicationDestroyed(function () {
             Storage::delete('serve-file-test.txt');
+            Storage::put('serve-file-test.txt?pad=x', 'Hello Question');
+            Storage::put('nested/folder/serve-file-test.txt', 'Hello Nested');
+        });
+
+        $this->beforeApplicationDestroyed(function () {
+            Storage::delete([
+                'serve-file-test.txt',
+                'serve-file-test.txt?pad=x',
+                'nested/folder/serve-file-test.txt',
+            ]);
         });
 
         parent::setUp();
@@ -45,6 +57,37 @@ class ServeFileTest extends TestCase
         $url = Storage::temporaryUrl('serve-file-test.txt', now()->addMinutes(1));
 
         $url = $url.'c';
+
+        $response = $this->get($url);
+
+        $response->assertForbidden();
+    }
+    #[RequiresOperatingSystem('Linux|Darwin')]
+    public function testItCanServeAFileWithUriDelimitersInThePath()
+    {
+        $url = Storage::temporaryUrl('serve-file-test.txt?pad=x', Carbon::now()->addMinute());
+
+        $response = $this->get($url);
+
+        $this->assertSame('Hello Question', $response->streamedContent());
+    }
+
+    #[RequiresOperatingSystem('Linux|Darwin')]
+    public function testTemporaryUrlPreservesPathSeparatorsInNestedPaths()
+    {
+        $url = Storage::temporaryUrl('nested/folder/serve-file-test.txt', Carbon::now()->addMinute());
+
+        $this->assertStringContainsString('nested/folder/serve-file-test.txt', $url);
+
+        $response = $this->get($url);
+
+        $this->assertSame('Hello Nested', $response->streamedContent());
+    }
+
+    #[RequiresOperatingSystem('Linux|Darwin')]
+    public function testUriDelimitersInThePathCannotHideAnExpiredUrl()
+    {
+        $url = Storage::temporaryUrl('serve-file-test.txt?pad=x', Carbon::now()->subMinute());
 
         $response = $this->get($url);
 

--- a/tests/Integration/Filesystem/ServeFileTest.php
+++ b/tests/Integration/Filesystem/ServeFileTest.php
@@ -58,6 +58,7 @@ class ServeFileTest extends TestCase
 
         $response->assertForbidden();
     }
+
     #[RequiresOperatingSystem('Linux|Darwin')]
     public function testItCanServeAFileWithUriDelimitersInThePath()
     {

--- a/tests/Integration/Filesystem/ServeFileTest.php
+++ b/tests/Integration/Filesystem/ServeFileTest.php
@@ -15,10 +15,6 @@ class ServeFileTest extends TestCase
     {
         $this->afterApplicationCreated(function () {
             Storage::put('serve-file-test.txt', 'Hello World');
-        });
-
-        $this->beforeApplicationDestroyed(function () {
-            Storage::delete('serve-file-test.txt');
             Storage::put('serve-file-test.txt?pad=x', 'Hello Question');
             Storage::put('nested/folder/serve-file-test.txt', 'Hello Nested');
         });
@@ -30,6 +26,7 @@ class ServeFileTest extends TestCase
                 'nested/folder/serve-file-test.txt',
             ]);
         });
+
 
         parent::setUp();
     }


### PR DESCRIPTION
The url encoding stuff was also in 12.x


so this is a back port of fixes https://github.com/laravel/framework/pull/60194 and  https://github.com/laravel/framework/pull/60230 


I've cherry picked the changes, and brought the tests cause... they're there.. I can pull the tests out tho if you dont want em.