### PR TITLE
[13.x] Add `Number::sub()` and `Number::sup()`

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -407,7 +407,7 @@ class Number
         }
 
         if ($number > 9) {
-            return implode('', array_map(fn (string $digit) => self::sup((int) $digit), str_split($number)));
+            return implode('', array_map(fn (string $digit) => self::sub((int) $digit), str_split($number)));
         }
 
         return match ($number) {

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -376,7 +376,7 @@ class Number
     public static function sup(int $number): string
     {
         if ($number < 0) {
-            throw new InvalidArgumentException('Negative numbers are not supported');
+            throw new \InvalidArgumentException('Negative numbers are not supported');
         }
 
         if ($number > 9) {
@@ -403,7 +403,7 @@ class Number
     public static function sub(int $number): string
     {
         if ($number < 0) {
-            throw new InvalidArgumentException('Negative numbers are not supported');
+            throw new \InvalidArgumentException('Negative numbers are not supported');
         }
 
         if ($number > 9) {

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -380,7 +380,7 @@ class Number
         }
 
         if ($number > 9) {
-            return implode('', array_map(fn (string $digit) => self::sup((int) $digit), (string) $number));
+            return implode('', array_map(fn (string $digit) => self::sup((int) $digit), str_split($number)));
         }
 
         return match ($number) {
@@ -407,7 +407,7 @@ class Number
         }
 
         if ($number > 9) {
-            return implode('', array_map(fn (string $digit) => self::sup((int) $digit), (string) $number));
+            return implode('', array_map(fn (string $digit) => self::sup((int) $digit), str_split($number)));
         }
 
         return match ($number) {

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -382,7 +382,7 @@ class Number
         if ($number > 9) {
             return implode('', array_map(fn (string $digit) => self::sup((int) $digit), (string) $number));
         }
-        
+
         return match ($number) {
             0 => "\u{2070}",
             1 => "\u{00B9}",
@@ -409,7 +409,7 @@ class Number
         if ($number > 9) {
             return implode('', array_map(fn (string $digit) => self::sup((int) $digit), (string) $number));
         }
-        
+
         return match ($number) {
             0 => "\u{2080}",
             1 => "\u{2081}",

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -371,6 +371,60 @@ class Number
     }
 
     /**
+     * @param  non-negative-int  $number
+     */
+    public static function sup(int $number): string
+    {
+        if ($number < 0) {
+            throw new InvalidArgumentException('Negative numbers are not supported');
+        }
+
+        if ($number > 9) {
+            return implode('', array_map(fn (string $digit) => self::sup((int) $digit), (string) $number));
+        }
+        
+        return match ($number) {
+            0 => "\u{2070}",
+            1 => "\u{00B9}",
+            2 => "\u{00B2}",
+            3 => "\u{00B3}",
+            4 => "\u{2074}",
+            5 => "\u{2075}",
+            6 => "\u{2076}",
+            7 => "\u{2077}",
+            8 => "\u{2078}",
+            9 => "\u{2079}",
+        };
+    }
+
+    /**
+     * @param  non-negative-int  $number
+     */
+    public static function sub(int $number): string
+    {
+        if ($number < 0) {
+            throw new InvalidArgumentException('Negative numbers are not supported');
+        }
+
+        if ($number > 9) {
+            return implode('', array_map(fn (string $digit) => self::sup((int) $digit), (string) $number));
+        }
+        
+        return match ($number) {
+            0 => "\u{2080}",
+            1 => "\u{2081}",
+            2 => "\u{2082}",
+            3 => "\u{2083}",
+            4 => "\u{2084}",
+            5 => "\u{2085}",
+            6 => "\u{2086}",
+            7 => "\u{2087}",
+            8 => "\u{2088}",
+            9 => "\u{2089}",
+        };
+    }
+
+    /**
      * Execute the given callback using the given locale.
      *
      * @template TReturn

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Support;
 
 use Illuminate\Support\Number;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\TestCase;
 
@@ -415,5 +416,45 @@ class SupportNumberTest extends TestCase
 
         $this->assertSame(1234.56, Number::parseFloat('1.234,56', locale: 'de'));
         $this->assertSame(1234.56, Number::parseFloat('1 234,56', locale: 'fr'));
+    }
+
+    #[DataProvider('provideSupNumbers')
+    public function testSup(int $number, string $result)
+    {
+        $this->assertSame($result, Number::sup($number));
+    }
+
+    public function testSupFails()
+    {
+        $this->expectExceptionObject(new \InvalidArgumentException('Negative numbers are not supported'));
+        Number::sup(-1);
+    }
+
+    public static function provideSupNumbers(): array
+    {
+        return [
+            'single-digit number' => [0, '⁰'],
+            'multi-digit number' => [42, '⁴²'],
+        ];
+    }
+
+    #[DataProvider('provideSubNumbers')
+    public function testSub(int $number, string $result)
+    {
+        $this->assertSame($result, Number::sub($number));
+    }
+
+    public function testSubFails()
+    {
+        $this->expectExceptionObject(new \InvalidArgumentException('Negative numbers are not supported'));
+        Number::sub(-1);
+    }
+
+    public static function provideSubNumbers(): array
+    {
+        return [
+            'single-digit number' => [0, '₀'],
+            'multi-digit number' => [42, '₄₂'],
+        ];
     }
 }

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -418,7 +418,7 @@ class SupportNumberTest extends TestCase
         $this->assertSame(1234.56, Number::parseFloat('1 234,56', locale: 'fr'));
     }
 
-    #[DataProvider('provideSupNumbers')
+    #[DataProvider('provideSupNumbers')]
     public function testSup(int $number, string $result)
     {
         $this->assertSame($result, Number::sup($number));
@@ -438,7 +438,7 @@ class SupportNumberTest extends TestCase
         ];
     }
 
-    #[DataProvider('provideSubNumbers')
+    #[DataProvider('provideSubNumbers')]
     public function testSub(int $number, string $result)
     {
         $this->assertSame($result, Number::sub($number));


### PR DESCRIPTION
# Motivation
Creating superscript and subscript numbers can be cumbersome. You either create them on your keyboard (1 – 3 should work, then it gets tricky), or you copy and paste them from somewhere (tedious), or you write the unicode number—however, having them nicely grouped as consecutive numbers would be too easy. Just like on the keyboard, after 3, the next numbers are on a different unicode block (who can keep all these in their head). With all of this in the already powerful `Number` helper, one doesn't have to!

# Example
```php
Number::sup(42); // ⁴²
Number::sub(42); // ₄₂
```