### PR TITLE
[13.x] Fix `Request::createFromBase()` compatibility with Symfony 8.1

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -546,7 +546,19 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
         $newRequest->content = $request->content;
 
         if ($newRequest->isJson()) {
-            $newRequest->request = $newRequest->json();
+            $newRequest->initialize(
+                $newRequest->query->all(),
+                $newRequest->json()->all(),
+                $newRequest->attributes->all(),
+                $newRequest->cookies->all(),
+                $newRequest->files->all(),
+                $newRequest->server->all(),
+                $newRequest->getContent()
+            );
+
+            $newRequest->setJson($newRequest->request);
+
+            $newRequest->headers->replace($request->headers->all());
         }
 
         return $newRequest;

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -546,19 +546,12 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
         $newRequest->content = $request->content;
 
         if ($newRequest->isJson()) {
-            $newRequest->initialize(
-                $newRequest->query->all(),
-                $newRequest->json()->all(),
-                $newRequest->attributes->all(),
-                $newRequest->cookies->all(),
-                $newRequest->files->all(),
-                $newRequest->server->all(),
-                $newRequest->getContent()
-            );
-
-            $newRequest->setJson($newRequest->request);
-
-            $newRequest->headers->replace($request->headers->all());
+            return tap($newRequest->duplicate(
+                request: $newRequest->json()->all(),
+            ), function ($jsonRequest) use ($request) {
+                $jsonRequest->setJson($jsonRequest->request);
+                $jsonRequest->headers->replace($request->headers->all());
+            });
         }
 
         return $newRequest;

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -546,12 +546,8 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
         $newRequest->content = $request->content;
 
         if ($newRequest->isJson()) {
-            return tap($newRequest->duplicate(
-                request: $newRequest->json()->all(),
-            ), function ($jsonRequest) use ($request) {
-                $jsonRequest->setJson($jsonRequest->request);
-                $jsonRequest->headers->replace($request->headers->all());
-            });
+            $newRequest->request->replace($newRequest->json()->all());
+            $newRequest->setJson($newRequest->request);
         }
 
         return $newRequest;

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -1890,36 +1890,12 @@ class HttpRequestTest extends TestCase
 
     public function testCreatingJsonRequestFromBaseDoesNotTriggerRequestPropertyDeprecation()
     {
-        if (! method_exists(SymfonyRequest::class, 'getPayload')) {
-            return;
-        }
-
         $base = SymfonyRequest::create('/', 'POST', server: ['CONTENT_TYPE' => 'application/json'], content: '{"hello":"world"}');
 
-        $deprecations = [];
+        $request = Request::createFromBase($base);
 
-        set_error_handler(static function (int $severity, string $message) use (&$deprecations) {
-            if ($severity === E_USER_DEPRECATED) {
-                $deprecations[] = $message;
-
-                return true;
-            }
-
-            return false;
-        });
-
-        try {
-            Request::createFromBase($base);
-        } finally {
-            restore_error_handler();
-        }
-
-        $relevantDeprecations = array_filter($deprecations, static fn (string $message) => str_contains($message,
-            'Directly setting property "request"') &&
-            str_contains($message, 'Symfony\\Component\\HttpFoundation\\Request')
-        );
-
-        $this->assertEmpty($relevantDeprecations);
+        $this->assertTrue($request->isJson());
+        $this->assertSame('world', $request->input('hello'));
     }
 
     public function testJsonRequestsCanMergeDataIntoJsonRequest()

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -1888,6 +1888,40 @@ class HttpRequestTest extends TestCase
         $this->assertSame('world', $request->getPayload()->get('hello'));
     }
 
+    public function testCreatingJsonRequestFromBaseDoesNotTriggerRequestPropertyDeprecation()
+    {
+        if (! method_exists(SymfonyRequest::class, 'getPayload')) {
+            return;
+        }
+
+        $base = SymfonyRequest::create('/', 'POST', server: ['CONTENT_TYPE' => 'application/json'], content: '{"hello":"world"}');
+
+        $deprecations = [];
+
+        set_error_handler(static function (int $severity, string $message) use (&$deprecations) {
+            if ($severity === E_USER_DEPRECATED) {
+                $deprecations[] = $message;
+
+                return true;
+            }
+
+            return false;
+        });
+
+        try {
+            Request::createFromBase($base);
+        } finally {
+            restore_error_handler();
+        }
+
+        $relevantDeprecations = array_filter($deprecations, static fn (string $message) =>
+            str_contains($message, 'Directly setting property "request"') &&
+            str_contains($message, 'Symfony\\Component\\HttpFoundation\\Request')
+        );
+
+        $this->assertEmpty($relevantDeprecations);
+    }
+
     public function testJsonRequestsCanMergeDataIntoJsonRequest()
     {
         if (! method_exists(SymfonyRequest::class, 'getPayload')) {

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -1914,8 +1914,8 @@ class HttpRequestTest extends TestCase
             restore_error_handler();
         }
 
-        $relevantDeprecations = array_filter($deprecations, static fn (string $message) =>
-            str_contains($message, 'Directly setting property "request"') &&
+        $relevantDeprecations = array_filter($deprecations, static fn (string $message) => str_contains($message,
+            'Directly setting property "request"') &&
             str_contains($message, 'Symfony\\Component\\HttpFoundation\\Request')
         );
 

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -1890,9 +1890,9 @@ class HttpRequestTest extends TestCase
 
     public function testCreatingJsonRequestFromBaseDoesNotTriggerRequestPropertyDeprecation()
     {
-        $base = SymfonyRequest::create('/', 'POST', server: ['CONTENT_TYPE' => 'application/json'], content: '{"hello":"world"}');
-
-        $request = Request::createFromBase($base);
+        $request = Request::createFromBase(
+            SymfonyRequest::create('/', 'POST', server: ['CONTENT_TYPE' => 'application/json'], content: '{"hello":"world"}')
+        );
 
         $this->assertTrue($request->isJson());
         $this->assertSame('world', $request->input('hello'));


### PR DESCRIPTION
[13.x] Fix Request::createFromBase compatibility with Symfony 8.1

Fixes: #60353

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
