### PR TITLE
Support "ShouldntRetry" on exceptions to prevent a job from retrying

### DIFF
--- a/src/Illuminate/Contracts/Queue/ShouldntRetry.php
+++ b/src/Illuminate/Contracts/Queue/ShouldntRetry.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Contracts\Queue;
+
+interface ShouldntRetry
+{
+    //
+}

--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -317,6 +317,16 @@ abstract class Job
     }
 
     /**
+     * Determine if the job should skip its remaining retries and fail immediately on exception.
+     *
+     * @return bool
+     */
+    public function shouldntRetry()
+    {
+        return $this->payload()['shouldntRetry'] ?? false;
+    }
+
+    /**
      * The number of seconds to wait before retrying a job that encountered an uncaught exception.
      *
      * @return int|int[]|null

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -11,6 +11,7 @@ use Illuminate\Contracts\Cache\Repository as Cache;
 use Illuminate\Contracts\Encryption\Encrypter;
 use Illuminate\Contracts\Queue\ShouldBeEncrypted;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Contracts\Queue\ShouldntRetry;
 use Illuminate\Contracts\Queue\ShouldQueueAfterCommit;
 use Illuminate\Queue\Attributes\Backoff;
 use Illuminate\Queue\Attributes\DeleteWhenMissingModels;
@@ -179,6 +180,7 @@ abstract class Queue
             'backoff' => $this->getJobBackoff($job),
             'timeout' => $this->getAttributeValue($job, Timeout::class, 'timeout'),
             'retryUntil' => $this->getJobExpiration($job),
+            'shouldntRetry' => $this->jobShouldntRetry($job),
             'deleteWhenMissingModels' => $this->getAttributeValue($job, DeleteWhenMissingModels::class, 'deleteWhenMissingModels') ?? false,
             'data' => [
                 'commandName' => $job,
@@ -296,6 +298,21 @@ abstract class Queue
     }
 
     /**
+     * Determine if the job should skip its remaining retries and fail immediately on exception.
+     *
+     * @param  object  $job
+     * @return bool
+     */
+    protected function jobShouldntRetry($job)
+    {
+        if ($job instanceof ShouldntRetry) {
+            return true;
+        }
+
+        return isset($job->shouldntRetry) && $job->shouldntRetry;
+    }
+
+    /**
      * Create a typical, string based queue payload array.
      *
      * @param  string  $job
@@ -312,6 +329,7 @@ abstract class Queue
             'maxTries' => null,
             'maxExceptions' => null,
             'failOnTimeout' => false,
+            'shouldntRetry' => false,
             'backoff' => null,
             'timeout' => null,
             'data' => $data,

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -578,10 +578,11 @@ class Worker
     protected function handleJobException($connectionName, $job, WorkerOptions $options, Throwable $e)
     {
         try {
-            // First, we will go ahead and mark the job as failed if it will exceed the maximum
-            // attempts it is allowed to run the next time we process it. If so we will just
-            // go ahead and mark it as failed now so we do not have to release this again.
             if (! $job->hasFailed()) {
+                $this->markJobAsFailedIfShouldntRetry(
+                    $connectionName, $job, $e
+                );
+
                 $this->markJobAsFailedIfWillExceedMaxAttempts(
                     $connectionName, $job, (int) $options->maxTries, $e
                 );
@@ -687,6 +688,21 @@ class Worker
         if ($maxExceptions <= $this->cache->increment('job-exceptions:'.$uuid)) {
             $this->cache->forget('job-exceptions:'.$uuid);
 
+            $this->failJob($job, $e);
+        }
+    }
+
+    /**
+     * Mark the given job as failed if it should skip its remaining retries.
+     *
+     * @param  string  $connectionName
+     * @param  \Illuminate\Contracts\Queue\Job  $job
+     * @param  \Throwable  $e
+     * @return void
+     */
+    protected function markJobAsFailedIfShouldntRetry($connectionName, $job, Throwable $e)
+    {
+        if (method_exists($job, 'shouldntRetry') ? $job->shouldntRetry() : false) {
             $this->failJob($job, $e);
         }
     }

