### PR TITLE
[13.x] Fix PHP object injection in Encrypter via disallowed classes

### DIFF
--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -201,7 +201,7 @@ class Encrypter implements EncrypterContract, StringEncrypter
             throw new DecryptException('Could not decrypt the data.');
         }
 
-        return $unserialize ? unserialize($decrypted, ['allowed_classes' => false]) : $decrypted;
+        return $unserialize ? unserialize($decrypted) : $decrypted;
     }
 
     /**

--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -201,7 +201,7 @@ class Encrypter implements EncrypterContract, StringEncrypter
             throw new DecryptException('Could not decrypt the data.');
         }
 
-        return $unserialize ? unserialize($decrypted) : $decrypted;
+        return $unserialize ? unserialize($decrypted, ['allowed_classes' => false]) : $decrypted;
     }
 
     /**

--- a/src/Illuminate/Session/EncryptedStore.php
+++ b/src/Illuminate/Session/EncryptedStore.php
@@ -24,7 +24,7 @@ class EncryptedStore extends Store
      * @param  string|null  $id
      * @param  string  $serialization
      */
-    public function __construct($name, SessionHandlerInterface $handler, EncrypterContract $encrypter, $id = null, $serialization = 'php')
+    public function __construct($name, SessionHandlerInterface $handler, EncrypterContract $encrypter, $id = null, $serialization = 'json')
     {
         $this->encrypter = $encrypter;
 

--- a/src/Illuminate/Session/SessionManager.php
+++ b/src/Illuminate/Session/SessionManager.php
@@ -197,7 +197,7 @@ class SessionManager extends Manager
                 $this->config->get('session.cookie'),
                 $handler,
                 $id = null,
-                $this->config->get('session.serialization', 'php')
+                $this->config->get('session.serialization', 'json')
             );
     }
 

--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -65,7 +65,7 @@ class Store implements Session
      *
      * @var string
      */
-    protected $serialization = 'php';
+    protected $serialization = 'json';
 
     /**
      * Session store started status.
@@ -82,7 +82,7 @@ class Store implements Session
      * @param  string|null  $id
      * @param  string  $serialization
      */
-    public function __construct($name, SessionHandlerInterface $handler, $id = null, $serialization = 'php')
+    public function __construct($name, SessionHandlerInterface $handler, $id = null, $serialization = 'json')
     {
         $this->setId($id);
         $this->name = $name;
@@ -162,9 +162,15 @@ class Store implements Session
             return;
         }
 
+        $errors = $this->get('errors');
+
+        if ($errors instanceof ViewErrorBag) {
+            return;
+        }
+
         $errorBag = new ViewErrorBag;
 
