### PR TITLE
[13.x] Fix Number::pairs() infinite loop when $to or $by is non-finite

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -338,6 +338,10 @@ class Number
             throw new \InvalidArgumentException('The $by argument must not be zero.');
         }
 
+        if (! is_finite($to) || ! is_finite($by)) {
+            throw new \InvalidArgumentException('The $to and $by arguments must be finite.');
+        }
+
         $by = abs($by);
 
         $output = [];

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -368,6 +368,34 @@ class SupportNumberTest extends TestCase
         $this->assertSame(Number::pairs(100, 10), Number::pairs(100, -10));
     }
 
+    public function testPairsThrowsWhenToIsNotFinite()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        Number::pairs(INF, 10);
+    }
+
+    public function testPairsThrowsWhenToIsNan()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        Number::pairs(NAN, 10);
+    }
+
+    public function testPairsThrowsWhenByIsNotFinite()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        Number::pairs(100, INF);
+    }
+
+    public function testPairsThrowsWhenByIsNan()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        Number::pairs(100, NAN);
+    }
+
     public function testTrim()
     {
         $this->assertSame(12, Number::trim(12));


### PR DESCRIPTION
`Number::pairs()` did not guard against non-finite `$to`/`$by` values, unlike its sibling methods
(`fileSize()`, `forHumans()`, `trim()`) in the same class, which already handle `INF`/`NAN` safely.

This currently produces three distinct bugs:

- `Number::pairs(INF, 10)` causes a **fatal out-of-memory crash**  the loop condition `$lower < $to` never becomes false, so it iterates until PHP exhausts its memory limit.
- `Number::pairs(NAN, 10)` silently returns an empty array (any comparison against `NAN` is `false`, so the loop body never runs).
- `Number::pairs(10, NAN)` returns a bogus pair containing `NAN`.

This PR extends the existing validation in `pairs()` (which already throws for `$by == 0`) to also reject non-finite `$to`/`$by`, consistent with how the rest of the class handles this input.

## Reproduction

​```php
Number::pairs(INF, 10); // Fatal error: Allowed memory size exhausted
Number::pairs(NAN, 10); // []  (silently wrong)
Number::pairs(10, NAN); // [[0, NAN]]  (silently wrong)
​```