### PR TITLE
[13.x] Add queue to InspectedJob

### DIFF
--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -145,7 +145,7 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
             ->whereNull('reserved_at')
             ->where('available_at', '<=', $this->currentTime())
             ->get()
-            ->map(fn ($record) => InspectedJob::fromPayload($record->payload, $record->attempts));
+            ->map(fn ($record) => InspectedJob::fromPayload($record->payload, $record->attempts, $record->queue));
     }
 
     /**
@@ -161,7 +161,7 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
             ->whereNull('reserved_at')
             ->where('available_at', '>', $this->currentTime())
             ->get()
-            ->map(fn ($record) => InspectedJob::fromPayload($record->payload, $record->attempts));
+            ->map(fn ($record) => InspectedJob::fromPayload($record->payload, $record->attempts, $record->queue));
     }
 
     /**
@@ -176,7 +176,7 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
             ->where('queue', $this->getQueue($queue))
             ->whereNotNull('reserved_at')
             ->get()
-            ->map(fn ($record) => InspectedJob::fromPayload($record->payload, $record->attempts));
+            ->map(fn ($record) => InspectedJob::fromPayload($record->payload, $record->attempts, $record->queue));
     }
 
     /**
@@ -190,7 +190,7 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
             ->whereNull('reserved_at')
             ->where('available_at', '<=', $this->currentTime())
             ->get()
-            ->map(fn ($record) => InspectedJob::fromPayload($record->payload, $record->attempts));
+            ->map(fn ($record) => InspectedJob::fromPayload($record->payload, $record->attempts, $record->queue));
     }
 
     /**
@@ -204,7 +204,7 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
             ->whereNull('reserved_at')
             ->where('available_at', '>', $this->currentTime())
             ->get()
-            ->map(fn ($record) => InspectedJob::fromPayload($record->payload, $record->attempts));
+            ->map(fn ($record) => InspectedJob::fromPayload($record->payload, $record->attempts, $record->queue));
     }
 
     /**
@@ -217,7 +217,7 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
         return $this->database->table($this->table)
             ->whereNotNull('reserved_at')
             ->get()
-            ->map(fn ($record) => InspectedJob::fromPayload($record->payload, $record->attempts));
+            ->map(fn ($record) => InspectedJob::fromPayload($record->payload, $record->attempts, $record->queue));
     }
 
     /**

--- a/src/Illuminate/Queue/Jobs/InspectedJob.php
+++ b/src/Illuminate/Queue/Jobs/InspectedJob.php
@@ -13,6 +13,7 @@ class InspectedJob
      * @param  string|null  $name  The display name of the job.
      * @param  int  $attempts  The number of times the job has been attempted.
      * @param  array  $payload
+     * @param  string|null  $queue  The name of the queue the job is on.
      * @param  \Illuminate\Support\Carbon|null  $createdAt  The date and time the job was created.
      */
     public function __construct(
@@ -20,6 +21,7 @@ class InspectedJob
         public readonly ?string $name,
         public readonly int $attempts,
         public readonly array $payload = [],
+        public readonly ?string $queue = null,
         public readonly ?Carbon $createdAt = null,
     ) {
     }
@@ -29,9 +31,10 @@ class InspectedJob
      *
      * @param  string  $payload  The raw JSON job payload.
      * @param  int|null  $attempts  The number of times the job has been attempted.
+     * @param  string|null  $queue  The name of the queue the job is on.
      * @return static
      */
-    public static function fromPayload(string $payload, ?int $attempts = null): static
+    public static function fromPayload(string $payload, ?int $attempts = null, ?string $queue = null): static
     {
         $decoded = json_decode($payload, true);
 
@@ -40,6 +43,7 @@ class InspectedJob
             name: $decoded['displayName'] ?? null,
             attempts: $attempts ?? $decoded['attempts'] ?? 0,
             payload: $decoded,
+            queue: $queue,
             createdAt: isset($decoded['createdAt']) ? Carbon::createFromTimestamp($decoded['createdAt']) : null,
         );
     }

--- a/src/Illuminate/Queue/Jobs/InspectedJob.php
+++ b/src/Illuminate/Queue/Jobs/InspectedJob.php
@@ -10,18 +10,18 @@ class InspectedJob
      * Create a new inspected job instance.
      *
      * @param  string|null  $uuid  The unique identifier for the job.
