### PR TITLE
Add error solutions to the exception renderer

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Renderer/SolutionRenderer.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/SolutionRenderer.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Illuminate\Foundation\Exceptions\Renderer;
+
+use Illuminate\Contracts\View\Factory;
+use Illuminate\Foundation\Exceptions\Renderer\Mappers\BladeMapper;
+use Illuminate\Foundation\Exceptions\Renderer\Solutions\SolutionProviderRepository;
+use Illuminate\Http\Request;
+use Symfony\Component\ErrorHandler\ErrorRenderer\HtmlErrorRenderer;
+use Throwable;
+
+class SolutionRenderer extends Renderer
+{
+    public function __construct(
+        Factory $viewFactory,
+        Listener $listener,
+        HtmlErrorRenderer $htmlErrorRenderer,
+        BladeMapper $bladeMapper,
+        string $basePath,
+        private readonly SolutionProviderRepository $solutionRepository,
+    ) {
+        parent::__construct($viewFactory, $listener, $htmlErrorRenderer, $bladeMapper, $basePath);
+    }
+
+    public function render(Request $request, Throwable $throwable)
+    {
+        $html = parent::render($request, $throwable);
+
+        $solutions = $this->solutionRepository->getSolutions($throwable);
+
+        if (empty($solutions)) {
+            return $html;
+        }
+
+        $solutionsHtml = $this->viewFactory->make('laravel-exceptions-renderer::solutions', [
+            'solutions' => $solutions,
+        ])->render();
+
+        // Inject before the separator that precedes the trace section.
+        $marker = 'class="h-0 w-full relative -mt-5 -z-10"';
+
+        $position = strpos($html, $marker);
+
+        if ($position !== false) {
+            $divStart = strrpos(substr($html, 0, $position), '<div');
+            if ($divStart !== false) {
+                return substr_replace($html, $solutionsHtml, $divStart, 0);
+            }
+        }
+
+        // Fallback: inject before </body>
+        return str_replace('</body>', $solutionsHtml.'</body>', $html);
+    }
+}

--- a/src/Illuminate/Foundation/Exceptions/Renderer/Solutions/BaseSolution.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/Solutions/BaseSolution.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Illuminate\Foundation\Exceptions\Renderer\Solutions;
+
+use Illuminate\Foundation\Exceptions\Renderer\Solutions\Contracts\Solution;
+
+class BaseSolution implements Solution
+{
+    /** @var array<string, string> */
+    private array $links = [];
+
+    public function __construct(
+        private readonly string $title,
+        private readonly string $description = '',
+    ) {
+    }
+
+    public static function create(string $title, string $description = ''): static
+    {
+        return new static($title, $description);
+    }
+
+    public function title(): string
+    {
+        return $this->title;
+    }
+
+    public function description(): string
+    {
+        return $this->description;
+    }
+
+    public function links(): array
+    {
+        return $this->links;
+    }
+
+    /**
+     * @param  array<string, string>  $links
+     */
+    public function withLinks(array $links): static
+    {
+        $this->links = $links;
+
+        return $this;
+    }
+}

--- a/src/Illuminate/Foundation/Exceptions/Renderer/Solutions/Contracts/HasSolutions.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/Solutions/Contracts/HasSolutions.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Illuminate\Foundation\Exceptions\Renderer\Solutions\Contracts;
+
+interface HasSolutions
+{
+    /**
+     * @return array<int, \Illuminate\Foundation\Exceptions\Renderer\Solutions\Contracts\Solution>
+     */
+    public function getSolutions(): array;
+}

--- a/src/Illuminate/Foundation/Exceptions/Renderer/Solutions/Contracts/RunnableSolution.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/Solutions/Contracts/RunnableSolution.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Foundation\Exceptions\Renderer\Solutions\Contracts;
+
+interface RunnableSolution extends Solution
+{
+    public function command(): string;
+
+    /**
+     * @return array<int, string>
+     */
+    public function commandArguments(): array;
+}

--- a/src/Illuminate/Foundation/Exceptions/Renderer/Solutions/Contracts/Solution.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/Solutions/Contracts/Solution.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Illuminate\Foundation\Exceptions\Renderer\Solutions\Contracts;
+
+interface Solution
+{
+    public function title(): string;
+
+    public function description(): string;
+
+    /**
+     * @return array<string, string>
+     */
+    public function links(): array;
+}

