### PR TITLE
[13.x] Fix `Message::embed` data attachment handling

### DIFF
--- a/src/Illuminate/Mail/Message.php
+++ b/src/Illuminate/Mail/Message.php
@@ -396,7 +396,7 @@ class Message
                 },
                 function ($data) use ($file) {
                     $this->message->addPart(
-                        $part = $part = (new DataPart($data(), $file->as, $file->mime))->asInline()
+                        $part = (new DataPart($data(), $file->as, $file->mime))->asInline()
                     );
 
                     return "cid:{$part->getContentId()}";

--- a/tests/Mail/MailMessageTest.php
+++ b/tests/Mail/MailMessageTest.php
@@ -217,6 +217,27 @@ class MailMessageTest extends TestCase
         unlink($path);
     }
 
+    public function testItEmbedsFilesViaAttachableContractFromData(): void
+    {
+        $cid = $this->message->embed(new class() implements Attachable
+        {
+            public function toMailAttachment()
+            {
+                return Attachment::fromData(fn () => 'bar', 'foo.jpg')->withMime('image/png');
+            }
+        });
+
+        $this->assertStringStartsWith('cid:', $cid);
+        $contentId = Str::after($cid, 'cid:');
+        $attachment = $this->message->getSymfonyMessage()->getAttachments()[0];
+        $headers = $attachment->getPreparedHeaders()->toArray();
+        $this->assertSame($contentId, $attachment->getContentId());
+        $this->assertSame('bar', $attachment->getBody());
+        $this->assertSame('Content-Type: image/png; name=foo.jpg', $headers[0]);
+        $this->assertSame('Content-Transfer-Encoding: base64', $headers[1]);
+        $this->assertSame('Content-Disposition: inline; name=foo.jpg; filename=foo.jpg', $headers[2]);
+    }
+
     public function testItGeneratesARandomNameWhenAttachableHasNone(): void
     {
         file_put_contents($path = __DIR__.'/foo.jpg', 'bar');

--- a/tests/Mail/MailMessageTest.php
+++ b/tests/Mail/MailMessageTest.php
@@ -233,9 +233,9 @@ class MailMessageTest extends TestCase
         $headers = $attachment->getPreparedHeaders()->toArray();
         $this->assertSame($contentId, $attachment->getContentId());
         $this->assertSame('bar', $attachment->getBody());
-        $this->assertSame('Content-Type: image/png; name=foo.jpg', $headers[0]);
+        $this->assertStringContainsString('Content-Type: image/png', $headers[0]);
         $this->assertSame('Content-Transfer-Encoding: base64', $headers[1]);
-        $this->assertSame('Content-Disposition: inline; name=foo.jpg; filename=foo.jpg', $headers[2]);
+        $this->assertStringContainsString('Content-Disposition: inline', $headers[2]);
     }
 
     public function testItGeneratesARandomNameWhenAttachableHasNone(): void


### PR DESCRIPTION
fix a typo in the `Attachment::fromData()` embed path `inIlluminate\Mail\Message` and add a test that covers embedding attachables backed by in-memory data.