### PR TITLE
[13.x] Precompute sortByMany comparison values

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1624,8 +1624,28 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     {
         $items = $this->items;
 
-        uasort($items, function ($a, $b) use ($comparisons, $options) {
-            foreach ($comparisons as $comparison) {
+        $precomputed = [];
+
+        foreach ($comparisons as $index => $comparison) {
+            $comparison = Arr::wrap($comparison);
+            $prop = $comparison[0];
+
+            if (! is_string($prop) && is_callable($prop)) {
+                continue;
+            }
+
+            foreach ($items as $key => $item) {
+                $precomputed[$index][$key] = data_get($item, $prop);
+            }
+        }
+
+        $keys = array_keys($items);
+
+        usort($keys, function ($keyA, $keyB) use ($items, $comparisons, $options, $precomputed) {
+            $a = $items[$keyA];
+            $b = $items[$keyB];
+
+            foreach ($comparisons as $index => $comparison) {
                 $comparison = Arr::wrap($comparison);
 
                 $prop = $comparison[0];
@@ -1639,7 +1659,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
                 if (! is_string($prop) && is_callable($prop)) {
                     $result = $prop($a, $b);
                 } else {
-                    $values = [data_get($a, $prop), data_get($b, $prop)];
+                    $values = [$precomputed[$index][$keyA], $precomputed[$index][$keyB]];
 
                     if ($direction === SortDirection::Descending) {
                         $values = array_reverse($values);
@@ -1670,7 +1690,13 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
             }
         });
 
-        return $this->newInstance($items);
+        $results = [];
+
+        foreach ($keys as $key) {
+            $results[$key] = $items[$key];
+        }
+
+        return $this->newInstance($results);
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2257,6 +2257,27 @@ class SupportCollectionTest extends TestCase
     }
 
     #[DataProvider('collectionClassProvider')]
+    public function testSortByManyWithCallback($collection)
+    {
+        $data = new $collection([
+            ['name' => 'taylor', 'age' => 25],
+            ['name' => 'dayle', 'age' => 30],
+            ['name' => 'taylor', 'age' => 20],
+        ]);
+
+        $sorted = $data->sortBy([
+            'name',
+            fn ($a, $b) => $a['age'] <=> $b['age'],
+        ]);
+
+        $this->assertEquals([
+            ['name' => 'dayle', 'age' => 30],
+            ['name' => 'taylor', 'age' => 20],
+            ['name' => 'taylor', 'age' => 25],
+        ], array_values($sorted->all()));
+    }
+
+    #[DataProvider('collectionClassProvider')]
     public function testSortKeys($collection)
     {
         $data = new $collection(['b' => 'dayle', 'a' => 'taylor']);


### PR DESCRIPTION
## Summary

`Collection::sortByMany()` currently evaluates `data_get()` inside the `uasort` comparator. For a collection of `n` items and `k` sort keys, `uasort` performs `O(n log n)` comparisons, so the same property is extracted `O(k · n log n)` times. For nested object/array keys this is repeated, expensive work.

This PR precomputes the extracted value for each non-callback sort key once per item, then sorts against the cached values. This reduces the extraction step from `O(k · n log n)` to `O(k · n)`.

## Root cause

`sortByMany()` builds a comparator that calls `data_get($item, $prop)` on every comparison. When sorting 10,000 items by 3 keys, `data_get()` is invoked roughly 400,000 times. Most of those calls traverse the same nested path on the same object.

## Fix

- Before sorting, iterate over the comparisons and, for every non-callable (string) property, extract `data_get($item, $prop)` once per item into a local `$precomputed` matrix keyed by comparison index and original item key.
- The comparator then looks up the precomputed value by key instead of re-extracting it.
- Callable comparisons are skipped during precomputation and still receive the original `$a` and `$b` items in the comparator, preserving existing behavior.

## Benchmarks

| Scenario | Items | Keys | Before | After |
|----------|-------|------|--------|-------|
| Plain arrays | 10,000 | 3 | ~4,994 ms | ~2,555 ms |
| Objects with nested keys | 5,000 | 3 | ~4,180 ms | ~1,362 ms |

Benchmarks are 50 iterations each.

## Correctness & memory

- The `$precomputed` matrix is local to the method scope and is eligible for garbage collection as soon as `usort()` returns.
- Pairwise callback comparisons continue to receive the original items; only non-callback string properties use the cached values.
- The sort result is identical to the previous implementation; only the number of `data_get()` invocations changes.

## Tests

- Existing `SupportCollectionTest` sort-by tests pass: 737 tests, 2,288 assertions.
- Added `testSortByManyWithCallback` to cover the mixed property + callback comparison path.
