### PR TITLE
Add anyOf support to JSON schema

### DIFF
--- a/src/Illuminate/Contracts/JsonSchema/JsonSchema.php
+++ b/src/Illuminate/Contracts/JsonSchema/JsonSchema.php
@@ -15,14 +15,6 @@ interface JsonSchema
     public function object(Closure|array $properties = []);
 
     /**
-     * Create a new anyOf schema instance.
-     *
-     * @param  (Closure(JsonSchema): array<int, \Illuminate\JsonSchema\Types\Type>)|array<int, \Illuminate\JsonSchema\Types\Type>  $schemas
-     * @return \Illuminate\JsonSchema\Types\AnyOfType
-     */
-    public function anyOf(Closure|array $schemas);
-
-    /**
      * Create a new array property instance.
      *
      * @return \Illuminate\JsonSchema\Types\ArrayType
@@ -64,4 +56,12 @@ interface JsonSchema
      * @return \Illuminate\JsonSchema\Types\UnionType
      */
     public function union(array $types);
+
+    /**
+     * Create a new anyOf schema instance.
+     *
+     * @param  (Closure(JsonSchema): array<int, \Illuminate\JsonSchema\Types\Type>)|array<int, \Illuminate\JsonSchema\Types\Type>  $schemas
+     * @return \Illuminate\JsonSchema\Types\AnyOfType
+     */
+    public function anyOf(Closure|array $schemas);
 }

--- a/src/Illuminate/Contracts/JsonSchema/JsonSchema.php
+++ b/src/Illuminate/Contracts/JsonSchema/JsonSchema.php
@@ -15,6 +15,14 @@ interface JsonSchema
     public function object(Closure|array $properties = []);
 
     /**
+     * Create a new anyOf schema instance.
+     *
+     * @param  (Closure(JsonSchema): array<int, \Illuminate\JsonSchema\Types\Type>)|array<int, \Illuminate\JsonSchema\Types\Type>  $schemas
+     * @return \Illuminate\JsonSchema\Types\AnyOfType
+     */
+    public function anyOf(Closure|array $schemas);
+
+    /**
      * Create a new array property instance.
      *
      * @return \Illuminate\JsonSchema\Types\ArrayType

--- a/src/Illuminate/JsonSchema/Deserializer.php
+++ b/src/Illuminate/JsonSchema/Deserializer.php
@@ -47,6 +47,12 @@ class Deserializer
     {
         [$schema, $refs] = $this->resolveRef($schema, $refs);
 
+        if (($type = $this->buildAnyOfComposition($schema, $refs)) !== null) {
+            $this->applyCommon($type, $schema);
+
+            return $type;
+        }
+
         [$schema, $nullableFromUnion, $refs] = $this->normalizeUnions($schema, $refs);
 
         [$name, $nullableFromType] = $this->resolveType($schema);
@@ -70,6 +76,53 @@ class Deserializer
         $this->applyCommon($type, $schema);
 
         if ($nullableFromUnion || $nullableFromType) {
+            $type->nullable();
+        }
+
+        return $type;
+    }
+
+    /**
+     * Build an anyOf composition unless it is the existing nullable single-schema form.
+     *
+     * @param  array<string, mixed>  $schema
+     * @param  array<int, string>  $refs
+     *
+     * @throws \InvalidArgumentException
+     */
+    protected function buildAnyOfComposition(array $schema, array $refs = []): ?Types\AnyOfType
+    {
+        if (! isset($schema['anyOf']) || ! is_array($schema['anyOf'])) {
+            return null;
+        }
+
+        $nullable = false;
+        $branches = [];
+
+        foreach ($schema['anyOf'] as $branch) {
+            if (! is_array($branch)) {
+                throw new InvalidArgumentException('Unable to represent the schema for an anyOf branch; boolean schemas are not supported.');
+            }
+
+            [$branch, $branchRefs] = $this->resolveRef($branch, $refs);
+
+            if ($this->isNullBranch($branch)) {
+                $nullable = true;
+            } else {
+                $branches[] = [$branch, $branchRefs];
+            }
+        }
+
+        if ($nullable && count($branches) === 1) {
+            return null;
+        }
+
+        $type = new Types\AnyOfType(array_map(
+            fn (array $branch) => $this->build($branch[0], $branch[1]),
+            $branches,
+        ));
+
+        if ($nullable) {
             $type->nullable();
         }
 

--- a/src/Illuminate/JsonSchema/JsonSchema.php
+++ b/src/Illuminate/JsonSchema/JsonSchema.php
@@ -7,6 +7,7 @@ use Illuminate\JsonSchema\Types\Type;
 
 /**
  * @method static Types\ObjectType object(Closure|array<string, Types\Type> $properties = [])
+ * @method static Types\AnyOfType anyOf(Closure|array<int, Types\Type> $schemas)
  * @method static Types\IntegerType integer()
  * @method static Types\NumberType number()
  * @method static Types\StringType string()

--- a/src/Illuminate/JsonSchema/JsonSchemaTypeFactory.php
+++ b/src/Illuminate/JsonSchema/JsonSchemaTypeFactory.php
@@ -22,20 +22,6 @@ class JsonSchemaTypeFactory extends JsonSchema implements JsonSchemaContract
     }
 
     /**
-     * Create a new anyOf schema instance.
-     *
-     * @param  (Closure(JsonSchemaTypeFactory): array<int, Types\Type>)|array<int, Types\Type>  $schemas
-     */
-    public function anyOf(Closure|array $schemas): Types\AnyOfType
-    {
-        if ($schemas instanceof Closure) {
-            $schemas = $schemas($this);
-        }
-
-        return new Types\AnyOfType($schemas);
-    }
-
-    /**
      * Create a new array property instance.
      */
     public function array(): Types\ArrayType
@@ -83,5 +69,19 @@ class JsonSchemaTypeFactory extends JsonSchema implements JsonSchemaContract
     public function union(array $types): Types\UnionType
     {
         return new Types\UnionType($types);
+    }
+
+    /**
+     * Create a new anyOf schema instance.
+     *
+     * @param  (Closure(JsonSchemaTypeFactory): array<int, Types\Type>)|array<int, Types\Type>  $schemas
+     */
+    public function anyOf(Closure|array $schemas): Types\AnyOfType
+    {
+        if ($schemas instanceof Closure) {
+            $schemas = $schemas($this);
+        }
+
+        return new Types\AnyOfType($schemas);
     }
 }

