### PR TITLE
[12.x] Pop managed queue jobs from the cloud-agent instead of SQS

### DIFF
--- a/src/Illuminate/Foundation/Cloud/AgentAwareLostConnectionDetector.php
+++ b/src/Illuminate/Foundation/Cloud/AgentAwareLostConnectionDetector.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Illuminate\Foundation\Cloud;
+
+use Illuminate\Contracts\Database\LostConnectionDetector;
+use Throwable;
+
+/**
+ * Treats an unreachable cloud-agent runtime socket as a lost connection so the
+ * worker exits and the pod restarts — the only way to recover an agent that
+ * has died in-pod. Every other exception is delegated to parent instance.
+ */
+class AgentAwareLostConnectionDetector implements LostConnectionDetector
+{
+    /**
+     * Create a new detector instance.
+     */
+    public function __construct(
+        protected LostConnectionDetector $detector,
+    ) {
+        //
+    }
+
+    /**
+     * Determine if the given exception was caused by a lost connection.
+     */
+    public function causedByLostConnection(Throwable $e): bool
+    {
+        return $e instanceof AgentUnreachableException
+            || $this->detector->causedByLostConnection($e);
+    }
+}

--- a/src/Illuminate/Foundation/Cloud/AgentUnreachableException.php
+++ b/src/Illuminate/Foundation/Cloud/AgentUnreachableException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Foundation\Cloud;
+
+use RuntimeException;
+
+class AgentUnreachableException extends RuntimeException
+{
+    //
+}

--- a/src/Illuminate/Foundation/Cloud/CloudJob.php
+++ b/src/Illuminate/Foundation/Cloud/CloudJob.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Illuminate\Foundation\Cloud;
+
+use Aws\Sqs\SqsClient;
+use Illuminate\Container\Container;
+use Illuminate\Queue\Jobs\Job;
+use Illuminate\Queue\Jobs\SqsJob;
+
+class CloudJob extends SqsJob
+{
+    /**
+     * Create a new job instance.
+     *
+     * @param  array  $job
+     * @param  string  $connectionName
+     * @param  string  $queue
+     * @param  callable(string, int|null): void  $reporter
+     */
+    public function __construct(
+        Container $container,
+        SqsClient $sqs,
+        array $job,
+        $connectionName,
+        $queue,
+        protected $reporter,
+    ) {
+        parent::__construct($container, $sqs, $job, $connectionName, $queue);
+    }
+
+    /**
+     * Delete the job from the queue.
+     *
+     * @return void
+     */
+    public function delete()
+    {
+        // Skip SQS deletion so SQS DeleteMessage is left to the poller...
+        Job::delete();
+
+        $this->report('processed');
+    }
+
+    /**
+     * Release the job back into the queue after (n) seconds.
+     *
+     * @param  int  $delay
+     * @return void
+     */
+    public function release($delay = 0)
+    {
+        // Skip SQS deletion so SQS release is left to the poller...
+        Job::release($delay);
+
+        $this->report('released', delay: $delay);
+    }
+
+    /**
+     * Report the job's outcome to the agent, which owns the SQS operation.
+     */
+    protected function report(string $status, ?int $delay = null): void
+    {
+        ($this->reporter)($status, $delay);
+    }
+}

--- a/src/Illuminate/Foundation/Cloud/Queue.php
+++ b/src/Illuminate/Foundation/Cloud/Queue.php
@@ -5,8 +5,13 @@ namespace Illuminate\Foundation\Cloud;
 use Carbon\CarbonImmutable;
 use Illuminate\Contracts\Queue\ClearableQueue;
 use Illuminate\Contracts\Queue\Queue as QueueContract;
