### PR TITLE
[13.x] Add generic to HasEvents::dispatchesEvents() return type

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -398,7 +398,7 @@ trait HasEvents
     /**
      * Get the event map for the model.
      *
-     * @return array
+     * @return array<string, class-string>
      */
     public function dispatchesEvents()
     {


### PR DESCRIPTION
`dispatchesEvents()` returns the `$dispatchesEvents` property directly, which is already declared `@var array<string, class-string>`, but the getter's `@return` is bare `array`. This syncs the return type with the property's existing generic so IDEs and static analysis can infer the model's event map.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
