### PR TITLE
[13.x] Add Prohibitable to `cache:clear` and `queue:flush`

### DIFF
--- a/src/Illuminate/Cache/Console/ClearCommand.php
+++ b/src/Illuminate/Cache/Console/ClearCommand.php
@@ -5,6 +5,7 @@ namespace Illuminate\Cache\Console;
 use BadMethodCallException;
 use Illuminate\Cache\CacheManager;
 use Illuminate\Console\Command;
+use Illuminate\Console\Prohibitable;
 use Illuminate\Filesystem\Filesystem;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
@@ -13,6 +14,8 @@ use Symfony\Component\Console\Input\InputOption;
 #[AsCommand(name: 'cache:clear')]
 class ClearCommand extends Command
 {
+    use Prohibitable;
+
     /**
      * The console command name.
      *
@@ -62,6 +65,10 @@ class ClearCommand extends Command
      */
     public function handle()
     {
+        if ($this->isProhibited()) {
+            return self::FAILURE;
+        }
+
         if ($this->option('locks')) {
             return $this->clearLocks();
         }

--- a/src/Illuminate/Queue/Console/FlushFailedCommand.php
+++ b/src/Illuminate/Queue/Console/FlushFailedCommand.php
@@ -3,11 +3,14 @@
 namespace Illuminate\Queue\Console;
 
 use Illuminate\Console\Command;
+use Illuminate\Console\Prohibitable;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'queue:flush')]
 class FlushFailedCommand extends Command
 {
+    use Prohibitable;
+
     /**
      * The console command name.
      *
@@ -29,6 +32,10 @@ class FlushFailedCommand extends Command
      */
     public function handle()
     {
+        if ($this->isProhibited()) {
+            return;
+        }
+
         $this->laravel['queue.failer']->flush($this->option('hours'));
 
         if ($this->option('hours')) {


### PR DESCRIPTION
I wanna prohibit these in production,  

`cache:clear` cus there's thing we store in the cache, as well as rate limiters etc and want to avoid anyone clearing it by accident
`queue:flush` cus I dont want someone to clear the failed jobs accidently, there could be failed jobs we're investigating 


These are opt in userland, no no b/c