-        foreach ($this->get('errors') as $key => $value) {
+        foreach ($errors as $key => $value) {
             $messageBag = new MessageBag($value['messages']);
 
             $errorBag->put($key, $messageBag->setFormat($value['format']));

--- a/tests/Encryption/EncrypterTest.php
+++ b/tests/Encryption/EncrypterTest.php
@@ -7,6 +7,7 @@ use Illuminate\Encryption\Encrypter;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
+use stdClass;
 
 class EncrypterTest extends TestCase
 {
@@ -309,5 +310,94 @@ class EncrypterTest extends TestCase
         $this->assertFalse(Encrypter::appearsEncrypted(123));
         $this->assertFalse(Encrypter::appearsEncrypted(['foo' => 'bar']));
         $this->assertFalse(Encrypter::appearsEncrypted(null));
+    }
+
+    public function testDecryptWithAllowedClassesFalseHandlesAllStandardTypes()
+    {
+        $e = new Encrypter(str_repeat('a', 16));
+
+        $this->assertSame('foo', $e->decrypt($e->encrypt('foo')));
+        $this->assertSame(['key' => 'value'], $e->decrypt($e->encrypt(['key' => 'value'])));
+        $this->assertSame('', $e->decrypt($e->encrypt('')));
+        $this->assertSame(123, $e->decrypt($e->encrypt(123)));
+        $this->assertSame(null, $e->decrypt($e->encrypt(null)));
+    }
+
+    public function testDecryptWithAllowedClassesFalseHandlesAllStandardTypesWithGcm()
+    {
+        $e = new Encrypter(str_repeat('b', 32), 'AES-256-GCM');
+
+        $this->assertSame('foo', $e->decrypt($e->encrypt('foo')));
+        $this->assertSame(['key' => 'value'], $e->decrypt($e->encrypt(['key' => 'value'])));
+        $this->assertSame('', $e->decrypt($e->encrypt('')));
+        $this->assertSame(123, $e->decrypt($e->encrypt(123)));
+        $this->assertSame(null, $e->decrypt($e->encrypt(null)));
+    }
+
+    public function testDecryptWithAllowedClassesFalseConvertsObjectsToIncompleteClass()
+    {
+        $e = new Encrypter(str_repeat('a', 16));
+
+        $result = $e->decrypt($e->encrypt(new stdClass));
+
+        $this->assertInstanceOf(\__PHP_Incomplete_Class::class, $result);
+    }
+
+    public function testDecryptWithAllowedClassesFalsePreventsObjectInjection()
+    {
+        $e = new Encrypter(str_repeat('a', 16));
+
+        $spyFile = sys_get_temp_dir().'/'.uniqid('laravel-encrypt-test', true);
+
+        $malicious = new _EncrypterTestMalicious($spyFile);
+        $this->assertFileExists($spyFile);
+
+        $encrypted = $e->encrypt($malicious);
+
+        @unlink($spyFile);
+        $this->assertFileDoesNotExist($spyFile);
+
+        $result = $e->decrypt($encrypted);
+
+        $this->assertInstanceOf(\__PHP_Incomplete_Class::class, $result);
+        $this->assertFileDoesNotExist($spyFile);
+    }
+
+    public function testDecryptStringAndEncryptStringRoundTrip()
+    {
+        $e = new Encrypter(str_repeat('a', 16));
+
+        $this->assertSame('foo', $e->decryptString($e->encryptString('foo')));
+        $this->assertSame('', $e->decryptString($e->encryptString('')));
+        $this->assertSame('secret data', $e->decryptString($e->encryptString('secret data')));
+    }
+
+    public function testDecryptWithUnserializeFalseDoesNotCallUnserialize()
+    {
+        $e = new Encrypter(str_repeat('a', 16));
+
+        $encrypted = $e->encryptString('still encrypted');
+        $this->assertSame('still encrypted', $e->decrypt($encrypted, false));
+    }
+}
+
+class _EncrypterTestMalicious
+{
+    public string $path;
+
+    public function __construct($path)
+    {
+        $this->path = $path;
+        @touch($path);
+    }
+
+    public function __wakeup()
+    {
+        @touch($this->path);
+    }
+
+    public function __destruct()
+    {
+        @unlink($this->path);
     }
 }

--- a/tests/Encryption/EncrypterTest.php
+++ b/tests/Encryption/EncrypterTest.php
@@ -7,7 +7,6 @@ use Illuminate\Encryption\Encrypter;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
-use stdClass;
 
 class EncrypterTest extends TestCase
 {
@@ -310,94 +309,5 @@ class EncrypterTest extends TestCase
         $this->assertFalse(Encrypter::appearsEncrypted(123));
         $this->assertFalse(Encrypter::appearsEncrypted(['foo' => 'bar']));
         $this->assertFalse(Encrypter::appearsEncrypted(null));
-    }
-
-    public function testDecryptWithAllowedClassesFalseHandlesAllStandardTypes()
-    {
-        $e = new Encrypter(str_repeat('a', 16));
-
-        $this->assertSame('foo', $e->decrypt($e->encrypt('foo')));
-        $this->assertSame(['key' => 'value'], $e->decrypt($e->encrypt(['key' => 'value'])));
-        $this->assertSame('', $e->decrypt($e->encrypt('')));
-        $this->assertSame(123, $e->decrypt($e->encrypt(123)));
-        $this->assertSame(null, $e->decrypt($e->encrypt(null)));
-    }
-
-    public function testDecryptWithAllowedClassesFalseHandlesAllStandardTypesWithGcm()
-    {
-        $e = new Encrypter(str_repeat('b', 32), 'AES-256-GCM');
-
-        $this->assertSame('foo', $e->decrypt($e->encrypt('foo')));
-        $this->assertSame(['key' => 'value'], $e->decrypt($e->encrypt(['key' => 'value'])));
-        $this->assertSame('', $e->decrypt($e->encrypt('')));
-        $this->assertSame(123, $e->decrypt($e->encrypt(123)));
-        $this->assertSame(null, $e->decrypt($e->encrypt(null)));
-    }
-
-    public function testDecryptWithAllowedClassesFalseConvertsObjectsToIncompleteClass()
-    {
-        $e = new Encrypter(str_repeat('a', 16));
-
-        $result = $e->decrypt($e->encrypt(new stdClass));
-
-        $this->assertInstanceOf(\__PHP_Incomplete_Class::class, $result);
-    }
-
-    public function testDecryptWithAllowedClassesFalsePreventsObjectInjection()
-    {
-        $e = new Encrypter(str_repeat('a', 16));
-
-        $spyFile = sys_get_temp_dir().'/'.uniqid('laravel-encrypt-test', true);
-
-        $malicious = new _EncrypterTestMalicious($spyFile);
-        $this->assertFileExists($spyFile);
-
-        $encrypted = $e->encrypt($malicious);
-
-        @unlink($spyFile);
-        $this->assertFileDoesNotExist($spyFile);
-
-        $result = $e->decrypt($encrypted);
-
-        $this->assertInstanceOf(\__PHP_Incomplete_Class::class, $result);
-        $this->assertFileDoesNotExist($spyFile);
-    }
-
-    public function testDecryptStringAndEncryptStringRoundTrip()
-    {
-        $e = new Encrypter(str_repeat('a', 16));
-
-        $this->assertSame('foo', $e->decryptString($e->encryptString('foo')));
-        $this->assertSame('', $e->decryptString($e->encryptString('')));
-        $this->assertSame('secret data', $e->decryptString($e->encryptString('secret data')));
-    }
-
-    public function testDecryptWithUnserializeFalseDoesNotCallUnserialize()
-    {
-        $e = new Encrypter(str_repeat('a', 16));
-
-        $encrypted = $e->encryptString('still encrypted');
-        $this->assertSame('still encrypted', $e->decrypt($encrypted, false));
-    }
-}
-
-class _EncrypterTestMalicious
-{
-    public string $path;
-
-    public function __construct($path)
-    {
-        $this->path = $path;
-        @touch($path);
-    }
-
-    public function __wakeup()
-    {
-        @touch($this->path);
-    }
-
-    public function __destruct()
-    {
-        @unlink($this->path);
     }
 }

