### PR TITLE
Add `Release` queue middleware

### DIFF
--- a/src/Illuminate/Queue/Middleware/Release.php
+++ b/src/Illuminate/Queue/Middleware/Release.php
@@ -8,11 +8,11 @@ class Release
 {
     /**
      * @param  bool  $release  Whether the job should be released back onto the queue.
-     * @param  int  $retryAfter  The number of seconds to wait before retrying the job.
+     * @param  int  $releaseAfter  The number of seconds before the job is available again.
      */
     public function __construct(
         protected bool $release = false,
-        protected int $retryAfter = 0,
+        protected int $releaseAfter = 0,
     ) {
     }
 
@@ -20,22 +20,22 @@ class Release
      * Release the job back onto the queue if the given condition is truthy.
      *
      * @param  bool|(\Closure(): bool)  $condition
-     * @param  int  $retryAfter  The number of seconds to wait before retrying the job.
+     * @param  int  $releaseAfter  The number of seconds before the job is available again.
      */
-    public static function when(Closure|bool $condition, int $retryAfter = 0): static
+    public static function when(Closure|bool $condition, int $releaseAfter = 0): static
     {
-        return new static(value($condition), $retryAfter);
+        return new static(value($condition), $releaseAfter);
     }
 
     /**
      * Release the job back onto the queue unless the given condition is truthy.
      *
      * @param  bool|(\Closure(): bool)  $condition
-     * @param  int  $retryAfter  The number of seconds to wait before retrying the job.
+     * @param  int  $releaseAfter  The number of seconds before the job is available again.
      */
-    public static function unless(Closure|bool $condition, int $retryAfter = 0): static
+    public static function unless(Closure|bool $condition, int $releaseAfter = 0): static
     {
-        return new static(! value($condition), $retryAfter);
+        return new static(! value($condition), $releaseAfter);
     }
 
     /**
@@ -44,7 +44,7 @@ class Release
     public function handle(mixed $job, callable $next): mixed
     {
         if ($this->release) {
-            return $job->release($this->retryAfter);
+            return $job->release($this->releaseAfter);
         }
 
         return $next($job);

--- a/src/Illuminate/Queue/Middleware/Release.php
+++ b/src/Illuminate/Queue/Middleware/Release.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Illuminate\Queue\Middleware;
+
+use Closure;
+
+class Release
+{
+    /**
+     * @param  bool  $release  Whether the job should be released back onto the queue.
+     * @param  int  $retryAfter  The number of seconds to wait before retrying the job.
+     */
+    public function __construct(
+        protected bool $release = false,
+        protected int $retryAfter = 0,
+    ) {
+    }
+
+    /**
+     * Release the job back onto the queue if the given condition is truthy.
+     *
+     * @param  bool|(\Closure(): bool)  $condition
+     * @param  int  $retryAfter  The number of seconds to wait before retrying the job.
+     */
+    public static function when(Closure|bool $condition, int $retryAfter = 0): static
+    {
+        return new static(value($condition), $retryAfter);
+    }
+
+    /**
+     * Release the job back onto the queue unless the given condition is truthy.
+     *
+     * @param  bool|(\Closure(): bool)  $condition
+     * @param  int  $retryAfter  The number of seconds to wait before retrying the job.
+     */
+    public static function unless(Closure|bool $condition, int $retryAfter = 0): static
+    {
+        return new static(! value($condition), $retryAfter);
+    }
+
+    /**
+     * Handle the job.
+     */
+    public function handle(mixed $job, callable $next): mixed
+    {
+        if ($this->release) {
+            return $job->release($this->retryAfter);
+        }
+
+        return $next($job);
+    }
+}

