### PR TITLE
refactor: add `match()`

### DIFF
--- a/src/Illuminate/Auth/DatabaseUserProvider.php
+++ b/src/Illuminate/Auth/DatabaseUserProvider.php
@@ -115,13 +115,11 @@ class DatabaseUserProvider implements UserProvider
         $query = $this->connection->table($this->table);
 
         foreach ($credentials as $key => $value) {
-            if (is_array($value) || $value instanceof Arrayable) {
-                $query->whereIn($key, $value);
-            } elseif ($value instanceof Closure) {
-                $value($query);
-            } else {
-                $query->where($key, $value);
-            }
+            match (true) {
+                is_array($value) || $value instanceof Arrayable => $query->whereIn($key, $value),
+                $value instanceof Closure => $value($query),
+                default => $query->where($key, $value),
+            };
         }
 
         // Now we are ready to execute the query to see if we have a user matching

--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -126,13 +126,11 @@ class EloquentUserProvider implements UserProvider
         $query = $this->newModelQuery();
 
         foreach ($credentials as $key => $value) {
-            if (is_array($value) || $value instanceof Arrayable) {
-                $query->whereIn($key, $value);
-            } elseif ($value instanceof Closure) {
-                $value($query);
-            } else {
-                $query->where($key, $value);
-            }
+            match (true) {
+                is_array($value) || $value instanceof Arrayable => $query->whereIn($key, $value),
+                $value instanceof Closure => $value($query),
+                default => $query->where($key, $value),
+            };
         }
 
         return $query->first();

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -463,13 +463,11 @@ class MySqlGrammar extends Grammar
      */
     protected function compileJsonUpdateColumn($key, $value)
     {
-        if (is_bool($value)) {
-            $value = $value ? 'true' : 'false';
-        } elseif (is_array($value)) {
-            $value = 'cast(? as json)';
-        } else {
-            $value = $this->parameter($value);
-        }
+        $value = match (true) {
+            is_bool($value) => $value ? 'true' : 'false',
+            is_array($value) => 'cast(? as json)',
+            default => $this->parameter($value),
+        };
 
         [$field, $path] = $this->wrapJsonFieldAndPath($key);
 


### PR DESCRIPTION
**Refactor `if/elseif/else` chains to `match` expressions**

Replaces verbose `if/elseif/else` blocks with `match(true)` expressions where applicable, improving readability and consistency.

**Example**
```php
// Before
if (is_array($value) || $value instanceof Arrayable) {
    $query->whereIn($key, $value);
} elseif ($value instanceof Closure) {
    $value($query);
} else {
    $query->where($key, $value);
}

// After
match (true) {
    is_array($value) || $value instanceof Arrayable => $query->whereIn($key, $value),
    $value instanceof Closure => $value($query),
    default => $query->where($key, $value),
};
```

**Changes**
- Replaced `if/elseif/else` chains with `match(true)` across affected files