### PR TITLE
Add support for caching HTTP client responses

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -36,6 +36,9 @@ use Psr\Http\Message\MessageInterface;
 use Psr\Http\Message\RequestInterface;
 use Symfony\Component\VarDumper\VarDumper;
 use Throwable;
+use UnitEnum;
+
+use function Illuminate\Support\enum_value;
 
 /**
  * @template TAsync of bool = false
@@ -702,14 +705,14 @@ class PendingRequest
      *
      * @param  string  $key
      * @param  \DateTimeInterface|\DateInterval|int|array  $ttl
-     * @param  array|string  $methods
+     * @param  \UnitEnum|array|string  $methods
      * @return $this
      */
-    public function cache(string $key, DateTimeInterface|DateInterval|int|array $ttl, array|string $methods = ['GET'])
+    public function cache(string $key, DateTimeInterface|DateInterval|int|array $ttl, UnitEnum|array|string $methods = ['GET'])
     {
         $this->cacheKey = $key;
         $this->cacheTtl = $ttl;
-        $this->cacheMethods = array_map('strtoupper', Arr::wrap($methods));
+        $this->cacheMethods = array_map(fn ($method) => strtoupper(enum_value($method)), Arr::wrap($methods));
 
         return $this;
     }

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -3,6 +3,8 @@
 namespace Illuminate\Http\Client;
 
 use Closure;
+use DateInterval;
+use DateTimeInterface;
 use Exception;
 use GuzzleHttp\Client;
 use GuzzleHttp\Cookie\CookieJar;
@@ -13,6 +15,7 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
 use GuzzleHttp\Promise\EachPromise;
 use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Psr7\Response as Psr7Response;
 use GuzzleHttp\UriTemplate\UriTemplate;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Http\Client\Events\ConnectionFailed;
@@ -22,6 +25,7 @@ use Illuminate\Http\Client\Promises\FluentPromise;
 use Illuminate\Http\Client\Promises\LazyPromise;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Str;
 use Illuminate\Support\Stringable;
 use Illuminate\Support\Traits\Conditionable;
@@ -158,6 +162,20 @@ class PendingRequest
      * @var (callable(\Throwable, static, string|null): bool)|null
      */
     protected $retryWhenCallback = null;
