### PR TITLE
[13.x] Add `assertEmpty` to the Storage facade

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -208,6 +208,18 @@ class FilesystemAdapter implements CloudFilesystemContract
     }
 
     /**
+     * Assert that the disk contains no files.
+     *
+     * @return $this
+     */
+    public function assertEmpty()
+    {
+        PHPUnit::assertEmpty($this->allFiles(), 'Disk is not empty.');
+
+        return $this;
+    }
+
+    /**
      * Determine if a file or directory exists.
      *
      * @param  string  $path

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -20,6 +20,7 @@ use League\Flysystem\UnableToRetrieveMetadata;
 use League\Flysystem\UnableToWriteFile;
 use Mockery as m;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
@@ -826,5 +827,23 @@ class FilesystemAdapterTest extends TestCase
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
 
         $this->assertFalse($filesystemAdapter->providesTemporaryUploadUrls());
+    }
+
+    public function testAssertEmpty()
+    {
+        $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
+
+        $filesystemAdapter->assertEmpty();
+    }
+
+    public function testAssertEmptyFailsWhenDiskContainsFiles()
+    {
+        $this->filesystem->write('foo/file.txt', 'Hello World');
+        $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('Disk is not empty.');
+
+        $filesystemAdapter->assertEmpty();
     }
 }


### PR DESCRIPTION
Currently, asserting the whole disk is empty requires passing an empty string to assertDirectoryEmpty which reads oddly / feels a bit like a hack.  

This PR adds an `assertEmpty` method, which is fully recursive, so it fails if a file exists anywhere on the disk.

```php
$disk = Storage::fake('some-path');

// Tests....


// Before
$disk->assertDirectoryEmpty(''); // wut wut?!

// After
$disk->assertEmpty();
```

We have a lot of tests that set specific disks up, and we need to make sure they're empty ie certain files are moved / deleted etc via jobs, commands, etc...
 
  
I can macro it worst case, but feels like something everyone may benefit from. 

Perhaps you prefer `assertDiskEmpty` - so open to changing!