### PR TITLE
[13.x] Prevent restored event when soft delete restore fails

### DIFF
--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -180,7 +180,9 @@ trait SoftDeletes
 
         $result = $this->save();
 
-        $this->fireModelEvent('restored', false);
+        if ($result) {
+            $this->fireModelEvent('restored', false);
+        }
 
         return $result;
     }

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Model as Eloquent;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\SoftDeletingScope;
 use Illuminate\Database\Query\Builder;
+use Illuminate\Events\Dispatcher;
 use Illuminate\Pagination\CursorPaginator;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Carbon;
@@ -321,6 +322,42 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $this->assertCount(2, $users);
         $this->assertNull($users->find(1)->deleted_at);
         $this->assertNull($users->find(2)->deleted_at);
+    }
+
+    public function testRestoreDoesNotFireRestoredEventWhenSavingEventCancelsSave()
+    {
+        $previousDispatcher = Eloquent::getEventDispatcher();
+
+        Eloquent::setEventDispatcher(new Dispatcher);
+
+        try {
+            $this->createUsers();
+
+            $restored = false;
+
+            SoftDeletesTestUser::saving(function () {
+                return false;
+            });
+
+            SoftDeletesTestUser::restored(function () use (&$restored) {
+                $restored = true;
+            });
+
+            $user = SoftDeletesTestUser::withTrashed()->find(1);
+
+            $this->assertFalse($user->restore());
+            $this->assertFalse($restored);
+            $this->assertNotNull(SoftDeletesTestUser::withTrashed()->find(1)->deleted_at);
+            $this->assertNull(SoftDeletesTestUser::find(1));
+        } finally {
+            SoftDeletesTestUser::flushEventListeners();
+
+            if ($previousDispatcher) {
+                Eloquent::setEventDispatcher($previousDispatcher);
+            } else {
+                Eloquent::unsetEventDispatcher();
+            }
+        }
     }
 
     public function testOnlyTrashedOnlyReturnsTrashedRecords()


### PR DESCRIPTION
Hello Taylor,

This PR updates `SoftDeletes::restore()` so the `restored` model event is only fired when the underlying `save()` call succeeds.