### PR TITLE
[13.x] Add `Model::isOnlyDirty()` and `Model::wasOnlyChanged()`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2227,6 +2227,19 @@ trait HasAttributes
     }
 
     /**
+     * Determine if only the given attribute(s) are dirty.
+     *
+     * @param  array<string>|string  $attributes
+     * @return bool
+     */
+    public function isOnlyDirty($attributes)
+    {
+        return $this->hasOnlyChanges(
+            $this->getDirty(), is_array($attributes) ? $attributes : func_get_args()
+        );
+    }
+
+    /**
      * Determine if the model or all the given attribute(s) have remained the same.
      *
      * @param  array<string>|string|null  $attributes
@@ -2266,6 +2279,19 @@ trait HasAttributes
     }
 
     /**
+     * Determine if only the given attribute(s) were changed when the model was last saved.
+     *
+     * @param  array<string>|string  $attributes
+     * @return bool
+     */
+    public function wasOnlyChanged($attributes)
+    {
+        return $this->hasOnlyChanges(
+            $this->getChanges(), is_array($attributes) ? $attributes : func_get_args()
+        );
+    }
+
+    /**
      * Determine if any of the given attributes were changed when the model was last saved.
      *
      * @param  array<string>  $changes
@@ -2291,6 +2317,22 @@ trait HasAttributes
         }
 
         return false;
+    }
+
+    /**
+     * Determine if only the given attributes were changed.
+     *
+     * @param  array<string>  $changes
+     * @param  array<string>  $attributes
+     * @return bool
+     */
+    protected function hasOnlyChanges($changes, $attributes)
+    {
+        $attributes = array_flip(Arr::wrap($attributes));
+
+        return count($changes) > 0
+            && count($changes) === count($attributes)
+            && count($changes) === count(array_intersect_key($changes, $attributes));
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -580,6 +580,22 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertTrue($model->hasCast('enumAttribute', StringStatus::class));
     }
 
+    public function testOnlyDirtyAttributes()
+    {
+        $model = new EloquentModelStub(['foo' => '1', 'bar' => 2, 'baz' => 3]);
+        $model->syncOriginal();
+        $model->foo = 1;
+        $model->bar = 20;
+        $model->baz = 30;
+
+        $this->assertFalse($model->isOnlyDirty('foo'));
+        $this->assertFalse($model->isOnlyDirty('bar'));
+        $this->assertFalse($model->isOnlyDirty('foo', 'bar'));
+        $this->assertTrue($model->isOnlyDirty('bar', 'baz'));
+        $this->assertTrue($model->isOnlyDirty(['bar', 'baz']));
+        $this->assertFalse($model->isOnlyDirty('foo', 'bar', 'baz'));
+    }
+
     public function testCleanAttributes()
     {
         $model = new EloquentModelStub(['foo' => '1', 'bar' => 2, 'baz' => 3]);

--- a/tests/Integration/Database/EloquentModelTest.php
+++ b/tests/Integration/Database/EloquentModelTest.php
@@ -66,6 +66,9 @@ class EloquentModelTest extends DatabaseTestCase
         $this->assertEquals(['name' => $originalName], $user->getPrevious());
         $this->assertTrue($user->wasChanged());
         $this->assertTrue($user->wasChanged('name'));
+        $this->assertTrue($user->wasOnlyChanged('name'));
+        $this->assertFalse($user->wasOnlyChanged('title'));
+        $this->assertFalse($user->wasOnlyChanged('name', 'title'));
     }
 
     public function testDiscardChanges()


### PR DESCRIPTION
**Description**:

This PR adds `wasOnlyChanged()` and `isOnlyDirty()` methods to Eloquent models for determining if only specific attributes were changed.

**Usage**:

A useful use case for this I found is with Laravel Scout. By default, models are always re-indexed when saved, regardless of whether searchable attributes actually changed:

```php
$model->save(); // Always dispatches `MakeSearchable`
```

By overriding the [`searchIndexShouldBeUpdated()` method](https://github.com/laravel/scout/blob/53e115ac80d8b7ccaa504ffc2720a4d2742a67ff/src/Searchable.php#L148-L156), we can skip reindexing when only irrelevant attributes (like `updated_at` if the model was `->touch()`'ed) were modified:

```php
/**
 * When updating a model, this method determines if we should update the search index.
 *
 * @return bool
 */
public function searchIndexShouldBeUpdated()
{
    return ! $this->wasOnlyChanged('updated_at');
}
```

Let me know your thoughts!