### PR TITLE
[13.x] Ensure unchanged compiled Blade views are not left expired

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -205,6 +205,14 @@ class BladeCompiler extends Compiler implements CompilerInterface
 
             if ($compiledHash !== hash('xxh128', $contents)) {
                 $this->files->replace($compiledPath, $contents);
+
+                return;
+            }
+
+            $lastModified = $this->files->lastModified($this->getPath());
+
+            if ($lastModified >= $this->files->lastModified($compiledPath)) {
+                touch($compiledPath, $lastModified + 1);
             }
         }
     }

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -104,7 +104,48 @@ class ViewBladeCompilerTest extends TestCase
         $files->shouldReceive('makeDirectory')->once()->with(__DIR__, 0777, true, true);
         $files->shouldReceive('exists')->once()->with($compiledPath)->andReturn(true);
         $files->shouldReceive('hash')->once()->with($compiledPath, 'xxh128')->andReturn(hash('xxh128', 'Hello World<?php /**PATH foo ENDPATH**/ ?>'));
+        $files->shouldReceive('lastModified')->once()->with('foo')->andReturn(100);
+        $files->shouldReceive('lastModified')->once()->with($compiledPath)->andReturn(200);
         $compiler->compile('foo');
+    }
+
+    public function testCompileRefreshesCacheTimestampIfUnchangedButExpired()
+    {
+        $files = new Filesystem;
+        $directory = sys_get_temp_dir().'/laravel-blade-compiler-test-'.uniqid();
+        $source = $directory.'/source.blade.php';
+        $cache = $directory.'/cache';
+
+        try {
+            $files->ensureDirectoryExists($cache);
+            $files->put($source, 'Hello World');
+
+            $compiler = new BladeCompiler($files, $cache);
+            $compiler->compile($source);
+
+            $compiled = $compiler->getCompiledPath($source);
+
+            $compiledModified = time();
+            $sourceModified = $compiledModified + 10;
+
+            touch($source, $sourceModified);
+            touch($compiled, $compiledModified);
+
+            clearstatcache(true, $source);
+            clearstatcache(true, $compiled);
+
+            $this->assertTrue($compiler->isExpired($source));
+
+            $compiler->compile($source);
+
+            clearstatcache(true, $source);
+            clearstatcache(true, $compiled);
+
+            $this->assertGreaterThan($files->lastModified($source), $files->lastModified($compiled));
+            $this->assertFalse($compiler->isExpired($source));
+        } finally {
+            $files->deleteDirectory($directory);
+        }
     }
 
     public function testCompileCompilesAndGetThePath()


### PR DESCRIPTION
This PR fixes a case where a Blade view can remain expired after `BladeCompiler::compile()` runs.

When the source Blade file is saved but the compiled output is identical, the compiler currently skips rewriting the compiled file. If the source file mtime is newer than or equal to the compiled file mtime, `Compiler::isExpired()` continues returning `true`, causing the same view to be recompiled on every request.

In practice, this can make affected pages repeatedly load several times slower after a save, even across manual browser refreshes, until the compiled views are cleared or the compiled file timestamp is refreshed.

This can happen during local development after saving a Blade file when the source file mtime changes but the compiled PHP output does not. For example, saving without effective changes, changing Blade/source formatting that compiles to the same PHP, or making edits that are normalized away by the compiler can leave the source file newer than the existing compiled file.

This updates the compiled file timestamp when the output is unchanged but the compiled view would otherwise remain expired.

This preserves the existing optimization that avoids rewriting unchanged compiled contents, while preventing the compiled view from staying expired.

Fixes #60396.

Tests:

```bash
./vendor/bin/pint src/Illuminate/View/Compilers/BladeCompiler.php tests/View/ViewBladeCompilerTest.php
./vendor/bin/phpunit tests/View
```