### PR TITLE
[12.x] Skip pg_collation lookup in compileColumns() on PostgreSQL servers before 9.1

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -156,12 +156,16 @@ class PostgresGrammar extends Grammar
      */
     public function compileColumns($schema, $table)
     {
+        $serverVersion = $this->connection->getServerVersion();
+
         return sprintf(
             'select a.attname as name, t.typname as type_name, format_type(a.atttypid, a.atttypmod) as type, '
-            .'(select tc.collcollate from pg_catalog.pg_collation tc where tc.oid = a.attcollation) as collation, '
+            .(version_compare($serverVersion, '9.1', '<')
+                ? 'null as collation, '
+                : '(select tc.collcollate from pg_catalog.pg_collation tc where tc.oid = a.attcollation) as collation, ')
             .'not a.attnotnull as nullable, '
             .'(select pg_get_expr(adbin, adrelid) from pg_attrdef where c.oid = pg_attrdef.adrelid and pg_attrdef.adnum = a.attnum) as default, '
-            .(version_compare($this->connection->getServerVersion(), '12.0', '<') ? "'' as generated, " : 'a.attgenerated as generated, ')
+            .(version_compare($serverVersion, '12.0', '<') ? "'' as generated, " : 'a.attgenerated as generated, ')
             .'col_description(c.oid, a.attnum) as comment '
             .'from pg_attribute a, pg_class c, pg_type t, pg_namespace n '
             .'where c.relname = %s and n.nspname = %s and a.attnum > 0 and a.attrelid = c.oid and a.atttypid = t.oid and n.oid = c.relnamespace '

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -1348,6 +1348,22 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statement = $connection->getSchemaGrammar()->compileColumns('public', 'table');
 
         $this->assertStringContainsString("where c.relname = 'table' and n.nspname = 'public'", $statement);
+        $this->assertStringContainsString('pg_catalog.pg_collation', $statement);
+        $this->assertStringContainsString('a.attgenerated as generated', $statement);
+    }
+
+    public function testCompileColumnsOnLegacyServer()
+    {
+        $connection = $this->getConnection();
+        $connection->shouldReceive('getServerVersion')->once()->andReturn('8.0.2');
+
+        $statement = $connection->getSchemaGrammar()->compileColumns('public', 'table');
+
+        $this->assertStringContainsString("where c.relname = 'table' and n.nspname = 'public'", $statement);
+        $this->assertStringContainsString('null as collation', $statement);
+        $this->assertStringContainsString("'' as generated", $statement);
+        $this->assertStringNotContainsString('pg_catalog.pg_collation', $statement);
+        $this->assertStringNotContainsString('a.attgenerated', $statement);
     }
 
     protected function getConnection(


### PR DESCRIPTION
The column listing query compiled by `PostgresGrammar::compileColumns()` subselects `pg_catalog.pg_collation` unconditionally. That catalog was only introduced in PostgreSQL 9.1, so servers reporting an older version fail with:

```
Undefined table: 7 ERROR: relation "pg_catalog.pg_collation" does not exist
```

The practical case is AWS Redshift, which speaks the Postgres wire protocol but reports server version `8.0.2` — any call to `Schema::getColumns()` (e.g. via package model introspection such as dedoc/scramble) fails there today. See dedoc/scramble#1070, where this surfaced.

`compileColumns()` already version-gates `a.attgenerated` for servers before 12.0 in exactly this way; this PR applies the same gate to the collation subquery, selecting `null as collation` when the server reports < 9.1. There is no behavior change for any supported PostgreSQL version (10+) — they all report ≥ 9.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)