### PR TITLE
Add a soft-prune methods to Models

### DIFF
--- a/src/Illuminate/Database/Console/PruneCommand.php
+++ b/src/Illuminate/Database/Console/PruneCommand.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Events\ModelPruningFinished;
 use Illuminate\Database\Events\ModelPruningStarting;
 use Illuminate\Database\Events\ModelsPruned;
+use Illuminate\Database\Events\ModelsSoftPruned;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
@@ -63,15 +64,11 @@ class PruneCommand extends Command
         $pruning = [];
 
         $events->listen(ModelsPruned::class, function ($event) use (&$pruning) {
-            if (! in_array($event->model, $pruning)) {
-                $pruning[] = $event->model;
+            $this->displayPruningProgress($event, 'Pruning [%s] records.', $pruning);
+        });
 
-                $this->newLine();
-
-                $this->components->info(sprintf('Pruning [%s] records.', $event->model));
-            }
-
-            $this->components->twoColumnDetail($event->model, "{$event->count} records");
+        $events->listen(ModelsSoftPruned::class, function ($event) use (&$pruning) {
+            $this->displayPruningProgress($event, 'Soft pruning [%s] records.', $pruning);
         });
 
         $events->dispatch(new ModelPruningStarting($models->all()));
@@ -83,6 +80,30 @@ class PruneCommand extends Command
         $events->dispatch(new ModelPruningFinished($models->all()));
 
         $events->forget(ModelsPruned::class);
