### PR TITLE
[13.x] Cache Str::pluralStudly() results

### DIFF
--- a/src/Illuminate/Support/Pluralizer.php
+++ b/src/Illuminate/Support/Pluralizer.php
@@ -113,6 +113,16 @@ class Pluralizer
     }
 
     /**
+     * Get the language that should be used by the inflector.
+     *
+     * @return string
+     */
+    public static function getLanguage(): string
+    {
+        return static::$language;
+    }
+
+    /**
      * Specify the language that should be used by the inflector.
      *
      * @param  string  $language

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -53,6 +53,13 @@ class Str
     protected static $studlyCache = [];
 
     /**
+     * The cache of plural studly-cased words, keyed by language and input value.
+     *
+     * @var array<string, array<string, string>>
+     */
+    protected static $pluralStudlyCache = [];
+
+    /**
      * The callback that should be used to generate UUIDs.
      *
      * @var (callable(): \Ramsey\Uuid\UuidInterface)|null
@@ -1023,11 +1030,25 @@ class Str
      */
     public static function pluralStudly($value, $count = 2)
     {
+        if (is_countable($count)) {
+            $count = count($count);
+        }
+
+        if ((int) abs($count) === 1) {
+            return $value;
+        }
+
+        $language = Pluralizer::getLanguage();
+
+        if (isset(static::$pluralStudlyCache[$language][$value])) {
+            return static::$pluralStudlyCache[$language][$value];
+        }
+
         $parts = preg_split('/(.)(?=[A-Z])/u', $value, -1, PREG_SPLIT_DELIM_CAPTURE);
 
         $lastWord = array_pop($parts);
 
-        return implode('', $parts).self::plural($lastWord, $count);
+        return static::$pluralStudlyCache[$language][$value] = implode('', $parts).self::plural($lastWord, $count);
     }
 
     /**

--- a/tests/Support/SupportPluralizerTest.php
+++ b/tests/Support/SupportPluralizerTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Support;
 
+use Illuminate\Support\Pluralizer;
 use Illuminate\Support\Str;
 use PHPUnit\Framework\TestCase;
 
@@ -111,6 +112,22 @@ class SupportPluralizerTest extends TestCase
         $this->assertPluralStudly('SomeUsers', 'SomeUser', collect());
         $this->assertPluralStudly('SomeUser', 'SomeUser', collect(['one']));
         $this->assertPluralStudly('SomeUsers', 'SomeUser', collect(['one', 'two']));
+    }
+
+    public function testPluralStudlyCacheRespectsLanguageSwitch()
+    {
+        $english = Str::pluralStudly('SomeMal');
+
+        Pluralizer::useLanguage('portuguese');
+
+        $portuguese = Str::pluralStudly('SomeMal');
+
+        $this->assertSame('SomeMales', $portuguese);
+        $this->assertNotSame($english, $portuguese);
+
+        Pluralizer::useLanguage('english');
+
+        $this->assertSame($english, Str::pluralStudly('SomeMal'));
     }
 
     private function assertPluralStudly($expected, $value, $count = 2)


### PR DESCRIPTION
Cache Str::pluralStudly() results keyed by language and input value to avoid repeated preg_split() and pluralization work on the Model::getTable() hot path. Adds Pluralizer::getLanguage() for correct cache keys when the inflector language is switched. Includes a regression test for language switching.