--- a/src/Illuminate/JsonSchema/JsonSchemaTypeFactory.php
+++ b/src/Illuminate/JsonSchema/JsonSchemaTypeFactory.php
@@ -22,6 +22,20 @@ class JsonSchemaTypeFactory extends JsonSchema implements JsonSchemaContract
     }
 
     /**
+     * Create a new anyOf schema instance.
+     *
+     * @param  (Closure(JsonSchemaTypeFactory): array<int, Types\Type>)|array<int, Types\Type>  $schemas
+     */
+    public function anyOf(Closure|array $schemas): Types\AnyOfType
+    {
+        if ($schemas instanceof Closure) {
+            $schemas = $schemas($this);
+        }
+
+        return new Types\AnyOfType($schemas);
+    }
+
+    /**
      * Create a new array property instance.
      */
     public function array(): Types\ArrayType

--- a/src/Illuminate/JsonSchema/Serializer.php
+++ b/src/Illuminate/JsonSchema/Serializer.php
@@ -25,6 +25,27 @@ class Serializer
         /** @var array<string, mixed> $attributes */
         $attributes = (fn () => get_object_vars($type))->call($type);
 
+        if ($type instanceof Types\AnyOfType) {
+            $attributes['anyOf'] = array_map(
+                static fn (Types\Type $schema) => static::serialize($schema),
+                $attributes['schemas'],
+            );
+
+            unset($attributes['schemas']);
+
+            if (static::isNullable($type)) {
+                $attributes['anyOf'][] = ['type' => 'null'];
+            }
+
+            return array_filter($attributes, static function (mixed $value, string $key) {
+                if (in_array($key, static::$ignore, true)) {
+                    return false;
+                }
+
+                return $value !== null;
+            }, ARRAY_FILTER_USE_BOTH);
+        }
+
         $attributes['type'] = match (get_class($type)) {
             Types\ArrayType::class => 'array',
             Types\BooleanType::class => 'boolean',

--- a/src/Illuminate/JsonSchema/Types/AnyOfType.php
+++ b/src/Illuminate/JsonSchema/Types/AnyOfType.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Illuminate\JsonSchema\Types;
+
+class AnyOfType extends Type
+{
+    /**
+     * Create a new anyOf type instance.
+     *
+     * @param  array<int, Type>  $schemas
+     */
+    public function __construct(protected array $schemas)
+    {
+        $this->schemas = array_values($schemas);
+    }
+
+    /**
+     * Get the anyOf schemas.
+     *
+     * @return array<int, Type>
+     */
+    public function schemas(): array
+    {
+        return $this->schemas;
+    }
+}

--- a/tests/JsonSchema/AnyOfTypeTest.php
+++ b/tests/JsonSchema/AnyOfTypeTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Illuminate\Tests\JsonSchema;
+
+use Illuminate\JsonSchema\JsonSchema;
+use PHPUnit\Framework\TestCase;
+
+class AnyOfTypeTest extends TestCase
+{
+    public function test_it_may_describe_any_of_multiple_schemas(): void
+    {
+        $type = JsonSchema::anyOf([
+            JsonSchema::string(),
+            JsonSchema::integer(),
+        ])->title('Identifier');
+
+        $this->assertEquals([
+            'title' => 'Identifier',
+            'anyOf' => [
+                ['type' => 'string'],
+                ['type' => 'integer'],
+            ],
+        ], $type->toArray());
+    }
+
+    public function test_it_may_be_initialized_with_a_closure(): void
+    {
+        $type = JsonSchema::anyOf(fn (JsonSchema $schema): array => [
+            $schema->string(),
+            $schema->integer(),
+        ]);
+
+        $this->assertEquals([
+            'anyOf' => [
+                ['type' => 'string'],
+                ['type' => 'integer'],
+            ],
+        ], $type->toArray());
+    }
+
+    public function test_it_may_be_nullable(): void
+    {
+        $type = JsonSchema::anyOf([
+            JsonSchema::string(),
+            JsonSchema::integer(),
+        ])->nullable();
+
+        $this->assertEquals([
+            'anyOf' => [
+                ['type' => 'string'],
+                ['type' => 'integer'],
+                ['type' => 'null'],
+            ],
+        ], $type->toArray());
+    }
+
+    public function test_it_may_describe_object_unions(): void
+    {
+        $type = JsonSchema::anyOf([
+            JsonSchema::object([
+                'type' => JsonSchema::string()->enum(['article'])->required(),
+                'title' => JsonSchema::string()->required(),
+                'content' => JsonSchema::string()->required(),
+            ]),
+            JsonSchema::object([
+                'type' => JsonSchema::string()->enum(['image'])->required(),
+                'url' => JsonSchema::string()->required(),
+                'caption' => JsonSchema::string(),
+            ]),
+        ]);
+
+        $this->assertEquals([
+            'anyOf' => [
+                [
+                    'type' => 'object',
+                    'properties' => [
+                        'type' => ['type' => 'string', 'enum' => ['article']],
+                        'title' => ['type' => 'string'],
+                        'content' => ['type' => 'string'],
+                    ],
+                    'required' => ['type', 'title', 'content'],
+                ],
+                [
+                    'type' => 'object',
+                    'properties' => [
+                        'type' => ['type' => 'string', 'enum' => ['image']],
+                        'url' => ['type' => 'string'],
+                        'caption' => ['type' => 'string'],
+                    ],
+                    'required' => ['type', 'url'],
+                ],
+            ],
+        ], $type->toArray());
+    }
+}

--- a/tests/JsonSchema/DeserializerTest.php
+++ b/tests/JsonSchema/DeserializerTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\JsonSchema;
 use Illuminate\JsonSchema\JsonSchema;
 use Illuminate\JsonSchema\Serializer;
 use Illuminate\JsonSchema\Types\ArrayType;
+use Illuminate\JsonSchema\Types\AnyOfType;
 use Illuminate\JsonSchema\Types\BooleanType;
 use Illuminate\JsonSchema\Types\IntegerType;
 use Illuminate\JsonSchema\Types\NumberType;
@@ -544,6 +545,76 @@ class DeserializerTest extends TestCase
         ], $type->toArray());
     }
 
