### PR TITLE
[13.x] Fix validation rule message return types

### DIFF
--- a/src/Illuminate/Validation/Rules/AnyOf.php
+++ b/src/Illuminate/Validation/Rules/AnyOf.php
@@ -68,7 +68,7 @@ class AnyOf implements Rule, ValidatorAwareRule
     /**
      * Get the validation error messages.
      *
-     * @return array
+     * @return string|array
      */
     public function message()
     {

--- a/src/Illuminate/Validation/Rules/Can.php
+++ b/src/Illuminate/Validation/Rules/Can.php
@@ -60,7 +60,7 @@ class Can implements Rule, ValidatorAwareRule
     /**
      * Get the validation error message.
      *
-     * @return array
+     * @return string|array
      */
     public function message()
     {

--- a/src/Illuminate/Validation/Rules/Enum.php
+++ b/src/Illuminate/Validation/Rules/Enum.php
@@ -124,7 +124,7 @@ class Enum implements Rule, ValidatorAwareRule, Stringable
     /**
      * Get the validation error message.
      *
-     * @return array
+     * @return string|array
      */
     public function message()
     {


### PR DESCRIPTION
## Summary

- Correct the `message()` PHPDoc return types for the `AnyOf`, `Can`, and `Enum` validation rules.
- These methods can return translated strings when validation language lines exist, and fallback arrays otherwise.

## Tests

- `vendor/bin/phpunit tests/Validation/ValidationAnyOfRuleTest.php tests/Validation/ValidationRuleCanTest.php tests/Validation/ValidationEnumRuleTest.php --no-coverage`
- `vendor/bin/pint --test src/Illuminate/Validation/Rules/AnyOf.php src/Illuminate/Validation/Rules/Can.php src/Illuminate/Validation/Rules/Enum.php`
- `vendor/bin/phpstan --configuration=phpstan.types.neon.dist --no-progress --memory-limit=1G`
