### PR TITLE
[13.x] Add `input()` method to console commands

### DIFF
--- a/src/Illuminate/Console/CommandInput.php
+++ b/src/Illuminate/Console/CommandInput.php
@@ -66,7 +66,7 @@ class CommandInput
      */
     public function all($keys = null)
     {
-        $input = array_merge($this->arguments, $this->options);
+        $input = array_merge($this->options, $this->arguments);
 
         if (! $keys) {
             return $input;

--- a/src/Illuminate/Console/CommandInput.php
+++ b/src/Illuminate/Console/CommandInput.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Illuminate\Console;
+
+use Illuminate\Support\Arr;
+use Illuminate\Support\Traits\Dumpable;
+use Illuminate\Support\Traits\InteractsWithData;
+
+class CommandInput
+{
+    use Dumpable, InteractsWithData;
+
+    /**
+     * The command arguments.
+     *
+     * @var array
+     */
+    protected $arguments;
+
+    /**
+     * The command options.
+     *
+     * @var array
+     */
+    protected $options;
+
+    /**
+     * Create a new command input container.
+     *
+     * @param  array  $arguments
+     * @param  array  $options
+     */
+    public function __construct(array $arguments = [], array $options = [])
+    {
+        $this->arguments = $arguments;
+        $this->options = $options;
+    }
+
+    /**
+     * Get all of the arguments passed to the command.
+     *
+     * @return array
+     */
+    public function arguments()
+    {
+        return $this->arguments;
+    }
+
+    /**
+     * Get all of the options passed to the command.
+     *
+     * @return array
+     */
+    public function options()
+    {
+        return $this->options;
+    }
+
+    /**
+     * Get all of the input for the command.
+     *
+     * Options take precedence over arguments when keys collide.
+     *
+     * @param  mixed  $keys
+     * @return array
+     */
+    public function all($keys = null)
+    {
+        $input = array_merge($this->arguments, $this->options);
+
+        if (! $keys) {
+            return $input;
+        }
+
+        $results = [];
+
+        foreach (is_array($keys) ? $keys : func_get_args() as $key) {
+            Arr::set($results, $key, Arr::get($input, $key));
+        }
+
+        return $results;
+    }
+
+    /**
+     * Retrieve data from the instance.
+     *
+     * @param  string|null  $key
+     * @param  mixed  $default
+     * @return mixed
+     */
+    protected function data($key = null, $default = null)
+    {
+        return data_get($this->all(), $key, $default);
+    }
+
+    /**
+     * Get the instance as an array.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return $this->all();
+    }
+
+    /**
+     * Dynamically access input data.
+     *
+     * @param  string  $name
+     * @return mixed
+     */
+    public function __get($name)
+    {
+        return $this->data($name);
+    }
+
+    /**
+     * Determine if an input item is set.
+     *
+     * @param  string  $name
+     * @return bool
+     */
+    public function __isset($name)
+    {
+        return $this->exists($name);
+    }
+}

--- a/src/Illuminate/Console/CommandInput.php
+++ b/src/Illuminate/Console/CommandInput.php
@@ -37,26 +37,6 @@ class CommandInput
     }
 
     /**
-     * Get all of the arguments passed to the command.
-     *
-     * @return array
-     */
-    public function arguments()
-    {
-        return $this->arguments;
-    }
-
-    /**
-     * Get all of the options passed to the command.
-     *
-     * @return array
-     */
-    public function options()
-    {
-        return $this->options;
-    }
-
-    /**
      * Get all of the input for the command.
      *
      * Options take precedence over arguments when keys collide.
@@ -91,6 +71,26 @@ class CommandInput
     protected function data($key = null, $default = null)
     {
         return data_get($this->all(), $key, $default);
+    }
+
+    /**
+     * Get all of the arguments passed to the command.
+     *
+     * @return array
+     */
+    public function arguments()
+    {
+        return $this->arguments;
+    }
+
+    /**
+     * Get all of the options passed to the command.
+     *
+     * @return array
+     */
+    public function options()
+    {
+        return $this->options;
     }
 
     /**

--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -58,6 +58,20 @@ trait InteractsWithIO
     ];
 
     /**
+     * Retrieve the command's input as a CommandInput instance or retrieve an input item.
+     *
+     * @param  string|null  $key
+     * @param  mixed  $default
+     * @return ($key is null ? \Illuminate\Console\CommandInput : mixed)
+     */
+    public function input($key = null, $default = null)
+    {
+        $input = new CommandInput($this->arguments(), $this->options());
+
+        return is_null($key) ? $input : data_get($input->all(), $key, $default);
+    }
+
+    /**
      * Determine if the given argument is present.
      *
      * @param  string|int  $name
@@ -127,20 +141,6 @@ trait InteractsWithIO
     public function options()
     {
         return $this->option();
-    }
-
-    /**
-     * Retrieve the command's input as a CommandInput instance or retrieve an input item.
-     *
-     * @param  string|null  $key
-     * @param  mixed  $default
-     * @return ($key is null ? \Illuminate\Console\CommandInput : mixed)
-     */
-    public function input($key = null, $default = null)
-    {
-        $input = new CommandInput($this->arguments(), $this->options());
-
-        return is_null($key) ? $input : data_get($input->all(), $key, $default);
     }
 
     /**

--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Console\Concerns;
 
 use Closure;
+use Illuminate\Console\CommandInput;
 use Illuminate\Console\OutputStyle;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Str;
@@ -126,6 +127,16 @@ trait InteractsWithIO
     public function options()
     {
         return $this->option();
+    }
+
+    /**
+     * Retrieve the command's input as a CommandInput instance.
+     *
+     * @return \Illuminate\Console\CommandInput
+     */
+    public function input()
+    {
+        return new CommandInput($this->arguments(), $this->options());
     }
 
     /**

--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -130,13 +130,17 @@ trait InteractsWithIO
     }
 
     /**
-     * Retrieve the command's input as a CommandInput instance.
+     * Retrieve the command's input as a CommandInput instance or retrieve an input item.
      *
-     * @return \Illuminate\Console\CommandInput
+     * @param  string|null  $key
+     * @param  mixed  $default
+     * @return ($key is null ? \Illuminate\Console\CommandInput : mixed)
      */
-    public function input()
+    public function input($key = null, $default = null)
     {
-        return new CommandInput($this->arguments(), $this->options());
+        $input = new CommandInput($this->arguments(), $this->options());
+
+        return is_null($key) ? $input : data_get($input->all(), $key, $default);
     }
 
     /**

--- a/tests/Console/CommandTest.php
+++ b/tests/Console/CommandTest.php
@@ -169,6 +169,8 @@ class CommandTest extends TestCase
         $this->assertSame('2026-06-26', $commandInput->date('when')->format('Y-m-d'));
         $this->assertSame(5, $commandInput->integer('limit'));
         $this->assertSame('admin', $commandInput->all()['role']);
+        $this->assertSame('admin', $command->input('role'));
+        $this->assertSame('fallback', $command->input('missing', 'fallback'));
         $this->assertSame('admin', (string) $commandInput->string('role'));
         $this->assertSame('admin', $commandInput->arguments()['role']);
         $this->assertSame('user', $commandInput->options()['role']);

--- a/tests/Console/CommandTest.php
+++ b/tests/Console/CommandTest.php
@@ -9,8 +9,10 @@ use Illuminate\Console\Attributes\Hidden;
 use Illuminate\Console\Attributes\Signature;
 use Illuminate\Console\Attributes\Usage;
 use Illuminate\Console\Command;
+use Illuminate\Console\CommandInput;
 use Illuminate\Console\OutputStyle;
 use Illuminate\Console\View\Components\Factory;
+use Illuminate\Support\Carbon;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -112,6 +114,59 @@ class CommandTest extends TestCase
         $this->assertSame('test-first-option', $command->option('option-one'));
         $this->assertSame('test-second-option', $command->option('option-two'));
         $this->assertSame('third-option-default', $command->option('option-three'));
+    }
+
+    public function testGettingCommandInputAsFluentData()
+    {
+        $command = new class extends Command
+        {
+            public function handle()
+            {
+            }
+
+            protected function getArguments()
+            {
+                return [
+                    ['type', InputArgument::OPTIONAL, 'a backed enum argument'],
+                    ['when', InputArgument::OPTIONAL, 'a date argument'],
+                    ['role', InputArgument::OPTIONAL, 'a colliding argument'],
+                ];
+            }
+
+            protected function getOptions()
+            {
+                return [
+                    ['limit', null, InputOption::VALUE_OPTIONAL, 'an integer option'],
+                    ['role', null, InputOption::VALUE_OPTIONAL, 'a colliding option'],
+                ];
+            }
+        };
+
+        $application = app();
+        $command->setLaravel($application);
+
+        $input = new ArrayInput([
+            'type' => 'foo',
+            'when' => '2026-06-26',
+            'role' => 'admin',
+            '--limit' => '5',
+            '--role' => 'user',
+        ]);
+        $output = new NullOutput;
+
+        $command->run($input, $output);
+
+        $commandInput = $command->input();
+
+        $this->assertInstanceOf(CommandInput::class, $commandInput);
+        $this->assertSame(CommandInputType::Foo, $commandInput->enum('type', CommandInputType::class));
+        $this->assertInstanceOf(Carbon::class, $commandInput->date('when'));
+        $this->assertSame('2026-06-26', $commandInput->date('when')->format('Y-m-d'));
+        $this->assertSame(5, $commandInput->integer('limit'));
+        $this->assertSame('user', $commandInput->all()['role']);
+        $this->assertSame('user', (string) $commandInput->string('role'));
+        $this->assertSame('admin', $commandInput->arguments()['role']);
+        $this->assertSame('user', $commandInput->options()['role']);
     }
 
     public function testTheInputSetterOverwrite()
@@ -260,6 +315,12 @@ class CommandTest extends TestCase
 
         $this->assertSame(['foo:bar 1', 'foo:bar 1 --force'], $command->getUsages());
     }
+}
+
+enum CommandInputType: string
+{
+    case Foo = 'foo';
+    case Bar = 'bar';
 }
 
 #[Signature('foo:bar', aliases: ['bar:baz', 'baz:qux'])]

--- a/tests/Console/CommandTest.php
+++ b/tests/Console/CommandTest.php
@@ -142,7 +142,7 @@ class CommandTest extends TestCase
             }
         };
 
-        $application = app();
+        $application = m::mock(Application::class);
         $command->setLaravel($application);
 
         $input = new ArrayInput([
@@ -153,6 +153,11 @@ class CommandTest extends TestCase
             '--role' => 'user',
         ]);
         $output = new NullOutput;
+        $outputStyle = m::mock(OutputStyle::class);
+        $application->shouldReceive('make')->with(OutputStyle::class, ['input' => $input, 'output' => $output])->andReturn($outputStyle);
+        $application->shouldReceive('make')->with(Factory::class, ['output' => $outputStyle])->andReturn(m::mock(Factory::class));
+        $application->shouldReceive('runningUnitTests')->andReturn(true);
+        $application->shouldReceive('call')->with([$command, 'handle'])->andReturn(0);
 
         $command->run($input, $output);
 
@@ -163,8 +168,8 @@ class CommandTest extends TestCase
         $this->assertInstanceOf(Carbon::class, $commandInput->date('when'));
         $this->assertSame('2026-06-26', $commandInput->date('when')->format('Y-m-d'));
         $this->assertSame(5, $commandInput->integer('limit'));
-        $this->assertSame('user', $commandInput->all()['role']);
-        $this->assertSame('user', (string) $commandInput->string('role'));
+        $this->assertSame('admin', $commandInput->all()['role']);
+        $this->assertSame('admin', (string) $commandInput->string('role'));
         $this->assertSame('admin', $commandInput->arguments()['role']);
         $this->assertSame('user', $commandInput->options()['role']);
     }


### PR DESCRIPTION
**Description:**

This PR adds an `input()` method to console commands that returns a `CommandInput` instance, giving you the same fluent, typed data accessors available on `Request`, `ValidatedInput`, and `Fluent` instances (`$request->enum('...')`, `date()`, `integer()`, `string()`, `boolean()`, `collect()`, etc.) when working with a command's arguments and options.

The `CommandInput` instance contains all of the command's arguments and options merged together, with arguments taking precedence when keys collide. You may also access them independently via the `$input->arguments()` and `$input->options()` methods if necessary.

**Example**:

```php
use App\Enums\ReportType;
use Illuminate\Console\Command;

class GenerateReport extends Command
{
    protected $signature = 'report:generate {type} {--from=} {--to=}';

    public function handle(): void
    {
        $input = $this->input();

        $type = $input->enum('type', ReportType::class);
        $from = $input->date('from');
        $to = $input->date('to');

        // Generate the report...
    }
}
```

Let me know your thoughts! ❤️ 