### PR TITLE
[13.x] Send bulk SQS jobs via SendMessageBatch

### DIFF
--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -365,21 +365,7 @@ abstract class Queue
     {
         if ($this->shouldDispatchAfterCommit($job) &&
             $this->container->bound('db.transactions')) {
-            if ($job instanceof ShouldBeUnique) {
-                $this->container->make('db.transactions')->addCallbackForRollback(
-                    function () use ($job) {
-                        (new UniqueLock($this->container->make(Cache::class)))->release($job);
-                    }
-                );
-            }
-
-            if (! empty($job->debounceOwner ?? '')) {
-                $this->container->make('db.transactions')->addCallbackForRollback(
-                    function () use ($job) {
-                        (new DebounceLock($this->container->make(Cache::class)))->release($job, $job->debounceOwner ?? '');
-                    }
-                );
-            }
+            $this->registerRollbackCallbacksForDeferredJob($job);
 
             return $this->container->make('db.transactions')->addCallback(
                 function () use ($queue, $job, $payload, $delay, $callback) {
@@ -416,6 +402,32 @@ abstract class Queue
         }
 
         return $this->dispatchAfterCommit ?? false;
+    }
+
+    /**
+     * Register rollback callbacks to release any unique or debounce locks held
+     * by the given job if the current database transaction is rolled back.
+     *
+     * @param  \Closure|string|object  $job
+     * @return void
+     */
+    protected function registerRollbackCallbacksForDeferredJob($job)
+    {
+        if ($job instanceof ShouldBeUnique) {
+            $this->container->make('db.transactions')->addCallbackForRollback(
+                function () use ($job) {
+                    (new UniqueLock($this->container->make(Cache::class)))->release($job);
+                }
+            );
+        }
+
+        if (! empty($job->debounceOwner ?? '')) {
+            $this->container->make('db.transactions')->addCallbackForRollback(
+                function () use ($job) {
+                    (new DebounceLock($this->container->make(Cache::class)))->release($job, $job->debounceOwner ?? '');
+                }
+            );
+        }
     }
 
     /**

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -365,7 +365,7 @@ abstract class Queue
     {
         if ($this->shouldDispatchAfterCommit($job) &&
             $this->container->bound('db.transactions')) {
-            $this->registerRollbackCallbacksForDeferredJob($job);
+            $this->registerRollbackCallbacksForJobsThatDispatchAfterCommit($job);
 
             return $this->container->make('db.transactions')->addCallback(
                 function () use ($queue, $job, $payload, $delay, $callback) {
@@ -405,12 +405,12 @@ abstract class Queue
     }
 
     /**
-     * Register rollback callbacks to release unique or debounce locks if the current database transaction is rolled back.
+     * Register callbacks to release locks if the current database transaction is rolled back.
      *
      * @param  \Closure|string|object  $job
      * @return void
      */
-    protected function registerRollbackCallbacksForDeferredJob($job)
+    protected function registerRollbackCallbacksForJobsThatDispatchAfterCommit($job)
     {
         if ($job instanceof ShouldBeUnique) {
             $this->container->make('db.transactions')->addCallbackForRollback(

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -405,8 +405,7 @@ abstract class Queue
     }
 
     /**
-     * Register rollback callbacks to release any unique or debounce locks held
-     * by the given job if the current database transaction is rolled back.
+     * Register rollback callbacks to release unique or debounce locks if the current database transaction is rolled back.
      *
      * @param  \Closure|string|object  $job
      * @return void

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -308,6 +308,241 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
     }
 
     /**
+     * Push an array of jobs onto the queue using the SendMessageBatch API.
+     *
+     * @param  array  $jobs
+     * @param  mixed  $data
+     * @param  string|null  $queue
+     * @return void
+     */
+    public function bulk($jobs, $data = '', $queue = null)
+    {
+        $jobs = array_values((array) $jobs);
+
+        if (empty($jobs)) {
+            return;
+        }
+
+        [$afterCommit, $immediate] = $this->partitionJobsByAfterCommit($jobs);
+
+        if (! empty($immediate)) {
+            $this->sendBatchedMessages($this->prepareBatchMessages($immediate, $data, $queue), $queue);
+        }
+
+        if (! empty($afterCommit)) {
+            foreach ($afterCommit as $job) {
+                $this->registerRollbackCallbacksForJobsThatDispatchAfterCommit($job);
+            }
+
+            $messages = $this->prepareBatchMessages($afterCommit, $data, $queue);
+
+            $this->container->make('db.transactions')->addCallback(
+                fn () => $this->sendBatchedMessages($messages, $queue),
+            );
+        }
+    }
+
+    /**
+     * Partition the given jobs by whether they should be deferred until the active database transaction commits.
+     *
+     * @param  array  $jobs
+     * @return array{0: array, 1: array}
+     */
+    protected function partitionJobsByAfterCommit(array $jobs)
+    {
+        if (! $this->container->bound('db.transactions')) {
+            return [[], $jobs];
+        }
+
+        return (new Collection($jobs))
+            ->partition(fn ($job) => $this->shouldDispatchAfterCommit($job))
+            ->map(fn ($jobs) => $jobs->values()->all())
+            ->all();
+    }
+
+    /**
+     * Create the payload for each of the given jobs.
+     *
+     * Payloads are created at dispatch time, even for jobs deferred until after the transaction commits.
+     *
+     * @param  array  $jobs
+     * @param  mixed  $data
+     * @param  string|null  $queue
+     * @return array<int, array{job: mixed, delay: mixed, payload: string}>
+     */
+    protected function prepareBatchMessages(array $jobs, $data, $queue)
+    {
+        return (new Collection($jobs))
+            ->map(function ($job) use ($data, $queue) {
+                $delay = is_object($job) ? ($job->delay ?? null) : null;
+
+                return [
+                    'job' => $job,
+                    'delay' => $delay,
+                    'payload' => $this->createPayload($job, $queue ?: $this->default, $data, $delay),
+                ];
+            })
+            ->all();
+    }
+
+    /**
+     * Build entries, raise queueing events, dispatch chunks, and raise queued events with SQS message IDs.
+     *
+     * @param  array  $messages
+     * @param  string|null  $queue
+     * @return void
+     *
+     * @throws \Aws\Sqs\Exception\SqsException
+     * @throws \Throwable
+     */
+    protected function sendBatchedMessages(array $messages, $queue)
+    {
+        $entries = [];
+
+        foreach ($messages as $id => $message) {
+            $this->raiseJobQueueingEvent($queue, $message['job'], $message['payload'], $message['delay']);
+
+            $entries[$id] = $this->prepareSendMessageBatchEntry($id, $message, $queue);
+        }
+
+        $queueUrl = $this->getQueue($queue);
+
+        // Dispatch chunks and stop at the first failure so later messages cannot arrive ahead of unsent ones...
+        foreach ($this->chunkBatchEntries($entries) as $chunk) {
+            $result = $this->sqs->sendMessageBatch([
+                'QueueUrl' => $queueUrl,
+                'Entries' => $chunk,
+            ]);
+
+            foreach ($result['Successful'] ?? [] as $success) {
+                if (! isset($messages[$success['Id']])) {
+                    continue;
+                }
+
+                $message = $messages[$success['Id']];
+
+                $this->raiseJobQueuedEvent(
+                    $queue, $success['MessageId'], $message['job'], $message['payload'], $message['delay']
+                );
+            }
+
+            // A batch can return HTTP 200 while rejecting entries, so surface those failures as an SqsException...
+            if (! empty($result['Failed'])) {
+                $failure = $result['Failed'][0];
+
+                throw new SqsException(
+                    sprintf(
+                        'SQS SendMessageBatch rejected [%d] of [%d] messages. First failure [%s]: %s',
+                        count($result['Failed']),
+                        count($chunk),
+                        $failure['Code'] ?? 'Unknown',
+                        $failure['Message'] ?? '',
+                    ),
+                    new Command('SendMessageBatch', ['QueueUrl' => $queueUrl, 'Entries' => $chunk]),
+                    [
+                        'code' => $failure['Code'] ?? null,
+                        'message' => $failure['Message'] ?? null,
+                        'result' => $result,
+                    ],
+                );
+            }
+        }
+    }
+
+    /**
+     * Build the SendMessageBatch entry for a single prepared message.
+     *
+     * The entry Id maps each Successful or Failed result returned by SQS back to its job.
+     *
+     * @param  int  $id
+     * @param  array{job: mixed, delay: mixed, payload: string}  $message
+     * @param  string|null  $queue
+     * @return array
+     */
+    protected function prepareSendMessageBatchEntry($id, array $message, $queue)
+    {
+        ['job' => $job, 'delay' => $delay, 'payload' => $payload] = $message;
+
+        return [
+            'Id' => (string) $id,
+            'MessageBody' => $this->willOverflow($payload) ? $this->overflow($payload) : $payload,
+            ...$this->getQueueableOptions($job, $queue, $payload, $delay),
+        ];
+    }
+
+    /**
+     * Chunk batch entries respecting both the 10-message and cumulative payload-size limits enforced by SendMessageBatch.
+     *
+     * @param  array  $entries
+     * @return array
+     */
+    protected function chunkBatchEntries(array $entries)
+    {
+        [$chunks, $currentChunk, $currentBytes] = [[], [], 0];
+
+        foreach ($entries as $item) {
+            $bytes = strlen($item['MessageBody']);
+
+            $wouldExceedCount = count($currentChunk) >= static::MAX_MESSAGES_PER_BATCH;
+            $wouldExceedBytes = $currentBytes + $bytes > static::MAX_SQS_PAYLOAD_SIZE;
+
+            if (! empty($currentChunk) && ($wouldExceedCount || $wouldExceedBytes)) {
+                $chunks[] = $currentChunk;
+                $currentChunk = [];
+                $currentBytes = 0;
+            }
+
+            $currentChunk[] = $item;
+            $currentBytes += $bytes;
+        }
+
+        if (! empty($currentChunk)) {
+            $chunks[] = $currentChunk;
+        }
+
+        return $chunks;
+    }
+
+    /**
+     * Determine if the payload should be stored in cache.
+     *
+     * @param  string  $payload
+     * @return bool
+     */
+    protected function willOverflow($payload)
+    {
+        if (! Arr::get($this->overflowStorage, 'enabled', false)) {
+            return false;
+        }
+
+        return Arr::get($this->overflowStorage, 'always', false)
+            || strlen($payload) >= static::MAX_SQS_PAYLOAD_SIZE;
+    }
+
+    /**
+     * Store the payload in cache and return a pointer payload.
+     *
+     * @param  string  $payload
+     * @return string
+     */
+    protected function overflow($payload)
+    {
+        $decoded = json_decode($payload);
+
+        $uuid = is_object($decoded) && isset($decoded->uuid)
+            ? $decoded->uuid
+            : (string) Str::uuid();
+
+        $this->container->make('cache')->store(
+            Arr::get($this->overflowStorage, 'store')
+        )->put(
+            $path = static::EXTENDED_PAYLOAD_CACHE_PREFIX.$uuid, $payload
+        );
+
+        return json_encode(['@pointer' => $path]);
+    }
+
+    /**
      * Get the queueable options from the job.
      *
      * @param  mixed  $job
@@ -358,8 +593,12 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
 
         if ($isFifo) {
             $messageDeduplicationId = match (true) {
-                $isObject && isset($job->deduplicator) && is_callable($job->deduplicator) => transform(call_user_func($job->deduplicator, $payload, $queue), $transformToString),
-                $isObject && method_exists($job, 'deduplicationId') => transform($job->deduplicationId($payload, $queue), $transformToString),
+                $isObject && isset($job->deduplicator) && is_callable($job->deduplicator) => transform(
+                    call_user_func($job->deduplicator, $payload, $queue), $transformToString
+                ),
+                $isObject && method_exists($job, 'deduplicationId') => transform(
+                    $job->deduplicationId($payload, $queue), $transformToString
+                ),
                 default => (string) Str::orderedUuid(),
             };
         }
@@ -367,249 +606,6 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
         $options['MessageDeduplicationId'] = $messageDeduplicationId;
 
         return array_filter($options);
-    }
-
-    /**
-     * Push an array of jobs onto the queue using the SendMessageBatch API.
-     *
-     * @param  array  $jobs
-     * @param  mixed  $data
-     * @param  string|null  $queue
-     * @return void
-     */
-    public function bulk($jobs, $data = '', $queue = null)
-    {
-        $jobs = array_values((array) $jobs);
-
-        if (empty($jobs)) {
-            return;
-        }
-
-        [$deferred, $immediate] = $this->partitionJobsByAfterCommit($jobs);
-
-        if (! empty($immediate)) {
-            $this->sendBatchedMessages($this->createBatchMessages($immediate, $data, $queue), $queue);
-        }
-
-        if (! empty($deferred)) {
-            foreach ($deferred as $job) {
-                $this->registerRollbackCallbacksForJobsThatDispatchAfterCommit($job);
-            }
-
-            $messages = $this->createBatchMessages($deferred, $data, $queue);
-
-            $this->container->make('db.transactions')->addCallback(
-                fn () => $this->sendBatchedMessages($messages, $queue),
-            );
-        }
-    }
-
-    /**
-     * Partition the given jobs by whether they should be deferred until the active database transaction commits.
-     *
-     * @param  array  $jobs
-     * @return array{0: array, 1: array}
-     */
-    protected function partitionJobsByAfterCommit(array $jobs)
-    {
-        if (! $this->container->bound('db.transactions')) {
-            return [[], $jobs];
-        }
-
-        $deferred = $immediate = [];
-
-        foreach ($jobs as $job) {
-            if ($this->shouldDispatchAfterCommit($job)) {
-                $deferred[] = $job;
-            } else {
-                $immediate[] = $job;
-            }
-        }
-
-        return [$deferred, $immediate];
-    }
-
-    /**
-     * Create the payload for each of the given jobs.
-     *
-     * Payloads are created at dispatch time, even for jobs deferred until after the transaction commits.
-     *
-     * @param  array  $jobs
-     * @param  mixed  $data
-     * @param  string|null  $queue
-     * @return array<int, array{job: mixed, delay: mixed, payload: string}>
-     */
-    protected function createBatchMessages(array $jobs, $data, $queue)
-    {
-        return array_map(function ($job) use ($data, $queue) {
-            $delay = is_object($job) ? ($job->delay ?? null) : null;
-
-            return [
-                'job' => $job,
-                'delay' => $delay,
-                'payload' => $this->createPayload($job, $queue ?: $this->default, $data, $delay),
-            ];
-        }, $jobs);
-    }
-
-    /**
-     * Build entries, raise queueing events, dispatch chunks, and raise queued events with SQS message IDs.
-     *
-     * @param  array  $messages
-     * @param  string|null  $queue
-     * @return void
-     *
-     * @throws \Aws\Sqs\Exception\SqsException
-     * @throws \Throwable
-     */
-    protected function sendBatchedMessages(array $messages, $queue)
-    {
-        $entries = [];
-
-        foreach ($messages as $id => $message) {
-            $this->raiseJobQueueingEvent($queue, $message['job'], $message['payload'], $message['delay']);
-
-            $entries[$id] = $this->createBatchEntry($id, $message, $queue);
-        }
-
-        $queueUrl = $this->getQueue($queue);
-
-        // Dispatch chunks one at a time and stop at the first failure so later messages cannot arrive ahead of unsent ones.
-        foreach ($this->chunkBatchEntries($entries) as $chunk) {
-            // Request-level errors throw an SqsException here, which we allow to propagate untouched.
-            $result = $this->sqs->sendMessageBatch([
-                'QueueUrl' => $queueUrl,
-                'Entries' => $chunk,
-            ]);
-
-            foreach ($result['Successful'] ?? [] as $success) {
-                if (! isset($messages[$success['Id']])) {
-                    continue;
-                }
-
-                $message = $messages[$success['Id']];
-
-                $this->raiseJobQueuedEvent(
-                    $queue, $success['MessageId'], $message['job'], $message['payload'], $message['delay']
-                );
-            }
-
-            // A batch can return HTTP 200 while rejecting entries, so surface those failures as an SqsException.
-            if (! empty($result['Failed'])) {
-                $failure = $result['Failed'][0];
-
-                throw new SqsException(
-                    sprintf(
-                        'SQS SendMessageBatch rejected [%d] of [%d] messages. First failure [%s]: %s',
-                        count($result['Failed']),
-                        count($chunk),
-                        $failure['Code'] ?? 'Unknown',
-                        $failure['Message'] ?? '',
-                    ),
-                    new Command('SendMessageBatch', ['QueueUrl' => $queueUrl, 'Entries' => $chunk]),
-                    [
-                        'code' => $failure['Code'] ?? null,
-                        'message' => $failure['Message'] ?? null,
-                        'result' => $result,
-                    ],
-                );
-            }
-        }
-    }
-
-    /**
-     * Build the SendMessageBatch entry for a single prepared message.
-     *
-     * The entry Id maps each Successful or Failed result returned by SQS back to its job.
-     *
-     * @param  int  $id
-     * @param  array{job: mixed, delay: mixed, payload: string}  $message
-     * @param  string|null  $queue
-     * @return array
-     */
-    protected function createBatchEntry($id, array $message, $queue)
-    {
-        ['job' => $job, 'delay' => $delay, 'payload' => $payload] = $message;
-
-        return [
-            'Id' => (string) $id,
-            'MessageBody' => $this->willOverflow($payload) ? $this->overflow($payload) : $payload,
-            ...$this->getQueueableOptions($job, $queue, $payload, $delay),
-        ];
-    }
-
-    /**
-     * Chunk batch entries respecting both the 10-message and cumulative payload-size limits enforced by SendMessageBatch.
-     *
-     * @param  array  $entries
-     * @return array
-     */
-    protected function chunkBatchEntries(array $entries)
-    {
-        $chunks = [];
-        $current = [];
-        $currentBytes = 0;
-
-        foreach ($entries as $item) {
-            $bytes = strlen($item['MessageBody']);
-
-            $wouldExceedCount = count($current) >= static::MAX_MESSAGES_PER_BATCH;
-            $wouldExceedBytes = $currentBytes + $bytes > static::MAX_SQS_PAYLOAD_SIZE;
-
-            if (! empty($current) && ($wouldExceedCount || $wouldExceedBytes)) {
-                $chunks[] = $current;
-                $current = [];
-                $currentBytes = 0;
-            }
-
-            $current[] = $item;
-            $currentBytes += $bytes;
-        }
-
-        if (! empty($current)) {
-            $chunks[] = $current;
-        }
-
-        return $chunks;
-    }
-
-    /**
-     * Determine if the payload should be stored in cache.
-     *
-     * @param  string  $payload
-     * @return bool
-     */
-    protected function willOverflow($payload)
-    {
-        if (! Arr::get($this->overflowStorage, 'enabled', false)) {
-            return false;
-        }
-
-        return Arr::get($this->overflowStorage, 'always', false)
-            || strlen($payload) >= static::MAX_SQS_PAYLOAD_SIZE;
-    }
-
-    /**
-     * Store the payload in cache and return a pointer payload.
-     *
-     * @param  string  $payload
-     * @return string
-     */
-    protected function overflow($payload)
-    {
-        $decoded = json_decode($payload);
-
-        $uuid = is_object($decoded) && isset($decoded->uuid)
-            ? $decoded->uuid
-            : (string) Str::uuid();
-
-        $this->container->make('cache')->store(
-            Arr::get($this->overflowStorage, 'store')
-        )->put(
-            $path = static::EXTENDED_PAYLOAD_CACHE_PREFIX.$uuid, $payload
-        );
-
-        return json_encode(['@pointer' => $path]);
     }
 
     /**

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -372,14 +372,6 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
     /**
      * Push an array of jobs onto the queue using the SendMessageBatch API.
      *
-     * Entries are chunked to respect the SQS per-batch limits of 10 messages
-     * and {@see static::MAX_SQS_PAYLOAD_SIZE} cumulative payload bytes, then
-     * each chunk is dispatched sequentially. FIFO queues stop at the first
-     * failure to preserve ordering, while standard queues attempt every chunk
-     * and aggregate any failures. Per-job afterCommit, unique and debounce
-     * locks, delays, and JobQueueing / JobQueued events all behave identically
-     * to {@see static::push()}.
-     *
      * @param  array  $jobs
      * @param  mixed  $data
      * @param  string|null  $queue
@@ -413,9 +405,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
     }
 
     /**
-     * Partition the given jobs into those that should be deferred until the
-     * active database transaction commits and those that should be dispatched
-     * immediately.
+     * Partition the given jobs by whether they should be deferred until the active database transaction commits.
      *
      * @param  array  $jobs
      * @return array{0: array, 1: array}
@@ -442,8 +432,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
     /**
      * Create the payload for each of the given jobs.
      *
-     * Payloads are created at dispatch time, even for jobs deferred until
-     * after the transaction commits, mirroring {@see static::push()}.
+     * Payloads are created at dispatch time, even for jobs deferred until after the transaction commits.
      *
      * @param  array  $jobs
      * @param  mixed  $data
@@ -464,9 +453,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
     }
 
     /**
-     * Build entries for the given messages, raise the queueing events,
-     * dispatch each chunk via SendMessageBatch, and then raise the queued
-     * events using the message IDs returned by SQS.
+     * Build entries, raise queueing events, dispatch chunks, and raise queued events with SQS message IDs.
      *
      * @param  array  $messages
      * @param  string|null  $queue
@@ -487,14 +474,9 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
 
         $queueUrl = $this->getQueue($queue);
 
-        // Chunks are dispatched one at a time and we stop at the first failure,
-        // mirroring push(): jobs already sent stay queued, later chunks are not
-        // attempted, and the error surfaces to the caller. Stopping also keeps
-        // FIFO ordering intact, since no later message can arrive ahead of one
-        // that was never sent.
+        // Dispatch chunks one at a time and stop at the first failure so later messages cannot arrive ahead of unsent ones.
         foreach ($this->chunkBatchEntries($entries) as $chunk) {
-            // Request-level errors (throttling, auth, networking) throw an
-            // SqsException here, which we allow to propagate untouched.
+            // Request-level errors throw an SqsException here, which we allow to propagate untouched.
             $result = $this->sqs->sendMessageBatch([
                 'QueueUrl' => $queueUrl,
                 'Entries' => $chunk,
@@ -512,11 +494,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
                 );
             }
 
-            // A batch can return HTTP 200 while still rejecting individual
-            // entries, which the SDK does not raise for. Surface those as the
-            // same SqsException a failed request would throw, carrying the
-            // reported error code and the full result, so the rejected jobs
-            // are not silently dropped.
+            // A batch can return HTTP 200 while rejecting entries, so surface those failures as an SqsException.
             if (! empty($result['Failed'])) {
                 $failure = $result['Failed'][0];
 
@@ -542,8 +520,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
     /**
      * Build the SendMessageBatch entry for a single prepared message.
      *
-     * The entry Id is the message's index, which lets the response handler map
-     * each Successful / Failed result returned by SQS back to its job.
+     * The entry Id maps each Successful or Failed result returned by SQS back to its job.
      *
      * @param  int  $id
      * @param  array{job: mixed, delay: mixed, payload: string}  $message
@@ -562,8 +539,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
     }
 
     /**
-     * Chunk batch entries respecting both the 10-message and cumulative
-     * payload-size limits enforced by SendMessageBatch.
+     * Chunk batch entries respecting both the 10-message and cumulative payload-size limits enforced by SendMessageBatch.
      *
      * @param  array  $entries
      * @return array

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Queue;
 
+use Aws\Command;
+use Aws\Sqs\Exception\SqsException;
 use Aws\Sqs\SqsClient;
 use Illuminate\Contracts\Queue\ClearableQueue;
 use Illuminate\Contracts\Queue\Queue as QueueContract;
@@ -18,6 +20,13 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
      * @var int
      */
     const MAX_SQS_PAYLOAD_SIZE = 1048576;
+
+    /**
+     * The maximum number of messages allowed per SendMessageBatch request.
+     *
+     * @var int
+     */
+    const MAX_MESSAGES_PER_BATCH = 10;
 
     /**
      * The cache key prefix for extended SQS payloads.
@@ -361,7 +370,15 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
     }
 
     /**
-     * Push an array of jobs onto the queue.
+     * Push an array of jobs onto the queue using the SendMessageBatch API.
+     *
+     * Entries are chunked to respect the SQS per-batch limits of 10 messages
+     * and {@see static::MAX_SQS_PAYLOAD_SIZE} cumulative payload bytes, then
+     * each chunk is dispatched sequentially. FIFO queues stop at the first
+     * failure to preserve ordering, while standard queues attempt every chunk
+     * and aggregate any failures. Per-job afterCommit, unique and debounce
+     * locks, delays, and JobQueueing / JobQueued events all behave identically
+     * to {@see static::push()}.
      *
      * @param  array  $jobs
      * @param  mixed  $data
@@ -370,13 +387,214 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
      */
     public function bulk($jobs, $data = '', $queue = null)
     {
-        foreach ((array) $jobs as $job) {
-            if (isset($job->delay)) {
-                $this->later($job->delay, $job, $data, $queue);
+        $jobs = array_values((array) $jobs);
+
+        if (empty($jobs)) {
+            return;
+        }
+
+        [$deferred, $immediate] = $this->partitionJobsByAfterCommit($jobs);
+
+        if (! empty($immediate)) {
+            $this->sendBatchedMessages($this->createBatchMessages($immediate, $data, $queue), $queue);
+        }
+
+        if (! empty($deferred)) {
+            foreach ($deferred as $job) {
+                $this->registerRollbackCallbacksForDeferredJob($job);
+            }
+
+            $messages = $this->createBatchMessages($deferred, $data, $queue);
+
+            $this->container->make('db.transactions')->addCallback(
+                fn () => $this->sendBatchedMessages($messages, $queue),
+            );
+        }
+    }
+
+    /**
+     * Partition the given jobs into those that should be deferred until the
+     * active database transaction commits and those that should be dispatched
+     * immediately.
+     *
+     * @param  array  $jobs
+     * @return array{0: array, 1: array}
+     */
+    protected function partitionJobsByAfterCommit(array $jobs)
+    {
+        if (! $this->container->bound('db.transactions')) {
+            return [[], $jobs];
+        }
+
+        $deferred = $immediate = [];
+
+        foreach ($jobs as $job) {
+            if ($this->shouldDispatchAfterCommit($job)) {
+                $deferred[] = $job;
             } else {
-                $this->push($job, $data, $queue);
+                $immediate[] = $job;
             }
         }
+
+        return [$deferred, $immediate];
+    }
+
+    /**
+     * Create the payload for each of the given jobs.
+     *
+     * Payloads are created at dispatch time, even for jobs deferred until
+     * after the transaction commits, mirroring {@see static::push()}.
+     *
+     * @param  array  $jobs
+     * @param  mixed  $data
+     * @param  string|null  $queue
+     * @return array<int, array{job: mixed, delay: mixed, payload: string}>
+     */
+    protected function createBatchMessages(array $jobs, $data, $queue)
+    {
+        return array_map(function ($job) use ($data, $queue) {
+            $delay = is_object($job) ? ($job->delay ?? null) : null;
+
+            return [
+                'job' => $job,
+                'delay' => $delay,
+                'payload' => $this->createPayload($job, $queue ?: $this->default, $data, $delay),
+            ];
+        }, $jobs);
+    }
+
+    /**
+     * Build entries for the given messages, raise the queueing events,
+     * dispatch each chunk via SendMessageBatch, and then raise the queued
+     * events using the message IDs returned by SQS.
+     *
+     * @param  array  $messages
+     * @param  string|null  $queue
+     * @return void
+     *
+     * @throws \Aws\Sqs\Exception\SqsException
+     * @throws \Throwable
+     */
+    protected function sendBatchedMessages(array $messages, $queue)
+    {
+        $entries = [];
+
+        foreach ($messages as $id => $message) {
+            $this->raiseJobQueueingEvent($queue, $message['job'], $message['payload'], $message['delay']);
+
+            $entries[$id] = $this->createBatchEntry($id, $message, $queue);
+        }
+
+        $queueUrl = $this->getQueue($queue);
+
+        // Chunks are dispatched one at a time and we stop at the first failure,
+        // mirroring push(): jobs already sent stay queued, later chunks are not
+        // attempted, and the error surfaces to the caller. Stopping also keeps
+        // FIFO ordering intact, since no later message can arrive ahead of one
+        // that was never sent.
+        foreach ($this->chunkBatchEntries($entries) as $chunk) {
+            // Request-level errors (throttling, auth, networking) throw an
+            // SqsException here, which we allow to propagate untouched.
+            $result = $this->sqs->sendMessageBatch([
+                'QueueUrl' => $queueUrl,
+                'Entries' => $chunk,
+            ]);
+
+            foreach ($result['Successful'] ?? [] as $success) {
+                if (! isset($messages[$success['Id']])) {
+                    continue;
+                }
+
+                $message = $messages[$success['Id']];
+
+                $this->raiseJobQueuedEvent(
+                    $queue, $success['MessageId'], $message['job'], $message['payload'], $message['delay']
+                );
+            }
+
+            // A batch can return HTTP 200 while still rejecting individual
+            // entries, which the SDK does not raise for. Surface those as the
+            // same SqsException a failed request would throw, carrying the
+            // reported error code and the full result, so the rejected jobs
+            // are not silently dropped.
+            if (! empty($result['Failed'])) {
+                $failure = $result['Failed'][0];
+
+                throw new SqsException(
+                    sprintf(
+                        'SQS SendMessageBatch rejected [%d] of [%d] messages. First failure [%s]: %s',
+                        count($result['Failed']),
+                        count($chunk),
+                        $failure['Code'] ?? 'Unknown',
+                        $failure['Message'] ?? '',
+                    ),
+                    new Command('SendMessageBatch', ['QueueUrl' => $queueUrl, 'Entries' => $chunk]),
+                    [
+                        'code' => $failure['Code'] ?? null,
+                        'message' => $failure['Message'] ?? null,
+                        'result' => $result,
+                    ],
+                );
+            }
+        }
+    }
+
+    /**
+     * Build the SendMessageBatch entry for a single prepared message.
+     *
+     * The entry Id is the message's index, which lets the response handler map
+     * each Successful / Failed result returned by SQS back to its job.
+     *
+     * @param  int  $id
+     * @param  array{job: mixed, delay: mixed, payload: string}  $message
+     * @param  string|null  $queue
+     * @return array
+     */
+    protected function createBatchEntry($id, array $message, $queue)
+    {
+        ['job' => $job, 'delay' => $delay, 'payload' => $payload] = $message;
+
+        return [
+            'Id' => (string) $id,
+            'MessageBody' => $this->willOverflow($payload) ? $this->overflow($payload) : $payload,
+            ...$this->getQueueableOptions($job, $queue, $payload, $delay),
+        ];
+    }
+
+    /**
+     * Chunk batch entries respecting both the 10-message and cumulative
+     * payload-size limits enforced by SendMessageBatch.
+     *
+     * @param  array  $entries
+     * @return array
+     */
+    protected function chunkBatchEntries(array $entries)
+    {
+        $chunks = [];
+        $current = [];
+        $currentBytes = 0;
+
+        foreach ($entries as $item) {
+            $bytes = strlen($item['MessageBody']);
+
+            $wouldExceedCount = count($current) >= static::MAX_MESSAGES_PER_BATCH;
+            $wouldExceedBytes = $currentBytes + $bytes > static::MAX_SQS_PAYLOAD_SIZE;
+
+            if (! empty($current) && ($wouldExceedCount || $wouldExceedBytes)) {
+                $chunks[] = $current;
+                $current = [];
+                $currentBytes = 0;
+            }
+
+            $current[] = $item;
+            $currentBytes += $bytes;
+        }
+
+        if (! empty($current)) {
+            $chunks[] = $current;
+        }
+
+        return $chunks;
     }
 
     /**

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -393,7 +393,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
 
         if (! empty($deferred)) {
             foreach ($deferred as $job) {
-                $this->registerRollbackCallbacksForDeferredJob($job);
+                $this->registerRollbackCallbacksForJobsThatDispatchAfterCommit($job);
             }
 
             $messages = $this->createBatchMessages($deferred, $data, $queue);

--- a/src/Illuminate/Queue/SyncQueue.php
+++ b/src/Illuminate/Queue/SyncQueue.php
@@ -2,12 +2,8 @@
 
 namespace Illuminate\Queue;
 
-use Illuminate\Bus\DebounceLock;
-use Illuminate\Bus\UniqueLock;
-use Illuminate\Contracts\Cache\Repository as Cache;
 use Illuminate\Contracts\Queue\Job;
 use Illuminate\Contracts\Queue\Queue as QueueContract;
-use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Queue\Events\JobAttempted;
 use Illuminate\Queue\Events\JobExceptionOccurred;
 use Illuminate\Queue\Events\JobProcessed;
@@ -160,21 +156,7 @@ class SyncQueue extends Queue implements QueueContract
     {
         if ($this->shouldDispatchAfterCommit($job) &&
             $this->container->bound('db.transactions')) {
-            if ($job instanceof ShouldBeUnique) {
-                $this->container->make('db.transactions')->addCallbackForRollback(
-                    function () use ($job) {
-                        (new UniqueLock($this->container->make(Cache::class)))->release($job);
-                    }
-                );
-            }
-
-            if (! empty($job->debounceOwner ?? '')) {
-                $this->container->make('db.transactions')->addCallbackForRollback(
-                    function () use ($job) {
-                        (new DebounceLock($this->container->make(Cache::class)))->release($job, $job->debounceOwner ?? '');
-                    }
-                );
-            }
+            $this->registerRollbackCallbacksForDeferredJob($job);
 
             return $this->container->make('db.transactions')->addCallback(
                 fn () => $this->executeJob($job, $data, $queue)

--- a/src/Illuminate/Queue/SyncQueue.php
+++ b/src/Illuminate/Queue/SyncQueue.php
@@ -156,7 +156,7 @@ class SyncQueue extends Queue implements QueueContract
     {
         if ($this->shouldDispatchAfterCommit($job) &&
             $this->container->bound('db.transactions')) {
-            $this->registerRollbackCallbacksForDeferredJob($job);
+            $this->registerRollbackCallbacksForJobsThatDispatchAfterCommit($job);
 
             return $this->container->make('db.transactions')->addCallback(
                 fn () => $this->executeJob($job, $data, $queue)

--- a/tests/Foundation/Cloud/QueueTest.php
+++ b/tests/Foundation/Cloud/QueueTest.php
@@ -386,7 +386,10 @@ class QueueTest extends TestCase
         Cloud::bootManagedQueues($this->app);
         $eventsFake = $this->fakeEvents();
         [$queue, $client] = $this->mockedQueue();
-        $client->shouldReceive('sendMessage')->times(7)->andReturn(new Result());
+        $client->shouldReceive('sendMessage')->times(5)->andReturn(new Result());
+        $client->shouldReceive('sendMessageBatch')->once()->andReturnUsing(fn ($args) => new Result([
+            'Successful' => array_map(fn ($entry) => ['Id' => $entry['Id'], 'MessageId' => 'id'], $args['Entries']),
+        ]));
 
         $queue->push(new FakeJob, queue: '1');
         $queue->pushOn('2', new FakeJob);
@@ -663,7 +666,10 @@ class QueueTest extends TestCase
         $eventsFake = $this->fakeEvents();
         $this->app['config']->set('queue.connections.cloud.connection.after_commit', true);
         [$queue, $client] = $this->mockedQueue();
-        $client->shouldReceive('sendMessage')->times(7)->andReturn(new Result());
+        $client->shouldReceive('sendMessage')->times(5)->andReturn(new Result());
+        $client->shouldReceive('sendMessageBatch')->once()->andReturnUsing(fn ($args) => new Result([
+            'Successful' => array_map(fn ($entry) => ['Id' => $entry['Id'], 'MessageId' => 'id'], $args['Entries']),
+        ]));
 
         DB::beginTransaction();
 

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -1107,8 +1107,7 @@ class QueueSqsQueueTest extends TestCase
         $queue->expects($this->once())->method('getQueue')->willReturn($this->fifoQueueUrl);
         $queue->method('createPayload')->willReturnCallback(fn ($job) => "payload-{$job}");
 
-        // Only the first of the two chunks is attempted; the exception from
-        // that request propagates untouched and later chunks are not sent.
+        // Only the first chunk is attempted; its exception propagates untouched and later chunks are not sent.
         $this->sqs->shouldReceive('sendMessageBatch')->once()->andThrow(new RuntimeException('SQS is down'));
 
         $this->expectException(RuntimeException::class);
@@ -1275,8 +1274,7 @@ class QueueSqsQueueTest extends TestCase
             $this->assertSame('chunk failed', $e->getMessage());
         }
 
-        // The first chunk was queued before the second failed, so its queued
-        // events must already have fired.
+        // The first chunk was queued before the second failed, so its queued events must already have fired.
         $queuedEvents = array_filter($dispatched, fn ($e) => $e instanceof \Illuminate\Queue\Events\JobQueued);
 
         $this->assertCount(10, $queuedEvents);

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -3,12 +3,16 @@
 namespace Illuminate\Tests\Queue;
 
 use Aws\Result;
+use Aws\Sqs\Exception\SqsException;
 use Aws\Sqs\SqsClient;
 use Illuminate\Bus\Dispatcher;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Bus\Dispatcher as DispatcherContract;
 use Illuminate\Contracts\Cache\Factory as CacheFactory;
 use Illuminate\Contracts\Cache\Repository as CacheRepository;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Queue\Jobs\SqsJob;
 use Illuminate\Queue\QueueRoutes;
 use Illuminate\Queue\SqsQueue;
@@ -20,6 +24,7 @@ use Illuminate\Tests\Queue\Fixtures\FakeSqsJobWithMessageGroup;
 use Laravel\SerializableClosure\SerializableClosure;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 class QueueSqsQueueTest extends TestCase
 {
@@ -880,6 +885,429 @@ class QueueSqsQueueTest extends TestCase
         $this->sqs->shouldReceive('purgeQueue')->once();
 
         $queue->clear($this->queueName);
+    }
+
+    public function testBulkSendsAllJobsInASingleBatchRequest()
+    {
+        $queue = $this->getMockBuilder(SqsQueue::class)
+            ->onlyMethods(['getQueue', 'createPayload'])
+            ->setConstructorArgs([$this->sqs, $this->queueName, $this->account])
+            ->getMock();
+        $queue->setContainer(m::spy(Container::class));
+        $queue->expects($this->once())->method('getQueue')->with($this->queueName)->willReturn($this->queueUrl);
+        $queue->expects($this->exactly(3))->method('createPayload')->willReturnOnConsecutiveCalls('p1', 'p2', 'p3');
+
+        $captured = null;
+
+        $this->sqs->shouldReceive('sendMessageBatch')->once()->with(m::on(function ($args) use (&$captured) {
+            $captured = $args;
+
+            return true;
+        }))->andReturn(new Result([
+            'Successful' => [
+                ['Id' => 'placeholder', 'MessageId' => 'mid-1'],
+            ],
+            'Failed' => [],
+        ]));
+
+        $queue->bulk(['a', 'b', 'c'], 'data', $this->queueName);
+
+        $this->assertSame($this->queueUrl, $captured['QueueUrl']);
+        $this->assertCount(3, $captured['Entries']);
+        $this->assertSame(['p1', 'p2', 'p3'], array_column($captured['Entries'], 'MessageBody'));
+    }
+
+    public function testBulkChunksAtTenMessagesPerBatch()
+    {
+        $queue = $this->getMockBuilder(SqsQueue::class)
+            ->onlyMethods(['getQueue', 'createPayload'])
+            ->setConstructorArgs([$this->sqs, $this->queueName, $this->account])
+            ->getMock();
+        $queue->setContainer(m::spy(Container::class));
+        $queue->expects($this->once())->method('getQueue')->willReturn($this->queueUrl);
+        $queue->method('createPayload')->willReturnCallback(fn ($job) => "payload-{$job}");
+
+        $batchSizes = [];
+
+        $this->sqs->shouldReceive('sendMessageBatch')->twice()->with(m::on(function ($args) use (&$batchSizes) {
+            $batchSizes[] = count($args['Entries']);
+
+            return true;
+        }))->andReturn(new Result(['Successful' => [], 'Failed' => []]));
+
+        $queue->bulk(range(1, 15), 'data', $this->queueName);
+
+        $this->assertSame([10, 5], $batchSizes);
+    }
+
+    public function testBulkChunksWhenCumulativePayloadSizeExceedsLimit()
+    {
+        $queue = $this->getMockBuilder(SqsQueue::class)
+            ->onlyMethods(['getQueue', 'createPayload'])
+            ->setConstructorArgs([$this->sqs, $this->queueName, $this->account])
+            ->getMock();
+        $queue->setContainer(m::spy(Container::class));
+        $queue->expects($this->once())->method('getQueue')->willReturn($this->queueUrl);
+
+        $halfPayload = str_repeat('x', (int) (SqsQueue::MAX_SQS_PAYLOAD_SIZE * 0.6));
+        $queue->method('createPayload')->willReturn($halfPayload);
+
+        $batchSizes = [];
+
+        $this->sqs->shouldReceive('sendMessageBatch')->twice()->with(m::on(function ($args) use (&$batchSizes) {
+            $batchSizes[] = count($args['Entries']);
+
+            return true;
+        }))->andReturn(new Result(['Successful' => [], 'Failed' => []]));
+
+        $queue->bulk(['a', 'b'], 'data', $this->queueName);
+
+        $this->assertSame([1, 1], $batchSizes);
+    }
+
+    public function testBulkRaisesQueueingAndQueuedEventsForEachJob()
+    {
+        $events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class);
+        $dispatched = [];
+        $events->shouldReceive('dispatch')->andReturnUsing(function ($event) use (&$dispatched) {
+            $dispatched[] = $event;
+        });
+
+        $container = m::mock(Container::class);
+        $container->shouldReceive('bound')->with('events')->andReturn(true);
+        $container->shouldReceive('bound')->with('db.transactions')->andReturn(false);
+        $container->shouldReceive('offsetGet')->with('events')->andReturn($events);
+
+        $queue = $this->getMockBuilder(SqsQueue::class)
+            ->onlyMethods(['getQueue', 'createPayload'])
+            ->setConstructorArgs([$this->sqs, $this->queueName, $this->account])
+            ->getMock();
+        $queue->setContainer($container);
+        $queue->setConnectionName('sqs');
+        $queue->expects($this->once())->method('getQueue')->willReturn($this->queueUrl);
+        $queue->method('createPayload')->willReturnCallback(fn ($job) => "payload-{$job}");
+
+        $this->sqs->shouldReceive('sendMessageBatch')->once()->andReturnUsing(function ($args) {
+            $successful = array_map(
+                fn ($entry, $i) => ['Id' => $entry['Id'], 'MessageId' => 'mid-'.$i],
+                $args['Entries'],
+                array_keys($args['Entries'])
+            );
+
+            return new Result(['Successful' => $successful, 'Failed' => []]);
+        });
+
+        $queue->bulk(['a', 'b'], 'data', $this->queueName);
+
+        $queueingEvents = array_filter($dispatched, fn ($e) => $e instanceof \Illuminate\Queue\Events\JobQueueing);
+        $queuedEvents = array_filter($dispatched, fn ($e) => $e instanceof \Illuminate\Queue\Events\JobQueued);
+
+        $this->assertCount(2, $queueingEvents);
+        $this->assertCount(2, $queuedEvents);
+        $this->assertSame(['mid-0', 'mid-1'], array_map(fn ($e) => $e->id, array_values($queuedEvents)));
+    }
+
+    public function testBulkHonoursPerJobDelay()
+    {
+        $jobA = new FakeSqsJob;
+        $jobA->delay = 30;
+
+        $jobB = new FakeSqsJob;
+
+        $queue = $this->getMockBuilder(SqsQueue::class)
+            ->onlyMethods(['getQueue', 'createPayload', 'secondsUntil'])
+            ->setConstructorArgs([$this->sqs, $this->queueName, $this->account])
+            ->getMock();
+        $queue->setContainer(m::spy(Container::class));
+        $queue->expects($this->once())->method('getQueue')->willReturn($this->queueUrl);
+        $queue->method('createPayload')->willReturnCallback(fn ($job, $q, $data, $delay) => 'payload-'.($delay ?? 'none'));
+        $queue->method('secondsUntil')->with(30)->willReturn(30);
+
+        $captured = null;
+
+        $this->sqs->shouldReceive('sendMessageBatch')->once()->with(m::on(function ($args) use (&$captured) {
+            $captured = $args;
+
+            return true;
+        }))->andReturn(new Result(['Successful' => [], 'Failed' => []]));
+
+        $queue->bulk([$jobA, $jobB], 'data', $this->queueName);
+
+        $this->assertSame(30, $captured['Entries'][0]['DelaySeconds']);
+        $this->assertArrayNotHasKey('DelaySeconds', $captured['Entries'][1]);
+    }
+
+    public function testBulkThrowsWhenSqsReportsFailedEntries()
+    {
+        $queue = $this->getMockBuilder(SqsQueue::class)
+            ->onlyMethods(['getQueue', 'createPayload'])
+            ->setConstructorArgs([$this->sqs, $this->queueName, $this->account])
+            ->getMock();
+        $queue->setContainer(m::spy(Container::class));
+        $queue->expects($this->once())->method('getQueue')->willReturn($this->queueUrl);
+        $queue->expects($this->once())->method('createPayload')->willReturn('payload-a');
+
+        $this->sqs->shouldReceive('sendMessageBatch')->once()->andReturnUsing(function ($args) {
+            return new Result([
+                'Successful' => [],
+                'Failed' => [
+                    ['Id' => $args['Entries'][0]['Id'], 'Code' => 'InternalError', 'Message' => 'oops', 'SenderFault' => false],
+                ],
+            ]);
+        });
+
+        try {
+            $queue->bulk(['a'], 'data', $this->queueName);
+
+            $this->fail('SqsException was not thrown.');
+        } catch (SqsException $e) {
+            $this->assertSame(
+                'SQS SendMessageBatch rejected [1] of [1] messages. First failure [InternalError]: oops',
+                $e->getMessage()
+            );
+            $this->assertSame('InternalError', $e->getAwsErrorCode());
+            $this->assertSame('oops', $e->getAwsErrorMessage());
+            $this->assertNotNull($e->getResult());
+        }
+    }
+
+    public function testBulkSendsFifoBatchesSequentiallyUsingTheQueueNameForMessageGroups()
+    {
+        $queue = $this->getMockBuilder(SqsQueue::class)
+            ->onlyMethods(['getQueue', 'createPayload'])
+            ->setConstructorArgs([$this->sqs, $this->fifoQueueName, $this->account])
+            ->getMock();
+        $queue->setContainer(m::spy(Container::class));
+        $queue->expects($this->once())->method('getQueue')->with($this->fifoQueueName)->willReturn($this->fifoQueueUrl);
+        $queue->method('createPayload')->willReturnCallback(fn ($job) => "payload-{$job}");
+
+        $captured = [];
+
+        $this->sqs->shouldReceive('sendMessageBatch')->twice()->with(m::on(function ($args) use (&$captured) {
+            $captured[] = $args;
+
+            return true;
+        }))->andReturn(new Result(['Successful' => [], 'Failed' => []]));
+
+        $queue->bulk(range(1, 15), 'data', $this->fifoQueueName);
+
+        $this->assertSame([10, 5], array_map(fn ($args) => count($args['Entries']), $captured));
+        $this->assertSame($this->fifoQueueUrl, $captured[0]['QueueUrl']);
+        $this->assertSame($this->fifoQueueName, $captured[0]['Entries'][0]['MessageGroupId']);
+        $this->assertNotEmpty($captured[0]['Entries'][0]['MessageDeduplicationId']);
+    }
+
+    public function testBulkStopsSendingFifoBatchesAfterAFailedRequest()
+    {
+        $queue = $this->getMockBuilder(SqsQueue::class)
+            ->onlyMethods(['getQueue', 'createPayload'])
+            ->setConstructorArgs([$this->sqs, $this->fifoQueueName, $this->account])
+            ->getMock();
+        $queue->setContainer(m::spy(Container::class));
+        $queue->expects($this->once())->method('getQueue')->willReturn($this->fifoQueueUrl);
+        $queue->method('createPayload')->willReturnCallback(fn ($job) => "payload-{$job}");
+
+        // Only the first of the two chunks is attempted; the exception from
+        // that request propagates untouched and later chunks are not sent.
+        $this->sqs->shouldReceive('sendMessageBatch')->once()->andThrow(new RuntimeException('SQS is down'));
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('SQS is down');
+
+        $queue->bulk(range(1, 15), 'data', $this->fifoQueueName);
+    }
+
+    public function testBulkDefersAfterCommitJobsUntilTheTransactionCommits()
+    {
+        $job = new FakeSqsJob;
+        $job->afterCommit = true;
+
+        $transactions = m::mock(\Illuminate\Database\DatabaseTransactionsManager::class);
+
+        $committed = null;
+
+        $transactions->shouldReceive('addCallback')->once()->andReturnUsing(function ($callback) use (&$committed) {
+            $committed = $callback;
+        });
+
+        $container = m::mock(Container::class);
+        $container->shouldReceive('bound')->with('db.transactions')->andReturn(true);
+        $container->shouldReceive('bound')->with('events')->andReturn(false);
+        $container->shouldReceive('make')->with('db.transactions')->andReturn($transactions);
+
+        $queue = $this->getMockBuilder(SqsQueue::class)
+            ->onlyMethods(['getQueue', 'createPayload'])
+            ->setConstructorArgs([$this->sqs, $this->queueName, $this->account])
+            ->getMock();
+        $queue->setContainer($container);
+        $queue->expects($this->once())->method('getQueue')->willReturn($this->queueUrl);
+        $queue->expects($this->once())->method('createPayload')->willReturn('payload-a');
+
+        $sent = false;
+
+        $this->sqs->shouldReceive('sendMessageBatch')->once()->andReturnUsing(function () use (&$sent) {
+            $sent = true;
+
+            return new Result(['Successful' => [], 'Failed' => []]);
+        });
+
+        $queue->bulk([$job], 'data', $this->queueName);
+
+        // The payload is created at dispatch time, but nothing is sent until commit...
+        $this->assertNotNull($committed);
+        $this->assertFalse($sent);
+
+        $committed();
+
+        $this->assertTrue($sent);
+    }
+
+    public function testBulkRegistersRollbackCallbacksForUniqueAfterCommitJobs()
+    {
+        $job = new class implements ShouldQueue, ShouldBeUnique
+        {
+            use Queueable;
+        };
+        $job->afterCommit = true;
+
+        $transactions = m::mock(\Illuminate\Database\DatabaseTransactionsManager::class);
+        $transactions->shouldReceive('addCallbackForRollback')->once();
+        $transactions->shouldReceive('addCallback')->once();
+
+        $container = m::mock(Container::class);
+        $container->shouldReceive('bound')->with('db.transactions')->andReturn(true);
+        $container->shouldReceive('make')->with('db.transactions')->andReturn($transactions);
+
+        $queue = $this->getMockBuilder(SqsQueue::class)
+            ->onlyMethods(['getQueue', 'createPayload'])
+            ->setConstructorArgs([$this->sqs, $this->queueName, $this->account])
+            ->getMock();
+        $queue->setContainer($container);
+        $queue->expects($this->once())->method('createPayload')->willReturn('payload-a');
+
+        $queue->bulk([$job], 'data', $this->queueName);
+    }
+
+    public function testBulkComputesQueueableOptionsBeforeApplyingOverflow()
+    {
+        $job = new FakeSqsJob;
+        $job->messageGroup = 'group-1';
+        $job->deduplicator = fn ($payload, $queue) => 'dedupe-'.$payload;
+
+        $store = m::mock(CacheRepository::class);
+        $store->shouldReceive('put')->once()->with(m::type('string'), 'original-payload');
+
+        $cache = m::mock(CacheFactory::class);
+        $cache->shouldReceive('store')->with('sqs-overflow')->andReturn($store);
+
+        $container = m::mock(Container::class);
+        $container->shouldReceive('bound')->andReturn(false);
+        $container->shouldReceive('make')->with('cache')->andReturn($cache);
+
+        $queue = $this->getMockBuilder(SqsQueue::class)
+            ->onlyMethods(['getQueue', 'createPayload'])
+            ->setConstructorArgs([$this->sqs, $this->fifoQueueName, $this->account, '', false, ['enabled' => true, 'always' => true, 'store' => 'sqs-overflow']])
+            ->getMock();
+        $queue->setContainer($container);
+        $queue->expects($this->once())->method('getQueue')->willReturn($this->fifoQueueUrl);
+        $queue->expects($this->once())->method('createPayload')->willReturn('original-payload');
+
+        $captured = null;
+
+        $this->sqs->shouldReceive('sendMessageBatch')->once()->with(m::on(function ($args) use (&$captured) {
+            $captured = $args;
+
+            return true;
+        }))->andReturn(new Result(['Successful' => [], 'Failed' => []]));
+
+        $queue->bulk([$job], 'data', $this->fifoQueueName);
+
+        // The deduplicator receives the original payload, while the message body is the overflow pointer...
+        $this->assertSame('dedupe-original-payload', $captured['Entries'][0]['MessageDeduplicationId']);
+        $this->assertSame('group-1', $captured['Entries'][0]['MessageGroupId']);
+        $this->assertStringStartsWith('{"@pointer":"laravel:sqs-payloads:', $captured['Entries'][0]['MessageBody']);
+    }
+
+    public function testBulkFiresQueuedEventsForSuccessfulChunksWhenAnotherChunkFails()
+    {
+        $events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class);
+        $dispatched = [];
+        $events->shouldReceive('dispatch')->andReturnUsing(function ($event) use (&$dispatched) {
+            $dispatched[] = $event;
+        });
+
+        $container = m::mock(Container::class);
+        $container->shouldReceive('bound')->with('events')->andReturn(true);
+        $container->shouldReceive('bound')->with('db.transactions')->andReturn(false);
+        $container->shouldReceive('offsetGet')->with('events')->andReturn($events);
+
+        $queue = $this->getMockBuilder(SqsQueue::class)
+            ->onlyMethods(['getQueue', 'createPayload'])
+            ->setConstructorArgs([$this->sqs, $this->queueName, $this->account])
+            ->getMock();
+        $queue->setContainer($container);
+        $queue->setConnectionName('sqs');
+        $queue->expects($this->once())->method('getQueue')->willReturn($this->queueUrl);
+        $queue->method('createPayload')->willReturnCallback(fn ($job) => "payload-{$job}");
+
+        $calls = 0;
+
+        $this->sqs->shouldReceive('sendMessageBatch')->twice()->andReturnUsing(function ($args) use (&$calls) {
+            if ($calls++ === 0) {
+                return new Result([
+                    'Successful' => array_map(
+                        fn ($entry, $i) => ['Id' => $entry['Id'], 'MessageId' => 'mid-'.$i],
+                        $args['Entries'],
+                        array_keys($args['Entries'])
+                    ),
+                    'Failed' => [],
+                ]);
+            }
+
+            throw new RuntimeException('chunk failed');
+        });
+
+        try {
+            $queue->bulk(range(1, 15), 'data', $this->queueName);
+
+            $this->fail('RuntimeException was not thrown.');
+        } catch (RuntimeException $e) {
+            $this->assertSame('chunk failed', $e->getMessage());
+        }
+
+        // The first chunk was queued before the second failed, so its queued
+        // events must already have fired.
+        $queuedEvents = array_filter($dispatched, fn ($e) => $e instanceof \Illuminate\Queue\Events\JobQueued);
+
+        $this->assertCount(10, $queuedEvents);
+    }
+
+    public function testBulkRethrowsTheOriginalExceptionWhenASingleBatchRequestFails()
+    {
+        $queue = $this->getMockBuilder(SqsQueue::class)
+            ->onlyMethods(['getQueue', 'createPayload'])
+            ->setConstructorArgs([$this->sqs, $this->queueName, $this->account])
+            ->getMock();
+        $queue->setContainer(m::spy(Container::class));
+        $queue->expects($this->once())->method('getQueue')->willReturn($this->queueUrl);
+        $queue->expects($this->once())->method('createPayload')->willReturn('payload-a');
+
+        $this->sqs->shouldReceive('sendMessageBatch')->once()->andThrow(new RuntimeException('SQS is down'));
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('SQS is down');
+
+        $queue->bulk(['a'], 'data', $this->queueName);
+    }
+
+    public function testBulkDoesNothingWithEmptyInput()
+    {
+        $queue = new SqsQueue($this->sqs, $this->queueName, $this->account);
+        $queue->setContainer(m::mock(Container::class));
+
+        $this->sqs->shouldNotReceive('sendMessageBatch');
+
+        $queue->bulk([], 'data', $this->queueName);
     }
 
     public function testPopPassesOverflowStorageOptionsToJob()


### PR DESCRIPTION
This PR makes the SQS queue's `bulk()` method dispatch jobs using the [`SendMessageBatch`](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SendMessageBatch.html) API instead of issuing one `SendMessage` call per job.

### Why

`bulk()` is how batched work reaches the queue (e.g. `Bus::batch([...])->dispatch()`). Today the SQS driver loops and sends each job individually, so a 500-job batch makes 500 API calls. `SendMessageBatch` sends up to 10 messages per call, cutting that by ~10× — fewer round trips, lower cost, higher throughput.

### Behavior

- Entries are chunked to respect the `SendMessageBatch` limits — **10 messages** and **1 MiB** cumulative payload (both documented limits are 1 MiB).
- Chunks are sent **sequentially and dispatch stops at the first failure**, mirroring `push()`: jobs already sent stay queued, later chunks aren't attempted, and the error surfaces to the caller. Stopping on failure also preserves **FIFO ordering** for free — no later message can arrive ahead of one that never sent.
- Per-job `afterCommit`, `ShouldBeUnique`/debounce lock release on rollback, delays, overflow storage, and the `JobQueueing` / `JobQueued` events all behave **identically to `push()`**. Because batching bypasses the per-job `enqueueUsing()` path, the rollback-callback registration is extracted into `Queue::registerRollbackCallbacksForDeferredJob()` and reused by both `SyncQueue` and this method so the behavior stays in one place.

### Error handling

- **Request-level failures** (throttling, auth, networking, 5xx after SDK retries) propagate as the `SqsException` the SDK already throws — unchanged from `push()`.
- **Entry-level failures**: `SendMessageBatch` can return HTTP 200 while rejecting individual entries, which the SDK does *not* raise for. Per the AWS docs — *"Because the batch request can result in a combination of successful and unsuccessful actions, you should check for batch errors even when the call returns an HTTP status code of 200"* — those are surfaced as an equivalent `SqsException` carrying the reported error code, message, and full result, so rejected jobs are never silently dropped.

### Notes

- `afterCommit` is honored here (unlike `DatabaseQueue::bulk()`, which currently ignores it) precisely because batching replaces the per-job `enqueueUsing()` path that would otherwise apply it — so the manual partitioning restores parity rather than adding new behavior.
- Standard queues send batches sequentially in this first cut for simplicity; concurrent dispatch could be a follow-up.

Tests cover chunking (count + payload size), FIFO ordering and message-group/dedup handling, delay, overflow, event parity, `afterCommit` deferral, unique-lock rollback registration, and both failure modes.
