### PR TITLE
[13.x] Support inspecting delayed jobs on the queue fake

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -55,6 +55,13 @@ class QueueFake extends QueueManager implements Fake, Queue
     protected $jobs = [];
 
     /**
+     * All of the jobs that have been pushed with a delay.
+     *
+     * @var array
+     */
+    protected $delayed = [];
+
+    /**
      * All of the payloads that have been raw pushed.
      *
      * @var list<RawPushType>
@@ -460,7 +467,7 @@ class QueueFake extends QueueManager implements Fake, Queue
      */
     public function delayedSize($queue = null)
     {
-        return 0;
+        return $this->delayedJobs($queue)->count();
     }
 
     /**
@@ -482,32 +489,18 @@ class QueueFake extends QueueManager implements Fake, Queue
      */
     public function pendingJobs($queue = null): Collection
     {
-        $queue = enum_value($queue);
-
-        return (new Collection($this->jobs))
-            ->flatten(1)
-            ->filter(fn ($job) => $job['queue'] === $queue)
-            ->map(fn ($data) => new InspectedJob(
-                uuid: null,
-                name: is_object($data['job'])
-                    ? (method_exists($data['job'], 'displayName') ? $data['job']->displayName() : get_class($data['job']))
-                    : $data['job'],
-                attempts: 0,
-                payload: [],
-                queue: $queue,
-                createdAt: null,
-            ));
+        return $this->allPendingJobs()->whereStrict('queue', enum_value($queue))->values();
     }
 
     /**
      * Get the delayed jobs for the given queue.
      *
      * @param  \UnitEnum|string|null  $queue
-     * @return \Illuminate\Support\Collection
+     * @return \Illuminate\Support\Collection<int, \Illuminate\Queue\Jobs\InspectedJob>
      */
     public function delayedJobs($queue = null): Collection
     {
-        return new Collection;
+        return $this->allDelayedJobs()->whereStrict('queue', enum_value($queue))->values();
     }
 
     /**
@@ -528,7 +521,28 @@ class QueueFake extends QueueManager implements Fake, Queue
      */
     public function allPendingJobs(): Collection
     {
-        return (new Collection($this->jobs))
+        return $this->inspectJobs($this->jobs);
+    }
+
+    /**
+     * Get all delayed jobs across every queue.
+     *
+     * @return \Illuminate\Support\Collection<int, \Illuminate\Queue\Jobs\InspectedJob>
+     */
+    public function allDelayedJobs(): Collection
+    {
+        return $this->inspectJobs($this->delayed);
+    }
+
+    /**
+     * Map an array of jobs to a collection of inspected jobs.
+     *
+     * @param  array  $jobs
+     * @return \Illuminate\Support\Collection<int, \Illuminate\Queue\Jobs\InspectedJob>
+     */
+    protected function inspectJobs(array $jobs): Collection
+    {
+        return (new Collection($jobs))
             ->flatten(1)
             ->map(fn ($data) => new InspectedJob(
                 uuid: null,
@@ -540,16 +554,6 @@ class QueueFake extends QueueManager implements Fake, Queue
                 queue: $data['queue'],
                 createdAt: null,
             ));
-    }
-
-    /**
-     * Get all delayed jobs across every queue.
-     *
-     * @return \Illuminate\Support\Collection
-     */
-    public function allDelayedJobs(): Collection
-    {
-        return new Collection;
     }
 
     /**
@@ -674,6 +678,13 @@ class QueueFake extends QueueManager implements Fake, Queue
      */
     public function later($delay, $job, $data = '', $queue = null)
     {
+        if ($this->shouldFakeJob($job)) {
+            $this->delayed[is_object($job) ? get_class($job) : $job][] = [
+                'job' => $job,
+                'queue' => enum_value($queue),
+            ];
+        }
+
         return $this->push($job, $data, $queue);
     }
 
@@ -701,7 +712,7 @@ class QueueFake extends QueueManager implements Fake, Queue
      */
     public function laterOn($queue, $delay, $job, $data = '')
     {
-        return $this->push($job, $data, $queue);
+        return $this->later($delay, $job, $data, $queue);
     }
 
     /**

--- a/tests/Support/SupportTestingQueueFakeTest.php
+++ b/tests/Support/SupportTestingQueueFakeTest.php
@@ -541,6 +541,50 @@ class SupportTestingQueueFakeTest extends TestCase
         $this->assertTrue($pending->contains(fn ($job) => $job->name === JobToFakeStub::class));
     }
 
+    public function testDelayedJobs()
+    {
+        $this->fake->later(10, $this->job, '', 'foo');
+        $this->fake->later(10, new JobToFakeStub, '', 'bar');
+
+        $delayed = $this->fake->delayedJobs('foo');
+
+        $this->assertCount(1, $delayed);
+        $this->assertInstanceOf(InspectedJob::class, $delayed->first());
+        $this->assertSame(JobStub::class, $delayed->first()->name);
+        $this->assertSame(0, $delayed->first()->attempts);
+        $this->assertSame('foo', $delayed->first()->queue);
+    }
+
+    public function testAllDelayedJobs()
+    {
+        $this->fake->later(10, $this->job, '', 'foo');
+        $this->fake->later(10, new JobToFakeStub, '', 'bar');
+
+        $delayed = $this->fake->allDelayedJobs();
+
+        $this->assertCount(2, $delayed);
+        $this->assertInstanceOf(InspectedJob::class, $delayed->first());
+        $this->assertTrue($delayed->contains(fn ($job) => $job->name === JobStub::class));
+        $this->assertTrue($delayed->contains(fn ($job) => $job->name === JobToFakeStub::class));
+    }
+
+    public function testDelayedSize()
+    {
+        $this->fake->later(10, $this->job, '', 'foo');
+        $this->fake->later(10, new JobToFakeStub, '', 'bar');
+
+        $this->assertSame(1, $this->fake->delayedSize('foo'));
+        $this->assertSame(1, $this->fake->delayedSize('bar'));
+        $this->assertSame(0, $this->fake->delayedSize('baz'));
+    }
+
+    public function testDelayedJobsAreStillPushed()
+    {
+        $this->fake->later(10, $this->job, '', 'foo');
+
+        $this->fake->assertPushedOn('foo', JobStub::class);
+    }
+
     public function testGetRawPushes()
     {
         $this->fake->pushRaw('some-payload', null, ['options' => 'yeah']);


### PR DESCRIPTION
If you call `Queue::delayedSize()` or any of the `Queue::delayedJobs` etc methods in commands, jobs, or anywhere & need to test them, you end up with something like the below because right now the methods are stubbed (I did this today): 

```php
      Queue::expects('delayedJobs')
            ->andReturn(
                new Collection([new InspectedJob(uuid: null, queue: 'default', name: 'App\Jobs\ExampleJob', attempts: 0)]),
            );
````

Which means requiring to know about the internal logic of what exactly is returned  or the alternative is use a real driver.

This PR allows all the delayed methods ie `delayedSize`, `delayedJobs` & `allDelayedJobs` to be faked properly, without the need for mocking. This means if your job has a delay on, it'll just work... or you can use the fake to manually call later etc.

This does not physically delay the jobs, but just records them as delayed, so any pushed assertions still work.

 I don't think it's a B/C as before these returned stubbed empty values, but happy to take to 14.x if u prefer?  

`reservedJobs` have a similar thing, but needs more thought so will do in a diff PR as may need a `Queue::reserve` method or something.

Open to your feedback if I'm a maniac, perhaps you prefer we just use the mocks, but imo felt like it would be nice to fake it cause we have most methods fakes, and others not (im workin on it 🖍️ ) 
