### PR TITLE
[13.x] Move flexible cache created-key cleanup from stores into Repository::forget()

### DIFF
--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -409,10 +409,9 @@ class DatabaseStore implements CanFlushLocks, LockProvider, Store
      */
     protected function forgetMany(array $keys)
     {
-        $this->table()->whereIn('key', (new Collection($keys))->flatMap(fn ($key) => [
-            $this->prefix.$key,
-            $this->prefix.Repository::FLEXIBLE_CREATED_KEY_PREFIX.$key,
-        ])->all())->delete();
+        $this->table()->whereIn('key', (new Collection($keys))->map(
+            fn ($key) => $this->prefix.$key
+        )->all())->delete();
 
         return true;
     }

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -276,11 +276,7 @@ class FileStore implements CanFlushLocks, LockProvider, Store
     public function forget($key)
     {
         if ($this->files->exists($file = $this->path($key))) {
-            return tap($this->files->delete($file), function ($forgotten) use ($key) {
-                if ($forgotten && $this->files->exists($file = $this->path(Repository::FLEXIBLE_CREATED_KEY_PREFIX.$key))) {
-                    $this->files->delete($file);
-                }
-            });
+            return $this->files->delete($file);
         }
 
         return false;

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -728,6 +728,7 @@ class Repository implements ArrayAccess, CacheContract
 
         return tap($this->store->forget($this->itemKey($key)), function ($result) use ($key) {
             if ($result) {
+                $this->store->forget($this->itemKey(self::FLEXIBLE_CREATED_KEY_PREFIX.$key));
                 $this->event(new KeyForgotten($this->getName(), $key));
             } else {
                 $this->event(new KeyForgetFailed($this->getName(), $key));

--- a/src/Illuminate/Cache/StorageStore.php
+++ b/src/Illuminate/Cache/StorageStore.php
@@ -164,13 +164,7 @@ class StorageStore implements Store
      */
     public function forget($key)
     {
-        $forgotten = $this->disk->delete($this->path($key));
-
-        if ($forgotten) {
-            $this->disk->delete($this->path(Repository::FLEXIBLE_CREATED_KEY_PREFIX.$key));
-        }
-
-        return $forgotten;
+        return $this->disk->delete($this->path($key));
     }
 
     /**

--- a/tests/Cache/CacheDatabaseStoreTest.php
+++ b/tests/Cache/CacheDatabaseStoreTest.php
@@ -124,7 +124,7 @@ class CacheDatabaseStoreTest extends TestCase
         $store = $this->getStore();
         $table = m::mock(stdClass::class);
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
-        $table->shouldReceive('whereIn')->once()->with('key', ['prefixfoo', 'prefixilluminate:cache:flexible:created:foo'])->andReturn($table);
+        $table->shouldReceive('whereIn')->once()->with('key', ['prefixfoo'])->andReturn($table);
         $table->shouldReceive('delete')->once();
 
         $store->forget('foo');

--- a/tests/Cache/CacheFileStoreTest.php
+++ b/tests/Cache/CacheFileStoreTest.php
@@ -437,47 +437,34 @@ class CacheFileStoreTest extends TestCase
         $store->flushLocks();
     }
 
-    public function testItHandlesForgettingNonFlexibleKeys()
+    public function testForgetDeletesKeyFile()
     {
         $store = new FileStore(new Filesystem, __DIR__);
 
         $key = Str::random();
         $path = $store->path($key);
-        $flexiblePath = "illuminate:cache:flexible:created:{$key}";
 
         $store->put($key, 'value', 5);
-
         $this->assertFileExists($path);
-        $this->assertFileDoesNotExist($flexiblePath);
 
         $store->forget($key);
-
         $this->assertFileDoesNotExist($path);
-        $this->assertFileDoesNotExist($flexiblePath);
     }
 
-    public function itOnlyForgetsFlexibleKeysIfParentIsForgotten()
+    public function testForgetDoesNotRemoveFlexibleCreatedKey()
     {
         $store = new FileStore(new Filesystem, __DIR__);
 
         $key = Str::random();
-        $path = $store->path($key);
-        $flexiblePath = "illuminate:cache:flexible:created:{$key}";
-
-        touch($flexiblePath);
-
-        $this->assertFileDoesNotExist($path);
-        $this->assertFileExists($flexiblePath);
+        $store->put($key, 'value', 5);
+        $store->put('illuminate:cache:flexible:created:'.$key, true, 5);
 
         $store->forget($key);
 
-        $this->assertFileDoesNotExist($path);
-        $this->assertFileExists($flexiblePath);
+        $this->assertFileDoesNotExist($store->path($key));
+        $this->assertFileExists($store->path('illuminate:cache:flexible:created:'.$key));
 
-        $store->put($key, 'value', 5);
-
-        $this->assertFileDoesNotExist($path);
-        $this->assertFileDoesNotExist($flexiblePath);
+        $store->forget('illuminate:cache:flexible:created:'.$key);
     }
 
     protected function mockFilesystem()

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -309,6 +309,7 @@ class CacheRepositoryTest extends TestCase
     {
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('forget')->once()->with('a-key')->andReturn(true);
+        $repo->getStore()->shouldReceive('forget')->once()->with('illuminate:cache:flexible:created:a-key')->andReturn(false);
         $repo->forget('a-key');
     }
 
@@ -317,7 +318,23 @@ class CacheRepositoryTest extends TestCase
         // Alias of Forget
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('forget')->once()->with('a-key')->andReturn(true);
+        $repo->getStore()->shouldReceive('forget')->once()->with('illuminate:cache:flexible:created:a-key')->andReturn(false);
         $repo->delete('a-key');
+    }
+
+    public function testForgettingCacheKeyAlsoForgetsFlexibleCreatedKey()
+    {
+        $repo = $this->getRepository();
+        $repo->getStore()->shouldReceive('forget')->once()->with('foo')->andReturn(true);
+        $repo->getStore()->shouldReceive('forget')->once()->with('illuminate:cache:flexible:created:foo')->andReturn(true);
+        $repo->forget('foo');
+    }
+
+    public function testFlexibleCreatedKeyIsNotForgottenWhenMainKeyForgetFails()
+    {
+        $repo = $this->getRepository();
+        $repo->getStore()->shouldReceive('forget')->once()->with('foo')->andReturn(false);
+        $repo->forget('foo');
     }
 
     public function testSettingCache()
@@ -349,7 +366,9 @@ class CacheRepositoryTest extends TestCase
     {
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('forget')->once()->with('a-key')->andReturn(true);
+        $repo->getStore()->shouldReceive('forget')->once()->with('illuminate:cache:flexible:created:a-key')->andReturn(false);
         $repo->getStore()->shouldReceive('forget')->once()->with('a-second-key')->andReturn(true);
+        $repo->getStore()->shouldReceive('forget')->once()->with('illuminate:cache:flexible:created:a-second-key')->andReturn(false);
 
         $this->assertTrue($repo->deleteMultiple(['a-key', 'a-second-key']));
     }
@@ -358,6 +377,7 @@ class CacheRepositoryTest extends TestCase
     {
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('forget')->once()->with('a-key')->andReturn(true);
+        $repo->getStore()->shouldReceive('forget')->once()->with('illuminate:cache:flexible:created:a-key')->andReturn(false);
         $repo->getStore()->shouldReceive('forget')->once()->with('a-second-key')->andReturn(false);
 
         $this->assertFalse($repo->deleteMultiple(['a-key', 'a-second-key']));

--- a/tests/Cache/CacheStorageStoreTest.php
+++ b/tests/Cache/CacheStorageStoreTest.php
@@ -81,21 +81,17 @@ class CacheStorageStoreTest extends TestCase
         $this->assertSame('bar', $store->get('foo'));
     }
 
-    public function testForgetRemovesFlexibleCreatedKeyOnlyWhenParentIsForgotten()
+    public function testForgetDoesNotRemoveFlexibleCreatedKey()
     {
         $disk = new ArrayFilesystem;
         $store = new StorageStore($disk, 'cache');
 
         $store->put('illuminate:cache:flexible:created:foo', true, 60);
-
-        $this->assertFalse($store->forget('foo'));
-        $this->assertTrue($disk->exists($store->path('illuminate:cache:flexible:created:foo')));
-
         $store->put('foo', 'bar', 60);
 
         $this->assertTrue($store->forget('foo'));
         $this->assertFalse($disk->exists($store->path('foo')));
-        $this->assertFalse($disk->exists($store->path('illuminate:cache:flexible:created:foo')));
+        $this->assertTrue($disk->exists($store->path('illuminate:cache:flexible:created:foo')));
     }
 
     public function testFlushRemovesScopedDirectory()


### PR DESCRIPTION
`FileStore`, `StorageStore`, and `DatabaseStore` each contained logic to delete the `illuminate:cache:flexible:created:{key}` companion key when forgetting a cache item. This forced low-level storage drivers to have knowledge of a high-level feature (`flexible()`), which also means any new Store implementation must remember to replicate this behavior or silently leave stale keys.

`Repository::forget() `is the right owner of this cleanup it is the layer that owns the `flexible() `feature and is always called regardless of the underlying driver.

This PR:

- Adds a `FLEXIBLE_CREATED_KEY_PREFIX` constant to Repository as the single source of truth
- Moves the flexible key cleanup from the three stores into `Repository::forget()`
- Keeps DatabaseStore::forgetManyIfExpired() unchanged this is an internal GC path that runs during reads, outside the `Repository::forget()` lifecycle