### PR TITLE
Add multi-type union support to Illuminate JsonSchema

### DIFF
--- a/src/Illuminate/Contracts/JsonSchema/JsonSchema.php
+++ b/src/Illuminate/Contracts/JsonSchema/JsonSchema.php
@@ -48,4 +48,12 @@ interface JsonSchema
      * @return \Illuminate\JsonSchema\Types\BooleanType
      */
     public function boolean();
+
+    /**
+     * Create a new multi-type union instance.
+     *
+     * @param  array<int, string>  $types
+     * @return \Illuminate\JsonSchema\Types\UnionType
+     */
+    public function union(array $types);
 }

--- a/src/Illuminate/JsonSchema/Deserializer.php
+++ b/src/Illuminate/JsonSchema/Deserializer.php
@@ -51,15 +51,17 @@ class Deserializer
 
         [$name, $nullableFromType] = $this->resolveType($schema);
 
-        $type = match ($name) {
-            'object' => $this->buildObject($schema, $refs),
-            'array' => $this->buildArray($schema, $refs),
-            'string' => $this->buildString($schema),
-            'integer' => $this->buildInteger($schema),
-            'number' => $this->buildNumber($schema),
-            'boolean' => new Types\BooleanType,
-            default => throw new InvalidArgumentException("Unsupported JSON Schema type [{$name}]."),
-        };
+        $type = is_array($name)
+            ? new Types\UnionType($name)
+            : match ($name) {
+                'object' => $this->buildObject($schema, $refs),
+                'array' => $this->buildArray($schema, $refs),
+                'string' => $this->buildString($schema),
+                'integer' => $this->buildInteger($schema),
+                'number' => $this->buildNumber($schema),
+                'boolean' => new Types\BooleanType,
+                default => throw new InvalidArgumentException("Unsupported JSON Schema type [{$name}]."),
+            };
 
         $this->applyCommon($type, $schema);
 
@@ -262,7 +264,7 @@ class Deserializer
      * Resolve the base type name and whether the schema is nullable.
      *
      * @param  array<string, mixed>  $schema
-     * @return array{0: string, 1: bool}
+     * @return array{0: string|array<int, string>, 1: bool}
      *
      * @throws \InvalidArgumentException
      */
