### PR TITLE
[13.x] Cache falsy JSON payloads in HTTP client responses

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -35,6 +35,13 @@ class Response implements ArrayAccess, Stringable
     protected $decoded;
 
     /**
+     * Indicates if the JSON response has been decoded.
+     *
+     * @var bool
+     */
+    protected bool $decodedJson = false;
+
+    /**
      * The flags that were used when decoding the JSON response.
      *
      * @var int-mask<JSON_BIGINT_AS_STRING, JSON_INVALID_UTF8_IGNORE, JSON_INVALID_UTF8_SUBSTITUTE, JSON_OBJECT_AS_ARRAY, JSON_THROW_ON_ERROR>
@@ -101,12 +108,13 @@ class Response implements ArrayAccess, Stringable
     {
         $flags ??= self::$defaultJsonDecodingFlags;
 
-        if (! $this->decoded || (isset($this->decodingFlags) && $this->decodingFlags !== $flags)) {
+        if (! $this->decodedJson || $this->decodingFlags !== $flags) {
             $this->decoded = json_decode(
                 $this->body(), true, flags: $flags
             );
 
             $this->decodingFlags = $flags;
+            $this->decodedJson = true;
         }
 
         if (is_null($key)) {

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -4730,6 +4730,63 @@ class HttpClientTest extends TestCase
         $response->json();
         $this->assertSame(3, $response->bodyCallCount);
     }
+
+    public function testJsonDecodingIsCachedForFalsyPayloads()
+    {
+        $payloads = [
+            '[]' => [],
+            'false' => false,
+            '0' => 0,
+            'null' => null,
+            '""' => '',
+        ];
+
+        foreach ($payloads as $body => $expected) {
+            $response = new BodyTrackingResponse(Factory::psr7Response($body));
+
+            // First call decodes and caches
+            $this->assertSame($expected, $response->json());
+            $this->assertSame(1, $response->bodyCallCount, "Failed for body: $body");
+
+            // Subsequent calls use cache (body() not called again)
+            $this->assertSame($expected, $response->json());
+            $this->assertSame(1, $response->bodyCallCount, "body() called again for falsy payload: $body");
+
+            // Third call to be sure
+            $this->assertSame($expected, $response->json());
+            $this->assertSame(1, $response->bodyCallCount, "body() called again for falsy payload: $body");
+        }
+    }
+
+    public function testJsonDecodingWithFalsyPayloadRespectsFlags()
+    {
+        $response = new BodyTrackingResponse(Factory::psr7Response('0'));
+
+        // First call decodes with default flags
+        $this->assertSame(0, $response->json());
+        $this->assertSame(1, $response->bodyCallCount);
+
+        // Different flags triggers re-decode
+        $response->json(flags: JSON_BIGINT_AS_STRING);
+        $this->assertSame(2, $response->bodyCallCount);
+
+        // Same flags uses cache
+        $response->json(flags: JSON_BIGINT_AS_STRING);
+        $this->assertSame(2, $response->bodyCallCount);
+    }
+
+    public function testJsonDecodingWithEmptyArrayRespectsKeyAccess()
+    {
+        $response = new BodyTrackingResponse(Factory::psr7Response('[]'));
+
+        // Accessing a key on an empty array returns default
+        $this->assertNull($response->json('missing'));
+        $this->assertSame('fallback', $response->json('missing', 'fallback'));
+
+        // body() should only be called once
+        $response->json();
+        $this->assertSame(1, $response->bodyCallCount);
+    }
 }
 
 class CustomFactory extends Factory


### PR DESCRIPTION
Fixes `json()` so valid falsy JSON payloads are cached correctly.

Introduces a dedicated `$decodedJson` boolean sentinel to track whether decoding has occurred, independent of the decoded value's truthiness.
