### PR TITLE
[13.x] Should Not Retry Exception Handler

### DIFF
--- a/src/Illuminate/Contracts/Debug/ExceptionHandler.php
+++ b/src/Illuminate/Contracts/Debug/ExceptionHandler.php
@@ -7,7 +7,7 @@ use Throwable;
 /**
  * @method bool isReporting(\Throwable $e)
  * @method array buildContextForException()
- * @method bool shouldRetry(\Throwable $e)
+ * @method bool shouldntRetry(\Throwable $e)
  */
 interface ExceptionHandler
 {

--- a/src/Illuminate/Contracts/Debug/ExceptionHandler.php
+++ b/src/Illuminate/Contracts/Debug/ExceptionHandler.php
@@ -7,6 +7,7 @@ use Throwable;
 /**
  * @method bool isReporting(\Throwable $e)
  * @method array buildContextForException()
+ * @method bool shouldRetry(\Throwable $e)
  */
 interface ExceptionHandler
 {

--- a/src/Illuminate/Contracts/Debug/ExceptionHandler.php
+++ b/src/Illuminate/Contracts/Debug/ExceptionHandler.php
@@ -7,7 +7,7 @@ use Throwable;
 /**
  * @method bool isReporting(\Throwable $e)
  * @method array buildContextForException()
- * @method bool shouldntRetry(\Throwable $e)
+ * @method bool shouldStopRetries(\Throwable $e)
  */
 interface ExceptionHandler
 {

--- a/src/Illuminate/Foundation/Configuration/Exceptions.php
+++ b/src/Illuminate/Foundation/Configuration/Exceptions.php
@@ -69,7 +69,7 @@ class Exceptions
     /**
      * Register a retryable callback.
      *
-     * @param  callable  $using
+     * @param  callable(\Throwable): bool|null  $using
      * @return $this
      */
     public function retry(callable $using)
@@ -82,7 +82,7 @@ class Exceptions
     /**
      * Register a retryable callback.
      *
-     * @param  callable  $retryUsing
+     * @param  callable(\Throwable): bool|null  $retryUsing
      * @return $this
      */
     public function retryable(callable $retryUsing)

--- a/src/Illuminate/Foundation/Configuration/Exceptions.php
+++ b/src/Illuminate/Foundation/Configuration/Exceptions.php
@@ -67,32 +67,6 @@ class Exceptions
     }
 
     /**
-     * Register a retryable callback.
-     *
-     * @param  callable(\Throwable): bool|null  $using
-     * @return $this
-     */
-    public function retry(callable $using)
-    {
-        $this->handler->retryable($using);
-
-        return $this;
-    }
-
-    /**
-     * Register a retryable callback.
-     *
-     * @param  callable(\Throwable): bool|null  $retryUsing
-     * @return $this
-     */
-    public function retryable(callable $retryUsing)
-    {
-        $this->handler->retryable($retryUsing);
-
-        return $this;
-    }
-
-    /**
      * Register a callback to prepare the final, rendered exception response.
      *
      * @param  callable  $using
@@ -177,6 +151,21 @@ class Exceptions
     }
 
     /**
+     * Indicate that the given exception type should not be retried.
+     *
+     * @param  array|string  $class
+     * @return $this
+     */
+    public function dontRetry(array|string $class)
+    {
+        foreach (Arr::wrap($class) as $exceptionClass) {
+            $this->handler->dontRetry($exceptionClass);
+        }
+
+        return $this;
+    }
+
+    /**
      * Register a callback to determine if an exception should not be reported.
      *
      * @param  (\Closure(\Throwable): bool)  $dontReportWhen
@@ -185,6 +174,19 @@ class Exceptions
     public function dontReportWhen(Closure $dontReportWhen)
     {
         $this->handler->dontReportWhen($dontReportWhen);
+
+        return $this;
+    }
+
+    /**
+     * Register a callback to determine if an exception should not be retried.
+     *
+     * @param  (\Closure(\Throwable): bool)  $dontRetryWhen
+     * @return $this
+     */
+    public function dontRetryWhen(Closure $dontRetryWhen)
+    {
+        $this->handler->dontRetryWhen($dontRetryWhen);
 
         return $this;
     }

--- a/src/Illuminate/Foundation/Configuration/Exceptions.php
+++ b/src/Illuminate/Foundation/Configuration/Exceptions.php
@@ -67,6 +67,32 @@ class Exceptions
     }
 
     /**
+     * Register a retryable callback.
+     *
+     * @param  callable  $using
+     * @return $this
+     */
+    public function retry(callable $using)
+    {
+        $this->handler->retryable($using);
+
+        return $this;
+    }
+
+    /**
+     * Register a retryable callback.
+     *
+     * @param  callable  $retryUsing
+     * @return $this
+     */
+    public function retryable(callable $retryUsing)
+    {
+        $this->handler->retryable($retryUsing);
+
+        return $this;
+    }
+
+    /**
      * Register a callback to prepare the final, rendered exception response.
      *
      * @param  callable  $using

--- a/src/Illuminate/Foundation/Configuration/Exceptions.php
+++ b/src/Illuminate/Foundation/Configuration/Exceptions.php
@@ -151,7 +151,7 @@ class Exceptions
     }
 
     /**
-     * Indicate that the given exception type should not be retried.
+     * Indicate that the given exception type should stop job retries.
      *
      * @param  array|string  $class
      * @return $this
@@ -179,7 +179,7 @@ class Exceptions
     }
 
     /**
-     * Register a callback to determine if an exception should not be retried.
+     * Register a callback to determine if an exception should stop job retries.
      *
      * @param  (\Closure(\Throwable): bool)  $dontRetryWhen
      * @return $this

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -79,6 +79,20 @@ class Handler implements ExceptionHandlerContract
     protected $dontReportCallbacks = [];
 
     /**
+     * A list of the exception types that should stop job retries.
+     *
+     * @var array<int, class-string<\Throwable>>
+     */
+    protected $dontRetry = [];
+
+    /**
+     * The callbacks that inspect exceptions to determine if they should stop job retries.
+     *
+     * @var array
+     */
+    protected $dontRetryCallbacks = [];
+
+    /**
      * The callbacks that should be used during reporting.
      *
      * @var \Illuminate\Foundation\Exceptions\ReportableHandler[]
@@ -119,20 +133,6 @@ class Handler implements ExceptionHandlerContract
      * @var \Closure[]
      */
     protected $renderCallbacks = [];
-
-    /**
-     * A list of the exception types that should not be retried.
-     *
-     * @var array<int, class-string<\Throwable>>
-     */
-    protected $dontRetry = [];
-
-    /**
-     * The callbacks that inspect exceptions to determine if they should not be retried.
-     *
-     * @var array
-     */
-    protected $dontRetryCallbacks = [];
 
     /**
      * The callback that determines if the exception handler response should be JSON.
@@ -339,7 +339,7 @@ class Handler implements ExceptionHandlerContract
     }
 
     /**
-     * Indicate that the given exception type should not be retried.
+     * Indicate that the given exception type should stop job retries.
      *
      * @param  array|string  $exceptions
      * @return $this
@@ -354,7 +354,7 @@ class Handler implements ExceptionHandlerContract
     }
 
     /**
-     * Register a callback to determine if an exception should not be retried.
+     * Register a callback to determine if an exception should stop job retries.
      *
      * @param  (callable(\Throwable): bool)  $dontRetryWhen
      * @return $this
@@ -371,12 +371,12 @@ class Handler implements ExceptionHandlerContract
     }
 
     /**
-     * Determine if the exception should not be retried when thrown from a queued job.
+     * Determine if the exception should stop job retries.
      *
      * @param  \Throwable  $e
      * @return bool
      */
-    public function shouldntRetry(Throwable $e)
+    public function shouldStopRetries(Throwable $e)
     {
         if (method_exists($e, 'dontRetry')) {
             return $e->dontRetry();

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -121,11 +121,18 @@ class Handler implements ExceptionHandlerContract
     protected $renderCallbacks = [];
 
     /**
-     * The callbacks that should be used to determine if an exception should be retried.
+     * A list of the exception types that should not be retried.
      *
-     * @var \Closure[]
+     * @var array<int, class-string<\Throwable>>
      */
-    protected $retryCallbacks = [];
+    protected $dontRetry = [];
+
+    /**
+     * The callbacks that inspect exceptions to determine if they should not be retried.
+     *
+     * @var array
+     */
+    protected $dontRetryCallbacks = [];
 
     /**
      * The callback that determines if the exception handler response should be JSON.
@@ -259,50 +266,6 @@ class Handler implements ExceptionHandlerContract
     }
 
     /**
-     * Register a retryable callback.
-     *
-     * @param  callable  $retryUsing
-     * @return $this
-     */
-    public function retryable(callable $retryUsing)
-    {
-        if (! $retryUsing instanceof Closure) {
-            $retryUsing = Closure::fromCallable($retryUsing);
-        }
-
-        $this->retryCallbacks[] = $retryUsing;
-
-        return $this;
-    }
-
-    /**
-     * Determine if the exception should be retried when thrown from a queued job.
-     *
-     * @param  \Throwable  $e
-     * @return bool
-     */
-    public function shouldRetry(Throwable $e)
-    {
-        if (method_exists($e, 'retry')) {
-            return $e->retry();
-        }
-
-        foreach ($this->retryCallbacks as $retryCallback) {
-            foreach ($this->firstClosureParameterTypes($retryCallback) as $type) {
-                if (is_a($e, $type)) {
-                    $result = $retryCallback($e);
-
-                    if (! is_null($result)) {
-                        return $result;
-                    }
-                }
-            }
-        }
-
-        return true;
-    }
-
-    /**
      * Register a new exception mapping.
      *
      * @param  \Closure|string  $from
@@ -373,6 +336,63 @@ class Handler implements ExceptionHandlerContract
         $this->dontReport = array_values(array_unique(array_merge($this->dontReport, $exceptions)));
 
         return $this;
+    }
+
+    /**
+     * Indicate that the given exception type should not be retried.
+     *
+     * @param  array|string  $exceptions
+     * @return $this
+     */
+    public function dontRetry(array|string $exceptions)
+    {
+        $exceptions = Arr::wrap($exceptions);
+
+        $this->dontRetry = array_values(array_unique(array_merge($this->dontRetry, $exceptions)));
+
+        return $this;
+    }
+
+    /**
+     * Register a callback to determine if an exception should not be retried.
+     *
+     * @param  (callable(\Throwable): bool)  $dontRetryWhen
+     * @return $this
+     */
+    public function dontRetryWhen(callable $dontRetryWhen)
+    {
+        if (! $dontRetryWhen instanceof Closure) {
+            $dontRetryWhen = Closure::fromCallable($dontRetryWhen);
+        }
+
+        $this->dontRetryCallbacks[] = $dontRetryWhen;
+
+        return $this;
+    }
+
+    /**
+     * Determine if the exception should not be retried when thrown from a queued job.
+     *
+     * @param  \Throwable  $e
+     * @return bool
+     */
+    public function shouldntRetry(Throwable $e)
+    {
+        if (method_exists($e, 'dontRetry')) {
+            return $e->dontRetry();
+        }
+
+        if (! is_null(Arr::first($this->dontRetry, fn ($type) => $e instanceof $type))) {
+            return true;
+        }
+
+        foreach ($this->dontRetryCallbacks as $dontRetryCallback) {
+            if ($dontRetryCallback($e) === true) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -378,10 +378,6 @@ class Handler implements ExceptionHandlerContract
      */
     public function shouldStopRetries(Throwable $e)
     {
-        if (method_exists($e, 'dontRetry')) {
-            return $e->dontRetry();
-        }
-
         if (! is_null(Arr::first($this->dontRetry, fn ($type) => $e instanceof $type))) {
             return true;
         }

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -121,6 +121,13 @@ class Handler implements ExceptionHandlerContract
     protected $renderCallbacks = [];
 
     /**
+     * The callbacks that should be used to determine if an exception should be retried.
+     *
+     * @var \Closure[]
+     */
+    protected $retryCallbacks = [];
+
+    /**
      * The callback that determines if the exception handler response should be JSON.
      *
      * @var callable|null
@@ -249,6 +256,50 @@ class Handler implements ExceptionHandlerContract
         $this->renderCallbacks[] = $renderUsing;
 
         return $this;
+    }
+
+    /**
+     * Register a retryable callback.
+     *
+     * @param  callable  $retryUsing
+     * @return $this
+     */
+    public function retryable(callable $retryUsing)
+    {
+        if (! $retryUsing instanceof Closure) {
+            $retryUsing = Closure::fromCallable($retryUsing);
+        }
+
+        $this->retryCallbacks[] = $retryUsing;
+
+        return $this;
+    }
+
+    /**
+     * Determine if the exception should be retried when thrown from a queued job.
+     *
+     * @param  \Throwable  $e
+     * @return bool
+     */
+    public function shouldRetry(Throwable $e)
+    {
+        if (method_exists($e, 'retry')) {
+            return $e->retry();
+        }
+
+        foreach ($this->retryCallbacks as $retryCallback) {
+            foreach ($this->firstClosureParameterTypes($retryCallback) as $type) {
+                if (is_a($e, $type)) {
+                    $result = $retryCallback($e);
+
+                    if (! is_null($result)) {
+                        return $result;
+                    }
+                }
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -589,6 +589,10 @@ class Worker
                 $this->markJobAsFailedIfWillExceedMaxExceptions(
                     $connectionName, $job, $e
                 );
+
+                $this->markJobAsFailedIfItShouldNotBeRetried(
+                    $connectionName, $job, $e
+                );
             }
 
             $this->raiseExceptionOccurredJobEvent(
@@ -687,6 +691,21 @@ class Worker
         if ($maxExceptions <= $this->cache->increment('job-exceptions:'.$uuid)) {
             $this->cache->forget('job-exceptions:'.$uuid);
 
+            $this->failJob($job, $e);
+        }
+    }
+
+    /**
+     * Mark the given job as failed if the exception handler determines it should not be retried.
+     *
+     * @param  string  $connectionName
+     * @param  \Illuminate\Contracts\Queue\Job  $job
+     * @param  \Throwable  $e
+     * @return void
+     */
+    protected function markJobAsFailedIfItShouldNotBeRetried($connectionName, $job, Throwable $e)
+    {
+        if (method_exists($this->exceptions, 'shouldRetry') && ! $this->exceptions->shouldRetry($e)) {
             $this->failJob($job, $e);
         }
     }

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -705,7 +705,7 @@ class Worker
      */
     protected function markJobAsFailedIfItShouldntBeRetried($connectionName, $job, Throwable $e)
     {
-        if (method_exists($this->exceptions, 'shouldntRetry') && $this->exceptions->shouldntRetry($e)) {
+        if (method_exists($this->exceptions, 'shouldStopRetries') && $this->exceptions->shouldStopRetries($e)) {
             $this->failJob($job, $e);
         }
     }

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -590,7 +590,7 @@ class Worker
                     $connectionName, $job, $e
                 );
 
-                $this->markJobAsFailedIfItShouldNotBeRetried(
+                $this->markJobAsFailedIfItShouldntBeRetried(
                     $connectionName, $job, $e
                 );
             }
@@ -703,9 +703,9 @@ class Worker
      * @param  \Throwable  $e
      * @return void
      */
-    protected function markJobAsFailedIfItShouldNotBeRetried($connectionName, $job, Throwable $e)
+    protected function markJobAsFailedIfItShouldntBeRetried($connectionName, $job, Throwable $e)
     {
-        if (method_exists($this->exceptions, 'shouldRetry') && ! $this->exceptions->shouldRetry($e)) {
+        if (method_exists($this->exceptions, 'shouldntRetry') && $this->exceptions->shouldntRetry($e)) {
             $this->failJob($job, $e);
         }
     }

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -265,32 +265,39 @@ class FoundationExceptionsHandlerTest extends TestCase
         $this->assertSame('{"response":"My renderable exception response"}', $response);
     }
 
-    public function testShouldRetryDefaultsToTrue()
+    public function testShouldntRetryDefaultsToFalse()
     {
-        $this->assertTrue($this->handler->shouldRetry(new CustomException));
+        $this->assertFalse($this->handler->shouldntRetry(new CustomException));
     }
 
-    public function testShouldRetryUsesRegisteredCallback()
+    public function testShouldntRetryUsesRegisteredExceptionClass()
     {
-        $this->handler->retryable(function (CustomException $e) {
+        $this->handler->dontRetry(CustomException::class);
+
+        $this->assertTrue($this->handler->shouldntRetry(new CustomException));
+    }
+
+    public function testShouldntRetryUsesRegisteredCallback()
+    {
+        $this->handler->dontRetryWhen(function (CustomException $e) {
+            return true;
+        });
+
+        $this->assertTrue($this->handler->shouldntRetry(new CustomException));
+    }
+
+    public function testShouldntRetryIgnoresFalseCallbackResult()
+    {
+        $this->handler->dontRetryWhen(function (CustomException $e) {
             return false;
         });
 
-        $this->assertFalse($this->handler->shouldRetry(new CustomException));
+        $this->assertFalse($this->handler->shouldntRetry(new CustomException));
     }
 
-    public function testShouldRetryIgnoresCallbackForDifferentException()
+    public function testShouldntRetryUsesExceptionMethod()
     {
-        $this->handler->retryable(function (CustomException $e) {
-            return false;
-        });
-
-        $this->assertTrue($this->handler->shouldRetry(new RuntimeException));
-    }
-
-    public function testShouldRetryUsesExceptionMethod()
-    {
-        $this->assertFalse($this->handler->shouldRetry(new RetryableException));
+        $this->assertTrue($this->handler->shouldntRetry(new NonRetryableException));
     }
 
     public function testReturnsCustomResponseWhenExceptionImplementsResponsable()
@@ -1006,11 +1013,11 @@ class RenderableException extends Exception
     }
 }
 
-class RetryableException extends Exception
+class NonRetryableException extends Exception
 {
-    public function retry()
+    public function dontRetry()
     {
-        return false;
+        return true;
     }
 }
 

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -267,14 +267,14 @@ class FoundationExceptionsHandlerTest extends TestCase
 
     public function testShouldntRetryDefaultsToFalse()
     {
-        $this->assertFalse($this->handler->shouldntRetry(new CustomException));
+        $this->assertFalse($this->handler->shouldStopRetries(new CustomException));
     }
 
     public function testShouldntRetryUsesRegisteredExceptionClass()
     {
         $this->handler->dontRetry(CustomException::class);
 
-        $this->assertTrue($this->handler->shouldntRetry(new CustomException));
+        $this->assertTrue($this->handler->shouldStopRetries(new CustomException));
     }
 
     public function testShouldntRetryUsesRegisteredCallback()
@@ -283,7 +283,7 @@ class FoundationExceptionsHandlerTest extends TestCase
             return true;
         });
 
-        $this->assertTrue($this->handler->shouldntRetry(new CustomException));
+        $this->assertTrue($this->handler->shouldStopRetries(new CustomException));
     }
 
     public function testShouldntRetryIgnoresFalseCallbackResult()
@@ -292,12 +292,12 @@ class FoundationExceptionsHandlerTest extends TestCase
             return false;
         });
 
-        $this->assertFalse($this->handler->shouldntRetry(new CustomException));
+        $this->assertFalse($this->handler->shouldStopRetries(new CustomException));
     }
 
     public function testShouldntRetryUsesExceptionMethod()
     {
-        $this->assertTrue($this->handler->shouldntRetry(new NonRetryableException));
+        $this->assertTrue($this->handler->shouldStopRetries(new NonRetryableException));
     }
 
     public function testReturnsCustomResponseWhenExceptionImplementsResponsable()

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -265,6 +265,34 @@ class FoundationExceptionsHandlerTest extends TestCase
         $this->assertSame('{"response":"My renderable exception response"}', $response);
     }
 
+    public function testShouldRetryDefaultsToTrue()
+    {
+        $this->assertTrue($this->handler->shouldRetry(new CustomException));
+    }
+
+    public function testShouldRetryUsesRegisteredCallback()
+    {
+        $this->handler->retryable(function (CustomException $e) {
+            return false;
+        });
+
+        $this->assertFalse($this->handler->shouldRetry(new CustomException));
+    }
+
+    public function testShouldRetryIgnoresCallbackForDifferentException()
+    {
+        $this->handler->retryable(function (CustomException $e) {
+            return false;
+        });
+
+        $this->assertTrue($this->handler->shouldRetry(new RuntimeException));
+    }
+
+    public function testShouldRetryUsesExceptionMethod()
+    {
+        $this->assertFalse($this->handler->shouldRetry(new RetryableException));
+    }
+
     public function testReturnsCustomResponseWhenExceptionImplementsResponsable()
     {
         $response = $this->handler->render($this->request, new ResponsableException)->getContent();
@@ -975,6 +1003,14 @@ class RenderableException extends Exception
     public function render($request)
     {
         return response()->json(['response' => 'My renderable exception response']);
+    }
+}
+
+class RetryableException extends Exception
+{
+    public function retry()
+    {
+        return false;
     }
 }
 

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -295,11 +295,6 @@ class FoundationExceptionsHandlerTest extends TestCase
         $this->assertFalse($this->handler->shouldStopRetries(new CustomException));
     }
 
