### PR TITLE
[13.x] Prevent queue:work failing when stop-when-empty-for option is …

### DIFF
--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -158,6 +158,10 @@ class WorkCommand extends Command
      */
     protected function gatherWorkerOptions()
     {
+        $stopWhenEmptyFor = $this->hasOption('stop-when-empty-for')
+            ? $this->option('stop-when-empty-for')
+            : 0;
+
         return new WorkerOptions(
             $this->option('name'),
             max($this->option('backoff'), $this->option('delay')),
@@ -170,7 +174,7 @@ class WorkCommand extends Command
             $this->option('max-jobs'),
             $this->option('max-time'),
             $this->option('rest'),
-            $this->option('stop-when-empty-for'),
+            $stopWhenEmptyFor,
         );
     }
 

--- a/tests/Integration/Queue/WorkCommandTest.php
+++ b/tests/Integration/Queue/WorkCommandTest.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Database\UniqueConstraintViolationException;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Queue\Console\WorkCommand;
 use Illuminate\Queue\Worker;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Artisan;
@@ -246,6 +247,18 @@ class WorkCommandTest extends QueueTestCase
         Worker::$pausable = true;
     }
 
+    public function testStopWhenEmptyForOptionIsOptionalForExtendingCommands()
+    {
+        // Simulates an older Horizon WorkCommand whose signature omits --stop-when-empty-for.
+        Artisan::registerCommand($command = new WorkCommandWithoutStopWhenEmptyFor(
+            $this->app['queue.worker'], $this->app['cache.store']
+        ));
+
+        $this->artisan('queue:work-legacy')->assertExitCode(0);
+
+        $this->assertSame(0, $command->capturedOptions->stopWhenEmptyFor);
+    }
+
     public function testFailedJobListenerOnlyRunsOnce()
     {
         $this->markTestSkippedWhenUsingQueueDrivers(['redis', 'beanstalkd']);
@@ -259,6 +272,36 @@ class WorkCommandTest extends QueueTestCase
         $this->withoutMockingConsoleOutput()->artisan('queue:work', ['--once' => true]);
         Exceptions::assertNotReported(UniqueConstraintViolationException::class);
         $this->assertSame(2, substr_count(Artisan::output(), JobWillFail::class));
+    }
+}
+
+class WorkCommandWithoutStopWhenEmptyFor extends WorkCommand
+{
+    protected $signature = 'queue:work-legacy
+                            {connection?}
+                            {--name=default}
+                            {--queue=}
+                            {--once}
+                            {--stop-when-empty}
+                            {--delay=0}
+                            {--backoff=0}
+                            {--max-jobs=0}
+                            {--max-time=0}
+                            {--force}
+                            {--memory=128}
+                            {--sleep=3}
+                            {--rest=0}
+                            {--timeout=60}
+                            {--tries=1}
+                            {--json}';
+
+    public $capturedOptions;
+
+    public function handle()
+    {
+        $this->capturedOptions = $this->gatherWorkerOptions();
+
+        return 0;
     }
 }
 


### PR DESCRIPTION
This PR fixes a fatal error that occurs when running a queue worker through an older version of Laravel Horizon.

**(CI appears to have failed due to a redis error; a rerun should be enough.)**

Horizon ships its own WorkCommand that extends Illuminate\Queue\Console\WorkCommand but defines its own command signature. Older Horizon versions do not define the --stop-when-empty-for option, so when the worker falls through to the parent's gatherWorkerOptions() method, the following call throws:


$this->option('stop-when-empty-for');

The "--stop-when-empty-for" option does not exist.
This guards the lookup so the option is only read when it is actually defined in the command's signature, falling back to 0 (the same default used by WorkerOptions) otherwise. Behavior is unchanged for the standard queue:work command.


$stopWhenEmptyFor = $this->hasOption('stop-when-empty-for')
    ? $this->option('stop-when-empty-for')
    : 0;

https://github.com/laravel/horizon/issues/1782