### PR TITLE
make intended url redirect logic auth guard aware

### DIFF
--- a/src/Illuminate/Routing/Redirector.php
+++ b/src/Illuminate/Routing/Redirector.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Routing;
 
+use Illuminate\Auth\AuthManager;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Session\Store as SessionStore;
 use Illuminate\Support\Traits\Macroable;
@@ -25,13 +26,22 @@ class Redirector
     protected $session;
 
     /**
+     * The auth manager instance.
+     *
+     * @var \Illuminate\Auth\AuthManager|null
+     */
+    protected $auth;
+
+    /**
      * Create a new Redirector instance.
      *
      * @param  \Illuminate\Routing\UrlGenerator  $generator
+     * @param  \Illuminate\Auth\AuthManager|null  $auth
      */
-    public function __construct(UrlGenerator $generator)
+    public function __construct(UrlGenerator $generator, ?AuthManager $auth = null)
     {
         $this->generator = $generator;
+        $this->auth = $auth;
     }
 
     /**
@@ -94,7 +104,7 @@ class Redirector
      */
     public function intended($default = '/', $status = 302, $headers = [], $secure = null)
     {
-        $path = $this->session->pull('url.intended', $default);
+        $path = $this->session->pull($this->getIntendedUrlSessionKey(), $default);
 
         return $this->to($path, $status, $headers, $secure);
     }
@@ -244,7 +254,7 @@ class Redirector
      */
     public function getIntendedUrl()
     {
-        return $this->session->get('url.intended');
+        return $this->session->get($this->getIntendedUrlSessionKey());
     }
 
     /**
@@ -255,8 +265,46 @@ class Redirector
      */
     public function setIntendedUrl($url)
     {
-        $this->session->put('url.intended', $url);
+        $this->session->put($this->getIntendedUrlSessionKey(), $url);
 
         return $this;
+    }
+
+    /**
+     * Get the "intended" URL for the given guard from the session.
+     *
+     * @param string|null $authDriver
+     * @return string|null
+     */
+    public function getIntendedUrlForGuard(?string $authDriver = null): ?string
+    {
+        return $this->session->get($this->getIntendedUrlSessionKey($authDriver));
+    }
+
+    /**
+     * Set the "intended" URL for the given guard from the session.
+     *
+     * @param string $url
+     * @param string|null $authDriver
+     * @return $this
+     */
+    public function setIntendedUrlForGuard(string $url, ?string $authDriver = null): self
+    {
+        $this->session->put($this->getIntendedUrlSessionKey($authDriver), $url);
+
+        return $this;
+    }
+
+    /**
+     * Get the session key for the "intended" URL for the current guard.
+     * 
+     * @param string|null $authDriver
+     * @return string
+     */
+    protected function getIntendedUrlSessionKey(?string $authDriver = null)
+    {
+        $guardName = $authDriver ?? $this->auth?->getDefaultDriver() ?? 'web';
+
+        return "$guardName.url.intended";
     }
 }

--- a/src/Illuminate/Routing/Redirector.php
+++ b/src/Illuminate/Routing/Redirector.php
@@ -273,7 +273,7 @@ class Redirector
     /**
      * Get the "intended" URL for the given guard from the session.
      *
-     * @param string|null $authDriver
+     * @param  string|null  $authDriver
      * @return string|null
      */
     public function getIntendedUrlForGuard(?string $authDriver = null): ?string
@@ -284,8 +284,8 @@ class Redirector
     /**
      * Set the "intended" URL for the given guard from the session.
      *
-     * @param string $url
-     * @param string|null $authDriver
+     * @param  string  $url
+     * @param  string|null  $authDriver
      * @return $this
      */
     public function setIntendedUrlForGuard(string $url, ?string $authDriver = null): self
@@ -297,8 +297,8 @@ class Redirector
 
     /**
      * Get the session key for the "intended" URL for the current guard.
-     * 
-     * @param string|null $authDriver
+     *
+     * @param  string|null  $authDriver
      * @return string
      */
     protected function getIntendedUrlSessionKey(?string $authDriver = null)