--- a/tests/Integration/Queue/ShouldntRetryTest.php
+++ b/tests/Integration/Queue/ShouldntRetryTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Queue;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldntRetry;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Support\Facades\DB;
+use Orchestra\Testbench\Attributes\WithMigration;
+
+#[WithMigration]
+#[WithMigration('queue')]
+class ShouldntRetryTest extends QueueTestCase
+{
+    protected function defineEnvironment($app)
+    {
+        parent::defineEnvironment($app);
+
+        $app['config']->set('queue.default', 'database');
+        $this->driver = 'database';
+    }
+
+    #[\Override]
+    protected function tearDown(): void
+    {
+        ShouldntRetryTestJob::$attempts = 0;
+        RetryableTestJob::$attempts = 0;
+
+        parent::tearDown();
+    }
+
+    public function testJobImplementingShouldntRetryFailsImmediatelyWithoutBeingReleased()
+    {
+        ShouldntRetryTestJob::dispatch();
+
+        // The job is given three tries, but it should fail on the first attempt and
+        // skip the remaining retries because it implements the ShouldntRetry contract.
+        $this->runQueueWorkerCommand(['--once' => true, '--tries' => 3]);
+
+        $this->assertSame(1, ShouldntRetryTestJob::$attempts);
+        $this->assertNull(DB::table('jobs')->first());
+        $this->assertNotNull(DB::table('failed_jobs')->first());
+    }
+
+    public function testJobWithoutShouldntRetryIsReleasedBackOntoTheQueue()
+    {
+        RetryableTestJob::dispatch();
+
+        $this->runQueueWorkerCommand(['--once' => true, '--tries' => 3]);
+
+        $this->assertSame(1, RetryableTestJob::$attempts);
+        $this->assertNotNull(DB::table('jobs')->first());
+        $this->assertNull(DB::table('failed_jobs')->first());
+    }
+}
+
+class ShouldntRetryTestJob implements ShouldQueue, ShouldntRetry
+{
+    use Dispatchable, InteractsWithQueue, Queueable;
+
+    public static int $attempts = 0;
+
+    public function handle()
+    {
+        static::$attempts++;
+
+        throw new \RuntimeException('Job failed.');
+    }
+}
+
+class RetryableTestJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable;
+
+    public static int $attempts = 0;
+
+    public function handle()
+    {
+        static::$attempts++;
+
+        throw new \RuntimeException('Job failed.');
+    }
+}

--- a/tests/Queue/QueueBeanstalkdQueueTest.php
+++ b/tests/Queue/QueueBeanstalkdQueueTest.php
@@ -45,7 +45,7 @@ class QueueBeanstalkdQueueTest extends TestCase
         $pheanstalk = $this->queue->getPheanstalk();
         $pheanstalk->shouldReceive('useTube')->once()->with(m::type(TubeName::class));
         $pheanstalk->shouldReceive('useTube')->once()->with(m::type(TubeName::class));
