### PR TITLE
[13.x] Speed up Eloquent attribute casting with memoized cast objects

### DIFF
--- a/src/Illuminate/Database/Eloquent/Casts/ClosureCast.php
+++ b/src/Illuminate/Database/Eloquent/Casts/ClosureCast.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Contracts\Database\Eloquent\ComparesCastableAttributes;
+
+/**
+ * An internal cast built from closures.
+ *
+ * Used by the model to represent each built-in cast type as a reusable cast
+ * object so the dispatch decision can be resolved once per class + cast type
+ * and memoized, instead of being re-evaluated on every attribute access.
+ *
+ * The closures always defer back to the model's own cast methods so userland
+ * overrides of those methods are preserved.
+ *
+ * @internal
+ */
+class ClosureCast implements CastsAttributes, ComparesCastableAttributes
+{
+    /**
+     * The closure used to transform the attribute from its stored value.
+     *
+     * @var callable
+     */
+    protected $get;
+
+    /**
+     * The closure used to transform the attribute to its stored value.
+     *
+     * @var callable
+     */
+    protected $set;
+
+    /**
+     * The closure used to compare two values for the attribute.
+     *
+     * @var callable
+     */
+    protected $comparator;
+
+    /**
+     * Create a new closure cast instance.
+     *
+     * @param  callable  $get
+     * @param  callable|null  $set
+     * @param  callable|null  $comparator
+     * @param  bool  $setsOwnAttribute  Whether the set closure writes the model's attributes itself.
+     * @param  bool  $nullable  Whether a null stored value should resolve to null without calling the get closure.
+     */
+    public function __construct(
+        callable $get,
+        ?callable $set = null,
+        ?callable $comparator = null,
+        public bool $setsOwnAttribute = false,
+        protected bool $nullable = true,
+    ) {
+        $this->get = $get;
+        $this->set = $set ?: fn ($model, $key, $value) => $value;
+        $this->comparator = $comparator ?: fn () => false;
+    }
+
+    /**
+     * Transform the attribute from the underlying model values.
+     */
+    public function get($model, string $key, mixed $value, array $attributes)
+    {
+        if (is_null($value) && $this->nullable) {
+            return null;
+        }
+
+        return ($this->get)($model, $key, $value, $attributes);
+    }
+
+    /**
+     * Transform the attribute to its underlying model values.
+     */
+    public function set($model, string $key, mixed $value, array $attributes)
+    {
+        return ($this->set)($model, $key, $value, $attributes);
+    }
+
+    /**
+     * Determine if the given values are equal.
+     */
+    public function compare($model, string $key, mixed $firstValue, mixed $secondValue)
+    {
+        return (bool) ($this->comparator)($model, $key, $firstValue, $secondValue);
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Casts/ClosureCast.php
+++ b/src/Illuminate/Database/Eloquent/Casts/ClosureCast.php
@@ -15,6 +15,9 @@ use Illuminate\Contracts\Database\Eloquent\ComparesCastableAttributes;
  * The closures always defer back to the model's own cast methods so userland
  * overrides of those methods are preserved.
  *
+ * @template TValue
+ * @template TRawValue
+ *
  * @internal
  */
 class ClosureCast implements CastsAttributes, ComparesCastableAttributes
@@ -22,30 +25,30 @@ class ClosureCast implements CastsAttributes, ComparesCastableAttributes
     /**
      * The closure used to transform the attribute from its stored value.
      *
-     * @var callable
+     * @var callable(\Illuminate\Database\Eloquent\Model, string, TRawValue, array<string, mixed>): TValue
      */
     protected $get;
 
     /**
      * The closure used to transform the attribute to its stored value.
      *
-     * @var callable
+     * @var callable(\Illuminate\Database\Eloquent\Model, string, TValue, array<string, mixed>): TRawValue
      */
     protected $set;
 
     /**
      * The closure used to compare two values for the attribute.
      *
-     * @var callable
+     * @var callable(\Illuminate\Database\Eloquent\Model, string, TValue, TValue): bool
      */
     protected $comparator;
 
     /**
      * Create a new closure cast instance.
      *
-     * @param  callable  $get
-     * @param  callable|null  $set
-     * @param  callable|null  $comparator
+     * @param  callable(\Illuminate\Database\Eloquent\Model, string, TRawValue, array<string, mixed>): TValue  $get
+     * @param  (callable(\Illuminate\Database\Eloquent\Model, string, TValue, array<string, mixed>): TRawValue)|null  $set
+     * @param  (callable(\Illuminate\Database\Eloquent\Model, string, TValue, TValue): bool)|null  $comparator
      * @param  bool  $setsOwnAttribute  Whether the set closure writes the model's attributes itself.
      * @param  bool  $nullable  Whether a null stored value should resolve to null without calling the get closure.
      */
@@ -63,6 +66,12 @@ class ClosureCast implements CastsAttributes, ComparesCastableAttributes
 
     /**
      * Transform the attribute from the underlying model values.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  array<string, mixed>  $attributes
+     * @return mixed
      */
     public function get($model, string $key, mixed $value, array $attributes)
     {
@@ -75,6 +84,12 @@ class ClosureCast implements CastsAttributes, ComparesCastableAttributes
 
     /**
      * Transform the attribute to its underlying model values.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  array<string, mixed>  $attributes
+     * @return mixed
      */
     public function set($model, string $key, mixed $value, array $attributes)
     {
@@ -83,6 +98,12 @@ class ClosureCast implements CastsAttributes, ComparesCastableAttributes
 
     /**
      * Determine if the given values are equal.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @param  mixed  $firstValue
+     * @param  mixed  $secondValue
+     * @return bool
      */
     public function compare($model, string $key, mixed $firstValue, mixed $secondValue)
     {

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -988,7 +988,7 @@ trait HasAttributes
         }
 
         if (is_null($caster = static::$castClassCache[$castType])) {
-            throw new InvalidCastException($this->getModel(), $key, $castType);
+            throw new InvalidCastException($this->getModel(), $key, $this->parseCasterClass($cast));
         }
 
         return $caster;
@@ -1134,6 +1134,10 @@ trait HasAttributes
                     static function ($model, $key, $value) {
                         $model->setEnumCastableAttribute($key, $value);
                     },
+                    // Two stored values are equivalent when they resolve to the same
+                    // enum case, so a backed enum is not reported dirty when the same
+                    // case is re-assigned even if the raw scalar types differ.
+                    comparator: $primitiveComparator,
                     setsOwnAttribute: true,
                 );
             } elseif (class_exists($this->parseCasterClass($cast))) {
@@ -1203,7 +1207,10 @@ trait HasAttributes
                         return false;
                     }
 
-                    return $model->fromEncryptedString($current) === $model->fromEncryptedString($original);
+                    // Compare the fully cast (decrypted, then inner-cast) values so
+                    // an encrypted JSON payload that re-encodes to a different string
+                    // but the same structure is not reported as a change.
+                    return $model->castAttribute($key, $current) === $model->castAttribute($key, $original);
                 },
             );
         }
@@ -2574,6 +2581,13 @@ trait HasAttributes
         // memoized per class and cast type alongside the get/set behavior.
         if ($caster = $this->getInternalCastClass($key)) {
             return $caster->compare($this, $key, $attribute, $original);
+        }
+
+        // Date attributes that are not in the casts array (such as the timestamp
+        // columns) have no cast object, so they are still compared by normalizing
+        // both values to their storage format before checking for equivalence.
+        if ($this->isDateAttribute($key) || $this->isDateCastableWithCustomFormat($key)) {
+            return $this->fromDateTime($attribute) === $this->fromDateTime($original);
         }
 
         return is_numeric($attribute) && is_numeric($original)

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -194,16 +194,32 @@ trait HasAttributes
     protected static $castTypeCache = [];
 
     /**
-     * The cache of resolved internal cast objects, keyed by cast type.
+     * The cache of resolved built-in cast objects, keyed by a canonical cast
+     * token.
      *
-     * The resolved cast object depends only on the cast type, not on the model
-     * class — its closures take the model and key as parameters and defer to the
-     * model's own cast methods — so a single instance is shared as a flyweight
-     * across every model class and field that uses the same cast.
+     * Each built-in cast resolves to a single shared ClosureCast: alias groups
+     * (real/float/double, …) collapse to one key, every enum or custom cast
+     * class shares one generic instance, and each encrypted variant is wrapped
+     * once. The closures take the model and key as parameters and never capture
+     * the concrete type, so a known cast allocates at most one object for the
+     * whole process, shared across every model class and field that uses it.
      *
-     * @var array<string, \Illuminate\Database\Eloquent\Casts\ClosureCast|null>
+     * @var array<string, ClosureCast|null>
      */
