### PR TITLE
[13.x] Add missing @throws \ReflectionException annotations

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -2316,6 +2316,8 @@ class Builder implements BuilderContract
      * @param  string  $mixin
      * @param  bool  $replace
      * @return void
+     *
+     * @throws \ReflectionException
      */
     protected static function registerMixin($mixin, $replace)
     {

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -700,6 +700,8 @@ class Dispatcher implements DispatcherContract
      * @param  string  $method
      * @param  array  $arguments
      * @return array{TListener, mixed}
+     *
+     * @throws \ReflectionException
      */
     protected function createListenerAndJob($class, $method, $arguments)
     {

--- a/src/Illuminate/Reflection/Reflector.php
+++ b/src/Illuminate/Reflection/Reflector.php
@@ -82,6 +82,8 @@ class Reflector
      * @param  class-string<TAttribute>  $attribute
      * @param  bool  $includeParents
      * @return ($includeParents is true ? Collection<class-string<contravariant TTarget>, Collection<int, TAttribute>> : Collection<int, TAttribute>)
+     *
+     * @throws \ReflectionException
      */
     public static function getClassAttributes($objectOrClass, $attribute, $includeParents = false)
     {

--- a/src/Illuminate/Reflection/helpers.php
+++ b/src/Illuminate/Reflection/helpers.php
@@ -13,6 +13,8 @@ if (! function_exists('lazy')) {
      * @param  int  $options
      * @param  array<string, mixed>  $eager
      * @return TValue
+     *
+     * @throws \ReflectionException
      */
     function lazy($class, $callback = 0, $options = 0, $eager = [])
     {
@@ -61,6 +63,8 @@ if (! function_exists('proxy')) {
      * @param  int  $options
      * @param  array<string, mixed>  $eager
      * @return TValue
+     *
+     * @throws \ReflectionException
      */
     function proxy($class, $callback = 0, $options = 0, $eager = [])
     {

--- a/src/Illuminate/Routing/RouteSignatureParameters.php
+++ b/src/Illuminate/Routing/RouteSignatureParameters.php
@@ -44,6 +44,8 @@ class RouteSignatureParameters
      *
      * @param  string  $uses
      * @return array
+     *
+     * @throws \ReflectionException
      */
     protected static function fromClassMethodString($uses)
     {


### PR DESCRIPTION
This adds missing `@throws \ReflectionException` PHPDoc annotations to a few methods/helpers that construct a reflection object from a class/method/function **name** without catching the resulting `ReflectionException`, so the exception can propagate to the caller.

Methods/helpers covered (each does an uncaught `new Reflection*()` on a name that may not resolve):
- `Eloquent\Builder::registerMixin()` - `new ReflectionClass($mixin)` (mirrors the already-annotated `Macroable::mixin()`)
- `Reflection\Reflector::getClassAttributes()` - `new ReflectionClass($objectOrClass)`
- `Events\Dispatcher::createListenerAndJob()` - `new ReflectionClass($class)`
- `Routing\RouteSignatureParameters::fromClassMethodString()` - `new ReflectionMethod($class, $method)`
- `lazy()` / `proxy()` helpers - `new ReflectionClass($class)`

No behavior changes.