+
+    /**
+     * The cache key to use for the request.
+     *
+     * @var string|null
+     */
+    protected $cacheKey;
+
+    /**
+     * The cache TTL to use for the request.
+     *
+     * @var \DateTimeInterface|\DateInterval|int|array|null
+     */
+    protected $cacheTtl;
 
     /**
      * The callbacks that should execute before the request is sent.
@@ -673,6 +691,21 @@ class PendingRequest
     }
 
     /**
+     * Cache successful GET responses for the request.
+     *
+     * @param  string  $key
+     * @param  \DateTimeInterface|\DateInterval|int|array  $ttl
+     * @return $this
+     */
+    public function cache(string $key, DateTimeInterface|DateInterval|int|array $ttl)
+    {
+        $this->cacheKey = $key;
+        $this->cacheTtl = $ttl;
+
+        return $this;
+    }
+
+    /**
      * Replace the specified options on the request.
      *
      * @param  array  $options
@@ -1042,6 +1075,26 @@ class PendingRequest
             );
         }
 
+        if ($this->shouldCacheRequest($method)) {
+            return $this->sendCachedRequest(fn () => $this->sendSynchronously($method, $url, $options));
+        }
+
+        return $this->sendSynchronously($method, $url, $options);
+    }
+
+    /**
+     * Send the request synchronously.
+     *
+     * @param  string  $method
+     * @param  string  $url
+     * @param  array  $options
+     * @return \Illuminate\Http\Client\Response
+     *
+     * @throws \Exception
+     * @throws \Illuminate\Http\Client\ConnectionException
+     */
+    protected function sendSynchronously(string $method, string $url, array $options)
+    {
         $shouldRetry = null;
 
         return retry($this->tries ?? 1, function ($attempt) use ($method, $url, $options, &$shouldRetry) {
@@ -1104,6 +1157,81 @@ class PendingRequest
 
             return $result;
         });
+    }
+
+    /**
+     * Determine if the request should be cached.
+     *
+     * @param  string  $method
+     * @return bool
+     */
+    protected function shouldCacheRequest(string $method)
+    {
+        return $this->cacheKey !== null && $this->cacheTtl !== null && strtoupper($method) === 'GET';
+    }
+
+    /**
+     * Send the request using the configured response cache.
+     *
+     * @param  \Closure(): \Illuminate\Http\Client\Response  $callback
+     * @return \Illuminate\Http\Client\Response
+     */
+    protected function sendCachedRequest(Closure $callback)
+    {
+        $response = null;
+
+        try {
+            $value = is_array($this->cacheTtl)
+                ? Cache::flexible($this->cacheKey, $this->cacheTtl, function () use (&$response, $callback) {
+                    return $this->cacheResponse($response = $callback());
+                })
+                : Cache::remember($this->cacheKey, $this->cacheTtl, function () use (&$response, $callback) {
+                    return $this->cacheResponse($response = $callback());
+                });
+        } catch (UncacheableResponseException $e) {
+            return $e->response;
+        }
+
+        return $response ?: $this->newResponseFromCachedValue($value)->setFromCache();
+    }
+
+    /**
+     * Get the cache value for the given response.
+     *
+     * @param  \Illuminate\Http\Client\Response  $response
+     * @return array
+     *
+     * @throws \Illuminate\Http\Client\UncacheableResponseException
+     */
+    protected function cacheResponse(Response $response)
+    {
+        if (! $response->successful()) {
+            throw new UncacheableResponseException($response);
+        }
+
+        return [
+            'body' => $response->body(),
+            'headers' => $response->headers(),
+            'reason' => $response->reason(),
+            'status' => $response->status(),
+        ];
+    }
+
+    /**
+     * Create a new response from a cached value.
+     *
+     * @param  array  $value
+     * @return \Illuminate\Http\Client\Response
+     */
+    protected function newResponseFromCachedValue(array $value)
+    {
+        return $this->newResponse(new Psr7Response(
+            $value['status'],
+            $value['headers'],
+            $value['body'],
+            '1.1',
+            $value['reason'] ?? null,
+        ));
     }
 
     /**

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -178,6 +178,13 @@ class PendingRequest
     protected $cacheTtl;
 
     /**
+     * The HTTP methods that should be cached.
+     *
+     * @var array
+     */
+    protected $cacheMethods = ['GET'];
+
+    /**
      * The callbacks that should execute before the request is sent.
      *
      * @var \Illuminate\Support\Collection
@@ -691,16 +698,18 @@ class PendingRequest
     }
 
     /**
-     * Cache successful GET responses for the request.
+     * Cache successful responses for the request.
      *
      * @param  string  $key
      * @param  \DateTimeInterface|\DateInterval|int|array  $ttl
+     * @param  array|string  $methods
      * @return $this
      */
-    public function cache(string $key, DateTimeInterface|DateInterval|int|array $ttl)
+    public function cache(string $key, DateTimeInterface|DateInterval|int|array $ttl, array|string $methods = ['GET'])
     {
         $this->cacheKey = $key;
         $this->cacheTtl = $ttl;
+        $this->cacheMethods = array_map('strtoupper', Arr::wrap($methods));
 
         return $this;
     }
