### PR TITLE
[13.x] Fix flexible() lock and defer label collisions in TaggedCache

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -661,7 +661,7 @@ class Repository implements ArrayAccess, CacheContract
 
         $refresh = function () use ($key, $ttl, $callback, $lock, $created) {
             $this->store->lock(
-                "illuminate:cache:flexible:lock:{$key}",
+                "illuminate:cache:flexible:lock:{$this->itemKey($key)}",
                 $lock['seconds'] ?? 0,
                 $lock['owner'] ?? null,
             )->get(function () use ($key, $callback, $created, $ttl) {
@@ -676,7 +676,7 @@ class Repository implements ArrayAccess, CacheContract
             });
         };
 
-        defer($refresh, "illuminate:cache:flexible:{$key}", $alwaysDefer);
+        defer($refresh, "illuminate:cache:flexible:{$this->itemKey($key)}", $alwaysDefer);
 
         return $value;
     }

--- a/tests/Integration/Cache/RepositoryTest.php
+++ b/tests/Integration/Cache/RepositoryTest.php
@@ -329,6 +329,75 @@ class RepositoryTest extends TestCase
         $this->assertSame(['foo' => null, 'bar' => null, 'baz' => null], $cache->many([TestCacheKey::FOO, TestCacheKey::BAR, TestCacheKey::BAZ]));
         $this->assertSame(['foo' => 'default', 'qux' => 'default'], $cache->getMultiple([TestCacheKey::FOO, TestCacheKey::QUX], 'default'));
     }
+
+    public function testFlexibleDeferLabelIsScopedToTagGroup(): void
+    {
+        Carbon::setTestNow('2000-01-01 00:00:00');
+
+        $users = Cache::driver('array')->tags(['users']);
+        $posts = Cache::driver('array')->tags(['posts']);
+
+        // Populate both tagged caches with the same raw key.
+        $users->flexible('profile', [10, 20], fn () => 'users');
+        $posts->flexible('profile', [10, 20], fn () => 'posts');
+
+        $this->assertCount(0, defer());
+
+        // Advance past the "fresh" TTL — both entries are now stale.
+        Carbon::setTestNow(Carbon::now()->addSeconds(11));
+
+        $users->flexible('profile', [10, 20], fn () => 'users-refreshed');
+        $posts->flexible('profile', [10, 20], fn () => 'posts-refreshed');
+
+        // Each tagged cache must register its own deferred callback. Before the
+        // fix, both calls produced the same defer label so one would be silently
+        // dropped by DeferredCallbackCollection::forgetDuplicates(), leaving only
+        // one refresh in the queue instead of two.
+        $this->assertCount(2, defer());
+
+        defer()->invoke();
+
+        $this->assertSame('users-refreshed', $users->get('profile'));
+        $this->assertSame('posts-refreshed', $posts->get('profile'));
+    }
+
+    public function testFlexibleLockIsScopedToTagGroup(): void
+    {
+        Carbon::setTestNow('2000-01-01 00:00:00');
+
+        $store = Cache::driver('array');
+        $users = $store->tags(['users']);
+        $posts = $store->tags(['posts']);
+
+        // Populate both tagged caches with the same raw key.
+        $users->flexible('profile', [10, 20], fn () => 'users');
+        $posts->flexible('profile', [10, 20], fn () => 'posts');
+
+        // Make both stale.
+        Carbon::setTestNow(Carbon::now()->addSeconds(11));
+
+        $users->flexible('profile', [10, 20], fn () => 'users-refreshed');
+        $posts->flexible('profile', [10, 20], fn () => 'posts-refreshed');
+
+        $this->assertCount(2, defer());
+
+        // Acquire the scoped lock that the users-tag refresh closure would use.
+        // Before the fix, both tagged caches shared the same lock key so this
+        // lock would also block the posts refresh — they are now independent.
+        $usersLockKey = 'illuminate:cache:flexible:lock:'.$users->taggedItemKey('profile');
+        $usersLock = $store->lock($usersLockKey);
+        $this->assertTrue($usersLock->acquire());
+
+        defer()->invoke();
+
+        // The users refresh was skipped because its lock was held.
+        $this->assertSame('users', $users->get('profile'));
+
+        // The posts refresh ran independently because its lock key is different.
+        $this->assertSame('posts-refreshed', $posts->get('profile'));
+
+        $usersLock->release();
+    }
 }
 
 enum TestCacheKey: string


### PR DESCRIPTION
When two TaggedCache groups use `flexible()` with the same raw key, the lock key and deferred-callback label were both derived from the raw key instead of the tag-scoped key returned by `itemKey()`.

This caused two distinct problems:
- The defer label was identical across tag groups, so `DeferredCallbackCollection::forgetDuplicates() `silently dropped one refresh callback, leaving a stale entry unrevalidated.
- The lock key was shared, so holding the lock for one tag group would block the refresh of an unrelated tag group.

Replacing `$key` with `$this->itemKey($key) `in both places scopes the lock and defer label to the tag namespace. 
For a plain Repository `itemKey()` returns the raw key so existing behaviour is unchanged.