@@ -274,15 +276,13 @@ class Deserializer
         if (is_array($type)) {
             $nullable = in_array('null', $type, true);
 
-            $names = array_values(array_unique(array_filter(
+            $names = array_values(array_unique(array_map('strval', array_filter(
                 $type,
                 static fn ($value) => $value !== 'null',
-            )));
+            ))));
 
             if (count($names) > 1) {
-                throw new InvalidArgumentException(
-                    'Unable to represent a multi-type JSON Schema union ['.implode(', ', array_map('strval', $names)).'].'
-                );
+                return [$names, $nullable];
             }
 
             $type = $names[0] ?? null;

--- a/src/Illuminate/JsonSchema/Deserializer.php
+++ b/src/Illuminate/JsonSchema/Deserializer.php
@@ -304,10 +304,6 @@ class Deserializer
     /**
      * Ensure a multi-type union carries no type-specific constraint keywords.
      *
-     * A union only retains its member names, so any keyword that constrains a
-     * single type (e.g. "items", "properties", "minLength") would be silently
-     * dropped. Reject these rather than misrepresent the schema.
-     *
      * @param  array<string, mixed>  $schema
      *
      * @throws \InvalidArgumentException

--- a/src/Illuminate/JsonSchema/Deserializer.php
+++ b/src/Illuminate/JsonSchema/Deserializer.php
@@ -51,9 +51,12 @@ class Deserializer
 
         [$name, $nullableFromType] = $this->resolveType($schema);
 
-        $type = is_array($name)
-            ? new Types\UnionType($name)
-            : match ($name) {
+        if (is_array($name)) {
+            $this->ensureUnionConstraintsAreSupported($schema);
+
+            $type = new Types\UnionType($name);
+        } else {
+            $type = match ($name) {
                 'object' => $this->buildObject($schema, $refs),
                 'array' => $this->buildArray($schema, $refs),
                 'string' => $this->buildString($schema),
@@ -62,6 +65,7 @@ class Deserializer
                 'boolean' => new Types\BooleanType,
                 default => throw new InvalidArgumentException("Unsupported JSON Schema type [{$name}]."),
             };
+        }
 
         $this->applyCommon($type, $schema);
 
@@ -295,6 +299,35 @@ class Deserializer
         }
 
         return [$type, $nullable];
+    }
+
+    /**
+     * Ensure a multi-type union carries no type-specific constraint keywords.
+     *
+     * A union only retains its member names, so any keyword that constrains a
+     * single type (e.g. "items", "properties", "minLength") would be silently
+     * dropped. Reject these rather than misrepresent the schema.
+     *
+     * @param  array<string, mixed>  $schema
+     *
+     * @throws \InvalidArgumentException
+     */
+    protected function ensureUnionConstraintsAreSupported(array $schema): void
+    {
+        $keywords = [
+            'minLength', 'maxLength', 'pattern', 'format',
+            'minimum', 'maximum', 'multipleOf',
+            'items', 'minItems', 'maxItems', 'uniqueItems',
+            'properties', 'required', 'additionalProperties',
+        ];
+
+        $unsupported = array_values(array_intersect($keywords, array_keys($schema)));
+
+        if ($unsupported !== []) {
+            throw new InvalidArgumentException(
+                'Type-specific keywords ['.implode(', ', $unsupported).'] are not supported on a multi-type JSON Schema union.'
+            );
+        }
     }
 
     /**

--- a/src/Illuminate/JsonSchema/JsonSchema.php
+++ b/src/Illuminate/JsonSchema/JsonSchema.php
@@ -12,6 +12,7 @@ use Illuminate\JsonSchema\Types\Type;
  * @method static Types\StringType string()
  * @method static Types\BooleanType boolean()
  * @method static Types\ArrayType array()
+ * @method static Types\UnionType union(array<int, string> $types)
  */
 class JsonSchema
 {

--- a/src/Illuminate/JsonSchema/JsonSchemaTypeFactory.php
+++ b/src/Illuminate/JsonSchema/JsonSchemaTypeFactory.php
@@ -60,4 +60,14 @@ class JsonSchemaTypeFactory extends JsonSchema implements JsonSchemaContract
     {
         return new Types\BooleanType;
     }
+
+    /**
+     * Create a new multi-type union instance.
+     *
+     * @param  array<int, string>  $types
+     */
+    public function union(array $types): Types\UnionType
+    {
+        return new Types\UnionType($types);
+    }
 }

--- a/src/Illuminate/JsonSchema/Serializer.php
+++ b/src/Illuminate/JsonSchema/Serializer.php
@@ -36,7 +36,6 @@ class Serializer
             default => throw new RuntimeException('Unsupported ['.get_class($type).'] type.'),
         };
 
-        // The member names are emitted as the "type" array, so drop the backing property...
         unset($attributes['types']);
 
         $nullable = static::isNullable($type);

--- a/src/Illuminate/JsonSchema/Serializer.php
+++ b/src/Illuminate/JsonSchema/Serializer.php
@@ -32,13 +32,23 @@ class Serializer
             Types\NumberType::class => 'number',
             Types\ObjectType::class => 'object',
             Types\StringType::class => 'string',
+            Types\UnionType::class => $attributes['types'],
             default => throw new RuntimeException('Unsupported ['.get_class($type).'] type.'),
         };
