### PR TITLE
[13.x] Resume sleeping when Sleep is interrupted by a signal

### DIFF
--- a/src/Illuminate/Support/Sleep.php
+++ b/src/Illuminate/Support/Sleep.php
@@ -342,7 +342,14 @@ class Sleep
 
         while ($while()) {
             if ($seconds > 0) {
-                sleep($seconds);
+                $secondsToSleep = $seconds;
+
+                // sleep() returns the number of seconds left to sleep if it was
+                // interrupted by a signal, such as those sent by a queue worker,
+                // so we keep sleeping until the requested duration has elapsed.
+                while ($secondsToSleep > 0) {
+                    $secondsToSleep = sleep($secondsToSleep);
+                }
 
                 $remaining = $remaining->subSeconds($seconds);
             }

--- a/tests/Support/SleepTest.php
+++ b/tests/Support/SleepTest.php
@@ -32,6 +32,29 @@ class SleepTest extends TestCase
         $this->assertEqualsWithDelta(1, $end - $start, 0.03);
     }
 
+    public function testItKeepsSleepingWhenInterruptedBySignal()
+    {
+        if (! function_exists('pcntl_alarm')) {
+            $this->markTestSkipped('The pcntl extension is required.');
+        }
+
+        pcntl_async_signals(true);
+        pcntl_signal(SIGALRM, fn () => null);
+
+        // Schedule a signal that will interrupt the sleep after one second.
+        pcntl_alarm(1);
+
+        $start = microtime(true);
+        Sleep::for(2)->seconds();
+        $elapsed = microtime(true) - $start;
+
+        pcntl_alarm(0);
+        pcntl_signal(SIGALRM, SIG_DFL);
+        pcntl_async_signals(false);
+
+        $this->assertGreaterThanOrEqual(2, round($elapsed, 1));
+    }
+
     public function testCallbacksMayBeExecutedUsingThen()
     {
         $this->assertEquals(123, Sleep::for(1)->milliseconds()->then(fn () => 123));


### PR DESCRIPTION
Fixes #56647

## The problem

Calling `Sleep` inside a queued job can wake up early. For example:

```php
public function handle(): void
{
    Log::debug('Should sleep for 60 seconds');

    Sleep::for(60)->seconds();

    Log::debug('Should be awake now'); // logged well before 60s have elapsed
}
```

The job logs "Should be awake now" before the full 60 seconds have passed. The same code sleeps correctly outside of a queue worker.

## Root cause

`Sleep::goodnight()` performs the actual sleeping:

```php
if ($seconds > 0) {
    sleep($seconds);

    $remaining = $remaining->subSeconds($seconds);
}
```

PHP's [`sleep()`](https://www.php.net/manual/en/function.sleep.php) returns **the number of seconds left to sleep** if the call is interrupted by a signal (otherwise it returns `0`). Queue workers — Horizon in the reported case — routinely deliver `pcntl` signals (timeout alarms, restart/termination signals, etc.). When one arrives mid-sleep, `sleep()` returns early, but `goodnight()` ignores the return value and assumes the whole duration was slept, so the remaining time is silently skipped.

This is straightforward to reproduce: an alarm scheduled with `pcntl_alarm(1)` interrupts `sleep(3)`, which then returns `2` and elapses only one second.

## The fix

Keep sleeping with the seconds that `sleep()` reports as remaining until the full duration has actually elapsed:

```php
$secondsToSleep = $seconds;

while ($secondsToSleep > 0) {
    $secondsToSleep = sleep($secondsToSleep);
}
```

`sleep()` returns `0` on success and `false` on error — both end the loop — so an uninterrupted sleep behaves exactly as before. Only the interrupted case changes: it now resumes instead of returning early.

## Tests

Added `testItKeepsSleepingWhenInterruptedBySignal`, which schedules a signal to interrupt a two-second sleep after one second and asserts the total elapsed time is still at least two seconds. It fails before this change (wakes after ~1s) and passes after it. The test skips automatically when the `pcntl` extension is unavailable.

The full `tests/Support` suite passes.
