### PR TITLE
[13.x] Respect child queue properties over inherited attributes

### DIFF
--- a/src/Illuminate/Support/Traits/ReadsClassAttributes.php
+++ b/src/Illuminate/Support/Traits/ReadsClassAttributes.php
@@ -26,7 +26,11 @@ trait ReadsClassAttributes
             return $target->{$property};
         }
 
-        if ($instance = $this->getAttributeInstance($target, $attributeClass)) {
+        if ($instance = $this->getAttributeInstance($target, $attributeClass, $attributeDeclaringClass)) {
+            if ($this->propertyOverridesAttribute($target, $reflection, $property, $attributeDeclaringClass)) {
+                return $target->{$property};
+            }
+
             return $this->extractAttributeValue($instance);
         }
 
@@ -51,9 +55,10 @@ trait ReadsClassAttributes
      *
      * @param  object  $target
      * @param  class-string  $attributeClass
+     * @param  \ReflectionClass|null  $declaringClass
      * @return object|null
      */
-    protected function getAttributeInstance($target, string $attributeClass)
+    protected function getAttributeInstance($target, string $attributeClass, ?ReflectionClass &$declaringClass = null)
     {
         $reflection = new ReflectionClass($target);
 
@@ -62,6 +67,8 @@ trait ReadsClassAttributes
                 $attributes = $reflection->getAttributes($attributeClass);
 
                 if (count($attributes) > 0) {
+                    $declaringClass = $reflection;
+
                     return $attributes[0]->newInstance();
                 }
             } while ($reflection = $reflection->getParentClass());
@@ -70,5 +77,27 @@ trait ReadsClassAttributes
         }
 
         return null;
+    }
+
+    /**
+     * Determine if a property declared on a child class overrides an inherited attribute.
+     *
+     * @param  object  $target
+     * @param  \ReflectionClass  $reflection
+     * @param  string|null  $property
+     * @param  \ReflectionClass  $attributeDeclaringClass
+     * @return bool
+     */
+    protected function propertyOverridesAttribute($target, ReflectionClass $reflection, ?string $property, ReflectionClass $attributeDeclaringClass)
+    {
+        if (is_null($property) || ! $reflection->hasProperty($property)) {
+            return false;
+        }
+
+        $property = $reflection->getProperty($property);
+
+        return $property->isPublic()
+            && $property->isInitialized($target)
+            && $property->getDeclaringClass()->isSubclassOf($attributeDeclaringClass->getName());
     }
 }

--- a/tests/Queue/QueueDatabaseQueueUnitTest.php
+++ b/tests/Queue/QueueDatabaseQueueUnitTest.php
@@ -4,7 +4,13 @@ namespace Illuminate\Tests\Queue;
 
 use Illuminate\Bus\Batchable;
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Database\Connection;
+use Illuminate\Queue\Attributes\Backoff;
+use Illuminate\Queue\Attributes\FailOnTimeout;
+use Illuminate\Queue\Attributes\MaxExceptions;
+use Illuminate\Queue\Attributes\Timeout;
+use Illuminate\Queue\Attributes\Tries;
 use Illuminate\Queue\DatabaseQueue;
 use Illuminate\Queue\Jobs\InspectedJob;
 use Illuminate\Queue\Queue;
@@ -117,6 +123,46 @@ class QueueDatabaseQueueUnitTest extends TestCase
         $container->shouldHaveReceived('bound')->with('events')->twice();
 
         Str::createUuidsNormally();
+    }
+
+    public function testPushUsesPropertiesDeclaredOnChildClassOverInheritedAttributes()
+    {
+        $queue = new DatabaseQueue($database = m::mock(Connection::class), 'table', 'default');
+        $queue->setContainer($container = m::spy(Container::class));
+        $database->shouldReceive('table')->with('table')->andReturn($query = m::mock(stdClass::class));
+        $query->shouldReceive('insertGetId')->once()->andReturnUsing(function ($array) {
+            $payload = json_decode($array['payload'], true);
+
+            $this->assertSame(1700, $payload['timeout']);
+            $this->assertSame(7, $payload['maxTries']);
+            $this->assertSame('13', $payload['backoff']);
+            $this->assertSame(11, $payload['maxExceptions']);
+            $this->assertFalse($payload['failOnTimeout']);
+        });
+
+        $queue->push(new ChildJobWithPropertiesOverridingParentAttributes, ['data']);
+
+        $container->shouldHaveReceived('bound')->with('events')->twice();
+    }
+
+    public function testPushStillUsesAttributesDeclaredOnSameClassOverDefaultProperties()
+    {
+        $queue = new DatabaseQueue($database = m::mock(Connection::class), 'table', 'default');
+        $queue->setContainer($container = m::spy(Container::class));
+        $database->shouldReceive('table')->with('table')->andReturn($query = m::mock(stdClass::class));
+        $query->shouldReceive('insertGetId')->once()->andReturnUsing(function ($array) {
+            $payload = json_decode($array['payload'], true);
+
+            $this->assertSame(40, $payload['timeout']);
+            $this->assertSame(2, $payload['maxTries']);
+            $this->assertSame('9', $payload['backoff']);
+            $this->assertSame(3, $payload['maxExceptions']);
+            $this->assertTrue($payload['failOnTimeout']);
+        });
+
+        $queue->push(new JobWithAttributesAndDefaultProperties, ['data']);
+
+        $container->shouldHaveReceived('bound')->with('events')->twice();
     }
 
     public function testFailureToCreatePayloadFromObject()
@@ -389,4 +435,44 @@ class MyTestJob
 class MyBatchableJob
 {
     use Batchable;
+}
+
+#[Backoff(9)]
+#[FailOnTimeout]
+#[MaxExceptions(3)]
+#[Timeout(40)]
+#[Tries(2)]
+abstract class ParentJobWithAttributes implements ShouldQueue
+{
+}
+
+class ChildJobWithPropertiesOverridingParentAttributes extends ParentJobWithAttributes
+{
+    public $backoff = 13;
+
+    public $failOnTimeout = false;
+
+    public $maxExceptions = 11;
+
+    public $timeout = 1700;
+
+    public $tries = 7;
+}
+
+#[Backoff(9)]
+#[FailOnTimeout]
+#[MaxExceptions(3)]
+#[Timeout(40)]
+#[Tries(2)]
+class JobWithAttributesAndDefaultProperties implements ShouldQueue
+{
+    public $backoff = 13;
+
+    public $failOnTimeout = false;
+
+    public $maxExceptions = 11;
+
+    public $timeout = 1700;
+
+    public $tries = 7;
 }


### PR DESCRIPTION
This PR fixes a narrow inheritance edge case in queue attribute resolution.

When a queue _attribute_ is declared on a parent class, a child class that redeclares the corresponding queue _property_ should be able to override that inherited attribute:

For example:

```php
#[Timeout(40)]
abstract class BaseJob implements ShouldQueue
{
    //
}

class GenerateReport extends BaseJob
{
    public $timeout = 1700;
}
```

Before this change, the queued payload uses the inherited `#[Timeout(40)]` value. The child class's `$timeout` property is present on the job object, but because its current value equals its declared default, it does not pass the existing runtime override check.

This change keeps the existing precedence behavior for attributes declared on the same class. It only lets a public property declared on a child class override an attribute found on one of its parent classes.

In other words, this does not make properties generally take precedence over attributes:

- same-class attributes still take precedence over same-class default properties
- runtime-modified properties still take precedence
- child-declared queue properties now take precedence over inherited queue attributes

The included tests cover both sides of that behavior:

- queue payload values resolved from child properties over inherited attributes
- same-class attributes continuing to win over same-class default properties
