### PR TITLE
[13.x] Improve BatchRepository transaction return type

### DIFF
--- a/src/Illuminate/Bus/BatchRepository.php
+++ b/src/Illuminate/Bus/BatchRepository.php
@@ -85,8 +85,10 @@ interface BatchRepository
     /**
      * Execute the given Closure within a storage specific transaction.
      *
-     * @param  \Closure  $callback
-     * @return mixed
+     * @template TReturn
+     *
+     * @param  (\Closure(): TReturn)  $callback
+     * @return TReturn
      */
     public function transaction(Closure $callback);
 

--- a/types/Bus/BatchRepository.php
+++ b/types/Bus/BatchRepository.php
@@ -1,0 +1,10 @@
+<?php
+
+use Illuminate\Bus\BatchRepository;
+
+use function PHPStan\Testing\assertType;
+
+/** @var BatchRepository $repository */
+$repository = resolve(BatchRepository::class);
+
+assertType("'foo'", $repository->transaction(fn () => 'foo'));


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR updates the `BatchRepository::transaction()` contract to preserve the return type of the provided callback.

The concrete batch repository implementations already use `@template TReturn`; this change aligns the interface so callers typed against `BatchRepository` also benefit from the same PHPStan inference.

A type assertion was added to cover the interface-typed usage.
