### PR TITLE
[13.x] Add array to supported maintainance mode drivers doc

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -143,7 +143,7 @@ return [
     | manage Laravel's "maintenance mode" status. The "cache" driver will
     | allow maintenance mode to be controlled across multiple machines.
     |
-    | Supported drivers: "array", "file", "cache"
+    | Supported drivers: "file", "cache", "array"
     |
     */
 

--- a/config/app.php
+++ b/config/app.php
@@ -143,7 +143,7 @@ return [
     | manage Laravel's "maintenance mode" status. The "cache" driver will
     | allow maintenance mode to be controlled across multiple machines.
     |
-    | Supported drivers: "file", "cache"
+    | Supported drivers: "array", "file", "cache"
     |
     */
 


### PR DESCRIPTION
Since array is now available via https://github.com/laravel/framework/pull/60489  

We can add it to the list of supported drivers

This follows elsewhere : 

https://github.com/laravel/framework/blob/47335d4339d36c395fa49b506ac059b02d5c865c/config/cache.php#L29

https://github.com/laravel/framework/blob/47335d4339d36c395fa49b506ac059b02d5c865c/config/mail.php#L33

https://github.com/laravel/framework/blob/47335d4339d36c395fa49b506ac059b02d5c865c/config/session.php#L17

I added it to the end, but up to you where you prefer it 🫡 