-    public function testShouldntRetryUsesExceptionMethod()
-    {
-        $this->assertTrue($this->handler->shouldStopRetries(new NonRetryableException));
-    }
-
     public function testReturnsCustomResponseWhenExceptionImplementsResponsable()
     {
         $response = $this->handler->render($this->request, new ResponsableException)->getContent();
@@ -1010,14 +1005,6 @@ class RenderableException extends Exception
     public function render($request)
     {
         return response()->json(['response' => 'My renderable exception response']);
-    }
-}
-
-class NonRetryableException extends Exception
-{
-    public function dontRetry()
-    {
-        return true;
     }
 }
 

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -248,7 +248,7 @@ class QueueWorkerTest extends TestCase
         $this->events->shouldNotHaveReceived('dispatch', [m::type(JobProcessed::class)]);
     }
 
-    public function testJobIsFailedIfExceptionHandlerSaysItShouldNotRetry()
+    public function testJobIsFailedIfExceptionHandlerSaysItShouldntRetry()
     {
         $e = new RuntimeException;
 
@@ -259,7 +259,7 @@ class QueueWorkerTest extends TestCase
         $worker = new InsomniacWorker(
             new WorkerFakeManager('default', new WorkerFakeConnection('default', ['queue' => [$job]])),
             $this->events,
-            new ShouldNotRetryExceptionHandler,
+            new ShouldntRetryExceptionHandler,
             function () {
                 return false;
             },
@@ -793,7 +793,7 @@ class BrokenQueueConnection
     }
 }
 
