### PR TITLE
[13.x] Guard JsonSchema deserializer against unbounded $ref expansion

### DIFF
--- a/src/Illuminate/JsonSchema/Deserializer.php
+++ b/src/Illuminate/JsonSchema/Deserializer.php
@@ -7,11 +7,28 @@ use InvalidArgumentException;
 class Deserializer
 {
     /**
+     * The maximum number of schema fragments that may be expanded.
+     */
+    protected const MAX_NODES = 20000;
+
+    /**
      * The root schema being deserialized (used to resolve local $refs).
      *
      * @var array<string, mixed>
      */
     protected array $root;
+
+    /**
+     * The number of schema fragments expanded so far.
+     */
+    protected int $nodes = 0;
+
+    /**
+     * The cache of resolved local "$ref" targets, keyed by reference.
+     *
+     * @var array<string, array<string, mixed>>
+     */
+    protected array $refCache = [];
 
     /**
      * Create a new deserializer instance.
@@ -45,6 +62,12 @@ class Deserializer
      */
     protected function build(array $schema, array $refs = []): Types\Type
     {
+        if (++$this->nodes > static::MAX_NODES) {
+            throw new InvalidArgumentException(
+                'The JSON Schema is too large to deserialize; it expands beyond ['.static::MAX_NODES.'] fragments.'
+            );
+        }
+
         [$schema, $refs] = $this->resolveRef($schema, $refs);
 
         if (($type = $this->buildAnyOfComposition($schema, $refs)) !== null) {
@@ -143,7 +166,7 @@ class Deserializer
 
         if (isset($schema['properties']) && is_array($schema['properties'])) {
             $required = is_array($schema['required'] ?? null)
-                ? array_map('strval', $schema['required'])
+                ? array_flip(array_map('strval', $schema['required']))
                 : [];
 
             foreach ($schema['properties'] as $key => $definition) {
@@ -155,7 +178,7 @@ class Deserializer
 
                 $property = $this->build($definition, $refs);
 
-                if (in_array((string) $key, $required, true)) {
+                if (isset($required[(string) $key])) {
                     $property->required();
                 }
 
@@ -547,8 +570,12 @@ class Deserializer
      */
     protected function lookupRef(string $ref): array
     {
+        if (isset($this->refCache[$ref])) {
+            return $this->refCache[$ref];
+        }
+
         if ($ref === '#') {
-            return $this->root;
+            return $this->refCache[$ref] = $this->root;
         }
 
         if (! str_starts_with($ref, '#/')) {
@@ -571,7 +598,7 @@ class Deserializer
             throw new InvalidArgumentException("The JSON Schema \$ref [{$ref}] does not point to a schema.");
         }
 
-        return $target;
+        return $this->refCache[$ref] = $target;
     }
 
     /**


### PR DESCRIPTION
When deserializing a schema whose `$defs` reference each other, `fromArray()` inlines each `$ref` into the type tree. With a lot of nested cross-references this expansion can grow very large and use a surprising amount of time and memory before you get anything back.

This adds a cap on how many fragments a single schema can expand into, throwing `InvalidArgumentException` once it goes past the limit instead of churning. Normal schemas are nowhere near it, so valid input is unaffected. Also includes two small behavior-preserving tweaks in the same method (`array_flip` lookup for `required`, and memoizing `lookupRef`).

<details>
<summary>Repro</summary>

A small schema where each `$defs` entry references the next one twice expands exponentially with depth:

```php
use Illuminate\JsonSchema\JsonSchema;

$depth = 25;
$defs = [];

for ($i = 0; $i < $depth; $i++) {
    $defs["a{$i}"] = ['type' => 'object', 'properties' => [
        'x' => ['$ref' => "#/\$defs/a" . ($i + 1)],
        'y' => ['$ref' => "#/\$defs/a" . ($i + 1)],
    ]];
}

$defs["a{$depth}"] = ['type' => 'string'];

// A ~2 KB schema that previously expanded into millions of nodes.
JsonSchema::fromArray(['$defs' => $defs, '$ref' => '#/$defs/a0']);
```

With this change the same input throws `InvalidArgumentException` once it crosses the limit instead of consuming large amounts of memory and time.
</details>