### PR TITLE
[13.x] Fix loose comparison in date_format validation rule

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -629,7 +629,7 @@ trait ValidatesAttributes
             try {
                 $date = DateTime::createFromFormat('!'.$format, $value, new DateTimeZone('UTC'));
 
-                if ($date && $date->format($format) == $value) {
+                if ($date && $date->format($format) === (string) $value) {
                     return true;
                 }
             } catch (ValueError) {

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -6551,6 +6551,15 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['x' => '17:43'], ['x' => 'date_format:H:i']);
         $this->assertTrue($v->passes());
+
+        // Numeric string coercion must not bypass strict format matching.
+        // '0.5' should not pass date_format:U.u because the canonical output is '0.500000'.
+        $v = new Validator($trans, ['x' => '0.5'], ['x' => 'date_format:U.u']);
+        $this->assertTrue($v->fails());
+
+        // Integer 0 coerced to '0' must still pass date_format:G (hour without leading zero, midnight).
+        $v = new Validator($trans, ['x' => 0], ['x' => 'date_format:G']);
+        $this->assertTrue($v->passes());
     }
 
     public function testDateEquals()


### PR DESCRIPTION
The `date_format` validation rule used a loose `==` comparison to verify that `$date->format($format)` matched the input `$value`. Because PHP 8 performs numeric coercion when comparing two numeric strings with `==`, this allowed values like `'0.5'` to pass `date_format: U.u` even though the canonical formatted output is `'0.500000'`.