### PR TITLE
# [13.x] Fix validation bypass in date_equals rule due to loose comparison

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -2846,7 +2846,7 @@ trait ValidatesAttributes
             '>' => $first > $second,
             '<=' => $first <= $second,
             '>=' => $first >= $second,
-            '=' => $first == $second,
+            '=' => ($first === $second) || ($first == $second && ! is_null($first) && ! is_null($second)),
             default => throw new InvalidArgumentException,
         };
     }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -6613,6 +6613,12 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['x' => '17:44'], ['x' => 'date_format:H:i|date_equals:17:45']);
         $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['x' => 'invalid-date'], ['x' => 'date_equals:1970-01-01 00:00:00']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['x' => '1970-01-01 00:00:00'], ['x' => 'date_equals:invalid-date']);
+        $this->assertTrue($v->fails());
     }
 
     public function testDateEqualsRespectsCarbonTestNowWhenParameterIsRelative()


### PR DESCRIPTION
### Description

This PR fixes a validation bypass vulnerability in the `date_equals` rule. 

When validating dates, an invalid date string (e.g. `'invalid-date'`) fails parsing and resolves to a timestamp of `null`. If the reference date evaluates to `0` (e.g. `'1970-01-01 00:00:00'`), the validation rule compares them using a loose comparison:

```php
'=' => $first == $second // evaluates null == 0, which is true
```

As a result, the validation incorrectly passes for completely invalid dates.

This patch updates the equal comparison operator in the validator's `compare` method to ensure that `null` values are not loosely compared and matched against `0` (or other falsy values), while still safely allowing standard loose comparison for distinct `DateTime` objects representing the same date.

### Example

```php
$validator = Validator::make(
    ['x' => 'invalid-date'],
    ['x' => 'date_equals:1970-01-01 00:00:00']
);

// Before this PR: returns true (passes)
// After this PR: returns false (fails)
```