### PR TITLE
Fix RateLimited middleware not serializing releaseAfter in __sleep()

### DIFF
--- a/src/Illuminate/Queue/Middleware/RateLimited.php
+++ b/src/Illuminate/Queue/Middleware/RateLimited.php
@@ -151,6 +151,7 @@ class RateLimited
     {
         return [
             'limiterName',
+            'releaseAfter',
             'shouldRelease',
         ];
     }

--- a/tests/Integration/Queue/RateLimitedTest.php
+++ b/tests/Integration/Queue/RateLimitedTest.php
@@ -166,6 +166,27 @@ class RateLimitedTest extends TestCase
         $this->assertInstanceOf(RateLimiter::class, $fetch('limiter'));
     }
 
+    public function testReleaseAfterIsSurvivedThroughSerialization()
+    {
+        $rateLimited = (new RateLimited('limiterName'))->releaseAfter(120);
+
+        $restoredRateLimited = unserialize(serialize($rateLimited));
+
+        $this->assertSame(120, $restoredRateLimited->releaseAfter);
+    }
+
+    public function testCustomReleaseAfterIsRespectedWhenMiddlewareIsStoredAsJobProperty()
+    {
+        $rateLimiter = $this->app->make(RateLimiter::class);
+
+        $rateLimiter->for('test', function ($job) {
+            return Limit::perHour(1);
+        });
+
+        $this->assertJobRanSuccessfully(RateLimitedSerializedPropertyTestJob::class);
+        $this->assertJobWasReleasedAfter(RateLimitedSerializedPropertyTestJob::class, 60);
+    }
+
     protected function assertJobRanSuccessfully($class)
     {
         $class::$handled = false;
@@ -377,6 +398,28 @@ class RateLimitedReleaseAfterTestJob extends RateLimitedTestJob
     public function middleware()
     {
         return [(new RateLimited('test'))->releaseAfter(60)];
+    }
+}
+
+class RateLimitedSerializedPropertyTestJob
+{
+    use InteractsWithQueue, Queueable;
+
+    public static $handled = false;
+
+    public function __construct()
+    {
+        $this->through([(new RateLimited('test'))->releaseAfter(60)]);
+    }
+
+    public function handle()
+    {
+        static::$handled = true;
+    }
+
+    public function middleware()
+    {
+        return [];
     }
 }
 


### PR DESCRIPTION
### Fix: Preserve `releaseAfter` in `RateLimited` middleware during job serialization

### The Problem

When the `RateLimited` middleware is assigned directly to a job's property (for example, using `$this->through(...)` inside the job's constructor), the `releaseAfter` value is silently lost after the job goes through the queue's serialization/deserialization loop.

This occurs because `RateLimited::__sleep()` forgets to include `'releaseAfter'` in its returned array. Since PHP serialization discards any property omitted from `__sleep()`, the configuration disappears, and the job unexpectedly falls back to `getTimeUntilNextRetry()`.

**Note:** This only breaks middleware stored in the job's `$middleware` property. Middleware instantiated dynamically inside a `middleware()` method is recreated fresh and remains unaffected.

---

### The Fix

I added `'releaseAfter'` to the `__sleep()` array inside `RateLimited`.

```php
public function __sleep()
{
    return [
        'limiterName',
        'releaseAfter', // Added to survive serialization
        'shouldRelease',
    ];
}