### PR TITLE
[13.x] Add return type hints to Number::defaultLocale() and Number::defaultCurrency()

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -421,7 +421,7 @@ class Number
      *
      * @return string
      */
-    public static function defaultLocale()
+    public static function defaultLocale(): string
     {
         return static::$locale;
     }
@@ -431,7 +431,7 @@ class Number
      *
      * @return string
      */
-    public static function defaultCurrency()
+    public static function defaultCurrency(): string
     {
         return static::$currency;
     }


### PR DESCRIPTION
`Number::defaultLocale()` and `Number::defaultCurrency()` had `@return string` in their docblocks but were missing the native PHP return type declaration. Other methods in the same class (`parse()`, `parseInt()`, `parseFloat()`) already carry native return types, so these two simple getters were inconsistent.

Both methods unconditionally return a `string` property, so the change is fully backward compatible.