### PR TITLE
[13.x] Ensure DevCommands doesnt stop itself from registering

### DIFF
--- a/src/Illuminate/Foundation/DevCommands.php
+++ b/src/Illuminate/Foundation/DevCommands.php
@@ -52,10 +52,14 @@ class DevCommands
      */
     public static function registerDefaults()
     {
-        self::artisan('serve --host=localhost', 'server');
-        self::artisan('queue:listen --tries=1 --timeout=0', 'queue');
-        self::artisan('pail --timeout=0', 'logs');
-        self::node('dev', 'vite');
+        foreach ([
+            'server' => 'php artisan serve --host=localhost',
+            'queue' => 'php artisan queue:listen --tries=1 --timeout=0',
+            'logs' => 'php artisan pail --timeout=0',
+            'vite' => self::getPackageManager()->getRunCommand('dev'),
+        ] as $name => $command) {
+            self::$commands[$name] = new DevCommand($command, $name);
+        }
     }
 
     /**

--- a/src/Illuminate/Foundation/DevCommands.php
+++ b/src/Illuminate/Foundation/DevCommands.php
@@ -52,6 +52,10 @@ class DevCommands
      */
     public static function registerDefaults()
     {
+        if (! app()->runningInConsole()) {
+            return;
+        }
+
         foreach ([
             'server' => 'php artisan serve --host=localhost',
             'queue' => 'php artisan queue:listen --tries=1 --timeout=0',


### PR DESCRIPTION
Closes https://github.com/laravel/framework/issues/60525 

This done broke me upgrade, because laravel framework itself is in vendor, it stops itself from registering dev commands which breaks composer updating...  (see issue for log)

**right now all new installs and upgrades fail cus of this**

All this PR does is manually add them into commands array, rather than call the methods which avoids the vendor check, which means it works.


Tested locally:

```
artisan dev

[server] php artisan serve --host=localhost
[queue]  php artisan queue:listen --tries=1 --timeout=0
[logs]   php artisan pail --timeout=0
[vite]   bun run dev

[vite] $ vite
[vite] 3:42:15 PM [vite] (client) Re-optimizing dependencies because lockfile has changed
[vite] 
[vite]   VITE v8.0.14  ready in 297 ms
[vite] 
[vite]   ➜  Local:   https://localhost:5173/
[vite]   ➜  Network: https://172.18.0.8:5173/
[vite] 
[vite]   LARAVEL v13.16.0  plugin v3.1.0
[vite] 
[vite]   ➜  APP_URL: https://local.xxxxxx.com
[queue] 
[queue]    INFO  Processing jobs from the [default] queue.  
[queue] 
[logs]
```

Granted there could be a nicer way, but thought i'd throw something up cause.. its broken 