### PR TITLE
Use translation function for unauthorized message

### DIFF
--- a/src/Illuminate/Auth/Access/AuthorizationException.php
+++ b/src/Illuminate/Auth/Access/AuthorizationException.php
@@ -30,7 +30,7 @@ class AuthorizationException extends Exception
      */
     public function __construct($message = null, $code = null, ?Throwable $previous = null)
     {
-        parent::__construct($message ?? 'This action is unauthorized.', 0, $previous);
+        parent::__construct($message ?? __('This action is unauthorized.'), 0, $previous);
 
         $this->code = $code ?: 0;
     }


### PR DESCRIPTION
This pull request updates the `AuthorizationException` class to ensure that the default unauthorized message is translatable. Now, when no custom message is provided, the exception uses Laravel's translation function to allow for localization.

Localization improvement:

* Updated the default exception message in the `AuthorizationException` constructor to use the `__()` translation helper, enabling the message to be localized. (`src/Illuminate/Auth/Access/AuthorizationException.php`)
