### PR TITLE
[12.x] Fix datetime cast storing non-UTC date instances incorrectly

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1600,9 +1600,13 @@ trait HasAttributes
      */
     public function fromDateTime($value)
     {
-        return empty($value) ? $value : $this->asDateTime($value)->format(
-            $this->getDateFormat()
-        );
+        if (empty($value)) {
+            return $value;
+        }
+
+        return $this->asDateTime($value)
+            ->timezone(date_default_timezone_get())
+            ->format($this->getDateFormat());
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1044,6 +1044,33 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertNull($model->fromDateTime(null));
     }
 
+    public function testFromDateTimeConvertsToApplicationTimezoneBeforeStoring()
+    {
+        $previousTimezone = date_default_timezone_get();
+
+        date_default_timezone_set('UTC');
+
+        try {
+            $model = new EloquentModelStub;
+            $model->setDateFormat('Y-m-d H:i:s');
+
+            $value = Carbon::parse('2026-06-19 15:00:00', 'Europe/Amsterdam');
+            $this->assertSame('2026-06-19 13:00:00', $model->fromDateTime($value));
+
+            $value = new DateTime('2026-06-19 15:00:00', new \DateTimeZone('Europe/Amsterdam'));
+            $this->assertSame('2026-06-19 13:00:00', $model->fromDateTime($value));
+
+            $model = new EloquentModelCastingStub;
+            $model->setDateFormat('Y-m-d H:i:s');
+            $model->datetimeAttribute = Carbon::parse('2026-06-19 15:00:00', 'Europe/Amsterdam');
+
+            $this->assertSame('2026-06-19 13:00:00', $model->getAttributes()['datetimeAttribute']);
+            $this->assertSame('2026-06-19 13:00:00', $model->toArray()['datetimeAttribute']);
+        } finally {
+            date_default_timezone_set($previousTimezone);
+        }
+    }
+
     public function testFromDateTimeMilliseconds()
     {
         $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentDateModelStub')->onlyMethods(['getDateFormat'])->getMock();


### PR DESCRIPTION
Convert date values to the application timezone before formatting for database storage so Carbon and DateTime instances with a non-UTC timezone persist the correct instant. fixes #60547

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
