### PR TITLE
[13.x] Allow assertDatabaseEmpty and assertDatabaseCount to accept iterables

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -100,13 +100,21 @@ trait InteractsWithDatabase
     /**
      * Assert the count of table entries.
      *
-     * @param  \Illuminate\Database\Eloquent\Model|class-string<\Illuminate\Database\Eloquent\Model>|string  $table
+     * @param  iterable<\Illuminate\Database\Eloquent\Model>|\Illuminate\Database\Eloquent\Model|class-string<\Illuminate\Database\Eloquent\Model>|string  $table
      * @param  int  $count
      * @param  string|null  $connection
      * @return $this
      */
     protected function assertDatabaseCount($table, int $count, $connection = null)
     {
+        if (is_iterable($table)) {
+            foreach ($table as $item) {
+                $this->assertDatabaseCount($item, $count, $connection);
+            }
+
+            return $this;
+        }
+
         $this->assertThat(
             $this->getTable($table), new CountInDatabase($this->getConnection($connection, $table), $count)
         );
@@ -117,12 +125,20 @@ trait InteractsWithDatabase
     /**
      * Assert that the given table has no entries.
      *
-     * @param  \Illuminate\Database\Eloquent\Model|class-string<\Illuminate\Database\Eloquent\Model>|string  $table
+     * @param  iterable<\Illuminate\Database\Eloquent\Model>|\Illuminate\Database\Eloquent\Model|class-string<\Illuminate\Database\Eloquent\Model>|string  $table
      * @param  string|null  $connection
      * @return $this
      */
     protected function assertDatabaseEmpty($table, $connection = null)
     {
+        if (is_iterable($table)) {
+            foreach ($table as $item) {
+                $this->assertDatabaseEmpty($item, $connection);
+            }
+
+            return $this;
+        }
+
         $this->assertThat(
             $this->getTable($table), new CountInDatabase($this->getConnection($connection, $table), 0)
         );

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -196,6 +196,22 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->assertDatabaseEmpty(new ProductStub);
     }
 
+    public function testAssertDatabaseEmptySupportsArrays()
+    {
+        $builder = $this->mockCountBuilder(false);
+        $this->connection->shouldReceive('table')->with('users')->andReturn($builder);
+
+        $this->assertDatabaseEmpty([$this->table, 'users']);
+    }
+
+    public function testAssertDatabaseCountSupportsArrays()
+    {
+        $builder = $this->mockCountBuilder(true);
+        $this->connection->shouldReceive('table')->with('users')->andReturn($builder);
+
+        $this->assertDatabaseCount([$this->table, 'users'], 1);
+    }
+
     public function testAssertTableEntriesCountWrong()
     {
         $this->expectException(ExpectationFailedException::class);


### PR DESCRIPTION
It is common to assert the same database state across multiple tables after cleanup operations such as `migrate:fresh`, rollbacks, or bulk deletion commands. Allowing iterables removes repetitive assertions and lets tests express a single expectation over a group of tables, making their intent easier to read and maintain.                                                                                                                                                           
                                                                                                                                                                                                                                         
  ```php                                                                                                                                                                                                                                 
  // Before                                                                                                                                                                                                                              
  $this->assertDatabaseEmpty(User::class);                                                                                                                                                                                               
  $this->assertDatabaseEmpty(Post::class);                                                                                                                                                                                               
  $this->assertDatabaseEmpty(Comment::class);                                                                                                                                                                                            
                                                                                                                                                                                                                                         
  // After                                                                                                                                                                                                                               
  $this->assertDatabaseEmpty([User::class, Post::class, Comment::class]);                                                                                                                                                                
   ```                                                                                                                                                                                                                        
  `assertDatabaseCount` gains the same support for asserting a shared count across multiple tables:                                                                                                                                                                                                                                
                                                                                                    
  ```                                                                                                                                     
  $this->assertDatabaseCount([Foo::class, Bar::class], 0); 
  ```                                                                                                                                                                             
                                                                                                                                                                                                                                         
Passing a single model or table name behaves exactly as before, while an empty iterable results in a no-op.  

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
