### PR TITLE
[13.x] Refactor: extract duplicate `addBinding` call in `join()`

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -618,8 +618,6 @@ class Builder implements BuilderContract
             $first($join);
 
             $this->joins[] = $join;
-
-            $this->addBinding($join->getBindings(), 'join');
         }
 
         // If the column is simply a string, we can assume the join simply has a basic
@@ -629,9 +627,9 @@ class Builder implements BuilderContract
             $method = $where ? 'where' : 'on';
 
             $this->joins[] = $join->$method($first, $operator, $second);
-
-            $this->addBinding($join->getBindings(), 'join');
         }
+
+        $this->addBinding($join->getBindings(), 'join');
 
         return $this;
     }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -624,7 +624,9 @@ class Builder implements BuilderContract
         // "on" clause with a single condition. So we will just build the join with
         // this simple join clauses attached to it. There is not a join callback.
         else {
-            $method = $where ? 'where' : 'on';
+            $method = $where
+                ? 'where'
+                : 'on';
 
             $this->joins[] = $join->$method($first, $operator, $second);
         }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -624,9 +624,7 @@ class Builder implements BuilderContract
         // "on" clause with a single condition. So we will just build the join with
         // this simple join clauses attached to it. There is not a join callback.
         else {
-            $method = $where
-                ? 'where'
-                : 'on';
+            $method = $where ? 'where' : 'on';
 
             $this->joins[] = $join->$method($first, $operator, $second);
         }


### PR DESCRIPTION
Refactor: deduplicate addBinding call in join()

The `$this->addBinding($join->getBindings(), 'join')` call was identically repeated in both branches of the `if/else`. Extracted it to a single call after the conditional block — no behavior change.