### PR TITLE
[13.x] Update docblocks of Blueprint foreignUuid and foreignUlid to match foreignId

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1413,7 +1413,7 @@ class Blueprint
     }
 
     /**
-     * Create a new UUID column on the table.
+     * Create a new UUID foreign ID column on the table.
      *
      * @param  string  $column
      * @return \Illuminate\Database\Schema\ColumnDefinition
@@ -1438,7 +1438,7 @@ class Blueprint
     }
 
     /**
-     * Create a new ULID column on the table.
+     * Create a new ULID foreign ID column on the table.
      *
      * @param  string  $column
      * @param  int|null  $length

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1424,7 +1424,7 @@ class Blueprint
     }
 
     /**
-     * Create a new UUID column on the table with a foreign key constraint.
+     * Create a new UUID column on the table.
      *
      * @param  string  $column
      * @return \Illuminate\Database\Schema\ForeignIdColumnDefinition
@@ -1450,7 +1450,7 @@ class Blueprint
     }
 
     /**
-     * Create a new ULID column on the table with a foreign key constraint.
+     * Create a new ULID column on the table.
      *
      * @param  string  $column
      * @param  int|null  $length


### PR DESCRIPTION
The description is misleading for `foreignUuid` and `foreignUlid` as it implies a foreign key constraint will be applied. Take a look at these three comparisons

**foreignId**

```
    /**
     * Create a new unsigned big integer column on the table (8-byte, 0 to 18,446,744,073,709,551,615).
     *
     * @param  string  $column
     * @param  bool  $autoIncrement
     * @return \Illuminate\Database\Schema\ColumnDefinition
     */
    public function unsignedBigInteger($column, $autoIncrement = false)

---

    /**
     * Create a new unsigned big integer column on the table (8-byte, 0 to 18,446,744,073,709,551,615).
     *
     * @param  string  $column
     * @return \Illuminate\Database\Schema\ForeignIdColumnDefinition
     */
    public function foreignId($column)
```

**foreignUuid**

```
    /**
     * Create a new UUID column on the table.
     *
     * @param  string  $column
     * @return \Illuminate\Database\Schema\ColumnDefinition
     */
    public function uuid($column = 'uuid')

---

    /**
     * Create a new UUID column on the table with a foreign key constraint.
     *
     * @param  string  $column
     * @return \Illuminate\Database\Schema\ForeignIdColumnDefinition
     */
    public function foreignUuid($column)
```

**foreignUlid**

```
    /**
     * Create a new ULID column on the table.
     *
     * @param  string  $column
     * @param  int|null  $length
     * @return \Illuminate\Database\Schema\ColumnDefinition
     */
    public function ulid($column = 'ulid', $length = 26)

---

    /**
     * Create a new ULID column on the table with a foreign key constraint.
     *
     * @param  string  $column
     * @param  int|null  $length
     * @return \Illuminate\Database\Schema\ForeignIdColumnDefinition
     */
    public function foreignUlid($column, $length = 26)
```

It should be noted that just like `foreignId`, these two function do not actually set a foreign key constraint and therefore the descriptions are misleading.

`foreignId` is ok as it just takes a direct copy from the `unsignedBigInteger` function. I have taken the same approach to fix `foreignUuid` and `foreignUlid` in this PR.

Thanks