### PR TITLE
[13.x] Fix orWhere clauses not being properly grouped in eager load constraints

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -940,7 +940,16 @@ class Builder implements BuilderContract
 
         $relation->addEagerConstraints($models);
 
+        $query = $relation->getQuery()->getQuery();
+        $originalWhereCount = is_null($query->wheres)
+            ? 0
+            : count($query->wheres);
+
         $constraints($relation);
+
+        if (count((array) $query->wheres) > $originalWhereCount) {
+            $this->addNewWheresWithinGroup($query, $originalWhereCount);
+        }
 
         // Once we have the results, we just match those back up to their parent models
         // using the relationship instance. Then we just return the finished arrays

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -866,6 +866,11 @@ class DatabaseEloquentBuilderTest extends TestCase
         $relation->shouldReceive('initRelation')->once()->with(['models'], 'orders')->andReturn(['models']);
         $relation->shouldReceive('getEager')->once()->andReturn(['results']);
         $relation->shouldReceive('match')->once()->with(['models'], ['results'], 'orders')->andReturn(['models.matched']);
+        $innerQueryBuilder = m::mock(stdClass::class);
+        $innerQueryBuilder->wheres = [];
+        $eloquentBuilder = m::mock(stdClass::class);
+        $eloquentBuilder->shouldReceive('getQuery')->andReturn($innerQueryBuilder);
+        $relation->shouldReceive('getQuery')->andReturn($eloquentBuilder);
         $builder->shouldReceive('getRelation')->once()->with('orders')->andReturn($relation);
         $results = $builder->eagerLoadRelations(['models']);
 
@@ -896,6 +901,35 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         unset($_SERVER['__eloquent.constrain']);
     }
+
+    public function testEagerLoadConstraintOrWhereIsProperlyGrouped()
+    {  
+        $model = new EloquentBuilderTestModelCloseRelatedStub;
+        $this->mockConnectionForModel($model, 'SQLite');
+        $model->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+        $model->getConnection()->shouldReceive('select')->andReturn([]);
+
+        $builder = $model->newQuery();
+        $builder->setEagerLoads([
+            'bar' => function ($query) {
+                $_SERVER['__eloquent.eager_constraints'] = $query;
+                $query->where('foo', '>', 1)->orWhere('bar', 'baz');
+            },
+        ]);
+
+        $parentModel = new EloquentBuilderTestModelCloseRelatedStub;
+        $parentModel->id = 5;
+
+        $builder->eagerLoadRelations([$parentModel]);
+
+        $this->assertSame(
+            'select * from "eloquent_builder_test_model_far_related_stubs" where "eloquent_builder_test_model_far_related_stubs"."eloquent_builder_test_model_close_related_stub_id" in (5) and ("foo" > ? or "bar" = ?)',
+            $_SERVER['__eloquent.eager_constraints']->getQuery()->toSql()
+        );
+
+        unset($_SERVER['__eloquent.eager_constraints']);
+    }
+
 
     public function testGetRelationProperlySetsNestedRelationships()
     {

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -903,7 +903,7 @@ class DatabaseEloquentBuilderTest extends TestCase
     }
 
     public function testEagerLoadConstraintOrWhereIsProperlyGrouped()
-    {  
+    {
         $model = new EloquentBuilderTestModelCloseRelatedStub;
         $this->mockConnectionForModel($model, 'SQLite');
         $model->getConnection()->shouldReceive('getName')->andReturn('sqlite');
@@ -929,7 +929,6 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         unset($_SERVER['__eloquent.eager_constraints']);
     }
-
 
     public function testGetRelationProperlySetsNestedRelationships()
     {


### PR DESCRIPTION
## Description

When using `with()` with a callback that contains `orWhere` clauses, the generated SQL is not properly grouped, which can produce unintended query results.

## Steps to Reproduce

```
User::query()
    ->with([
        'posts' => function ($query) {
            $query->where('favorites', '>', 10)->orWhere('created_at', '2026-01-01');
        }
    ])
    ->first();
```

## Current Behavior

```
select * from `posts`
where (`posts`.`user_id` in (5) and `favorites` > 10 or `created_at` = '2026-01-01')
and `posts`.`deleted_at` is null
```

The `orWhere` clause is not isolated from the eager load `whereIn` constraint, causing unintended results.

## Expected Behavior

```
select * from `posts`
where `posts`.`user_id` in (5)
  and (`favorites` > 10 or `created_at` = '2026-01-01')
and `posts`.`deleted_at` is null
```

## Fix

Applied the same grouping logic used in `callScope()` to `eagerLoadRelation()`. When the callback adds new where clauses containing `or`, they are properly wrapped in a nested group.