### PR TITLE
[13.x] Add `last` and `lastOrFail` QueryBuilder helper methods

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -385,6 +385,43 @@ trait BuildsQueries
     }
 
     /**
+     * Execute the query and get the last result.
+     *
+     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Contracts\Database\Query\Expression|string|array  $column
+     * @param  array|string  $columns
+     * @return TValue|null
+     */
+    public function last($column = 'created_at', $columns = ['*'])
+    {
+        if (is_array($column)) {
+            $columns = $column;
+            $column = 'created_at';
+        }
+
+        return $this->latest($column)->first($columns);
+    }
+
+    /**
+     * Execute the query and get the last result or throw an exception.
+     *
+     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Contracts\Database\Query\Expression|string|array  $column
+     * @param  array|string  $columns
+     * @param  string|null  $message
+     * @return TValue
+     *
+     * @throws \Illuminate\Database\RecordNotFoundException
+     */
+    public function lastOrFail($column = 'created_at', $columns = ['*'], $message = null)
+    {
+        if (is_array($column)) {
+            $columns = $column;
+            $column = 'created_at';
+        }
+
+        return $this->latest($column)->firstOrFail($columns, $message);
+    }
+
+    /**
      * Execute the query and get the first result if it's the sole matching record.
      *
      * @param  array|string  $columns

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -770,6 +770,23 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Execute the query and get the last result.
+     *
+     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Contracts\Database\Query\Expression|string|array  $column
+     * @param  array|string  $columns
+     * @return TValue|null
+     */
+    public function last($column = null, $columns = ['*'])
+    {
+        if (is_array($column)) {
+            $columns = $column;
+            $column = null;
+        }
+
+        return $this->latest($column)->first($columns);
+    }
+
+    /**
      * Execute the query and get the first result or throw an exception.
      *
      * @param  array|string  $columns
@@ -784,6 +801,25 @@ class Builder implements BuilderContract
         }
 
         throw (new ModelNotFoundException)->setModel(get_class($this->model));
+    }
+
+    /**
+     * Execute the query and get the last result or throw an exception.
+     *
+     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Contracts\Database\Query\Expression|string|array  $column
+     * @param  array|string  $columns
+     * @return TModel
+     *
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException<TModel>
+     */
+    public function lastOrFail($column = null, $columns = ['*'])
+    {
+        if (is_array($column)) {
+            $columns = $column;
+            $column = null;
+        }
+
+        return $this->latest($column)->firstOrFail($columns);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -889,6 +889,23 @@ class BelongsToMany extends Relation
     }
 
     /**
+     * Execute the query and get the last result or throw an exception.
+     *
+     * @param  array|string  $columns
+     * @return TModel
+     *
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException<TModel>
+     */
+    public function lastOrFail($columns = ['*'])
+    {
+        if (! is_null($model = $this->last($columns))) {
+            return $model;
+        }
+
+        throw (new ModelNotFoundException)->setModel(get_class($this->related));
+    }
+
+    /**
      * Execute the query and get the first result or call a callback.
      *
      * @template TValue

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrManyThrough.php
@@ -311,6 +311,23 @@ abstract class HasOneOrManyThrough extends Relation
     }
 
     /**
+     * Execute the query and get the last result or throw an exception.
+     *
+     * @param  array|string  $columns
+     * @return TModel
+     *
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException<TModel>
+     */
+    public function lastOrFail($columns = ['*'])
+    {
+        if (! is_null($model = $this->last($columns))) {
+            return $model;
+        }
+
+        throw (new ModelNotFoundException)->setModel(get_class($this->related));
+    }
+
+    /**
      * Execute the query and get the first result or call a callback.
      *
      * @template TValue

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -274,6 +274,23 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->firstOrFail(['column']);
     }
 
+    public function testLastOrFailMethodThrowsModelNotFoundException()
+    {
+        $this->expectException(ModelNotFoundException::class);
+
+        $query = $this->getMockQueryBuilder();
+        $query->shouldReceive('latest')->with('foo')->andReturnSelf();
+
+        $model = $this->getMockModel();
+        $model->shouldReceive('getCreatedAtColumn')->andReturn('foo');
+
+        $builder = m::mock(Builder::class.'[first]', [$query]);
+        $builder->setModel($model);
+        $builder->shouldReceive('first')->once()->with(['column'])->andReturn(null);
+
+        $builder->lastOrFail(['column']);
+    }
+
     public function testFindWithMany()
     {
         $builder = m::mock(Builder::class.'[get]', [$this->getMockQueryBuilder()]);
@@ -308,6 +325,23 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->shouldReceive('get')->with(['*'])->andReturn(new Collection(['bar']));
 
         $result = $builder->first();
+        $this->assertSame('bar', $result);
+    }
+
+    public function testLastMethod()
+    {
+        $query = $this->getMockQueryBuilder();
+        $query->shouldReceive('latest')->with('created_at')->andReturnSelf();
+
+        $model = $this->getMockModel();
+        $model->shouldReceive('getCreatedAtColumn')->andReturn('created_at');
+
+        $builder = m::mock(Builder::class.'[get,take]', [$query]);
+        $builder->setModel($model);
+        $builder->shouldReceive('limit')->with(1)->andReturnSelf();
+        $builder->shouldReceive('get')->with(['*'])->andReturn(new Collection(['bar']));
+
+        $result = $builder->last();
         $this->assertSame('bar', $result);
     }
 
@@ -2562,6 +2596,84 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->getQuery()->shouldReceive('latest')->once()->with('foo');
 
         $builder->latest('foo');
+    }
+
+    public function testLastWithoutColumnWithCreatedAt()
+    {
+        $model = $this->getMockModel();
+        $model->shouldReceive('getCreatedAtColumn')->andReturn('created_at');
+        $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);
+        $builder->setModel($model);
+
+        $builder->getQuery()->shouldReceive('latest')->once()->with('created_at');
+        $builder->shouldReceive('first')->once()->with(['*'])->andReturn(null);
+
+        $builder->last();
+    }
+
+    public function testLastWithoutColumnWithCreatedAtAndSelectColumns()
+    {
+        $model = $this->getMockModel();
+        $model->shouldReceive('getCreatedAtColumn')->andReturn('created_at');
+        $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);
+        $builder->setModel($model);
+
+        $builder->getQuery()->shouldReceive('latest')->once()->with('created_at');
+        $builder->shouldReceive('first')->once()->with(['column'])->andReturn(null);
+
+        $builder->last(['column']);
+    }
+
+    public function testLastWithoutColumnWithoutCreatedAt()
+    {
+        $model = $this->getMockModel();
+        $model->shouldReceive('getCreatedAtColumn')->andReturn(null);
+        $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);
+        $builder->setModel($model);
+
+        $builder->getQuery()->shouldReceive('latest')->once()->with('created_at');
+        $builder->shouldReceive('first')->once()->with(['*'])->andReturn(null);
+
+        $builder->last();
+    }
+
+    public function testLastWithoutColumnWithoutCreatedAtAndSelectColumns()
+    {
+        $model = $this->getMockModel();
+        $model->shouldReceive('getCreatedAtColumn')->andReturn(null);
+        $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);
+        $builder->setModel($model);
+
+        $builder->getQuery()->shouldReceive('latest')->once()->with('created_at');
+        $builder->shouldReceive('first')->once()->with(['column'])->andReturn(null);
+
+        $builder->last(['column']);
+    }
+
+    public function testLastWithColumn()
+    {
+        $model = $this->getMockModel();
+        $model->shouldReceive('getCreatedAtColumn')->andReturn(null);
+        $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);
+        $builder->setModel($model);
+
+        $builder->getQuery()->shouldReceive('latest')->once()->with('foo');
+        $builder->shouldReceive('first')->once()->with(['*'])->andReturn(null);
+
+        $builder->last('foo');
+    }
+
+    public function testLastWithColumnAndSelectColumns()
+    {
+        $model = $this->getMockModel();
+        $model->shouldReceive('getCreatedAtColumn')->andReturn(null);
+        $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);
+        $builder->setModel($model);
+
+        $builder->getQuery()->shouldReceive('latest')->once()->with('foo');
+        $builder->shouldReceive('first')->once()->with(['column'])->andReturn(null);
+
+        $builder->last('foo', ['column']);
     }
 
     public function testOldestWithoutColumnWithCreatedAt()

--- a/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
@@ -180,6 +180,17 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
         HasManyThroughTestCountry::first()->posts()->firstOrFail();
     }
 
+    public function testLastOrFailThrowsAnException()
+    {
+        $this->expectException(ModelNotFoundException::class);
+        $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Database\HasManyThroughTestPost].');
+
+        HasManyThroughTestCountry::create(['id' => 1, 'name' => 'United States of America', 'shortname' => 'us'])
+            ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us']);
+
+        HasManyThroughTestCountry::first()->posts()->lastOrFail();
+    }
+
     public function testFindOrFailThrowsAnException()
     {
         $this->expectException(ModelNotFoundException::class);

--- a/tests/Database/DatabaseEloquentHasOneThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasOneThroughIntegrationTest.php
@@ -141,6 +141,17 @@ class DatabaseEloquentHasOneThroughIntegrationTest extends TestCase
         HasOneThroughTestPosition::first()->contract()->firstOrFail();
     }
 
+    public function testLastOrFailThrowsAnException()
+    {
+        $this->expectException(ModelNotFoundException::class);
+        $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Database\HasOneThroughTestContract].');
+
+        HasOneThroughTestPosition::create(['id' => 1, 'name' => 'President', 'shortname' => 'ps'])
+            ->user()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'position_short' => 'ps']);
+
+        HasOneThroughTestPosition::first()->contract()->lastOrFail();
+    }
+
     public function testFindOrFailThrowsAnException()
     {
         $this->expectException(ModelNotFoundException::class);

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -3863,6 +3863,91 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->from('users')->where('id', '=', 1)->firstOrFail();
     }
 
+    public function testLastMethodReturnsLastResult()
+    {
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('select')->once()->with('select * from "users" where "id" = ? order by "created_at" desc limit 1', [1], true, [])->andReturn([['foo' => 'bar']]);
+        $builder->getProcessor()->shouldReceive('processSelect')->once()->with($builder, [['foo' => 'bar']])->andReturnUsing(function ($query, $results) {
+            return $results;
+        });
+        $results = $builder->from('users')->where('id', '=', 1)->last();
+        $this->assertEquals(['foo' => 'bar'], $results);
+
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('select')->once()->with('select * from "users" where "id" = ? order by "updated_at" desc limit 1', [1], true, [])->andReturn([['foo' => 'bar']]);
+        $builder->getProcessor()->shouldReceive('processSelect')->once()->with($builder, [['foo' => 'bar']])->andReturnUsing(function ($query, $results) {
+            return $results;
+        });
+        $results = $builder->from('users')->where('id', '=', 1)->last('updated_at');
+        $this->assertEquals(['foo' => 'bar'], $results);
+
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('select')->once()->with('select "id" from "users" where "id" = ? order by "created_at" desc limit 1', [1], true, [])->andReturn([['foo' => 'bar']]);
+        $builder->getProcessor()->shouldReceive('processSelect')->once()->with($builder, [['foo' => 'bar']])->andReturnUsing(function ($query, $results) {
+            return $results;
+        });
+        $results = $builder->from('users')->where('id', '=', 1)->last(['id']);
+
+        $this->assertEquals(['foo' => 'bar'], $results);
+
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('select')->once()->with('select "id" from "users" where "id" = ? order by "updated_at" desc limit 1', [1], true, [])->andReturn([['foo' => 'bar']]);
+        $builder->getProcessor()->shouldReceive('processSelect')->once()->with($builder, [['foo' => 'bar']])->andReturnUsing(function ($query, $results) {
+            return $results;
+        });
+        $results = $builder->from('users')->where('id', '=', 1)->last('updated_at', ['id']);
+
+        $this->assertEquals(['foo' => 'bar'], $results);
+    }
+
+    public function testLastOrFailMethodReturnsLastResult()
+    {
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('select')->once()->with('select * from "users" where "id" = ? order by "created_at" desc limit 1', [1], true, [])->andReturn([['foo' => 'bar']]);
+        $builder->getProcessor()->shouldReceive('processSelect')->once()->with($builder, [['foo' => 'bar']])->andReturnUsing(function ($query, $results) {
+            return $results;
+        });
+        $results = $builder->from('users')->where('id', '=', 1)->lastOrFail();
+        $this->assertEquals(['foo' => 'bar'], $results);
+
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('select')->once()->with('select * from "users" where "id" = ? order by "updated_at" desc limit 1', [1], true, [])->andReturn([['foo' => 'bar']]);
+        $builder->getProcessor()->shouldReceive('processSelect')->once()->with($builder, [['foo' => 'bar']])->andReturnUsing(function ($query, $results) {
+            return $results;
+        });
+        $results = $builder->from('users')->where('id', '=', 1)->lastOrFail('updated_at');
+        $this->assertEquals(['foo' => 'bar'], $results);
+
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('select')->once()->with('select "id" from "users" where "id" = ? order by "created_at" desc limit 1', [1], true, [])->andReturn([['foo' => 'bar']]);
+        $builder->getProcessor()->shouldReceive('processSelect')->once()->with($builder, [['foo' => 'bar']])->andReturnUsing(function ($query, $results) {
+            return $results;
+        });
+        $results = $builder->from('users')->where('id', '=', 1)->lastOrFail(['id']);
+        $this->assertEquals(['foo' => 'bar'], $results);
+
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('select')->once()->with('select "id" from "users" where "id" = ? order by "updated_at" desc limit 1', [1], true, [])->andReturn([['foo' => 'bar']]);
+        $builder->getProcessor()->shouldReceive('processSelect')->once()->with($builder, [['foo' => 'bar']])->andReturnUsing(function ($query, $results) {
+            return $results;
+        });
+        $results = $builder->from('users')->where('id', '=', 1)->lastOrFail('updated_at', ['id']);
+        $this->assertEquals(['foo' => 'bar'], $results);
+    }
+
+    public function testLastOrFailMethodThrowsRecordNotFoundException()
+    {
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('select')->once()->with('select * from "users" where "id" = ? order by "created_at" desc limit 1', [1], true, [])->andReturn([]);
+
+        $builder->getProcessor()->shouldReceive('processSelect')->once()->with($builder, [])->andReturn([]);
+
+        $this->expectException(RecordNotFoundException::class);
+        $this->expectExceptionMessage('No record found for the given query.');
+
+        $builder->from('users')->where('id', '=', 1)->lastOrFail();
+    }
+
     public function testPluckMethodGetsCollectionOfColumnValues()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
Adds `last()` and `lastOrFail()` helper methods to the query builder, providing concise aliases for the common "get most recent record" pattern.

## Motivation

Retrieving the most recent record is a very common query pattern, currently written as:

```php
$query->latest()->first();
$query->latest('published_at')->first();
$query->latest('published_at')->firstOrFail();
```

These new methods offer a more concise, expressive alias, consistent with the existing `first()` / `firstOrFail()` methods.

## Usage

`last()` is an alias for `$this->latest($column)->first($columns)`. `lastOrFail()` behaves the same way but throws an exception when no record is found, aliasing `$this->latest($column)->firstOrFail($columns)`.

Both accept an optional sort column and/or selected columns, in any combination:

```php
// Before
Post::latest()->first();
Post::latest('published_at')->first();
Post::latest()->first(['id', 'title']);

// After
Post::last();
Post::last('published_at');
Post::last(['id', 'title']);
Post::last('published_at', ['id', 'title']);

// lastOrFail works the same way
Post::lastOrFail();
Post::lastOrFail('published_at');
Post::lastOrFail(['id', 'title']);
Post::lastOrFail('published_at', ['id', 'title']);
```

This change is purely additive and does not modify any existing query behavior.