### PR TITLE
Grant contents: read and pull-requests: write to issues workflow

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -5,7 +5,9 @@ on:
     types: [labeled]
 
 permissions:
+  contents: read
   issues: write
+  pull-requests: write
 
 jobs:
   help-wanted:


### PR DESCRIPTION
Follow-up to #60370.

The `issues` workflow currently fails at startup with a permissions error.

It calls the reusable workflow `laravel/.github/.github/workflows/issues.yml`, which declares `permissions: { contents: read, issues: write, pull-requests: write }`. A reusable workflow's declared permissions may not exceed the caller's. This caller only granted `issues: write`, so `contents` and `pull-requests` were `none` — less than the reusable workflow requests — causing a `startup_failure`.

This adds the missing `contents: read` and `pull-requests: write` so the caller's grants cover what the reusable workflow needs. Still least-privilege.