+use Illuminate\Foundation\Application;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\ForwardsCalls;
+use Symfony\Component\Console\Input\ArgvInput;
 
 class Queue implements QueueContract, ClearableQueue
 {
@@ -37,6 +42,7 @@ class Queue implements QueueContract, ClearableQueue
      * Create a new Queue instance.
      */
     public function __construct(
+        protected Application $app,
         protected QueueContract $queue,
         protected Events $events,
         protected array $config,
@@ -185,6 +191,10 @@ class Queue implements QueueContract, ClearableQueue
     /**
      * Pop the next job off of the queue.
      *
+     * Jobs come straight from SQS unless the cloud-agent is enabled.
+     *
+     * When cloud-agent is enabled, we long-poll the agent's runtime socket instead.
+     *
      * @param  string|null  $queue
      * @return \Illuminate\Contracts\Queue\Job|null
      */
@@ -192,11 +202,130 @@ class Queue implements QueueContract, ClearableQueue
     {
         $this->finishProcessingJob();
 
-        $job = $this->queue->pop(...func_get_args());
+        $job = $this->usesAgent($queue)
+            ? $this->popFromAgent()
+            : $this->queue->pop(...func_get_args());
 
         $this->startProcessingJob($queue, $job);
 
         return $job;
+    }
+
+    /**
+     * Long-poll the cloud-agent's runtime socket and wrap the next message in a CloudJob.
+     *
+     * @return \Illuminate\Foundation\Cloud\CloudJob|null
+     */
+    protected function popFromAgent()
+    {
+        $data = $this->requestNextJobFromAgent();
+
+        if (! (is_array($data) && is_string($messageId = $data['messageId'] ?? null) && $messageId !== '')) {
+            return null;
+        }
+
+        // Coerce a non-string handle to null so a malformed response degrades gracefully...
+        $receiptHandle = is_string($handle = $data['receiptHandle'] ?? null) ? $handle : null;
+
+        return new CloudJob(
+            $this->queue->getContainer(),
+            $this->queue->getSqs(),
+            [
+                'MessageId' => $messageId,
+                'ReceiptHandle' => $receiptHandle,
+                'Body' => is_string($body = $data['body'] ?? null) ? $body : '',
+                'Attributes' => $data['attributes'] ?? [],
+            ],
+            $this->queue->getConnectionName(),
+            $data['queueUrl'] ?? null,
+            fn (string $status, ?int $delay) => $this->reportJobStatusToAgent(
+                $messageId, $receiptHandle, $status, $delay
+            ),
+        );
+    }
+
+    /**
+     * Long-poll the agent's runtime socket (GET /next) for the next job.
+     *
+     * @throws \Illuminate\Foundation\Cloud\AgentUnreachableException
+     */
+    protected function requestNextJobFromAgent(): ?array
+    {
+        try {
+            $response = $this->agentRequest()
+                ->timeout(65)
+                ->get('/next');
+        } catch (ConnectionException $e) {
+            throw new AgentUnreachableException(
+                'The Laravel Cloud agent runtime socket is unreachable.', previous: $e
+            );
+        }
+
+        if ($response->status() === 204) {
+            return null;
+        }
+
+        if (! $response->ok()) {
+            throw new AgentUnreachableException(
+                "The Laravel Cloud agent returned HTTP {$response->status()} from GET /next."
+            );
+        }
+
+        if (! is_array($data = $response->json())) {
+            throw new AgentUnreachableException(
+                'The Laravel Cloud agent returned a non-array body from GET /next.'
+            );
+        }
+
+        return $data;
+    }
+
+    /**
+     * Report a job's terminal outcome back to the agent (POST /result).
+     *
+     * @throws \Illuminate\Http\Client\RequestException
+     * @throws \Illuminate\Foundation\Cloud\AgentUnreachableException
+     */
+    protected function reportJobStatusToAgent(string $messageId, ?string $receiptHandle, string $status, ?int $delay = null): void
+    {
+        try {
+            $this->agentRequest()
+                ->timeout(10)
+                ->throw()
+                ->retry(3, 100, fn ($exception) => $exception instanceof ConnectionException)
+                ->post('/result', array_filter([
+                    'messageId' => $messageId,
+                    'receiptHandle' => $receiptHandle,
+                    'status' => $status,
+                    'delay' => $delay,
+                ], fn ($value) => $value !== null));
+        } catch (ConnectionException $e) {
+            throw new AgentUnreachableException(
+                'The Laravel Cloud agent runtime socket is unreachable.', previous: $e
+            );
+        } catch (RequestException $e) {
+            if ($e->response->serverError()) {
+                throw new AgentUnreachableException(
+                    "The Laravel Cloud agent returned HTTP {$e->response->status()} from POST /result.", previous: $e
+                );
+            }
+
+            throw $e;
+        }
+    }
+
+    /**
+     * Get a pending HTTP request bound to the agent's Unix runtime socket.
+     *
+     * @return \Illuminate\Http\Client\PendingRequest
+     */
+    protected function agentRequest()
+    {
+        return Http::baseUrl('http://localhost')->withOptions([
+            'curl' => [
+                CURLOPT_UNIX_SOCKET_PATH => $this->config['agent']['socket'] ?? '/tmp/cloud-agent.sock',
+            ],
+        ]);
     }
 
     /**
@@ -208,6 +337,29 @@ class Queue implements QueueContract, ClearableQueue
     public function clear($queue)
     {
         return $this->queue->clear(...func_get_args());
+    }
+
+    /**
+     * Determine whether the next job should be received from the in-container cloud-agent.
+     *
+     * @param  string|null  $queue
+     */
+    protected function usesAgent($queue = null): bool
+    {
+        return ($this->config['agent']['enabled'] ?? false)
+            && $this->app->runningConsoleCommand('queue:work')
+            && $this->queue->getQueue($queue) === $this->queue->getQueue($this->workerQueue());
+    }
+
+    /**
+     * Get the queue the running queue:work worker is processing.
+     *
+     * @return string
+     */
+    protected function workerQueue()
+    {
+        return (new ArgvInput)->getParameterOption('--queue')
+            ?: ($this->config['queue'] ?? 'default');
     }
 
     /**

--- a/src/Illuminate/Foundation/Cloud/QueueConnector.php
+++ b/src/Illuminate/Foundation/Cloud/QueueConnector.php
@@ -5,6 +5,7 @@ namespace Illuminate\Foundation\Cloud;
 use Aws\CommandInterface;
 use Aws\Exception\AwsException;
 use Aws\Sqs\SqsClient;
+use Illuminate\Contracts\Database\LostConnectionDetector;
 use Illuminate\Foundation\Application;
 use Illuminate\Queue\Connectors\ConnectorInterface;
 use Illuminate\Queue\Events\JobQueued;
@@ -39,6 +40,7 @@ class QueueConnector implements ConnectorInterface
         $underlying = $this->connector->connect($config['connection']);
 
         $queue = new Queue(
+            $this->app,
             $underlying,
             $this->app[Events::class],
             $config,
@@ -100,6 +102,12 @@ class QueueConnector implements ConnectorInterface
     {
         Worker::$restartable = false;
         Worker::$pausable = false;
+
+        // Exit the worker (and restart the pod) when the agent socket is unreachable...
+        $this->app->extend(
+            LostConnectionDetector::class,
+            fn ($detector) => new AgentAwareLostConnectionDetector($detector),
+        );
 
         $this->app['events']->listen(fn (WorkerStopping $event) => match ($event->reason) {
             WorkerStopReason::TimedOut => $queue->finishProcessingJob(default: 'released'),

--- a/src/Illuminate/Queue/Jobs/SqsJob.php
+++ b/src/Illuminate/Queue/Jobs/SqsJob.php
@@ -50,6 +50,17 @@ class SqsJob extends Job implements JobContract
     {
         parent::release($delay);
 
+        $this->changeMessageVisibilityInSqs($delay);
+    }
+
+    /**
+     * Reset the SQS message's visibility timeout so it becomes available again.
+     *
+     * @param  int  $delay
+     * @return void
+     */
+    protected function changeMessageVisibilityInSqs($delay)
+    {
         $this->sqs->changeMessageVisibility([
             'QueueUrl' => $this->queue,
             'ReceiptHandle' => $this->job['ReceiptHandle'],
@@ -66,6 +77,16 @@ class SqsJob extends Job implements JobContract
     {
         parent::delete();
 
+        $this->deleteMessageFromSqs();
+    }
+
+    /**
+     * Delete the message from the SQS queue.
+     *
+     * @return void
+     */
+    protected function deleteMessageFromSqs()
+    {
         $this->sqs->deleteMessage([
             'QueueUrl' => $this->queue, 'ReceiptHandle' => $this->job['ReceiptHandle'],
         ]);

--- a/tests/Foundation/Cloud/QueueTest.php
+++ b/tests/Foundation/Cloud/QueueTest.php
@@ -9,19 +9,25 @@ use Aws\MockHandler;
 use Aws\Result;
 use Aws\Sqs\SqsClient;
 use Illuminate\Contracts\Encryption\DecryptException;
+use Illuminate\Database\LostConnectionDetector;
 use Illuminate\Foundation\Cloud;
+use Illuminate\Foundation\Cloud\AgentAwareLostConnectionDetector;
+use Illuminate\Foundation\Cloud\AgentUnreachableException;
+use Illuminate\Foundation\Cloud\CloudJob;
 use Illuminate\Foundation\Cloud\Events;
 use Illuminate\Foundation\Cloud\FailedJobProvider;
 use Illuminate\Foundation\Cloud\ManagedQueueNotFoundException;
 use Illuminate\Foundation\Cloud\Queue;
 use Illuminate\Foundation\Cloud\QueueConnector;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Queue\Connectors\ConnectorInterface;
 use Illuminate\Queue\Connectors\SqsConnector;
 use Illuminate\Queue\Events\WorkerStopping;
 use Illuminate\Queue\Failed\FileFailedJobProvider;
 use Illuminate\Queue\Jobs\FakeJob;
+use Illuminate\Queue\Jobs\SqsJob;
 use Illuminate\Queue\SqsQueue;
 use Illuminate\Queue\Worker;
 use Illuminate\Queue\WorkerStopReason;
@@ -45,6 +51,14 @@ class QueueTest extends TestCase
 {
     use DatabaseMigrations;
 
+    /**
+     * The original $_SERVER['argv'], restored in tearDown() after fakeQueue()
+     * spoofs a queue:work worker.
+     *
+     * @var array|null
+     */
+    private $savedArgv = null;
+
     protected function defineEnvironment($app)
     {
         $app['config']->set('app.key', Str::random(32));
@@ -52,6 +66,8 @@ class QueueTest extends TestCase
 
     protected function setUp(): void
     {
+        $this->savedArgv = $_SERVER['argv'];
+
         Worker::$restartable = true;
         Worker::$pausable = true;
         $_SERVER['LARAVEL_CLOUD'] = '1';
@@ -73,6 +89,13 @@ class QueueTest extends TestCase
 
     protected function tearDown(): void
     {
+        // Restore before the parent tears down (and even when setUp failed) so
+        // a spoofed queue:work argv never leaks into the rest of the process.
+        if ($this->savedArgv !== null) {
+            $_SERVER['argv'] = $this->savedArgv;
+            $this->savedArgv = null;
+        }
+
         parent::tearDown();
 
         unset($_SERVER['LARAVEL_CLOUD'], $_SERVER['LARAVEL_CLOUD_MANAGED_QUEUES_CONFIG']);
@@ -209,9 +232,9 @@ class QueueTest extends TestCase
     {
         $this->travelTo('2000-01-02 03:04:05.060708');
         $eventsFake = $this->fakeEvents();
-        [$queue, $queueFake] = $this->fakeQueue();
+        [$queue, $agent] = $this->fakeQueue();
 
-        $queueFake->jobsToPop[] = new FakeJob;
+        $agent->pushJob();
         $queue->pop();
 
         $this->assertSame([[
@@ -226,9 +249,9 @@ class QueueTest extends TestCase
     {
         $this->travelTo('2000-01-02 03:04:05.060708');
         $eventsFake = $this->fakeEvents();
-        [$queue, $queueFake] = $this->fakeQueue();
+        [$queue, $agent] = $this->fakeQueue();
 
-        $queueFake->jobsToPop[] = new FakeJob;
+        $agent->pushJob();
         $queue->pop();
         $this->travel(1)->second();
         $queue->pop();
@@ -254,9 +277,9 @@ class QueueTest extends TestCase
     {
         $this->travelTo('2000-01-02 03:04:05.060708');
         $eventsFake = $this->fakeEvents();
-        [$queue, $queueFake] = $this->fakeQueue();
+        [$queue, $agent] = $this->fakeQueue();
 
-        $queueFake->jobsToPop[] = new FakeJob;
+        $agent->pushJob();
         $queue->pop();
         $queue->pop();
         $queue->pop();
@@ -269,11 +292,19 @@ class QueueTest extends TestCase
     {
         $this->travelTo('2000-01-02 03:04:05.060708');
         $eventsFake = $this->fakeEvents();
-        [$queue, $queueFake] = $this->fakeQueue();
+        [$queue, $agent] = $this->fakeQueue();
 
-        $queueFake->jobsToPop = [new FakeJob, new FakeJob];
+        $agent->pushJob();
+        $agent->pushJob();
+        // Each pop finishes the previous job, so its processed event must carry
+        // the queue that job was popped from, not the queue being popped now.
+        // The agent only serves the worker's own queue, so retarget the worker
+        // alongside each pop.
+        $_SERVER['argv'] = ['artisan', 'queue:work', '--queue=first'];
         $queue->pop('first');
+        $_SERVER['argv'] = ['artisan', 'queue:work', '--queue=second'];
         $queue->pop('second');
+        $_SERVER['argv'] = ['artisan', 'queue:work', '--queue=third'];
         $queue->pop('third');
 
         $this->assertSame([
@@ -305,19 +336,115 @@ class QueueTest extends TestCase
         ], $eventsFake->emitted);
     }
 
+    public function testPopReceivesFromTheAgentForANonDefaultWorkerQueue()
+    {
+        $this->fakeEvents();
+        [$queue, $agent] = $this->fakeQueue();
+        $agent->pushJob(['messageId' => 'message-id']);
+
+        // A managed worker started for a non-default queue is still served by the
+        // agent: the agent polls whatever queue the worker is processing.
+        $_SERVER['argv'] = ['artisan', 'queue:work', '--queue=emails'];
+
+        $job = $queue->pop('emails');
+
+        $this->assertInstanceOf(CloudJob::class, $job);
+        $this->assertSame('message-id', $job->getJobId());
+    }
+
+    public function testPopReadsTheWorkerQueueFromTheSpaceSeparatedQueueOption()
+    {
+        $this->fakeEvents();
+        [$queue, $agent] = $this->fakeQueue();
+        $agent->pushJob(['messageId' => 'message-id']);
+
+        // The --queue option may be given space-separated rather than with "=".
+        $_SERVER['argv'] = ['artisan', 'queue:work', '--queue', 'emails'];
+
+        $job = $queue->pop('emails');
+
+        $this->assertInstanceOf(CloudJob::class, $job);
+        $this->assertSame('message-id', $job->getJobId());
+    }
+
+    public function testPopReceivesFromSqsWhenTheQueueIsNotTheWorkerQueue()
+    {
+        $this->fakeEvents();
+        [$queue, $agent] = $this->fakeQueue();
+        $agent->pushJob();
+
+        // A pop for a queue other than the one the worker is processing has no
+        // agent feeding it, so it comes from SQS directly and the socket is never
+        // polled.
+        $_SERVER['argv'] = ['artisan', 'queue:work', '--queue=emails'];
+
+        $this->assertNull($queue->pop('not-the-worker-queue'));
+
+        Http::assertNothingSent();
+    }
+
+    public function testPopReceivesFromSqsForAMultiQueueWorker()
+    {
+        $this->fakeEvents();
+        [$queue, $agent] = $this->fakeQueue();
+        $agent->pushJob();
+
+        // The agent serves a single queue, so a worker spanning several queues
+        // (the worker pops each individually) cannot be served by it and falls
+        // back to SQS rather than being handed the agent's one queue for all.
+        $_SERVER['argv'] = ['artisan', 'queue:work', '--queue=high,low'];
+
+        $this->assertNull($queue->pop('high'));
+        $this->assertNull($queue->pop('low'));
+
+        Http::assertNothingSent();
+    }
+
+    public function testPopReceivesFromTheAgentWhenTheQueueOptionIsOmitted()
+    {
+        $this->fakeEvents();
+        // WorkCommand falls back to the connection's top-level "queue" key when
+        // --queue is omitted, so workerQueue() must mirror that exact fallback.
+        config(['queue.connections.cloud.queue' => 'emails']);
+        [$queue, $agent] = $this->fakeQueue();
+        $agent->pushJob(['messageId' => 'message-id']);
+
+        $_SERVER['argv'] = ['artisan', 'queue:work'];
+
+        $job = $queue->pop('emails');
+
+        $this->assertInstanceOf(CloudJob::class, $job);
+        $this->assertSame('message-id', $job->getJobId());
+    }
+
+    public function testPopReceivesFromSqsWhenNotRunningAsAQueueWorker()
+    {
+        $this->fakeEvents();
+        [$queue, $agent] = $this->fakeQueue();
+        $agent->pushJob();
+
+        // Outside a queue:work worker (e.g. a web request) the agent sidecar is
+        // not serving us, so jobs come from SQS directly.
+        $_SERVER['argv'] = ['artisan', 'tinker'];
+
+        $this->assertNull($queue->pop());
+
+        Http::assertNothingSent();
+    }
+
     public function testItEmitsFailedJobEvents()
     {
         $this->travelTo('2000-01-02 03:04:05.060708');
         $eventsFake = $this->fakeEvents();
-        [$queue, $queueFake] = $this->fakeQueue();
+        [$queue, $agent] = $this->fakeQueue();
         $failerFake = $this->fakeFailer();
         $failedJobProvider = new FailedJobProvider($failerFake, $eventsFake, $this->app['encrypter']);
         $failedJobProvider->setQueue($queue);
         $this->app[FailedJobProvider::class] = $failedJobProvider;
 
-        $queueFake->jobsToPop[] = $jobFake = new FakeJob;
-        $queue->pop();
-        $jobFake->fail();
+        $agent->pushJob();
+        $job = $queue->pop();
+        $job->fail();
         Str::createUuidsUsingSequence([Uuid::fromString('00dc709e-90c4-70c2-87c8-9b7127d20e8f')]);
         $failedJobProvider->log('cloud', 'default', ['payload' => 'here'], new RuntimeException('Whoops!'));
         Str::createUuidsNormally();
@@ -355,11 +482,11 @@ class QueueTest extends TestCase
     {
         $this->travelTo('2000-01-02 03:04:05.060708');
         $eventsFake = $this->fakeEvents();
-        [$queue, $queueFake] = $this->fakeQueue();
+        [$queue, $agent] = $this->fakeQueue();
 
-        $queueFake->jobsToPop[] = $jobFake = new FakeJob;
-        $queue->pop();
-        $jobFake->release();
+        $agent->pushJob();
+        $job = $queue->pop();
+        $job->release();
         $queue->pop();
 
         $this->assertSame([
@@ -377,6 +504,350 @@ class QueueTest extends TestCase
                 'duration_ms' => 0,
             ],
         ], $eventsFake->emitted);
+    }
+
+    public function testPopReturnsACloudJobBuiltFromTheAgentResponse()
+    {
+        $this->fakeEvents();
+        [$queue, $agent] = $this->fakeQueue();
+
+        $agent->pushJob(['messageId' => 'message-id', 'body' => 'job-body']);
+
+        $job = $queue->pop();
+
+        $this->assertInstanceOf(CloudJob::class, $job);
+        $this->assertSame('message-id', $job->getJobId());
+        $this->assertSame('job-body', $job->getRawBody());
+    }
+
+    public function testPopReturnsNullWhenTheAgentHasNoJob()
+    {
+        $this->fakeEvents();
+        [$queue] = $this->fakeQueue();
+
+        $this->assertNull($queue->pop());
+    }
+
+    public function testPopReceivesDirectlyFromSqsWhenTheAgentIsDisabled()
+    {
+        // With the agent disabled (the default) the queue receives from SQS.
+        Http::fake();
+        $this->fakeEvents();
+        [$queue, $client] = $this->mockedQueue();
+
+        $client->shouldReceive('receiveMessage')->once()->andReturn(new Result([
+            'Messages' => [[
+                'MessageId' => 'message-id',
+                'ReceiptHandle' => 'receipt-handle',
+                'Body' => 'job-body',
+                'Attributes' => ['ApproximateReceiveCount' => 1],
+            ]],
+        ]));
+
+        $job = $queue->pop();
+
+        $this->assertInstanceOf(SqsJob::class, $job);
+        $this->assertNotInstanceOf(CloudJob::class, $job);
+        $this->assertSame('message-id', $job->getJobId());
+        $this->assertSame('job-body', $job->getRawBody());
+        Http::assertNothingSent();
+    }
+
+    public function testPopReturnsNullWhenSqsHasNoMessageAndTheAgentIsDisabled()
+    {
+        $this->fakeEvents();
+        [$queue, $client] = $this->mockedQueue();
+
+        $client->shouldReceive('receiveMessage')->once()->andReturn(new Result(['Messages' => null]));
+
+        $this->assertNull($queue->pop());
+    }
+
+    public function testDeletingAJobReportsProcessedToTheAgentWithoutTouchingSqs()
+    {
+        $this->fakeEvents();
+        [$queue, $agent] = $this->fakeQueue();
+        $pushed = $agent->pushJob();
+
+        $job = $queue->pop();
+        $job->delete();
+
+        $this->assertTrue($job->isDeleted());
+        $this->assertAgentResults([
+            ['messageId' => $pushed['messageId'], 'receiptHandle' => $pushed['receiptHandle'], 'status' => 'processed'],
+        ]);
+    }
+
+    public function testFailingAJobReportsProcessedExactlyOnce()
+    {
+        $this->fakeEvents();
+        [$queue, $agent] = $this->fakeQueue();
+        $pushed = $agent->pushJob();
+
+        $job = $queue->pop();
+        $job->fail(new RuntimeException('Whoops!'));
+
+        // fail() routes through delete(), so it reports a single "processed".
+        $this->assertTrue($job->hasFailed());
+        $this->assertAgentResults([
+            ['messageId' => $pushed['messageId'], 'receiptHandle' => $pushed['receiptHandle'], 'status' => 'processed'],
+        ]);
+    }
+
+    public function testReleasingAJobReportsReleasedWithTheDelayToTheAgent()
+    {
+        $this->fakeEvents();
+        [$queue, $agent] = $this->fakeQueue();
+        $pushed = $agent->pushJob();
+
+        $job = $queue->pop();
+        $job->release(30);
+
+        $this->assertTrue($job->isReleased());
+        $this->assertAgentResults([
+            ['messageId' => $pushed['messageId'], 'receiptHandle' => $pushed['receiptHandle'], 'status' => 'released', 'delay' => 30],
+        ]);
+    }
+
+    public function testPopBuildsTheJobWithTheCloudConnectionName()
+    {
+        $this->fakeEvents();
+        [$queue, $agent] = $this->fakeQueue();
+        $agent->pushJob();
+
+        $this->assertSame('cloud', $queue->pop()->getConnectionName());
+    }
+
+    public function testPopUsesTheReceiveCountSuppliedByTheAgent()
+    {
+        $this->fakeEvents();
+        [$queue, $agent] = $this->fakeQueue();
+        $agent->pushJob(['attributes' => ['ApproximateReceiveCount' => '5']]);
+
+        $this->assertSame(5, $queue->pop()->attempts());
+    }
+
+    public function testReportingAnOutcomeOmitsTheReceiptHandleWhenTheAgentDoesNotSupplyOne()
+    {
+        $this->fakeEvents();
+        [$queue, $agent] = $this->fakeQueue();
+        // A non-string handle is treated as absent, so the result omits it and
+        // the agent falls back to matching on the message id alone.
+        $pushed = $agent->pushJob(['receiptHandle' => null]);
+
+        $queue->pop()->delete();
+
+        $this->assertAgentResults([
+            ['messageId' => $pushed['messageId'], 'status' => 'processed'],
+        ]);
+    }
+
+    public function testPopToleratesANonStringBodyFromTheAgent()
+    {
+        $this->fakeEvents();
+        [$queue, $agent] = $this->fakeQueue();
+        $agent->pushJob(['body' => ['not' => 'a-string']]);
+
+        $job = $queue->pop();
+
+        $this->assertInstanceOf(CloudJob::class, $job);
+        $this->assertSame('', $job->getRawBody());
+    }
+
+    public function testPopAcceptsAFalsyButValidMessageId()
+    {
+        $this->fakeEvents();
+        [$queue, $agent] = $this->fakeQueue();
+        // "0" is a valid, non-empty id that empty() would wrongly reject.
+        $agent->pushJob(['messageId' => '0']);
+
+        $this->assertSame('0', $queue->pop()->getJobId());
+    }
+
+    public function testARejectedResultIsReportedOnlyOnce()
+    {
+        $this->fakeEvents();
+        [$queue, $agent] = $this->fakeQueue();
+        $pushed = $agent->pushJob();
+
+        $agent->resultStatus = 422;
+
+        $job = $queue->pop();
+
+        try {
+            $job->delete();
+            $this->fail('Expected the rejected report to throw a RequestException.');
+        } catch (RequestException) {
+            //
+        }
+
+        // The agent's rejection is authoritative for this message, so only
+        // transient socket failures are retried - never the verdict itself.
+        $this->assertAgentResults([
+            ['messageId' => $pushed['messageId'], 'receiptHandle' => $pushed['receiptHandle'], 'status' => 'processed'],
+        ]);
+    }
+
+    public function testDeletingPropagatesWhenTheAgentIsUnreachable()
+    {
+        $this->fakeEvents();
+        $sqs = $this->mock(SqsClient::class);
+        [$queue, $agent] = $this->fakeQueue($sqs);
+        $agent->pushJob();
+
+        $job = $queue->pop();
+
+        // An unreachable agent propagates rather than deleting from SQS directly.
+        $agent->resultUnreachable = true;
+        $sqs->shouldNotReceive('deleteMessage');
+
+        $this->expectException(AgentUnreachableException::class);
+
+        $job->delete();
+    }
+
+    public function testReleasingPropagatesWhenTheAgentIsUnreachable()
+    {
+        $this->fakeEvents();
+        $sqs = $this->mock(SqsClient::class);
+        [$queue, $agent] = $this->fakeQueue($sqs);
+        $agent->pushJob();
+
+        $job = $queue->pop();
+
+        // An unreachable agent propagates rather than resetting visibility on SQS.
+        $agent->resultUnreachable = true;
+        $sqs->shouldNotReceive('changeMessageVisibility');
+
+        $this->expectException(AgentUnreachableException::class);
+
+        $job->release(30);
+    }
+
+    public function testReportingThrowsWhenTheAgentRejectsTheResult()
+    {
+        $this->fakeEvents();
+        $sqs = $this->mock(SqsClient::class);
+        [$queue, $agent] = $this->fakeQueue($sqs);
+        $agent->pushJob();
+
+        $job = $queue->pop();
+
+        // A client-error rejection is message-specific, so it propagates as a
+        // RequestException for the worker to report rather than deleting from
+        // SQS directly or restarting the pod.
+        $agent->resultStatus = 422;
+        $sqs->shouldNotReceive('deleteMessage');
+
+        $this->expectException(RequestException::class);
+
+        $job->delete();
+    }
+
+    public function testReportingEscalatesWhenTheAgentReturnsAServerError()
+    {
+        $this->fakeEvents();
+        $sqs = $this->mock(SqsClient::class);
+        [$queue, $agent] = $this->fakeQueue($sqs);
+        $agent->pushJob();
+
+        $job = $queue->pop();
+
+        // A server error means the agent itself is wedged, so it escalates as
+        // an unreachable fault to restart the pod rather than deleting from SQS.
+        $agent->resultStatus = 500;
+        $sqs->shouldNotReceive('deleteMessage');
+
+        $this->expectException(AgentUnreachableException::class);
+
+        $job->delete();
+    }
+
+    public function testPopThrowsWhenTheAgentReturnsAnError()
+    {
+        $this->fakeEvents();
+        [$queue, $agent] = $this->fakeQueue();
+
+        // Drive the agent's own GET /next stub so the non-200 branch is hit;
+        // a separate Http::fake() would be shadowed by the agent closure.
+        $agent->nextResponse = Http::response('error', 500);
+
+        // An error status means the agent cannot serve work, so it escalates
+        // as an unrecoverable fault rather than idling and re-polling forever.
+        $this->expectException(AgentUnreachableException::class);
+
+        $queue->pop();
+    }
+
+    public function testPopThrowsWhenTheAgentReturnsAnUnexpectedSuccessStatus()
+    {
+        $this->fakeEvents();
+        [$queue, $agent] = $this->fakeQueue();
+
+        // The agent only ever answers 200 (job) or 204 (empty); any other 2xx
+        // is off-contract, so it escalates rather than being decoded as a job.
+        $agent->nextResponse = Http::response('', 202);
+
+        $this->expectException(AgentUnreachableException::class);
+
+        $queue->pop();
+    }
+
+    public function testPopThrowsWhenTheAgentReturnsANonArrayBody()
+    {
+        $this->fakeEvents();
+        [$queue, $agent] = $this->fakeQueue();
+
+        // A 200 that decodes to a scalar is an agent fault; treat it the same
+        // as an unreachable agent rather than idling.
+        $agent->nextResponse = Http::response('"not-an-array"', 200);
+
+        $this->expectException(AgentUnreachableException::class);
+
+        $queue->pop();
+    }
+
+    public function testPopThrowsWhenTheAgentSocketIsUnreachable()
+    {
+        $this->fakeEvents();
+        [$queue] = $this->fakeQueue();
+
+        // An unreachable socket must escalate as an unrecoverable fault, not idle.
+        Http::fake(fn () => throw new ConnectionException('Connection refused'));
+
+        $this->expectException(AgentUnreachableException::class);
+
+        $queue->pop();
+    }
+
+    public function testAgentAwareDetectorTreatsAnUnreachableAgentAsALostConnection()
+    {
+        $detector = new AgentAwareLostConnectionDetector(new LostConnectionDetector);
+
+        // An unreachable agent is treated as a lost connection so the worker exits.
+        $this->assertTrue($detector->causedByLostConnection(new AgentUnreachableException));
+
+        // Everything else is delegated to the wrapped detector untouched.
+        $this->assertFalse($detector->causedByLostConnection(new \RuntimeException('boom')));
+        $this->assertTrue($detector->causedByLostConnection(new \RuntimeException('server has gone away')));
+    }
+
+    public function testReleasingThenFailingReportsBothOutcomesToTheAgent()
+    {
+        $this->fakeEvents();
+        [$queue, $agent] = $this->fakeQueue();
+        $pushed = $agent->pushJob();
+
+        $job = $queue->pop();
+        $job->release(30);
+        $job->fail(new RuntimeException('Whoops!'));
+
+        // CloudJob keeps no memory of prior reports, so both outcomes are
+        // reported in order; reconciling them is the agent's responsibility.
+        $this->assertAgentResults([
+            ['messageId' => $pushed['messageId'], 'receiptHandle' => $pushed['receiptHandle'], 'status' => 'released', 'delay' => 30],
+            ['messageId' => $pushed['messageId'], 'receiptHandle' => $pushed['receiptHandle'], 'status' => 'processed'],
+        ]);
     }
 
     public function testItEmitsJobQueuedEvent()
@@ -451,9 +922,9 @@ class QueueTest extends TestCase
             Cloud::configureManagedQueues($this->app);
             Cloud::bootManagedQueues($this->app);
             $eventsFake = $this->fakeEvents();
-            [$queue, $queueFake] = $this->fakeQueue();
+            [$queue, $agent] = $this->fakeQueue();
 
-            $queueFake->jobsToPop[] = new FakeJob;
+            $agent->pushJob();
             $queue->pop();
             $this->travel(2)->seconds();
 
@@ -499,10 +970,10 @@ class QueueTest extends TestCase
             Cloud::configureManagedQueues($this->app);
             Cloud::bootManagedQueues($this->app);
             $eventsFake = $this->fakeEvents();
-            [$queue, $queueFake] = $this->fakeQueue();
+            [$queue, $agent] = $this->fakeQueue();
 
             foreach ($reasons as $index => $reason) {
-                $queueFake->jobsToPop[] = new FakeJob;
+                $agent->pushJob();
                 $queue->pop();
 
                 $this->app['events']->dispatch(new WorkerStopping(0, null, $reason));
@@ -530,9 +1001,9 @@ class QueueTest extends TestCase
             Cloud::configureManagedQueues($this->app);
             Cloud::bootManagedQueues($this->app);
             $eventsFake = $this->fakeEvents();
-            [$queue, $queueFake] = $this->fakeQueue();
+            [$queue, $agent] = $this->fakeQueue();
 
-            $queueFake->jobsToPop[] = new FakeJob;
+            $agent->pushJob();
             $queue->pop();
 
             $this->app['events']->dispatch(new WorkerStopping);
@@ -567,11 +1038,11 @@ class QueueTest extends TestCase
             Cloud::configureManagedQueues($this->app);
             Cloud::bootManagedQueues($this->app);
             $eventsFake = $this->fakeEvents();
-            [$queue, $queueFake] = $this->fakeQueue();
+            [$queue, $agent] = $this->fakeQueue();
 
-            $queueFake->jobsToPop[] = $jobFake = new FakeJob;
-            $queue->pop();
-            $jobFake->fail();
+            $agent->pushJob();
+            $job = $queue->pop();
+            $job->fail();
 
             $this->app['events']->dispatch(new WorkerStopping(0, null, WorkerStopReason::TimedOut));
 
@@ -591,11 +1062,11 @@ class QueueTest extends TestCase
             Cloud::configureManagedQueues($this->app);
             Cloud::bootManagedQueues($this->app);
             $eventsFake = $this->fakeEvents();
-            [$queue, $queueFake] = $this->fakeQueue();
+            [$queue, $agent] = $this->fakeQueue();
 
-            $queueFake->jobsToPop[] = $jobFake = new FakeJob;
-            $queue->pop();
-            $jobFake->release();
+            $agent->pushJob();
+            $job = $queue->pop();
+            $job->release();
 
             $this->app['events']->dispatch(new WorkerStopping(0, null, WorkerStopReason::MaxJobsExceeded));
 
@@ -635,9 +1106,9 @@ class QueueTest extends TestCase
             Cloud::configureManagedQueues($this->app);
             Cloud::bootManagedQueues($this->app);
             $eventsFake = $this->fakeEvents();
-            [$queue, $queueFake] = $this->fakeQueue();
+            [$queue, $agent] = $this->fakeQueue();
 
-            $queueFake->jobsToPop[] = new FakeJob;
+            $agent->pushJob();
             $queue->pop();
 
             $this->app['events']->dispatch(new WorkerStopping(0, null, WorkerStopReason::TimedOut));
@@ -727,9 +1198,10 @@ class QueueTest extends TestCase
     {
         $this->travelTo('2000-01-02 03:04:05.060708');
         $eventsFake = $this->fakeEvents();
-        [$queue, $queueFake] = $this->fakeQueue();
+        [$queue, $agent] = $this->fakeQueue();
 
-        $queueFake->jobsToPop = [new FakeJob, new FakeJob];
+        $agent->pushJob();
+        $agent->pushJob();
         $queue->pop();
         $this->travel(1)->second();
         $queue->pop();
@@ -745,9 +1217,9 @@ class QueueTest extends TestCase
         date_default_timezone_set('Australia/Melbourne');
         $this->travelTo(Carbon::parse('2000-01-02 03:04:05.060708', 'Australia/Melbourne'));
         $eventsFake = $this->fakeEvents();
-        [$queue, $queueFake] = $this->fakeQueue();
+        [$queue, $agent] = $this->fakeQueue();
 
-        $queueFake->jobsToPop[] = new FakeJob;
+        $agent->pushJob();
         $queue->pop();
         $this->travel(1)->second();
         $queue->pop();
@@ -970,9 +1442,8 @@ class QueueTest extends TestCase
 
         $queue->push(new FakeJob, queue: 'orders.fifo');
 
-        // The suffix is injected before the ".fifo" extension on the real SQS
-        // queue name, so the normalized name must strip it back out and keep
-        // the ".fifo" terminal rather than reporting "orders-env-....fifo".
+        // The suffix is injected before ".fifo", so it must be stripped without
+        // leaking into the normalized name.
         $this->assertSame('orders.fifo', $eventsFake->emitted[0]['queue']);
     }
 
@@ -1026,17 +1497,31 @@ class QueueTest extends TestCase
     }
 
     /**
-     * @return array{Queue, object{jobsToPop: array}}
+     * Build a Cloud queue whose agent runtime socket is faked via Http::fake().
+     *
+     * The returned agent exposes pushJob() to script the next GET /next
+     * responses; once drained the agent answers 204. POST /result requests are
+     * recorded by the HTTP fake and can be asserted with Http::assertSent().
+     *
+     * @return array{Queue, object{jobs: array}}
      */
-    private function fakeQueue()
+    private function fakeQueue($sqs = null)
     {
-        $fakeQueue = new class($this->app, [], null) extends QueueFake
-        {
-            public array $jobsToPop = [];
+        // Enable the agent so pop() long-polls the faked runtime socket.
+        $this->app['config']->set('queue.connections.cloud.agent', [
+            'enabled' => true,
+            'socket' => '/tmp/cloud-agent.sock',
+        ]);
 
-            public function pop($queue = null)
+        // A real client suffices while the SQS seams stay no-ops; callers asserting
+        // direct SQS calls pass a mock instead.
+        $sqs ??= new SqsClient(['region' => 'us-east-2', 'version' => 'latest', 'credentials' => false]);
+
+        $fakeQueue = new class($this->app, $sqs) extends QueueFake
+        {
+            public function __construct($app, private $sqs)
             {
-                return array_shift($this->jobsToPop);
+                parent::__construct($app);
             }
 
             public function getQueue($queue)
@@ -1044,6 +1529,21 @@ class QueueTest extends TestCase
                 $queue ??= 'default';
 
                 return config('queue.connections.cloud.connection.prefix').'/'.$queue.config('queue.connections.cloud.connection.suffix');
+            }
+
+            public function getContainer()
+            {
+                return $this->app;
+            }
+
+            public function getSqs()
+            {
+                return $this->sqs;
+            }
+
+            public function getConnectionName()
+            {
+                return 'cloud';
             }
 
             public function setConfig(array $config)
@@ -1072,12 +1572,97 @@ class QueueTest extends TestCase
 
         $this->app['queue']->addConnector('cloud', $this->app->factory(QueueConnector::class));
 
-        return [$this->app['queue']->connection('cloud'), $fakeQueue];
+        $agent = $this->fakeAgent();
+
+        $connection = $this->app['queue']->connection('cloud');
+
+        // The agent only serves a queue:work worker popping its queue, so present
+        // as one for pop() (see usesAgent()). Set after connecting so the
+        // connector's worker wiring - which expects the cloud failed-job provider
+        // - isn't exercised here. Restored in tearDown().
+        $_SERVER['argv'] = ['artisan', 'queue:work'];
+
+        return [$connection, $agent];
+    }
+
+    /**
+     * Fake the cloud-agent runtime socket with Http::fake(): GET /next serves
+     * scripted jobs (204 once drained) and POST /result is accepted (and
+     * recorded for assertions). The returned object scripts jobs via pushJob().
+     */
+    private function fakeAgent()
+    {
+        $agent = new class
+        {
+            public array $jobs = [];
+
+            public int $resultStatus = 200;
+
+            public bool $resultUnreachable = false;
+
+            public $nextResponse = null;
+
+            public function pushJob(array $job = []): array
+            {
+                $job = array_merge([
+                    'messageId' => (string) Str::uuid(),
+                    'receiptHandle' => 'receipt-handle',
+                    // The agent always reports the SQS queue URL the message came from.
+                    'queueUrl' => 'https://sqs.us-east-1.amazonaws.com/123456789012/default',
+                    'body' => json_encode(['job' => MyJob::class, 'data' => []]),
+                    // SQS always returns ApproximateReceiveCount, so mirror it.
+                    'attributes' => ['ApproximateReceiveCount' => 1],
+                ], $job);
+
+                $this->jobs[] = $job;
+
+                return $job;
+            }
+        };
+
+        Http::fake(function ($request) use ($agent) {
+            if (str_ends_with($request->url(), '/next')) {
+                if ($agent->nextResponse !== null) {
+                    return $agent->nextResponse;
+                }
+
+                $job = array_shift($agent->jobs);
+
+                return $job === null
+                    ? Http::response('', 204)
+                    : Http::response($job, 200);
+            }
+
+            if (str_ends_with($request->url(), '/result')) {
+                if ($agent->resultUnreachable) {
+                    throw new ConnectionException('Connection refused');
+                }
+
+                return Http::response('', $agent->resultStatus);
+            }
+
+            return Http::response('', 404);
+        });
+
+        return $agent;
     }
 
     private function fakeFailer()
     {
         return new FileFailedJobProvider(tempnam(sys_get_temp_dir(), 'cloud_failed_job_test_'));
+    }
+
+    /**
+     * Assert the exact sequence of POST /result bodies sent to the agent.
+     */
+    private function assertAgentResults(array $expected): void
+    {
+        $results = Http::recorded(fn ($request) => str_ends_with($request->url(), '/result'))
+            ->map(fn ($record) => $record[0]->data())
+            ->values()
+            ->all();
+
+        $this->assertSame($expected, $results);
     }
 }
 


### PR DESCRIPTION
Backport of #60659 to `12.x`; see that PR for full context. The large-payload overflow storage (#59734) is 13.x-only, so the `CloudJob` overflow parameter, the `SqsJob::deleteOverflowPayload()` extraction, and the two overflow tests are omitted. The injectable `LostConnectionDetector` (#56493) exists on 12.x, so the restart mechanism is backported unchanged.

## What

When Laravel Cloud's managed-queue agent is enabled, a `queue:work` worker pops jobs from the in-container cloud-agent over its unix-socket runtime API instead of receiving from SQS directly. The agent long-polls SQS and owns the terminal delete/visibility operations; the worker just processes each job and reports the outcome back.

## How

- `Queue::pop()` routes to the agent (`GET /next`) only when the agent is enabled, the process is a `queue:work` worker, and the popped queue is the one that worker is serving. Every other case (other queues, non-worker contexts, non-SQS connections) pops from SQS exactly as before.
- Jobs come back as a `CloudJob` (extends `SqsJob`). Its `delete()`/`release()` don't touch SQS — they report the outcome to the agent (`POST /result`), which performs the SQS operation. The agent is the single writer to SQS.
- If the agent socket is unreachable, or returns an error/malformed response, an `AgentUnreachableException` is raised and treated as a lost connection (`AgentAwareLostConnectionDetector`), so the worker exits and the pod restarts rather than spinning against a dead agent. Reporting retries only transient socket failures; the agent's own 4xx verdict for a message propagates as-is.

## Notes

- Opt-in per connection via `agent.enabled`; socket path defaults to `/tmp/cloud-agent.sock` (`agent.socket`).
- `SqsJob`'s SQS calls are split into small protected methods (`deleteMessageFromSqs`, `changeMessageVisibilityInSqs`) so the delete/release flow reads clearly and stays extensible. No behavioural change to the standard SQS path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
