### PR TITLE
Support custom weekend days for scheduled events

### DIFF
--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -409,7 +409,11 @@ trait ManagesFrequencies
      */
     public function weekdays()
     {
-        return $this->days(Schedule::MONDAY.'-'.Schedule::FRIDAY);
+        if (Schedule::getWeekendDays() === [Schedule::SATURDAY, Schedule::SUNDAY]) {
+            return $this->days(Schedule::MONDAY.'-'.Schedule::FRIDAY);
+        }
+
+        return $this->days(Schedule::getWeekDays());
     }
 
     /**
@@ -419,7 +423,7 @@ trait ManagesFrequencies
      */
     public function weekends()
     {
-        return $this->days(Schedule::SATURDAY.','.Schedule::SUNDAY);
+        return $this->days(Schedule::getWeekendDays());
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -116,6 +116,11 @@ class Schedule
     public static $interruptible = true;
 
     /**
+     * @var array<int, int>
+     */
+    protected static array $weekends = [self::SATURDAY, self::SUNDAY];
+
+    /**
      * Create a new schedule instance.
      *
      * @param  \DateTimeZone|string|null  $timezone
@@ -514,6 +519,41 @@ class Schedule
     {
         static::$pausable = false;
         static::$interruptible = false;
+    }
+
+    /**
+     * Set the days of the week that should be treated as weekends.
+     *
+     * @param  list<int<0, 6>>  $days
+     */
+    public static function setWeekendDays(array $days): void
+    {
+        static::$weekends = $days;
+    }
+
+    /**
+     * Get the days of the week that are treated as weekends.
+     *
+     * @return list<int<0, 6>>
+     */
+    public static function getWeekendDays(): array
+    {
+        return static::$weekends;
+    }
+
+    /**
+     * Get the days of the week that are not treated as weekends.
+     *
+     * @return list<int<0, 6>>
+     */
+    public static function getWeekDays(): array
+    {
+        return array_values(
+            array_diff(
+                range(static::SUNDAY, static::SATURDAY),
+                static::$weekends
+            )
+        );
     }
 
     /**

--- a/tests/Console/Scheduling/FrequencyTest.php
+++ b/tests/Console/Scheduling/FrequencyTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Console\Scheduling;
 
 use Illuminate\Console\Scheduling\Event;
 use Illuminate\Console\Scheduling\EventMutex;
+use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Support\Carbon;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -19,6 +20,13 @@ class FrequencyTest extends TestCase
             m::mock(EventMutex::class),
             'php foo'
         );
+    }
+
+    protected function tearDown(): void
+    {
+        $this->resetWeekendDays();
+
+        parent::tearDown();
     }
 
     public function testEveryMinute()
@@ -154,12 +162,16 @@ class FrequencyTest extends TestCase
 
     public function testWeekdays()
     {
-        $this->assertSame('* * * * 1-5', $this->event->weekdays()->getExpression());
+        Schedule::setWeekendDays([Schedule::FRIDAY]);
+
+        $this->assertSame('* * * * 0,1,2,3,4,6', $this->event->weekdays()->getExpression());
     }
 
     public function testWeekends()
     {
-        $this->assertSame('* * * * 6,0', $this->event->weekends()->getExpression());
+        Schedule::setWeekendDays([Schedule::FRIDAY, Schedule::SATURDAY]);
+
+        $this->assertSame('* * * * 5,6', $this->event->weekends()->getExpression());
     }
 
     public function testSundays()
@@ -229,5 +241,10 @@ class FrequencyTest extends TestCase
         });
 
         $this->assertSame('*/6 * * * *', $this->event->everyXMinutes(6)->getExpression());
+    }
+
+    private function resetWeekendDays(): void
+    {
+        Schedule::setWeekendDays([Schedule::SATURDAY, Schedule::SUNDAY]);
     }
 }


### PR DESCRIPTION
## Summary

  This PR adds support for customizing which days the scheduler treats as weekends.

  The default behavior remains unchanged: Saturday and Sunday are still treated as weekends, and `weekdays()` continues to generate the existing
  `1-5` cron expression.

  ## Usage

  Applications can configure custom weekend days from a service provider:

  ```php
  use Illuminate\Console\Scheduling\Schedule;

  public function boot(): void
  {
      Schedule::setWeekendDays([
          Schedule::FRIDAY,
          Schedule::SATURDAY,
      ]);
  }
  ```

  With this configuration:

  - weekends() runs on Friday and Saturday
  - weekdays() runs on Sunday through Thursday

  ## Notes

  This keeps scheduler defaults inside the framework, so directly instantiated scheduling events continue to work without requiring a bound config repository.