### PR TITLE
[13.x] Add conditional visibility helpers to Eloquent collections

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -577,6 +577,18 @@ class Collection extends BaseCollection implements QueueableCollection
     }
 
     /**
+     * Make the given, typically visible, attributes hidden across the entire collection if the given truth test passes.
+     *
+     * @param  bool|\Closure  $condition
+     * @param  array<array-key, string>|string  $attributes
+     * @return $this
+     */
+    public function makeHiddenIf($condition, $attributes)
+    {
+        return $this->each->makeHiddenIf($condition, $attributes);
+    }
+
+    /**
      * Merge the given, typically visible, attributes hidden across the entire collection.
      *
      * @param  array<array-key, string>|string  $attributes
@@ -607,6 +619,18 @@ class Collection extends BaseCollection implements QueueableCollection
     public function makeVisible($attributes)
     {
         return $this->each->makeVisible($attributes);
+    }
+
+    /**
+     * Make the given, typically hidden, attributes visible across the entire collection if the given truth test passes.
+     *
+     * @param  bool|\Closure  $condition
+     * @param  array<array-key, string>|string  $attributes
+     * @return $this
+     */
+    public function makeVisibleIf($condition, $attributes)
+    {
+        return $this->each->makeVisibleIf($condition, $attributes);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -538,12 +538,38 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertEquals(['hidden', 'visible'], $c[0]->getHidden());
     }
 
+    public function testMakeHiddenIfAddsHiddenOnEntireCollection()
+    {
+        $first = new TestEloquentCollectionModel;
+        $second = new TestEloquentCollectionModel;
+
+        $c = new Collection([$first, $second]);
+        $result = $c->makeHiddenIf(fn ($model) => $model === $first, ['visible']);
+
+        $this->assertSame($c, $result);
+        $this->assertEquals(['hidden', 'visible'], $first->getHidden());
+        $this->assertEquals(['hidden'], $second->getHidden());
+    }
+
     public function testMakeVisibleRemovesHiddenFromEntireCollection()
     {
         $c = new Collection([new TestEloquentCollectionModel]);
         $c = $c->makeVisible(['hidden']);
 
         $this->assertSame([], $c[0]->getHidden());
+    }
+
+    public function testMakeVisibleIfRemovesHiddenFromEntireCollection()
+    {
+        $first = new TestEloquentCollectionModel;
+        $second = new TestEloquentCollectionModel;
+
+        $c = new Collection([$first, $second]);
+        $result = $c->makeVisibleIf(fn ($model) => $model === $first, ['hidden']);
+
+        $this->assertSame($c, $result);
+        $this->assertSame([], $first->getHidden());
+        $this->assertEquals(['hidden'], $second->getHidden());
     }
 
     public function testMergeHiddenAddsHiddenOnEntireCollection()


### PR DESCRIPTION
`Model` already has `makeHiddenIf()` and `makeVisibleIf()`, but Eloquent collections only exposed the unconditional `makeHidden()` and `makeVisible()` helpers.

This adds the same conditional helpers to `Illuminate\Database\Eloquent\Collection` and forwards the call to each model in the collection, matching the existing collection-level visibility methods.

Tests cover applying the helpers across a collection and making sure closure conditions are evaluated per model.