### PR TITLE
[13.x] Fix O(n^2) relation filtering in ResolvesJsonApiElements::compileIncludedNestedRelationshipsMap()

### DIFF
--- a/src/Illuminate/Http/Resources/JsonApi/Concerns/ResolvesJsonApiElements.php
+++ b/src/Illuminate/Http/Resources/JsonApi/Concerns/ResolvesJsonApiElements.php
@@ -310,7 +310,7 @@ trait ResolvesJsonApiElements
         (new Collection($resource->toRelationships($request)))
             ->transform(fn ($value, $key) => is_int($key) ? new RelationResolver($value) : new RelationResolver($key, $value))
             ->mapWithKeys(fn ($relationResolver) => [$relationResolver->relationName => $relationResolver])
-            ->filter(fn ($value, $key) => in_array($key, array_keys($relation->getRelations())))
+            ->filter(fn ($value, $key) => array_key_exists($key, $relation->getRelations()))
             ->each(function ($relationResolver, $key) use ($relation, $request) {
                 $this->compileResourceRelationshipUsingResolver($request, $relation, $relationResolver, $relation->getRelation($key));
             });


### PR DESCRIPTION
Optimizes the `filter()` closure in `compileIncludedNestedRelationshipsMap()` by replacing a linear `in_array()` scan with a direct `array_key_exists()` lookup.

**Context & Performance Impact**
Previously, the closure used:
`in_array($key, array_keys($relation->getRelations()))`

This rebuilt a fresh keys array from `$relation->getRelations()` and performed a linear scan on every single element being filtered—resulting in an **O(n*m)** time complexity instead of **O(n)**.

Since `getRelations()` returns an associative array (`relation name => value`), a direct `array_key_exists()` lookup is O(1) per check. 