### PR TITLE
[13.x] Add queue:peek command

### DIFF
--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -101,6 +101,7 @@ use Illuminate\Queue\Console\ListenCommand as QueueListenCommand;
 use Illuminate\Queue\Console\ListFailedCommand as ListFailedQueueCommand;
 use Illuminate\Queue\Console\MonitorCommand as QueueMonitorCommand;
 use Illuminate\Queue\Console\PauseCommand as QueuePauseCommand;
+use Illuminate\Queue\Console\PeekCommand as QueuePeekCommand;
 use Illuminate\Queue\Console\PruneBatchesCommand as QueuePruneBatchesCommand;
 use Illuminate\Queue\Console\PruneFailedJobsCommand as QueuePruneFailedJobsCommand;
 use Illuminate\Queue\Console\RestartCommand as QueueRestartCommand;
@@ -156,6 +157,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'QueueListen' => QueueListenCommand::class,
         'QueueMonitor' => QueueMonitorCommand::class,
         'QueuePause' => QueuePauseCommand::class,
+        'QueuePeek' => QueuePeekCommand::class,
         'QueuePruneBatches' => QueuePruneBatchesCommand::class,
         'QueuePruneFailedJobs' => QueuePruneFailedJobsCommand::class,
         'QueueRestart' => QueueRestartCommand::class,

--- a/src/Illuminate/Queue/Console/PeekCommand.php
+++ b/src/Illuminate/Queue/Console/PeekCommand.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Illuminate\Queue\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(name: 'queue:peek')]
+class PeekCommand extends Command
+{
+    /**
+     * The console command signature.
+     *
+     * @var string
+     */
+    protected $signature = 'queue:peek
+                            {connection? : The name of the connection}
+                            {--queue= : The name of the queue to inspect}
+                            {--state=pending : The state of the jobs to inspect (pending, delayed, reserved)}
+                            {--limit=25 : The maximum number of jobs to display}
+                            {--json : Output the jobs as JSON}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Inspect the jobs on a given queue';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $state = $this->option('state');
+
+        if (! in_array($state, ['pending', 'delayed', 'reserved'])) {
+            $this->components->error('The state must be one of: pending, delayed, reserved.');
+
+            return 1;
+        }
+
+        $connection = $this->argument('connection')
+            ?: $this->laravel['config']['queue.default'];
+
+        $queue = $this->laravel['queue']->connection($connection);
+
+        if (! method_exists($queue, $state.'Jobs')) {
+            $this->components->error("The [{$connection}] connection does not support inspecting jobs.");
+
+            return self::FAILURE;
+        }
+
+        $queueName = $this->getQueue($connection);
+
+        $jobs = match ($state) {
+            'pending' => $queue->pendingJobs($queueName),
+            'delayed' => $queue->delayedJobs($queueName),
+            'reserved' => $queue->reservedJobs($queueName),
+        };
+
+        $jobs = $jobs->take((int) $this->option('limit'))->values();
+
+        if ($this->option('json')) {
+            $this->displayJobsAsJson($jobs);
+
+            return self::SUCCESS;
+        }
+
+        if ($jobs->isEmpty()) {
+            $this->components->info('No '.$state.' jobs found on the ['.$queueName.'] queue.');
+
+            return self::SUCCESS;
+        }
+
+        $this->newLine();
+        $this->displayJobs($jobs);
+        $this->newLine();
+    }
+
+    /**
+     * Get the queue name to inspect.
+     *
+     * @param  string  $connection
+     * @return string
+     */
+    protected function getQueue($connection)
+    {
+        return $this->option('queue') ?: $this->laravel['config']->get(
+            "queue.connections.{$connection}.queue", 'default'
+        );
+    }
+
+    /**
+     * Display the jobs in the console.
+     *
+     * @param  \Illuminate\Support\Collection<int, \Illuminate\Queue\Jobs\InspectedJob>  $jobs
+     * @return void
+     */
+    protected function displayJobs(Collection $jobs)
+    {
+        $jobs->each(
+            fn ($job) => $this->components->twoColumnDetail(
+                sprintf('<fg=gray>%s</> %s', $job->uuid, $job->name),
+                sprintf('<fg=gray>%s</> %s', $job->attempts.' '.Str::plural('attempt', $job->attempts), $job->createdAt?->diffForHumans() ?? '')
+            )
+        );
+    }
+
+    /**
+     * Display the jobs as JSON.
+     *
+     * @param  \Illuminate\Support\Collection<int, \Illuminate\Queue\Jobs\InspectedJob>  $jobs
+     * @return void
+     */
+    protected function displayJobsAsJson(Collection $jobs)
+    {
+        $this->output->writeln($jobs->map(fn ($job) => [
+            'uuid' => $job->uuid,
+            'queue' => $job->queue,
+            'name' => $job->name,
+            'attempts' => $job->attempts,
+            'created_at' => $job->createdAt?->toIso8601String(),
+        ])->toJson());
+    }
+}

