### PR TITLE
[13.x] Feat: add `created()` and `success()` and `notFound()`

### DIFF
--- a/src/Illuminate/Routing/ResponseFactory.php
+++ b/src/Illuminate/Routing/ResponseFactory.php
@@ -62,6 +62,42 @@ class ResponseFactory implements FactoryContract
     }
 
     /**
+     * Create a new "created" response.
+     *
+     * @param  string  $content
+     * @param  array  $headers
+     * @return \Illuminate\Http\Response
+     */
+    public function created($content = '', array $headers = [])
+    {
+        return $this->make($content, 201, $headers);
+    }
+
+    /**
+     * Create a new "success" response.
+     *
+     * @param  string  $content
+     * @param  array  $headers
+     * @return \Illuminate\Http\Response
+     */
+    public function success($content = '', array $headers = [])
+    {
+        return $this->make($content, 200, $headers);
+    }
+
+    /**
+     * Create a new "not found" response.
+     *
+     * @param  string  $content
+     * @param  array  $headers
+     * @return \Illuminate\Http\Response
+     */
+    public function notFound($content = '', array $headers = [])
+    {
+        return $this->make($content, 404, $headers);
+    }
+
+    /**
      * Create a new "no content" response.
      *
      * @param  int  $status


### PR DESCRIPTION
**Add `created()`, `success()`, and `notFound()` methods to `ResponseFactory`**

Adds three expressive shorthand methods to `ResponseFactory` (and its `Factory` contract), consistent with the existing `noContent()` pattern.

**Usage**

```php
response()->created($content, $headers);  // 201
response()->success($content, $headers);  // 200
response()->notFound($content, $headers); // 404
```

**Motivation**

Closes the gap left by having `noContent()` for `204` but no equivalents for other common status codes, eliminating the need for verbose `response('', Response::HTTP_*)` calls.

**Changes**
- Added `success()`, `created()`, `notFound()` to `ResponseFactory` and the `Factory` contract