@@ -1167,7 +1176,9 @@ class PendingRequest
      */
     protected function shouldCacheRequest(string $method)
     {
-        return $this->cacheKey !== null && $this->cacheTtl !== null && strtoupper($method) === 'GET';
+        return $this->cacheKey !== null &&
+            $this->cacheTtl !== null &&
+            in_array(strtoupper($method), $this->cacheMethods, true);
     }
 
     /**

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -70,6 +70,13 @@ class Response implements ArrayAccess, Stringable
     protected $truncateExceptionsAt = null;
 
     /**
+     * Indicates if the response was served from cache.
+     *
+     * @var bool
+     */
+    protected bool $fromCache = false;
+
+    /**
      * The flags passed to `json_decode` by default.
      *
      * @var int-mask<JSON_BIGINT_AS_STRING, JSON_INVALID_UTF8_IGNORE, JSON_INVALID_UTF8_SUBSTITUTE, JSON_OBJECT_AS_ARRAY, JSON_THROW_ON_ERROR>
@@ -220,6 +227,29 @@ class Response implements ArrayAccess, Stringable
     public function effectiveUri()
     {
         return $this->transferStats?->getEffectiveUri();
+    }
+
+    /**
+     * Determine if the response was served from cache.
+     *
+     * @return bool
+     */
+    public function fromCache(): bool
+    {
+        return $this->fromCache;
+    }
+
+    /**
+     * Indicate if the response was served from cache.
+     *
+     * @param  bool  $fromCache
+     * @return $this
+     */
+    public function setFromCache(bool $fromCache = true)
+    {
+        $this->fromCache = $fromCache;
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Http/Client/UncacheableResponseException.php
+++ b/src/Illuminate/Http/Client/UncacheableResponseException.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\Http\Client;
+
+use Illuminate\Contracts\Debug\ShouldntReport;
+
+class UncacheableResponseException extends HttpClientException implements ShouldntReport
+{
+    /**
+     * Create a new exception instance.
+     *
+     * @param  \Illuminate\Http\Client\Response  $response
+     */
+    public function __construct(public Response $response)
+    {
+        parent::__construct('The HTTP client response is not cacheable.');
+    }
+}

--- a/src/Illuminate/Support/Facades/Http.php
+++ b/src/Illuminate/Support/Facades/Http.php
@@ -61,6 +61,7 @@ use Illuminate\Http\Client\Factory;
  * @method static \Illuminate\Http\Client\PendingRequest timeout(int|float $seconds)
  * @method static \Illuminate\Http\Client\PendingRequest connectTimeout(int|float $seconds)
  * @method static \Illuminate\Http\Client\PendingRequest retry(array|int $times, \Closure|int $sleepMilliseconds = 0, callable|null $when = null, bool $throw = true)
+ * @method static \Illuminate\Http\Client\PendingRequest cache(string $key, \DateTimeInterface|\DateInterval|int|array $ttl, array|string $methods = ['GET'])
  * @method static \Illuminate\Http\Client\PendingRequest withOptions(array $options)
  * @method static \Illuminate\Http\Client\PendingRequest withMiddleware(callable $middleware)
  * @method static \Illuminate\Http\Client\PendingRequest withRequestMiddleware(callable $middleware)

--- a/src/Illuminate/Support/Facades/Http.php
+++ b/src/Illuminate/Support/Facades/Http.php
@@ -61,7 +61,7 @@ use Illuminate\Http\Client\Factory;
  * @method static \Illuminate\Http\Client\PendingRequest timeout(int|float $seconds)
  * @method static \Illuminate\Http\Client\PendingRequest connectTimeout(int|float $seconds)
  * @method static \Illuminate\Http\Client\PendingRequest retry(array|int $times, \Closure|int $sleepMilliseconds = 0, callable|null $when = null, bool $throw = true)
- * @method static \Illuminate\Http\Client\PendingRequest cache(string $key, \DateTimeInterface|\DateInterval|int|array $ttl, array|string $methods = ['GET'])
+ * @method static \Illuminate\Http\Client\PendingRequest cache(string $key, \DateTimeInterface|\DateInterval|int|array $ttl, \UnitEnum|array|string $methods = ['GET'])
  * @method static \Illuminate\Http\Client\PendingRequest withOptions(array $options)
  * @method static \Illuminate\Http\Client\PendingRequest withMiddleware(callable $middleware)
  * @method static \Illuminate\Http\Client\PendingRequest withRequestMiddleware(callable $middleware)

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Http;
 
+use Closure;
 use Exception;
 use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\Exception\ConnectException;
@@ -16,6 +17,8 @@ use GuzzleHttp\Psr7\Request as GuzzleRequest;
 use GuzzleHttp\Psr7\Response as Psr7Response;
 use GuzzleHttp\Psr7\Utils;
 use GuzzleHttp\TransferStats;
+use Illuminate\Cache\ArrayStore;
+use Illuminate\Cache\Repository as CacheRepository;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Http\Client\Batch;
@@ -36,6 +39,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Defer\DeferredCallback;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Fluent;
 use Illuminate\Support\Sleep;
 use Illuminate\Support\Str;
@@ -75,6 +79,12 @@ class HttpClientTest extends TestCase
     protected function tearDown(): void
     {
         Response::flushState();
+        Cache::clearResolvedInstance('cache');
+    }
+
+    protected function swapCacheRepository(?CacheRepository $repository = null)
+    {
+        Cache::swap($repository ?: new CacheRepository(new ArrayStore));
     }
 
     public function testStubbedResponsesAreReturnedAfterFaking()
@@ -4207,6 +4217,140 @@ class HttpClientTest extends TestCase
 
         $this->assertInstanceOf(TestResponse::class, $response);
         $this->assertSame('expected content', $response->body());
+    }
+
+    public function testSuccessfulGetResponsesCanBeCached()
+    {
+        $this->swapCacheRepository();
+
+        $this->factory->fake([
+            'https://laravel.com' => $this->factory->sequence()
+                ->push('fresh content', 200, ['X-Test' => 'one'])
+                ->push('uncached content'),
+        ]);
+
+        $first = $this->factory->cache('laravel-docs', 600)->get('https://laravel.com');
+        $second = $this->factory->cache('laravel-docs', 600)->get('https://laravel.com');
+
+        $this->assertFalse($first->fromCache());
+        $this->assertTrue($second->fromCache());
+        $this->assertSame('fresh content', $second->body());
+        $this->assertSame(200, $second->status());
+        $this->assertSame('OK', $second->reason());
+        $this->assertSame('one', $second->header('X-Test'));
+        $this->factory->assertSentCount(1);
+    }
+
+    public function testSuccessfulGetResponsesUseRememberForNormalTtl()
+    {
+        $cache = new class(new ArrayStore) extends CacheRepository
+        {
+            public bool $rememberCalled = false;
+
+            public function remember($key, $ttl, Closure $callback)
+            {
+                $this->rememberCalled = true;
+
+                return parent::remember($key, $ttl, $callback);
+            }
+        };
+
+        $this->swapCacheRepository($cache);
+
+        $this->factory->fake([
+            'https://laravel.com' => $this->factory::response('remembered'),
+        ]);
+
+        $response = $this->factory->cache('laravel-docs', 600)->get('https://laravel.com');
+
+        $this->assertFalse($response->fromCache());
+        $this->assertTrue($cache->rememberCalled);
+        $this->assertSame('remembered', $this->factory->cache('laravel-docs', 600)->get('https://laravel.com')->body());
+    }
+
+    public function testSuccessfulGetResponsesUseFlexibleForArrayTtl()
+    {
+        $cache = new class(new ArrayStore) extends CacheRepository
+        {
+            public bool $flexibleCalled = false;
+
+            public function flexible($key, $ttl, $callback, $lock = null, $alwaysDefer = false)
+            {
+                $this->flexibleCalled = true;
+
+                return parent::flexible($key, $ttl, $callback, $lock, $alwaysDefer);
+            }
+        };
+
+        $this->swapCacheRepository($cache);
+
+        $this->factory->fake([
+            'https://laravel.com' => $this->factory::response('flexible'),
+        ]);
+
+        $response = $this->factory->cache('laravel-docs', [60, 300])->get('https://laravel.com');
+
+        $this->assertFalse($response->fromCache());
+        $this->assertTrue($cache->flexibleCalled);
+        $this->assertSame('flexible', $this->factory->cache('laravel-docs', [60, 300])->get('https://laravel.com')->body());
+    }
+
+    public function testFailedResponsesAreNotCachedByDefault()
+    {
+        $this->swapCacheRepository();
+
+        $this->factory->fake([
+            'https://laravel.com' => $this->factory->sequence()
+                ->push('failed', 500)
+                ->push('recovered', 200),
+        ]);
+
+        $first = $this->factory->cache('laravel-docs', 600)->get('https://laravel.com');
+        $second = $this->factory->cache('laravel-docs', 600)->get('https://laravel.com');
+
+        $this->assertFalse($first->fromCache());
+        $this->assertFalse($second->fromCache());
+        $this->assertSame(500, $first->status());
+        $this->assertSame('recovered', $second->body());
+        $this->factory->assertSentCount(2);
+    }
+
+    public function testNonGetResponsesAreNotCachedByDefault()
+    {
+        $this->swapCacheRepository();
+
+        $this->factory->fake([
+            'https://laravel.com' => $this->factory->sequence()
+                ->push('created')
+                ->push('created again'),
+        ]);
+
+        $first = $this->factory->cache('laravel-docs', 600)->post('https://laravel.com');
+        $second = $this->factory->cache('laravel-docs', 600)->post('https://laravel.com');
+
+        $this->assertFalse($first->fromCache());
+        $this->assertFalse($second->fromCache());
+        $this->assertSame('created again', $second->body());
+        $this->factory->assertSentCount(2);
+    }
+
+    public function testHttpFakeWorksWithCachedResponses()
+    {
+        $this->swapCacheRepository();
+
+        $this->factory->fake([
+            'https://laravel.com' => $this->factory->sequence()
+                ->push('fake response')
+                ->push('next response'),
+        ]);
+
+        $first = $this->factory->cache('laravel-docs', 600)->get('https://laravel.com');
+        $second = $this->factory->cache('laravel-docs', 600)->get('https://laravel.com');
+
+        $this->assertFalse($first->fromCache());
+        $this->assertTrue($second->fromCache());
+        $this->assertSame('fake response', $second->body());
+        $this->factory->assertSentCount(1);
     }
 
     public function testItCanHaveGlobalDefaultValues()

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -4248,7 +4248,7 @@ class HttpClientTest extends TestCase
         $docComment = (new \ReflectionClass(HttpFacade::class))->getDocComment();
 
         $this->assertStringContainsString(
-            '@method static \Illuminate\Http\Client\PendingRequest cache(string $key, \DateTimeInterface|\DateInterval|int|array $ttl, array|string $methods = [\'GET\'])',
+            '@method static \Illuminate\Http\Client\PendingRequest cache(string $key, \DateTimeInterface|\DateInterval|int|array $ttl, \UnitEnum|array|string $methods = [\'GET\'])',
             $docComment
         );
     }
