### PR TITLE
feat: Add DialectExpression for driver-aware raw SQL expressions

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -14,6 +14,7 @@ use Illuminate\Database\Events\TransactionCommitted;
 use Illuminate\Database\Events\TransactionCommitting;
 use Illuminate\Database\Events\TransactionRolledBack;
 use Illuminate\Database\Query\Builder as QueryBuilder;
+use Illuminate\Database\Query\DialectExpression;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Query\Grammars\Grammar as QueryGrammar;
 use Illuminate\Database\Query\Processors\Processor;
@@ -1136,6 +1137,23 @@ class Connection implements ConnectionInterface
     public function raw($value)
     {
         return new Expression($value);
+    }
+
+    /**
+     * Get a dialect-aware raw expression that resolves to the correct SQL
+     * for the active connection driver when the grammar compiles the query.
+     *
+     * Valid driver keys: 'mysql', 'mariadb', 'pgsql', 'sqlite', 'sqlsrv', 'default' for default SQL string.
+     *
+     * @param  array<string, string>  $dialects  Map of driver name => raw SQL string.
+     * @return \Illuminate\Database\Query\DialectExpression
+     *
+     * @throws \InvalidArgumentException For unknown driver keys or an empty map.
+     * @throws \RuntimeException For drivers with no mapping and no default.
+     */
+    public function rawDialect(array $dialects): DialectExpression
+    {
+        return new DialectExpression($dialects);
     }
 
     /**

--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -29,6 +29,16 @@ abstract class Grammar
     }
 
     /**
+     * Get the connection used by this grammar.
+     *
+     * @return \Illuminate\Database\Connection
+     */
+    public function getConnection(): Connection
+    {
+        return $this->connection;
+    }
+
+    /**
      * Wrap an array of values.
      *
      * @param  array<\Illuminate\Contracts\Database\Query\Expression|string>  $values

--- a/src/Illuminate/Database/Query/DialectExpression.php
+++ b/src/Illuminate/Database/Query/DialectExpression.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Illuminate\Database\Query;
+
+use Illuminate\Database\Grammar;
+
+/**
+ * A dialect-aware extension of Expression that picks
+ * the correct raw SQL string for the active connection driver
+ * when the grammar compiles the query.
+ *
+ * @template DValue of literal-string - Drive Name
+ * @template TValue of literal-string|int|float
+ */
+class DialectExpression extends Expression
+{
+    private const SUPPORTED_DRIVERS = ['mysql', 'mariadb', 'pgsql', 'sqlite', 'sqlsrv', 'default'];
+
+    /**
+     * Create a new dialect expression.
+     *
+     * @param  array<DValue, TValue>  $dialects  Map of driver name => raw SQL.
+     *
+     * @throws \InvalidArgumentException For unknown driver keys or an empty map.
+     */
+    public function __construct(protected array $dialects)
+    {
+        if (empty($dialects)) {
+            throw new \InvalidArgumentException(
+                'DialectExpression requires at least one dialect entry.'
+            );
+        }
+
+        $invalidDrivers = array_diff(array_keys($dialects), self::SUPPORTED_DRIVERS);
+        if (! empty($invalidDrivers)) {
+            throw new \InvalidArgumentException(
+                'DialectExpression received unknown driver key(s): ['.implode(', ', $invalidDrivers).']. '.
+                'Valid drivers are: '.implode(', ', self::SUPPORTED_DRIVERS).'.'
+            );
+        }
+
+        // we generate the value based on the driver name at the run time.
+        parent::__construct('');
+    }
+
+    /**
+     * Return the raw SQL for the active connection driver.
+     *
+     * Overrides Expression::getValue() to return a dialect-specific string
+     * instead of the fixed value stored by the parent class.
+     *
+     * @param  \Illuminate\Database\Grammar  $grammar
+     * @return string
+     *
+     * @throws \RuntimeException For drivers with no mapping and no default.
+     */
+    public function getValue(Grammar $grammar): string
+    {
+        $driver = $grammar->getConnection()->getDriverName();
+
+        // get right sql string based on driver name
+        if (isset($this->dialects[$driver])) {
+            return $this->dialects[$driver];
+        }
+
+        // use default sql string if not found the driver
+        if (isset($this->dialects['default'])) {
+            return $this->dialects['default'];
+        }
+
+        // throw exception if not found the driver and default sql string
+        throw new \RuntimeException(
+            "DialectExpression has no SQL for driver [{$driver}] and no 'default' fallback. ".
+            'Registered: ['.implode(', ', array_keys($this->dialects)).'].'
+        );
+    }
+}