-        $pheanstalk->shouldReceive('put')->twice()->with(json_encode(['uuid' => $uuid, 'displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'maxExceptions' => null, 'failOnTimeout' => false, 'backoff' => null, 'timeout' => null, 'data' => ['data'], 'createdAt' => $time->getTimestamp(), 'delay' => null]), 1024, 0, 60);
+        $pheanstalk->shouldReceive('put')->twice()->with(json_encode(['uuid' => $uuid, 'displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'maxExceptions' => null, 'failOnTimeout' => false, 'shouldntRetry' => false, 'backoff' => null, 'timeout' => null, 'data' => ['data'], 'createdAt' => $time->getTimestamp(), 'delay' => null]), 1024, 0, 60);
 
         $this->queue->push('foo', ['data'], 'stack');
         $this->queue->push('foo', ['data']);
@@ -71,7 +71,7 @@ class QueueBeanstalkdQueueTest extends TestCase
         $pheanstalk = $this->queue->getPheanstalk();
         $pheanstalk->shouldReceive('useTube')->once()->with(m::type(TubeName::class));
         $pheanstalk->shouldReceive('useTube')->once()->with(m::type(TubeName::class));
-        $pheanstalk->shouldReceive('put')->twice()->with(json_encode(['uuid' => $uuid, 'displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'maxExceptions' => null, 'failOnTimeout' => false, 'backoff' => null, 'timeout' => null, 'data' => ['data'], 'createdAt' => $time->getTimestamp(), 'delay' => 5]), Pheanstalk::DEFAULT_PRIORITY, 5, Pheanstalk::DEFAULT_TTR);
+        $pheanstalk->shouldReceive('put')->twice()->with(json_encode(['uuid' => $uuid, 'displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'maxExceptions' => null, 'failOnTimeout' => false, 'shouldntRetry' => false, 'backoff' => null, 'timeout' => null, 'data' => ['data'], 'createdAt' => $time->getTimestamp(), 'delay' => 5]), Pheanstalk::DEFAULT_PRIORITY, 5, Pheanstalk::DEFAULT_TTR);
 
         $this->queue->later(5, 'foo', ['data'], 'stack');
         $this->queue->later(5, 'foo', ['data']);

--- a/tests/Queue/QueueDatabaseQueueUnitTest.php
+++ b/tests/Queue/QueueDatabaseQueueUnitTest.php
@@ -85,7 +85,7 @@ class QueueDatabaseQueueUnitTest extends TestCase
         $database->shouldReceive('table')->with('table')->andReturn($query = m::mock(stdClass::class));
         $query->shouldReceive('insertGetId')->once()->andReturnUsing(function ($array) use ($uuid, $time) {
             $this->assertSame('default', $array['queue']);
-            $this->assertSame(json_encode(['uuid' => $uuid, 'displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'maxExceptions' => null, 'failOnTimeout' => false, 'backoff' => null, 'timeout' => null, 'data' => ['data'], 'createdAt' => $time->getTimestamp(), 'delay' => 10]), $array['payload']);
+            $this->assertSame(json_encode(['uuid' => $uuid, 'displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'maxExceptions' => null, 'failOnTimeout' => false, 'shouldntRetry' => false, 'backoff' => null, 'timeout' => null, 'data' => ['data'], 'createdAt' => $time->getTimestamp(), 'delay' => 10]), $array['payload']);
             $this->assertEquals(0, $array['attempts']);
             $this->assertNull($array['reserved_at']);
             $this->assertIsInt($array['available_at']);
@@ -215,14 +215,14 @@ class QueueDatabaseQueueUnitTest extends TestCase
         $query->shouldReceive('insert')->once()->andReturnUsing(function ($records) use ($uuid, $time) {
             $this->assertEquals([[
                 'queue' => 'queue',
-                'payload' => json_encode(['uuid' => $uuid, 'displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'maxExceptions' => null, 'failOnTimeout' => false, 'backoff' => null, 'timeout' => null, 'data' => ['data'], 'createdAt' => $time->getTimestamp(), 'delay' => null]),
+                'payload' => json_encode(['uuid' => $uuid, 'displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'maxExceptions' => null, 'failOnTimeout' => false, 'shouldntRetry' => false, 'backoff' => null, 'timeout' => null, 'data' => ['data'], 'createdAt' => $time->getTimestamp(), 'delay' => null]),
                 'attempts' => 0,
                 'reserved_at' => null,
                 'available_at' => 'available',
                 'created_at' => 'created',
             ], [
                 'queue' => 'queue',
-                'payload' => json_encode(['uuid' => $uuid, 'displayName' => 'bar', 'job' => 'bar', 'maxTries' => null, 'maxExceptions' => null, 'failOnTimeout' => false, 'backoff' => null, 'timeout' => null, 'data' => ['data'], 'createdAt' => $time->getTimestamp(), 'delay' => null]),
+                'payload' => json_encode(['uuid' => $uuid, 'displayName' => 'bar', 'job' => 'bar', 'maxTries' => null, 'maxExceptions' => null, 'failOnTimeout' => false, 'shouldntRetry' => false, 'backoff' => null, 'timeout' => null, 'data' => ['data'], 'createdAt' => $time->getTimestamp(), 'delay' => null]),
                 'attempts' => 0,
                 'reserved_at' => null,
                 'available_at' => 'available',

--- a/tests/Queue/QueueRedisQueueTest.php
+++ b/tests/Queue/QueueRedisQueueTest.php
@@ -32,7 +32,7 @@ class QueueRedisQueueTest extends TestCase
         $queue->setContainer($container = m::spy(Container::class));
         $redis->shouldReceive('connection')->atLeast()->once()->andReturn($redis);
         $redis->shouldReceive('isCluster')->andReturn(false);
-        $redis->shouldReceive('eval')->once()->with(LuaScripts::push(), 2, 'queues:default', 'queues:default:notify', json_encode(['uuid' => $uuid, 'displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'maxExceptions' => null, 'failOnTimeout' => false, 'backoff' => null, 'timeout' => null, 'data' => ['data'], 'createdAt' => $time->getTimestamp(), 'id' => 'foo', 'attempts' => 0, 'delay' => null]));
+        $redis->shouldReceive('eval')->once()->with(LuaScripts::push(), 2, 'queues:default', 'queues:default:notify', json_encode(['uuid' => $uuid, 'displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'maxExceptions' => null, 'failOnTimeout' => false, 'shouldntRetry' => false, 'backoff' => null, 'timeout' => null, 'data' => ['data'], 'createdAt' => $time->getTimestamp(), 'id' => 'foo', 'attempts' => 0, 'delay' => null]));
 
         $id = $queue->push('foo', ['data']);
         $this->assertSame('foo', $id);
@@ -58,7 +58,7 @@ class QueueRedisQueueTest extends TestCase
         $queue->setContainer($container = m::spy(Container::class));
         $redis->shouldReceive('connection')->atLeast()->once()->andReturn($redis);
         $redis->shouldReceive('isCluster')->andReturn(false);
-        $redis->shouldReceive('eval')->once()->with(LuaScripts::push(), 2, 'queues:default', 'queues:default:notify', json_encode(['uuid' => $uuid, 'displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'maxExceptions' => null, 'failOnTimeout' => false, 'backoff' => null, 'timeout' => null, 'data' => ['data'], 'createdAt' => $time->getTimestamp(), 'custom' => 'taylor', 'id' => 'foo', 'attempts' => 0, 'delay' => null]));
+        $redis->shouldReceive('eval')->once()->with(LuaScripts::push(), 2, 'queues:default', 'queues:default:notify', json_encode(['uuid' => $uuid, 'displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'maxExceptions' => null, 'failOnTimeout' => false, 'shouldntRetry' => false, 'backoff' => null, 'timeout' => null, 'data' => ['data'], 'createdAt' => $time->getTimestamp(), 'custom' => 'taylor', 'id' => 'foo', 'attempts' => 0, 'delay' => null]));
 
         Queue::createPayloadUsing(function ($connection, $queue, $payload) {
             return ['custom' => 'taylor'];
@@ -90,7 +90,7 @@ class QueueRedisQueueTest extends TestCase
         $queue->setContainer($container = m::spy(Container::class));
         $redis->shouldReceive('connection')->atLeast()->once()->andReturn($redis);
         $redis->shouldReceive('isCluster')->andReturn(false);
-        $redis->shouldReceive('eval')->once()->with(LuaScripts::push(), 2, 'queues:default', 'queues:default:notify', json_encode(['uuid' => $uuid, 'displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'maxExceptions' => null, 'failOnTimeout' => false, 'backoff' => null, 'timeout' => null, 'data' => ['data'], 'createdAt' => $time->getTimestamp(), 'custom' => 'taylor', 'bar' => 'foo', 'id' => 'foo', 'attempts' => 0, 'delay' => null]));
+        $redis->shouldReceive('eval')->once()->with(LuaScripts::push(), 2, 'queues:default', 'queues:default:notify', json_encode(['uuid' => $uuid, 'displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'maxExceptions' => null, 'failOnTimeout' => false, 'shouldntRetry' => false, 'backoff' => null, 'timeout' => null, 'data' => ['data'], 'createdAt' => $time->getTimestamp(), 'custom' => 'taylor', 'bar' => 'foo', 'id' => 'foo', 'attempts' => 0, 'delay' => null]));
 
         Queue::createPayloadUsing(function ($connection, $queue, $payload) {
             return ['custom' => 'taylor'];
@@ -133,7 +133,7 @@ class QueueRedisQueueTest extends TestCase
             1,
             'queues:default:delayed',
             2,
-            json_encode(['uuid' => $uuid, 'displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'maxExceptions' => null, 'failOnTimeout' => false, 'backoff' => null, 'timeout' => null, 'data' => ['data'], 'createdAt' => $time->getTimestamp(), 'id' => 'foo', 'attempts' => 0, 'delay' => 1])
+            json_encode(['uuid' => $uuid, 'displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'maxExceptions' => null, 'failOnTimeout' => false, 'shouldntRetry' => false, 'backoff' => null, 'timeout' => null, 'data' => ['data'], 'createdAt' => $time->getTimestamp(), 'id' => 'foo', 'attempts' => 0, 'delay' => 1])
         );
 
         $id = $queue->later(1, 'foo', ['data']);
@@ -166,7 +166,7 @@ class QueueRedisQueueTest extends TestCase
             1,
             'queues:default:delayed',
             5,
-            json_encode(['uuid' => $uuid, 'displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'maxExceptions' => null, 'failOnTimeout' => false, 'backoff' => null, 'timeout' => null, 'data' => ['data'], 'createdAt' => $time->getTimestamp(), 'id' => 'foo', 'attempts' => 0, 'delay' => 5])
+            json_encode(['uuid' => $uuid, 'displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'maxExceptions' => null, 'failOnTimeout' => false, 'shouldntRetry' => false, 'backoff' => null, 'timeout' => null, 'data' => ['data'], 'createdAt' => $time->getTimestamp(), 'id' => 'foo', 'attempts' => 0, 'delay' => 5])
         );
 
         $queue->later($date->addSeconds(5), 'foo', ['data']);

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -248,6 +248,57 @@ class QueueWorkerTest extends TestCase
         $this->events->shouldNotHaveReceived('dispatch', [m::type(JobProcessed::class)]);
     }
 
+    public function testJobIsFailedWithoutRetryingWhenItShouldntRetry()
+    {
+        $e = new RuntimeException;
+
+        $job = new WorkerFakeJob(function ($job) use ($e) {
+            // In normal use this would be incremented by being popped off the queue
+            $job->attempts++;
+
+            throw $e;
+        });
+
+        // The job has plenty of attempts remaining, but it should still fail immediately.
+        $job->shouldntRetry = true;
+        $job->attempts = 0;
+
+        $worker = $this->getWorker('default', ['queue' => [$job]]);
+        $worker->runNextJob('default', 'queue', $this->workerOptions(['maxTries' => 3]));
+
+        $this->assertNull($job->releaseAfter);
+        $this->assertFalse($job->released);
+        $this->assertTrue($job->deleted);
+        $this->assertEquals($e, $job->failedWith);
+        $this->exceptionHandler->shouldHaveReceived('report')->with($e);
+        $this->events->shouldHaveReceived('dispatch')->with(m::type(JobExceptionOccurred::class))->once();
+        $this->events->shouldNotHaveReceived('dispatch', [m::type(JobProcessed::class)]);
+    }
+
+    public function testJobIsReleasedOnExceptionWhenItShouldRetry()
+    {
+        $e = new RuntimeException;
+
+        $job = new WorkerFakeJob(function ($job) use ($e) {
+            $job->attempts++;
+
+            throw $e;
+        });
+
+        $job->shouldntRetry = false;
+        $job->attempts = 0;
+
+        $worker = $this->getWorker('default', ['queue' => [$job]]);
+        $worker->runNextJob('default', 'queue', $this->workerOptions(['maxTries' => 3, 'backoff' => 10]));
+
+        $this->assertEquals(10, $job->releaseAfter);
+        $this->assertTrue($job->released);
+        $this->assertFalse($job->deleted);
+        $this->assertNull($job->failedWith);
+        $this->exceptionHandler->shouldHaveReceived('report')->with($e);
+        $this->events->shouldHaveReceived('dispatch')->with(m::type(JobExceptionOccurred::class))->once();
+    }
+
     public function testExceptionIsNotReportedIfReportJobExceptionsIsDisabled()
     {
         $e = new RuntimeException;
@@ -779,6 +830,7 @@ class WorkerFakeJob implements QueueJobContract
     public $maxTries;
     public $maxExceptions;
     public $shouldFailOnTimeout = false;
+    public $shouldntRetry = false;
     public $uuid;
     public $backoff;
     public $retryUntil;
@@ -826,6 +878,11 @@ class WorkerFakeJob implements QueueJobContract
     public function shouldFailOnTimeout()
     {
         return $this->shouldFailOnTimeout;
+    }
+
+    public function shouldntRetry()
+    {
+        return $this->shouldntRetry;
     }
 
     public function uuid()


### PR DESCRIPTION
Adding a `ShouldntRetry` contract to a Job, it will mean that a job can explicitly fail and not have the retries on a job keep retrying.

This is useful for situations where an exception is not recoverable, so retrying multiple times is pointless.