### PR TITLE
[13.x] Improve types of InteractsWithData when* helpers

### DIFF
--- a/src/Illuminate/Support/Traits/InteractsWithData.php
+++ b/src/Illuminate/Support/Traits/InteractsWithData.php
@@ -82,10 +82,13 @@ trait InteractsWithData
     /**
      * Apply the callback if the instance contains the given key.
      *
+     * @template TReturn
+     * @template TReturnDefault = never
+     *
      * @param  string  $key
-     * @param  callable  $callback
-     * @param  callable|null  $default
-     * @return $this|mixed
+     * @param  callable(mixed): TReturn  $callback
+     * @param  (callable(): TReturnDefault)|null  $default
+     * @return $this|TReturn|TReturnDefault
      */
     public function whenHas($key, callable $callback, ?callable $default = null)
     {
@@ -160,10 +163,13 @@ trait InteractsWithData
     /**
      * Apply the callback if the instance contains a non-empty value for the given key.
      *
+     * @template TReturn
+     * @template TReturnDefault = never
+     *
      * @param  string  $key
-     * @param  callable  $callback
-     * @param  callable|null  $default
-     * @return $this|mixed
+     * @param  callable(mixed): TReturn  $callback
+     * @param  (callable(): TReturnDefault)|null  $default
+     * @return $this|TReturn|TReturnDefault
      */
     public function whenFilled($key, callable $callback, ?callable $default = null)
     {
@@ -224,10 +230,13 @@ trait InteractsWithData
     /**
      * Apply the callback if the instance is missing the given key.
      *
+     * @template TReturn
+     * @template TReturnDefault = never
+     *
      * @param  string  $key
-     * @param  callable  $callback
-     * @param  callable|null  $default
-     * @return $this|mixed
+     * @param  callable(mixed): TReturn  $callback
+     * @param  (callable(): TReturnDefault)|null  $default
+     * @return $this|TReturn|TReturnDefault
      */
     public function whenMissing($key, callable $callback, ?callable $default = null)
     {

--- a/types/Support/Traits.php
+++ b/types/Support/Traits.php
@@ -27,6 +27,42 @@ $interactsWithData = function (UriQueryString $query): void {
     assertType('3|Illuminate\Support\UriQueryString', $query->whenEnum('foo', TestIntEnum::class, function ($enum) {
         return 3;
     }));
+
+    assertType('1|2|Illuminate\Support\UriQueryString', $query->whenHas('foo', function ($value) {
+        assertType('mixed', $value);
+
+        return 1;
+    }, function () {
+        return 2;
+    }));
+
+    assertType('3|Illuminate\Support\UriQueryString', $query->whenHas('foo', function ($value) {
+        return 3;
+    }));
+
+    assertType('1|2|Illuminate\Support\UriQueryString', $query->whenFilled('foo', function ($value) {
+        assertType('mixed', $value);
+
+        return 1;
+    }, function () {
+        return 2;
+    }));
+
+    assertType('3|Illuminate\Support\UriQueryString', $query->whenFilled('foo', function ($value) {
+        return 3;
+    }));
+
+    assertType('1|2|Illuminate\Support\UriQueryString', $query->whenMissing('foo', function ($value) {
+        assertType('mixed', $value);
+
+        return 1;
+    }, function () {
+        return 2;
+    }));
+
+    assertType('3|Illuminate\Support\UriQueryString', $query->whenMissing('foo', function ($value) {
+        return 3;
+    }));
 };
 
 enum TestIntEnum: int


### PR DESCRIPTION
The `InteractsWithData::whenEnum()` method already carries full generic type information for its callback/default and return type, so static analysis can infer the precise result of a `whenEnum(...)` call. Its sibling conditional helpers in the same trait - `whenHas()`, `whenFilled()` and `whenMissing()` - share the identical shape (run `$callback($value)` when the condition holds, otherwise run `$default()` or return `$this`) but are still typed `@return $this|mixed`, so a call collapses to `mixed`.

This PR brings those three helpers in line by giving them the same generics:

```php
@template TReturn
@template TReturnDefault = never

@param  string  $key
@param  callable(mixed): TReturn  $callback
@param  (callable(): TReturnDefault)|null  $default
@return $this|TReturn|TReturnDefault
```

The callback receives the resolved value (`data_get($this->all(), $key)`), which is `mixed`, hence `callable(mixed): TReturn`.

`assertType` coverage for all three helpers is added under `types/`. No behavior changes.