### PR TITLE
Add query route method support

### DIFF
--- a/src/Illuminate/Contracts/Routing/Registrar.php
+++ b/src/Illuminate/Contracts/Routing/Registrar.php
@@ -59,6 +59,15 @@ interface Registrar
     public function options($uri, $action);
 
     /**
+     * Register a new QUERY route with the router.
+     *
+     * @param  string  $uri
+     * @param  array|string|callable  $action
+     * @return \Illuminate\Routing\Route
+     */
+    public function query($uri, $action);
+
+    /**
      * Register a new route with the given verbs.
      *
      * @param  array|string  $methods

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -66,6 +66,7 @@ class RouteListCommand extends Command
         'GET' => 'blue',
         'HEAD' => '#6C7280',
         'OPTIONS' => '#6C7280',
+        'QUERY' => '#6C7280',
         'POST' => 'yellow',
         'PUT' => 'yellow',
         'PATCH' => 'yellow',
@@ -394,7 +395,7 @@ class RouteListCommand extends Command
         $routes = $routes->map(
             fn ($route) => array_merge($route, [
                 'action' => $this->formatActionForCli($route),
-                'method' => $route['method'] == 'GET|HEAD|POST|PUT|PATCH|DELETE|OPTIONS' ? 'ANY' : $route['method'],
+                'method' => $route['method'] == implode('|', Router::$verbs) ? 'ANY' : $route['method'],
                 'uri' => $route['domain'] ? ($route['domain'].'/'.ltrim($route['uri'], '/')) : $route['uri'],
             ]),
         );

--- a/src/Illuminate/Foundation/Http/Middleware/PreventRequestForgery.php
+++ b/src/Illuminate/Foundation/Http/Middleware/PreventRequestForgery.php
@@ -119,7 +119,7 @@ class PreventRequestForgery
      */
     protected function isReading($request)
     {
-        return in_array($request->method(), ['HEAD', 'GET', 'OPTIONS']);
+        return in_array($request->method(), ['HEAD', 'GET', 'OPTIONS', 'QUERY']);
     }
 
     /**

--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -18,6 +18,7 @@ use InvalidArgumentException;
  * @method \Illuminate\Routing\Route patch(string $uri, \Closure|array|string|null $action = null)
  * @method \Illuminate\Routing\Route post(string $uri, \Closure|array|string|null $action = null)
  * @method \Illuminate\Routing\Route put(string $uri, \Closure|array|string|null $action = null)
+ * @method \Illuminate\Routing\Route query(string $uri, \Closure|array|string|null $action = null)
  * @method \Illuminate\Routing\RouteRegistrar as(string $value)
  * @method \Illuminate\Routing\RouteRegistrar can(\UnitEnum|string  $ability, array|string $models = [])
  * @method \Illuminate\Routing\RouteRegistrar controller(string $controller)
@@ -60,7 +61,7 @@ class RouteRegistrar
      * @var string[]
      */
     protected $passthru = [
-        'get', 'post', 'put', 'patch', 'delete', 'options', 'any',
+        'get', 'post', 'put', 'patch', 'delete', 'options', 'query', 'any',
     ];
 
     /**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -133,7 +133,7 @@ class Router implements BindingRegistrar, RegistrarContract
      *
      * @var string[]
      */
