### PR TITLE
[13.x] Allow assertDatabaseEmpty to handle iterable

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -117,12 +117,20 @@ trait InteractsWithDatabase
     /**
      * Assert that the given table has no entries.
      *
-     * @param  \Illuminate\Database\Eloquent\Model|class-string<\Illuminate\Database\Eloquent\Model>|string  $table
+     * @param  iterable<\Illuminate\Database\Eloquent\Model>|\Illuminate\Database\Eloquent\Model|class-string<\Illuminate\Database\Eloquent\Model>|string  $table
      * @param  string|null  $connection
      * @return $this
      */
     protected function assertDatabaseEmpty($table, $connection = null)
     {
+        if (is_iterable($table)) {
+            foreach ($table as $item) {
+                $this->assertDatabaseEmpty($item, $connection);
+            }
+
+            return $this;
+        }
+
         $this->assertThat(
             $this->getTable($table), new CountInDatabase($this->getConnection($connection, $table), 0)
         );

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -115,7 +115,7 @@ trait InteractsWithDatabase
     }
 
     /**
-     * Assert that the given table has no entries.
+     * Assert that the given table or tables has no entries.
      *
      * @param  iterable<\Illuminate\Database\Eloquent\Model>|\Illuminate\Database\Eloquent\Model|class-string<\Illuminate\Database\Eloquent\Model>|string  $table
      * @param  string|null  $connection

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -196,6 +196,17 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->assertDatabaseEmpty(new ProductStub);
     }
 
+    public function testAssertDatabaseEmptySupportsArrays()
+    {
+        $builder = m::mock(Builder::class);
+        $builder->shouldReceive('count')->twice()->andReturn(0);
+
+        $this->connection->shouldReceive('table')->with($this->table)->andReturn($builder);
+        $this->connection->shouldReceive('table')->with('orders')->andReturn($builder);
+
+        $this->assertDatabaseEmpty([ProductStub::class, OrderStub::class]);
+    }
+
     public function testAssertTableEntriesCountWrong()
     {
         $this->expectException(ExpectationFailedException::class);
@@ -616,4 +627,11 @@ class ProductStub extends Model
 class CustomProductStub extends ProductStub
 {
     const DELETED_AT = 'trashed_at';
+}
+
+class OrderStub extends Model
+{
+    protected $table = 'orders';
+
+    protected $guarded = [];
 }


### PR DESCRIPTION
`assertDatabaseHas`,`assertDatabaseMissing`,`assertSoftDeleted` & `assertNotSoftDeleted` all accept an iterable, this PR allows `assertDatabaseEmpty` to too, so it saves re calling the method. 

I noticed this in quite a few of ours tests and wanted to clean them up, but realised it doesn't allow an iterable, this means it matches all the other similar methods and behaves the same

This means we can change: 
```php
$this->assertDatabaseEmpty(Ticket::class);
$this->assertDatabaseEmpty(Movie::class);
$this->assertDatabaseEmpty(Person::class);
```

becomes below, which matches 99% of the methods in `InteractsWithDatabase`

```php 

$this->assertDatabaseEmpty([Ticket::class, Movie::class, Person::class]);

// Also works w strings
$this->assertDatabaseEmpty(['ticket','movie','people']);

``` 

Thank you 🫡 