### PR TITLE
[13x] Allow `Arr::exceptValues()` to handle enums

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -247,7 +247,7 @@ class Arr
      */
     public static function exceptValues($array, $values, $strict = false)
     {
-        $values = (array) $values;
+        $values = self::wrap($values);
 
         return array_filter($array, function ($value) use ($values, $strict) {
             return ! in_array($value, $values, $strict);

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -247,7 +247,7 @@ class Arr
      */
     public static function exceptValues($array, $values, $strict = false)
     {
-        $values = self::wrap($values);
+        $values = static::wrap($values);
 
         return array_filter($array, function ($value) use ($values, $strict) {
             return ! in_array($value, $values, $strict);

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -346,6 +346,11 @@ class SupportArrTest extends TestCase
         $array = [1, 2, 3, 4, 5];
         $this->assertEquals([0 => 1, 1 => 2, 4 => 5], Arr::exceptValues($array, [3, 4]));
 
+        $array = [1 => TestEnum::A, 2 => TestBackedEnum::A, 3 => TestStringBackedEnum::A];
+        $this->assertEquals([2 => TestBackedEnum::A, 3 => TestStringBackedEnum::A], Arr::exceptValues($array, TestEnum::A));
+        $this->assertEquals([1 => TestEnum::A, 3 => TestStringBackedEnum::A], Arr::exceptValues($array, TestBackedEnum::A));
+        $this->assertEquals([1 => TestEnum::A, 2 => TestBackedEnum::A], Arr::exceptValues($array, TestStringBackedEnum::A));
+
         $array = ['a' => 1, 'b' => 2, 'c' => 1, 'd' => 3];
         $this->assertEquals(['b' => 2, 'd' => 3], Arr::exceptValues($array, 1));
 


### PR DESCRIPTION
While working with the `Arr` helper I was stumped earlier today because I was trying to use it to filter a given case returned by an enum's `cases()` method. I poked around a little and found that the `$values = (array) $values;` was transforming the value passed in, which is fine in most cases, but not for objects, which enums behave like in this instance.

Given the increasing use of enums throughout the framework, and my own project's heavier and heavier reliance on enums over constants or strings, I think it's much safer to make use of `Arr::wrap()` here as the intention of the array casting was to ensure the method could accept any type of input and it be equally evaluated. Throughout the Arr class, many of the methods rely on `wrap()` for similar reasons.

I have added tests that prove it works as expected for Enums, BackedEnums and StringBackedEnums.

I expect to use this helper in future when determining actions for certain queues, which we have planned to soon convert to using enums to keep their references throughout the code unified.