+        $events->forget(ModelsSoftPruned::class);
+    }
+
+    /**
+     * Display the pruning progress for the given event.
+     *
+     * @param  \Illuminate\Database\Events\ModelsPruned|\Illuminate\Database\Events\ModelsSoftPruned  $event
+     * @param  string  $message
+     * @param  array<int, string>  $pruning
+     * @return void
+     */
+    protected function displayPruningProgress($event, $message, array &$pruning)
+    {
+        $key = $message.$event->model;
+
+        if (! in_array($key, $pruning)) {
+            $pruning[] = $key;
+
+            $this->newLine();
+
+            $this->components->info(sprintf($message, $event->model));
+        }
+
+        $this->components->twoColumnDetail($event->model, "{$event->count} records");
     }
 
     /**
@@ -171,10 +192,17 @@ class PruneCommand extends Command
     {
         $instance = new $model;
 
-        $count = $instance->prunable()
-            ->when($model::isSoftDeletable(), function ($query) {
+        $count = 0;
+
+        if (! is_null($hard = $instance->prunable())) {
+            $count += $hard->when($model::isSoftDeletable(), function ($query) {
                 $query->withTrashed();
             })->count();
+        }
+
+        if (method_exists($instance, 'softPrunable') && ! is_null($soft = $instance->softPrunable())) {
+            $count += $soft->count();
+        }
 
         if ($count === 0) {
             $this->components->info("No prunable [$model] records found.");

--- a/src/Illuminate/Database/Eloquent/Prunable.php
+++ b/src/Illuminate/Database/Eloquent/Prunable.php
@@ -4,6 +4,7 @@ namespace Illuminate\Database\Eloquent;
 
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Database\Events\ModelsPruned;
+use Illuminate\Database\Events\ModelsSoftPruned;
 use LogicException;
 use Throwable;
 
@@ -19,44 +20,96 @@ trait Prunable
      */
     public function pruneAll(int $chunkSize = 1000)
     {
+        $hard = $this->prunable();
+        $soft = $this->softPrunable();
+
+        if (is_null($hard) && is_null($soft)) {
+            throw new LogicException('Please implement the prunable or softPrunable method on your model.');
+        }
+
+        if (! is_null($soft) && ! static::isSoftDeletable()) {
+            throw new LogicException(sprintf(
+                'Model [%s] uses soft pruning but does not use the SoftDeletes trait.',
+                static::class
+            ));
+        }
+
         $total = 0;
 
-        $this->prunable()
-            ->when(static::isSoftDeletable(), function ($query) {
+        // Run the hard prune window first: if a record happened to match both windows, soft
+        // pruning it first would let the (withTrashed) hard prune window force delete it in
+        // the same pass. The two windows are expected to be disjoint regardless.
+        if (! is_null($hard)) {
+            $hard->when(static::isSoftDeletable(), function ($query) {
                 $query->withTrashed();
-            })->chunkById($chunkSize, function ($models) use (&$total) {
-                $models->each(function ($model) use (&$total) {
-                    try {
-                        $model->prune();
-
-                        $total++;
-                    } catch (Throwable $e) {
-                        $handler = app(ExceptionHandler::class);
-
-                        if ($handler) {
-                            $handler->report($e);
-                        } else {
-                            throw $e;
-                        }
-                    }
-                });
-
-                event(new ModelsPruned(static::class, $total));
             });
+
+            $total += $this->pruneQuery($hard, $chunkSize, 'prune', ModelsPruned::class);
+        }
+
+        if (! is_null($soft)) {
+            $total += $this->pruneQuery($soft, $chunkSize, 'softPrune', ModelsSoftPruned::class);
+        }
 
         return $total;
     }
 
     /**
+     * Prune the records matching the given query.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder<static>  $query
+     * @param  int  $chunkSize
+     * @param  string  $method
+     * @param  class-string  $event
+     * @return int
+     *
+     * @throws \Throwable
+     */
+    private function pruneQuery($query, int $chunkSize, string $method, string $event)
+    {
+        $count = 0;
+
+        $query->chunkById($chunkSize, function ($models) use ($method, $event, &$count) {
+            $models->each(function ($model) use ($method, &$count) {
+                try {
+                    $model->{$method}();
+
+                    $count++;
+                } catch (Throwable $e) {
+                    $handler = app(ExceptionHandler::class);
+
+                    if ($handler) {
+                        $handler->report($e);
+                    } else {
+                        throw $e;
+                    }
+                }
+            });
+
+            event(new $event(static::class, $count));
+        });
+
+        return $count;
+    }
+
+    /**
      * Get the prunable model query.
      *
-     * @return \Illuminate\Database\Eloquent\Builder<static>
-     *
-     * @throws \LogicException
+     * @return \Illuminate\Database\Eloquent\Builder<static>|null
      */
     public function prunable()
     {
-        throw new LogicException('Please implement the prunable method on your model.');
+        return null;
+    }
+
+    /**
+     * Get the soft prunable model query.
+     *
+     * @return \Illuminate\Database\Eloquent\Builder<static>|null
+     */
+    public function softPrunable()
+    {
+        return null;
     }
 
     /**
@@ -74,11 +127,36 @@ trait Prunable
     }
 
     /**
+     * Soft prune the model in the database.
+     *
+     * The record is only soft deleted, so it remains restorable until it is later hard
+     * pruned (e.g. through the model's prunable query).
+     *
+     * @return bool|null
+     */
+    public function softPrune()
+    {
+        $this->softPruning();
+
+        return $this->delete();
+    }
+
+    /**
      * Prepare the model for pruning.
      *
      * @return void
      */
     protected function pruning()
+    {
+        //
+    }
+
+    /**
+     * Prepare the soft deletable model for soft pruning.
+     *
+     * @return void
+     */
+    protected function softPruning()
     {
         //
     }

--- a/src/Illuminate/Database/Events/ModelsSoftPruned.php
+++ b/src/Illuminate/Database/Events/ModelsSoftPruned.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\Database\Events;
+
+class ModelsSoftPruned
+{
+    /**
+     * Create a new event instance.
+     *
+     * @param  string  $model  The class name of the model that was soft pruned.
+     * @param  int  $count  The number of soft pruned records.
+     */
+    public function __construct(
+        public $model,
+        public $count,
+    ) {
+    }
+}

--- a/tests/Database/PruneCommandTest.php
+++ b/tests/Database/PruneCommandTest.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Console\PruneCommand;
 use Illuminate\Database\Events\ModelPruningFinished;
 use Illuminate\Database\Events\ModelPruningStarting;
 use Illuminate\Database\Events\ModelsPruned;
+use Illuminate\Database\Events\ModelsSoftPruned;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Foundation\Application;
 use Mockery as m;
@@ -233,6 +234,70 @@ class PruneCommandTest extends TestCase
         $this->assertEquals(4, Pruning\Models\PrunableTestSoftDeletedModelWithPrunableRecords::withTrashed()->count());
     }
 
+    public function testTheCommandMayBePretendedOnSoftPrunableModel()
+    {
+        $db = new DB;
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+        $db->bootEloquent();
+        $db->setAsGlobal();
+        DB::connection('default')->getSchemaBuilder()->create('prunables', function ($table) {
+            $table->string('value')->nullable();
+            $table->datetime('deleted_at')->nullable();
+        });
+        DB::connection('default')->table('prunables')->insert([
+            ['value' => 1, 'deleted_at' => null],
+            ['value' => 2, 'deleted_at' => '2021-12-01 00:00:00'],
+            ['value' => 3, 'deleted_at' => null],
+            ['value' => 4, 'deleted_at' => '2021-12-02 00:00:00'],
+        ]);
+
+        $output = $this->artisan([
+            '--model' => Pruning\Models\PrunableTestSoftPrunableModelWithPrunableRecords::class,
+            '--pretend' => true,
+        ]);
+
+        // Soft pruning only targets live records, so the already-trashed value 4 is excluded.
+        $this->assertStringContainsString(
+            '1 [Illuminate\Tests\Database\Pruning\Models\PrunableTestSoftPrunableModelWithPrunableRecords] records will be pruned.',
+            $output->fetch(),
+        );
+
+        $this->assertEquals(4, Pruning\Models\PrunableTestSoftPrunableModelWithPrunableRecords::withTrashed()->count());
+    }
+
+    public function testPruneSoftPrunableModelWithPrunableRecords()
+    {
+        $db = new DB;
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+        $db->bootEloquent();
+        $db->setAsGlobal();
+        DB::connection('default')->getSchemaBuilder()->create('prunables', function ($table) {
+            $table->increments('id');
+            $table->string('value')->nullable();
+            $table->datetime('deleted_at')->nullable();
+        });
+        DB::connection('default')->table('prunables')->insert([
+            ['value' => 1, 'deleted_at' => null],
+            ['value' => 2, 'deleted_at' => '2021-12-01 00:00:00'],
+            ['value' => 3, 'deleted_at' => null],
+            ['value' => 4, 'deleted_at' => '2021-12-02 00:00:00'],
+        ]);
+
+        $this->artisan(['--model' => Pruning\Models\PrunableTestSoftPrunableModelWithPrunableRecords::class]);
+
+        // The live matching record (value 3) is soft deleted (per-model pruning chunks by id),
+        // nothing is hard deleted.
+        $this->assertEquals(4, Pruning\Models\PrunableTestSoftPrunableModelWithPrunableRecords::withTrashed()->count());
+        $this->assertEquals(1, Pruning\Models\PrunableTestSoftPrunableModelWithPrunableRecords::count());
+        $this->assertEquals(3, Pruning\Models\PrunableTestSoftPrunableModelWithPrunableRecords::onlyTrashed()->count());
+    }
+
     public function testTheCommandDispatchesEvents()
     {
         $dispatcher = m::mock(DispatcherContract::class);
@@ -242,12 +307,14 @@ class PruneCommandTest extends TestCase
                 $event->models === [Pruning\Models\PrunableTestModelWithPrunableRecords::class];
         });
         $dispatcher->shouldReceive('listen')->once()->with(ModelsPruned::class, m::type(Closure::class));
