### PR TITLE
[13.x] refactor: avoid repeated count() calls in reverse named parameters loop

### DIFF
--- a/src/Illuminate/Routing/RouteUrlGenerator.php
+++ b/src/Illuminate/Routing/RouteUrlGenerator.php
@@ -253,9 +253,10 @@ class RouteUrlGenerator
         } elseif ($requiredRouteParametersWithoutDefaultsOrNamedParameters === [] && count($parameters) !== 0) {
             // Handle the case where all passed parameters are for parameters that have default values...
             $remainingCount = count($parameters);
+            $parameterCount = count($namedParameters);
 
             // Loop over empty parameters backwards and stop when we run out of passed parameters...
-            for ($i = count($namedParameters) - 1; $i >= 0; $i--) {
+            for ($i = $parameterCount - 1; $i >= 0; $i--) {
                 if ($namedParameters[array_keys($namedParameters)[$i]] === '') {
                     $offset = $i;
                     $remainingCount--;


### PR DESCRIPTION
This avoids calling `count($namedParameters)` multiple times inside the loop
and improves readability by making the loop boundary explicit.

No functional change.