### PR TITLE
Allow prohibitable to accept closure

### DIFF
--- a/src/Illuminate/Console/Prohibitable.php
+++ b/src/Illuminate/Console/Prohibitable.php
@@ -2,19 +2,25 @@
 
 namespace Illuminate\Console;
 
+use Closure;
+
 trait Prohibitable
 {
     /**
      * Indicates if the command should be prohibited from running.
      *
-     * @var bool
+     * @var bool|(\Closure(\Symfony\Component\Console\Input\InputInterface): bool)
      */
     protected static $prohibitedFromRunning = false;
 
     /**
      * Indicate whether the command should be prohibited from running.
      *
-     * @param  bool  $prohibit
+     * Pass a closure to prohibit the command only for specific input. The
+     * closure receives the command's input and should return true to
+     * prohibit the command from running for that invocation.
+     *
+     * @param  bool|(\Closure(\Symfony\Component\Console\Input\InputInterface): bool)  $prohibit
      * @return void
      */
     public static function prohibit($prohibit = true)
@@ -30,7 +36,11 @@ trait Prohibitable
      */
     protected function isProhibited(bool $quiet = false)
     {
-        if (! static::$prohibitedFromRunning) {
+        $prohibited = static::$prohibitedFromRunning instanceof Closure
+            ? (bool) (static::$prohibitedFromRunning)($this->input)
+            : static::$prohibitedFromRunning;
+
+        if (! $prohibited) {
             return false;
         }
 

--- a/tests/Cache/ClearCommandTest.php
+++ b/tests/Cache/ClearCommandTest.php
@@ -53,6 +53,16 @@ class ClearCommandTest extends TestCase
         $this->command->setLaravel($app);
     }
 
+    /**
+     * {@inheritdoc}
+     */
+    protected function tearDown(): void
+    {
+        ClearCommand::prohibit(false);
+
+        parent::tearDown();
+    }
+
     public function testClearWithNoStoreArgument()
     {
         $this->files->shouldReceive('exists')->andReturn(true);
@@ -183,6 +193,81 @@ class ClearCommandTest extends TestCase
         $this->cacheRepository->shouldNotReceive('flush');
 
         $this->assertSame(1, $this->runCommand($this->command, ['--locks' => true]));
+    }
+
+    public function testProhibitWithoutArgumentsBlocksEveryStore()
+    {
+        ClearCommand::prohibit();
+
+        $this->cacheManager->shouldNotReceive('store');
+        $this->cacheRepository->shouldNotReceive('flush');
+
+        $this->assertSame(1, $this->runCommand($this->command, ['store' => 'cache']));
+    }
+
+    public function testProhibitWithClosureCanBlockSpecificStores()
+    {
+        // Deny "cache:clear locks", but allow other stores through.
+        ClearCommand::prohibit(fn ($input) => $input->getArgument('store') === 'locks');
+
+        $this->cacheManager->shouldNotReceive('store');
+        $this->cacheRepository->shouldNotReceive('flush');
+
+        $this->assertSame(1, $this->runCommand($this->command, ['store' => 'locks']));
+    }
+
+    public function testProhibitWithClosureAllowsStoresThatAreNotBlocked()
+    {
+        // Same denylist closure as above: "cache:clear cache" must still run.
+        ClearCommand::prohibit(fn ($input) => $input->getArgument('store') === 'locks');
+
+        $this->files->shouldReceive('exists')->andReturn(true);
+        $this->files->shouldReceive('files')->andReturn([]);
+
+        $this->cacheManager->shouldReceive('store')->once()->with('cache')->andReturn($this->cacheRepository);
+        $this->cacheRepository->shouldReceive('flush')->once()->andReturn(true);
+
+        $this->assertSame(0, $this->runCommand($this->command, ['store' => 'cache']));
+    }
+
+    public function testProhibitWithAllowlistBlocksUnlistedStores()
+    {
+        // Allowlist: anything other than the "cache" store is prohibited. This
+        // protects custom stores by default, including new ones added later
+        // and the bare "cache:clear" (default store) invocation.
+        ClearCommand::prohibit(fn ($input) => ! in_array($input->getArgument('store'), ['cache'], true));
+
+        $this->cacheManager->shouldNotReceive('store');
+        $this->cacheRepository->shouldNotReceive('flush');
+
+        $this->assertSame(1, $this->runCommand($this->command, ['store' => 'locks']));
+        $this->assertSame(1, $this->runCommand($this->command));
+    }
+
+    public function testProhibitWithAllowlistAllowsListedStores()
+    {
+        ClearCommand::prohibit(fn ($input) => ! in_array($input->getArgument('store'), ['cache'], true));
+
+        $this->files->shouldReceive('exists')->andReturn(true);
+        $this->files->shouldReceive('files')->andReturn([]);
+
+        $this->cacheManager->shouldReceive('store')->once()->with('cache')->andReturn($this->cacheRepository);
+        $this->cacheRepository->shouldReceive('flush')->once()->andReturn(true);
+
+        $this->assertSame(0, $this->runCommand($this->command, ['store' => 'cache']));
+    }
+
+    public function testProhibitByStoreArgumentIgnoresTheLocksOption()
+    {
+        // A store *named* "locks" (the argument) is unrelated to the --locks
+        // *option*, which clears lock entries from the default store. A closure
+        // keyed on the store argument therefore does not block "cache:clear --locks".
+        ClearCommand::prohibit(fn ($input) => $input->getArgument('store') === 'locks');
+
+        $this->cacheManager->shouldReceive('store')->once()->with(null)->andReturn($this->cacheRepository);
+        $this->cacheRepository->shouldReceive('flushLocks')->once()->andReturn(true);
+
+        $this->assertSame(0, $this->runCommand($this->command, ['--locks' => true]));
     }
 
     protected function runCommand($command, $input = [])


### PR DESCRIPTION
Follow-up to #60430: 

Prohibitable::prohibit() is currently all-or-nothing, so you can block cache:clear entirely but can't allow some invocations while denying others. This change lets prohibit() accept a Closure (in addition to the existing bool); the closure receives the command's $this->input and returns whether that specific invocation is prohibited — e.g. for an app with extra cache stores (admittedly not the typical setup), you can allow "php artisan cache:clear cache" while blocking "php artisan cache:clear locks".

It's fully backwards compatible since a bool argument behaves exactly as before and only a Closure triggers the new path, so every existing caller (DB::prohibitDestructiveCommands(), the migration commands, etc.) is unaffected.

Example of usage

```
<?php

namespace App\Providers;

use Illuminate\Cache\Console\ClearCommand as CacheClearCommand;
use Illuminate\Support\ServiceProvider;

class AppServiceProvider extends ServiceProvider
{
    public function boot(): void
    {
        if ($this->app->isProduction()) {
            CacheClearCommand::prohibit(
                fn ($input) => in_array($input->getArgument('store'), ['queues', 'locks'], true)
            );
        }
    }
}

```