--- a/tests/Database/DatabaseDialectExpressionTest.php
+++ b/tests/Database/DatabaseDialectExpressionTest.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Connection;
+use Illuminate\Database\Grammar;
+use Illuminate\Database\Query\DialectExpression;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseDialectExpressionTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    public function testThrowsOnEmptyDialects()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('DialectExpression requires at least one dialect entry.');
+
+        new DialectExpression([]);
+    }
+
+    public function testThrowsListsAllUnknownDriverKeysInMessage()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('baddriver');
+        $this->expectExceptionMessage('anotherbad');
+
+        new DialectExpression(['baddriver' => 'sql', 'anotherbad' => 'sql']);
+    }
+
+    public function testAcceptsAllKnownDriverKeys()
+    {
+        // Should not throw — all supported drivers plus 'default'
+        $expression = new DialectExpression([
+            'mysql' => 'mysql_sql',
+            'mariadb' => 'mariadb_sql',
+            'pgsql' => 'pgsql_sql',
+            'sqlite' => 'sqlite_sql',
+            'sqlsrv' => 'sqlsrv_sql',
+            'default' => 'default_sql',
+        ]);
+
+        $this->assertInstanceOf(DialectExpression::class, $expression);
+    }
+
+    public function testResolvesExactMatchForActiveDriver()
+    {
+        $expression = new DialectExpression([
+            'mysql' => 'mysql_sql',
+            'pgsql' => 'pgsql_sql',
+            'sqlite' => 'sqlite_sql',
+        ]);
+
+        $this->assertSame('mysql_sql', $expression->getValue($this->mockGrammarWithDriver('mysql')));
+        $this->assertSame('pgsql_sql', $expression->getValue($this->mockGrammarWithDriver('pgsql')));
+        $this->assertSame('sqlite_sql', $expression->getValue($this->mockGrammarWithDriver('sqlite')));
+    }
+
+    public function testMariadbUsesExplicitEntryWhenPresent()
+    {
+        $expression = new DialectExpression([
+            'mysql' => 'mysql_sql',
+            'mariadb' => 'mariadb_sql',
+            'pgsql' => 'pgsql_sql',
+        ]);
+
+        $this->assertSame('mariadb_sql', $expression->getValue($this->mockGrammarWithDriver('mariadb')));
+    }
+
+    public function testFallsBackToDefaultWhenDriverHasNoMapping()
+    {
+        $expression = new DialectExpression([
+            'mysql' => 'mysql_sql',
+            'default' => 'default_sql',
+        ]);
+
+        // pgsql is not mapped → should resolve to 'default'
+        $this->assertSame('default_sql', $expression->getValue($this->mockGrammarWithDriver('pgsql')));
+    }
+
+    public function testThrowsWhenNoMappingAndNoDefault()
+    {
+        $this->expectException(\RuntimeException::class);
+
+        $expression = new DialectExpression(['mysql' => 'mysql_sql']);
+        $expression->getValue($this->mockGrammarWithDriver('pgsql'));
+    }
+
+    public function testExceptionMessageContainsActiveDriverName()
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('pgsql');
+
+        $expression = new DialectExpression(['mysql' => 'mysql_sql']);
+        $expression->getValue($this->mockGrammarWithDriver('pgsql'));
+    }
+
+    public function testExceptionMessageListsRegisteredDrivers()
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('mysql');
+
+        $expression = new DialectExpression(['mysql' => 'mysql_sql']);
+        $expression->getValue($this->mockGrammarWithDriver('sqlsrv'));
+    }
+
+    public function testDialectExpressionCompilesWithDifferentGrammars()
+    {
+        $expression = new DialectExpression([
+            'mysql' => "DATE_FORMAT(created_at, '%Y-%m')",
+            'mariadb' => "DATE_FORMAT(created_at, '%Y-%m-mariadb')",
+            'pgsql' => "TO_CHAR(created_at, 'YYYY-MM')",
+            'sqlite' => "strftime('%Y-%m', created_at)",
+            'sqlsrv' => "FORMAT(created_at, 'yyyy-MM')",
+        ]);
+
+        $this->assertSame(
+            "select strftime('%Y-%m', created_at) from \"users\"",
+            $this->buildQuery('sqlite', \Illuminate\Database\Query\Grammars\SQLiteGrammar::class, $expression)
+        );
+
+        $this->assertSame(
+            "select DATE_FORMAT(created_at, '%Y-%m') from `users`",
+            $this->buildQuery('mysql', \Illuminate\Database\Query\Grammars\MySqlGrammar::class, $expression)
+        );
+
+        $this->assertSame(
+            "select TO_CHAR(created_at, 'YYYY-MM') from \"users\"",
+            $this->buildQuery('pgsql', \Illuminate\Database\Query\Grammars\PostgresGrammar::class, $expression)
+        );
+
+        $this->assertSame(
+            "select FORMAT(created_at, 'yyyy-MM') from [users]",
+            $this->buildQuery('sqlsrv', \Illuminate\Database\Query\Grammars\SqlServerGrammar::class, $expression)
+        );
+
+        $this->assertSame(
+            "select DATE_FORMAT(created_at, '%Y-%m-mariadb') from `users`",
+            $this->buildQuery('mariadb', \Illuminate\Database\Query\Grammars\MySqlGrammar::class, $expression)
+        );
+    }
+
+    protected function mockGrammarWithDriver(string $driver): Grammar
+    {
+        $connection = m::mock(Connection::class);
+        $connection->shouldReceive('getDriverName')->andReturn($driver);
+
+        $grammar = m::mock(Grammar::class);
+        $grammar->shouldReceive('getConnection')->andReturn($connection);
+
+        return $grammar;
+    }
+
+    protected function buildQuery(string $driver, string $grammarClass, DialectExpression $expression): string
+    {
+        $connection = m::mock(Connection::class);
+        $connection->shouldReceive('getDatabaseName')->andReturn('database');
+        $connection->shouldReceive('getTablePrefix')->andReturn('');
+        $connection->shouldReceive('getDriverName')->andReturn($driver);
+
+        $grammar = new $grammarClass($connection);
+
+        $builder = new \Illuminate\Database\Query\Builder(
+            $connection,
+            $grammar,
+            m::mock(\Illuminate\Database\Query\Processors\Processor::class)
+        );
+
+        return $builder->select($expression)->from('users')->toSql();
+    }
+}


### PR DESCRIPTION
### Dialect Experssion 
a driver-aware SQL expression that automatically resolves to the correct raw SQL string for the active database connection when the query is compiled.

#### Example
```php
$users = DB::table('users')
   ->select(DB::rawDialect([
        'mysql'  => "DATE_FORMAT(created_at, '%Y-%m')",
        'pgsql'  => "TO_CHAR(created_at, 'YYYY-MM')",
        'sqlite' => "strftime('%Y-%m', created_at)",
        'sqlsrv' => "FORMAT(created_at, 'yyyy-MM')",
   ]))
  ->get();
```

It extends Expression so it works anywhere DB::raw() is accepted.  'default' driver key can be used as a fallback for unmapped drivers like switch statement.
