### PR TITLE
[13.x] Fix: use `trim()`

### DIFF
--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -269,7 +269,7 @@ class PhpRedisConnector implements Connector
     {
         $host = $options['host'] ?? null;
 
-        if (! is_string($host) || $host === '') {
+        if (! is_string($host) || trim($host) === '') {
             throw new InvalidArgumentException('Redis host must be a non-empty string.');
         }
 


### PR DESCRIPTION
Fix Redis host validation to reject whitespace-only strings

The previous check `$host === ''` would not catch hosts containing only spaces or tabs, allowing invalid values to pass through silently. Wrapped the empty string check with `trim()` so that whitespace-only values are treated as empty and trigger the expected `InvalidArgumentException`.