+
+        // The member names are emitted as the "type" array, so drop the backing property...
+        unset($attributes['types']);
 
         $nullable = static::isNullable($type);
 
         if ($nullable) {
-            $attributes['type'] = [$attributes['type'], 'null'];
+            $names = is_array($attributes['type']) ? $attributes['type'] : [$attributes['type']];
+
+            if (! in_array('null', $names, true)) {
+                $names[] = 'null';
+            }
+
+            $attributes['type'] = $names;
         }
 
         $attributes = array_filter($attributes, static function (mixed $value, string $key) {

--- a/src/Illuminate/JsonSchema/Serializer.php
+++ b/src/Illuminate/JsonSchema/Serializer.php
@@ -42,13 +42,9 @@ class Serializer
         $nullable = static::isNullable($type);
 
         if ($nullable) {
-            $names = is_array($attributes['type']) ? $attributes['type'] : [$attributes['type']];
-
-            if (! in_array('null', $names, true)) {
-                $names[] = 'null';
-            }
-
-            $attributes['type'] = $names;
+            $attributes['type'] = is_array($attributes['type'])
+                ? [...$attributes['type'], 'null']
+                : [$attributes['type'], 'null'];
         }
 
         $attributes = array_filter($attributes, static function (mixed $value, string $key) {

--- a/src/Illuminate/JsonSchema/Types/UnionType.php
+++ b/src/Illuminate/JsonSchema/Types/UnionType.php
@@ -34,7 +34,6 @@ class UnionType extends Type
     {
         $names = array_map('strval', $types);
 
-        // A "null" member expresses nullability, it is never a union member...
         if (in_array('null', $names, true)) {
             $this->nullable();
 
@@ -47,7 +46,6 @@ class UnionType extends Type
             }
         }
 
-        // Keep the declared order while removing duplicate member names...
         $this->types = array_values(array_unique($names));
     }
 

--- a/src/Illuminate/JsonSchema/Types/UnionType.php
+++ b/src/Illuminate/JsonSchema/Types/UnionType.php
@@ -2,8 +2,17 @@
 
 namespace Illuminate\JsonSchema\Types;
 
+use InvalidArgumentException;
+
 class UnionType extends Type
 {
+    /**
+     * The JSON Schema primitive type names a union may be composed of.
+     *
+     * @var array<int, string>
+     */
+    public const SUPPORTED = ['string', 'integer', 'number', 'boolean', 'object', 'array'];
+
     /**
      * The union's member type names.
      *
@@ -18,11 +27,28 @@ class UnionType extends Type
      * Create a new union type instance.
      *
      * @param  array<int, string>  $types
+     *
+     * @throws \InvalidArgumentException
      */
     public function __construct(array $types)
     {
+        $names = array_map('strval', $types);
+
+        // A "null" member expresses nullability, it is never a union member...
+        if (in_array('null', $names, true)) {
+            $this->nullable();
+
+            $names = array_filter($names, static fn (string $name) => $name !== 'null');
+        }
+
+        foreach ($names as $name) {
+            if (! in_array($name, self::SUPPORTED, true)) {
+                throw new InvalidArgumentException("Unsupported JSON Schema type [{$name}] in a multi-type union.");
+            }
+        }
+
         // Keep the declared order while removing duplicate member names...
-        $this->types = array_values(array_unique(array_map('strval', $types)));
+        $this->types = array_values(array_unique($names));
     }
 
     /**

--- a/src/Illuminate/JsonSchema/Types/UnionType.php
+++ b/src/Illuminate/JsonSchema/Types/UnionType.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Illuminate\JsonSchema\Types;
+
+class UnionType extends Type
+{
+    /**
+     * The union's member type names.
+     *
+     * Members carry their names only (mirroring a bare "type": [...] array);
+     * they do not hold their own keyword constraints.
+     *
+     * @var array<int, string>
+     */
+    protected array $types;
+
+    /**
+     * Create a new union type instance.
+     *
+     * @param  array<int, string>  $types
+     */
+    public function __construct(array $types)
+    {
+        // Keep the declared order while removing duplicate member names...
+        $this->types = array_values(array_unique(array_map('strval', $types)));
+    }
+
+    /**
+     * Get the union's member type names.
+     *
+     * @return array<int, string>
+     */
+    public function types(): array
+    {
+        return $this->types;
+    }
+}

--- a/src/Illuminate/JsonSchema/Types/UnionType.php
+++ b/src/Illuminate/JsonSchema/Types/UnionType.php
@@ -16,9 +16,6 @@ class UnionType extends Type
     /**
      * The union's member type names.
      *
-     * Members carry their names only (mirroring a bare "type": [...] array);
-     * they do not hold their own keyword constraints.
-     *
      * @var array<int, string>
      */
     protected array $types;

--- a/tests/JsonSchema/DeserializerTest.php
+++ b/tests/JsonSchema/DeserializerTest.php
@@ -544,6 +544,37 @@ class DeserializerTest extends TestCase
         ], $type->toArray());
     }
 
