### PR TITLE
[13.x] Feat: add `onlyValues()` and `exceptValues()`

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -416,6 +416,18 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Get all items except for a specified array of values.
+     *
+     * @param  mixed  $values
+     * @param  bool  $strict
+     * @return static
+     */
+    public function exceptValues($values, $strict = false)
+    {
+        return $this->newInstance(Arr::exceptValues($this->items, $values, $strict));
+    }
+
+    /**
      * Run a filter over each of the items.
      *
      * @param  (callable(TValue, TKey): bool)|null  $callback
@@ -991,6 +1003,18 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
         $keys = is_array($keys) ? $keys : func_get_args();
 
         return $this->newInstance(Arr::only($this->items, $keys));
+    }
+
+    /**
+     * Get a subset of the items from the given array by value.
+     *
+     * @param  mixed  $values
+     * @param  bool  $strict
+     * @return static
+     */
+    public function onlyValues($values, $strict = false)
+    {
+        return $this->newInstance(Arr::onlyValues($this->items, $values, $strict));
     }
 
     /**


### PR DESCRIPTION
continuation of: #58317

✨ Add `onlyValues()` and `exceptValues()` methods to `Collection`

This PR introduces two new helper methods to the `Collection` class: `onlyValues()` and `exceptValues()`.

🔹 What’s added?

`onlyValues($values, $strict = false)`
Returns a new collection containing only items whose values exist in the given list.

`exceptValues($values, $strict = false)`
Returns a new collection excluding items whose values exist in the given list.

🔹 Behavior

Mirrors the behavior of `Arr::onlyValues` and `Arr::exceptValues`

Preserves original keys

Supports both strict and non-strict comparisons

Returns a new collection instance (non-mutating)

🔹 Why?

These methods provide a value-based filtering counterpart to existing key-based helpers (only, except), improving API symmetry between `Arr` and `Collection` and reducing the need for manual filter callbacks.