### PR TITLE
[13.x] Escape single quotes in quoteString

### DIFF
--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -232,7 +232,7 @@ abstract class Grammar
             return implode(', ', array_map([$this, __FUNCTION__], $value));
         }
 
-        return "'$value'";
+        return sprintf("'%s'", str_replace("'", "''", $value));
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -1040,6 +1040,6 @@ class SqlServerGrammar extends Grammar
             return implode(', ', array_map([$this, __FUNCTION__], $value));
         }
 
-        return "N'$value'";
+        return sprintf("N'%s'", str_replace("'", "''", $value));
     }
 }

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -1739,6 +1739,18 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertSame('alter table `users` add index `custom_idx` using btree(`name`), lock=none', $statements[0]);
     }
 
+    public function testQuoteString()
+    {
+        $this->assertSame("'中文測試'", $this->getGrammar()->quoteString('中文測試'));
+        $this->assertSame("'foo''bar'", $this->getGrammar()->quoteString("foo'bar"));
+    }
+
+    public function testQuoteStringOnArray()
+    {
+        $this->assertSame("'中文', '測試'", $this->getGrammar()->quoteString(['中文', '測試']));
+        $this->assertSame("'foo''bar', 'baz''qux'", $this->getGrammar()->quoteString(["foo'bar", "baz'qux"]));
+    }
+
     public function getGrammar(?Connection $connection = null)
     {
         return new MySqlGrammar($connection ?? $this->getConnection());

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -959,11 +959,13 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
     public function testQuoteString()
     {
         $this->assertSame("N'中文測試'", $this->getGrammar()->quoteString('中文測試'));
+        $this->assertSame("N'foo''bar'", $this->getGrammar()->quoteString("foo'bar"));
     }
 
     public function testQuoteStringOnArray()
     {
         $this->assertSame("N'中文', N'測試'", $this->getGrammar()->quoteString(['中文', '測試']));
+        $this->assertSame("N'foo''bar', N'baz''qux'", $this->getGrammar()->quoteString(["foo'bar", "baz'qux"]));
     }
 
     public function testCreateDatabase()


### PR DESCRIPTION
This PR secures database schema compilation by escaping single quotes (apostrophes) when quoting string literals in grammar objects.
### Root Cause
Previously, `quoteString()` implementations in `Illuminate\Database\Grammar` and `SqlServerGrammar` wrapped values with quotes (e.g., `'$value'` or `N'$value'`) without escaping existing single quotes within the value. When used to compile `ENUM` or `SET` columns with values containing apostrophes, this could lead to broken queries or SQL injection.
### Fix
* Updated `Illuminate\Database\Grammar::quoteString` to escape single quotes using `sprintf` and `str_replace`.
* Updated `SqlServerGrammar::quoteString` to safely escape single quotes when compiling SQL Server string literals.
* Added corresponding regression unit tests in `DatabaseMySqlSchemaGrammarTest` and `DatabaseSqlServerSchemaGrammarTest`.