### PR TITLE
[13.x] Fix Str::password() throwing ValueError when all character types are disabled

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1075,6 +1075,7 @@ class Str
             'spaces' => $spaces === true ? [' '] : null,
         ]))
             ->filter()
+            ->whenEmpty(fn () => throw new \InvalidArgumentException('At least one character type must be enabled to generate a password.'))
             ->each(fn ($c) => $password->push($c[random_int(0, count($c) - 1)]))
             ->flatten();
 

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1050,7 +1050,7 @@ class Str
      * @param  bool  $numbers
      * @param  bool  $symbols
      * @param  bool  $spaces
-     * @return ($letters is false ? ($numbers is true ? ($symbols is false ? ($spaces is false ? numeric-string : string) : string) : string) : string)
+     * @return ($letters is false ? ($numbers is true ? ($symbols is false ? ($spaces is false ? numeric-string : string) : string) : ($symbols is false ? ($spaces is false ? never : string) : string)) : string)
      */
     public static function password($length = 32, $letters = true, $numbers = true, $symbols = true, $spaces = false)
     {

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1876,6 +1876,14 @@ class SupportStrTest extends TestCase
         );
     }
 
+    public function testPasswordThrowsWhenAllTypesDisabled()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('At least one character type must be enabled to generate a password.');
+
+        Str::password(32, letters: false, numbers: false, symbols: false, spaces: false);
+    }
+
     public function testToBase64()
     {
         $this->assertSame(base64_encode('foo'), Str::toBase64('foo'));


### PR DESCRIPTION
If you call `Str::password()` and explicitly turn off every single character type, it triggers an uncaught `ValueError` deep inside the method:

```php
Str::password(32, letters: false, numbers: false, symbols: false, spaces: false);
// ValueError: random_int(): Argument #1 ($min) must be <= $max

```

### Why This Happens

When you disable all the character options, the underlying `$options` collection ends up completely empty. Further down the line, the `Collection::times()` method tries to pull a random character using `random_int(0, $c->count() - 1)`.

Because the count is zero, that math evaluates to `random_int(0, -1)`. Since the minimum value is now greater than the maximum, PHP throws a `ValueError`.

### The Fix

Instead of letting it fail with a cryptic PHP error later on, we should catch this right after the `$options` are filtered. If the resulting set is empty, we immediately throw a descriptive `InvalidArgumentException` before any random generation even attempts to run.