### PR TITLE
[13.x] Improve return type for `Localizable::withLocale()`

### DIFF
--- a/src/Illuminate/Support/Traits/Localizable.php
+++ b/src/Illuminate/Support/Traits/Localizable.php
@@ -9,9 +9,11 @@ trait Localizable
     /**
      * Run the callback with the given locale.
      *
+     * @template TReturn
+     *
      * @param  string  $locale
-     * @param  \Closure  $callback
-     * @return mixed
+     * @param  \Closure(): TReturn  $callback
+     * @return TReturn
      */
     public function withLocale($locale, $callback)
     {

--- a/types/Support/Traits.php
+++ b/types/Support/Traits.php
@@ -1,0 +1,15 @@
+<?php
+
+use Illuminate\Support\Traits\Localizable;
+
+use function PHPStan\Testing\assertType;
+
+$localizable = new class
+{
+    use Localizable;
+
+    public function useWithLocale(): void
+    {
+        assertType("'foo'", $this->withLocale('en', fn () => 'foo'));
+    }
+};


### PR DESCRIPTION
This allows tools like PHPStan to properly infer the return type of `Localizable::withLocale()`