### PR TITLE
[13.x] Add missing shared methods to the Enumerable contract

### DIFF
--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -119,6 +119,13 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public function collapse();
 
     /**
+     * Collapse the items into a single enumerable while preserving its keys.
+     *
+     * @return static<mixed, mixed>
+     */
+    public function collapseWithKeys();
+
+    /**
      * Alias for the "contains" method.
      *
      * @param  (callable(TValue, TKey): bool)|TValue|string  $key
@@ -164,6 +171,16 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * @return bool
      */
     public function doesntContain($key, $operator = null, $value = null);
+
+    /**
+     * Determine if an item is not contained in the enumerable, using strict comparison.
+     *
+     * @param  mixed  $key
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function doesntContainStrict($key, $operator = null, $value = null);
 
     /**
      * Cross join with the given lists, returning all possible permutations.
@@ -775,6 +792,14 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public function merge($items);
 
     /**
+     * Multiply the items in the enumerable by the multiplier.
+     *
+     * @param  int  $multiplier
+     * @return static
+     */
+    public function multiply(int $multiplier);
+
+    /**
      * Recursively merge the collection with the given items.
      *
      * @template TMergeRecursiveValue
@@ -933,6 +958,14 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * @return TKey|false
      */
     public function search($value, $strict = false);
+
+    /**
+     * Select specific values from the items within the enumerable.
+     *
+     * @param  \Illuminate\Support\Enumerable<array-key, TKey>|array<array-key, TKey>|string|null  $keys
+     * @return static
+     */
+    public function select($keys);
 
     /**
      * Get the item before the given item.
@@ -1202,6 +1235,14 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * @return static
      */
     public function reject($callback = true);
+
+    /**
+     * Flatten a multi-dimensional associative array with dots.
+     *
+     * @param  int  $depth
+     * @return static
+     */
+    public function dot($depth = INF);
 
     /**
      * Convert a flatten "dot" notation array into an expanded array.

--- a/tests/Support/SupportEnumerableContractTest.php
+++ b/tests/Support/SupportEnumerableContractTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\Enumerable;
+use Illuminate\Support\LazyCollection;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+class SupportEnumerableContractTest extends TestCase
+{
+    /**
+     * Methods that are implemented by both Collection and LazyCollection
+     * and therefore are expected to be part of the Enumerable contract.
+     */
+    public static function sharedMethodsProvider(): array
+    {
+        return [
+            ['collapseWithKeys'],
+            ['doesntContainStrict'],
+            ['dot'],
+            ['multiply'],
+            ['select'],
+        ];
+    }
+
+    #[DataProvider('sharedMethodsProvider')]
+    public function testEnumerableContractDeclaresSharedMethod(string $method)
+    {
+        $this->assertTrue(
+            method_exists(Enumerable::class, $method),
+            "Failed asserting that the Enumerable contract declares [{$method}]."
+        );
+    }
+
+    #[DataProvider('sharedMethodsProvider')]
+    public function testImplementorsProvideSharedMethod(string $method)
+    {
+        $this->assertTrue(method_exists(Collection::class, $method));
+        $this->assertTrue(method_exists(LazyCollection::class, $method));
+    }
+
+    public function testCollectionImplementsEveryEnumerableMethod()
+    {
+        $this->assertImplementsContract(Collection::class);
+    }
+
+    public function testLazyCollectionImplementsEveryEnumerableMethod()
+    {
+        $this->assertImplementsContract(LazyCollection::class);
+    }
+
+    protected function assertImplementsContract(string $class)
+    {
+        $missing = [];
+
+        foreach ((new ReflectionClass(Enumerable::class))->getMethods() as $method) {
+            if (! method_exists($class, $method->getName())) {
+                $missing[] = $method->getName();
+            }
+        }
+
+        $this->assertSame(
+            [],
+            $missing,
+            "[{$class}] is missing Enumerable contract methods: ".implode(', ', $missing)
+        );
+    }
+}


### PR DESCRIPTION
`Collection` and `LazyCollection` both implement the `Enumerable` contract, but five methods present on **both** concrete classes were never added to the interface itself:

- `collapseWithKeys()`
- `doesntContainStrict()`
- `dot()`
- `multiply()`
- `select()`

Because they're absent from the contract, anyone type-hinting `Enumerable` (rather than the concrete classes) gets static analysis / IDE errors when calling them, even though they always work at runtime:

```php
function pick(\Illuminate\Support\Enumerable $items): \Illuminate\Support\Enumerable
{
    return $items->select(['id', 'name']); // flagged: undefined method
}
```

This PR adds the five missing declarations, mirroring the existing implementations' signatures and docblocks. Each is placed next to its sibling in the interface (e.g. collapseWithKeys after collapse, dot before undot).

Since both implementers already define all five methods, there is no behavioural or BC impact for the framework.
A contract test is included that fails if either concrete class drifts from the Enumerable interface in the future.