### PR TITLE
[13.x] Add missing type hints to WorkerIdle and listenForSignals to match sibling events

### DIFF
--- a/src/Illuminate/Queue/Events/WorkerIdle.php
+++ b/src/Illuminate/Queue/Events/WorkerIdle.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Queue\Events;
 
+use Illuminate\Queue\WorkerOptions;
+
 class WorkerIdle
 {
     /**
@@ -12,9 +14,9 @@ class WorkerIdle
      * @param  \Illuminate\Queue\WorkerOptions  $workerOptions
      */
     public function __construct(
-        public $connectionName,
-        public $queue,
-        public $workerOptions,
+        public string $connectionName,
+        public string $queue,
+        public WorkerOptions $workerOptions,
     ) {
     }
 }

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -837,9 +837,10 @@ class Worker
      *
      * @param  string|null  $connectionName
      * @param  string|null  $queue
+     * @param  \Illuminate\Queue\WorkerOptions|null  $options
      * @return void
      */
-    protected function listenForSignals($connectionName = null, $queue = null, $options = null)
+    protected function listenForSignals($connectionName = null, $queue = null, ?WorkerOptions $options = null)
     {
         pcntl_async_signals(true);
 


### PR DESCRIPTION
WorkerIdle was introduced in #60134 and listenForSignals received an $options parameter in #60135, but neither received proper type hints unlike their sibling events WorkerPausing, WorkerResuming, and WorkerInterrupted which all enforce ?WorkerOptions and typed string properties.

Without type hints, passing a wrong type silently fails at runtime with no clear error, which is inconsistent with how the rest of the worker event system behaves.

This PR brings WorkerIdle and listenForSignals in line with that pattern:
- WorkerIdle: adds string hints to $connectionName/$queue and WorkerOptions to $workerOptions
- Worker::listenForSignals(): adds ?WorkerOptions to $options