### PR TITLE
[13.x] Fix shell quoting when scheduled commands run as another user

### DIFF
--- a/src/Illuminate/Console/Scheduling/CommandBuilder.php
+++ b/src/Illuminate/Console/Scheduling/CommandBuilder.php
@@ -70,6 +70,8 @@ class CommandBuilder
      */
     protected function ensureCorrectUser(Event $event, $command)
     {
-        return $event->user && ! windows_os() ? 'sudo -u '.$event->user.' -- sh -c \''.$command.'\'' : $command;
+        return $event->user && ! windows_os()
+            ? 'sudo -u '.$event->user.' -- sh -c '.ProcessUtils::escapeArgument($command)
+            : $command;
     }
 }

--- a/tests/Console/Scheduling/EventTest.php
+++ b/tests/Console/Scheduling/EventTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Console\Scheduling;
 use Illuminate\Console\Scheduling\Event;
 use Illuminate\Console\Scheduling\EventMutex;
 use Illuminate\Container\Container;
+use Illuminate\Support\ProcessUtils;
 use Illuminate\Support\Str;
 use Illuminate\Support\Stringable;
 use Mockery as m;
@@ -51,6 +52,46 @@ class EventTest extends TestCase
         $scheduleId = '"framework'.DIRECTORY_SEPARATOR.'schedule-eeb46c93d45e928d62aaf684d727e213b7094822"';
 
         $this->assertSame('start /b cmd /v:on /c "(php -i & '.php_binary().' artisan schedule:finish '.$scheduleId.' ^!ERRORLEVEL^!) > "NUL" 2>&1"', $event->buildCommand());
+    }
+
+    #[RequiresOperatingSystem('Linux|Darwin')]
+    public function testBuildCommandWithUserUsingUnix()
+    {
+        $event = new Event(m::mock(EventMutex::class), 'php -i');
+        $event->user('forge');
+
+        $this->assertSame("sudo -u forge -- sh -c 'php -i > '\''/dev/null'\'' 2>&1'", $event->buildCommand());
+    }
+
+    #[RequiresOperatingSystem('Linux|Darwin')]
+    public function testBuildCommandWithUserAndSpacesInOutputPathUsingUnix()
+    {
+        $event = new Event(m::mock(EventMutex::class), 'php -i');
+        $event->user('forge')->sendOutputTo('/my folder/foo.log');
+
+        $this->assertSame("sudo -u forge -- sh -c 'php -i > '\''/my folder/foo.log'\'' 2>&1'", $event->buildCommand());
+    }
+
+    #[RequiresOperatingSystem('Linux|Darwin')]
+    public function testBuildCommandWithUserAndSingleQuotesInOutputPathUsingUnix()
+    {
+        $event = new Event(m::mock(EventMutex::class), 'php -i');
+        $event->user('forge')->sendOutputTo("/tmp/o'brien.log");
+
+        $this->assertSame("sudo -u forge -- sh -c 'php -i > '\''/tmp/o'\''\'\'''\''brien.log'\'' 2>&1'", $event->buildCommand());
+    }
+
+    #[RequiresOperatingSystem('Linux|Darwin')]
+    public function testBuildCommandInBackgroundWithUserUsingUnix()
+    {
+        $event = new Event(m::mock(EventMutex::class), 'php -i');
+        $event->user('forge')->runInBackground();
+
+        $scheduleId = '"framework'.DIRECTORY_SEPARATOR.'schedule-eeb46c93d45e928d62aaf684d727e213b7094822"';
+
+        $background = "(php -i > '/dev/null' 2>&1 ; '".php_binary()."' 'artisan' schedule:finish {$scheduleId} \"$?\") > '/dev/null' 2>&1 &";
+
+        $this->assertSame('sudo -u forge -- sh -c '.ProcessUtils::escapeArgument($background), $event->buildCommand());
     }
 
     public function testBuildCommandSendOutputTo()


### PR DESCRIPTION
# [13.x] Fix shell quoting when scheduled commands run as another user

## Problem

`CommandBuilder::ensureCorrectUser()` wraps the built command in literal single quotes:

```php
'sudo -u '.$event->user.' -- sh -c \''.$command.'\''
```

But `$command` already contains single-quoted segments, because both `buildForegroundCommand()` and `buildBackgroundCommand()` embed `ProcessUtils::escapeArgument($event->output)`, which on Unix produces `'...'`. Single quotes cannot be nested inside single quotes in `sh`, so the wrapping only works by accident when the output path contains no spaces or special characters (the default `/dev/null` case happens to survive because the misaligned quote boundaries concatenate cleanly).

## Reproduction

```php
$schedule->command('inspire')
    ->user('forge')
    ->sendOutputTo('/var/log/my app/inspire.log');
```

builds:

```
sudo -u forge -- sh -c 'php artisan inspire > '/var/log/my app/inspire.log' 2>&1'
```

The outer quotes terminate at the inner ones, so `sh -c` receives `php artisan inspire > /var/log/my` and the rest becomes stray arguments — the output is silently written to a stray file named `/var/log/my` and the intended log is never created. A path containing a literal `'` produces unbalanced quotes and fails outright.

This is not limited to unusual output paths. The command string also embeds the escaped PHP binary path (via `Application::formatCommandString()`), so on any system where the binary path contains a space — e.g. Laravel Herd on macOS, where PHP lives under `~/Library/Application Support/Herd/bin/` — **every** scheduled command using `->user()` fails with exit code 127 and never runs at all, even with the default `/dev/null` output:

```
sh -c ''/Users/x/Library/Application Support/Herd/bin/php85' 'artisan' list > '/dev/null' 2>&1'
sh: /Users/x/Library/Application: No such file or directory
```

## Fix

Escape the wrapped command with `ProcessUtils::escapeArgument()` instead of hand-quoting it. `escapeArgument()` turns inner `'` into `'\''`, which nests correctly.

Behavior is fully preserved for currently-working cases:

- For commands whose output path contains no single quotes other than the `escapeArgument` wrappers, the resulting string executes identically.
- For the background case, `"$?"` remains literal to the outer shell and is expanded by the inner `sh`, exactly as today.

## Tests

Added regression tests to `EventTest` covering `user()` with the default output, an output path containing a space, an output path containing a single quote, and `user()` combined with `runInBackground()`. Each expected string was verified against a real `sh` to confirm the quoting parses and the redirect target survives intact.