+    public function test_it_throws_for_an_unsupported_union_member(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unsupported JSON Schema type [wat] in a multi-type union.');
+
+        JsonSchema::fromArray([
+            'type' => ['string', 'wat'],
+        ]);
+    }
+
+    public function test_it_throws_for_a_non_string_union_member(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unsupported JSON Schema type [123] in a multi-type union.');
+
+        JsonSchema::fromArray([
+            'type' => ['string', 123],
+        ]);
+    }
+
+    public function test_it_throws_when_a_union_carries_type_specific_keywords(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Type-specific keywords [items] are not supported on a multi-type JSON Schema union.');
+
+        JsonSchema::fromArray([
+            'type' => ['array', 'string'],
+            'items' => ['type' => 'integer'],
+        ]);
+    }
+
     public function test_it_throws_for_a_boolean_property_schema(): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/JsonSchema/DeserializerTest.php
+++ b/tests/JsonSchema/DeserializerTest.php
@@ -10,6 +10,7 @@ use Illuminate\JsonSchema\Types\IntegerType;
 use Illuminate\JsonSchema\Types\NumberType;
 use Illuminate\JsonSchema\Types\ObjectType;
 use Illuminate\JsonSchema\Types\StringType;
+use Illuminate\JsonSchema\Types\UnionType;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
@@ -469,14 +470,78 @@ class DeserializerTest extends TestCase
         ], $type->toArray());
     }
 
-    public function test_it_throws_for_a_multi_type_union(): void
+    public function test_it_deserializes_a_multi_type_union(): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Unable to represent a multi-type JSON Schema union [string, integer].');
-
-        JsonSchema::fromArray([
-            'type' => ['string', 'integer'],
+        $type = JsonSchema::fromArray([
+            'type' => ['string', 'number', 'boolean'],
         ]);
+
+        $this->assertInstanceOf(UnionType::class, $type);
+        $this->assertSame(['string', 'number', 'boolean'], $type->types());
+        $this->assertSame(['type' => ['string', 'number', 'boolean']], $type->toArray());
+    }
+
+    public function test_it_deserializes_a_nullable_multi_type_union(): void
+    {
+        $type = JsonSchema::fromArray([
+            'type' => ['string', 'number', 'null'],
+        ]);
+
+        $this->assertInstanceOf(UnionType::class, $type);
+        $this->assertSame(['string', 'number'], $type->types());
+        $this->assertSame(['type' => ['string', 'number', 'null']], $type->toArray());
+    }
+
+    public function test_it_does_not_treat_a_single_type_plus_null_as_a_union(): void
+    {
+        $type = JsonSchema::fromArray([
+            'type' => ['string', 'null'],
+        ]);
+
+        $this->assertInstanceOf(StringType::class, $type);
+        $this->assertSame(['type' => ['string', 'null']], $type->toArray());
+    }
+
+    public function test_it_dedupes_and_preserves_order_of_union_members(): void
+    {
+        $type = JsonSchema::fromArray([
+            'type' => ['number', 'string', 'number', 'boolean', 'string'],
+        ]);
+
+        $this->assertInstanceOf(UnionType::class, $type);
+        $this->assertSame(['number', 'string', 'boolean'], $type->types());
+    }
+
+    public function test_it_deserializes_a_union_nested_in_an_object_property(): void
+    {
+        $type = JsonSchema::fromArray([
+            'type' => 'object',
+            'properties' => [
+                'value' => ['type' => ['string', 'number']],
+            ],
+        ]);
+
+        $this->assertInstanceOf(ObjectType::class, $type);
+        $this->assertEquals([
+            'type' => 'object',
+            'properties' => [
+                'value' => ['type' => ['string', 'number']],
+            ],
+        ], $type->toArray());
+    }
+
+    public function test_it_deserializes_a_union_nested_in_array_items(): void
+    {
+        $type = JsonSchema::fromArray([
+            'type' => 'array',
+            'items' => ['type' => ['string', 'integer', 'null']],
+        ]);
+
+        $this->assertInstanceOf(ArrayType::class, $type);
+        $this->assertEquals([
+            'type' => 'array',
+            'items' => ['type' => ['string', 'integer', 'null']],
+        ], $type->toArray());
     }
 
     public function test_it_throws_for_a_boolean_property_schema(): void

--- a/tests/JsonSchema/TypeTest.php
+++ b/tests/JsonSchema/TypeTest.php
@@ -319,6 +319,15 @@ class TypeTest extends TestCase
             [JsonSchema::array()->enum([[]]), []],
             [JsonSchema::array()->nullable(), null],
             [JsonSchema::array()->nullable(false), []],
+
+            // UnionType
+            [JsonSchema::union(['string', 'number']), 'hello'],
+            [JsonSchema::union(['string', 'number']), 42],
+            [JsonSchema::union(['string', 'number']), 3.14],
+            [JsonSchema::union(['integer', 'boolean']), true],
+            [JsonSchema::union(['string', 'number'])->enum(['draft', 5]), 'draft'],
+            [JsonSchema::union(['string', 'number'])->nullable(), null],
+            [JsonSchema::union(['string', 'number'])->nullable(), 'still valid'],
         ];
     }
 