+        $dispatcher->shouldReceive('listen')->once()->with(ModelsSoftPruned::class, m::type(Closure::class));
         $dispatcher->shouldReceive('dispatch')->twice()->with(m::type(ModelsPruned::class));
         $dispatcher->shouldReceive('dispatch')->once()->withArgs(function ($event) {
             return get_class($event) === ModelPruningFinished::class &&
                 $event->models === [Pruning\Models\PrunableTestModelWithPrunableRecords::class];
         });
         $dispatcher->shouldReceive('forget')->once()->with(ModelsPruned::class);
+        $dispatcher->shouldReceive('forget')->once()->with(ModelsSoftPruned::class);
 
         Application::getInstance()->instance(DispatcherContract::class, $dispatcher);
 

--- a/tests/Database/Pruning/Models/PrunableTestSoftPrunableModelWithPrunableRecords.php
+++ b/tests/Database/Pruning/Models/PrunableTestSoftPrunableModelWithPrunableRecords.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Tests\Database\Pruning\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Prunable;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class PrunableTestSoftPrunableModelWithPrunableRecords extends Model
+{
+    use Prunable, SoftDeletes;
+
+    protected $table = 'prunables';
+    protected $connection = 'default';
+    public $timestamps = false;
+
+    public function softPrunable()
+    {
+        return static::where('value', '>=', 3);
+    }
+}

