### PR TITLE
[13.x] Cache classic mutator existence checks

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -186,6 +186,20 @@ trait HasAttributes
     protected static $setAttributeMutatorCache = [];
 
     /**
+     * The cache of the classic "getXAttribute" mutator existence for each class.
+     *
+     * @var array
+     */
+    protected static $hasGetMutatorCache = [];
+
+    /**
+     * The cache of the classic "setXAttribute" mutator existence for each class.
+     *
+     * @var array
+     */
+    protected static $hasSetMutatorCache = [];
+
+    /**
      * The cache of the converted cast types.
      *
      * @var array
@@ -661,7 +675,12 @@ trait HasAttributes
      */
     public function hasGetMutator($key)
     {
-        return method_exists($this, 'get'.Str::studly($key).'Attribute');
+        if (isset(static::$hasGetMutatorCache[$class = static::class][$key])) {
+            return static::$hasGetMutatorCache[$class][$key];
+        }
+
+        return static::$hasGetMutatorCache[$class][$key] =
+                    method_exists($this, 'get'.Str::studly($key).'Attribute');
     }
 
     /**
@@ -1141,7 +1160,12 @@ trait HasAttributes
      */
     public function hasSetMutator($key)
     {
-        return method_exists($this, 'set'.Str::studly($key).'Attribute');
+        if (isset(static::$hasSetMutatorCache[$class = static::class][$key])) {
+            return static::$hasSetMutatorCache[$class][$key];
+        }
+
+        return static::$hasSetMutatorCache[$class][$key] =
+                    method_exists($this, 'set'.Str::studly($key).'Attribute');
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -2619,6 +2619,24 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals(['firstName', 'middleName', 'lastName'], $model->getMutatedAttributes());
     }
 
+    public function testClassicMutatorChecksAreIsolatedPerClass()
+    {
+        $withMutators = new EloquentModelWithClassicMutatorsStub;
+        $withoutMutators = new EloquentModelWithoutClassicMutatorsStub;
+
+        // Prime any cache from the model that defines the classic mutators first.
+        $this->assertTrue($withMutators->hasGetMutator('name'));
+        $this->assertTrue($withMutators->hasSetMutator('name'));
+
+        // A different class without those mutators must not inherit the cached result.
+        $this->assertFalse($withoutMutators->hasGetMutator('name'));
+        $this->assertFalse($withoutMutators->hasSetMutator('name'));
+
+        // Unknown attributes are still reported correctly on the mutating model.
+        $this->assertFalse($withMutators->hasGetMutator('missing'));
+        $this->assertFalse($withMutators->hasSetMutator('missing'));
+    }
+
     public function testReplicateCreatesANewModelInstanceWithSameAttributeValues()
     {
         $model = new EloquentModelStub;
@@ -4192,6 +4210,24 @@ class EloquentModelAppendsStub extends Model
     {
         return 'StudlyCased';
     }
+}
+
+class EloquentModelWithClassicMutatorsStub extends Model
+{
+    public function getNameAttribute($value)
+    {
+        return ucfirst((string) $value);
+    }
+
+    public function setNameAttribute($value)
+    {
+        $this->attributes['name'] = strtolower((string) $value);
+    }
+}
+
+class EloquentModelWithoutClassicMutatorsStub extends Model
+{
+    //
 }
 
 class EloquentModelGetMutatorsStub extends Model


### PR DESCRIPTION
This caches the result of classic `getXAttribute` / `setXAttribute` mutator checks per model class and attribute.

These checks currently rebuild the method name and call `method_exists()` every time `hasGetMutator()` or `hasSetMutator()` runs. Since those methods are used on Eloquent's attribute read/write paths, avoiding the repeated lookup helps keep that path cheaper.

Local micro-benchmark for 1,000,000 repeated checks, median of 7 runs:

| Check | Before | After |
| --- | ---: | ---: |
| get mutator | 135.6ms | 75.8ms |
| set mutator | 146.8ms | 76.9ms |
| missing get mutator | 161.2ms | 78.7ms |
| missing set mutator | 157.6ms | 75.5ms |

The cache is keyed by model class, so one model's mutator result cannot leak into another model. No invalidation is needed because this only depends on methods declared on the model class, not on mutable model state.

Tests were added to cover class isolation for both get and set mutator checks.

Tests run:

- `./vendor/bin/phpunit tests/Database/DatabaseEloquentModelTest.php --filter testClassicMutatorChecksAreIsolatedPerClass`
- `./vendor/bin/phpunit tests/Database/DatabaseEloquentModelTest.php`
- `./vendor/bin/phpunit tests/Database`
