### PR TITLE
[13.x] Add conditional return types to several methods

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -948,7 +948,7 @@ class Arr
      * @param  array  $array
      * @param  int|null  $number
      * @param  bool  $preserveKeys
-     * @return mixed
+     * @return ($number is null ? mixed : array)
      *
      * @throws \InvalidArgumentException
      */

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -873,7 +873,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Get one or a specified number of items randomly from the collection.
      *
      * @param  int|null  $number
-     * @return static<int, TValue>|TValue
+     * @return ($number is null ? TValue : static<int, TValue>)
      *
      * @throws \InvalidArgumentException
      */

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1031,7 +1031,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      *
      * @param  int|null  $number
      * @param  bool  $preserveKeys
-     * @return static<int, TValue>|TValue
+     * @return ($number is null ? TValue : static<int, TValue>)
      *
      * @throws \InvalidArgumentException
      */

--- a/src/Illuminate/Contracts/Pagination/CursorPaginator.php
+++ b/src/Illuminate/Contracts/Pagination/CursorPaginator.php
@@ -32,7 +32,7 @@ interface CursorPaginator
      * Get / set the URL fragment to be appended to URLs.
      *
      * @param  string|null  $fragment
-     * @return $this|string|null
+     * @return ($fragment is null ? string|null : $this)
      */
     public function fragment($fragment = null);
 

--- a/src/Illuminate/Contracts/Pagination/Paginator.php
+++ b/src/Illuminate/Contracts/Pagination/Paginator.php
@@ -32,7 +32,7 @@ interface Paginator
      * Get / set the URL fragment to be appended to URLs.
      *
      * @param  string|null  $fragment
