### PR TITLE
[13.x] Feat: add `searchStrict()`, `beforeStrict()` and `afterStrict()`

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1206,6 +1206,21 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Search the collection for a given value, using strict comparison and return the corresponding key if successful.
+     *
+     * @param  TValue|(callable(TValue,TKey): bool)  $value
+     * @return TKey|false
+     */
+    public function searchStrict($value)
+    {
+        if (! $this->useAsCallable($value)) {
+            return array_search($value, $this->items, true);
+        }
+
+        return array_find_key($this->items, $value) ?? false;
+    }
+
+    /**
      * Get the item before the given item.
      *
      * @param  TValue|(callable(TValue,TKey): bool)  $value
@@ -1230,6 +1245,29 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Get the item before the given item, using strict comparison.
+     *
+     * @param  TValue|(callable(TValue,TKey): bool)  $value
+     * @return TValue|null
+     */
+    public function beforeStrict($value)
+    {
+        $key = $this->search($value, true);
+
+        if ($key === false) {
+            return null;
+        }
+
+        $position = ($keys = $this->keys())->search($key);
+
+        if ($position === 0) {
+            return null;
+        }
+
+        return $this->get($keys->get($position - 1));
+    }
+
+    /**
      * Get the item after the given item.
      *
      * @param  TValue|(callable(TValue,TKey): bool)  $value
@@ -1239,6 +1277,29 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     public function after($value, $strict = false)
     {
         $key = $this->search($value, $strict);
+
+        if ($key === false) {
+            return null;
+        }
+
+        $position = ($keys = $this->keys())->search($key);
+
+        if ($position === $keys->count() - 1) {
+            return null;
+        }
+
+        return $this->get($keys->get($position + 1));
+    }
+
+    /**
+     * Get the item after the given item, using strict comparison.
+     *
+     * @param  TValue|(callable(TValue,TKey): bool)  $value
+     * @return TValue|null
+     */
+    public function afterStrict($value)
+    {
+        $key = $this->search($value, true);
 
         if ($key === false) {
             return null;


### PR DESCRIPTION
## Add `searchStrict`, `beforeStrict`, and `afterStrict` to Collection

This PR adds strict-comparison variants for `search`, `before`, and `after` — following the same convention already established by `containsStrict`, `searchStrict`, and similar methods in the framework.

Just as `containsStrict` mirrors `contains` but uses strict (`===`) comparison, these three new methods mirror their non-strict counterparts:

| Loose | Strict |
|---|---|
| `search($value)` | `searchStrict($value)` |
| `before($value)` | `beforeStrict($value)` |
| `after($value)` | `afterStrict($value)` |

### Motivation

The existing `search`, `before`, and `after` methods use loose comparison (`==`), which can produce unexpected results when working with values of different types (e.g., `0` matching `false`, or `"1"` matching `1`). The new strict variants give developers explicit control over type-safe lookups — consistent with how `containsStrict` already works.

### Changes
- Added `searchStrict()` — uses `array_search(..., true)` for scalar values and `array_find_key()` for callables
- Added `beforeStrict()` — delegates to `search(..., true)` internally
- Added `afterStrict()` — delegates to `search(..., true)` internally

No breaking changes.