### PR TITLE
[13.x] Cache `rememberWithState()`

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -550,20 +550,35 @@ class Repository implements ArrayAccess, CacheContract
      */
     public function remember($key, $ttl, Closure $callback)
     {
+        return $this->rememberWithState($key, $ttl, $callback)['value'];
+    }
+
+    /**
+     * Get an item from the cache, or execute the given Closure and store the result.
+     *
+     * @template TCacheValue
+     *
+     * @param  \UnitEnum|string  $key
+     * @param  \Closure|\DateTimeInterface|\DateInterval|int|null  $ttl
+     * @param  \Closure(): TCacheValue  $callback
+     * @return array{value: TCacheValue, foundInCache: bool}
+     */
+    public function rememberWithState($key, $ttl, Closure $callback): array
+    {
         $value = $this->get($key);
 
         // If the item exists in the cache we will just return this immediately and if
         // not we will execute the given Closure and cache the result of that for a
         // given number of seconds so it's available for all subsequent requests.
         if (! is_null($value)) {
-            return $value;
+            return ['foundInCache' => true, 'value' => $value];
         }
 
         $value = $callback();
 
         $this->put($key, $value, value($ttl, $value));
 
-        return $value;
+        return ['foundInCache' => false, 'value' => $value];
     }
 
     /**

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -550,7 +550,7 @@ class Repository implements ArrayAccess, CacheContract
      */
     public function remember($key, $ttl, Closure $callback)
     {
-        return $this->rememberWithState($key, $ttl, $callback)['value'];
+        return $this->rememberWithState($key, $ttl, $callback)[0];
     }
 
     /**
@@ -561,7 +561,7 @@ class Repository implements ArrayAccess, CacheContract
      * @param  \UnitEnum|string  $key
      * @param  \Closure|\DateTimeInterface|\DateInterval|int|null  $ttl
      * @param  \Closure(): TCacheValue  $callback
-     * @return array{value: TCacheValue, foundInCache: bool}
+     * @return array{TCacheValue, bool}
      */
     public function rememberWithState($key, $ttl, Closure $callback): array
     {
@@ -571,14 +571,14 @@ class Repository implements ArrayAccess, CacheContract
         // not we will execute the given Closure and cache the result of that for a
         // given number of seconds so it's available for all subsequent requests.
         if (! is_null($value)) {
-            return ['foundInCache' => true, 'value' => $value];
+            return [$value, true];
         }
 
         $value = $callback();
 
         $this->put($key, $value, value($ttl, $value));
 
-        return ['foundInCache' => false, 'value' => $value];
+        return [$value, false];
     }
 
     /**

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -550,7 +550,7 @@ class Repository implements ArrayAccess, CacheContract
      */
     public function remember($key, $ttl, Closure $callback)
     {
-        return $this->rememberWithState($key, $ttl, $callback)[0];
+        return $this->rememberWithWarmth($key, $ttl, $callback)[0];
     }
 
     /**
@@ -561,9 +561,9 @@ class Repository implements ArrayAccess, CacheContract
      * @param  \UnitEnum|string  $key
      * @param  \Closure|\DateTimeInterface|\DateInterval|int|null  $ttl
      * @param  \Closure(): TCacheValue  $callback
-     * @return array{TCacheValue, bool}
+     * @return array{TCacheValue, bool} The cached value and whether it was warm.
      */
-    public function rememberWithState($key, $ttl, Closure $callback): array
+    public function rememberWithWarmth($key, $ttl, Closure $callback): array
     {
         $value = $this->get($key);
 

--- a/src/Illuminate/Support/Facades/Cache.php
+++ b/src/Illuminate/Support/Facades/Cache.php
@@ -39,6 +39,7 @@ use Mockery;
  * @method static int|bool decrement(\UnitEnum|string $key, mixed $value = 1)
  * @method static bool forever(\UnitEnum|string $key, mixed $value)
  * @method static mixed remember(\UnitEnum|string $key, \Closure|\DateTimeInterface|\DateInterval|int|null $ttl, \Closure $callback)
+ * @method static array rememberWithWarmth(\UnitEnum|string $key, \Closure|\DateTimeInterface|\DateInterval|int|null $ttl, \Closure $callback)
  * @method static mixed sear(\UnitEnum|string $key, \Closure $callback)
  * @method static mixed rememberForever(\UnitEnum|string $key, \Closure $callback)
  * @method static mixed flexible(\UnitEnum|string $key, array $ttl, callable $callback, array|null $lock = null, bool $alwaysDefer = false)

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -147,6 +147,36 @@ class CacheRepositoryTest extends TestCase
         $this->assertSame('bar', $result);
     }
 
