### PR TITLE
[13.x] Add make:action command

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -507,6 +507,7 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
             'name' => [
                 'What should the '.strtolower($this->type).' be named?',
                 match ($this->type) {
+                    'Action' => 'E.g. CreateInvoice',
                     'Cast' => 'E.g. Json',
                     'Channel' => 'E.g. OrderChannel',
                     'Console command' => 'E.g. SendEmails',

--- a/src/Illuminate/Foundation/Console/ActionMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ActionMakeCommand.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputOption;
+
+#[AsCommand(name: 'make:action')]
+class ActionMakeCommand extends GeneratorCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'make:action';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new action class';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Action';
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub(): string
+    {
+        return $this->resolveStubPath('/stubs/action.stub');
+    }
+
+    /**
+     * Resolve the fully-qualified path to the stub.
+     *
+     * @param  string  $stub
+     * @return string
+     */
+    protected function resolveStubPath($stub): string
+    {
+        return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
+            ? $customPath
+            : __DIR__.$stub;
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param  string  $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace): string
+    {
+        return $rootNamespace.'\Actions';
+    }
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getOptions(): array
+    {
+        return [
+            ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the action already exists'],
+        ];
+    }
+}

--- a/src/Illuminate/Foundation/Console/stubs/action.stub
+++ b/src/Illuminate/Foundation/Console/stubs/action.stub
@@ -1,0 +1,14 @@
+<?php
+
+namespace {{ namespace }};
+
+class {{ class }}
+{
+    /**
+     * Execute the action.
+     */
+    public function handle(): void
+    {
+        //
+    }
+}

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -31,6 +31,7 @@ use Illuminate\Database\Console\ShowModelCommand;
 use Illuminate\Database\Console\TableCommand as DatabaseTableCommand;
 use Illuminate\Database\Console\WipeCommand;
 use Illuminate\Foundation\Console\AboutCommand;
+use Illuminate\Foundation\Console\ActionMakeCommand;
 use Illuminate\Foundation\Console\ApiInstallCommand;
 use Illuminate\Foundation\Console\BroadcastingInstallCommand;
 use Illuminate\Foundation\Console\CastMakeCommand;
@@ -192,6 +193,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      * @var array
      */
     protected $devCommands = [
+        'ActionMake' => ActionMakeCommand::class,
         'ApiInstall' => ApiInstallCommand::class,
         'BroadcastingInstall' => BroadcastingInstallCommand::class,
         'CacheTable' => CacheTableCommand::class,
@@ -288,6 +290,18 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
     {
         $this->app->singleton(AboutCommand::class, function ($app) {
             return new AboutCommand($app['composer']);
+        });
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerActionMakeCommand(): void
+    {
+        $this->app->singleton(ActionMakeCommand::class, function ($app) {
+            return new ActionMakeCommand($app['files']);
         });
     }
 

--- a/tests/Integration/Generators/ActionMakeCommandTest.php
+++ b/tests/Integration/Generators/ActionMakeCommandTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Generators;
+
+class ActionMakeCommandTest extends TestCase
+{
+    protected $files = [
+        'app/Actions/CreateInvoice.php',
+        'app/Actions/Billing/CreateInvoice.php',
+    ];
+
+    public function testItCanGenerateActionFile(): void
+    {
+        $this->artisan('make:action', ['name' => 'CreateInvoice'])
+            ->assertExitCode(0);
+
+        $this->assertFileContains([
+            'namespace App\Actions;',
+            'class CreateInvoice',
+            'public function handle(): void',
+        ], 'app/Actions/CreateInvoice.php');
+    }
+
+    public function testItCanGenerateNestedActionFile(): void
+    {
+        $this->artisan('make:action', ['name' => 'Billing/CreateInvoice'])
+            ->assertExitCode(0);
+
+        $this->assertFileContains([
+            'namespace App\Actions\Billing;',
+            'class CreateInvoice',
+            'public function handle(): void',
+        ], 'app/Actions/Billing/CreateInvoice.php');
+    }
+}


### PR DESCRIPTION
## Summary

This pull request adds a minimal `make:action` Artisan generator command.

```bash
php artisan make:action CreateInvoice
```

This generates an action class under the application's `App\Actions` namespace:

```php
namespace App\Actions;

class CreateInvoice
{
    public function handle(): void
    {
        //
    }
}
```

Nested action names are also supported:

```bash
php artisan make:action Billing/CreateInvoice
```

which generates:

```php
App\Actions\Billing\CreateInvoice
```

## Motivation

This idea originated from a presentation by Nuno Maduro during the Laravel Greece Meetup on June 11, 2026, where he demonstrated AI-assisted Laravel development and strict engineering practices. During the demonstration, an AI workflow attempted to use a `make:action` command, highlighting how action classes have become a familiar convention within the Laravel ecosystem.

While action classes are commonly used across Laravel applications and packages, Laravel currently does not provide a first-party generator for them.

## Benefit to End Users

Many Laravel applications use action classes to organize single-purpose business operations such as:

* Creating invoices
* Onboarding users
* Synchronizing external services
* Processing domain workflows

Laravel already provides generators for controllers, requests, jobs, events, listeners, mailables, notifications, policies, and other common application building blocks.

This command reduces boilerplate by allowing developers to quickly generate action classes using a familiar Artisan workflow instead of manually creating directories, namespaces, and class structures.

It also provides a consistent experience for developers and AI-assisted workflows that already recognize action classes as a common application pattern.

## Why This Does Not Break Existing Features

This change is fully additive.

* Introduces a new Artisan command only
* Does not modify any existing command behavior
* Does not affect runtime framework behavior
* Does not impact existing applications
* Does not introduce any new dependencies
* Reuses Laravel's existing generator infrastructure and conventions

## Scope

The implementation intentionally remains minimal:

* Generates classes under `App\Actions`
* Provides a simple `handle(): void` method
* Supports nested namespaces
* Follows existing `GeneratorCommand` conventions

No additional options or action-specific features are included.

## Examples

```bash
php artisan make:action CreateUser
```

Generates:

```php
App\Actions\CreateUser
```

```bash
php artisan make:action Billing/CreateInvoice
```

Generates:

```php
App\Actions\Billing\CreateInvoice
```

## Tests

Added tests covering:

* Basic action generation
* Nested namespace generation
* Generated file contents
* Expected file locations