@@ -4377,6 +4377,25 @@ class HttpClientTest extends TestCase
 
         $first = $this->factory->cache('laravel-docs', 600, 'post')->post('https://laravel.com');
         $second = $this->factory->cache('laravel-docs', 600, 'post')->post('https://laravel.com');
+
+        $this->assertFalse($first->fromCache());
+        $this->assertTrue($second->fromCache());
+        $this->assertSame('created', $second->body());
+        $this->factory->assertSentCount(1);
+    }
+
+    public function testCacheMethodsMayBeEnums()
+    {
+        $this->swapCacheRepository();
+
+        $this->factory->fake([
+            'https://laravel.com' => $this->factory->sequence()
+                ->push('created')
+                ->push('created again'),
+        ]);
+
+        $first = $this->factory->cache('laravel-docs', 600, HttpClientCacheMethod::Post)->post('https://laravel.com');
+        $second = $this->factory->cache('laravel-docs', 600, HttpClientCacheMethod::Post)->post('https://laravel.com');
 
         $this->assertFalse($first->fromCache());
         $this->assertTrue($second->fromCache());
@@ -5021,4 +5040,9 @@ class BodyTrackingResponse extends Response
 
         return parent::body();
     }
+}
+
+enum HttpClientCacheMethod: string
+{
+    case Post = 'POST';
 }

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Http;
 
