### PR TITLE
Clear transaction manager state on disconnect

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -1075,6 +1075,8 @@ class Connection implements ConnectionInterface
      */
     public function disconnect()
     {
+        $this->transactionsManager?->rollback($this->getName(), 0);
+
         $this->setPdo(null)->setReadPdo(null)->setDirectPdo(null);
     }
 

--- a/src/Illuminate/Database/DatabaseTransactionsManager.php
+++ b/src/Illuminate/Database/DatabaseTransactionsManager.php
@@ -159,7 +159,7 @@ class DatabaseTransactionsManager
     protected function removeAllTransactionsForConnection($connection)
     {
         if ($this->currentTransaction) {
-            for ($currentTransaction = $this->currentTransaction[$connection]; isset($currentTransaction); $currentTransaction = $currentTransaction->parent) {
+            for ($currentTransaction = $this->currentTransaction[$connection] ?? null; isset($currentTransaction); $currentTransaction = $currentTransaction->parent) {
                 $currentTransaction->executeCallbacksForRollback();
             }
         }

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -7,6 +7,7 @@ use ErrorException;
 use Exception;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Connection;
+use Illuminate\Database\DatabaseTransactionsManager;
 use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Database\Events\TransactionBeginning;
 use Illuminate\Database\Events\TransactionCommitted;
@@ -250,6 +251,26 @@ class DatabaseConnectionTest extends TestCase
         $connection->beginTransaction();
         $connection->disconnect();
         $this->assertEquals(0, $connection->transactionLevel());
+    }
+
+    public function testDisconnectClearsTransactionManagerState()
+    {
+        $connection = $this->getMockConnection(['getName']);
+        $connection->method('getName')->willReturn('default');
+        $manager = new DatabaseTransactionsManager;
+        $connection->setTransactionManager($manager);
+
+        $manager->begin('default', 1);
+        $manager->begin('default', 2);
+        $manager->stageTransactions('default', 2);
+
+        $this->assertCount(1, $manager->getCommittedTransactions());
+        $this->assertCount(1, $manager->getPendingTransactions());
+
+        $connection->disconnect();
+
+        $this->assertCount(0, $manager->getCommittedTransactions());
+        $this->assertCount(0, $manager->getPendingTransactions());
     }
 
     public function testBeganTransactionFiresEventsIfSet()


### PR DESCRIPTION
When a database connection is disconnected, any pending or committed transactions tracked by `DatabaseTransactionsManager` are not cleared. On serverless runtimes like Laravel Vapor, a warm Lambda reuse the same connection object across invocations, so `afterCommit` callbacks staged in `committedTransactions` from a previous invocation can fire during the next one's commit.

`Connection::disconnect()` now calls `$this->transactionsManager?->rollback($this->getName(), 0)` before resetting the PDO, which delegates to the existing `removeAllTransactionsForConnection()` path that already handles clearing pending transactions, committed transactions, and rollback callbacks.

Closes #60528