### PR TITLE
[13.x] Refactor: add ?:

### DIFF
--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -284,8 +284,6 @@ if (! function_exists('when')) {
     {
         $condition = $condition instanceof Closure ? $condition() : $condition;
 
-        return $condition
-            ? value($value, $condition)
-            : value($default, $condition);
+        return value($condition ? $value : $default, $condition);
     }
 }

--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -284,10 +284,8 @@ if (! function_exists('when')) {
     {
         $condition = $condition instanceof Closure ? $condition() : $condition;
 
-        if ($condition) {
-            return value($value, $condition);
-        }
-
-        return value($default, $condition);
+        return $condition
+            ? value($value, $condition)
+            : value($default, $condition);
     }
 }


### PR DESCRIPTION
Simplify `when()` using ternary operator

Refactored the `when()` helper to replace the `if/return` block with a single ternary expression, reducing unnecessary lines while keeping the same behavior.