### PR TITLE
[13.x] Add correct return type to FileHelpers extension method

### DIFF
--- a/src/Illuminate/Http/FileHelpers.php
+++ b/src/Illuminate/Http/FileHelpers.php
@@ -26,7 +26,7 @@ trait FileHelpers
     /**
      * Get the file's extension.
      *
-     * @return string
+     * @return string|null
      */
     public function extension()
     {


### PR DESCRIPTION
This PR updates the return type of the `FileHelpers` extension method from `string` to `string|null` to match its actual behavior