### PR TITLE
Use `--kill-others-on-fail` for `artisan dev`

### DIFF
--- a/src/Illuminate/Foundation/Console/DevCommand.php
+++ b/src/Illuminate/Foundation/Console/DevCommand.php
@@ -71,7 +71,7 @@ class DevCommand extends Command
         $this->line('');
 
         $command = $packageManager->getExecCommand(sprintf(
-            'concurrently -c "%s" "%s" --names=%s --kill-others',
+            'concurrently -c "%s" "%s" --names=%s --kill-others-on-fail',
             implode(',', $colors),
             implode('" "', $commands),
             implode(',', $names)


### PR DESCRIPTION
Short-lived dev commands (like a migration or seed) that exit successfully no longer kill the other running processes. If they fail, everything still gets torn down.