### PR TITLE
[13.x] Supports scalar Predis retry config to allows `config:cache`

### DIFF
--- a/src/Illuminate/Redis/Connectors/PredisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PredisConnector.php
@@ -9,6 +9,10 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
 use Predis\Client;
+use Predis\Retry\Retry;
+use Predis\Retry\Strategy\EqualBackoff;
+use Predis\Retry\Strategy\ExponentialBackoff;
+use Predis\Retry\Strategy\NoBackoff;
 
 class PredisConnector implements Connector
 {
@@ -21,6 +25,8 @@ class PredisConnector implements Connector
      */
     public function connect(array $config, array $options)
     {
+        $config = $this->formatRetry($config);
+
         $formattedOptions = array_merge(
             ['timeout' => 10.0], $options, Arr::pull($config, 'options', [])
         );
@@ -57,6 +63,61 @@ class PredisConnector implements Connector
         return new PredisClusterConnection(new Client($servers, array_merge(
             $options, $clusterOptions, $clusterSpecificOptions
         )));
+    }
+
+    /**
+     * Format scalar retry configuration into a Predis retry instance.
+     *
+     * @param  array  $config
+     * @return array
+     */
+    protected function formatRetry(array $config)
+    {
+        if (! array_key_exists('retry', $config) || ! is_array($config['retry'])) {
+            return $config;
+        }
+
+        if (! class_exists(Retry::class) ||
+            ! class_exists(ExponentialBackoff::class) ||
+            ! class_exists(EqualBackoff::class) ||
+            ! class_exists(NoBackoff::class)) {
+            throw new InvalidArgumentException('Predis retry configuration requires predis/predis 3.4.0 or newer.');
+        }
+
+        $retry = $config['retry'];
+        $retries = Arr::pull($retry, 'max_retries', Arr::pull($retry, 'retries', 0));
+        $algorithm = Arr::pull($retry, 'backoff_algorithm', 'exponential');
+        $base = Arr::pull($retry, 'backoff_base', ExponentialBackoff::DEFAULT_BASE);
+        $cap = Arr::pull($retry, 'backoff_cap', ExponentialBackoff::DEFAULT_CAP);
+
+        $config['retry'] = new Retry(
+            $this->parseBackoffStrategy($algorithm, (int) $base, (int) $cap),
+            (int) $retries
+        );
+
+        return $config;
+    }
+
+    /**
+     * Parse a Predis backoff strategy.
+     *
+     * @param  mixed  $algorithm
+     * @param  int  $base
+     * @param  int  $cap
+     * @return \Predis\Retry\Strategy\RetryStrategyInterface
+     */
+    protected function parseBackoffStrategy($algorithm, int $base, int $cap)
+    {
+        if (! is_string($algorithm)) {
+            throw new InvalidArgumentException('Predis backoff algorithm must be a string.');
+        }
+
+        return match (Str::snake($algorithm)) {
+            'default', 'exponential' => new ExponentialBackoff($base, $cap),
+            'constant', 'equal', 'equal_backoff' => new EqualBackoff($base),
+            'none', 'no_backoff' => new NoBackoff,
+            default => throw new InvalidArgumentException("Algorithm [{$algorithm}] is not a valid Predis backoff algorithm."),
+        };
     }
 
     /**

--- a/src/Illuminate/Redis/Connectors/PredisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PredisConnector.php
@@ -23,7 +23,7 @@ class PredisConnector implements Connector
      */
     public function connect(array $config, array $options)
     {
-        $config = $this->formatRetry($config);
+        $config = $this->formatRetryConfig($config);
 
         $formattedOptions = array_merge(
             ['timeout' => 10.0], $options, Arr::pull($config, 'options', [])
@@ -61,41 +61,10 @@ class PredisConnector implements Connector
         $options = array_merge($options, $clusterOptions, $clusterSpecificOptions);
 
         if (isset($options['parameters']) && is_array($options['parameters'])) {
-            $options['parameters'] = $this->formatRetry($options['parameters']);
+            $options['parameters'] = $this->formatRetryConfig($options['parameters']);
         }
 
         return new PredisClusterConnection(new Client($servers, $options));
-    }
-
-    /**
-     * Format scalar retry configuration into a Predis retry instance.
-     *
-     * @param  array  $config
-     * @return array
-     */
-    protected function formatRetry(array $config)
-    {
-        if (! array_key_exists('retry', $config) || ! is_array($config['retry'])) {
-            return $config;
-        }
-
-        if (! class_exists(Retry::class) || ! interface_exists(RetryStrategyInterface::class)) {
-            throw new InvalidArgumentException('Predis retry configuration requires predis/predis 3.4.0 or newer.');
-        }
-
-        $strategy = array_key_first($config['retry']);
-        $retries = $config['max_retries'] ?? 0;
-
-        if (! is_subclass_of($strategy, RetryStrategyInterface::class)) {
-            throw new InvalidArgumentException("Strategy [{$strategy}] is not a valid Predis backoff strategy.");
-        }
-
-        $config['retry'] = new Retry(
-            new $strategy(...$config['retry'][$strategy]),
-            $retries,
-        );
-
-        return $config;
     }
 
     /**
@@ -124,6 +93,38 @@ class PredisConnector implements Connector
 
         $config['scheme'] = $config['scheme'] ?? $hostScheme;
         $config['host'] = Str::after($host, "{$hostScheme}://");
+
+        return $config;
+    }
+
+    /**
+     * Format a scalar retry configuration into a Predis retry instance if applicable.
+     *
+     * @param  array  $config
+     * @return array
+     */
+    protected function formatRetryConfig(array $config)
+    {
+        if (! array_key_exists('retry', $config) || ! is_array($config['retry'])) {
+            return $config;
+        }
+
+        if (! class_exists(Retry::class) || ! interface_exists(RetryStrategyInterface::class)) {
+            throw new InvalidArgumentException('Predis retry configuration requires predis/predis 3.4.0 or newer.');
+        }
+
+        $strategy = array_key_first($config['retry']);
+
+        $retries = $config['max_retries'] ?? 0;
+
+        if (! is_subclass_of($strategy, RetryStrategyInterface::class)) {
+            throw new InvalidArgumentException("Strategy [{$strategy}] is not a valid Predis backoff strategy.");
+        }
+
+        $config['retry'] = new Retry(
+            new $strategy(...$config['retry'][$strategy]),
+            $retries,
+        );
 
         return $config;
     }

--- a/src/Illuminate/Redis/Connectors/PredisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PredisConnector.php
@@ -58,9 +58,13 @@ class PredisConnector implements Connector
             return is_array($server) ? $this->formatHost($server) : $server;
         }, array_values($config));
 
