### PR TITLE
[13.x] Respect existing Content-Type header in HTTP test responses

### DIFF
--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -181,7 +181,9 @@ class Factory
         if (is_array($body)) {
             $body = json_encode($body);
 
-            $headers['Content-Type'] = 'application/json';
+            if (! isset($headers['Content-Type'])) {
+                $headers['Content-Type'] = 'application/json';
+            }
         }
 
         return new Psr7Response($status, static::normalizeResponseHeaders($headers), $body);

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -4790,6 +4790,18 @@ class HttpClientTest extends TestCase
         $response->json();
         $this->assertSame(1, $response->bodyCallCount);
     }
+
+    public function testPSR7ResponseJsonHeaders()
+    {
+        $defaultJsonRequest = Factory::psr7Response(['input' => 'array']);
+        $this->assertEquals('application/json', $defaultJsonRequest->getHeader('Content-Type')[0]);
+
+        $stringRequest = Factory::psr7Response('string');
+        $this->assertEmpty($stringRequest->getHeader('Content-Type'));
+
+        $overrideContentTypeRequest = Factory::psr7Response(['input' => 'array'], 200, ['Content-Type' => 'application/ld+json']);
+        $this->assertEquals('application/ld+json', $overrideContentTypeRequest->getHeader('Content-Type')[0]);
+    }
 }
 
 class CustomFactory extends Factory


### PR DESCRIPTION
```php
use Illuminate\Support\Facades\Http;

Http::fake([
    '*' => Http::response(['error' => 'Not Found']), 404, ['Content-Type' => 'application/fhir+json']),
]);
```

The Content-Type header here gets overwritten with `application/json` internally within the Http Factory. Currently, the only way of allowing this custom Content-Type is to JSON encode it, and pass it in as a string.

This MR checks to see if the user has passed in a Content-Type header, and will not overwrite it.