--- a/tests/Integration/Queue/ReleaseMiddlewareTest.php
+++ b/tests/Integration/Queue/ReleaseMiddlewareTest.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Queue;
+
+use Illuminate\Bus\Dispatcher;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\Job;
+use Illuminate\Queue\CallQueuedHandler;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\Middleware\Release;
+use Laravel\SerializableClosure\SerializableClosure;
+use Mockery as m;
+use Orchestra\Testbench\TestCase;
+
+class ReleaseMiddlewareTest extends TestCase
+{
+    public function testJobIsReleasedWhenConditionIsTrue()
+    {
+        $job = new ReleaseTestJob(release: true, retryAfter: 60);
+
+        $this->assertJobWasReleased($job, retryAfter: 60);
+    }
+
+    public function testJobIsReleasedWhenConditionIsTrueUsingClosure()
+    {
+        $job = new ReleaseTestJob(release: new SerializableClosure(fn () => true), retryAfter: 60);
+
+        $this->assertJobWasReleased($job, retryAfter: 60);
+    }
+
+    public function testJobRunsWhenConditionIsFalse()
+    {
+        $job = new ReleaseTestJob(release: false);
+
+        $this->assertJobRanSuccessfully($job);
+    }
+
+    public function testJobRunsWhenConditionIsFalseUsingClosure()
+    {
+        $job = new ReleaseTestJob(release: new SerializableClosure(fn () => false));
+
+        $this->assertJobRanSuccessfully($job);
+    }
+
+    public function testJobIsReleasedWithoutDelayByDefault()
+    {
+        $job = new ReleaseTestJob(release: true);
+
+        $this->assertJobWasReleased($job, retryAfter: 0);
+    }
+
+    public function testJobRunsWhenConditionIsTrueWithUnless()
+    {
+        $job = new ReleaseTestJob(release: true, useUnless: true);
+
+        $this->assertJobRanSuccessfully($job);
+    }
+
+    public function testJobRunsWhenConditionIsTrueWithUnlessUsingClosure()
+    {
+        $job = new ReleaseTestJob(release: new SerializableClosure(fn () => true), useUnless: true);
+
+        $this->assertJobRanSuccessfully($job);
+    }
+
+    public function testJobIsReleasedWhenConditionIsFalseWithUnless()
+    {
+        $job = new ReleaseTestJob(release: false, useUnless: true, retryAfter: 60);
+
+        $this->assertJobWasReleased($job, retryAfter: 60);
+    }
+
+    public function testJobIsReleasedWhenConditionIsFalseWithUnlessUsingClosure()
+    {
+        $job = new ReleaseTestJob(release: new SerializableClosure(fn () => false), useUnless: true, retryAfter: 60);
+
+        $this->assertJobWasReleased($job, retryAfter: 60);
+    }
+
+    protected function assertJobRanSuccessfully(ReleaseTestJob $class)
+    {
+        $class::$handled = false;
+        $instance = new CallQueuedHandler(new Dispatcher($this->app), $this->app);
+
+        $job = m::mock(Job::class);
+
+        $job->shouldReceive('hasFailed')->andReturn(false);
+        $job->shouldReceive('isReleased')->andReturn(false);
+        $job->shouldReceive('isDeletedOrReleased')->andReturn(false);
+        $job->shouldReceive('delete')->once();
+        $job->shouldReceive('release')->never();
+
+        $instance->call($job, [
+            'command' => serialize($class),
+        ]);
+
+        $this->assertTrue($class::$handled);
+    }
+
+    protected function assertJobWasReleased(ReleaseTestJob $class, int $retryAfter = 0)
+    {
+        $class::$handled = false;
+        $instance = new CallQueuedHandler(new Dispatcher($this->app), $this->app);
+
+        $job = m::mock(Job::class);
+
+        $job->shouldReceive('hasFailed')->andReturn(false);
+        $job->shouldReceive('isReleased')->andReturn(true);
+        $job->shouldReceive('isDeletedOrReleased')->andReturn(true);
+        $job->shouldReceive('release')->once()->with($retryAfter);
+        $job->shouldReceive('delete')->never();
+
+        $instance->call($job, [
+            'command' => serialize($class),
+        ]);
+
+        $this->assertFalse($class::$handled);
+    }
+}
+
+class ReleaseTestJob
+{
+    use InteractsWithQueue, Queueable;
+
+    public static $handled = false;
+
+    public function __construct(
+        protected bool|SerializableClosure $release,
+        protected bool $useUnless = false,
+        protected int $retryAfter = 0,
+    ) {
+    }
+
+    public function handle(): void
+    {
+        static::$handled = true;
+    }
+
+    public function middleware(): array
+    {
+        $release = $this->release instanceof SerializableClosure
+            ? $this->release->getClosure()
+            : $this->release;
+
+        if ($this->useUnless) {
+            return [Release::unless($release, $this->retryAfter)];
+        }
+
+        return [Release::when($release, $this->retryAfter)];
+    }
+}

