### PR TITLE
[14.x] Mark Address properties as readonly

### DIFF
--- a/src/Illuminate/Mail/Mailables/Address.php
+++ b/src/Illuminate/Mail/Mailables/Address.php
@@ -7,32 +7,17 @@ use InvalidArgumentException;
 class Address
 {
     /**
-     * The recipient's email address.
-     *
-     * @var string
-     */
-    public $address;
-
-    /**
-     * The recipient's name.
-     *
-     * @var string|null
-     */
-    public $name;
-
-    /**
      * Create a new address instance.
      *
      * @param  string  $address
      * @param  string|null  $name
      */
-    public function __construct(string $address, ?string $name = null)
-    {
+    public function __construct(
+        public string $address,
+        public ?string $name = null,
+    ) {
         if (preg_match('/[\r\n]/', $address) > 0) {
             throw new InvalidArgumentException('Email addresses may not contain line break characters.');
         }
-
-        $this->address = $address;
-        $this->name = $name;
     }
 }

--- a/src/Illuminate/Mail/Mailables/Address.php
+++ b/src/Illuminate/Mail/Mailables/Address.php
@@ -13,8 +13,8 @@ class Address
      * @param  string|null  $name
      */
     public function __construct(
-        public string $address,
-        public ?string $name = null,
+        public readonly string $address,
+        public readonly ?string $name = null,
     ) {
         if (preg_match('/[\r\n]/', $address) > 0) {
             throw new InvalidArgumentException('Email addresses may not contain line break characters.');


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Recently a validator was added to the `Address` class to prevent malicious values from being used as email address. However, given the property is writable at runtime, this change does not fully cover all potential use-cases. This PR makes the properties of the class `readonly`, to ensure they are not overwritten later and thus always 'safe'. This prevents accidental misuse of this class.

As this is technically a breaking change, I've targeted `master`. The scope of impact is likely low-to-none, as dynamic updating of an `Address` record seems like an odd operation.

If wanted, a helper method `withAddress` or `withEmail` could be added, that would create a new instance (including value validation) to cover those cases if needed.

Finally it could be considered to make the class `readonly` in its entirety, and maybe even `final`, which I would consider best practice for a 'record' class like this, but have left out to not broaden the scope of this PR too much. If there is interest in such changes, let me know.