--- a/src/Illuminate/Foundation/Exceptions/Renderer/Solutions/Contracts/SolutionProvider.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/Solutions/Contracts/SolutionProvider.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Illuminate\Foundation\Exceptions\Renderer\Solutions\Contracts;
+
+use Throwable;
+
+interface SolutionProvider
+{
+    public function canSolve(Throwable $throwable): bool;
+
+    /**
+     * @return array<int, \Illuminate\Foundation\Exceptions\Renderer\Solutions\Contracts\Solution>
+     */
+    public function getSolutions(Throwable $throwable): array;
+}

--- a/src/Illuminate/Foundation/Exceptions/Renderer/Solutions/Providers/AccessDeniedSolutionProvider.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/Solutions/Providers/AccessDeniedSolutionProvider.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Illuminate\Foundation\Exceptions\Renderer\Solutions\Providers;
+
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Exceptions\Renderer\Solutions\BaseSolution;
+use Illuminate\Foundation\Exceptions\Renderer\Solutions\Contracts\SolutionProvider;
+use Throwable;
+
+class AccessDeniedSolutionProvider implements SolutionProvider
+{
+    public function canSolve(Throwable $throwable): bool
+    {
+        if (! $throwable instanceof QueryException) {
+            return false;
+        }
+
+        return str_contains($throwable->getMessage(), 'Access denied for user');
+    }
+
+    public function getSolutions(Throwable $throwable): array
+    {
+        return [
+            new BaseSolution(
+                title: 'Database access denied',
+                description: "The database credentials are incorrect.\nCheck DB_USERNAME and DB_PASSWORD in your .env file.",
+            ),
+        ];
+    }
+}

--- a/src/Illuminate/Foundation/Exceptions/Renderer/Solutions/Providers/ConnectionRefusedSolutionProvider.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/Solutions/Providers/ConnectionRefusedSolutionProvider.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Illuminate\Foundation\Exceptions\Renderer\Solutions\Providers;
+
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Exceptions\Renderer\Solutions\BaseSolution;
+use Illuminate\Foundation\Exceptions\Renderer\Solutions\Contracts\SolutionProvider;
+use Throwable;
+
+class ConnectionRefusedSolutionProvider implements SolutionProvider
+{
+    public function canSolve(Throwable $throwable): bool
+    {
+        if (! $throwable instanceof QueryException) {
+            return false;
+        }
+
+        return str_contains($throwable->getMessage(), 'Connection refused')
+            || str_contains($throwable->getMessage(), 'SQLSTATE[HY000] [2002]');
+    }
+
+    public function getSolutions(Throwable $throwable): array
+    {
+        return [
+            new BaseSolution(
+                title: 'Database connection refused',
+                description: "The database server is not reachable. Check that:\n"
+                    ."- The database server is running\n"
+                    ."- The host and port in your .env are correct\n"
+                    .'- No firewall is blocking the connection',
+            ),
+        ];
+    }
+}

--- a/src/Illuminate/Foundation/Exceptions/Renderer/Solutions/Providers/MissingAppKeySolutionProvider.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/Solutions/Providers/MissingAppKeySolutionProvider.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Illuminate\Foundation\Exceptions\Renderer\Solutions\Providers;
+
+use Illuminate\Foundation\Exceptions\Renderer\Solutions\Contracts\SolutionProvider;
+use Illuminate\Foundation\Exceptions\Renderer\Solutions\RunnableSolution;
+use RuntimeException;
+use Throwable;
+
+class MissingAppKeySolutionProvider implements SolutionProvider
+{
+    public function canSolve(Throwable $throwable): bool
+    {
+        if (! $throwable instanceof RuntimeException) {
+            return false;
+        }
+
+        return str_contains($throwable->getMessage(), 'No application encryption key');
+    }
+
+    public function getSolutions(Throwable $throwable): array
+    {
+        return [
+            RunnableSolution::artisan(
+                title: 'Generate an application key',
+                description: 'No APP_KEY is set in your .env file.',
+                command: 'key:generate',
+            ),
+        ];
+    }
+}

