### PR TITLE
Add `artisan dev` command

### DIFF
--- a/src/Illuminate/Foundation/Console/DevCommand.php
+++ b/src/Illuminate/Foundation/Console/DevCommand.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Foundation\DevCommands;
+use Illuminate\Support\NodePackageManager;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+use function Laravel\Prompts\info;
+
+#[AsCommand(name: 'dev')]
+class DevCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'dev';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Run the dev processes';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     *
+     * @throws \Exception
+     */
+    public function handle(NodePackageManager $packageManager)
+    {
+        // TODO: These probably belong elsewhere? Earlier in the process?
+        DevCommands::artisan('serve --host=localhost', 'server');
+        DevCommands::artisan('queue:listen --tries=1 --timeout=0', 'queue');
+        DevCommands::artisan('pail --timeout=0', 'logs');
+        DevCommands::node('dev', 'vite');
+
+        $devCommands = DevCommands::getCommands();
+
+        $commands = array_column($devCommands, 'command');
+        $colors = array_column($devCommands, 'color');
+        $names = array_column($devCommands, 'name');
+
+        $longestName = max(array_map('strlen', $names));
+
+        $this->line('');
+
+        foreach ($devCommands as $devCommand) {
+            $this->line(
+                sprintf(
+                    '<fg=%s>[%s]</>%s<fg=#888888>%s</>',
+                    $devCommand['color'],
+                    $devCommand['name'],
+                    str_repeat(' ', ($longestName - strlen($devCommand['name'])) + 1),
+                    $devCommand['command'],
+                ),
+            );
+        }
+
+        $this->line('');
+
+        $command = $packageManager->getExecCommand(sprintf(
+            'concurrently -c "%s" "%s" --names=%s --kill-others',
+            implode(',', $colors),
+            implode('" "', $commands),
+            implode(',', $names)
+        ));
+
+        if (extension_loaded('pcntl')) {
+            pcntl_exec('/usr/bin/env', ['sh', '-c', $command]);
+        } else {
+            passthru($command, $exitCode);
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Illuminate/Foundation/Console/DevCommand.php
+++ b/src/Illuminate/Foundation/Console/DevCommand.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Command;
+use Illuminate\Console\Prohibitable;
 use Illuminate\Foundation\DevCommands;
 use Illuminate\Support\NodePackageManager;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -10,6 +11,8 @@ use Symfony\Component\Console\Attribute\AsCommand;
 #[AsCommand(name: 'dev')]
 class DevCommand extends Command
 {
+    use Prohibitable;
+
     /**
      * The console command name.
      *
@@ -33,6 +36,10 @@ class DevCommand extends Command
      */
     public function handle(NodePackageManager $packageManager)
     {
+        if ($this->isProhibited()) {
+            return;
+        }
+
         $devCommands = DevCommands::commands();
 
         $commands = array_column($devCommands, 'command');

--- a/src/Illuminate/Foundation/Console/DevCommand.php
+++ b/src/Illuminate/Foundation/Console/DevCommand.php
@@ -7,8 +7,6 @@ use Illuminate\Foundation\DevCommands;
 use Illuminate\Support\NodePackageManager;
 use Symfony\Component\Console\Attribute\AsCommand;
 
-use function Laravel\Prompts\info;
-
 #[AsCommand(name: 'dev')]
 class DevCommand extends Command
 {

--- a/src/Illuminate/Foundation/Console/DevCommand.php
+++ b/src/Illuminate/Foundation/Console/DevCommand.php
@@ -33,7 +33,7 @@ class DevCommand extends Command
      */
     public function handle(NodePackageManager $packageManager)
     {
-        $devCommands = DevCommands::getCommands();
+        $devCommands = DevCommands::commands();
 
         $commands = array_column($devCommands, 'command');
         $colors = array_column($devCommands, 'color');

--- a/src/Illuminate/Foundation/Console/DevCommand.php
+++ b/src/Illuminate/Foundation/Console/DevCommand.php
@@ -37,7 +37,7 @@ class DevCommand extends Command
     public function handle(NodePackageManager $packageManager)
     {
         if ($this->isProhibited()) {
-            return;
+            return self::FAILURE;
         }
 
         $devCommands = DevCommands::commands();

--- a/src/Illuminate/Foundation/Console/DevCommand.php
+++ b/src/Illuminate/Foundation/Console/DevCommand.php
@@ -8,6 +8,8 @@ use Illuminate\Foundation\DevCommands;
 use Illuminate\Support\NodePackageManager;
 use Symfony\Component\Console\Attribute\AsCommand;
 
+use function Termwind\terminal;
+
 #[AsCommand(name: 'dev')]
 class DevCommand extends Command
 {
@@ -48,6 +50,10 @@ class DevCommand extends Command
 
         $longestName = max(array_map(strlen(...), $names));
 
+        $columns = getenv('COLUMNS');
+
+        putenv('COLUMNS='.max(terminal()->width() - $longestName - 4, 1));
+
         $this->line('');
 
         foreach ($devCommands as $devCommand) {
@@ -76,6 +82,8 @@ class DevCommand extends Command
         }
 
         passthru($command, $exitCode);
+
+        $columns === false ? putenv('COLUMNS') : putenv("COLUMNS={$columns}");
 
         return $exitCode;
     }

--- a/src/Illuminate/Foundation/Console/DevCommand.php
+++ b/src/Illuminate/Foundation/Console/DevCommand.php
@@ -39,7 +39,7 @@ class DevCommand extends Command
         $colors = array_column($devCommands, 'color');
         $names = array_column($devCommands, 'name');
 
-        $longestName = max(array_map('strlen', $names));
+        $longestName = max(array_map(strlen(...), $names));
 
         $this->line('');
 

--- a/src/Illuminate/Foundation/Console/DevCommand.php
+++ b/src/Illuminate/Foundation/Console/DevCommand.php
@@ -66,10 +66,10 @@ class DevCommand extends Command
 
         if (extension_loaded('pcntl')) {
             pcntl_exec('/usr/bin/env', ['sh', '-c', $command]);
-        } else {
-            passthru($command, $exitCode);
         }
 
-        return self::SUCCESS;
+        passthru($command, $exitCode);
+
+        return $exitCode;
     }
 }

--- a/src/Illuminate/Foundation/Console/DevCommand.php
+++ b/src/Illuminate/Foundation/Console/DevCommand.php
@@ -35,12 +35,6 @@ class DevCommand extends Command
      */
     public function handle(NodePackageManager $packageManager)
     {
-        // TODO: These probably belong elsewhere? Earlier in the process?
-        DevCommands::artisan('serve --host=localhost', 'server');
-        DevCommands::artisan('queue:listen --tries=1 --timeout=0', 'queue');
-        DevCommands::artisan('pail --timeout=0', 'logs');
-        DevCommands::node('dev', 'vite');
-
         $devCommands = DevCommands::getCommands();
 
         $commands = array_column($devCommands, 'command');

--- a/src/Illuminate/Foundation/DevCommand.php
+++ b/src/Illuminate/Foundation/DevCommand.php
@@ -57,7 +57,7 @@ class DevCommand
      * Create a new DevCommand instance.
      *
      * @param  string  $command
-     * @param  null|string  $name
+     * @param  string|null  $name
      * @return void
      */
     public function __construct(protected string $command, protected ?string $name = null)
@@ -66,10 +66,20 @@ class DevCommand
     }
 
     /**
+     * Get the command name.
+     *
+     * @return string
+     */
+    public function name(): string
+    {
+        return $this->name;
+    }
+
+    /**
      * Set the command color.
      *
      * @param  string  $color
-     * @return DevCommand
+     * @return self
      */
     public function color(string $color): self
     {
@@ -81,7 +91,7 @@ class DevCommand
     /**
      * Set the command color to blue.
      *
-     * @return DevCommand
+     * @return self
      */
     public function blue(): self
     {
@@ -91,7 +101,7 @@ class DevCommand
     /**
      * Set the command color to purple.
      *
-     * @return DevCommand
+     * @return self
      */
     public function purple(): self
     {
@@ -101,7 +111,7 @@ class DevCommand
     /**
      * Set the command color to pink.
      *
-     * @return DevCommand
+     * @return self
      */
     public function pink(): self
     {
@@ -111,7 +121,7 @@ class DevCommand
     /**
      * Set the command color to orange.
      *
-     * @return DevCommand
+     * @return self
      */
     public function orange(): self
     {
@@ -121,7 +131,7 @@ class DevCommand
     /**
      * Set the command color to green.
      *
-     * @return DevCommand
+     * @return self
      */
     public function green(): self
     {
@@ -131,7 +141,7 @@ class DevCommand
     /**
      * Set the command color to yellow.
      *
-     * @return DevCommand
+     * @return self
      */
     public function yellow(): self
     {

--- a/src/Illuminate/Foundation/DevCommand.php
+++ b/src/Illuminate/Foundation/DevCommand.php
@@ -4,16 +4,46 @@ namespace Illuminate\Foundation;
 
 class DevCommand
 {
+    /**
+     * Blue color.
+     *
+     * @var string
+     */
     public const BLUE = '#93c5fd';
 
+    /**
+     * Purple color.
+     *
+     * @var string
+     */
     public const PURPLE = '#c4b5fd';
 
+    /**
+     * Pink color.
+     *
+     * @var string
+     */
     public const PINK = '#fb7185';
 
+    /**
+     * Orange color.
+     *
+     * @var string
+     */
     public const ORANGE = '#fdba74';
 
+    /**
+     * Green color.
+     *
+     * @var string
+     */
     public const GREEN = '#86efac';
 
+    /**
+     * Yellow color.
+     *
+     * @var string
+     */
     public const YELLOW = '#fcd34d';
 
     /**
@@ -26,8 +56,8 @@ class DevCommand
     /**
      * Create a new DevCommand instance.
      *
-     * @param string $command
-     * @param null|string $name
+     * @param  string  $command
+     * @param  null|string  $name
      * @return void
      */
     public function __construct(protected string $command, protected ?string $name = null)
@@ -38,7 +68,7 @@ class DevCommand
     /**
      * Set the command color.
      *
-     * @param string $color
+     * @param  string  $color
      * @return DevCommand
      */
     public function color(string $color): self

--- a/src/Illuminate/Foundation/DevCommand.php
+++ b/src/Illuminate/Foundation/DevCommand.php
@@ -49,7 +49,7 @@ class DevCommand
     /**
      * Color of the command when output to the console.
      *
-     * @var string
+     * @var string|null
      */
     protected ?string $color = null;
 

--- a/src/Illuminate/Foundation/DevCommand.php
+++ b/src/Illuminate/Foundation/DevCommand.php
@@ -5,48 +5,6 @@ namespace Illuminate\Foundation;
 class DevCommand
 {
     /**
-     * Blue color.
-     *
-     * @var string
-     */
-    public const BLUE = '#93c5fd';
-
-    /**
-     * Purple color.
-     *
-     * @var string
-     */
-    public const PURPLE = '#c4b5fd';
-
-    /**
-     * Pink color.
-     *
-     * @var string
-     */
-    public const PINK = '#fb7185';
-
-    /**
-     * Orange color.
-     *
-     * @var string
-     */
-    public const ORANGE = '#fdba74';
-
-    /**
-     * Green color.
-     *
-     * @var string
-     */
-    public const GREEN = '#86efac';
-
-    /**
-     * Yellow color.
-     *
-     * @var string
-     */
-    public const YELLOW = '#fcd34d';
-
-    /**
      * Color of the command when output to the console.
      *
      * @var string|null
@@ -95,7 +53,7 @@ class DevCommand
      */
     public function blue(): self
     {
-        return $this->color(self::BLUE);
+        return $this->color(DevCommandColor::BLUE->value);
     }
 
     /**
@@ -105,7 +63,7 @@ class DevCommand
      */
     public function purple(): self
     {
-        return $this->color(self::PURPLE);
+        return $this->color(DevCommandColor::PURPLE->value);
     }
 
     /**
@@ -115,7 +73,7 @@ class DevCommand
      */
     public function pink(): self
     {
-        return $this->color(self::PINK);
+        return $this->color(DevCommandColor::PINK->value);
     }
 
     /**
@@ -125,7 +83,7 @@ class DevCommand
      */
     public function orange(): self
     {
-        return $this->color(self::ORANGE);
+        return $this->color(DevCommandColor::ORANGE->value);
     }
 
     /**
@@ -135,7 +93,7 @@ class DevCommand
      */
     public function green(): self
     {
-        return $this->color(self::GREEN);
+        return $this->color(DevCommandColor::GREEN->value);
     }
 
     /**
@@ -145,7 +103,7 @@ class DevCommand
      */
     public function yellow(): self
     {
-        return $this->color(self::YELLOW);
+        return $this->color(DevCommandColor::YELLOW->value);
     }
 
     /**

--- a/src/Illuminate/Foundation/DevCommand.php
+++ b/src/Illuminate/Foundation/DevCommand.php
@@ -109,7 +109,7 @@ class DevCommand
     /**
      * Get the command as an array.
      *
-     * @return array
+     * @return array{command: string, name: string, color: string|null}
      */
     public function toArray(): array
     {

--- a/src/Illuminate/Foundation/DevCommand.php
+++ b/src/Illuminate/Foundation/DevCommand.php
@@ -20,7 +20,7 @@ class DevCommand
      */
     public function __construct(protected string $command, protected ?string $name = null)
     {
-        $this->name ??= collect(explode(' ', $command))->first();
+        $this->name ??= strstr($command, ' ', true);
     }
 
     /**

--- a/src/Illuminate/Foundation/DevCommand.php
+++ b/src/Illuminate/Foundation/DevCommand.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Illuminate\Foundation;
+
+class DevCommand
+{
+    public const BLUE = '#93c5fd';
+
+    public const PURPLE = '#c4b5fd';
+
+    public const PINK = '#fb7185';
+
+    public const ORANGE = '#fdba74';
+
+    public const GREEN = '#86efac';
+
+    public const YELLOW = '#fcd34d';
+
+    /**
+     * Color of the command when output to the console.
+     *
+     * @var string
+     */
+    protected ?string $color = null;
+
+    /**
+     * Create a new DevCommand instance.
+     *
+     * @param string $command
+     * @param null|string $name
+     * @return void
+     */
+    public function __construct(protected string $command, protected ?string $name = null)
+    {
+        $this->name ??= collect(explode(' ', $command))->first();
+    }
+
+    /**
+     * Set the command color.
+     *
+     * @param string $color
+     * @return DevCommand
+     */
+    public function color(string $color): self
+    {
+        $this->color = $color;
+
+        return $this;
+    }
+
+    /**
+     * Set the command color to blue.
+     *
+     * @return DevCommand
+     */
+    public function blue(): self
+    {
+        return $this->color(self::BLUE);
+    }
+
+    /**
+     * Set the command color to purple.
+     *
+     * @return DevCommand
+     */
+    public function purple(): self
+    {
+        return $this->color(self::PURPLE);
+    }
+
+    /**
+     * Set the command color to pink.
+     *
+     * @return DevCommand
+     */
+    public function pink(): self
+    {
+        return $this->color(self::PINK);
+    }
+
+    /**
+     * Set the command color to orange.
+     *
+     * @return DevCommand
+     */
+    public function orange(): self
+    {
+        return $this->color(self::ORANGE);
+    }
+
+    /**
+     * Set the command color to green.
+     *
+     * @return DevCommand
+     */
+    public function green(): self
+    {
+        return $this->color(self::GREEN);
+    }
+
+    /**
+     * Set the command color to yellow.
+     *
+     * @return DevCommand
+     */
+    public function yellow(): self
+    {
+        return $this->color(self::YELLOW);
+    }
+
+    /**
+     * Get the command as an array.
+     *
+     * @return array
+     */
+    public function toArray(): array
+    {
+        return [
+            'command' => $this->command,
+            'name' => $this->name,
+            'color' => $this->color,
+        ];
+    }
+}

--- a/src/Illuminate/Foundation/DevCommandColor.php
+++ b/src/Illuminate/Foundation/DevCommandColor.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Foundation;
+
+enum DevCommandColor: string
+{
+    case BLUE = '#93c5fd';
+    case PURPLE = '#c4b5fd';
+    case PINK = '#fb7185';
+    case ORANGE = '#fdba74';
+    case GREEN = '#86efac';
+    case YELLOW = '#fcd34d';
+}

--- a/src/Illuminate/Foundation/DevCommands.php
+++ b/src/Illuminate/Foundation/DevCommands.php
@@ -237,7 +237,7 @@ class DevCommands
      */
     protected static function nameFromCommand(string $command): string
     {
-        return collect(explode(' ', $command))->first();
+        return strstr($command, ' ', true);
     }
 
     /**

--- a/src/Illuminate/Foundation/DevCommands.php
+++ b/src/Illuminate/Foundation/DevCommands.php
@@ -119,16 +119,6 @@ class DevCommands
     }
 
     /**
-     * Create a new DevCommands instance.
-     *
-     * @return NodePackageManager
-     */
-    protected static function getPackageManager(): NodePackageManager
-    {
-        return self::$packageManager ??= new NodePackageManager();
-    }
-
-    /**
      * Get the registered development commands.
      *
      * @return array
@@ -150,6 +140,29 @@ class DevCommands
         $commands = self::fillInEmptyColors($commands);
 
         return $commands;
+    }
+
+    /**
+     * Clear all registered development commands and reset the state of the DevCommands class, including registered commands, exceptions, inclusions, and color assignments.
+     *
+     * @return void
+     */
+    public static function clear(): void
+    {
+        self::$commands = [];
+        self::$except = [];
+        self::$only = [];
+        self::$colorCount = 0;
+    }
+
+    /**
+     * Create a new DevCommands instance.
+     *
+     * @return NodePackageManager
+     */
+    protected static function getPackageManager(): NodePackageManager
+    {
+        return self::$packageManager ??= new NodePackageManager();
     }
 
     /**

--- a/src/Illuminate/Foundation/DevCommands.php
+++ b/src/Illuminate/Foundation/DevCommands.php
@@ -131,25 +131,25 @@ class DevCommands
     }
 
     /**
-     * Set the commands that should be included when running the "dev" command, excluding any commands not in the given list.
+     * Set the commands that should be excluded when running the "dev" command.
      *
-     * @param  mixed  ...$commands
+     * @param  mixed  ...$names
      * @return void
      */
-    public static function except(...$commands): void
+    public static function except(...$names): void
     {
-        self::$except = $commands;
+        self::$except = $names;
     }
 
     /**
-     * Set the commands that should be included when running the "dev" command, excluding any commands not in the given list.
+     * Set the commands that should be included when running the "dev" command.
      *
-     * @param  mixed  ...$commands
+     * @param  mixed  ...$names
      * @return void
      */
-    public static function only(...$commands): void
+    public static function only(...$names): void
     {
-        self::$only = $commands;
+        self::$only = $names;
     }
 
     /**

--- a/src/Illuminate/Foundation/DevCommands.php
+++ b/src/Illuminate/Foundation/DevCommands.php
@@ -157,7 +157,7 @@ class DevCommands
      *
      * @return array
      */
-    public static function getCommands(): array
+    public static function commands(): array
     {
         $commands = [];
 

--- a/src/Illuminate/Foundation/DevCommands.php
+++ b/src/Illuminate/Foundation/DevCommands.php
@@ -49,9 +49,7 @@ class DevCommands
      */
     public static function register(string $command, ?string $name = null): DevCommand
     {
-        // $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2);
-
-        // self::preventVendorRegistration($name, $trace);
+        self::preventVendorRegistration($name);
 
         $devCommand = new DevCommand($command, $name);
 
@@ -169,12 +167,12 @@ class DevCommands
      * Prevent automatic registration of DevCommands from within vendor packages.
      *
      * @param string $name
-     * @param array $trace
      * @return void
      * @throws Exception
      */
-    protected static function preventVendorRegistration(string $name, array $trace)
+    protected static function preventVendorRegistration(string $name)
     {
+        $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
         $caller = $trace[1];
 
         if ($caller['class']) {

--- a/src/Illuminate/Foundation/DevCommands.php
+++ b/src/Illuminate/Foundation/DevCommands.php
@@ -75,7 +75,7 @@ class DevCommands
      * Register a development command.
      *
      * @param  string  $command
-     * @param  null|string  $name
+     * @param  string|null  $name
      * @return DevCommand
      */
     public static function register(string $command, ?string $name = null): DevCommand
@@ -89,7 +89,7 @@ class DevCommands
 
         $devCommand = new DevCommand($command, $name);
 
-        self::$commands[$name] = $devCommand;
+        self::$commands[$devCommand->name()] = $devCommand;
 
         return $devCommand;
     }
@@ -98,7 +98,7 @@ class DevCommands
      * Registers an Artisan command, automatically prefixing it with "php artisan".
      *
      * @param  string  $command
-     * @param  null|string  $name
+     * @param  string|null  $name
      * @return DevCommand
      */
     public static function artisan(string $command, ?string $name = null): DevCommand
@@ -110,7 +110,7 @@ class DevCommands
      * Registers a Node command, automatically prefixing it with the detected package manager's run command.
      *
      * @param  string  $command
-     * @param  null|string  $name
+     * @param  string|null  $name
      * @return DevCommand
      */
     public static function node(string $command, ?string $name = null): DevCommand
@@ -122,7 +122,7 @@ class DevCommands
      * Registers a Node command, automatically prefixing it with the detected package manager's exec command.
      *
      * @param  string  $command
-     * @param  null|string  $name
+     * @param  string|null  $name
      * @return DevCommand
      */
     public static function nodeExec(string $command, ?string $name = null): DevCommand
@@ -133,7 +133,7 @@ class DevCommands
     /**
      * Set the commands that should be excluded when running the "dev" command.
      *
-     * @param  mixed  ...$names
+     * @param  string  ...$names
      * @return void
      */
     public static function except(...$names): void
@@ -144,7 +144,7 @@ class DevCommands
     /**
      * Set the commands that should be included when running the "dev" command.
      *
-     * @param  mixed  ...$names
+     * @param  string  ...$names
      * @return void
      */
     public static function only(...$names): void
@@ -191,7 +191,7 @@ class DevCommands
     }
 
     /**
-     * Create a new DevCommands instance.
+     * Resolve and return the NodePackageManager instance.
      *
      * @return NodePackageManager
      */

--- a/src/Illuminate/Foundation/DevCommands.php
+++ b/src/Illuminate/Foundation/DevCommands.php
@@ -33,14 +33,14 @@ class DevCommands
     /**
      * The names of commands that should be excluded when running the "dev" command.
      *
-     * @var array
+     * @var array<int, string>
      */
     protected static $except = [];
 
     /**
      * The names of commands that should be included when running the "dev" command.
      *
-     * @var array
+     * @var array<int, string>
      */
     protected static $only = [];
 

--- a/src/Illuminate/Foundation/DevCommands.php
+++ b/src/Illuminate/Foundation/DevCommands.php
@@ -8,8 +8,19 @@ use ReflectionClass;
 
 class DevCommands
 {
+    /**
+     * Counter to keep track of how many colors have been assigned,
+     * used to ensure colors are reused only after all have been used at least once.
+     *
+     * @var int
+     */
     protected static $colorCount = 0;
 
+    /**
+     * Predefined colors to assign to commands when displayed in the console.
+     *
+     * @var array<int, string>
+     */
     protected static $colors = [
         DevCommand::BLUE,
         DevCommand::PURPLE,
@@ -19,12 +30,32 @@ class DevCommands
         DevCommand::YELLOW,
     ];
 
+    /**
+     * The resolved NodePackageManager instance.
+     *
+     * @var null|NodePackageManager
+     */
     protected static ?NodePackageManager $packageManager = null;
 
+    /**
+     * The registered development commands.
+     *
+     * @var array
+     */
     protected static $commands = [];
 
+    /**
+     * The names of commands that should be excluded when running the "dev" command.
+     *
+     * @var array
+     */
     protected static $except = [];
 
+    /**
+     * The names of commands that should be included when running the "dev" command.
+     *
+     * @var array
+     */
     protected static $only = [];
 
     /**
@@ -43,8 +74,8 @@ class DevCommands
     /**
      * Register a development command.
      *
-     * @param string $command
-     * @param null|string $name
+     * @param  string  $command
+     * @param  null|string  $name
      * @return DevCommand
      */
     public static function register(string $command, ?string $name = null): DevCommand
@@ -66,8 +97,8 @@ class DevCommands
     /**
      * Registers an Artisan command, automatically prefixing it with "php artisan".
      *
-     * @param string $command
-     * @param null|string $name
+     * @param  string  $command
+     * @param  null|string  $name
      * @return DevCommand
      */
     public static function artisan(string $command, ?string $name = null): DevCommand
@@ -78,8 +109,8 @@ class DevCommands
     /**
      * Registers a Node command, automatically prefixing it with the detected package manager's run command.
      *
-     * @param string $command
-     * @param null|string $name
+     * @param  string  $command
+     * @param  null|string  $name
      * @return DevCommand
      */
     public static function node(string $command, ?string $name = null): DevCommand
@@ -90,8 +121,8 @@ class DevCommands
     /**
      * Registers a Node command, automatically prefixing it with the detected package manager's exec command.
      *
-     * @param string $command
-     * @param null|string $name
+     * @param  string  $command
+     * @param  null|string  $name
      * @return DevCommand
      */
     public static function nodeExec(string $command, ?string $name = null): DevCommand
@@ -102,7 +133,7 @@ class DevCommands
     /**
      * Set the commands that should be included when running the "dev" command, excluding any commands not in the given list.
      *
-     * @param mixed ...$commands
+     * @param  mixed  ...$commands
      * @return void
      */
     public static function except(...$commands): void
@@ -113,7 +144,7 @@ class DevCommands
     /**
      * Set the commands that should be included when running the "dev" command, excluding any commands not in the given list.
      *
-     * @param mixed ...$commands
+     * @param  mixed  ...$commands
      * @return void
      */
     public static function only(...$commands): void
@@ -133,7 +164,7 @@ class DevCommands
         foreach (self::$commands as $command) {
             $cmd = $command->toArray();
 
-            if ((!empty(self::$only) && !in_array($cmd['name'], self::$only)) || in_array($cmd['name'], self::$except)) {
+            if ((! empty(self::$only) && ! in_array($cmd['name'], self::$only)) || in_array($cmd['name'], self::$except)) {
                 continue;
             }
 
@@ -172,8 +203,9 @@ class DevCommands
     /**
      * Prevent automatic registration of DevCommands from within vendor packages.
      *
-     * @param string $name
+     * @param  string  $name
      * @return void
+     *
      * @throws Exception
      */
     protected static function preventVendorRegistration(string $name)
@@ -214,7 +246,7 @@ class DevCommands
     /**
      * Derive a command name from the given command string by taking the first word.
      *
-     * @param string $command
+     * @param  string  $command
      * @return string
      */
     protected static function nameFromCommand(string $command): string
@@ -225,7 +257,7 @@ class DevCommands
     /**
      * Fill in any empty colors in the given commands array, ensuring each command has a color assigned.
      *
-     * @param array $commands
+     * @param  array  $commands
      * @return array
      */
     protected static function fillInEmptyColors(array $commands): array
@@ -242,7 +274,7 @@ class DevCommands
     /**
      * Get a color for a command, ensuring that colors are reused only after all available colors have been used at least once.
      *
-     * @param array $commands
+     * @param  array  $commands
      * @return string
      */
     protected static function getColor(array $commands): string

--- a/src/Illuminate/Foundation/DevCommands.php
+++ b/src/Illuminate/Foundation/DevCommands.php
@@ -23,6 +23,30 @@ class DevCommands
 
     protected static $commands = [];
 
+    protected static $except = [];
+
+    protected static $only = [];
+
+    /**
+     * Register the default development commands.
+     *
+     * @return void
+     */
+    public static function registerDefaults()
+    {
+        self::artisan('serve --host=localhost', 'server');
+        self::artisan('queue:listen --tries=1 --timeout=0', 'queue');
+        self::artisan('pail --timeout=0', 'logs');
+        self::node('dev', 'vite');
+    }
+
+    /**
+     * Register a development command.
+     *
+     * @param string $command
+     * @param null|string $name
+     * @return DevCommand
+     */
     public static function register(string $command, ?string $name = null): DevCommand
     {
         // $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2);
@@ -36,6 +60,106 @@ class DevCommands
         return $devCommand;
     }
 
+    /**
+     * Registers an Artisan command, automatically prefixing it with "php artisan".
+     *
+     * @param string $command
+     * @param null|string $name
+     * @return DevCommand
+     */
+    public static function artisan(string $command, ?string $name = null): DevCommand
+    {
+        return self::register("php artisan {$command}", $name ?? self::nameFromCommand($command));
+    }
+
+    /**
+     * Registers a Node command, automatically prefixing it with the detected package manager's run command.
+     *
+     * @param string $command
+     * @param null|string $name
+     * @return DevCommand
+     */
+    public static function node(string $command, ?string $name = null): DevCommand
+    {
+        return self::register(self::getPackageManager()->getRunCommand($command), $name ?? self::nameFromCommand($command));
+    }
+
+    /**
+     * Registers a Node command, automatically prefixing it with the detected package manager's exec command.
+     *
+     * @param string $command
+     * @param null|string $name
+     * @return DevCommand
+     */
+    public static function nodeExec(string $command, ?string $name = null): DevCommand
+    {
+        return self::register(self::getPackageManager()->getExecCommand($command), $name ?? self::nameFromCommand($command));
+    }
+
+    /**
+     * Set the commands that should be included when running the "dev" command, excluding any commands not in the given list.
+     *
+     * @param mixed ...$commands
+     * @return void
+     */
+    public static function except(...$commands): void
+    {
+        self::$except = $commands;
+    }
+
+    /**
+     * Set the commands that should be included when running the "dev" command, excluding any commands not in the given list.
+     *
+     * @param mixed ...$commands
+     * @return void
+     */
+    public static function only(...$commands): void
+    {
+        self::$only = $commands;
+    }
+
+    /**
+     * Create a new DevCommands instance.
+     *
+     * @return NodePackageManager
+     */
+    protected static function getPackageManager(): NodePackageManager
+    {
+        return self::$packageManager ??= new NodePackageManager();
+    }
+
+    /**
+     * Get the registered development commands.
+     *
+     * @return array
+     */
+    public static function getCommands(): array
+    {
+        $commands = [];
+
+        foreach (self::$commands as $command) {
+            $cmd = $command->toArray();
+
+            if ((!empty(self::$only) && !in_array($cmd['name'], self::$only)) || in_array($cmd['name'], self::$except)) {
+                continue;
+            }
+
+            $commands[] = $cmd;
+        }
+
+        $commands = self::fillInEmptyColors($commands);
+
+        return $commands;
+    }
+
+    /**
+     * Prevent automatic registration of DevCommands from within vendor packages.
+     *
+     * @param string $name
+     * @param array $trace
+     * @return void
+     * @throws Exception
+     */
     protected static function preventVendorRegistration(string $name, array $trace)
     {
         $caller = $trace[1];
@@ -52,53 +176,22 @@ class DevCommands
     }
 
     /**
-     * Registers an Artisan command, automatically prefixing it with "php artisan".
+     * Derive a command name from the given command string by taking the first word.
+     *
+     * @param string $command
+     * @return string
      */
-    public static function artisan(string $command, ?string $name = null): DevCommand
-    {
-        return self::register("php artisan {$command}", $name ?? self::nameFromCommand($command));
-    }
-
-    /**
-     * Registers a JavaScript command, automatically prefixing it with the detected package manager's run command.
-     */
-    public static function node(string $command, ?string $name = null): DevCommand
-    {
-        return self::register(self::getPackageManager()->getRunCommand($command), $name ?? self::nameFromCommand($command));
-    }
-
-    /**
-     * Registers a JavaScript command with the full command provided, bypassing the package manager prefix.
-     */
-    public static function nodeExec(string $command, ?string $name = null): DevCommand
-    {
-        return self::register(self::getPackageManager()->getExecCommand($command), $name ?? self::nameFromCommand($command));
-    }
-
-    protected static function getPackageManager(): NodePackageManager
-    {
-        return self::$packageManager ??= new NodePackageManager();
-    }
-
-    public static function getCommands(): array
-    {
-        $commands = [];
-
-        foreach (self::$commands as $command) {
-            $cmd = $command->toArray();
-            $commands[] = $cmd;
-        }
-
-        $commands = self::fillInEmptyColors($commands);
-
-        return $commands;
-    }
-
     protected static function nameFromCommand(string $command): string
     {
         return collect(explode(' ', $command))->first();
     }
 
+    /**
+     * Fill in any empty colors in the given commands array, ensuring each command has a color assigned.
+     *
+     * @param array $commands
+     * @return array
+     */
     protected static function fillInEmptyColors(array $commands): array
     {
         foreach ($commands as &$command) {
@@ -110,6 +203,12 @@ class DevCommands
         return $commands;
     }
 
+    /**
+     * Get a color for a command, ensuring that colors are reused only after all available colors have been used at least once.
+     *
+     * @param array $commands
+     * @return string
+     */
     protected static function getColor(array $commands): string
     {
         $existing = array_values(array_filter(array_column($commands, 'color')));

--- a/src/Illuminate/Foundation/DevCommands.php
+++ b/src/Illuminate/Foundation/DevCommands.php
@@ -16,7 +16,7 @@ class DevCommands
     protected static ?NodePackageManager $packageManager = null;
 
     /**
-     * Counter to keep track of how many colors have been assigned,
+     * Counter to keep track of how many colors have been assigned,.
      *
      * Used to ensure colors are reused only after all have been used at least once.
      *

--- a/src/Illuminate/Foundation/DevCommands.php
+++ b/src/Illuminate/Foundation/DevCommands.php
@@ -201,6 +201,7 @@ class DevCommands
             }
 
             if (! str_contains($file, base_path('vendor'))) {
+                // We found at least one frame that came from userland code, we're good.
                 return;
             }
         }

--- a/src/Illuminate/Foundation/DevCommands.php
+++ b/src/Illuminate/Foundation/DevCommands.php
@@ -9,19 +9,20 @@ use ReflectionClass;
 class DevCommands
 {
     /**
-     * Counter to keep track of how many colors have been assigned,
-     * used to ensure colors are reused only after all have been used at least once.
-     *
-     * @var int
-     */
-    protected static $colorCount = 0;
-
-    /**
      * The resolved NodePackageManager instance.
      *
      * @var NodePackageManager|null
      */
     protected static ?NodePackageManager $packageManager = null;
+
+    /**
+     * Counter to keep track of how many colors have been assigned,
+     *
+     * Used to ensure colors are reused only after all have been used at least once.
+     *
+     * @var int
+     */
+    protected static $colorCount = 0;
 
     /**
      * The registered development commands.
@@ -31,18 +32,18 @@ class DevCommands
     protected static $commands = [];
 
     /**
-     * The names of commands that should be excluded when running the "dev" command.
-     *
-     * @var array<int, string>
-     */
-    protected static $except = [];
-
-    /**
      * The names of commands that should be included when running the "dev" command.
      *
      * @var array<int, string>
      */
     protected static $only = [];
+
+    /**
+     * The names of commands that should be excluded when running the "dev" command.
+     *
+     * @var array<int, string>
+     */
+    protected static $except = [];
 
     /**
      * Register the default development commands.
@@ -67,7 +68,6 @@ class DevCommands
     public static function register(string $command, ?string $name = null): DevCommand
     {
         if (! app()->runningInConsole()) {
-            // If we're not running in the console, just return a dummy DevCommand instance.
             return new DevCommand('', '');
         }
 
@@ -117,28 +117,6 @@ class DevCommands
     }
 
     /**
-     * Set the commands that should be excluded when running the "dev" command.
-     *
-     * @param  string  ...$names
-     * @return void
-     */
-    public static function except(...$names): void
-    {
-        self::$except = $names;
-    }
-
-    /**
-     * Set the commands that should be included when running the "dev" command.
-     *
-     * @param  string  ...$names
-     * @return void
-     */
-    public static function only(...$names): void
-    {
-        self::$only = $names;
-    }
-
-    /**
      * Get the registered development commands.
      *
      * @return array
@@ -157,33 +135,40 @@ class DevCommands
             $commands[] = $cmd;
         }
 
-        $commands = self::fillInEmptyColors($commands);
+        return self::fillInEmptyColors($commands);
+    }
+
+    /**
+     * Fill in any empty colors in the given commands array, ensuring each command has a color assigned.
+     *
+     * @param  array  $commands
+     * @return array
+     */
+    protected static function fillInEmptyColors(array $commands): array
+    {
+        foreach ($commands as &$command) {
+            if (empty($command['color'])) {
+                $command['color'] = self::getColor($commands);
+            }
+        }
 
         return $commands;
     }
 
     /**
-     * Clear all registered development commands and reset the state of the DevCommands class,
-     * including registered commands, exceptions, inclusions, and color assignments.
+     * Get a color for a command, ensuring that colors are reused only after all available colors have been used at least once.
      *
-     * @return void
+     * @param  array  $commands
+     * @return string
      */
-    public static function clear(): void
+    protected static function getColor(array $commands): string
     {
-        self::$commands = [];
-        self::$except = [];
-        self::$only = [];
-        self::$colorCount = 0;
-    }
+        $available = array_values(array_diff(
+            $colors = array_map(fn ($color) => $color->value, DevCommandColor::cases()),
+            $existing = array_values(array_filter(array_column($commands, 'color')))
+        ));
 
-    /**
-     * Resolve and return the NodePackageManager instance.
-     *
-     * @return NodePackageManager
-     */
-    protected static function getPackageManager(): NodePackageManager
-    {
-        return self::$packageManager ??= new NodePackageManager();
+        return $available[0] ?? $colors[self::$colorCount++ % count($colors)];
     }
 
     /**
@@ -219,7 +204,7 @@ class DevCommands
             }
 
             if (! str_contains($file, base_path('vendor'))) {
-                // We found at least one frame that came from userland code, we're good.
+                // We found at least one frame that came from userland code, we're good...
                 return;
             }
         }
@@ -227,6 +212,28 @@ class DevCommands
         throw new Exception(
             "DevCommands should be registered in application code, not within vendor packages. Attempted to register command: {$name}"
         );
+    }
+
+    /**
+     * Set the commands that should be included when running the "dev" command.
+     *
+     * @param  string  ...$names
+     * @return void
+     */
+    public static function only(...$names): void
+    {
+        self::$only = $names;
+    }
+
+    /**
+     * Set the commands that should be excluded when running the "dev" command.
+     *
+     * @param  string  ...$names
+     * @return void
+     */
+    public static function except(...$names): void
+    {
+        self::$except = $names;
     }
 
     /**
@@ -241,34 +248,25 @@ class DevCommands
     }
 
     /**
-     * Fill in any empty colors in the given commands array, ensuring each command has a color assigned.
+     * Resolve and return the NodePackageManager instance.
      *
-     * @param  array  $commands
-     * @return array
+     * @return NodePackageManager
      */
-    protected static function fillInEmptyColors(array $commands): array
+    protected static function getPackageManager(): NodePackageManager
     {
-        foreach ($commands as &$command) {
-            if (empty($command['color'])) {
-                $command['color'] = self::getColor($commands);
-            }
-        }
-
-        return $commands;
+        return self::$packageManager ??= new NodePackageManager();
     }
 
     /**
-     * Get a color for a command, ensuring that colors are reused only after all available colors have been used at least once.
+     * Clear all registered development commands and reset the state of the DevCommands class.
      *
-     * @param  array  $commands
-     * @return string
+     * @return void
      */
-    protected static function getColor(array $commands): string
+    public static function clear(): void
     {
-        $colors = array_map(fn ($color) => $color->value, DevCommandColor::cases());
-        $existing = array_values(array_filter(array_column($commands, 'color')));
-        $available = array_values(array_diff($colors, $existing));
-
-        return $available[0] ?? $colors[self::$colorCount++ % count($colors)];
+        self::$commands = [];
+        self::$except = [];
+        self::$only = [];
+        self::$colorCount = 0;
     }
 }

--- a/src/Illuminate/Foundation/DevCommands.php
+++ b/src/Illuminate/Foundation/DevCommands.php
@@ -17,20 +17,6 @@ class DevCommands
     protected static $colorCount = 0;
 
     /**
-     * Predefined colors to assign to commands when displayed in the console.
-     *
-     * @var array<int, string>
-     */
-    protected static $colors = [
-        DevCommand::BLUE,
-        DevCommand::PURPLE,
-        DevCommand::PINK,
-        DevCommand::ORANGE,
-        DevCommand::GREEN,
-        DevCommand::YELLOW,
-    ];
-
-    /**
      * The resolved NodePackageManager instance.
      *
      * @var NodePackageManager|null
@@ -279,9 +265,10 @@ class DevCommands
      */
     protected static function getColor(array $commands): string
     {
+        $colors = array_map(fn ($color) => $color->value, DevCommandColor::cases());
         $existing = array_values(array_filter(array_column($commands, 'color')));
-        $available = array_values(array_diff(self::$colors, $existing));
+        $available = array_values(array_diff($colors, $existing));
 
-        return $available[0] ?? self::$colors[self::$colorCount++ % count(self::$colors)];
+        return $available[0] ?? $colors[self::$colorCount++ % count($colors)];
     }
 }

--- a/src/Illuminate/Foundation/DevCommands.php
+++ b/src/Illuminate/Foundation/DevCommands.php
@@ -33,7 +33,7 @@ class DevCommands
     /**
      * The resolved NodePackageManager instance.
      *
-     * @var null|NodePackageManager
+     * @var NodePackageManager|null
      */
     protected static ?NodePackageManager $packageManager = null;
 

--- a/src/Illuminate/Foundation/DevCommands.php
+++ b/src/Illuminate/Foundation/DevCommands.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Illuminate\Foundation;
+
+use Exception;
+use Illuminate\Support\NodePackageManager;
+use ReflectionClass;
+
+class DevCommands
+{
+    protected static $colorCount = 0;
+
+    protected static $colors = [
+        DevCommand::BLUE,
+        DevCommand::PURPLE,
+        DevCommand::PINK,
+        DevCommand::ORANGE,
+        DevCommand::GREEN,
+        DevCommand::YELLOW,
+    ];
+
+    protected static ?NodePackageManager $packageManager = null;
+
+    protected static $commands = [];
+
+    public static function register(string $command, ?string $name = null): DevCommand
+    {
+        // $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2);
+
+        // self::preventVendorRegistration($name, $trace);
+
+        $devCommand = new DevCommand($command, $name);
+
+        self::$commands[$name] = $devCommand;
+
+        return $devCommand;
+    }
+
+    protected static function preventVendorRegistration(string $name, array $trace)
+    {
+        $caller = $trace[1];
+
+        if ($caller['class']) {
+            $reflection = new ReflectionClass($caller['class']);
+
+            if (str_contains($reflection->getFileName(), 'vendor')) {
+                throw new Exception("DevCommands should be registered in application code, not within vendor packages. Attempted to register command: {$name}");
+            }
+        } else if (str_contains($caller['file'], 'vendor')) {
+            throw new Exception("DevCommands should be registered in application code, not within vendor packages. Attempted to register command: {$name}");
+        }
+    }
+
+    /**
+     * Registers an Artisan command, automatically prefixing it with "php artisan".
+     */
+    public static function artisan(string $command, ?string $name = null): DevCommand
+    {
+        return self::register("php artisan {$command}", $name ?? self::nameFromCommand($command));
+    }
+
+    /**
+     * Registers a JavaScript command, automatically prefixing it with the detected package manager's run command.
+     */
+    public static function node(string $command, ?string $name = null): DevCommand
+    {
+        return self::register(self::getPackageManager()->getRunCommand($command), $name ?? self::nameFromCommand($command));
+    }
+
+    /**
+     * Registers a JavaScript command with the full command provided, bypassing the package manager prefix.
+     */
+    public static function nodeExec(string $command, ?string $name = null): DevCommand
+    {
+        return self::register(self::getPackageManager()->getExecCommand($command), $name ?? self::nameFromCommand($command));
+    }
+
+    protected static function getPackageManager(): NodePackageManager
+    {
+        return self::$packageManager ??= new NodePackageManager();
+    }
+
+    public static function getCommands(): array
+    {
+        $commands = [];
+
+        foreach (self::$commands as $command) {
+            $cmd = $command->toArray();
+            $commands[] = $cmd;
+        }
+
+        $commands = self::fillInEmptyColors($commands);
+
+        return $commands;
+    }
+
+    protected static function nameFromCommand(string $command): string
+    {
+        return collect(explode(' ', $command))->first();
+    }
+
+    protected static function fillInEmptyColors(array $commands): array
+    {
+        foreach ($commands as &$command) {
+            if (empty($command['color'])) {
+                $command['color'] = self::getColor($commands);
+            }
+        }
+
+        return $commands;
+    }
+
+    protected static function getColor(array $commands): string
+    {
+        $existing = array_values(array_filter(array_column($commands, 'color')));
+        $available = array_values(array_diff(self::$colors, $existing));
+
+        return $available[0] ?? self::$colors[self::$colorCount++ % count(self::$colors)];
+    }
+}

--- a/src/Illuminate/Foundation/DevCommands.php
+++ b/src/Illuminate/Foundation/DevCommands.php
@@ -188,7 +188,7 @@ class DevCommands
                 continue;
             }
 
-            if (!$file && $class) {
+            if (! $file && $class) {
                 $file = (new ReflectionClass($class))->getFileName();
             }
 
@@ -196,14 +196,18 @@ class DevCommands
                 continue;
             }
 
-            // The first non-DevCommands frame is the actual caller.
-            // If it's in vendor, it's auto-registration. If not, the user initiated it.
-            if (str_contains($file, base_path('vendor'))) {
-                throw new Exception(
-                    "DevCommands should be registered in application code, not within vendor packages. Attempted to register command: {$name}"
-                );
+            if (! $file) {
+                continue;
+            }
+
+            if (! str_contains($file, base_path('vendor'))) {
+                return;
             }
         }
+
+        throw new Exception(
+            "DevCommands should be registered in application code, not within vendor packages. Attempted to register command: {$name}"
+        );
     }
 
     /**

--- a/src/Illuminate/Foundation/DevCommands.php
+++ b/src/Illuminate/Foundation/DevCommands.php
@@ -49,7 +49,12 @@ class DevCommands
      */
     public static function register(string $command, ?string $name = null): DevCommand
     {
-        self::preventVendorRegistration($name);
+        if (! app()->runningInConsole()) {
+            // If we're not running in the console, just return a dummy DevCommand instance.
+            return new DevCommand('', '');
+        }
+
+        self::preventVendorRegistration($name ?? $command);
 
         $devCommand = new DevCommand($command, $name);
 
@@ -141,7 +146,8 @@ class DevCommands
     }
 
     /**
-     * Clear all registered development commands and reset the state of the DevCommands class, including registered commands, exceptions, inclusions, and color assignments.
+     * Clear all registered development commands and reset the state of the DevCommands class,
+     * including registered commands, exceptions, inclusions, and color assignments.
      *
      * @return void
      */
@@ -173,16 +179,30 @@ class DevCommands
     protected static function preventVendorRegistration(string $name)
     {
         $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
-        $caller = $trace[1];
 
-        if ($caller['class']) {
-            $reflection = new ReflectionClass($caller['class']);
+        foreach ($trace as $frame) {
+            $file = $frame['file'] ?? null;
+            $class = $frame['class'] ?? null;
 
-            if (str_contains($reflection->getFileName(), 'vendor')) {
-                throw new Exception("DevCommands should be registered in application code, not within vendor packages. Attempted to register command: {$name}");
+            if ($class === self::class) {
+                continue;
             }
-        } else if (str_contains($caller['file'], 'vendor')) {
-            throw new Exception("DevCommands should be registered in application code, not within vendor packages. Attempted to register command: {$name}");
+
+            if (!$file && $class) {
+                $file = (new ReflectionClass($class))->getFileName();
+            }
+
+            if ($file === base_path('artisan')) {
+                continue;
+            }
+
+            // The first non-DevCommands frame is the actual caller.
+            // If it's in vendor, it's auto-registration. If not, the user initiated it.
+            if (str_contains($file, base_path('vendor'))) {
+                throw new Exception(
+                    "DevCommands should be registered in application code, not within vendor packages. Attempted to register command: {$name}"
+                );
+            }
         }
     }
 

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -45,6 +45,7 @@ use Illuminate\Foundation\Console\ConfigMakeCommand;
 use Illuminate\Foundation\Console\ConfigPublishCommand;
 use Illuminate\Foundation\Console\ConfigShowCommand;
 use Illuminate\Foundation\Console\ConsoleMakeCommand;
+use Illuminate\Foundation\Console\DevCommand;
 use Illuminate\Foundation\Console\DocsCommand;
 use Illuminate\Foundation\Console\DownCommand;
 use Illuminate\Foundation\Console\EnumMakeCommand;
@@ -204,6 +205,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'ConfigPublish' => ConfigPublishCommand::class,
         'ConsoleMake' => ConsoleMakeCommand::class,
         'ControllerMake' => ControllerMakeCommand::class,
+        'Dev' => DevCommand::class,
         'Docs' => DocsCommand::class,
         'EnumMake' => EnumMakeCommand::class,
         'EventGenerate' => EventGenerateCommand::class,

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -92,6 +92,7 @@ use Illuminate\Foundation\Console\VendorPublishCommand;
 use Illuminate\Foundation\Console\ViewCacheCommand;
 use Illuminate\Foundation\Console\ViewClearCommand;
 use Illuminate\Foundation\Console\ViewMakeCommand;
+use Illuminate\Foundation\DevCommands;
 use Illuminate\Notifications\Console\NotificationTableCommand;
 use Illuminate\Queue\Console\BatchesTableCommand;
 use Illuminate\Queue\Console\ClearCommand as QueueClearCommand;
@@ -259,6 +260,16 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
                 && ! $this->app->runningUnitTests()
                 && extension_loaded('pcntl');
         });
+    }
+
+    /**
+     * Bootstrap the application services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        DevCommands::registerDefaults();
     }
 
     /**

--- a/src/Illuminate/Support/Contracts/NodePackageManager.php
+++ b/src/Illuminate/Support/Contracts/NodePackageManager.php
@@ -4,7 +4,7 @@ namespace Illuminate\Support\Contracts;
 
 interface NodePackageManager
 {
-    public static function isInUse(): bool;
+    public static function matches(): bool;
 
     public function getRunCommand(string $command): string;
 

--- a/src/Illuminate/Support/Contracts/NodePackageManager.php
+++ b/src/Illuminate/Support/Contracts/NodePackageManager.php
@@ -4,9 +4,26 @@ namespace Illuminate\Support\Contracts;
 
 interface NodePackageManager
 {
+    /**
+     * Determine if the package manager is in use.
+     *
+     * @return bool
+     */
     public static function matches(): bool;
 
+    /**
+     * Get the command to run a script using the package manager.
+     *
+     * @param  string  $command
+     * @return string
+     */
     public function getRunCommand(string $command): string;
 
+    /**
+     * Get the command to execute a package using the package manager.
+     *
+     * @param  string  $command
+     * @return string
+     */
     public function getExecCommand(string $command): string;
 }

--- a/src/Illuminate/Support/Contracts/NodePackageManager.php
+++ b/src/Illuminate/Support/Contracts/NodePackageManager.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Illuminate\Support\Contracts;
+
+interface NodePackageManager
+{
+    public static function isInUse(): bool;
+
+    public function getRunCommand(string $command): string;
+
+    public function getExecCommand(string $command): string;
+}

--- a/src/Illuminate/Support/NodePackageManager.php
+++ b/src/Illuminate/Support/NodePackageManager.php
@@ -29,7 +29,7 @@ class NodePackageManager
     /**
      * Get the command to execute a package using the detected package manager.
      *
-     * @param string $command
+     * @param  string  $command
      * @return string
      */
     public function getExecCommand(string $command): string
@@ -40,7 +40,7 @@ class NodePackageManager
     /**
      * Get the command to run a script using the detected package manager.
      *
-     * @param string $command
+     * @param  string  $command
      * @return string
      */
     public function getRunCommand(string $command): string

--- a/src/Illuminate/Support/NodePackageManager.php
+++ b/src/Illuminate/Support/NodePackageManager.php
@@ -62,7 +62,7 @@ class NodePackageManager
         ];
 
         foreach ($candidates as $packageManager) {
-            if ($packageManager::isInUse()) {
+            if ($packageManager::matches()) {
                 return new $packageManager;
             }
         }

--- a/src/Illuminate/Support/NodePackageManager.php
+++ b/src/Illuminate/Support/NodePackageManager.php
@@ -17,16 +17,6 @@ class NodePackageManager
     }
 
     /**
-     * Get the node package manager in use.
-     *
-     * @return NodePackageManagerContract
-     */
-    public function packageManager(): NodePackageManagerContract
-    {
-        return $this->packageManager ??= $this->detect();
-    }
-
-    /**
      * Get the command to execute a package using the detected package manager.
      *
      * @param  string  $command
@@ -49,19 +39,27 @@ class NodePackageManager
     }
 
     /**
+     * Get the Node package manager in use.
+     *
+     * @return NodePackageManagerContract
+     */
+    public function packageManager(): NodePackageManagerContract
+    {
+        return $this->packageManager ??= $this->detect();
+    }
+
+    /**
      * Detect the current package manager.
      *
      * @return NodePackageManagerContract
      */
     protected function detect(): NodePackageManagerContract
     {
-        $candidates = [
+        foreach ([
             NodePackageManagers\Bun::class,
             NodePackageManagers\Pnpm::class,
             NodePackageManagers\Yarn::class,
-        ];
-
-        foreach ($candidates as $packageManager) {
+        ] as $packageManager) {
             if ($packageManager::matches()) {
                 return new $packageManager;
             }

--- a/src/Illuminate/Support/NodePackageManager.php
+++ b/src/Illuminate/Support/NodePackageManager.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Illuminate\Support;
+
+use Illuminate\Support\Contracts\NodePackageManager as NodePackageManagerContract;
+
+class NodePackageManager
+{
+    /**
+     * Create a new NodePackageManager manager instance.
+     *
+     * @param  NodePackageManager|null  $packageManager
+     */
+    public function __construct(protected ?NodePackageManagerContract $packageManager = null)
+    {
+        //
+    }
+
+    /**
+     * Get the node package manager in use.
+     *
+     * @return NodePackageManagerContract
+     */
+    public function packageManager(): NodePackageManagerContract
+    {
+        return $this->packageManager ??= $this->detect();
+    }
+
+    /**
+     * Get the command to run a script using the detected package manager.
+     *
+     * @param string $command
+     * @return string
+     */
+    public function getExecCommand(string $command): string
+    {
+        return $this->packageManager()->getExecCommand($command);
+    }
+
+    /**
+     * Get the command to run a script using the detected package manager.
+     *
+     * @param string $command
+     * @return string
+     */
+    public function getRunCommand(string $command): string
+    {
+        return $this->packageManager()->getRunCommand($command);
+    }
+
+    /**
+     * Detect the current package manager.
+     *
+     * @return NodePackageManagerContract
+     */
+    protected function detect(): NodePackageManagerContract
+    {
+        $candidates = [
+            NodePackageManagers\Bun::class,
+            NodePackageManagers\Pnpm::class,
+            NodePackageManagers\Yarn::class,
+        ];
+
+        foreach ($candidates as $packageManager) {
+            if ($packageManager::isInUse()) {
+                return new $packageManager;
+            }
+        }
+
+        return new NodePackageManagers\Npm;
+    }
+}

--- a/src/Illuminate/Support/NodePackageManager.php
+++ b/src/Illuminate/Support/NodePackageManager.php
@@ -9,7 +9,7 @@ class NodePackageManager
     /**
      * Create a new NodePackageManager manager instance.
      *
-     * @param  NodePackageManager|null  $packageManager
+     * @param  NodePackageManagerContract|null  $packageManager
      */
     public function __construct(protected ?NodePackageManagerContract $packageManager = null)
     {
@@ -27,7 +27,7 @@ class NodePackageManager
     }
 
     /**
-     * Get the command to run a script using the detected package manager.
+     * Get the command to execute a package using the detected package manager.
      *
      * @param string $command
      * @return string

--- a/src/Illuminate/Support/NodePackageManagers/Bun.php
+++ b/src/Illuminate/Support/NodePackageManagers/Bun.php
@@ -14,7 +14,7 @@ class Bun implements NodePackageManager
     public static function matches(): bool
     {
         foreach (['bun.lock', 'bun.lockb'] as $lockFile) {
-            if (file_exists(getcwd() . '/' . $lockFile)) {
+            if (file_exists(getcwd().'/'.$lockFile)) {
                 return true;
             }
         }
@@ -25,7 +25,7 @@ class Bun implements NodePackageManager
     /**
      * Get the command to run a script using bun.
      *
-     * @param string $command
+     * @param  string  $command
      * @return string
      */
     public function getRunCommand(string $command): string
@@ -36,7 +36,7 @@ class Bun implements NodePackageManager
     /**
      * Get the command to execute a package using bun.
      *
-     * @param string $command
+     * @param  string  $command
      * @return string
      */
     public function getExecCommand(string $command): string

--- a/src/Illuminate/Support/NodePackageManagers/Bun.php
+++ b/src/Illuminate/Support/NodePackageManagers/Bun.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Illuminate\Support\NodePackageManagers;
+
+use Illuminate\Support\Contracts\NodePackageManager;
+
+class Bun implements NodePackageManager
+{
+    /**
+     * Determine if the bun package manager is in use.
+     *
+     * @return bool
+     */
+    public static function isInUse(): bool
+    {
+        foreach (['bun.lock', 'bun.lockb'] as $lockFile) {
+            if (file_exists(getcwd() . '/' . $lockFile)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Get the command to run a script using bun.
+     *
+     * @param string $command
+     * @return string
+     */
+    public function getRunCommand(string $command): string
+    {
+        return "bun run {$command}";
+    }
+
+    /**
+     * Get the command to execute a package using bun.
+     *
+     * @param string $command
+     * @return string
+     */
+    public function getExecCommand(string $command): string
+    {
+        return "bunx {$command}";
+    }
+}

--- a/src/Illuminate/Support/NodePackageManagers/Bun.php
+++ b/src/Illuminate/Support/NodePackageManagers/Bun.php
@@ -11,7 +11,7 @@ class Bun implements NodePackageManager
      *
      * @return bool
      */
-    public static function isInUse(): bool
+    public static function matches(): bool
     {
         foreach (['bun.lock', 'bun.lockb'] as $lockFile) {
             if (file_exists(getcwd() . '/' . $lockFile)) {

--- a/src/Illuminate/Support/NodePackageManagers/Bun.php
+++ b/src/Illuminate/Support/NodePackageManagers/Bun.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Contracts\NodePackageManager;
 class Bun implements NodePackageManager
 {
     /**
-     * Determine if the bun package manager is in use.
+     * Determine if the Bun package manager is in use.
      *
      * @return bool
      */
@@ -23,7 +23,7 @@ class Bun implements NodePackageManager
     }
 
     /**
-     * Get the command to run a script using bun.
+     * Get the command to run a script using Bun.
      *
      * @param  string  $command
      * @return string
@@ -34,7 +34,7 @@ class Bun implements NodePackageManager
     }
 
     /**
-     * Get the command to execute a package using bun.
+     * Get the command to execute a package using Bun.
      *
      * @param  string  $command
      * @return string

--- a/src/Illuminate/Support/NodePackageManagers/Npm.php
+++ b/src/Illuminate/Support/NodePackageManagers/Npm.php
@@ -13,13 +13,13 @@ class Npm implements NodePackageManager
      */
     public static function matches(): bool
     {
-        return file_exists(getcwd() . '/package-lock.json');
+        return file_exists(getcwd().'/package-lock.json');
     }
 
     /**
      * Get the command to run a script using npm.
      *
-     * @param string $command
+     * @param  string  $command
      * @return string
      */
     public function getRunCommand(string $command): string
@@ -30,7 +30,7 @@ class Npm implements NodePackageManager
     /**
      * Get the command to execute a package using npm.
      *
-     * @param string $command
+     * @param  string  $command
      * @return string
      */
     public function getExecCommand(string $command): string

--- a/src/Illuminate/Support/NodePackageManagers/Npm.php
+++ b/src/Illuminate/Support/NodePackageManagers/Npm.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Illuminate\Support\NodePackageManagers;
+
+use Illuminate\Support\Contracts\NodePackageManager;
+
+class Npm implements NodePackageManager
+{
+    /**
+     * Determine if the npm package manager is in use.
+     *
+     * @return bool
+     */
+    public static function isInUse(): bool
+    {
+        return file_exists(getcwd() . '/package-lock.json');
+    }
+
+    /**
+     * Get the command to run a script using npm.
+     *
+     * @param string $command
+     * @return string
+     */
+    public function getRunCommand(string $command): string
+    {
+        return "npm run {$command}";
+    }
+
+    /**
+     * Get the command to execute a package using npm.
+     *
+     * @param string $command
+     * @return string
+     */
+    public function getExecCommand(string $command): string
+    {
+        return "npx {$command}";
+    }
+}

--- a/src/Illuminate/Support/NodePackageManagers/Npm.php
+++ b/src/Illuminate/Support/NodePackageManagers/Npm.php
@@ -11,7 +11,7 @@ class Npm implements NodePackageManager
      *
      * @return bool
      */
-    public static function isInUse(): bool
+    public static function matches(): bool
     {
         return file_exists(getcwd() . '/package-lock.json');
     }

--- a/src/Illuminate/Support/NodePackageManagers/Pnpm.php
+++ b/src/Illuminate/Support/NodePackageManagers/Pnpm.php
@@ -13,13 +13,13 @@ class Pnpm implements NodePackageManager
      */
     public static function matches(): bool
     {
-        return file_exists(getcwd() . '/pnpm-lock.yaml');
+        return file_exists(getcwd().'/pnpm-lock.yaml');
     }
 
     /**
      * Get the command to run a script using pnpm.
      *
-     * @param string $command
+     * @param  string  $command
      * @return string
      */
     public function getRunCommand(string $command): string
@@ -30,7 +30,7 @@ class Pnpm implements NodePackageManager
     /**
      * Get the command to execute a package using pnpm.
      *
-     * @param string $command
+     * @param  string  $command
      * @return string
      */
     public function getExecCommand(string $command): string

--- a/src/Illuminate/Support/NodePackageManagers/Pnpm.php
+++ b/src/Illuminate/Support/NodePackageManagers/Pnpm.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Illuminate\Support\NodePackageManagers;
+
+use Illuminate\Support\Contracts\NodePackageManager;
+
+class Pnpm implements NodePackageManager
+{
+    /**
+     * Determine if the pnpm package manager is in use.
+     *
+     * @return bool
+     */
+    public static function isInUse(): bool
+    {
+        return file_exists(getcwd() . '/pnpm-lock.yaml');
+    }
+
+    /**
+     * Get the command to run a script using pnpm.
+     *
+     * @param string $command
+     * @return string
+     */
+    public function getRunCommand(string $command): string
+    {
+        return "pnpm run {$command}";
+    }
+
+    /**
+     * Get the command to execute a package using pnpm.
+     *
+     * @param string $command
+     * @return string
+     */
+    public function getExecCommand(string $command): string
+    {
+        return "pnpm dlx {$command}";
+    }
+}

--- a/src/Illuminate/Support/NodePackageManagers/Pnpm.php
+++ b/src/Illuminate/Support/NodePackageManagers/Pnpm.php
@@ -11,7 +11,7 @@ class Pnpm implements NodePackageManager
      *
      * @return bool
      */
-    public static function isInUse(): bool
+    public static function matches(): bool
     {
         return file_exists(getcwd() . '/pnpm-lock.yaml');
     }

--- a/src/Illuminate/Support/NodePackageManagers/Yarn.php
+++ b/src/Illuminate/Support/NodePackageManagers/Yarn.php
@@ -11,7 +11,7 @@ class Yarn implements NodePackageManager
      *
      * @return bool
      */
-    public static function isInUse(): bool
+    public static function matches(): bool
     {
         return file_exists(getcwd() . '/yarn.lock');
     }

--- a/src/Illuminate/Support/NodePackageManagers/Yarn.php
+++ b/src/Illuminate/Support/NodePackageManagers/Yarn.php
@@ -13,13 +13,13 @@ class Yarn implements NodePackageManager
      */
     public static function matches(): bool
     {
-        return file_exists(getcwd() . '/yarn.lock');
+        return file_exists(getcwd().'/yarn.lock');
     }
 
     /**
      * Get the command to run a script using yarn.
      *
-     * @param string $command
+     * @param  string  $command
      * @return string
      */
     public function getRunCommand(string $command): string
@@ -30,7 +30,7 @@ class Yarn implements NodePackageManager
     /**
      * Get the command to execute a package using yarn.
      *
-     * @param string $command
+     * @param  string  $command
      * @return string
      */
     public function getExecCommand(string $command): string

--- a/src/Illuminate/Support/NodePackageManagers/Yarn.php
+++ b/src/Illuminate/Support/NodePackageManagers/Yarn.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Contracts\NodePackageManager;
 class Yarn implements NodePackageManager
 {
     /**
-     * Determine if the yarn package manager is in use.
+     * Determine if the Yarn package manager is in use.
      *
      * @return bool
      */
@@ -17,7 +17,7 @@ class Yarn implements NodePackageManager
     }
 
     /**
-     * Get the command to run a script using yarn.
+     * Get the command to run a script using Yarn.
      *
      * @param  string  $command
      * @return string
@@ -28,7 +28,7 @@ class Yarn implements NodePackageManager
     }
 
     /**
-     * Get the command to execute a package using yarn.
+     * Get the command to execute a package using Yarn.
      *
      * @param  string  $command
      * @return string

--- a/src/Illuminate/Support/NodePackageManagers/Yarn.php
+++ b/src/Illuminate/Support/NodePackageManagers/Yarn.php
@@ -16,7 +16,8 @@ class Yarn implements NodePackageManager
         return file_exists(getcwd() . '/yarn.lock');
     }
 
-    /* Get the command to run a script using yarn.
+    /**
+     * Get the command to run a script using yarn.
      *
      * @param string $command
      * @return string

--- a/src/Illuminate/Support/NodePackageManagers/Yarn.php
+++ b/src/Illuminate/Support/NodePackageManagers/Yarn.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Illuminate\Support\NodePackageManagers;
+
+use Illuminate\Support\Contracts\NodePackageManager;
+
+class Yarn implements NodePackageManager
+{
+    /**
+     * Determine if the yarn package manager is in use.
+     *
+     * @return bool
+     */
+    public static function isInUse(): bool
+    {
+        return file_exists(getcwd() . '/yarn.lock');
+    }
+
+    /* Get the command to run a script using yarn.
+     *
+     * @param string $command
+     * @return string
+     */
+    public function getRunCommand(string $command): string
+    {
+        return "yarn run {$command}";
+    }
+
+    /**
+     * Get the command to execute a package using yarn.
+     *
+     * @param string $command
+     * @return string
+     */
+    public function getExecCommand(string $command): string
+    {
+        return "yarn dlx {$command}";
+    }
+}

--- a/tests/Foundation/FoundationDevCommandTest.php
+++ b/tests/Foundation/FoundationDevCommandTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Illuminate\Tests\Foundation;
+
+use Illuminate\Foundation\DevCommand;
+use PHPUnit\Framework\TestCase;
+
+class FoundationDevCommandTest extends TestCase
+{
+    public function testNameDefaultsToFirstWordOfCommand()
+    {
+        $command = new DevCommand('php artisan serve');
+
+        $this->assertSame('php', $command->name());
+    }
+
+    public function testNameCanBeExplicitlySet()
+    {
+        $command = new DevCommand('php artisan serve', 'server');
+
+        $this->assertSame('server', $command->name());
+    }
+
+    public function testToArrayReturnsCommandDetails()
+    {
+        $command = new DevCommand('php artisan serve', 'server');
+
+        $this->assertSame([
+            'command' => 'php artisan serve',
+            'name' => 'server',
+            'color' => null,
+        ], $command->toArray());
+    }
+
+    public function testColorCanBeSet()
+    {
+        $command = new DevCommand('php artisan serve', 'server');
+        $result = $command->color('#ff0000');
+
+        $this->assertSame($command, $result);
+        $this->assertSame('#ff0000', $command->toArray()['color']);
+    }
+
+    public function testBlueColor()
+    {
+        $command = new DevCommand('cmd', 'test');
+        $result = $command->blue();
+
+        $this->assertSame($command, $result);
+        $this->assertSame(DevCommand::BLUE, $command->toArray()['color']);
+    }
+
+    public function testPurpleColor()
+    {
+        $command = new DevCommand('cmd', 'test');
+        $command->purple();
+
+        $this->assertSame(DevCommand::PURPLE, $command->toArray()['color']);
+    }
+
+    public function testPinkColor()
+    {
+        $command = new DevCommand('cmd', 'test');
+        $command->pink();
+
+        $this->assertSame(DevCommand::PINK, $command->toArray()['color']);
+    }
+
+    public function testOrangeColor()
+    {
+        $command = new DevCommand('cmd', 'test');
+        $command->orange();
+
+        $this->assertSame(DevCommand::ORANGE, $command->toArray()['color']);
+    }
+
+    public function testGreenColor()
+    {
+        $command = new DevCommand('cmd', 'test');
+        $command->green();
+
+        $this->assertSame(DevCommand::GREEN, $command->toArray()['color']);
+    }
+
+    public function testYellowColor()
+    {
+        $command = new DevCommand('cmd', 'test');
+        $command->yellow();
+
+        $this->assertSame(DevCommand::YELLOW, $command->toArray()['color']);
+    }
+
+    public function testColorMethodsAreFluent()
+    {
+        $command = new DevCommand('cmd', 'test');
+
+        $this->assertSame($command, $command->blue());
+        $this->assertSame($command, $command->purple());
+        $this->assertSame($command, $command->pink());
+        $this->assertSame($command, $command->orange());
+        $this->assertSame($command, $command->green());
+        $this->assertSame($command, $command->yellow());
+    }
+}

--- a/tests/Foundation/FoundationDevCommandTest.php
+++ b/tests/Foundation/FoundationDevCommandTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Foundation;
 
 use Illuminate\Foundation\DevCommand;
+use Illuminate\Foundation\DevCommandColor;
 use PHPUnit\Framework\TestCase;
 
 class FoundationDevCommandTest extends TestCase
@@ -47,7 +48,7 @@ class FoundationDevCommandTest extends TestCase
         $result = $command->blue();
 
         $this->assertSame($command, $result);
-        $this->assertSame(DevCommand::BLUE, $command->toArray()['color']);
+        $this->assertSame(DevCommandColor::BLUE->value, $command->toArray()['color']);
     }
 
     public function testPurpleColor()
@@ -55,7 +56,7 @@ class FoundationDevCommandTest extends TestCase
         $command = new DevCommand('cmd', 'test');
         $command->purple();
 
-        $this->assertSame(DevCommand::PURPLE, $command->toArray()['color']);
+        $this->assertSame(DevCommandColor::PURPLE->value, $command->toArray()['color']);
     }
 
     public function testPinkColor()
@@ -63,7 +64,7 @@ class FoundationDevCommandTest extends TestCase
         $command = new DevCommand('cmd', 'test');
         $command->pink();
 
-        $this->assertSame(DevCommand::PINK, $command->toArray()['color']);
+        $this->assertSame(DevCommandColor::PINK->value, $command->toArray()['color']);
     }
 
     public function testOrangeColor()
@@ -71,7 +72,7 @@ class FoundationDevCommandTest extends TestCase
         $command = new DevCommand('cmd', 'test');
         $command->orange();
 
-        $this->assertSame(DevCommand::ORANGE, $command->toArray()['color']);
+        $this->assertSame(DevCommandColor::ORANGE->value, $command->toArray()['color']);
     }
 
     public function testGreenColor()
@@ -79,7 +80,7 @@ class FoundationDevCommandTest extends TestCase
         $command = new DevCommand('cmd', 'test');
         $command->green();
 
-        $this->assertSame(DevCommand::GREEN, $command->toArray()['color']);
+        $this->assertSame(DevCommandColor::GREEN->value, $command->toArray()['color']);
     }
 
     public function testYellowColor()
@@ -87,7 +88,7 @@ class FoundationDevCommandTest extends TestCase
         $command = new DevCommand('cmd', 'test');
         $command->yellow();
 
-        $this->assertSame(DevCommand::YELLOW, $command->toArray()['color']);
+        $this->assertSame(DevCommandColor::YELLOW->value, $command->toArray()['color']);
     }
 
     public function testColorMethodsAreFluent()

--- a/tests/Foundation/FoundationDevCommandsTest.php
+++ b/tests/Foundation/FoundationDevCommandsTest.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Tests\Foundation;
 
-use Exception;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\DevCommand;
 use Illuminate\Foundation\DevCommands;

--- a/tests/Foundation/FoundationDevCommandsTest.php
+++ b/tests/Foundation/FoundationDevCommandsTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Foundation;
 
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\DevCommand;
+use Illuminate\Foundation\DevCommandColor;
 use Illuminate\Foundation\DevCommands;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Process\PhpProcess;
@@ -143,8 +144,8 @@ class FoundationDevCommandsTest extends TestCase
 
         $commands = DevCommands::commands();
 
-        $this->assertSame(DevCommand::PINK, $commands[0]['color']);
-        $this->assertNotSame(DevCommand::PINK, $commands[1]['color']);
+        $this->assertSame(DevCommandColor::PINK->value, $commands[0]['color']);
+        $this->assertNotSame(DevCommandColor::PINK->value, $commands[1]['color']);
     }
 
     public function testAutoColorSkipsExplicitlyUsedColors()
@@ -154,8 +155,8 @@ class FoundationDevCommandsTest extends TestCase
 
         $commands = DevCommands::commands();
 
-        $this->assertSame(DevCommand::BLUE, $commands[0]['color']);
-        $this->assertNotSame(DevCommand::BLUE, $commands[1]['color']);
+        $this->assertSame(DevCommandColor::BLUE->value, $commands[0]['color']);
+        $this->assertNotSame(DevCommandColor::BLUE->value, $commands[1]['color']);
     }
 
     public function testColorsRecycleWhenAllUsed()

--- a/tests/Foundation/FoundationDevCommandsTest.php
+++ b/tests/Foundation/FoundationDevCommandsTest.php
@@ -1,0 +1,267 @@
+<?php
+
+namespace Illuminate\Tests\Foundation;
+
+use Exception;
+use Illuminate\Foundation\Application;
+use Illuminate\Foundation\DevCommand;
+use Illuminate\Foundation\DevCommands;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\PhpProcess;
+
+class FoundationDevCommandsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        DevCommands::clear();
+
+        $app = new Application(__DIR__);
+        $app['env'] = 'testing';
+    }
+
+    protected function tearDown(): void
+    {
+        DevCommands::clear();
+
+        parent::tearDown();
+    }
+
+    public function testRegisterAddsCommand()
+    {
+        $devCommand = DevCommands::register('echo hello', 'greeter');
+
+        $this->assertInstanceOf(DevCommand::class, $devCommand);
+
+        $commands = DevCommands::commands();
+
+        $this->assertCount(1, $commands);
+        $this->assertSame('echo hello', $commands[0]['command']);
+        $this->assertSame('greeter', $commands[0]['name']);
+    }
+
+    public function testRegisterDerivesNameFromCommand()
+    {
+        DevCommands::register('echo hello world');
+
+        $commands = DevCommands::commands();
+
+        $this->assertSame('echo', $commands[0]['name']);
+    }
+
+    public function testArtisanPrefixesCommand()
+    {
+        DevCommands::artisan('serve --host=localhost', 'server');
+
+        $commands = DevCommands::commands();
+
+        $this->assertSame('php artisan serve --host=localhost', $commands[0]['command']);
+        $this->assertSame('server', $commands[0]['name']);
+    }
+
+    public function testArtisanDerivesNameFromCommand()
+    {
+        DevCommands::artisan('queue:listen --tries=1');
+
+        $commands = DevCommands::commands();
+
+        $this->assertSame('queue:listen', $commands[0]['name']);
+    }
+
+    public function testExceptExcludesCommands()
+    {
+        DevCommands::register('echo one', 'one');
+        DevCommands::register('echo two', 'two');
+        DevCommands::register('echo three', 'three');
+
+        DevCommands::except('two');
+
+        $commands = DevCommands::commands();
+
+        $this->assertCount(2, $commands);
+        $this->assertSame('one', $commands[0]['name']);
+        $this->assertSame('three', $commands[1]['name']);
+    }
+
+    public function testOnlyIncludesOnlySpecifiedCommands()
+    {
+        DevCommands::register('echo one', 'one');
+        DevCommands::register('echo two', 'two');
+        DevCommands::register('echo three', 'three');
+
+        DevCommands::only('one', 'three');
+
+        $commands = DevCommands::commands();
+
+        $this->assertCount(2, $commands);
+        $this->assertSame('one', $commands[0]['name']);
+        $this->assertSame('three', $commands[1]['name']);
+    }
+
+    public function testOnlyTakesPrecedenceOverExcept()
+    {
+        DevCommands::register('echo one', 'one');
+        DevCommands::register('echo two', 'two');
+        DevCommands::register('echo three', 'three');
+
+        DevCommands::only('one', 'two');
+        DevCommands::except('two');
+
+        $commands = DevCommands::commands();
+
+        $this->assertCount(1, $commands);
+        $this->assertSame('one', $commands[0]['name']);
+    }
+
+    public function testClearResetsState()
+    {
+        DevCommands::register('echo one', 'one');
+        DevCommands::except('something');
+        DevCommands::only('something');
+
+        DevCommands::clear();
+
+        $this->assertEmpty(DevCommands::commands());
+    }
+
+    public function testCommandsGetAutoAssignedColors()
+    {
+        DevCommands::register('echo one', 'one');
+        DevCommands::register('echo two', 'two');
+
+        $commands = DevCommands::commands();
+
+        $this->assertNotNull($commands[0]['color']);
+        $this->assertNotNull($commands[1]['color']);
+        $this->assertNotSame($commands[0]['color'], $commands[1]['color']);
+    }
+
+    public function testExplicitColorIsPreserved()
+    {
+        DevCommands::register('echo one', 'one')->pink();
+        DevCommands::register('echo two', 'two');
+
+        $commands = DevCommands::commands();
+
+        $this->assertSame(DevCommand::PINK, $commands[0]['color']);
+        $this->assertNotSame(DevCommand::PINK, $commands[1]['color']);
+    }
+
+    public function testAutoColorSkipsExplicitlyUsedColors()
+    {
+        DevCommands::register('echo one', 'one')->blue();
+        DevCommands::register('echo two', 'two');
+
+        $commands = DevCommands::commands();
+
+        $this->assertSame(DevCommand::BLUE, $commands[0]['color']);
+        $this->assertNotSame(DevCommand::BLUE, $commands[1]['color']);
+    }
+
+    public function testColorsRecycleWhenAllUsed()
+    {
+        DevCommands::register('cmd1', 'c1');
+        DevCommands::register('cmd2', 'c2');
+        DevCommands::register('cmd3', 'c3');
+        DevCommands::register('cmd4', 'c4');
+        DevCommands::register('cmd5', 'c5');
+        DevCommands::register('cmd6', 'c6');
+        DevCommands::register('cmd7', 'c7');
+
+        $commands = DevCommands::commands();
+
+        $this->assertCount(7, $commands);
+
+        foreach ($commands as $command) {
+            $this->assertNotNull($command['color']);
+        }
+    }
+
+    public function testRegisteringCommandWithSameNameOverwritesPrevious()
+    {
+        DevCommands::register('echo old', 'myname');
+        DevCommands::register('echo new', 'myname');
+
+        $commands = DevCommands::commands();
+
+        $this->assertCount(1, $commands);
+        $this->assertSame('echo new', $commands[0]['command']);
+    }
+
+    public function testRegisterDefaultsRegistersExpectedCommands()
+    {
+        DevCommands::registerDefaults();
+
+        $commands = DevCommands::commands();
+
+        $this->assertCount(4, $commands);
+
+        $names = array_column($commands, 'name');
+        $this->assertContains('server', $names);
+        $this->assertContains('queue', $names);
+        $this->assertContains('logs', $names);
+        $this->assertContains('vite', $names);
+    }
+
+    public function testVendorRegistrationIsPrevented()
+    {
+        $basePath = realpath(__DIR__.'/../..');
+
+        $process = new PhpProcess(<<<EOF
+<?php
+require '{$basePath}/vendor/autoload.php';
+
+\$app = new Illuminate\Foundation\Application('{$basePath}');
+\$app['env'] = 'testing';
+
+try {
+    // Simulate a vendor package registering a dev command by calling from
+    // a file that only has vendor frames in the backtrace.
+    Illuminate\Foundation\DevCommands::register('echo hello', 'vendor-cmd');
+    echo 'REGISTERED';
+} catch (Exception \$e) {
+    echo 'EXCEPTION:' . \$e->getMessage();
+}
+EOF, $basePath);
+
+        $process->run();
+
+        $this->assertStringContainsString('EXCEPTION:', $process->getOutput());
+        $this->assertStringContainsString('DevCommands should be registered in application code', $process->getOutput());
+    }
+
+    public function testUserlandRegistrationIsAllowed()
+    {
+        $devCommand = DevCommands::register('echo hello', 'test-cmd');
+
+        $this->assertInstanceOf(DevCommand::class, $devCommand);
+        $this->assertSame('echo hello', DevCommands::commands()[0]['command']);
+    }
+
+    public function testVendorHelperCalledFromUserlandIsAllowed()
+    {
+        $basePath = realpath(__DIR__.'/../..');
+        $vendorHelper = $basePath.'/vendor/_test_helper_'.uniqid().'.php';
+
+        file_put_contents($vendorHelper, <<<'PHP'
+<?php
+function _test_register_dev_command() {
+    Illuminate\Foundation\DevCommands::register('echo from-vendor-helper', 'vendor-helper');
+}
+PHP);
+
+        try {
+            require $vendorHelper;
+
+            _test_register_dev_command();
+
+            $commands = DevCommands::commands();
+            $this->assertCount(1, $commands);
+            $this->assertSame('echo from-vendor-helper', $commands[0]['command']);
+            $this->assertSame('vendor-helper', $commands[0]['name']);
+        } finally {
+            unlink($vendorHelper);
+        }
+    }
+}

--- a/tests/Support/SupportNodePackageManagerTest.php
+++ b/tests/Support/SupportNodePackageManagerTest.php
@@ -1,0 +1,282 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use Illuminate\Support\Contracts\NodePackageManager as NodePackageManagerContract;
+use Illuminate\Support\NodePackageManager;
+use Illuminate\Support\NodePackageManagers\Bun;
+use Illuminate\Support\NodePackageManagers\Npm;
+use Illuminate\Support\NodePackageManagers\Pnpm;
+use Illuminate\Support\NodePackageManagers\Yarn;
+use PHPUnit\Framework\TestCase;
+
+class SupportNodePackageManagerTest extends TestCase
+{
+    public function testNpmRunCommand()
+    {
+        $npm = new Npm;
+
+        $this->assertSame('npm run dev', $npm->getRunCommand('dev'));
+    }
+
+    public function testNpmExecCommand()
+    {
+        $npm = new Npm;
+
+        $this->assertSame('npx concurrently', $npm->getExecCommand('concurrently'));
+    }
+
+    public function testNpmMatches()
+    {
+        $dir = sys_get_temp_dir().'/npm_test_'.uniqid();
+        mkdir($dir);
+        touch($dir.'/package-lock.json');
+
+        $original = getcwd();
+        chdir($dir);
+
+        try {
+            $this->assertTrue(Npm::matches());
+        } finally {
+            chdir($original);
+            unlink($dir.'/package-lock.json');
+            rmdir($dir);
+        }
+    }
+
+    public function testNpmDoesNotMatchWithoutLockFile()
+    {
+        $dir = sys_get_temp_dir().'/npm_test_'.uniqid();
+        mkdir($dir);
+
+        $original = getcwd();
+        chdir($dir);
+
+        try {
+            $this->assertFalse(Npm::matches());
+        } finally {
+            chdir($original);
+            rmdir($dir);
+        }
+    }
+
+    public function testYarnRunCommand()
+    {
+        $yarn = new Yarn;
+
+        $this->assertSame('yarn run dev', $yarn->getRunCommand('dev'));
+    }
+
+    public function testYarnExecCommand()
+    {
+        $yarn = new Yarn;
+
+        $this->assertSame('yarn dlx concurrently', $yarn->getExecCommand('concurrently'));
+    }
+
+    public function testYarnMatches()
+    {
+        $dir = sys_get_temp_dir().'/yarn_test_'.uniqid();
+        mkdir($dir);
+        touch($dir.'/yarn.lock');
+
+        $original = getcwd();
+        chdir($dir);
+
+        try {
+            $this->assertTrue(Yarn::matches());
+        } finally {
+            chdir($original);
+            unlink($dir.'/yarn.lock');
+            rmdir($dir);
+        }
+    }
+
+    public function testPnpmRunCommand()
+    {
+        $pnpm = new Pnpm;
+
+        $this->assertSame('pnpm run dev', $pnpm->getRunCommand('dev'));
+    }
+
+    public function testPnpmExecCommand()
+    {
+        $pnpm = new Pnpm;
+
+        $this->assertSame('pnpm dlx concurrently', $pnpm->getExecCommand('concurrently'));
+    }
+
+    public function testPnpmMatches()
+    {
+        $dir = sys_get_temp_dir().'/pnpm_test_'.uniqid();
+        mkdir($dir);
+        touch($dir.'/pnpm-lock.yaml');
+
+        $original = getcwd();
+        chdir($dir);
+
+        try {
+            $this->assertTrue(Pnpm::matches());
+        } finally {
+            chdir($original);
+            unlink($dir.'/pnpm-lock.yaml');
+            rmdir($dir);
+        }
+    }
+
+    public function testBunRunCommand()
+    {
+        $bun = new Bun;
+
+        $this->assertSame('bun run dev', $bun->getRunCommand('dev'));
+    }
+
+    public function testBunExecCommand()
+    {
+        $bun = new Bun;
+
+        $this->assertSame('bunx concurrently', $bun->getExecCommand('concurrently'));
+    }
+
+    public function testBunMatchesWithBunLock()
+    {
+        $dir = sys_get_temp_dir().'/bun_test_'.uniqid();
+        mkdir($dir);
+        touch($dir.'/bun.lock');
+
+        $original = getcwd();
+        chdir($dir);
+
+        try {
+            $this->assertTrue(Bun::matches());
+        } finally {
+            chdir($original);
+            unlink($dir.'/bun.lock');
+            rmdir($dir);
+        }
+    }
+
+    public function testBunMatchesWithBunLockb()
+    {
+        $dir = sys_get_temp_dir().'/bun_test_'.uniqid();
+        mkdir($dir);
+        touch($dir.'/bun.lockb');
+
+        $original = getcwd();
+        chdir($dir);
+
+        try {
+            $this->assertTrue(Bun::matches());
+        } finally {
+            chdir($original);
+            unlink($dir.'/bun.lockb');
+            rmdir($dir);
+        }
+    }
+
+    public function testManagerDelegatesToInjectedPackageManager()
+    {
+        $mock = new class implements NodePackageManagerContract {
+            public static function matches(): bool
+            {
+                return true;
+            }
+
+            public function getRunCommand(string $command): string
+            {
+                return "custom run {$command}";
+            }
+
+            public function getExecCommand(string $command): string
+            {
+                return "custom exec {$command}";
+            }
+        };
+
+        $manager = new NodePackageManager($mock);
+
+        $this->assertSame('custom run dev', $manager->getRunCommand('dev'));
+        $this->assertSame('custom exec vite', $manager->getExecCommand('vite'));
+    }
+
+    public function testManagerDetectsPackageManagerWhenNoneInjected()
+    {
+        $dir = sys_get_temp_dir().'/detect_test_'.uniqid();
+        mkdir($dir);
+        touch($dir.'/package-lock.json');
+
+        $original = getcwd();
+        chdir($dir);
+
+        try {
+            $manager = new NodePackageManager;
+
+            $this->assertSame('npm run dev', $manager->getRunCommand('dev'));
+            $this->assertSame('npx vite', $manager->getExecCommand('vite'));
+        } finally {
+            chdir($original);
+            unlink($dir.'/package-lock.json');
+            rmdir($dir);
+        }
+    }
+
+    public function testDetectionPriorityBunOverNpm()
+    {
+        $dir = sys_get_temp_dir().'/priority_test_'.uniqid();
+        mkdir($dir);
+        touch($dir.'/bun.lock');
+        touch($dir.'/package-lock.json');
+
+        $original = getcwd();
+        chdir($dir);
+
+        try {
+            $manager = new NodePackageManager;
+
+            $this->assertSame('bun run dev', $manager->getRunCommand('dev'));
+        } finally {
+            chdir($original);
+            unlink($dir.'/bun.lock');
+            unlink($dir.'/package-lock.json');
+            rmdir($dir);
+        }
+    }
+
+    public function testDetectionFallsBackToNpm()
+    {
+        $dir = sys_get_temp_dir().'/fallback_test_'.uniqid();
+        mkdir($dir);
+
+        $original = getcwd();
+        chdir($dir);
+
+        try {
+            $manager = new NodePackageManager;
+
+            $this->assertSame('npm run dev', $manager->getRunCommand('dev'));
+        } finally {
+            chdir($original);
+            rmdir($dir);
+        }
+    }
+
+    public function testPackageManagerMethodReturnsDetectedManager()
+    {
+        $dir = sys_get_temp_dir().'/pm_method_test_'.uniqid();
+        mkdir($dir);
+        touch($dir.'/yarn.lock');
+
+        $original = getcwd();
+        chdir($dir);
+
+        try {
+            $manager = new NodePackageManager;
+
+            $this->assertInstanceOf(Yarn::class, $manager->packageManager());
+        } finally {
+            chdir($original);
+            unlink($dir.'/yarn.lock');
+            rmdir($dir);
+        }
+    }
+}

--- a/tests/Support/SupportNodePackageManagerTest.php
+++ b/tests/Support/SupportNodePackageManagerTest.php
@@ -176,7 +176,8 @@ class SupportNodePackageManagerTest extends TestCase
 
     public function testManagerDelegatesToInjectedPackageManager()
     {
-        $mock = new class implements NodePackageManagerContract {
+        $mock = new class implements NodePackageManagerContract
+        {
             public static function matches(): bool
             {
                 return true;


### PR DESCRIPTION
Adds a new `php artisan dev` command that runs your development processes (server, queue worker, log tailing, Vite) concurrently using `concurrently`. The default behavior is effectively the same as the current `composer dev`.

Commands are registered via `DevCommands` and can be customized, filtered with `only`/`except`, and color-coded.

Includes automatic Node package manager detection (npm, yarn, pnpm, bun) and prevents vendor packages from registering dev commands.

## The Pain Point

Adding commands to `composer dev` is tedious and error-prone. With this new convention, you can simply add the following to your service provider, and the new commands will be included in the mix:

```php
DevCommands::artisan('reverb:start');
DevCommands::register('stripe listen --forward-to ' . config('app.url'));
```

You can optionally provide a name for the process as the second argument; otherwise, the name will be the first segment before the first space.

If you'd like a specific color for the command:

```php
DevCommands::artisan('reverb:start', 'reverb')->orange();
DevCommands::register('stripe listen --forward-to ' . config('app.url'))->green();
```

## Vendor Protection

`DevCommands` explicitly prohibits automatic command registration from the `vendor` directory. That said, it does allow a package to provide a helper that can be called from userland code to register commands, for example:

```php
Reverb::registerDevCommands();
```

I'd like more eyes on this part of the code, as it's the most sensitive area of the changes.

## Bonus: Node Package Manager Helper

This PR also includes `NodePackageManager`, which is probably overdue at this point. It auto-detects the package manager based on the lockfiles present, which allows a generic `DevCommand` like the following to auto-resolve to the correct command for the project:

```php
DevCommand::node('dev'); // pnpm run dev
DevCommand::nodeExec('prettier') // pnpm dlx prettier
```

For the scope of this PR, I kept the helper limited to the methods that were necessary for these changes, but they can be easily expanded in the future.