--- a/tests/Integration/Database/EloquentPrunableTest.php
+++ b/tests/Integration/Database/EloquentPrunableTest.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Prunable;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Events\ModelsPruned;
+use Illuminate\Database\Events\ModelsSoftPruned;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Event;
@@ -24,6 +25,11 @@ class EloquentPrunableTest extends DatabaseTestCase
             'prunable_test_model_missing_prunable_methods',
             'prunable_with_custom_prune_method_test_models',
             'prunable_with_exceptions',
+            'soft_prunable_test_models',
+            'soft_prunable_without_soft_deletes_test_models',
+            'soft_prunable_with_hook_test_models',
+            'prunable_with_soft_hook_test_models',
+            'prunable_both_window_test_models',
         ])->each(function ($table) {
             Schema::create($table, function (Blueprint $table) {
                 $table->increments('id');
@@ -100,6 +106,115 @@ class EloquentPrunableTest extends DatabaseTestCase
         $this->assertEquals(5000, PrunableWithCustomPruneMethodTestModel::count());
 
         Event::assertDispatched(ModelsPruned::class, 1);
+    }
+
+    public function testSoftPrunesRecords()
+    {
+        Event::fake();
+
+        collect(range(1, 5000))->map(function ($id) {
+            return ['name' => 'foo'];
+        })->chunk(200)->each(function ($chunk) {
+            SoftPrunableTestModel::insert($chunk->all());
+        });
+
+        $count = (new SoftPrunableTestModel)->pruneAll();
+
+        // The 3000 matching records are soft deleted (across 3 chunks of 1000),
+        // not hard deleted: nothing leaves the table, and they are now trashed.
+        $this->assertEquals(3000, $count);
+        $this->assertEquals(2000, SoftPrunableTestModel::count());
+        $this->assertEquals(3000, SoftPrunableTestModel::onlyTrashed()->count());
+        $this->assertEquals(5000, SoftPrunableTestModel::withTrashed()->count());
+
+        Event::assertDispatched(ModelsSoftPruned::class, 3);
+        Event::assertNotDispatched(ModelsPruned::class);
+    }
+
+    public function testSoftPruningIsIdempotentAcrossRuns()
+    {
+        collect(range(1, 5000))->map(function ($id) {
+            return ['name' => 'foo'];
+        })->chunk(200)->each(function ($chunk) {
+            SoftPrunableTestModel::insert($chunk->all());
+        });
+
+        $this->assertEquals(3000, (new SoftPrunableTestModel)->pruneAll());
+
+        // A second run finds nothing: already-trashed records are excluded by the
+        // default soft-deleting scope, so they are never re-processed.
+        $this->assertEquals(0, (new SoftPrunableTestModel)->pruneAll());
+        $this->assertEquals(2000, SoftPrunableTestModel::count());
+        $this->assertEquals(5000, SoftPrunableTestModel::withTrashed()->count());
+    }
+
+    public function testSoftPruningThrowsWithoutSoftDeletes()
+    {
+        collect(range(1, 100))->map(function ($id) {
+            return ['name' => 'foo'];
+        })->chunk(50)->each(function ($chunk) {
+            SoftPrunableWithoutSoftDeletesTestModel::insert($chunk->all());
+        });
+
+        try {
+            (new SoftPrunableWithoutSoftDeletesTestModel)->pruneAll();
+            $this->fail('Expected a LogicException to be thrown.');
+        } catch (LogicException $e) {
+            $this->assertStringContainsString('does not use the SoftDeletes trait', $e->getMessage());
+        }
+
+        // No records were touched before the guard threw.
+        $this->assertEquals(100, SoftPrunableWithoutSoftDeletesTestModel::count());
+    }
+
+    public function testSoftPruningHookFiresOnlyOnSoftPrune()
+    {
+        SoftPrunableWithHookTestModel::$pruned = 0;
+        PrunableWithSoftHookTestModel::$pruned = 0;
+
+        collect(range(1, 1000))->map(function ($id) {
+            return ['name' => 'foo'];
+        })->chunk(200)->each(function ($chunk) {
+            SoftPrunableWithHookTestModel::insert($chunk->all());
+            PrunableWithSoftHookTestModel::insert($chunk->all());
+        });
+
+        (new SoftPrunableWithHookTestModel)->pruneAll();
+        (new PrunableWithSoftHookTestModel)->pruneAll();
+
+        // The softPruning() hook fires for every soft-pruned record...
+        $this->assertEquals(1000, SoftPrunableWithHookTestModel::$pruned);
+        $this->assertEquals(1000, SoftPrunableWithHookTestModel::onlyTrashed()->count());
+
+        // ...but never for a model that hard-prunes (force deletes).
+        $this->assertEquals(0, PrunableWithSoftHookTestModel::$pruned);
+        $this->assertEquals(0, PrunableWithSoftHookTestModel::withTrashed()->count());
+    }
+
+    public function testPrunesBothWindowsInOnePass()
+    {
+        Event::fake();
+
+        collect(range(1, 5000))->map(function ($id) {
+            return ['name' => 'foo'];
+        })->chunk(200)->each(function ($chunk) {
+            PrunableBothWindowTestModel::insert($chunk->all());
+        });
+
+        $count = (new PrunableBothWindowTestModel)->pruneAll();
+
+        // Hard window (id <= 1000) is force deleted, soft window (1000 < id <= 3000) is
+        // soft deleted. The two windows are disjoint.
+        $this->assertEquals(3000, $count);
+        $this->assertEquals(4000, PrunableBothWindowTestModel::withTrashed()->count());
+        $this->assertEquals(2000, PrunableBothWindowTestModel::count());
+        $this->assertEquals(2000, PrunableBothWindowTestModel::onlyTrashed()->count());
+
+        // Each window reports its own cumulative count through its own event.
+        Event::assertDispatched(ModelsPruned::class, 1);
+        Event::assertDispatched(fn (ModelsPruned $event) => $event->count === 1000);
+        Event::assertDispatched(ModelsSoftPruned::class, 2);
+        Event::assertDispatched(fn (ModelsSoftPruned $event) => $event->count === 2000);
     }
 
     public function testPruneWithExceptionAtOneOfModels()
@@ -181,4 +296,73 @@ class PrunableWithException extends Model
 class PrunableTestModelMissingPrunableMethod extends Model
 {
     use Prunable;
+}
+
+class SoftPrunableTestModel extends Model
+{
+    use Prunable, SoftDeletes;
+
+    public function softPrunable()
+    {
+        return $this->where('id', '<=', 3000);
+    }
+}
+
+class SoftPrunableWithoutSoftDeletesTestModel extends Model
+{
+    use Prunable;
+
+    public function softPrunable()
+    {
+        return $this->where('id', '<=', 50);
+    }
+}
+
+class SoftPrunableWithHookTestModel extends Model
+{
+    use Prunable, SoftDeletes;
+
+    public static $pruned = 0;
+
+    public function softPrunable()
+    {
+        return $this->where('id', '<=', 1000);
+    }
+
+    protected function softPruning()
+    {
+        static::$pruned++;
+    }
+}
+
+class PrunableWithSoftHookTestModel extends Model
+{
+    use Prunable, SoftDeletes;
+
+    public static $pruned = 0;
+
+    public function prunable()
+    {
+        return $this->where('id', '<=', 1000);
+    }
+
+    protected function softPruning()
+    {
+        static::$pruned++;
+    }
+}
+
+class PrunableBothWindowTestModel extends Model
+{
+    use Prunable, SoftDeletes;
+
+    public function prunable()
+    {
+        return $this->where('id', '<=', 1000);
+    }
+
+    public function softPrunable()
+    {
+        return $this->whereBetween('id', [1001, 3000]);
+    }
 }


### PR DESCRIPTION
Full motivation and design discussion: https://github.com/laravel/framework/discussions/60468

## Subject

Adds an optional soft-pruning stage to the `Prunable` trait. Alongside `prunable()` (force delete), a model can define `softPrunable()` to **soft delete** records after a first window, keeping them restorable until they're later force deleted. Ships with `softPrune()` / `softPruning()` hooks and a `ModelsSoftPruned` event, mirroring the existing API.

## Benefits

Built-in support for grace periods and staged data retention (e.g. GDPR) - hide records first, purge them permanently later - instead of hand-rolling two scheduled commands and custom queries.

## Backward compatibility

Fully backward, and the hard prune runs first, so permanent deletion always takes precedence over soft pruning.

## Tests

Added coverage tests you to test it.