-    protected static $castClassCache = [];
+    protected static $internalCasterCache = [];
+
+    /**
+     * The cache of cast objects resolved for a specific model class and cast.
+     *
+     * Whether an attribute is encrypted is governed by the overrideable
+     * isEncryptedCastable(), so the object a class ultimately uses can differ
+     * from the shared default. This per-class layer memoizes that decision
+     * (keyed by class, then cast type) while still pointing at the shared
+     * flyweights above, so no closures are duplicated per class.
+     *
+     * @var array<class-string, array<string, ClosureCast|null>>
+     */
+    protected static $resolvedCasterCache = [];
 
     /**
      * The encrypter instance that is used to encrypt attributes.
@@ -969,7 +985,7 @@ trait HasAttributes
      * userland overrides.
      *
      * @param  string  $key
-     * @return \Illuminate\Database\Eloquent\Casts\ClosureCast|null
+     * @return ClosureCast|null
      */
     protected function getInternalCastClass($key)
     {
@@ -981,13 +997,22 @@ trait HasAttributes
 
         $cast = $casts[$key];
 
-        $castType = $this->resolveCastType($cast);
+        // Resolve the cast type through getCastType() rather than inlining
+        // resolveCastType() so a model that overrides getCastType() is still
+        // honored on the cast path. The type is re-derived from the live
+        // getCasts() on every call and is the only thing that keys the cache
+        // below, so runtime cast changes (e.g. mergeCasts()) are always
+        // honored — do not hoist it into the cache.
+        $castType = $this->getCastType($key);
 
-        if (! array_key_exists($castType, static::$castClassCache)) {
-            static::$castClassCache[$castType] = $this->resolveInternalCastClass($castType, $cast);
+        $class = static::class;
+
+        if (! isset(static::$resolvedCasterCache[$class]) ||
+            ! array_key_exists($castType, static::$resolvedCasterCache[$class])) {
+            static::$resolvedCasterCache[$class][$castType] = $this->resolveCasterFor($key, $castType, $cast);
         }
 
-        if (is_null($caster = static::$castClassCache[$castType])) {
+        if (is_null($caster = static::$resolvedCasterCache[$class][$castType])) {
             throw new InvalidCastException($this->getModel(), $key, $this->parseCasterClass($cast));
         }
 
@@ -1006,146 +1031,71 @@ trait HasAttributes
      *
      * @param  string  $castType
      * @param  string  $cast
-     * @return \Illuminate\Database\Eloquent\Casts\ClosureCast|null
+     * @return ClosureCast|null
      */
     protected function resolveInternalCastClass($castType, $cast)
     {
-        $caster = null;
+        // Map the cast to a canonical cache key so a single shared instance backs
+        // every equivalent cast: alias groups collapse (real/float/double → float)
+        // and all enums / custom cast classes share one generic instance each,
+        // since the closures defer to the model and key at call time and never
+        // capture the concrete type.
+        if (in_array($castType, static::$primitiveCastTypes, true)) {
+            $cacheKey = match ($castType) {
+                'integer' => 'int',
+                'real', 'double' => 'float',
+                'boolean' => 'bool',
+                'json', 'json:unicode' => 'array',
+                'custom_datetime' => 'datetime',
+                'immutable_custom_datetime' => 'immutable_datetime',
+                default => $castType,
+            };
+        } else {
+            $cacheKey = match (true) {
+                enum_exists($cast) && ! is_subclass_of($cast, Castable::class) => '@enum',
+                class_exists($this->parseCasterClass($cast)) => '@class',
+                default => $castType,
+            };
+        }
 
+        if (array_key_exists($cacheKey, static::$internalCasterCache)) {
+            return static::$internalCasterCache[$cacheKey];
+        }
+
+        return static::$internalCasterCache[$cacheKey] = $this->buildInternalCastClass($castType, $cacheKey);
+    }
+
+    /**
+     * Build the cast object for the given canonical cast key.
+     *
+     * Only invoked on a cache miss in resolveInternalCastClass(), so the
+     * comparator closures created here are allocated once per logical cast type
+     * for the whole process, never per access.
+     *
+     * @param  string  $castType
+     * @param  string  $cacheKey
+     * @return ClosureCast|null
+     */
+    protected function buildInternalCastClass($castType, $cacheKey)
+    {
         $primitiveComparator = static fn ($model, $key, $current, $original) => $model->castAttribute($key, $current) === $model->castAttribute($key, $original);
 
-        $jsonSetter = static fn ($model, $key, $value) => is_null($value) ? null : $model->castAttributeAsJson($key, $value);
-
-        $jsonComparator = static fn ($model, $key, $current, $original) => $model->fromJson($current) === $model->fromJson($original);
-
-        $encrypted = in_array($castType, [
-            'encrypted', 'encrypted:array', 'encrypted:collection', 'encrypted:json', 'encrypted:object',
-        ], true);
-
-        if ($encrypted) {
-            $castType = Str::after($castType, 'encrypted:');
+        if ($cacheKey === '@enum') {
+            return new ClosureCast(
+                static fn ($model, $key, $value) => $model->getEnumCastableAttributeValue($key, $value),
+                static function ($model, $key, $value) {
+                    $model->setEnumCastableAttribute($key, $value);
+                },
+                // Two stored values are equivalent when they resolve to the same
+                // enum case, so a backed enum is not reported dirty when the same
+                // case is re-assigned even if the raw scalar types differ.
+                comparator: $primitiveComparator,
+                setsOwnAttribute: true,
+            );
         }
 
-        switch ($castType) {
-            case 'int':
-            case 'integer':
-                $caster = new ClosureCast(
-                    static fn ($model, $key, $value) => (int) $value,
-                    comparator: $primitiveComparator,
-                );
-                break;
-            case 'real':
-            case 'float':
-            case 'double':
-                $caster = new ClosureCast(
-                    static fn ($model, $key, $value) => $model->fromFloat($value),
-                    comparator: static function ($model, $key, $current, $original) {
-                        if ($original === null) {
-                            return false;
-                        }
-
-                        return abs($model->castAttribute($key, $current) - $model->castAttribute($key, $original)) < PHP_FLOAT_EPSILON * 4;
-                    },
-                );
-                break;
-            case 'decimal':
-                $caster = new ClosureCast(
-                    static fn ($model, $key, $value) => $model->asDecimal($value, explode(':', $model->getCasts()[$key], 2)[1]),
-                    comparator: $primitiveComparator,
-                );
-                break;
-            case 'string':
-                $caster = new ClosureCast(
-                    static fn ($model, $key, $value) => (string) $value,
-                    comparator: $primitiveComparator,
-                );
-                break;
-            case 'bool':
-            case 'boolean':
-                $caster = new ClosureCast(
-                    static fn ($model, $key, $value) => (bool) $value,
-                    comparator: $primitiveComparator,
-                );
-                break;
-            case 'object':
-                $caster = new ClosureCast(
-                    static fn ($model, $key, $value) => $model->fromJson($value, true),
-                    $jsonSetter,
-                    comparator: $jsonComparator,
-                );
-                break;
-            case 'array':
-            case 'json':
-            case 'json:unicode':
-                $caster = new ClosureCast(
-                    static fn ($model, $key, $value) => $model->fromJson($value),
-                    $jsonSetter,
-                    comparator: $jsonComparator,
-                );
-                break;
-            case 'collection':
-                $caster = new ClosureCast(
-                    static fn ($model, $key, $value) => new BaseCollection($model->fromJson($value)),
-                    $jsonSetter,
-                    comparator: $jsonComparator,
-                );
-                break;
-            case 'date':
-                $caster = new ClosureCast(
-                    static fn ($model, $key, $value) => $model->asDate($value),
-                    comparator: static fn ($model, $key, $current, $original) => $model->fromDateTime($current) === $model->fromDateTime($original),
-                );
-                break;
-            case 'datetime':
-            case 'custom_datetime':
-                $caster = new ClosureCast(
-                    static fn ($model, $key, $value) => $model->asDateTime($value),
-                    comparator: static fn ($model, $key, $current, $original) => $model->fromDateTime($current) === $model->fromDateTime($original),
-                );
-                break;
-            case 'immutable_date':
-                $caster = new ClosureCast(
-                    static fn ($model, $key, $value) => $model->asDate($value)->toImmutable(),
-                    comparator: static fn ($model, $key, $current, $original) => $model->fromDateTime($current) === $model->fromDateTime($original),
-                );
-                break;
-            case 'immutable_custom_datetime':
-            case 'immutable_datetime':
-                $caster = new ClosureCast(
-                    static fn ($model, $key, $value) => $model->asDateTime($value)->toImmutable(),
-                    comparator: static fn ($model, $key, $current, $original) => $model->fromDateTime($current) === $model->fromDateTime($original),
-                );
-                break;
-            case 'timestamp':
-                $caster = new ClosureCast(
-                    static fn ($model, $key, $value) => $model->asTimestamp($value),
-                    comparator: $primitiveComparator,
-                );
-                break;
-            case 'hashed':
-                $caster = new ClosureCast(
-                    static fn ($model, $key, $value) => $value,
-                    static fn ($model, $key, $value) => $model->castAttributeAsHashedString($key, $value),
-                    comparator: $primitiveComparator,
-                );
-                break;
-        }
-
-        if (! in_array($castType, static::$primitiveCastTypes, true)) {
-            if (enum_exists($cast) && ! is_subclass_of($cast, Castable::class)) {
-                $caster = new ClosureCast(
-                    static fn ($model, $key, $value) => $model->getEnumCastableAttributeValue($key, $value),
-                    static function ($model, $key, $value) {
-                        $model->setEnumCastableAttribute($key, $value);
-                    },
-                    // Two stored values are equivalent when they resolve to the same
-                    // enum case, so a backed enum is not reported dirty when the same
-                    // case is re-assigned even if the raw scalar types differ.
-                    comparator: $primitiveComparator,
-                    setsOwnAttribute: true,
-                );
-            } elseif (class_exists($this->parseCasterClass($cast))) {
-                $caster = new ClosureCast(
+        if ($cacheKey === '@class') {
+            return new ClosureCast(
                 static fn ($model, $key, $value) => $model->getClassCastableAttributeValue($key, $value),
                 static function ($model, $key, $value) {
                     $model->setClassCastableAttribute($key, $value);
@@ -1172,54 +1122,183 @@ trait HasAttributes
                     return is_numeric($current) && is_numeric($original)
                         && strcmp((string) $current, (string) $original) === 0;
                 },
-                    setsOwnAttribute: true,
-                    nullable: false,
-                );
-            }
-        }
-
-        // If the cast type is an encrypted type, we'll decrypt the value first
-        // and then leverage the underlying cast (resolved above from the inner
-        // type) for casting the decrypted value to any additionally specified
-        // type before re-encrypting on the way back out.
-        if ($encrypted) {
-            $originalCaster = $caster;
-
-            $caster = new ClosureCast(
-                static function ($model, $key, $value, $attributes) use ($originalCaster) {
-                    $value = $model->fromEncryptedString($value);
-
-                    if ($originalCaster) {
-                        $value = $originalCaster->get($model, $key, $value, $attributes);
-                    }
-
-                    return $value;
-                },
-                static function ($model, $key, $value, $attributes) use ($originalCaster) {
-                    if (is_null($value)) {
-                        return null;
-                    }
-
-                    if ($originalCaster) {
-                        $value = $originalCaster->set($model, $key, $value, $attributes);
-                    }
-
-                    return $model->castAttributeAsEncryptedString($key, $value);
-                },
-                comparator: static function ($model, $key, $current, $original) {
-                    if (! empty($model::currentEncrypter()->getPreviousKeys())) {
-                        return false;
-                    }
-
-                    // Compare the fully cast (decrypted, then inner-cast) values so
-                    // an encrypted JSON payload that re-encodes to a different string
-                    // but the same structure is not reported as a change.
-                    return $model->castAttribute($key, $current) === $model->castAttribute($key, $original);
-                },
+                setsOwnAttribute: true,
+                nullable: false,
             );
         }
 
-        return $caster;
+        $jsonSetter = static fn ($model, $key, $value) => is_null($value) ? null : $model->castAttributeAsJson($key, $value);
+
+        $jsonComparator = static fn ($model, $key, $current, $original) => $model->fromJson($current) === $model->fromJson($original);
+
+        $dateComparator = static fn ($model, $key, $current, $original) => $model->fromDateTime($current) === $model->fromDateTime($original);
+
+        switch ($castType) {
+            case 'int':
+            case 'integer':
+                return new ClosureCast(
+                    static fn ($model, $key, $value) => (int) $value,
+                    comparator: $primitiveComparator,
+                );
+            case 'real':
+            case 'float':
+            case 'double':
+                return new ClosureCast(
+                    static fn ($model, $key, $value) => $model->fromFloat($value),
+                    comparator: static function ($model, $key, $current, $original) {
+                        if ($original === null) {
+                            return false;
+                        }
+
+                        return abs($model->castAttribute($key, $current) - $model->castAttribute($key, $original)) < PHP_FLOAT_EPSILON * 4;
+                    },
+                );
+            case 'decimal':
+                return new ClosureCast(
+                    static fn ($model, $key, $value) => $model->asDecimal($value, explode(':', $model->getCasts()[$key], 2)[1]),
+                    comparator: $primitiveComparator,
+                );
+            case 'string':
+                return new ClosureCast(
+                    static fn ($model, $key, $value) => (string) $value,
+                    comparator: $primitiveComparator,
+                );
+            case 'bool':
+            case 'boolean':
+                return new ClosureCast(
+                    static fn ($model, $key, $value) => (bool) $value,
+                    comparator: $primitiveComparator,
+                );
+            case 'object':
+                return new ClosureCast(
+                    static fn ($model, $key, $value) => $model->fromJson($value, true),
+                    $jsonSetter,
+                    comparator: $jsonComparator,
+                );
+            case 'array':
+            case 'json':
+            case 'json:unicode':
+                return new ClosureCast(
+                    static fn ($model, $key, $value) => $model->fromJson($value),
+                    $jsonSetter,
+                    comparator: $jsonComparator,
+                );
+            case 'collection':
+                return new ClosureCast(
+                    static fn ($model, $key, $value) => new BaseCollection($model->fromJson($value)),
+                    $jsonSetter,
+                    comparator: $jsonComparator,
+                );
+            case 'date':
+                return new ClosureCast(
+                    static fn ($model, $key, $value) => $model->asDate($value),
+                    comparator: $dateComparator,
+                );
+            case 'datetime':
+            case 'custom_datetime':
+                return new ClosureCast(
+                    static fn ($model, $key, $value) => $model->asDateTime($value),
+                    comparator: $dateComparator,
+                );
+            case 'immutable_date':
+                return new ClosureCast(
+                    static fn ($model, $key, $value) => $model->asDate($value)->toImmutable(),
+                    comparator: $dateComparator,
+                );
+            case 'immutable_custom_datetime':
+            case 'immutable_datetime':
+                return new ClosureCast(
+                    static fn ($model, $key, $value) => $model->asDateTime($value)->toImmutable(),
+                    comparator: $dateComparator,
+                );
+            case 'timestamp':
+                return new ClosureCast(
+                    static fn ($model, $key, $value) => $model->asTimestamp($value),
+                    comparator: $primitiveComparator,
+                );
+            case 'hashed':
+                return new ClosureCast(
+                    static fn ($model, $key, $value) => $value,
+                    static fn ($model, $key, $value) => $model->castAttributeAsHashedString($key, $value),
+                    comparator: $primitiveComparator,
+                );
+        }
+
+        return null;
+    }
+
+    /**
+     * Resolve the cast object this model class uses for the given attribute.
+     *
+     * Built-in casts resolve to a shared flyweight (see resolveInternalCastClass).
+     * Encrypted casts additionally wrap that flyweight in a decrypt/encrypt
+     * layer. Whether an attribute is encrypted is decided by the overrideable
+     * isEncryptedCastable(), so a subclass that widens the set of encrypted cast
+     * types is honored consistently on the read, write, and dirty-comparison
+     * paths. The caller memoizes this decision per class and cast type; an
+     * override that varies by individual attribute key while sharing a cast type
+     * is therefore not honored — overrides are expected to key off the cast type.
+     *
+     * @param  string  $key
+     * @param  string  $castType
+     * @param  string  $cast
+     * @return ClosureCast|null
+     */
+    protected function resolveCasterFor($key, $castType, $cast)
+    {
+        if (! $this->isEncryptedCastable($key)) {
+            return $this->resolveInternalCastClass($castType, $cast);
+        }
+
+        // The decrypt/encrypt wrapper is itself pure per inner cast type — it
+        // closes over the shared inner flyweight and drives everything through
+        // the model at call time — so it is cached and shared across classes too.
+        $innerType = Str::after($castType, 'encrypted:');
+
+        return static::$internalCasterCache['@encrypted:'.$innerType]
+            ??= $this->wrapEncryptedCaster($this->resolveInternalCastClass($innerType, $cast));
+    }
+
+    /**
+     * Wrap an inner cast object in the encrypted decrypt/encrypt layer.
+     *
+     * @param  ClosureCast|null  $inner
+     * @return ClosureCast
+     */
+    protected function wrapEncryptedCaster($inner)
+    {
+        return new ClosureCast(
+            static function ($model, $key, $value, $attributes) use ($inner) {
+                $value = $model->fromEncryptedString($value);
+
+                if ($inner) {
+                    $value = $inner->get($model, $key, $value, $attributes);
+                }
+
+                return $value;
+            },
+            static function ($model, $key, $value, $attributes) use ($inner) {
+                if (is_null($value)) {
+                    return null;
+                }
+
+                if ($inner) {
+                    $value = $inner->set($model, $key, $value, $attributes);
+                }
+
+                return $model->castAttributeAsEncryptedString($key, $value);
+            },
+            comparator: static function ($model, $key, $current, $original) {
+                if (! empty($model::currentEncrypter()->getPreviousKeys())) {
+                    return false;
+                }
+
+                // Compare the fully cast (decrypted, then inner-cast) values so
+                // an encrypted JSON payload that re-encodes to a different string
+                // but the same structure is not reported as a change.
+                return $model->castAttribute($key, $current) === $model->castAttribute($key, $original);
+            },
+        );
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -929,8 +929,17 @@ trait HasAttributes
      */
     protected function getCastType($key)
     {
-        $castType = $this->getCasts()[$key];
+        return $this->resolveCastType($this->getCasts()[$key]);
+    }
 
+    /**
+     * Normalize a raw cast definition to its cast type.
+     *
+     * @param  string  $castType
+     * @return string
+     */
+    protected function resolveCastType($castType)
+    {
         if (isset(static::$castTypeCache[$castType])) {
             return static::$castTypeCache[$castType];
         }
@@ -964,14 +973,18 @@ trait HasAttributes
      */
     protected function getInternalCastClass($key)
     {
-        if (! array_key_exists($key, $this->getCasts())) {
+        $casts = $this->getCasts();
+
+        if (! array_key_exists($key, $casts)) {
             return null;
         }
 
-        $castType = $this->getCastType($key);
+        $cast = $casts[$key];
+
+        $castType = $this->resolveCastType($cast);
 
         if (! array_key_exists($castType, static::$castClassCache)) {
-            static::$castClassCache[$castType] = $this->resolveInternalCastClass($castType, $this->getCasts()[$key]);
+            static::$castClassCache[$castType] = $this->resolveInternalCastClass($castType, $cast);
         }
 
         if (is_null($caster = static::$castClassCache[$castType])) {

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -239,15 +239,16 @@ trait HasAttributes
     ];
 
     /**
-     * The cache of whether a model class overrides a cast-resolution hook.
+     * The cache of whether a model class uses custom cast resolution.
      *
-     * Detecting an override once per class lets the common case (no override)
-     * keep the fast, fully memoized path, while a model that overrides
-     * getCastType()/isEncryptedCastable() transparently gets per-key fidelity.
+     * True when the class overrides getCastType() or isEncryptedCastable().
+     * Detecting this once per class lets the common case (no override) keep the
+     * fast, fully memoized path, while a model that overrides either hook
+     * transparently gets per-key fidelity.
      *
-     * @var array<class-string, array<string, bool>>
+     * @var array<class-string, bool>
      */
-    protected static $castHookOverrides = [];
+    protected static $customCastResolution = [];
 
     /**
      * The encrypter instance that is used to encrypt attributes.
@@ -904,6 +905,13 @@ trait HasAttributes
      */
     protected function castAttribute($key, $value)
     {
+        // A null value on a primitive cast resolves to null without building or
+        // dispatching through a cast object — the cheapest possible path, kept
+        // as a short-circuit ahead of cast-object resolution.
+        if (is_null($value) && in_array($this->getCastType($key), static::$primitiveCastTypes, true)) {
+            return $value;
+        }
+
         if ($caster = $this->getInternalCastClass($key)) {
             return $caster->get($this, $key, $value, $this->attributes);
         }
@@ -1029,23 +1037,13 @@ trait HasAttributes
 
         $class = static::class;
 
-        // Resolve the cast type. A model that overrides getCastType() must have
-        // that override honored, but the call re-reads getCasts(); the common
-        // case (no override) skips it and reuses the cast string already in hand.
-        // The type is re-derived on every call, never hoisted into a cache, so
-        // runtime cast changes (e.g. mergeCasts()) are always honored.
-        $castType = $this->castResolutionHookIsOverridden('getCastType')
-            ? $this->getCastType($key)
-            : $this->resolveCastType($cast);
+        // The common case: the model uses Eloquent's built-in cast resolution.
+        // The cast type is derived from the cast string already in hand (one
+        // getCasts()), encryption is a pure function of that type, and the
+        // resolved caster is memoized per class and cast type.
+        if (! $this->usesCustomCastResolution()) {
+            $castType = $this->resolveCastType($cast);
 
-        // When isEncryptedCastable() is overridden it may decide encryption per
-        // attribute key, not just per cast type, so the resolved caster cannot be
-        // memoized by cast type — resolve it live (the cast objects themselves are
-        // still shared flyweights). Otherwise encryption is a pure function of the
-        // cast type and the resolved caster is memoized per class and cast type.
-        if ($this->castResolutionHookIsOverridden('isEncryptedCastable')) {
-            $caster = $this->resolveCasterFor($castType, $cast, $this->isEncryptedCastable($key));
-        } else {
             if (! isset(static::$resolvedCasterCache[$class]) ||
                 ! array_key_exists($castType, static::$resolvedCasterCache[$class])) {
                 static::$resolvedCasterCache[$class][$castType] = $this->resolveCasterFor(
@@ -1054,6 +1052,15 @@ trait HasAttributes
             }
 
             $caster = static::$resolvedCasterCache[$class][$castType];
+        } else {
+            // The model overrides getCastType() and/or isEncryptedCastable(), so
+            // both are consulted per key — the override may decide the cast type
+            // or encryption per attribute, not just per cast type, so the result
+            // is resolved live rather than memoized by cast type. The cast
+            // objects themselves are still shared flyweights.
+            $castType = $this->getCastType($key);
+
+            $caster = $this->resolveCasterFor($castType, $cast, $this->isEncryptedCastable($key));
         }
 
         if (is_null($caster)) {
@@ -1066,28 +1073,39 @@ trait HasAttributes
     /**
      * Determine whether the model class overrides a cast-resolution hook.
      *
-     * Detected once per class and memoized. Lets the common case (no override)
-     * keep the fully memoized fast path while a model that overrides the hook
-     * transparently gets per-key resolution, so userland overrides of
-     * getCastType()/isEncryptedCastable() are always honored without taxing
-     * every other model.
+     * Detected once per class and memoized as a single flag. Lets the common
+     * case (no override) keep the fully memoized fast path while a model that
+     * overrides getCastType()/isEncryptedCastable() transparently gets per-key
+     * resolution, so userland overrides are always honored without taxing every
+     * other model with a per-access check.
+     *
+     * @return bool
+     */
+    protected function usesCustomCastResolution()
+    {
+        $class = static::class;
+
+        if (isset(static::$customCastResolution[$class])) {
+            return static::$customCastResolution[$class];
+        }
+
+        return static::$customCastResolution[$class] =
+            $this->castResolutionHookIsOverridden('getCastType')
+            || $this->castResolutionHookIsOverridden('isEncryptedCastable');
+    }
+
+    /**
+     * Determine whether the model class overrides the given trait method.
      *
      * @param  string  $method
      * @return bool
      */
     protected function castResolutionHookIsOverridden($method)
     {
-        $class = static::class;
-
-        if (isset(static::$castHookOverrides[$class][$method])) {
-            return static::$castHookOverrides[$class][$method];
-        }
-
-        $defined = new ReflectionMethod($class, $method);
+        $defined = new ReflectionMethod(static::class, $method);
         $original = new ReflectionMethod(__TRAIT__, $method);
 
-        return static::$castHookOverrides[$class][$method] =
-            $defined->getStartLine() !== $original->getStartLine()
+        return $defined->getStartLine() !== $original->getStartLine()
             || $defined->getFileName() !== $original->getFileName();
     }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -24,6 +24,7 @@ use Illuminate\Database\Eloquent\Casts\AsEncryptedCollection;
 use Illuminate\Database\Eloquent\Casts\AsEnumArrayObject;
 use Illuminate\Database\Eloquent\Casts\AsEnumCollection;
 use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Casts\ClosureCast;
 use Illuminate\Database\Eloquent\Casts\Json;
 use Illuminate\Database\Eloquent\InvalidCastException;
 use Illuminate\Database\Eloquent\JsonEncodingException;
@@ -191,6 +192,13 @@ trait HasAttributes
      * @var array
      */
     protected static $castTypeCache = [];
+
+    /**
+     * The cache of resolved internal cast objects, keyed by class and cast type.
+     *
+     * @var array<class-string, array<string, \Illuminate\Database\Eloquent\Casts\ClosureCast|null>>
+     */
+    protected static $castClassCache = [];
 
     /**
      * The encrypter instance that is used to encrypt attributes.
@@ -847,64 +855,8 @@ trait HasAttributes
      */
     protected function castAttribute($key, $value)
     {
-        $castType = $this->getCastType($key);
-
-        if (is_null($value) && in_array($castType, static::$primitiveCastTypes)) {
-            return $value;
-        }
-
-        // If the key is one of the encrypted castable types, we'll first decrypt
-        // the value and update the cast type so we may leverage the following
-        // logic for casting this value to any additionally specified types.
-        if ($this->isEncryptedCastable($key)) {
-            $value = $this->fromEncryptedString($value);
-
-            $castType = Str::after($castType, 'encrypted:');
-        }
-
-        switch ($castType) {
-            case 'int':
-            case 'integer':
-                return (int) $value;
-            case 'real':
-            case 'float':
-            case 'double':
-                return $this->fromFloat($value);
-            case 'decimal':
-                return $this->asDecimal($value, explode(':', $this->getCasts()[$key], 2)[1]);
-            case 'string':
-                return (string) $value;
-            case 'bool':
-            case 'boolean':
-                return (bool) $value;
-            case 'object':
-                return $this->fromJson($value, true);
-            case 'array':
-            case 'json':
-            case 'json:unicode':
-                return $this->fromJson($value);
-            case 'collection':
-                return new BaseCollection($this->fromJson($value));
-            case 'date':
-                return $this->asDate($value);
-            case 'datetime':
-            case 'custom_datetime':
-                return $this->asDateTime($value);
-            case 'immutable_date':
-                return $this->asDate($value)->toImmutable();
-            case 'immutable_custom_datetime':
-            case 'immutable_datetime':
-                return $this->asDateTime($value)->toImmutable();
-            case 'timestamp':
-                return $this->asTimestamp($value);
-        }
-
-        if ($this->isEnumCastable($key)) {
-            return $this->getEnumCastableAttributeValue($key, $value);
-        }
-
-        if ($this->isClassCastable($key)) {
-            return $this->getClassCastableAttributeValue($key, $value);
+        if ($caster = $this->getInternalCastClass($key)) {
+            return $caster->get($this, $key, $value, $this->attributes);
         }
 
         return $value;
@@ -991,6 +943,237 @@ trait HasAttributes
         }
 
         return static::$castTypeCache[$castType] = $convertedCastType;
+    }
+
+    /**
+     * Get the resolved internal cast object for the given attribute.
+     *
+     * Built-in casts are represented as reusable cast objects so the dispatch
+     * decision (which cast type, which branch) is made once and memoized per
+     * class and cast type, instead of being recomputed on every access. The
+     * cast object's closures defer to the model's own cast methods, preserving
+     * userland overrides.
+     *
+     * @param  string  $key
+     * @return \Illuminate\Database\Eloquent\Casts\ClosureCast|null
+     */
+    protected function getInternalCastClass($key)
+    {
+        if (! array_key_exists($key, $this->getCasts())) {
+            return null;
+        }
+
+        $castType = $this->getCastType($key);
+
+        if (! isset(static::$castClassCache[static::class][$castType])) {
+            static::$castClassCache[static::class][$castType] = $this->resolveInternalCastClass($key);
+        }
+
+        return static::$castClassCache[static::class][$castType];
+    }
+
+    /**
+     * Build the internal cast object for the given attribute's cast type.
+     *
+     * @param  string  $key
+     * @return \Illuminate\Database\Eloquent\Casts\ClosureCast|null
+     */
+    protected function resolveInternalCastClass($key)
+    {
+        $castType = $this->getCastType($key);
+
+        $caster = null;
+
+        $primitiveComparator = static fn ($model, $key, $current, $original) => $model->castAttribute($key, $current) === $model->castAttribute($key, $original);
+
+        if (Str::startsWith($castType, 'encrypted:')) {
+            $castType = Str::after($castType, 'encrypted:');
+        }
+
+        switch ($castType) {
+            case 'int':
+            case 'integer':
+                $caster = new ClosureCast(
+                    static fn ($model, $key, $value) => (int) $value,
+                    comparator: $primitiveComparator,
+                );
+                break;
+            case 'real':
+            case 'float':
+            case 'double':
+                $caster = new ClosureCast(
+                    static fn ($model, $key, $value) => $model->fromFloat($value),
+                    comparator: static function ($model, $key, $current, $original) {
+                        if ($original === null) {
+                            return false;
+                        }
+
+                        return abs($model->castAttribute($key, $current) - $model->castAttribute($key, $original)) < PHP_FLOAT_EPSILON * 4;
+                    },
+                );
+                break;
+            case 'decimal':
+                $caster = new ClosureCast(
+                    static fn ($model, $key, $value) => $model->asDecimal($value, explode(':', $model->getCasts()[$key], 2)[1]),
+                    comparator: $primitiveComparator,
+                );
+                break;
+            case 'string':
+                $caster = new ClosureCast(
+                    static fn ($model, $key, $value) => (string) $value,
+                    comparator: $primitiveComparator,
+                );
+                break;
+            case 'bool':
+            case 'boolean':
+                $caster = new ClosureCast(
+                    static fn ($model, $key, $value) => (bool) $value,
+                    comparator: $primitiveComparator,
+                );
+                break;
+            case 'object':
+                $caster = new ClosureCast(
+                    static fn ($model, $key, $value) => $model->fromJson($value, true),
+                    static fn ($model, $key, $value) => is_null($value) ? null : $model->castAttributeAsJson($key, $value),
+                    comparator: static fn ($model, $key, $current, $original) => $model->fromJson($current) === $model->fromJson($original),
+                );
+                break;
+            case 'array':
+            case 'json':
+            case 'json:unicode':
+                $caster = new ClosureCast(
+                    static fn ($model, $key, $value) => $model->fromJson($value),
+                    static fn ($model, $key, $value) => is_null($value) ? null : $model->castAttributeAsJson($key, $value),
+                    comparator: static fn ($model, $key, $current, $original) => $model->fromJson($current) === $model->fromJson($original),
+                );
+                break;
+            case 'collection':
+                $caster = new ClosureCast(
+                    static fn ($model, $key, $value) => new BaseCollection($model->fromJson($value)),
+                    static fn ($model, $key, $value) => is_null($value) ? null : $model->castAttributeAsJson($key, $value),
+                    comparator: static fn ($model, $key, $current, $original) => $model->fromJson($current) === $model->fromJson($original),
+                );
+                break;
+            case 'date':
+                $caster = new ClosureCast(
+                    static fn ($model, $key, $value) => $model->asDate($value),
+                    comparator: static fn ($model, $key, $current, $original) => $model->fromDateTime($current) === $model->fromDateTime($original),
+                );
+                break;
+            case 'datetime':
+            case 'custom_datetime':
+                $caster = new ClosureCast(
+                    static fn ($model, $key, $value) => $model->asDateTime($value),
+                    comparator: static fn ($model, $key, $current, $original) => $model->fromDateTime($current) === $model->fromDateTime($original),
+                );
+                break;
+            case 'immutable_date':
+                $caster = new ClosureCast(
+                    static fn ($model, $key, $value) => $model->asDate($value)->toImmutable(),
+                    comparator: static fn ($model, $key, $current, $original) => $model->fromDateTime($current) === $model->fromDateTime($original),
+                );
+                break;
+            case 'immutable_custom_datetime':
+            case 'immutable_datetime':
+                $caster = new ClosureCast(
+                    static fn ($model, $key, $value) => $model->asDateTime($value)->toImmutable(),
+                    comparator: static fn ($model, $key, $current, $original) => $model->fromDateTime($current) === $model->fromDateTime($original),
+                );
+                break;
+            case 'timestamp':
+                $caster = new ClosureCast(
+                    static fn ($model, $key, $value) => $model->asTimestamp($value),
+                    comparator: $primitiveComparator,
+                );
+                break;
+            case 'hashed':
+                $caster = new ClosureCast(
+                    static fn ($model, $key, $value) => $value,
+                    static fn ($model, $key, $value) => $model->castAttributeAsHashedString($key, $value),
+                    comparator: $primitiveComparator,
+                );
+                break;
+        }
+
+        if ($this->isEnumCastable($key)) {
+            $caster = new ClosureCast(
+                static fn ($model, $key, $value) => $model->getEnumCastableAttributeValue($key, $value),
+                static function ($model, $key, $value) {
+                    $model->setEnumCastableAttribute($key, $value);
+                },
+                setsOwnAttribute: true,
+            );
+        } elseif ($this->isClassCastable($key)) {
+            $caster = new ClosureCast(
+                static fn ($model, $key, $value) => $model->getClassCastableAttributeValue($key, $value),
+                static function ($model, $key, $value) {
+                    $model->setClassCastableAttribute($key, $value);
+                },
+                comparator: static function ($model, $key, $current, $original) {
+                    if ($model->isClassComparable($key)) {
+                        return $model->compareClassCastableAttribute($key, $original, $current);
+                    }
+
+                    $castType = $model->getCasts()[$key];
+
+                    if (Str::startsWith($castType, [AsArrayObject::class, AsCollection::class])) {
+                        return $model->fromJson($current) === $model->fromJson($original);
+                    } elseif (Str::startsWith($castType, [AsEnumArrayObject::class, AsEnumCollection::class])) {
+                        return $model->fromJson($current) === $model->fromJson($original);
+                    } elseif ($original !== null && Str::startsWith($castType, [AsEncryptedArrayObject::class, AsEncryptedCollection::class])) {
+                        if (empty($model::currentEncrypter()->getPreviousKeys())) {
+                            return $model->fromEncryptedString($current) === $model->fromEncryptedString($original);
+                        }
+
+                        return false;
+                    }
+
+                    return is_numeric($current) && is_numeric($original)
+                        && strcmp((string) $current, (string) $original) === 0;
+                },
+                setsOwnAttribute: true,
+                nullable: false,
+            );
+        }
+
+        // If the key is one of the encrypted castable types, we'll first decrypt
+        // the value and update the cast type so we may leverage the underlying
+        // cast for casting this value to any additionally specified types.
+        if ($this->isEncryptedCastable($key)) {
+            $originalCaster = $caster;
+
+            $caster = new ClosureCast(
+                static function ($model, $key, $value, $attributes) use ($originalCaster) {
+                    $value = $model->fromEncryptedString($value);
+
+                    if ($originalCaster) {
+                        $value = $originalCaster->get($model, $key, $value, $attributes);
+                    }
+
+                    return $value;
+                },
+                static function ($model, $key, $value, $attributes) use ($originalCaster) {
+                    if (is_null($value)) {
+                        return null;
+                    }
+
+                    if ($originalCaster) {
+                        $value = $originalCaster->set($model, $key, $value, $attributes);
+                    }
+
+                    return $model->castAttributeAsEncryptedString($key, $value);
+                },
+                comparator: static function ($model, $key, $current, $original) {
+                    if (! empty($model::currentEncrypter()->getPreviousKeys())) {
+                        return false;
+                    }
+
+                    return $model->fromEncryptedString($current) === $model->fromEncryptedString($original);
+                },
+            );
+        }
+
+        return $caster;
     }
 
     /**
@@ -1097,20 +1280,17 @@ trait HasAttributes
             $value = $this->fromDateTime($value);
         }
 
-        if ($this->isEnumCastable($key)) {
-            $this->setEnumCastableAttribute($key, $value);
+        // Each built-in cast is resolved to a reusable cast object (memoized per
+        // class and cast type), so the dispatch decision is only made once. The
+        // cast's "set" closure still defers to the model's own cast methods so
+        // any userland overrides of those methods are preserved. Enum and class
+        // casts write their own attributes and signal that via setsOwnAttribute.
+        if ($caster = $this->getInternalCastClass($key)) {
+            $value = $caster->set($this, $key, $value, $this->attributes);
 
-            return $this;
-        }
-
-        if ($this->isClassCastable($key)) {
-            $this->setClassCastableAttribute($key, $value);
-
-            return $this;
-        }
-
-        if (! is_null($value) && $this->isJsonCastable($key)) {
-            $value = $this->castAttributeAsJson($key, $value);
+            if ($caster->setsOwnAttribute) {
+                return $this;
+            }
         }
 
         // If this attribute contains a JSON ->, we'll set the proper value in the
@@ -1118,14 +1298,6 @@ trait HasAttributes
         // attribute in the array's value in the case of deeply nested items.
         if (str_contains($key, '->')) {
             return $this->fillJsonAttribute($key, $value);
-        }
-
-        if (! is_null($value) && $this->isEncryptedCastable($key)) {
-            $value = $this->castAttributeAsEncryptedString($key, $value);
-        }
-
-        if (! is_null($value) && $this->hasCast($key, 'hashed')) {
-            $value = $this->castAttributeAsHashedString($key, $value);
         }
 
         $this->attributes[$key] = $value;
@@ -2360,35 +2532,13 @@ trait HasAttributes
             return true;
         } elseif (is_null($attribute)) {
             return false;
-        } elseif ($this->isDateAttribute($key) || $this->isDateCastableWithCustomFormat($key)) {
-            return $this->fromDateTime($attribute) ===
-                $this->fromDateTime($original);
-        } elseif ($this->hasCast($key, ['object', 'collection'])) {
-            return $this->fromJson($attribute) ===
-                $this->fromJson($original);
-        } elseif ($this->hasCast($key, ['real', 'float', 'double'])) {
-            if ($original === null) {
-                return false;
-            }
+        }
 
-            return abs($this->castAttribute($key, $attribute) - $this->castAttribute($key, $original)) < PHP_FLOAT_EPSILON * 4;
-        } elseif ($this->isEncryptedCastable($key) && ! empty(static::currentEncrypter()->getPreviousKeys())) {
-            return false;
-        } elseif ($this->hasCast($key, static::$primitiveCastTypes)) {
-            return $this->castAttribute($key, $attribute) ===
-                $this->castAttribute($key, $original);
-        } elseif ($this->isClassCastable($key) && Str::startsWith($this->getCasts()[$key], [AsArrayObject::class, AsCollection::class])) {
-            return $this->fromJson($attribute) === $this->fromJson($original);
-        } elseif ($this->isClassCastable($key) && Str::startsWith($this->getCasts()[$key], [AsEnumArrayObject::class, AsEnumCollection::class])) {
-            return $this->fromJson($attribute) === $this->fromJson($original);
-        } elseif ($this->isClassCastable($key) && $original !== null && Str::startsWith($this->getCasts()[$key], [AsEncryptedArrayObject::class, AsEncryptedCollection::class])) {
-            if (empty(static::currentEncrypter()->getPreviousKeys())) {
-                return $this->fromEncryptedString($attribute) === $this->fromEncryptedString($original);
-            }
-
-            return false;
-        } elseif ($this->isClassComparable($key)) {
-            return $this->compareClassCastableAttribute($key, $original, $attribute);
+        // The resolved cast object carries the equivalence rule for its type
+        // (e.g. float epsilon comparison, JSON re-encoding, custom cast compare),
+        // memoized per class and cast type alongside the get/set behavior.
+        if ($caster = $this->getInternalCastClass($key)) {
+            return $caster->compare($this, $key, $attribute, $original);
         }
 
         return is_numeric($attribute) && is_numeric($original)

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1014,6 +1014,10 @@ trait HasAttributes
 
         $primitiveComparator = static fn ($model, $key, $current, $original) => $model->castAttribute($key, $current) === $model->castAttribute($key, $original);
 
+        $jsonSetter = static fn ($model, $key, $value) => is_null($value) ? null : $model->castAttributeAsJson($key, $value);
+
+        $jsonComparator = static fn ($model, $key, $current, $original) => $model->fromJson($current) === $model->fromJson($original);
+
         $encrypted = in_array($castType, [
             'encrypted', 'encrypted:array', 'encrypted:collection', 'encrypted:json', 'encrypted:object',
         ], true);
@@ -1066,8 +1070,8 @@ trait HasAttributes
             case 'object':
                 $caster = new ClosureCast(
                     static fn ($model, $key, $value) => $model->fromJson($value, true),
-                    static fn ($model, $key, $value) => is_null($value) ? null : $model->castAttributeAsJson($key, $value),
-                    comparator: static fn ($model, $key, $current, $original) => $model->fromJson($current) === $model->fromJson($original),
+                    $jsonSetter,
+                    comparator: $jsonComparator,
                 );
                 break;
             case 'array':
@@ -1075,15 +1079,15 @@ trait HasAttributes
             case 'json:unicode':
                 $caster = new ClosureCast(
                     static fn ($model, $key, $value) => $model->fromJson($value),
-                    static fn ($model, $key, $value) => is_null($value) ? null : $model->castAttributeAsJson($key, $value),
-                    comparator: static fn ($model, $key, $current, $original) => $model->fromJson($current) === $model->fromJson($original),
+                    $jsonSetter,
+                    comparator: $jsonComparator,
                 );
                 break;
             case 'collection':
                 $caster = new ClosureCast(
                     static fn ($model, $key, $value) => new BaseCollection($model->fromJson($value)),
-                    static fn ($model, $key, $value) => is_null($value) ? null : $model->castAttributeAsJson($key, $value),
-                    comparator: static fn ($model, $key, $current, $original) => $model->fromJson($current) === $model->fromJson($original),
+                    $jsonSetter,
+                    comparator: $jsonComparator,
                 );
                 break;
             case 'date':

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -194,9 +194,14 @@ trait HasAttributes
     protected static $castTypeCache = [];
 
     /**
-     * The cache of resolved internal cast objects, keyed by class and cast type.
+     * The cache of resolved internal cast objects, keyed by cast type.
      *
-     * @var array<class-string, array<string, \Illuminate\Database\Eloquent\Casts\ClosureCast|null>>
+     * The resolved cast object depends only on the cast type, not on the model
+     * class — its closures take the model and key as parameters and defer to the
+     * model's own cast methods — so a single instance is shared as a flyweight
+     * across every model class and field that uses the same cast.
+     *
+     * @var array<string, \Illuminate\Database\Eloquent\Casts\ClosureCast|null>
      */
     protected static $castClassCache = [];
 
@@ -965,28 +970,42 @@ trait HasAttributes
 
         $castType = $this->getCastType($key);
 
-        if (! isset(static::$castClassCache[static::class][$castType])) {
-            static::$castClassCache[static::class][$castType] = $this->resolveInternalCastClass($key);
+        if (! array_key_exists($castType, static::$castClassCache)) {
+            static::$castClassCache[$castType] = $this->resolveInternalCastClass($castType, $this->getCasts()[$key]);
         }
 
-        return static::$castClassCache[static::class][$castType];
+        if (is_null($caster = static::$castClassCache[$castType])) {
+            throw new InvalidCastException($this->getModel(), $key, $castType);
+        }
+
+        return $caster;
     }
 
     /**
-     * Build the internal cast object for the given attribute's cast type.
+     * Build the internal cast object for the given cast type.
      *
-     * @param  string  $key
+     * The result depends only on the cast definition, never on the model class
+     * or the attribute key, so a single resolved instance is shared as a
+     * flyweight. The normalized $castType drives the built-in type dispatch; the
+     * original $cast string is needed for case-correct enum/class detection
+     * (getCastType() lowercases parameterized casts, which breaks class_exists).
+     * A null return means the cast type is not recognized (an invalid cast).
+     *
+     * @param  string  $castType
+     * @param  string  $cast
      * @return \Illuminate\Database\Eloquent\Casts\ClosureCast|null
      */
-    protected function resolveInternalCastClass($key)
+    protected function resolveInternalCastClass($castType, $cast)
     {
-        $castType = $this->getCastType($key);
-
         $caster = null;
 
         $primitiveComparator = static fn ($model, $key, $current, $original) => $model->castAttribute($key, $current) === $model->castAttribute($key, $original);
 
-        if (Str::startsWith($castType, 'encrypted:')) {
+        $encrypted = in_array($castType, [
+            'encrypted', 'encrypted:array', 'encrypted:collection', 'encrypted:json', 'encrypted:object',
+        ], true);
+
+        if ($encrypted) {
             $castType = Str::after($castType, 'encrypted:');
         }
 
@@ -1095,16 +1114,17 @@ trait HasAttributes
                 break;
         }
 
-        if ($this->isEnumCastable($key)) {
-            $caster = new ClosureCast(
-                static fn ($model, $key, $value) => $model->getEnumCastableAttributeValue($key, $value),
-                static function ($model, $key, $value) {
-                    $model->setEnumCastableAttribute($key, $value);
-                },
-                setsOwnAttribute: true,
-            );
-        } elseif ($this->isClassCastable($key)) {
-            $caster = new ClosureCast(
+        if (! in_array($castType, static::$primitiveCastTypes, true)) {
+            if (enum_exists($cast) && ! is_subclass_of($cast, Castable::class)) {
+                $caster = new ClosureCast(
+                    static fn ($model, $key, $value) => $model->getEnumCastableAttributeValue($key, $value),
+                    static function ($model, $key, $value) {
+                        $model->setEnumCastableAttribute($key, $value);
+                    },
+                    setsOwnAttribute: true,
+                );
+            } elseif (class_exists($this->parseCasterClass($cast))) {
+                $caster = new ClosureCast(
                 static fn ($model, $key, $value) => $model->getClassCastableAttributeValue($key, $value),
                 static function ($model, $key, $value) {
                     $model->setClassCastableAttribute($key, $value);
@@ -1131,15 +1151,17 @@ trait HasAttributes
                     return is_numeric($current) && is_numeric($original)
                         && strcmp((string) $current, (string) $original) === 0;
                 },
-                setsOwnAttribute: true,
-                nullable: false,
-            );
+                    setsOwnAttribute: true,
+                    nullable: false,
+                );
+            }
         }
 
-        // If the key is one of the encrypted castable types, we'll first decrypt
-        // the value and update the cast type so we may leverage the underlying
-        // cast for casting this value to any additionally specified types.
-        if ($this->isEncryptedCastable($key)) {
+        // If the cast type is an encrypted type, we'll decrypt the value first
+        // and then leverage the underlying cast (resolved above from the inner
+        // type) for casting the decrypted value to any additionally specified
+        // type before re-encrypting on the way back out.
+        if ($encrypted) {
             $originalCaster = $caster;
 
             $caster = new ClosureCast(

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -187,9 +187,13 @@ trait HasAttributes
     protected static $setAttributeMutatorCache = [];
 
     /**
-     * The cache of the converted cast types.
+     * The cache of converted cast types, keyed by model class then raw cast.
      *
-     * @var array
+     * Keyed per class (not globally) so a model overriding the cast-type
+     * normalization hooks (resolveCastType, isDecimalCast, isCustomDateTimeCast,
+     * isImmutableCustomDateTimeCast) is never served another class's result.
+     *
+     * @var array<class-string, array<string, string>>
      */
     protected static $castTypeCache = [];
 
@@ -211,15 +215,39 @@ trait HasAttributes
     /**
      * The cache of cast objects resolved for a specific model class and cast.
      *
-     * Whether an attribute is encrypted is governed by the overrideable
-     * isEncryptedCastable(), so the object a class ultimately uses can differ
-     * from the shared default. This per-class layer memoizes that decision
-     * (keyed by class, then cast type) while still pointing at the shared
-     * flyweights above, so no closures are duplicated per class.
+     * Used for models that do not override the cast-resolution hooks: the
+     * resolved caster is then a pure function of the cast type, so it is
+     * memoized per class and cast type while pointing at the shared flyweights
+     * above (no closures duplicated per class). Models that override
+     * getCastType()/isEncryptedCastable() bypass this cache and resolve per key
+     * (see getInternalCastClass).
      *
      * @var array<class-string, array<string, ClosureCast|null>>
      */
     protected static $resolvedCasterCache = [];
+
+    /**
+     * The set of built-in encrypted cast types.
+     *
+     * The single source of truth shared by isEncryptedCastable() and the cast
+     * resolver's fast path, so the two can never drift apart.
+     *
+     * @var string[]
+     */
+    protected static $encryptedCastTypes = [
+        'encrypted', 'encrypted:array', 'encrypted:collection', 'encrypted:json', 'encrypted:object',
+    ];
+
+    /**
+     * The cache of whether a model class overrides a cast-resolution hook.
+     *
+     * Detecting an override once per class lets the common case (no override)
+     * keep the fast, fully memoized path, while a model that overrides
+     * getCastType()/isEncryptedCastable() transparently gets per-key fidelity.
+     *
+     * @var array<class-string, array<string, bool>>
+     */
+    protected static $castHookOverrides = [];
 
     /**
      * The encrypter instance that is used to encrypt attributes.
@@ -956,8 +984,10 @@ trait HasAttributes
      */
     protected function resolveCastType($castType)
     {
-        if (isset(static::$castTypeCache[$castType])) {
-            return static::$castTypeCache[$castType];
+        $class = static::class;
+
+        if (isset(static::$castTypeCache[$class][$castType])) {
+            return static::$castTypeCache[$class][$castType];
         }
 
         if ($this->isCustomDateTimeCast($castType)) {
@@ -972,7 +1002,7 @@ trait HasAttributes
             $convertedCastType = trim(strtolower($castType));
         }
 
-        return static::$castTypeCache[$castType] = $convertedCastType;
+        return static::$castTypeCache[$class][$castType] = $convertedCastType;
     }
 
     /**
@@ -997,26 +1027,68 @@ trait HasAttributes
 
         $cast = $casts[$key];
 
-        // Resolve the cast type through getCastType() rather than inlining
-        // resolveCastType() so a model that overrides getCastType() is still
-        // honored on the cast path. The type is re-derived from the live
-        // getCasts() on every call and is the only thing that keys the cache
-        // below, so runtime cast changes (e.g. mergeCasts()) are always
-        // honored — do not hoist it into the cache.
-        $castType = $this->getCastType($key);
-
         $class = static::class;
 
-        if (! isset(static::$resolvedCasterCache[$class]) ||
-            ! array_key_exists($castType, static::$resolvedCasterCache[$class])) {
-            static::$resolvedCasterCache[$class][$castType] = $this->resolveCasterFor($key, $castType, $cast);
+        // Resolve the cast type. A model that overrides getCastType() must have
+        // that override honored, but the call re-reads getCasts(); the common
+        // case (no override) skips it and reuses the cast string already in hand.
+        // The type is re-derived on every call, never hoisted into a cache, so
+        // runtime cast changes (e.g. mergeCasts()) are always honored.
+        $castType = $this->castResolutionHookIsOverridden('getCastType')
+            ? $this->getCastType($key)
+            : $this->resolveCastType($cast);
+
+        // When isEncryptedCastable() is overridden it may decide encryption per
+        // attribute key, not just per cast type, so the resolved caster cannot be
+        // memoized by cast type — resolve it live (the cast objects themselves are
+        // still shared flyweights). Otherwise encryption is a pure function of the
+        // cast type and the resolved caster is memoized per class and cast type.
+        if ($this->castResolutionHookIsOverridden('isEncryptedCastable')) {
+            $caster = $this->resolveCasterFor($castType, $cast, $this->isEncryptedCastable($key));
+        } else {
+            if (! isset(static::$resolvedCasterCache[$class]) ||
+                ! array_key_exists($castType, static::$resolvedCasterCache[$class])) {
+                static::$resolvedCasterCache[$class][$castType] = $this->resolveCasterFor(
+                    $castType, $cast, in_array($castType, static::$encryptedCastTypes, true)
+                );
+            }
+
+            $caster = static::$resolvedCasterCache[$class][$castType];
         }
 
-        if (is_null($caster = static::$resolvedCasterCache[$class][$castType])) {
+        if (is_null($caster)) {
             throw new InvalidCastException($this->getModel(), $key, $this->parseCasterClass($cast));
         }
 
         return $caster;
+    }
+
+    /**
+     * Determine whether the model class overrides a cast-resolution hook.
+     *
+     * Detected once per class and memoized. Lets the common case (no override)
+     * keep the fully memoized fast path while a model that overrides the hook
+     * transparently gets per-key resolution, so userland overrides of
+     * getCastType()/isEncryptedCastable() are always honored without taxing
+     * every other model.
+     *
+     * @param  string  $method
+     * @return bool
+     */
+    protected function castResolutionHookIsOverridden($method)
+    {
+        $class = static::class;
+
+        if (isset(static::$castHookOverrides[$class][$method])) {
+            return static::$castHookOverrides[$class][$method];
+        }
+
+        $defined = new ReflectionMethod($class, $method);
+        $original = new ReflectionMethod(__TRAIT__, $method);
+
+        return static::$castHookOverrides[$class][$method] =
+            $defined->getStartLine() !== $original->getStartLine()
+            || $defined->getFileName() !== $original->getFileName();
     }
 
     /**
@@ -1050,19 +1122,20 @@ trait HasAttributes
                 'immutable_custom_datetime' => 'immutable_datetime',
                 default => $castType,
             };
+        } elseif (enum_exists($cast) && ! is_subclass_of($cast, Castable::class)) {
+            $cacheKey = '@enum';
+        } elseif (class_exists($this->parseCasterClass($cast))) {
+            $cacheKey = '@class';
         } else {
-            $cacheKey = match (true) {
-                enum_exists($cast) && ! is_subclass_of($cast, Castable::class) => '@enum',
-                class_exists($this->parseCasterClass($cast)) => '@class',
-                default => $castType,
-            };
+            // An unrecognized cast type. Return null without caching so the
+            // reserved @enum/@class keys are only ever assigned by genuine
+            // enum/class detection — a userland cast string such as a literal
+            // '@class' cannot collide with them and still resolves to null
+            // (i.e. throws InvalidCastException upstream).
+            return null;
         }
 
-        if (array_key_exists($cacheKey, static::$internalCasterCache)) {
-            return static::$internalCasterCache[$cacheKey];
-        }
-
-        return static::$internalCasterCache[$cacheKey] = $this->buildInternalCastClass($castType, $cacheKey);
+        return static::$internalCasterCache[$cacheKey] ??= $this->buildInternalCastClass($castType, $cacheKey);
     }
 
     /**
@@ -1228,25 +1301,22 @@ trait HasAttributes
     }
 
     /**
-     * Resolve the cast object this model class uses for the given attribute.
+     * Resolve the cast object for the given cast type and encryption decision.
      *
      * Built-in casts resolve to a shared flyweight (see resolveInternalCastClass).
-     * Encrypted casts additionally wrap that flyweight in a decrypt/encrypt
-     * layer. Whether an attribute is encrypted is decided by the overrideable
-     * isEncryptedCastable(), so a subclass that widens the set of encrypted cast
-     * types is honored consistently on the read, write, and dirty-comparison
-     * paths. The caller memoizes this decision per class and cast type; an
-     * override that varies by individual attribute key while sharing a cast type
-     * is therefore not honored — overrides are expected to key off the cast type.
+     * When $encrypted is true the flyweight is additionally wrapped in a
+     * decrypt/encrypt layer. The caller decides encryption — via the overrideable
+     * isEncryptedCastable() — so a subclass that widens the set of encrypted casts
+     * is honored consistently on the read, write, and dirty-comparison paths.
      *
-     * @param  string  $key
      * @param  string  $castType
      * @param  string  $cast
+     * @param  bool  $encrypted
      * @return ClosureCast|null
      */
-    protected function resolveCasterFor($key, $castType, $cast)
+    protected function resolveCasterFor($castType, $cast, $encrypted)
     {
-        if (! $this->isEncryptedCastable($key)) {
+        if (! $encrypted) {
             return $this->resolveInternalCastClass($castType, $cast);
         }
 
@@ -2067,7 +2137,7 @@ trait HasAttributes
      */
     protected function isEncryptedCastable($key)
     {
-        return $this->hasCast($key, ['encrypted', 'encrypted:array', 'encrypted:collection', 'encrypted:json', 'encrypted:object']);
+        return $this->hasCast($key, static::$encryptedCastTypes);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentCastEquivalenceTest.php
+++ b/tests/Database/DatabaseEloquentCastEquivalenceTest.php
@@ -126,6 +126,47 @@ class DatabaseEloquentCastEquivalenceTest extends TestCase
         $this->assertSame($expectedDirty, $model->isDirty('updated_at'));
         $this->assertSame(! $expectedDirty, $model->originalIsEquivalent('updated_at'));
     }
+
+    public function testGetCastTypeOverrideIsHonoredOnTheCastPath()
+    {
+        // The attribute is declared as a string cast, but the model overrides
+        // getCastType() to force it to boolean. Casting must follow the override,
+        // not the raw declaration — guards against resolving the cast type
+        // without consulting getCastType().
+        $model = (new CastTypeOverrideModel)->newFromBuilder(['flag' => '1']);
+
+        $this->assertTrue($model->flag);
+
+        $model->flag = '0';
+
+        $this->assertFalse($model->flag);
+    }
+
+    public function testBuiltInCastObjectsAreSharedFlyweights()
+    {
+        $resolve = fn ($model, $cast) => \Closure::bind(
+            fn ($key) => $this->getInternalCastClass($key),
+            (new CastEquivalenceModel([], ['value' => $cast]))->newFromBuilder(['value' => null]),
+            Model::class,
+        )('value');
+
+        // Aliases collapse to a single shared instance...
+        $float = $resolve(null, 'float');
+        $this->assertSame($float, $resolve(null, 'double'));
+        $this->assertSame($float, $resolve(null, 'real'));
+
+        // ...as does every enum, regardless of the concrete enum class...
+        $enum = $resolve(null, CastEquivalenceIntEnum::class);
+        $this->assertSame($enum, $resolve(null, CastEquivalenceStringEnum::class));
+
+        // ...and every custom cast class.
+        $class = $resolve(null, CastEquivalenceReverseCast::class);
+        $this->assertSame($class, $resolve(null, CastEquivalenceReverseCast::class));
+
+        // Different logical types remain distinct.
+        $this->assertNotSame($float, $enum);
+        $this->assertNotSame($float, $class);
+    }
 }
 
 enum CastEquivalenceIntEnum: int
@@ -180,5 +221,19 @@ class CastEquivalenceTimestampModel extends Model
     public function getDates()
     {
         return ['created_at', 'updated_at'];
+    }
+}
+
+class CastTypeOverrideModel extends Model
+{
+    protected $guarded = [];
+
+    public $timestamps = false;
+
+    protected $casts = ['flag' => 'string'];
+
+    protected function getCastType($key)
+    {
+        return $key === 'flag' ? 'boolean' : parent::getCastType($key);
     }
 }

--- a/tests/Database/DatabaseEloquentCastEquivalenceTest.php
+++ b/tests/Database/DatabaseEloquentCastEquivalenceTest.php
@@ -1,0 +1,184 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Database\Eloquent\Model;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Exercises attribute-cast equivalence (dirty checking) across every built-in
+ * cast type and the edge cases that distinguish a real change from an equivalent
+ * re-assignment: differently typed scalars (e.g. the string '1' a driver may
+ * return for an integer column vs the int 1), differently formatted but
+ * equivalent dates, and JSON that re-encodes to a different string but the same
+ * structure. These paths are not exercised by the sqlite-backed suite, so they
+ * are asserted here directly against crafted "stored" values.
+ */
+class DatabaseEloquentCastEquivalenceTest extends TestCase
+{
+    /**
+     * @return array<string, array{string|object, mixed, mixed, bool}>
+     */
+    public static function dirtyCases(): array
+    {
+        return [
+            // [cast, stored "original" value, freshly set value, expected isDirty]
+
+            // Integers — a string original (as some drivers return) is not dirty.
+            'int: string original vs int set' => ['integer', '1', 1, false],
+            'int: unchanged' => ['integer', 1, 1, false],
+            'int: changed' => ['integer', 1, 2, true],
+            'int: zero forms' => ['integer', '0', 0, false],
+            'int: null/null' => ['integer', null, null, false],
+
+            // Floats.
+            'float: string vs float' => ['float', '1.5', 1.5, false],
+            'float: int vs float one' => ['float', '1.0', 1, false],
+            'float: changed' => ['float', 1.5, 1.6, true],
+
+            // Decimals (precision-normalized).
+            'decimal: trailing zero' => ['decimal:2', '1.00', '1.0', false],
+            'decimal: string vs int' => ['decimal:2', '1.00', 1, false],
+            'decimal: rounds equal' => ['decimal:2', '1.23', '1.234', false],
+
+            // Strings.
+            'string: string vs int' => ['string', '1', 1, false],
+            'string: changed' => ['string', 'a', 'b', true],
+
+            // Booleans.
+            'bool: string vs bool' => ['boolean', '1', true, false],
+            'bool: int vs bool' => ['boolean', 1, true, false],
+            'bool: falsey' => ['boolean', '0', false, false],
+            'bool: changed' => ['boolean', true, false, true],
+
+            // Object / array / json — whitespace differences decode equal.
+            'object: same' => ['object', '{"a":1,"b":2}', ['a' => 1, 'b' => 2], false],
+            'object: whitespace' => ['object', '{"a": 1, "b": 2}', ['a' => 1, 'b' => 2], false],
+            'object: reordered keys' => ['object', '{"a":1,"b":2}', ['b' => 2, 'a' => 1], true],
+            'array: same' => ['array', '{"a":1,"b":2}', ['a' => 1, 'b' => 2], false],
+            'array: whitespace' => ['array', '{"a": 1, "b": 2}', ['a' => 1, 'b' => 2], false],
+            'array: list reordered' => ['array', '[1,2,3]', [3, 2, 1], true],
+            'json:unicode same' => ['json:unicode', '{"a":"é"}', ['a' => 'é'], false],
+            'collection: same' => ['collection', '[1,2,3]', [1, 2, 3], false],
+            'collection: whitespace' => ['collection', '{"a": 1}', ['a' => 1], false],
+
+            // Dates — an equivalent instant in a different textual form is not dirty.
+            'date: equivalent format' => ['date', '2025-01-01', '2025-01-01 00:00:00', false],
+            'date: changed' => ['date', '2025-01-01', '2025-01-02', true],
+            'datetime: equivalent format' => ['datetime', '2025-01-01', '2025-01-01 00:00:00', false],
+            'datetime: changed' => ['datetime', '2025-01-01 12:00:00', '2025-01-01 13:00:00', true],
+            'custom datetime: equivalent' => ['datetime:Y-m-d', '2025-01-01', '2025-01-01 00:00:00', false],
+            'immutable date: equivalent' => ['immutable_date', '2025-01-01', '2025-01-01 00:00:00', false],
+            'immutable datetime: equivalent' => ['immutable_datetime', '2025-01-01', '2025-01-01 00:00:00', false],
+
+            // Timestamps.
+            'timestamp: string vs int' => ['timestamp', '1700000000', 1700000000, false],
+            'timestamp: changed' => ['timestamp', 1700000000, 1700000001, true],
+
+            // Backed enums — same case from a differently typed scalar is not dirty.
+            'int enum: string original vs case' => [CastEquivalenceIntEnum::class, '1', CastEquivalenceIntEnum::A, false],
+            'int enum: int original vs case' => [CastEquivalenceIntEnum::class, 1, CastEquivalenceIntEnum::A, false],
+            'int enum: changed case' => [CastEquivalenceIntEnum::class, 1, CastEquivalenceIntEnum::B, true],
+            'string enum: same' => [CastEquivalenceStringEnum::class, 'a', CastEquivalenceStringEnum::A, false],
+            'string enum: changed' => [CastEquivalenceStringEnum::class, 'a', CastEquivalenceStringEnum::B, true],
+
+            // Custom cast (round-trips through set()).
+            'custom cast: round trip' => [CastEquivalenceReverseCast::class, 'cba', 'abc', false],
+        ];
+    }
+
+    #[DataProvider('dirtyCases')]
+    public function testCastDirtyEquivalence($cast, $original, $set, bool $expectedDirty)
+    {
+        $model = (new CastEquivalenceModel([], ['value' => $cast]))->newFromBuilder(['value' => $original]);
+
+        $model->value = $set;
+
+        $this->assertSame($expectedDirty, $model->isDirty('value'));
+        $this->assertSame($expectedDirty, array_key_exists('value', $model->getDirty()));
+    }
+
+    /**
+     * @return array<string, array{mixed, mixed, bool}>
+     */
+    public static function nonCastDateCases(): array
+    {
+        return [
+            // updated_at is a date attribute via getDates() but is NOT in $casts.
+            'equivalent format' => ['2025-01-01', '2025-01-01 00:00:00', false],
+            'same' => ['2025-01-01 12:00:00', '2025-01-01 12:00:00', false],
+            'changed' => ['2025-01-01 12:00:00', '2025-01-01 13:00:00', true],
+            'null/null' => [null, null, false],
+        ];
+    }
+
+    #[DataProvider('nonCastDateCases')]
+    public function testNonCastDateAttributeDirtyEquivalence($original, $set, bool $expectedDirty)
+    {
+        $model = (new CastEquivalenceTimestampModel)->newFromBuilder(['updated_at' => $original]);
+
+        $attributes = $model->getAttributes();
+        $attributes['updated_at'] = $set;
+        $model->setRawAttributes($attributes, false);
+
+        $this->assertSame($expectedDirty, $model->isDirty('updated_at'));
+        $this->assertSame(! $expectedDirty, $model->originalIsEquivalent('updated_at'));
+    }
+}
+
+enum CastEquivalenceIntEnum: int
+{
+    case A = 1;
+    case B = 2;
+}
+
+enum CastEquivalenceStringEnum: string
+{
+    case A = 'a';
+    case B = 'b';
+}
+
+class CastEquivalenceReverseCast implements CastsAttributes
+{
+    public function get(Model $model, string $key, mixed $value, array $attributes): mixed
+    {
+        return is_null($value) ? null : strrev((string) $value);
+    }
+
+    public function set(Model $model, string $key, mixed $value, array $attributes): mixed
+    {
+        return is_null($value) ? null : strrev((string) $value);
+    }
+}
+
+class CastEquivalenceModel extends Model
+{
+    protected $guarded = [];
+
+    protected $dateFormat = 'Y-m-d H:i:s';
+
+    public $timestamps = false;
+
+    public function __construct(array $attributes = [], array $casts = [])
+    {
+        $this->casts = $casts;
+
+        parent::__construct($attributes);
+    }
+}
+
+class CastEquivalenceTimestampModel extends Model
+{
+    protected $guarded = [];
+
+    protected $dateFormat = 'Y-m-d H:i:s';
+
+    public $timestamps = true;
+
+    public function getDates()
+    {
+        return ['created_at', 'updated_at'];
+    }
+}

--- a/tests/Database/DatabaseEloquentCastOverrideTest.php
+++ b/tests/Database/DatabaseEloquentCastOverrideTest.php
@@ -1,0 +1,384 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Database\Eloquent\Model;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Proves the memoized cast-object dispatch never bypasses a userland override.
+ *
+ * Every built-in cast resolves to a shared flyweight cast object whose closures
+ * defer to the model at call time. These tests assert that (a) overriding any of
+ * the hooks those closures call is honored through the read, write, and
+ * comparison paths, and (b) the cache — which is shared across model classes for
+ * the cast objects themselves — never leaks one class's overridden behavior into
+ * another. Together they make the "overrides are preserved" guarantee provable
+ * rather than assumed.
+ */
+class DatabaseEloquentCastOverrideTest extends TestCase
+{
+    public function testReadValueHookOverridesAreHonored()
+    {
+        $model = (new CastHookModel([], [
+            'd' => 'date',
+            'dt' => 'datetime',
+            'ts' => 'timestamp',
+            'f' => 'float',
+            'dec' => 'decimal:2',
+            'arr' => 'array',
+        ]))->newFromBuilder([
+            'd' => '2020-01-01',
+            'dt' => '2020-01-01 00:00:00',
+            'ts' => '2020-01-01 00:00:00',
+            'f' => '1.5',
+            'dec' => '1.5',
+            'arr' => '{"a":1}',
+        ]);
+
+        $this->assertSame('date:2020-01-01', $model->d);
+        $this->assertSame('datetime:2020-01-01 00:00:00', $model->dt);
+        $this->assertSame('ts:2020-01-01 00:00:00', $model->ts);
+        $this->assertSame('float:1.5', $model->f);
+        $this->assertSame('decimal:1.5:2', $model->dec);
+        $this->assertSame(['hooked' => '{"a":1}'], $model->arr);
+    }
+
+    public function testWriteValueHookOverridesAreHonored()
+    {
+        $model = new CastHookModel([], ['arr' => 'array', 'pw' => 'hashed']);
+
+        $model->arr = ['a' => 1];
+        $model->pw = 'secret';
+
+        $this->assertSame('json-set:{"a":1}', $model->getAttributes()['arr']);
+        $this->assertSame('hashed:secret', $model->getAttributes()['pw']);
+    }
+
+    public function testEnumHookOverrideIsHonored()
+    {
+        $model = (new EnumHookModel([], ['e' => CastOverrideEnum::class]))
+            ->newFromBuilder(['e' => 'a']);
+
+        $this->assertSame('enum-hook:a', $model->e);
+    }
+
+    public function testDatetimeFlyweightDoesNotLeakAcrossClasses()
+    {
+        $a = (new DatetimeOverrideModelA)->newFromBuilder(['dt' => '2020-01-01 00:00:00']);
+        $b = (new DatetimeOverrideModelB)->newFromBuilder(['dt' => '2020-01-01 00:00:00']);
+
+        // Resolve through class A first so the shared 'datetime' flyweight is
+        // populated while reading A's instance...
+        $this->assertSame('A:2020-01-01 00:00:00', $a->dt);
+
+        // ...then class B must still use its own asDateTime() override, proving
+        // the shared flyweight dispatches to the live model, not a captured one.
+        $this->assertSame('B:2020-01-01 00:00:00', $b->dt);
+
+        // And A is unchanged after B populated the cache.
+        $this->assertSame('A:2020-01-01 00:00:00', $a->dt);
+    }
+
+    public function testEnumFlyweightDoesNotLeakAcrossClasses()
+    {
+        // All enum casts share one '@enum' flyweight; assert two classes keep
+        // their own getEnumCastableAttributeValue() override.
+        $a = (new EnumOverrideModelA([], ['e' => CastOverrideEnum::class]))->newFromBuilder(['e' => 'a']);
+        $b = (new EnumOverrideModelB([], ['e' => CastOverrideEnum::class]))->newFromBuilder(['e' => 'a']);
+
+        $this->assertSame('A:a', $a->e);
+        $this->assertSame('B:a', $b->e);
+        $this->assertSame('A:a', $a->e);
+    }
+
+    public function testCustomClassCastFlyweightDoesNotLeakAcrossClasses()
+    {
+        // All custom-class casts share one '@class' flyweight; assert two classes
+        // keep their own getClassCastableAttributeValue() override.
+        $a = (new ClassCastOverrideModelA([], ['c' => CastOverrideValueObject::class]))->newFromBuilder(['c' => 'x']);
+        $b = (new ClassCastOverrideModelB([], ['c' => CastOverrideValueObject::class]))->newFromBuilder(['c' => 'x']);
+
+        $this->assertSame('A:x', $a->c);
+        $this->assertSame('B:x', $b->c);
+        $this->assertSame('A:x', $a->c);
+    }
+
+    public function testResolveCastTypeOverrideIsHonoredAndClassIsolated()
+    {
+        // Two classes map the same raw cast string ('shared') to different types
+        // via a resolveCastType() override. The cast-type cache is keyed per
+        // class, so resolving one first must not make the other inherit its
+        // normalization (the bug a global cache would cause).
+        $asInt = (new ResolveCastTypeIntModel([], ['x' => 'shared']))->newFromBuilder(['x' => '5']);
+        $asString = (new ResolveCastTypeStringModel([], ['x' => 'shared']))->newFromBuilder(['x' => '5']);
+
+        $this->assertSame(5, $asInt->x);
+        $this->assertSame('5', $asString->x);
+
+        // ...and independent of resolution order.
+        $this->assertSame('5', $asString->x);
+        $this->assertSame(5, $asInt->x);
+    }
+
+    public function testIsDecimalCastOverrideIsHonored()
+    {
+        $model = (new DecimalCastModel([], ['m' => 'money:2']))->newFromBuilder(['m' => '1.5']);
+
+        $this->assertSame('1.50', $model->m);
+    }
+}
+
+class CastHookModel extends Model
+{
+    protected $guarded = [];
+
+    public $timestamps = false;
+
+    public function __construct(array $attributes = [], array $casts = [])
+    {
+        $this->casts = $casts;
+
+        parent::__construct($attributes);
+    }
+
+    protected function asDate($value)
+    {
+        return 'date:'.$value;
+    }
+
+    protected function asDateTime($value)
+    {
+        return 'datetime:'.$value;
+    }
+
+    protected function asTimestamp($value)
+    {
+        return 'ts:'.$value;
+    }
+
+    public function fromFloat($value)
+    {
+        return 'float:'.$value;
+    }
+
+    protected function asDecimal($value, $decimals)
+    {
+        return 'decimal:'.$value.':'.$decimals;
+    }
+
+    public function fromJson($value, $asObject = false)
+    {
+        return ['hooked' => $value];
+    }
+
+    protected function castAttributeAsJson($key, $value)
+    {
+        return 'json-set:'.json_encode($value);
+    }
+
+    protected function castAttributeAsHashedString($key, #[\SensitiveParameter] $value)
+    {
+        return 'hashed:'.$value;
+    }
+}
+
+class EnumHookModel extends Model
+{
+    protected $guarded = [];
+
+    public $timestamps = false;
+
+    public function __construct(array $attributes = [], array $casts = [])
+    {
+        $this->casts = $casts;
+
+        parent::__construct($attributes);
+    }
+
+    protected function getEnumCastableAttributeValue($key, $value)
+    {
+        return 'enum-hook:'.$value;
+    }
+}
+
+class DatetimeOverrideModelA extends Model
+{
+    protected $guarded = [];
+
+    public $timestamps = false;
+
+    protected $casts = ['dt' => 'datetime'];
+
+    protected function asDateTime($value)
+    {
+        return 'A:'.$value;
+    }
+}
+
+class DatetimeOverrideModelB extends Model
+{
+    protected $guarded = [];
+
+    public $timestamps = false;
+
+    protected $casts = ['dt' => 'datetime'];
+
+    protected function asDateTime($value)
+    {
+        return 'B:'.$value;
+    }
+}
+
+class EnumOverrideModelA extends Model
+{
+    protected $guarded = [];
+
+    public $timestamps = false;
+
+    public function __construct(array $attributes = [], array $casts = [])
+    {
+        $this->casts = $casts;
+
+        parent::__construct($attributes);
+    }
+
+    protected function getEnumCastableAttributeValue($key, $value)
+    {
+        return 'A:'.$value;
+    }
+}
+
+class EnumOverrideModelB extends Model
+{
+    protected $guarded = [];
+
+    public $timestamps = false;
+
+    public function __construct(array $attributes = [], array $casts = [])
+    {
+        $this->casts = $casts;
+
+        parent::__construct($attributes);
+    }
+
+    protected function getEnumCastableAttributeValue($key, $value)
+    {
+        return 'B:'.$value;
+    }
+}
+
+class ResolveCastTypeIntModel extends Model
+{
+    protected $guarded = [];
+
+    public $timestamps = false;
+
+    public function __construct(array $attributes = [], array $casts = [])
+    {
+        $this->casts = $casts;
+
+        parent::__construct($attributes);
+    }
+
+    protected function resolveCastType($castType)
+    {
+        return $castType === 'shared' ? 'int' : parent::resolveCastType($castType);
+    }
+}
+
+class ResolveCastTypeStringModel extends Model
+{
+    protected $guarded = [];
+
+    public $timestamps = false;
+
+    public function __construct(array $attributes = [], array $casts = [])
+    {
+        $this->casts = $casts;
+
+        parent::__construct($attributes);
+    }
+
+    protected function resolveCastType($castType)
+    {
+        return $castType === 'shared' ? 'string' : parent::resolveCastType($castType);
+    }
+}
+
+class DecimalCastModel extends Model
+{
+    protected $guarded = [];
+
+    public $timestamps = false;
+
+    public function __construct(array $attributes = [], array $casts = [])
+    {
+        $this->casts = $casts;
+
+        parent::__construct($attributes);
+    }
+
+    protected function isDecimalCast($cast)
+    {
+        return str_starts_with($cast, 'money:') || parent::isDecimalCast($cast);
+    }
+}
+
+class ClassCastOverrideModelA extends Model
+{
+    protected $guarded = [];
+
+    public $timestamps = false;
+
+    public function __construct(array $attributes = [], array $casts = [])
+    {
+        $this->casts = $casts;
+
+        parent::__construct($attributes);
+    }
+
+    protected function getClassCastableAttributeValue($key, $value)
+    {
+        return 'A:'.$value;
+    }
+}
+
+class ClassCastOverrideModelB extends Model
+{
+    protected $guarded = [];
+
+    public $timestamps = false;
+
+    public function __construct(array $attributes = [], array $casts = [])
+    {
+        $this->casts = $casts;
+
+        parent::__construct($attributes);
+    }
+
+    protected function getClassCastableAttributeValue($key, $value)
+    {
+        return 'B:'.$value;
+    }
+}
+
+class CastOverrideValueObject implements CastsAttributes
+{
+    public function get($model, string $key, $value, array $attributes): mixed
+    {
+        return $value;
+    }
+
+    public function set($model, string $key, $value, array $attributes): mixed
+    {
+        return $value;
+    }
+}
+
+enum CastOverrideEnum: string
+{
+    case A = 'a';
+    case B = 'b';
+}

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -164,6 +164,37 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertTrue($model->isDirty('datetimeAttribute'));
     }
 
+    public function testNotDirtyWhenBackedEnumReassignedFromDifferentlyTypedOriginal()
+    {
+        $model = new EloquentModelWithIntEnumCastStub;
+
+        // Some database drivers (e.g. MySQL via emulated prepares) return the
+        // original integer column as a string, while the freshly set enum is
+        // stored as its int backing value. The model must not be reported dirty.
+        $model->setRawAttributes(['status' => '1'], true);
+
+        $model->status = EloquentModelTestIntBackedEnum::One;
+
+        $this->assertFalse($model->isDirty());
+        $this->assertFalse($model->isDirty('status'));
+    }
+
+    public function testNotDirtyWhenNonCastDateAttributeHasEquivalentFormat()
+    {
+        $model = new EloquentDateModelStub;
+        $model->setDateFormat('Y-m-d H:i:s');
+
+        // updated_at is a date attribute via getDates() but is NOT in $casts.
+        $model->setRawAttributes(['updated_at' => '2017-11-14'], true);
+
+        $attributes = $model->getAttributes();
+        $attributes['updated_at'] = '2017-11-14 00:00:00';
+        $model->setRawAttributes($attributes, false);
+
+        $this->assertTrue($model->originalIsEquivalent('updated_at'));
+        $this->assertFalse($model->isDirty('updated_at'));
+    }
+
     public function testDirtyOnCastedObjects()
     {
         $model = new EloquentModelCastingStub;
@@ -4041,6 +4072,21 @@ class EloquentDateModelStub extends EloquentModelStub
     {
         return ['created_at', 'updated_at'];
     }
+}
+
+enum EloquentModelTestIntBackedEnum: int
+{
+    case Zero = 0;
+    case One = 1;
+}
+
+class EloquentModelWithIntEnumCastStub extends Model
+{
+    protected $guarded = [];
+
+    protected $casts = [
+        'status' => EloquentModelTestIntBackedEnum::class,
+    ];
 }
 
 class EloquentModelSaveStub extends Model

--- a/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
@@ -288,6 +288,25 @@ class DatabaseEloquentModelCustomCastingTest extends DatabaseTestCase
         $model->undefined_cast_column = 'Glāžšķūņu rūķīši';
     }
 
+    public function testReservedCacheKeyCastStringsAreInvalidCasts()
+    {
+        // The internal cast cache uses reserved keys (@enum, @class,
+        // @encrypted:*) for its shared flyweights. A userland cast string that
+        // collides with one of those must still be treated as an unknown cast,
+        // not silently dispatched to the enum/class/encrypted machinery.
+        foreach (['@class', '@enum', '@encrypted:array'] as $reserved) {
+            $model = new TestEloquentModelWithCustomCast;
+            $model->mergeCasts(['reserved_column' => $reserved]);
+
+            try {
+                $model->reserved_column;
+                $this->fail("Expected InvalidCastException for the cast '{$reserved}'.");
+            } catch (InvalidCastException $e) {
+                $this->addToAssertionCount(1);
+            }
+        }
+    }
+
     public function testMutatorCanDependOnAnotherCastedAttribute()
     {
         $model = new TestEloquentModelWithCustomCast([

--- a/tests/Integration/Database/EloquentModelEncryptedDirtyTest.php
+++ b/tests/Integration/Database/EloquentModelEncryptedDirtyTest.php
@@ -4,11 +4,30 @@ namespace Illuminate\Tests\Integration\Database;
 
 use Illuminate\Database\Eloquent\Casts\AsEncryptedArrayObject;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Crypt;
 use Orchestra\Testbench\TestCase;
 
 class EloquentModelEncryptedDirtyTest extends TestCase
 {
+    public function testEncryptedJsonIsNotDirtyWhenStoredFormattingDiffersFromReEncoded()
+    {
+        config(['app.key' => str_repeat('a', 32)]);
+        Model::$encrypter = null;
+
+        $model = new EncryptedDirtyAttributeCast;
+
+        // Simulate a row whose encrypted JSON was stored with non-canonical
+        // whitespace (e.g. migrated from another system). Decrypting yields the
+        // same structure Laravel re-encodes, so the attribute is not dirty.
+        $model->setRawAttributes([
+            'secret_array' => Crypt::encryptString('{"a": 1, "b": 2}'),
+        ], true);
+
+        $model->secret_array = ['a' => 1, 'b' => 2];
+
+        $this->assertFalse($model->isDirty('secret_array'));
+    }
+
     public function testDirtyAttributeBehaviorWithNoPreviousKeys()
     {
         config(['app.key' => str_repeat('a', 32)]);

--- a/tests/Integration/Database/EloquentModelEncryptedDirtyTest.php
+++ b/tests/Integration/Database/EloquentModelEncryptedDirtyTest.php
@@ -58,6 +58,33 @@ class EloquentModelEncryptedDirtyTest extends TestCase
         $this->assertTrue($model->isDirty('secret_array_object'));
     }
 
+    public function testIsEncryptedCastableOverrideIsHonoredOnTheCastPath()
+    {
+        config(['app.key' => str_repeat('a', 32)]);
+        Model::$encrypter = null;
+
+        // The attribute is declared as a plain "array" cast, but the model
+        // overrides isEncryptedCastable() to treat it as encrypted. The read,
+        // write, and dirty-comparison paths must all honor that override.
+        $model = new OverriddenEncryptedCastable;
+
+        $model->data = ['a' => 1, 'b' => 2];
+
+        // The stored value must be encrypted (not plain JSON)...
+        $stored = $model->getAttributes()['data'];
+        $this->assertNotSame('{"a":1,"b":2}', $stored);
+        $this->assertSame('{"a":1,"b":2}', Model::currentEncrypter()->decrypt($stored, false));
+
+        // ...and reading must decrypt then JSON-decode it back.
+        $this->assertSame(['a' => 1, 'b' => 2], $model->data);
+
+        // Dirty comparison runs through the encrypted comparator (always dirty
+        // on any re-assignment because of rotatable keys), not the plain JSON one.
+        $model->syncOriginal();
+        $model->data = ['a' => 1, 'b' => 2];
+        $this->assertFalse($model->isDirty('data'));
+    }
+
     public function testDirtyAttributeBehaviorWithPreviousKeys()
     {
         config(['app.key' => str_repeat('a', 32)]);
@@ -109,4 +136,18 @@ class EncryptedDirtyAttributeCast extends Model
         'secret_collection' => 'encrypted:collection',
         'secret_array_object' => AsEncryptedArrayObject::class,
     ];
+}
+
+class OverriddenEncryptedCastable extends Model
+{
+    protected $guarded = [];
+
+    public $casts = [
+        'data' => 'array',
+    ];
+
+    protected function isEncryptedCastable($key)
+    {
+        return $key === 'data' || parent::isEncryptedCastable($key);
+    }
 }


### PR DESCRIPTION
*A note up front: I'm opening this as much to start a conversation as to land a patch. The 13.x change below is real, tested, and behavior-preserving — but I'm under no illusion that a memoization rewrite of the cast path is an obvious merge into a patch release. What I'm actually hoping to start is a discussion about Eloquent's cast-resolution design and what a future major could do with it. That part is at the bottom; the proof that it works comes first.*

## Summary

Eloquent re-evaluates how to cast an attribute on **every** read, write, and dirty-check: `getCastType()` is consulted, the `is*Castable()` predicates are re-probed, and a per-type `switch`/`if`-chain is walked — once per attribute, per access. For models with casts this is a meaningful share of the cost of reads, `toArray()`, and especially `isDirty()`/`getDirty()` on every `save()`.

This PR resolves each cast **once** to a small reusable cast object and memoizes it, then dispatches `get`/`set`/`compare` through that object. The decision of *which* cast and *which* branch is made a single time instead of on every touch.

Crucially, the cast objects' closures **defer to the model's own cast methods** (`asDateTime()`, `fromJson()`, `getEnumCastableAttributeValue()`, etc.), so any userland override of those methods is preserved — this is a behavior-preserving internal change, not a reimplementation.

No public API changes; three new `protected` methods on `HasAttributes` and one small internal `ClosureCast` class reusing the existing `CastsAttributes` / `ComparesCastableAttributes` contracts.

## Performance

Measured with a phpbench harness driving the Eloquent attribute test suite, **10 interleaved rounds with the run order flipped each round** so directional drift cancels (verified: timing on cast-*unrelated* methods centers at ≈0%).

Harness, runner, and full per-method results: https://gist.github.com/serpentblade/d32ec1cd7b5716c50e65bad461fab41e

| Path | Δ |
|---|---|
| `isDirty()` / `isClean()` (no real change) | **−46%** |
| dirty-check on cast/date attributes | **−32%** |
| dirty-check on float attributes | **−26%** |
| dirty-check on object/array/collection/enum casts | **−16% to −20%** |
| attribute reads / `toArray()` | ~−2% to −7% |

Net faster: ~140 methods improve (many substantially), ~90 are marginally slower, and every "slower" result is under ~+3% and within measurement noise (the worst is a cast-*unrelated* boot method). Reading a `null` primitive-cast attribute — the cheapest possible operation — is held at parity (+1.5%) by a short-circuit ahead of cast-object resolution.

Memory: a small, fixed set of cast objects is cached — one per distinct cast type, shared across all models — so the cast-object footprint is bounded regardless of how many models or attributes use casts. A small per-class lookup cache backs the override-fidelity layers (see the note on 13.x vs 14.x below).

## Backward compatibility

Behavior-preserving. The full existing Eloquent casting/attribute suites pass unchanged. To verify equivalence beyond the suite, I ran a differential check of **345 cases** (every cast type × edge values × read/`toArray`/write/dirty) against the current `13.x` implementation — **byte-identical results**, including cases the sqlite-backed suite doesn't reach: differently-typed scalar originals (a `'1'` string vs `1` int, as some drivers return), equivalent dates in different textual forms, JSON that re-encodes differently but decodes equal, and the encrypted/enum/immutable variants.

This PR also **adds permanent coverage** for those gaps (`DatabaseEloquentCastEquivalenceTest`, plus cases in the existing dirty/encrypted tests), so the dirty-equivalence behavior of every cast type is now asserted directly and is database-driver independent. A dedicated `DatabaseEloquentCastOverrideTest` proves the override guarantee explicitly: every value hook the cast objects defer to (`asDate`/`asDateTime`/`fromJson`/`fromFloat`/`asDecimal`/`castAttributeAs*`/the enum and custom-class hooks) is asserted honored through the cast path, the shared flyweights are proven class-isolated (no override leaks between model classes), and `getCastType()`/`isEncryptedCastable()`/`resolveCastType()` overrides are covered too.

## Let's talk about direction: 13.x today, 14.x as the real opportunity

I'll be candid about intent. This PR targets **13.x** and is deliberately **behavior-preserving**: it keeps Eloquent's entire cast-override surface intact (every `as*`/`from*`/`is*Castable`/`getCastType` hook still overrideable, per attribute) and wraps the memoized fast path in just enough protective machinery — per-class override detection, per-class type-cache keying — that no existing model can observe a difference. That's what would let a speedup like this land without a breaking change. It's also why a handful of the cheapest paths carry a sub-3% tax: that machinery isn't free.

But I don't expect this to be a slam-dunk merge, and that's fine — I'd rather it start a conversation than sit in a queue. The question I think is worth Eloquent's attention is the one underneath it:

**How do we keep the nuance and flexibility that make Eloquent's casting so capable, while paying down the cost of re-deciding everything on every single attribute access?**

Those two goals are in tension today, and the tension is structural. The cast-resolution path has accreted a lot over the years — the per-type `switch`, the parallel `is*Castable()` probes, the date/decimal/enum/encrypted/immutable branches interleaved — and all of it is re-walked on every read, write, and dirty-check. It's correct, but it's a lot to hold in your head, and the cost is paid per touch. The moment you try to memoize it, you discover exactly how many overrideable seams that flexibility is spread across (~20 of them), and the protective layers in this PR are the price of preserving every one — flexibility that, in practice, is rarely used.

So part of what I'm hoping this does is simply get a few more eyes on that corner of Eloquent. If it nudges the cast path toward something more legible — the cast surface named in one place instead of re-derived everywhere — and if it gets someone looking at how much has grown there, I'd count that a win on its own, independent of whether this exact diff lands.

**Where this really goes is a major.** The deeper win is available if Eloquent is willing to **narrow the cast-resolution contract**: declare that *which* cast applies (the cast type + the encryption decision) is resolved per cast-type and memoized, while the *value* transforms still defer to the model at call time. That removes the protective layers entirely and collapses the hot path to ~10 lines — faster, and considerably cleaner. I have that **14.x variant built and ready** as a follow-up.

The trade is explicit and worth weighing on its own terms: value-method overrides (`asDate`, `fromJson`, the enum/custom-class hooks, …) keep working untouched; what you'd give up is per-key/per-class overriding of the *resolution decision* itself (`getCastType()`, per-key `isEncryptedCastable()`). My read is that's flexibility almost nobody relies on — the idiomatic way to encrypt a single field is its own cast type (`'ssn' => 'encrypted:string'`), which still works — but that's exactly the kind of contract call that belongs to the maintainers, and it's the conversation I'd most like to have.

So: happy to land the conservative 13.x version here, open the 14.x simplification separately, or retarget this entirely — your call. But more than any of those, I'd love to talk about what **14.x** could do to really move the needle on cast performance. Speed is one of Eloquent's most-cited weaknesses, and this is a concrete, measured path at it.

## Notes

- `resolveInternalCastClass()` mirrors Eloquent's built-in cast surface, so a future new built-in cast type needs a matching arm (otherwise it falls through to `InvalidCastException`, same as an unknown cast today).
- Overriding `getCastType()` or `isEncryptedCastable()` is detected per class and transparently switches that model to per-key resolution, so those overrides are honored exactly as before; models that don't override them keep the fully memoized fast path.

---

*Disclosure:* this is an optimization I set out to make — replacing Eloquent's per-access conditional cast dispatch with a memoized, override-preserving cast object. I used AI tooling to assist with the implementation, to expand test coverage, and during debugging. Every line has been reviewed, tested, and is understood by me, and I'm able to maintain and explain it.
