### PR TITLE
[13.x] Fix validation bypass in before/after date rules due to null comparison

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -257,7 +257,13 @@ trait ValidatesAttributes
             $date = $this->getDateTimestamp($this->getValue($parameters[0]));
         }
 
-        return $this->compare($this->getDateTimestamp($value), $date, $operator);
+        $first = $this->getDateTimestamp($value);
+
+        if (is_null($first) || is_null($date)) {
+            return false;
+        }
+
+        return $this->compare($first, $date, $operator);
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -6751,6 +6751,20 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['x' => '0001-01-01T00:00'], ['x' => 'after:1970-01-01']);
         $this->assertTrue($v->fails());
+
+        // An invalid (unparseable) date value must not bypass before/after rules via null comparison.
+        $v = new Validator($trans, ['x' => 'invalid-date'], ['x' => 'before:2024-01-01']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['x' => 'invalid-date'], ['x' => 'after:2000-01-01']);
+        $this->assertTrue($v->fails());
+
+        // A valid date must not bypass after when the reference field is absent (resolves to null).
+        $v = new Validator($trans, ['x' => '2024-01-01'], ['x' => 'after:missing_field']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['x' => '2024-01-01'], ['x' => 'before:missing_field']);
+        $this->assertTrue($v->fails());
     }
 
     public function testBeforeAndAfterWithFormat()
@@ -6976,6 +6990,35 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['from' => '2020-05-08', 'to' => '2020-08-05'], ['from' => 'date_format:Y-m-d', 'to' => 'date_format:Y-d-m|after_or_equal:from']);
+        $this->assertTrue($v->passes());
+
+        // An invalid (unparseable) date value must not bypass before_or_equal / after_or_equal
+        // via PHP's null-coercion: compare(null, null, '<=') and compare(null, null, '>=') both
+        // evaluate to true because null is cast to 0. See also: PR #60393 for date_equals.
+        $v = new Validator($trans, ['x' => 'invalid-date'], ['x' => 'before_or_equal:1970-01-01 00:00:00']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['x' => 'invalid-date'], ['x' => 'after_or_equal:1970-01-01 00:00:00']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['x' => 'invalid-date'], ['x' => 'before_or_equal:2024-01-01']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['x' => 'invalid-date'], ['x' => 'after_or_equal:2000-01-01']);
+        $this->assertTrue($v->fails());
+
+        // A valid date must not bypass after_or_equal when the reference field is absent (null).
+        $v = new Validator($trans, ['x' => '2024-01-01'], ['x' => 'after_or_equal:missing_field']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['x' => '1970-01-01'], ['x' => 'before_or_equal:missing_field']);
+        $this->assertTrue($v->fails());
+
+        // Normal valid comparisons remain unaffected.
+        $v = new Validator($trans, ['x' => '2012-01-15'], ['x' => 'before_or_equal:2012-01-15']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => '2012-01-15'], ['x' => 'after_or_equal:2012-01-15']);
         $this->assertTrue($v->passes());
     }
 


### PR DESCRIPTION
This PR fixes a validation bypass in the `before`, `after`, `before_or_equal`, and
`after_or_equal` rules when either the submitted value or the reference date cannot
be parsed into a valid timestamp.

```php
// Passes - but it should fail.
$v = Validator::make(
    ['end_date' => 'invalid-date'],
    ['end_date' => 'before_or_equal:1970-01-01 00:00:00']
);
$v->passes(); // true  bug

// Passes — but it should fail.
$v = Validator::make(
    ['end_date' => '2024-01-01'],
    ['end_date' => 'after_or_equal:missing_field']
);
$v->passes(); // true  bug
