### PR TITLE
[13.x] Extract ':timer' key suffix into RateLimiter::TIMER_KEY_SUFFIX

### DIFF
--- a/src/Illuminate/Cache/RateLimiter.php
+++ b/src/Illuminate/Cache/RateLimiter.php
@@ -15,6 +15,13 @@ class RateLimiter
     use InteractsWithTime;
 
     /**
+     * The cache key suffix used to store the lockout timer for a key.
+     *
+     * @var string
+     */
+    public const TIMER_KEY_SUFFIX = ':timer';
+
+    /**
      * The cache store implementation.
      *
      * @var \Illuminate\Contracts\Cache\Repository
@@ -127,7 +134,7 @@ class RateLimiter
     public function tooManyAttempts($key, $maxAttempts)
     {
         if ($this->attempts($key) >= $maxAttempts) {
-            if ($this->cache->has($this->cleanRateLimiterKey($key).':timer')) {
+            if ($this->cache->has($this->cleanRateLimiterKey($key).self::TIMER_KEY_SUFFIX)) {
                 return true;
             }
 
@@ -162,7 +169,7 @@ class RateLimiter
         $key = $this->cleanRateLimiterKey($key);
 
         $this->cache->add(
-            $key.':timer', $this->availableAt($decaySeconds), $decaySeconds
+            $key.self::TIMER_KEY_SUFFIX, $this->availableAt($decaySeconds), $decaySeconds
         );
 
         $added = $this->withoutSerializationOrCompression(
@@ -259,7 +266,7 @@ class RateLimiter
 
         $this->resetAttempts($key);
 
-        $this->cache->forget($key.':timer');
+        $this->cache->forget($key.self::TIMER_KEY_SUFFIX);
     }
 
     /**
@@ -272,7 +279,7 @@ class RateLimiter
     {
         $key = $this->cleanRateLimiterKey($key);
 
-        return max(0, $this->cache->get($key.':timer') - $this->currentTime());
+        return max(0, $this->cache->get($key.self::TIMER_KEY_SUFFIX) - $this->currentTime());
     }
 
     /**


### PR DESCRIPTION
This PR extracts the hardcoded `':timer'` cache key suffix in `RateLimiter` into a single named constant.

The suffix was duplicated across four methods (`tooManyAttempts`,`increment`, `clear`, and `availableIn`). 
A typo or change in any one of them would silently break rate limiting, since the timer key would no longer match the one written elsewhere.

Behaviour is completely unchanged the constant resolves to the exact same `':timer'` value. The constant is `public` so packages relying on the timer key can reference it instead of re-hardcoding the string.