+    public function test_it_deserializes_an_any_of_composition(): void
+    {
+        $type = JsonSchema::fromArray([
+            'title' => 'Identifier',
+            'anyOf' => [
+                ['type' => 'string'],
+                ['type' => 'integer'],
+            ],
+        ]);
+
+        $this->assertInstanceOf(AnyOfType::class, $type);
+        $this->assertEquals([
+            'title' => 'Identifier',
+            'anyOf' => [
+                ['type' => 'string'],
+                ['type' => 'integer'],
+            ],
+        ], $type->toArray());
+    }
+
+    public function test_it_deserializes_a_nullable_any_of_composition(): void
+    {
+        $type = JsonSchema::fromArray([
+            'anyOf' => [
+                ['type' => 'string'],
+                ['type' => 'integer'],
+                ['type' => 'null'],
+            ],
+        ]);
+
+        $this->assertInstanceOf(AnyOfType::class, $type);
+        $this->assertEquals([
+            'anyOf' => [
+                ['type' => 'string'],
+                ['type' => 'integer'],
+                ['type' => 'null'],
+            ],
+        ], $type->toArray());
+    }
+
+    public function test_it_deserializes_an_any_of_nested_in_an_object_property(): void
+    {
+        $type = JsonSchema::fromArray([
+            'type' => 'object',
+            'properties' => [
+                'value' => [
+                    'anyOf' => [
+                        ['type' => 'string'],
+                        ['type' => 'integer'],
+                    ],
+                ],
+            ],
+            'required' => ['value'],
+        ]);
+
+        $this->assertInstanceOf(ObjectType::class, $type);
+        $this->assertEquals([
+            'type' => 'object',
+            'properties' => [
+                'value' => [
+                    'anyOf' => [
+                        ['type' => 'string'],
+                        ['type' => 'integer'],
+                    ],
+                ],
+            ],
+            'required' => ['value'],
+        ], $type->toArray());
+    }
+
     public function test_it_throws_for_an_unsupported_union_member(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -638,13 +709,13 @@ class DeserializerTest extends TestCase
         ]);
     }
 
