### PR TITLE
[13.x] Add units to queue attributes

### DIFF
--- a/src/Illuminate/Queue/Attributes/Backoff.php
+++ b/src/Illuminate/Queue/Attributes/Backoff.php
@@ -17,7 +17,7 @@ class Backoff
     /**
      * Create a new attribute instance.
      *
-     * @param  array<int>|int  ...$backoff
+     * @param  array<int>|int  ...$backoff  Seconds to wait before retrying the job.
      */
     public function __construct(array|int ...$backoff)
     {

--- a/src/Illuminate/Queue/Attributes/Delay.php
+++ b/src/Illuminate/Queue/Attributes/Delay.php
@@ -10,7 +10,7 @@ class Delay
     /**
      * Create a new attribute instance.
      *
-     * @param  int  $delay
+     * @param  int  $delay  Seconds to delay the job for.
      */
     public function __construct(public int $delay)
     {

--- a/src/Illuminate/Queue/Attributes/Timeout.php
+++ b/src/Illuminate/Queue/Attributes/Timeout.php
@@ -10,7 +10,7 @@ class Timeout
     /**
      * Create a new attribute instance.
      *
-     * @param  int  $timeout
+     * @param  int  $timeout  Seconds before the job is considered timed out.
      */
     public function __construct(public int $timeout)
     {


### PR DESCRIPTION
Following on from https://github.com/laravel/framework/pull/60388 

This adds unit doc blocks for a few queue attributes, so it clear that the params are seconds, useful if you're clicking through to the attribute code, or when you're using them and forget the unit 🌚  

These are the only ones I thought it would be useful for.

