### PR TITLE
Allow disabling the default email verification listener

### DIFF
--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -95,9 +95,10 @@ class ApplicationBuilder
      * Register the core event service provider for the application.
      *
      * @param  iterable<int, string>|bool  $discover
+     * @param  bool  $emailVerification
      * @return $this
      */
-    public function withEvents(iterable|bool $discover = true)
+    public function withEvents(iterable|bool $discover = true, bool $emailVerification = true)
     {
         if (is_iterable($discover)) {
             AppEventServiceProvider::setEventDiscoveryPaths($discover);
@@ -105,6 +106,10 @@ class ApplicationBuilder
 
         if ($discover === false) {
             AppEventServiceProvider::disableEventDiscovery();
+        }
+
+        if ($emailVerification === false) {
+            AppEventServiceProvider::disableEmailVerification();
         }
 
         if (! isset($this->pendingProviders[AppEventServiceProvider::class])) {

--- a/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
@@ -48,6 +48,13 @@ class EventServiceProvider extends ServiceProvider
     protected static $eventDiscoveryPaths;
 
     /**
+     * Indicates if the default email verification notification listener should be registered.
+     *
+     * @var bool
+     */
+    protected static $configureEmailVerification = true;
+
+    /**
      * Register the application's event listeners.
      *
      * @return void
@@ -216,12 +223,26 @@ class EventServiceProvider extends ServiceProvider
     }
 
     /**
+     * Disable the registration of the default email verification notification listener.
+     *
+     * @return void
+     */
+    public static function disableEmailVerification()
+    {
+        static::$configureEmailVerification = false;
+    }
+
+    /**
      * Configure the proper event listeners for email verification.
      *
      * @return void
      */
     protected function configureEmailVerification()
     {
+        if (! static::$configureEmailVerification) {
+            return;
+        }
+
         if (! isset($this->listen[Registered::class]) ||
             ! in_array(SendEmailVerificationNotification::class, Arr::wrap($this->listen[Registered::class]))) {
             Event::listen(Registered::class, SendEmailVerificationNotification::class);

--- a/tests/Integration/Foundation/Configuration/WithEventsTest.php
+++ b/tests/Integration/Foundation/Configuration/WithEventsTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Foundation\Configuration;
+
+use Illuminate\Auth\Events\Registered;
+use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
+use Illuminate\Foundation\Application;
+use Illuminate\Foundation\Support\Providers\EventServiceProvider;
+use Orchestra\Testbench\TestCase;
+use ReflectionProperty;
+
+class WithEventsTest extends TestCase
+{
+    protected bool $emailVerification = true;
+
+    protected function tearDown(): void
+    {
+        // Disabling email verification flips a process-global static on the
+        // event service provider, so restore it to keep the opt-out from
+        // leaking into the rest of the suite.
+        (new ReflectionProperty(EventServiceProvider::class, 'configureEmailVerification'))
+            ->setValue(null, true);
+
+        parent::tearDown();
+    }
+
+    protected function resolveApplication()
+    {
+        return Application::configure(static::applicationBasePath())
+            ->withEvents(emailVerification: $this->emailVerification)
+            ->create();
+    }
+
+    public function testTheEmailVerificationListenerIsRegisteredByDefault()
+    {
+        $this->assertContains(
+            SendEmailVerificationNotification::class,
+            $this->app['events']->getRawListeners()[Registered::class] ?? []
+        );
+    }
+
+    public function testTheEmailVerificationListenerCanBeDisabled()
+    {
+        $this->emailVerification = false;
+
+        $this->refreshApplication();
+
+        $this->assertNotContains(
+            SendEmailVerificationNotification::class,
+            $this->app['events']->getRawListeners()[Registered::class] ?? []
+        );
+    }
+}


### PR DESCRIPTION
`Application::configure()` registers the framework's `EventServiceProvider`, which automatically wires the `Registered` event to the `SendEmailVerificationNotification` listener. That's the right default for most apps — but there's currently no first-class way to turn it off.

Applications that implement their own verification flow (one-time passwords, magic links, a third-party identity provider) don't want Laravel sending its own verification email on registration. Today the only way to suppress it is to abandon the streamlined skeleton and hand-roll an `EventServiceProvider` subclass that overrides the protected `configureEmailVerification()` method. That workaround is undocumented and easy to get wrong.

This adds a discoverable, one-line opt-out that keeps you on the default `bootstrap/app.php`:

```php
return Application::configure(basePath: dirname(__DIR__))
    ->withRouting(...)
    ->withMiddleware(...)
    ->withEvents(emailVerification: false) // <-- Tadaaa
    ->withExceptions(...)
    ->create();
```

It deliberately mirrors the event-discovery opt-out the framework already ships (`disableEventDiscovery()` / `withEvents(discover: false)`), so it's an extension of an existing pattern rather than a new concept.

## Implementation

`EventServiceProvider` gains a `disableEmailVerification()` static (paralleling `disableEventDiscovery()`), and `configureEmailVerification()` early-returns when it's been disabled. `ApplicationBuilder::withEvents()` gains an `$emailVerification` parameter that calls it.

## No breaking changes

This is purely additive. A stock application sees no change whatsoever:
- The new `withEvents()` parameter is **appended and defaults to `true`**, so existing `withEvents()` / `withEvents(discover: ...)` calls keep their exact behavior.
- The new `$configureEmailVerification` static **defaults to `true`**, so the listener is registered exactly as it is today.
- Suppression happens **only** when a developer explicitly passes `emailVerification: false`.
- Nothing is removed, renamed, or re-typed; the sole signature change is one new optional parameter with a default value.

Docs: laravel/docs#11246