### PR TITLE
[13.x] Support enum for broadcastAs

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastEvent.php
+++ b/src/Illuminate/Broadcasting/BroadcastEvent.php
@@ -13,11 +13,11 @@ use Illuminate\Queue\Attributes\ReadsQueueAttributes;
 use Illuminate\Queue\Attributes\Timeout;
 use Illuminate\Queue\Attributes\Tries;
 use Illuminate\Support\Arr;
-
-use function Illuminate\Support\enum_value;
 use ReflectionClass;
 use ReflectionProperty;
 use Throwable;
+
+use function Illuminate\Support\enum_value;
 
 class BroadcastEvent implements ShouldQueue
 {

--- a/src/Illuminate/Broadcasting/BroadcastEvent.php
+++ b/src/Illuminate/Broadcasting/BroadcastEvent.php
@@ -13,6 +13,8 @@ use Illuminate\Queue\Attributes\ReadsQueueAttributes;
 use Illuminate\Queue\Attributes\Timeout;
 use Illuminate\Queue\Attributes\Tries;
 use Illuminate\Support\Arr;
+
+use function Illuminate\Support\enum_value;
 use ReflectionClass;
 use ReflectionProperty;
 use Throwable;
@@ -88,7 +90,7 @@ class BroadcastEvent implements ShouldQueue
     public function handle(BroadcastingFactory $manager)
     {
         $name = method_exists($this->event, 'broadcastAs')
-            ? $this->event->broadcastAs()
+            ? enum_value($this->event->broadcastAs())
             : get_class($this->event);
 
         $channels = Arr::wrap($this->event->broadcastOn());

--- a/tests/Broadcasting/BroadcastEventTest.php
+++ b/tests/Broadcasting/BroadcastEventTest.php
@@ -84,6 +84,40 @@ class BroadcastEventTest extends TestCase
         (new BroadcastEvent($event))->handle($manager);
     }
 
+    public function testBroadcastAsStringIsUsedAsEventName()
+    {
+        $broadcaster = m::mock(Broadcaster::class);
+
+        $broadcaster->shouldReceive('broadcast')->once()->with(
+            ['test-channel'], 'custom-name', ['firstName' => 'Taylor', 'lastName' => 'Otwell', 'collection' => ['foo' => 'bar']]
+        );
+
+        $manager = m::mock(BroadcastingFactory::class);
+
+        $manager->shouldReceive('connection')->once()->with(null)->andReturn($broadcaster);
+
+        $event = new TestBroadcastEventWithStringName;
+
+        (new BroadcastEvent($event))->handle($manager);
+    }
+
+    public function testBroadcastAsBackedEnumResolvesToValue()
+    {
+        $broadcaster = m::mock(Broadcaster::class);
+
+        $broadcaster->shouldReceive('broadcast')->once()->with(
+            ['test-channel'], 'custom-enum-name', ['firstName' => 'Taylor', 'lastName' => 'Otwell', 'collection' => ['foo' => 'bar']]
+        );
+
+        $manager = m::mock(BroadcastingFactory::class);
+
+        $manager->shouldReceive('connection')->once()->with(null)->andReturn($broadcaster);
+
+        $event = new TestBroadcastEventWithEnumName;
+
+        (new BroadcastEvent($event))->handle($manager);
+    }
+
     public function testMiddlewareProxiesMiddlewareFromUnderlyingEvent()
     {
         $event = new class
@@ -134,6 +168,27 @@ class TestBroadcastEvent
     {
         return ['test-channel'];
     }
+}
+
+class TestBroadcastEventWithStringName extends TestBroadcastEvent
+{
+    public function broadcastAs()
+    {
+        return 'custom-name';
+    }
+}
+
+class TestBroadcastEventWithEnumName extends TestBroadcastEvent
+{
+    public function broadcastAs()
+    {
+        return TestBroadcastEventName::Custom;
+    }
+}
+
+enum TestBroadcastEventName: string
+{
+    case Custom = 'custom-enum-name';
 }
 
 class TestBroadcastEventWithManualData extends TestBroadcastEvent


### PR DESCRIPTION
This will allow the use of enums for the broadcast event name, so if you're using an SDK generator (eg. OpenAPI Spec generator), you can have typed event names on both sides, ensuring that you have consistency.

This also matches other parts of the framework now, such as #[Queue()]` attribute on jobs, which support enums.