### PR TITLE
[13.x] Improve return types for database connection callback wrappers

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -679,8 +679,10 @@ class Connection implements ConnectionInterface
     /**
      * Execute the given callback without "pretending".
      *
-     * @param  \Closure  $callback
-     * @return mixed
+     * @template TReturn
+     *
+     * @param  \Closure(): TReturn  $callback
+     * @return TReturn
      */
     public function withoutPretending(Closure $callback)
     {
@@ -1738,8 +1740,10 @@ class Connection implements ConnectionInterface
     /**
      * Execute the given callback without table prefix.
      *
-     * @param  \Closure  $callback
-     * @return mixed
+     * @template TReturn
+     *
+     * @param  (\Closure($this): TReturn)  $callback
+     * @return TReturn
      */
     public function withoutTablePrefix(Closure $callback): mixed
     {

--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -343,9 +343,11 @@ class DatabaseManager implements ConnectionResolverInterface
     /**
      * Set the default database connection for the callback execution.
      *
+     * @template TReturn
+     *
      * @param  \UnitEnum|string  $name
-     * @param  callable  $callback
-     * @return mixed
+     * @param  (callable(): TReturn)  $callback
+     * @return TReturn
      */
     public function usingConnection($name, callable $callback)
     {

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -659,7 +659,7 @@ class Migrator
      *
      * @param  string  $name
      * @param  (callable(): TReturn)  $callback
-     * @return mixed
+     * @return TReturn
      */
     public function usingConnection($name, callable $callback)
     {

--- a/types/Database/Connection.php
+++ b/types/Database/Connection.php
@@ -1,0 +1,11 @@
+<?php
+
+use Illuminate\Database\Connection;
+
+use function PHPStan\Testing\assertType;
+
+/** @var Connection $connection */
+$connection = resolve(Connection::class);
+
+assertType("'foo'", $connection->withoutPretending(fn () => 'foo'));
+assertType("'foo'", $connection->withoutTablePrefix(fn () => 'foo'));

--- a/types/Database/DatabaseManager.php
+++ b/types/Database/DatabaseManager.php
@@ -1,0 +1,10 @@
+<?php
+
+use Illuminate\Database\DatabaseManager;
+
+use function PHPStan\Testing\assertType;
+
+/** @var DatabaseManager $manager */
+$manager = resolve(DatabaseManager::class);
+
+assertType("'foo'", $manager->usingConnection('mysql', fn () => 'foo'));

--- a/types/Database/Migrations/Migrator.php
+++ b/types/Database/Migrations/Migrator.php
@@ -1,0 +1,10 @@
+<?php
+
+use Illuminate\Database\Migrations\Migrator;
+
+use function PHPStan\Testing\assertType;
+
+/** @var Migrator $migrator */
+$migrator = resolve(Migrator::class);
+
+assertType("'foo'", $migrator->usingConnection('mysql', fn () => 'foo'));


### PR DESCRIPTION
This allows tools like PHPStan to properly infer the return type of the database callback wrappers `Connection::withoutPretending()`, `Connection::withoutTablePrefix()`, `DatabaseManager::usingConnection()`, and `Migrator::usingConnection()`, which execute a callback and return its result, but were previously typed as `mixed`.                                                                                                                   
                                                                                                                                                                                                                                         
`Migrator::usingConnection()` already declared `@template TReturn` for its callback, but its `@return` annotation remained `mixed`, preventing the template from affecting the inferred return type. This change fixes that.           
          

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