+use ArgumentCountError;
 use Closure;
 use Exception;
 use GuzzleHttp\Client as GuzzleClient;
@@ -40,6 +41,7 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Defer\DeferredCallback;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http as HttpFacade;
 use Illuminate\Support\Fluent;
 use Illuminate\Support\Sleep;
 use Illuminate\Support\Str;
@@ -4241,6 +4243,16 @@ class HttpClientTest extends TestCase
         $this->factory->assertSentCount(1);
     }
 
+    public function testHttpFacadeHasCacheAutocompleteAnnotation()
+    {
+        $docComment = (new \ReflectionClass(HttpFacade::class))->getDocComment();
+
+        $this->assertStringContainsString(
+            '@method static \Illuminate\Http\Client\PendingRequest cache(string $key, \DateTimeInterface|\DateInterval|int|array $ttl, array|string $methods = [\'GET\'])',
+            $docComment
+        );
+    }
+
     public function testSuccessfulGetResponsesUseRememberForNormalTtl()
     {
         $cache = new class(new ArrayStore) extends CacheRepository
@@ -4334,6 +4346,44 @@ class HttpClientTest extends TestCase
         $this->factory->assertSentCount(2);
     }
 
+    public function testNonGetResponsesCanBeCachedWhenExplicitlyConfigured()
+    {
+        $this->swapCacheRepository();
+
+        $this->factory->fake([
+            'https://laravel.com' => $this->factory->sequence()
+                ->push('created')
+                ->push('created again'),
+        ]);
+
+        $first = $this->factory->cache('laravel-docs', 600, ['POST'])->post('https://laravel.com');
+        $second = $this->factory->cache('laravel-docs', 600, ['POST'])->post('https://laravel.com');
+
+        $this->assertFalse($first->fromCache());
+        $this->assertTrue($second->fromCache());
+        $this->assertSame('created', $second->body());
+        $this->factory->assertSentCount(1);
+    }
+
+    public function testCacheMethodsAreNormalized()
+    {
+        $this->swapCacheRepository();
+
+        $this->factory->fake([
+            'https://laravel.com' => $this->factory->sequence()
+                ->push('created')
+                ->push('created again'),
+        ]);
+
+        $first = $this->factory->cache('laravel-docs', 600, 'post')->post('https://laravel.com');
+        $second = $this->factory->cache('laravel-docs', 600, 'post')->post('https://laravel.com');
+
+        $this->assertFalse($first->fromCache());
+        $this->assertTrue($second->fromCache());
+        $this->assertSame('created', $second->body());
+        $this->factory->assertSentCount(1);
+    }
+
     public function testHttpFakeWorksWithCachedResponses()
     {
         $this->swapCacheRepository();
@@ -4351,6 +4401,13 @@ class HttpClientTest extends TestCase
         $this->assertTrue($second->fromCache());
         $this->assertSame('fake response', $second->body());
         $this->factory->assertSentCount(1);
+    }
+
+    public function testCacheKeyIsMandatory()
+    {
+        $this->expectException(ArgumentCountError::class);
+
+        $this->factory->cache();
     }
 
     public function testItCanHaveGlobalDefaultValues()


