### PR TITLE
[13.x] Add Prohibitable to prune commands

### DIFF
--- a/src/Illuminate/Database/Console/PruneCommand.php
+++ b/src/Illuminate/Database/Console/PruneCommand.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Console;
 
 use Illuminate\Console\Command;
+use Illuminate\Console\Prohibitable;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Events\ModelPruningFinished;
@@ -17,6 +18,8 @@ use Symfony\Component\Finder\Finder;
 #[AsCommand(name: 'model:prune')]
 class PruneCommand extends Command
 {
+    use Prohibitable;
+
     /**
      * The console command name.
      *
@@ -44,6 +47,10 @@ class PruneCommand extends Command
      */
     public function handle(Dispatcher $events)
     {
+        if ($this->isProhibited()) {
+            return;
+        }
+
         $models = $this->models();
 
         if ($models->isEmpty()) {

--- a/src/Illuminate/Queue/Console/PruneBatchesCommand.php
+++ b/src/Illuminate/Queue/Console/PruneBatchesCommand.php
@@ -6,12 +6,15 @@ use Illuminate\Bus\BatchRepository;
 use Illuminate\Bus\DatabaseBatchRepository;
 use Illuminate\Bus\PrunableBatchRepository;
 use Illuminate\Console\Command;
+use Illuminate\Console\Prohibitable;
 use Illuminate\Support\Carbon;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'queue:prune-batches')]
 class PruneBatchesCommand extends Command
 {
+    use Prohibitable;
+
     /**
      * The console command signature.
      *
@@ -36,6 +39,10 @@ class PruneBatchesCommand extends Command
      */
     public function handle()
     {
+        if ($this->isProhibited()) {
+            return;
+        }
+
         $repository = $this->laravel[BatchRepository::class];
 
         $count = 0;

--- a/src/Illuminate/Queue/Console/PruneFailedJobsCommand.php
+++ b/src/Illuminate/Queue/Console/PruneFailedJobsCommand.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Queue\Console;
 
 use Illuminate\Console\Command;
+use Illuminate\Console\Prohibitable;
 use Illuminate\Queue\Failed\PrunableFailedJobProvider;
 use Illuminate\Support\Carbon;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -10,6 +11,8 @@ use Symfony\Component\Console\Attribute\AsCommand;
 #[AsCommand(name: 'queue:prune-failed')]
 class PruneFailedJobsCommand extends Command
 {
+    use Prohibitable;
+
     /**
      * The console command signature.
      *
@@ -32,6 +35,10 @@ class PruneFailedJobsCommand extends Command
      */
     public function handle()
     {
+        if ($this->isProhibited()) {
+            return self::FAILURE;
+        }
+
         $failer = $this->laravel['queue.failer'];
 
         if ($failer instanceof PrunableFailedJobProvider) {


### PR DESCRIPTION
#60430 added `Prohibitable` to `cache:clear` and `queue:flush`. The prune commands permanently **delete data** but can't be prohibited, which is inconsistent - they are more destructive than the commands that just received it.                                                                                                                                                      
                                                                                                                                                                                                                                        This adds `Prohibitable` to:                                                                                                                                                                                                           
  - `model:prune` - deletes model records                                                                                                                                                                                                
  - `queue:prune-failed` - deletes failed job records                                                                                                                                                                                    
  - `queue:prune-batches` - deletes batch records                                                                                                                                                                                        
                                                                                                                                                                                                                                         Same wiring as #60430. `Prohibitable` is opt-in (`Command::prohibit()`), so the default behavior of these commands is unchanged.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
