### PR TITLE
[13.x] Namespace the cloud logging formatter

### DIFF
--- a/src/Illuminate/Foundation/Cloud.php
+++ b/src/Illuminate/Foundation/Cloud.php
@@ -8,6 +8,7 @@ use Illuminate\Foundation\Bootstrap\HandleExceptions;
 use Illuminate\Foundation\Bootstrap\LoadConfiguration;
 use Illuminate\Foundation\Cloud\Events;
 use Illuminate\Foundation\Cloud\FailedJobProvider;
+use Illuminate\Foundation\Cloud\JsonFormatter;
 use Illuminate\Foundation\Cloud\QueueConnector;
 use Illuminate\Queue\Connectors\SqsConnector;
 use Monolog\Handler\SocketHandler;
@@ -188,7 +189,7 @@ class Cloud
             'driver' => 'monolog',
             'level' => $_ENV['LOG_LEVEL'] ?? $_SERVER['LOG_LEVEL'] ?? 'debug',
             'handler' => SocketHandler::class,
-            'formatter' => LaravelCloudJsonFormatter::class,
+            'formatter' => JsonFormatter::class,
             'formatter_with' => [
                 'includeStacktraces' => true,
             ],

--- a/src/Illuminate/Foundation/Cloud/JsonFormatter.php
+++ b/src/Illuminate/Foundation/Cloud/JsonFormatter.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Illuminate\Foundation;
+namespace Illuminate\Foundation\Cloud;
 
 use Illuminate\Container\Container;
-use Monolog\Formatter\JsonFormatter;
+use Monolog\Formatter\JsonFormatter as BaseFormatter;
 use Monolog\LogRecord;
 
-class LaravelCloudJsonFormatter extends JsonFormatter
+class JsonFormatter extends BaseFormatter
 {
     /**
      * {@inheritdoc}

--- a/tests/Foundation/Cloud/JsonFormatterTest.php
+++ b/tests/Foundation/Cloud/JsonFormatterTest.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace Illuminate\Tests\Foundation;
+namespace Illuminate\Tests\Foundation\Cloud;
 
 use Illuminate\Container\Container;
-use Illuminate\Foundation\LaravelCloudJsonFormatter;
+use Illuminate\Foundation\Cloud\JsonFormatter;
 use Illuminate\Http\Request;
 use Monolog\Level;
 use Monolog\LogRecord;
 use PHPUnit\Framework\TestCase;
 
-class LaravelCloudJsonFormatterTest extends TestCase
+class JsonFormatterTest extends TestCase
 {
     protected function setUp(): void
     {
@@ -42,7 +42,7 @@ class LaravelCloudJsonFormatterTest extends TestCase
         $request->headers->set('Cloud-Request-ID', '550e8400-e29b-41d4-a716-446655440000');
         $app->instance('request', $request);
 
-        $formatter = new LaravelCloudJsonFormatter;
+        $formatter = new JsonFormatter();
         $formatted = $formatter->format($this->createRecord());
         $decoded = json_decode($formatted, true);
 
@@ -51,7 +51,7 @@ class LaravelCloudJsonFormatterTest extends TestCase
 
     public function test_does_not_add_field_when_no_request_bound()
     {
-        $formatter = new LaravelCloudJsonFormatter;
+        $formatter = new JsonFormatter;
         $formatted = $formatter->format($this->createRecord());
         $decoded = json_decode($formatted, true);
 
@@ -64,7 +64,7 @@ class LaravelCloudJsonFormatterTest extends TestCase
         $request = Request::create('/');
         $app->instance('request', $request);
 
-        $formatter = new LaravelCloudJsonFormatter;
+        $formatter = new JsonFormatter;
         $formatted = $formatter->format($this->createRecord());
         $decoded = json_decode($formatted, true);
 
@@ -87,7 +87,7 @@ class LaravelCloudJsonFormatterTest extends TestCase
             context: ['context_field' => 'context_value'],
         );
 
-        $formatter = new LaravelCloudJsonFormatter;
+        $formatter = new JsonFormatter;
         $formatted = $formatter->format($record);
         $decoded = json_decode($formatted, true);
 


### PR DESCRIPTION
Small refactor to ensure all the Cloud specific classes are tucked away neatly in `Illuminate/Foundation/Cloud`