--- a/src/Illuminate/Foundation/Exceptions/Renderer/Solutions/Providers/MissingColumnSolutionProvider.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/Solutions/Providers/MissingColumnSolutionProvider.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Illuminate\Foundation\Exceptions\Renderer\Solutions\Providers;
+
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Exceptions\Renderer\Solutions\Contracts\SolutionProvider;
+use Illuminate\Foundation\Exceptions\Renderer\Solutions\RunnableSolution;
+use Throwable;
+
+class MissingColumnSolutionProvider implements SolutionProvider
+{
+    public function canSolve(Throwable $throwable): bool
+    {
+        if (! $throwable instanceof QueryException) {
+            return false;
+        }
+
+        return str_contains($throwable->getMessage(), 'Column not found')
+            || str_contains($throwable->getMessage(), 'Unknown column');
+    }
+
+    public function getSolutions(Throwable $throwable): array
+    {
+        $column = $this->extractColumnName($throwable->getMessage());
+
+        $description = 'A column referenced in the query does not exist in the database.';
+        if ($column) {
+            $description = "The column `{$column}` does not exist in the database.";
+        }
+
+        return [
+            RunnableSolution::artisan(
+                title: 'Run database migrations',
+                description: $description,
+                command: 'migrate',
+            ),
+        ];
+    }
+
+    private function extractColumnName(string $message): ?string
+    {
+        if (preg_match("/Unknown column '([^']+)'/", $message, $matches)) {
+            return $matches[1];
+        }
+
+        return null;
+    }
+}

--- a/src/Illuminate/Foundation/Exceptions/Renderer/Solutions/Providers/TableNotFoundSolutionProvider.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/Solutions/Providers/TableNotFoundSolutionProvider.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Illuminate\Foundation\Exceptions\Renderer\Solutions\Providers;
+
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Exceptions\Renderer\Solutions\Contracts\SolutionProvider;
+use Illuminate\Foundation\Exceptions\Renderer\Solutions\RunnableSolution;
+use Throwable;
+
+class TableNotFoundSolutionProvider implements SolutionProvider
+{
+    public function canSolve(Throwable $throwable): bool
+    {
+        if (! $throwable instanceof QueryException) {
+            return false;
+        }
+
+        return str_contains($throwable->getMessage(), 'Table')
+            && str_contains($throwable->getMessage(), "doesn't exist");
+    }
+
+    public function getSolutions(Throwable $throwable): array
+    {
+        $table = $this->extractTableName($throwable->getMessage());
+
+        $description = 'The table referenced in the query does not exist.';
+        if ($table) {
+            $description = "The table `{$table}` does not exist in the database.";
+        }
+
+        return [
+            RunnableSolution::artisan(
+                title: 'Run database migrations',
+                description: $description,
+                command: 'migrate',
+            ),
+        ];
+    }
+
+    private function extractTableName(string $message): ?string
+    {
+        if (preg_match("/Table '(?:[^.]+\.)?([^']+)' doesn't exist/", $message, $matches)) {
+            return $matches[1];
+        }
+
+        return null;
+    }
+}

--- a/src/Illuminate/Foundation/Exceptions/Renderer/Solutions/Providers/ViewNotFoundSolutionProvider.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/Solutions/Providers/ViewNotFoundSolutionProvider.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Illuminate\Foundation\Exceptions\Renderer\Solutions\Providers;
+
+use Illuminate\Foundation\Exceptions\Renderer\Solutions\BaseSolution;
+use Illuminate\Foundation\Exceptions\Renderer\Solutions\Contracts\SolutionProvider;
+use InvalidArgumentException;
+use Throwable;
+
+class ViewNotFoundSolutionProvider implements SolutionProvider
+{
+    public function canSolve(Throwable $throwable): bool
+    {
+        if (! $throwable instanceof InvalidArgumentException) {
+            return false;
+        }
+
+        return str_contains($throwable->getMessage(), 'View [')
+            && str_contains($throwable->getMessage(), '] not found');
+    }
+
+    public function getSolutions(Throwable $throwable): array
+    {
+        $view = $this->extractViewName($throwable->getMessage());
+
+        $description = 'The view file could not be found.';
+        if ($view) {
+            $description = "The view `{$view}` could not be found.\nCheck that the file exists and the name is spelled correctly.";
+        }
+
+        return [
+            new BaseSolution(
+                title: 'Check the view file exists',
+                description: $description,
+            ),
+        ];
+    }
+
+    private function extractViewName(string $message): ?string
+    {
+        if (preg_match('/View \[([^\]]+)\] not found/', $message, $matches)) {
+            return $matches[1];
+        }
+
+        return null;
+    }
+}

