### PR TITLE
[13.x] Add X-Laravel-Maintenance-Mode response header

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
+++ b/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
@@ -147,7 +147,11 @@ class PreventRequestsDuringMaintenance
      */
     protected function getHeaders($data)
     {
-        $headers = isset($data['retry']) ? ['Retry-After' => $data['retry']] : [];
+        $headers = ['X-Laravel-Maintenance-Mode' => 'active'];
+
+        if (isset($data['retry'])) {
+            $headers['Retry-After'] = $data['retry'];
+        }
 
         if (isset($data['refresh'])) {
             $headers['Refresh'] = $data['refresh'];

--- a/tests/Integration/Foundation/MaintenanceModeTest.php
+++ b/tests/Integration/Foundation/MaintenanceModeTest.php
@@ -43,6 +43,7 @@ class MaintenanceModeTest extends TestCase
         $response->assertStatus(503);
         $response->assertHeader('Retry-After', '60');
         $response->assertHeader('Refresh', '60');
+        $response->assertHeader('X-Laravel-Maintenance-Mode', 'active');
     }
 
     public function testMaintenanceModeCanHaveCustomStatus()


### PR DESCRIPTION
When monitoring third-party Laravel applications from the outside,
there is currently no reliable way to detect that the application is
in maintenance mode:

- The `storage/framework/down` file only exists when the file driver
  is used; cache-based drivers leave nothing on disk.
- `php artisan about` requires application access (e.g. via SSH),
  which is not desirable for an external monitor.
- The HTTP 503 status is not a reliable signal: an upstream nginx
  with a down backend returns 503 too.
- The default maintenance template is frequently customised, so
  matching response bodies on the word "maintenance" produces
  false positives and false negatives.

By emitting an `X-Laravel-Maintenance-Mode: active` header from the
`PreventRequestsDuringMaintenance` middleware, external monitors can
unambiguously distinguish a deliberate maintenance window from an
actual outage and suppress alerts accordingly.