### PR TITLE
[13.x] Introduce `LazyValue`

### DIFF
--- a/src/Illuminate/Support/LazyValue.php
+++ b/src/Illuminate/Support/LazyValue.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Illuminate\Support;
+
+use Closure;
+use Illuminate\Container\Container;
+use RuntimeException;
+
+/**
+ * @template TReturn of mixed
+ *
+ * @property-read TReturn $value
+ */
+class LazyValue
+{
+    /**
+     * The memoized result of the callback.
+     *
+     * @var TReturn
+     */
+    protected $value;
+
+    /**
+     * Whether the callback has been evaluated.
+     */
+    protected bool $wasEvaluated = false;
+
+    /**
+     * Create the LazyValue instance.
+     *
+     * @param  \Closure(): TReturn  $callback  The function to evaluate lazily.
+     */
+    public function __construct(
+        protected Closure $callback,
+    ) {
+    }
+
+    /**
+     * Execute the callback and memoize the value.
+     *
+     * @return TReturn
+     */
+    protected function evaluate()
+    {
+        $this->value = call_user_func($this->callback);
+        $this->wasEvaluated = true;
+
+        return $this->value;
+    }
+
+    /**
+     * Get the memoized result.
+     *
+     * @return TReturn
+     */
+    public function value()
+    {
+        if ($this->wasEvaluated) {
+            return $this->value;
+        }
+
+        return $this->evaluate();
+    }
+
+    /**
+     * Get the memoized result.
+     *
+     * @return TReturn
+     */
+    public function __invoke()
+    {
+        return $this->value();
+    }
+
+    public function __get($key)
+    {
+        if ($key !== 'value') {
+            throw new RuntimeException('Unable to access undefined property on '.__CLASS__.': '.$key);
+        }
+
+        return $this->value();
+    }
+
+    /**
+     * Create a LazyValue instance that uses the container to inject any dependencies before executing the callback.
+     *
+     * @template TContainerReturn
+     *
+     * @param  callable(): TContainerReturn  $callback
+     * @return static<TContainerReturn>
+     */
+    public static function resolveWithContainer(callable $callback)
+    {
+        return new static(static fn () => Container::getInstance()->call($callback));
+    }
+}

--- a/src/Illuminate/Support/LazyValue.php
+++ b/src/Illuminate/Support/LazyValue.php
@@ -4,12 +4,9 @@ namespace Illuminate\Support;
 
 use Closure;
 use Illuminate\Container\Container;
-use RuntimeException;
 
 /**
  * @template TReturn of mixed
- *
- * @property-read TReturn $value
  */
 class LazyValue
 {
@@ -26,24 +23,37 @@ class LazyValue
     protected bool $wasEvaluated = false;
 
     /**
+     * The function to evaluate lazily.
+     *
+     * @var (Closure(): TReturn)|null
+     */
+    protected ?Closure $callback;
+
+    /**
      * Create the LazyValue instance.
      *
-     * @param  \Closure(): TReturn  $callback  The function to evaluate lazily.
+     * @param  \Closure(): TReturn  $callback
      */
     public function __construct(
-        protected Closure $callback,
+        Closure $callback,
     ) {
+        $this->callback = $callback;
     }
 
     /**
      * Execute the callback and memoize the value.
      *
      * @return TReturn
+     *
+     * @throws \Throwable
      */
     protected function evaluate()
     {
         $this->value = call_user_func($this->callback);
         $this->wasEvaluated = true;
+
+        // Clear the callback to avoid retaining the full closure-scope after evaluation.
+        $this->callback = null;
 
         return $this->value;
     }
@@ -52,6 +62,8 @@ class LazyValue
      * Get the memoized result.
      *
      * @return TReturn
+     *
+     * @throws \Throwable
      */
     public function value()
     {
@@ -66,18 +78,11 @@ class LazyValue
      * Get the memoized result.
      *
      * @return TReturn
+     *
+     * @throws \Throwable
      */
     public function __invoke()
     {
-        return $this->value();
-    }
-
-    public function __get($key)
-    {
-        if ($key !== 'value') {
-            throw new RuntimeException('Unable to access undefined property on '.__CLASS__.': '.$key);
-        }
-
         return $this->value();
     }
 

--- a/src/Illuminate/Support/LazyValue.php
+++ b/src/Illuminate/Support/LazyValue.php
@@ -58,7 +58,7 @@ class LazyValue
     }
 
     /**
-     * Get the memoized result.
+     * Execute the callback if not already evaluated and return the result.
      *
      * @return TReturn
      *
@@ -66,15 +66,11 @@ class LazyValue
      */
     public function value()
     {
-        if ($this->wasEvaluated) {
-            return $this->value;
-        }
-
-        return $this->evaluate();
+        return $this->wasEvaluated ? $this->value : $this->evaluate();
     }
 
     /**
-     * Get the memoized result.
+     * Execute the callback if not already evaluated and return the result.
      *
      * @return TReturn
      *

--- a/src/Illuminate/Support/LazyValue.php
+++ b/src/Illuminate/Support/LazyValue.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Support;
 
 use Closure;
-use Illuminate\Container\Container;
 
 /**
  * @template TReturn of mixed
@@ -84,18 +83,5 @@ class LazyValue
     public function __invoke()
     {
         return $this->value();
-    }
-
-    /**
-     * Create a LazyValue instance that uses the container to inject any dependencies before executing the callback.
-     *
-     * @template TContainerReturn
-     *
-     * @param  callable(): TContainerReturn  $callback
-     * @return static<TContainerReturn>
-     */
-    public static function resolveWithContainer(callable $callback)
-    {
-        return new static(static fn () => Container::getInstance()->call($callback));
     }
 }