### PR DESCRIPTION
This PR adds opt-in response caching to Laravel's outgoing HTTP client.

It allows developers to cache successful `GET` responses directly from the HTTP client chain by providing an explicit cache key and TTL:

```php
$response = Http::cache('products-api', 600)
    ->get('https://api.example.com/products');

$response->fromCache(); // true or false
```

It also supports Laravel's existing stale-while-revalidate cache behavior by using an array TTL, which delegates to `Cache::flexible()`:

```php
$response = Http::cache('products-api', [60, 300])
    ->get('https://api.example.com/products');
```

By default, only `GET` requests are cached. Other HTTP methods can be explicitly opted into when the developer knows the request is read-only, such as APIs or legacy ERPs that use `POST` for fetching data:

```php
$response = Http::cache('erp-report', 600, methods: ['GET', 'POST'])
    ->post('https://api.example.com/report', [
        'from' => '2026-01-01',
        'to' => '2026-01-31',
    ]);
```

## Motivation

Caching responses from external APIs is a common requirement when working with stable endpoints, rate-limited services, third-party integrations, and expensive remote requests.

Today, this usually requires wrapping the HTTP request manually with `Cache::remember()` or `Cache::flexible()`:

```php
$response = Cache::remember('products-api', 600, function () {
    return Http::get('https://api.example.com/products');
});
```

This works, but it separates the caching behavior from the HTTP request definition. This PR keeps that behavior closer to the request itself while remaining explicit and fully opt-in.

The goal is to make common external API caching easier without changing the default behavior of Laravel's HTTP client.

## Proposed Usage

Normal cache TTL:

```php
$response = Http::cache('products-api', 600)
    ->get('https://api.example.com/products');
```

Flexible stale-while-revalidate cache TTL:

```php
$response = Http::cache('products-api', [60, 300])
    ->get('https://api.example.com/products');
```

Explicitly allowing additional cacheable methods:

```php
$response = Http::cache('erp-report', 600, methods: ['GET', 'POST'])
    ->post('https://api.example.com/report', [
        'from' => '2026-01-01',
        'to' => '2026-01-31',
    ]);
```

Checking whether the response was served from cache:

```php
if ($response->fromCache()) {
    // The response was served from cache.
}
```

## Behavior

This PR:

