### PR TITLE
[13.x] Fix Json parsing for top level zero bodies

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -462,7 +462,6 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     public function json($key = null, $default = null)
     {
         if (! isset($this->json)) {
-
             $content = $this->getContent();
             $this->json = new InputBag((array) json_decode($content === '' ? '[]' : $content, true));
         }

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -462,7 +462,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     public function json($key = null, $default = null)
     {
         if (! isset($this->json)) {
-            $this->json = new InputBag((array) json_decode($this->getContent() ?: '[]', true));
+            $this->json = new InputBag((array) json_decode($this->getContent() ?? '[]', true));
         }
 
         if (is_null($key)) {

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -463,7 +463,8 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     {
         if (! isset($this->json)) {
             $content = $this->getContent();
-            $this->json = new InputBag((array) json_decode($content === '' ? '[]' : $content, true));
+
+            $this->json = new InputBag((array) json_decode(trim($content) === '' ? '[]' : $content, true));
         }
 
         if (is_null($key)) {

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -462,7 +462,9 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     public function json($key = null, $default = null)
     {
         if (! isset($this->json)) {
-            $this->json = new InputBag((array) json_decode($this->getContent() ?? '[]', true));
+
+            $content = $this->getContent();
+            $this->json = new InputBag((array) json_decode($content === '' ? '[]' : $content, true));
         }
 
         if (is_null($key)) {

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -1278,6 +1278,13 @@ class HttpRequestTest extends TestCase
         $this->assertEquals($payload, $data);
     }
 
+    public function testJSONMethodDecodesTopLevelZero()
+    {
+        $request = Request::create('/', 'POST', [], [], [], ['CONTENT_TYPE' => 'application/json'], '0');
+
+        $this->assertSame([0], $request->json()->all());
+    }
+
     public function testJSONEmulatingPHPBuiltInServer()
     {
         $payload = ['name' => 'taylor'];


### PR DESCRIPTION
This PR fixes `Request::json()` so a valid JSON request body containing the top-level scalar `0` is not treated as an empty body.