### PR TITLE
[13.x] Throw LogicException when trying to save existing model without defined primary key

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1468,6 +1468,10 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     protected function performUpdate(Builder $query)
     {
+        if (is_null($this->getKeyForSaveQuery())) {
+            throw new LogicException('No primary key defined on model.');
+        }
+
         // If the updating event returns false, we will cancel the update operation so
         // developers can hook Validation systems into their models and cancel this
         // operation if the model does not pass validation. Otherwise, we update.

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1468,10 +1468,6 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     protected function performUpdate(Builder $query)
     {
-        if (is_null($this->getKeyForSaveQuery())) {
-            throw new LogicException('No primary key defined on model.');
-        }
-
         // If the updating event returns false, we will cancel the update operation so
         // developers can hook Validation systems into their models and cancel this
         // operation if the model does not pass validation. Otherwise, we update.
@@ -1533,7 +1529,12 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     protected function setKeysForSaveQuery($query)
     {
-        $query->where($this->getKeyName(), '=', $this->getKeyForSaveQuery());
+        $keyForSaveQuery = $this->getKeyForSaveQuery();
+
+        if (is_null($keyForSaveQuery)) {
+            throw new LogicException('No primary key defined on model.');
+        }
+        $query->where($this->getKeyName(), '=', $keyForSaveQuery);
 
         return $query;
     }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -876,7 +876,7 @@ class DatabaseEloquentModelTest extends TestCase
         $events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
         $events->shouldReceive('until')->once()->with('eloquent.updating: '.get_class($model), $model)->andReturn(false);
         $model->exists = true;
-        $model->id = 123;
+        $model->foo = 'bar';
 
         $this->assertFalse($model->save());
     }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -943,7 +943,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('No primary key defined on model.');
 
-        $model->foo    = 'bar';
+        $model->foo = 'bar';
         $model->exists = true;
 
         $model->save();

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -876,7 +876,7 @@ class DatabaseEloquentModelTest extends TestCase
         $events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
         $events->shouldReceive('until')->once()->with('eloquent.updating: '.get_class($model), $model)->andReturn(false);
         $model->exists = true;
-        $model->foo = 'bar';
+        $model->id = 123;
 
         $this->assertFalse($model->save());
     }
@@ -932,6 +932,21 @@ class DatabaseEloquentModelTest extends TestCase
         $model->exists = true;
 
         $this->assertTrue($model->save());
+    }
+
+    public function testUpdateProcessThrowErrorWhenExistWithoutPrimaryKey()
+    {
+        $model = $this->getMockBuilder(EloquentModelStub::class)->onlyMethods(['newModelQuery'])->getMock();
+        $query = m::mock(Builder::class);
+        $model->expects($this->once())->method('newModelQuery')->willReturn($query);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('No primary key defined on model.');
+
+        $model->foo    = 'bar';
+        $model->exists = true;
+
+        $model->save();
     }
 
     public function testTimestampsAreReturnedAsObjects()


### PR DESCRIPTION
**Issue**

```php
Model::query()
            ->select('my_column_one', 'my_column_two')
            ->each(function (Model $model) {
                $model->my_column_three = $model->my_column_one + $model->my_column_two;
                $model->save(); // <-- return true, but nothing happened in DB
            });
```

**Why**

Because even if the model if flagged as `exists` **we don't know the primary key as not included in our select**.

**Idea**

I think it should be appreciable to replace this **silent-fail** by a `LogicException`.

**Note**

I finally placed the logic inside `Model@setKeysForSaveQuery` to handle pivots and morph models, as they don't have mandatory primary key : their keys logic are located inside `AsPivot` trait, outside of this new condition.

---

Link to an old issue discussing about this use-case : https://github.com/laravel/framework/issues/21886