### PR TITLE
[12.x] Build Predis Retry from scalar config values

### DIFF
--- a/src/Illuminate/Redis/Connectors/PredisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PredisConnector.php
@@ -7,7 +7,12 @@ use Illuminate\Redis\Connections\PredisClusterConnection;
 use Illuminate\Redis\Connections\PredisConnection;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use InvalidArgumentException;
 use Predis\Client;
+use Predis\Retry\Retry;
+use Predis\Retry\Strategy\EqualBackoff;
+use Predis\Retry\Strategy\ExponentialBackoff;
+use Predis\Retry\Strategy\NoBackoff;
 
 class PredisConnector implements Connector
 {
@@ -33,6 +38,10 @@ class PredisConnector implements Connector
             $config['host'] = Str::after($config['host'], 'tls://');
         }
 
+        if ($retry = $this->buildRetry($config)) {
+            $config['retry'] = $retry;
+        }
+
         return new PredisConnection(new Client($config, $formattedOptions));
     }
 
@@ -55,5 +64,54 @@ class PredisConnector implements Connector
         return new PredisClusterConnection(new Client(array_values($config), array_merge(
             $options, $clusterOptions, $clusterSpecificOptions
         )));
+    }
+
+    /**
+     * Build a Predis Retry instance from scalar configuration values.
+     *
+     * This allows retry/backoff configuration to be stored as scalar values
+     * in the config, making it compatible with config:cache serialization.
+     *
+     * @param  array  $config
+     * @return \Predis\Retry\Retry|null
+     */
+    protected function buildRetry(array $config)
+    {
+        $retries = $config['max_retries'] ?? null;
+        $algorithm = $config['backoff_algorithm'] ?? null;
+        $base = $config['backoff_base'] ?? null;
+        $cap = $config['backoff_cap'] ?? null;
+
+        if ($retries === null && $algorithm === null) {
+            return null;
+        }
+
+        $retries = (int) ($retries ?? 0);
+        $base = (int) ($base ?? 100_000);
+        $cap = (int) ($cap ?? 0);
+        $algorithm = $algorithm ?? 'exponential';
+
+        return new Retry($this->buildBackoffStrategy($algorithm, $base, $cap), $retries);
+    }
+
+    /**
+     * Build a backoff strategy from the given algorithm name and parameters.
+     *
+     * @param  string  $algorithm
+     * @param  int  $base  Base delay in microseconds.
+     * @param  int  $cap  Maximum delay in microseconds.
+     * @return \Predis\Retry\Strategy\RetryStrategyInterface
+     *
+     * @throws \InvalidArgumentException
+     */
+    protected function buildBackoffStrategy(string $algorithm, int $base, int $cap)
+    {
+        return match ($algorithm) {
+            'exponential' => new ExponentialBackoff($base, $cap),
+            'exponential_jitter' => new ExponentialBackoff($base, $cap, true),
+            'equal' => new EqualBackoff($base),
+            'none' => new NoBackoff,
+            default => throw new InvalidArgumentException("Algorithm [{$algorithm}] is not a valid Predis backoff algorithm."),
+        };
     }
 }

