### PR TITLE
[13.x] Fix StartSession docblock

### DIFF
--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -300,7 +300,7 @@ class StartSession
      * Resolve the given cache driver.
      *
      * @param  string  $driver
-     * @return \Illuminate\Cache\Store
+     * @return \Illuminate\Contracts\Cache\Repository
      */
     protected function cache($driver)
     {


### PR DESCRIPTION
Let's look at `StartSession::cache` method, its return docblock is invalid because `\Illuminate\Cache\Store` doesn't exist.

Actually, in runtime, `call_user_func($this->cacheFactoryResolver)` must return an instance of `CacheManager`, so the expected returned value must be an implementation of `\Illuminate\Contracts\Cache\Repository` interface.

```php
/**
 * Resolve the given cache driver.
 *
 * @param  string  $driver
 * @return \Illuminate\Contracts\Cache\Repository
 */
protected function cache($driver)
{
    // call_user_func($this->cacheFactoryResolver) returns an instance of CacheManager
    // CacheManager::driver() returns an implementation of \Illuminate\Contracts\Cache\Repository interface
    return call_user_func($this->cacheFactoryResolver)->driver($driver);
}
```