### PR TITLE
[13.x] Add `whenNotNull` method to `Conditionable` trait

### DIFF
--- a/src/Illuminate/Conditionable/Traits/Conditionable.php
+++ b/src/Illuminate/Conditionable/Traits/Conditionable.php
@@ -40,6 +40,34 @@ trait Conditionable
     }
 
     /**
+     * Apply the callback if the given "value" is (or resolves to) not null.
+     *
+     * @template TWhenNotNullParameter
+     * @template TWhenNotNullReturnType
+     *
+     * @param  (\Closure($this): (TWhenNotNullParameter|null))|TWhenNotNullParameter|null  $value
+     * @param  (callable($this, TWhenNotNullParameter): TWhenNotNullReturnType)|null  $callback
+     * @param  (callable($this, null): TWhenNotNullReturnType)|null  $default
+     * @return $this|TWhenNotNullReturnType
+     */
+    public function whenNotNull($value = null, ?callable $callback = null, ?callable $default = null)
+    {
+        $value = $value instanceof Closure ? $value($this) : $value;
+
+        if (func_num_args() <= 1) {
+            return (new HigherOrderWhenProxy($this))->condition($value !== null);
+        }
+
+        if ($value !== null) {
+            return $callback($this, $value) ?? $this;
+        } elseif ($default) {
+            return $default($this, $value) ?? $this;
+        }
+
+        return $this;
+    }
+
+    /**
      * Apply the callback if the given "value" is (or resolves to) falsy.
      *
      * @template TUnlessParameter

--- a/tests/Support/SupportConditionableTest.php
+++ b/tests/Support/SupportConditionableTest.php
@@ -57,6 +57,90 @@ class SupportConditionableTest extends TestCase
         $this->assertSame(['default', false], $logger->values);
     }
 
+    public function testWhenNotNullConditionCallback()
+    {
+        // With falsy but non-null values
+        foreach ([0, '0', false, ''] as $value) {
+            $logger = (new ConditionableLogger())
+                ->whenNotNull($value, function ($logger, $value) {
+                    $logger->log('when', $value);
+                }, function ($logger, $value) {
+                    $logger->log('default', $value);
+                });
+
+            $this->assertSame(['when', $value], $logger->values);
+        }
+
+        // With callback condition
+        $logger = (new ConditionableLogger())
+            ->whenNotNull(function ($logger) {
+                return 0;
+            }, function ($logger, $value) {
+                $logger->log('when', $value);
+            }, function ($logger, $value) {
+                $logger->log('default', $value);
+            });
+
+        $this->assertSame(['when', 0], $logger->values);
+    }
+
+    public function testWhenNotNullDefaultCallback()
+    {
+        // With static condition
+        $logger = (new ConditionableLogger())
+            ->whenNotNull(null, function ($logger, $value) {
+                $logger->log('when', $value);
+            }, function ($logger, $value) {
+                $logger->log('default', $value);
+            });
+
+        $this->assertSame(['default', null], $logger->values);
+
+        // With callback condition
+        $logger = (new ConditionableLogger())
+            ->whenNotNull(function ($logger) {
+                return null;
+            }, function ($logger, $value) {
+                $logger->log('when', $value);
+            }, function ($logger, $value) {
+                $logger->log('default', $value);
+            });
+
+        $this->assertSame(['default', null], $logger->values);
+
+        // Without default callback
+        $logger = (new ConditionableLogger())
+            ->whenNotNull(null, function ($logger, $value) {
+                $logger->log('when', $value);
+            });
+
+        $this->assertSame([], $logger->values);
+    }
+
+    public function testWhenNotNullProxy()
+    {
+        // With static condition
+        $logger = (new ConditionableLogger())
+            ->whenNotNull(0)->log('one')
+            ->whenNotNull(null)->log('two')
+            ->whenNotNull()->log('three');
+
+        $this->assertSame(['one'], $logger->values);
+
+        // With callback condition
+        $logger = (new ConditionableLogger())
+            ->whenNotNull(function ($logger) {
+                return false;
+            })
+            ->log('one')
+            ->whenNotNull(function ($logger) {
+                return null;
+            })
+            ->log('two');
+
+        $this->assertSame(['one'], $logger->values);
+    }
+
     public function testUnlessConditionCallback()
     {
         // With static condition

--- a/types/Support/Traits.php
+++ b/types/Support/Traits.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Localizable;
 
 use function PHPStan\Testing\assertType;
@@ -11,5 +12,23 @@ $localizable = new class
     public function useWithLocale(): void
     {
         assertType("'foo'", $this->withLocale('en', fn () => 'foo'));
+    }
+};
+
+$conditionable = new class
+{
+    use Conditionable;
+
+    public function useWhenNotNull(?int $nullableValue): void
+    {
+        $this->whenNotNull($nullableValue, function ($conditionable, $value) {
+            assertType('int', $value);
+        }, function ($conditionable, $value) {
+            assertType('null', $value);
+        });
+
+        $this->whenNotNull(fn () => $nullableValue, function ($conditionable, $value) {
+            assertType('int', $value);
+        });
     }
 };


### PR DESCRIPTION
## Problem

`Conditionable::when()` provides excellent type inference: pass a nullable value, and the docblock
template absorbs `null`, so the callback's second argument is narrowed to the non-null type.

```php
public function scopeStatus(Builder $query, ?int $status): Builder
{
    return $query->when($status, fn ($q, int $status) => $q->where('status', $status));
    // ✅ $status is narrowed to non-null `int` inside the callback
    // ❌ but the callback is silently skipped when $status is 0
}
```

The runtime check is loose truthiness (`if ($value)`), so the callback never runs for `0`, `'0'`,
`false`, or `''` — values that are often perfectly valid (e.g. a "draft" status of `0`).

The common workaround gives up exactly what made `when()` nice:

```php
$query->when($status !== null, fn ($q) => $q->where('status', $status));
// ❌ the narrowed value is gone — the second callback argument is now just `true`
// ❌ static analysis still sees the captured $status as `int|null` inside the closure
```

Today you have to choose between correct runtime behavior and te both.

## Solution

This PR adds a `whenNotNull` method to the `Conditionable` trait. It mirrors `when()` exactly,
except the check is `$value !== null`, and the docblock template (`TWhenNotNullParameter|null`)
guarantees the callback receives a non-null value both at runtime and for static analysis:

```php
$query->whenNotNull($status, fn ($q, int $status) => $q->where('status', $status));
// ✅ runs for 0, '0', false, ''
// ✅ $status is non-null `int` — runtime behavior and the infe
```

It supports the same call shapes as `when()`:

```php
// Closure condition — the resolved value is passed to the callback, narrowed to non-null
$query->whenNotNull(fn () => $request->enum('type', Type::class);

// Default callback — invoked when the value is null
$collection->whenNotNull($limit, fn ($c, int $limit) => $c->take($limit), fn ($c) => $c->take(10));

// Higher order proxy
$query->whenNotNull($limit)->limit($limit);
```

The naming follows existing precedent (`JsonResource::whenNotNull()`, `Stringable::whenNotEmpty()`),
and the method becomes available everywhere `Conditionable` is used (query builders, collections,
`Http`, `Context`, `Pipeline`, etc.).

Includes unit tests (falsy-but-not-null values, default callbacmode)
and PHPStan type assertions in `types/Support/Traits.php` verifying the non-null narrowing.

No breaking changes — purely additive.