--- a/src/Illuminate/Queue/Console/PeekCommand.php
+++ b/src/Illuminate/Queue/Console/PeekCommand.php
@@ -27,7 +27,7 @@ class PeekCommand extends Command
      *
      * @var string
      */
-    protected $description = 'Inspect the jobs on a given queue';
+    protected $description = 'Peek at the jobs on a given queue';
 
     /**
      * Execute the console command.

--- a/src/Illuminate/Queue/Console/PeekCommand.php
+++ b/src/Illuminate/Queue/Console/PeekCommand.php
@@ -41,7 +41,7 @@ class PeekCommand extends Command
         if (! in_array($state, ['pending', 'delayed', 'reserved'])) {
             $this->components->error('The state must be one of: pending, delayed, reserved.');
 
-            return 1;
+            return self::FAILURE;
         }
 
         $connection = $this->argument('connection')
@@ -80,6 +80,8 @@ class PeekCommand extends Command
         $this->newLine();
         $this->displayJobs($jobs);
         $this->newLine();
+
+        return self::SUCCESS;
     }
 
     /**

--- a/tests/Queue/QueuePeekCommandTest.php
+++ b/tests/Queue/QueuePeekCommandTest.php
@@ -83,8 +83,15 @@ class QueuePeekCommandTest extends TestCase
 
         $output = $this->runPeekCommand(['--json' => true])->fetch();
 
-        $this->assertStringContainsString('"uuid":"1cde062a-8c6a-4d67-8125-e83f585c18cb"', $output);
-        $this->assertStringContainsString('"name":"App\\\\Jobs\\\\ProcessPodcast"', $output);
+        $jobs = json_decode($output, true);
+
+        $this->assertSame([
+            'uuid' => '1cde062a-8c6a-4d67-8125-e83f585c18cb',
+            'queue' => 'default',
+            'name' => 'App\\Jobs\\ProcessPodcast',
+            'attempts' => 1,
+            'created_at' => '2026-01-01T12:00:00+00:00',
+        ], $jobs[0]);
     }
 
     public function testItDisplaysDelayedJobs()

--- a/tests/Queue/QueuePeekCommandTest.php
+++ b/tests/Queue/QueuePeekCommandTest.php
@@ -60,7 +60,7 @@ class QueuePeekCommandTest extends TestCase
             ->assertSuccessful();
     }
 
-    public function testItCanOutputAsJsjon()
+    public function testItCanOutputAsJson()
     {
         $this->app['config']->set('queue.default', 'redis');
         $this->app['config']->set('queue.connections.redis.queue', 'default');

--- a/tests/Queue/QueuePeekCommandTest.php
+++ b/tests/Queue/QueuePeekCommandTest.php
@@ -3,12 +3,15 @@
 namespace Illuminate\Tests\Queue;
 
 use Illuminate\Contracts\Queue\Factory;
+use Illuminate\Queue\Console\PeekCommand;
 use Illuminate\Queue\Jobs\InspectedJob;
 use Illuminate\Queue\RedisQueue;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Mockery as m;
 use Orchestra\Testbench\TestCase;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
 
 class QueuePeekCommandTest extends TestCase
 {
@@ -37,12 +40,12 @@ class QueuePeekCommandTest extends TestCase
 
         $this->mockQueueConnection($queue);
 
-        $this->artisan('queue:peek')
-            ->expectsOutputToContain('App\\Jobs\\ProcessPodcast')
-            ->expectsOutputToContain('1cde062a-8c6a-4d67-8125-e83f585c18cb')
-            ->expectsOutputToContain('1 attempt')
-            ->expectsOutputToContain('5 minutes ago')
-            ->assertSuccessful();
+        $output = $this->runPeekCommand()->fetch();
+
+        $this->assertStringContainsString('App\\Jobs\\ProcessPodcast', $output);
+        $this->assertStringContainsString('1cde062a-8c6a-4d67-8125-e83f585c18cb', $output);
+        $this->assertStringContainsString('1 attempt', $output);
+        $this->assertStringContainsString('5 minutes ago', $output);
     }
 
     public function testItDisplaysWhenEmpty()
@@ -55,9 +58,9 @@ class QueuePeekCommandTest extends TestCase
 
         $this->mockQueueConnection($queue);
 
-        $this->artisan('queue:peek')
-            ->expectsOutputToContain('No pending jobs found on the [default] queue.')
-            ->assertSuccessful();
+        $output = $this->runPeekCommand()->fetch();
+
+        $this->assertStringContainsString('No pending jobs found on the [default] queue.', $output);
     }
 
     public function testItCanOutputAsJson()
@@ -78,10 +81,10 @@ class QueuePeekCommandTest extends TestCase
 
         $this->mockQueueConnection($queue);
 
-        $this->artisan('queue:peek', ['--json' => true])
-            ->expectsOutputToContain('"uuid":"1cde062a-8c6a-4d67-8125-e83f585c18cb"')
-            ->expectsOutputToContain('"name":"App\\\\Jobs\\\\ProcessPodcast"')
-            ->assertSuccessful();
+        $output = $this->runPeekCommand(['--json' => true])->fetch();
+
+        $this->assertStringContainsString('"uuid":"1cde062a-8c6a-4d67-8125-e83f585c18cb"', $output);
+        $this->assertStringContainsString('"name":"App\\\\Jobs\\\\ProcessPodcast"', $output);
     }
 
     public function testItDisplaysDelayedJobs()
@@ -102,9 +105,9 @@ class QueuePeekCommandTest extends TestCase
 
         $this->mockQueueConnection($queue);
 
-        $this->artisan('queue:peek', ['--state' => 'delayed'])
-            ->expectsOutputToContain('App\\Jobs\\ProcessPodcast')
-            ->assertSuccessful();
+        $output = $this->runPeekCommand(['--state' => 'delayed'])->fetch();
+
+        $this->assertStringContainsString('App\\Jobs\\ProcessPodcast', $output);
     }
 
     public function testItDisplaysReservedJobs()
@@ -125,10 +128,10 @@ class QueuePeekCommandTest extends TestCase
 
         $this->mockQueueConnection($queue);
 
-        $this->artisan('queue:peek', ['--state' => 'reserved'])
-            ->expectsOutputToContain('App\\Jobs\\ProcessPodcast')
-            ->expectsOutputToContain('2 attempts')
-            ->assertSuccessful();
+        $output = $this->runPeekCommand(['--state' => 'reserved'])->fetch();
+
+        $this->assertStringContainsString('App\\Jobs\\ProcessPodcast', $output);
+        $this->assertStringContainsString('2 attempts', $output);
     }
 
     public function testItUsesTheQueueOption()
@@ -140,16 +143,16 @@ class QueuePeekCommandTest extends TestCase
 
         $this->mockQueueConnection($queue);
 
-        $this->artisan('queue:peek', ['--queue' => 'high'])
-            ->expectsOutputToContain('No pending jobs found on the [high] queue.')
-            ->assertSuccessful();
+        $output = $this->runPeekCommand(['--queue' => 'high'])->fetch();
+
+        $this->assertStringContainsString('No pending jobs found on the [high] queue.', $output);
     }
 
     public function testItRejectsAnInvalidState()
     {
-        $this->artisan('queue:peek', ['--state' => 'failed'])
-            ->expectsOutputToContain('The state must be one of: pending, delayed, reserved.')
-            ->assertFailed();
+        $output = $this->runPeekCommand(['--state' => 'failed'])->fetch();
+
+        $this->assertStringContainsString('The state must be one of: pending, delayed, reserved.', $output);
     }
 
     public function testItOutputsWhenQueueDoesNotSupportInspection()
@@ -158,9 +161,9 @@ class QueuePeekCommandTest extends TestCase
 
         $this->mockQueueConnection(m::mock());
 
-        $this->artisan('queue:peek')
-            ->expectsOutputToContain('The [jack] connection does not support inspecting jobs.')
-            ->assertFailed();
+        $output = $this->runPeekCommand()->fetch();
+
+        $this->assertStringContainsString('The [jack] connection does not support inspecting jobs.', $output);
     }
 
     protected function mockQueueConnection(mixed $queue): void
@@ -168,5 +171,17 @@ class QueuePeekCommandTest extends TestCase
         $manager = m::mock(Factory::class);
         $manager->shouldReceive('connection')->andReturn($queue);
         $this->app->instance('queue', $manager);
+    }
+
+    protected function runPeekCommand($arguments = [])
+    {
+        $input = new ArrayInput($arguments);
+        $output = new BufferedOutput;
+
+        tap(new PeekCommand)
+            ->setLaravel($this->app)
+            ->run($input, $output);
+
+        return $output;
     }
 }

--- a/tests/Queue/QueuePeekCommandTest.php
+++ b/tests/Queue/QueuePeekCommandTest.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace Illuminate\Tests\Queue;
+
+use Illuminate\Contracts\Queue\Factory;
+use Illuminate\Queue\Jobs\InspectedJob;
+use Illuminate\Queue\RedisQueue;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
+use Mockery as m;
+use Orchestra\Testbench\TestCase;
+
+class QueuePeekCommandTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+
+        parent::tearDown();
+    }
+
+    public function testItDisplaysJobsOnTheQueue()
+    {
+        $this->app['config']->set('queue.default', 'redis');
+        $this->app['config']->set('queue.connections.redis.queue', 'default');
+
+        $queue = m::mock(RedisQueue::class);
+        $queue->shouldReceive('pendingJobs')->with('default')->andReturn(new Collection([
+            new InspectedJob(
+                uuid: '1cde062a-8c6a-4d67-8125-e83f585c18cb',
+                queue: 'default',
+                name: 'App\\Jobs\\ProcessPodcast',
+                attempts: 1,
+                createdAt: Carbon::now()->subMinutes(5),
+            ),
+        ]));
+
+        $this->mockQueueConnection($queue);
+
+        $this->artisan('queue:peek')
+            ->expectsOutputToContain('App\\Jobs\\ProcessPodcast')
+            ->expectsOutputToContain('1cde062a-8c6a-4d67-8125-e83f585c18cb')
+            ->expectsOutputToContain('1 attempt')
+            ->expectsOutputToContain('5 minutes ago')
+            ->assertSuccessful();
+    }
+
+    public function testItDisplaysWhenEmpty()
+    {
+        $this->app['config']->set('queue.default', 'redis');
+        $this->app['config']->set('queue.connections.redis.queue', 'default');
+
+        $queue = m::mock(RedisQueue::class);
+        $queue->shouldReceive('pendingJobs')->with('default')->andReturn(new Collection);
+
+        $this->mockQueueConnection($queue);
+
+        $this->artisan('queue:peek')
+            ->expectsOutputToContain('No pending jobs found on the [default] queue.')
+            ->assertSuccessful();
+    }
+
+    public function testItCanOutputAsJsjon()
+    {
+        $this->app['config']->set('queue.default', 'redis');
+        $this->app['config']->set('queue.connections.redis.queue', 'default');
+
+        $queue = m::mock(RedisQueue::class);
+        $queue->shouldReceive('pendingJobs')->with('default')->andReturn(new Collection([
+            new InspectedJob(
+                uuid: '1cde062a-8c6a-4d67-8125-e83f585c18cb',
+                queue: 'default',
+                name: 'App\\Jobs\\ProcessPodcast',
+                attempts: 1,
+                createdAt: Carbon::parse('2026-01-01 12:00:00', 'UTC'),
+            ),
+        ]));
+
+        $this->mockQueueConnection($queue);
+
+        $this->artisan('queue:peek', ['--json' => true])
+            ->expectsOutputToContain('"uuid":"1cde062a-8c6a-4d67-8125-e83f585c18cb"')
+            ->expectsOutputToContain('"name":"App\\\\Jobs\\\\ProcessPodcast"')
+            ->assertSuccessful();
+    }
+
+    public function testItDisplaysDelayedJobs()
+    {
+        $this->app['config']->set('queue.default', 'redis');
+        $this->app['config']->set('queue.connections.redis.queue', 'default');
+
+        $queue = m::mock(RedisQueue::class);
+        $queue->shouldReceive('delayedJobs')->with('default')->andReturn(new Collection([
+            new InspectedJob(
+                uuid: '1cde062a-8c6a-4d67-8125-e83f585c18cb',
+                queue: 'default',
+                name: 'App\\Jobs\\ProcessPodcast',
+                attempts: 0,
+                createdAt: Carbon::now()->subMinutes(2),
+            ),
+        ]));
+
+        $this->mockQueueConnection($queue);
+
+        $this->artisan('queue:peek', ['--state' => 'delayed'])
+            ->expectsOutputToContain('App\\Jobs\\ProcessPodcast')
+            ->assertSuccessful();
+    }
+
+    public function testItDisplaysReservedJobs()
+    {
+        $this->app['config']->set('queue.default', 'redis');
+        $this->app['config']->set('queue.connections.redis.queue', 'default');
+
+        $queue = m::mock(RedisQueue::class);
+        $queue->shouldReceive('reservedJobs')->with('default')->andReturn(new Collection([
+            new InspectedJob(
+                uuid: '1cde062a-8c6a-4d67-8125-e83f585c18cb',
+                queue: 'default',
+                name: 'App\\Jobs\\ProcessPodcast',
+                attempts: 2,
+                createdAt: Carbon::now()->subMinutes(1),
+            ),
+        ]));
+
+        $this->mockQueueConnection($queue);
+
+        $this->artisan('queue:peek', ['--state' => 'reserved'])
+            ->expectsOutputToContain('App\\Jobs\\ProcessPodcast')
+            ->expectsOutputToContain('2 attempts')
+            ->assertSuccessful();
+    }
+
+    public function testItUsesTheQueueOption()
+    {
+        $this->app['config']->set('queue.default', 'redis');
+
+        $queue = m::mock(RedisQueue::class);
+        $queue->shouldReceive('pendingJobs')->with('high')->andReturn(new Collection);
+
+        $this->mockQueueConnection($queue);
+
+        $this->artisan('queue:peek', ['--queue' => 'high'])
+            ->expectsOutputToContain('No pending jobs found on the [high] queue.')
+            ->assertSuccessful();
+    }
+
+    public function testItRejectsAnInvalidState()
+    {
+        $this->artisan('queue:peek', ['--state' => 'failed'])
+            ->expectsOutputToContain('The state must be one of: pending, delayed, reserved.')
+            ->assertFailed();
+    }
+
+    public function testItOutputsWhenQueueDoesNotSupportInspection()
+    {
+        $this->app['config']->set('queue.default', 'jack');
+
+        $this->mockQueueConnection(m::mock());
+
+        $this->artisan('queue:peek')
+            ->expectsOutputToContain('The [jack] connection does not support inspecting jobs.')
+            ->assertFailed();
+    }
+
+    protected function mockQueueConnection(mixed $queue): void
+    {
+        $manager = m::mock(Factory::class);
+        $manager->shouldReceive('connection')->andReturn($queue);
+        $this->app->instance('queue', $manager);
+    }
+}


### PR DESCRIPTION
Currently to see the queue inspection stuff you either run it in a command yourself, or rely on tinker.  Or alternatively rely on telescope/horizon/nightwatch 


This PR adds a `queue:peek` command, which allows you to specify a connection, queue, and state, This gives you an instant, read-only answer without a DB or Redis Client, and no need to dive into Tinker. 

It compliments `queue:monitor` as if the queue size is spiking, you can quickly see exactly what's backing it up

How to use:
```
php artisan queue:peek // uses default, pending jobs
php artisan queue:peek redis --queue=high --state=delayed // you can specify a connection / queue and state
php artisan queue:peek --json // json output
php artisan queue:peek --limit=5 // ability to limit output
```

Output I followed the same as the ListFailedCommand see below:

<details> 

```
php artisan queue:peek --json
[{"uuid":"1cde062a-8c6a-4d67-8125-e83f585c18cb","queue":"default","name":"App\\Jobs\\TestJob","attempts":0,"created_at":"2026-05-05T09:32:09+00:00"},{"uuid":"7c029c59-e7da-4165-a50b-112c5dfc9bbe","queue":"default","name":"App\\Jobs\\TestJob","attempts":0,"created_at":"2026-05-05T09:32:09+00:00"},{"uuid":"be5a6e41-3b8d-4c38-af43-8d786cb5ffa7","queue":"default","name":"App\\Jobs\\TestJob","attempts":0,"created_at":"2026-05-05T09:32:10+00:00"},{"uuid":"01256a13-4c51-465d-9858-695915daf61a","queue":"default","name":"App\\Jobs\\TestJob","attempts":0,"created_at":"2026-05-05T09:32:15+00:00"},{"uuid":"4bf7b0c7-9382-4f77-b0f9-185e69ff7cbf","queue":"default","name":"App\\Jobs\\TestJob","attempts":0,"created_at":"2026-06-09T21:47:33+00:00"}]
php artisan queue:peek

  1cde062a-8c6a-4d67-8125-e83f585c18cb App\Jobs\TestJob ..................................................................... 0 attempts 1 month ago  
  7c029c59-e7da-4165-a50b-112c5dfc9bbe App\Jobs\TestJob ..................................................................... 0 attempts 1 month ago  
  be5a6e41-3b8d-4c38-af43-8d786cb5ffa7 App\Jobs\TestJob ..................................................................... 0 attempts 1 month ago  
  01256a13-4c51-465d-9858-695915daf61a App\Jobs\TestJob ..................................................................... 0 attempts 1 month ago  
  4bf7b0c7-9382-4f77-b0f9-185e69ff7cbf App\Jobs\TestJob .................................................................. 0 attempts 28 minutes ago  

php artisan queue:peek --limit=1

  1cde062a-8c6a-4d67-8125-e83f585c18cb App\Jobs\TestJob ..................................................................... 0 attempts 1 month ago  
```


</details>

It also means we can run it in Laravel Cloud's commands tab wooooo so even on mobile 😎 

Open to any suggestions you may have here, as I kinda worked it to how I would use it.  Perhaps `queue::inspect` is a better command sig but thought I'd try peek.