### PR TITLE
[13.x] Use strict comparison in decimal validation rule

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -680,11 +680,11 @@ trait ValidatesAttributes
         $decimals = strlen(end($matches));
 
         if (! isset($parameters[1])) {
-            return $decimals == $parameters[0];
+            return $decimals === (int) $parameters[0];
         }
 
-        return $decimals >= $parameters[0] &&
-               $decimals <= $parameters[1];
+        return $decimals >= (int) $parameters[0] &&
+               $decimals <= (int) $parameters[1];
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3802,6 +3802,20 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['foo' => 1.23], ['foo' => 'Decimal:0,3']);
         $this->assertTrue($v->passes());
+
+        // Strict type comparison: parameter is a string from rule definition but must
+        // be cast to int before comparing against the int returned by strlen().
+        $v = new Validator($trans, ['foo' => '1.23'], ['foo' => 'Decimal:2']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => '1.2'], ['foo' => 'Decimal:2']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => '1.23'], ['foo' => 'Decimal:2,3']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => '1.2'], ['foo' => 'Decimal:2,3']);
+        $this->assertFalse($v->passes());
     }
 
     public function testValidateInt()


### PR DESCRIPTION
`validateDecimal` compared `$decimals` (an `int` from `strlen()`) against `$parameters[0]` / `$parameters[1]` (strings parsed from the rule definition) using loose `==` / `>=` / `<=`. While PHP 8 numeric-string coercion means this produces correct results today, the intent is clearly integer arithmetic and the types should be explicit.
