### PR TITLE
[13.x] Add `reduceInto` method to collection

### DIFF
--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -892,6 +892,17 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public function reduce(callable $callback, $initial = null);
 
     /**
+     * Reduce the collection to a single value by mutating an initial value.
+     *
+     * @template TReduceIntoInitial
+     *
+     * @param  TReduceIntoInitial  $initial
+     * @param  callable(TReduceIntoInitial, TValue, TKey): void  $callback
+     * @return TReduceIntoInitial
+     */
+    public function reduceInto($initial, callable $callback);
+
+    /**
      * Reduce the collection to multiple aggregate values.
      *
      * @param  callable  $callback

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -858,6 +858,24 @@ trait EnumeratesValues
     }
 
     /**
+     * Reduce the collection to a single value by mutating an initial value.
+     *
+     * @template TReduceIntoInitial
+     *
+     * @param  TReduceIntoInitial  $initial
+     * @param  callable(TReduceIntoInitial, TValue, TKey): void  $callback
+     * @return TReduceIntoInitial
+     */
+    public function reduceInto($initial, callable $callback)
+    {
+        foreach ($this as $key => $value) {
+            $callback($initial, $value, $key);
+        }
+
+        return $initial;
+    }
+
+    /**
      * Reduce the collection to multiple aggregate values.
      *
      * @param  callable  $callback

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -4930,6 +4930,31 @@ class SupportCollectionTest extends TestCase
     }
 
     #[DataProvider('collectionClassProvider')]
+    public function testReduceInto($collection)
+    {
+        $data = new $collection([1, 2, 3]);
+        $this->assertEquals(6, $data->reduceInto(0, function (&$result, $element) {
+            $result += $element;
+        }));
+
+        $data = new $collection([
+            'foo' => 'bar',
+            'baz' => 'qux',
+        ]);
+        $this->assertSame('foobarbazqux', $data->reduceInto('', function (&$result, $element, $key) {
+            $result .= $key.$element;
+        }));
+
+        $data = new $collection([1, 2, 3, 4, 5]);
+        $result = $data->reduceInto([], function (&$result, $value) {
+            if ($value % 2 === 0) {
+                $result[] = $value;
+            }
+        });
+        $this->assertSame([2, 4], $result);
+    }
+
+    #[DataProvider('collectionClassProvider')]
     public function testReduceSpread($collection)
     {
         $data = new $collection([-1, 0, 1, 2, 3, 4, 5]);


### PR DESCRIPTION
Similar to `reduce`, but works by mutating the accumulated value. The callback has no return.

This pattern exists in many other ecosystems. Here are a few:

- Swift has `reduce(into:_:)` ([docs](https://developer.apple.com/documentation/swift/array/reduce(into:_:)))
- Ruby has `each_with_object` ([docs](https://ruby-doc.org/3.4.1/Enumerable.html#method-i-each_with_object))
- Lodash has `_.transform` ([docs](https://lodash.com/docs/#transform))

---

Consider a collection of orders that you need to reduce into aggregate statistics:

```php
$stats = $orders->reduce(function ($stats, $order) {
    $stats->total += $order->amount;
    $stats->count++;
    $stats->largest = max($stats->largest, $order->amount);

    return $stats; // <-- this serves no purpose
}, new OrderStats);
```

In a case such as above, where you keep mutating a single value, the FP-style `reduce` doesn't really make that much sense. The new `reduceInto` method is simpler and clearer:

```php
$stats = $orders->reduceInto(new OrderStats, function ($stats, $order) {
    $stats->total += $order->amount;
    $stats->count++;
    $stats->largest = max($stats->largest, $order->amount);
});
```

The sample above uses a reference type. For arrays and scalars, pass the accumulator by reference:

```php
$tagsMap = $posts->reduceInto([], function (&$map, $post) {
    $post->tags->each(fn ($tag) => $map[$tag][] = $post->title);
});
```