### PR TITLE
[13.x] Reduce redundant getCasts() calls in HasAttributes::originalIsEquivalent

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2377,18 +2377,20 @@ trait HasAttributes
         } elseif ($this->hasCast($key, static::$primitiveCastTypes)) {
             return $this->castAttribute($key, $attribute) ===
                 $this->castAttribute($key, $original);
-        } elseif ($this->isClassCastable($key) && Str::startsWith($this->getCasts()[$key], [AsArrayObject::class, AsCollection::class])) {
-            return $this->fromJson($attribute) === $this->fromJson($original);
-        } elseif ($this->isClassCastable($key) && Str::startsWith($this->getCasts()[$key], [AsEnumArrayObject::class, AsEnumCollection::class])) {
-            return $this->fromJson($attribute) === $this->fromJson($original);
-        } elseif ($this->isClassCastable($key) && $original !== null && Str::startsWith($this->getCasts()[$key], [AsEncryptedArrayObject::class, AsEncryptedCollection::class])) {
-            if (empty(static::currentEncrypter()->getPreviousKeys())) {
-                return $this->fromEncryptedString($attribute) === $this->fromEncryptedString($original);
-            }
+        } elseif ($this->isClassCastable($key)) {
+            $castValue = $this->getCasts()[$key];
 
-            return false;
-        } elseif ($this->isClassComparable($key)) {
-            return $this->compareClassCastableAttribute($key, $original, $attribute);
+            if (Str::startsWith($castValue, [AsArrayObject::class, AsCollection::class, AsEnumArrayObject::class, AsEnumCollection::class])) {
+                return $this->fromJson($attribute) === $this->fromJson($original);
+            } elseif ($original !== null && Str::startsWith($castValue, [AsEncryptedArrayObject::class, AsEncryptedCollection::class])) {
+                if (empty(static::currentEncrypter()->getPreviousKeys())) {
+                    return $this->fromEncryptedString($attribute) === $this->fromEncryptedString($original);
+                }
+
+                return false;
+            } elseif ($this->isClassComparable($key)) {
+                return $this->compareClassCastableAttribute($key, $original, $attribute);
+            }
         }
 
         return is_numeric($attribute) && is_numeric($original)


### PR DESCRIPTION
`originalIsEquivalent()` calls `getCasts()` multiple times for class-castable attributes — once inside `isClassCastable()` and again in each branch that checks `AsArrayObject`, `AsEnum*`, `AsEncrypted*`, etc.

That method runs on every `isDirty()`, `getDirty()`, and `save()`, so the repeated `array_merge` allocations add up for models with several cast attributes.

Collapses those branches so `getCasts()` is only called once when we already know the attribute is class-castable.

Refs laravel/framework#59349