-    public static $verbs = ['GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'];
+    public static $verbs = ['GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS', 'QUERY'];
 
     /**
      * Create a new Router instance.
@@ -218,6 +218,18 @@ class Router implements BindingRegistrar, RegistrarContract
     public function options($uri, $action = null)
     {
         return $this->addRoute('OPTIONS', $uri, $action);
+    }
+
+    /**
+     * Register a new QUERY route with the router.
+     *
+     * @param  string  $uri
+     * @param  array|string|callable|null  $action
+     * @return \Illuminate\Routing\Route
+     */
+    public function query($uri, $action = null)
+    {
+        return $this->addRoute('QUERY', $uri, $action);
     }
 
     /**

--- a/src/Illuminate/Support/Facades/Route.php
+++ b/src/Illuminate/Support/Facades/Route.php
@@ -9,6 +9,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Routing\Route patch(string $uri, array|string|callable|null $action = null)
  * @method static \Illuminate\Routing\Route delete(string $uri, array|string|callable|null $action = null)
  * @method static \Illuminate\Routing\Route options(string $uri, array|string|callable|null $action = null)
+ * @method static \Illuminate\Routing\Route query(string $uri, array|string|callable|null $action = null)
  * @method static \Illuminate\Routing\Route any(string $uri, array|string|callable|null $action = null)
  * @method static \Illuminate\Routing\Route fallback(array|string|callable|null $action)
  * @method static \Illuminate\Routing\Route redirect(string $uri, string $destination, int $status = 302)

--- a/tests/Http/Middleware/PreventRequestForgeryTest.php
+++ b/tests/Http/Middleware/PreventRequestForgeryTest.php
@@ -32,6 +32,16 @@ class PreventRequestForgeryTest extends TestCase
         $this->assertSame('OK', $response->getContent());
     }
 
+    public function test_query_requests_pass_without_token()
+    {
+        $middleware = $this->createMiddleware();
+        $request = $this->createRequest(method: 'QUERY');
+
+        $response = $middleware->handle($request, fn () => new Response('OK'));
+
+        $this->assertSame('OK', $response->getContent());
+    }
+
     public function test_same_site_header_rejected_by_default()
     {
         $middleware = $this->createMiddleware();
@@ -121,11 +131,11 @@ class PreventRequestForgeryTest extends TestCase
         $this->assertSame('OK', $response->getContent());
     }
 
-    protected function createRequest(array $server = [], ?string $token = null)
+    protected function createRequest(array $server = [], ?string $token = null, string $method = 'POST')
     {
         $request = Request::create(
             'http://example.com/test',
-            'POST',
+            $method,
             $token ? ['_token' => $token] : [],
             [],
             [],

--- a/tests/Integration/Routing/Fixtures/query_routes.php
+++ b/tests/Integration/Routing/Fixtures/query_routes.php
@@ -1,0 +1,11 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+
+Route::query('/search', function () {
+    return response()->json([
+        'method' => request()->method(),
+        'term' => request()->query('term'),
+        'filter' => request()->input('filter'),
+    ]);
+});

--- a/tests/Integration/Routing/RouteCachingTest.php
+++ b/tests/Integration/Routing/RouteCachingTest.php
@@ -23,6 +23,17 @@ class RouteCachingTest extends TestCase
         $this->get('/foo/1')->assertRedirect('/foo/1/bar');
     }
 
+    public function testQueryRoutes()
+    {
+        $this->routes(__DIR__.'/Fixtures/query_routes.php');
+
+        $this->call('QUERY', '/search?term=laravel', ['filter' => 'framework'])->assertExactJson([
+            'method' => 'QUERY',
+            'term' => 'laravel',
+            'filter' => 'framework',
+        ]);
+    }
+
     protected function routes(string $file)
     {
         $this->defineCacheRoutes(file_get_contents($file));

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -216,6 +216,17 @@ class RouteRegistrarTest extends TestCase
         $this->seeMiddleware('post-middleware');
     }
 
+    public function testCanRegisterQueryRouteWithClosureAction()
+    {
+        $this->router->middleware('query-middleware')->query('users', function () {
+            return 'found';
+        });
+
+        $this->assertTrue($this->getRoute()->matches(Request::create('users', 'QUERY')));
+        $this->assertSame(['QUERY'], $this->getRoute()->methods());
+        $this->seeMiddleware('query-middleware');
+    }
+
     public function testCanRegisterAnyRouteWithClosureAction()
     {
         $this->router->middleware('test-middleware')->any('users', function () {

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -86,8 +86,12 @@ class RoutingRouteTest extends TestCase
         $router->post('foo/bar', function () {
             return 'post hello';
         });
+        $router->query('foo/bar', function () {
+            return 'query hello';
+        });
         $this->assertSame('hello', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
         $this->assertSame('post hello', $router->dispatch(Request::create('foo/bar', 'POST'))->getContent());
+        $this->assertSame('query hello', $router->dispatch(Request::create('foo/bar', 'QUERY'))->getContent());
 
         $router = $this->getRouter();
         $router->get('foo/{bar}', function ($name) {
@@ -157,6 +161,7 @@ class RoutingRouteTest extends TestCase
             return 'hello';
         });
         $this->assertEmpty($router->dispatch(Request::create('foo/bar', 'HEAD'))->getContent());
+        $this->assertSame('hello', $router->dispatch(Request::create('foo/bar', 'QUERY'))->getContent());
 
         $router = $this->getRouter();
         $router->get('foo/bar', function () {


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Re-targeting this to `master` after feedback on the previous PR (#60650).

This PR adds first-class routing support for the HTTP `QUERY` method.

Laravel already supports custom methods through `Route::match()` and `Router::addRoute()`, but there is no native `Route::query()` helper like there is for `get`, `post`, `put`, `patch`, `delete`, and `options`.

With this change, applications can define `QUERY` routes directly:

```php
Route::query('/search', function () {
    return request()->input('filter');
});
```

QUERY is also included in Route::any(), exposed through the route registrar and facade docs, and treated as a read request by PreventRequestForgery.

That last part is important because QUERY is defined as a safe HTTP method, so it should behave like GET, HEAD, and OPTIONS for CSRF purposes.

Tests cover direct router dispatching, route registrar usage, framework integration, cached routes, and CSRF middleware behavior.