### PR TITLE
[13.x] Fix `Batchable::batching` for finished batches

### DIFF
--- a/src/Illuminate/Bus/Batchable.php
+++ b/src/Illuminate/Bus/Batchable.php
@@ -48,7 +48,7 @@ trait Batchable
     {
         $batch = $this->batch();
 
-        return $batch && ! $batch->cancelled();
+        return $batch && ! $batch->finished() && ! $batch->cancelled();
     }
 
     /**

--- a/tests/Bus/BusBatchableTest.php
+++ b/tests/Bus/BusBatchableTest.php
@@ -65,4 +65,16 @@ class BusBatchableTest extends TestCase
         $job->batch()->cancel();
         $this->assertFalse($job->batching());
     }
+
+    public function test_batching_returns_false_when_batch_is_finished()
+    {
+        $job = new class
+        {
+            use Batchable;
+        };
+
+        $job->withFakeBatch('test-batch-id', 'test-batch-name', finishedAt: \Carbon\CarbonImmutable::now());
+
+        $this->assertFalse($job->batching());
+    }
 }


### PR DESCRIPTION
`Batchable::batching` now returns false for finished batches as well as cancelled ones, matching the batch lifecycle.
 Added coverage for finished fake batches in `BusBatchableTest`.