### PR TITLE
[13.x] Fix Number::forHumans() and Number::abbreviate() crashing on INF/NAN

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -263,9 +263,15 @@ class Number
      * @param  int|null  $maxPrecision
      * @param  array<int, string>  $units
      * @return string|false
+     *
+     * @phpstan-return ($number is INF ? '∞' : ($number is NAN ? 'NaN' : ($number is 0 ? ($precision is non-positive-int ? '0' : non-empty-string|false) : non-empty-string|false)))
      */
     protected static function summarize(int|float $number, int $precision = 0, ?int $maxPrecision = null, array $units = [])
     {
+        if (! is_finite($number)) {
+            return static::format($number, $precision, $maxPrecision);
+        }
+
         if (empty($units)) {
             $units = [
                 3 => 'K',

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -261,6 +261,10 @@ class SupportNumberTest extends TestCase
         $this->assertSame('999 thousand', Number::forHumans(999499));
         $this->assertSame('1 million', Number::forHumans(999500));
         $this->assertSame('1 million', Number::forHumans(999999));
+
+        $this->assertSame('∞', Number::forHumans(INF));
+        $this->assertSame('-∞', Number::forHumans(-INF));
+        $this->assertSame('NaN', Number::forHumans(NAN));
     }
 
     public function testSummarize()
@@ -326,6 +330,10 @@ class SupportNumberTest extends TestCase
 
         Number::withLocale('de', fn () => $this->assertSame('1M', Number::abbreviate(999500)));
         Number::withLocale('fr', fn () => $this->assertSame('1M', Number::abbreviate(999500)));
+
+        $this->assertSame('∞', Number::abbreviate(INF));
+        $this->assertSame('-∞', Number::abbreviate(-INF));
+        $this->assertSame('NaN', Number::abbreviate(NAN));
     }
 
     public function testPairs()


### PR DESCRIPTION
## Summary

`Number::abbreviate()`, `Number::forHumans()` (and their negative counterparts) currently crash the PHP process with memory exhaustion when given `INF` or `-INF`, and emit deprecation/warning noise on PHP 8.5 when given `NAN`.

```php
Number::abbreviate(INF);   // PHP Fatal error: Allowed memory size exhausted
Number::forHumans(-INF);   // Same crash
Number::forHumans(NAN);    // Warning: float NAN is not representable as an int (x4)
                           // Deprecated: Implicit conversion from float NAN to int (x4)
```

## Root cause

`Number::summarize()` recurses on `$number >= 1e15` with `$number / 1e15` to scale into higher units. When `$number` is `INF`, `INF / 1e15` is still `INF`, so the recursion has no base case and the process OOM-kills. The `-INF` path hits the `$number < 0` branch first, recurses with `abs(-INF) = INF`, then takes the same infinite-recursion path. For `NAN`, the `floor(log10(NAN))` → int coercion downstream triggers the PHP 8.5 deprecation noise.

## Fix

Short-circuit `summarize()` on non-finite inputs and delegate to `Number::format()`, which already produces the locale-aware `∞`, `-∞`, and `NaN` strings via `NumberFormatter`. This mirrors the guard pattern adopted by `Number::trim()` in #60322 and keeps the output consistent with the rest of the class (e.g. `Number::format(INF)` already returns `'∞'`).

```php
if (is_infinite($number) || is_nan($number)) {
    return static::format($number, $precision, $maxPrecision);
}
```

## Output after the fix

| Call | Before | After |
| --- | --- | --- |
| `Number::abbreviate(INF)` | crash (OOM) | `'∞'` |
| `Number::abbreviate(-INF)` | crash (OOM) | `'-∞'` |
| `Number::abbreviate(NAN)` | `'NaN'` + 8 PHP warnings | `'NaN'` |
| `Number::forHumans(INF)` | crash (OOM) | `'∞'` |
| `Number::forHumans(-INF)` | crash (OOM) | `'-∞'` |
| `Number::forHumans(NAN)` | `'NaN'` + 8 PHP warnings | `'NaN'` |

## Tests

Added six assertions to the existing `testToHuman` and `testSummarize` methods covering `INF`, `-INF`, and `NAN` for both `forHumans()` and `abbreviate()`. The full `Support` suite (2,099 tests / 7,350 assertions) stays green.

## Note on the prior closed PR

[#59556](https://github.com/laravel/framework/pull/59556) attempted the same fix but returned `(string) $number`, which yields `'INF'` / `'-INF'` / `'NAN'` — inconsistent with the locale-aware `'∞'` / `'-∞'` / `'NaN'` produced by `Number::format()` and every other Number helper. This PR returns the formatted value so the output stays consistent with the rest of the class and matches the convention established by the merged `Number::trim()` fix in #60322.
