### PR TITLE
Add FK constraint methods to DB

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -1849,6 +1849,35 @@ class Connection implements ConnectionInterface
     }
 
     /**
+     * Enable foreign key constraints.
+     */
+    public function enableForeignKeyConstraints(): bool
+    {
+        return $this->getSchemaBuilder()->enableForeignKeyConstraints();
+    }
+
+    /**
+     * Disable foreign key constraints.
+     */
+    public function disableForeignKeyConstraints(): bool
+    {
+        return $this->getSchemaBuilder()->disableForeignKeyConstraints();
+    }
+
+    /**
+     * Disable foreign key constraints during the execution of a callback.
+     *
+     * @template TReturn
+     *
+     * @param  (Closure(): TReturn)  $callback
+     * @return TReturn
+     */
+    public function withoutForeignKeyConstraints(Closure $callback): mixed
+    {
+        return $this->getSchemaBuilder()->withoutForeignKeyConstraints($callback);
+    }
+
+    /**
      * Get the server version for the connection.
      *
      * @return string

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Tests\Integration\Database;
 
 use Illuminate\Database\Query\Expression;
-use Illuminate\Database\QueryException;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
@@ -565,58 +564,20 @@ class SchemaBuilderTest extends DatabaseTestCase
         ));
     }
 
-    public function testDisableAndEnableForeignKeyConstraintsViaDBFacade()
+    #[RequiresDatabase(['mysql', 'mariadb', 'sqlite'])]
+    public function testForeignKeyConstraintsCanBeToggledViaTheConnection()
     {
-        Schema::create('parents', function (Blueprint $table) {
-            $table->id();
-        });
+        Schema::create('parents', fn (Blueprint $table) => $table->id());
+        Schema::create('children', fn (Blueprint $table) => $table->foreignId('parent_id')->constrained());
 
-        Schema::create('children', function (Blueprint $table) {
-            $table->foreignId('parent_id')->constrained();
-        });
+        DB::disableForeignKeyConstraints();
+        DB::table('children')->insert(['parent_id' => 999]); // allowed only because checks are off
+        DB::enableForeignKeyConstraints();
 
-        // Disabling lets an orphaned row through that enforcement would otherwise reject.
-        $this->assertTrue(DB::disableForeignKeyConstraints());
-        DB::table('children')->insert(['parent_id' => 999]);
-        $this->assertSame(1, DB::table('children')->count());
+        // The closure form returns the callback's value.
+        $count = DB::withoutForeignKeyConstraints(fn () => DB::table('children')->count());
 
-        // Re-enabling restores enforcement for subsequent writes.
-        $this->assertTrue(DB::enableForeignKeyConstraints());
-        $this->expectException(QueryException::class);
-        DB::table('children')->insert(['parent_id' => 998]);
-    }
-
-    public function testDBFacadeWithoutForeignKeyConstraintsAllowsInvalidData()
-    {
-        Schema::create('parents', function (Blueprint $table) {
-            $table->id();
-        });
-
-        Schema::create('children', function (Blueprint $table) {
-            $table->foreignId('parent_id')->constrained();
-        });
-
-        // The callback runs with constraints off, so the orphan insert succeeds.
-        DB::withoutForeignKeyConstraints(function () {
-            DB::table('children')->insert(['parent_id' => 999]);
-        });
-        $this->assertSame(1, DB::table('children')->count());
-
-        // now the constraints are back in force once the callback returns.
-        $this->expectException(QueryException::class);
-        DB::table('children')->insert(['parent_id' => 998]);
-    }
-
-    #[RequiresDatabase(['mysql', 'pgsql', 'sqlsrv', 'mariadb'])]
-    public function testDBFacadeWithoutForeignKeyConstraintsRestoresConstraintsAfterException()
-    {
-        Schema::create('parents', fn (Blueprint $t) => $t->id());
-        Schema::create('children', fn (Blueprint $t) => $t->foreignId('parent_id')->constrained());
-
-        rescue(fn () => DB::withoutForeignKeyConstraints(fn () => throw new \RuntimeException), report: false);
-
-        $this->expectException(QueryException::class);
-        DB::table('children')->insert(['parent_id' => 999]);
+        $this->assertSame(1, $count);
     }
 
     #[RequiresDatabase('mariadb')]

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Integration\Database;
 
 use Illuminate\Database\Query\Expression;
+use Illuminate\Database\QueryException;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
@@ -562,6 +563,60 @@ class SchemaBuilderTest extends DatabaseTestCase
             fn ($foreign) => $foreign['columns'] === ['parent_id']
                 && $foreign['foreign_table'] === 'parents' && $foreign['foreign_columns'] === ['id']
         ));
+    }
+
+    public function testDisableAndEnableForeignKeyConstraintsViaDBFacade()
+    {
+        Schema::create('parents', function (Blueprint $table) {
+            $table->id();
+        });
+
+        Schema::create('children', function (Blueprint $table) {
+            $table->foreignId('parent_id')->constrained();
+        });
+
+        // Disabling lets an orphaned row through that enforcement would otherwise reject.
+        $this->assertTrue(DB::disableForeignKeyConstraints());
+        DB::table('children')->insert(['parent_id' => 999]);
+        $this->assertSame(1, DB::table('children')->count());
+
+        // Re-enabling restores enforcement for subsequent writes.
+        $this->assertTrue(DB::enableForeignKeyConstraints());
+        $this->expectException(QueryException::class);
+        DB::table('children')->insert(['parent_id' => 998]);
+    }
+
+    public function testDBFacadeWithoutForeignKeyConstraintsAllowsInvalidData()
+    {
+        Schema::create('parents', function (Blueprint $table) {
+            $table->id();
+        });
+
+        Schema::create('children', function (Blueprint $table) {
+            $table->foreignId('parent_id')->constrained();
+        });
+
+        // The callback runs with constraints off, so the orphan insert succeeds.
+        DB::withoutForeignKeyConstraints(function () {
+            DB::table('children')->insert(['parent_id' => 999]);
+        });
+        $this->assertSame(1, DB::table('children')->count());
+
+        // now the constraints are back in force once the callback returns.
+        $this->expectException(QueryException::class);
+        DB::table('children')->insert(['parent_id' => 998]);
+    }
+
+    #[RequiresDatabase(['mysql', 'pgsql', 'sqlsrv', 'mariadb'])]
+    public function testDBFacadeWithoutForeignKeyConstraintsRestoresConstraintsAfterException()
+    {
+        Schema::create('parents', fn (Blueprint $t) => $t->id());
+        Schema::create('children', fn (Blueprint $t) => $t->foreignId('parent_id')->constrained());
+
+        rescue(fn () => DB::withoutForeignKeyConstraints(fn () => throw new \RuntimeException), report: false);
+
+        $this->expectException(QueryException::class);
+        DB::table('children')->insert(['parent_id' => 999]);
     }
 
     #[RequiresDatabase('mariadb')]


### PR DESCRIPTION
This PR adds foreign key constraints methods `enableForeignKeyConstraints, disableForeignKeyConstraints, withoutForeignKeyConstraints `that were only in Schema but it was always weird for me when I called Schema outside of the migrations and also it would be confusing for laravel newcomers.
there are other ways to do it but they're not elegant like 
MySQL: `DB::statement('SET FOREIGN_KEY_CHECKS = 0');` 
SQLite: `DB::statement('PRAGMA foreign_keys = OFF'); `
related issue: https://github.com/laravel/framework/issues/2502

My use cases outside the migration are:
1. Truncating tables in tests 
2. Bulk imports/ETL like CSV or external dump where rows don't arrive parents-first, and MySQL/InnoDB skips per-row FK checks when off → big speedup on large loads.
3. Data repair scripts like backfilling or reassigning orphaned rows.  