--- a/tests/Session/EncryptedSessionStoreTest.php
+++ b/tests/Session/EncryptedSessionStoreTest.php
@@ -53,6 +53,7 @@ class EncryptedSessionStoreTest extends TestCase
             m::mock(SessionHandlerInterface::class),
             m::mock(Encrypter::class),
             $this->getSessionId(),
+            'php',
         ];
     }
 

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -12,7 +12,6 @@ use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use SessionHandlerInterface;
-use stdClass;
 use Symfony\Component\HttpFoundation\Request;
 
 class SessionStoreTest extends TestCase

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -12,13 +12,14 @@ use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use SessionHandlerInterface;
+use stdClass;
 use Symfony\Component\HttpFoundation\Request;
 
 class SessionStoreTest extends TestCase
 {
     public function testSessionIsLoadedFromHandler()
     {
-        $session = $this->getSession();
+        $session = $this->getSession('php');
         $session->getHandler()->shouldReceive('read')->once()->with($this->getSessionId())->andReturn(serialize(['foo' => 'bar', 'bagged' => ['name' => 'taylor'], '123' => 'bax']));
         $session->start();
 
@@ -95,7 +96,7 @@ class SessionStoreTest extends TestCase
 
     public function testBrandNewSessionIsProperlySaved()
     {
-        $session = $this->getSession();
+        $session = $this->getSession('php');
         $session->getHandler()->shouldReceive('read')->once()->andReturn(serialize([]));
         $session->start();
         $session->put('foo', 'bar');
@@ -120,7 +121,7 @@ class SessionStoreTest extends TestCase
 
     public function testSessionIsProperlyUpdated()
     {
-        $session = $this->getSession();
+        $session = $this->getSession('php');
         $session->getHandler()->shouldReceive('read')->once()->andReturn(serialize([
             '_token' => Str::random(40),
             'foo' => 'bar',
@@ -151,7 +152,7 @@ class SessionStoreTest extends TestCase
 
     public function testSessionIsReSavedWhenNothingHasChanged()
     {
-        $session = $this->getSession();
+        $session = $this->getSession('php');
         $session->getHandler()->shouldReceive('read')->once()->andReturn(serialize([
             '_token' => Str::random(40),
             'foo' => 'bar',
@@ -183,7 +184,7 @@ class SessionStoreTest extends TestCase
 
     public function testSessionIsReSavedWhenNothingHasChangedExceptSessionId()
     {
-        $session = $this->getSession();
+        $session = $this->getSession('php');
         $oldId = $session->getId();
         $token = Str::random(40);
         $session->getHandler()->shouldReceive('read')->once()->with($oldId)->andReturn(serialize([
@@ -832,7 +833,92 @@ class SessionStoreTest extends TestCase
         $this->assertSame('macroable', $this->getSession()->foo());
     }
 
-    public function getSession($serialization = 'php')
+    public function testDefaultSerializationIsJson()
+    {
+        $session = new Store('test', m::mock(SessionHandlerInterface::class));
+
+        $this->assertSame('json', $this->getSerializationProperty($session));
+    }
+
+    private function getSerializationProperty(Store $session): string
+    {
+        return (new ReflectionClass(Store::class))
+            ->getProperty('serialization')
+            ->getValue($session);
+    }
+
+    public function testJsonSerializationIsUsedByDefault()
+    {
+        $session = $this->getSession('json');
+        $session->getHandler()->shouldReceive('read')->once()->andReturn(json_encode(['foo' => 'bar']));
+        $session->start();
+
+        $this->assertSame('bar', $session->get('foo'));
+
+        $session->put('baz', 'boom');
+        $session->getHandler()->shouldReceive('write')->once()->with(
+            $this->getSessionId(),
+            \Mockery::on(function ($data) {
+                $decoded = json_decode($data, true);
+
+                return is_array($decoded)
+                    && $decoded['foo'] === 'bar'
+                    && $decoded['baz'] === 'boom';
+            })
+        );
+        $session->save();
+    }
+
+    public function testJsonSerializationRejectsMaliciousSerializedPayload()
+    {
+        $session = $this->getSession('json');
+
+        $maliciousPayload = 'O:12:"FakeMalicious":0:{}';
+
+        $session->getHandler()->shouldReceive('read')->once()->andReturn($maliciousPayload);
+        $session->start();
+
+        $this->assertFalse($session->has('foo'));
+        $this->assertTrue($session->has('_token'));
+        $this->assertNull($session->get('foo'));
+    }
+
+    public function testJsonSerializationRejectsObjectInjectionViaSerializedArray()
+    {
+        $session = $this->getSession('json');
+
+        $maliciousPayload = 'a:1:{s:3:"foo";O:12:"FakeMalicious":0:{}}';
+
+        $session->getHandler()->shouldReceive('read')->once()->andReturn($maliciousPayload);
+        $session->start();
+
+        $this->assertFalse($session->has('foo'));
+        $this->assertNull($session->get('foo'));
+    }
+
+    public function testPhpSerializationBackwardCompatibleWhenExplicitlySet()
+    {
+        $session = $this->getSession('php');
+        $session->getHandler()->shouldReceive('read')->once()->andReturn(serialize(['foo' => 'bar']));
+        $session->start();
+
+        $this->assertSame('bar', $session->get('foo'));
+
+        $session->put('baz', 'boom');
+        $session->getHandler()->shouldReceive('write')->once()->with(
+            $this->getSessionId(),
+            \Mockery::on(function ($data) {
+                $decoded = @unserialize($data);
+
+                return is_array($decoded)
+                    && $decoded['foo'] === 'bar'
+                    && $decoded['baz'] === 'boom';
+            })
+        );
+        $session->save();
+    }
+
+    public function getSession($serialization = 'json')
     {
         $reflection = new ReflectionClass(Store::class);
 

--- a/tests/Validation/ValidationImageFileRuleTest.php
+++ b/tests/Validation/ValidationImageFileRuleTest.php
@@ -32,22 +32,19 @@ class ValidationImageFileRuleTest extends TestCase
 
     public function testDimensionsWithCustomImageSizeMethod()
     {
-        $path1 = tempnam(sys_get_temp_dir(), 'laravel-test');
-        $path2 = tempnam(sys_get_temp_dir(), 'laravel-test');
+        $stream = tmpfile();
+        $path = stream_get_meta_data($stream)['uri'];
 
         $this->fails(
             File::image()->dimensions(Rule::dimensions()->width(100)->height(100)),
-            new UploadedFileWithCustomImageSizeMethod($path1, 'foo.png'),
+            new UploadedFileWithCustomImageSizeMethod($path, 'foo.png'),
             ['validation.dimensions'],
         );
 
         $this->passes(
             File::image()->dimensions(Rule::dimensions()->width(200)->height(200)),
-            new UploadedFileWithCustomImageSizeMethod($path2, 'foo.png'),
+            new UploadedFileWithCustomImageSizeMethod($path, 'foo.png'),
         );
-
-        @unlink($path1);
-        @unlink($path2);
     }
 
     public function testDimensionWithTheRatioMethod()

--- a/tests/Validation/ValidationImageFileRuleTest.php
+++ b/tests/Validation/ValidationImageFileRuleTest.php
@@ -32,16 +32,22 @@ class ValidationImageFileRuleTest extends TestCase
 
     public function testDimensionsWithCustomImageSizeMethod()
     {
+        $path1 = tempnam(sys_get_temp_dir(), 'laravel-test');
+        $path2 = tempnam(sys_get_temp_dir(), 'laravel-test');
+
         $this->fails(
             File::image()->dimensions(Rule::dimensions()->width(100)->height(100)),
-            new UploadedFileWithCustomImageSizeMethod(stream_get_meta_data(tmpfile())['uri'], 'foo.png'),
+            new UploadedFileWithCustomImageSizeMethod($path1, 'foo.png'),
             ['validation.dimensions'],
         );
 
         $this->passes(
             File::image()->dimensions(Rule::dimensions()->width(200)->height(200)),
-            new UploadedFileWithCustomImageSizeMethod(stream_get_meta_data(tmpfile())['uri'], 'foo.png'),
+            new UploadedFileWithCustomImageSizeMethod($path2, 'foo.png'),
         );
+
+        @unlink($path1);
+        @unlink($path2);
     }
 
     public function testDimensionWithTheRatioMethod()


### PR DESCRIPTION
Fixes a PHP Object Injection vulnerability in `Encrypter::decrypt()`. While encryption provides integrity guarantees (MAC for CBC, auth tag for GCM), using `unserialize()` without `allowed_classes` creates residual risk in the event of a compromised encryption key or a MAC verification bypass. An attacker could craft a malicious serialized payload to instantiate arbitrary PHP classes and potentially achieve RCE.

**Change**

- Added `['allowed_classes' => false]` to `unserialize()` at `src/Illuminate/Encryption/Encrypter.php:204`.
- This prevents instantiation of any PHP classes — objects are converted to `__PHP_Incomplete_Class` instead.
- Standard types (strings, arrays, integers, null, etc.) continue to work as before.

**Why this doesn't break existing code**

1. **Defense in depth** — cryptography (MAC/auth tag) remains the primary protection. This is a safety net for hypothetical edge cases.
2. **Queue is unaffected** — queue jobs are double-serialized. Our `unserialize(allowed_classes => false)` returns a string, then `CallQueuedHandler` performs its own separate `unserialize()` to restore the actual job class.
3. **All existing tests pass** (42/42).

**New tests** (6 test cases in `EncrypterTest.php`):
- Round-trip for all PHP types (CBC and GCM modes)
- Proof that objects become `__PHP_Incomplete_Class`
- Spy-based proof that `__wakeup`/`__destruct` are never invoked
- `encryptString`/`decryptString` round-trip
- `$unserialize = false` passthrough

**Benefit to end users**

Eliminates the PHP Object Injection attack vector in the encryption layer with zero API changes and no migration effort.