### PR TITLE
[13.x] Support scalar Predis retry config

### DIFF
--- a/src/Illuminate/Redis/Connectors/PredisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PredisConnector.php
@@ -9,6 +9,10 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
 use Predis\Client;
+use Predis\Retry\Retry;
+use Predis\Retry\Strategy\EqualBackoff;
+use Predis\Retry\Strategy\ExponentialBackoff;
+use Predis\Retry\Strategy\NoBackoff;
 
 class PredisConnector implements Connector
 {
@@ -21,6 +25,8 @@ class PredisConnector implements Connector
      */
     public function connect(array $config, array $options)
     {
+        $config = $this->formatRetry($config);
+
         $formattedOptions = array_merge(
             ['timeout' => 10.0], $options, Arr::pull($config, 'options', [])
         );
@@ -57,6 +63,61 @@ class PredisConnector implements Connector
         return new PredisClusterConnection(new Client($servers, array_merge(
             $options, $clusterOptions, $clusterSpecificOptions
         )));
+    }
+
+    /**
+     * Format scalar retry configuration into a Predis retry instance.
+     *
+     * @param  array  $config
+     * @return array
+     */
+    protected function formatRetry(array $config)
+    {
+        if (! array_key_exists('retry', $config) || ! is_array($config['retry'])) {
+            return $config;
+        }
+
+        if (! class_exists(Retry::class) ||
+            ! class_exists(ExponentialBackoff::class) ||
+            ! class_exists(EqualBackoff::class) ||
+            ! class_exists(NoBackoff::class)) {
+            throw new InvalidArgumentException('Predis retry configuration requires predis/predis 3.4.0 or newer.');
+        }
+
+        $retry = $config['retry'];
+        $retries = Arr::pull($retry, 'max_retries', Arr::pull($retry, 'retries', 0));
+        $algorithm = Arr::pull($retry, 'backoff_algorithm', 'exponential');
+        $base = Arr::pull($retry, 'backoff_base', ExponentialBackoff::DEFAULT_BASE);
+        $cap = Arr::pull($retry, 'backoff_cap', ExponentialBackoff::DEFAULT_CAP);
+
+        $config['retry'] = new Retry(
+            $this->parseBackoffStrategy($algorithm, (int) $base, (int) $cap),
+            (int) $retries
+        );
+
+        return $config;
+    }
+
+    /**
+     * Parse a Predis backoff strategy.
+     *
+     * @param  mixed  $algorithm
+     * @param  int  $base
+     * @param  int  $cap
+     * @return \Predis\Retry\Strategy\RetryStrategyInterface
+     */
+    protected function parseBackoffStrategy($algorithm, int $base, int $cap)
+    {
+        if (! is_string($algorithm)) {
+            throw new InvalidArgumentException('Predis backoff algorithm must be a string.');
+        }
+
+        return match (Str::snake($algorithm)) {
+            'default', 'exponential' => new ExponentialBackoff($base, $cap),
+            'constant', 'equal', 'equal_backoff' => new EqualBackoff($base),
+            'none', 'no_backoff' => new NoBackoff,
+            default => throw new InvalidArgumentException("Algorithm [{$algorithm}] is not a valid Predis backoff algorithm."),
+        };
     }
 
     /**

--- a/tests/Redis/PredisConnectorTest.php
+++ b/tests/Redis/PredisConnectorTest.php
@@ -4,6 +4,10 @@ namespace Illuminate\Tests\Redis;
 
 use Illuminate\Redis\Connectors\PredisConnector;
 use PHPUnit\Framework\TestCase;
+use Predis\Retry\Retry;
+use Predis\Retry\Strategy\EqualBackoff;
+use Predis\Retry\Strategy\ExponentialBackoff;
+use Predis\Retry\Strategy\NoBackoff;
 
 class PredisConnectorTest extends TestCase
 {
@@ -75,10 +79,130 @@ class PredisConnectorTest extends TestCase
             'scheme' => 'tls',
         ]);
     }
+
+    public function testFormatRetryCreatesRetryFromScalarOptions()
+    {
+        $this->requiresPredisRetrySupport();
+
+        $connector = new TestablePredisConnector;
+
+        $config = $connector->testFormatRetry([
+            'host' => '127.0.0.1',
+            'retry' => [
+                'max_retries' => 3,
+                'backoff_algorithm' => 'exponential',
+                'backoff_base' => 250000,
+                'backoff_cap' => 2000000,
+            ],
+        ]);
+
+        $this->assertInstanceOf(Retry::class, $config['retry']);
+        $this->assertSame(3, $config['retry']->getRetries());
+
+        $this->assertInstanceOf(ExponentialBackoff::class, $config['retry']->getStrategy());
+        $this->assertSame(250000, $config['retry']->getStrategy()->getBase());
+        $this->assertSame(2000000, $config['retry']->getStrategy()->getCap());
+    }
+
+    public function testFormatRetryDoesNotTreatPhpRedisBackoffOptionsAsPredisRetryConfig()
+    {
+        $connector = new TestablePredisConnector;
+
+        $config = [
+            'host' => '127.0.0.1',
+            'max_retries' => 3,
+            'backoff_algorithm' => 'decorrelated_jitter',
+            'backoff_base' => 100,
+            'backoff_cap' => 1000,
+        ];
+
+        $this->assertSame($config, $connector->testFormatRetry($config));
+    }
+
+    public function testFormatRetryUsesConstantBackoff()
+    {
+        $this->requiresPredisRetrySupport();
+
+        $connector = new TestablePredisConnector;
+
+        $config = $connector->testFormatRetry([
+            'retry' => [
+                'max_retries' => 3,
+                'backoff_algorithm' => 'constant',
+                'backoff_base' => 250000,
+            ],
+        ]);
+
+        $this->assertInstanceOf(EqualBackoff::class, $config['retry']->getStrategy());
+        $this->assertSame(250000, $config['retry']->getStrategy()->compute(0));
+    }
+
+    public function testFormatRetryUsesNoBackoff()
+    {
+        $this->requiresPredisRetrySupport();
+
+        $connector = new TestablePredisConnector;
+
+        $config = $connector->testFormatRetry([
+            'retry' => [
+                'max_retries' => 3,
+                'backoff_algorithm' => 'none',
+            ],
+        ]);
+
+        $this->assertInstanceOf(NoBackoff::class, $config['retry']->getStrategy());
+        $this->assertSame(0, $config['retry']->getStrategy()->compute(0));
+    }
+
+    public function testFormatRetryKeepsExplicitRetryInstance()
+    {
+        $this->requiresPredisRetrySupport();
+
+        $connector = new TestablePredisConnector;
+        $retry = new Retry(new NoBackoff, 3);
+
+        $config = $connector->testFormatRetry([
+            'retry' => $retry,
+            'max_retries' => 5,
+            'backoff_algorithm' => 'exponential',
+        ]);
+
+        $this->assertSame($retry, $config['retry']);
+        $this->assertSame(5, $config['max_retries']);
+    }
+
+    public function testFormatRetryThrowsForInvalidBackoffAlgorithm()
+    {
+        $this->requiresPredisRetrySupport();
+
+        $connector = new TestablePredisConnector;
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Algorithm [bogus] is not a valid Predis backoff algorithm.');
+
+        $connector->testFormatRetry([
+            'retry' => [
+                'max_retries' => 3,
+                'backoff_algorithm' => 'bogus',
+            ],
+        ]);
+    }
+
+    protected function requiresPredisRetrySupport()
+    {
+        if (! class_exists(Retry::class)) {
+            $this->markTestSkipped('Predis retry support is not available.');
+        }
+    }
 }
 
 class TestablePredisConnector extends PredisConnector
 {
+    public function testFormatRetry(array $config): array
+    {
+        return $this->formatRetry($config);
+    }
+
     public function testFormatHost(array $config): array
     {
         return $this->formatHost($config);


### PR DESCRIPTION
Fixes #60355.

The documented Predis retry setup currently requires putting a `Predis\Retry\Retry` object in Redis config. That works at runtime, but it breaks `config:cache` because cached config has to be exportable.

This lets Predis connections use a cache-safe scalar `retry` array instead. The connector builds the Predis `Retry` object at runtime after config is loaded. Existing `retry => new Retry(...)` configs are left alone.

The stock top-level Redis retry/backoff keys are intentionally left untouched, since those are also used by PhpRedis and include PhpRedis-only values like `decorrelated_jitter`.

Tests:
- `/opt/homebrew/bin/php vendor/bin/pint --test src/Illuminate/Redis/Connectors/PredisConnector.php tests/Redis/PredisConnectorTest.php`
- `/opt/homebrew/bin/php -d memory_limit=-1 vendor/bin/phpunit tests/Redis/PredisConnectorTest.php`
- `/opt/homebrew/bin/php -d memory_limit=-1 vendor/bin/phpunit tests/Redis`