-class ShouldNotRetryExceptionHandler implements ExceptionHandler
+class ShouldntRetryExceptionHandler implements ExceptionHandler
 {
     public function report(\Throwable $e)
     {
@@ -815,9 +815,9 @@ class ShouldNotRetryExceptionHandler implements ExceptionHandler
         //
     }
 
-    public function shouldRetry(\Throwable $e)
+    public function shouldntRetry(\Throwable $e)
     {
-        return false;
+        return true;
     }
 }
 

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -248,6 +248,31 @@ class QueueWorkerTest extends TestCase
         $this->events->shouldNotHaveReceived('dispatch', [m::type(JobProcessed::class)]);
     }
 
+    public function testJobIsFailedIfExceptionHandlerSaysItShouldNotRetry()
+    {
+        $e = new RuntimeException;
+
+        $job = new WorkerFakeJob(function () use ($e) {
+            throw $e;
+        });
+
+        $worker = new InsomniacWorker(
+            new WorkerFakeManager('default', new WorkerFakeConnection('default', ['queue' => [$job]])),
+            $this->events,
+            new ShouldNotRetryExceptionHandler,
+            function () {
+                return false;
+            },
+        );
+
+        $worker->runNextJob('default', 'queue', $this->workerOptions(['backoff' => 10]));
+
+        $this->assertNull($job->releaseAfter);
+        $this->assertTrue($job->deleted);
+        $this->assertEquals($e, $job->failedWith);
+        $this->events->shouldNotHaveReceived('dispatch', [m::type(JobReleasedAfterException::class)]);
+    }
+
     public function testExceptionIsNotReportedIfReportJobExceptionsIsDisabled()
     {
         $e = new RuntimeException;
@@ -765,6 +790,34 @@ class BrokenQueueConnection
     public function getConnectionName()
     {
         return $this->connectionName;
+    }
+}
+
+class ShouldNotRetryExceptionHandler implements ExceptionHandler
+{
+    public function report(\Throwable $e)
+    {
+        //
+    }
+
+    public function shouldReport(\Throwable $e)
+    {
+        return true;
+    }
+
+    public function render($request, \Throwable $e)
+    {
+        //
+    }
+
+    public function renderForConsole($output, \Throwable $e)
+    {
+        //
+    }
+
+    public function shouldRetry(\Throwable $e)
+    {
+        return false;
     }
 }
 

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -815,7 +815,7 @@ class ShouldntRetryExceptionHandler implements ExceptionHandler
         //
     }
 
-    public function shouldntRetry(\Throwable $e)
+    public function shouldStopRetries(\Throwable $e)
     {
         return true;
     }


### PR DESCRIPTION
Allow specific exceptions to determine whether a queued job should be re-tried, or whether the error is unrecoverable.

The retry mechanism can be defined on either the exception itself, using the `retry()` method, with a `false` value returned determining that the job should not be retried.

The same method can be added to the `withExceptions` handler in the bootstrap process.

I have purposefully added the method to the `ExceptionHandler` docblock rather than directly on the interface itself, since adding to the interface is a breaking change.

Not sure if you'd prefer to make this a breaking change, or keep it like this.

I'll leave that decision to you, however, it's a 2 line change should we want to change it.