### PR TITLE
[13.x] Fix relations losing constraints inside global scope constructors during eager loading

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -25,6 +25,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\Concerns\AsPivot;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\Relations\Pivot;
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Support\Str;
@@ -340,12 +341,13 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
             $this->fireModelEvent('booting', false);
 
             static::booting();
-            static::boot();
+
+            Relation::withConstraints(static::boot(...));
 
             static::$booted[static::class] = true;
             unset(static::$booting[static::class]);
 
-            static::booted();
+            Relation::withConstraints(static::booted(...));
 
             static::$bootedCallbacks[static::class] ??= [];
 

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -123,6 +123,27 @@ abstract class Relation implements BuilderContract
     }
 
     /**
+     * Run a callback with constraints enabled on the relation.
+     *
+     * @template TReturn of mixed
+     *
+     * @param  Closure(): TReturn  $callback
+     * @return TReturn
+     */
+    public static function withConstraints(Closure $callback)
+    {
+        $previous = static::$constraints;
+
+        static::$constraints = true;
+
+        try {
+            return $callback();
+        } finally {
+            static::$constraints = $previous;
+        }
+    }
+
+    /**
      * Set the base constraints on the relation query.
      *
      * @return void

--- a/tests/Integration/Database/EloquentEagerLoadGlobalScopeConstraintsTest.php
+++ b/tests/Integration/Database/EloquentEagerLoadGlobalScopeConstraintsTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentEagerLoadGlobalScopeConstraintsTest;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Scope;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+class EloquentEagerLoadGlobalScopeConstraintsTest extends DatabaseTestCase
+{
+    protected function afterRefreshingDatabase()
+    {
+        Schema::create('eager_scope_users', function (Blueprint $table) {
+            $table->increments('id');
+        });
+
+        Schema::create('eager_scope_posts', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('eager_scope_user_id');
+        });
+
+        Schema::create('eager_scope_unrelateds', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('eager_scope_owner_id');
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        ScopeWithRelationQueryInConstructor::$capturedSql = null;
+
+        parent::tearDown();
+    }
+
+    public function testRelationsBuiltInsideGlobalScopeConstructorKeepTheirConstraintsDuringEagerLoad()
+    {
+        EagerScopeUser::query()->getConnection()->table('eager_scope_users')->insert(['id' => 1]);
+        EagerScopeUser::query()->getConnection()->table('eager_scope_posts')->insert(['id' => 1, 'eager_scope_user_id' => 1]);
+
+        ScopeWithRelationQueryInConstructor::$capturedSql = null;
+
+        EagerScopeUser::with('posts')->get();
+
+        $this->assertNotNull(
+            ScopeWithRelationQueryInConstructor::$capturedSql,
+            'The global scope constructor did not run during the eager load.'
+        );
+
+        $this->assertStringContainsString(
+            'eager_scope_owner_id',
+            ScopeWithRelationQueryInConstructor::$capturedSql,
+            'The relation built inside the global scope constructor lost its foreign key constraint during eager loading.'
+        );
+    }
+}
+
+class EagerScopeUser extends Model
+{
+    public $table = 'eager_scope_users';
+    public $timestamps = false;
+    protected $guarded = [];
+
+    public function posts()
+    {
+        return $this->hasMany(EagerScopePost::class, 'eager_scope_user_id');
+    }
+}
+
+class EagerScopePost extends Model
+{
+    public $table = 'eager_scope_posts';
+    public $timestamps = false;
+    protected $guarded = [];
+
+    protected static function booted()
+    {
+        static::addGlobalScope(new ScopeWithRelationQueryInConstructor());
+    }
+}
+
+class EagerScopeUnrelated extends Model
+{
+    public $table = 'eager_scope_unrelateds';
+    public $timestamps = false;
+    protected $guarded = [];
+
+    public function children()
+    {
+        return $this->hasMany(EagerScopeUnrelated::class, 'eager_scope_owner_id');
+    }
+}
+
+class ScopeWithRelationQueryInConstructor implements Scope
+{
+    public static ?string $capturedSql = null;
+
+    public function __construct()
+    {
+        $owner = new EagerScopeUnrelated();
+        $owner->id = 99;
+
+        static::$capturedSql = $owner->children()->toSql();
+    }
+
+    public function apply(Builder $builder, Model $model)
+    {
+        //
+    }
+}


### PR DESCRIPTION
Fixes #56951

## The problem

When you eager load a relation whose related model has a global scope, and that scope's **constructor** runs its own relationship query, the query silently loses its foreign key constraint and returns the wrong results — no error is thrown.

```php
class Post extends Model
{
    protected static function booted()
    {
        static::addGlobalScope(new SomeScope()); // SomeScope::__construct() runs a relation query
    }
}

User::with('posts')->get(); // the query inside SomeScope::__construct() runs without its foreign key WHERE
```

The same code works correctly when the scoped model is **not** eager loaded (e.g. lazy loaded, or queried directly).

## Root cause

`Builder::getRelation()` builds the relation inside `Relation::noConstraints()`:

```php
$relation = Relation::noConstraints(function () use ($name) {
    return $this->getModel()->newInstance()->$name();
});
```

`noConstraints()` flips the **global** static `Relation::$constraints` to `false` so that `addConstraints()` skips the base foreign key clause (eager loading adds its own constraints afterwards via `addEagerConstraints()`).

The first time the related model is touched inside that window, it **boots** (`bootIfNotBooted()`), and booting registers the model's global scopes — constructing them. Because `Relation::$constraints` is a process-wide static, any relationship query built from a scope's constructor during this boot inherits `false`, so `HasOneOrMany::addConstraints()` (and the equivalent on other relations) skips the `where <foreign_key> = ?` clause. The result is a query across the whole table instead of the constrained set.

## The fix

Model booting is a one-time, class-level side effect that is independent of whether we happen to be in the middle of building an eager-load relation. It should always build relations with constraints enabled.

This adds a `Relation::withConstraints()` helper — the direct mirror of the existing `Relation::noConstraints()` — and runs the boot hooks (`boot()`, which also boots traits such as `SoftDeletes`, and `booted()`) through it. Those are the only points where global scopes are registered, so this is the minimal surface that covers the bug:

```php
Relation::withConstraints(static::boot(...));
...
Relation::withConstraints(static::booted(...));
```

No public API changes, and no behavior change for models without query-running scope constructors.

## Tests

Added `EloquentEagerLoadGlobalScopeConstraintsTest`, which seeds via the query builder so the scoped model boots for the first time **inside** the eager-load `noConstraints` window, then asserts that a relation built in the scope's constructor still contains its foreign key constraint. The test fails on `13.x` before this change and passes after it.

Full `tests/Database` and `tests/Integration/Database` suites pass.
