### PR TITLE
[13.x] Allow the exception renderer to have additional source paths

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Renderer/Exception.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/Exception.php
@@ -41,19 +41,28 @@ class Exception
     protected $basePath;
 
     /**
+     * Additional paths that should be treated as source code.
+     *
+     * @var string[]
+     */
+    protected $sourcePaths;
+
+    /**
      * Creates a new exception renderer instance.
      *
      * @param  \Symfony\Component\ErrorHandler\Exception\FlattenException  $exception
      * @param  \Illuminate\Http\Request  $request
      * @param  \Illuminate\Foundation\Exceptions\Renderer\Listener  $listener
      * @param  string  $basePath
+     * @param  string[]  $sourcePaths
      */
-    public function __construct(FlattenException $exception, Request $request, Listener $listener, string $basePath)
+    public function __construct(FlattenException $exception, Request $request, Listener $listener, string $basePath, array $sourcePaths = [])
     {
         $this->exception = $exception;
         $this->request = $request;
         $this->listener = $listener;
         $this->basePath = $basePath;
+        $this->sourcePaths = $sourcePaths;
     }
 
     /**
@@ -114,7 +123,7 @@ class Exception
     public function previousExceptions()
     {
         return once(fn () => (new Collection($this->exception->getAllPrevious()))->map(
-            fn ($previous) => new static($previous, $this->request, $this->listener, $this->basePath),
+            fn ($previous) => new static($previous, $this->request, $this->listener, $this->basePath, $this->sourcePaths),
         ));
     }
 
@@ -152,7 +161,7 @@ class Exception
             $previousFrame = null;
 
             foreach (array_reverse($trace) as $frameData) {
-                $frame = new Frame($this->exception, $classMap, $frameData, $this->basePath, $previousFrame);
+                $frame = new Frame($this->exception, $classMap, $frameData, $this->basePath, $this->sourcePaths, $previousFrame);
                 $frames[] = $frame;
                 $previousFrame = $frame;
             }

--- a/src/Illuminate/Foundation/Exceptions/Renderer/Frame.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/Frame.php
@@ -54,20 +54,29 @@ class Frame
     protected $isMain = false;
 
     /**
+     * Additional paths that should be treated as source code.
+     *
+     * @var string[]
+     */
+    protected $sourcePaths;
+
+    /**
      * Create a new frame instance.
      *
      * @param  \Symfony\Component\ErrorHandler\Exception\FlattenException  $exception
      * @param  array<string, string>  $classMap
      * @param  array{file: string, line: int, class?: string, type?: string, function?: string, args?: array}  $frame
      * @param  string  $basePath
+     * @param  string[]  $sourcePaths
      * @param  \Illuminate\Foundation\Exceptions\Renderer\Frame|null  $previous
      */
-    public function __construct(FlattenException $exception, array $classMap, array $frame, string $basePath, ?Frame $previous = null)
+    public function __construct(FlattenException $exception, array $classMap, array $frame, string $basePath, array $sourcePaths = [], ?Frame $previous = null)
     {
         $this->exception = $exception;
         $this->classMap = $classMap;
         $this->frame = $frame;
         $this->basePath = $basePath;
+        $this->sourcePaths = $sourcePaths;
         $this->previous = $previous;
     }
 
@@ -211,6 +220,12 @@ class Frame
      */
     public function isFromVendor()
     {
+        foreach ($this->sourcePaths as $path) {
+            if (str_starts_with($this->frame['file'], $path)) {
+                return false;
+            }
+        }
+
         return ! str_starts_with($this->frame['file'], $this->basePath)
             || str_starts_with($this->frame['file'], join_paths($this->basePath, 'vendor'));
     }

