### PR TITLE
[13.x] Make between()/unlessBetween() independent of timezone() call order

### DIFF
--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -55,9 +55,16 @@ trait ManagesFrequencies
      */
     private function inTimeInterval($startTime, $endTime)
     {
-        return function () use ($startTime, $endTime) {
-            [$now, $startTime, $endTime] = [
-                Carbon::now($this->timezone),
+        $now = Carbon::now();
+
+        return function () use ($startTime, $endTime, $now) {
+            $now = $now->copy();
+
+            if ($this->timezone) {
+                $now->setTimezone($this->timezone);
+            }
+
+            [$startTime, $endTime] = [
                 Carbon::parse($startTime, $this->timezone),
                 Carbon::parse($endTime, $this->timezone),
             ];

--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -55,21 +55,23 @@ trait ManagesFrequencies
      */
     private function inTimeInterval($startTime, $endTime)
     {
-        [$now, $startTime, $endTime] = [
-            Carbon::now($this->timezone),
-            Carbon::parse($startTime, $this->timezone),
-            Carbon::parse($endTime, $this->timezone),
-        ];
+        return function () use ($startTime, $endTime) {
+            [$now, $startTime, $endTime] = [
+                Carbon::now($this->timezone),
+                Carbon::parse($startTime, $this->timezone),
+                Carbon::parse($endTime, $this->timezone),
+            ];
 
-        if ($endTime->lessThan($startTime)) {
-            if ($startTime->greaterThan($now)) {
-                $startTime = $startTime->subDay();
-            } else {
-                $endTime = $endTime->addDay();
+            if ($endTime->lessThan($startTime)) {
+                if ($startTime->greaterThan($now)) {
+                    $startTime = $startTime->subDay();
+                } else {
+                    $endTime = $endTime->addDay();
+                }
             }
-        }
 
-        return fn () => $now->between($startTime, $endTime);
+            return $now->between($startTime, $endTime);
+        };
     }
 
     /**

--- a/tests/Console/ConsoleScheduledEventTest.php
+++ b/tests/Console/ConsoleScheduledEventTest.php
@@ -119,6 +119,27 @@ class ConsoleScheduledEventTest extends TestCase
         $this->assertFalse($event->between('10:00', '8:00')->filtersPass($app));
     }
 
+    public function testTimeBetweenChecksTimezoneCallOrder()
+    {
+        $app = m::mock(Application::class.'[isDownForMaintenance,environment]');
+        $app->shouldReceive('isDownForMaintenance')->andReturn(false);
+        $app->shouldReceive('environment')->andReturn('production');
+
+        Carbon::setTestNow(Carbon::parse('2024-07-01 09:00:00', 'UTC'));
+
+        $event = new Event(m::mock(EventMutex::class), 'php foo', 'UTC');
+        $this->assertTrue($event->timezone('Europe/Rome')->between('10:00', '12:00')->filtersPass($app));
+
+        $event = new Event(m::mock(EventMutex::class), 'php foo', 'UTC');
+        $this->assertTrue($event->between('10:00', '12:00')->timezone('Europe/Rome')->filtersPass($app));
+
+        $event = new Event(m::mock(EventMutex::class), 'php foo', 'UTC');
+        $this->assertFalse($event->timezone('Europe/Rome')->unlessBetween('10:00', '12:00')->filtersPass($app));
+
+        $event = new Event(m::mock(EventMutex::class), 'php foo', 'UTC');
+        $this->assertFalse($event->unlessBetween('10:00', '12:00')->timezone('Europe/Rome')->filtersPass($app));
+    }
+
     public function testTimeUnlessBetweenChecks()
     {
         $app = m::mock(Application::class.'[isDownForMaintenance,environment]');


### PR DESCRIPTION
The problem

`between()` / `unlessBetween()` evaluate the timezone eagerly, the moment the method is called. So the result silently depends on where `timezone()` sits in the chain:

```php
// ✅ uses Europe/Rome
$schedule->command('foo')->timezone('Europe/Rome')->between('10:00', '12:00');

// ❌ silently uses the previous timezone (e.g. UTC) — task runs at the wrong hour
$schedule->command('foo')->between('10:00', '12:00')->timezone('Europe/Rome');
```

Why this is a bug, not user error

`between()` / `unlessBetween()` are the only frequency methods whose outcome changes with call order. Every other one is order-independent: testBasicCronCompilation already asserts "chained rules should be commutative". This PR brings these two in line with that existing guarantee.

The fix

Defer the time-interval computation into the filter closure, so `$this->timezone` is read when the filter runs rather than when it's defined. The two forms above become equivalent.

- No public API change, ~minimal diff.
- No behavioral change for chains that were already in the "lucky" order.
- The schedule is defined and evaluated within the same `schedule:run`, so moving `Carbon::now()` into the closure doesn't change timing.

Regression test (`testTimeBetweenChecksTimezoneCallOrder`) covers both `between()` and `unlessBetween()` in both chaining orders.