--- a/tests/Support/LazyValueTest.php
+++ b/tests/Support/LazyValueTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use Illuminate\Container\Container;
+use Illuminate\Support\LazyValue;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class LazyValueTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Container::setInstance(null);
+
+        parent::tearDown();
+    }
+
+    public function testCallbackIsNotEvaluatedUntilValueIsRequested()
+    {
+        $evaluated = false;
+        $lazyValue = new LazyValue(function () use (&$evaluated) {
+            $evaluated = true;
+
+            return 'Totwell';
+        });
+
+        $this->assertFalse($evaluated);
+        $this->assertSame('Totwell', $lazyValue->value());
+        $this->assertTrue($evaluated);
+    }
+
+    public function testValueIsMemoized()
+    {
+        $count = 0;
+        $lazyValue = new LazyValue(function () use (&$count) {
+            return ++$count;
+        });
+
+        $this->assertSame(1, $lazyValue->value());
+        $this->assertSame(1, $lazyValue->value());
+        $this->assertSame(1, $count);
+    }
+
+    public function testNullValueIsMemoized()
+    {
+        $count = 0;
+        $lazyValue = new LazyValue(function () use (&$count) {
+            $count++;
+
+            return null;
+        });
+
+        $this->assertNull($lazyValue->value());
+        $this->assertNull($lazyValue->value());
+        $this->assertSame(1, $count);
+    }
+
+    public function testValueCanBeResolvedByInvokingInstance()
+    {
+        $count = 0;
+        $lazyValue = new LazyValue(function () use (&$count) {
+            $count++;
+
+            return 'cosmastech';
+        });
+
+        $this->assertSame('cosmastech', $lazyValue());
+        $this->assertSame('cosmastech', $lazyValue());
+        $this->assertSame(1, $count);
+    }
+
+    public function testCallbackIsRetriedAfterException()
+    {
+        $count = 0;
+        $lazyValue = new LazyValue(function () use (&$count) {
+            $count++;
+
+            if ($count === 1) {
+                throw new RuntimeException('Failed resolving lazy value.');
+            }
+
+            return 'Taylor';
+        });
+
+        try {
+            $lazyValue->value();
+
+            $this->fail('Exception was not thrown.');
+        } catch (RuntimeException $e) {
+            $this->assertSame('Failed resolving lazy value.', $e->getMessage());
+        }
+
+        $this->assertSame('Taylor', $lazyValue->value());
+        $this->assertSame(2, $count);
+    }
+}
+
+class LazyValueDependency
+{
+    public function __construct(public string $name)
+    {
+        //
+    }
+}

--- a/tests/Support/LazyValueTest.php
+++ b/tests/Support/LazyValueTest.php
@@ -2,20 +2,12 @@
 
 namespace Illuminate\Tests\Support;
 
-use Illuminate\Container\Container;
 use Illuminate\Support\LazyValue;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
 class LazyValueTest extends TestCase
 {
-    protected function tearDown(): void
-    {
-        Container::setInstance(null);
-
-        parent::tearDown();
-    }
-
     public function testCallbackIsNotEvaluatedUntilValueIsRequested()
     {
         $evaluated = false;

--- a/types/Support/LazyValue.php
+++ b/types/Support/LazyValue.php
@@ -4,7 +4,7 @@ use Illuminate\Support\LazyValue;
 
 use function PHPStan\Testing\assertType;
 
-$myCallback = static fn() => 123;
+$myCallback = static fn () => 123;
 $lazyValue = new LazyValue($myCallback);
 assertType('int', $lazyValue->value());
 assertType('int', $lazyValue->__invoke());

--- a/types/Support/LazyValue.php
+++ b/types/Support/LazyValue.php
@@ -1,0 +1,11 @@
+<?php
+
+use Illuminate\Support\LazyValue;
+
+use function PHPStan\Testing\assertType;
+
+$myCallback = static fn() => 123;
+$lazyValue = new LazyValue($myCallback);
+assertType('int', $lazyValue->value());
+assertType('int', $lazyValue->__invoke());
+assertType('int', $lazyValue());


### PR DESCRIPTION
Adds a simple proxy object for memoizing and lazily executing a callback.

## Why not `once()?`
Onceable computes the value immediately.

## Prior Art
* Nightwatch's `LazyValue` https://github.com/laravel/nightwatch/blob/1.x/src/LazyValue.php
* Laravel Data's `Lazy` https://github.com/spatie/laravel-data/blob/main/src/Lazy.php

## When Would I Want to Use This
Here is a toy example where we have a potentially expensive call to an ML service for determining fraud risk.

```php
class RefundOutcomeDeterminer
{
    public function __construct(
        private OrderData $order,
        /** @var LazyValue<FraudAndRiskEvaluation> */
        private LazyValue $fraudEvaluation
    ) {}

    public function handle()
    {
        if ($this->order->isInternal()) {
            return 'ok';
        }

        if ($this->order->amount > 100_00) {
            return 'flagged:amount';
        }

        if ($this->fraudEvaluation->value()->riskScore >= 60) {
            return 'flagged:risk';
        }

        return 'ok';
    }
}

$orderData = $orderService->retrieve($shopId, 123);
// This shop may not be paying for our premium service, so we may or may not assess risk
$fraudServiceEvaluator = FraudRiskFactory::for($shopId);

$refundOutcomeDeterminer = new RefundOutcomeDeterminer(
    $orderData,
    // This calls our internal ML service
    new LazyValue(static fn () => $fraudServiceEvaluator->getFraudData($shopId, $orderData))
);
```