### PR TITLE
[13.x] Add opt-in page clamping to paginator

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -15,6 +15,7 @@ use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Database\RecordsNotFoundException;
 use Illuminate\Database\UniqueConstraintViolationException;
+use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection as BaseCollection;
@@ -1127,6 +1128,10 @@ class Builder implements BuilderContract
 
         $perPage = value($perPage, $total) ?: $this->model->getPerPage();
 
+        if (($this->query->clampPage || LengthAwarePaginator::$defaultClampPage) && $total > 0) {
+            $page = min($page, max((int) ceil($total / $perPage), 1));
+        }
+
         $results = $total
             ? $this->forPage($page, $perPage)->get($columns)
             : $this->model->newCollection();
@@ -1135,6 +1140,19 @@ class Builder implements BuilderContract
             'path' => Paginator::resolveCurrentPath(),
             'pageName' => $pageName,
         ]);
+    }
+
+    /**
+     * Indicate that the paginator should clamp the current page to the last page when out of range.
+     *
+     * @param  bool  $clamp
+     * @return $this
+     */
+    public function clampPage(bool $clamp = true): static
+    {
+        $this->query->clampPage($clamp);
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -19,6 +19,7 @@ use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection as BaseCollection;
+use Illuminate\Support\Number;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\ForwardsCalls;
 use ReflectionClass;
@@ -1129,7 +1130,7 @@ class Builder implements BuilderContract
         $perPage = value($perPage, $total) ?: $this->model->getPerPage();
 
         if (($this->query->clampPage || LengthAwarePaginator::$defaultClampPage) && $total > 0) {
-            $page = min($page, max((int) ceil($total / $perPage), 1));
+            $page = Number::clamp($page, 1, (int) ceil($total / $perPage));
         }
 
         $results = $total

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -24,6 +24,7 @@ use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\LazyCollection;
+use Illuminate\Support\Number;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\ForwardsCalls;
 use Illuminate\Support\Traits\Macroable;
@@ -3628,7 +3629,7 @@ class Builder implements BuilderContract
         $perPage = value($perPage, $total);
 
         if (($this->clampPage || LengthAwarePaginator::$defaultClampPage) && $total > 0) {
-            $page = min($page, max((int) ceil($total / $perPage), 1));
+            $page = Number::clamp($page, 1, (int) ceil($total / $perPage));
         }
 
         $results = $total ? $this->forPage($page, $perPage)->get($columns) : new Collection;

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -19,6 +19,7 @@ use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\PostgresConnection;
 use Illuminate\Database\Query\Grammars\Grammar;
 use Illuminate\Database\Query\Processors\Processor;
+use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
@@ -277,6 +278,13 @@ class Builder implements BuilderContract
      * @var array
      */
     public array $fetchUsing = [];
+
+    /**
+     * Indicates whether paginate() should clamp the page to the last available page.
+     *
+     * @var bool
+     */
+    public $clampPage = false;
 
     /**
      * Create a new query builder instance.
@@ -3619,12 +3627,29 @@ class Builder implements BuilderContract
 
         $perPage = value($perPage, $total);
 
+        if (($this->clampPage || LengthAwarePaginator::$defaultClampPage) && $total > 0) {
+            $page = min($page, max((int) ceil($total / $perPage), 1));
+        }
+
         $results = $total ? $this->forPage($page, $perPage)->get($columns) : new Collection;
 
         return $this->paginator($results, $total, $perPage, $page, [
             'path' => Paginator::resolveCurrentPath(),
             'pageName' => $pageName,
         ]);
+    }
+
+    /**
+     * Indicate that the paginator should clamp the current page to the last page when out of range.
+     *
+     * @param  bool  $clamp
+     * @return $this
+     */
+    public function clampPage(bool $clamp = true): static
+    {
+        $this->clampPage = $clamp;
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -40,6 +40,13 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
     protected $lastPage;
 
     /**
+     * Indicates whether all paginators should clamp the current page to the last page by default.
+     *
+     * @var bool
+     */
+    public static $defaultClampPage = false;
+
+    /**
      * Create a new paginator instance.
      *
      * @param  Collection<TKey, TValue>|Arrayable<TKey, TValue>|iterable<TKey, TValue>|null  $items
@@ -76,6 +83,17 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
         $currentPage = $currentPage ?: static::resolveCurrentPage($pageName);
 
         return $this->isValidPageNumber($currentPage) ? (int) $currentPage : 1;
+    }
+
+    /**
+     * Indicate that all paginators should clamp the current page to the last page by default.
+     *
+     * @param  bool  $clamp
+     * @return void
+     */
+    public static function clampPageByDefault(bool $clamp = true): void
+    {
+        static::$defaultClampPage = $clamp;
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -18,6 +18,7 @@ use Illuminate\Database\Query\Builder as BaseBuilder;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Query\Grammars\Grammar;
 use Illuminate\Database\Query\Processors\Processor;
+use Illuminate\Pagination\AbstractPaginator as Paginator;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection as BaseCollection;
 use Mockery as m;
@@ -3011,6 +3012,31 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $result = $builder->incrementEach(['votes' => 1]);
         $this->assertEquals(1, $result);
+    }
+
+    public function testPaginateWithClampPageClampsToLastPage()
+    {
+        $perPage = 15;
+        $pageName = 'page';
+        $page = 100;
+        $lastPage = 2;
+        $total = 30;
+        $path = 'http://foo.bar?page=100';
+
+        $model = new EloquentBuilderTestStub;
+        $connection = $this->mockConnectionForModel($model, 'SQLite');
+        $connection->shouldReceive('getName')->andReturn('sqlite');
+        $connection->shouldReceive('select')->twice()->andReturnUsing(
+            fn () => [['aggregate' => $total]],
+            fn () => [['id' => 1], ['id' => 2]],
+        );
+
+        Paginator::currentPathResolver(fn () => $path);
+
+        $result = $model->newQuery()->clampPage()->paginate($perPage, ['*'], $pageName, $page);
+
+        $this->assertEquals($lastPage, $result->currentPage());
+        $this->assertEquals($total, $result->total());
     }
 
     protected function getMockModel()

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -6299,6 +6299,156 @@ SQL;
         $this->assertEquals(10, $result->total());
     }
 
+    public function testPaginateWithClampPageClampsToLastPage()
+    {
+        $perPage = 15;
+        $pageName = 'page';
+        $page = 100;
+        $lastPage = 2;
+        $total = 30;
+        $path = 'http://foo.bar?page=100';
+
+        $builder = $this->getBuilder();
+        $builder->from('users');
+        $builder->getProcessor()->shouldReceive('processSelect')->andReturnUsing(fn ($b, $results) => $results);
+        $builder->getConnection()->shouldReceive('select')->once()
+            ->andReturn([['aggregate' => $total]]);
+        $builder->getConnection()->shouldReceive('select')->once()
+            ->with(m::pattern('/limit 15 offset 15/'), m::any(), m::any(), m::any())
+            ->andReturn([['id' => 1], ['id' => 2]]);
+
+        Paginator::currentPathResolver(fn () => $path);
+
+        $result = $builder->clampPage()->paginate($perPage, ['*'], $pageName, $page);
+
+        $this->assertEquals($lastPage, $result->currentPage());
+        $this->assertEquals($total, $result->total());
+    }
+
+    public function testPaginateWithClampPageWhenPageIsWithinRange()
+    {
+        $perPage = 15;
+        $pageName = 'page';
+        $page = 1;
+        $total = 30;
+        $path = 'http://foo.bar?page=1';
+
+        $builder = $this->getBuilder();
+        $builder->from('users');
+        $builder->getProcessor()->shouldReceive('processSelect')->andReturnUsing(fn ($b, $results) => $results);
+        $builder->getConnection()->shouldReceive('select')->once()
+            ->andReturn([['aggregate' => $total]]);
+        $builder->getConnection()->shouldReceive('select')->once()
+            ->with(m::pattern('/limit 15 offset 0/'), m::any(), m::any(), m::any())
+            ->andReturn([['id' => 1], ['id' => 2]]);
+
+        Paginator::currentPathResolver(fn () => $path);
+
+        $result = $builder->clampPage()->paginate($perPage, ['*'], $pageName, $page);
+
+        $this->assertEquals($page, $result->currentPage());
+    }
+
+    public function testPaginateWithClampPageWhenPageIsExactlyLastPage()
+    {
+        $perPage = 15;
+        $pageName = 'page';
+        $page = 2;
+        $total = 30;
+        $path = 'http://foo.bar?page=2';
+
+        $builder = $this->getBuilder();
+        $builder->from('users');
+        $builder->getProcessor()->shouldReceive('processSelect')->andReturnUsing(fn ($b, $results) => $results);
+        $builder->getConnection()->shouldReceive('select')->once()
+            ->andReturn([['aggregate' => $total]]);
+        $builder->getConnection()->shouldReceive('select')->once()
+            ->with(m::pattern('/limit 15 offset 15/'), m::any(), m::any(), m::any())
+            ->andReturn([['id' => 1], ['id' => 2]]);
+
+        Paginator::currentPathResolver(fn () => $path);
+
+        $result = $builder->clampPage()->paginate($perPage, ['*'], $pageName, $page);
+
+        $this->assertEquals($page, $result->currentPage());
+    }
+
+    public function testPaginateWithClampPageWhenTotalIsZero()
+    {
+        $perPage = 15;
+        $pageName = 'page';
+        $page = 5;
+        $path = 'http://foo.bar?page=5';
+
+        $builder = $this->getBuilder();
+        $builder->from('users');
+        $builder->getProcessor()->shouldReceive('processSelect')->andReturnUsing(fn ($b, $results) => $results);
+        $builder->getConnection()->shouldReceive('select')->once()
+            ->andReturn([['aggregate' => 0]]);
+
+        Paginator::currentPathResolver(fn () => $path);
+
+        $result = $builder->clampPage()->paginate($perPage, ['*'], $pageName, $page);
+
+        $this->assertEquals(0, $result->total());
+        $this->assertTrue($result->isEmpty());
+    }
+
+    public function testPaginateDefaultDoesNotClamp()
+    {
+        $perPage = 15;
+        $pageName = 'page';
+        $page = 100;
+        $total = 30;
+        $path = 'http://foo.bar?page=100';
+
+        $builder = $this->getBuilder();
+        $builder->from('users');
+        $builder->getProcessor()->shouldReceive('processSelect')->andReturnUsing(fn ($b, $results) => $results);
+        $builder->getConnection()->shouldReceive('select')->once()
+            ->andReturn([['aggregate' => $total]]);
+        $builder->getConnection()->shouldReceive('select')->once()
+            ->with(m::pattern('/limit 15 offset 1485/'), m::any(), m::any(), m::any())
+            ->andReturn([]);
+
+        Paginator::currentPathResolver(fn () => $path);
+
+        $result = $builder->paginate($perPage, ['*'], $pageName, $page);
+
+        $this->assertEquals($page, $result->currentPage());
+        $this->assertTrue($result->isEmpty());
+    }
+
+    public function testPaginateWithDefaultClampPage()
+    {
+        $perPage = 15;
+        $pageName = 'page';
+        $page = 100;
+        $lastPage = 2;
+        $total = 30;
+        $path = 'http://foo.bar?page=100';
+
+        $builder = $this->getBuilder();
+        $builder->from('users');
+        $builder->getProcessor()->shouldReceive('processSelect')->andReturnUsing(fn ($b, $results) => $results);
+        $builder->getConnection()->shouldReceive('select')->once()
+            ->andReturn([['aggregate' => $total]]);
+        $builder->getConnection()->shouldReceive('select')->once()
+            ->with(m::pattern('/limit 15 offset 15/'), m::any(), m::any(), m::any())
+            ->andReturn([['id' => 1], ['id' => 2]]);
+
+        Paginator::currentPathResolver(fn () => $path);
+
+        LengthAwarePaginator::clampPageByDefault();
+
+        try {
+            $result = $builder->paginate($perPage, ['*'], $pageName, $page);
+            $this->assertEquals($lastPage, $result->currentPage());
+        } finally {
+            LengthAwarePaginator::clampPageByDefault(false);
+        }
+    }
+
     public function testCursorPaginate()
     {
         $perPage = 16;


### PR DESCRIPTION
## Summary

Currently, when a page number beyond the last page is requested (e.g., `page=100` on a dataset with only 2 pages), the paginator returns empty results.

This PR adds an **opt-in** feature to clamp out-of-range page numbers to the last available page and return its results. Backward compatibility is fully preserved.

## Usage

### Per-query

```php
// Query Builder
$results = DB::table('users')->clampPage()->paginate(15);

// Eloquent
$results = User::query()->clampPage()->paginate(15);
```

### Application-wide

Call this in `AppServiceProvider::boot()` or equivalent.

```php
use Illuminate\Pagination\LengthAwarePaginator;

LengthAwarePaginator::clampPageByDefault();
```

## Behavior

- `page=100` when only 2 pages exist → returns results for `page=2`
- Page within range → no change (result of `min($page, $lastPage)`)
- `total=0` → no clamping (guarded against division by zero)
- `simplePaginate` / `cursorPaginate` → not affected (no total count available)

Note that invalid values such as `page=0` or `page=hoge` continue to be resolved to `1` by the existing `currentPageResolver` behavior, which predates this PR. This PR does not alter that behavior.

## Use Case

A common scenario where this feature proves useful is when deleting the last remaining record on a page and redirecting back to the same page number. For example, if there is only one record on page 3 and it is deleted, redirecting to `page=3`
would previously return empty results. With this feature enabled, the paginator automatically returns the new last page (page 2 in this case) instead.