### PR TITLE
[13.x] Add Arr::skip method

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -353,6 +353,18 @@ class Arr
     }
 
     /**
+     * Skip the first {$count} items from an array.
+     *
+     * @param  array  $array
+     * @param  int  $count
+     * @return array
+     */
+    public static function skip($array, $count)
+    {
+        return array_slice($array, $count, null, true);
+    }
+
+    /**
      * Flatten a multi-dimensional array into a single level.
      *
      * @param  iterable  $array

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1856,6 +1856,15 @@ class SupportArrTest extends TestCase
         $this->assertEquals([1, 2, 3, 4, 5, 6], Arr::take($array, -10));
     }
 
+    public function testSkip(): void
+    {
+        $array = ['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4];
+
+        $this->assertSame(['c' => 3, 'd' => 4], Arr::skip($array, 2));
+        $this->assertSame([], Arr::skip($array, 10));
+        $this->assertSame($array, Arr::skip($array, 0));
+    }
+
     public function testSelect()
     {
         $array = [


### PR DESCRIPTION
This PR adds `Arr::skip()` as an array helper for returning all elements after the first given number of items.

Collection already has `skip()` and `take()`, Arr only had `take()`. This fills the gap.
