### PR TITLE
[13.x] Check traits in resolveClassAttribute 

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2673,6 +2673,16 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
 
                     return static::$classAttributes[$cacheKey] = $property ? $instance->{$property} : $instance;
                 }
+
+                foreach ($reflection->getTraits() as $trait) {
+                    $attributes = $trait->getAttributes($attributeClass);
+
+                    if (count($attributes) > 0) {
+                        $instance = $attributes[0]->newInstance();
+
+                        return static::$classAttributes[$cacheKey] = $property ? $instance->{$property} : $instance;
+                    }
+                }
             } while ($reflection = $reflection->getParentClass());
         } catch (Exception) {
             //

--- a/tests/Database/DatabaseEloquentModelAttributesTest.php
+++ b/tests/Database/DatabaseEloquentModelAttributesTest.php
@@ -451,6 +451,7 @@ class DatabaseEloquentModelAttributesTest extends TestCase
     public function test_trait_with_attribute_applies_to_class(): void
     {
         $model = new ModelUsingWithoutIncrementingTraitWithAttribute;
+
         $this->assertFalse($model->getIncrementing());
     }
 

--- a/tests/Database/DatabaseEloquentModelAttributesTest.php
+++ b/tests/Database/DatabaseEloquentModelAttributesTest.php
@@ -454,6 +454,12 @@ class DatabaseEloquentModelAttributesTest extends TestCase
         $this->assertFalse($model->getIncrementing());
     }
 
+    public function test_class_attribute_takes_precedence_over_trait(): void
+    {
+        $model = new ModelOverridingTraitConnectionAttribute;
+
+        $this->assertSame('primary', $model->getConnectionName());
+    }
 }
 
 enum ConnectionUnitEnum
@@ -789,5 +795,16 @@ trait TraitUsingWithoutIncrementingAttribute
 class ModelUsingWithoutIncrementingTraitWithAttribute extends Model
 {
     use TraitUsingWithoutIncrementingAttribute;
+}
+
+#[Connection('secondary')]
+trait TraitUsingConnectionAttribute
+{
+}
+
+#[Connection('primary')]
+class ModelOverridingTraitConnectionAttribute extends Model
+{
+    use TraitUsingConnectionAttribute;
 }
 

--- a/tests/Database/DatabaseEloquentModelAttributesTest.php
+++ b/tests/Database/DatabaseEloquentModelAttributesTest.php
@@ -808,4 +808,3 @@ class ModelOverridingTraitConnectionAttribute extends Model
 {
     use TraitUsingConnectionAttribute;
 }
-

--- a/tests/Database/DatabaseEloquentModelAttributesTest.php
+++ b/tests/Database/DatabaseEloquentModelAttributesTest.php
@@ -447,6 +447,13 @@ class DatabaseEloquentModelAttributesTest extends TestCase
 
         $this->assertEqualsCanonicalizing(['name', 'email', 'phone'], $model->getFillable());
     }
+
+    public function test_trait_with_attribute_applies_to_class(): void
+    {
+        $model = new ModelUsingWithoutIncrementingTraitWithAttribute;
+        $this->assertFalse($model->getIncrementing());
+    }
+
 }
 
 enum ConnectionUnitEnum
@@ -773,3 +780,14 @@ class ModelWithFillableAttributeAndTrait extends Model
 {
     use AddsPhoneFillable;
 }
+
+#[WithoutIncrementing]
+trait TraitUsingWithoutIncrementingAttribute
+{
+}
+
+class ModelUsingWithoutIncrementingTraitWithAttribute extends Model
+{
+    use TraitUsingWithoutIncrementingAttribute;
+}
+


### PR DESCRIPTION
This is the exact same as I did here https://github.com/laravel/framework/pull/60519 

This means queue attributes 🤝 model attributes (We are same same but different)

This essentially means, traits can carry model attributes which means we can put attributes on a trait, and reuse the trait.  

This only checks traits on the current class in the hierarchy same as the other PR

Nice for package maintainers, or teams using traits.  

``` php
#[Connection('warehouse')]
trait UsesWarehouse
{
  // methods etc... that are shared
}

class Product extends Model
{
    use UsesWarehouse;
}

class StockTransfer extends Model
{
    use UsesWarehouse;
}
``` 

I'm completely fine if you close this, just thought I'd try bring the same behaviour as queues to models for the attributes 🫡 