### PR TITLE
[13.x] Fix Number::fileSize crashing on INF/NAN inputs

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -205,6 +205,10 @@ class Number
      */
     public static function fileSize(int|float $bytes, int $precision = 0, ?int $maxPrecision = null)
     {
+        if (! is_finite($bytes)) {
+            return sprintf('%s B', static::format($bytes, $precision, $maxPrecision));
+        }
+
         $units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
 
         $unitCount = count($units);

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -192,6 +192,10 @@ class SupportNumberTest extends TestCase
         $this->assertSame('-2.00 KB', Number::fileSize(-2048, precision: 2));
         $this->assertSame('-1.23 KB', Number::fileSize(-1264, precision: 2));
         $this->assertSame('-5 GB', Number::fileSize(-1024 * 1024 * 1024 * 5));
+
+        $this->assertSame('∞ B', Number::fileSize(INF));
+        $this->assertSame('-∞ B', Number::fileSize(-INF));
+        $this->assertSame('NaN B', Number::fileSize(NAN));
     }
 
     public function testClamp()


### PR DESCRIPTION
`Number::fileSize()` produces an incorrect result when given non-finite inputs (`INF`, `-INF`, `NAN`):
- `Number::fileSize(INF)`  → `"∞ YB"` 
- `Number::fileSize(-INF)` → `"-∞ YB"`

The `for` loop iterates to the last unit (`YB`) because `INF / 1024 === INF` never decreases, so the only exit condition is exhausting the units array.

This mirrors the issue fixed in #60617, which added an `is_finite()` guard to `Number::summarize()` (used by `forHumans` / `abbreviate`).

This PR applies the same guard to `Number::fileSize()`.