### PR TITLE
[13.x] Feat: support `ascending` and `descending` in `orderBy()`

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2982,16 +2982,9 @@ class Builder implements BuilderContract
             $this->addBinding($bindings, $this->unions ? 'unionOrder' : 'order');
         }
 
-        $direction = match (true) {
-            $direction instanceof SortDirection => match ($direction) {
-                SortDirection::Ascending => 'asc',
-                SortDirection::Descending => 'desc',
-            },
-            strtolower($direction) === 'asc', strtolower($direction) === 'ascending' => 'asc',
-            strtolower($direction) === 'desc', strtolower($direction) === 'descending' => 'desc',
         $direction = match (strtolower(enum_value($direction))) {
             'asc', 'ascending' => 'asc',
-            desc', 'descending' => 'desc',
+            'desc', 'descending' => 'desc',
             default => throw new InvalidArgumentException('Order direction must be a SortDirection, "asc" or "desc", "ascending" or "descending".'),
         };
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2989,6 +2989,9 @@ class Builder implements BuilderContract
             },
             strtolower($direction) === 'asc', strtolower($direction) === 'ascending' => 'asc',
             strtolower($direction) === 'desc', strtolower($direction) === 'descending' => 'desc',
+        $direction = match (strtolower(enum_value($direction))) {
+            'asc', 'ascending' => 'asc',
+            desc', 'descending' => 'desc',
             default => throw new InvalidArgumentException('Order direction must be a SortDirection, "asc" or "desc", "ascending" or "descending".'),
         };
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2967,7 +2967,7 @@ class Builder implements BuilderContract
      * Add an "order by" clause to the query.
      *
      * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<*>|\Illuminate\Contracts\Database\Query\Expression|string  $column
-     * @param  SortDirection|'asc'|'desc'  $direction
+     * @param  SortDirection|'asc'|'ascending'|'desc'|'descending'  $direction
      * @return $this
      *
      * @throws \InvalidArgumentException
@@ -2987,9 +2987,9 @@ class Builder implements BuilderContract
                 SortDirection::Ascending => 'asc',
                 SortDirection::Descending => 'desc',
             },
-            strtolower($direction) === 'asc' => 'asc',
-            strtolower($direction) === 'desc' => 'desc',
-            default => throw new InvalidArgumentException('Order direction must be a SortDirection, "asc" or "desc".'),
+            strtolower($direction) === 'asc', strtolower($direction) === 'ascending' => 'asc',
+            strtolower($direction) === 'desc', strtolower($direction) === 'descending' => 'desc',
+            default => throw new InvalidArgumentException('Order direction must be a SortDirection, "asc" or "desc", "ascending" or "descending".'),
         };
 
         $this->{$this->unions ? 'unionOrders' : 'orders'}[] = [


### PR DESCRIPTION
While working on a project with an enum whose values were `ascending` and `descending`, passing them directly to `orderBy()` threw an `InvalidArgumentException`. This change adds support for the full-word variants alongside the existing `asc` / `desc` shorthands, making the method more flexible without breaking any existing behavior.