* Adds `PendingRequest::cache(string $key, DateTimeInterface|DateInterval|int|array $ttl, array $methods = ['GET'])`.
* Adds `Response::fromCache(): bool`.
* Requires an explicit cache key.
* Uses `Cache::remember()` when the TTL is not an array.
* Uses `Cache::flexible()` when the TTL is an array.
* Caches only successful `GET` responses by default.
* Allows additional HTTP methods to be cached through the explicit `methods` argument.
* Does not cache failed responses by default.
* Does not cache non-allowed methods by default.
* Preserves cached response body, status code, reason phrase, and headers.
* Preserves compatibility with `Http::fake()`.

## Benefit to End Users

This makes it easier to build Laravel applications that consume external APIs efficiently.

Developers can reduce repeated network calls, avoid unnecessary API rate-limit usage, and improve response times without manually wrapping every HTTP request in cache logic.

For example, instead of writing separate cache code around every stable external API call, developers can express the intent directly:

```php
$response = Http::cache('github-releases', [60, 300])
    ->get('https://api.github.com/repos/laravel/framework/releases');
```

For APIs that use `POST` for read-only data retrieval, such as some legacy ERPs, developers can opt in explicitly:

```php
$response = Http::cache('erp-report', 600, methods: ['GET', 'POST'])
    ->post('https://api.example.com/report', $payload);
```

The explicit cache key keeps the behavior predictable and avoids surprising automatic cache key generation. The default method behavior remains conservative, while still allowing developers to support real-world APIs that do not use `GET` for all read-only operations.

## Backward Compatibility

This feature is fully opt-in.

Existing HTTP client behavior is unchanged unless `cache()` is explicitly called on the pending request.

By default, the implementation only caches successful `GET` responses. Failed responses and non-allowed HTTP methods continue through the normal HTTP client flow and are not cached.

Additional HTTP methods are only cached when explicitly passed through the `methods` argument.

Async requests are excluded from this cache wrapper, so the implementation does not alter the async request path.

## Implementation Notes

The cache logic is kept inside `PendingRequest` and only wraps the synchronous request path after async requests have been excluded.

Cached values are stored as a small serializable response payload rather than storing the full `Response` object. Cache hits rebuild a PSR-7 response from that payload and mark the Laravel response as coming from cache.

An internal `UncacheableResponseException` is used to prevent Laravel's cache repository from writing failed responses when using `Cache::remember()` or `Cache::flexible()`. The exception is caught immediately by the HTTP client cache wrapper and implements `ShouldntReport`.

## Tests

This PR adds HTTP client tests covering:

* Successful `GET` responses can be cached.
* The first cached request returns `fromCache() === false`.
* The second cached request with the same key returns `fromCache() === true`.
* Normal TTL values use `Cache::remember()`.
* Array TTL values use `Cache::flexible()`.
* Failed responses are not cached by default.
* Non-allowed methods are not cached by default.
* Additional methods can be cached when explicitly allowed.
* `Http::fake()` continues to work with cached responses.
* Cached response body, status code, reason phrase, and headers are preserved.

## Verification

The following checks passed locally:

```bash
php -l src/Illuminate/Http/Client/PendingRequest.php
php -l src/Illuminate/Http/Client/Response.php
php -l src/Illuminate/Http/Client/UncacheableResponseException.php
php -l tests/Http/HttpClientTest.php

vendor/bin/phpunit tests/Http/HttpClientTest.php --filter 'Cache|Cached|cache|fromCache'
vendor/bin/phpunit tests/Http/HttpClientTest.php --filter 'Retry|retry|Throw|throw|Fake|fake|AfterResponse|afterResponse|Event|Response|Pool'

vendor/bin/pint --test src/Illuminate/Http/Client/PendingRequest.php src/Illuminate/Http/Client/Response.php src/Illuminate/Http/Client/UncacheableResponseException.php tests/Http/HttpClientTest.php
```

The full `tests/Http/HttpClientTest.php` file was also attempted locally, but one existing test attempted to resolve `example.com` and failed because DNS/network access is restricted in my local environment.

## Out of Scope

This first implementation intentionally does not include:

* Cache tags
* Stale lock customization
* Automatic cache key generation
* Cache invalidation APIs
* Caching non-GET requests by default
* Advanced conditional caching callbacks