### PR TITLE
[13.x] Add fluent verification and thread setters to ArgonHasher

### DIFF
--- a/src/Illuminate/Hashing/ArgonHasher.php
+++ b/src/Illuminate/Hashing/ArgonHasher.php
@@ -212,6 +212,19 @@ class ArgonHasher extends AbstractHasher implements HasherContract
     }
 
     /**
+     * Set whether to verify the hashed value's algorithm before checking.
+     *
+     * @param  bool  $verify
+     * @return $this
+     */
+    public function setVerify(bool $verify)
+    {
+        $this->verifyAlgorithm = $verify;
+
+        return $this;
+    }
+
+    /**
      * Extract the memory cost value from the options array.
      *
      * @param  array  $options

--- a/tests/Hashing/HasherTest.php
+++ b/tests/Hashing/HasherTest.php
@@ -110,6 +110,25 @@ class HasherTest extends TestCase
         (new ArgonHasher(['verify' => true]))->check('password', $bcryptHashed);
     }
 
+    public function testArgon2iVerificationCanBeEnabledAfterConstruction()
+    {
+        $this->expectException(RuntimeException::class);
+
+        $bcryptHasher = new BcryptHasher;
+        $bcryptHashed = $bcryptHasher->make('password');
+
+        (new ArgonHasher)->setVerify(true)->check('password', $bcryptHashed);
+    }
+
+    public function testArgon2iThreadsCanBeSetAfterConstruction()
+    {
+        $hasher = new ArgonHasher;
+        $value = $hasher->make('password');
+
+        $this->assertFalse($hasher->needsRehash($value));
+        $this->assertTrue($hasher->setThreads(1)->needsRehash($value));
+    }
+
     #[Depends('testBasicArgon2idHashing')]
     public function testBasicArgon2idVerification()
     {


### PR DESCRIPTION
This change adds a fluent setter for Argon algorithm verification and covers both verification and thread configuration with tests. 
It keeps the existing hashing behavior unchanged while making the `ArgonHasher` API consistent with the other setter methods in the class.