--- a/src/Illuminate/Redis/Connectors/PredisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PredisConnector.php
@@ -77,6 +77,10 @@ class PredisConnector implements Connector
      */
     protected function buildRetry(array $config)
     {
+        if (! class_exists(Retry::class)) {
+            return null;
+        }
+
         $retries = $config['max_retries'] ?? null;
         $algorithm = $config['backoff_algorithm'] ?? null;
         $base = $config['backoff_base'] ?? null;

--- a/tests/Redis/PredisConnectorTest.php
+++ b/tests/Redis/PredisConnectorTest.php
@@ -6,9 +6,19 @@ use Illuminate\Foundation\Application;
 use Illuminate\Redis\RedisManager;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
+use Predis\Retry\Retry;
 
 class PredisConnectorTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (! class_exists(Retry::class)) {
+            $this->markTestSkipped('Predis >= 3.0 is required to test retry configuration.');
+        }
+    }
+
     public function testRetryConfigurationWithScalarValues()
     {
         $manager = new RedisManager(new Application, 'predis', [
@@ -112,7 +122,7 @@ class PredisConnectorTest extends TestCase
         $this->assertEquals(5, $retry->getRetries());
     }
 
-    public function testNoRetryConfigurationWhenNotProvided()
+    public function testNoRetryOverrideWhenNotProvided()
     {
         $manager = new RedisManager(new Application, 'predis', [
             'cluster' => false,
@@ -125,7 +135,7 @@ class PredisConnectorTest extends TestCase
         $client = $manager->connection()->client();
         $parameters = $client->getConnection()->getParameters();
 
-        // Predis defaults to Retry with NoBackoff and 0 retries
+        // Predis 3.x defaults to Retry with NoBackoff and 0 retries
         $retry = $parameters->retry;
         $this->assertEquals(0, $retry->getRetries());
     }

--- a/tests/Redis/PredisConnectorTest.php
+++ b/tests/Redis/PredisConnectorTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Illuminate\Tests\Redis;
+
+use Illuminate\Foundation\Application;
+use Illuminate\Redis\RedisManager;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+class PredisConnectorTest extends TestCase
+{
+    public function testRetryConfigurationWithScalarValues()
+    {
+        $manager = new RedisManager(new Application, 'predis', [
+            'cluster' => false,
+            'default' => [
+                'host' => '127.0.0.1',
+                'port' => 6379,
+                'max_retries' => 5,
+                'backoff_algorithm' => 'exponential',
+                'backoff_base' => 250000,
+                'backoff_cap' => 2000000,
+            ],
+        ]);
+
+        $client = $manager->connection()->client();
+        $parameters = $client->getConnection()->getParameters();
+
+        $retry = $parameters->retry;
+        $this->assertEquals(5, $retry->getRetries());
+        $this->assertEquals(250000, $retry->getStrategy()->getBase());
+        $this->assertEquals(2000000, $retry->getStrategy()->getCap());
+    }
+
+    public function testRetryConfigurationWithExponentialJitter()
+    {
+        $manager = new RedisManager(new Application, 'predis', [
+            'cluster' => false,
+            'default' => [
+                'host' => '127.0.0.1',
+                'port' => 6379,
+                'max_retries' => 3,
+                'backoff_algorithm' => 'exponential_jitter',
+                'backoff_base' => 100000,
+                'backoff_cap' => 500000,
+            ],
+        ]);
+
+        $client = $manager->connection()->client();
+        $parameters = $client->getConnection()->getParameters();
+
+        $retry = $parameters->retry;
+        $this->assertEquals(3, $retry->getRetries());
+        $this->assertEquals(100000, $retry->getStrategy()->getBase());
+        $this->assertEquals(500000, $retry->getStrategy()->getCap());
+    }
+
+    public function testRetryConfigurationWithEqualBackoff()
+    {
+        $manager = new RedisManager(new Application, 'predis', [
+            'cluster' => false,
+            'default' => [
+                'host' => '127.0.0.1',
+                'port' => 6379,
+                'max_retries' => 10,
+                'backoff_algorithm' => 'equal',
+                'backoff_base' => 500000,
+            ],
+        ]);
+
+        $client = $manager->connection()->client();
+        $parameters = $client->getConnection()->getParameters();
+
+        $retry = $parameters->retry;
+        $this->assertEquals(10, $retry->getRetries());
+    }
+
+    public function testRetryConfigurationWithNoneBackoff()
+    {
+        $manager = new RedisManager(new Application, 'predis', [
+            'cluster' => false,
+            'default' => [
+                'host' => '127.0.0.1',
+                'port' => 6379,
+                'max_retries' => 3,
+                'backoff_algorithm' => 'none',
+            ],
+        ]);
+
+        $client = $manager->connection()->client();
+        $parameters = $client->getConnection()->getParameters();
+
+        $retry = $parameters->retry;
+        $this->assertEquals(3, $retry->getRetries());
+    }
+
+    public function testRetryConfigurationDefaultsWhenOnlyRetriesSpecified()
+    {
+        $manager = new RedisManager(new Application, 'predis', [
+            'cluster' => false,
+            'default' => [
+                'host' => '127.0.0.1',
+                'port' => 6379,
+                'max_retries' => 5,
+            ],
+        ]);
+
+        $client = $manager->connection()->client();
+        $parameters = $client->getConnection()->getParameters();
+
+        $retry = $parameters->retry;
+        $this->assertEquals(5, $retry->getRetries());
+    }
+
+    public function testNoRetryConfigurationWhenNotProvided()
+    {
+        $manager = new RedisManager(new Application, 'predis', [
+            'cluster' => false,
+            'default' => [
+                'host' => '127.0.0.1',
+                'port' => 6379,
+            ],
+        ]);
+
+        $client = $manager->connection()->client();
+        $parameters = $client->getConnection()->getParameters();
+
+        // Predis defaults to Retry with NoBackoff and 0 retries
+        $retry = $parameters->retry;
+        $this->assertEquals(0, $retry->getRetries());
+    }
+
+    public function testInvalidBackoffAlgorithmThrowsException()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Algorithm [invalid] is not a valid Predis backoff algorithm');
+
+        $manager = new RedisManager(new Application, 'predis', [
+            'cluster' => false,
+            'default' => [
+                'host' => '127.0.0.1',
+                'port' => 6379,
+                'max_retries' => 3,
+                'backoff_algorithm' => 'invalid',
+            ],
+        ]);
+
+        $manager->connection();
+    }
+}


### PR DESCRIPTION
## Problem

The Predis retry/backoff configuration currently requires instantiating a `Predis\Retry\Retry` object directly in `config/database.php`, which breaks `php artisan config:cache` because the object cannot be serialized via `var_export()`.

```php
// This breaks config:cache:
"retry" => new Retry(new ExponentialBackoff(250000, 2000000), 10),
```

```
LogicException: Your configuration files could not be serialized because the value at
"database.redis.default.retry" is non-serializable.
```

Fixes #60355

## Solution

Updated `PredisConnector` to build the `Retry` instance at runtime from scalar configuration values (`max_retries`, `backoff_algorithm`, `backoff_base`, `backoff_cap`), matching the pattern already used by `PhpRedisConnector`.

These scalar values are already present in the default `config/database.php`:

```php
"max_retries" => env("REDIS_MAX_RETRIES", 3),
"backoff_algorithm" => env("REDIS_BACKOFF_ALGORITHM", "decorrelated_jitter"),
"backoff_base" => env("REDIS_BACKOFF_BASE", 100),
"backoff_cap" => env("REDIS_BACKOFF_CAP", 1000),
```

## Supported Backoff Algorithms

| Algorithm | Description |
|---|---|
| `exponential` | Exponential backoff |
| `exponential_jitter` | Exponential backoff with jitter |
| `equal` | Equal/fixed backoff |
| `none` | No backoff between retries |

## Testing

Added `PredisConnectorTest` with 7 tests covering:
- Exponential backoff configuration
- Exponential with jitter
- Equal backoff
- No backoff
- Defaults when only retries specified
- No retry when not configured
- Invalid algorithm throws exception