### PR TITLE
[13.x] Add implodeStr() and joinStr() methods to Collection

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -648,6 +648,18 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Concatenate values of a given key as a Stringable.
+     *
+     * @param  (callable(TValue, TKey): mixed)|string|null  $value
+     * @param  string|null  $glue
+     * @return \Illuminate\Support\Stringable
+     */
+    public function implodeStr($value, $glue = null)
+    {
+        return str($this->implode($value, $glue));
+    }
+
+    /**
      * Intersect the collection with the given items.
      *
      * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
@@ -776,6 +788,18 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
         $finalItem = $collection->pop();
 
         return $collection->implode($glue).$finalGlue.$finalItem;
+    }
+
+    /**
+     * Join all items from the collection using a Stringable. The final items can use a separate glue string.
+     *
+     * @param  string  $glue
+     * @param  string  $finalGlue
+     * @return \Illuminate\Support\Stringable
+     */
+    public function joinStr($glue, $finalGlue = '')
+    {
+        return str($this->join($glue, $finalGlue));
     }
 
     /**

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -633,6 +633,18 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
+     * Concatenate values of a given key as a Stringable.
+     *
+     * @param  (callable(TValue, TKey): mixed)|string  $value
+     * @param  string|null  $glue
+     * @return Stringable
+     */
+    public function implodeStr($value, $glue = null)
+    {
+        return str($this->implode($value, $glue));
+    }
+
+    /**
      * {@inheritDoc}
      */
     #[\Override]
@@ -722,6 +734,18 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     public function join($glue, $finalGlue = '')
     {
         return $this->collect()->join(...func_get_args());
+    }
+
+    /**
+     * Join all items from the collection using a Stringable. The final items can use a separate glue string.
+     *
+     * @param  string  $glue
+     * @param  string  $finalGlue
+     * @return Stringable
+     */
+    public function joinStr($glue, $finalGlue = '')
+    {
+        return str($this->join($glue, $finalGlue));
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2624,7 +2624,7 @@ class SupportCollectionTest extends TestCase
         $this->assertSame('foobar', $data->implode('email'));
         $this->assertSame('foo,bar', $data->implode('email', ','));
     }
-    
+
     #[DataProvider('collectionClassProvider')]
     public function testImplodeStr($collection)
     {

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1973,6 +1973,20 @@ class SupportCollectionTest extends TestCase
     }
 
     #[DataProvider('collectionClassProvider')]
+    public function testJoinStr($collection)
+    {
+        $this->assertSame('a, b, c', (new $collection(['a', 'b', 'c']))->joinStr(', ')->toString());
+
+        $this->assertSame('a, b and c', (new $collection(['a', 'b', 'c']))->joinStr(', ', ' and ')->toString());
+
+        $this->assertSame('a and b', (new $collection(['a', 'b']))->joinStr(', ', ' and ')->toString());
+
+        $this->assertSame('a', (new $collection(['a']))->joinStr(', ', ' and ')->toString());
+
+        $this->assertSame('', (new $collection([]))->joinStr(', ', ' and ')->toString());
+    }
+
+    #[DataProvider('collectionClassProvider')]
     public function testCrossJoin($collection)
     {
         // Cross join with an array
@@ -2609,6 +2623,34 @@ class SupportCollectionTest extends TestCase
 
         $this->assertSame('foobar', $data->implode('email'));
         $this->assertSame('foo,bar', $data->implode('email', ','));
+    }
+    
+    #[DataProvider('collectionClassProvider')]
+    public function testImplodeStr($collection)
+    {
+        $data = new $collection([['name' => 'taylor', 'email' => 'foo'], ['name' => 'dayle', 'email' => 'bar']]);
+        $this->assertSame('foobar', $data->implodeStr('email')->toString());
+        $this->assertSame('foo,bar', $data->implodeStr('email', ',')->toString());
+
+        $data = new $collection(['taylor', 'dayle']);
+        $this->assertSame('taylordayle', $data->implodeStr('')->toString());
+        $this->assertSame('taylor,dayle', $data->implodeStr(',')->toString());
+
+        $data = new $collection([
+            ['name' => new Stringable('taylor'), 'email' => new Stringable('foo')],
+            ['name' => new Stringable('dayle'), 'email' => new Stringable('bar')],
+        ]);
+        $this->assertSame('foobar', $data->implodeStr('email'));
+        $this->assertSame('foo,bar', $data->implodeStr('email', ','));
+
+        $data = new $collection([new Stringable('taylor'), new Stringable('dayle')]);
+        $this->assertSame('taylordayle', $data->implodeStr('')->toString());
+        $this->assertSame('taylor,dayle', $data->implodeStr(',')->toString());
+        $this->assertSame('taylor_dayle', $data->implodeStr('_')->toString());
+
+        $data = new $collection([['name' => 'taylor', 'email' => 'foo'], ['name' => 'dayle', 'email' => 'bar']]);
+        $this->assertSame('taylor-foodayle-bar', $data->implodeStr(fn ($user) => $user['name'].'-'.$user['email'])->toString());
+        $this->assertSame('taylor-foo,dayle-bar', $data->implodeStr(fn ($user) => $user['name'].'-'.$user['email'], ',')->toString());
     }
 
     #[DataProvider('collectionClassProvider')]

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2640,8 +2640,8 @@ class SupportCollectionTest extends TestCase
             ['name' => new Stringable('taylor'), 'email' => new Stringable('foo')],
             ['name' => new Stringable('dayle'), 'email' => new Stringable('bar')],
         ]);
-        $this->assertSame('foobar', $data->implodeStr('email'));
-        $this->assertSame('foo,bar', $data->implodeStr('email', ','));
+        $this->assertSame('foobar', $data->implodeStr('email')->toString());
+        $this->assertSame('foo,bar', $data->implodeStr('email', ',')->toString());
 
         $data = new $collection([new Stringable('taylor'), new Stringable('dayle')]);
         $this->assertSame('taylordayle', $data->implodeStr('')->toString());


### PR DESCRIPTION
When working with Stringables we can use `explode()` which returns a Collection instance, this is quite usefull as further methods can be chained on, but when `implode()` is called on a Collection it returns a simple string and stops the fluent calls you can make causing code to look a bit messy.

A trivial example of how this could help make code easier to read.
```php
// Before
$intermediary = str('some.route.name')->explode('.')->reverse()->implode('/');
$stringable = str($intermediary);

// After
$stringable = str('some.route.name')
    ->explode('.')
    ->reverse()
    ->implodeStr('/');
```