### PR TITLE
[13.x] Expose jobs processed count and last job timestamp on the WorkerStopping event

### DIFF
--- a/src/Illuminate/Queue/Events/WorkerStopping.php
+++ b/src/Illuminate/Queue/Events/WorkerStopping.php
@@ -10,11 +10,15 @@ class WorkerStopping
      * @param  int  $status  The worker exit status.
      * @param  \Illuminate\Queue\WorkerOptions|null  $workerOptions  The worker options.
      * @param  \Illuminate\Queue\WorkerStopReason|null  $reason  The reason why the worker is stopping.
+     * @param  int|null  $jobsProcessed  The number of jobs processed by the worker.
+     * @param  float|null  $lastJobProcessedAt  The timestamp of the last job processed by the worker.
      */
     public function __construct(
         public $status = 0,
         public $workerOptions = null,
         public $reason = null,
+        public $jobsProcessed = null,
+        public $lastJobProcessedAt = null,
     ) {
     }
 }

--- a/src/Illuminate/Queue/Events/WorkerStopping.php
+++ b/src/Illuminate/Queue/Events/WorkerStopping.php
@@ -11,7 +11,7 @@ class WorkerStopping
      * @param  \Illuminate\Queue\WorkerOptions|null  $workerOptions  The worker options.
      * @param  \Illuminate\Queue\WorkerStopReason|null  $reason  The reason why the worker is stopping.
      * @param  int|null  $jobsProcessed  The number of jobs processed by the worker.
