### PR TITLE
[13.x] Throw exception when Eloquent column listing is empty to prevent mass-assignment bypass

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
@@ -254,7 +254,10 @@ trait GuardsAttributes
                 ->getColumnListing($this->getTable());
 
             if (empty($columns)) {
-                return true;
+                throw new \RuntimeException(sprintf(
+                    'Unable to retrieve columns for table [%s].',
+                    $this->getTable()
+                ));
             }
 
             static::$guardableColumns[get_class($this)] = $columns;

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1817,6 +1817,21 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertSame([], $model->getAttributes());
     }
 
+    public function testGuardedThrowsExceptionWhenColumnListingIsEmpty()
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Unable to retrieve columns for table [stub].');
+
+        $model = new EloquentModelStub;
+        $model->guard(['secret']);
+
+        EloquentModelStub::setConnectionResolver($resolver = m::mock(Resolver::class));
+        $resolver->shouldReceive('connection')->andReturn($connection = m::mock(stdClass::class));
+        $connection->shouldReceive('getSchemaBuilder->getColumnListing')->andReturn([]);
+
+        $model->isGuarded('foo');
+    }
+
     public function testGuarded()
     {
         $model = new EloquentModelStub;


### PR DESCRIPTION
### Description

This PR fixes a potential mass-assignment protection bypass in Eloquent models when database connectivity fails or when the column listing schema helper returns an empty array.

Currently, in `GuardsAttributes::isGuardableColumn()`, if `getColumnListing()` returns an empty array, the method falls back to returning `true` for any attribute:

```php
if (empty($columns)) {
    return true;
}
```

Returning `true` from `isGuardableColumn` indicates that the column is guardable (part of the table schema). However, when checking if a non-guarded attribute is guarded via `isGuarded($key)`:

```php
return $this->getGuarded() == ['*'] ||
       ! empty(preg_grep('/^'.preg_quote($key, '/').'$/i', $this->getGuarded())) ||
       ! $this->isGuardableColumn($key);
```

If `isGuardableColumn` returns `true` (and the attribute is not explicitly in the `$guarded` array), `isGuarded` returns `false` (meaning the attribute is not guarded). This completely bypasses the guard mechanism for all model columns that are not explicitly listed in the `$guarded` array, allowing arbitrary mass assignment.

This PR changes the fallback behavior to throw a `RuntimeException` instead of returning `true` to fail securely and ensure mass-assignment protection remains active.