### PR TITLE
[13.x] Fix HandleExceptions fatal when static::$app is null during Octane request marshaling

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -125,6 +125,7 @@ class HandleExceptions
     protected function shouldIgnoreDeprecationErrors()
     {
         return ! class_exists(LogManager::class)
+            || is_null(static::$app)
             || ! static::$app->hasBeenBootstrapped()
             || (static::$app->runningUnitTests() && ! Env::get('LOG_DEPRECATIONS_WHILE_TESTING'));
     }

--- a/tests/Foundation/Bootstrap/HandleExceptionsTest.php
+++ b/tests/Foundation/Bootstrap/HandleExceptionsTest.php
@@ -403,6 +403,23 @@ class HandleExceptionsTest extends TestCase
         $this->assertNotSame($this->app, $appResolver());
         $this->assertSame($newApp, $appResolver());
     }
+
+    public function testDeprecationErrorsAreIgnoredWhenAppIsNull()
+    {
+        $instance = $this->handleExceptions();
+
+        HandleExceptions::forgetApp();
+
+        // Should not throw when static::$app is null (e.g., during Octane request marshaling)
+        $instance->handleError(
+            E_USER_DEPRECATED,
+            'Directly setting property "request" of "Illuminate\Http\Request" is deprecated',
+            '/vendor/symfony/http-foundation/Request.php',
+            100
+        );
+
+        $this->assertTrue(true);
+    }
 }
 
 class CustomNullHandler extends NullHandler


### PR DESCRIPTION
## Problem

When using Laravel Octane with FrankenPHP and `symfony/http-foundation` 8.1, all JSON requests return empty HTTP 500 responses with no logged errors.

**Root cause (two combined bugs):**

1. Symfony 8.1 added PHP 8.4 property `set` hooks on `Request::$request` and other public properties that fire `E_USER_DEPRECATED` on direct assignment. FrankenPHP's `marshalRequest()` assigns to this property during request setup — *before* the Octane sandbox app is fully initialized.

2. When the deprecation fires, `HandleExceptions::shouldIgnoreDeprecationErrors()` calls `static::$app->hasBeenBootstrapped()` — but in Octane's transitional state, `static::$app` can be `null`, causing a fatal "Call to member function on null", which results in a silent empty HTTP 500.

## Fix

Add a `null` guard before calling any method on `static::$app`:

```php
protected function shouldIgnoreDeprecationErrors()
{
    return ! class_exists(LogManager::class)
        || is_null(static::$app)    // ← added
        || ! static::$app->hasBeenBootstrapped()
        || ...;
}
```

## Why it doesn't break existing features

- The check short-circuits only when `$app` is `null` — a state where logging deprecations is impossible anyway.
- All 17 existing `HandleExceptionsTest` tests pass unchanged.
- Existing behavior for normal (non-Octane) apps is completely unaffected.

## Benefit to end users

Octane + FrankenPHP users running `symfony/http-foundation` 8.1 can send JSON requests without getting silent HTTP 500 errors.

Closes #60365