-     * @param  float|null  $lastJobProcessedAt  The timestamp of the last job processed by the worker.
+     * @param  int|float|null  $lastJobProcessedAt  The timestamp of the last job processed by the worker.
      */
     public function __construct(
         public $status = 0,

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -93,7 +93,7 @@ class Worker
     /**
      * The timestamp of the last job processed by the worker.
      *
-     * @var float|null
+     * @var int|float|null
      */
     protected $lastJobProcessedAt;
 

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -84,6 +84,20 @@ class Worker
     protected $resetScope;
 
     /**
+     * The number of jobs processed by the worker.
+     *
+     * @var int|null
+     */
+    protected $jobsProcessed;
+
+    /**
+     * The timestamp of the last job processed by the worker.
+     *
+     * @var float|null
+     */
+    protected $lastJobProcessedAt;
+
+    /**
      * The job currently being processed.
      *
      * @var \Illuminate\Contracts\Queue\Job|null
@@ -199,9 +213,11 @@ class Worker
 
         $lastRestart = $this->getTimestampOfLastQueueRestart();
 
-        [$startTime, $jobsProcessed] = [$this->currentTime(), 0];
+        $startTime = $this->currentTime();
 
-        $lastJobProcessedAt = $startTime;
+        $this->jobsProcessed = 0;
+
+        $this->lastJobProcessedAt = $startTime;
 
         $this->raiseWorkerStartingEvent($connectionName, $queue, $options);
 
@@ -210,9 +226,7 @@ class Worker
             // if it is we will just pause this worker for a given amount of time and
             // make sure we do not need to kill this worker process off completely.
             if (! $this->daemonShouldRun($options, $connectionName, $queue)) {
-                [$status, $reason] = $this->pauseWorker(
-                    $options, $lastRestart, $startTime, $jobsProcessed, $lastJobProcessedAt
-                );
+                [$status, $reason] = $this->pauseWorker($options, $lastRestart, $startTime);
 
                 if (! is_null($status)) {
                     return $this->stop($status, $options, $reason);
@@ -240,11 +254,11 @@ class Worker
             // fire off this job for processing. Otherwise, we will need to sleep the
             // worker so no more jobs are processed until they should be processed.
             if ($job) {
-                $jobsProcessed++;
+                $this->jobsProcessed++;
 
                 $this->runJob($job, $connectionName, $options);
 
-                $lastJobProcessedAt = $this->currentTime();
+                $this->lastJobProcessedAt = $this->currentTime();
 
                 if ($options->rest > 0) {
                     $this->sleep($options->rest);
@@ -262,9 +276,7 @@ class Worker
             // Finally, we will check to see if we have exceeded our memory limits or if
             // the queue should restart based on other indications. If so, we'll stop
             // this worker and let whatever is "monitoring" it restart the process.
-            [$status, $reason] = $this->stopIfNecessary(
-                $options, $lastRestart, $startTime, $jobsProcessed, $job, $lastJobProcessedAt
-            );
+            [$status, $reason] = $this->stopIfNecessary($options, $lastRestart, $startTime, $job);
 
             if (! is_null($status)) {
                 return $this->stop($status, $options, $reason);
@@ -354,15 +366,13 @@ class Worker
      * @param  \Illuminate\Queue\WorkerOptions  $options
      * @param  int  $lastRestart
      * @param  int|float  $startTime
-     * @param  int  $jobsProcessed
-     * @param  int|float|null  $lastJobProcessedAt
      * @return array|null
      */
-    protected function pauseWorker(WorkerOptions $options, $lastRestart, $startTime = 0, $jobsProcessed = 0, $lastJobProcessedAt = null)
+    protected function pauseWorker(WorkerOptions $options, $lastRestart, $startTime = 0)
     {
         $this->sleep($options->sleep > 0 ? $options->sleep : 1);
 
-        return $this->stopIfNecessary($options, $lastRestart, $startTime, $jobsProcessed, null, $lastJobProcessedAt);
+        return $this->stopIfNecessary($options, $lastRestart, $startTime);
     }
 
     /**
@@ -371,12 +381,10 @@ class Worker
      * @param  \Illuminate\Queue\WorkerOptions  $options
      * @param  int  $lastRestart
      * @param  int  $startTime
-     * @param  int  $jobsProcessed
      * @param  mixed  $job
-     * @param  int|float|null  $lastJobProcessedAt
      * @return array|null
      */
-    protected function stopIfNecessary(WorkerOptions $options, $lastRestart, $startTime = 0, $jobsProcessed = 0, $job = null, $lastJobProcessedAt = null)
+    protected function stopIfNecessary(WorkerOptions $options, $lastRestart, $startTime = 0, $job = null)
     {
         return match (true) {
             $this->lostConnection => [static::EXIT_SUCCESS, WorkerStopReason::LostConnection],
@@ -384,9 +392,9 @@ class Worker
             $this->memoryExceeded($options->memory) => [static::$memoryExceededExitCode ?? static::EXIT_MEMORY_LIMIT, WorkerStopReason::MaxMemoryExceeded],
             $this->queueShouldRestart($lastRestart) => [static::EXIT_SUCCESS, WorkerStopReason::ReceivedRestartSignal],
             $options->stopWhenEmpty && is_null($job) => [static::EXIT_SUCCESS, WorkerStopReason::QueueEmpty],
-            $options->stopWhenEmptyFor && is_null($job) && $this->currentTime() - ($lastJobProcessedAt ?? $startTime) >= $options->stopWhenEmptyFor => [static::EXIT_SUCCESS, WorkerStopReason::QueueEmptyFor],
+            $options->stopWhenEmptyFor && is_null($job) && $this->currentTime() - ($this->lastJobProcessedAt ?? $startTime) >= $options->stopWhenEmptyFor => [static::EXIT_SUCCESS, WorkerStopReason::QueueEmptyFor],
             $options->maxTime && $this->currentTime() - $startTime >= $options->maxTime => [static::EXIT_SUCCESS, WorkerStopReason::MaxTimeExceeded],
-            $options->maxJobs && $jobsProcessed >= $options->maxJobs => [static::EXIT_SUCCESS, WorkerStopReason::MaxJobsExceeded],
+            $options->maxJobs && $this->jobsProcessed >= $options->maxJobs => [static::EXIT_SUCCESS, WorkerStopReason::MaxJobsExceeded],
             default => null
         };
     }
@@ -960,7 +968,7 @@ class Worker
      */
     public function stop($status = 0, $options = null, $reason = null)
     {
-        $this->events->dispatch(new WorkerStopping($status, $options, $reason));
+        $this->events->dispatch(new WorkerStopping($status, $options, $reason, $this->jobsProcessed, $this->lastJobProcessedAt));
 
         return $status;
     }
@@ -975,7 +983,7 @@ class Worker
      */
     public function kill($status = 0, $options = null, $reason = null)
     {
-        $this->events->dispatch(new WorkerStopping($status, $options, $reason));
+        $this->events->dispatch(new WorkerStopping($status, $options, $reason, $this->jobsProcessed, $this->lastJobProcessedAt));
 
         if (extension_loaded('posix')) {
             posix_kill(getmypid(), SIGKILL);

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -556,7 +556,9 @@ class QueueWorkerTest extends TestCase
             return $event instanceof WorkerStopping
                 && $event->status === 0
                 && $event->workerOptions === $workerOptions
-                && $event->reason === WorkerStopReason::QueueEmpty;
+                && $event->reason === WorkerStopReason::QueueEmpty
+                && $event->jobsProcessed === 2
+                && $event->lastJobProcessedAt !== null;
         }));
     }
 


### PR DESCRIPTION
This PR passes `jobsProcessed` and `lastJobProcessedAt` to the `WorkerStopping` event

The worker itself already tracks how many jobs it processes and when one was last processed etc internally, but its not exposed explicitly to any events.  Yes we can track it from other events, but piecing it together observability wise can be painful.

Exposing these values makes it easier to understand  a worker's lifecycle when it stops, ie we can correlate shutdowns with memory running out to how many jobs it ran (ie perhaps theres a memory leak), and generally be more informed about options  like `max-time` or `stop-when-empty-for` so we can see when to raise / lower set options etc..  

I've had to make them properties, because of the kill() method and since they're properties it's stopped passing them around which is nicer I think?

No B/C afaik cus all these method previous changed via https://github.com/laravel/framework/commit/29e5b70109f4e2eb61de719f4f2a664acea65774 also in 13.x  (but happy to move to 14.x if u prefer)

Feel free to change or throw away, it was something I thought would be nice to see as a glance rather than chase other bits and piece together the timeline basically    

(I also have one more idea about adding `peakMemoryUsage` to the event in a diff PR, mainly so we can see the amount of memory it used before it was stopped via telemetry too, idk if you like that idea, but im open to ur thoughts ofc 🫡  )