### PR TITLE
[13.x] Add units to DebounceFor

### DIFF
--- a/src/Illuminate/Queue/Attributes/DebounceFor.php
+++ b/src/Illuminate/Queue/Attributes/DebounceFor.php
@@ -9,6 +9,9 @@ class DebounceFor
 {
     /**
      * Create a new attribute instance.
+     *
+     * @param  int  $debounceFor  Seconds to debounce the job for.
+     * @param  int|null  $maxWait  The maximum number of seconds the job can be deferred before it is forced to run.
      */
     public function __construct(public int $debounceFor, public ?int $maxWait = null)
     {


### PR DESCRIPTION
Boring docblock PR

Given the following DM I received: 

<img width="498" height="373" alt="image" src="https://github.com/user-attachments/assets/25962a7b-54de-4a60-be3c-8cfe3fe2d955" />

I've added docblock so when anyone clicks through to view the attribute in future it's super obvious **its seconds.**

There's probably a few attributes like this... but will look through the others on the weekend or when I get chance to do them all in one sweep.