### PR TITLE
[13.x] Fix FileStore cache deserialization with short timestamps

### DIFF
--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -91,7 +91,7 @@ class FileStore implements CanFlushLocks, LockProvider, Store
         $this->ensureCacheDirectoryExists($path = $this->path($key));
 
         $result = $this->files->put(
-            $path, $this->expiration($seconds).serialize($value), true
+            $path, str_pad($this->expiration($seconds), 10, '0', STR_PAD_LEFT).serialize($value), true
         );
 
         if ($result !== false && $result > 0) {
@@ -129,7 +129,7 @@ class FileStore implements CanFlushLocks, LockProvider, Store
 
         if (empty($expire) || $this->currentTime() >= $expire) {
             $file->truncate()
-                ->write($this->expiration($seconds).serialize($value))
+                ->write(str_pad($this->expiration($seconds), 10, '0', STR_PAD_LEFT).serialize($value))
                 ->close();
 
             $this->ensurePermissionsAreCorrect($path);

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -91,7 +91,7 @@ class FileStore implements CanFlushLocks, LockProvider, Store
         $this->ensureCacheDirectoryExists($path = $this->path($key));
 
         $result = $this->files->put(
-            $path, str_pad($this->expiration($seconds), 10, '0', STR_PAD_LEFT).serialize($value), true
+            $path, str_pad((string) $this->expiration($seconds), 10, '0', STR_PAD_LEFT).serialize($value), true
         );
 
         if ($result !== false && $result > 0) {
@@ -129,7 +129,7 @@ class FileStore implements CanFlushLocks, LockProvider, Store
 
         if (empty($expire) || $this->currentTime() >= $expire) {
             $file->truncate()
-                ->write(str_pad($this->expiration($seconds), 10, '0', STR_PAD_LEFT).serialize($value))
+                ->write(str_pad((string) $this->expiration($seconds), 10, '0', STR_PAD_LEFT).serialize($value))
                 ->close();
 
             $this->ensurePermissionsAreCorrect($path);

--- a/tests/Cache/CacheFileStoreTest.php
+++ b/tests/Cache/CacheFileStoreTest.php
@@ -112,6 +112,30 @@ class CacheFileStoreTest extends TestCase
         $this->assertTrue($result);
     }
 
+    public function testPutPadsShortTimestampsToTenDigits()
+    {
+        $files = $this->mockFilesystem();
+        $store = $this->getMockBuilder(FileStore::class)->onlyMethods(['expiration'])->setConstructorArgs([$files, __DIR__])->getMock();
+        $store->expects($this->once())->method('expiration')->with(3)->willReturn(990464403);
+        $contents = '0990464403'.serialize('Hello World');
+        $hash = sha1('foo');
+        $cache_dir = substr($hash, 0, 2).'/'.substr($hash, 2, 2);
+        $files->expects($this->once())->method('put')->with(__DIR__.'/'.$cache_dir.'/'.$hash, $contents)->willReturn(strlen($contents));
+        $result = $store->put('foo', 'Hello World', 3);
+        $this->assertTrue($result);
+    }
+
+    public function testGetPayloadReadsZeroPaddedTimestampsCorrectly()
+    {
+        Carbon::setTestNow(Carbon::createFromTimestampUTC(990464400));
+
+        $files = $this->mockFilesystem();
+        $contents = '0990464403'.serialize('Hello World');
+        $files->expects($this->once())->method('get')->willReturn($contents);
+        $store = new FileStore($files, __DIR__);
+        $this->assertSame('Hello World', $store->get('foo'));
+    }
+
     public function testTouchExtendsTtl(): void
     {
         $files = $this->mockFilesystem();


### PR DESCRIPTION
Fixes #56075

`FileStore` writes the expiration timestamp directly before the serialized value and reads it back with `substr($contents, 0, 10)`. When the timestamp has fewer than 10 digits — which happens when time-traveling to dates before September 2001 via `setTestNow()` — the read grabs part of the serialized data as the timestamp, silently corrupting the cache entry.

This pads the timestamp to 10 digits on write using `str_pad`. The read side doesn't need changes since padded timestamps are already valid 10-character numeric strings.

Backward compatible: current timestamps are already 10 digits, so `str_pad` is a no-op for normal usage. Existing cache files are unaffected.