### PR TITLE
[13.x] Foundation\Cloud\Events: remove an unused import and fix docblock

### DIFF
--- a/src/Illuminate/Foundation/Cloud/Events.php
+++ b/src/Illuminate/Foundation/Cloud/Events.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Foundation\Cloud;
 
-use Illuminate\Foundation\Cloud;
 use RuntimeException;
 use Throwable;
 
@@ -55,8 +54,6 @@ class Events
 
     /**
      * Write the payload to the socket.
-     *
-     * @param  list<array<string, mixed>>  $payloads
      */
     protected function write(string $payload): void
     {


### PR DESCRIPTION
In Foundation\Cloud\Events,
- `use Illuminate\Foundation\Cloud;` is unused -> remove it.
- `write` only accepts `$payload` as a string, `@param list<array<string, mixed>> $payloads` may be accidentally copied from other methods -> remove it

Please see code changes for more detail!