### PR TITLE
Fix mutable promise chaining in FluentPromise and LazyPromise

### DIFF
--- a/src/Illuminate/Http/Client/Promises/FluentPromise.php
+++ b/src/Illuminate/Http/Client/Promises/FluentPromise.php
@@ -88,8 +88,6 @@ class FluentPromise implements PromiseInterface
             return $result;
         }
 
-        $this->guzzlePromise = $result;
-
-        return $this;
+        return new static($result);
     }
 }

--- a/src/Illuminate/Http/Client/Promises/LazyPromise.php
+++ b/src/Illuminate/Http/Client/Promises/LazyPromise.php
@@ -59,9 +59,10 @@ class LazyPromise implements PromiseInterface
     public function then(?callable $onFulfilled = null, ?callable $onRejected = null): PromiseInterface
     {
         if ($this->promiseNeedsBuilt()) {
-            $this->pending[] = static fn (PromiseInterface $promise) => $promise->then($onFulfilled, $onRejected);
-
-            return $this;
+            return new self(function () use ($onFulfilled, $onRejected) {
+                return ($this->promiseNeedsBuilt() ? $this->buildPromise() : $this->guzzlePromise)
+                    ->then($onFulfilled, $onRejected);
+            });
         }
 
         return $this->guzzlePromise->then($onFulfilled, $onRejected);

--- a/tests/Http/Promises/FluentPromiseTest.php
+++ b/tests/Http/Promises/FluentPromiseTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Illuminate\Tests\Http\Client\Promises;
+
+use GuzzleHttp\Promise\Promise;
+use GuzzleHttp\Promise\PromiseInterface;
+use Illuminate\Http\Client\Promises\FluentPromise;
+use PHPUnit\Framework\TestCase;
+
+class FluentPromiseTest extends TestCase
+{
+    public function test_then_returns_new_instance(): void
+    {
+        $guzzlePromise = new Promise();
+        $fluent = new FluentPromise($guzzlePromise);
+
+        $chained = $fluent->then(fn ($v) => $v);
+
+        $this->assertNotSame($fluent, $chained);
+        $this->assertInstanceOf(FluentPromise::class, $chained);
+    }
+
+    public function test_otherwise_returns_new_instance(): void
+    {
+        $guzzlePromise = new Promise();
+        $fluent = new FluentPromise($guzzlePromise);
+
+        $chained = $fluent->otherwise(fn ($v) => $v);
+
+        $this->assertNotSame($fluent, $chained);
+        $this->assertInstanceOf(FluentPromise::class, $chained);
+    }
+
+    public function test_chained_then_calls_return_distinct_instances(): void
+    {
+        $guzzlePromise = new Promise();
+        $fluent = new FluentPromise($guzzlePromise);
+
+        $promise1 = $fluent->then(fn ($v) => $v);
+        $promise2 = $fluent->then(fn ($v) => 'one');
+        $promise3 = $promise2->then(fn ($v) => 'two');
+
+        $this->assertNotSame($promise1, $promise2);
+        $this->assertNotSame($promise2, $promise3);
+        $this->assertNotSame($promise1, $promise3);
+    }
+
+    public function test_then_chain_resolves_correct_values(): void
+    {
+        $guzzlePromise = new Promise();
+        $fluent = new FluentPromise($guzzlePromise);
+
+        $result1 = null;
+        $result2 = null;
+        $result3 = null;
+
+        $promise1 = $fluent->then(function ($v) use (&$result1) {
+            $result1 = $v;
+            return $v * 2;
+        });
+
+        $promise2 = $promise1->then(function ($v) use (&$result2) {
+            $result2 = $v;
+            return $v + 1;
+        });
+
+        $promise3 = $promise2->then(function ($v) use (&$result3) {
+            $result3 = $v;
+            return $v;
+        });
+
+        $guzzlePromise->resolve(5);
+        $promise3->wait(false);
+
+        $this->assertSame(5, $result1);   // отримав вихідне значення
+        $this->assertSame(10, $result2);  // отримав 5 * 2
+        $this->assertSame(11, $result3);  // отримав 10 + 1
+    }
+
+    public function test_underlying_guzzle_promise_differs_per_chain(): void
+    {
+        $guzzlePromise = new Promise();
+        $fluent = new FluentPromise($guzzlePromise);
+
+        $p1 = $fluent->then(fn ($v) => $v);
+        $p2 = $fluent->then(fn ($v) => $v);
+
+        $this->assertNotSame($p1->getGuzzlePromise(), $p2->getGuzzlePromise());
+    }
+}

--- a/tests/Http/Promises/LazyPromiseTest.php
+++ b/tests/Http/Promises/LazyPromiseTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Illuminate\Tests\Http\Client\Promises;
+
+use GuzzleHttp\Promise\Promise;
+use GuzzleHttp\Promise\PromiseInterface;
+use Illuminate\Http\Client\Promises\LazyPromise;
+use PHPUnit\Framework\TestCase;
+
+class LazyPromiseTest extends TestCase
+{
+    private function makeLazy(mixed $resolveWith = 'value'): LazyPromise
+    {
+        return new LazyPromise(function () use ($resolveWith) {
+            $p = new Promise();
+            $p->resolve($resolveWith);
+            return $p;
+        });
+    }
+
+    public function test_then_before_build_returns_new_instance(): void
+    {
+        $lazy = $this->makeLazy();
+
+        $chained = $lazy->then(fn ($v) => $v);
+
+        $this->assertNotSame($lazy, $chained);
+        $this->assertInstanceOf(LazyPromise::class, $chained);
+    }
+
+    public function test_otherwise_before_build_returns_new_instance(): void
+    {
+        $lazy = $this->makeLazy();
+
+        $chained = $lazy->otherwise(fn ($e) => null);
+
+        $this->assertNotSame($lazy, $chained);
+        $this->assertInstanceOf(LazyPromise::class, $chained);
+    }
+
+    public function test_chained_then_calls_return_distinct_instances(): void
+    {
+        $lazy = $this->makeLazy();
+
+        $p1 = $lazy->then(fn ($v) => $v);
+        $p2 = $lazy->then(fn ($v) => 'one');
+        $p3 = $p2->then(fn ($v) => 'two');
+
+        $this->assertNotSame($p1, $p2);
+        $this->assertNotSame($p2, $p3);
+        $this->assertNotSame($lazy, $p1);
+    }
+
+    public function test_chained_promises_resolve_correct_values(): void
+    {
+        $lazy = $this->makeLazy(10);
+
+        $promise1 = $lazy->then(fn ($v) => $v * 2);       // 20
+        $promise2 = $promise1->then(fn ($v) => $v + 5);   // 25
+        $promise3 = $promise2->then(fn ($v) => $v . '!'); // "25!"
+
+        $this->assertSame(20, $promise1->wait());
+        $this->assertSame(25, $promise2->wait());
+        $this->assertSame('25!', $promise3->wait());
+    }
+
+    public function test_parallel_then_chains_on_same_lazy_are_independent(): void
+    {
+        $lazy = $this->makeLazy(100);
+
+        $branchA = $lazy->then(fn ($v) => $v + 1);  // 101
+        $branchB = $lazy->then(fn ($v) => $v - 1);  // 99
+
+        $this->assertSame(101, $branchA->wait());
+        $this->assertSame(99, $branchB->wait());
+    }
+
+    public function test_then_after_build_returns_non_lazy_promise(): void
+    {
+        $lazy = $this->makeLazy('hello');
+        $lazy->buildPromise();
+
+        $result = $lazy->then(fn ($v) => strtoupper($v));
+
+
+        $this->assertNotInstanceOf(LazyPromise::class, $result);
+        $this->assertInstanceOf(PromiseInterface::class, $result);
+    }
+
+    public function test_wait_on_chained_builds_parent_lazily(): void
+    {
+        $built = false;
+
+        $lazy = new LazyPromise(function () use (&$built) {
+            $built = true;
+            $p = new Promise();
+            $p->resolve('done');
+            return $p;
+        });
+
+        $chained = $lazy->then(fn ($v) => $v . '!');
+
+        $this->assertFalse($built);
+
+        $result = $chained->wait();
+
+        $this->assertTrue($built);
+        $this->assertSame('done!', $result);
+    }
+}


### PR DESCRIPTION
FluentPromise::__call() was mutating $this->guzzlePromise and returning $this on every then()/otherwise() call, causing all chained variables to reference the same object. Fixed by returning new static($result) instead.

LazyPromise::then() and otherwise() were also returning $this when the underlying promise had not yet been built, and the pending[] callbacks were never chained — their return values were silently discarded. Replaced the pending[] mechanism with a new LazyPromise that lazily builds the parent and chains the callback on first wait(), restoring PromiseInterface immutability semantics.

Fixes: https://github.com/laravel/framework/issues/60196

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
