### PR TITLE
[13.x] Support Queue attributes on traits

### DIFF
--- a/src/Illuminate/Support/Traits/ReadsClassAttributes.php
+++ b/src/Illuminate/Support/Traits/ReadsClassAttributes.php
@@ -71,6 +71,16 @@ trait ReadsClassAttributes
 
                     return $attributes[0]->newInstance();
                 }
+
+                foreach ($reflection->getTraits() as $trait) {
+                    $attributes = $trait->getAttributes($attributeClass);
+
+                    if (count($attributes) > 0) {
+                        $declaringClass = $reflection;
+
+                        return $attributes[0]->newInstance();
+                    }
+                }
             } while ($reflection = $reflection->getParentClass());
         } catch (Exception) {
             //

--- a/tests/Integration/Queue/JobDispatchingTest.php
+++ b/tests/Integration/Queue/JobDispatchingTest.php
@@ -236,6 +236,20 @@ class JobDispatchingTest extends QueueTestCase
         $this->assertSame('default', $events[1]->queue);
     }
 
+    public function testQueueAttributeOnTraitIsResolved()
+    {
+        Config::set('queue.default', 'database');
+        $events = [];
+        $this->app['events']->listen(function (JobQueued $e) use (&$events) {
+            $events[] = $e;
+        });
+
+        JobWithTraitQueueAttribute::dispatch();
+
+        $this->assertCount(1, $events);
+        $this->assertSame('notifications', $events[0]->queue);
+    }
+
     /**
      * Helpers.
      */
@@ -294,4 +308,12 @@ enum JobDispatchingTestQueueEnum: string
 class JobWithEnumQueueAttribute implements ShouldQueue
 {
     use Dispatchable;
+}
+
+#[QueueAttribute('notifications')]
+trait JobDispatchingTestQueueTrait {}
+
+class JobWithTraitQueueAttribute implements ShouldQueue
+{
+    use Dispatchable, JobDispatchingTestQueueTrait;
 }

--- a/tests/Integration/Queue/JobDispatchingTest.php
+++ b/tests/Integration/Queue/JobDispatchingTest.php
@@ -250,6 +250,20 @@ class JobDispatchingTest extends QueueTestCase
         $this->assertSame('notifications', $events[0]->queue);
     }
 
+    public function testClassQueueAttributeTakesPrecedenceOverTrait()
+    {
+        Config::set('queue.default', 'database');
+        $events = [];
+        $this->app['events']->listen(function (JobQueued $e) use (&$events) {
+            $events[] = $e;
+        });
+
+        JobWithClassQueueAttributeOverridingTrait::dispatch();
+
+        $this->assertCount(1, $events);
+        $this->assertSame('high', $events[0]->queue);
+    }
+
     /**
      * Helpers.
      */
@@ -316,6 +330,12 @@ trait JobDispatchingTestQueueTrait
 }
 
 class JobWithTraitQueueAttribute implements ShouldQueue
+{
+    use Dispatchable, JobDispatchingTestQueueTrait;
+}
+
+#[QueueAttribute('high')]
+class JobWithClassQueueAttributeOverridingTrait implements ShouldQueue
 {
     use Dispatchable, JobDispatchingTestQueueTrait;
 }

--- a/tests/Integration/Queue/JobDispatchingTest.php
+++ b/tests/Integration/Queue/JobDispatchingTest.php
@@ -311,7 +311,9 @@ class JobWithEnumQueueAttribute implements ShouldQueue
 }
 
 #[QueueAttribute('notifications')]
-trait JobDispatchingTestQueueTrait {}
+trait JobDispatchingTestQueueTrait
+{
+}
 
 class JobWithTraitQueueAttribute implements ShouldQueue
 {


### PR DESCRIPTION
This PR allows support for Queue Attributes on traits, so Queue,Connection etc... ie anything that uses getAttributeValue

We have a lot of events that share the same details, so use traits, but @ziadoz highlighted to me that queue attributes currently dont work on traits. So, in comes this PR! 

 This only checks traits on the current class in the hierarchy, rather than traits of traits etc, which I think is fine for now.

This is a fairly simple one so thought i'd try it on 13.x, but happy to move it to 14x if you want?

Imagine the following: 

```php
 #[Queue(Queues::broadcast)] // This doesnt currently work 
  trait BroadcastsImports
  {
     // We specify a bunch of broadcast methods
     public function broadcastWhen(): bool
      // ...
  }


  class ImportCreated implements ShouldBroadcast
  {
      use BroadcastsImports;
  }
  
    class ImportDeleted implements ShouldBroadcast
  {
      use BroadcastsImports;
  }

```