### PR TITLE
[13.x] Restrict allowed classes in routing unserialization

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -241,7 +241,13 @@ class Route
         $callable = $this->action['uses'];
 
         if ($this->isSerializedClosure()) {
-            $callable = unserialize($this->action['uses'])->getClosure();
+            $callable = unserialize($this->action['uses'], ['allowed_classes' => [
+                SerializableClosure::class,
+                \Laravel\SerializableClosure\UnsignedSerializableClosure::class,
+                \Laravel\SerializableClosure\Serializers\Native::class,
+                \Laravel\SerializableClosure\Serializers\Signed::class,
+                \Laravel\SerializableClosure\Support\SelfReference::class,
+            ]])->getClosure();
         }
 
         return $this->container[CallableDispatcher::class]->dispatch($this, $callable);
@@ -1029,7 +1035,13 @@ class Route
             Str::startsWith($missing, [
                 'O:47:"Laravel\\SerializableClosure\\SerializableClosure',
                 'O:55:"Laravel\\SerializableClosure\\UnsignedSerializableClosure',
-            ]) ? unserialize($missing) : $missing;
+            ]) ? unserialize($missing, ['allowed_classes' => [
+                SerializableClosure::class,
+                \Laravel\SerializableClosure\UnsignedSerializableClosure::class,
+                \Laravel\SerializableClosure\Serializers\Native::class,
+                \Laravel\SerializableClosure\Serializers\Signed::class,
+                \Laravel\SerializableClosure\Support\SelfReference::class,
+            ]]) : $missing;
     }
 
     /**

--- a/src/Illuminate/Routing/RouteSignatureParameters.php
+++ b/src/Illuminate/Routing/RouteSignatureParameters.php
@@ -19,7 +19,13 @@ class RouteSignatureParameters
     public static function fromAction(array $action, $conditions = [])
     {
         $callback = RouteAction::containsSerializedClosure($action)
-            ? unserialize($action['uses'])->getClosure()
+            ? unserialize($action['uses'], ['allowed_classes' => [
+                \Laravel\SerializableClosure\SerializableClosure::class,
+                \Laravel\SerializableClosure\UnsignedSerializableClosure::class,
+                \Laravel\SerializableClosure\Serializers\Native::class,
+                \Laravel\SerializableClosure\Serializers\Signed::class,
+                \Laravel\SerializableClosure\Support\SelfReference::class,
+            ]])->getClosure()
             : $action['uses'];
 
         $parameters = is_string($callback)

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -2282,7 +2282,7 @@ class RoutingRouteTest extends TestCase
     {
         $badObject = new RouteTestInsecureDeserializationStub;
         $closureWithUse = function () use ($badObject) {
-            return 'hello';
+            return $badObject;
         };
 
         $serializedClosure = serialize(\Laravel\SerializableClosure\SerializableClosure::unsigned($closureWithUse));

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -2745,4 +2745,3 @@ class RouteTestInsecureDeserializationStub
         self::$instantiated = true;
     }
 }
-

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -2277,6 +2277,33 @@ class RoutingRouteTest extends TestCase
 
         return $router;
     }
+
+    public function testRouteDeserializationAllowedClasses()
+    {
+        $badObject = new RouteTestInsecureDeserializationStub;
+        $closureWithUse = function () use ($badObject) {
+            return 'hello';
+        };
+
+        $serializedClosure = serialize(\Laravel\SerializableClosure\SerializableClosure::unsigned($closureWithUse));
+
+        RouteTestInsecureDeserializationStub::$instantiated = false;
+        unserialize($serializedClosure);
+        $this->assertTrue(RouteTestInsecureDeserializationStub::$instantiated);
+        $route = new Route(['GET'], 'foo', [
+            'uses' => $serializedClosure,
+        ]);
+
+        RouteTestInsecureDeserializationStub::$instantiated = false;
+
+        try {
+            $route->run();
+        } catch (\Throwable $e) {
+            //
+        }
+
+        $this->assertFalse(RouteTestInsecureDeserializationStub::$instantiated);
+    }
 }
 
 class RouteTestControllerStub extends Controller
@@ -2708,3 +2735,14 @@ final class RoutingTestHasTenantImpl
         $this->tenant = $tenant;
     }
 }
+
+class RouteTestInsecureDeserializationStub
+{
+    public static $instantiated = false;
+
+    public function __wakeup()
+    {
+        self::$instantiated = true;
+    }
+}
+


### PR DESCRIPTION
This PR restricts the classes that can be instantiated during the deserialization of cached route closures to prevent PHP Object Injection.

### Detail

When compiling or resolving route cache, route closures are serialized using `laravel/serializable-closure`. Currently, these are deserialized using native `unserialize()` without class restrictions, which can lead to PHP Object Injection / RCE if an attacker is able to manipulate the cached routes.

This change restricts the `unserialize()` calls in `Route` and `RouteSignatureParameters` to only allow the specific classes needed to reconstruct the serializable closures:

* `Laravel\SerializableClosure\SerializableClosure`
* `Laravel\SerializableClosure\UnsignedSerializableClosure`
* `Laravel\SerializableClosure\Serializers\Native`
* `Laravel\SerializableClosure\Serializers\Signed`
* `Laravel\SerializableClosure\Support\SelfReference`

A test has been added to verify that arbitrary classes are not instantiated/woken up during deserialization.