### PR TITLE
[13.x] Preserve Rule::can falsy arguments

### DIFF
--- a/src/Illuminate/Validation/Rules/Can.php
+++ b/src/Illuminate/Validation/Rules/Can.php
@@ -50,11 +50,7 @@ class Can implements Rule, ValidatorAwareRule
      */
     public function passes($attribute, $value)
     {
-        $arguments = $this->arguments;
-
-        $model = array_shift($arguments);
-
-        return Gate::allows($this->ability, array_filter([$model, ...$arguments, $value]));
+        return Gate::allows($this->ability, array_values([...$this->arguments, $value]));
     }
 
     /**

--- a/tests/Validation/ValidationRuleCanTest.php
+++ b/tests/Validation/ValidationRuleCanTest.php
@@ -92,6 +92,27 @@ class ValidationRuleCanTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
+    public function testValidationPassesFalsyValuesToGate()
+    {
+        $this->gate()->define('update-company', function ($user, $class, $zero, $flag, $empty, $value) {
+            $this->assertEquals(\App\Models\Company::class, $class);
+            $this->assertSame(0, $zero);
+            $this->assertFalse($flag);
+            $this->assertSame('', $empty);
+            $this->assertSame('0', $value);
+
+            return true;
+        });
+
+        $v = new Validator(
+            resolve('translator'),
+            ['company' => '0'],
+            ['company' => new Can('update-company', [\App\Models\Company::class, 0, false, ''])]
+        );
+
+        $this->assertTrue($v->passes());
+    }
+
     public function testCustomMessageUsingDotNotationAndFqcnWorks()
     {
         $v = new Validator(


### PR DESCRIPTION
`Rule::can()` currently sends its Gate arguments through `array_filter()`. That drops values like `0`, `false`, `''`, and even a validated value of `"0"` before `Gate::allows()` runs.

So a policy callback can receive too few arguments even though the caller passed those values explicitly. This keeps the given rule arguments and the validated value as-is.

Tests:
- `/opt/homebrew/bin/php -d memory_limit=-1 vendor/bin/phpunit tests/Validation/ValidationRuleCanTest.php`
- `/opt/homebrew/bin/php -d memory_limit=-1 vendor/bin/phpunit tests/Validation`