### PR TITLE
[14.x] Update trans helper return type

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -14,7 +14,6 @@ use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Routing\ResponseFactory;
 use Illuminate\Contracts\Routing\UrlGenerator;
 use Illuminate\Contracts\Support\Responsable;
-use Illuminate\Contracts\Translation\Translator;
 use Illuminate\Contracts\Validation\Factory as ValidationFactory;
 use Illuminate\Contracts\Validation\Validator as ValidatorContract;
 use Illuminate\Contracts\View\Factory as ViewFactory;
@@ -37,6 +36,7 @@ use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Uri;
+use Illuminate\Translation\Translator;
 use League\Uri\Contracts\UriInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Cookie;
@@ -985,7 +985,7 @@ if (! function_exists('trans')) {
      * @param  string|null  $key
      * @param  array  $replace
      * @param  string|null  $locale
-     * @return ($key is null ? \Illuminate\Contracts\Translation\Translator : array|string)
+     * @return ($key is null ? \Illuminate\Translation\Translator : array|string)
      */
     function trans($key = null, $replace = [], $locale = null): Translator|array|string
     {

--- a/types/Foundation/Helpers.php
+++ b/types/Foundation/Helpers.php
@@ -56,7 +56,7 @@ assertType('Illuminate\Session\SessionManager', session());
 assertType('mixed', session('foo'));
 assertType('null', session(['foo' => 'bar']));
 
-assertType('Illuminate\Contracts\Translation\Translator', trans());
+assertType('Illuminate\Translation\Translator', trans());
 assertType('array|string', trans('foo'));
 
 assertType('Illuminate\Contracts\Validation\Factory', validator());


### PR DESCRIPTION
This updates the `trans()` helper return type for the no-key case to the concrete translator implementation.

The `trans()` helper currently returns the translation contract instead of Laravel's concrete translator.
This differs from the other no-argument service helpers:

```php
trans(): Illuminate\Contracts\Translation\Translator // Contract instead of Illuminate\Translation\Translator
config(): Illuminate\Config\Repository
request(): Illuminate\Http\Request
session(): Illuminate\Session\SessionManager
cache(): Illuminate\Cache\CacheManager
redirect(): Illuminate\Routing\Redirector
logs(): Illuminate\Log\LogManager
```

These helpers resolve Laravel's underlying concrete service or manager when called without arguments.

## Why is this beneficial?

`Illuminate\Translation\Translator` includes useful methods that are not included in the contract, such as `string(...): string` and `array(...): array`. The same pattern exists for helpers like `config()`, which exposes `Illuminate\Config\Repository` rather than only `Illuminate\Contracts\Config\Repository`.

Some Laravel-aware tools can already infer this through framework-specific service analysis. For example, Larastan can infer this through Laravel-specific extensions such as `ContractsMethodsExtension`. However, the native signature should make the helper more accurate for other static analysis tools, IDEs, language servers, and simpler type inference paths that read the helper return type directly.

Typing `trans()` as the concrete translator lets Laravel add convenience methods to `Illuminate\Translation\Translator` in minor releases without expanding the translation contract. Adding those methods to the contract would be breaking, since custom contract implementations would be required to implement them.

## Backward Compatibility

This targets 14.x because it changes the native `trans()` return type from `Illuminate\Contracts\Translation\Translator|array|string` to `Illuminate\Translation\Translator|array|string`.

Applications or packages that replace the `translator` binding with a custom contract implementation may need to update it to extend `Illuminate\Translation\Translator`, or avoid using `trans()` with no arguments to retrieve it. Such cases should be rare.

Tooling that special-cases the `trans()` helper, such as static analysis extensions or IDE stubs, may also need to update their inferred no-key return type from `Illuminate\Contracts\Translation\Translator` to `Illuminate\Translation\Translator`. For example, Larastan currently has a `TransHelperReturnTypeExtension` that infers the no-key helper return as the translation contract.