### PR TITLE
[12.x] Ensure `config` is bound before trying to log deprecation notice

### DIFF
--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -130,6 +130,7 @@ class MySqlSchemaState extends SchemaState
             $value .= ' --ssl-key="${:LARAVEL_LOAD_SSL_KEY}"';
         }
 
+        /** @phpstan-ignore classConstant.notFound */
         if (($config['options'][Mysql::ATTR_SSL_VERIFY_SERVER_CERT] ?? null) === false) {
             if (version_compare($versionInfo['version'], '5.7.11', '>=') && ! $versionInfo['isMariaDb']) {
                 $value .= ' --ssl-mode=DISABLED';

--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -92,6 +92,10 @@ class HandleExceptions
             return;
         }
 
+        if (! static::$app->bound('config')) {
+            return;
+        }
+
         try {
             $logger = static::$app->make(LogManager::class);
         } catch (Exception) {


### PR DESCRIPTION
fixes laravel/octane#1135
fixes #60365