### PR TITLE
Grant contents: read to pull requests workflow

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -5,6 +5,7 @@ on:
     types: [opened]
 
 permissions:
+  contents: read
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
The `pull requests` workflow (`pull_request_target`) currently fails at startup with a permissions error.

It calls the reusable workflow `laravel/.github/.github/workflows/pull-requests.yml`, which (since the recent hardening) declares `permissions: { contents: read, pull-requests: write }`. A reusable workflow's declared permissions may not exceed the caller's. This caller only grants `pull-requests: write` — so `contents` is `none` — which is less than the `contents: read` the reusable workflow requests, causing a `startup_failure`.

This adds `contents: read` to the caller so its grants cover what the reusable workflow needs. Still least-privilege.