### PR TITLE
[13.x] Pass reflection parameter to contextual attribute resolve method

### DIFF
--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -175,7 +175,7 @@ class BoundMethod
 
             unset($parameters[$paramName]);
         } elseif ($attribute = Util::getContextualAttributeFromDependency($parameter)) {
-            $pendingDependencies[] = $container->resolveFromAttribute($attribute);
+            $pendingDependencies[] = $container->resolveFromAttribute($attribute, $parameter);
         } elseif (! is_null($className = Util::getParameterClassName($parameter))) {
             if (array_key_exists($className, $parameters)) {
                 $pendingDependencies[] = $parameters[$className];

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1229,7 +1229,7 @@ class Container implements ArrayAccess, ContainerContract
             $result = null;
 
             if (! is_null($attribute = Util::getContextualAttributeFromDependency($dependency))) {
-                $result = $this->resolveFromAttribute($attribute);
+                $result = $this->resolveFromAttribute($attribute, $dependency);
             }
 
             // If the class is null, it means the dependency is a string or some other
@@ -1378,7 +1378,7 @@ class Container implements ArrayAccess, ContainerContract
      *
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
-    public function resolveFromAttribute(ReflectionAttribute $attribute)
+    public function resolveFromAttribute(ReflectionAttribute $attribute, ReflectionParameter $parameter)
     {
         $handler = $this->contextualAttributes[$attribute->getName()] ?? null;
 
@@ -1392,7 +1392,7 @@ class Container implements ArrayAccess, ContainerContract
             throw new BindingResolutionException("Contextual binding attribute [{$attribute->getName()}] has no registered handler.");
         }
 
-        return $handler($instance, $this);
+        return $handler($instance, $this, $parameter);
     }
 
     /**

--- a/src/Illuminate/Routing/ResolvesRouteDependencies.php
+++ b/src/Illuminate/Routing/ResolvesRouteDependencies.php
@@ -76,7 +76,7 @@ trait ResolvesRouteDependencies
     protected function transformDependency(ReflectionParameter $parameter, $parameters, $skippableValue)
     {
         if ($attribute = Util::getContextualAttributeFromDependency($parameter)) {
-            return $this->container->resolveFromAttribute($attribute);
+            return $this->container->resolveFromAttribute($attribute, $parameter);
         }
 
         $className = Reflector::getParameterClassName($parameter);

--- a/tests/Container/ContextualAttributeBindingTest.php
+++ b/tests/Container/ContextualAttributeBindingTest.php
@@ -35,6 +35,7 @@ use Illuminate\Log\LogManager;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use ReflectionParameter;
 
 class ContextualAttributeBindingTest extends TestCase
 {
@@ -369,6 +370,28 @@ class ContextualAttributeBindingTest extends TestCase
 
         $this->assertEquals([1, 2], iterator_to_array($value));
     }
+
+    public function testParameterIsPassedToContextualAttributeResolver()
+    {
+        $container = new Container;
+
+        $value = $container->make(HasParameterAwareAttribute::class);
+
+        $this->assertSame('name', $value->name);
+    }
+
+    public function testParameterIsPassedToContextualAttributeResolverOnAppCall()
+    {
+        $container = new Container;
+
+        $value = $container->call(function (
+            #[ContainerTestParameterAwareAttribute] ?string $name
+        ) {
+            return $name;
+        });
+
+        $this->assertSame('name', $value);
+    }
 }
 
 #[Attribute(Attribute::TARGET_PARAMETER)]
@@ -492,6 +515,15 @@ final class ContainerTestConfigValueWithResolveAndAfter implements ContextualAtt
     public function after(self $attribute, object $value, Container $container): void
     {
         $value->role = 'Developer';
+    }
+}
+
+#[Attribute(Attribute::TARGET_PARAMETER)]
+final class ContainerTestParameterAwareAttribute implements ContextualAttribute
+{
+    public function resolve(self $attribute, Container $container, ReflectionParameter $parameter): string
+    {
+        return $parameter->getName();
     }
 }
 
@@ -634,6 +666,15 @@ final class LocaleObject
 {
     public function __construct(
         #[Config('app.locale')] public readonly ?string $locale
+    ) {
+        //
+    }
+}
+
+final class HasParameterAwareAttribute
+{
+    public function __construct(
+        #[ContainerTestParameterAwareAttribute] public readonly ?string $name,
     ) {
         //
     }


### PR DESCRIPTION
This PR allows contextual attributes to introspect the parameter they are resolving by passing the current `ReflectionParameter` instance to the attribute resolver.

This enables richer contextual bindings where the resolved value may depend on the parameter name, type, declaring class, default value, or other reflection metadata.

```
#[Attribute(Attribute::TARGET_PARAMETER)]
class TestAttribute implements ContextualAttribute
{
    public static function resolve(self $attribute, Container $container, ReflectionParameter $parameter)
    {
        return $parameter->getName();
    }
}

class Test
{
     public function __construct(
         #[TestAttribute]
        public string $aParamName,
     )
    {
        dd($this->aParamName);
    }
}

app()->make(Test::class); => "aParamName" 
```

Instead of exposing the `ReflectionParameter`, it would also be possible to use a small context object.