### PR TITLE
Introduce `Str::limit()` (and `Stringable::limit()`) with optional threshold

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -724,11 +724,12 @@ class Str
      * @param  int  $limit
      * @param  string  $end
      * @param  bool  $preserveWords
+     * @param  non-negative-int  $threshold
      * @return string
      */
-    public static function limit($value, $limit = 100, $end = '...', $preserveWords = false)
+    public static function limit($value, $limit = 100, $end = '...', $preserveWords = false, int $threshold = 0)
     {
-        if (mb_strwidth($value, 'UTF-8') <= $limit) {
+        if (mb_strwidth($value, 'UTF-8') <= $limit + max(0, $threshold)) {
             return $value;
         }
 

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -470,11 +470,12 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
      * @param  int  $limit
      * @param  string  $end
      * @param  bool  $preserveWords
+     * @param  non-negative-int  $threshold
      * @return static
      */
-    public function limit($limit = 100, $end = '...', $preserveWords = false)
+    public function limit($limit = 100, $end = '...', $preserveWords = false, int $threshold = 0)
     {
-        return new static(Str::limit($this->value, $limit, $end, $preserveWords));
+        return new static(Str::limit($this->value, $limit, $end, $preserveWords, $threshold));
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -816,8 +816,8 @@ class SupportStrTest extends TestCase
         $this->assertSame('The PHP framework for web artisans.', Str::limit($string, 100));
         $this->assertSame('The PHP framework for web artisans.', Str::limit($string, 100, preserveWords: true));
         $this->assertSame('The PHP framework...', Str::limit($string, 20, preserveWords: true));
-        $this->assertSame('The PHP framework for web artisans.', Str::limit($string, 20, threshold: 20));
-        $this->assertSame('The PHP framework...', Str::limit($string, 20, threshold: 10));
+        $this->assertSame('The PHP framework for web artisans.', Str::limit($string, 20, preserveWords: true, threshold: 20));
+        $this->assertSame('The PHP framework...', Str::limit($string, 20, preserveWords: true, threshold: 10));
 
         $nonAsciiString = '这是一段中文';
         $this->assertSame('这是一...', Str::limit($nonAsciiString, 6));

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -816,6 +816,8 @@ class SupportStrTest extends TestCase
         $this->assertSame('The PHP framework for web artisans.', Str::limit($string, 100));
         $this->assertSame('The PHP framework for web artisans.', Str::limit($string, 100, preserveWords: true));
         $this->assertSame('The PHP framework...', Str::limit($string, 20, preserveWords: true));
+        $this->assertSame('The PHP framework for web artisans.', Str::limit($string, 20, threshold: 20));
+        $this->assertSame('The PHP framework...', Str::limit($string, 20, threshold: 10));
 
         $nonAsciiString = '这是一段中文';
         $this->assertSame('这是一...', Str::limit($nonAsciiString, 6));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -1031,6 +1031,8 @@ class SupportStringableTest extends TestCase
         $this->assertSame('The PHP...', (string) $this->stringable($string)->limit(7));
         $this->assertSame('The PHP', (string) $this->stringable($string)->limit(7, ''));
         $this->assertSame('The PHP framework for web artisans.', (string) $this->stringable($string)->limit(100));
+        $this->assertSame('The PHP framework for web artisans.', (string) $this->stringable($string)->limit(20, threshold: 20));
+        $this->assertSame('The PHP framework...', (string) $this->stringable($string)->limit(20, threshold: 10));
 
         $nonAsciiString = '这是一段中文';
         $this->assertSame('这是一...', (string) $this->stringable($nonAsciiString)->limit(6));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -1031,8 +1031,8 @@ class SupportStringableTest extends TestCase
         $this->assertSame('The PHP...', (string) $this->stringable($string)->limit(7));
         $this->assertSame('The PHP', (string) $this->stringable($string)->limit(7, ''));
         $this->assertSame('The PHP framework for web artisans.', (string) $this->stringable($string)->limit(100));
-        $this->assertSame('The PHP framework for web artisans.', (string) $this->stringable($string)->limit(20, threshold: 20));
-        $this->assertSame('The PHP framework...', (string) $this->stringable($string)->limit(20, threshold: 10));
+        $this->assertSame('The PHP framework for web artisans.', (string) $this->stringable($string)->limit(20, preserveWords: true, threshold: 20));
+        $this->assertSame('The PHP framework...', (string) $this->stringable($string)->limit(20, preserveWords: true, threshold: 10));
 
         $nonAsciiString = '这是一段中文';
         $this->assertSame('这是一...', (string) $this->stringable($nonAsciiString)->limit(6));


### PR DESCRIPTION
This PR adds a `$threshold` parameter to the `Str::limit()` (and `Stringable::limit()`) methods.

The `$threshold` can be used to keep the original string up to that threshold, before truncating to the defined `$limit`.

## Example

### Without threshold

```php
Str::limit('The PHP framework for web artisans.', 30, preserveWords: true);
// => The PHP framework for web...
```

### With threshold

```php
Str::limit('The PHP framework for web artisans.', 30, preserveWords: true, threshold: 5);
// => The PHP framework for web artisans.

Str::limit('The PHP framework for everyone around the world.', 30, preserveWords: true, threshold: 5);
// => The PHP framework for everyone...
```

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
