### PR TITLE
[13.x] Feat: add `to_array()` helper function

### DIFF
--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 
@@ -264,6 +265,22 @@ if (! function_exists('value')) {
     function value($value, ...$args)
     {
         return $value instanceof Closure ? $value(...$args) : $value;
+    }
+}
+
+if (! function_exists('to_array')) {
+    /**
+     * Convert an Arrayable instance to a plain array, or return the value unchanged if it's already an array.
+     *
+     * @template TKey of array-key
+     * @template TValue
+     *
+     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|array<TKey, TValue>  $value
+     * @return array<TKey, TValue>
+     */
+    function to_array($value)
+    {
+        return $value instanceof Arrayable ? $value->toArray() : $value;
     }
 }
 


### PR DESCRIPTION
## Add `to_array()` global helper

Adds a new `to_array()` helper function to `src/Illuminate/Collections/helpers.php` that converts an `Arrayable`
instance to a plain PHP array, or returns the value unchanged if it is already an array.

The pattern below is repeated in numerous places across the codebase (e.g. `Illuminate\Validation\Rule`):

```php
    if ($values instanceof Arrayable) {
        $values = $values->toArray();
    }
```
 
This helper consolidates that logic into a single reusable function, allowing call sites to be reduced
to a one-liner: `$values = to_array($values);`