### PR TITLE
[13.x] schedule:work catch signals

### DIFF
--- a/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
@@ -84,8 +84,8 @@ class ScheduleWorkCommand extends Command
             $this->sleep();
 
             // Once a stop signal has been received we stop scheduling new runs so
-            // that the worker can drain any in-flight executions before exiting.
-            // This lets the current tasks finish instead of being interrupted.
+            // that the worker can stop any in-flight executions before exiting
+            // which lets the current tasks execute instead of being stopped.
             if (! $this->shouldQuit &&
                 Carbon::now()->second === 0 &&
                 ! Carbon::now()->startOfMinute()->equalTo($lastExecutionStartedAt)) {
@@ -107,9 +107,6 @@ class ScheduleWorkCommand extends Command
                 }
             }
 
-            // When a stop signal has been received and every in-flight execution
-            // has finished, we can break out of the loop and exit cleanly so the
-            // process can be safely restarted (for example on a Kubernetes pod).
             if ($this->shouldQuit && empty($this->executions)) {
                 return static::SUCCESS;
             }
@@ -118,9 +115,6 @@ class ScheduleWorkCommand extends Command
 
     /**
      * Listen for the signals that should terminate the schedule worker.
-     *
-     * This mirrors the queue worker so the process can be stopped gracefully,
-     * allowing any in-flight tasks to finish before the worker exits.
      *
      * @return void
      */

--- a/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
@@ -30,9 +30,23 @@ class ScheduleWorkCommand extends Command
     protected $description = 'Start the schedule worker';
 
     /**
+     * Indicates if the schedule worker should exit.
+     *
+     * @var bool
+     */
+    protected $shouldQuit = false;
+
+    /**
+     * The "schedule:run" executions that are currently running.
+     *
+     * @var \Symfony\Component\Process\Process[]
+     */
+    protected $executions = [];
+
+    /**
      * Execute the console command.
      *
-     * @return never
+     * @return int
      */
     public function handle()
     {
@@ -40,8 +54,6 @@ class ScheduleWorkCommand extends Command
             'Running scheduled tasks.',
             $this->getLaravel()->environment('local') ? OutputInterface::VERBOSITY_NORMAL : OutputInterface::VERBOSITY_VERBOSE
         );
-
-        [$lastExecutionStartedAt, $executions] = [Carbon::now()->subMinutes(10), []];
 
         $command = Application::formatCommandString('schedule:run');
 
@@ -53,28 +65,79 @@ class ScheduleWorkCommand extends Command
             $command .= ' >> '.ProcessUtils::escapeArgument($this->option('run-output-file')).' 2>&1';
         }
 
