### PR TITLE
Normalize deferred installer hook environment

### DIFF
--- a/src/Illuminate/Foundation/ComposerScripts.php
+++ b/src/Illuminate/Foundation/ComposerScripts.php
@@ -49,6 +49,8 @@ class ComposerScripts
     {
         require_once $event->getComposer()->getConfig()->get('vendor-dir').'/autoload.php';
 
+        static::setDeferredInstallerHookEnvironmentVariable();
+
         static::clearCompiled();
     }
 
@@ -111,6 +113,26 @@ class ComposerScripts
 
         if (is_file($packagesPath = $laravel->getCachedPackagesPath())) {
             @unlink($packagesPath);
+        }
+    }
+
+    /**
+     * Ensure deferred installer hooks are inherited by Composer child processes.
+     *
+     * @return void
+     */
+    protected static function setDeferredInstallerHookEnvironmentVariable()
+    {
+        $variable = 'LARAVEL_INSTALLER_DEFER_HOOKS';
+
+        if (getenv($variable) !== false) {
+            return;
+        }
+
+        if (array_key_exists($variable, $_ENV)) {
+            putenv($variable.'='.$_ENV[$variable]);
+        } elseif (array_key_exists($variable, $_SERVER)) {
+            putenv($variable.'='.$_SERVER[$variable]);
         }
     }
 }

--- a/tests/Foundation/FoundationComposerScriptsTest.php
+++ b/tests/Foundation/FoundationComposerScriptsTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Illuminate\Tests\Foundation;
+
+use Illuminate\Foundation\ComposerScripts;
+use PHPUnit\Framework\TestCase;
+
+class FoundationComposerScriptsTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        unset($_ENV['LARAVEL_INSTALLER_DEFER_HOOKS'], $_SERVER['LARAVEL_INSTALLER_DEFER_HOOKS']);
+        putenv('LARAVEL_INSTALLER_DEFER_HOOKS');
+
+        parent::tearDown();
+    }
+
+    public function testItSetsDeferredInstallerHookEnvironmentVariableFromEnv(): void
+    {
+        $_ENV['LARAVEL_INSTALLER_DEFER_HOOKS'] = '1';
+        putenv('LARAVEL_INSTALLER_DEFER_HOOKS');
+
+        ComposerScriptsTestProxy::setDeferredInstallerHookEnvironmentVariable();
+
+        $this->assertSame('1', getenv('LARAVEL_INSTALLER_DEFER_HOOKS'));
+    }
+
+    public function testItSetsDeferredInstallerHookEnvironmentVariableFromServer(): void
+    {
+        $_SERVER['LARAVEL_INSTALLER_DEFER_HOOKS'] = '1';
+        putenv('LARAVEL_INSTALLER_DEFER_HOOKS');
+
+        ComposerScriptsTestProxy::setDeferredInstallerHookEnvironmentVariable();
+
+        $this->assertSame('1', getenv('LARAVEL_INSTALLER_DEFER_HOOKS'));
+    }
+
+    public function testItDoesNotOverwriteExistingDeferredInstallerHookEnvironmentVariable(): void
+    {
+        $_ENV['LARAVEL_INSTALLER_DEFER_HOOKS'] = '1';
+        putenv('LARAVEL_INSTALLER_DEFER_HOOKS=0');
+
+        ComposerScriptsTestProxy::setDeferredInstallerHookEnvironmentVariable();
+
+        $this->assertSame('0', getenv('LARAVEL_INSTALLER_DEFER_HOOKS'));
+    }
+}
+
+class ComposerScriptsTestProxy extends ComposerScripts
+{
+    public static function setDeferredInstallerHookEnvironmentVariable(): void
+    {
+        parent::setDeferredInstallerHookEnvironmentVariable();
+    }
+}


### PR DESCRIPTION
This updates the Composer autoload hook to copy `LARAVEL_INSTALLER_DEFER_HOOKS` from `$_ENV` or `$_SERVER` into the process environment when `getenv()` cannot see it.

That lets later `@php artisan ...` Composer scripts inherit the deferred installer flag and avoid prompting during starter kit installs on platforms where Composer exposes the value through PHP superglobals.

Fixes #60253.

Tests:
- `vendor/bin/phpunit tests/Foundation/FoundationComposerScriptsTest.php`
- `vendor/bin/pint --test src/Illuminate/Foundation/ComposerScripts.php tests/Foundation/FoundationComposerScriptsTest.php`