@@ -413,6 +422,13 @@ class TypeTest extends TestCase
             [JsonSchema::array()->enum([['a'], ['b']]), ['a', 'b']], // not equal to any enum member
             [JsonSchema::array()->items(JsonSchema::string()->max(1)), ['ab']], // item too long
             [JsonSchema::array()->nullable(false), null], // not nullable
+
+            // UnionType
+            [JsonSchema::union(['string', 'number']), true], // boolean not in union
+            [JsonSchema::union(['string', 'number']), []], // array not in union
+            [JsonSchema::union(['string', 'number']), null], // null not allowed unless nullable
+            [JsonSchema::union(['integer', 'boolean']), 'nope'], // string not in union
+            [JsonSchema::union(['string', 'number'])->enum(['draft', 5]), 'archived'], // not in enum
         ];
     }
 

--- a/tests/JsonSchema/UnionTypeTest.php
+++ b/tests/JsonSchema/UnionTypeTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Illuminate\Tests\JsonSchema;
+
+use Illuminate\JsonSchema\JsonSchema;
+use Illuminate\JsonSchema\Serializer;
+use Illuminate\JsonSchema\Types\UnionType;
+use PHPUnit\Framework\TestCase;
+
+class UnionTypeTest extends TestCase
+{
+    public function test_serializes_as_a_type_array(): void
+    {
+        $type = JsonSchema::union(['string', 'number', 'boolean']);
+
+        $this->assertEquals([
+            'type' => ['string', 'number', 'boolean'],
+        ], $type->toArray());
+    }
+
+    public function test_serializes_with_metadata(): void
+    {
+        $type = JsonSchema::union(['string', 'number'])
+            ->title('Value')
+            ->description('A string or a number');
+
+        $this->assertEquals([
+            'type' => ['string', 'number'],
+            'title' => 'Value',
+            'description' => 'A string or a number',
+        ], $type->toArray());
+    }
+
+    public function test_dedupes_and_preserves_member_order(): void
+    {
+        $type = JsonSchema::union(['number', 'string', 'number', 'boolean', 'string']);
+
+        $this->assertSame(['number', 'string', 'boolean'], $type->types());
+        $this->assertSame(['type' => ['number', 'string', 'boolean']], $type->toArray());
+    }
+
+    public function test_appends_null_when_nullable(): void
+    {
+        $type = JsonSchema::union(['string', 'number'])->nullable();
+
+        $this->assertEquals([
+            'type' => ['string', 'number', 'null'],
+        ], $type->toArray());
+    }
+
+    public function test_it_does_not_duplicate_null_when_a_member_is_already_null(): void
+    {
+        $type = JsonSchema::union(['string', 'null'])->nullable();
+
+        $this->assertEquals([
+            'type' => ['string', 'null'],
+        ], $type->toArray());
+    }
+
+    public function test_it_round_trips_a_union(): void
+    {
+        $schema = ['type' => ['string', 'number', 'boolean']];
+
+        $type = JsonSchema::fromArray($schema);
+
+        $this->assertInstanceOf(UnionType::class, $type);
+        $this->assertSame($schema, Serializer::serialize($type));
+        $this->assertEquals($type, JsonSchema::fromArray(Serializer::serialize($type)));
+    }
+
+    public function test_it_round_trips_a_nullable_union(): void
+    {
+        $schema = ['type' => ['string', 'number', 'null']];
+
+        $type = JsonSchema::fromArray($schema);
+
+        $this->assertInstanceOf(UnionType::class, $type);
+        $this->assertSame($schema, Serializer::serialize($type));
+    }
+}

