### PR TITLE
[13.x] Fix loose contains validation comparisons

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -26,6 +26,7 @@ use Illuminate\Validation\Rules\Exists;
 use Illuminate\Validation\Rules\Unique;
 use Illuminate\Validation\ValidationData;
 use InvalidArgumentException;
+use Stringable;
 use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use ValueError;
@@ -530,7 +531,7 @@ trait ValidatesAttributes
         }
 
         foreach ($parameters as $parameter) {
-            if (! in_array($parameter, $value)) {
+            if (! $this->arrayContainsParameter($value, $parameter)) {
                 return false;
             }
         }
@@ -553,12 +554,31 @@ trait ValidatesAttributes
         }
 
         foreach ($parameters as $parameter) {
-            if (in_array($parameter, $value)) {
+            if ($this->arrayContainsParameter($value, $parameter)) {
                 return false;
             }
         }
 
         return true;
+    }
+
+    /**
+     * Determine if an array contains a validation rule parameter.
+     *
+     * @param  array<int, mixed>  $values
+     * @param  int|string  $parameter
+     * @return bool
+     */
+    protected function arrayContainsParameter($values, $parameter)
+    {
+        foreach ($values as $value) {
+            if ((is_string($value) || is_int($value) || is_float($value) || $value instanceof Stringable)
+                && (string) $value === (string) $parameter) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/tests/Validation/ValidationRuleContainsTest.php
+++ b/tests/Validation/ValidationRuleContainsTest.php
@@ -86,4 +86,24 @@ class ValidationRuleContainsTest extends TestCase
         $v = new Validator($trans, ['roles' => null], ['roles' => ['nullable', Rule::contains('admin')]]);
         $this->assertTrue($v->passes());
     }
+
+    public function testContainsValidationDoesNotUseLooseBooleanComparison()
+    {
+        $trans = new Translator(new ArrayLoader, 'en');
+
+        $v = new Validator($trans, ['roles' => [true]], ['roles' => Rule::contains('admin')]);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['roles' => [true]], ['roles' => Rule::contains(1)]);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['roles' => [false]], ['roles' => Rule::contains(0)]);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['roles' => [1]], ['roles' => Rule::contains(1)]);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['roles' => [0]], ['roles' => Rule::contains(0)]);
+        $this->assertTrue($v->passes());
+    }
 }

--- a/tests/Validation/ValidationRuleDoesntContainTest.php
+++ b/tests/Validation/ValidationRuleDoesntContainTest.php
@@ -86,4 +86,24 @@ class ValidationRuleDoesntContainTest extends TestCase
         $v = new Validator($trans, ['roles' => null], ['roles' => ['nullable', Rule::doesntContain('admin')]]);
         $this->assertTrue($v->passes());
     }
+
+    public function testDoesntContainValidationDoesNotUseLooseBooleanComparison()
+    {
+        $trans = new Translator(new ArrayLoader, 'en');
+
+        $v = new Validator($trans, ['roles' => [true]], ['roles' => Rule::doesntContain('admin')]);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['roles' => [true]], ['roles' => Rule::doesntContain(1)]);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['roles' => [false]], ['roles' => Rule::doesntContain(0)]);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['roles' => [1]], ['roles' => Rule::doesntContain(1)]);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['roles' => [0]], ['roles' => Rule::doesntContain(0)]);
+        $this->assertTrue($v->fails());
+    }
 }


### PR DESCRIPTION
The `contains` and `doesnt_contain` validation rules currently use loose `in_array` checks. That lets boolean array values match unrelated rule parameters. For example, `contains:admin` passes for `[true]`, and `doesnt_contain:admin` fails for `[true]`.

This compares rule parameters against string, integer, float, and stringable array values by string value instead. That keeps normal cases like `contains:1` against `[1]` working, while avoiding PHP loose boolean coercion.

Tests added for both `Rule::contains` and `Rule::doesntContain`.

Tested:
- `php -d memory_limit=-1 vendor/bin/phpunit tests/Validation/ValidationRuleContainsTest.php tests/Validation/ValidationRuleDoesntContainTest.php`
- `php -d memory_limit=-1 vendor/bin/phpunit tests/Validation/ValidationValidatorTest.php`
- `php -d memory_limit=-1 vendor/bin/phpunit tests/Validation`