### PR TITLE
[13.X] Fix too narrow typehint for validateBoolean and validateNumeric

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -488,7 +488,7 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @param  array{0: 'strict'}  $parameters
+     * @param  array{0?: 'strict'}  $parameters
      * @return bool
      */
     public function validateBoolean($attribute, $value, $parameters)
@@ -1985,7 +1985,7 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @param  array{0: 'strict'}  $parameters
+     * @param  array{0?: 'strict'}  $parameters
      * @return bool
      */
     public function validateNumeric($attribute, $value, array $parameters)


### PR DESCRIPTION
## Summary

Fixes docbloc for two methods in the trait ValidatesAttributes.
- validateBoolean
- validateNumeric

### Problem

The previous typehint basically nailed `$parameters` to `[0 => 'strict']`, therefor not allowing an empty array which the method is called with when not using strict.

That this is actually used internally can be seen in the laravel code for validateNumeric.
```
        if (! $this->validateNumeric($attribute, $value, []) || ! $this->validateNumeric($attribute, $parameters[0], [])) {
```

### Solution

The new typehint makes `$parameter` accept both `[]` and `[0 => 'strict']` - this should be the narrowest possible typehint and also aligns with the pr linked under previous work

## previous work

Same fix was done last year for the validateInteger method https://github.com/laravel/framework/pull/57435