### PR TITLE
Add priority-based registration to dev commands

### DIFF
--- a/src/Illuminate/Foundation/Console/DevListCommand.php
+++ b/src/Illuminate/Foundation/Console/DevListCommand.php
@@ -3,9 +3,9 @@
 namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Command;
+use Illuminate\Foundation\DevCommand;
 use Illuminate\Foundation\DevCommands;
 use Laravel\Prompts\Prompt;
-use ReflectionClass;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;
 
@@ -115,15 +115,7 @@ class DevListCommand extends Command
      */
     protected function isVendorCommand(array $command): bool
     {
-        $source = $command['source'];
-
-        if ($class = $source['class'] ?? null) {
-            $reflection = new ReflectionClass($class);
-
-            return str_contains($reflection->getFileName(), base_path('vendor'));
-        }
-
-        return str_contains($source['file'] ?? '', base_path('vendor'));
+        return $command['priority'] === DevCommand::PRIORITY_VENDOR;
     }
 
     /**

--- a/src/Illuminate/Foundation/DevCommand.php
+++ b/src/Illuminate/Foundation/DevCommand.php
@@ -32,7 +32,7 @@ class DevCommand
      * @param  string  $command
      * @param  array{'file': string, 'line': int, 'class'?: string, 'function'?: string}  $source
      * @param  string|null  $name
-     * @param  int  $priority
+     * @param  self::PRIORITY_DEFAULT|self::PRIORITY_VENDOR|self::PRIORITY_USERLAND  $priority
      * @return void
      */
     public function __construct(

--- a/src/Illuminate/Foundation/DevCommand.php
+++ b/src/Illuminate/Foundation/DevCommand.php
@@ -5,6 +5,21 @@ namespace Illuminate\Foundation;
 class DevCommand
 {
     /**
+     * The priority level for default commands that are registered by the framework.
+     */
+    const PRIORITY_DEFAULT = 0;
+
+    /**
+     * The priority level for commands that are registered by packages in the vendor directory.
+     */
+    const PRIORITY_VENDOR = 1;
+
+    /**
+     * The priority level for commands that are registered by the user in their application.
+     */
+    const PRIORITY_USERLAND = 2;
+
+    /**
      * Color of the command when output to the console.
      *
      * @var string|null
@@ -17,12 +32,14 @@ class DevCommand
      * @param  string  $command
      * @param  array{'file': string, 'line': int, 'class'?: string, 'function'?: string}  $source
      * @param  string|null  $name
+     * @param  int  $priority
      * @return void
      */
     public function __construct(
         protected string $command,
         protected array $source,
         protected ?string $name = null,
+        protected int $priority = self::PRIORITY_USERLAND,
     ) {
         $this->name ??= self::nameFromCommand($command);
     }
@@ -46,6 +63,16 @@ class DevCommand
     public function name(): string
     {
         return $this->name;
+    }
+
+    /**
+     * Get the command priority.
+     *
+     * @return int
+     */
+    public function priority(): int
+    {
+        return $this->priority;
     }
 
     /**
@@ -124,7 +151,7 @@ class DevCommand
     /**
      * Get the command as an array.
      *
-     * @return array{command: string, name: string, color: string|null, source: array{'file': string, 'line': int, 'class'?: string, 'function'?: string}}
+     * @return array{command: string, name: string, color: string|null, source: array{'file': string, 'line': int, 'class'?: string, 'function'?: string, 'priority': int}}
      */
     public function toArray(): array
     {
@@ -133,6 +160,7 @@ class DevCommand
             'name' => $this->name,
             'color' => $this->color,
             'source' => $this->source,
+            'priority' => $this->priority,
         ];
     }
 }

