### PR TITLE
[13.x] Fix incorrect casing of StdClass in SupportHelpersTest

### DIFF
--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -136,7 +136,7 @@ class SupportHelpersTest extends TestCase
         $this->assertNull(when(0, fn () => null));
         $this->assertSame('True', when([1, 2, 3, 4], 'True')); // Array
         $this->assertNull(when([], 'True')); // Empty Array = Falsy
-        $this->assertSame('True', when(new StdClass, fn () => 'True')); // Object
+        $this->assertSame('True', when(new stdClass, fn () => 'True')); // Object
         $this->assertSame('World', when(false, 'Hello', 'World'));
         $this->assertSame('World', when(1 === 0, 'Hello', 'World')); // strict types
         $this->assertSame('World', when(1 == '0', 'Hello', 'World')); // loose types


### PR DESCRIPTION
Replace `new StdClass` with `new stdClass` to use the canonical lowercase form.

This is flagged as a case-sensitivity violation by the upcoming [PHP 8.6 RFC](https://wiki.php.net/rfc/case_sensitive_php), which will emit `E_DEPRECATED` for class references that don't match their declared casing. Fixing it now keeps Laravel ahead of the deprecation.