### PR TITLE
[13.x] Add withQueryParameters() to HTTP testing helpers

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -44,6 +44,13 @@ trait MakesHttpRequests
     protected $serverVariables = [];
 
     /**
+     * Additional query parameters for the request.
+     *
+     * @var array
+     */
+    protected $queryParameters = [];
+
+    /**
      * Indicates whether redirects should be followed.
      *
      * @var bool
@@ -176,6 +183,19 @@ trait MakesHttpRequests
     public function withServerVariables(array $server)
     {
         $this->serverVariables = $server;
+
+        return $this;
+    }
+
+    /**
+     * Define additional query parameters to be appended to the request URI.
+     *
+     * @param  array  $query
+     * @return $this
+     */
+    public function withQueryParameters(array $query)
+    {
+        $this->queryParameters = array_merge($this->queryParameters, $query);
 
         return $this;
     }
@@ -625,6 +645,10 @@ trait MakesHttpRequests
      */
     protected function prepareUrlForRequest($uri)
     {
+        if ($this->queryParameters !== []) {
+            $uri = Uri::of($uri)->withQuery($this->queryParameters);
+        }
+
         $uri = $uri instanceof Uri ? $uri->value() : $uri;
 
         if (str_starts_with($uri, '/')) {

--- a/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
+++ b/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
@@ -238,7 +238,7 @@ class MakesHttpRequestsTest extends TestCase
     public function testWithQueryParametersAppendsToRequestUri()
     {
         $this->app->make(Registrar::class)
-            ->get('users', fn () => request()->query());
+            ->get('users', fn () => request());
 
         $this->withQueryParameters(['page' => 2, 'sort' => 'name'])
             ->getJson('users')
@@ -249,7 +249,7 @@ class MakesHttpRequestsTest extends TestCase
     public function testWithQueryParametersMergesWithExistingQueryString()
     {
         $this->app->make(Registrar::class)
-            ->get('users', fn () => request()->query());
+            ->get('users', fn () => request());
 
         $this->withQueryParameters(['sort' => 'name'])
             ->getJson('users?filter=active')
@@ -260,7 +260,7 @@ class MakesHttpRequestsTest extends TestCase
     public function testWithQueryParametersSupportsNestedArrays()
     {
         $this->app->make(Registrar::class)
-            ->get('users', fn () => request()->query());
+            ->get('users', fn () => request());
 
         $this->withQueryParameters(['filters' => ['status' => 'active', 'tags' => ['a', 'b']]])
             ->getJson('users')

--- a/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
+++ b/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
@@ -227,6 +227,58 @@ class MakesHttpRequestsTest extends TestCase
         $this->assertEquals(['from', 'to'], $callOrder);
     }
 
+    public function testWithQueryParametersMergesIntoState()
+    {
+        $this->withQueryParameters(['page' => 2]);
+        $this->withQueryParameters(['sort' => 'name']);
+
+        $this->assertSame(['page' => 2, 'sort' => 'name'], $this->queryParameters);
+    }
+
+    public function testWithQueryParametersAppendsToRequestUri()
+    {
+        $this->app->make(Registrar::class)
+            ->get('users', fn () => request()->query());
+
+        $this->withQueryParameters(['page' => 2, 'sort' => 'name'])
+            ->getJson('users')
+            ->assertOk()
+            ->assertExactJson(['page' => '2', 'sort' => 'name']);
+    }
+
+    public function testWithQueryParametersMergesWithExistingQueryString()
+    {
+        $this->app->make(Registrar::class)
+            ->get('users', fn () => request()->query());
+
+        $this->withQueryParameters(['sort' => 'name'])
+            ->getJson('users?filter=active')
+            ->assertOk()
+            ->assertExactJson(['filter' => 'active', 'sort' => 'name']);
+    }
+
+    public function testWithQueryParametersSupportsNestedArrays()
+    {
+        $this->app->make(Registrar::class)
+            ->get('users', fn () => request()->query());
+
+        $this->withQueryParameters(['filters' => ['status' => 'active', 'tags' => ['a', 'b']]])
+            ->getJson('users')
+            ->assertOk()
+            ->assertExactJson(['filters' => ['status' => 'active', 'tags' => ['a', 'b']]]);
+    }
+
+    public function testWithQueryParametersAppliesToNonGetVerbs()
+    {
+        $this->app->make(Registrar::class)
+            ->post('users', fn () => request()->query());
+
+        $this->withQueryParameters(['page' => 2])
+            ->postJson('users', ['name' => 'Taylor'])
+            ->assertOk()
+            ->assertExactJson(['page' => '2']);
+    }
+
     public function testWithPrecognition()
     {
         $this->withPrecognition();


### PR DESCRIPTION
This PR adds a `withQueryParameters()` method to the `MakesHttpRequests` testing
trait, allowing query string parameters to be supplied as an array rather than
hand-built into the URL.

### Before

Today, testing a request with query parameters means string-concatenating them
into the URI yourself, which gets awkward with multiple, nested, or conditional
parameters:

```php
$this->getJson('/users?page=2&sort=name&filters[status]=active');
```
After
```php

$this->withQueryParameters(['page' => 2, 'sort' => 'name'])
    ->getJson('/users');

  // Nested arrays are supported and correctly encoded
$this->withQueryParameters(['filters' => ['status' => 'active']])
    ->getJson('/users');
```
Details

- Follows the existing fluent withHeaders() / withCookies() /
withServerVariables() convention already used throughout the trait, so it
reads naturally and is discoverable via IDE autocompletion.
- Applied once in prepareUrlForRequest(), so it works for every verb
(get, getJson, post, postJson, json, etc.) with no changes to any
existing method signatures.
- Parameters are merged into the URI via Illuminate\Support\Uri::withQuery(),
which handles encoding, nested arrays, and UrlRoutable resolution for free.
Parameters passed to withQueryParameters() merge with (and take precedence
over) any query string already present in the URI.

Non-breaking

The change is purely additive, a new property and a new method. No existing
behavior or signatures change, so it cannot break existing tests or features.

Tests cover state merging, appending to a plain path, merging with an existing
query string, nested arrays, and application to a non-GET verb.