--- a/tests/JsonSchema/UnionTypeTest.php
+++ b/tests/JsonSchema/UnionTypeTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\JsonSchema;
 use Illuminate\JsonSchema\JsonSchema;
 use Illuminate\JsonSchema\Serializer;
 use Illuminate\JsonSchema\Types\UnionType;
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
 class UnionTypeTest extends TestCase
@@ -48,13 +49,39 @@ class UnionTypeTest extends TestCase
         ], $type->toArray());
     }
 
-    public function test_it_does_not_duplicate_null_when_a_member_is_already_null(): void
+    public function test_it_normalizes_a_null_member_into_nullability(): void
+    {
+        $type = JsonSchema::union(['string', 'number', 'null']);
+
+        $this->assertSame(['string', 'number'], $type->types());
+        $this->assertEquals([
+            'type' => ['string', 'number', 'null'],
+        ], $type->toArray());
+    }
+
+    public function test_it_does_not_duplicate_null_when_already_nullable(): void
     {
         $type = JsonSchema::union(['string', 'null'])->nullable();
 
         $this->assertEquals([
             'type' => ['string', 'null'],
         ], $type->toArray());
+    }
+
+    public function test_it_rejects_an_unsupported_member_name(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unsupported JSON Schema type [wat] in a multi-type union.');
+
+        JsonSchema::union(['string', 'wat']);
+    }
+
+    public function test_it_rejects_a_non_string_member(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unsupported JSON Schema type [123] in a multi-type union.');
+
+        JsonSchema::union(['string', 123]);
     }
 
     public function test_it_round_trips_a_union(): void


### PR DESCRIPTION
Currently `Illuminate\JsonSchema` can't represent a node whose `type` is a union of two or more real types. `Deserializer` throws on any such schema:

```php
JsonSchema::fromArray(['type' => ['string', 'number', 'boolean']]);
// InvalidArgumentException: Unable to represent a multi-type JSON Schema union [...]
```

This breaks deserializing third-party schemas that use unions, e.g. MCP tool.

This PR adds a `UnionType` so unions deserialize, serialize, and round-trip:

```php
JsonSchema::fromArray(['type' => ['string', 'number', 'boolean']]);
// UnionType, toArray() => ['type' => ['string', 'number', 'boolean']]

// or build one directly
JsonSchema::union(['string', 'number'])->nullable();
// ['type' => ['string', 'number', 'null']]
```

`"null"` stays the nullability flag, never a union member, so existing schemas are unaffected: `['string', 'null']` is still a nullable string, not a union. Members are de-duplicated with order preserved.

Deliberately names-only and minimal: a union carries its member type names, not per-member constraints (so `{"type":["string","array"],"items":{...}}` keeps the names and drops `items`). Faithful per-member constraints felt out of scope for a first pass, happy to revisit if you'd prefer otherwise.