-        while (true) {
-            usleep(100 * 1000);
+        $this->listenForSignals();
 
-            if (Carbon::now()->second === 0 &&
+        return $this->work($command);
+    }
+
+    /**
+     * Run the schedule worker loop until it is signalled to stop.
+     *
+     * @param  string  $command
+     * @return int
+     */
+    protected function work($command)
+    {
+        $lastExecutionStartedAt = Carbon::now()->subMinutes(10);
+
+        while (true) {
+            $this->sleep();
+
+            // Once a stop signal has been received we stop scheduling new runs so
+            // that the worker can drain any in-flight executions before exiting.
+            // This lets the current tasks finish instead of being interrupted.
+            if (! $this->shouldQuit &&
+                Carbon::now()->second === 0 &&
                 ! Carbon::now()->startOfMinute()->equalTo($lastExecutionStartedAt)) {
-                $executions[] = $execution = Process::fromShellCommandline($command, base_path());
+                $this->executions[] = $execution = Process::fromShellCommandline($command, base_path());
 
                 $execution->start();
 
                 $lastExecutionStartedAt = Carbon::now()->startOfMinute();
             }
 
-            foreach ($executions as $key => $execution) {
+            foreach ($this->executions as $key => $execution) {
                 $output = $execution->getIncrementalOutput().
                     $execution->getIncrementalErrorOutput();
 
                 $this->output->write(ltrim($output, "\n"));
 
                 if (! $execution->isRunning()) {
-                    unset($executions[$key]);
+                    unset($this->executions[$key]);
                 }
             }
+
+            // When a stop signal has been received and every in-flight execution
+            // has finished, we can break out of the loop and exit cleanly so the
+            // process can be safely restarted (for example on a Kubernetes pod).
+            if ($this->shouldQuit && empty($this->executions)) {
+                return static::SUCCESS;
+            }
         }
+    }
+
+    /**
+     * Listen for the signals that should terminate the schedule worker.
+     *
+     * This mirrors the queue worker so the process can be stopped gracefully,
+     * allowing any in-flight tasks to finish before the worker exits.
+     *
+     * @return void
+     */
+    protected function listenForSignals()
+    {
+        $this->trap(fn () => [SIGINT, SIGTERM, SIGQUIT], function () {
+            $this->shouldQuit = true;
+        });
+    }
+
+    /**
+     * Sleep for a short period before the next worker tick.
+     *
+     * @return void
+     */
+    protected function sleep()
+    {
+        usleep(100 * 1000);
     }
 }

--- a/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
@@ -30,18 +30,18 @@ class ScheduleWorkCommand extends Command
     protected $description = 'Start the schedule worker';
 
     /**
-     * Indicates if the schedule worker should exit.
-     *
-     * @var bool
-     */
-    protected $shouldQuit = false;
-
-    /**
      * The "schedule:run" executions that are currently running.
      *
      * @var \Symfony\Component\Process\Process[]
      */
     protected $executions = [];
+
+    /**
+     * Indicates if the schedule worker should exit.
+     *
+     * @var bool
+     */
+    protected $shouldQuit = false;
 
     /**
      * Execute the console command.

--- a/tests/Console/Scheduling/ScheduleWorkCommandTest.php
+++ b/tests/Console/Scheduling/ScheduleWorkCommandTest.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace Illuminate\Tests\Console\Scheduling;
+
+use Illuminate\Console\OutputStyle;
+use Illuminate\Console\Scheduling\ScheduleWorkCommand;
+use Illuminate\Console\Signals;
+use Illuminate\Support\Carbon;
+use Illuminate\Tests\Console\Fixtures\FakeSignalsRegistry;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Process\Process;
+
+class ScheduleWorkCommandTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    /**
+     * The signal availability resolver in place before the test ran.
+     *
+     * @var (callable(): bool)|null
+     */
+    protected $originalAvailabilityResolver;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->originalAvailabilityResolver = (new ReflectionProperty(Signals::class, 'availabilityResolver'))
+            ->getValue();
+
+        Carbon::setTestNow(Carbon::create(2026, 6, 27, 12, 0, 30));
+    }
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+
+        Signals::resolveAvailabilityUsing($this->originalAvailabilityResolver);
+
+        parent::tearDown();
+    }
+
+    public function test_stop_signal_marks_the_worker_to_quit()
+    {
+        if (! extension_loaded('pcntl')) {
+            $this->markTestSkipped('The pcntl extension is required to trap signals.');
+        }
+
+        // When a handler is registered, Signals chains any handler already bound
+        // to the signal (see Signals::initializeSignal). Other tests may leave
+        // real handlers in place, so reset these signals to their default
+        // disposition to keep this test isolated from the global signal state.
+        $previousHandlers = [];
+
+        foreach ([SIGINT, SIGTERM, SIGQUIT] as $signal) {
+            $previousHandlers[$signal] = pcntl_signal_get_handler($signal);
+
+            pcntl_signal($signal, SIG_DFL);
+        }
+
+        try {
+            Signals::resolveAvailabilityUsing(fn () => true);
+
+            $registry = new FakeSignalsRegistry;
+
+            $command = new ScheduleWorkCommandTestStub;
+
+            // Wire the command up to a fake signal registry so we can simulate a
+            // signal being delivered without sending a real one to the process.
+            (fn () => $this->signals = new Signals($registry))->call($command);
+
+            $command->callListenForSignals();
+
+            $this->assertFalse($command->shouldQuit(), 'The worker should not quit before a signal is received.');
+
+            $registry->handle(SIGTERM);
+
+            $this->assertTrue($command->shouldQuit(), 'The worker should be marked to quit after a SIGTERM.');
+        } finally {
+            foreach ($previousHandlers as $signal => $handler) {
+                pcntl_signal($signal, $handler ?: SIG_DFL);
+            }
+        }
+    }
+
+    public function test_in_flight_executions_finish_before_the_worker_quits()
+    {
+        $execution = m::mock(Process::class);
+        $execution->shouldReceive('getIncrementalOutput')->andReturn('scheduled task ran', '');
+        $execution->shouldReceive('getIncrementalErrorOutput')->andReturn('');
+
+        // The worker should poll the running execution after the signal arrives,
+        // wait for it to report finished, and flush its output before quitting.
+        $execution->shouldReceive('isRunning')->twice()->andReturn(true, false);
+
+        $command = new ScheduleWorkCommandTestStub;
+        $command->setOutput(new OutputStyle(new ArrayInput([]), $buffer = new BufferedOutput));
+
+        // Simulate the stop signal arriving while a "schedule:run" execution is
+        // still in progress (after the worker's very first loop tick).
+        $command->onTick = function (ScheduleWorkCommandTestStub $command) {
+            if ($command->ticks === 1) {
+                $command->markShouldQuit();
+            }
+        };
+
+        $status = $command->work('schedule:run', [$execution]);
+
+        $this->assertSame(ScheduleWorkCommand::SUCCESS, $status);
+        $this->assertSame([], $command->remainingExecutions(), 'The execution should have been drained before quitting.');
+        $this->assertStringContainsString('scheduled task ran', $buffer->fetch());
+    }
+
+    public function test_no_new_executions_are_started_after_a_stop_signal()
+    {
+        // A new run would normally be started on the zero second of the minute.
+        Carbon::setTestNow(Carbon::create(2026, 6, 27, 12, 0, 0));
+
+        $command = new ScheduleWorkCommandTestStub;
+        $command->markShouldQuit();
+
+        // With no executions in flight and a stop signal already received, the
+        // worker must exit immediately without starting a new "schedule:run".
+        // If the guard regressed, it would try to spawn a real process here.
+        $status = $command->work('schedule:run');
+
+        $this->assertSame(ScheduleWorkCommand::SUCCESS, $status);
+        $this->assertSame([], $command->remainingExecutions());
+        $this->assertSame(1, $command->ticks, 'The worker should exit after a single tick when idle and quitting.');
+    }
+}
+
+class ScheduleWorkCommandTestStub extends ScheduleWorkCommand
+{
+    /**
+     * The number of times the worker has ticked (slept).
+     *
+     * @var int
+     */
+    public $ticks = 0;
+
+    /**
+     * A callback invoked on every worker tick, used to drive the loop in tests.
+     *
+     * @var (callable(self): void)|null
+     */
+    public $onTick;
+
+    public function callListenForSignals(): void
+    {
+        $this->listenForSignals();
+    }
+
+    public function shouldQuit(): bool
+    {
+        return $this->shouldQuit;
+    }
+
+    public function markShouldQuit(): void
+    {
+        $this->shouldQuit = true;
+    }
+
+    public function work($command, array $executions = [])
+    {
+        $this->executions = $executions;
+
+        return parent::work($command);
+    }
+
+    public function remainingExecutions(): array
+    {
+        return $this->executions;
+    }
+
+    protected function sleep()
+    {
+        $this->ticks++;
+
+        if ($this->onTick) {
+            ($this->onTick)($this);
+        }
+    }
+}


### PR DESCRIPTION
schedule:work currently doesn't respond to termination signals, so if the
process is stopped while a task is running (for example when Kubernetes sends
SIGTERM during a pod shutdown, or you hit Ctrl+C) it gets killed mid-task. This
adds graceful shutdown: on SIGINT/SIGTERM/SIGQUIT it stops starting new runs and
waits for any in-progress schedule:run to finish before exiting, the same way
queue:work already behaves. This makes it safe to run the scheduler as a
long-lived process in containerized environments.
