### PR TITLE
[13.x] Fix DatabaseLock::acquire() swallowing unrelated query errors

### DIFF
--- a/src/Illuminate/Cache/DatabaseLock.php
+++ b/src/Illuminate/Cache/DatabaseLock.php
@@ -4,7 +4,7 @@ namespace Illuminate\Cache;
 
 use Illuminate\Database\Connection;
 use Illuminate\Database\DetectsConcurrencyErrors;
-use Illuminate\Database\QueryException;
+use Illuminate\Database\UniqueConstraintViolationException;
 use Throwable;
 
 class DatabaseLock extends Lock
@@ -77,7 +77,7 @@ class DatabaseLock extends Lock
             ]);
 
             $acquired = true;
-        } catch (QueryException) {
+        } catch (UniqueConstraintViolationException) {
             $updated = $this->connection->table($this->table)
                 ->where('key', $this->name)
                 ->where(function ($query) {

--- a/tests/Integration/Database/DatabaseLockTest.php
+++ b/tests/Integration/Database/DatabaseLockTest.php
@@ -6,6 +6,7 @@ use Illuminate\Cache\DatabaseLock;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Database\QueryException;
+use Illuminate\Database\UniqueConstraintViolationException;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
@@ -172,6 +173,62 @@ class DatabaseLockTest extends DatabaseTestCase
             $this->expectException(QueryException::class);
             $this->assertFalse($lock->acquire());
         }
+    }
+
+    public function testAcquireRethrowsNonUniqueConstraintQueryExceptions()
+    {
+        $connection = m::mock(Connection::class);
+        $insertBuilder = m::mock(Builder::class);
+        $updateBuilder = m::mock(Builder::class);
+
+        $insertBuilder->shouldReceive('insert')->once()->andThrow(
+            new QueryException(
+                'mysql',
+                'insert into cache_locks (key, owner, expiration) values (?, ?, ?)',
+                [],
+                new PDOException("SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column 'key' at row 1", 22001)
+            )
+        );
+
+        // If acquire() were to (incorrectly) fall through to the update path, it would
+        // match zero rows and return false instead of surfacing the real failure.
+        $updateBuilder->shouldReceive('where')->andReturnSelf();
+        $updateBuilder->shouldReceive('update')->andReturn(0);
+
+        $connection->shouldReceive('table')->with('cache_locks')->andReturn($insertBuilder, $updateBuilder);
+
+        $lock = new DatabaseLock($connection, 'cache_locks', str_repeat('a', 260), 0, lottery: null);
+
+        $this->expectException(QueryException::class);
+        $this->expectExceptionMessage('Data too long for column');
+
+        $lock->acquire();
+    }
+
+    public function testAcquireFallsBackToUpdateOnUniqueConstraintViolation()
+    {
+        $connection = m::mock(Connection::class);
+        $insertBuilder = m::mock(Builder::class);
+        $updateBuilder = m::mock(Builder::class);
+
+        $insertBuilder->shouldReceive('insert')->once()->andThrow(
+            new UniqueConstraintViolationException(
+                'mysql',
+                'insert into cache_locks (key, owner, expiration) values (?, ?, ?)',
+                [],
+                new PDOException("SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry 'foo' for key 'cache_locks.PRIMARY'", 23000)
+            )
+        );
+
+        $updateBuilder->shouldReceive('where')->with('key', 'foo')->once()->andReturnSelf();
+        $updateBuilder->shouldReceive('where')->once()->andReturnSelf();
+        $updateBuilder->shouldReceive('update')->once()->andReturn(1);
+
+        $connection->shouldReceive('table')->with('cache_locks')->andReturn($insertBuilder, $updateBuilder);
+
+        $lock = new DatabaseLock($connection, 'cache_locks', 'foo', 0, lottery: null);
+
+        $this->assertTrue($lock->acquire());
     }
 
     #[TestWith(['Serialization failure: 1213 Deadlock', 40001, true])]


### PR DESCRIPTION
Fixes #60171

## The problem

`DatabaseLock::acquire()` catches **every** `QueryException` thrown by its `INSERT` and assumes the failure means *"the lock row already exists"*, so it falls back to an `UPDATE`:

```php
try {
    $this->connection->table($this->table)->insert([...]);
    $acquired = true;
} catch (QueryException) { // catches *everything*
    $updated = $this->connection->table($this->table)
        ->where('key', $this->name)
        ->where(fn ($q) => $q->where('owner', $this->owner)->orWhere('expiration', '<=', $this->currentTime()))
        ->update([...]);
    $acquired = $updated >= 1;
}
```

That assumption only holds for a duplicate-key (integrity constraint) violation. Any *other* query error is silently swallowed: the `UPDATE` matches zero rows, `acquire()` returns `false` on every attempt, and `block()` keeps retrying for the full timeout before throwing a `LockTimeoutException` that hides the real cause.

The reported trigger is a lock key longer than the `cache_locks` `key` column (`varchar(255)`), which makes MySQL raise `SQLSTATE[22001]: String data, right truncated`. Instead of surfacing that error, the lock spins for the whole block duration and then throws an unrelated timeout exception. (Originally surfaced as an infinite 503 loop in a Statamic static-cache install.)

## The fix

Catch the more specific `UniqueConstraintViolationException` instead of the broad `QueryException`. The connection already raises this subclass for duplicate-key errors (`Connection::runQueryCallback()`), so the "row already exists → update it" path is preserved, while genuinely unrelated errors (`22001`, etc.) now propagate with their real message.

## Why this approach (vs. inspecting the SQLSTATE)

The issue suggested re-throwing when the SQLSTATE doesn't start with `23`. Catching `UniqueConstraintViolationException` is better because:

- **It reuses the framework's existing, per-driver unique-constraint detection.** MySQL, PostgreSQL, SQL Server and SQLite each already implement `isUniqueConstraintError()` with their own driver-specific quirks (MySQL matches `1062`, Postgres matches `23505`, etc.). Hardcoding a `23xxx` SQLSTATE prefix in the lock would duplicate that logic and miss driver differences (e.g. MySQL's exception code isn't a clean SQLSTATE class).
- **It matches an idiom already used in the framework** for exactly this "insert, fall back because the row exists" pattern — see `Builder::createOrFirst()`, which catches `UniqueConstraintViolationException` for the same reason.
- **It's a one-line, semantically precise change** — no new trait, no SQLSTATE table to maintain — and it narrows the catch to the *only* error class that legitimately indicates the lock already exists.

## Tests

- `testAcquireRethrowsNonUniqueConstraintQueryExceptions` — an `INSERT` failing with a non-unique error (`SQLSTATE[22001]`) now propagates instead of being swallowed and looping. (Fails on `13.x` before this change.)
- `testAcquireFallsBackToUpdateOnUniqueConstraintViolation` — a duplicate-key `UniqueConstraintViolationException` still falls back to the `UPDATE` path, preserving existing lock-contention behaviour.

The full `DatabaseLockTest` suite passes.
