### PR TITLE
[13.x] Add memory usage to WorkerStopping

### DIFF
--- a/src/Illuminate/Queue/Events/WorkerStopping.php
+++ b/src/Illuminate/Queue/Events/WorkerStopping.php
@@ -12,7 +12,7 @@ class WorkerStopping
      * @param  \Illuminate\Queue\WorkerStopReason|null  $reason  The reason why the worker is stopping.
      * @param  int|null  $jobsProcessed  The number of jobs processed by the worker.
      * @param  int|float|null  $lastJobProcessedAt  The timestamp of the last job processed by the worker.
-     * @param  float|null  $memoryUsage  The memory usage of the worker in MB.
+     * @param  int|float|null  $memoryUsage  The memory usage of the worker in MB.
      */
     public function __construct(
         public $status = 0,

--- a/src/Illuminate/Queue/Events/WorkerStopping.php
+++ b/src/Illuminate/Queue/Events/WorkerStopping.php
@@ -12,6 +12,7 @@ class WorkerStopping
      * @param  \Illuminate\Queue\WorkerStopReason|null  $reason  The reason why the worker is stopping.
      * @param  int|null  $jobsProcessed  The number of jobs processed by the worker.
      * @param  int|float|null  $lastJobProcessedAt  The timestamp of the last job processed by the worker.
+     * @param  float|null  $memoryUsage  The memory usage of the worker in MB.
      */
     public function __construct(
         public $status = 0,
@@ -19,6 +20,7 @@ class WorkerStopping
         public $reason = null,
         public $jobsProcessed = null,
         public $lastJobProcessedAt = null,
+        public $memoryUsage = null,
     ) {
     }
 }

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -966,7 +966,9 @@ class Worker
      */
     public function stop($status = 0, $options = null, $reason = null)
     {
-        $this->events->dispatch(new WorkerStopping($status, $options, $reason, $this->jobsProcessed, $this->lastJobProcessedAt));
+        $memoryUsage = memory_get_usage(true) / 1024 / 1024;
+
+        $this->events->dispatch(new WorkerStopping($status, $options, $reason, $this->jobsProcessed, $this->lastJobProcessedAt, $memoryUsage));
 
         return $status;
     }
@@ -981,7 +983,9 @@ class Worker
      */
     public function kill($status = 0, $options = null, $reason = null)
     {
-        $this->events->dispatch(new WorkerStopping($status, $options, $reason, $this->jobsProcessed, $this->lastJobProcessedAt));
+        $memoryUsage = memory_get_usage(true) / 1024 / 1024;
+
+        $this->events->dispatch(new WorkerStopping($status, $options, $reason, $this->jobsProcessed, $this->lastJobProcessedAt, $memoryUsage));
 
         if (extension_loaded('posix')) {
             posix_kill(getmypid(), SIGKILL);

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -953,7 +953,7 @@ class Worker
      */
     public function memoryExceeded($memoryLimit)
     {
-        return ((int) $memoryLimit) > 0 && (memory_get_usage(true) / 1024 / 1024) >= ((int) $memoryLimit);
+        return ((int) $memoryLimit) > 0 && ($this->currentMemoryUsage()) >= ((int) $memoryLimit);
     }
 
     /**
@@ -966,9 +966,9 @@ class Worker
      */
     public function stop($status = 0, $options = null, $reason = null)
     {
-        $memoryUsage = memory_get_usage(true) / 1024 / 1024;
-
-        $this->events->dispatch(new WorkerStopping($status, $options, $reason, $this->jobsProcessed, $this->lastJobProcessedAt, $memoryUsage));
+        $this->events->dispatch(new WorkerStopping(
+            $status, $options, $reason, $this->jobsProcessed, $this->lastJobProcessedAt, $this->currentMemoryUsage()
+        ));
 
         return $status;
     }
@@ -983,9 +983,9 @@ class Worker
      */
     public function kill($status = 0, $options = null, $reason = null)
     {
-        $memoryUsage = memory_get_usage(true) / 1024 / 1024;
-
-        $this->events->dispatch(new WorkerStopping($status, $options, $reason, $this->jobsProcessed, $this->lastJobProcessedAt, $memoryUsage));
+        $this->events->dispatch(new WorkerStopping(
+            $status, $options, $reason, $this->jobsProcessed, $this->lastJobProcessedAt, $this->currentMemoryUsage()
+        ));
 
         if (extension_loaded('posix')) {
             posix_kill(getmypid(), SIGKILL);
@@ -1102,5 +1102,15 @@ class Worker
     protected function currentTime()
     {
         return hrtime(true) / 1e9;
+    }
+
+    /**
+     * Get the current memory usage in MB.
+     *
+     * @return int|float
+     */
+    protected function currentMemoryUsage()
+    {
+        return memory_get_usage(true) / 1024 / 1024;
     }
 }

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -953,7 +953,7 @@ class Worker
      */
     public function memoryExceeded($memoryLimit)
     {
-        return ((int) $memoryLimit) > 0 && ($this->currentMemoryUsage()) >= ((int) $memoryLimit);
+        return ((int) $memoryLimit) > 0 && $this->currentMemoryUsage() >= ((int) $memoryLimit);
     }
 
     /**

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -559,7 +559,7 @@ class QueueWorkerTest extends TestCase
                 && $event->reason === WorkerStopReason::QueueEmpty
                 && $event->jobsProcessed === 2
                 && $event->lastJobProcessedAt !== null
-                && $event->memoryUsage !== null;
+                && $event->memoryUsage > 0;
         }));
     }
 

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -558,7 +558,8 @@ class QueueWorkerTest extends TestCase
                 && $event->workerOptions === $workerOptions
                 && $event->reason === WorkerStopReason::QueueEmpty
                 && $event->jobsProcessed === 2
-                && $event->lastJobProcessedAt !== null;
+                && $event->lastJobProcessedAt !== null
+                && $event->memoryUsage !== null;
         }));
     }
 


### PR DESCRIPTION
This PR adds `$memoryUsage` (in MB) to the `WorkerStopping` event so you can see the actual usage at the point the worker decided to stop, which is helpful for `--memory` adjustments, and observability.  I've also put the logic into a method cos it was getting duplicated

This is useful as you can see your workers restart and the WorkerStopReason tells you it's memory related, but you don't actually know what the memory usage was. 

Cloud does give cool metrics, but they give you clusters level metrics. 

I have a bunch of cool ideas, that include drilling down into individual Worker metrics which this PR helps either way and reveals it for us to log and see :)  

Thanks! Any feedback let me know.