+     * @param  string|null  $queue  The name of the queue the job is on.
      * @param  string|null  $name  The display name of the job.
      * @param  int  $attempts  The number of times the job has been attempted.
      * @param  array  $payload
-     * @param  string|null  $queue  The name of the queue the job is on.
      * @param  \Illuminate\Support\Carbon|null  $createdAt  The date and time the job was created.
      */
     public function __construct(
         public readonly ?string $uuid,
+        public readonly ?string $queue,
         public readonly ?string $name,
         public readonly int $attempts,
         public readonly array $payload = [],
-        public readonly ?string $queue = null,
         public readonly ?Carbon $createdAt = null,
     ) {
     }
@@ -40,10 +40,10 @@ class InspectedJob
 
         return new static(
             uuid: $decoded['uuid'] ?? null,
+            queue: $queue,
             name: $decoded['displayName'] ?? null,
             attempts: $attempts ?? $decoded['attempts'] ?? 0,
             payload: $decoded,
-            queue: $queue,
             createdAt: isset($decoded['createdAt']) ? Carbon::createFromTimestamp($decoded['createdAt']) : null,
         );
     }

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -160,10 +160,10 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
      */
     public function pendingJobs($queue = null): Collection
     {
-        $queue = $this->getQueueRedisKey($queue);
+        $name = $queue ?: $this->default;
 
-        return (new Collection($this->getConnection()->lrange($queue, 0, -1)))
-            ->map(fn ($payload) => InspectedJob::fromPayload($payload));
+        return (new Collection($this->getConnection()->lrange($this->getQueueRedisKey($queue), 0, -1)))
+            ->map(fn ($payload) => InspectedJob::fromPayload($payload, queue: $name));
     }
 
     /**
@@ -174,10 +174,10 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
      */
     public function delayedJobs($queue = null): Collection
     {
-        $queue = $this->getQueueRedisKey($queue);
+        $name = $queue ?: $this->default;
 
-        return (new Collection($this->getConnection()->zrange($queue.':delayed', 0, -1)))
-            ->map(fn ($payload) => InspectedJob::fromPayload($payload));
+        return (new Collection($this->getConnection()->zrange($this->getQueueRedisKey($queue).':delayed', 0, -1)))
+            ->map(fn ($payload) => InspectedJob::fromPayload($payload, queue: $name));
     }
 
     /**
@@ -188,10 +188,10 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
      */
     public function reservedJobs($queue = null): Collection
     {
-        $queue = $this->getQueueRedisKey($queue);
+        $name = $queue ?: $this->default;
 
-        return (new Collection($this->getConnection()->zrange($queue.':reserved', 0, -1)))
-            ->map(fn ($payload) => InspectedJob::fromPayload($payload));
+        return (new Collection($this->getConnection()->zrange($this->getQueueRedisKey($queue).':reserved', 0, -1)))
+            ->map(fn ($payload) => InspectedJob::fromPayload($payload, queue: $name));
     }
 
     /**
@@ -201,9 +201,7 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
      */
     public function allPendingJobs(): Collection
     {
-        return $this->allQueueNames()
-            ->flatMap(fn ($name) => $this->getConnection()->lrange($this->getQueueRedisKey($name), 0, -1))
-            ->map(fn ($payload) => InspectedJob::fromPayload($payload));
+        return $this->allQueueNames()->flatMap(fn ($name) => $this->pendingJobs($name));
     }
 
     /**
@@ -213,9 +211,7 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
      */
     public function allDelayedJobs(): Collection
     {
-        return $this->allQueueNames()
-            ->flatMap(fn ($name) => $this->getConnection()->zrange($this->getQueueRedisKey($name).':delayed', 0, -1))
-            ->map(fn ($payload) => InspectedJob::fromPayload($payload));
+        return $this->allQueueNames()->flatMap(fn ($name) => $this->delayedJobs($name));
     }
 
     /**
@@ -225,9 +221,7 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
      */
     public function allReservedJobs(): Collection
     {
-        return $this->allQueueNames()
-            ->flatMap(fn ($name) => $this->getConnection()->zrange($this->getQueueRedisKey($name).':reserved', 0, -1))
-            ->map(fn ($payload) => InspectedJob::fromPayload($payload));
+        return $this->allQueueNames()->flatMap(fn ($name) => $this->reservedJobs($name));
     }
 
     /**
@@ -238,7 +232,7 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
     protected function allQueueNames(): Collection
     {
         return (new Collection($this->getConnection()->keys('queues:*')))
-            ->map(fn ($key) => Str::between($key, 'queues:', ':'))
+            ->map(fn ($key) => trim(Str::between($key, 'queues:', ':'), '{}'))
             ->unique()
             ->values();
     }

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -232,6 +232,7 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
     protected function allQueueNames(): Collection
     {
         return (new Collection($this->getConnection()->keys('queues:*')))
+            // Trim to ensure clusters get their braces removed...
             ->map(fn ($key) => trim(Str::between($key, 'queues:', ':'), '{}'))
             ->unique()
             ->values();

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -494,6 +494,7 @@ class QueueFake extends QueueManager implements Fake, Queue
                     : $data['job'],
                 attempts: 0,
                 payload: [],
+                queue: $queue,
                 createdAt: null,
             ));
     }
@@ -536,6 +537,7 @@ class QueueFake extends QueueManager implements Fake, Queue
                     : $data['job'],
                 attempts: 0,
                 payload: [],
+                queue: $data['queue'],
                 createdAt: null,
             ));
     }

--- a/tests/Integration/Queue/RedisQueueTest.php
+++ b/tests/Integration/Queue/RedisQueueTest.php
@@ -628,6 +628,7 @@ class RedisQueueTest extends TestCase
         $this->assertSame(0, $pending->first()->attempts);
         $this->assertNotNull($pending->first()->uuid);
         $this->assertInstanceOf(Carbon::class, $pending->first()->createdAt);
+        $this->assertSame($default, $pending->first()->queue);
     }
 
     #[DataProvider('redisDriverProvider')]
@@ -647,6 +648,7 @@ class RedisQueueTest extends TestCase
         $this->assertSame(0, $delayed->first()->attempts);
         $this->assertNotNull($delayed->first()->uuid);
         $this->assertInstanceOf(Carbon::class, $delayed->first()->createdAt);
+        $this->assertSame($default, $delayed->first()->queue);
     }
 
     #[DataProvider('redisDriverProvider')]
@@ -667,6 +669,7 @@ class RedisQueueTest extends TestCase
         $this->assertSame(1, $reserved->first()->attempts);
         $this->assertNotNull($reserved->first()->uuid);
         $this->assertInstanceOf(Carbon::class, $reserved->first()->createdAt);
+        $this->assertSame($default, $reserved->first()->queue);
     }
 
     #[DataProvider('redisDriverProvider')]
@@ -686,6 +689,8 @@ class RedisQueueTest extends TestCase
         $this->assertSame(0, $pending->first()->attempts);
         $this->assertNotNull($pending->first()->uuid);
         $this->assertInstanceOf(Carbon::class, $pending->first()->createdAt);
+        $this->assertTrue($pending->contains(fn ($job) => $job->queue === $default));
+        $this->assertTrue($pending->contains(fn ($job) => $job->queue === 'emails'));
     }
 
     #[DataProvider('redisDriverProvider')]
@@ -705,6 +710,8 @@ class RedisQueueTest extends TestCase
         $this->assertSame(0, $delayed->first()->attempts);
         $this->assertNotNull($delayed->first()->uuid);
         $this->assertInstanceOf(Carbon::class, $delayed->first()->createdAt);
+        $this->assertTrue($delayed->contains(fn ($job) => $job->queue === $default));
+        $this->assertTrue($delayed->contains(fn ($job) => $job->queue === 'emails'));
     }
 
     #[DataProvider('redisDriverProvider')]
@@ -726,6 +733,8 @@ class RedisQueueTest extends TestCase
         $this->assertSame(1, $reserved->first()->attempts);
         $this->assertNotNull($reserved->first()->uuid);
         $this->assertInstanceOf(Carbon::class, $reserved->first()->createdAt);
+        $this->assertTrue($reserved->contains(fn ($job) => $job->queue === $default));
+        $this->assertTrue($reserved->contains(fn ($job) => $job->queue === 'emails'));
     }
 }
 

--- a/tests/Integration/Queue/RedisQueueTest.php
+++ b/tests/Integration/Queue/RedisQueueTest.php
@@ -689,8 +689,7 @@ class RedisQueueTest extends TestCase
         $this->assertSame(0, $pending->first()->attempts);
         $this->assertNotNull($pending->first()->uuid);
         $this->assertInstanceOf(Carbon::class, $pending->first()->createdAt);
-        $this->assertTrue($pending->contains(fn ($job) => $job->queue === $default));
-        $this->assertTrue($pending->contains(fn ($job) => $job->queue === 'emails'));
+        $this->assertSame([$default, 'emails'], $pending->pluck('queue')->sort()->values()->all());
     }
 
     #[DataProvider('redisDriverProvider')]
@@ -710,8 +709,7 @@ class RedisQueueTest extends TestCase
         $this->assertSame(0, $delayed->first()->attempts);
         $this->assertNotNull($delayed->first()->uuid);
         $this->assertInstanceOf(Carbon::class, $delayed->first()->createdAt);
-        $this->assertTrue($delayed->contains(fn ($job) => $job->queue === $default));
-        $this->assertTrue($delayed->contains(fn ($job) => $job->queue === 'emails'));
+        $this->assertSame([$default, 'emails'], $delayed->pluck('queue')->sort()->values()->all());
     }
 
     #[DataProvider('redisDriverProvider')]
@@ -733,8 +731,7 @@ class RedisQueueTest extends TestCase
         $this->assertSame(1, $reserved->first()->attempts);
         $this->assertNotNull($reserved->first()->uuid);
         $this->assertInstanceOf(Carbon::class, $reserved->first()->createdAt);
-        $this->assertTrue($reserved->contains(fn ($job) => $job->queue === $default));
-        $this->assertTrue($reserved->contains(fn ($job) => $job->queue === 'emails'));
+        $this->assertSame([$default, 'emails'], $reserved->pluck('queue')->sort()->values()->all());
     }
 }
 

--- a/tests/Queue/QueueDatabaseQueueUnitTest.php
+++ b/tests/Queue/QueueDatabaseQueueUnitTest.php
@@ -264,6 +264,7 @@ class QueueDatabaseQueueUnitTest extends TestCase
         $this->assertSame('MyTestJob', $jobs->first()->name);
         $this->assertSame('test-uuid', $jobs->first()->uuid);
         $this->assertSame(0, $jobs->first()->attempts);
+        $this->assertSame('default', $jobs->first()->queue);
         $this->assertInstanceOf(Carbon::class, $jobs->first()->createdAt);
         $this->assertSame(1000000, $jobs->first()->createdAt->getTimestamp());
     }
@@ -288,6 +289,7 @@ class QueueDatabaseQueueUnitTest extends TestCase
         $this->assertSame('MyDelayedJob', $jobs->first()->name);
         $this->assertSame('test-uuid', $jobs->first()->uuid);
         $this->assertSame(0, $jobs->first()->attempts);
+        $this->assertSame('default', $jobs->first()->queue);
         $this->assertInstanceOf(Carbon::class, $jobs->first()->createdAt);
         $this->assertSame(1000000, $jobs->first()->createdAt->getTimestamp());
     }
@@ -311,6 +313,7 @@ class QueueDatabaseQueueUnitTest extends TestCase
         $this->assertSame('MyTestJob', $jobs->first()->name);
         $this->assertSame('test-uuid', $jobs->first()->uuid);
         $this->assertSame(1, $jobs->first()->attempts);
+        $this->assertSame('default', $jobs->first()->queue);
         $this->assertInstanceOf(Carbon::class, $jobs->first()->createdAt);
         $this->assertSame(1000000, $jobs->first()->createdAt->getTimestamp());
     }
@@ -338,10 +341,12 @@ class QueueDatabaseQueueUnitTest extends TestCase
         $this->assertSame('JobA', $jobs->first()->name);
         $this->assertSame('uuid-1', $jobs->first()->uuid);
         $this->assertSame(0, $jobs->first()->attempts);
+        $this->assertSame('default', $jobs->first()->queue);
         $this->assertInstanceOf(Carbon::class, $jobs->first()->createdAt);
         $this->assertSame(1000000, $jobs->first()->createdAt->getTimestamp());
         $this->assertSame('JobB', $jobs->last()->name);
         $this->assertSame('uuid-2', $jobs->last()->uuid);
+        $this->assertSame('emails', $jobs->last()->queue);
     }
 
     public function testAllDelayedJobs()
@@ -367,10 +372,12 @@ class QueueDatabaseQueueUnitTest extends TestCase
         $this->assertSame('JobA', $jobs->first()->name);
         $this->assertSame('uuid-1', $jobs->first()->uuid);
         $this->assertSame(0, $jobs->first()->attempts);
+        $this->assertSame('default', $jobs->first()->queue);
         $this->assertInstanceOf(Carbon::class, $jobs->first()->createdAt);
         $this->assertSame(1000000, $jobs->first()->createdAt->getTimestamp());
         $this->assertSame('JobB', $jobs->last()->name);
         $this->assertSame('uuid-2', $jobs->last()->uuid);
+        $this->assertSame('emails', $jobs->last()->queue);
     }
 
     public function testAllReservedJobs()
@@ -395,11 +402,13 @@ class QueueDatabaseQueueUnitTest extends TestCase
         $this->assertSame('JobA', $jobs->first()->name);
         $this->assertSame('uuid-1', $jobs->first()->uuid);
         $this->assertSame(1, $jobs->first()->attempts);
+        $this->assertSame('default', $jobs->first()->queue);
         $this->assertInstanceOf(Carbon::class, $jobs->first()->createdAt);
         $this->assertSame(1000000, $jobs->first()->createdAt->getTimestamp());
         $this->assertSame('JobB', $jobs->last()->name);
         $this->assertSame('uuid-2', $jobs->last()->uuid);
         $this->assertSame(2, $jobs->last()->attempts);
+        $this->assertSame('emails', $jobs->last()->queue);
     }
 
     public function testGetLockForPoppingIsCached()

--- a/tests/Queue/QueueRedisQueueTest.php
+++ b/tests/Queue/QueueRedisQueueTest.php
@@ -411,6 +411,14 @@ class QueueRedisQueueTest extends TestCase
         $this->assertTrue($queue->testIsClusterConnection());
         $this->assertTrue($queue->testIsClusterConnection());
     }
+
+    public function testAllQueueNamesStripsClusterBraces()
+    {
+        $queue = new TestableRedisQueue($redis = m::mock(Factory::class), 'default');
+        $redis->shouldReceive('connection->keys')->andReturn(['queues:{default}', 'queues:{default}:delayed', 'queues:{emails}']);
+
+        $this->assertSame(['default', 'emails'], $queue->testAllQueueNames()->all());
+    }
 }
 
 class TestableRedisQueue extends RedisQueue
@@ -423,5 +431,10 @@ class TestableRedisQueue extends RedisQueue
     public function testIsClusterConnection()
     {
         return $this->isClusterConnection();
+    }
+
+    public function testAllQueueNames()
+    {
+        return $this->allQueueNames();
     }
 }

--- a/tests/Support/SupportTestingQueueFakeTest.php
+++ b/tests/Support/SupportTestingQueueFakeTest.php
@@ -514,6 +514,7 @@ class SupportTestingQueueFakeTest extends TestCase
         $this->assertInstanceOf(InspectedJob::class, $pending->first());
         $this->assertSame(JobStub::class, $pending->first()->name);
         $this->assertSame(0, $pending->first()->attempts);
+        $this->assertSame('foo', $pending->first()->queue);
     }
 
     public function testPendingJobsAcceptsUnitEnums()


### PR DESCRIPTION
When you do `Queue::allPendingJobs()` or any of the `all` methods,  it would be mighty useful to see the queue the job is on.  This is very useful in general for debugging or clarifying behavior in live data.


The database one was straight forward 

The redis one was a bit of a pain and has few changes, but I de-duplicated some bits, essentially just makes the queue name available.  

I've put queue prop b4 created_at, which should be fine as all this is fairly new.


Sorry I keep tweaking this, I keep reaching for it for different bits and realize I wanna see more. This is the last of it 🗡️ (at least for awhile 🙇🏻 )  


Feel free to tweak as perhaps you can see somethin I cant!