### PR TITLE
[13.x] Add generics to DatabaseTransactionsManager transaction getters

### DIFF
--- a/src/Illuminate/Database/DatabaseTransactionsManager.php
+++ b/src/Illuminate/Database/DatabaseTransactionsManager.php
@@ -248,7 +248,7 @@ class DatabaseTransactionsManager
     /**
      * Get all of the pending transactions.
      *
-     * @return \Illuminate\Support\Collection
+     * @return \Illuminate\Support\Collection<int, \Illuminate\Database\DatabaseTransactionRecord>
      */
     public function getPendingTransactions()
     {
@@ -258,7 +258,7 @@ class DatabaseTransactionsManager
     /**
      * Get all of the committed transactions.
      *
-     * @return \Illuminate\Support\Collection
+     * @return \Illuminate\Support\Collection<int, \Illuminate\Database\DatabaseTransactionRecord>
      */
     public function getCommittedTransactions()
     {


### PR DESCRIPTION
`getPendingTransactions()` and `getCommittedTransactions()` return the `$pendingTransactions` / `$committedTransactions` collections, which are already declared as `Collection<int, DatabaseTransactionRecord>` on the properties and in the sibling `callbackApplicableTransactions()` method. This mirrors that generic on the two getters' `@return` so IDEs and static analysis can infer the element type.                                                                                                                                                                                                   
                                                                                                                                                                                                                                         
Docblock-only change: no behavior change and nothing to test.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