-        return new PredisClusterConnection(new Client($servers, array_merge(
-            $options, $clusterOptions, $clusterSpecificOptions
-        )));
+        $options = array_merge($options, $clusterOptions, $clusterSpecificOptions);
+
+        if (isset($options['parameters']) && is_array($options['parameters'])) {
+            $options['parameters'] = $this->formatRetry($options['parameters']);
+        }
+
+        return new PredisClusterConnection(new Client($servers, $options));
     }
 
     /**

--- a/src/Illuminate/Redis/Connectors/PredisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PredisConnector.php
@@ -10,9 +10,7 @@ use Illuminate\Support\Str;
 use InvalidArgumentException;
 use Predis\Client;
 use Predis\Retry\Retry;
-use Predis\Retry\Strategy\EqualBackoff;
-use Predis\Retry\Strategy\ExponentialBackoff;
-use Predis\Retry\Strategy\NoBackoff;
+use Predis\Retry\Strategy\RetryStrategyInterface;
 
 class PredisConnector implements Connector
 {
@@ -77,22 +75,20 @@ class PredisConnector implements Connector
             return $config;
         }
 
-        if (! class_exists(Retry::class) ||
-            ! class_exists(ExponentialBackoff::class) ||
-            ! class_exists(EqualBackoff::class) ||
-            ! class_exists(NoBackoff::class)) {
+        if (! class_exists(Retry::class) || ! interface_exists(RetryStrategyInterface::class)) {
             throw new InvalidArgumentException('Predis retry configuration requires predis/predis 3.4.0 or newer.');
         }
 
-        $retry = $config['retry'];
-        $retries = Arr::pull($retry, 'max_retries', Arr::pull($retry, 'retries', 0));
-        $algorithm = Arr::pull($retry, 'backoff_algorithm', 'exponential');
-        $base = Arr::pull($retry, 'backoff_base', ExponentialBackoff::DEFAULT_BASE);
-        $cap = Arr::pull($retry, 'backoff_cap', ExponentialBackoff::DEFAULT_CAP);
+        $strategy = array_key_first($config['retry']);
+        $retries = $config['max_retries'] ?? 0;
+
+        if (! is_subclass_of($strategy, RetryStrategyInterface::class)) {
+            throw new InvalidArgumentException("Strategy [{$strategy}] is not a valid Predis backoff strategy.");
+        }
 
         $config['retry'] = new Retry(
-            $this->parseBackoffStrategy($algorithm, (int) $base, (int) $cap),
-            (int) $retries
+            new $strategy(...$config['retry'][$strategy]),
+            $retries,
         );
 
         return $config;

--- a/src/Illuminate/Redis/Connectors/PredisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PredisConnector.php
@@ -95,28 +95,6 @@ class PredisConnector implements Connector
     }
 
     /**
-     * Parse a Predis backoff strategy.
-     *
-     * @param  mixed  $algorithm
-     * @param  int  $base
-     * @param  int  $cap
-     * @return \Predis\Retry\Strategy\RetryStrategyInterface
-     */
-    protected function parseBackoffStrategy($algorithm, int $base, int $cap)
-    {
-        if (! is_string($algorithm)) {
-            throw new InvalidArgumentException('Predis backoff algorithm must be a string.');
-        }
-
-        return match (Str::snake($algorithm)) {
-            'default', 'exponential' => new ExponentialBackoff($base, $cap),
-            'constant', 'equal', 'equal_backoff' => new EqualBackoff($base),
-            'none', 'no_backoff' => new NoBackoff,
-            default => throw new InvalidArgumentException("Algorithm [{$algorithm}] is not a valid Predis backoff algorithm."),
-        };
-    }
-
-    /**
      * Format the host using the scheme if available.
      *
      * @param  array  $config

--- a/tests/Redis/PredisConnectorTest.php
+++ b/tests/Redis/PredisConnectorTest.php
@@ -4,6 +4,10 @@ namespace Illuminate\Tests\Redis;
 
 use Illuminate\Redis\Connectors\PredisConnector;
 use PHPUnit\Framework\TestCase;
+use Predis\Retry\Retry;
+use Predis\Retry\Strategy\EqualBackoff;
+use Predis\Retry\Strategy\ExponentialBackoff;
+use Predis\Retry\Strategy\NoBackoff;
 
 class PredisConnectorTest extends TestCase
 {
@@ -75,10 +79,130 @@ class PredisConnectorTest extends TestCase
             'scheme' => 'tls',
         ]);
     }
+
+    public function testFormatRetryCreatesRetryFromScalarOptions()
+    {
+        $this->requiresPredisRetrySupport();
+
+        $connector = new TestablePredisConnector;
+
+        $config = $connector->testFormatRetry([
+            'host' => '127.0.0.1',
+            'retry' => [
+                'max_retries' => 3,
+                'backoff_algorithm' => 'exponential',
+                'backoff_base' => 250000,
+                'backoff_cap' => 2000000,
+            ],
+        ]);
+
+        $this->assertInstanceOf(Retry::class, $config['retry']);
+        $this->assertSame(3, $config['retry']->getRetries());
+
+        $this->assertInstanceOf(ExponentialBackoff::class, $config['retry']->getStrategy());
+        $this->assertSame(250000, $config['retry']->getStrategy()->getBase());
+        $this->assertSame(2000000, $config['retry']->getStrategy()->getCap());
+    }
+
+    public function testFormatRetryDoesNotTreatPhpRedisBackoffOptionsAsPredisRetryConfig()
+    {
+        $connector = new TestablePredisConnector;
+
+        $config = [
+            'host' => '127.0.0.1',
+            'max_retries' => 3,
+            'backoff_algorithm' => 'decorrelated_jitter',
+            'backoff_base' => 100,
+            'backoff_cap' => 1000,
+        ];
+
+        $this->assertSame($config, $connector->testFormatRetry($config));
+    }
+
+    public function testFormatRetryUsesConstantBackoff()
+    {
+        $this->requiresPredisRetrySupport();
+
+        $connector = new TestablePredisConnector;
+
+        $config = $connector->testFormatRetry([
+            'retry' => [
+                'max_retries' => 3,
+                'backoff_algorithm' => 'constant',
+                'backoff_base' => 250000,
+            ],
+        ]);
+
+        $this->assertInstanceOf(EqualBackoff::class, $config['retry']->getStrategy());
+        $this->assertSame(250000, $config['retry']->getStrategy()->compute(0));
+    }
+
+    public function testFormatRetryUsesNoBackoff()
+    {
+        $this->requiresPredisRetrySupport();
+
+        $connector = new TestablePredisConnector;
+
+        $config = $connector->testFormatRetry([
+            'retry' => [
+                'max_retries' => 3,
+                'backoff_algorithm' => 'none',
+            ],
+        ]);
+
+        $this->assertInstanceOf(NoBackoff::class, $config['retry']->getStrategy());
+        $this->assertSame(0, $config['retry']->getStrategy()->compute(0));
+    }
+
+    public function testFormatRetryKeepsExplicitRetryInstance()
+    {
+        $this->requiresPredisRetrySupport();
+
+        $connector = new TestablePredisConnector;
+        $retry = new Retry(new NoBackoff, 3);
+
+        $config = $connector->testFormatRetry([
+            'retry' => $retry,
+            'max_retries' => 5,
+            'backoff_algorithm' => 'exponential',
+        ]);
+
+        $this->assertSame($retry, $config['retry']);
+        $this->assertSame(5, $config['max_retries']);
+    }
+
+    public function testFormatRetryThrowsForInvalidBackoffAlgorithm()
+    {
+        $this->requiresPredisRetrySupport();
+
+        $connector = new TestablePredisConnector;
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Algorithm [bogus] is not a valid Predis backoff algorithm.');
+
+        $connector->testFormatRetry([
+            'retry' => [
+                'max_retries' => 3,
+                'backoff_algorithm' => 'bogus',
+            ],
+        ]);
+    }
+
+    protected function requiresPredisRetrySupport()
+    {
+        if (! class_exists(Retry::class)) {
+            $this->markTestSkipped('Predis retry support is not available.');
+        }
+    }
 }
 
 class TestablePredisConnector extends PredisConnector
 {
+    public function testFormatRetry(array $config): array
+    {
+        return $this->formatRetry($config);
+    }
+
     public function testFormatHost(array $config): array
     {
         return $this->formatHost($config);

--- a/tests/Redis/PredisConnectorTest.php
+++ b/tests/Redis/PredisConnectorTest.php
@@ -104,6 +104,32 @@ class PredisConnectorTest extends TestCase
         $this->assertSame(2000000, $config['retry']->getStrategy()->getCap());
     }
 
+    public function testFormatRetryCreatesRetryFromScalarOptionsWithNamedArray()
+    {
+        $this->requiresPredisRetrySupport();
+
+        $connector = new TestablePredisConnector;
+
+        $config = $connector->testFormatRetry([
+            'host' => '127.0.0.1',
+            'retry' => [
+                ExponentialBackoff::class => [
+                    'withJitter' => true,
+                    'base' => 250_000,
+                    'cap' => 2_000_000,
+                ],
+            ],
+            'max_retries' => 3,
+        ]);
+
+        $this->assertInstanceOf(Retry::class, $config['retry']);
+        $this->assertSame(3, $config['retry']->getRetries());
+
+        $this->assertInstanceOf(ExponentialBackoff::class, $config['retry']->getStrategy());
+        $this->assertSame(250000, $config['retry']->getStrategy()->getBase());
+        $this->assertSame(2000000, $config['retry']->getStrategy()->getCap());
+    }
+
     public function testFormatRetryDoesNotTreatPhpRedisBackoffOptionsAsPredisRetryConfig()
     {
         $connector = new TestablePredisConnector;

--- a/tests/Redis/PredisConnectorTest.php
+++ b/tests/Redis/PredisConnectorTest.php
@@ -179,6 +179,32 @@ class PredisConnectorTest extends TestCase
         $this->assertSame(0, $config['retry']->getStrategy()->compute(0));
     }
 
+    public function testConnectToClusterFormatsRetryParameters()
+    {
+        $this->requiresPredisRetrySupport();
+
+        $connector = new TestablePredisConnector;
+
+        $connection = $connector->connectToCluster([
+            ['host' => '127.0.0.1', 'port' => 6379],
+        ], [
+            'cluster' => 'redis',
+            'parameters' => [
+                'retry' => [
+                    NoBackoff::class => [],
+                ],
+                'max_retries' => 3,
+            ],
+        ], []);
+
+        $property = new \ReflectionProperty($connection->client()->getConnection(), 'connectionParameters');
+        $parameters = $property->getValue($connection->client()->getConnection());
+
+        $this->assertInstanceOf(Retry::class, $parameters->retry);
+        $this->assertSame(3, $parameters->retry->getRetries());
+        $this->assertInstanceOf(NoBackoff::class, $parameters->retry->getStrategy());
+    }
+
     public function testFormatRetryKeepsExplicitRetryInstance()
     {
         $this->requiresPredisRetrySupport();

--- a/tests/Redis/PredisConnectorTest.php
+++ b/tests/Redis/PredisConnectorTest.php
@@ -89,11 +89,11 @@ class PredisConnectorTest extends TestCase
         $config = $connector->testFormatRetry([
             'host' => '127.0.0.1',
             'retry' => [
-                'max_retries' => 3,
-                'backoff_algorithm' => 'exponential',
-                'backoff_base' => 250000,
-                'backoff_cap' => 2000000,
+                ExponentialBackoff::class => [
+                    250_000, 2_000_000,
+                ],
             ],
+            'max_retries' => 3,
         ]);
 
         $this->assertInstanceOf(Retry::class, $config['retry']);
@@ -127,10 +127,9 @@ class PredisConnectorTest extends TestCase
 
         $config = $connector->testFormatRetry([
             'retry' => [
-                'max_retries' => 3,
-                'backoff_algorithm' => 'constant',
-                'backoff_base' => 250000,
+                EqualBackoff::class => [250_000],
             ],
+            'max_retries' => 3,
         ]);
 
         $this->assertInstanceOf(EqualBackoff::class, $config['retry']->getStrategy());
@@ -145,9 +144,9 @@ class PredisConnectorTest extends TestCase
 
         $config = $connector->testFormatRetry([
             'retry' => [
-                'max_retries' => 3,
-                'backoff_algorithm' => 'none',
+                NoBackoff::class => [],
             ],
+            'max_retries' => 3,
         ]);
 
         $this->assertInstanceOf(NoBackoff::class, $config['retry']->getStrategy());
@@ -178,13 +177,13 @@ class PredisConnectorTest extends TestCase
         $connector = new TestablePredisConnector;
 
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Algorithm [bogus] is not a valid Predis backoff algorithm.');
+        $this->expectExceptionMessage('Strategy [bogus] is not a valid Predis backoff strategy.');
 
         $connector->testFormatRetry([
             'retry' => [
-                'max_retries' => 3,
-                'backoff_algorithm' => 'bogus',
+                'bogus' => [],
             ],
+            'max_retries' => 3,
         ]);
     }
 


### PR DESCRIPTION
### Before

```php
use Predis\Retry;
use Predis\Retry\Strategy\ExponentialBackoff;
 
'default' => [
    'url' => env('REDIS_URL'),
    // ...
    'retry' => new Retry(
        new ExponentialBackoff(
            env('REDIS_BACKOFF_BASE', 100),
            env('REDIS_BACKOFF_CAP', 1000),
            true, // Enables jitter
        ),
        env('REDIS_MAX_RETRIES', 3)
    )
],
```

### After

```php

```php
use Predis\Retry;
use Predis\Retry\Strategy\ExponentialBackoff;
 
'default' => [
    'url' => env('REDIS_URL'),
    // ...
    'retry' => [
        ExponentialBackoff::class => [
            env('REDIS_BACKOFF_BASE', 100),
            env('REDIS_BACKOFF_CAP', 1000),
            true, // Enables jitter
        ],
    ],
    'max_retries' => env('REDIS_MAX_RETRIES', 3),
],
```

1. Existing structure still work without any changes
2. normalize `max_retries` configuration for both `phpredis` and `predis` configuration.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