+    public function testRememberWithStateReturnsCachedValue()
+    {
+        $repo = $this->getRepository();
+        $repo->getStore()->shouldReceive('get')->once()->with('foo')->andReturn('bar');
+        $repo->getStore()->shouldReceive('put')->never();
+
+        $result = $repo->rememberWithState('foo', 10, function () {
+            $this->fail('The cache callback should not be called.');
+        });
+
+        $this->assertSame(['bar', true], $result);
+    }
+
+    public function testRememberWithStateCallsPutAndReturnsDefault()
+    {
+        $repo = $this->getRepository();
+        $repo->getStore()->shouldReceive('get')->once()->with('foo')->andReturn(null);
+        $repo->getStore()->shouldReceive('put')->once()->with('foo', 'bar', 10);
+
+        $result = $repo->rememberWithState('foo', function ($value) {
+            $this->assertSame('bar', $value);
+
+            return 10;
+        }, function () {
+            return 'bar';
+        });
+
+        $this->assertSame(['bar', false], $result);
+    }
+
     public function testRememberForeverMethodCallsForeverAndReturnsDefault()
     {
         $repo = $this->getRepository();

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -147,26 +147,26 @@ class CacheRepositoryTest extends TestCase
         $this->assertSame('bar', $result);
     }
 
-    public function testRememberWithStateReturnsCachedValue()
+    public function testRememberWithWarmthReturnsCachedValue()
     {
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('get')->once()->with('foo')->andReturn('bar');
         $repo->getStore()->shouldReceive('put')->never();
 
-        $result = $repo->rememberWithState('foo', 10, function () {
+        $result = $repo->rememberWithWarmth('foo', 10, function () {
             $this->fail('The cache callback should not be called.');
         });
 
         $this->assertSame(['bar', true], $result);
     }
 
-    public function testRememberWithStateCallsPutAndReturnsDefault()
+    public function testRememberWithWarmthCallsPutAndReturnsDefault()
     {
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('get')->once()->with('foo')->andReturn(null);
         $repo->getStore()->shouldReceive('put')->once()->with('foo', 'bar', 10);
 
-        $result = $repo->rememberWithState('foo', function ($value) {
+        $result = $repo->rememberWithWarmth('foo', function ($value) {
             $this->assertSame('bar', $value);
 
             return 10;

--- a/types/Cache/Repository.php
+++ b/types/Cache/Repository.php
@@ -25,6 +25,9 @@ assertType('33', $cache->sear('cache', function (): int {
 assertType('36', $cache->remember('cache', Carbon::now(), function (): int {
     return 36;
 }));
+assertType('array{36, bool}', $cache->rememberWithWarmth('cache', Carbon::now(), function (): int {
+    return 36;
+}));
 assertType('36', $cache->rememberForever('cache', function (): int {
     return 36;
 }));

--- a/types/Support/Facades/Cache.php
+++ b/types/Support/Facades/Cache.php
@@ -22,6 +22,9 @@ assertType('mixed', Cache::sear('cache', function (): int {
 assertType('mixed', Cache::remember('cache', Carbon::now(), function (): int {
     return 36;
 }));
+assertType('array', Cache::rememberWithWarmth('cache', Carbon::now(), function (): int {
+    return 36;
+}));
 assertType('mixed', Cache::rememberForever('cache', function (): int {
     return 36;
 }));


### PR DESCRIPTION
It's often quite advantageous to be able to know whether something was retrieved from cache or not. Especially when running complex workflows, it's easier to be able to debug a giant trace if I can record whether or not the cache was hit, for instance. Or I can return this information in a header in an HTTP request (`Cache-Hit: true` for instance)

## Note
This name is dogshit and I'm very open to suggestions.