### PR TITLE
[13.x] Fix too narrow array-shape typehints where the first parameter is optional

### DIFF
--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -293,7 +293,7 @@ class Fluent implements Arrayable, ArrayAccess, IteratorAggregate, Jsonable, Jso
      * Handle dynamic calls to the fluent instance to set attributes.
      *
      * @param  TKey  $method
-     * @param  array{0: ?TValue}  $parameters
+     * @param  array{0?: ?TValue}  $parameters
      * @return $this
      */
     public function __call($method, $parameters)

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -507,7 +507,7 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @param  array{0: string}  $parameters
+     * @param  array{0?: string}  $parameters
      * @return bool
      */
     public function validateConfirmed($attribute, $value, $parameters)


### PR DESCRIPTION
## Summary

Two methods document their `$parameters` as a shape that requires the first element, even though their implementations explicitly handle it being absent.

- `Illuminate\Validation\Concerns\ValidatesAttributes::validateConfirmed()` is typed `@param array{0: string}`, but the body falls back when index `0` is missing:

  ```php
  return $this->validateSame($attribute, $value, [$parameters[0] ?? $attribute.'_confirmation']);
  ```

  The `confirmed` rule is commonly used without an argument, so it is called with `[]`.

- `Illuminate\Support\Fluent::__call()` is typed `@param array{0: ?TValue}`, but the body handles the empty case:

  ```php
  $this->attributes[$method] = count($parameters) > 0 ? array_first($parameters) : true;
  ```

  A fluent call like `$fluent->active()` passes no arguments, so `$parameters` is `[]`.

## Change

Widen both shapes from `array{0: ...}` to `array{0?: ...}` so the (supported and intended) empty-array call type-checks correctly. Documentation-only, no behavior changes.
