### PR TITLE
[13.x] Add `counted` method to `Str` and `Stringable`

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -376,6 +376,18 @@ class Str
     }
 
     /**
+     * Get the plural form of an English word with the count prepended.
+     *
+     * @param  string  $value
+     * @param  int|array|\Countable  $count
+     * @return string
+     */
+    public static function counted($value, $count)
+    {
+        return static::plural($value, $count, prependCount: true);
+    }
+
+    /**
      * Replace consecutive instances of a given character with a single character in the given string.
      *
      * @param  string  $string

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -247,6 +247,17 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
+     * Get the plural form of an English word with the count prepended.
+     *
+     * @param  int|array|\Countable  $count
+     * @return static
+     */
+    public function counted($count)
+    {
+        return new static(Str::counted($this->value, $count));
+    }
+
+    /**
      * Replace consecutive instances of a given character with a single character.
      *
      * @param  array<string>|string  $characters

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -2023,6 +2023,18 @@ class SupportStrTest extends TestCase
         $this->assertSame('foo baZ baz bar', $result);
     }
 
+    public function testCounted(): void
+    {
+        $this->assertSame('1 order', Str::counted('order', 1));
+        $this->assertSame('2 orders', Str::counted('order', 2));
+        $this->assertSame('0 orders', Str::counted('order', 0));
+        $this->assertSame('1 child', Str::counted('child', 1));
+        $this->assertSame('3 children', Str::counted('child', 3));
+        $this->assertSame('1,000 orders', Str::counted('order', 1000));
+        $this->assertSame('1 order', Str::counted('order', ['a']));
+        $this->assertSame('2 orders', Str::counted('order', ['a', 'b']));
+    }
+
     public function testPlural(): void
     {
         $this->assertSame('Laracon', Str::plural('Laracon', 1));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -113,6 +113,16 @@ class SupportStringableTest extends TestCase
         $this->assertTrue($this->stringable('A')->isNotEmpty());
     }
 
+    public function testCounted()
+    {
+        $this->assertSame('1 order', (string) $this->stringable('order')->counted(1));
+        $this->assertSame('2 orders', (string) $this->stringable('order')->counted(2));
+        $this->assertSame('0 orders', (string) $this->stringable('order')->counted(0));
+        $this->assertSame('1,000 orders', (string) $this->stringable('order')->counted(1000));
+        $this->assertSame('1 order', (string) $this->stringable('order')->counted(['a']));
+        $this->assertSame('2 orders', (string) $this->stringable('order')->counted(['a', 'b']));
+    }
+
     public function testPluralStudly()
     {
         $this->assertSame('LaraCon', (string) $this->stringable('LaraCon')->pluralStudly(1));


### PR DESCRIPTION
`str('order')->plural($count)` is nice, but many times you end up having to prepend the number anyway (think "1 order", "2 orders"). And if you're computing the count, you now have to store it in a variable so you can use it twice.

`plural` does support a `prependCount` parameter, but `str('order')->plural($count, prependCount: true)` is quite verbose for such a common operation.

This PR adds a `counted` method, which reads much nicer:

```php
str('order')->counted(1) // 1 order
str('order')->counted(2) // 2 orders
```