--- a/src/Illuminate/Foundation/Exceptions/Renderer/Solutions/Providers/ViteManifestNotFoundSolutionProvider.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/Solutions/Providers/ViteManifestNotFoundSolutionProvider.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Illuminate\Foundation\Exceptions\Renderer\Solutions\Providers;
+
+use Illuminate\Foundation\Exceptions\Renderer\Solutions\BaseSolution;
+use Illuminate\Foundation\Exceptions\Renderer\Solutions\Contracts\SolutionProvider;
+use Illuminate\Foundation\ViteException;
+use Throwable;
+
+class ViteManifestNotFoundSolutionProvider implements SolutionProvider
+{
+    public function canSolve(Throwable $throwable): bool
+    {
+        return $throwable instanceof ViteException;
+    }
+
+    public function getSolutions(Throwable $throwable): array
+    {
+        return [
+            new BaseSolution(
+                title: 'Run the Vite dev server or build assets',
+                description: "The Vite manifest file was not found. Either:\n"
+                    ."- Start the dev server: pnpm run dev\n"
+                    .'- Or build for production: pnpm run build',
+            ),
+        ];
+    }
+}

--- a/src/Illuminate/Foundation/Exceptions/Renderer/Solutions/RunSolutionController.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/Solutions/RunSolutionController.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Illuminate\Foundation\Exceptions\Renderer\Solutions;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Artisan;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class RunSolutionController
+{
+    public function __invoke(Request $request): JsonResponse
+    {
+        if (! $this->isLocalRequest($request)) {
+            return response()->json(['success' => false, 'output' => 'Forbidden.'], 403);
+        }
+
+        $command = $request->input('command');
+
+        if (! is_string($command) || blank($command)) {
+            return response()->json(['success' => false, 'output' => 'Invalid command.'], 422);
+        }
+
+        if (! $this->isAllowedCommand($command)) {
+            return response()->json(['success' => false, 'output' => 'Command not allowed.'], 403);
+        }
+
+        try {
+            $outputBuffer = new BufferedOutput();
+
+            $exitCode = Artisan::call($command, [], $outputBuffer);
+
+            $output = $outputBuffer->fetch();
+
+            return response()->json([
+                'success' => $exitCode === 0,
+                'output' => trim($output),
+                'exitCode' => $exitCode,
+            ]);
+        } catch (\Throwable $e) {
+            return response()->json([
+                'success' => false,
+                'output' => $e->getMessage(),
+            ], 500);
+        }
+    }
+
+    private function isLocalRequest(Request $request): bool
+    {
+        $ip = $request->ip();
+
+        return in_array($ip, ['127.0.0.1', '::1', '10.0.2.2'], true)
+            || str_starts_with((string) $ip, '192.168.')
+            || str_starts_with((string) $ip, '10.');
+    }
+
+    private function isAllowedCommand(string $command): bool
+    {
+        $allowed = [
+            'migrate',
+            'key:generate',
+            'config:clear',
+            'cache:clear',
+            'view:clear',
+            'route:clear',
+            'optimize:clear',
+        ];
+
+        return in_array($command, $allowed, true);
+    }
+}

--- a/src/Illuminate/Foundation/Exceptions/Renderer/Solutions/RunnableSolution.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/Solutions/RunnableSolution.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Illuminate\Foundation\Exceptions\Renderer\Solutions;
+
+use Illuminate\Foundation\Exceptions\Renderer\Solutions\Contracts\RunnableSolution as RunnableSolutionContract;
+
+class RunnableSolution extends BaseSolution implements RunnableSolutionContract
+{
+    /** @var array<int, string> */
+    private array $arguments = [];
+
+    public function __construct(
+        string $title,
+        string $description,
+        private readonly string $command,
+    ) {
+        parent::__construct($title, $description);
+    }
+
+    /**
+     * @param  array<int, string>  $arguments
+     */
+    public static function artisan(string $title, string $description, string $command, array $arguments = []): static
+    {
+        $solution = new static($title, $description, $command);
+        $solution->arguments = $arguments;
+
+        return $solution;
+    }
+
+    public function command(): string
+    {
+        return $this->command;
+    }
+
+    public function commandArguments(): array
+    {
+        return $this->arguments;
+    }
+}

