### PR TITLE
[13.x] Ensure `deletedAtColumn` is passed to `assertSoftDeleted` & `assertNotSoftDeleted`

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -151,7 +151,7 @@ trait InteractsWithDatabase
     {
         if (is_iterable($table)) {
             foreach ($table as $item) {
-                $this->assertSoftDeleted($item, $data, $connection);
+                $this->assertSoftDeleted($item, $data, $connection, $deletedAtColumn);
             }
 
             return $this;
@@ -199,7 +199,7 @@ trait InteractsWithDatabase
     {
         if (is_iterable($table)) {
             foreach ($table as $item) {
-                $this->assertNotSoftDeleted($item, $data, $connection);
+                $this->assertNotSoftDeleted($item, $data, $connection, $deletedAtColumn);
             }
 
             return $this;

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -248,6 +248,32 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         ]);
     }
 
+    public function testAssertSoftDeletedTableSupportsIterablesWithCustomDeletedAtColumn()
+    {
+        $builder = m::mock(Builder::class);
+        $builder->shouldReceive('where')->with($this->data)->twice()->andReturnSelf();
+        $builder->shouldReceive('whereNotNull')->with('removed_at')->twice()->andReturnSelf();
+        $builder->shouldReceive('exists')->twice()->andReturn(true);
+
+        $this->connection->shouldReceive('table')->with($this->table)->andReturn($builder);
+        $this->connection->shouldReceive('table')->with('orders')->andReturn($builder);
+
+        $this->assertSoftDeleted(['products', 'orders'], $this->data, deletedAtColumn: 'removed_at');
+    }
+
+    public function testAssertNotSoftDeletedTableSupportsIterablesWithCustomDeletedAtColumn()
+    {
+        $builder = m::mock(Builder::class);
+        $builder->shouldReceive('where')->with($this->data)->twice()->andReturnSelf();
+        $builder->shouldReceive('whereNull')->with('removed_at')->twice()->andReturnSelf();
+        $builder->shouldReceive('exists')->twice()->andReturn(true);
+
+        $this->connection->shouldReceive('table')->with($this->table)->andReturn($builder);
+        $this->connection->shouldReceive('table')->with('orders')->andReturn($builder);
+
+        $this->assertNotSoftDeleted(['products', 'orders'], $this->data, deletedAtColumn: 'removed_at');
+    }
+
     public function testAssertDatabaseMissingPassesWhenDoesNotFindResults()
     {
         $this->mockCountBuilder(false);


### PR DESCRIPTION
If you were asserting multiple tables, you couldn't pass in a custom deleted column. 

This PR means you now can. 

This was being passed in elsewhere 
https://github.com/laravel/framework/blob/4e963ce20316e438c4bea690b670282bf9b374ff/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php#L171

so feels right to put it in here too 

I don't think this is a b/c as you'd have to explicitly set the column for it to pass through.
