### PR TITLE
[13.x] Add `whenFilledEnum` method to `InteractsWithData`

### DIFF
--- a/src/Illuminate/Support/Traits/InteractsWithData.php
+++ b/src/Illuminate/Support/Traits/InteractsWithData.php
@@ -179,6 +179,33 @@ trait InteractsWithData
     }
 
     /**
+     * Apply the callback if the instance contains a non-empty value for the given key
+     * and the value can be converted to the given backed enum.
+     *
+     * @param  string  $key
+     * @param  class-string<\BackedEnum>  $enumClass
+     * @param  callable  $callback
+     * @param  callable|null  $default
+     * @return $this|mixed
+     */
+    public function whenFilledEnum($key, string $enumClass, callable $callback, ?callable $default = null)
+    {
+        if ($this->filled($key) && $this->isBackedEnum($enumClass)) {
+            $value = $enumClass::tryFrom(data_get($this->all(), $key));
+
+            if ($value !== null) {
+                return $callback($value) ?: $this;
+            }
+        }
+
+        if ($default) {
+            return $default();
+        }
+
+        return $this;
+    }
+
+    /**
      * Determine if the instance is missing a given key.
      *
      * @param  string|array  $key

--- a/src/Illuminate/Support/Traits/InteractsWithData.php
+++ b/src/Illuminate/Support/Traits/InteractsWithData.php
@@ -179,8 +179,7 @@ trait InteractsWithData
     }
 
     /**
-     * Apply the callback if the instance contains a non-empty value for the given key
-     * and the value can be converted to the given backed enum.
+     * Apply the callback if the instance contains a valid enum value for the given key.
      *
      * @param  string  $key
      * @param  class-string<\BackedEnum>  $enumClass
@@ -188,7 +187,7 @@ trait InteractsWithData
      * @param  callable|null  $default
      * @return $this|mixed
      */
-    public function whenFilledEnum($key, string $enumClass, callable $callback, ?callable $default = null)
+    public function whenEnum($key, string $enumClass, callable $callback, ?callable $default = null)
     {
         if ($this->filled($key) && $this->isBackedEnum($enumClass)) {
             $value = $enumClass::tryFrom(data_get($this->all(), $key));

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -453,6 +453,37 @@ class HttpRequestTest extends TestCase
         $this->assertTrue($bar);
     }
 
+    public function testWhenFilledEnumMethod()
+    {
+        $request = Request::create('/', 'GET', ['status' => 'test', 'invalid' => 'invalid', 'empty' => '']);
+
+        $status = $invalid = $empty = $missing = $default = false;
+
+        $request->whenFilledEnum('status', TestEnumBacked::class, function ($value) use (&$status) {
+            $status = $value;
+        });
+
+        $request->whenFilledEnum('invalid', TestEnumBacked::class, function ($value) use (&$invalid) {
+            $invalid = $value;
+        });
+
+        $request->whenFilledEnum('empty', TestEnumBacked::class, function ($value) use (&$empty) {
+            $empty = $value;
+        });
+
+        $request->whenFilledEnum('missing', TestEnumBacked::class, function ($value) use (&$missing) {
+            $missing = $value;
+        }, function () use (&$default) {
+            $default = true;
+        });
+
+        $this->assertSame(TestEnumBacked::test, $status);
+        $this->assertFalse($invalid);
+        $this->assertFalse($empty);
+        $this->assertFalse($missing);
+        $this->assertTrue($default);
+    }
+
     public function testMissingMethod()
     {
         $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => '', 'city' => null]);

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -453,25 +453,25 @@ class HttpRequestTest extends TestCase
         $this->assertTrue($bar);
     }
 
