### PR TITLE
[13.x] Add missing @throws \JsonException annotations

### DIFF
--- a/src/Illuminate/Foundation/Cloud.php
+++ b/src/Illuminate/Foundation/Cloud.php
@@ -132,6 +132,8 @@ class Cloud
 
     /**
      * Configure managed queues if applicable.
+     *
+     * @throws \JsonException
      */
     public static function configureManagedQueues(Application $app): void
     {

--- a/src/Illuminate/Foundation/Cloud/Events.php
+++ b/src/Illuminate/Foundation/Cloud/Events.php
@@ -99,6 +99,8 @@ class Events
      * Format the payload.
      *
      * @param  list<array<string, mixed>>  $payloads
+     *
+     * @throws \JsonException
      */
     protected function format(array $payloads): string
     {

--- a/src/Illuminate/Foundation/Cloud/FailedJobProvider.php
+++ b/src/Illuminate/Foundation/Cloud/FailedJobProvider.php
@@ -103,6 +103,8 @@ class FailedJobProvider implements FailedJobProviderInterface, CountableFailedJo
      *
      * @param  mixed  $id
      * @return object|null
+     *
+     * @throws \JsonException
      */
     public function find($id)
     {

--- a/src/Illuminate/Queue/Events/JobQueued.php
+++ b/src/Illuminate/Queue/Events/JobQueued.php
@@ -28,6 +28,8 @@ class JobQueued
      * Get the decoded job payload.
      *
      * @return array
+     *
+     * @throws \JsonException
      */
     public function payload()
     {

--- a/src/Illuminate/Queue/Events/JobQueueing.php
+++ b/src/Illuminate/Queue/Events/JobQueueing.php
@@ -26,6 +26,8 @@ class JobQueueing
      * Get the decoded job payload.
      *
      * @return array
+     *
+     * @throws \JsonException
      */
     public function payload()
     {

--- a/src/Illuminate/Support/Composer.php
+++ b/src/Illuminate/Support/Composer.php
@@ -116,6 +116,7 @@ class Composer
      * @param  callable(array<string, mixed>):array<string, mixed>  $callback
      * @return void
      *
+     * @throws \JsonException
      * @throws \RuntimeException
      */
     public function modify(callable $callback)

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1748,6 +1748,8 @@ class TestResponse implements ArrayAccess
      * Assert that the session has no errors.
      *
      * @return $this
+     *
+     * @throws \JsonException
      */
     public function assertSessionHasNoErrors()
     {


### PR DESCRIPTION
Adds `@throws \JsonException` to the methods that call `json_encode()`/ `json_decode()` with a hardcoded `JSON_THROW_ON_ERROR` flag and let the exception propagate (i.e. it is not caught and rethrown as something else):                                                                                               
                                                                                                                                                                            
  - `Support\Composer::modify()`                                                                                                                                            
  - `Queue\Events\JobQueueing::payload()`                                                                                                                                   
  - `Queue\Events\JobQueued::payload()`                                                                                                                                     
  - `Foundation\Cloud::configureManagedQueues()`                                                                                                                            
  - `Foundation\Cloud\FailedJobProvider::find()`                                                                                                                            
  - `Foundation\Cloud\Events::format()`                                                                                                                                     
  - `Testing\TestResponse::assertSessionHasNoErrors()`                                                                                                                      
                                                                                                                                                                            
  Methods that catch `JsonException` internally and rethrow it (e.g. `Model::toJson()`, `JsonResource::toJson()`) are intentionally left untouched, as are the `Http\Client\Response` JSON helpers where the throw flag is opt-in rather than hardcoded. Docblock-only, no behavior change.    

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
