### PR TITLE
[13.x] Fix LazyCollection::get() ignoring $default when key is null

### DIFF
--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -534,7 +534,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     public function get($key, $default = null)
     {
         if (is_null($key)) {
-            return;
+            return value($default);
         }
 
         foreach ($this as $outerKey => $outerValue) {


### PR DESCRIPTION
`LazyCollection::get()` silently returned `null` when a `null` key was passed, regardless of the `$default` argument provided by the caller.
The `return;` statement on an early-exit path discarded `$default` entirely, inconsistent with how `Collection::get()` behaves.

**Before:**
```php
LazyCollection::make(['a' => 1])->get(null, 'fallback');
// returns null - wrong
```
After:
```php
LazyCollection::make(['a' => 1])->get(null, 'fallback');
// returns 'fallback' 
```