### PR TITLE
[13.x] Cast morph relation parent keys to strings for PostgreSQL compatibility

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
@@ -57,16 +57,38 @@ abstract class MorphOneOrMany extends HasOneOrMany
         if (static::$constraints) {
             $this->getRelationQuery()->where($this->morphType, $this->morphClass);
 
-            parent::addConstraints();
+            $this->getRelationQuery()->where(
+                $this->foreignKey, '=', (string) $this->getParentKey()
+            );
+
+            $this->getRelationQuery()->whereNotNull($this->foreignKey);
         }
     }
 
     /** @inheritDoc */
     public function addEagerConstraints(array $models)
     {
-        parent::addEagerConstraints($models);
+        $this->whereInEager(
+            'whereIn',
+            $this->foreignKey,
+            $this->getEagerModelKeys($models),
+            $this->getRelationQuery()
+        );
 
         $this->getRelationQuery()->where($this->morphType, $this->morphClass);
+    }
+
+    /**
+     * Get the keys of the models used for the eager loading query.
+     *
+     * @param  array<int, TDeclaringModel>  $models
+     * @return array
+     */
+    protected function getEagerModelKeys(array $models)
+    {
+        return array_map(function ($value) {
+            return (string) $value;
+        }, $this->getKeys($models, $this->localKey));
     }
 
     /**

--- a/tests/Database/DatabaseEloquentMorphOneOfManyTest.php
+++ b/tests/Database/DatabaseEloquentMorphOneOfManyTest.php
@@ -60,7 +60,7 @@ class DatabaseEloquentMorphOneOfManyTest extends TestCase
         $product = MorphOneOfManyTestProduct::create();
         $relation = $product->current_state();
         $relation->addEagerConstraints([$product]);
-        $this->assertSame('select MAX("states"."id") as "id_aggregate", "states"."stateful_id", "states"."stateful_type" from "states" where "states"."stateful_type" = ? and "states"."stateful_id" = ? and "states"."stateful_id" is not null and "states"."stateful_id" in (1) and "states"."stateful_type" = ? group by "states"."stateful_id", "states"."stateful_type"', $relation->getOneOfManySubQuery()->toSql());
+        $this->assertSame('select MAX("states"."id") as "id_aggregate", "states"."stateful_id", "states"."stateful_type" from "states" where "states"."stateful_type" = ? and "states"."stateful_id" = ? and "states"."stateful_id" is not null and "states"."stateful_id" in (?) and "states"."stateful_type" = ? group by "states"."stateful_id", "states"."stateful_type"', $relation->getOneOfManySubQuery()->toSql());
     }
 
     public function testReceivingModel()

--- a/tests/Database/DatabaseEloquentMorphTest.php
+++ b/tests/Database/DatabaseEloquentMorphTest.php
@@ -31,9 +31,7 @@ class DatabaseEloquentMorphTest extends TestCase
     public function testMorphOneEagerConstraintsAreProperlyAdded()
     {
         $relation = $this->getOneRelation();
-        $relation->getParent()->shouldReceive('getKeyName')->once()->andReturn('id');
-        $relation->getParent()->shouldReceive('getKeyType')->once()->andReturn('string');
-        $relation->getQuery()->shouldReceive('whereIn')->once()->with('table.morph_id', [1, 2]);
+        $relation->getQuery()->shouldReceive('whereIn')->once()->with('table.morph_id', ['1', '2']);
         $relation->getQuery()->shouldReceive('where')->once()->with('table.morph_type', get_class($relation->getParent()));
 
         $model1 = new EloquentMorphResetModelStub;
@@ -55,9 +53,7 @@ class DatabaseEloquentMorphTest extends TestCase
     public function testMorphManyEagerConstraintsAreProperlyAdded()
     {
         $relation = $this->getManyRelation();
-        $relation->getParent()->shouldReceive('getKeyName')->once()->andReturn('id');
-        $relation->getParent()->shouldReceive('getKeyType')->once()->andReturn('int');
-        $relation->getQuery()->shouldReceive('whereIntegerInRaw')->once()->with('table.morph_id', [1, 2]);
+        $relation->getQuery()->shouldReceive('whereIn')->once()->with('table.morph_id', ['1', '2']);
         $relation->getQuery()->shouldReceive('where')->once()->with('table.morph_type', get_class($relation->getParent()));
 
         $model1 = new EloquentMorphResetModelStub;
@@ -65,6 +61,68 @@ class DatabaseEloquentMorphTest extends TestCase
         $model2 = new EloquentMorphResetModelStub;
         $model2->id = 2;
         $relation->addEagerConstraints([$model1, $model2]);
+    }
+
+    public function testMorphManyCastsIntegerParentKeyToStringForPostgreSQLCompatibility()
+    {
+        $queryBuilder = m::mock(QueryBuilder::class);
+        $builder = m::mock(Builder::class, [$queryBuilder]);
+        $related = m::mock(Model::class);
+        $builder->shouldReceive('getModel')->andReturn($related);
+
+        $capturedValue = null;
+        $builder->shouldReceive('where')->andReturnUsing(function (...$args) use (&$capturedValue) {
+            if ($args[0] === 'table.morph_id' && ($args[1] ?? null) === '=') {
+                $capturedValue = $args[2] ?? null;
+            }
+        });
+        $builder->shouldReceive('whereNotNull')->with('table.morph_id');
+
+        $parent = m::mock(Model::class);
+        $parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
+        $parent->shouldReceive('getMorphClass')->andReturn('App\User');
+
+        new MorphMany($builder, $parent, 'table.morph_type', 'table.morph_id', 'id');
+
+        $this->assertSame('1', $capturedValue);
+    }
+
+    public function testMorphManyEagerConstraintsCastIntegerParentKeysToStringsForPostgreSQLCompatibility()
+    {
+        $queryBuilder = m::mock(QueryBuilder::class);
+        $builder = m::mock(Builder::class, [$queryBuilder]);
+        $related = m::mock(Model::class);
+        $builder->shouldReceive('getModel')->andReturn($related);
+
+        $capturedValues = null;
+        $builder->shouldReceive('whereIn')->andReturnUsing(function (...$args) use (&$capturedValues) {
+            if (($args[0] ?? null) === 'table.morph_id') {
+                $capturedValues = $args[1] ?? null;
+            }
+        });
+        $builder->shouldReceive('whereIntegerInRaw')->andReturnUsing(function () {
+            //
+        });
+        $builder->shouldReceive('where')->andReturnUsing(function () {
+            //
+        });
+        $builder->shouldReceive('whereNotNull')->with('table.morph_id');
+
+        $parent = m::mock(Model::class);
+        $parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
+        $parent->shouldReceive('getMorphClass')->andReturn('App\User');
+        $parent->shouldReceive('getKeyName')->andReturn('id');
+        $parent->shouldReceive('getKeyType')->andReturn('int');
+
+        $relation = new MorphMany($builder, $parent, 'table.morph_type', 'table.morph_id', 'id');
+
+        $model1 = new EloquentMorphResetModelStub;
+        $model1->id = 1;
+        $model2 = new EloquentMorphResetModelStub;
+        $model2->id = 2;
+        $relation->addEagerConstraints([$model1, $model2]);
+
+        $this->assertSame(['1', '2'], $capturedValues);
     }
 
     public function testMorphRelationUpsertFillsForeignKey()
@@ -484,7 +542,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $queryBuilder = m::mock(QueryBuilder::class);
         $builder = m::mock(Builder::class, [$queryBuilder]);
         $builder->shouldReceive('whereNotNull')->once()->with('table.morph_id');
-        $builder->shouldReceive('where')->once()->with('table.morph_id', '=', 1);
+        $builder->shouldReceive('where')->once()->with('table.morph_id', '=', '1');
         $related = m::mock(Model::class);
         $builder->shouldReceive('getModel')->andReturn($related);
         $parent = m::mock(Model::class);
@@ -497,9 +555,10 @@ class DatabaseEloquentMorphTest extends TestCase
 
     protected function getManyRelation()
     {
-        $builder = m::mock(Builder::class);
+        $queryBuilder = m::mock(QueryBuilder::class);
+        $builder = m::mock(Builder::class, [$queryBuilder]);
         $builder->shouldReceive('whereNotNull')->once()->with('table.morph_id');
-        $builder->shouldReceive('where')->once()->with('table.morph_id', '=', 1);
+        $builder->shouldReceive('where')->once()->with('table.morph_id', '=', '1');
         $related = m::mock(Model::class);
         $builder->shouldReceive('getModel')->andReturn($related);
         $parent = m::mock(Model::class);
@@ -518,9 +577,10 @@ class DatabaseEloquentMorphTest extends TestCase
             $alias => EloquentModelNamespacedStub::class,
         ]);
 
-        $builder = m::mock(Builder::class);
+        $queryBuilder = m::mock(QueryBuilder::class);
+        $builder = m::mock(Builder::class, [$queryBuilder]);
         $builder->shouldReceive('whereNotNull')->once()->with('table.morph_id');
-        $builder->shouldReceive('where')->once()->with('table.morph_id', '=', 1);
+        $builder->shouldReceive('where')->once()->with('table.morph_id', '=', '1');
         $related = m::mock(Model::class);
         $builder->shouldReceive('getModel')->andReturn($related);
         $parent = m::mock(EloquentModelNamespacedStub::class);


### PR DESCRIPTION
When a morph table's `foreign_id` column is a string but the parent model has an integer primary key, PostgreSQL fails with `operator does not exist: character varying = integer`. `MorphOneOrMany` was binding the parent key as an integer.

Casts the parent key to a string in `addConstraints()` and `addEagerConstraints()`, and uses parameterized `whereIn` instead of `whereIntegerInRaw` for eager loading.

Fixes laravel/framework#54401