### PR TITLE
[13.x] Add `array` maintenance mode driver for parallel testing

### DIFF
--- a/src/Illuminate/Foundation/ArrayMaintenanceMode.php
+++ b/src/Illuminate/Foundation/ArrayMaintenanceMode.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Illuminate\Foundation;
+
+use Illuminate\Contracts\Foundation\MaintenanceMode;
+
+class ArrayMaintenanceMode implements MaintenanceMode
+{
+    /**
+     * Indicates if maintenance mode is currently active.
+     *
+     * @var bool
+     */
+    protected $active = false;
+
+    /**
+     * The payload provided when maintenance mode was activated.
+     *
+     * @var array
+     */
+    protected $payload = [];
+
+    /**
+     * Take the application down for maintenance.
+     *
+     * @param  array  $payload
+     * @return void
+     */
+    public function activate(array $payload): void
+    {
+        $this->active = true;
+        $this->payload = $payload;
+    }
+
+    /**
+     * Take the application out of maintenance.
+     *
+     * @return void
+     */
+    public function deactivate(): void
+    {
+        $this->active = false;
+        $this->payload = [];
+    }
+
+    /**
+     * Determine if the application is currently down for maintenance.
+     *
+     * @return bool
+     */
+    public function active(): bool
+    {
+        return $this->active;
+    }
+
+    /**
+     * Get the data array which was provided when the application was placed into maintenance.
+     *
+     * @return array
+     */
+    public function data(): array
+    {
+        return $this->payload;
+    }
+}

--- a/src/Illuminate/Foundation/MaintenanceModeManager.php
+++ b/src/Illuminate/Foundation/MaintenanceModeManager.php
@@ -17,6 +17,16 @@ class MaintenanceModeManager extends Manager
     }
 
     /**
+     * Create an instance of the array based maintenance driver.
+     *
+     * @return \Illuminate\Foundation\ArrayMaintenanceMode
+     */
+    protected function createArrayDriver(): ArrayMaintenanceMode
+    {
+        return new ArrayMaintenanceMode();
+    }
+
+    /**
      * Create an instance of the cache based maintenance driver.
      *
      * @return \Illuminate\Foundation\CacheBasedMaintenanceMode

--- a/tests/Foundation/FoundationArrayMaintenanceModeTest.php
+++ b/tests/Foundation/FoundationArrayMaintenanceModeTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Illuminate\Tests\Foundation;
+
+use Illuminate\Foundation\ArrayMaintenanceMode;
+use PHPUnit\Framework\TestCase;
+
+class FoundationArrayMaintenanceModeTest extends TestCase
+{
+    public function test_it_is_inactive_by_default()
+    {
+        $maintenanceMode = new ArrayMaintenanceMode();
+
+        $this->assertFalse($maintenanceMode->active());
+        $this->assertSame([], $maintenanceMode->data());
+    }
+
+    public function test_it_stores_payload_when_activated()
+    {
+        $maintenanceMode = new ArrayMaintenanceMode();
+
+        $maintenanceMode->activate(['payload']);
+
+        $this->assertTrue($maintenanceMode->active());
+        $this->assertSame(['payload'], $maintenanceMode->data());
+    }
+
+    public function test_it_clears_payload_when_deactivated()
+    {
+        $maintenanceMode = new ArrayMaintenanceMode();
+
+        $maintenanceMode->activate(['payload']);
+        $maintenanceMode->deactivate();
+
+        $this->assertFalse($maintenanceMode->active());
+        $this->assertSame([], $maintenanceMode->data());
+    }
+}

--- a/tests/Foundation/FoundationArrayMaintenanceModeTest.php
+++ b/tests/Foundation/FoundationArrayMaintenanceModeTest.php
@@ -7,32 +7,42 @@ use PHPUnit\Framework\TestCase;
 
 class FoundationArrayMaintenanceModeTest extends TestCase
 {
-    public function test_it_is_inactive_by_default()
+    public function test_it_determines_whether_maintenance_mode_is_active()
     {
-        $maintenanceMode = new ArrayMaintenanceMode();
+        $manager = new ArrayMaintenanceMode();
 
-        $this->assertFalse($maintenanceMode->active());
-        $this->assertSame([], $maintenanceMode->data());
+        $this->assertFalse($manager->active());
+
+        $manager->activate(['payload']);
+        $this->assertTrue($manager->active());
     }
 
-    public function test_it_stores_payload_when_activated()
+    public function test_it_retrieves_payload()
     {
-        $maintenanceMode = new ArrayMaintenanceMode();
+        $manager = new ArrayMaintenanceMode();
 
-        $maintenanceMode->activate(['payload']);
-
-        $this->assertTrue($maintenanceMode->active());
-        $this->assertSame(['payload'], $maintenanceMode->data());
+        $manager->activate(['payload']);
+        $this->assertSame(['payload'], $manager->data());
     }
 
-    public function test_it_clears_payload_when_deactivated()
+    public function test_it_stores_payload()
     {
-        $maintenanceMode = new ArrayMaintenanceMode();
+        $manager = new ArrayMaintenanceMode();
 
-        $maintenanceMode->activate(['payload']);
-        $maintenanceMode->deactivate();
+        $manager->activate(['payload']);
 
-        $this->assertFalse($maintenanceMode->active());
-        $this->assertSame([], $maintenanceMode->data());
+        $this->assertTrue($manager->active());
+        $this->assertSame(['payload'], $manager->data());
+    }
+
+    public function test_it_removes_payload()
+    {
+        $manager = new ArrayMaintenanceMode();
+
+        $manager->activate(['payload']);
+        $manager->deactivate();
+
+        $this->assertFalse($manager->active());
+        $this->assertSame([], $manager->data());
     }
 }


### PR DESCRIPTION
This adds a simple array-based maintenance mode driver, similar to existing cache and session drivers, that eases parallel testing.

If tests call `php artisan (up|down)` in a parallel testsuite, the file-based driver inevitably trips up, and the cache-based one also gets tripped up by `Cache` facade mocking calls. However, with this new driver parallel testing works fine.

Kinda niche I suppose, but our suppliers expect test coverage for deployment processes. Also, an array-based maintenance mode for tests in general seemed sensible to me.