### PR TITLE
Improve types of `InteractsWithData::whenEnum`

### DIFF
--- a/src/Illuminate/Support/Traits/InteractsWithData.php
+++ b/src/Illuminate/Support/Traits/InteractsWithData.php
@@ -181,11 +181,15 @@ trait InteractsWithData
     /**
      * Apply the callback if the instance contains a valid enum value for the given key.
      *
+     * @template TEnum of \BackedEnum
+     * @template TReturn
+     * @template TReturnDefault = never
+     *
      * @param  string  $key
-     * @param  class-string<\BackedEnum>  $enumClass
-     * @param  callable  $callback
-     * @param  callable|null  $default
-     * @return $this|mixed
+     * @param  class-string<TEnum>  $enumClass
+     * @param  callable(TEnum):TReturn  $callback
+     * @param  (callable(): TReturnDefault)|null  $default
+     * @return $this|TReturn|TReturnDefault
      */
     public function whenEnum($key, string $enumClass, callable $callback, ?callable $default = null)
     {

--- a/types/Support/Traits.php
+++ b/types/Support/Traits.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Traits\Localizable;
+use Illuminate\Support\UriQueryString;
 
 use function PHPStan\Testing\assertType;
 
@@ -13,3 +14,21 @@ $localizable = new class
         assertType("'foo'", $this->withLocale('en', fn () => 'foo'));
     }
 };
+
+$interactsWithData = function (UriQueryString $query): void {
+    assertType('1|2|Illuminate\Support\UriQueryString', $query->whenEnum('foo', TestIntEnum::class, function ($enum) {
+        assertType('TestIntEnum', $enum);
+
+        return 1;
+    }, function () {
+        return 2;
+    }));
+
+    assertType('3|Illuminate\Support\UriQueryString', $query->whenEnum('foo', TestIntEnum::class, function ($enum) {
+        return 3;
+    }));
+};
+
+enum TestIntEnum: int
+{
+}


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This PR improves PHPDoc types of `InteractsWithData::whenEnum()`, which was introduced in #60486.
Return type of the method and `$callback`'s parameter type will be inferred correctly with this fix.