### PR TITLE
[13.x] Add missing @throws \InvalidArgumentException annotations

### DIFF
--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -176,6 +176,8 @@ class Factory
      * @param  int  $status
      * @param  array<string, mixed>  $headers
      * @return \GuzzleHttp\Psr7\Response
+     *
+     * @throws \InvalidArgumentException
      */
     public static function psr7Response($body = null, $status = 200, $headers = [])
     {
@@ -201,6 +203,8 @@ class Factory
      *
      * @param  array  $headers
      * @return array
+     *
+     * @throws \InvalidArgumentException
      */
     protected static function normalizeResponseHeaders(array $headers): array
     {
@@ -363,6 +367,8 @@ class Factory
      * @param  string  $url
      * @param  \Illuminate\Http\Client\Response|\GuzzleHttp\Promise\PromiseInterface|callable|int|string|array|\Illuminate\Http\Client\ResponseSequence  $callback
      * @return $this
+     *
+     * @throws \InvalidArgumentException
      */
     public function stubUrl($url, $callback)
     {

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -1442,6 +1442,8 @@ class PendingRequest
      *
      * @param  mixed  $value
      * @return string|array
+     *
+     * @throws \InvalidArgumentException
      */
     protected function normalizeHeaderValue($value): string|array
     {
@@ -1531,6 +1533,8 @@ class PendingRequest
      *
      * @param  array  $multipart
      * @return array
+     *
+     * @throws \InvalidArgumentException
      */
     protected function normalizeMultipartHeaders(array $multipart): array
     {
@@ -1590,6 +1594,8 @@ class PendingRequest
      *
      * @param  mixed  $body
      * @return void
+     *
+     * @throws \InvalidArgumentException
      */
     protected function ensureValidRequestBody($body): void
     {


### PR DESCRIPTION
This MR adds missing `@throws \InvalidArgumentException` annotations to the HTTP client's response and header/body normalisation methods. These methods already throw InvalidArgumentException, so no behaviour changes
