### PR TITLE
[13.x] Add `getEvent()` method to `PendingBroadcast`

### DIFF
--- a/src/Illuminate/Broadcasting/FakePendingBroadcast.php
+++ b/src/Illuminate/Broadcasting/FakePendingBroadcast.php
@@ -34,6 +34,16 @@ class FakePendingBroadcast extends PendingBroadcast
     }
 
     /**
+     * Get the event instance.
+     *
+     * @return mixed
+     */
+    public function getEvent()
+    {
+        return null;
+    }
+
+    /**
      * Handle the object's destruction.
      *
      * @return void

--- a/src/Illuminate/Broadcasting/PendingBroadcast.php
+++ b/src/Illuminate/Broadcasting/PendingBroadcast.php
@@ -64,6 +64,16 @@ class PendingBroadcast
     }
 
     /**
+     * Get the event instance.
+     *
+     * @return mixed
+     */
+    public function getEvent()
+    {
+        return $this->event;
+    }
+
+    /**
      * Handle the object's destruction.
      *
      * @return void

--- a/tests/Broadcasting/PendingBroadcastTest.php
+++ b/tests/Broadcasting/PendingBroadcastTest.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Illuminate\Tests\Broadcasting;
+
+use Illuminate\Broadcasting\PendingBroadcast;
+use Illuminate\Events\Dispatcher;
+use PHPUnit\Framework\TestCase;
+
+class PendingBroadcastTest extends TestCase
+{
+    public function testGetEvent()
+    {
+        $event = new class {
+            public $data = 'test';
+        };
+
+        $pendingBroadcast = new PendingBroadcast(new Dispatcher, $event);
+
+        $this->assertSame($event, $pendingBroadcast->getEvent());
+    }
+
+    public function testViaCallsBroadcastViaOnEvent()
+    {
+        $event = new class {
+            public $connection = null;
+
+            public function broadcastVia($connection)
+            {
+                $this->connection = $connection;
+            }
+        };
+
+        $pendingBroadcast = new PendingBroadcast(new Dispatcher, $event);
+        $pendingBroadcast->via('custom-connection');
+
+        $this->assertSame('custom-connection', $event->connection);
+    }
+
+    public function testViaWithNullConnection()
+    {
+        $event = new class {
+            public $connection = 'default';
+
+            public function broadcastVia($connection)
+            {
+                $this->connection = $connection;
+            }
+        };
+
+        $pendingBroadcast = new PendingBroadcast(new Dispatcher, $event);
+        $pendingBroadcast->via(null);
+
+        $this->assertNull($event->connection);
+    }
+
+    public function testViaDoesNothingWhenEventHasNoBroadcastViaMethod()
+    {
+        $event = new class {
+            // No broadcastVia method
+        };
+
+        $pendingBroadcast = new PendingBroadcast(new Dispatcher, $event);
+        $result = $pendingBroadcast->via('custom-connection');
+
+        $this->assertSame($pendingBroadcast, $result);
+    }
+
+    public function testToOthersCallsDontBroadcastToCurrentUser()
+    {
+        $event = new class {
+            public $excludeCurrentUser = false;
+
+            public function dontBroadcastToCurrentUser()
+            {
+                $this->excludeCurrentUser = true;
+            }
+        };
+
+        $pendingBroadcast = new PendingBroadcast(new Dispatcher, $event);
+        $pendingBroadcast->toOthers();
+
+        $this->assertTrue($event->excludeCurrentUser);
+    }
+
+    public function testToOthersDoesNothingWhenEventHasNoDontBroadcastToCurrentUserMethod()
+    {
+        $event = new class {
+            // No dontBroadcastToCurrentUser method
+        };
+
+        $pendingBroadcast = new PendingBroadcast(new Dispatcher, $event);
+        $result = $pendingBroadcast->toOthers();
+
+        $this->assertSame($pendingBroadcast, $result);
+    }
+
+    public function testViaReturnsSelf()
+    {
+        $pendingBroadcast = new PendingBroadcast(new Dispatcher, new class {});
+        $result = $pendingBroadcast->via('custom');
+
+        $this->assertSame($pendingBroadcast, $result);
+    }
+
+    public function testToOthersReturnsSelf()
+    {
+        $pendingBroadcast = new PendingBroadcast(new Dispatcher, new class {});
+        $result = $pendingBroadcast->toOthers();
+
+        $this->assertSame($pendingBroadcast, $result);
+    }
+
+    public function testDestructDispatchesEvent()
+    {
+        $dispatchedEvents = [];
+
+        $dispatcher = new class extends Dispatcher {
+            public function dispatch($event)
+            {
+                $dispatchedEvents[] = $event;
+                return $event;
+            }
+        };
+
+        $event = new class {
+            public $data = 'test';
+        };
+
+        $pendingBroadcast = new PendingBroadcast($dispatcher, $event);
+        unset($pendingBroadcast);
+
+        $this->assertCount(1, $dispatchedEvents);
+        $this->assertSame($event, $dispatchedEvents[0]);
+    }
+}

--- a/tests/Broadcasting/PendingBroadcastTest.php
+++ b/tests/Broadcasting/PendingBroadcastTest.php
@@ -10,7 +10,8 @@ class PendingBroadcastTest extends TestCase
 {
     public function testGetEvent()
     {
-        $event = new class {
+        $event = new class
+        {
             public $data = 'test';
         };
 
@@ -21,7 +22,8 @@ class PendingBroadcastTest extends TestCase
 
     public function testViaCallsBroadcastViaOnEvent()
     {
-        $event = new class {
+        $event = new class
+        {
             public $connection = null;
 
             public function broadcastVia($connection)
@@ -38,7 +40,8 @@ class PendingBroadcastTest extends TestCase
 
     public function testViaWithNullConnection()
     {
-        $event = new class {
+        $event = new class
+        {
             public $connection = 'default';
 
             public function broadcastVia($connection)
@@ -67,7 +70,8 @@ class PendingBroadcastTest extends TestCase
 
     public function testToOthersCallsDontBroadcastToCurrentUser()
     {
-        $event = new class {
+        $event = new class
+        {
             public $excludeCurrentUser = false;
 
             public function dontBroadcastToCurrentUser()
@@ -114,15 +118,24 @@ class PendingBroadcastTest extends TestCase
     {
         $dispatchedEvents = [];
 
-        $dispatcher = new class extends Dispatcher {
-            public function dispatch($event)
+        $dispatcher = new class($dispatchedEvents) extends Dispatcher
+        {
+            private $events;
+
+            public function __construct(&$events)
             {
-                $dispatchedEvents[] = $event;
+                $this->events = &$events;
+            }
+
+            public function dispatch($event, $payload = [], $halt = false)
+            {
+                $this->events[] = $event;
                 return $event;
             }
         };
 
-        $event = new class {
+        $event = new class
+        {
             public $data = 'test';
         };
 


### PR DESCRIPTION
Add `getEvent()` method to `PendingBroadcast` and `FakePendingBroadcast` classes to allow accessing the underlying event instance. 
Also adds comprehensive unit tests for the `PendingBroadcast` class.

Consistent API
Follows the pattern of other Laravel Pending classes (e.g., `PendingDispatch`). 