### PR TITLE
[13.x] Further reduce cache hits when using debounced jobs

### DIFF
--- a/src/Illuminate/Bus/DebounceLock.php
+++ b/src/Illuminate/Bus/DebounceLock.php
@@ -86,26 +86,14 @@ class DebounceLock
     }
 
     /**
-     * Determine if the given owner is the current owner for this debounce key.
+     * Get the current owner for the given job.
      *
      * @param  mixed  $job
-     * @param  string  $owner
-     * @return bool
+     * @return string|null
      */
-    public function isCurrentOwner($job, string $owner)
+    public function getCurrentOwner($job)
     {
-        return $this->resolveCache($job)->get(static::getKey($job)) === $owner;
-    }
-
-    /**
-     * Determine if a debounce token exists for the given job.
-     *
-     * @param  mixed  $job
-     * @return bool
-     */
-    public function lockExists($job)
-    {
-        return ! is_null($this->resolveCache($job)->get(static::getKey($job)));
+        return $this->resolveCache($job)->get(static::getKey($job));
     }
 
     /**

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -251,12 +251,14 @@ class CallQueuedHandler
 
         $lock = new DebounceLock($this->container->make(Cache::class));
 
+        $currentOwner = $lock->getCurrentOwner($command);
+
         // Fail-open: if the lock no longer exists (cache eviction, TTL expiry), let the job execute...
-        if (! $lock->lockExists($command)) {
+        if (is_null($currentOwner)) {
             return false;
         }
 
-        return ! $lock->isCurrentOwner($command, $owner);
+        return $currentOwner !== $owner;
     }
 
     /**

--- a/tests/Integration/Queue/DebouncedJobTest.php
+++ b/tests/Integration/Queue/DebouncedJobTest.php
@@ -203,7 +203,7 @@ class DebouncedJobTest extends QueueTestCase
         $lock->release($jobA, $ownerA);
 
         // B should still be the current owner.
-        $this->assertTrue($lock->isCurrentOwner($jobB, $ownerB));
+        $this->assertTrue($lock->getCurrentOwner($jobB) === $ownerB);
     }
 
     public function testReleaseClearsMaxWaitTimestamp()


### PR DESCRIPTION
Good morning! 

Same vein as https://github.com/laravel/framework/pull/60559 

But, this applies for ALL debounced jobs. 

Essentially, the code was calling `lockExists` and then `isCurrentOwner` which are 2x cache hits for the same thing.    
500 jobs being debounced that's 1k cache hits.

This PR drops the  `lockExists` & `isCurrentOwner` methods, and adds a `getCurrentOwner` method, I did consider sending to 14.x, but I cant imagine anyone is using the methods? But happy to restore them if you think it's possible? and sort it in 14.x

The `getCurrentOwner` method is defined by loads of other locks internally, hence why I saw it  / went with this name :D 

This is very useful for the DB driver as its less queries, but also still useful regardless the driver.  

If you have any feedback please take me under your wing 😆 