### PR TITLE
[13.x] Add nightly workflow to verify framework install

### DIFF
--- a/.github/workflows/install-nightly.yml
+++ b/.github/workflows/install-nightly.yml
@@ -1,0 +1,44 @@
+name: install-nightly
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+permissions:
+  contents: read
+
+jobs:
+  install:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Setup PHP
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
+        with:
+          php-version: 8.3
+          extensions: dom, curl, libxml, mbstring, zip, pcntl
+          tools: composer:v2
+          coverage: none
+
+      - name: Create a Laravel application
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          # rm -rf app ensures each retry starts clean in case it previously fails...
+          command: rm -rf app && composer create-project laravel/laravel app --no-install --no-scripts --no-interaction
+
+      - name: Require the development release
+        working-directory: app
+        run: composer require laravel/framework:13.x-dev --no-update --no-interaction
+
+      - name: Install dependencies
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          command: cd app && composer update --with-all-dependencies --no-interaction --no-progress
+
+      - name: Boot the application
+        working-directory: app
+        run: php artisan about


### PR DESCRIPTION
Currently, there's no tests for ensuring the latest branch installs correctly which https://github.com/laravel/framework/issues/60525 highlighted 

  This PR adds a **nightly workflow** that:
  - Creates a fresh laravel/laravel app
  - Requires laravel/framework:13.x-dev
  - Composer installs & runs php artisan about

Passing: https://github.com/jackbayliss/framework/actions/runs/27650345931
Catching a real breakage: https://github.com/jackbayliss/framework/actions/runs/27650957089/job/81774575916#step:5:492

This essentially is an attempt at catching any issues that affect installation / updating before it reaches the public

Should be fairly easy to maintain like all the other workflows.

Thought I'd give this a go to be visible to all, would rather more eyes, but I can run it myself so no drama if you don't dig it :bowtie:  


Note: this currently relies on checking the workflow results, like the other nightly workflows, but you can wire them up to notifications etc if you want. Idea is for now, at least it's visible!  