### PR TITLE
[13.x] Fix TokenGuard::validate() when API token is hashed

### DIFF
--- a/src/Illuminate/Auth/TokenGuard.php
+++ b/src/Illuminate/Auth/TokenGuard.php
@@ -114,7 +114,11 @@ class TokenGuard implements Guard
             return false;
         }
 
-        $credentials = [$this->storageKey => $credentials[$this->inputKey]];
+        $token = $credentials[$this->inputKey];
+
+        $credentials = [
+            $this->storageKey => $this->hash ? hash('sha256', $token) : $token,
+        ];
 
         return (bool) $this->provider->retrieveByCredentials($credentials);
     }

--- a/tests/Auth/AuthTokenGuardTest.php
+++ b/tests/Auth/AuthTokenGuardTest.php
@@ -199,6 +199,19 @@ class AuthTokenGuardTest extends TestCase
 
         $this->assertFalse($guard->validate(['custom_token_field' => '']));
     }
+
+    public function testValidateCanDetermineIfCredentialsAreValidWhenHashed()
+    {
+        $provider = m::mock(UserProvider::class);
+        $user = new AuthTokenGuardTestUser;
+        $user->id = 1;
+        $provider->shouldReceive('retrieveByCredentials')->once()->with(['api_token' => hash('sha256', 'foo')])->andReturn($user);
+        $request = Request::create('/', 'GET', ['api_token' => 'foo']);
+
+        $guard = new TokenGuard($provider, $request, 'api_token', 'api_token', $hash = true);
+
+        $this->assertTrue($guard->validate(['api_token' => 'foo']));
+    }
 }
 
 class AuthTokenGuardTestUser


### PR DESCRIPTION
## Description

This PR fixes an issue where the `TokenGuard::validate()` method fails to authenticate users when API token hashing is enabled (`$this->hash` is set to `true`).

### Context

When configuring `TokenGuard` with hashing enabled, `user()` correctly hashes the token prior to querying the database provider:

```php
$user = $this->provider->retrieveByCredentials([
    $this->storageKey => $this->hash ? hash('sha256', $token) : $token,
]);

```

However, `validate()` did not check `$this->hash` and queried the user provider using the raw token directly, causing validation to fail for hashed configurations:

```php
$credentials = [$this->storageKey => $credentials[$this->inputKey]];
return (bool) $this->provider->retrieveByCredentials($credentials);

```

### Solution

This PR updates `validate()` to hash the token (if `$this->hash` is enabled) before calling `retrieveByCredentials()`:

```php
$token = $credentials[$this->inputKey];
$credentials = [
    $this->storageKey => $this->hash ? hash('sha256', $token) : $token,
];

```