### PR TITLE
[13.x] Add `withCookies` method to `ResponseTrait`

### DIFF
--- a/src/Illuminate/Http/RedirectResponse.php
+++ b/src/Illuminate/Http/RedirectResponse.php
@@ -52,21 +52,6 @@ class RedirectResponse extends BaseRedirectResponse
     }
 
     /**
-     * Add multiple cookies to the response.
-     *
-     * @param  array  $cookies
-     * @return $this
-     */
-    public function withCookies(array $cookies)
-    {
-        foreach ($cookies as $cookie) {
-            $this->headers->setCookie($cookie);
-        }
-
-        return $this;
-    }
-
-    /**
      * Flash an array of input to the session.
      *
      * @param  array|null  $input

--- a/src/Illuminate/Http/ResponseTrait.php
+++ b/src/Illuminate/Http/ResponseTrait.php
@@ -142,6 +142,21 @@ trait ResponseTrait
     }
 
     /**
+     * Add multiple cookies to the response.
+     *
+     * @param  array  $cookies
+     * @return $this
+     */
+    public function withCookies(array $cookies)
+    {
+        foreach ($cookies as $cookie) {
+            $this->headers->setCookie($cookie);
+        }
+
+        return $this;
+    }
+
+    /**
      * Expire a cookie when sending the response.
      *
      * @param  \Symfony\Component\HttpFoundation\Cookie|mixed  $cookie

--- a/tests/Http/HttpResponseTest.php
+++ b/tests/Http/HttpResponseTest.php
@@ -85,6 +85,22 @@ class HttpResponseTest extends TestCase
         $this->assertSame('bar', $cookies[0]->getValue());
     }
 
+    public function testWithCookies()
+    {
+        $response = new Response;
+        $this->assertCount(0, $response->headers->getCookies());
+        $this->assertEquals($response, $response->withCookies([
+            new Cookie('foo', 'bar'),
+            new Cookie('baz', 'qux'),
+        ]));
+        $cookies = $response->headers->getCookies();
+        $this->assertCount(2, $cookies);
+        $this->assertSame('foo', $cookies[0]->getName());
+        $this->assertSame('bar', $cookies[0]->getValue());
+        $this->assertSame('baz', $cookies[1]->getName());
+        $this->assertSame('qux', $cookies[1]->getValue());
+    }
+
     public function testResponseCookiesInheritRequestSecureState()
     {
         $cookie = Cookie::create('foo', 'bar');


### PR DESCRIPTION
This PR promotes the `withCookies()` method from `RedirectResponse` to `ResponseTrait`.

Previously, `withCookies()` was only available on redirects, which forced developers to chain multiple `withCookie()` calls when working with other response types (like `JsonResponse` or standard `Response` objects). By moving this to the trait, we can now attach multiple cookies to any response in a single, clean method call.

**Before:**

```php
return response()->json($data)
    ->withCookie($cookieA)
    ->withCookie($cookieB)
    ->withCookie($cookieC);

```

**After:**

```php
return response()->json($data)->withCookies([$cookieA, $cookieB, $cookieC]);

```

**Implementation Details:**

* The implementation was moved as-is from `RedirectResponse`.
* Existing tests for `RedirectResponse` remain passing.
* Added a new test case to verify `withCookies()` works correctly on a base `Response` object.
* This is a purely additive, non-breaking change.