### PR TITLE
[13.x] Ensure lastJobProcessedAt is null if nothing is processed

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -217,8 +217,6 @@ class Worker
 
         $this->jobsProcessed = 0;
 
-        $this->lastJobProcessedAt = $startTime;
-
         $this->raiseWorkerStartingEvent($connectionName, $queue, $options);
 
         while (true) {


### PR DESCRIPTION
This PR ensures `lastJobProcessedAt` is only set when a job is actually processed.

Ie right now, it looks like:...
```
   INFO  Processing jobs from the [default] queue.  

^C
// lastJobProcessedAt should be null, i havent done anything yet
[2026-06-26 22:15:27] local.INFO: Worker stopping jobsProcessed":0,"lastJobProcessedAt":646.199322542}
```

This happens cus we set  lastJobProcessedAt to the $startTime, to follow how it was originally ie: https://github.com/laravel/framework/blame/112cf499c5180aff272ee4c6463e098dea1ae02d/src/Illuminate/Queue/Worker.php#L204 

But, we don't actually need it because, we null coalesce  it here ie: `this->lastJobProcessedAt ?? $startTime` https://github.com/laravel/framework/blob/eb473d3c370369ea8702908c133ec6aae5868c7a/src/Illuminate/Queue/Worker.php#L395 

So, this PR ensures `lastJobProcessedAt` is only set when a job is **actually processed**

Thanks! 🙏🏻 