--- a/src/Illuminate/Foundation/Exceptions/Renderer/Solutions/SolutionProviderRepository.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/Solutions/SolutionProviderRepository.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Illuminate\Foundation\Exceptions\Renderer\Solutions;
+
+use Illuminate\Foundation\Exceptions\Renderer\Solutions\Contracts\HasSolutions;
+use Throwable;
+
+class SolutionProviderRepository
+{
+    /** @var array<int, class-string<\Illuminate\Foundation\Exceptions\Renderer\Solutions\Contracts\SolutionProvider>> */
+    private array $providers = [];
+
+    /**
+     * @param  array<int, class-string<\Illuminate\Foundation\Exceptions\Renderer\Solutions\Contracts\SolutionProvider>>  $providers
+     */
+    public function register(array $providers): static
+    {
+        $this->providers = array_merge($this->providers, $providers);
+
+        return $this;
+    }
+
+    /**
+     * @return array<int, \Illuminate\Foundation\Exceptions\Renderer\Solutions\Contracts\Solution>
+     */
+    public function getSolutions(Throwable $throwable): array
+    {
+        $solutions = [];
+
+        $current = $throwable;
+        while ($current !== null) {
+            if ($current instanceof HasSolutions) {
+                $solutions = array_merge($solutions, $current->getSolutions());
+            }
+
+            foreach ($this->providers as $providerClass) {
+                /** @var \Illuminate\Foundation\Exceptions\Renderer\Solutions\Contracts\SolutionProvider $provider */
+                $provider = app($providerClass);
+
+                if ($provider->canSolve($current)) {
+                    $solutions = array_merge($solutions, $provider->getSolutions($current));
+                }
+            }
+
+            $current = $current->getPrevious();
+        }
+
+        return $solutions;
+    }
+}

--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -17,6 +17,17 @@ use Illuminate\Foundation\Console\CliDumper;
 use Illuminate\Foundation\Exceptions\Renderer\Listener;
 use Illuminate\Foundation\Exceptions\Renderer\Mappers\BladeMapper;
 use Illuminate\Foundation\Exceptions\Renderer\Renderer;
+use Illuminate\Foundation\Exceptions\Renderer\SolutionRenderer;
+use Illuminate\Foundation\Exceptions\Renderer\Solutions\Providers\AccessDeniedSolutionProvider;
+use Illuminate\Foundation\Exceptions\Renderer\Solutions\Providers\ConnectionRefusedSolutionProvider;
+use Illuminate\Foundation\Exceptions\Renderer\Solutions\Providers\MissingAppKeySolutionProvider;
+use Illuminate\Foundation\Exceptions\Renderer\Solutions\Providers\MissingColumnSolutionProvider;
+use Illuminate\Foundation\Exceptions\Renderer\Solutions\Providers\TableNotFoundSolutionProvider;
+use Illuminate\Foundation\Exceptions\Renderer\Solutions\Providers\ViewNotFoundSolutionProvider;
+use Illuminate\Foundation\Exceptions\Renderer\Solutions\Providers\ViteManifestNotFoundSolutionProvider;
+use Illuminate\Foundation\Exceptions\Renderer\Solutions\RunSolutionController;
+use Illuminate\Foundation\Exceptions\Renderer\Solutions\SolutionProviderRepository;
+use Illuminate\Support\Facades\Route;
 use Illuminate\Foundation\Http\HtmlDumper;
 use Illuminate\Foundation\MaintenanceModeManager;
 use Illuminate\Foundation\Precognition;
@@ -264,21 +275,36 @@ class FoundationServiceProvider extends AggregateServiceProvider
 
         $this->loadViewsFrom(__DIR__.'/../resources/exceptions/renderer', 'laravel-exceptions-renderer');
 
