### PR TITLE
[13.x] fix model:prune Command options validation typo

### DIFF
--- a/src/Illuminate/Database/Console/PruneCommand.php
+++ b/src/Illuminate/Database/Console/PruneCommand.php
@@ -121,7 +121,7 @@ class PruneCommand extends Command
         $except = $this->option('except');
 
         if ($models && $except) {
-            throw new InvalidArgumentException('The --models and --except options cannot be combined.');
+            throw new InvalidArgumentException('The --model and --except options cannot be combined.');
         }
 
         if ($models) {


### PR DESCRIPTION
This is just simply fixing a typo on the error message we see when we use both `model` and `except` with the `php artisan model:prune` Command.