### PR TITLE
[13.x] Add typed translation accessors

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -190,6 +190,44 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
     }
 
     /**
+     * Get the specified string translation value.
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function string(string $key, array $replace = [], ?string $locale = null, bool $fallback = true): string
+    {
+        $value = $this->get($key, $replace, $locale, $fallback);
+
+        if (! is_string($value)) {
+            throw new InvalidArgumentException(
+                sprintf('Translation value for key [%s] must be a string, %s given.', $key, gettype($value))
+            );
+        }
+
+        return $value;
+    }
+
+    /**
+     * Get the specified array translation value.
+     *
+     * @return array<array-key, mixed>
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function array(string $key, array $replace = [], ?string $locale = null, bool $fallback = true): array
+    {
+        $value = $this->get($key, $replace, $locale, $fallback);
+
+        if (! is_array($value)) {
+            throw new InvalidArgumentException(
+                sprintf('Translation value for key [%s] must be an array, %s given.', $key, gettype($value))
+            );
+        }
+
+        return $value;
+    }
+
+    /**
      * Get a translation according to an integer value.
      *
      * @param  string  $key

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -64,6 +64,44 @@ class TranslationTranslatorTest extends TestCase
         $this->assertSame('foo', $t->get('foo::bar.foo'));
     }
 
+    public function testStringMethodProperlyLoadsAndRetrievesStringItem()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn(['baz' => 'breeze :foo']);
+        $this->assertSame('breeze bar', $t->string('foo::bar.baz', ['foo' => 'bar'], 'en'));
+    }
+
+    public function testStringMethodThrowsExceptionForArrayItem()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn(['baz' => ['breeze']]);
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Translation value for key [foo::bar.baz] must be a string, array given.');
+
+        $t->string('foo::bar.baz', [], 'en');
+    }
+
+    public function testArrayMethodProperlyLoadsAndRetrievesArrayItem()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn(['baz' => ['breeze :foo']]);
+        $this->assertSame(['breeze bar'], $t->array('foo::bar.baz', ['foo' => 'bar'], 'en'));
+    }
+
+    public function testArrayMethodThrowsExceptionForStringItem()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn(['baz' => 'breeze']);
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Translation value for key [foo::bar.baz] must be an array, string given.');
+
+        $t->array('foo::bar.baz', [], 'en');
+    }
+
     public function testGetMethodForNonExistingReturnsSameKey()
     {
         $t = new Translator($this->getLoader(), 'en');


### PR DESCRIPTION
This PR adds typed translation accessors to the `Translator`:

```php
trans()->string(...): string
trans()->array(...): array
```

Laravel's current translation helpers expose broad return types:

```php
__(...): array|string|null
trans(...): Translator|array|string
```

While the existing helpers work well in Blade and other loosely typed contexts, they can be awkward in code with strict return types or static analysis expectations. For example:

```php
public function label(): string
{
    // __() returns array|string|null, which is too broad here.
    return trans()->string($this->name);
}
```

These new methods allow callers to request a predictable translation value type without manually checking the broad `string|array` result. They follow the same direction as Laravel's existing typed helpers for `config()` and `request()`, such as the typed configuration getters added in #50140.

Related discussion: #57730

The discussion also explores narrower translation array shapes such as `list<string>` and `array<string, string>`. After considering that further, I intentionally left those out of this PR so this change stays aligned with Laravel's existing typed getter pattern and does not distract from the base `string()` / `array()` API. If maintainers are interested in those narrower translation array shapes, I would be happy to explore the exact API and naming in a separate PR.

Tests:
```bash
vendor/bin/phpunit tests/Translation
```