### PR TITLE
[13.x] Fix: add `@throws \ReflectionException`

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -236,6 +236,8 @@ class RouteListCommand extends Command
      *
      * @param  \Illuminate\Routing\Route  $route
      * @return string|null
+     *
+     * @throws \ReflectionException
      */
     protected function getClosurePath(Route $route)
     {


### PR DESCRIPTION
Add missing `@throws \ReflectionException` to `getClosurePath()` docblock, as the method instantiates `ReflectionFunction` which can throw this exception.