-    public function test_it_throws_for_an_unsupported_union(): void
+    public function test_it_throws_for_an_unsupported_one_of_union(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Only a nullable "anyOf" (a single schema plus a "null" branch) is supported.');
+        $this->expectExceptionMessage('Only a nullable "oneOf" (a single schema plus a "null" branch) is supported.');
 
         JsonSchema::fromArray([
-            'anyOf' => [
+            'oneOf' => [
                 ['type' => 'string'],
                 ['type' => 'integer'],
             ],

--- a/tests/JsonSchema/DeserializerTest.php
+++ b/tests/JsonSchema/DeserializerTest.php
@@ -4,8 +4,8 @@ namespace Illuminate\Tests\JsonSchema;
 
 use Illuminate\JsonSchema\JsonSchema;
 use Illuminate\JsonSchema\Serializer;
-use Illuminate\JsonSchema\Types\ArrayType;
 use Illuminate\JsonSchema\Types\AnyOfType;
+use Illuminate\JsonSchema\Types\ArrayType;
 use Illuminate\JsonSchema\Types\BooleanType;
 use Illuminate\JsonSchema\Types\IntegerType;
 use Illuminate\JsonSchema\Types\NumberType;

--- a/tests/JsonSchema/TypeTest.php
+++ b/tests/JsonSchema/TypeTest.php
@@ -328,6 +328,21 @@ class TypeTest extends TestCase
             [JsonSchema::union(['string', 'number'])->enum(['draft', 5]), 'draft'],
             [JsonSchema::union(['string', 'number'])->nullable(), null],
             [JsonSchema::union(['string', 'number'])->nullable(), 'still valid'],
+
+            // AnyOfType
+            [JsonSchema::anyOf([JsonSchema::string(), JsonSchema::integer()]), 'hello'],
+            [JsonSchema::anyOf([JsonSchema::string(), JsonSchema::integer()]), 10],
+            [JsonSchema::anyOf([JsonSchema::string(), JsonSchema::integer()])->nullable(), null],
+            [JsonSchema::anyOf([
+                JsonSchema::object([
+                    'type' => JsonSchema::string()->enum(['card'])->required(),
+                    'last4' => JsonSchema::string()->min(4)->max(4)->required(),
+                ]),
+                JsonSchema::object([
+                    'type' => JsonSchema::string()->enum(['bank_account'])->required(),
+                    'iban' => JsonSchema::string()->required(),
+                ]),
+            ]), (object) ['type' => 'card', 'last4' => '1234']],
         ];
     }
 
@@ -429,6 +444,20 @@ class TypeTest extends TestCase
             [JsonSchema::union(['string', 'number']), null], // null not allowed unless nullable
             [JsonSchema::union(['integer', 'boolean']), 'nope'], // string not in union
             [JsonSchema::union(['string', 'number'])->enum(['draft', 5]), 'archived'], // not in enum
+
+            // AnyOfType
+            [JsonSchema::anyOf([JsonSchema::string(), JsonSchema::integer()]), true],
+            [JsonSchema::anyOf([JsonSchema::string(), JsonSchema::integer()]), null],
+            [JsonSchema::anyOf([
+                JsonSchema::object([
+                    'type' => JsonSchema::string()->enum(['card'])->required(),
+                    'last4' => JsonSchema::string()->min(4)->max(4)->required(),
+                ]),
+                JsonSchema::object([
+                    'type' => JsonSchema::string()->enum(['bank_account'])->required(),
+                    'iban' => JsonSchema::string()->required(),
+                ]),
+            ]), (object) ['type' => 'card', 'iban' => 'wrong-branch']],
         ];
     }
 


### PR DESCRIPTION
This adds first-class `anyOf` support to `Illuminate\JsonSchema`.

This is important for AI structured output. Some schemas need to describe a field that can be one of several valid shapes, such as content that may be either an article object or an image object, with each shape having its own required fields. Without `anyOf`, these schemas have to be flattened or made overly loose, which loses useful structure.

OpenAI structured outputs and Gemini 2.5+ support `anyOf`. Prism PHP also supports this through `AnyOfSchema`:
https://github.com/prism-php/prism/blob/main/src/Schema/AnyOfSchema.php

There was a previous broader PR for JSON Schema composition helpers (#60222). This takes a smaller approach and only adds `anyOf`, which is the main piece needed for these structured output use cases.

If this is merged, I plan to follow up with a PR to `laravel/ai` to add proper support for these schemas in Laravel AI structured output.