### PR TITLE
[13.x] Add `const` support to Illuminate JsonSchema

### DIFF
--- a/src/Illuminate/JsonSchema/Deserializer.php
+++ b/src/Illuminate/JsonSchema/Deserializer.php
@@ -254,6 +254,10 @@ class Deserializer
             $type->enum($schema['enum']);
         }
 
+        if (array_key_exists('const', $schema)) {
+            $type->const($schema['const']);
+        }
+
         if (array_key_exists('default', $schema)) {
             if ($schema['default'] === null) {
                 throw new InvalidArgumentException('A null JSON Schema [default] is not supported.');
@@ -294,6 +298,10 @@ class Deserializer
 
         $type ??= $this->inferType($schema);
 
+        if (is_array($type)) {
+            return [$type, $nullable];
+        }
+
         if (! is_string($type)) {
             throw new InvalidArgumentException('Unable to determine the JSON Schema type for the given schema.');
         }
@@ -305,15 +313,36 @@ class Deserializer
      * Infer the type name when "type" is absent but the shape is unambiguous.
      *
      * @param  array<string, mixed>  $schema
+     * @return string|array<int, string>|null
      */
-    protected function inferType(array $schema): ?string
+    protected function inferType(array $schema): string|array|null
     {
         return match (true) {
             isset($schema['properties']), isset($schema['additionalProperties']), isset($schema['required']) => 'object',
             isset($schema['items']), isset($schema['minItems']), isset($schema['maxItems']), isset($schema['uniqueItems']) => 'array',
             isset($schema['enum']) && is_array($schema['enum']) => $this->inferEnumType($schema['enum']),
+            array_key_exists('const', $schema) => $this->inferConstType($schema['const']),
             isset($schema['minLength']), isset($schema['maxLength']), isset($schema['pattern']), isset($schema['format']) => 'string',
             isset($schema['minimum']), isset($schema['maximum']), isset($schema['multipleOf']) => 'number',
+            default => null,
+        };
+    }
+
+    /**
+     * Infer the type name for a JSON Schema const value.
+     *
+     * @return string|array<int, string>|null
+     */
+    protected function inferConstType(mixed $value): string|array|null
+    {
+        return match (true) {
+            is_bool($value) => 'boolean',
+            is_int($value) => 'integer',
+            is_float($value) => 'number',
+            is_string($value) => 'string',
+            is_array($value) => array_is_list($value) ? 'array' : 'object',
+            is_object($value) => 'object',
+            $value === null => ['null'],
             default => null,
         };
     }

--- a/src/Illuminate/JsonSchema/Serializer.php
+++ b/src/Illuminate/JsonSchema/Serializer.php
@@ -11,7 +11,7 @@ class Serializer
      *
      * @var array<int, string>
      */
-    protected static array $ignore = ['required', 'nullable'];
+    protected static array $ignore = ['required', 'nullable', 'hasConst'];
 
     /**
      * Serialize the given property to an array.
@@ -46,9 +46,15 @@ class Serializer
                 : [$attributes['type'], 'null'];
         }
 
-        $attributes = array_filter($attributes, static function (mixed $value, string $key) {
+        $hasConst = $attributes['hasConst'] ?? false;
+
+        $attributes = array_filter($attributes, static function (mixed $value, string $key) use ($hasConst) {
             if (in_array($key, static::$ignore, true)) {
                 return false;
+            }
+
+            if ($key === 'const') {
+                return $hasConst;
             }
 
             return $value !== null;

--- a/src/Illuminate/JsonSchema/Types/Type.php
+++ b/src/Illuminate/JsonSchema/Types/Type.php
@@ -37,6 +37,16 @@ abstract class Type extends JsonSchema
     protected ?array $enum = null;
 
     /**
+     * The exact value this type must equal.
+     */
+    protected mixed $const = null;
+
+    /**
+     * Indicates if a const value has been set.
+     */
+    protected bool $hasConst = false;
+
+    /**
      * Indicates if the type is nullable.
      */
     protected ?bool $nullable = null;
@@ -100,6 +110,17 @@ abstract class Type extends JsonSchema
 
         // Keep order and allow complex values (arrays / objects) without forcing uniqueness...
         $this->enum = array_values($values);
+
+        return $this;
+    }
+
+    /**
+     * Restrict the value to exactly match the provided constant value.
+     */
+    public function const(mixed $value): static
+    {
+        $this->const = $value;
+        $this->hasConst = true;
 
         return $this;
     }

--- a/tests/JsonSchema/DeserializerTest.php
+++ b/tests/JsonSchema/DeserializerTest.php
@@ -400,6 +400,63 @@ class DeserializerTest extends TestCase
         ], $type->toArray());
     }
 
