### PR TITLE
[13.x] Refactor: add `@throws`

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastEvent.php
+++ b/src/Illuminate/Broadcasting/BroadcastEvent.php
@@ -119,6 +119,8 @@ class BroadcastEvent implements ShouldQueue
      *
      * @param  mixed  $event
      * @return array
+     *
+     * @throws \ReflectionException
      */
     protected function getPayloadFromEvent($event)
     {

--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -251,6 +251,8 @@ class Application extends SymfonyApplication implements ApplicationContract
      *
      * @param  \Illuminate\Console\Command|string  $command
      * @return \Symfony\Component\Console\Command\Command|null
+     *
+     * @throws \ReflectionException
      */
     public function resolve($command)
     {

--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -332,6 +332,8 @@ class ScheduleListCommand extends Command
      *
      * @param  \Illuminate\Console\Scheduling\CallbackEvent  $event
      * @return string
+     *
+     * @throws \ReflectionException
      */
     private function getClosureLocation(CallbackEvent $event)
     {

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -257,6 +257,8 @@ class RouteListCommand extends Command
      *
      * @param  \Illuminate\Routing\Route  $route
      * @return bool
+     *
+     * @throws \ReflectionException
      */
     protected function isVendorRoute(Route $route)
     {

--- a/src/Illuminate/Foundation/Exceptions/Renderer/Mappers/BladeMapper.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/Mappers/BladeMapper.php
@@ -115,6 +115,8 @@ class BladeMapper
      * Get the list of known paths from the compiler engine.
      *
      * @return array<string, string>
+     *
+     * @throws \ReflectionException
      */
     protected function getKnownPaths()
     {

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
@@ -218,6 +218,8 @@ trait InteractsWithTestCaseLifecycle
      * Boot the testing helper traits.
      *
      * @return array
+     *
+     * @throws \ReflectionException
      */
     protected function setUpTraits()
     {

--- a/src/Illuminate/Queue/Console/ClearCommand.php
+++ b/src/Illuminate/Queue/Console/ClearCommand.php
@@ -35,6 +35,8 @@ class ClearCommand extends Command
      * Execute the console command.
      *
      * @return int|null
+     *
+     * @throws \ReflectionException
      */
     public function handle()
     {

--- a/src/Illuminate/Routing/ResolvesRouteDependencies.php
+++ b/src/Illuminate/Routing/ResolvesRouteDependencies.php
@@ -72,6 +72,8 @@ trait ResolvesRouteDependencies
      * @param  array  $parameters
      * @param  object  $skippableValue
      * @return mixed
+     *
+     * @throws \ReflectionException
      */
     protected function transformDependency(ReflectionParameter $parameter, $parameters, $skippableValue)
     {


### PR DESCRIPTION
**Follow-up to #60436 — Add `@throws \ReflectionException` to remaining methods**

Adds missing `* @throws \ReflectionException` docblock annotations to all methods that were not covered in #60436.

**Changes**
- Added `@throws \ReflectionException` to all remaining unannotated methods