-    public function testWhenFilledEnumMethod()
+    public function testWhenEnumMethod()
     {
         $request = Request::create('/', 'GET', ['status' => 'test', 'invalid' => 'invalid', 'empty' => '']);
 
         $status = $invalid = $empty = $missing = $default = false;
 
-        $request->whenFilledEnum('status', TestEnumBacked::class, function ($value) use (&$status) {
+        $request->whenEnum('status', TestEnumBacked::class, function ($value) use (&$status) {
             $status = $value;
         });
 
-        $request->whenFilledEnum('invalid', TestEnumBacked::class, function ($value) use (&$invalid) {
+        $request->whenEnum('invalid', TestEnumBacked::class, function ($value) use (&$invalid) {
             $invalid = $value;
         });
 
-        $request->whenFilledEnum('empty', TestEnumBacked::class, function ($value) use (&$empty) {
+        $request->whenEnum('empty', TestEnumBacked::class, function ($value) use (&$empty) {
             $empty = $value;
         });
 
-        $request->whenFilledEnum('missing', TestEnumBacked::class, function ($value) use (&$missing) {
+        $request->whenEnum('missing', TestEnumBacked::class, function ($value) use (&$missing) {
             $missing = $value;
         }, function () use (&$default) {
             $default = true;

--- a/tests/Support/ValidatedInputTest.php
+++ b/tests/Support/ValidatedInputTest.php
@@ -231,6 +231,37 @@ class ValidatedInputTest extends TestCase
         $this->assertFalse($bar);
     }
 
+    public function test_when_filled_enum_method()
+    {
+        $input = new ValidatedInput(['status' => 'Hello world', 'invalid' => 'invalid', 'age' => '']);
+
+        $status = $invalid = $age = $missing = $default = false;
+
+        $input->whenFilledEnum('status', StringBackedEnum::class, function ($value) use (&$status) {
+            $status = $value;
+        });
+
+        $input->whenFilledEnum('invalid', StringBackedEnum::class, function ($value) use (&$invalid) {
+            $invalid = $value;
+        });
+
+        $input->whenFilledEnum('age', StringBackedEnum::class, function ($value) use (&$age) {
+            $age = $value;
+        });
+
+        $input->whenFilledEnum('missing', StringBackedEnum::class, function ($value) use (&$missing) {
+            $missing = $value;
+        }, function () use (&$default) {
+            $default = true;
+        });
+
+        $this->assertSame(StringBackedEnum::HELLO_WORLD, $status);
+        $this->assertFalse($invalid);
+        $this->assertFalse($age);
+        $this->assertFalse($missing);
+        $this->assertTrue($default);
+    }
+
     public function test_missing_method()
     {
         $input = new ValidatedInput(['name' => 'Fatih', 'surname' => 'AYDIN', 'foo' => ['bar' => null, 'baz' => '']]);

--- a/tests/Support/ValidatedInputTest.php
+++ b/tests/Support/ValidatedInputTest.php
@@ -231,25 +231,25 @@ class ValidatedInputTest extends TestCase
         $this->assertFalse($bar);
     }
 
-    public function test_when_filled_enum_method()
+    public function test_when_enum_method()
     {
         $input = new ValidatedInput(['status' => 'Hello world', 'invalid' => 'invalid', 'age' => '']);
 
         $status = $invalid = $age = $missing = $default = false;
 
-        $input->whenFilledEnum('status', StringBackedEnum::class, function ($value) use (&$status) {
+        $input->whenEnum('status', StringBackedEnum::class, function ($value) use (&$status) {
             $status = $value;
         });
 
-        $input->whenFilledEnum('invalid', StringBackedEnum::class, function ($value) use (&$invalid) {
+        $input->whenEnum('invalid', StringBackedEnum::class, function ($value) use (&$invalid) {
             $invalid = $value;
         });
 
-        $input->whenFilledEnum('age', StringBackedEnum::class, function ($value) use (&$age) {
+        $input->whenEnum('age', StringBackedEnum::class, function ($value) use (&$age) {
             $age = $value;
         });
 
-        $input->whenFilledEnum('missing', StringBackedEnum::class, function ($value) use (&$missing) {
+        $input->whenEnum('missing', StringBackedEnum::class, function ($value) use (&$missing) {
             $missing = $value;
         }, function () use (&$default) {
             $default = true;


### PR DESCRIPTION
## Motivation

When working with backed enums in request handling, a common pattern is to call `whenFilled` and then manually convert the value with `tryFrom`, along with a null check:

```php
$request->whenFilled('status', function (string $input) use ($query): void {
    $status = Status::tryFrom($input);

    if ($status === null) {
        return;
    }

    $query->where('status', $status);
});
```

This is repetitive boilerplate. The new `whenFilledEnum` method encapsulates this pattern, allowing developers to work directly with a typed enum instance in the callback.

Additionally, because the callback is executed only when the value can be converted to a valid enum case using `tryFrom()`, unexpected or invalid values can be handled safely without causing errors.

## Behavior

The callback is invoked only when all of the following conditions are met:

- The given key has a non-empty value (`filled()`)
- The given class is a backed enum (`isBackedEnum()`)
- The value can be cast to a valid enum case (`tryFrom()` returns non-null)

Otherwise, the callback is not invoked. This allows processing to be skipped without throwing exceptions or errors, even when the request contains unexpected or invalid enum values.

An optional `$default` callback can be provided, which is called when the primary callback is not invoked.

```php
$request->whenFilledEnum('status', Status::class, function (Status $status) use ($query): void {
    $query->where('status', $status);
});

// With a default callback
$request->whenFilledEnum('status', Status::class, function (Status $status) use ($query): void {
    $query->where('status', $status);
}, function () use ($query): void {
    $query->where('status', Status::Active);
});
```