### PR TITLE
[13.x] Improve return types for callback-passthrough interfaces and helpers

### DIFF
--- a/src/Illuminate/Bus/BatchRepository.php
+++ b/src/Illuminate/Bus/BatchRepository.php
@@ -85,8 +85,10 @@ interface BatchRepository
     /**
      * Execute the given Closure within a storage specific transaction.
      *
-     * @param  \Closure  $callback
-     * @return mixed
+     * @template TReturn
+     *
+     * @param  (\Closure(): TReturn)  $callback
+     * @return TReturn
      */
     public function transaction(Closure $callback);
 

--- a/src/Illuminate/Cache/RateLimiter.php
+++ b/src/Illuminate/Cache/RateLimiter.php
@@ -289,8 +289,10 @@ class RateLimiter
     /**
      * Execute the given callback without serialization or compression when applicable.
      *
-     * @param  callable  $callback
-     * @return mixed
+     * @template TReturn
+     *
+     * @param  (callable(): TReturn)  $callback
+     * @return TReturn
      */
     protected function withoutSerializationOrCompression(callable $callback)
     {

--- a/src/Illuminate/Database/ConnectionInterface.php
+++ b/src/Illuminate/Database/ConnectionInterface.php
@@ -131,9 +131,11 @@ interface ConnectionInterface
     /**
      * Execute a Closure within a transaction.
      *
-     * @param  \Closure  $callback
+     * @template TReturn
+     *
+     * @param  (\Closure(static): TReturn)  $callback
      * @param  int  $attempts
-     * @return mixed
+     * @return TReturn
      *
      * @throws \Throwable
      */

--- a/src/Illuminate/Queue/Failed/FileFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/FileFailedJobProvider.php
@@ -167,8 +167,10 @@ class FileFailedJobProvider implements CountableFailedJobProvider, FailedJobProv
     /**
      * Execute the given callback while holding a lock.
      *
-     * @param  \Closure  $callback
-     * @return mixed
+     * @template TReturn
+     *
+     * @param  (\Closure(): TReturn)  $callback
+     * @return TReturn
      */
     protected function lock(Closure $callback)
     {

--- a/src/Illuminate/Redis/Connections/PacksPhpRedisValues.php
+++ b/src/Illuminate/Redis/Connections/PacksPhpRedisValues.php
@@ -88,8 +88,10 @@ trait PacksPhpRedisValues
     /**
      * Execute the given callback without serialization or compression when applicable.
      *
-     * @param  callable  $callback
-     * @return mixed
+     * @template TReturn
+     *
+     * @param  (callable(): TReturn)  $callback
+     * @return TReturn
      */
     public function withoutSerializationOrCompression(callable $callback)
     {

--- a/types/Bus/BatchRepository.php
+++ b/types/Bus/BatchRepository.php
@@ -1,0 +1,10 @@
+<?php
+
+use Illuminate\Bus\BatchRepository;
+
+use function PHPStan\Testing\assertType;
+
+/** @var BatchRepository $repository */
+$repository = resolve(BatchRepository::class);
+
+assertType("'foo'", $repository->transaction(fn () => 'foo'));

--- a/types/Database/ConnectionInterface.php
+++ b/types/Database/ConnectionInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+use Illuminate\Database\ConnectionInterface;
+
+use function PHPStan\Testing\assertType;
+
+/** @var ConnectionInterface $connection */
+$connection = resolve(ConnectionInterface::class);
+
+assertType("'foo'", $connection->transaction(fn () => 'foo'));

--- a/types/Redis/Connections/PhpRedisConnection.php
+++ b/types/Redis/Connections/PhpRedisConnection.php
@@ -1,0 +1,10 @@
+<?php
+
+use Illuminate\Redis\Connections\PhpRedisConnection;
+
+use function PHPStan\Testing\assertType;
+
+/** @var PhpRedisConnection $connection */
+$connection = resolve(PhpRedisConnection::class);
+
+assertType("'foo'", $connection->withoutSerializationOrCompression(fn () => 'foo'));


### PR DESCRIPTION
Completes the `@template TReturn` treatment on the callback-passthrough transaction **interfaces** whose implementations already received it, so the contract matches the concrete classes and inference works through the interface:                                                                                                                                                                                                                                           
  - `Database\ConnectionInterface::transaction()`                                                                                                                           
  - `Bus\BatchRepository::transaction()`                                                                                                                                    
                                                                                                                                                                            
  Plus the remaining passthrough helpers that still returned `mixed` but simply                                                                                             
  invoke the given callback and return its result:                                                                                                                          
                                                                                                                                                                            
  - `Redis\Connections\PacksPhpRedisValues::withoutSerializationOrCompression()`                                                                                            
  - `Cache\RateLimiter::withoutSerializationOrCompression()`                                                                                                                
  - `Queue\Failed\FileFailedJobProvider::lock()`                                                                                                                            
                                                                                                                                                                     
  Docblock/generic-only, no behavior change; types/ assertions added for the interfaces and the public trait method.  

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
