### PR TITLE
[13.x] Sanitize default session cookie name for non-alphanumeric APP_NAME

### DIFF
--- a/config/session.php
+++ b/config/session.php
@@ -129,7 +129,7 @@ return [
 
     'cookie' => env(
         'SESSION_COOKIE',
-        Str::snake((string) env('APP_NAME', 'laravel')).'_session'
+        Str::slug(Str::snake((string) env('APP_NAME', 'laravel')), '_').'_session'
     ),
 
     /*

--- a/tests/Foundation/Bootstrap/LoadConfigurationTest.php
+++ b/tests/Foundation/Bootstrap/LoadConfigurationTest.php
@@ -72,4 +72,19 @@ class LoadConfigurationTest extends TestCase
             ]))->map(fn ($file) => $file->getBaseName('.php'))->unique()->values()->toArray()
         );
     }
+
+    public function testLoadsSessionCookieNameCorrectly()
+    {
+        $_ENV['APP_NAME'] = '[LOCAL] My App';
+        putenv('APP_NAME=[LOCAL] My App');
+
+        $app = new Application();
+
+        (new LoadConfiguration)->bootstrap($app);
+
+        $this->assertSame('l_o_c_a_l_my_app_session', $app['config']['session.cookie']);
+
+        unset($_ENV['APP_NAME']);
+        putenv('APP_NAME');
+    }
 }


### PR DESCRIPTION
This PR fixes a bug where Str::snake() preserves special characters (like brackets) in the default session cookie name, breaking session persistence.

Instead of reverting to Str::slug directly (which would lose the camelCase word spacing introduced in #56172), this wraps Str::snake inside Str::slug(..., '_') to sanitize invalid cookie characters while maintaining the intended word formatting.

Fixes #59344