--- a/src/Illuminate/Foundation/DevCommand.php
+++ b/src/Illuminate/Foundation/DevCommand.php
@@ -151,7 +151,7 @@ class DevCommand
     /**
      * Get the command as an array.
      *
-     * @return array{command: string, name: string, color: string|null, source: array{'file': string, 'line': int, 'class'?: string, 'function'?: string, 'priority': int}}
+     * @return array{command: string, name: string, color: string|null, source: array{'file': string, 'line': int, 'class'?: string, 'function'?: string}, priority: int}
      */
     public function toArray(): array
     {

--- a/src/Illuminate/Foundation/DevCommands.php
+++ b/src/Illuminate/Foundation/DevCommands.php
@@ -181,28 +181,6 @@ class DevCommands
     }
 
     /**
-     * Set the commands that should be included when running the "dev" command.
-     *
-     * @param  string  ...$names
-     * @return void
-     */
-    public static function only(...$names): void
-    {
-        self::$only = $names;
-    }
-
-    /**
-     * Set the commands that should be excluded when running the "dev" command.
-     *
-     * @param  string  ...$names
-     * @return void
-     */
-    public static function except(...$names): void
-    {
-        self::$except = $names;
-    }
-
-    /**
      * Resolve the first external caller frame from a debug backtrace.
      *
      * @param  array<int, array{'file': string, 'line': int, 'class'?: string, 'function'?: string}>  $trace
@@ -259,6 +237,28 @@ class DevCommands
         }
 
         return DevCommand::PRIORITY_VENDOR;
+    }
+
+    /**
+     * Set the commands that should be included when running the "dev" command.
+     *
+     * @param  string  ...$names
+     * @return void
+     */
+    public static function only(...$names): void
+    {
+        self::$only = $names;
+    }
+
+    /**
+     * Set the commands that should be excluded when running the "dev" command.
+     *
+     * @param  string  ...$names
+     * @return void
+     */
+    public static function except(...$names): void
+    {
+        self::$except = $names;
     }
 
     /**

--- a/src/Illuminate/Foundation/DevCommands.php
+++ b/src/Illuminate/Foundation/DevCommands.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation;
 
 use Illuminate\Support\NodePackageManager;
+use ReflectionClass;
 
 class DevCommands
 {
@@ -74,25 +75,16 @@ class DevCommands
         }
 
         $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
-        $source = [];
+        $source = self::resolveSource($trace);
+        $priority = self::resolvePriority($trace);
 
-        foreach ($trace as $frame) {
-            if (($frame['file'] ?? null) === __FILE__) {
-                continue;
-            }
+        $devCommand = new DevCommand($command, $source, $name, $priority);
 
-            if (($frame['class'] ?? null) === self::class) {
-                continue;
-            }
+        $existing = self::$commands[$devCommand->name()] ?? null;
 
-            $source = $frame;
-
-            break;
+        if (! $existing || $devCommand->priority() >= $existing->priority()) {
+            self::$commands[$devCommand->name()] = $devCommand;
         }
-
-        $devCommand = new DevCommand($command, $source, $name);
-
-        self::$commands[$devCommand->name()] = $devCommand;
 
         return $devCommand;
     }
@@ -208,6 +200,65 @@ class DevCommands
     public static function except(...$names): void
     {
         self::$except = $names;
+    }
+
+    /**
+     * Resolve the first external caller frame from a debug backtrace.
+     *
+     * @param  array<int, array{'file': string, 'line': int, 'class'?: string, 'function'?: string}>  $trace
+     * @return array{'file': string, 'line': int, 'class'?: string, 'function'?: string}
+     */
+    protected static function resolveSource(array $trace): array
+    {
+        foreach ($trace as $frame) {
+            if (($frame['file'] ?? null) === __FILE__) {
+                continue;
+            }
+
+            if (($frame['class'] ?? null) === self::class) {
+                continue;
+            }
+
+            return $frame;
+        }
+
+        return [];
+    }
+
+    /**
+     * Determine the registration priority from a debug backtrace.
+     *
+     * @param  array<int, array{'file': string, 'line': int, 'class'?: string, 'function'?: string}>  $trace
+     * @return int
+     */
+    protected static function resolvePriority(array $trace): int
+    {
+        foreach ($trace as $frame) {
+            $file = $frame['file'] ?? null;
+            $class = $frame['class'] ?? null;
+
+            if ($file === __FILE__) {
+                continue;
+            }
+
+            if ($class === self::class && ($frame['function'] ?? null) === 'registerDefaults') {
+                return DevCommand::PRIORITY_DEFAULT;
+            }
+
+            if (! $file && $class) {
+                $file = (new ReflectionClass($class))->getFileName();
+            }
+
+            if (! $file || $file === base_path('artisan')) {
+                continue;
+            }
+
+            if (! str_contains($file, base_path('vendor'))) {
+                return DevCommand::PRIORITY_USERLAND;
+            }
+        }
+
+        return DevCommand::PRIORITY_VENDOR;
     }
 
     /**

--- a/tests/Foundation/FoundationDevCommandTest.php
+++ b/tests/Foundation/FoundationDevCommandTest.php
@@ -31,6 +31,7 @@ class FoundationDevCommandTest extends TestCase
             'name' => 'server',
             'color' => null,
             'source' => [],
+            'priority' => DevCommand::PRIORITY_USERLAND,
         ], $command->toArray());
     }
 

--- a/tests/Foundation/FoundationDevCommandsTest.php
+++ b/tests/Foundation/FoundationDevCommandsTest.php
@@ -166,7 +166,7 @@ class FoundationDevCommandsTest extends TestCase
         }
     }
 
-    public function testRegisteringCommandWithSameNameOverwritesPrevious()
+    public function testRegisteringCommandWithSameNameAndSamePriorityOverwritesPrevious()
     {
         DevCommands::register('echo old', 'myname');
         DevCommands::register('echo new', 'myname');
@@ -175,6 +175,121 @@ class FoundationDevCommandsTest extends TestCase
 
         $this->assertCount(1, $commands);
         $this->assertSame('echo new', $commands[0]['command']);
+    }
+
+    public function testUserlandOverwritesVendorPriority()
+    {
+        $ref = new ReflectionClass(DevCommands::class);
+        $ref->getProperty('commands')->setValue(null, [
+            'myname' => new DevCommand('echo vendor', [], 'myname', DevCommand::PRIORITY_VENDOR),
+        ]);
+
+        // register() resolves as userland from test code — should overwrite vendor
+        DevCommands::register('echo userland', 'myname');
+
+        $result = DevCommands::commands();
+        $this->assertSame('echo userland', collect($result)->firstWhere('name', 'myname')['command']);
+    }
+
+    public function testUserlandOverwritesDefaultPriority()
+    {
+        // registerDefaults() gets DEFAULT priority, then register() gets USERLAND
+        DevCommands::registerDefaults();
+        DevCommands::register('custom-server', 'server');
+
+        $result = DevCommands::commands();
+        $server = collect($result)->firstWhere('name', 'server');
+        $this->assertSame('custom-server', $server['command']);
+        $this->assertSame(DevCommand::PRIORITY_USERLAND, $server['priority']);
+    }
+
+    public function testDefaultDoesNotOverwriteUserlandPriority()
+    {
+        $ref = new ReflectionClass(DevCommands::class);
+        $ref->getProperty('commands')->setValue(null, [
+            'server' => new DevCommand('userland-server', [], 'server', DevCommand::PRIORITY_USERLAND),
+        ]);
+
+        // registerDefaults() gets DEFAULT priority — should NOT overwrite userland
+        DevCommands::registerDefaults();
+
+        $result = DevCommands::commands();
+        $this->assertSame('userland-server', collect($result)->firstWhere('name', 'server')['command']);
+    }
+
+    public function testDefaultDoesNotOverwriteVendorPriority()
+    {
+        $ref = new ReflectionClass(DevCommands::class);
+        $ref->getProperty('commands')->setValue(null, [
+            'server' => new DevCommand('vendor-server', [], 'server', DevCommand::PRIORITY_VENDOR),
+        ]);
+
+        // registerDefaults() gets DEFAULT priority — should NOT overwrite vendor
+        DevCommands::registerDefaults();
+
+        $result = DevCommands::commands();
+        $this->assertSame('vendor-server', collect($result)->firstWhere('name', 'server')['command']);
+    }
+
+    public function testDefaultPriorityIsLowest()
+    {
+        DevCommands::registerDefaults();
+
+        $commands = DevCommands::commands();
+        $serverCommand = collect($commands)->firstWhere('name', 'server');
+
+        $this->assertSame(DevCommand::PRIORITY_DEFAULT, $serverCommand['priority']);
+    }
+
+    public function testUserlandRegistrationGetsUserlandPriority()
+    {
+        DevCommands::register('echo hello', 'greeter');
+
+        $commands = DevCommands::commands();
+
+        $this->assertSame(DevCommand::PRIORITY_USERLAND, $commands[0]['priority']);
+    }
+
+    public function testResolvePriorityDetectsUserlandThroughDevCommandsFrame()
+    {
+        $ref = new ReflectionClass(DevCommands::class);
+        $method = $ref->getMethod('resolvePriority');
+
+        $trace = [
+            ['file' => $ref->getFileName(), 'line' => 99, 'function' => 'register', 'class' => DevCommands::class],
+            ['file' => base_path('app/Providers/AppServiceProvider.php'), 'line' => 19, 'function' => 'artisan', 'class' => DevCommands::class],
+            ['file' => base_path('vendor/laravel/framework/src/Illuminate/Foundation/Application.php'), 'line' => 896, 'function' => 'register', 'class' => 'App\\Providers\\AppServiceProvider'],
+        ];
+
+        $this->assertSame(DevCommand::PRIORITY_USERLAND, $method->invoke(null, $trace));
+    }
+
+    public function testResolvePriorityDetectsVendor()
+    {
+        $ref = new ReflectionClass(DevCommands::class);
+        $method = $ref->getMethod('resolvePriority');
+
+        $trace = [
+            ['file' => $ref->getFileName(), 'line' => 99, 'function' => 'register', 'class' => DevCommands::class],
+            ['file' => base_path('vendor/some-package/src/ServiceProvider.php'), 'line' => 10, 'function' => 'register', 'class' => DevCommands::class],
+            ['file' => base_path('vendor/laravel/framework/src/Illuminate/Foundation/Application.php'), 'line' => 896, 'function' => 'register', 'class' => 'Some\\Package\\ServiceProvider'],
+        ];
+
+        $this->assertSame(DevCommand::PRIORITY_VENDOR, $method->invoke(null, $trace));
+    }
+
+    public function testResolvePriorityDetectsUserlandCallingVendorHelper()
+    {
+        $ref = new ReflectionClass(DevCommands::class);
+        $method = $ref->getMethod('resolvePriority');
+
+        $trace = [
+            ['file' => base_path('vendor/some-package/src/Helper.php'), 'line' => 10, 'function' => 'register', 'class' => DevCommands::class],
+            ['file' => base_path('app/Providers/AppServiceProvider.php'), 'line' => 25, 'function' => 'setupDev', 'class' => 'Some\\Package\\Helper'],
+            ['file' => base_path('vendor/laravel/framework/src/Illuminate/Foundation/Application.php'), 'line' => 896, 'function' => 'register', 'class' => 'App\\Providers\\AppServiceProvider'],
+        ];
+
+        $this->assertSame(DevCommand::PRIORITY_USERLAND, $method->invoke(null, $trace));
     }
 
     public function testRegisterDefaultsRegistersExpectedCommands()


### PR DESCRIPTION
Dev commands now auto-detect their origin (framework default, vendor, or userland) via the call stack and assign a priority. Higher-priority registrations win when two commands share the same name, so user overrides always take effect regardless of service provider boot order.

This means that user-registered commands get the highest priority and can't be overwritten. It also means that a user can overwrite default or package-provided commands, such as:

```php
DevCommands::artisan('run-server-another-way', 'server');
DevCommands::artisan('reverb:start --host="0.0.0.0"', 'reverb');
```

Priority order is (highest to lowest):

- userland
- vendor (packages)
- framework defaults