### PR TITLE
[13.x] Add `Batch::failureCallbacks` for callback inspection

### DIFF
--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -421,6 +421,16 @@ class Batch implements Arrayable, JsonSerializable
     }
 
     /**
+     * Get the "failure" callbacks that have been registered with the batch.
+     *
+     * @return array
+     */
+    public function failureCallbacks()
+    {
+        return $this->options['failure'] ?? [];
+    }
+
+    /**
      * Determine if the batch has "finally" callbacks.
      *
      * @return bool

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -597,6 +597,13 @@ class BusBatchTest extends TestCase
         $batch->options['catch'] = [1];
         $this->assertTrue($batch->hasCatchCallbacks());
 
+        $this->assertSame([], $batch->failureCallbacks());
+        $batch->options['failure'] = [];
+        $this->assertFalse($batch->hasFailureCallbacks());
+        $batch->options['failure'] = [1];
+        $this->assertTrue($batch->hasFailureCallbacks());
+        $this->assertSame([1], $batch->failureCallbacks());
+
         $this->assertFalse($batch->cancelled());
         $batch->cancelledAt = Carbon::now();
         $this->assertTrue($batch->cancelled());


### PR DESCRIPTION
Batch now exposes `failureCallbacks()` so stored batches can be inspected in the same way as `PendingBatch`. 

`PendingBatch` already has `failureCallbacks()`, but `Illuminate\Bus\Batch` only exposed the boolean callback checks. 
This change fills that gap and keeps the pending and persisted batch APIs aligned.

The new method returns the registered failure callbacks from the batch options, or an empty array when none are present. I also added coverage in the Bus batch state tests for both `hasFailureCallbacks()` and `failureCallbacks()`.