### PR TITLE
[13.x] Add Str::isEmail() and Str::isIp() methods

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -2150,6 +2150,20 @@ class Str
         return $ulid;
     }
 
+    public static function isEmail(string $value): bool
+    {
+        return filter_var($value, FILTER_VALIDATE_EMAIL) !== false;
+    }
+
+    public static function isIp(string $value, ?string $version = null): bool
+    {
+        return match (strtolower($version ?? '')) {
+            'ipv4' => filter_var($value, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) !== false,
+            'ipv6' => filter_var($value, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== false,
+            default => filter_var($value, FILTER_VALIDATE_IP) !== false,
+        };
+    }
+
     /**
      * Remove all strings from the casing caches.
      *

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1603,6 +1603,16 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
         unset($this->value[$offset]);
     }
 
+    public function isEmail(): bool
+    {
+        return Str::isEmail($this->value);
+    }
+
+    public function isIp(?string $version = null): bool
+    {
+        return Str::isIp($this->value, $version);
+    }
+
     /**
      * Proxy dynamic properties onto methods.
      *

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -2041,22 +2041,22 @@ class SupportStrTest extends TestCase
 
     public function testIsIp()
     {
-    // Test IPV4 addresses
-    $this->assertTrue(Str::isIp('192.168.1.1', 'ipv4'));
-    $this->assertTrue(Str::isIp('255.255.255.255', 'ipv4'));
-    $this->assertTrue(Str::isIp('192.168.1.1'));
-    $this->assertFalse(Str::isIp('2001:0db8:85a3:0000:0000:8a2e:0370:7334', 'ipv4'));
-    $this->assertFalse(Str::isIp('invalid-ipv4', 'ipv4'));
+        // Test IPV4 addresses
+        $this->assertTrue(Str::isIp('192.168.1.1', 'ipv4'));
+        $this->assertTrue(Str::isIp('255.255.255.255', 'ipv4'));
+        $this->assertTrue(Str::isIp('192.168.1.1'));
+        $this->assertFalse(Str::isIp('2001:0db8:85a3:0000:0000:8a2e:0370:7334', 'ipv4'));
+        $this->assertFalse(Str::isIp('invalid-ipv4', 'ipv4'));
+        $this->assertTrue(Str::isIp('127.0.0.1', 'IPV4'));
+        $this->assertTrue(Str::isIp('127.0.0.1'));
 
-    // Test IPV6 addresses
-    $this->assertTrue(Str::isIp('2001:0db8:85a3:0000:0000:8a2e:0370:7334'));
-    $this->assertTrue(Str::isIp('2001:0db8:85a3:0000:0000:8a2e:0370:7334', 'ipv6'));
-    $this->assertFalse(Str::isIp('invalid-ipv6', 'ipv6'));
-    $this->assertFalse(Str::isIp('192.168.1.1', 'ipv6'));
+        // Test IPV6 addresses
+        $this->assertTrue(Str::isIp('2001:0db8:85a3:0000:0000:8a2e:0370:7334'));
+        $this->assertTrue(Str::isIp('2001:0db8:85a3:0000:0000:8a2e:0370:7334', 'ipv6'));
+        $this->assertFalse(Str::isIp('invalid-ipv6', 'ipv6'));
+        $this->assertFalse(Str::isIp('192.168.1.1', 'ipv6'));
+        $this->assertTrue(Str::isIp('::1'));
+        $this->assertTrue(Str::isIp('::1', 'ipv6'));
 
-    $this->assertTrue(Str::isIp('127.0.0.1'));
-    $this->assertTrue(Str::isIp('::1'));
-    $this->assertTrue(Str::isIp('::1', 'ipv6'));
-    $this->assertTrue(Str::isIp('127.0.0.1', 'IPV4'));
-}
+    }
 }

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -2030,4 +2030,33 @@ class SupportStrTest extends TestCase
 
         $this->assertSame('UserGroups', Str::pluralPascal('UserGroup', $countable));
     }
+
+    public function testIsEmail()
+    {
+        $this->assertTrue(Str::isEmail('test@example.com'));
+        $this->assertTrue(Str::isEmail('john.doe+test@example.com'));
+        $this->assertTrue(Str::isEmail('test@sub.example.com'));
+        $this->assertFalse(Str::isEmail('invalid-email'));
+    }
+
+    public function testIsIp()
+    {
+    // Test IPV4 addresses
+    $this->assertTrue(Str::isIp('192.168.1.1', 'ipv4'));
+    $this->assertTrue(Str::isIp('255.255.255.255', 'ipv4'));
+    $this->assertTrue(Str::isIp('192.168.1.1'));
+    $this->assertFalse(Str::isIp('2001:0db8:85a3:0000:0000:8a2e:0370:7334', 'ipv4'));
+    $this->assertFalse(Str::isIp('invalid-ipv4', 'ipv4'));
+
+    // Test IPV6 addresses
+    $this->assertTrue(Str::isIp('2001:0db8:85a3:0000:0000:8a2e:0370:7334'));
+    $this->assertTrue(Str::isIp('2001:0db8:85a3:0000:0000:8a2e:0370:7334', 'ipv6'));
+    $this->assertFalse(Str::isIp('invalid-ipv6', 'ipv6'));
+    $this->assertFalse(Str::isIp('192.168.1.1', 'ipv6'));
+
+    $this->assertTrue(Str::isIp('127.0.0.1'));
+    $this->assertTrue(Str::isIp('::1'));
+    $this->assertTrue(Str::isIp('::1', 'ipv6'));
+    $this->assertTrue(Str::isIp('127.0.0.1', 'IPV4'));
+}
 }

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -2057,6 +2057,5 @@ class SupportStrTest extends TestCase
         $this->assertFalse(Str::isIp('192.168.1.1', 'ipv6'));
         $this->assertTrue(Str::isIp('::1'));
         $this->assertTrue(Str::isIp('::1', 'ipv6'));
-
     }
 }

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -1601,4 +1601,22 @@ class SupportStringableTest extends TestCase
         $this->assertNotSame('foo', $encrypted->value());
         $this->assertSame('foo', $encrypted->decrypt()->value());
     }
+
+    public function testIsEmail()
+    {
+        $this->assertTrue($this->stringable('user@example.com')->isEmail());
+        $this->assertFalse($this->stringable('invalid-email')->isEmail());
+    }
+
+    public function testIsIp()
+    {
+        $this->assertTrue($this->stringable('192.168.1.1')->isIp());
+        $this->assertTrue($this->stringable('192.168.1.1')->isIp('ipv4'));
+        $this->assertFalse($this->stringable('2001:0db8:85a3:0000:0000:8a2e:0370:7334')->isIp('ipv4'));
+        $this->assertFalse($this->stringable('invalid-ipv4')->isIp('ipv4'));
+
+        $this->assertTrue($this->stringable('2001:0db8:85a3:0000:0000:8a2e:0370:7334')->isIp('ipv6'));
+        $this->assertFalse($this->stringable('192.168.1.1')->isIp('ipv6'));
+        $this->assertFalse($this->stringable('invalid-ipv6')->isIp('ipv6'));
+    }
 }


### PR DESCRIPTION
This PR adds two new string inspection methods to `Illuminate\Support\Str` and their corresponding `Stringable` counterparts:

* `Str::isEmail(string $value): bool`
* `Str::isIp(string $value, ?string $version = null): bool`

The `isIp` method supports validating any IP address, or restricting validation to IPv4 or IPv6 addresses.

### Examples

```php
Str::isEmail('user@example.com');

Str::isIp('192.168.1.1');
Str::isIp('192.168.1.1', 'ipv4');

Str::isIp('2001:db8::1');
Str::isIp('2001:db8::1', 'ipv6');

str('user@example.com')->isEmail();
str('192.168.1.1')->isIp();
```

### Why?

Laravel already provides several string inspection helpers such as `Str::isAscii()`, `Str::isJson()`, `Str::isUrl()`, `Str::isUuid()`, and `Str::isUlid()`.

Email addresses and IP addresses are also common string formats that developers frequently need to identify when working with user input, configuration values, integrations, logging, and general string processing. These methods provide a consistent and expressive API for those checks without requiring direct use of `filter_var()`.

### Benefits

* Provides a more discoverable and expressive API for common email and IP checks.
* Aligns with Laravel's existing family of string inspection helpers.
* Supports both static (`Str`) and fluent (`Stringable`) usage.
* Supports IPv4 and IPv6 specific validation when needed.

### Backward Compatibility

This change is fully backward compatible. It only adds new methods and does not modify any existing functionality or behavior.

### Tests

Tests have been added for both `Str` and `Stringable`, covering:

* Valid and invalid email addresses
* Valid and invalid IP addresses
* IPv4-specific validation
* IPv6-specific validation
* Invalid values for each IP version
* Fluent `Stringable` usage
