### PR TITLE
[13.x] Improve return types for model callback-scope helpers

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -439,8 +439,10 @@ trait HasEvents
     /**
      * Execute a callback without firing any model events for any model type.
      *
-     * @param  callable  $callback
-     * @return mixed
+     * @template TReturn
+     *
+     * @param  callable(): TReturn  $callback
+     * @return TReturn
      */
     public static function withoutEvents(callable $callback)
     {

--- a/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
@@ -216,9 +216,11 @@ trait HasTimestamps
     /**
      * Disable timestamps for the given model classes during the given callback scope.
      *
+     * @template TReturn
+     *
      * @param  array  $models
-     * @param  callable  $callback
-     * @return mixed
+     * @param  callable(): TReturn  $callback
+     * @return TReturn
      */
     public static function withoutTimestampsOn($models, $callback)
     {

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -651,8 +651,10 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * Execute a callback without broadcasting any model events for all model types.
      *
-     * @param  callable  $callback
-     * @return mixed
+     * @template TReturn
+     *
+     * @param  callable(): TReturn  $callback
+     * @return TReturn
      */
     public static function withoutBroadcasting(callable $callback)
     {

--- a/types/Database/Eloquent/Model.php
+++ b/types/Database/Eloquent/Model.php
@@ -49,6 +49,10 @@ function test(User $user, Post $post, Comment $comment, Article $article): void
     assertType('bool', $user->restore());
     assertType('User', $user->restoreOrCreate());
     assertType('User', $user->createOrRestore());
+
+    assertType("'foo'", User::withoutEvents(fn () => 'foo'));
+    assertType("'foo'", User::withoutBroadcasting(fn () => 'foo'));
+    assertType("'foo'", User::withoutTimestampsOn([], fn () => 'foo'));
 }
 
 class Post extends Model


### PR DESCRIPTION
This allows tools like PHPStan to properly infer the return type of callback-scope helpers `Model::withoutEvents()`, `Model::withoutBroadcasting()`, and `Model::withoutTimestampsOn()`, which execute a callback and return   
  its result, but were previously typed as `mixed`. 

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