--- a/src/Illuminate/Foundation/Exceptions/Renderer/Renderer.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/Renderer.php
@@ -53,6 +53,13 @@ class Renderer
     protected $basePath;
 
     /**
+     * Additional paths that should be treated as source code.
+     *
+     * @var string[]
+     */
+    protected static $sourcePaths = [];
+
+    /**
      * Creates a new exception renderer instance.
      *
      * @param  \Illuminate\Contracts\View\Factory  $viewFactory
@@ -88,7 +95,7 @@ class Renderer
             $this->htmlErrorRenderer->render($throwable),
         );
 
-        $exception = new Exception($flattenException, $request, $this->listener, $this->basePath);
+        $exception = new Exception($flattenException, $request, $this->listener, $this->basePath, self::$sourcePaths);
 
         $exceptionAsMarkdown = $this->viewFactory->make('laravel-exceptions-renderer::markdown', [
             'exception' => $exception,
@@ -98,6 +105,21 @@ class Renderer
             'exception' => $exception,
             'exceptionAsMarkdown' => $exceptionAsMarkdown,
         ])->render();
+    }
+
+    /**
+     * Set additional paths that should be considered as source code, instead of vendor code.
+     *
+     * @param  string[]  $paths
+     * @return void
+     */
+    public static function sourcePaths(array $paths): void
+    {
+        self::$sourcePaths = array_filter(array_map(function ($path) {
+            $path = realpath($path);
+
+            return $path ? rtrim($path, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR : null;
+        }, $paths));
     }
 
     /**

--- a/src/Illuminate/Foundation/resources/exceptions/renderer/components/file-with-line.blade.php
+++ b/src/Illuminate/Foundation/resources/exceptions/renderer/components/file-with-line.blade.php
@@ -9,7 +9,7 @@
     {{ $attributes->merge(['class' => 'truncate font-mono text-xs text-neutral-500 dark:text-neutral-400']) }}
     dir="{{ $direction }}"
 >
-    <span data-tippy-content="{{ $file }}:{{ $line }}">
+    <bdi data-tippy-content="{{ $file }}:{{ $line }}">
         @if (config('app.editor'))
             <a href="{{ $frame->editorHref() }}" @click.stop>
                 <span class="hover:underline decoration-neutral-400">{{ $file }}</span><span class="text-neutral-500">:{{ $line }}</span>
@@ -17,5 +17,5 @@
         @else
             {{ $file }}<span class="text-neutral-500">:{{ $line }}</span>
         @endif
-    </span>
+    </bdi>
 </div>

--- a/tests/Foundation/Exceptions/Renderer/FrameTest.php
+++ b/tests/Foundation/Exceptions/Renderer/FrameTest.php
@@ -87,7 +87,7 @@ class FrameTest extends TestCase
     {
         $exception = m::mock(FlattenException::class);
         $classMap = [];
-        $frame = new Frame($exception, $classMap, $frameData, $basePath);
+        $frame = new Frame($exception, $classMap, $frameData, $basePath, ['/path/to/your-package']);
 
         $this->assertEquals($expected, $frame->isFromVendor());
     }
@@ -114,6 +114,11 @@ class FrameTest extends TestCase
             '/path/to/your-app',
             false,
         ];
+        yield 'external source path' => [
+            ['file' => '/path/to/your-package/src/file.php', 'line' => 10],
+            '/path/to/your-package/src/file.php',
+            false,
+        ];
     }
 
     #[RequiresOperatingSystem('Windows')]
@@ -122,7 +127,7 @@ class FrameTest extends TestCase
     {
         $exception = m::mock(FlattenException::class);
         $classMap = [];
-        $frame = new Frame($exception, $classMap, $frameData, $basePath);
+        $frame = new Frame($exception, $classMap, $frameData, $basePath, ['C:/path/to/your-package']);
 
         $this->assertEquals($expected, $frame->isFromVendor());
     }
@@ -147,6 +152,11 @@ class FrameTest extends TestCase
         yield 'vendor in filename' => [
             ['file' => 'C:\path\to\your-app\app\vendorfile.php', 'line' => 10],
             'C:\path\to\your-app',
+            false,
+        ];
+        yield 'external source path' => [
+            ['file' => 'C:\path\to\your-package\src\file.php', 'line' => 10],
+            'C:\path\to\your-package',
             false,
         ];
     }


### PR DESCRIPTION
This PR adds a new method to the `\Illuminate\Foundation\Exceptions\Renderer\Renderer` class that allows developers to specify additional source paths so that files in those paths are not considered "vendor code". 

This will make the source code rendered on the exception page, and therefore super useful for package development.

My motivation for this is that I link my packages into the vendor directory when developing them.

Example: (I linked `./vendor/laravel/framework` into `./../framework`), and tested on Windows/Linux.

```
/project
   /vendor/laravel/framework  (symlink to /framework)
/framework
```


```php
Renderer::sourcePaths([
    base_path('../vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware'),
]);
```

<img width="1199" height="1293" alt="Screenshot 2026-06-11 112045" src="https://github.com/user-attachments/assets/bdbf2033-bbf3-4324-bb66-4d46214d32cf" />