-     * @return $this|string|null
+     * @return ($fragment is null ? string|null : $this)
      */
     public function fragment($fragment = null);
 

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -1018,6 +1018,7 @@ if (! function_exists('__')) {
      * @param  string|null  $key
      * @param  array  $replace
      * @param  string|null  $locale
+     * @return ($key is null ? null : array|string)
      */
     function __($key = null, $replace = [], $locale = null): string|array|null
     {

--- a/src/Illuminate/Pagination/AbstractCursorPaginator.php
+++ b/src/Illuminate/Pagination/AbstractCursorPaginator.php
@@ -274,7 +274,7 @@ abstract class AbstractCursorPaginator implements Htmlable, Stringable
      * Get / set the URL fragment to be appended to URLs.
      *
      * @param  string|null  $fragment
-     * @return $this|string|null
+     * @return ($fragment is null ? string|null : $this)
      */
     public function fragment($fragment = null)
     {

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -204,7 +204,7 @@ abstract class AbstractPaginator implements CanBeEscapedWhenCastToString, Htmlab
      * Get / set the URL fragment to be appended to URLs.
      *
      * @param  string|null  $fragment
-     * @return $this|string|null
+     * @return ($fragment is null ? string|null : $this)
      */
     public function fragment($fragment = null)
     {

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -1355,7 +1355,7 @@ class Route
      *
      * @param  string|null  $key
      * @param  mixed  $default
-     * @return ($key is null ? array<string, mixed> : mixed)
+     * @return ($key is null ? array<array-key, mixed> : mixed)
      */
     public function getMetadata($key = null, $default = null)
     {

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -1355,7 +1355,7 @@ class Route
      *
      * @param  string|null  $key
      * @param  mixed  $default
-     * @return mixed
+     * @return ($key is null ? array<string, mixed> : mixed)
      */
     public function getMetadata($key = null, $default = null)
     {

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -766,7 +766,7 @@ class Route
      * Get or set the domain for the route.
      *
      * @param  \BackedEnum|string|null  $domain
-     * @return $this|string|null
+     * @return ($domain is null ? string|null : $this)
      *
      * @throws \InvalidArgumentException
      */

--- a/src/Illuminate/Support/Lottery.php
+++ b/src/Illuminate/Support/Lottery.php
@@ -117,7 +117,7 @@ class Lottery
      * Run the lottery.
      *
      * @param  null|int  $times
-     * @return mixed
+     * @return ($times is null ? mixed : list<mixed>)
      */
     public function choose($times = null)
     {

--- a/src/Illuminate/Validation/Rules/Email.php
+++ b/src/Illuminate/Validation/Rules/Email.php
@@ -63,9 +63,7 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
      * If no arguments are passed, the default email rule configuration will be returned.
      *
      * @param  static|callable|null  $callback
-     * @return static|void
-     *
-     * @phpstan-return ($callback is null ? static : ($callback is callable ? void : ($callback is static ? void : never)))
+     * @return ($callback is null ? static : void)
      *
      * @throws \InvalidArgumentException
      */

--- a/src/Illuminate/Validation/Rules/File.php
+++ b/src/Illuminate/Validation/Rules/File.php
@@ -92,9 +92,7 @@ class File implements Rule, DataAwareRule, ValidatorAwareRule
      * If no arguments are passed, the default file rule configuration will be returned.
      *
      * @param  static|callable|null  $callback
-     * @return static|void
-     *
-     * @phpstan-return ($callback is null ? static : ($callback is callable ? void : ($callback is static ? void : never)))
+     * @return ($callback is null ? static : void)
      *
      * @throws \InvalidArgumentException
      */

--- a/src/Illuminate/Validation/Rules/File.php
+++ b/src/Illuminate/Validation/Rules/File.php
@@ -94,6 +94,8 @@ class File implements Rule, DataAwareRule, ValidatorAwareRule
      * @param  static|callable|null  $callback
      * @return static|void
      *
+     * @phpstan-return ($callback is null ? static : ($callback is callable ? void : ($callback is static ? void : never)))
+     *
      * @throws \InvalidArgumentException
      */
     public static function defaults($callback = null)

--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -141,9 +141,7 @@ class Password implements DataAwareRule, ImplicitRule, IteratorAggregate, Rule, 
      * If no arguments are passed, the default password rule configuration will be returned.
      *
      * @param  static|callable|null  $callback
-     * @return static|void
-     *
-     * @phpstan-return ($callback is null ? static : ($callback is callable ? void : ($callback is static ? void : never)))
+     * @return ($callback is null ? static : void)
      *
      * @throws \InvalidArgumentException
      */

--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -143,6 +143,8 @@ class Password implements DataAwareRule, ImplicitRule, IteratorAggregate, Rule, 
      * @param  static|callable|null  $callback
      * @return static|void
      *
+     * @phpstan-return ($callback is null ? static : ($callback is callable ? void : ($callback is static ? void : never)))
+     *
      * @throws \InvalidArgumentException
      */
     public static function defaults($callback = null)

--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -82,7 +82,7 @@ class ComponentAttributeBag implements Arrayable, ArrayAccess, IteratorAggregate
      *
      * @param  string|null  $key
      * @param  mixed  $default
-     * @return mixed
+     * @return ($key is null ? array<array-key, mixed> : mixed)
      */
     protected function data($key = null, $default = null)
     {

--- a/types/Pagination/Paginator.php
+++ b/types/Pagination/Paginator.php
@@ -14,6 +14,9 @@ $paginator = new Paginator($items, 1, 1);
 assertType('array<int, Post>', $paginator->items());
 assertType('ArrayIterator<int, Post>', $paginator->getIterator());
 
+assertType('string|null', $paginator->fragment());
+assertType('Illuminate\Pagination\Paginator<int, Post>', $paginator->fragment('foo'));
+
 $paginator->each(function ($post) {
     assertType('Post', $post);
 });
@@ -41,6 +44,9 @@ $cursorPaginator = new CursorPaginator($items, 1);
 
 assertType('array<int, Post>', $cursorPaginator->items());
 assertType('ArrayIterator<int, Post>', $cursorPaginator->getIterator());
+
+assertType('string|null', $cursorPaginator->fragment());
+assertType('Illuminate\Pagination\CursorPaginator<int, Post>', $cursorPaginator->fragment('foo'));
 
 $cursorPaginator->each(function ($post) {
     assertType('Post', $post);

--- a/types/Routing/Route.php
+++ b/types/Routing/Route.php
@@ -12,5 +12,5 @@ assertType(Route::class, RouteFacade::get('/')->middleware(['auth']));
 assertType('string|null', RouteFacade::get('/')->domain());
 assertType(Route::class, RouteFacade::get('/')->domain('example.com'));
 
-assertType('array<string, mixed>', RouteFacade::get('/')->getMetadata());
+assertType('array<mixed>', RouteFacade::get('/')->getMetadata());
 assertType('mixed', RouteFacade::get('/')->getMetadata('key'));

--- a/types/Routing/Route.php
+++ b/types/Routing/Route.php
@@ -8,3 +8,6 @@ use function PHPStan\Testing\assertType;
 assertType('array', RouteFacade::get('/')->middleware());
 assertType(Route::class, RouteFacade::get('/')->middleware('auth'));
 assertType(Route::class, RouteFacade::get('/')->middleware(['auth']));
+
+assertType('string|null', RouteFacade::get('/')->domain());
+assertType(Route::class, RouteFacade::get('/')->domain('example.com'));

--- a/types/Routing/Route.php
+++ b/types/Routing/Route.php
@@ -11,3 +11,6 @@ assertType(Route::class, RouteFacade::get('/')->middleware(['auth']));
 
 assertType('string|null', RouteFacade::get('/')->domain());
 assertType(Route::class, RouteFacade::get('/')->domain('example.com'));
+
+assertType('array<string, mixed>', RouteFacade::get('/')->getMetadata());
+assertType('mixed', RouteFacade::get('/')->getMetadata('key'));

--- a/types/Support/Arr.php
+++ b/types/Support/Arr.php
@@ -202,3 +202,6 @@ assertType('array<string, int>', Arr::whereNotNull($arr));
 
 /** @var list<int|null> $arr */
 assertType('array<int<0, max>, int>', Arr::whereNotNull($arr));
+
+assertType('mixed', Arr::random($array));
+assertType('array', Arr::random($array, 2));

--- a/types/Support/LazyCollection.php
+++ b/types/Support/LazyCollection.php
@@ -594,8 +594,8 @@ assertType('Illuminate\Support\LazyCollection<int, int>', $collection::make([1])
 assertType('Illuminate\Support\LazyCollection<int, string>', $collection::make(['string'])->concat(['string']));
 assertType('Illuminate\Support\LazyCollection<int, int|string>', $collection::make([1])->concat(['string']));
 
-assertType('Illuminate\Support\LazyCollection<int, int>|int', $collection::make([1])->random(2));
-assertType('Illuminate\Support\LazyCollection<int, string>|string', $collection::make(['string'])->random());
+assertType('Illuminate\Support\LazyCollection<int, int>', $collection::make([1])->random(2));
+assertType('string', $collection::make(['string'])->random());
 
 assertType('1|null', $collection
     ->reduce(function ($null, $user) {


### PR DESCRIPTION
Some Laravel methods return a different type depending on the argument you pass. `Route::domain()` is a good example:

```php
$route->domain();              // string|null  (you get the domain)
$route->domain('example.com'); // $this        (you set it, chainable)
```

Most of these are documented with a plain union like `@return $this|string|null`, so analysis tools and IDEs always see every option, even when the call clearly hits one branch. This PR adds conditional return types (`@return ($domain is null ? string|null : $this)`) so PHPStan, Psalm and PhpStorm pick the right type at each call.

Methods updated: `fragment()` on the paginators, `Route::domain()`, `random()` on `Enumerable` / `LazyCollection` / `Arr`, `Lottery::choose()`, `ComponentAttributeBag::data()`, `Route::getMetadata()`, the `__()` helper, and `defaults()` on the `Password` / `File` / `Email` rules.

Most global helpers (`app`, `config`, `redirect`, `view`, and so on) already do this, so the change is small. PHPDoc only, no runtime changes. Added `assertType` coverage; PHPStan and Pint pass with no new errors.

---

This is part of a series of PRs to improve the framework's PHPDoc. Tools like `psalm-plugin-laravel` and `larastan` have accumulated many type refinements over the years (conditional returns, generics, stricter array shapes) that could be ported back into core so every analyzer and IDE benefits out of the box. Happy to follow up with more.
