### PR TITLE
Improve return types for the remaining callback-passthrough helpers

### DIFF
--- a/src/Illuminate/Bus/DatabaseBatchRepository.php
+++ b/src/Illuminate/Bus/DatabaseBatchRepository.php
@@ -304,8 +304,10 @@ class DatabaseBatchRepository implements PrunableBatchRepository
     /**
      * Execute the given Closure within a storage specific transaction.
      *
-     * @param  \Closure  $callback
-     * @return mixed
+     * @template TReturn
+     *
+     * @param  (\Closure(): TReturn)  $callback
+     * @return TReturn
      */
     public function transaction(Closure $callback)
     {

--- a/src/Illuminate/Bus/DynamoBatchRepository.php
+++ b/src/Illuminate/Bus/DynamoBatchRepository.php
@@ -377,8 +377,10 @@ class DynamoBatchRepository implements BatchRepository
     /**
      * Execute the given Closure within a storage specific transaction.
      *
-     * @param  \Closure  $callback
-     * @return mixed
+     * @template TReturn
+     *
+     * @param  (\Closure(): TReturn)  $callback
+     * @return TReturn
      */
     public function transaction(Closure $callback)
     {

--- a/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
@@ -206,7 +206,10 @@ trait HasTimestamps
     /**
      * Disable timestamps for the current class during the given callback scope.
      *
-     * @return mixed
+     * @template TReturn
+     *
+     * @param  (callable(): TReturn)  $callback
+     * @return TReturn
      */
     public static function withoutTimestamps(callable $callback)
     {

--- a/src/Illuminate/Database/SqlServerConnection.php
+++ b/src/Illuminate/Database/SqlServerConnection.php
@@ -25,9 +25,11 @@ class SqlServerConnection extends Connection
     /**
      * Execute a Closure within a transaction.
      *
-     * @param  \Closure  $callback
+     * @template TReturn
+     *
+     * @param  (\Closure(static): TReturn)  $callback
      * @param  int  $attempts
-     * @return mixed
+     * @return TReturn
      *
      * @throws \Throwable
      */

--- a/src/Illuminate/Support/Testing/Fakes/BatchRepositoryFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BatchRepositoryFake.php
@@ -144,8 +144,10 @@ class BatchRepositoryFake implements BatchRepository
     /**
      * Execute the given Closure within a storage specific transaction.
      *
-     * @param  \Closure  $callback
-     * @return mixed
+     * @template TReturn
+     *
+     * @param  (\Closure(): TReturn)  $callback
+     * @return TReturn
      */
     public function transaction(Closure $callback)
     {

--- a/types/Bus/DatabaseBatchRepository.php
+++ b/types/Bus/DatabaseBatchRepository.php
@@ -1,0 +1,10 @@
+<?php
+
+use Illuminate\Bus\DatabaseBatchRepository;
+
+use function PHPStan\Testing\assertType;
+
+/** @var DatabaseBatchRepository $repository */
+$repository = resolve(DatabaseBatchRepository::class);
+
+assertType("'foo'", $repository->transaction(fn () => 'foo'));

--- a/types/Bus/DynamoBatchRepository.php
+++ b/types/Bus/DynamoBatchRepository.php
@@ -1,0 +1,10 @@
+<?php
+
+use Illuminate\Bus\DynamoBatchRepository;
+
+use function PHPStan\Testing\assertType;
+
+/** @var DynamoBatchRepository $repository */
+$repository = resolve(DynamoBatchRepository::class);
+
+assertType("'foo'", $repository->transaction(fn () => 'foo'));

--- a/types/Database/Eloquent/Model.php
+++ b/types/Database/Eloquent/Model.php
@@ -53,6 +53,7 @@ function test(User $user, Post $post, Comment $comment, Article $article): void
     assertType("'foo'", User::withoutEvents(fn () => 'foo'));
     assertType("'foo'", User::withoutBroadcasting(fn () => 'foo'));
     assertType("'foo'", User::withoutTimestampsOn([], fn () => 'foo'));
+    assertType("'foo'", User::withoutTimestamps(fn () => 'foo'));
 }
 
 class Post extends Model

--- a/types/Database/SqlServerConnection.php
+++ b/types/Database/SqlServerConnection.php
@@ -1,0 +1,10 @@
+<?php
+
+use Illuminate\Database\SqlServerConnection;
+
+use function PHPStan\Testing\assertType;
+
+/** @var SqlServerConnection $connection */
+$connection = resolve(SqlServerConnection::class);
+
+assertType("'foo'", $connection->transaction(fn () => 'foo'));

--- a/types/Support/Testing/Fakes/BatchRepositoryFake.php
+++ b/types/Support/Testing/Fakes/BatchRepositoryFake.php
@@ -1,0 +1,10 @@
+<?php
+
+use Illuminate\Support\Testing\Fakes\BatchRepositoryFake;
+
+use function PHPStan\Testing\assertType;
+
+/** @var BatchRepositoryFake $repository */
+$repository = resolve(BatchRepositoryFake::class);
+
+assertType("'foo'", $repository->transaction(fn () => 'foo'));


### PR DESCRIPTION
Applies `@template TReturn` to the remaining callback-passthrough helpers that still returned `mixed`. Since each method simply invokes the provided callback and returns its result, the return type can be inferred from the callback instead of being widened to `mixed`.

Methods updated:                                                                                                                                                                                                                                                                                                                                    
  - `Bus\DatabaseBatchRepository::transaction()`                                                                                                                         
  - `Bus\DynamoBatchRepository::transaction()`                                                                                                                                
  - `Support\Testing\Fakes\BatchRepositoryFake::transaction()`                                                                                                                
  - `Database\SqlServerConnection::transaction()`                                                                                                                             
  - `Database\Eloquent\Concerns\HasTimestamps::withoutTimestamps()`                                                                                                           
                                                                                                                                                                            
  These are docblock/generic-only changes with no behavioral impact. Type                                                                                                   
  assertions are added under types/ to cover the inferred return types.
  
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
