### PR TITLE
[13.x] Fix duplicated word in newBroadcastableModelEvent docblock

### DIFF
--- a/src/Illuminate/Database/Eloquent/BroadcastsEvents.php
+++ b/src/Illuminate/Database/Eloquent/BroadcastsEvents.php
@@ -121,7 +121,7 @@ trait BroadcastsEvents
     }
 
     /**
-     * Create a new broadcastable model event event.
+     * Create a new broadcastable model event.
      *
      * @param  string  $event
      * @return mixed


### PR DESCRIPTION
The docblock for `newBroadcastableModelEvent()` in `BroadcastsEvents.php`                                                                                                                                                         reads "Create a new broadcastable model event **event**" — "event" is                                                                                                                                                                  duplicated. This drops the redundant word.                                                                                                                                                                                             
                                                                                                                                                                                                                                         
Comment-only change: no behavior change and nothing to test.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
