### PR TITLE
[13.x] An exception can implement ShouldntRetry to prevent retries of jobs

### DIFF
--- a/src/Illuminate/Contracts/Queue/ShouldntRetry.php
+++ b/src/Illuminate/Contracts/Queue/ShouldntRetry.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Illuminate\Contracts\Queue;
+
+/**
+ * Marks an exception that should cause a job to fail immediately.
+ *
+ * When a job throws an exception implementing this contract, the job skips any
+ * retries it has remaining and is failed immediately, regardless of the number
+ * of attempts or the "retry until" timestamp configured for the job.
+ */
+interface ShouldntRetry
+{
+    //
+}

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Queue\Factory as QueueManager;
 use Illuminate\Contracts\Queue\Interruptible;
+use Illuminate\Contracts\Queue\ShouldntRetry;
 use Illuminate\Database\DetectsLostConnections;
 use Illuminate\Queue\Events\JobAttempted;
 use Illuminate\Queue\Events\JobExceptionOccurred;
@@ -582,6 +583,12 @@ class Worker
             // attempts it is allowed to run the next time we process it. If so we will just
             // go ahead and mark it as failed now so we do not have to release this again.
             if (! $job->hasFailed()) {
+                $this->markJobAsFailedIfExceptionShouldntRetry(
+                    $connectionName, $job, $e
+                );
+            }
+
+            if (! $job->hasFailed()) {
                 $this->markJobAsFailedIfWillExceedMaxAttempts(
                     $connectionName, $job, (int) $options->maxTries, $e
                 );
@@ -687,6 +694,21 @@ class Worker
         if ($maxExceptions <= $this->cache->increment('job-exceptions:'.$uuid)) {
             $this->cache->forget('job-exceptions:'.$uuid);
 
+            $this->failJob($job, $e);
+        }
+    }
+
+    /**
+     * Mark the given job as failed if the thrown exception should skip remaining retries.
+     *
+     * @param  string  $connectionName
+     * @param  \Illuminate\Contracts\Queue\Job  $job
+     * @param  \Throwable  $e
+     * @return void
+     */
+    protected function markJobAsFailedIfExceptionShouldntRetry($connectionName, $job, Throwable $e)
+    {
+        if ($e instanceof ShouldntRetry) {
             $this->failJob($job, $e);
         }
     }

--- a/tests/Integration/Queue/ShouldntRetryTest.php
+++ b/tests/Integration/Queue/ShouldntRetryTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Queue;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldntRetry;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Support\Facades\DB;
+use Orchestra\Testbench\Attributes\WithMigration;
+use RuntimeException;
+
+#[WithMigration]
+#[WithMigration('queue')]
+class ShouldntRetryTest extends QueueTestCase
+{
+    protected function defineEnvironment($app)
+    {
+        parent::defineEnvironment($app);
+
+        $app['config']->set('queue.default', 'database');
+        $this->driver = 'database';
+    }
+
+    #[\Override]
+    protected function tearDown(): void
+    {
+        ShouldntRetryTestJob::$attempts = 0;
+
+        parent::tearDown();
+    }
+
+    public function testJobFailsImmediatelyWhenItThrowsAnExceptionThatShouldntRetry()
+    {
+        ShouldntRetryTestJob::$exception = new ShouldntRetryTestException;
+
+        ShouldntRetryTestJob::dispatch();
+
+        $this->runQueueWorkerCommand(['--once' => true, '--tries' => 3]);
+
+        $this->assertSame(1, ShouldntRetryTestJob::$attempts);
+        $this->assertNull(DB::table('jobs')->first());
+        $this->assertNotNull(DB::table('failed_jobs')->first());
+    }
+
+    public function testJobIsRetriedWhenItThrowsAnExceptionThatDoesNotOptOutOfRetries()
+    {
+        ShouldntRetryTestJob::$exception = new RuntimeException('Transient failure.');
+
+        ShouldntRetryTestJob::dispatch();
+
+        $this->runQueueWorkerCommand(['--once' => true, '--tries' => 3]);
+
+        $this->assertSame(1, ShouldntRetryTestJob::$attempts);
+        $this->assertNotNull(DB::table('jobs')->first());
+        $this->assertNull(DB::table('failed_jobs')->first());
+    }
+}
+
+class ShouldntRetryTestException extends RuntimeException implements ShouldntRetry
+{
+    //
+}
+
+class ShouldntRetryTestJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable;
+
+    public static int $attempts = 0;
+
+    public static ?\Throwable $exception = null;
+
+    public function handle()
+    {
+        static::$attempts++;
+
+        throw static::$exception;
+    }
+}

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Queue\Interruptible;
 use Illuminate\Contracts\Queue\Job as QueueJobContract;
