### PR TITLE
Pin pull requests and issues workflows to latest laravel/.github

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -9,4 +9,4 @@ permissions:
 
 jobs:
   help-wanted:
-    uses: laravel/.github/.github/workflows/issues.yml@ae831fb2746b4ad21f6751fde03da7d146822d61 # main
+    uses: laravel/.github/.github/workflows/issues.yml@b019b7649633cd7149a2d2a4a6e3bba5d7e5ba01 # main

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -9,4 +9,4 @@ permissions:
 
 jobs:
   pull-requests:
-    uses: laravel/.github/.github/workflows/pull-requests.yml@ae831fb2746b4ad21f6751fde03da7d146822d61 # main
+    uses: laravel/.github/.github/workflows/pull-requests.yml@b019b7649633cd7149a2d2a4a6e3bba5d7e5ba01 # main


### PR DESCRIPTION
Bumps the pinned `laravel/.github` reusable workflow references in `pull-requests.yml` and `issues.yml` to the latest revision, so every repository tracks the same current, least-privilege reusable workflows.

Caller permissions are already minimal (`pull-requests: write` / `issues: write`) and are left unchanged.