### PR TITLE
Restore Container::getInstance after config:cache and route:cache

### DIFF
--- a/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Command;
+use Illuminate\Container\Container;
 use Illuminate\Contracts\Console\Kernel as ConsoleKernelContract;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Arr;
@@ -91,12 +92,18 @@ class ConfigCacheCommand extends Command
      */
     protected function getFreshConfiguration()
     {
-        $app = require $this->laravel->bootstrapPath('app.php');
+        $originalContainer = Container::getInstance();
 
-        $app->useStoragePath($this->laravel->storagePath());
+        try {
+            $app = require $this->laravel->bootstrapPath('app.php');
 
-        $app->make(ConsoleKernelContract::class)->bootstrap();
+            $app->useStoragePath($this->laravel->storagePath());
 
-        return $app['config']->all();
+            $app->make(ConsoleKernelContract::class)->bootstrap();
+
+            return $app['config']->all();
+        } finally {
+            Container::setInstance($originalContainer);
+        }
     }
 }

--- a/src/Illuminate/Foundation/Console/RouteCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteCacheCommand.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Command;
+use Illuminate\Container\Container;
 use Illuminate\Contracts\Console\Kernel as ConsoleKernelContract;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Routing\RouteCollection;
@@ -90,9 +91,15 @@ class RouteCacheCommand extends Command
      */
     protected function getFreshApplication()
     {
-        return tap(require $this->laravel->bootstrapPath('app.php'), function ($app) {
-            $app->make(ConsoleKernelContract::class)->bootstrap();
-        });
+        $originalContainer = Container::getInstance();
+
+        try {
+            return tap(require $this->laravel->bootstrapPath('app.php'), function ($app) {
+                $app->make(ConsoleKernelContract::class)->bootstrap();
+            });
+        } finally {
+            Container::setInstance($originalContainer);
+        }
     }
 
     /**

--- a/tests/Integration/Foundation/Console/CacheCommandsContainerLeakTest.php
+++ b/tests/Integration/Foundation/Console/CacheCommandsContainerLeakTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Foundation\Console;
+
+use Illuminate\Container\Container;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Tests\Integration\Generators\TestCase;
+
+class CacheCommandsContainerLeakTest extends TestCase
+{
+    protected $files = [
+        'bootstrap/cache/config.php',
+        'bootstrap/cache/routes-v7.php',
+    ];
+
+    public function testConfigCacheRestoresGlobalContainerInstance()
+    {
+        $original = Container::getInstance();
+
+        $this->artisan('config:cache')->assertSuccessful();
+
+        $this->assertSame(
+            $original,
+            Container::getInstance(),
+            'config:cache leaked the secondary Application instance into Container::getInstance().'
+        );
+    }
+
+    public function testRouteCacheRestoresGlobalContainerInstance()
+    {
+        Route::get('/cache-leak-test', fn () => 'ok');
+
+        $original = Container::getInstance();
+
+        $this->artisan('route:cache')->assertSuccessful();
+
+        $this->assertSame(
+            $original,
+            Container::getInstance(),
+            'route:cache leaked the secondary Application instance into Container::getInstance().'
+        );
+    }
+}


### PR DESCRIPTION
 ## Summary

  `config:cache` and `route:cache` bootstrap a secondary `Application` instance to inspect a clean copy of config / routes. `Application::__construct` unconditionally calls `static::setInstance($this)` on the `Container`, replacing the **global**
  `Container::getInstance()` pointer.

  Neither command restores the original pointer. After they run inside a long-lived process — `optimize`, Octane workers, queue workers, tests, custom artisan commands that chain these — `Container::getInstance()` and the `app()` helper resolve
  services from the now-defunct secondary `Application` instead of the parent.

  ## Reproduction

  `php artisan optimize` runs `config:cache → event:cache → route:cache → view:cache` in one process (`OptimizeCommand::getOptimizeTasks()`). After `route:cache`, `view:cache` compiles views using the parent app's compiler (via
  `$this->laravel['view']`), but any Blade directive callback that resolves services through `app(...)` hits the secondary app — including package-registered directives that call `app('blade.compiler')->getPath()`.

  A real-world manifestation: Livewire's `@script` directive computes a deterministic key from `app('blade.compiler')->getPath()`. Under `optimize`, the helper returns the secondary compiler whose `path` is `null`, so every `@script` key collapses into a single bucket and the counter becomes process-global and order-dependent. Behind a load balancer with multiple app containers and no sticky sessions, scripts get re-evaluated on every cross-container Livewire update, causing duplicated
  event listeners and modal components. The bug disappears when `view:cache` runs in a separate PHP process from `route:cache`.

  Minimal repro on any Laravel app with a package that calls `app('blade.compiler')->getPath()` from a directive callback (e.g. Livewire's `@script`):


```bash
  # good: standalone view:cache uses the correct compiler instance
  php artisan view:cache
  grep -rh '__scriptKey' storage/framework/views/*.php | sort -u
  # -> $__scriptKey = '617248320-1'; ...  (real crc32 of view path)

  # bad: optimize runs route:cache first, then view:cache resolves the
  # wrong BladeCompiler from the global container
  php artisan optimize
  grep -rh '__scriptKey' storage/framework/views/*.php | sort -u
  # -> $__scriptKey = '0-13'; $__scriptKey = '0-14'; ...  (crc32('') = 0)
```


  ## Fix

  Capture `Container::getInstance()` before bootstrapping the secondary app and restore it in a `finally` block. Two-method change in `ConfigCacheCommand::getFreshConfiguration()` and `RouteCacheCommand::getFreshApplication()`.

  ## Tests

  Added `tests/Integration/Foundation/Console/CacheCommandsContainerLeakTest.php` asserting `Container::getInstance()` is the same instance before and after each command runs.