### PR TITLE
[13.x] fix: respect channel name for on-demand log stacks

### DIFF
--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -103,7 +103,7 @@ class LogManager implements LoggerInterface
     public function stack(array $channels, $channel = null)
     {
         return (new Logger(
-            $this->createStackDriver(['channels' => $channels, 'channel' => $channel]),
+            $this->createStackDriver(['channels' => $channels, 'name' => $channel]),
             $this->app['events']
         ))->withContext($this->sharedContext);
     }

--- a/tests/Log/LogManagerTest.php
+++ b/tests/Log/LogManagerTest.php
@@ -500,6 +500,15 @@ class LogManagerTest extends TestCase
         $this->assertSame(storage_path('logs/custom.log'), $url->getValue($handler));
     }
 
+    public function testLogManagerCanSetChannelNameForOnDemandStack()
+    {
+        $manager = new LogManager($this->app);
+
+        $logger = $manager->stack(['single'], 'custom');
+
+        $this->assertSame('custom', $logger->getName());
+    }
+
     public function testWrappingHandlerInFingersCrossedWhenActionLevelIsUsed()
     {
         $config = $this->app['config'];


### PR DESCRIPTION
This PR fixes the channel name handling in `LogManager::stack(array $channels, $channel = null)`.

`stack()` currently passes the second argument to the stack driver config as `channel`:

```php
$this->createStackDriver([
    'channels' => $channels,
    'channel' => $channel,
]);
```

However, `createStackDriver()` resolves the Monolog channel name via `parseChannel()`, which reads the `name` key. As a result, the explicit channel name is ignored and Laravel falls back to the application environment name.

For example:

```php
Log::stack(['stack_probe'], 'expected_channel')
    ->getLogger()
    ->getName();
```

Currently returns the fallback channel name:

```php
'local'
```

instead of:

```php
'expected_channel'
```

This PR passes the value using the expected `name` key and adds a regression test for the explicit channel name.

This is backward compatible: calls without a channel name keep the existing fallback behavior, while calls with an explicit channel name now use it correctly.
