### PR TITLE
[13.x] Add missing @throws \InvalidArgumentException annotations

### DIFF
--- a/src/Illuminate/Database/Console/PruneCommand.php
+++ b/src/Illuminate/Database/Console/PruneCommand.php
@@ -112,6 +112,8 @@ class PruneCommand extends Command
      * Determine the models that should be pruned.
      *
      * @return \Illuminate\Support\Collection
+     *
+     * @throws \InvalidArgumentException
      */
     protected function models()
     {

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -792,6 +792,8 @@ trait HasAttributes
      *
      * @param  array  $casts
      * @return array
+     *
+     * @throws \InvalidArgumentException
      */
     protected function ensureCastsAreStringValues($casts)
     {

--- a/src/Illuminate/Mail/Attachment.php
+++ b/src/Illuminate/Mail/Attachment.php
@@ -63,6 +63,8 @@ class Attachment
      *
      * @param  string  $url
      * @return static
+     *
+     * @throws \InvalidArgumentException
      */
     public static function fromUrl($url)
     {

--- a/src/Illuminate/Mail/Mailables/Address.php
+++ b/src/Illuminate/Mail/Mailables/Address.php
@@ -25,6 +25,8 @@ class Address
      *
      * @param  string  $address
      * @param  string|null  $name
+     *
+     * @throws \InvalidArgumentException
      */
     public function __construct(string $address, ?string $name = null)
     {

--- a/src/Illuminate/Mail/Message.php
+++ b/src/Illuminate/Mail/Message.php
@@ -270,6 +270,8 @@ class Message
      *
      * @param  mixed  $address
      * @return mixed
+     *
+     * @throws \InvalidArgumentException
      */
     protected function ensureAddressIsSafe($address)
     {

--- a/src/Illuminate/View/ComponentSlot.php
+++ b/src/Illuminate/View/ComponentSlot.php
@@ -83,6 +83,8 @@ class ComponentSlot implements Htmlable, Stringable
      *
      * @param  callable|string|null  $callable
      * @return bool
+     *
+     * @throws \InvalidArgumentException
      */
     public function hasActualContent(callable|string|null $callable = null)
     {


### PR DESCRIPTION
This PR adds missing `@throws \InvalidArgumentException` annotations