### PR TITLE
[13.x] Add JSON Schema array deserializer

### DIFF
--- a/src/Illuminate/JsonSchema/Deserializer.php
+++ b/src/Illuminate/JsonSchema/Deserializer.php
@@ -24,7 +24,7 @@ class Deserializer
     }
 
     /**
-     * Deserialize the given JSON Schema array into a type.
+     * Deserialize the Laravel-supported JSON Schema subset into a type.
      *
      * @param  array<string, mixed>  $schema
      *
@@ -118,12 +118,18 @@ class Deserializer
      *
      * @param  array<string, mixed>  $schema
      * @param  array<int, string>  $refs
+     *
+     * @throws \InvalidArgumentException
      */
     protected function buildArray(array $schema, array $refs = []): Types\ArrayType
     {
         $type = new Types\ArrayType;
 
-        if (isset($schema['items']) && is_array($schema['items']) && ! array_is_list($schema['items'])) {
+        if (isset($schema['items']) && $schema['items'] !== []) {
+            if (! is_array($schema['items']) || array_is_list($schema['items'])) {
+                throw new InvalidArgumentException('Tuple and boolean JSON Schema "items" are not supported.');
+            }
+
             $type->items($this->build($schema['items'], $refs));
         }
 
@@ -177,7 +183,7 @@ class Deserializer
      */
     protected function buildInteger(array $schema): Types\IntegerType
     {
-        return $this->applyNumericBounds(new Types\IntegerType, $schema, intval(...));
+        return $this->applyNumericBounds(new Types\IntegerType, $schema, $this->toInteger(...));
     }
 
     /**
@@ -199,15 +205,23 @@ class Deserializer
      * @param  array<string, mixed>  $schema
      * @param  (callable(int|float): (int|float))|null  $cast
      * @return TType
+     *
+     * @throws \InvalidArgumentException
      */
     protected function applyNumericBounds(Types\IntegerType|Types\NumberType $type, array $schema, ?callable $cast = null)
     {
         $cast ??= static fn (int|float $value) => $value;
 
         foreach (['minimum' => 'min', 'maximum' => 'max', 'multipleOf' => 'multipleOf'] as $keyword => $method) {
-            if (isset($schema[$keyword]) && ($value = $this->toNumber($schema[$keyword])) !== null) {
-                $type->{$method}($cast($value));
+            if (! isset($schema[$keyword])) {
+                continue;
             }
+
+            if (($value = $this->toNumber($schema[$keyword])) === null) {
+                throw new InvalidArgumentException("The JSON Schema [{$keyword}] constraint must be a number.");
+            }
+
+            $type->{$method}($cast($value));
         }
 
         return $type;
@@ -217,6 +231,8 @@ class Deserializer
      * Apply the keywords shared by every type to the given instance.
      *
      * @param  array<string, mixed>  $schema
+     *
+     * @throws \InvalidArgumentException
      */
     protected function applyCommon(Types\Type $type, array $schema): void
     {
@@ -232,7 +248,11 @@ class Deserializer
             $type->enum($schema['enum']);
         }
 
-        if (array_key_exists('default', $schema) && $schema['default'] !== null) {
+        if (array_key_exists('default', $schema)) {
+            if ($schema['default'] === null) {
+                throw new InvalidArgumentException('A null JSON Schema [default] is not supported.');
+            }
+
             // The "default" setter is typed per concrete type, so assign it directly...
             (fn () => $this->default = $schema['default'])->call($type);
         }
@@ -341,6 +361,8 @@ class Deserializer
      * @param  array<string, mixed>  $schema
      * @param  array<int, string>  $refs
      * @return array{0: array<string, mixed>, 1: bool, 2: array<int, string>}
+     *
+     * @throws \InvalidArgumentException
      */
     protected function normalizeUnions(array $schema, array $refs = []): array
     {
@@ -366,16 +388,26 @@ class Deserializer
                 }
             }
 
+            if (! $nullable || count($branches) !== 1) {
+                throw new InvalidArgumentException(
+                    "Only a nullable \"{$key}\" (a single schema plus a \"null\" branch) is supported."
+                );
+            }
+
+            [$branch, $branchRefs] = $branches[0];
+
             $siblings = $schema;
             unset($siblings[$key]);
 
-            if (count($branches) === 1) {
-                [$branch, $branchRefs] = $branches[0];
-
-                return [array_merge($siblings, $branch), $nullable, $branchRefs];
+            foreach ($siblings as $siblingKey => $value) {
+                if (array_key_exists($siblingKey, $branch) && $branch[$siblingKey] !== $value) {
+                    throw new InvalidArgumentException(
+                        "Conflicting [{$siblingKey}] between a \"{$key}\" branch and its sibling keys."
+                    );
+                }
             }
 
-            return [$siblings, $nullable, $refs];
+            return [array_merge($siblings, $branch), true, $branchRefs];
         }
 
         return [$schema, false, $refs];
@@ -433,6 +465,10 @@ class Deserializer
      */
     protected function lookupRef(string $ref): array
     {
+        if ($ref === '#') {
+            return $this->root;
+        }
+
         if (! str_starts_with($ref, '#/')) {
             throw new InvalidArgumentException("Unable to resolve non-local JSON Schema \$ref [{$ref}].");
         }
@@ -470,5 +506,19 @@ class Deserializer
         }
 
         return null;
+    }
+
+    /**
+     * Cast the given number to an integer, rejecting non-integer values.
+     *
+     * @throws \InvalidArgumentException
+     */
+    protected function toInteger(int|float $value): int
+    {
+        if (is_float($value) && floor($value) !== $value) {
+            throw new InvalidArgumentException("The JSON Schema integer constraint [{$value}] must be an integer.");
+        }
+
+        return (int) $value;
     }
 }

--- a/src/Illuminate/JsonSchema/Deserializer.php
+++ b/src/Illuminate/JsonSchema/Deserializer.php
@@ -1,0 +1,474 @@
+<?php
+
+namespace Illuminate\JsonSchema;
+
+use InvalidArgumentException;
+
+class Deserializer
+{
+    /**
+     * The root schema being deserialized (used to resolve local $refs).
+     *
+     * @var array<string, mixed>
+     */
+    protected array $root;
+
+    /**
+     * Create a new deserializer instance.
+     *
+     * @param  array<string, mixed>  $root
+     */
+    protected function __construct(array $root)
+    {
+        $this->root = $root;
+    }
+
+    /**
+     * Deserialize the given JSON Schema array into a type.
+     *
+     * @param  array<string, mixed>  $schema
+     *
+     * @throws \InvalidArgumentException
+     */
+    public static function deserialize(array $schema): Types\Type
+    {
+        return (new static($schema))->build($schema);
+    }
+
+    /**
+     * Build a type from the given schema fragment.
+     *
+     * @param  array<string, mixed>  $schema
+     * @param  array<int, string>  $refs
+     *
+     * @throws \InvalidArgumentException
+     */
+    protected function build(array $schema, array $refs = []): Types\Type
+    {
+        [$schema, $refs] = $this->resolveRef($schema, $refs);
+
+        [$schema, $nullableFromUnion, $refs] = $this->normalizeUnions($schema, $refs);
+
+        [$name, $nullableFromType] = $this->resolveType($schema);
+
+        $type = match ($name) {
+            'object' => $this->buildObject($schema, $refs),
+            'array' => $this->buildArray($schema, $refs),
+            'string' => $this->buildString($schema),
+            'integer' => $this->buildInteger($schema),
+            'number' => $this->buildNumber($schema),
+            'boolean' => new Types\BooleanType,
+            default => throw new InvalidArgumentException("Unsupported JSON Schema type [{$name}]."),
+        };
+
+        $this->applyCommon($type, $schema);
+
+        if ($nullableFromUnion || $nullableFromType) {
+            $type->nullable();
+        }
+
+        return $type;
+    }
+
+    /**
+     * Build an object type from the given schema fragment.
+     *
+     * @param  array<string, mixed>  $schema
+     * @param  array<int, string>  $refs
+     *
+     * @throws \InvalidArgumentException
+     */
+    protected function buildObject(array $schema, array $refs = []): Types\ObjectType
+    {
+        $properties = [];
+
+        if (isset($schema['properties']) && is_array($schema['properties'])) {
+            $required = is_array($schema['required'] ?? null)
+                ? array_map('strval', $schema['required'])
+                : [];
+
+            foreach ($schema['properties'] as $key => $definition) {
+                if (! is_array($definition)) {
+                    throw new InvalidArgumentException(
+                        "Unable to represent the schema for property [{$key}]; boolean schemas are not supported."
+                    );
+                }
+
+                $property = $this->build($definition, $refs);
+
+                if (in_array((string) $key, $required, true)) {
+                    $property->required();
+                }
+
+                $properties[$key] = $property;
+            }
+        }
+
+        $type = new Types\ObjectType($properties);
+
+        if (($schema['additionalProperties'] ?? null) === false) {
+            $type->withoutAdditionalProperties();
+        }
+
+        return $type;
+    }
+
+    /**
+     * Build an array type from the given schema fragment.
+     *
+     * @param  array<string, mixed>  $schema
+     * @param  array<int, string>  $refs
+     */
+    protected function buildArray(array $schema, array $refs = []): Types\ArrayType
+    {
+        $type = new Types\ArrayType;
+
+        if (isset($schema['items']) && is_array($schema['items']) && ! array_is_list($schema['items'])) {
+            $type->items($this->build($schema['items'], $refs));
+        }
+
+        if (isset($schema['minItems'])) {
+            $type->min((int) $schema['minItems']);
+        }
+
+        if (isset($schema['maxItems'])) {
+            $type->max((int) $schema['maxItems']);
+        }
+
+        if (isset($schema['uniqueItems'])) {
+            $type->unique((bool) $schema['uniqueItems']);
+        }
+
+        return $type;
+    }
+
+    /**
+     * Build a string type from the given schema fragment.
+     *
+     * @param  array<string, mixed>  $schema
+     */
+    protected function buildString(array $schema): Types\StringType
+    {
+        $type = new Types\StringType;
+
+        if (isset($schema['minLength'])) {
+            $type->min((int) $schema['minLength']);
+        }
+
+        if (isset($schema['maxLength'])) {
+            $type->max((int) $schema['maxLength']);
+        }
+
+        if (isset($schema['pattern'])) {
+            $type->pattern((string) $schema['pattern']);
+        }
+
+        if (isset($schema['format'])) {
+            $type->format((string) $schema['format']);
+        }
+
+        return $type;
+    }
+
+    /**
+     * Build an integer type from the given schema fragment.
+     *
+     * @param  array<string, mixed>  $schema
+     */
+    protected function buildInteger(array $schema): Types\IntegerType
+    {
+        return $this->applyNumericBounds(new Types\IntegerType, $schema, intval(...));
+    }
+
+    /**
+     * Build a number type from the given schema fragment.
+     *
+     * @param  array<string, mixed>  $schema
+     */
+    protected function buildNumber(array $schema): Types\NumberType
+    {
+        return $this->applyNumericBounds(new Types\NumberType, $schema);
+    }
+
+    /**
+     * Apply the numeric bound keywords to the given integer or number type.
+     *
+     * @template TType of Types\IntegerType|Types\NumberType
+     *
+     * @param  TType  $type
+     * @param  array<string, mixed>  $schema
+     * @param  (callable(int|float): (int|float))|null  $cast
+     * @return TType
+     */
+    protected function applyNumericBounds(Types\IntegerType|Types\NumberType $type, array $schema, ?callable $cast = null)
+    {
+        $cast ??= static fn (int|float $value) => $value;
+
+        foreach (['minimum' => 'min', 'maximum' => 'max', 'multipleOf' => 'multipleOf'] as $keyword => $method) {
+            if (isset($schema[$keyword]) && ($value = $this->toNumber($schema[$keyword])) !== null) {
+                $type->{$method}($cast($value));
+            }
+        }
+
+        return $type;
+    }
+
+    /**
+     * Apply the keywords shared by every type to the given instance.
+     *
+     * @param  array<string, mixed>  $schema
+     */
+    protected function applyCommon(Types\Type $type, array $schema): void
+    {
+        if (isset($schema['title'])) {
+            $type->title((string) $schema['title']);
+        }
+
+        if (isset($schema['description'])) {
+            $type->description((string) $schema['description']);
+        }
+
+        if (isset($schema['enum']) && is_array($schema['enum'])) {
+            $type->enum($schema['enum']);
+        }
+
+        if (array_key_exists('default', $schema) && $schema['default'] !== null) {
+            // The "default" setter is typed per concrete type, so assign it directly...
+            (fn () => $this->default = $schema['default'])->call($type);
+        }
+    }
+
+    /**
+     * Resolve the base type name and whether the schema is nullable.
+     *
+     * @param  array<string, mixed>  $schema
+     * @return array{0: string, 1: bool}
+     *
+     * @throws \InvalidArgumentException
+     */
+    protected function resolveType(array $schema): array
+    {
+        $type = $schema['type'] ?? null;
+        $nullable = false;
+
+        if (is_array($type)) {
+            $nullable = in_array('null', $type, true);
+
+            $names = array_values(array_unique(array_filter(
+                $type,
+                static fn ($value) => $value !== 'null',
+            )));
+
+            if (count($names) > 1) {
+                throw new InvalidArgumentException(
+                    'Unable to represent a multi-type JSON Schema union ['.implode(', ', array_map('strval', $names)).'].'
+                );
+            }
+
+            $type = $names[0] ?? null;
+        }
+
+        $type ??= $this->inferType($schema);
+
+        if (! is_string($type)) {
+            throw new InvalidArgumentException('Unable to determine the JSON Schema type for the given schema.');
+        }
+
+        return [$type, $nullable];
+    }
+
+    /**
+     * Infer the type name when "type" is absent but the shape is unambiguous.
+     *
+     * @param  array<string, mixed>  $schema
+     */
+    protected function inferType(array $schema): ?string
+    {
+        return match (true) {
+            isset($schema['properties']), isset($schema['additionalProperties']), isset($schema['required']) => 'object',
+            isset($schema['items']), isset($schema['minItems']), isset($schema['maxItems']), isset($schema['uniqueItems']) => 'array',
+            isset($schema['enum']) && is_array($schema['enum']) => $this->inferEnumType($schema['enum']),
+            isset($schema['minLength']), isset($schema['maxLength']), isset($schema['pattern']), isset($schema['format']) => 'string',
+            isset($schema['minimum']), isset($schema['maximum']), isset($schema['multipleOf']) => 'number',
+            default => null,
+        };
+    }
+
+    /**
+     * Infer the scalar type shared by a homogeneous enum of scalars.
+     *
+     * @param  array<int, mixed>  $enum
+     */
+    protected function inferEnumType(array $enum): ?string
+    {
+        $resolved = null;
+
+        foreach ($enum as $value) {
+            $current = match (true) {
+                is_bool($value) => 'boolean',
+                is_int($value) => 'integer',
+                is_float($value) => 'number',
+                is_string($value) => 'string',
+                default => null,
+            };
+
+            if ($current === null) {
+                return null;
+            }
+
+            if ($resolved === null || $resolved === $current) {
+                $resolved = $current;
+
+                continue;
+            }
+
+            // A mix of integers and floats is still numeric; anything else is ambiguous...
+            if (in_array($resolved, ['integer', 'number'], true) && in_array($current, ['integer', 'number'], true)) {
+                $resolved = 'number';
+
+                continue;
+            }
+
+            return null;
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * Collapse "anyOf"/"oneOf" null branches into a single effective schema.
+     *
+     * @param  array<string, mixed>  $schema
+     * @param  array<int, string>  $refs
+     * @return array{0: array<string, mixed>, 1: bool, 2: array<int, string>}
+     */
+    protected function normalizeUnions(array $schema, array $refs = []): array
+    {
+        foreach (['anyOf', 'oneOf'] as $key) {
+            if (! isset($schema[$key]) || ! is_array($schema[$key])) {
+                continue;
+            }
+
+            $nullable = false;
+            $branches = [];
+
+            foreach ($schema[$key] as $branch) {
+                if (! is_array($branch)) {
+                    continue;
+                }
+
+                [$branch, $branchRefs] = $this->resolveRef($branch, $refs);
+
+                if ($this->isNullBranch($branch)) {
+                    $nullable = true;
+                } else {
+                    $branches[] = [$branch, $branchRefs];
+                }
+            }
+
+            $siblings = $schema;
+            unset($siblings[$key]);
+
+            if (count($branches) === 1) {
+                [$branch, $branchRefs] = $branches[0];
+
+                return [array_merge($siblings, $branch), $nullable, $branchRefs];
+            }
+
+            return [$siblings, $nullable, $refs];
+        }
+
+        return [$schema, false, $refs];
+    }
+
+    /**
+     * Determine if the given schema branch describes only the "null" type.
+     *
+     * @param  array<string, mixed>  $branch
+     */
+    protected function isNullBranch(array $branch): bool
+    {
+        $type = $branch['type'] ?? null;
+
+        return $type === 'null' || $type === ['null'];
+    }
+
+    /**
+     * Resolve a local "$ref" against the root schema, merging sibling keys.
+     *
+     * @param  array<string, mixed>  $schema
+     * @param  array<int, string>  $refs
+     * @return array{0: array<string, mixed>, 1: array<int, string>}
+     *
+     * @throws \InvalidArgumentException
+     */
+    protected function resolveRef(array $schema, array $refs = []): array
+    {
+        if (! isset($schema['$ref']) || ! is_string($schema['$ref'])) {
+            return [$schema, $refs];
+        }
+
+        $ref = $schema['$ref'];
+
+        if (in_array($ref, $refs, true)) {
+            throw new InvalidArgumentException("Circular JSON Schema \$ref [{$ref}] detected.");
+        }
+
+        $refs[] = $ref;
+
+        $resolved = $this->lookupRef($ref);
+
+        $siblings = $schema;
+        unset($siblings['$ref']);
+
+        return $this->resolveRef(array_merge($resolved, $siblings), $refs);
+    }
+
+    /**
+     * Look up a local JSON pointer reference within the root schema.
+     *
+     * @return array<string, mixed>
+     *
+     * @throws \InvalidArgumentException
+     */
+    protected function lookupRef(string $ref): array
+    {
+        if (! str_starts_with($ref, '#/')) {
+            throw new InvalidArgumentException("Unable to resolve non-local JSON Schema \$ref [{$ref}].");
+        }
+
+        $target = $this->root;
+
+        foreach (explode('/', substr($ref, 2)) as $segment) {
+            $segment = str_replace(['~1', '~0'], ['/', '~'], rawurldecode($segment));
+
+            if (! is_array($target) || ! array_key_exists($segment, $target)) {
+                throw new InvalidArgumentException("Unable to resolve JSON Schema \$ref [{$ref}].");
+            }
+
+            $target = $target[$segment];
+        }
+
+        if (! is_array($target)) {
+            throw new InvalidArgumentException("The JSON Schema \$ref [{$ref}] does not point to a schema.");
+        }
+
+        return $target;
+    }
+
+    /**
+     * Normalize the given value to an integer or float, or null when not numeric.
+     */
+    protected function toNumber(mixed $value): int|float|null
+    {
+        if (is_int($value) || is_float($value)) {
+            return $value;
+        }
+
+        if (is_string($value) && is_numeric($value)) {
+            return $value + 0;
+        }
+
+        return null;
+    }
+}

--- a/src/Illuminate/JsonSchema/Deserializer.php
+++ b/src/Illuminate/JsonSchema/Deserializer.php
@@ -356,7 +356,7 @@ class Deserializer
     }
 
     /**
-     * Collapse "anyOf"/"oneOf" null branches into a single effective schema.
+     * Collapse "anyOf" / "oneOf" null branches into a single effective schema.
      *
      * @param  array<string, mixed>  $schema
      * @param  array<int, string>  $refs

--- a/src/Illuminate/JsonSchema/JsonSchema.php
+++ b/src/Illuminate/JsonSchema/JsonSchema.php
@@ -16,6 +16,18 @@ use Illuminate\JsonSchema\Types\Type;
 class JsonSchema
 {
     /**
+     * Build a type from the given raw JSON Schema array.
+     *
+     * @param  array<string, mixed>  $schema
+     *
+     * @throws \InvalidArgumentException
+     */
+    public static function deserialize(array $schema): Type
+    {
+        return Deserializer::deserialize($schema);
+    }
+
+    /**
      * Dynamically pass static methods to the schema instance.
      */
     public static function __callStatic(string $name, mixed $arguments): Type

--- a/src/Illuminate/JsonSchema/JsonSchema.php
+++ b/src/Illuminate/JsonSchema/JsonSchema.php
@@ -16,13 +16,13 @@ use Illuminate\JsonSchema\Types\Type;
 class JsonSchema
 {
     /**
-     * Build a type from the given raw JSON Schema array.
+     * Build a type from a raw array of the Laravel-supported JSON Schema subset.
      *
      * @param  array<string, mixed>  $schema
      *
      * @throws \InvalidArgumentException
      */
-    public static function deserialize(array $schema): Type
+    public static function fromArray(array $schema): Type
     {
         return Deserializer::deserialize($schema);
     }

--- a/tests/JsonSchema/DeserializerTest.php
+++ b/tests/JsonSchema/DeserializerTest.php
@@ -31,7 +31,7 @@ class DeserializerTest extends TestCase
 
         $array = Serializer::serialize($type);
 
-        $rebuilt = JsonSchema::deserialize($array);
+        $rebuilt = JsonSchema::fromArray($array);
 
         $this->assertInstanceOf(ObjectType::class, $rebuilt);
         $this->assertSame($array, Serializer::serialize($rebuilt));
@@ -40,17 +40,17 @@ class DeserializerTest extends TestCase
 
     public function test_it_maps_every_supported_type(): void
     {
-        $this->assertInstanceOf(ObjectType::class, JsonSchema::deserialize(['type' => 'object']));
-        $this->assertInstanceOf(ArrayType::class, JsonSchema::deserialize(['type' => 'array']));
-        $this->assertInstanceOf(StringType::class, JsonSchema::deserialize(['type' => 'string']));
-        $this->assertInstanceOf(IntegerType::class, JsonSchema::deserialize(['type' => 'integer']));
-        $this->assertInstanceOf(NumberType::class, JsonSchema::deserialize(['type' => 'number']));
-        $this->assertInstanceOf(BooleanType::class, JsonSchema::deserialize(['type' => 'boolean']));
+        $this->assertInstanceOf(ObjectType::class, JsonSchema::fromArray(['type' => 'object']));
+        $this->assertInstanceOf(ArrayType::class, JsonSchema::fromArray(['type' => 'array']));
+        $this->assertInstanceOf(StringType::class, JsonSchema::fromArray(['type' => 'string']));
+        $this->assertInstanceOf(IntegerType::class, JsonSchema::fromArray(['type' => 'integer']));
+        $this->assertInstanceOf(NumberType::class, JsonSchema::fromArray(['type' => 'number']));
+        $this->assertInstanceOf(BooleanType::class, JsonSchema::fromArray(['type' => 'boolean']));
     }
 
     public function test_it_applies_string_constraints(): void
     {
-        $type = JsonSchema::deserialize([
+        $type = JsonSchema::fromArray([
             'type' => 'string',
             'minLength' => 2,
             'maxLength' => 8,
@@ -69,7 +69,7 @@ class DeserializerTest extends TestCase
 
     public function test_it_applies_integer_constraints(): void
     {
-        $type = JsonSchema::deserialize([
+        $type = JsonSchema::fromArray([
             'type' => 'integer',
             'minimum' => 0,
             'maximum' => 100,
@@ -87,7 +87,7 @@ class DeserializerTest extends TestCase
 
     public function test_it_applies_number_constraints_and_preserves_floats(): void
     {
-        $type = JsonSchema::deserialize([
+        $type = JsonSchema::fromArray([
             'type' => 'number',
             'minimum' => 0.5,
             'maximum' => 9.9,
@@ -105,7 +105,7 @@ class DeserializerTest extends TestCase
 
     public function test_it_applies_array_constraints_and_nested_items(): void
     {
-        $type = JsonSchema::deserialize([
+        $type = JsonSchema::fromArray([
             'type' => 'array',
             'items' => ['type' => 'string', 'maxLength' => 3],
             'minItems' => 1,
@@ -128,7 +128,7 @@ class DeserializerTest extends TestCase
 
     public function test_it_builds_nested_objects_and_marks_required_children(): void
     {
-        $type = JsonSchema::deserialize([
+        $type = JsonSchema::fromArray([
             'type' => 'object',
             'properties' => [
                 'name' => ['type' => 'string', 'minLength' => 1],
@@ -163,7 +163,7 @@ class DeserializerTest extends TestCase
 
     public function test_it_preserves_numeric_string_property_names_when_marking_required(): void
     {
-        $type = JsonSchema::deserialize([
+        $type = JsonSchema::fromArray([
             'type' => 'object',
             'properties' => [
                 '1' => ['type' => 'string'],
@@ -180,7 +180,7 @@ class DeserializerTest extends TestCase
 
     public function test_it_disallows_additional_properties_when_false(): void
     {
-        $type = JsonSchema::deserialize([
+        $type = JsonSchema::fromArray([
             'type' => 'object',
             'additionalProperties' => false,
         ]);
@@ -193,7 +193,7 @@ class DeserializerTest extends TestCase
 
     public function test_it_normalizes_nullable_from_a_type_array(): void
     {
-        $type = JsonSchema::deserialize([
+        $type = JsonSchema::fromArray([
             'type' => ['string', 'null'],
             'minLength' => 1,
         ]);
@@ -207,7 +207,7 @@ class DeserializerTest extends TestCase
 
     public function test_it_normalizes_nullable_from_an_any_of_null_branch(): void
     {
-        $type = JsonSchema::deserialize([
+        $type = JsonSchema::fromArray([
             'title' => 'Nickname',
             'anyOf' => [
                 ['type' => 'string', 'minLength' => 1],
@@ -225,7 +225,7 @@ class DeserializerTest extends TestCase
 
     public function test_it_normalizes_nullable_from_a_one_of_null_branch(): void
     {
-        $type = JsonSchema::deserialize([
+        $type = JsonSchema::fromArray([
             'oneOf' => [
                 ['type' => 'null'],
                 ['type' => 'integer', 'minimum' => 0],
@@ -241,7 +241,7 @@ class DeserializerTest extends TestCase
 
     public function test_it_resolves_a_local_ref_against_defs(): void
     {
-        $type = JsonSchema::deserialize([
+        $type = JsonSchema::fromArray([
             'type' => 'object',
             'properties' => [
                 'author' => ['$ref' => '#/$defs/User'],
@@ -275,7 +275,7 @@ class DeserializerTest extends TestCase
 
     public function test_it_resolves_a_local_ref_against_definitions(): void
     {
-        $type = JsonSchema::deserialize([
+        $type = JsonSchema::fromArray([
             '$ref' => '#/definitions/Tag',
             'definitions' => [
                 'Tag' => ['type' => 'string', 'minLength' => 1],
@@ -291,7 +291,7 @@ class DeserializerTest extends TestCase
 
     public function test_it_merges_sibling_keys_over_a_ref(): void
     {
-        $type = JsonSchema::deserialize([
+        $type = JsonSchema::fromArray([
             'type' => 'object',
             'properties' => [
                 'handle' => [
@@ -325,7 +325,7 @@ class DeserializerTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Unable to resolve JSON Schema $ref [#/$defs/Missing].');
 
-        JsonSchema::deserialize([
+        JsonSchema::fromArray([
             '$ref' => '#/$defs/Missing',
             '$defs' => [],
         ]);
@@ -336,14 +336,14 @@ class DeserializerTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Unable to resolve non-local JSON Schema $ref [https://example.com/user.json].');
 
-        JsonSchema::deserialize([
+        JsonSchema::fromArray([
             '$ref' => 'https://example.com/user.json',
         ]);
     }
 
     public function test_it_infers_object_type_from_properties(): void
     {
-        $type = JsonSchema::deserialize([
+        $type = JsonSchema::fromArray([
             'properties' => [
                 'name' => ['type' => 'string'],
             ],
@@ -354,7 +354,7 @@ class DeserializerTest extends TestCase
 
     public function test_it_infers_array_type_from_items(): void
     {
-        $type = JsonSchema::deserialize([
+        $type = JsonSchema::fromArray([
             'items' => ['type' => 'integer'],
         ]);
 
@@ -367,26 +367,26 @@ class DeserializerTest extends TestCase
 
     public function test_it_infers_scalar_type_from_a_homogeneous_enum(): void
     {
-        $this->assertInstanceOf(StringType::class, JsonSchema::deserialize([
+        $this->assertInstanceOf(StringType::class, JsonSchema::fromArray([
             'enum' => ['draft', 'published'],
         ]));
 
-        $this->assertInstanceOf(IntegerType::class, JsonSchema::deserialize([
+        $this->assertInstanceOf(IntegerType::class, JsonSchema::fromArray([
             'enum' => [1, 2, 3],
         ]));
 
-        $this->assertInstanceOf(NumberType::class, JsonSchema::deserialize([
+        $this->assertInstanceOf(NumberType::class, JsonSchema::fromArray([
             'enum' => [1, 2.5, 3],
         ]));
 
-        $this->assertInstanceOf(BooleanType::class, JsonSchema::deserialize([
+        $this->assertInstanceOf(BooleanType::class, JsonSchema::fromArray([
             'enum' => [true, false],
         ]));
     }
 
     public function test_it_applies_enum_and_default(): void
     {
-        $type = JsonSchema::deserialize([
+        $type = JsonSchema::fromArray([
             'type' => 'string',
             'enum' => ['draft', 'published'],
             'default' => 'draft',
@@ -401,7 +401,7 @@ class DeserializerTest extends TestCase
 
     public function test_it_ignores_unknown_keywords(): void
     {
-        $type = JsonSchema::deserialize([
+        $type = JsonSchema::fromArray([
             'type' => 'string',
             'minLength' => 1,
             '$schema' => 'https://json-schema.org/draft/2020-12/schema',
@@ -421,7 +421,7 @@ class DeserializerTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Unable to determine the JSON Schema type for the given schema.');
 
-        JsonSchema::deserialize([
+        JsonSchema::fromArray([
             'title' => 'Mystery',
         ]);
     }
@@ -431,7 +431,7 @@ class DeserializerTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Circular JSON Schema $ref [#/$defs/node] detected.');
 
-        JsonSchema::deserialize([
+        JsonSchema::fromArray([
             'type' => 'object',
             'properties' => [
                 'children' => ['type' => 'array', 'items' => ['$ref' => '#/$defs/node']],
@@ -449,7 +449,7 @@ class DeserializerTest extends TestCase
 
     public function test_it_resolves_the_same_ref_used_in_sibling_positions(): void
     {
-        $type = JsonSchema::deserialize([
+        $type = JsonSchema::fromArray([
             'type' => 'object',
             'properties' => [
                 'home' => ['$ref' => '#/$defs/address'],
@@ -474,7 +474,7 @@ class DeserializerTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Unable to represent a multi-type JSON Schema union [string, integer].');
 
-        JsonSchema::deserialize([
+        JsonSchema::fromArray([
             'type' => ['string', 'integer'],
         ]);
     }
@@ -484,7 +484,7 @@ class DeserializerTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Unable to represent the schema for property [meta]; boolean schemas are not supported.');
 
-        JsonSchema::deserialize([
+        JsonSchema::fromArray([
             'type' => 'object',
             'properties' => [
                 'meta' => true,
@@ -492,46 +492,86 @@ class DeserializerTest extends TestCase
         ]);
     }
 
-    public function test_it_ignores_non_numeric_numeric_constraints_instead_of_failing(): void
+    public function test_it_throws_for_a_non_numeric_numeric_constraint(): void
     {
-        $type = JsonSchema::deserialize([
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The JSON Schema [minimum] constraint must be a number.');
+
+        JsonSchema::fromArray([
             'type' => 'number',
             'minimum' => 'oops',
-            'maximum' => ['not', 'a', 'number'],
-            'multipleOf' => 0.5,
         ]);
-
-        $this->assertInstanceOf(NumberType::class, $type);
-        $this->assertEquals([
-            'type' => 'number',
-            'multipleOf' => 0.5,
-        ], $type->toArray());
     }
 
-    public function test_it_prefers_a_union_branch_over_outer_sibling_keys(): void
+    public function test_it_throws_for_a_non_integer_integer_constraint(): void
     {
-        $type = JsonSchema::deserialize([
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The JSON Schema integer constraint [1.9] must be an integer.');
+
+        JsonSchema::fromArray([
+            'type' => 'integer',
+            'minimum' => 1.9,
+        ]);
+    }
+
+    public function test_it_throws_for_tuple_items(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Tuple and boolean JSON Schema "items" are not supported.');
+
+        JsonSchema::fromArray([
+            'type' => 'array',
+            'items' => [
+                ['type' => 'string'],
+                ['type' => 'integer'],
+            ],
+        ]);
+    }
+
+    public function test_it_throws_when_a_union_branch_conflicts_with_sibling_keys(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Conflicting [type] between a "anyOf" branch and its sibling keys.');
+
+        JsonSchema::fromArray([
             'type' => 'integer',
             'anyOf' => [
                 ['type' => 'string', 'minLength' => 3],
                 ['type' => 'null'],
             ],
         ]);
-
-        $this->assertInstanceOf(StringType::class, $type);
-        $this->assertEquals([
-            'type' => ['string', 'null'],
-            'minLength' => 3,
-        ], $type->toArray());
     }
 
-    public function test_it_does_not_carry_an_explicit_null_default(): void
+    public function test_it_throws_for_an_unsupported_union(): void
     {
-        $type = JsonSchema::deserialize([
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Only a nullable "anyOf" (a single schema plus a "null" branch) is supported.');
+
+        JsonSchema::fromArray([
+            'anyOf' => [
+                ['type' => 'string'],
+                ['type' => 'integer'],
+            ],
+        ]);
+    }
+
+    public function test_it_throws_for_a_null_default(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('A null JSON Schema [default] is not supported.');
+
+        JsonSchema::fromArray([
             'type' => 'string',
             'default' => null,
         ]);
+    }
 
-        $this->assertEquals(['type' => 'string'], $type->toArray());
+    public function test_it_resolves_the_root_ref_pointer(): void
+    {
+        // "#" resolves to the root, so a self-reference is detected as circular...
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Circular JSON Schema $ref [#] detected.');
+
+        JsonSchema::fromArray(['$ref' => '#']);
     }
 }

--- a/tests/JsonSchema/DeserializerTest.php
+++ b/tests/JsonSchema/DeserializerTest.php
@@ -1,0 +1,537 @@
+<?php
+
+namespace Illuminate\Tests\JsonSchema;
+
+use Illuminate\JsonSchema\JsonSchema;
+use Illuminate\JsonSchema\Serializer;
+use Illuminate\JsonSchema\Types\ArrayType;
+use Illuminate\JsonSchema\Types\BooleanType;
+use Illuminate\JsonSchema\Types\IntegerType;
+use Illuminate\JsonSchema\Types\NumberType;
+use Illuminate\JsonSchema\Types\ObjectType;
+use Illuminate\JsonSchema\Types\StringType;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+class DeserializerTest extends TestCase
+{
+    public function test_it_round_trips_a_type_built_with_the_factory(): void
+    {
+        $type = JsonSchema::object([
+            'name' => JsonSchema::string()->min(1)->max(50)->pattern('^[a-z]+$')->required(),
+            'age' => JsonSchema::integer()->min(0)->max(120)->default(18),
+            'score' => JsonSchema::number()->min(0)->max(100)->multipleOf(0.5),
+            'active' => JsonSchema::boolean()->default(true),
+            'tags' => JsonSchema::array()->items(JsonSchema::string()->max(20))->min(1)->max(5)->unique(),
+            'meta' => JsonSchema::object([
+                'created' => JsonSchema::string()->format('date-time')->required(),
+            ])->withoutAdditionalProperties(),
+            'status' => JsonSchema::string()->enum(['draft', 'published'])->nullable(),
+        ])->title('User')->description('A user payload');
+
+        $array = Serializer::serialize($type);
+
+        $rebuilt = JsonSchema::deserialize($array);
+
+        $this->assertInstanceOf(ObjectType::class, $rebuilt);
+        $this->assertSame($array, Serializer::serialize($rebuilt));
+        $this->assertEquals($type, $rebuilt);
+    }
+
+    public function test_it_maps_every_supported_type(): void
+    {
+        $this->assertInstanceOf(ObjectType::class, JsonSchema::deserialize(['type' => 'object']));
+        $this->assertInstanceOf(ArrayType::class, JsonSchema::deserialize(['type' => 'array']));
+        $this->assertInstanceOf(StringType::class, JsonSchema::deserialize(['type' => 'string']));
+        $this->assertInstanceOf(IntegerType::class, JsonSchema::deserialize(['type' => 'integer']));
+        $this->assertInstanceOf(NumberType::class, JsonSchema::deserialize(['type' => 'number']));
+        $this->assertInstanceOf(BooleanType::class, JsonSchema::deserialize(['type' => 'boolean']));
+    }
+
+    public function test_it_applies_string_constraints(): void
+    {
+        $type = JsonSchema::deserialize([
+            'type' => 'string',
+            'minLength' => 2,
+            'maxLength' => 8,
+            'pattern' => '^foo.*$',
+            'format' => 'email',
+        ]);
+
+        $this->assertEquals([
+            'type' => 'string',
+            'minLength' => 2,
+            'maxLength' => 8,
+            'pattern' => '^foo.*$',
+            'format' => 'email',
+        ], $type->toArray());
+    }
+
+    public function test_it_applies_integer_constraints(): void
+    {
+        $type = JsonSchema::deserialize([
+            'type' => 'integer',
+            'minimum' => 0,
+            'maximum' => 100,
+            'multipleOf' => 5,
+        ]);
+
+        $this->assertInstanceOf(IntegerType::class, $type);
+        $this->assertEquals([
+            'type' => 'integer',
+            'minimum' => 0,
+            'maximum' => 100,
+            'multipleOf' => 5,
+        ], $type->toArray());
+    }
+
+    public function test_it_applies_number_constraints_and_preserves_floats(): void
+    {
+        $type = JsonSchema::deserialize([
+            'type' => 'number',
+            'minimum' => 0.5,
+            'maximum' => 9.9,
+            'multipleOf' => 0.1,
+        ]);
+
+        $this->assertInstanceOf(NumberType::class, $type);
+
+        $array = $type->toArray();
+
+        $this->assertSame(0.5, $array['minimum']);
+        $this->assertSame(9.9, $array['maximum']);
+        $this->assertSame(0.1, $array['multipleOf']);
+    }
+
+    public function test_it_applies_array_constraints_and_nested_items(): void
+    {
+        $type = JsonSchema::deserialize([
+            'type' => 'array',
+            'items' => ['type' => 'string', 'maxLength' => 3],
+            'minItems' => 1,
+            'maxItems' => 4,
+            'uniqueItems' => true,
+        ]);
+
+        $this->assertInstanceOf(ArrayType::class, $type);
+        $this->assertEquals([
+            'type' => 'array',
+            'minItems' => 1,
+            'maxItems' => 4,
+            'items' => [
+                'type' => 'string',
+                'maxLength' => 3,
+            ],
+            'uniqueItems' => true,
+        ], $type->toArray());
+    }
+
+    public function test_it_builds_nested_objects_and_marks_required_children(): void
+    {
+        $type = JsonSchema::deserialize([
+            'type' => 'object',
+            'properties' => [
+                'name' => ['type' => 'string', 'minLength' => 1],
+                'age' => ['type' => 'integer', 'minimum' => 0],
+                'address' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'city' => ['type' => 'string'],
+                    ],
+                    'required' => ['city'],
+                ],
+            ],
+            'required' => ['name'],
+        ]);
+
+        $this->assertEquals([
+            'type' => 'object',
+            'properties' => [
+                'name' => ['type' => 'string', 'minLength' => 1],
+                'age' => ['type' => 'integer', 'minimum' => 0],
+                'address' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'city' => ['type' => 'string'],
+                    ],
+                    'required' => ['city'],
+                ],
+            ],
+            'required' => ['name'],
+        ], $type->toArray());
+    }
+
+    public function test_it_preserves_numeric_string_property_names_when_marking_required(): void
+    {
+        $type = JsonSchema::deserialize([
+            'type' => 'object',
+            'properties' => [
+                '1' => ['type' => 'string'],
+                '4' => ['type' => 'string'],
+            ],
+            'required' => ['1', '4'],
+        ]);
+
+        $array = $type->toArray();
+
+        $this->assertEquals(['1', '4'], $array['required']);
+        $this->assertIsString($array['required'][0]);
+    }
+
+    public function test_it_disallows_additional_properties_when_false(): void
+    {
+        $type = JsonSchema::deserialize([
+            'type' => 'object',
+            'additionalProperties' => false,
+        ]);
+
+        $this->assertEquals([
+            'type' => 'object',
+            'additionalProperties' => false,
+        ], $type->toArray());
+    }
+
+    public function test_it_normalizes_nullable_from_a_type_array(): void
+    {
+        $type = JsonSchema::deserialize([
+            'type' => ['string', 'null'],
+            'minLength' => 1,
+        ]);
+
+        $this->assertInstanceOf(StringType::class, $type);
+        $this->assertEquals([
+            'type' => ['string', 'null'],
+            'minLength' => 1,
+        ], $type->toArray());
+    }
+
+    public function test_it_normalizes_nullable_from_an_any_of_null_branch(): void
+    {
+        $type = JsonSchema::deserialize([
+            'title' => 'Nickname',
+            'anyOf' => [
+                ['type' => 'string', 'minLength' => 1],
+                ['type' => 'null'],
+            ],
+        ]);
+
+        $this->assertInstanceOf(StringType::class, $type);
+        $this->assertEquals([
+            'title' => 'Nickname',
+            'minLength' => 1,
+            'type' => ['string', 'null'],
+        ], $type->toArray());
+    }
+
+    public function test_it_normalizes_nullable_from_a_one_of_null_branch(): void
+    {
+        $type = JsonSchema::deserialize([
+            'oneOf' => [
+                ['type' => 'null'],
+                ['type' => 'integer', 'minimum' => 0],
+            ],
+        ]);
+
+        $this->assertInstanceOf(IntegerType::class, $type);
+        $this->assertEquals([
+            'minimum' => 0,
+            'type' => ['integer', 'null'],
+        ], $type->toArray());
+    }
+
+    public function test_it_resolves_a_local_ref_against_defs(): void
+    {
+        $type = JsonSchema::deserialize([
+            'type' => 'object',
+            'properties' => [
+                'author' => ['$ref' => '#/$defs/User'],
+            ],
+            'required' => ['author'],
+            '$defs' => [
+                'User' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'name' => ['type' => 'string'],
+                    ],
+                    'required' => ['name'],
+                ],
+            ],
+        ]);
+
+        $this->assertEquals([
+            'type' => 'object',
+            'properties' => [
+                'author' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'name' => ['type' => 'string'],
+                    ],
+                    'required' => ['name'],
+                ],
+            ],
+            'required' => ['author'],
+        ], $type->toArray());
+    }
+
+    public function test_it_resolves_a_local_ref_against_definitions(): void
+    {
+        $type = JsonSchema::deserialize([
+            '$ref' => '#/definitions/Tag',
+            'definitions' => [
+                'Tag' => ['type' => 'string', 'minLength' => 1],
+            ],
+        ]);
+
+        $this->assertInstanceOf(StringType::class, $type);
+        $this->assertEquals([
+            'type' => 'string',
+            'minLength' => 1,
+        ], $type->toArray());
+    }
+
+    public function test_it_merges_sibling_keys_over_a_ref(): void
+    {
+        $type = JsonSchema::deserialize([
+            'type' => 'object',
+            'properties' => [
+                'handle' => [
+                    '$ref' => '#/$defs/Name',
+                    'description' => 'Overridden description',
+                ],
+            ],
+            '$defs' => [
+                'Name' => [
+                    'type' => 'string',
+                    'description' => 'Original description',
+                    'minLength' => 1,
+                ],
+            ],
+        ]);
+
+        $this->assertEquals([
+            'type' => 'object',
+            'properties' => [
+                'handle' => [
+                    'description' => 'Overridden description',
+                    'minLength' => 1,
+                    'type' => 'string',
+                ],
+            ],
+        ], $type->toArray());
+    }
+
+    public function test_it_throws_for_an_unresolvable_ref(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unable to resolve JSON Schema $ref [#/$defs/Missing].');
+
+        JsonSchema::deserialize([
+            '$ref' => '#/$defs/Missing',
+            '$defs' => [],
+        ]);
+    }
+
+    public function test_it_throws_for_a_remote_ref(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unable to resolve non-local JSON Schema $ref [https://example.com/user.json].');
+
+        JsonSchema::deserialize([
+            '$ref' => 'https://example.com/user.json',
+        ]);
+    }
+
+    public function test_it_infers_object_type_from_properties(): void
+    {
+        $type = JsonSchema::deserialize([
+            'properties' => [
+                'name' => ['type' => 'string'],
+            ],
+        ]);
+
+        $this->assertInstanceOf(ObjectType::class, $type);
+    }
+
+    public function test_it_infers_array_type_from_items(): void
+    {
+        $type = JsonSchema::deserialize([
+            'items' => ['type' => 'integer'],
+        ]);
+
+        $this->assertInstanceOf(ArrayType::class, $type);
+        $this->assertEquals([
+            'type' => 'array',
+            'items' => ['type' => 'integer'],
+        ], $type->toArray());
+    }
+
+    public function test_it_infers_scalar_type_from_a_homogeneous_enum(): void
+    {
+        $this->assertInstanceOf(StringType::class, JsonSchema::deserialize([
+            'enum' => ['draft', 'published'],
+        ]));
+
+        $this->assertInstanceOf(IntegerType::class, JsonSchema::deserialize([
+            'enum' => [1, 2, 3],
+        ]));
+
+        $this->assertInstanceOf(NumberType::class, JsonSchema::deserialize([
+            'enum' => [1, 2.5, 3],
+        ]));
+
+        $this->assertInstanceOf(BooleanType::class, JsonSchema::deserialize([
+            'enum' => [true, false],
+        ]));
+    }
+
+    public function test_it_applies_enum_and_default(): void
+    {
+        $type = JsonSchema::deserialize([
+            'type' => 'string',
+            'enum' => ['draft', 'published'],
+            'default' => 'draft',
+        ]);
+
+        $this->assertEquals([
+            'type' => 'string',
+            'default' => 'draft',
+            'enum' => ['draft', 'published'],
+        ], $type->toArray());
+    }
+
+    public function test_it_ignores_unknown_keywords(): void
+    {
+        $type = JsonSchema::deserialize([
+            'type' => 'string',
+            'minLength' => 1,
+            '$schema' => 'https://json-schema.org/draft/2020-12/schema',
+            '$comment' => 'ignore me',
+            'readOnly' => true,
+            'contentEncoding' => 'base64',
+        ]);
+
+        $this->assertEquals([
+            'type' => 'string',
+            'minLength' => 1,
+        ], $type->toArray());
+    }
+
+    public function test_it_throws_when_the_type_cannot_be_determined(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unable to determine the JSON Schema type for the given schema.');
+
+        JsonSchema::deserialize([
+            'title' => 'Mystery',
+        ]);
+    }
+
+    public function test_it_detects_a_circular_ref_instead_of_recursing(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Circular JSON Schema $ref [#/$defs/node] detected.');
+
+        JsonSchema::deserialize([
+            'type' => 'object',
+            'properties' => [
+                'children' => ['type' => 'array', 'items' => ['$ref' => '#/$defs/node']],
+            ],
+            '$defs' => [
+                'node' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'children' => ['type' => 'array', 'items' => ['$ref' => '#/$defs/node']],
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    public function test_it_resolves_the_same_ref_used_in_sibling_positions(): void
+    {
+        $type = JsonSchema::deserialize([
+            'type' => 'object',
+            'properties' => [
+                'home' => ['$ref' => '#/$defs/address'],
+                'work' => ['$ref' => '#/$defs/address'],
+            ],
+            '$defs' => [
+                'address' => ['type' => 'object', 'properties' => ['city' => ['type' => 'string']]],
+            ],
+        ]);
+
+        $this->assertEquals([
+            'type' => 'object',
+            'properties' => [
+                'home' => ['type' => 'object', 'properties' => ['city' => ['type' => 'string']]],
+                'work' => ['type' => 'object', 'properties' => ['city' => ['type' => 'string']]],
+            ],
+        ], $type->toArray());
+    }
+
+    public function test_it_throws_for_a_multi_type_union(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unable to represent a multi-type JSON Schema union [string, integer].');
+
+        JsonSchema::deserialize([
+            'type' => ['string', 'integer'],
+        ]);
+    }
+
+    public function test_it_throws_for_a_boolean_property_schema(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unable to represent the schema for property [meta]; boolean schemas are not supported.');
+
+        JsonSchema::deserialize([
+            'type' => 'object',
+            'properties' => [
+                'meta' => true,
+            ],
+        ]);
+    }
+
+    public function test_it_ignores_non_numeric_numeric_constraints_instead_of_failing(): void
+    {
+        $type = JsonSchema::deserialize([
+            'type' => 'number',
+            'minimum' => 'oops',
+            'maximum' => ['not', 'a', 'number'],
+            'multipleOf' => 0.5,
+        ]);
+
+        $this->assertInstanceOf(NumberType::class, $type);
+        $this->assertEquals([
+            'type' => 'number',
+            'multipleOf' => 0.5,
+        ], $type->toArray());
+    }
+
+    public function test_it_prefers_a_union_branch_over_outer_sibling_keys(): void
+    {
+        $type = JsonSchema::deserialize([
+            'type' => 'integer',
+            'anyOf' => [
+                ['type' => 'string', 'minLength' => 3],
+                ['type' => 'null'],
+            ],
+        ]);
+
+        $this->assertInstanceOf(StringType::class, $type);
+        $this->assertEquals([
+            'type' => ['string', 'null'],
+            'minLength' => 3,
+        ], $type->toArray());
+    }
+
+    public function test_it_does_not_carry_an_explicit_null_default(): void
+    {
+        $type = JsonSchema::deserialize([
+            'type' => 'string',
+            'default' => null,
+        ]);
+
+        $this->assertEquals(['type' => 'string'], $type->toArray());
+    }
+}


### PR DESCRIPTION
Currently `Illuminate\JsonSchema` only goes one direction. You can build `Type` objects with the factory and render them to an array with `Serializer::serialize()`, but there's no way to take a raw JSON Schema array (say, decoded from JSON received over the wire) and turn it back into `Type` objects.

This PR adds `JsonSchema::fromArray()`, backed by a new `Deserializer` that mirrors how `Serializer` backs serialization:

```php
$type = JsonSchema::fromArray([
    'type' => 'object',
    'properties' => [
        'name' => ['type' => 'string', 'minLength' => 1],
        'age'  => ['type' => 'integer', 'minimum' => 0],
    ],
    'required' => ['name'],
]); // returns an ObjectType
```

It round-trips cleanly with `Serializer`, so `fromArray(Serializer::serialize($type))` reproduces an equivalent type.