### PR TITLE
[14.x] Ensure `config` is bound before trying to log deprecation notice

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -79,7 +79,7 @@
         "league/flysystem-sftp-v3": "^3.25.1",
         "mockery/mockery": "^1.6.10",
         "opis/json-schema": "^2.4.1",
-        "orchestra/testbench-core": "^11.0.0",
+        "orchestra/testbench-core": "dev-12/laravel-60380",
         "pda/pheanstalk": "^7.0.0 || ^8.0.0",
         "php-http/discovery": "^1.15",
         "phpstan/phpstan": "^2.0",

--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Bootstrap;
 
 use ErrorException;
 use Exception;
+use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Log\LogManager;
@@ -92,15 +93,16 @@ class HandleExceptions
             return;
         }
 
-        try {
-            $logger = static::$app->make(LogManager::class);
-        } catch (Exception) {
+        $logger = rescue(fn () => static::$app->make(LogManager::class), report: false);
+        $config = rescue(fn () => static::$app->make('config'), report: false);
+
+        if (is_null($logger) || is_null($config)) {
             return;
         }
 
-        $this->ensureDeprecationLoggerIsConfigured();
+        $this->ensureDeprecationLoggerIsConfigured($config);
 
-        $options = static::$app['config']->get('logging.deprecations') ?? [];
+        $options = $config->get('logging.deprecations') ?? [];
 
         with($logger->channel('deprecations'), function ($log) use ($message, $file, $line, $level, $options) {
             if ($options['trace'] ?? false) {
@@ -130,15 +132,13 @@ class HandleExceptions
      *
      * @return void
      */
-    protected function ensureDeprecationLoggerIsConfigured()
+    protected function ensureDeprecationLoggerIsConfigured(ConfigRepository $config)
     {
-        $config = static::$app['config'];
-
         if ($config->get('logging.channels.deprecations')) {
             return;
         }
 
-        $this->ensureNullLogDriverIsConfigured();
+        $this->ensureNullLogDriverIsConfigured($config);
 
         if (is_array($options = $config->get('logging.deprecations'))) {
             $driver = $options['channel'] ?? 'null';
@@ -154,10 +154,8 @@ class HandleExceptions
      *
      * @return void
      */
-    protected function ensureNullLogDriverIsConfigured()
+    protected function ensureNullLogDriverIsConfigured(ConfigRepository $config)
     {
-        $config = static::$app['config'];
-
         if ($config->get('logging.channels.null')) {
             return;
         }


### PR DESCRIPTION
Improvements based on #60376 PR and introduce breaking changes.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
