### PR TITLE
[13.x] Add callback support to LazyCollection containsManyItems

### DIFF
--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -703,13 +703,14 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     /**
      * Determine if the collection contains multiple items.
      *
+     * @param  (callable(TValue, TKey): bool)|null  $callback
      * @return bool
      *
      * @deprecated 12.50.0 Use the `hasMany()` method instead.
      */
-    public function containsManyItems(): bool
+    public function containsManyItems(?callable $callback = null): bool
     {
-        return $this->hasMany();
+        return $this->hasMany($callback);
     }
 
     /**

--- a/tests/Support/SupportLazyCollectionIsLazyTest.php
+++ b/tests/Support/SupportLazyCollectionIsLazyTest.php
@@ -588,6 +588,17 @@ class SupportLazyCollectionIsLazyTest extends TestCase
         });
     }
 
+    public function testContainsManyItemsIsLazy()
+    {
+        $this->assertEnumerates(2, function ($collection) {
+            $collection->containsManyItems();
+        });
+
+        $this->assertEnumerates(2, function ($collection) {
+            $collection->containsManyItems(fn ($item) => $item <= 2);
+        });
+    }
+
     public function testHasSoleIsLazy()
     {
         $this->assertEnumerates(2, function ($collection) {

--- a/tests/Support/SupportLazyCollectionTest.php
+++ b/tests/Support/SupportLazyCollectionTest.php
@@ -403,6 +403,11 @@ class SupportLazyCollectionTest extends TestCase
 
         $manyCollection = new LazyCollection([1, 2, 3]);
         $this->assertTrue($manyCollection->containsManyItems());
+
+        $this->assertTrue((new LazyCollection([1, 2, 2]))->containsManyItems(fn ($number) => $number === 2));
+        $this->assertFalse((new LazyCollection(['ant', 'bear', 'cat']))->containsManyItems(fn ($word) => strlen($word) === 4));
+        $this->assertFalse((new LazyCollection(['ant', 'bear', 'cat']))->containsManyItems(fn ($word) => strlen($word) > 4));
+        $this->assertTrue((new LazyCollection(['ant', 'bear', 'cat']))->containsManyItems(fn ($word) => strlen($word) === 3));
     }
 
     public function testDoesntContain()


### PR DESCRIPTION
`Collection::containsManyItems()` already accepts an optional callback and passes it through to `hasMany()`, but `LazyCollection::containsManyItems()` always called `hasMany()` without arguments.

This updates the lazy collection implementation to accept the same optional callback while keeping the existing behavior unchanged when no callback is given.

Tests added for the callback behavior and to make sure the method still only enumerates as much as needed.