### PR TITLE
[13.x] feat: add #[Override] to Redis connection methods

### DIFF
--- a/src/Illuminate/Redis/Connections/PhpRedisClusterConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisClusterConnection.php
@@ -50,6 +50,7 @@ class PhpRedisClusterConnection extends PhpRedisConnection
      *
      * @return void
      */
+    #[\Override]
     public function flushdb()
     {
         $arguments = func_get_args();

--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -455,6 +455,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
      * @param  \Closure  $callback
      * @return void
      */
+    #[\Override]
     public function subscribe($channels, Closure $callback)
     {
         $this->client->subscribe((array) $channels, function ($redis, $channel, $message) use ($callback) {
@@ -469,6 +470,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
      * @param  \Closure  $callback
      * @return void
      */
+    #[\Override]
     public function psubscribe($channels, Closure $callback)
     {
         $this->client->psubscribe((array) $channels, function ($redis, $pattern, $channel, $message) use ($callback) {
@@ -525,6 +527,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
      *
      * @throws \RedisException
      */
+    #[\Override]
     public function command($method, array $parameters = [])
     {
         try {
@@ -555,6 +558,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
      * @param  array  $parameters
      * @return mixed
      */
+    #[\Override]
     public function __call($method, $parameters)
     {
         return parent::__call(strtolower($method), $parameters);

--- a/src/Illuminate/Redis/Connections/PredisConnection.php
+++ b/src/Illuminate/Redis/Connections/PredisConnection.php
@@ -58,6 +58,7 @@ class PredisConnection extends Connection implements ConnectionContract
      * @param  array  $parameters
      * @return array
      */
+    #[\Override]
     protected function parseParametersForEvent(array $parameters)
     {
         return (new Collection($parameters))


### PR DESCRIPTION
Marks the overridden methods with the proper PHP attribute.