### PR TITLE
[13.x] Widen return types of methods returning json_encode() to string|false

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -743,7 +743,7 @@ class Grammar extends BaseGrammar
      * Prepare the binding for a "JSON contains" statement.
      *
      * @param  mixed  $binding
-     * @return string
+     * @return string|false
      */
     public function prepareBindingForJsonContains($binding)
     {

--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -155,7 +155,7 @@ class RetryCommand extends Command
      * Applicable to Redis and other jobs which store attempts in their payload.
      *
      * @param  string  $payload
-     * @return string
+     * @return string|false
      */
     protected function resetAttempts($payload)
     {
@@ -172,7 +172,7 @@ class RetryCommand extends Command
      * Refresh the "retry until" timestamp for the job.
      *
      * @param  string  $payload
-     * @return string
+     * @return string|false
      *
      * @throws \RuntimeException
      */

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -399,7 +399,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
      * Store the payload in cache and return a pointer payload.
      *
      * @param  string  $payload
-     * @return string
+     * @return string|false
      */
     protected function overflow($payload)
     {


### PR DESCRIPTION
A handful of internal methods return the result of `json_encode()` directly but document their return type as `@return string`. Without the `JSON_THROW_ON_ERROR` flag, `json_encode()` returns `string|false` - it yields `false` on failure                                                                                                                                                            
  (e.g. invalid UTF-8 in the input, recursion, or exceeding the maximum depth), so the declared type is too narrow.                                                                                                                                                                                                    
                                                                                                                                                                                                                                         
  This aligns these methods with `Illuminate\Http\Response::morphToJson()`, which already documents the exact same `return json_encode(...)` pattern as `@return string|false`.                                                                                                                                                                                                                
                                                                                                                                                                                                                                         
  Methods updated:                                                                                                                                                                                                                                                                                                                                                                                                                        
  - `Query\Grammars\Grammar::prepareBindingForJsonContains()`                                                                                                                                                                            
  - `Queue\SqsQueue::overflow()`                                                                                                                                                                                                         
  - `Queue\Console\RetryCommand::resetAttempts()`                                                                                                                                                                                        
  - `Queue\Console\RetryCommand::refreshRetryUntil()`                                                                                                                                                                                    
                                                                                                                                                                                                                                         
  Documentation-only change, no behavior is affected.                      

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
