### PR TITLE
[13.x] Add missing RedisManager tests

### DIFF
--- a/tests/Redis/RedisManagerExtensionTest.php
+++ b/tests/Redis/RedisManagerExtensionTest.php
@@ -3,7 +3,9 @@
 namespace Illuminate\Tests\Redis;
 
 use Illuminate\Contracts\Redis\Connector;
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Foundation\Application;
+use Illuminate\Redis\Connections\Connection;
 use Illuminate\Redis\RedisManager;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -103,6 +105,96 @@ class RedisManagerExtensionTest extends TestCase
 
         $redis->purge(FakeRedisConnectionName::Default);
         $this->assertCount(0, $redis->connections());
+    }
+
+    public function testConnectionIsCachedAfterFirstResolution()
+    {
+        $connection = new FakeRedisConnection;
+
+        $connector = m::mock(Connector::class);
+        $connector->shouldReceive('connect')->once()->andReturn($connection);
+
+        $redis = new RedisManager(new Application, 'my_custom_driver', [
+            'default' => [
+                'host' => 'some-host',
+            ],
+        ]);
+
+        $redis->extend('my_custom_driver', fn () => $connector);
+
+        $this->assertSame($connection, $redis->connection());
+        $this->assertSame($connection, $redis->connection());
+    }
+
+    public function testConnectionSetsEventDispatcherWhenEnabled()
+    {
+        $connection = new FakeRedisConnection;
+
+        $connector = m::mock(Connector::class);
+        $connector->shouldReceive('connect')->once()->andReturn($connection);
+
+        $app = m::mock(Application::class)->makePartial();
+        $app->shouldReceive('bound')->once()->with('events')->andReturn(true);
+        $app->shouldReceive('make')->once()->with('events')->andReturn(m::mock(Dispatcher::class));
+
+        $redis = new RedisManager($app, 'my_custom_driver', [
+            'default' => [
+                'host' => 'some-host',
+            ],
+        ]);
+
+        $redis->extend('my_custom_driver', fn () => $connector);
+        $redis->enableEvents();
+
+        $redis->connection();
+
+        $this->assertSame('default', $connection->getName());
+        $this->assertInstanceOf(Dispatcher::class, $connection->getEventDispatcher());
+    }
+
+    public function testResolveThrowsWhenConnectionIsNotConfigured()
+    {
+        $redis = new RedisManager(new Application, 'my_custom_driver', []);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Redis connection [missing] not configured.');
+
+        $redis->resolve('missing');
+    }
+
+    public function testResolveUsesPerConnectionParameters()
+    {
+        $connector = m::mock(Connector::class);
+        $connector->shouldReceive('connect')->once()->with(
+            ['host' => 'some-host'],
+            ['foo' => 'bar', 'parameters' => ['timeout' => 1]]
+        )->andReturn('my-redis-connection');
+
+        $redis = new RedisManager(new Application, 'my_custom_driver', [
+            'options' => [
+                'foo' => 'bar',
+                'parameters' => [
+                    'default' => [
+                        'timeout' => 1,
+                    ],
+                ],
+            ],
+            'default' => [
+                'host' => 'some-host',
+            ],
+        ]);
+
+        $redis->extend('my_custom_driver', fn () => $connector);
+
+        $this->assertSame('my-redis-connection', $redis->resolve());
+    }
+}
+
+class FakeRedisConnection extends Connection
+{
+    public function createSubscription($channels, \Closure $callback, $method = 'subscribe')
+    {
+        //
     }
 }
 


### PR DESCRIPTION
Add targeted tests for `RedisManager` caching, event dispatcher wiring, missing connection errors, and parameter merging. 
These cases are not covered by the existing Redis connector/connection tests.