### PR TITLE
Replace request data with JSON data in newRequest

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -546,7 +546,9 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
         $newRequest->content = $request->content;
 
         if ($newRequest->isJson()) {
-            $newRequest->request = $newRequest->json();
+            $newRequest->request->replace(
+                $newRequest->json()->all()
+            );
         }
 
         return $newRequest;


### PR DESCRIPTION
```
Since symfony/http-foundation 8.1: Directly setting property "request" of "Illuminate\Http\Request" is deprecated; pass the POST data as a constructor argument or call "initialize()" instead.
```

Close https://github.com/laravel/octane/issues/1129

The test failed because the behavior described in #48696 conflicts with the current implementation; this usage is not supported.