### PR TITLE
[13.x] Add generic to QueueRoutes::all() return type

### DIFF
--- a/src/Illuminate/Queue/QueueRoutes.php
+++ b/src/Illuminate/Queue/QueueRoutes.php
@@ -101,7 +101,7 @@ class QueueRoutes
     /**
      * Get all registered queue routes.
      *
-     * @return array
+     * @return array<class-string, array|string>
      */
     public function all()
     {


### PR DESCRIPTION
`QueueRoutes::all()` returns the `$routes` property directly, but its `@return` is bare `array` while the property is already declared `@var array<class-string, array|string>`. This syncs the getter's return type with the property's existing generic so IDEs and static analysis can infer it. 

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
