### PR TITLE
[13.x] Add generics to applyInverseRelationToCollection docblock

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/SupportsInverseRelations.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/SupportsInverseRelations.php
@@ -88,9 +88,9 @@ trait SupportsInverseRelations
     /**
      * Set the inverse relation on all models in a collection.
      *
-     * @param  \Illuminate\Database\Eloquent\Collection  $models
+     * @param  \Illuminate\Database\Eloquent\Collection<int, \Illuminate\Database\Eloquent\Model>  $models
      * @param  \Illuminate\Database\Eloquent\Model|null  $parent
-     * @return \Illuminate\Database\Eloquent\Collection
+     * @return \Illuminate\Database\Eloquent\Collection<int, \Illuminate\Database\Eloquent\Model>
      */
     protected function applyInverseRelationToCollection($models, ?Model $parent = null)
     {


### PR DESCRIPTION
`applyInverseRelationToCollection()` returns the same `$models` collection it receives and iterates it as Eloquent models. This adds the `<int, \Illuminate\Database\Eloquent\Model>` generic to both the `@param` and `@return`, matching the `<int, Model>` style already used elsewhere in the codebase, so IDEs and static analysis can infer the element type.                                                                                                                                                                      
                                                                                                                                                                                                                                         
Docblock-only change: no behavior change and nothing to test.    

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
