### PR TITLE
[13.x] Extract flexible cache created-key prefix into a named constant

### DIFF
--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -411,7 +411,7 @@ class DatabaseStore implements CanFlushLocks, LockProvider, Store
     {
         $this->table()->whereIn('key', (new Collection($keys))->flatMap(fn ($key) => [
             $this->prefix.$key,
-            "{$this->prefix}illuminate:cache:flexible:created:{$key}",
+            $this->prefix.Repository::FLEXIBLE_CREATED_KEY_PREFIX.$key,
         ])->all())->delete();
 
         return true;
@@ -429,10 +429,10 @@ class DatabaseStore implements CanFlushLocks, LockProvider, Store
         $this->table()
             ->whereIn('key', (new Collection($keys))->flatMap(fn ($key) => $prefixed ? [
                 $key,
-                $this->prefix.'illuminate:cache:flexible:created:'.Str::chopStart($key, $this->prefix),
+                $this->prefix.Repository::FLEXIBLE_CREATED_KEY_PREFIX.Str::chopStart($key, $this->prefix),
             ] : [
                 "{$this->prefix}{$key}",
-                "{$this->prefix}illuminate:cache:flexible:created:{$key}",
+                $this->prefix.Repository::FLEXIBLE_CREATED_KEY_PREFIX.$key,
             ])->all())
             ->where('expiration', '<=', $this->getTime())
             ->delete();

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -277,7 +277,7 @@ class FileStore implements CanFlushLocks, LockProvider, Store
     {
         if ($this->files->exists($file = $this->path($key))) {
             return tap($this->files->delete($file), function ($forgotten) use ($key) {
-                if ($forgotten && $this->files->exists($file = $this->path("illuminate:cache:flexible:created:{$key}"))) {
+                if ($forgotten && $this->files->exists($file = $this->path(Repository::FLEXIBLE_CREATED_KEY_PREFIX.$key))) {
                     $this->files->delete($file);
                 }
             });

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -48,6 +48,13 @@ class Repository implements ArrayAccess, CacheContract
     }
 
     /**
+     * The cache key prefix used to track when a flexible cache value was last refreshed.
+     *
+     * @var string
+     */
+    const FLEXIBLE_CREATED_KEY_PREFIX = 'illuminate:cache:flexible:created:';
+
+    /**
      * The cache store implementation.
      *
      * @var \Illuminate\Contracts\Cache\Store
@@ -623,13 +630,13 @@ class Repository implements ArrayAccess, CacheContract
 
         [
             $key => $value,
-            "illuminate:cache:flexible:created:{$key}" => $created,
-        ] = $this->many([$key, "illuminate:cache:flexible:created:{$key}"]);
+            self::FLEXIBLE_CREATED_KEY_PREFIX.$key => $created,
+        ] = $this->many([$key, self::FLEXIBLE_CREATED_KEY_PREFIX.$key]);
 
         if (in_array(null, [$value, $created], true)) {
             return tap(value($callback), fn ($value) => $this->putMany([
                 $key => $value,
-                "illuminate:cache:flexible:created:{$key}" => Carbon::now()->getTimestamp(),
+                self::FLEXIBLE_CREATED_KEY_PREFIX.$key => Carbon::now()->getTimestamp(),
             ], $ttl[1]));
         }
 
@@ -643,13 +650,13 @@ class Repository implements ArrayAccess, CacheContract
                 $lock['seconds'] ?? 0,
                 $lock['owner'] ?? null,
             )->get(function () use ($key, $callback, $created, $ttl) {
-                if ($created !== $this->get("illuminate:cache:flexible:created:{$key}")) {
+                if ($created !== $this->get(self::FLEXIBLE_CREATED_KEY_PREFIX.$key)) {
                     return;
                 }
 
                 $this->putMany([
                     $key => value($callback),
-                    "illuminate:cache:flexible:created:{$key}" => Carbon::now()->getTimestamp(),
+                    self::FLEXIBLE_CREATED_KEY_PREFIX.$key => Carbon::now()->getTimestamp(),
                 ], $ttl[1]);
             });
         };

--- a/src/Illuminate/Cache/StorageStore.php
+++ b/src/Illuminate/Cache/StorageStore.php
@@ -167,7 +167,7 @@ class StorageStore implements Store
         $forgotten = $this->disk->delete($this->path($key));
 
         if ($forgotten) {
-            $this->disk->delete($this->path("illuminate:cache:flexible:created:{$key}"));
+            $this->disk->delete($this->path(Repository::FLEXIBLE_CREATED_KEY_PREFIX.$key));
         }
 
         return $forgotten;


### PR DESCRIPTION
The string `illuminate:cache:flexible:created:` was duplicated as a raw literal across four files (Repository, FileStore, StorageStore, DatabaseStore). 
A rename or typo in any one of them would cause a silent mismatch deleted keys would linger and flexible cache entries would never refresh.

This PR extracts the prefix into `Repository::FLEXIBLE_CREATED_KEY_PREFIX` and replaces all ten occurrences. No behavior changes pure refactor.