### PR TITLE
[13.x] Allow Predis retry to be configured with a serializable array

### DIFF
--- a/src/Illuminate/Redis/Connectors/PredisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PredisConnector.php
@@ -9,6 +9,10 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
 use Predis\Client;
+use Predis\Retry\Retry;
+use Predis\Retry\Strategy\EqualBackoff;
+use Predis\Retry\Strategy\ExponentialBackoff;
+use Predis\Retry\Strategy\NoBackoff;
 
 class PredisConnector implements Connector
 {
@@ -31,6 +35,8 @@ class PredisConnector implements Connector
 
         $config = $this->formatHost($config);
 
+        $config = $this->formatRetry($config);
+
         return new PredisConnection(new Client($config, $formattedOptions));
     }
 
@@ -51,12 +57,49 @@ class PredisConnector implements Connector
         }
 
         $servers = array_map(function ($server) {
-            return is_array($server) ? $this->formatHost($server) : $server;
+            if (is_array($server)) {
+                $server = $this->formatHost($server);
+                $server = $this->formatRetry($server);
+            }
+
+            return $server;
         }, array_values($config));
 
         return new PredisClusterConnection(new Client($servers, array_merge(
             $options, $clusterOptions, $clusterSpecificOptions
         )));
+    }
+
+    /**
+     * Format the retry parameter.
+     *
+     * @param  array  $config
+     * @return array
+     */
+    protected function formatRetry(array $config)
+    {
+        if (isset($config['retry']) && is_array($config['retry']) && class_exists(Retry::class)) {
+            $retry = $config['retry'];
+            $retries = $retry['retries'] ?? 0;
+            $strategy = $retry['strategy'] ?? 'exponential';
+
+            $backoff = match ($strategy) {
+                'equal' => new EqualBackoff($retry['backoff'] ?? 0),
+                'no' => new NoBackoff,
+                'exponential' => new ExponentialBackoff(
+                    $retry['base'] ?? 250000,
+                    $retry['cap'] ?? 2000000,
+                    $retry['with_jitter'] ?? false
+                ),
+                default => is_string($strategy) && class_exists($strategy)
+                    ? new $strategy(...($retry['parameters'] ?? []))
+                    : $strategy,
+            };
+
+            $config['retry'] = new Retry($backoff, $retries);
+        }
+
+        return $config;
     }
 
     /**

--- a/tests/Cache/CacheFileStoreTest.php
+++ b/tests/Cache/CacheFileStoreTest.php
@@ -262,6 +262,8 @@ class CacheFileStoreTest extends TestCase
 
     public function testIncrementNonNumericValues()
     {
+        Carbon::setTestNow(Carbon::now());
+
         $filePath = $this->getCachePath('foo');
 
         $files = $this->mockFilesystem();

--- a/tests/Redis/PredisConnectorTest.php
+++ b/tests/Redis/PredisConnectorTest.php
@@ -75,6 +75,79 @@ class PredisConnectorTest extends TestCase
             'scheme' => 'tls',
         ]);
     }
+
+    public function testFormatRetryWithArray()
+    {
+        if (! class_exists(\Predis\Retry\Retry::class)) {
+            $this->markTestSkipped('Predis retry support is only available in Predis >= 3.4.0');
+        }
+
+        $connector = new TestablePredisConnector;
+
+        $config = [
+            'retry' => [
+                'retries' => 3,
+                'strategy' => 'exponential',
+                'base' => 1000,
+                'cap' => 5000,
+                'with_jitter' => true,
+            ],
+        ];
+
+        $formatted = $connector->testFormatRetry($config);
+
+        $this->assertInstanceOf(\Predis\Retry\Retry::class, $formatted['retry']);
+        $this->assertSame(3, $formatted['retry']->getRetries());
+        $this->assertInstanceOf(\Predis\Retry\Strategy\ExponentialBackoff::class, $formatted['retry']->getStrategy());
+        $this->assertSame(1000, $formatted['retry']->getStrategy()->getBase());
+        $this->assertSame(5000, $formatted['retry']->getStrategy()->getCap());
+    }
+
+    public function testFormatRetryWithEqualStrategy()
+    {
+        if (! class_exists(\Predis\Retry\Retry::class)) {
+            $this->markTestSkipped('Predis retry support is only available in Predis >= 3.4.0');
+        }
+
+        $connector = new TestablePredisConnector;
+
+        $config = [
+            'retry' => [
+                'retries' => 5,
+                'strategy' => 'equal',
+                'backoff' => 2000,
+            ],
+        ];
+
+        $formatted = $connector->testFormatRetry($config);
+
+        $this->assertInstanceOf(\Predis\Retry\Retry::class, $formatted['retry']);
+        $this->assertSame(5, $formatted['retry']->getRetries());
+        $this->assertInstanceOf(\Predis\Retry\Strategy\EqualBackoff::class, $formatted['retry']->getStrategy());
+        $this->assertSame(2000, $formatted['retry']->getStrategy()->compute(0));
+    }
+
+    public function testFormatRetryWithNoStrategy()
+    {
+        if (! class_exists(\Predis\Retry\Retry::class)) {
+            $this->markTestSkipped('Predis retry support is only available in Predis >= 3.4.0');
+        }
+
+        $connector = new TestablePredisConnector;
+
+        $config = [
+            'retry' => [
+                'retries' => 2,
+                'strategy' => 'no',
+            ],
+        ];
+
+        $formatted = $connector->testFormatRetry($config);
+
+        $this->assertInstanceOf(\Predis\Retry\Retry::class, $formatted['retry']);
+        $this->assertSame(2, $formatted['retry']->getRetries());
+        $this->assertInstanceOf(\Predis\Retry\Strategy\NoBackoff::class, $formatted['retry']->getStrategy());
+    }
 }
 
 class TestablePredisConnector extends PredisConnector
@@ -82,5 +155,10 @@ class TestablePredisConnector extends PredisConnector
     public function testFormatHost(array $config): array
     {
         return $this->formatHost($config);
+    }
+
+    public function testFormatRetry(array $config): array
+    {
+        return $this->formatRetry($config);
     }
 }


### PR DESCRIPTION
Closes #60355

This PR allows configuring the Predis retry strategy using a serializable array, making it compatible with `config:cache`. 

Currently, the documentation asks users to pass a `Predis\Retry\Retry` object directly in the config, which fails during serialization on `config:cache`.

### Solution
Instead of parsing flat root-level keys (which conflict with default PhpRedis settings), this solution parses the configurations nested under the `retry` array key. 

### Usage Example
```php
'default' => [
    // ...
    'retry' => [
        'strategy' => 'exponential', // 'exponential', 'equal', 'no'
        'retries' => 3,
        'base' => 250000,
        'cap' => 2000000,
        'with_jitter' => false,
    ],
],