+    public function test_it_applies_const(): void
+    {
+        $type = JsonSchema::fromArray([
+            'type' => 'string',
+            'const' => 'published',
+        ]);
+
+        $this->assertEquals([
+            'const' => 'published',
+            'type' => 'string',
+        ], $type->toArray());
+    }
+
+    public function test_it_preserves_null_const(): void
+    {
+        $type = JsonSchema::fromArray([
+            'type' => ['string', 'null'],
+            'const' => null,
+        ]);
+
+        $this->assertEquals([
+            'const' => null,
+            'type' => ['string', 'null'],
+        ], $type->toArray());
+    }
+
+    public function test_it_infers_type_from_const(): void
+    {
+        $this->assertInstanceOf(StringType::class, JsonSchema::fromArray([
+            'const' => 'published',
+        ]));
+
+        $this->assertInstanceOf(IntegerType::class, JsonSchema::fromArray([
+            'const' => 1,
+        ]));
+
+        $this->assertInstanceOf(NumberType::class, JsonSchema::fromArray([
+            'const' => 1.5,
+        ]));
+
+        $this->assertInstanceOf(BooleanType::class, JsonSchema::fromArray([
+            'const' => true,
+        ]));
+
+        $this->assertInstanceOf(ArrayType::class, JsonSchema::fromArray([
+            'const' => ['one', 'two'],
+        ]));
+
+        $this->assertInstanceOf(ObjectType::class, JsonSchema::fromArray([
+            'const' => ['status' => 'published'],
+        ]));
+
+        $this->assertInstanceOf(UnionType::class, JsonSchema::fromArray([
+            'const' => null,
+        ]));
+    }
+
     public function test_it_ignores_unknown_keywords(): void
     {
         $type = JsonSchema::fromArray([

--- a/tests/JsonSchema/TypeTest.php
+++ b/tests/JsonSchema/TypeTest.php
@@ -136,6 +136,19 @@ class TypeTest extends TestCase
         $this->assertNotValidOnJsonSchema($schema, null);
     }
 
+    public function test_const_may_be_null(): void
+    {
+        $schema = JsonSchema::union(['null'])->const(null);
+
+        $this->assertEquals([
+            'const' => null,
+            'type' => ['null'],
+        ], $schema->toArray());
+
+        $this->assertValidOnJsonSchema($schema, null);
+        $this->assertNotValidOnJsonSchema($schema, false);
+    }
+
     public function test_throws_with_invalid_enum_string(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -173,6 +186,7 @@ class TypeTest extends TestCase
             [JsonSchema::string()->pattern('^foo.*$'), 'foobar'],
             [JsonSchema::string()->default('x'), 'x'],
             [JsonSchema::string()->enum(['draft', 'published']), 'draft'],
+            [JsonSchema::string()->const('draft'), 'draft'],
             // additional StringType cases
             [JsonSchema::string()->min(0), ''], // empty allowed with min 0
             [JsonSchema::string()->max(0), ''], // exactly zero length
@@ -189,6 +203,7 @@ class TypeTest extends TestCase
             [JsonSchema::integer()->max(120), 120],
             [JsonSchema::integer()->default(18), 18],
             [JsonSchema::integer()->enum([1, 2, 3]), 2],
+            [JsonSchema::integer()->const(2), 2],
             [JsonSchema::integer()->multipleOf(5), 10],
             [JsonSchema::integer()->multipleOf(3), 9],
             [JsonSchema::integer()->multipleOf(7), 0],
@@ -208,6 +223,7 @@ class TypeTest extends TestCase
             [JsonSchema::number()->max(100.0), 99.9],
             [JsonSchema::number()->default(9.99), 9.99],
             [JsonSchema::number()->enum([1, 2.5, 3]), 2.5],
+            [JsonSchema::number()->const(2.5), 2.5],
             [JsonSchema::number()->multipleOf(0.5), 2.5],
             [JsonSchema::number()->multipleOf(3), 9],
             [JsonSchema::number()->multipleOf(0.1), 0.3],
@@ -224,6 +240,7 @@ class TypeTest extends TestCase
             [JsonSchema::boolean(), true],
             [JsonSchema::boolean()->default(false), false],
             [JsonSchema::boolean()->enum([true, false]), true],
+            [JsonSchema::boolean()->const(true), true],
             // additional BooleanType cases
             [JsonSchema::boolean(), false],
             [JsonSchema::boolean()->enum([true, false]), false],
@@ -257,6 +274,10 @@ class TypeTest extends TestCase
                 JsonSchema::object([
                     'status' => JsonSchema::string()->enum(['draft', 'published']),
                 ]),
+                (object) ['status' => 'published'],
+            ],
+            [
+                JsonSchema::object()->const(['status' => 'published']),
                 (object) ['status' => 'published'],
             ],
             // additional ObjectType cases
@@ -308,6 +329,7 @@ class TypeTest extends TestCase
             [JsonSchema::array()->items(JsonSchema::string()->max(3)), ['one', 'two']],
             [JsonSchema::array()->default(['x']), ['x']],
             [JsonSchema::array()->enum([['a'], ['b', 'c']]), ['b', 'c']],
+            [JsonSchema::array()->const(['b', 'c']), ['b', 'c']],
             [JsonSchema::array()->unique(), [1, 2, 3]],
             [JsonSchema::array()->items(JsonSchema::string())->unique(), ['a', 'b', 'c']],
             [JsonSchema::array()->unique(), []],
@@ -326,6 +348,7 @@ class TypeTest extends TestCase
             [JsonSchema::union(['string', 'number']), 3.14],
             [JsonSchema::union(['integer', 'boolean']), true],
             [JsonSchema::union(['string', 'number'])->enum(['draft', 5]), 'draft'],
+            [JsonSchema::union(['string', 'number'])->const('draft'), 'draft'],
             [JsonSchema::union(['string', 'number'])->nullable(), null],
             [JsonSchema::union(['string', 'number'])->nullable(), 'still valid'],
         ];
@@ -341,6 +364,7 @@ class TypeTest extends TestCase
             [JsonSchema::string()->pattern('^foo.*$'), 'barbaz'], // pattern mismatch
             [JsonSchema::string()->default('x'), 10], // default doesn't enforce, but data wrong type
             [JsonSchema::string()->enum(['draft', 'published']), 'archived'], // not in enum
+            [JsonSchema::string()->const('draft'), 'published'],
             // additional StringType cases
             [JsonSchema::string()->min(1), ''], // too short (empty)
             [JsonSchema::string()->max(0), 'a'], // too long for zero max
@@ -356,6 +380,7 @@ class TypeTest extends TestCase
             [JsonSchema::integer()->max(5), 6], // above max
             [JsonSchema::integer()->default(1), '1'], // wrong type
             [JsonSchema::integer()->enum([1, 2, 3]), 4], // not in enum
+            [JsonSchema::integer()->const(2), 3],
             [JsonSchema::integer()->multipleOf(5), 7], // not a multiple
             [JsonSchema::integer()->multipleOf(3), 10], // not a multiple
             // additional IntegerType cases
@@ -373,6 +398,7 @@ class TypeTest extends TestCase
             [JsonSchema::number()->max(1.5), 1.6], // above max
             [JsonSchema::number()->default(1.1), '1.1'], // wrong type
             [JsonSchema::number()->enum([1, 2.5, 3]), 4], // not in enum
+            [JsonSchema::number()->const(2.5), 2.6],
             [JsonSchema::number()->multipleOf(0.5), 1.3], // not a multiple
             [JsonSchema::number()->multipleOf(3), 10], // not a multiple
             // additional NumberType cases
@@ -387,6 +413,7 @@ class TypeTest extends TestCase
             [JsonSchema::boolean(), 'true'], // type mismatch
             [JsonSchema::boolean()->default(false), 0], // wrong type
             [JsonSchema::boolean()->enum([true, false]), null], // not in enum
+            [JsonSchema::boolean()->const(true), false],
             // additional BooleanType cases
             [JsonSchema::boolean()->enum([true]), false], // not in enum
             [JsonSchema::boolean()->enum([false]), true], // not in enum
@@ -399,6 +426,7 @@ class TypeTest extends TestCase
             [JsonSchema::object(['name' => JsonSchema::string()->required()]), (object) []], // missing required
             [JsonSchema::object(['meta' => JsonSchema::object()->withoutAdditionalProperties()]), (object) ['meta' => (object) ['x' => 1]]], // additional prop not allowed
             [JsonSchema::object(['age' => JsonSchema::integer()->min(21)]), (object) ['age' => 18]], // below min in nested schema
+            [JsonSchema::object()->const(['status' => 'published']), (object) ['status' => 'draft']],
             // additional ObjectType cases
             [JsonSchema::object([])->withoutAdditionalProperties(), (object) ['x' => 1]], // no additional properties allowed
             [JsonSchema::object(['name' => JsonSchema::string()]), (object) ['name' => 123]], // wrong type for property
@@ -413,6 +441,7 @@ class TypeTest extends TestCase
             [JsonSchema::array()->max(1), ['a', 'b']], // too many items
             [JsonSchema::array()->items(JsonSchema::string()->max(3)), ['four']], // item too long
             [JsonSchema::array()->enum([['a'], ['b', 'c']]), ['c', 'd']], // not in enum
+            [JsonSchema::array()->const(['b', 'c']), ['c', 'd']],
             [JsonSchema::array()->unique(), [1, 1, 2]],
             [JsonSchema::array()->items(JsonSchema::string())->unique(), ['a', 'b', 'a']],
             // additional ArrayType cases
@@ -429,6 +458,7 @@ class TypeTest extends TestCase
             [JsonSchema::union(['string', 'number']), null], // null not allowed unless nullable
             [JsonSchema::union(['integer', 'boolean']), 'nope'], // string not in union
             [JsonSchema::union(['string', 'number'])->enum(['draft', 5]), 'archived'], // not in enum
+            [JsonSchema::union(['string', 'number'])->const('draft'), 'archived'],
         ];
     }
 


### PR DESCRIPTION
Add support for the JSON Schema `const` keyword to `Illuminate\JsonSchema`.

It allows schemas to restrict a value to an exact constant value:

```php
JsonSchema::string()->const('published');
```
The const keyword is also supported when deserializing schemas through `JsonSchema::fromArray()`, including const: `null`.