### PR TITLE
feat: add response()->created() to ResponseFactory

### DIFF
--- a/src/Illuminate/Contracts/Routing/ResponseFactory.php
+++ b/src/Illuminate/Contracts/Routing/ResponseFactory.php
@@ -18,6 +18,15 @@ interface ResponseFactory
     public function make($content = '', $status = 200, array $headers = []);
 
     /**
+     * Create a new "created" response.
+     *
+     * @param  string  $content
+     * @param  array  $headers
+     * @return \Illuminate\Http\Response
+     */
+    public function created($content = '', array $headers = []);
+
+    /**
      * Create a new "no content" response.
      *
      * @param  int  $status

--- a/src/Illuminate/Routing/ResponseFactory.php
+++ b/src/Illuminate/Routing/ResponseFactory.php
@@ -62,6 +62,18 @@ class ResponseFactory implements FactoryContract
     }
 
     /**
+     * Create a new "created" response.
+     *
+     * @param  string  $content
+     * @param  array  $headers
+     * @return \Illuminate\Http\Response
+     */
+    public function created($content = '', array $headers = [])
+    {
+        return $this->make($content, 201, $headers);
+    }
+
+    /**
      * Create a new "no content" response.
      *
      * @param  int  $status

--- a/tests/Routing/RoutingResponseFactoryTest.php
+++ b/tests/Routing/RoutingResponseFactoryTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Illuminate\Tests\Routing;
+
+use Illuminate\Contracts\View\Factory as ViewFactory;
+use Illuminate\Http\Response;
+use Illuminate\Routing\Redirector;
+use Illuminate\Routing\ResponseFactory;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class RoutingResponseFactoryTest extends TestCase
+{
+    protected ResponseFactory $factory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->factory = new ResponseFactory(
+            m::mock(ViewFactory::class),
+            m::mock(Redirector::class)
+        );
+    }
+
+    public function testMakeResponse()
+    {
+        $response = $this->factory->make('hello', 200, ['X-Foo' => 'bar']);
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame('hello', $response->getContent());
+        $this->assertSame('bar', $response->headers->get('X-Foo'));
+    }
+
+    public function testCreatedResponse()
+    {
+        $response = $this->factory->created();
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertEquals(201, $response->getStatusCode());
+        $this->assertEmpty($response->getContent());
+    }
+
+    public function testCreatedResponseWithContentAndHeaders()
+    {
+        $response = $this->factory->created('{"id":1}', ['X-Foo' => 'bar']);
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertEquals(201, $response->getStatusCode());
+        $this->assertSame('{"id":1}', $response->getContent());
+        $this->assertSame('bar', $response->headers->get('X-Foo'));
+    }
+
+    public function testNoContentResponse()
+    {
+        $response = $this->factory->noContent();
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertEquals(204, $response->getStatusCode());
+        $this->assertEmpty($response->getContent());
+    }
+
+    public function testNoContentResponseWithHeaders()
+    {
+        $response = $this->factory->noContent(204, ['X-Foo' => 'bar']);
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertEquals(204, $response->getStatusCode());
+        $this->assertSame('bar', $response->headers->get('X-Foo'));
+    }
+}


### PR DESCRIPTION
Added a `created()` method to `ResponseFactory` (and its contract), allowing developers to use `response()->created()` for HTTP 201 responses, consistent with the existing `response()->noContent()` pattern. 
The method accepts an optional response body and custom headers.

Before this, there was no consistent way to return a 201 response:  `response()->noContent()` existed for 204, but 201 required `response('', Response::HTTP_CREATED)`.