### PR TITLE
[13.x] Allow RouteParameter to use the attributed parameter name

### DIFF
--- a/src/Illuminate/Container/Attributes/RouteParameter.php
+++ b/src/Illuminate/Container/Attributes/RouteParameter.php
@@ -5,6 +5,7 @@ namespace Illuminate\Container\Attributes;
 use Attribute;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Container\ContextualAttribute;
+use ReflectionParameter;
 
 #[Attribute(Attribute::TARGET_PARAMETER)]
 class RouteParameter implements ContextualAttribute
@@ -12,7 +13,7 @@ class RouteParameter implements ContextualAttribute
     /**
      * Create a new class instance.
      */
-    public function __construct(public string $parameter)
+    public function __construct(public ?string $parameter = null)
     {
     }
 
@@ -23,8 +24,8 @@ class RouteParameter implements ContextualAttribute
      * @param  \Illuminate\Contracts\Container\Container  $container
      * @return mixed
      */
-    public static function resolve(self $attribute, Container $container)
+    public static function resolve(self $attribute, Container $container, ReflectionParameter $parameter)
     {
-        return $container->make('request')->route($attribute->parameter);
+        return $container->make('request')->route($attribute->parameter ?? $parameter->getName());
     }
 }

--- a/tests/Container/ContextualAttributeBindingTest.php
+++ b/tests/Container/ContextualAttributeBindingTest.php
@@ -255,6 +255,20 @@ class ContextualAttributeBindingTest extends TestCase
         $container->make(RouteParameterTest::class);
     }
 
+    public function testRouteParameterAttributeWithouthParameterName()
+    {
+        $container = new Container;
+        $container->singleton('request', function () {
+            $request = m::mock(Request::class);
+            $request->shouldReceive('route')->with('foo')->andReturn(m::mock(Model::class));
+            $request->shouldReceive('route')->with('bar')->andReturn('bar');
+
+            return $request;
+        });
+
+        $container->make(RouteParameterTestWithoutParameterName::class);
+    }
+
     public function testContextAttribute(): void
     {
         $container = new Container;
@@ -620,6 +634,13 @@ final class LogTest
 final class RouteParameterTest
 {
     public function __construct(#[RouteParameter('foo')] Model $foo, #[RouteParameter('bar')] string $bar)
+    {
+    }
+}
+
+final class RouteParameterTestWithoutParameterName
+{
+    public function __construct(#[RouteParameter] Model $foo, #[RouteParameter] string $bar)
     {
     }
 }


### PR DESCRIPTION
Small follow-up of https://github.com/laravel/framework/pull/60457 
This change allows shorter notation of the `RouteParameter`

```
    public function show(
        #[RouteParameter('photo')] Photo $photo,
    ) { 
        // 
    }
```

Can be shortened to 

```
    public function show(
        #[RouteParameter] Photo $photo,
    ) { 
        // 
    }
```

While route parameters can already be resolved without the attribute in many cases, using `#[RouteParameter]` makes the source of the value explicit.