--- a/src/Illuminate/Routing/RoutingServiceProvider.php
+++ b/src/Illuminate/Routing/RoutingServiceProvider.php
@@ -112,7 +112,7 @@ class RoutingServiceProvider extends ServiceProvider
     protected function registerRedirector()
     {
         $this->app->singleton('redirect', function ($app) {
-            $redirector = new Redirector($app['url']);
+            $redirector = new Redirector($app['url'], $app['auth']);
 
             // If the session is set on the application instance, we'll inject it into
             // the redirector instance. This allows the redirect responses to allow

--- a/src/Illuminate/Support/Facades/Redirect.php
+++ b/src/Illuminate/Support/Facades/Redirect.php
@@ -17,6 +17,8 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Routing\UrlGenerator getUrlGenerator()
  * @method static void setSession(\Illuminate\Session\Store $session)
  * @method static string|null getIntendedUrl()
+ * @method static string|null getIntendedUrlForGuard(?string $authDriver = null)
+ * @method static \Illuminate\Routing\Redirector setIntendedUrlForGuard(string $url, ?string $authDriver = null)
  * @method static \Illuminate\Routing\Redirector setIntendedUrl(string $url)
  * @method static void macro(string $name, object|callable $macro)
  * @method static void mixin(object $mixin, bool $replace = true)

--- a/tests/Routing/RoutingRedirectorTest.php
+++ b/tests/Routing/RoutingRedirectorTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Routing;
 
+use Illuminate\Auth\AuthManager;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Redirector;
@@ -69,7 +70,7 @@ class RoutingRedirectorTest extends TestCase
     public function testGuestPutCurrentUrlInSession()
     {
         $this->url->shouldReceive('full')->andReturn('http://foo.com/bar');
-        $this->session->shouldReceive('put')->once()->with('url.intended', 'http://foo.com/bar');
+        $this->session->shouldReceive('put')->once()->with('web.url.intended', 'http://foo.com/bar');
 
         $response = $this->redirect->guest('login');
 
@@ -79,7 +80,7 @@ class RoutingRedirectorTest extends TestCase
     public function testGuestPutPreviousUrlInSession()
     {
         $this->request->shouldReceive('isMethod')->once()->with('GET')->andReturn(false);
-        $this->session->shouldReceive('put')->once()->with('url.intended', 'http://foo.com/bar');
+        $this->session->shouldReceive('put')->once()->with('web.url.intended', 'http://foo.com/bar');
         $this->url->shouldReceive('previous')->once()->andReturn('http://foo.com/bar');
 
         $response = $this->redirect->guest('login');
@@ -89,7 +90,7 @@ class RoutingRedirectorTest extends TestCase
 
     public function testIntendedRedirectToIntendedUrlInSession()
     {
-        $this->session->shouldReceive('pull')->with('url.intended', '/')->andReturn('http://foo.com/bar');
+        $this->session->shouldReceive('pull')->with('web.url.intended', '/')->andReturn('http://foo.com/bar');
 
         $response = $this->redirect->intended();
 
@@ -98,15 +99,15 @@ class RoutingRedirectorTest extends TestCase
 
     public function testIntendedWithoutIntendedUrlInSession()
     {
-        $this->session->shouldReceive('forget')->with('url.intended');
+        $this->session->shouldReceive('forget')->with('web.url.intended');
 
         // without fallback url
-        $this->session->shouldReceive('pull')->with('url.intended', '/')->andReturn('/');
+        $this->session->shouldReceive('pull')->with('web.url.intended', '/')->andReturn('/');
         $response = $this->redirect->intended();
         $this->assertSame('http://foo.com/', $response->getTargetUrl());
 
         // with a fallback url
-        $this->session->shouldReceive('pull')->with('url.intended', 'bar')->andReturn('bar');
+        $this->session->shouldReceive('pull')->with('web.url.intended', 'bar')->andReturn('bar');
         $response = $this->redirect->intended('bar');
         $this->assertSame('http://foo.com/bar', $response->getTargetUrl());
     }
@@ -172,12 +173,29 @@ class RoutingRedirectorTest extends TestCase
 
     public function testItSetsAndGetsValidIntendedUrl()
     {
-        $this->session->shouldReceive('put')->once()->with('url.intended', 'http://foo.com/bar');
+        $this->session->shouldReceive('put')->once()->with('web.url.intended', 'http://foo.com/bar');
         $this->session->shouldReceive('get')->andReturn('http://foo.com/bar');
 
         $result = $this->redirect->setIntendedUrl('http://foo.com/bar');
         $this->assertInstanceOf(Redirector::class, $result);
 
         $this->assertSame('http://foo.com/bar', $this->redirect->getIntendedUrl());
+    }
+
+    public function testIntendedUrlUsesCustomDefaultAuthDriver()
+    {
+        // Simulates Auth::shouldUse('admin') changing the default guard
+        $auth = m::mock(AuthManager::class);
+        $auth->shouldReceive('getDefaultDriver')->andReturn('admin');
+
+        $redirect = new Redirector($this->url, $auth);
+        $redirect->setSession($this->session);
+
+        $this->session->shouldReceive('put')->once()->with('admin.url.intended', 'http://foo.com/bar');
+        $this->session->shouldReceive('get')->once()->with('admin.url.intended')->andReturn('http://foo.com/bar');
+
+        $redirect->setIntendedUrl('http://foo.com/bar');
+
+        $this->assertSame('http://foo.com/bar', $redirect->getIntendedUrl());
     }
 }


### PR DESCRIPTION
Hello, I ran into an issue when using multiple guards — a user trying to access a page protected by the `super_admin` guard would, after logging in via the `web` guard, get redirected to the `super_admin` login page instead of their intended destination.

I've seen this same problem across several multi-guard apps, so I thought making the intended URL logic guard-aware at the framework level would be a clean fix. I resolved it in my own apps with a manual check, but it feels like something the framework should handle.

This stores intended URLs per guard (`{guard}.url.intended`) instead of a single `url.intended` key.

Thank you.