### PR TITLE
[13.x] Add Str::isNot() and Stringable::isNot() methods

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -550,6 +550,19 @@ class Str
     }
 
     /**
+     * Determine if a given string doesn't match a given pattern.
+     *
+     * @param  string|iterable<string>  $pattern
+     * @param  string  $value
+     * @param  bool  $ignoreCase
+     * @return bool
+     */
+    public static function isNot($pattern, $value, $ignoreCase = false)
+    {
+        return ! static::is($pattern, $value, $ignoreCase);
+    }
+
+    /**
      * Determine if a given string is 7 bit ASCII.
      *
      * @param  string  $value

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -372,6 +372,18 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
+     * Determine if a given string doesn't match a given pattern.
+     *
+     * @param  string|iterable<string>  $pattern
+     * @param  bool  $ignoreCase
+     * @return bool
+     */
+    public function isNot($pattern, $ignoreCase = false)
+    {
+        return Str::isNot($pattern, $this->value, $ignoreCase);
+    }
+
+    /**
      * Determine if a given string is 7 bit ASCII.
      *
      * @return bool

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -612,6 +612,33 @@ class SupportStrTest extends TestCase
         $this->assertSame('some: "json"', Str::unwrap('{some: "json"}', '{', '}'));
     }
 
+    public function testIsNot()
+    {
+        $this->assertFalse(Str::isNot('/', '/'));
+        $this->assertTrue(Str::isNot('/', ' /'));
+        $this->assertTrue(Str::isNot('/', '/a'));
+        $this->assertFalse(Str::isNot('foo/*', 'foo/bar/baz'));
+
+        // isNot is case sensitive
+        $this->assertTrue(Str::isNot('*BAZ*', 'foo/bar/baz'));
+        $this->assertTrue(Str::isNot('A', 'a'));
+
+        // isNot is not case sensitive
+        $this->assertFalse(Str::isNot('A', 'a', true));
+        $this->assertFalse(Str::isNot('*BAZ*', 'foo/bar/baz', true));
+
+        // Accepts array of patterns
+        $this->assertFalse(Str::isNot(['a*', 'b*'], 'a/'));
+        $this->assertTrue(Str::isNot(['a*', 'b*'], 'f/'));
+
+        // empty patterns
+        $this->assertTrue(Str::isNot([], 'test'));
+
+        // Always the exact inverse of is()
+        $this->assertSame(! Str::is('foo/*', 'foo/bar/baz'), Str::isNot('foo/*', 'foo/bar/baz'));
+        $this->assertSame(! Str::is('foo/*', 'other'), Str::isNot('foo/*', 'other'));
+    }
+
     public function testIs()
     {
         $this->assertTrue(Str::is('/', '/'));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -925,6 +925,26 @@ class SupportStringableTest extends TestCase
         $this->assertSame('abcbbc', (string) $this->stringable('abcbbcbc')->finish('bc'));
     }
 
+    public function testIsNot()
+    {
+        $this->assertFalse($this->stringable('/')->isNot('/'));
+        $this->assertTrue($this->stringable(' /')->isNot('/'));
+        $this->assertTrue($this->stringable('/a')->isNot('/'));
+        $this->assertFalse($this->stringable('foo/bar/baz')->isNot('foo/*'));
+
+        // isNot is case sensitive
+        $this->assertTrue($this->stringable('foo/bar/baz')->isNot('*BAZ*'));
+        $this->assertTrue($this->stringable('a')->isNot('A'));
+
+        // isNot is not case sensitive
+        $this->assertFalse($this->stringable('a')->isNot('A', true));
+        $this->assertFalse($this->stringable('foo/bar/baz')->isNot('*BAZ*', true));
+
+        // Accepts array of patterns
+        $this->assertFalse($this->stringable('a/')->isNot(['a*', 'b*']));
+        $this->assertTrue($this->stringable('f/')->isNot(['a*', 'b*']));
+    }
+
     public function testIs()
     {
         $this->assertTrue($this->stringable('/')->is('/'));


### PR DESCRIPTION
This adds `isNot()` to `Illuminate\Support\Str` and `Illuminate\Support\Stringable` as a readable negation of `is()`, instead of writing `! Str::is(...)`. It mirrors the existing negation helpers `doesntContain()`, `doesntStartWith()` and `doesntEndWith()` (#53035, #56168). The `is` / `isNot` naming follows the precedent already used in the framework by `Model::isNot()`.                                                                                                                                                                           
                                                                                                                                                                                                                                         
Tests are added for both classes.
  
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
