### PR TITLE
[13.x] Execute rollback callbacks for committed savepoints (follow-up to #55420)

### DIFF
--- a/src/Illuminate/Database/DatabaseTransactionsManager.php
+++ b/src/Illuminate/Database/DatabaseTransactionsManager.php
@@ -158,6 +158,14 @@ class DatabaseTransactionsManager
      */
     protected function removeAllTransactionsForConnection($connection)
     {
+        // Execute rollback callbacks in deepest-first order: committed savepoint
+        // records first (innermost committed level was staged first, so natural
+        // iteration is deepest-first), then the currently open transaction chain
+        // from innermost to outermost.
+        $this->committedTransactions
+            ->filter(fn ($transaction) => $transaction->connection == $connection)
+            ->each(fn ($transaction) => $transaction->executeCallbacksForRollback());
+
         if ($this->currentTransaction) {
             for ($currentTransaction = $this->currentTransaction[$connection]; isset($currentTransaction); $currentTransaction = $currentTransaction->parent) {
                 $currentTransaction->executeCallbacksForRollback();
@@ -169,10 +177,6 @@ class DatabaseTransactionsManager
         $this->pendingTransactions = $this->pendingTransactions->reject(
             fn ($transaction) => $transaction->connection == $connection
         )->values();
-
-        $this->committedTransactions
-            ->filter(fn ($transaction) => $transaction->connection == $connection)
-            ->each(fn ($transaction) => $transaction->executeCallbacksForRollback());
 
         $this->committedTransactions = $this->committedTransactions->reject(
             fn ($transaction) => $transaction->connection == $connection
@@ -192,14 +196,16 @@ class DatabaseTransactionsManager
                                $committed->parent === $transaction
         );
 
-        $removedTransactions->each(fn ($transaction) => $transaction->executeCallbacksForRollback());
-
         // There may be multiple deeply nested transactions that have already committed that we
         // also need to remove. We will recurse down the children of all removed transaction
         // instances until there are no more deeply nested child transactions for removal.
+        // Recursion runs first so descendant rollback callbacks fire deepest-first before
+        // this level's callbacks fire.
         $removedTransactions->each(
             fn ($transaction) => $this->removeCommittedTransactionsThatAreChildrenOf($transaction)
         );
+
+        $removedTransactions->each(fn ($transaction) => $transaction->executeCallbacksForRollback());
     }
 
     /**

--- a/src/Illuminate/Database/DatabaseTransactionsManager.php
+++ b/src/Illuminate/Database/DatabaseTransactionsManager.php
@@ -170,6 +170,10 @@ class DatabaseTransactionsManager
             fn ($transaction) => $transaction->connection == $connection
         )->values();
 
+        $this->committedTransactions
+            ->filter(fn ($transaction) => $transaction->connection == $connection)
+            ->each(fn ($transaction) => $transaction->executeCallbacksForRollback());
+
         $this->committedTransactions = $this->committedTransactions->reject(
             fn ($transaction) => $transaction->connection == $connection
         )->values();
@@ -187,6 +191,8 @@ class DatabaseTransactionsManager
             fn ($committed) => $committed->connection == $transaction->connection &&
                                $committed->parent === $transaction
         );
+
+        $removedTransactions->each(fn ($transaction) => $transaction->executeCallbacksForRollback());
 
         // There may be multiple deeply nested transactions that have already committed that we
         // also need to remove. We will recurse down the children of all removed transaction

--- a/tests/Database/DatabaseTransactionsManagerTest.php
+++ b/tests/Database/DatabaseTransactionsManagerTest.php
@@ -274,9 +274,8 @@ class DatabaseTransactionsManagerTest extends TestCase
         $manager->commit('default', 2, 1);
         $manager->rollback('default', 0);
 
-        $this->assertCount(2, $callbacks);
-        $this->assertContains(['default', 2], $callbacks);
-        $this->assertContains(['default', 1], $callbacks);
+        // Deepest-first order: committed savepoint (level 2) then open transaction (level 1).
+        $this->assertSame([['default', 2], ['default', 1]], $callbacks);
     }
 
     public function testPartialRollbackExecutesCallbacksForCommittedDescendantSavepoints()
@@ -301,9 +300,8 @@ class DatabaseTransactionsManagerTest extends TestCase
         $manager->commit('default', 3, 2);
         $manager->rollback('default', 1);
 
-        $this->assertCount(2, $callbacks);
-        $this->assertContains(['default', 3], $callbacks);
-        $this->assertContains(['default', 2], $callbacks);
+        // Deepest-first order: committed grandchild (level 3) then open child (level 2).
+        $this->assertSame([['default', 3], ['default', 2]], $callbacks);
     }
 
     public function testRollbackExecutesOnlyCallbacksOfTheConnection()

--- a/tests/Database/DatabaseTransactionsManagerTest.php
+++ b/tests/Database/DatabaseTransactionsManagerTest.php
@@ -253,6 +253,59 @@ class DatabaseTransactionsManagerTest extends TestCase
         $this->assertEquals(['default', 1], $callbacks[1]);
     }
 
+    public function testRollbackExecutesCallbacksForCommittedSavepointsWhenOuterRollsBack()
+    {
+        $callbacks = [];
+
+        $manager = new DatabaseTransactionsManager;
+
+        $manager->begin('default', 1);
+
+        $manager->addCallbackForRollback(function () use (&$callbacks) {
+            $callbacks[] = ['default', 1];
+        });
+
+        $manager->begin('default', 2);
+
+        $manager->addCallbackForRollback(function () use (&$callbacks) {
+            $callbacks[] = ['default', 2];
+        });
+
+        $manager->commit('default', 2, 1);
+        $manager->rollback('default', 0);
+
+        $this->assertCount(2, $callbacks);
+        $this->assertContains(['default', 2], $callbacks);
+        $this->assertContains(['default', 1], $callbacks);
+    }
+
+    public function testPartialRollbackExecutesCallbacksForCommittedDescendantSavepoints()
+    {
+        $callbacks = [];
+
+        $manager = new DatabaseTransactionsManager;
+
+        $manager->begin('default', 1);
+        $manager->begin('default', 2);
+
+        $manager->addCallbackForRollback(function () use (&$callbacks) {
+            $callbacks[] = ['default', 2];
+        });
+
+        $manager->begin('default', 3);
+
+        $manager->addCallbackForRollback(function () use (&$callbacks) {
+            $callbacks[] = ['default', 3];
+        });
+
+        $manager->commit('default', 3, 2);
+        $manager->rollback('default', 1);
+
+        $this->assertCount(2, $callbacks);
+        $this->assertContains(['default', 3], $callbacks);
+        $this->assertContains(['default', 2], $callbacks);
+    }
+
     public function testRollbackExecutesOnlyCallbacksOfTheConnection()
     {
         $callbacks = [];


### PR DESCRIPTION
Hi team

Hit this one in production today. Took me hours to figure out.

Setup: controller wraps its work in `DB::transaction`. Inside it calls a service that does its own `DB::transaction` (so a savepoint). Service dispatches a `ShouldBeUnique` job with `after_commit => true`. After all the work the controller calls the payment gateway. Gateway throws. Outer rolls back.

Expected: job not queued. Unique lock released. Move on.

What actually happens: job not queued (correct) but the unique lock is NEVER released. Every future dispatch of that job silently does nothing forever.

Took me a while to find why. PR #55420 added the rollback callback mechanism a few months ago which is exactly the right idea. It fires `executeCallbacksForRollback()` for the OPEN transaction chain. But when an inner savepoint commits its record moves from `pendingTransactions` to `committedTransactions`. Then when the outer rolls back `removeAllTransactionsForConnection` just `->reject()`s those committed records without firing their callbacks.

Same gap in `removeCommittedTransactionsThatAreChildrenOf` (the partial rollback path).

### Fix

Fire the callbacks before dropping the committed records. The callbacks already exist on the record. Nobody just calls them in this path.

3 lines in `removeAllTransactionsForConnection`. 1 line in `removeCommittedTransactionsThatAreChildrenOf`.

### Tests

Added 2 tests next to `testRollbackTransactionsExecutesCallbacks`:
- inner savepoint commits then outer rolls back
- partial rollback with a committed grandchild

All 17 `DatabaseTransactionsManagerTest` pass. All 52 `EloquentTransactionWithAfterCommit*` integration tests across the 5 variants pass.

### Backward compat

Zero behavior change for code that does not register rollback callbacks on inner savepoints. Code that does (i.e. `ShouldBeUnique` with `after_commit` inside nested transactions) finally sees the rollback callbacks it registered actually run.

Same incomplete-fix-completion shape as the recent #60149 cleanup if that helps frame review.

Thanks