### PR TITLE
[13.x] Fix DevCommands vendor registration check skipping userland frames

### DIFF
--- a/src/Illuminate/Foundation/DevCommands.php
+++ b/src/Illuminate/Foundation/DevCommands.php
@@ -195,7 +195,7 @@ class DevCommands
             $file = $frame['file'] ?? null;
             $class = $frame['class'] ?? null;
 
-            if ($class === self::class) {
+            if ($file === __FILE__) {
                 continue;
             }
 

--- a/tests/Foundation/FoundationDevCommandsTest.php
+++ b/tests/Foundation/FoundationDevCommandsTest.php
@@ -8,6 +8,7 @@ use Illuminate\Foundation\DevCommandColor;
 use Illuminate\Foundation\DevCommands;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Process\PhpProcess;
+use Symfony\Component\Process\Process;
 
 class FoundationDevCommandsTest extends TestCase
 {
@@ -207,8 +208,9 @@ class FoundationDevCommandsTest extends TestCase
     public function testVendorRegistrationIsPrevented()
     {
         $basePath = realpath(__DIR__.'/../..');
+        $vendorFile = $basePath.'/vendor/_test_vendor_register_'.uniqid().'.php';
 
-        $process = new PhpProcess(<<<EOF
+        file_put_contents($vendorFile, <<<PHP
 <?php
 require '{$basePath}/vendor/autoload.php';
 
@@ -216,16 +218,17 @@ require '{$basePath}/vendor/autoload.php';
 \$app['env'] = 'testing';
 
 try {
-    // Simulate a vendor package registering a dev command by calling from
-    // a file that only has vendor frames in the backtrace.
     Illuminate\Foundation\DevCommands::register('echo hello', 'vendor-cmd');
     echo 'REGISTERED';
 } catch (Exception \$e) {
     echo 'EXCEPTION:' . \$e->getMessage();
 }
-EOF, $basePath);
+PHP);
 
+        $process = new Process(['php', $vendorFile], $basePath);
         $process->run();
+
+        @unlink($vendorFile);
 
         $this->assertStringContainsString('EXCEPTION:', $process->getOutput());
         $this->assertStringContainsString('DevCommands should be registered in application code', $process->getOutput());

--- a/tests/Foundation/FoundationDevCommandsTest.php
+++ b/tests/Foundation/FoundationDevCommandsTest.php
@@ -7,7 +7,6 @@ use Illuminate\Foundation\DevCommand;
 use Illuminate\Foundation\DevCommandColor;
 use Illuminate\Foundation\DevCommands;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Process\PhpProcess;
 use Symfony\Component\Process\Process;
 
 class FoundationDevCommandsTest extends TestCase


### PR DESCRIPTION
The vendor prevention check was comparing `$class === self::class` to skip internal frames, but in PHP backtraces `$frame["class"]` is the class being called, not the caller. So when userland code (e.g. AppServiceProvider) calls `DevCommands::register()`, the frame has the userland file but `DevCommands` as the class, causing it to be skipped. This meant legitimate userland registrations could be incorrectly rejected.

Switches to `$file === __FILE__` so we only skip frames that physically originate from DevCommands.php.