### PR TITLE
[13.x] Support inspecting reserved jobs on the queue fake

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -62,6 +62,13 @@ class QueueFake extends QueueManager implements Fake, Queue
     protected $delayed = [];
 
     /**
+     * All of the jobs that have been marked as reserved.
+     *
+     * @var array
+     */
+    protected $reserved = [];
+
+    /**
      * All of the payloads that have been raw pushed.
      *
      * @var list<RawPushType>
@@ -478,7 +485,7 @@ class QueueFake extends QueueManager implements Fake, Queue
      */
     public function reservedSize($queue = null)
     {
-        return 0;
+        return $this->reservedJobs($queue)->count();
     }
 
     /**
@@ -507,11 +514,11 @@ class QueueFake extends QueueManager implements Fake, Queue
      * Get the reserved jobs for the given queue.
      *
      * @param  \UnitEnum|string|null  $queue
-     * @return \Illuminate\Support\Collection
+     * @return \Illuminate\Support\Collection<int, \Illuminate\Queue\Jobs\InspectedJob>
      */
     public function reservedJobs($queue = null): Collection
     {
-        return new Collection;
+        return $this->allReservedJobs()->whereStrict('queue', enum_value($queue))->values();
     }
 
     /**
@@ -559,11 +566,11 @@ class QueueFake extends QueueManager implements Fake, Queue
     /**
      * Get all reserved jobs across every queue.
      *
-     * @return \Illuminate\Support\Collection
+     * @return \Illuminate\Support\Collection<int, \Illuminate\Queue\Jobs\InspectedJob>
      */
     public function allReservedJobs(): Collection
     {
-        return new Collection;
+        return $this->inspectJobs($this->reserved);
     }
 
     /**
@@ -607,6 +614,49 @@ class QueueFake extends QueueManager implements Fake, Queue
             is_object($job) && isset($job->connection)
                 ? $this->queue->connection($job->connection)->push($job, $data, $queue)
                 : $this->queue->push($job, $data, $queue);
+        }
+    }
+
+    /**
+     * Mark the given job as reserved.
+     *
+     * @param  \Closure|string|object  $job
+     * @param  \UnitEnum|string|null  $queue
+     * @return void
+     */
+    public function reserve($job, $queue = null)
+    {
+        $queue = enum_value($queue);
+
+        if ($job instanceof Closure) {
+            $job = CallQueuedClosure::create($job);
+        }
+
+        $this->reserved[is_object($job) ? get_class($job) : $job][] = [
+            'job' => $this->serializeAndRestore ? $this->serializeAndRestoreJob($job) : $job,
+            'queue' => $queue,
+        ];
+    }
+
+    /**
+     * Delete a reserved job.
+     *
+     * @param  string|object  $job
+     * @param  \UnitEnum|string|null  $queue
+     * @return void
+     */
+    public function deleteReserved($job, $queue = null)
+    {
+        $queue = enum_value($queue);
+
+        $class = is_object($job) ? get_class($job) : $job;
+
+        foreach ($this->reserved[$class] ?? [] as $index => $reserved) {
+            if ($reserved['queue'] === $queue) {
+                unset($this->reserved[$class][$index]);
+
+                break;
+            }
         }
     }
 

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -62,13 +62,6 @@ class QueueFake extends QueueManager implements Fake, Queue
     protected $delayed = [];
 
     /**
-     * All of the jobs that have been marked as reserved.
-     *
-     * @var array
-     */
-    protected $reserved = [];
-
-    /**
      * All of the payloads that have been raw pushed.
      *
      * @var list<RawPushType>
@@ -80,7 +73,14 @@ class QueueFake extends QueueManager implements Fake, Queue
      *
      * @var array
      */
