### PR TITLE
[13.x] Handle api / json routes with Down (Maintenance) command

### DIFF
--- a/src/Illuminate/Foundation/Console/DownCommand.php
+++ b/src/Illuminate/Foundation/Console/DownCommand.php
@@ -9,6 +9,7 @@ use Illuminate\Console\Command;
 use Illuminate\Foundation\Events\MaintenanceModeEnabled;
 use Illuminate\Foundation\Exceptions\RegisterErrorViewPaths;
 use Illuminate\Foundation\Http\Middleware\PreventRequestsDuringMaintenance;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -28,7 +29,8 @@ class DownCommand extends Command
                                  {--refresh= : The number of seconds after which the browser may refresh}
                                  {--secret= : The secret phrase that may be used to bypass maintenance mode}
                                  {--with-secret : Generate a random secret phrase that may be used to bypass maintenance mode}
-                                 {--status=503 : The status code that should be used when returning the maintenance mode response}';
+                                 {--status=503 : The status code that should be used when returning the maintenance mode response}
+                                 {--ignore=* : The paths to ignore and allow the framework to handle}';
 
     /**
      * The console command description.
@@ -86,7 +88,8 @@ class DownCommand extends Command
     protected function getDownFilePayload()
     {
         return [
-            'except' => $this->excludedPaths(),
+            'except' => $this->ignoredAndExcludedPaths(),
+            'ignore' => $this->ignoredPaths(),
             'redirect' => $this->redirectPath(),
             'retry' => $this->getRetryTime(),
             'refresh' => $this->option('refresh'),
@@ -94,6 +97,16 @@ class DownCommand extends Command
             'status' => (int) ($this->option('status') ?? 503),
             'template' => $this->option('render') ? $this->prerenderView() : null,
         ];
+    }
+
+    /**
+     * Get the paths that should be ignored and passed to the framework
+     *
+     * @return array
+     */
+    protected function ignoredPaths()
+    {
+        return $this->option('ignore') ?? [];
     }
 
     /**
@@ -112,6 +125,17 @@ class DownCommand extends Command
                 return [];
             }
         }
+    }
+
+    /**
+     * Get the paths that should be excluded from maintenance
+     * or ignored and passed to the framework.
+     *
+     * @return array
+     */
+    protected function ignoredAndExcludedPaths()
+    {
+        return array_merge($this->ignoredPaths(), $this->excludedPaths());
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/DownCommand.php
+++ b/src/Illuminate/Foundation/Console/DownCommand.php
@@ -28,8 +28,7 @@ class DownCommand extends Command
                                  {--refresh= : The number of seconds after which the browser may refresh}
                                  {--secret= : The secret phrase that may be used to bypass maintenance mode}
                                  {--with-secret : Generate a random secret phrase that may be used to bypass maintenance mode}
-                                 {--status=503 : The status code that should be used when returning the maintenance mode response}
-                                 {--ignore=* : The paths to ignore and allow the framework to handle}';
+                                 {--status=503 : The status code that should be used when returning the maintenance mode response}';
 
     /**
      * The console command description.
@@ -87,8 +86,7 @@ class DownCommand extends Command
     protected function getDownFilePayload()
     {
         return [
-            'except' => $this->ignoredAndExcludedPaths(),
-            'ignore' => $this->ignoredPaths(),
+            'except' => $this->excludedPaths(),
             'redirect' => $this->redirectPath(),
             'retry' => $this->getRetryTime(),
             'refresh' => $this->option('refresh'),
@@ -96,16 +94,6 @@ class DownCommand extends Command
             'status' => (int) ($this->option('status') ?? 503),
             'template' => $this->option('render') ? $this->prerenderView() : null,
         ];
-    }
-
-    /**
-     * Get the paths that should be ignored and passed to the framework.
-     *
-     * @return array
-     */
-    protected function ignoredPaths()
-    {
-        return $this->option('ignore') ?? [];
     }
 
     /**
@@ -124,17 +112,6 @@ class DownCommand extends Command
                 return [];
             }
         }
-    }
-
-    /**
-     * Get the paths that should be excluded from maintenance
-     * or ignored and passed to the framework.
-     *
-     * @return array
-     */
-    protected function ignoredAndExcludedPaths()
-    {
-        return array_merge($this->ignoredPaths(), $this->excludedPaths());
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/DownCommand.php
+++ b/src/Illuminate/Foundation/Console/DownCommand.php
@@ -9,7 +9,6 @@ use Illuminate\Console\Command;
 use Illuminate\Foundation\Events\MaintenanceModeEnabled;
 use Illuminate\Foundation\Exceptions\RegisterErrorViewPaths;
 use Illuminate\Foundation\Http\Middleware\PreventRequestsDuringMaintenance;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -100,7 +99,7 @@ class DownCommand extends Command
     }
 
     /**
-     * Get the paths that should be ignored and passed to the framework
+     * Get the paths that should be ignored and passed to the framework.
      *
      * @return array
      */

--- a/src/Illuminate/Foundation/Console/stubs/maintenance-mode.stub
+++ b/src/Illuminate/Foundation/Console/stubs/maintenance-mode.stub
@@ -8,6 +8,21 @@ if (! file_exists($down = __DIR__.'/down')) {
 // Decode the "down" file's JSON...
 $data = json_decode(file_get_contents($down), true);
 
+$expectsJson = (function () {
+    $acceptable = array_map('trim', explode(',', $_SERVER['HTTP_ACCEPT'] ?? ''));
+
+    $firstAcceptable = strtolower(strtok($acceptable[0] ?? '', ';'));
+
+    if (str_contains($firstAcceptable, '/json') || str_contains($firstAcceptable, '+json')) {
+        return true;
+    }
+
+    return isset($_SERVER['HTTP_X_REQUESTED_WITH']) &&
+        strcasecmp($_SERVER['HTTP_X_REQUESTED_WITH'], 'XMLHttpRequest') === 0 &&
+        (! isset($_SERVER['HTTP_X_PJAX']) || strcasecmp($_SERVER['HTTP_X_PJAX'], 'true') !== 0) &&
+        in_array($firstAcceptable, ['', '*/*', '*'], true);
+})();
+
 // Allow framework to handle request if no prerendered template...
 if (! isset($data['template'])) {
     return;
@@ -52,6 +67,11 @@ if (isset($_COOKIE['laravel_maintenance']) && isset($data['secret'])) {
         (int) $payload['expires_at'] >= time()) {
         return;
     }
+}
+
+// Allow framework to handle requests expecting a JSON response...
+if ($expectsJson) {
+    return;
 }
 
 // Redirect to the proper path if necessary...

--- a/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
+++ b/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
@@ -80,7 +80,7 @@ class PreventRequestsDuringMaintenance
                 return $next($request);
             }
 
-            if (isset($data['redirect'])) {
+            if (isset($data['redirect']) && ! $request->expectsJson()) {
                 $path = $data['redirect'] === '/'
                     ? $data['redirect']
                     : trim($data['redirect'], '/');
@@ -90,7 +90,7 @@ class PreventRequestsDuringMaintenance
                 }
             }
 
-            if (isset($data['template']) && ! $this->inIgnoreArray($request, $data)) {
+            if (isset($data['template']) && ! $request->expectsJson()) {
                 return response(
                     $data['template'],
                     $data['status'] ?? 503,
@@ -107,25 +107,6 @@ class PreventRequestsDuringMaintenance
         }
 
         return $next($request);
-    }
-
-    protected function inIgnoreArray($request, array $data)
-    {
-        if (! isset($data['ignore']) || ! is_array($data['ignore'])) {
-            return false;
-        }
-
-        foreach ($data['ignore'] as $ignore) {
-            if ($ignore !== '/') {
-                $ignore = trim($ignore, '/');
-            }
-
-            if ($request->fullUrlIs($ignore) || $request->is($ignore)) {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     /**

--- a/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
+++ b/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
@@ -90,7 +90,7 @@ class PreventRequestsDuringMaintenance
                 }
             }
 
-            if (isset($data['template'])) {
+            if (isset($data['template']) && ! $this->inIgnoreArray($request, $data) ) {
                 return response(
                     $data['template'],
                     $data['status'] ?? 503,
@@ -107,6 +107,25 @@ class PreventRequestsDuringMaintenance
         }
 
         return $next($request);
+    }
+
+    protected function inIgnoreArray($request, array $data)
+    {
+        if ( ! isset($data['ignore']) || ! is_array($data['ignore']) ) {
+            return false;
+        }
+
+        foreach ($data['ignore'] as $ignore) {
+            if ($ignore !== '/') {
+                $ignore = trim($ignore, '/');
+            }
+
+            if ($request->fullUrlIs($ignore) || $request->is($ignore)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
+++ b/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
@@ -90,7 +90,7 @@ class PreventRequestsDuringMaintenance
                 }
             }
 
-            if (isset($data['template']) && ! $this->inIgnoreArray($request, $data) ) {
+            if (isset($data['template']) && ! $this->inIgnoreArray($request, $data)) {
                 return response(
                     $data['template'],
                     $data['status'] ?? 503,
@@ -111,7 +111,7 @@ class PreventRequestsDuringMaintenance
 
     protected function inIgnoreArray($request, array $data)
     {
-        if ( ! isset($data['ignore']) || ! is_array($data['ignore']) ) {
+        if (! isset($data['ignore']) || ! is_array($data['ignore'])) {
             return false;
         }
 

--- a/tests/Integration/Foundation/MaintenanceModeTest.php
+++ b/tests/Integration/Foundation/MaintenanceModeTest.php
@@ -22,6 +22,7 @@ class MaintenanceModeTest extends TestCase
     {
         $this->beforeApplicationDestroyed(function () {
             @unlink(storage_path('framework/down'));
+            @unlink(storage_path('framework/maintenance.php'));
         });
 
         parent::setUp();
@@ -78,6 +79,67 @@ class MaintenanceModeTest extends TestCase
         $response->assertStatus(503);
         $response->assertHeader('Retry-After', '60');
         $this->assertSame('Rendered Content', $response->original);
+    }
+
+    public function testMaintenanceModeDoesNotUseCustomTemplateForJsonRequests()
+    {
+        file_put_contents(storage_path('framework/down'), json_encode([
+            'retry' => 60,
+            'template' => 'Rendered Content',
+        ]));
+
+        Route::get('/foo', function () {
+            return 'Hello World';
+        })->middleware(PreventRequestsDuringMaintenance::class);
+
+        $response = $this->getJson('/foo');
+
+        $response->assertStatus(503);
+        $response->assertHeader('Retry-After', '60');
+        $response->assertJson(['message' => 'Service Unavailable']);
+    }
+
+    public function testMaintenanceModeDoesNotRedirectJsonRequests()
+    {
+        file_put_contents(storage_path('framework/down'), json_encode([
+            'redirect' => '/maintenance',
+        ]));
+
+        Route::get('/foo', function () {
+            return 'Hello World';
+        })->middleware(PreventRequestsDuringMaintenance::class);
+
+        $response = $this->getJson('/foo');
+
+        $response->assertStatus(503);
+        $response->assertJson(['message' => 'Service Unavailable']);
+    }
+
+    public function testPrerenderedMaintenanceFileAllowsJsonRequestsToReachFramework()
+    {
+        file_put_contents(storage_path('framework/down'), json_encode([
+            'template' => 'Rendered Content',
+        ]));
+
+        file_put_contents(
+            storage_path('framework/maintenance.php'),
+            file_get_contents(__DIR__.'/../../../src/Illuminate/Foundation/Console/stubs/maintenance-mode.stub')
+        );
+
+        $server = $_SERVER;
+
+        try {
+            $_SERVER['REQUEST_URI'] = '/foo';
+            $_SERVER['HTTP_ACCEPT'] = 'application/json';
+
+            ob_start();
+            include storage_path('framework/maintenance.php');
+            $output = ob_get_clean();
+        } finally {
+            $_SERVER = $server;
+        }
+
+        $this->assertSame('', $output);
     }
 
     public function testMaintenanceModeCanRedirectWithBypassCookie()


### PR DESCRIPTION
On our application we occasionally use `--render` or `--redirect` with maintenance mode during scheduled maintenance. For example `php artisan down --render=errors.503-scheduled` shows a pre-planned maintenance template rather than the application default (unexpected outage).

The issue is that the Laravel `storage/framework/maintenance.php` file always spits that out, regardless if the client (in this case our mobile app) is expecting JSON rather than HTML. 

This would be the same if a redirect was intended for web and would break API / mobile clients that are expecting JSON.

This PR adds an `--ignore=*` option to the DownCommand. Paths or patterns here will skip the `storage/framework/maintenance.php` catch and instead refer to the framework `PreventRequestsDuringMaintenance` middleware. This will only render the template if the request path is not in the ignore array. Tested this works as expected by returning JSON on `api/users` and the custom view on `/` when I run:

```
php artisan down --render=errors.503-scheduled --ignore="api/*"
```

Note: This merges both ignore and except into the `data['except']` (`down` file) to avoid a non-framework Laravel change / upgrade.