--- a/tests/Integration/Queue/ReleaseMiddlewareTest.php
+++ b/tests/Integration/Queue/ReleaseMiddlewareTest.php
@@ -16,16 +16,16 @@ class ReleaseMiddlewareTest extends TestCase
 {
     public function testJobIsReleasedWhenConditionIsTrue()
     {
-        $job = new ReleaseTestJob(release: true, retryAfter: 60);
+        $job = new ReleaseTestJob(release: true, releaseAfter: 60);
 
-        $this->assertJobWasReleased($job, retryAfter: 60);
+        $this->assertJobWasReleased($job, releaseAfter: 60);
     }
 
     public function testJobIsReleasedWhenConditionIsTrueUsingClosure()
     {
-        $job = new ReleaseTestJob(release: new SerializableClosure(fn () => true), retryAfter: 60);
+        $job = new ReleaseTestJob(release: new SerializableClosure(fn () => true), releaseAfter: 60);
 
-        $this->assertJobWasReleased($job, retryAfter: 60);
+        $this->assertJobWasReleased($job, releaseAfter: 60);
     }
 
     public function testJobRunsWhenConditionIsFalse()
@@ -46,7 +46,7 @@ class ReleaseMiddlewareTest extends TestCase
     {
         $job = new ReleaseTestJob(release: true);
 
-        $this->assertJobWasReleased($job, retryAfter: 0);
+        $this->assertJobWasReleased($job, releaseAfter: 0);
     }
 
     public function testJobRunsWhenConditionIsTrueWithUnless()
@@ -65,16 +65,16 @@ class ReleaseMiddlewareTest extends TestCase
 
     public function testJobIsReleasedWhenConditionIsFalseWithUnless()
     {
-        $job = new ReleaseTestJob(release: false, useUnless: true, retryAfter: 60);
+        $job = new ReleaseTestJob(release: false, useUnless: true, releaseAfter: 60);
 
-        $this->assertJobWasReleased($job, retryAfter: 60);
+        $this->assertJobWasReleased($job, releaseAfter: 60);
     }
 
     public function testJobIsReleasedWhenConditionIsFalseWithUnlessUsingClosure()
     {
-        $job = new ReleaseTestJob(release: new SerializableClosure(fn () => false), useUnless: true, retryAfter: 60);
+        $job = new ReleaseTestJob(release: new SerializableClosure(fn () => false), useUnless: true, releaseAfter: 60);
 
-        $this->assertJobWasReleased($job, retryAfter: 60);
+        $this->assertJobWasReleased($job, releaseAfter: 60);
     }
 
     protected function assertJobRanSuccessfully(ReleaseTestJob $class)
@@ -97,7 +97,7 @@ class ReleaseMiddlewareTest extends TestCase
         $this->assertTrue($class::$handled);
     }
 
-    protected function assertJobWasReleased(ReleaseTestJob $class, int $retryAfter = 0)
+    protected function assertJobWasReleased(ReleaseTestJob $class, int $releaseAfter = 0)
     {
         $class::$handled = false;
         $instance = new CallQueuedHandler(new Dispatcher($this->app), $this->app);
@@ -107,7 +107,7 @@ class ReleaseMiddlewareTest extends TestCase
         $job->shouldReceive('hasFailed')->andReturn(false);
         $job->shouldReceive('isReleased')->andReturn(true);
         $job->shouldReceive('isDeletedOrReleased')->andReturn(true);
-        $job->shouldReceive('release')->once()->with($retryAfter);
+        $job->shouldReceive('release')->once()->with($releaseAfter);
         $job->shouldReceive('delete')->never();
 
         $instance->call($job, [
@@ -127,7 +127,7 @@ class ReleaseTestJob
     public function __construct(
         protected bool|SerializableClosure $release,
         protected bool $useUnless = false,
-        protected int $retryAfter = 0,
+        protected int $releaseAfter = 0,
     ) {
     }
 
@@ -143,9 +143,9 @@ class ReleaseTestJob
             : $this->release;
 
         if ($this->useUnless) {
-            return [Release::unless($release, $this->retryAfter)];
+            return [Release::unless($release, $this->releaseAfter)];
         }
 
-        return [Release::when($release, $this->retryAfter)];
+        return [Release::when($release, $this->releaseAfter)];
     }
 }


### PR DESCRIPTION
Adds a `Release` queue middleware that releases a job back onto the queue based on a condition, instead of executing it immediately. 

Where `Skip` deletes the job, `Release` defers its execution to a later attempt.

Example usage:

```php
use Illuminate\Queue\Middleware\Release;

public function middleware(): array
{
    return [
        Release::when(
            fn () => ! $this->order->isPaid(),
            releaseAfter: 60
        ),
    ];
}
```

`Release::when($condition)` releases the job when the condition is truthy.
`Release::unless($condition)` releases the job when the condition is not truthy. 
`$releaseAfter` defines the delay, in seconds, before the job is executed again.