-    private $uniqueJobs = [];
+    protected $uniqueJobs = [];
+
+    /**
+     * All of the jobs that have been marked as reserved.
+     *
+     * @var array
+     */
+    protected $reserved = [];
 
     /**
      * Indicates if items should be serialized and restored when pushed to the queue.
@@ -618,37 +618,6 @@ class QueueFake extends QueueManager implements Fake, Queue
     }
 
     /**
-     * Mark the given job as reserved.
-     *
-     * @param  \Closure|string|object  $job
-     * @param  \UnitEnum|string|null  $queue
-     * @return void
-     */
-    public function reserve($job, $queue = null)
-    {
-        $queue = enum_value($queue);
-
-        if ($job instanceof Closure) {
-            $job = CallQueuedClosure::create($job);
-        }
-
-        $this->reserved[is_object($job) ? get_class($job) : $job][] = [
-            'job' => $this->serializeAndRestore ? $this->serializeAndRestoreJob($job) : $job,
-            'queue' => $queue,
-        ];
-    }
-
-    /**
-     * Clear all of the reserved jobs.
-     *
-     * @return void
-     */
-    public function clearReserved()
-    {
-        $this->reserved = [];
-    }
-
-    /**
      * Determine if a job should be faked or actually dispatched.
      *
      * @param  object  $job
@@ -754,6 +723,27 @@ class QueueFake extends QueueManager implements Fake, Queue
     }
 
     /**
+     * Mark the given job as reserved.
+     *
+     * @param  \Closure|string|object  $job
+     * @param  \UnitEnum|string|null  $queue
+     * @return void
+     */
+    public function reserve($job, $queue = null)
+    {
+        $queue = enum_value($queue);
+
+        if ($job instanceof Closure) {
+            $job = CallQueuedClosure::create($job);
+        }
+
+        $this->reserved[is_object($job) ? get_class($job) : $job][] = [
+            'job' => $this->serializeAndRestore ? $this->serializeAndRestoreJob($job) : $job,
+            'queue' => $queue,
+        ];
+    }
+
+    /**
      * Pop the next job off of the queue.
      *
      * @param  \UnitEnum|string|null  $queue
@@ -837,6 +827,16 @@ class QueueFake extends QueueManager implements Fake, Queue
         }
 
         $this->uniqueJobs = [];
+    }
+
+    /**
+     * Clear all of the reserved jobs.
+     *
+     * @return void
+     */
+    public function clearReserved()
+    {
+        $this->reserved = [];
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -639,25 +639,13 @@ class QueueFake extends QueueManager implements Fake, Queue
     }
 
     /**
-     * Delete a reserved job.
+     * Clear all of the reserved jobs.
      *
-     * @param  string|object  $job
-     * @param  \UnitEnum|string|null  $queue
      * @return void
      */
