### PR TITLE
[13.x] Reduce cache hits when debouncing with maxWait

### DIFF
--- a/src/Illuminate/Bus/DebounceLock.php
+++ b/src/Illuminate/Bus/DebounceLock.php
@@ -66,15 +66,15 @@ class DebounceLock
 
         $timestampKey = $key.':first_dispatched_at';
 
-        $dispatchedAt = $cache->get($timestampKey);
+        $firstDispatchedAt = $cache->get($timestampKey);
 
-        if (is_null($dispatchedAt)) {
+        if (is_null($firstDispatchedAt)) {
             $cache->put($timestampKey, Carbon::now()->getTimestamp(), $ttl);
 
             return false;
         }
 
-        $elapsed = Carbon::now()->getTimestamp() - $dispatchedAt;
+        $elapsed = Carbon::now()->getTimestamp() - $firstDispatchedAt;
 
         if ($elapsed >= $maxWait) {
             $cache->forget($timestampKey);

--- a/src/Illuminate/Bus/DebounceLock.php
+++ b/src/Illuminate/Bus/DebounceLock.php
@@ -66,13 +66,15 @@ class DebounceLock
 
         $timestampKey = $key.':first_dispatched_at';
 
-        if (! $cache->has($timestampKey)) {
+        $dispatchedAt = $cache->get($timestampKey);
+
+        if (is_null($dispatchedAt)) {
             $cache->put($timestampKey, Carbon::now()->getTimestamp(), $ttl);
 
             return false;
         }
 
-        $elapsed = Carbon::now()->getTimestamp() - $cache->get($timestampKey);
+        $elapsed = Carbon::now()->getTimestamp() - $dispatchedAt;
 
         if ($elapsed >= $maxWait) {
             $cache->forget($timestampKey);


### PR DESCRIPTION
When a job sets `maxWait`  in the debounce lock,  every dispatch after the first reads the cache 2x 

```php
// Such as....
#[DebounceFor(30, maxWait: 120)]
class UpdateSearchIndex implements ShouldQueue
```

 This PR replaces the `has()` check to reuse the value from `get()`.. (`has` actually calls `get` under the hood for anyone reading that didnt know)  
 
This is very useful for high traffic debounced jobs, so rather than 2000 reads of the timestamp from cache, its now half.  Which means the cache can breath a lil

No test changes as behavior is identical 