### PR TITLE
[13.x] Harden HTTP client request and fake response serialization

### DIFF
--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -15,6 +15,7 @@ use Illuminate\Support\Str;
 use Illuminate\Support\Stringable;
 use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
+use JsonException;
 use PHPUnit\Framework\Assert as PHPUnit;
 
 /**
@@ -179,9 +180,17 @@ class Factory
     public static function psr7Response($body = null, $status = 200, $headers = [])
     {
         if (is_array($body)) {
-            $body = json_encode($body);
+            try {
+                $body = json_encode($body, JSON_THROW_ON_ERROR);
+            } catch (JsonException $e) {
+                throw new InvalidArgumentException('HTTP fake response body could not be JSON encoded.', previous: $e);
+            }
 
             $headers['Content-Type'] = 'application/json';
+        }
+
+        if (! is_string($body) && ! is_null($body)) {
+            throw new InvalidArgumentException('HTTP fake response body must be a string, array, or null.');
         }
 
         return new Psr7Response($status, static::normalizeResponseHeaders($headers), $body);
@@ -206,7 +215,7 @@ class Factory
                 foreach ($value as $key => $item) {
                     $value[$key] = match (true) {
                         $item === null => '',
-                        is_scalar($item) => (string) $item,
+                        is_scalar($item) => static::normalizeScalarString($item),
                         $item instanceof Stringable => $item->toString(),
                         default => throw new InvalidArgumentException('HTTP fake response header values must be scalar, null, Laravel Stringable, or arrays of scalar, null, or Laravel Stringable values.'),
                     };
@@ -219,13 +228,32 @@ class Factory
 
             $headers[$name] = match (true) {
                 $value === null => '',
-                is_scalar($value) => (string) $value,
+                is_scalar($value) => static::normalizeScalarString($value),
                 $value instanceof Stringable => $value->toString(),
                 default => throw new InvalidArgumentException('HTTP fake response header values must be scalar, null, Laravel Stringable, or arrays of scalar, null, or Laravel Stringable values.'),
             };
         }
 
         return $headers;
+    }
+
+    /**
+     * Normalize a scalar to a string without triggering PHP 8.5 non-finite float warnings.
+     *
+     * @param  scalar  $value
+     * @return string
+     */
+    protected static function normalizeScalarString($value): string
+    {
+        if (is_float($value) && ! is_finite($value)) {
+            return match (true) {
+                is_nan($value) => 'NAN',
+                $value > 0 => 'INF',
+                default => '-INF',
+            };
+        }
+
+        return (string) $value;
     }
 
     /**
@@ -343,11 +371,15 @@ class Factory
                 return;
             }
 
-            if (is_int($callback) && $callback >= 100 && $callback < 600) {
-                return static::response(status: $callback);
+            if (is_int($callback)) {
+                if ($callback >= 100 && $callback < 600) {
+                    return static::response(status: $callback);
+                }
+
+                throw new InvalidArgumentException('HTTP status code must be between 100 and 599.');
             }
 
-            if (is_int($callback) || is_string($callback)) {
+            if (is_string($callback)) {
                 return static::response($callback);
             }
 

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -1471,38 +1471,6 @@ class PendingRequest
     }
 
     /**
-     * Normalize a scalar to a string without triggering PHP 8.5 non-finite float warnings.
-     *
-     * @param  scalar  $value
-     * @return string
-     */
-    protected function normalizeScalarString($value): string
-    {
-        if (is_float($value) && ! is_finite($value)) {
-            return match (true) {
-                is_nan($value) => 'NAN',
-                $value > 0 => 'INF',
-                default => '-INF',
-            };
-        }
-
-        return (string) $value;
-    }
-
-    /**
-     * Ensure the given request body can be passed to Guzzle.
-     *
-     * @param  mixed  $body
-     * @return void
-     */
-    protected function ensureValidRequestBody($body): void
-    {
-        if (! is_string($body) && ! is_null($body) && ! is_resource($body) && ! $body instanceof StreamInterface) {
-            throw new InvalidArgumentException('HTTP request body must be a string, resource, Psr\Http\Message\StreamInterface, or null.');
-        }
-    }
-
-    /**
      * Normalize non-finite floats within a nested array.
      *
      * @param  array  $values
@@ -1596,6 +1564,38 @@ class PendingRequest
             $value instanceof Stringable => $value->toString(),
             default => $value,
         };
+    }
+
+    /**
+     * Normalize a scalar to a string without triggering PHP 8.5 non-finite float warnings.
+     *
+     * @param  scalar  $value
+     * @return string
+     */
+    protected function normalizeScalarString($value): string
+    {
+        if (is_float($value) && ! is_finite($value)) {
+            return match (true) {
+                is_nan($value) => 'NAN',
+                $value > 0 => 'INF',
+                default => '-INF',
+            };
+        }
+
+        return (string) $value;
+    }
+
+    /**
+     * Ensure the given request body can be passed to Guzzle.
+     *
+     * @param  mixed  $body
+     * @return void
+     */
+    protected function ensureValidRequestBody($body): void
+    {
+        if (! is_string($body) && ! is_null($body) && ! is_resource($body) && ! $body instanceof StreamInterface) {
+            throw new InvalidArgumentException('HTTP request body must be a string, resource, Psr\Http\Message\StreamInterface, or null.');
+        }
     }
 
     /**

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -30,6 +30,7 @@ use InvalidArgumentException;
 use JsonSerializable;
 use Psr\Http\Message\MessageInterface;
 use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\StreamInterface;
 use Symfony\Component\VarDumper\VarDumper;
 use Throwable;
 
@@ -303,6 +304,10 @@ class PendingRequest
     public function withBody($content, $contentType = 'application/json')
     {
         $this->bodyFormat('body');
+
+        $content = $this->normalizeRequestOptionValue($content);
+
+        $this->ensureValidRequestBody($content);
 
         $this->pendingBody = $content;
 
@@ -1389,8 +1394,24 @@ class PendingRequest
                 continue;
             }
 
+            if (($key === 'query' || $key === 'form_params') && is_array($value)) {
+                $options[$key] = $this->normalizeNonFiniteFloatValues(
+                    $this->normalizeRequestOptionValue($value)
+                );
+
+                continue;
+            }
+
             if ($key === 'multipart' && is_array($value)) {
                 $options[$key] = $this->normalizeMultipartOption($value);
+
+                continue;
+            }
+
+            if ($key === 'body') {
+                $options[$key] = $this->normalizeRequestOptionValue($value);
+
+                $this->ensureValidRequestBody($options[$key]);
 
                 continue;
             }
@@ -1432,7 +1453,7 @@ class PendingRequest
             foreach ($value as $key => $item) {
                 $value[$key] = match (true) {
                     $item === null => '',
-                    is_scalar($item) => (string) $item,
+                    is_scalar($item) => $this->normalizeScalarString($item),
                     $item instanceof Stringable => $item->toString(),
                     default => throw new InvalidArgumentException('HTTP header values must be scalar, null, Laravel Stringable, or arrays of scalar, null, or Laravel Stringable values.'),
                 };
@@ -1443,10 +1464,61 @@ class PendingRequest
 
         return match (true) {
             $value === null => '',
-            is_scalar($value) => (string) $value,
+            is_scalar($value) => $this->normalizeScalarString($value),
             $value instanceof Stringable => $value->toString(),
             default => throw new InvalidArgumentException('HTTP header values must be scalar, null, Laravel Stringable, or arrays of scalar, null, or Laravel Stringable values.'),
         };
+    }
+
+    /**
+     * Normalize a scalar to a string without triggering PHP 8.5 non-finite float warnings.
+     *
+     * @param  scalar  $value
+     * @return string
+     */
+    protected function normalizeScalarString($value): string
+    {
+        if (is_float($value) && ! is_finite($value)) {
+            return match (true) {
+                is_nan($value) => 'NAN',
+                $value > 0 => 'INF',
+                default => '-INF',
+            };
+        }
+
+        return (string) $value;
+    }
+
+    /**
+     * Ensure the given request body can be passed to Guzzle.
+     *
+     * @param  mixed  $body
+     * @return void
+     */
+    protected function ensureValidRequestBody($body): void
+    {
+        if (! is_string($body) && ! is_null($body) && ! is_resource($body) && ! $body instanceof StreamInterface) {
+            throw new InvalidArgumentException('HTTP request body must be a string, resource, Psr\Http\Message\StreamInterface, or null.');
+        }
+    }
+
+    /**
+     * Normalize non-finite floats within a nested array.
+     *
+     * @param  array  $values
+     * @return array
+     */
+    protected function normalizeNonFiniteFloatValues(array $values): array
+    {
+        foreach ($values as $key => $value) {
+            if (is_array($value)) {
+                $values[$key] = $this->normalizeNonFiniteFloatValues($value);
+            } elseif (is_float($value) && ! is_finite($value)) {
+                $values[$key] = $this->normalizeScalarString($value);
+            }
+        }
+
+        return $values;
     }
 
     /**
@@ -1470,6 +1542,14 @@ class PendingRequest
                 }
 
                 $part[$key] = $this->normalizeRequestOptionValue($value);
+
+                if ($key === 'contents') {
+                    if (is_array($part[$key])) {
+                        $part[$key] = $this->normalizeNonFiniteFloatValues($part[$key]);
+                    } elseif (is_float($part[$key]) && ! is_finite($part[$key])) {
+                        $part[$key] = $this->normalizeScalarString($part[$key]);
+                    }
+                }
             }
 
             $multipart[$index] = $part;
@@ -1492,7 +1572,7 @@ class PendingRequest
                     $multipart[$index]['headers'][$name] = match (true) {
                         $value === [] => '',
                         $value === null => '',
-                        is_scalar($value) => (string) $value,
+                        is_scalar($value) => $this->normalizeScalarString($value),
                         $value instanceof Stringable => $value->toString(),
                         default => throw new InvalidArgumentException('Multipart header values must be scalar, null, or Laravel Stringable.'),
                     };

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -119,6 +119,48 @@ class HttpClientTest extends TestCase
         $this->assertSame(['first', '123', '1', '', ''], $response->getHeader('X-Multiple'));
     }
 
+    public function testFakeResponseScalarBodiesAreRejected()
+    {
+        foreach ([123, 1.5, true, false, NAN, INF, -INF] as $body) {
+            try {
+                $this->factory::response($body);
+
+                $this->fail('The fake response body was not rejected.');
+            } catch (InvalidArgumentException $e) {
+                $this->assertSame('HTTP fake response body must be a string, array, or null.', $e->getMessage());
+            }
+        }
+    }
+
+    public function testFakeResponseHeaderValuesNormalizeNonFiniteFloats()
+    {
+        $response = $this->factory::response('OK', 200, [
+            'X-Nan' => NAN,
+            'X-Inf' => INF,
+            'X-Negative-Inf' => -INF,
+            'X-Multiple' => [NAN, INF, -INF],
+        ])->wait();
+
+        $this->assertSame(['NAN'], $response->getHeader('X-Nan'));
+        $this->assertSame(['INF'], $response->getHeader('X-Inf'));
+        $this->assertSame(['-INF'], $response->getHeader('X-Negative-Inf'));
+        $this->assertSame(['NAN', 'INF', '-INF'], $response->getHeader('X-Multiple'));
+    }
+
+    public function testJsonFakeResponseBodiesWithNonFiniteFloatsAreRejected()
+    {
+        foreach ([NAN, INF, -INF] as $value) {
+            try {
+                $this->factory::response(['value' => $value]);
+
+                $this->fail('The JSON fake response body was not rejected.');
+            } catch (InvalidArgumentException $e) {
+                $this->assertStringContainsString('could not be JSON encoded', $e->getMessage());
+                $this->assertInstanceOf(\JsonException::class, $e->getPrevious());
+            }
+        }
+    }
+
     #[DataProvider('invalidFakeResponseHeaderValuesProvider')]
     public function testInvalidFakeResponseHeaderValuesAreRejected($value)
     {
@@ -142,20 +184,16 @@ class HttpClientTest extends TestCase
         $this->assertTrue($response->created());
     }
 
-    public function testStatusCodeShorthandAssumeBodyWhenInvalidHttpStatusCode()
+    public function testStatusCodeShorthandRejectsInvalidHttpStatusCode()
     {
         $this->factory->fake([
-            'forge.laravel.com' => 999,
-            'vapor.laravel.com' => 1,
+            'foo.com/*' => 999,
         ]);
 
-        $response = $this->factory->post('http://forge.laravel.com');
-        $this->assertTrue($response->ok());
-        $this->assertSame('999', $response->body());
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('HTTP status code must be between 100 and 599.');
 
-        $response = $this->factory->post('http://vapor.laravel.com');
-        $this->assertTrue($response->ok());
-        $this->assertSame('1', $response->body());
+        $this->factory->get('http://foo.com/test');
     }
 
     public function testBodyShorthands()
@@ -1120,6 +1158,19 @@ class HttpClientTest extends TestCase
 
         // The sequence is empty, it should throw an exception.
         $this->factory->get('https://example.com');
+    }
+
+    public function testResponseSequencesRejectScalarBodies()
+    {
+        foreach ([123, 1.5, true, false, NAN, INF, -INF] as $body) {
+            try {
+                $this->factory->sequence()->push($body);
+
+                $this->fail('The fake response body was not rejected.');
+            } catch (InvalidArgumentException $e) {
+                $this->assertSame('HTTP fake response body must be a string, array, or null.', $e->getMessage());
+            }
+        }
     }
 
     public function testSequenceBuilderCanKeepGoingWhenEmpty()
@@ -2890,6 +2941,34 @@ class HttpClientTest extends TestCase
         $this->assertEqualsCanonicalizing(['code' => 'not_found'], $requestException->response->json());
         $this->assertEquals(404, $requestException->response->status());
         $this->assertEquals(199, $requestException->response->header('X-RateLimit-Remaining'));
+    }
+
+    public function testFailedRequestRejectsScalarBody()
+    {
+        foreach ([123, 1.5, true, false, NAN, INF, -INF] as $body) {
+            try {
+                $this->factory::failedRequest($body, 404);
+
+                $this->fail('The fake response body was not rejected.');
+            } catch (InvalidArgumentException $e) {
+                $this->assertSame('HTTP fake response body must be a string, array, or null.', $e->getMessage());
+            }
+        }
+    }
+
+    public function testFailedRequestHeaderValuesNormalizeNonFiniteFloats()
+    {
+        $exception = $this->factory::failedRequest('error', 500, [
+            'X-Nan' => NAN,
+            'X-Inf' => INF,
+            'X-Negative-Inf' => -INF,
+        ]);
+
+        $this->assertSame('error', $exception->response->body());
+        $this->assertSame(500, $exception->response->status());
+        $this->assertSame('NAN', $exception->response->header('X-Nan'));
+        $this->assertSame('INF', $exception->response->header('X-Inf'));
+        $this->assertSame('-INF', $exception->response->header('X-Negative-Inf'));
     }
 
     public function testFakeConnectionException()

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -119,19 +119,6 @@ class HttpClientTest extends TestCase
         $this->assertSame(['first', '123', '1', '', ''], $response->getHeader('X-Multiple'));
     }
 
-    public function testFakeResponseScalarBodiesAreRejected()
-    {
-        foreach ([123, 1.5, true, false, NAN, INF, -INF] as $body) {
-            try {
-                $this->factory::response($body);
-
-                $this->fail('The fake response body was not rejected.');
-            } catch (InvalidArgumentException $e) {
-                $this->assertSame('HTTP fake response body must be a string, array, or null.', $e->getMessage());
-            }
-        }
-    }
-
     public function testFakeResponseHeaderValuesNormalizeNonFiniteFloats()
     {
         $response = $this->factory::response('OK', 200, [
@@ -145,20 +132,6 @@ class HttpClientTest extends TestCase
         $this->assertSame(['INF'], $response->getHeader('X-Inf'));
         $this->assertSame(['-INF'], $response->getHeader('X-Negative-Inf'));
         $this->assertSame(['NAN', 'INF', '-INF'], $response->getHeader('X-Multiple'));
-    }
-
-    public function testJsonFakeResponseBodiesWithNonFiniteFloatsAreRejected()
-    {
-        foreach ([NAN, INF, -INF] as $value) {
-            try {
-                $this->factory::response(['value' => $value]);
-
-                $this->fail('The JSON fake response body was not rejected.');
-            } catch (InvalidArgumentException $e) {
-                $this->assertStringContainsString('could not be JSON encoded', $e->getMessage());
-                $this->assertInstanceOf(\JsonException::class, $e->getPrevious());
-            }
-        }
     }
 
     #[DataProvider('invalidFakeResponseHeaderValuesProvider')]
@@ -182,18 +155,6 @@ class HttpClientTest extends TestCase
 
         $response = $this->factory->post('http://vapor.laravel.com');
         $this->assertTrue($response->created());
-    }
-
-    public function testStatusCodeShorthandRejectsInvalidHttpStatusCode()
-    {
-        $this->factory->fake([
-            'foo.com/*' => 999,
-        ]);
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('HTTP status code must be between 100 and 599.');
-
-        $this->factory->get('http://foo.com/test');
     }
 
     public function testBodyShorthands()
@@ -595,34 +556,6 @@ class HttpClientTest extends TestCase
         $this->factory->fake($fakeRequest);
 
         $this->factory->withBody($body, 'text/plain')->send('post', 'http://foo.com/api');
-    }
-
-    public function testWithBodyRejectsInvalidBodies()
-    {
-        foreach ([123, 1.5, true, false, NAN, INF, -INF, ['foo' => 'bar'], new stdClass] as $body) {
-            try {
-                $this->factory->withBody($body, 'text/plain');
-
-                $this->fail('The request body was not rejected.');
-            } catch (InvalidArgumentException $e) {
-                $this->assertSame('HTTP request body must be a string, resource, Psr\Http\Message\StreamInterface, or null.', $e->getMessage());
-            }
-        }
-    }
-
-    public function testWithOptionsBodyRejectsInvalidBodies()
-    {
-        $this->factory->fake();
-
-        foreach ([123, 1.5, true, false, NAN, INF, -INF, ['foo' => 'bar'], new stdClass] as $body) {
-            try {
-                $this->factory->withOptions(['body' => $body])->send('POST', 'http://foo.com/api');
-
-                $this->fail('The request body was not rejected.');
-            } catch (InvalidArgumentException $e) {
-                $this->assertSame('HTTP request body must be a string, resource, Psr\Http\Message\StreamInterface, or null.', $e->getMessage());
-            }
-        }
     }
 
     public function testUrlsCanBeStubbedByPath()
@@ -1254,19 +1187,6 @@ class HttpClientTest extends TestCase
 
         // The sequence is empty, it should throw an exception.
         $this->factory->get('https://example.com');
-    }
-
-    public function testResponseSequencesRejectScalarBodies()
-    {
-        foreach ([123, 1.5, true, false, NAN, INF, -INF] as $body) {
-            try {
-                $this->factory->sequence()->push($body);
-
-                $this->fail('The fake response body was not rejected.');
-            } catch (InvalidArgumentException $e) {
-                $this->assertSame('HTTP fake response body must be a string, array, or null.', $e->getMessage());
-            }
-        }
     }
 
     public function testSequenceBuilderCanKeepGoingWhenEmpty()
@@ -3037,19 +2957,6 @@ class HttpClientTest extends TestCase
         $this->assertEqualsCanonicalizing(['code' => 'not_found'], $requestException->response->json());
         $this->assertEquals(404, $requestException->response->status());
         $this->assertEquals(199, $requestException->response->header('X-RateLimit-Remaining'));
-    }
-
-    public function testFailedRequestRejectsScalarBody()
-    {
-        foreach ([123, 1.5, true, false, NAN, INF, -INF] as $body) {
-            try {
-                $this->factory::failedRequest($body, 404);
-
-                $this->fail('The fake response body was not rejected.');
-            } catch (InvalidArgumentException $e) {
-                $this->assertSame('HTTP fake response body must be a string, array, or null.', $e->getMessage());
-            }
-        }
     }
 
     public function testFailedRequestHeaderValuesNormalizeNonFiniteFloats()
@@ -4912,14 +4819,14 @@ class HttpClientTest extends TestCase
     public function testJsonDecodingIsCachedForFalsyPayloads()
     {
         $payloads = [
-            '[]' => [],
-            'false' => false,
-            '0' => 0,
-            'null' => null,
-            '""' => '',
+            ['[]', []],
+            ['false', false],
+            ['0', 0],
+            ['null', null],
+            ['""', ''],
         ];
 
-        foreach ($payloads as $body => $expected) {
+        foreach ($payloads as [$body, $expected]) {
             $response = new BodyTrackingResponse(Factory::psr7Response($body));
 
             // First call decodes and caches

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -597,6 +597,34 @@ class HttpClientTest extends TestCase
         $this->factory->withBody($body, 'text/plain')->send('post', 'http://foo.com/api');
     }
 
+    public function testWithBodyRejectsInvalidBodies()
+    {
+        foreach ([123, 1.5, true, false, NAN, INF, -INF, ['foo' => 'bar'], new stdClass] as $body) {
+            try {
+                $this->factory->withBody($body, 'text/plain');
+
+                $this->fail('The request body was not rejected.');
+            } catch (InvalidArgumentException $e) {
+                $this->assertSame('HTTP request body must be a string, resource, Psr\Http\Message\StreamInterface, or null.', $e->getMessage());
+            }
+        }
+    }
+
+    public function testWithOptionsBodyRejectsInvalidBodies()
+    {
+        $this->factory->fake();
+
+        foreach ([123, 1.5, true, false, NAN, INF, -INF, ['foo' => 'bar'], new stdClass] as $body) {
+            try {
+                $this->factory->withOptions(['body' => $body])->send('POST', 'http://foo.com/api');
+
+                $this->fail('The request body was not rejected.');
+            } catch (InvalidArgumentException $e) {
+                $this->assertSame('HTTP request body must be a string, resource, Psr\Http\Message\StreamInterface, or null.', $e->getMessage());
+            }
+        }
+    }
+
     public function testUrlsCanBeStubbedByPath()
     {
         $this->factory->fake([
@@ -652,6 +680,39 @@ class HttpClientTest extends TestCase
             return $request->url() === 'http://foo.com/form' &&
                    $request->hasHeader('Content-Type', 'application/x-www-form-urlencoded') &&
                    $request['name'] === 'Taylor';
+        });
+    }
+
+    public function testQueryParametersNormalizeNonFiniteFloats()
+    {
+        $this->factory->fake();
+
+        $this->factory->get('https://laravel.com/search', [
+            'nan' => NAN,
+            'inf' => INF,
+            'negative_inf' => -INF,
+            'nested' => ['value' => NAN],
+        ]);
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'https://laravel.com/search?nan=NAN&inf=INF&negative_inf=-INF&nested%5Bvalue%5D=NAN';
+        });
+    }
+
+    public function testFormParamsNormalizeNonFiniteFloats()
+    {
+        $this->factory->fake();
+
+        $this->factory->asForm()->post('http://foo.com/form', [
+            'nan' => NAN,
+            'inf' => INF,
+            'negative_inf' => -INF,
+            'nested' => ['value' => NAN],
+        ]);
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://foo.com/form'
+                && $request->body() === 'nan=NAN&inf=INF&negative_inf=-INF&nested%5Bvalue%5D=NAN';
         });
     }
 
@@ -754,8 +815,11 @@ class HttpClientTest extends TestCase
             'X-Null' => null,
             'X-True' => true,
             'X-False' => false,
+            'X-Nan' => NAN,
+            'X-Inf' => INF,
+            'X-Negative-Inf' => -INF,
             'X-Laravel-Stringable' => new Stringable('laravel stringable'),
-            'X-Multiple' => ['first', 123, true, false, null],
+            'X-Multiple' => ['first', 123, true, false, null, NAN, INF, -INF],
             'X-Empty' => [],
         ])->post('http://foo.com/json');
 
@@ -765,8 +829,11 @@ class HttpClientTest extends TestCase
                 && $request->hasHeader('X-Null', '')
                 && $request->hasHeader('X-True', '1')
                 && $request->hasHeader('X-False', '')
+                && $request->hasHeader('X-Nan', 'NAN')
+                && $request->hasHeader('X-Inf', 'INF')
+                && $request->hasHeader('X-Negative-Inf', '-INF')
                 && $request->hasHeader('X-Laravel-Stringable', 'laravel stringable')
-                && $request->hasHeader('X-Multiple', ['first', '123', '1', '', ''])
+                && $request->hasHeader('X-Multiple', ['first', '123', '1', '', '', 'NAN', 'INF', '-INF'])
                 && $request->hasHeader('X-Empty', '');
         });
     }
@@ -787,12 +854,13 @@ class HttpClientTest extends TestCase
         $this->factory->fake();
 
         $this->factory->withOptions([
-            'headers' => ['X-Test' => 123, 'X-Null' => null],
+            'headers' => ['X-Test' => 123, 'X-Null' => null, 'X-Nan' => NAN],
         ])->post('http://foo.com/json');
 
         $this->factory->assertSent(function (Request $request) {
             return $request->hasHeader('X-Test', '123')
-                && $request->hasHeader('X-Null', '');
+                && $request->hasHeader('X-Null', '')
+                && $request->hasHeader('X-Nan', 'NAN');
         });
     }
 
@@ -950,11 +1018,12 @@ class HttpClientTest extends TestCase
     {
         $this->factory->fake();
 
-        $this->factory->attach('file', 'data', 'file.txt', ['X-Part' => 123, 'X-Null' => null])->post('http://foo.com/file');
+        $this->factory->attach('file', 'data', 'file.txt', ['X-Part' => 123, 'X-Null' => null, 'X-Nan' => NAN])->post('http://foo.com/file');
 
         $this->factory->assertSent(function (Request $request) {
             return $request[0]['headers']['X-Part'] === '123'
-                && $request[0]['headers']['X-Null'] === '';
+                && $request[0]['headers']['X-Null'] === ''
+                && $request[0]['headers']['X-Nan'] === 'NAN';
         });
     }
 
@@ -969,6 +1038,9 @@ class HttpClientTest extends TestCase
                 'headers' => [
                     'X-Part' => 123,
                     'X-Null' => null,
+                    'X-Nan' => NAN,
+                    'X-Inf' => INF,
+                    'X-Negative-Inf' => -INF,
                     'X-Empty' => [],
                     'X-Laravel-Stringable' => new Stringable('laravel stringable'),
                 ],
@@ -978,6 +1050,9 @@ class HttpClientTest extends TestCase
         $this->factory->assertSent(function (Request $request) {
             return $request[0]['headers']['X-Part'] === '123'
                 && $request[0]['headers']['X-Null'] === ''
+                && $request[0]['headers']['X-Nan'] === 'NAN'
+                && $request[0]['headers']['X-Inf'] === 'INF'
+                && $request[0]['headers']['X-Negative-Inf'] === '-INF'
                 && $request[0]['headers']['X-Empty'] === ''
                 && $request[0]['headers']['X-Laravel-Stringable'] === 'laravel stringable';
         });
@@ -1056,6 +1131,27 @@ class HttpClientTest extends TestCase
                 $request[0]['contents'] === 'Steve' &&
                 $request[1]['name'] === 'roles' &&
                 $request[1]['contents'] === ['Network Administrator', 'Janitor'];
+        });
+    }
+
+    public function testMultipartContentsNormalizeNonFiniteFloats()
+    {
+        $this->factory->fake();
+
+        $this->factory->asMultipart()->post('http://foo.com/multipart', [
+            'nan' => NAN,
+            'inf' => INF,
+            'negative_inf' => -INF,
+            'nested' => ['value' => NAN],
+        ]);
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://foo.com/multipart'
+                && $request->isMultipart()
+                && $request[0]['contents'] === 'NAN'
+                && $request[1]['contents'] === 'INF'
+                && $request[2]['contents'] === '-INF'
+                && $request[3]['contents'] === ['value' => 'NAN'];
         });
     }
 


### PR DESCRIPTION
This should avoid PHP 8.5 deprecation warnings about casting non-finite floats to strings, upcoming deprecations in the Guzzle 7.12/PSR 2.12 releases I am likely to do later today, and to ensure consistent errors when there's invalid input.