-    public function deleteReserved($job, $queue = null)
+    public function clearReserved()
     {
-        $queue = enum_value($queue);
-
-        $class = is_object($job) ? get_class($job) : $job;
-
-        foreach ($this->reserved[$class] ?? [] as $index => $reserved) {
-            if ($reserved['queue'] === $queue) {
-                unset($this->reserved[$class][$index]);
-
-                break;
-            }
-        }
+        $this->reserved = [];
     }
 
     /**

--- a/tests/Support/SupportTestingQueueFakeTest.php
+++ b/tests/Support/SupportTestingQueueFakeTest.php
@@ -622,15 +622,15 @@ class SupportTestingQueueFakeTest extends TestCase
         $this->assertSame(0, $this->fake->reservedSize('baz'));
     }
 
-    public function testDeleteReserved()
+    public function testClearReserved()
     {
         $this->fake->reserve($this->job, 'foo');
         $this->fake->reserve(new JobToFakeStub, 'bar');
 
-        $this->fake->deleteReserved($this->job, 'foo');
+        $this->fake->clearReserved();
 
         $this->assertSame(0, $this->fake->reservedSize('foo'));
-        $this->assertSame(1, $this->fake->reservedSize('bar'));
+        $this->assertSame(0, $this->fake->reservedSize('bar'));
     }
 
     public function testGetRawPushes()

--- a/tests/Support/SupportTestingQueueFakeTest.php
+++ b/tests/Support/SupportTestingQueueFakeTest.php
@@ -628,6 +628,7 @@ class SupportTestingQueueFakeTest extends TestCase
 
         $this->fake->assertNotPushed(JobStub::class);
     }
+
     public function testClearReserved()
     {
         $this->fake->reserve($this->job, 'foo');

--- a/tests/Support/SupportTestingQueueFakeTest.php
+++ b/tests/Support/SupportTestingQueueFakeTest.php
@@ -585,6 +585,54 @@ class SupportTestingQueueFakeTest extends TestCase
         $this->fake->assertPushedOn('foo', JobStub::class);
     }
 
+    public function testReservedJobs()
+    {
+        $this->fake->reserve($this->job, 'foo');
+        $this->fake->reserve(new JobToFakeStub, 'bar');
+
+        $reserved = $this->fake->reservedJobs('foo');
+
+        $this->assertCount(1, $reserved);
+        $this->assertInstanceOf(InspectedJob::class, $reserved->first());
+        $this->assertSame(JobStub::class, $reserved->first()->name);
+        $this->assertSame(0, $reserved->first()->attempts);
+        $this->assertSame('foo', $reserved->first()->queue);
+    }
+
+    public function testAllReservedJobs()
+    {
+        $this->fake->reserve($this->job, 'foo');
+        $this->fake->reserve(new JobToFakeStub, 'bar');
+
+        $reserved = $this->fake->allReservedJobs();
+
+        $this->assertCount(2, $reserved);
+        $this->assertInstanceOf(InspectedJob::class, $reserved->first());
+        $this->assertTrue($reserved->contains(fn ($job) => $job->name === JobStub::class));
+        $this->assertTrue($reserved->contains(fn ($job) => $job->name === JobToFakeStub::class));
+    }
+
+    public function testReservedSize()
+    {
+        $this->fake->reserve($this->job, 'foo');
+        $this->fake->reserve(new JobToFakeStub, 'bar');
+
+        $this->assertSame(1, $this->fake->reservedSize('foo'));
+        $this->assertSame(1, $this->fake->reservedSize('bar'));
+        $this->assertSame(0, $this->fake->reservedSize('baz'));
+    }
+
+    public function testDeleteReserved()
+    {
+        $this->fake->reserve($this->job, 'foo');
+        $this->fake->reserve(new JobToFakeStub, 'bar');
+
+        $this->fake->deleteReserved($this->job, 'foo');
+
+        $this->assertSame(0, $this->fake->reservedSize('foo'));
+        $this->assertSame(1, $this->fake->reservedSize('bar'));
+    }
+
     public function testGetRawPushes()
     {
         $this->fake->pushRaw('some-payload', null, ['options' => 'yeah']);

--- a/tests/Support/SupportTestingQueueFakeTest.php
+++ b/tests/Support/SupportTestingQueueFakeTest.php
@@ -622,6 +622,12 @@ class SupportTestingQueueFakeTest extends TestCase
         $this->assertSame(0, $this->fake->reservedSize('baz'));
     }
 
+    public function testReservedJobsAreNotPushed()
+    {
+        $this->fake->reserve($this->job, 'foo');
+
+        $this->fake->assertNotPushed(JobStub::class);
+    }
     public function testClearReserved()
     {
         $this->fake->reserve($this->job, 'foo');


### PR DESCRIPTION
Follow up of https://github.com/laravel/framework/pull/60636 

This PR means `reservedSize()`, `reservedJobs()` and `allReservedJobs()` work on the fake. I've added a `reserve` method to the queue fake, meaning we can do `Queue::reserve(ExampleJob::class)` in tests for explicitly reserving jobs.

This avoids having to reach for mocking:

```php
Queue::fake();

Queue::expects('reservedJobs')
    ->andReturn(new Collection([new InspectedJob(uuid: null, queue: 'default', name: 'App\Jobs\ExampleJob', attempts: 0)]));
      
$this->artisan('app:deploy')
->expectsOutputToContain('Waiting to deploy, 1 reserved job found...(xxxxx)');
```

And instead becomes simpler: 

```php
Queue::fake();

// New reserve method so we can be explicit with what we expect reserved.
Queue::reserve(ExampleJob::class);

$this->artisan('app:deploy')
     ->expectsOutputToContain('Waiting to deploy, 1 reserved job found...(xxxxx)');
``` 
 
 

The alternative is to maybe have it auto reserve when you push, but that felt like a B/C so went for this. 

 I've also added a clear method so people can test explicit logic such as a deployment command (my scenario) where they may expect a reserved job temporarily.

Feel free to adjust etc as you see fit 🫡 as I'm not sure what you'd prefer, happy to change about if you see a nicer way.

Thank you!