+        $this->app->singleton(SolutionProviderRepository::class, function () {
+            return (new SolutionProviderRepository())->register([
+                MissingColumnSolutionProvider::class,
+                TableNotFoundSolutionProvider::class,
+                ConnectionRefusedSolutionProvider::class,
+                MissingAppKeySolutionProvider::class,
+                AccessDeniedSolutionProvider::class,
+                ViewNotFoundSolutionProvider::class,
+                ViteManifestNotFoundSolutionProvider::class,
+            ]);
+        });
+
         $this->app->singleton(Renderer::class, function (Application $app) {
             $errorRenderer = new HtmlErrorRenderer(
                 $app['config']->get('app.debug'),
             );
 
-            return new Renderer(
+            return new SolutionRenderer(
                 $app->make(Factory::class),
                 $app->make(Listener::class),
                 $errorRenderer,
                 $app->make(BladeMapper::class),
                 $app->basePath(),
+                $app->make(SolutionProviderRepository::class),
             );
         });
 
         $this->app->singleton(Listener::class);
+
+        Route::post('/_error-solutions/run', RunSolutionController::class);
     }
 
     /**

--- a/src/Illuminate/Foundation/resources/exceptions/renderer/solutions.blade.php
+++ b/src/Illuminate/Foundation/resources/exceptions/renderer/solutions.blade.php
@@ -1,0 +1,111 @@
+@use('Illuminate\Foundation\Exceptions\Renderer\Solutions\Contracts\RunnableSolution')
+
+@if (! empty($solutions))
+    <section class="w-full max-w-7xl mx-auto p-4 sm:p-14 border-x border-dashed border-neutral-300 dark:border-white/[9%] flex flex-col gap-2.5 pt-8">
+        <div class="bg-neutral-50 dark:bg-white/1 border border-neutral-200 dark:border-neutral-800 rounded-xl p-2.5 shadow-xs flex flex-col gap-2.5">
+            <div class="flex items-center gap-2.5 p-2">
+                <div class="bg-white dark:bg-neutral-800 border border-neutral-200 dark:border-white/5 rounded-md w-6 h-6 flex items-center justify-center p-1">
+                    <svg class="w-3 h-3 text-emerald-500" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M12 18v-5.25m0 0a6.01 6.01 0 0 0 1.5-.189m-1.5.189a6.01 6.01 0 0 1-1.5-.189m3.75 7.478a12.06 12.06 0 0 1-4.5 0m3.75 2.383a14.406 14.406 0 0 1-3 0M14.25 18v-.192c0-.983.658-1.823 1.508-2.316a7.5 7.5 0 1 0-7.517 0c.85.493 1.509 1.333 1.509 2.316V18" />
+                    </svg>
+                </div>
+                <h3 class="text-base font-semibold text-neutral-900 dark:text-white">Suggested solutions</h3>
+            </div>
+
+            <div class="flex flex-col gap-1.5">
+                @foreach ($solutions as $index => $solution)
+                    <div class="rounded-lg bg-white dark:bg-white/3 border border-neutral-200 dark:border-white/10 shadow-xs overflow-hidden">
+                        <div class="flex items-center justify-between gap-4 p-4">
+                            <div class="flex-1 min-w-0">
+                                <p class="text-sm font-medium text-neutral-900 dark:text-white">
+                                    {{ $solution->title() }}
+                                </p>
+                                @if ($solution->description())
+                                    <p class="mt-1 text-sm text-neutral-600 dark:text-neutral-400">{{ $solution->description() }}</p>
+                                @endif
+                            </div>
+
+                            @if ($solution instanceof RunnableSolution)
+                                <button
+                                    type="button"
+                                    onclick="runSolution(this, {{ json_encode($solution->command()) }}, {{ json_encode($solution->commandArguments()) }})"
+                                    class="shrink-0 text-sm rounded-md border px-3 h-8 flex items-center gap-2 transition-colors duration-200 ease-in-out cursor-pointer shadow-xs text-neutral-600 dark:text-neutral-400 bg-white/5 border-neutral-200 hover:bg-neutral-100 dark:bg-white/5 dark:border-white/10 dark:hover:bg-white/10"
+                                >
+                                    <svg class="w-3 h-3 text-emerald-500" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor">
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="M5.25 5.653c0-.856.917-1.398 1.667-.986l11.54 6.347a1.125 1.125 0 0 1 0 1.972l-11.54 6.347a1.125 1.125 0 0 1-1.667-.986V5.653Z" />
+                                    </svg>
+                                    Run
+                                </button>
+                            @endif
+                        </div>
+
+                        @if ($solution instanceof RunnableSolution)
+                            <div class="hidden p-4" data-solution-output="{{ $index }}">
+                                <pre class="text-xs font-mono p-3 pb-6 rounded-md bg-neutral-950 text-neutral-200 overflow-x-auto max-h-48 overflow-y-auto border border-neutral-800"></pre>
+                            </div>
+                        @endif
+
+                        @if (! empty($solution->links()))
+                            <div class="px-4 pb-4 flex flex-wrap gap-3">
+                                @foreach ($solution->links() as $label => $url)
+                                    <a href="{{ $url }}" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1 text-xs text-neutral-500 dark:text-neutral-400 hover:text-blue-500 dark:hover:text-emerald-500 transition-colors">
+                                        {{ $label }}
+                                        <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+                                            <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
+                                        </svg>
+                                    </a>
+                                @endforeach
+                            </div>
+                        @endif
+                    </div>
+                @endforeach
+            </div>
+        </div>
+    </section>
+
+    <style>
+        @keyframes spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+    </style>
+
+    <script>
+        async function runSolution(button, command, args) {
+            var card = button.closest('[class*="rounded-lg"]');
+            var outputContainer = card.querySelector('[data-solution-output]');
+            var pre = outputContainer ? outputContainer.querySelector('pre') : null;
+
+            button.disabled = true;
+            button.innerHTML = '<svg class="w-3 h-3" style="animation: spin 1s linear infinite" fill="none" viewBox="0 0 24 24" stroke-width="2.5"><circle cx="12" cy="12" r="10" stroke="#e5e7eb" /><path stroke="#10b981" stroke-linecap="round" d="M12 2a10 10 0 0 1 10 10" /></svg> Running\u2026';
+
+            try {
+                var response = await fetch('/_error-solutions/run', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
+                    body: JSON.stringify({ command: command, arguments: args }),
+                });
+
+                var data = await response.json();
+
+                if (outputContainer && pre) {
+                    outputContainer.classList.remove('hidden');
+                    pre.textContent = data.output || '(no output)';
+                }
+
+                if (data.success) {
+                    button.innerHTML = '<svg class="w-3 h-3 text-emerald-500" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5" /></svg> Done';
+
+                    setTimeout(function() {
+                        button.innerHTML = '<svg class="w-3 h-3 text-emerald-500" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.992 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182m0-4.991v4.99" /></svg> Reload';
+                        button.disabled = false;
+                        button.onclick = function() { window.location.reload(); };
+                    }, 800);
+                } else {
+                    button.innerHTML = '<svg class="w-3 h-3 text-rose-500" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" /></svg> Failed';
+                    button.disabled = false;
+                }
+            } catch (e) {
+                button.innerHTML = 'Error';
+                button.disabled = false;
+            }
+        }
+    </script>
+@endif


### PR DESCRIPTION
## Summary

This PR integrates solution suggestions directly into the built-in exception renderer.

When an exception is thrown in debug mode, registered solution providers analyze the exception and display actionable suggestions in the error page. Some solutions offer one-click artisan commands (e.g. \php artisan migrate\, \php artisan key:generate\).

## Changes

- **\SolutionRenderer\** — extends the existing \Renderer\ to inject solution HTML before the stack trace
- **Contracts** — \Solution\, \SolutionProvider\, \RunnableSolution\, \HasSolutions\
- **\SolutionProviderRepository\** — collects solutions from registered providers (walks the full exception chain)
- **Built-in providers:**
  - \MissingColumnSolutionProvider\ — suggests running migrations
  - \TableNotFoundSolutionProvider\ — suggests running migrations
  - \ConnectionRefusedSolutionProvider\ — advises checking DB config
  - \MissingAppKeySolutionProvider\ — offers to run \key:generate\
  - \AccessDeniedSolutionProvider\ — advises checking DB credentials
  - \ViewNotFoundSolutionProvider\ — advises checking view path
  - \ViteManifestNotFoundSolutionProvider\ — advises running Vite
- **\RunSolutionController\** — POST endpoint to execute allowed artisan commands (local requests only)
- **Blade template** — renders solutions with Tailwind-styled cards

## Security

- The \RunSolutionController\ only responds to local requests
- Only a whitelisted set of artisan commands can be executed
- The entire feature is only active in debug mode