### PR TITLE
[13.x] Allow enums in Queue::route

### DIFF
--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -129,8 +129,8 @@ class QueueManager implements FactoryContract, MonitorContract
      * Set the queue route for the given class.
      *
      * @param  array|class-string  $class
-     * @param  string|null  $queue
-     * @param  string|null  $connection
+     * @param  \UnitEnum|string|null  $queue
+     * @param  \UnitEnum|string|null  $connection
      * @return void
      */
     public function route(array|string $class, $queue = null, $connection = null)

--- a/src/Illuminate/Queue/QueueRoutes.php
+++ b/src/Illuminate/Queue/QueueRoutes.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Queue;
 
+use function Illuminate\Support\enum_value;
+
 class QueueRoutes
 {
     /**
@@ -81,8 +83,8 @@ class QueueRoutes
      * Register the queue route for the given class.
      *
      * @param  array|class-string  $class
-     * @param  string|null  $queue
-     * @param  string|null  $connection
+     * @param  \UnitEnum|string|null  $queue
+     * @param  \UnitEnum|string|null  $connection
      * @return void
      */
     public function set(array|string $class, $queue = null, $connection = null)
@@ -90,7 +92,9 @@ class QueueRoutes
         $routes = is_array($class) ? $class : [$class => [$connection, $queue]];
 
         foreach ($routes as $from => $to) {
-            $this->routes[$from] = $to;
+            $this->routes[$from] = is_array($to)
+                ? array_map(enum_value(...), $to)
+                : enum_value($to);
         }
     }
 

--- a/tests/Queue/QueueRoutesTest.php
+++ b/tests/Queue/QueueRoutesTest.php
@@ -87,11 +87,6 @@ class QueueRoutesTest extends TestCase
 
         $this->assertSame('payments', $defaults->getQueue(new SomeJob));
         $this->assertSame('redis', $defaults->getConnection(new SomeJob));
-    }
-
-    public function testEnumsWithArray()
-    {
-        $defaults = new QueueRoutes();
 
         $defaults->set([SomeJob::class => [ConnectionName::redis, QueueName::payments]]);
 

--- a/tests/Queue/QueueRoutesTest.php
+++ b/tests/Queue/QueueRoutesTest.php
@@ -78,6 +78,36 @@ class QueueRoutesTest extends TestCase
         $this->assertSame('notifications', $defaults->getQueue(new FinanceNotification));
         $this->assertNull($defaults->getConnection(new FinanceNotification));
     }
+
+    public function testEnumsAreResolved()
+    {
+        $defaults = new QueueRoutes();
+
+        $defaults->set(SomeJob::class, QueueName::payments, ConnectionName::redis);
+
+        $this->assertSame('payments', $defaults->getQueue(new SomeJob));
+        $this->assertSame('redis', $defaults->getConnection(new SomeJob));
+    }
+
+    public function testEnumsWithArray()
+    {
+        $defaults = new QueueRoutes();
+
+        $defaults->set([SomeJob::class => [ConnectionName::redis, QueueName::payments]]);
+
+        $this->assertSame('payments', $defaults->getQueue(new SomeJob));
+        $this->assertSame('redis', $defaults->getConnection(new SomeJob));
+    }
+}
+
+enum QueueName: string
+{
+    case payments = 'payments';
+}
+
+enum ConnectionName: string
+{
+    case redis = 'redis';
 }
 
 trait CustomTrait


### PR DESCRIPTION
Welcome to your fav PRs, ENUMS  

This PR adds the ability for you to use enums in `Queue::route` for the queue or connection.

We have jobs that specify: 

``` php
    public function __construct()
    {
        $this->onQueue(Queues::statistics);
    }
``` 

It would be nice to use it in `Queue::route` just for parity with the other methods like onQueue,onConnection and the attributes.

```php


Queue::route(StatisticBaseJob::class, Queues::payments, Connections::redis);

// Or via array

Queue::route([ 
  StatisticBaseJob::class => Queues::statistics,
  // more
]);
```  

This means enums will work for queue and connection basically..

We can just use ->value but thought I'd give this a go