+use Illuminate\Contracts\Queue\ShouldntRetry;
 use Illuminate\Queue\CallQueuedHandler;
 use Illuminate\Queue\Events\JobExceptionOccurred;
 use Illuminate\Queue\Events\JobPopped;
@@ -246,6 +247,53 @@ class QueueWorkerTest extends TestCase
         $this->exceptionHandler->shouldHaveReceived('report')->with($e);
         $this->events->shouldHaveReceived('dispatch')->with(m::type(JobExceptionOccurred::class))->once();
         $this->events->shouldNotHaveReceived('dispatch', [m::type(JobProcessed::class)]);
+    }
+
+    public function testJobIsFailedWithoutRetryingWhenExceptionShouldntRetry()
+    {
+        $e = new WorkerShouldntRetryException;
+
+        $job = new WorkerFakeJob(function ($job) use ($e) {
+            $job->attempts++;
+
+            throw $e;
+        });
+
+        $job->attempts = 0;
+
+        $worker = $this->getWorker('default', ['queue' => [$job]]);
+        $worker->runNextJob('default', 'queue', $this->workerOptions(['maxTries' => 3, 'backoff' => 10]));
+
+        $this->assertNull($job->releaseAfter);
+        $this->assertFalse($job->released);
+        $this->assertTrue($job->deleted);
+        $this->assertEquals($e, $job->failedWith);
+        $this->exceptionHandler->shouldHaveReceived('report')->with($e);
+        $this->events->shouldHaveReceived('dispatch')->with(m::type(JobExceptionOccurred::class))->once();
+        $this->events->shouldNotHaveReceived('dispatch', [m::type(JobProcessed::class)]);
+    }
+
+    public function testJobIsReleasedWhenExceptionDoesNotImplementShouldntRetry()
+    {
+        $e = new RuntimeException;
+
+        $job = new WorkerFakeJob(function ($job) use ($e) {
+            $job->attempts++;
+
+            throw $e;
+        });
+
+        $job->attempts = 0;
+
+        $worker = $this->getWorker('default', ['queue' => [$job]]);
+        $worker->runNextJob('default', 'queue', $this->workerOptions(['maxTries' => 3, 'backoff' => 10]));
+
+        $this->assertEquals(10, $job->releaseAfter);
+        $this->assertTrue($job->released);
+        $this->assertFalse($job->deleted);
+        $this->assertNull($job->failedWith);
+        $this->exceptionHandler->shouldHaveReceived('report')->with($e);
+        $this->events->shouldHaveReceived('dispatch')->with(m::type(JobExceptionOccurred::class))->once();
     }
 
     public function testExceptionIsNotReportedIfReportJobExceptionsIsDisabled()
@@ -936,6 +984,11 @@ class WorkerFakeJob implements QueueJobContract
 }
 
 class LoopBreakerException extends RuntimeException
+{
+    //
+}
+
+class WorkerShouldntRetryException extends RuntimeException implements ShouldntRetry
 {
     //
 }


### PR DESCRIPTION
Some jobs when processing are useful to be retried a few times, for example, if you hit a rate limit or a temporary network problem, however, within those jobs there can also be times where the system is not recoverable at all.

Currently, you have to call `$this->fail()` on these jobs, and it adds a layer of boilerplate that you have to remember for each job you're writing, since it's controlled within the job itself.

However, some exceptions are _always_ unrecoverable, for example, in stripe a PaymentDeclined cannot be recovered, and retrying is completely pointless.

Adding `ShouldntRetry` on that exception will now make it so that that specific exception flags the job as failed, without the manual boilerplate on each job.

```php
  use Illuminate\Contracts\Queue\ShouldntRetry;

  class PaymentDeclinedException extends RuntimeException implements ShouldntRetry
  {
  }

  class ChargeCustomer implements ShouldQueue
  {
      use Dispatchable, InteractsWithQueue, Queueable;

      public int $tries = 5;

      public function handle(PaymentGateway $gateway): void
      {
          // A declined card throws PaymentDeclinedException → fails immediately.
          // A gateway timeout throws something else → retried up to 5 times.
          $gateway->charge($this->customerId, $this->amount);
      }
  }
```

---

To get the same behaviour today, the code looks something like this:

```php
 class ChargeCustomer implements ShouldQueue
  {
      use Dispatchable, InteractsWithQueue, Queueable;

      public int $tries = 5;

      public function handle(PaymentGateway $gateway): void
      {
          try {
              $gateway->charge($this->customerId, $this->amount);
          } catch (PaymentDeclinedException $e) {
              $this->fail($e);

              return;
          }
      }
  }
```

However, this setup gets worse if you have the `$gateway->charge()` inside of a method you want to return a value for.

Since you cannot just throw an exception without getting the retries, you have to either catch the exception like this, or you can do a `$this->fail()` inside that method, but then the return type has to be nullable so that you can return early and handle the response.

