### PR TITLE
fix: cache headers not set on HEAD requests

### DIFF
--- a/src/Illuminate/Http/Middleware/SetCacheHeaders.php
+++ b/src/Illuminate/Http/Middleware/SetCacheHeaders.php
@@ -50,7 +50,7 @@ class SetCacheHeaders
     {
         $response = $next($request);
 
-        if (! $request->isMethodCacheable() || (! $response->getContent() && ! $response instanceof BinaryFileResponse && ! $response instanceof StreamedResponse)) {
+        if (! $request->isMethodCacheable() || (! $response->getContent() && ! $request->isMethod('HEAD') && ! $response instanceof BinaryFileResponse && ! $response instanceof StreamedResponse)) {
             return $response;
         }
 

--- a/tests/Http/Middleware/CacheTest.php
+++ b/tests/Http/Middleware/CacheTest.php
@@ -92,6 +92,17 @@ class CacheTest extends TestCase
         $this->assertSame('max-age=100, public, s-maxage=200', $response->headers->get('Cache-Control'));
     }
 
+    public function testAddCacheHeadersForMethodHEAD()
+    {
+        $request = new Request;
+        $request->setMethod('HEAD');
+        $response = (new Cache)->handle($request, function () {
+            return new Response;
+        }, 'max_age=120;s_maxage=60');
+
+        $this->assertNotNull($response->getMaxAge());
+    }
+
     public function testAddHeadersUsingArray()
     {
         $response = (new Cache)->handle(new Request, function () {


### PR DESCRIPTION
This is my proposed fix for https://github.com/laravel/framework/issues/60588