### PR TITLE
[13.x] Add `without-migration-data` flag to DumpCommand

### DIFF
--- a/src/Illuminate/Database/Console/DumpCommand.php
+++ b/src/Illuminate/Database/Console/DumpCommand.php
@@ -84,8 +84,12 @@ class DumpCommand extends Command
 
         $migrationTable = is_array($migrations) ? ($migrations['table'] ?? 'migrations') : $migrations;
 
+        if ($this->option('without-migration-data')) {
+            $migrationTable = null;
+        }
+
         return $connection->getSchemaState()
-            ->withMigrationTable($this->option('without-migration-data') ? null : $migrationTable)
+            ->withMigrationTable($migrationTable)
             ->handleOutputUsing(function ($type, $buffer) {
                 $this->output->write($buffer);
             });

--- a/src/Illuminate/Database/Console/DumpCommand.php
+++ b/src/Illuminate/Database/Console/DumpCommand.php
@@ -26,7 +26,8 @@ class DumpCommand extends Command
     protected $signature = 'schema:dump
                 {--database= : The database connection to use}
                 {--path= : The path where the schema dump file should be stored}
-                {--prune : Delete all existing migration files}';
+                {--prune : Delete all existing migration files}
+                {--without-migration-data : Dump the schema without the migration data}';
 
     /**
      * The console command description.
@@ -84,7 +85,7 @@ class DumpCommand extends Command
         $migrationTable = is_array($migrations) ? ($migrations['table'] ?? 'migrations') : $migrations;
 
         return $connection->getSchemaState()
-            ->withMigrationTable($migrationTable)
+            ->withMigrationTable($this->option('without-migration-data') ? null : $migrationTable)
             ->handleOutputUsing(function ($type, $buffer) {
                 $this->output->write($buffer);
             });

--- a/src/Illuminate/Database/Schema/SchemaState.php
+++ b/src/Illuminate/Database/Schema/SchemaState.php
@@ -25,7 +25,7 @@ abstract class SchemaState
     /**
      * The name of the application's migration table.
      *
-     * @var string
+     * @var string|null
      */
     protected $migrationTable = 'migrations';
 
@@ -100,7 +100,8 @@ abstract class SchemaState
      */
     public function hasMigrationTable(): bool
     {
-        return $this->connection->getSchemaBuilder()->hasTable($this->migrationTable);
+        return $this->migrationTable &&
+               $this->connection->getSchemaBuilder()->hasTable($this->migrationTable);
     }
 
     /**
@@ -116,10 +117,10 @@ abstract class SchemaState
     /**
      * Specify the name of the application's migration table.
      *
-     * @param  string  $table
+     * @param  string|null  $table
      * @return $this
      */
-    public function withMigrationTable(string $table)
+    public function withMigrationTable(?string $table)
     {
         $this->migrationTable = $table;
 

--- a/tests/Integration/Database/Sqlite/SchemaStateTest.php
+++ b/tests/Integration/Database/Sqlite/SchemaStateTest.php
@@ -61,4 +61,34 @@ class SchemaStateTest extends TestCase
             'sqlite_sequence',
         ], 'database/schema/sqlite-schema.sql');
     }
+
+    #[RequiresOperatingSystem('Linux|Darwin')]
+    public function testSchemaDumpWithoutMigrationDataOnSqlite()
+    {
+        if ($this->usesSqliteInMemoryDatabaseConnection()) {
+            $this->markTestSkipped('Test cannot be run using :in-memory: database connection');
+        }
+
+        $connection = DB::connection();
+        $connection->getSchemaBuilder()->createDatabase($connection->getConfig('database'));
+
+        $connection->statement('CREATE TABLE IF NOT EXISTS migrations (id integer primary key autoincrement not null, migration varchar not null, batch integer not null);');
+        $connection->statement('CREATE TABLE users (id integer primary key autoincrement not null, email varchar not null, name varchar not null);');
+        $connection->statement('INSERT INTO migrations (migration, batch) VALUES ("2014_10_12_000000_create_users_table", 1);');
+
+        $this->app['files']->ensureDirectoryExists(database_path('schema'));
+
+        $connection->getSchemaState()
+            ->withMigrationTable(null)
+            ->dump($connection, database_path('schema/sqlite-schema.sql'));
+
+        $this->assertFileContains([
+            'CREATE TABLE migrations',
+            'CREATE TABLE users',
+        ], 'database/schema/sqlite-schema.sql');
+
+        $this->assertFileNotContains([
+            'INSERT INTO "migrations"',
+        ], 'database/schema/sqlite-schema.sql');
+    }
 }


### PR DESCRIPTION
This PR  adds a `--without-migration-data` flag  to `schema:dump` that skips appending the migration rows, so the dump becomes pure structure.

ie...
```
artisan schema:dump --without-migration-data
```

I/we use the dump command a lot  internally for dumping the schema for our tests (as the docs suggest), as well as various commands for our feature flags etc to ensure the schema is always updated when something is released.

At the moment we end up truncating the migration table using the DB facade before we call dump to ensure its not appended, which feels less magic / painful.

it would be nice to just have the ability to opt out hence the PR which I've tried to keep dead simple but you may see a nicer way? 😎  

Open to a nicer flag too...