### PR TITLE
[11.x] Pop managed queue jobs from the cloud-agent instead of SQS

### DIFF
--- a/src/Illuminate/Foundation/Cloud/AgentUnreachableException.php
+++ b/src/Illuminate/Foundation/Cloud/AgentUnreachableException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Foundation\Cloud;
+
+use RuntimeException;
+
+class AgentUnreachableException extends RuntimeException
+{
+    //
+}

--- a/src/Illuminate/Foundation/Cloud/CloudJob.php
+++ b/src/Illuminate/Foundation/Cloud/CloudJob.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Illuminate\Foundation\Cloud;
+
+use Aws\Sqs\SqsClient;
+use Illuminate\Container\Container;
+use Illuminate\Queue\Jobs\Job;
+use Illuminate\Queue\Jobs\SqsJob;
+
+class CloudJob extends SqsJob
+{
+    /**
+     * Create a new job instance.
+     *
+     * @param  array  $job
+     * @param  string  $connectionName
+     * @param  string  $queue
+     * @param  callable(string, int|null): void  $reporter
+     */
+    public function __construct(
+        Container $container,
+        SqsClient $sqs,
+        array $job,
+        $connectionName,
+        $queue,
+        protected $reporter,
+    ) {
+        parent::__construct($container, $sqs, $job, $connectionName, $queue);
+    }
+
+    /**
+     * Delete the job from the queue.
+     *
+     * @return void
+     */
+    public function delete()
+    {
+        // Skip SQS deletion so SQS DeleteMessage is left to the poller...
+        Job::delete();
+
+        $this->report('processed');
+    }
+
+    /**
+     * Release the job back into the queue after (n) seconds.
+     *
+     * @param  int  $delay
+     * @return void
+     */
+    public function release($delay = 0)
+    {
+        // Skip SQS deletion so SQS release is left to the poller...
+        Job::release($delay);
+
+        $this->report('released', delay: $delay);
+    }
+
+    /**
+     * Report the job's outcome to the agent, which owns the SQS operation.
+     */
+    protected function report(string $status, ?int $delay = null): void
+    {
+        ($this->reporter)($status, $delay);
+    }
+}

--- a/src/Illuminate/Foundation/Cloud/Queue.php
+++ b/src/Illuminate/Foundation/Cloud/Queue.php
@@ -5,8 +5,14 @@ namespace Illuminate\Foundation\Cloud;
 use Carbon\CarbonImmutable;
 use Illuminate\Contracts\Queue\ClearableQueue;
 use Illuminate\Contracts\Queue\Queue as QueueContract;
+use Illuminate\Foundation\Application;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\ForwardsCalls;
+use Symfony\Component\Console\Input\ArgvInput;
+use Throwable;
 
 class Queue implements QueueContract, ClearableQueue
 {
@@ -37,6 +43,7 @@ class Queue implements QueueContract, ClearableQueue
      * Create a new Queue instance.
      */
     public function __construct(
+        protected Application $app,
         protected QueueContract $queue,
         protected Events $events,
         protected array $config,
@@ -185,6 +192,10 @@ class Queue implements QueueContract, ClearableQueue
     /**
      * Pop the next job off of the queue.
      *
+     * Jobs come straight from SQS unless the cloud-agent is enabled.
+     *
+     * When cloud-agent is enabled, we long-poll the agent's runtime socket instead.
+     *
      * @param  string|null  $queue
      * @return \Illuminate\Contracts\Queue\Job|null
      */
@@ -192,11 +203,148 @@ class Queue implements QueueContract, ClearableQueue
     {
         $this->finishProcessingJob();
 
-        $job = $this->queue->pop(...func_get_args());
+        $job = $this->usesAgent($queue)
+            ? $this->popFromAgent()
+            : $this->queue->pop(...func_get_args());
 
         $this->startProcessingJob($queue, $job);
 
         return $job;
+    }
+
+    /**
+     * Long-poll the cloud-agent's runtime socket and wrap the next message in a CloudJob.
+     *
+     * @return \Illuminate\Foundation\Cloud\CloudJob|null
+     */
+    protected function popFromAgent()
+    {
+        $data = $this->requestNextJobFromAgent();
+
+        if (! (is_array($data) && is_string($messageId = $data['messageId'] ?? null) && $messageId !== '')) {
+            return null;
+        }
+
+        // Coerce a non-string handle to null so a malformed response degrades gracefully...
+        $receiptHandle = is_string($handle = $data['receiptHandle'] ?? null) ? $handle : null;
+
+        return new CloudJob(
+            $this->queue->getContainer(),
+            $this->queue->getSqs(),
+            [
+                'MessageId' => $messageId,
+                'ReceiptHandle' => $receiptHandle,
+                'Body' => is_string($body = $data['body'] ?? null) ? $body : '',
+                'Attributes' => $data['attributes'] ?? [],
+            ],
+            $this->queue->getConnectionName(),
+            $data['queueUrl'] ?? null,
+            fn (string $status, ?int $delay) => $this->reportJobStatusToAgent(
+                $messageId, $receiptHandle, $status, $delay
+            ),
+        );
+    }
+
+    /**
+     * Long-poll the agent's runtime socket (GET /next) for the next job.
+     *
+     * @throws \Illuminate\Foundation\Cloud\AgentUnreachableException
+     */
+    protected function requestNextJobFromAgent(): ?array
+    {
+        try {
+            $response = $this->agentRequest()
+                ->timeout(65)
+                ->get('/next');
+        } catch (ConnectionException $e) {
+            throw $this->agentUnreachable(
+                'The Laravel Cloud agent runtime socket is unreachable.', $e
+            );
+        }
+
+        if ($response->status() === 204) {
+            return null;
+        }
+
+        if (! $response->ok()) {
+            throw $this->agentUnreachable(
+                "The Laravel Cloud agent returned HTTP {$response->status()} from GET /next."
+            );
+        }
+
+        if (! is_array($data = $response->json())) {
+            throw $this->agentUnreachable(
+                'The Laravel Cloud agent returned a non-array body from GET /next.'
+            );
+        }
+
+        return $data;
+    }
+
+    /**
+     * Report a job's terminal outcome back to the agent (POST /result).
+     *
+     * @throws \Illuminate\Http\Client\RequestException
+     * @throws \Illuminate\Foundation\Cloud\AgentUnreachableException
+     */
+    protected function reportJobStatusToAgent(string $messageId, ?string $receiptHandle, string $status, ?int $delay = null): void
+    {
+        try {
+            $this->agentRequest()
+                ->timeout(10)
+                ->throw()
+                ->retry(3, 100, fn ($exception) => $exception instanceof ConnectionException)
+                ->post('/result', array_filter([
+                    'messageId' => $messageId,
+                    'receiptHandle' => $receiptHandle,
+                    'status' => $status,
+                    'delay' => $delay,
+                ], fn ($value) => $value !== null));
+        } catch (ConnectionException $e) {
+            throw $this->agentUnreachable(
+                'The Laravel Cloud agent runtime socket is unreachable.', $e
+            );
+        } catch (RequestException $e) {
+            if ($e->response->serverError()) {
+                throw $this->agentUnreachable(
+                    "The Laravel Cloud agent returned HTTP {$e->response->status()} from POST /result.", $e
+                );
+            }
+
+            throw $e;
+        }
+    }
+
+    /**
+     * Build the exception for an unreachable agent, first flagging the running
+     * queue:work worker to stop so the pod restarts.
+     *
+     * This release has no injectable LostConnectionDetector, so rather than
+     * teaching the worker to recognize the exception, flag the shared worker
+     * singleton directly. Its daemon loop then exits with a "lost connection"
+     * stop reason on the next tick and the process is restarted.
+     */
+    protected function agentUnreachable(string $message, ?Throwable $previous = null): AgentUnreachableException
+    {
+        if ($this->app->bound('queue.worker')) {
+            $this->app['queue.worker']->lostConnection = true;
+        }
+
+        return new AgentUnreachableException($message, previous: $previous);
+    }
+
+    /**
+     * Get a pending HTTP request bound to the agent's Unix runtime socket.
+     *
+     * @return \Illuminate\Http\Client\PendingRequest
+     */
+    protected function agentRequest()
+    {
+        return Http::baseUrl('http://localhost')->withOptions([
+            'curl' => [
+                CURLOPT_UNIX_SOCKET_PATH => $this->config['agent']['socket'] ?? '/tmp/cloud-agent.sock',
+            ],
+        ]);
     }
 
     /**
@@ -208,6 +356,29 @@ class Queue implements QueueContract, ClearableQueue
     public function clear($queue)
     {
         return $this->queue->clear(...func_get_args());
+    }
+
+    /**
+     * Determine whether the next job should be received from the in-container cloud-agent.
+     *
+     * @param  string|null  $queue
+     */
+    protected function usesAgent($queue = null): bool
+    {
+        return ($this->config['agent']['enabled'] ?? false)
+            && $this->app->runningConsoleCommand('queue:work')
+            && $this->queue->getQueue($queue) === $this->queue->getQueue($this->workerQueue());
+    }
+
+    /**
+     * Get the queue the running queue:work worker is processing.
+     *
+     * @return string
+     */
+    protected function workerQueue()
+    {
+        return (new ArgvInput)->getParameterOption('--queue')
+            ?: ($this->config['queue'] ?? 'default');
     }
 
     /**

--- a/src/Illuminate/Foundation/Cloud/QueueConnector.php
+++ b/src/Illuminate/Foundation/Cloud/QueueConnector.php
@@ -39,6 +39,7 @@ class QueueConnector implements ConnectorInterface
         $underlying = $this->connector->connect($config['connection']);
 
         $queue = new Queue(
+            $this->app,
             $underlying,
             $this->app[Events::class],
             $config,

--- a/src/Illuminate/Queue/Jobs/SqsJob.php
+++ b/src/Illuminate/Queue/Jobs/SqsJob.php
@@ -51,6 +51,17 @@ class SqsJob extends Job implements JobContract
     {
         parent::release($delay);
 
+        $this->changeMessageVisibilityInSqs($delay);
+    }
+
+    /**
+     * Reset the SQS message's visibility timeout so it becomes available again.
+     *
+     * @param  int  $delay
+     * @return void
+     */
+    protected function changeMessageVisibilityInSqs($delay)
+    {
         $this->sqs->changeMessageVisibility([
             'QueueUrl' => $this->queue,
             'ReceiptHandle' => $this->job['ReceiptHandle'],
@@ -67,6 +78,16 @@ class SqsJob extends Job implements JobContract
     {
         parent::delete();
 
+        $this->deleteMessageFromSqs();
+    }
+
+    /**
+     * Delete the message from the SQS queue.
+     *
+     * @return void
+     */
+    protected function deleteMessageFromSqs()
+    {
         $this->sqs->deleteMessage([
             'QueueUrl' => $this->queue, 'ReceiptHandle' => $this->job['ReceiptHandle'],
         ]);

--- a/tests/Foundation/Cloud/QueueTest.php
+++ b/tests/Foundation/Cloud/QueueTest.php
@@ -10,18 +10,22 @@ use Aws\Result;
 use Aws\Sqs\SqsClient;
 use Illuminate\Contracts\Encryption\DecryptException;
 use Illuminate\Foundation\Cloud;
+use Illuminate\Foundation\Cloud\AgentUnreachableException;
+use Illuminate\Foundation\Cloud\CloudJob;
 use Illuminate\Foundation\Cloud\Events;
 use Illuminate\Foundation\Cloud\FailedJobProvider;
 use Illuminate\Foundation\Cloud\ManagedQueueNotFoundException;
 use Illuminate\Foundation\Cloud\Queue;
 use Illuminate\Foundation\Cloud\QueueConnector;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Queue\Connectors\ConnectorInterface;
 use Illuminate\Queue\Connectors\SqsConnector;
 use Illuminate\Queue\Events\WorkerStopping;
 use Illuminate\Queue\Failed\FileFailedJobProvider;
 use Illuminate\Queue\Jobs\FakeJob;
+use Illuminate\Queue\Jobs\SqsJob;
 use Illuminate\Queue\SqsQueue;
 use Illuminate\Queue\WorkerStopReason;
 use Illuminate\Support\Carbon;
@@ -44,6 +48,14 @@ class QueueTest extends TestCase
 {
     use DatabaseMigrations;
 
+    /**
+     * The original $_SERVER['argv'], restored in tearDown() after fakeQueue()
+     * spoofs a queue:work worker.
+     *
+     * @var array|null
+     */
+    private $savedArgv = null;
+
     protected function defineEnvironment($app)
     {
         $app['config']->set('app.key', Str::random(32));
@@ -51,6 +63,8 @@ class QueueTest extends TestCase
 
     protected function setUp(): void
     {
+        $this->savedArgv = $_SERVER['argv'];
+
         $_SERVER['LARAVEL_CLOUD'] = '1';
         $_SERVER['LARAVEL_CLOUD_MANAGED_QUEUES_CONFIG'] = json_encode([
             'driver' => 'cloud',
@@ -70,6 +84,13 @@ class QueueTest extends TestCase
 
     protected function tearDown(): void
     {
+        // Restore before the parent tears down (and even when setUp failed) so
+        // a spoofed queue:work argv never leaks into the rest of the process.
+        if ($this->savedArgv !== null) {
+            $_SERVER['argv'] = $this->savedArgv;
+            $this->savedArgv = null;
+        }
+
         parent::tearDown();
 
         unset($_SERVER['LARAVEL_CLOUD'], $_SERVER['LARAVEL_CLOUD_MANAGED_QUEUES_CONFIG']);
@@ -172,9 +193,9 @@ class QueueTest extends TestCase
     {
         $this->travelTo('2000-01-02 03:04:05.060708');
         $eventsFake = $this->fakeEvents();
-        [$queue, $queueFake] = $this->fakeQueue();
+        [$queue, $agent] = $this->fakeQueue();
 
-        $queueFake->jobsToPop[] = new FakeJob;
+        $agent->pushJob();
         $queue->pop();
 
         $this->assertSame([[
@@ -189,9 +210,9 @@ class QueueTest extends TestCase
     {
         $this->travelTo('2000-01-02 03:04:05.060708');
         $eventsFake = $this->fakeEvents();
-        [$queue, $queueFake] = $this->fakeQueue();
+        [$queue, $agent] = $this->fakeQueue();
 
-        $queueFake->jobsToPop[] = new FakeJob;
+        $agent->pushJob();
         $queue->pop();
         $this->travel(1)->second();
         $queue->pop();
@@ -217,9 +238,9 @@ class QueueTest extends TestCase
     {
         $this->travelTo('2000-01-02 03:04:05.060708');
         $eventsFake = $this->fakeEvents();
-        [$queue, $queueFake] = $this->fakeQueue();
+        [$queue, $agent] = $this->fakeQueue();
 
-        $queueFake->jobsToPop[] = new FakeJob;
+        $agent->pushJob();
         $queue->pop();
         $queue->pop();
         $queue->pop();
@@ -232,11 +253,19 @@ class QueueTest extends TestCase
     {
         $this->travelTo('2000-01-02 03:04:05.060708');
         $eventsFake = $this->fakeEvents();
-        [$queue, $queueFake] = $this->fakeQueue();
+        [$queue, $agent] = $this->fakeQueue();
 
-        $queueFake->jobsToPop = [new FakeJob, new FakeJob];
+        $agent->pushJob();
+        $agent->pushJob();
+        // Each pop finishes the previous job, so its processed event must carry
+        // the queue that job was popped from, not the queue being popped now.
+        // The agent only serves the worker's own queue, so retarget the worker
+        // alongside each pop.
+        $_SERVER['argv'] = ['artisan', 'queue:work', '--queue=first'];
         $queue->pop('first');
+        $_SERVER['argv'] = ['artisan', 'queue:work', '--queue=second'];
         $queue->pop('second');
+        $_SERVER['argv'] = ['artisan', 'queue:work', '--queue=third'];
         $queue->pop('third');
 
         $this->assertSame([
@@ -268,19 +297,115 @@ class QueueTest extends TestCase
         ], $eventsFake->emitted);
     }
 
+    public function testPopReceivesFromTheAgentForANonDefaultWorkerQueue()
+    {
+        $this->fakeEvents();
+        [$queue, $agent] = $this->fakeQueue();
+        $agent->pushJob(['messageId' => 'message-id']);
+
+        // A managed worker started for a non-default queue is still served by the
+        // agent: the agent polls whatever queue the worker is processing.
+        $_SERVER['argv'] = ['artisan', 'queue:work', '--queue=emails'];
+
+        $job = $queue->pop('emails');
+
+        $this->assertInstanceOf(CloudJob::class, $job);
+        $this->assertSame('message-id', $job->getJobId());
+    }
+
+    public function testPopReadsTheWorkerQueueFromTheSpaceSeparatedQueueOption()
+    {
+        $this->fakeEvents();
+        [$queue, $agent] = $this->fakeQueue();
+        $agent->pushJob(['messageId' => 'message-id']);
+
+        // The --queue option may be given space-separated rather than with "=".
+        $_SERVER['argv'] = ['artisan', 'queue:work', '--queue', 'emails'];
+
+        $job = $queue->pop('emails');
+
+        $this->assertInstanceOf(CloudJob::class, $job);
+        $this->assertSame('message-id', $job->getJobId());
+    }
+
+    public function testPopReceivesFromSqsWhenTheQueueIsNotTheWorkerQueue()
+    {
+        $this->fakeEvents();
+        [$queue, $agent] = $this->fakeQueue();
+        $agent->pushJob();
+
+        // A pop for a queue other than the one the worker is processing has no
+        // agent feeding it, so it comes from SQS directly and the socket is never
+        // polled.
+        $_SERVER['argv'] = ['artisan', 'queue:work', '--queue=emails'];
+
+        $this->assertNull($queue->pop('not-the-worker-queue'));
+
+        Http::assertNothingSent();
+    }
+
+    public function testPopReceivesFromSqsForAMultiQueueWorker()
+    {
+        $this->fakeEvents();
+        [$queue, $agent] = $this->fakeQueue();
+        $agent->pushJob();
+
+        // The agent serves a single queue, so a worker spanning several queues
+        // (the worker pops each individually) cannot be served by it and falls
+        // back to SQS rather than being handed the agent's one queue for all.
+        $_SERVER['argv'] = ['artisan', 'queue:work', '--queue=high,low'];
+
+        $this->assertNull($queue->pop('high'));
+        $this->assertNull($queue->pop('low'));
+
+        Http::assertNothingSent();
+    }
+
+    public function testPopReceivesFromTheAgentWhenTheQueueOptionIsOmitted()
+    {
+        $this->fakeEvents();
+        // WorkCommand falls back to the connection's top-level "queue" key when
+        // --queue is omitted, so workerQueue() must mirror that exact fallback.
+        config(['queue.connections.cloud.queue' => 'emails']);
+        [$queue, $agent] = $this->fakeQueue();
+        $agent->pushJob(['messageId' => 'message-id']);
+
+        $_SERVER['argv'] = ['artisan', 'queue:work'];
+
+        $job = $queue->pop('emails');
+
+        $this->assertInstanceOf(CloudJob::class, $job);
+        $this->assertSame('message-id', $job->getJobId());
+    }
+
+    public function testPopReceivesFromSqsWhenNotRunningAsAQueueWorker()
+    {
+        $this->fakeEvents();
+        [$queue, $agent] = $this->fakeQueue();
+        $agent->pushJob();
+
+        // Outside a queue:work worker (e.g. a web request) the agent sidecar is
+        // not serving us, so jobs come from SQS directly.
+        $_SERVER['argv'] = ['artisan', 'tinker'];
+
+        $this->assertNull($queue->pop());
+
+        Http::assertNothingSent();
+    }
+
     public function testItEmitsFailedJobEvents()
     {
         $this->travelTo('2000-01-02 03:04:05.060708');
         $eventsFake = $this->fakeEvents();
-        [$queue, $queueFake] = $this->fakeQueue();
+        [$queue, $agent] = $this->fakeQueue();
         $failerFake = $this->fakeFailer();
         $failedJobProvider = new FailedJobProvider($failerFake, $eventsFake, $this->app['encrypter']);
         $failedJobProvider->setQueue($queue);
         $this->app[FailedJobProvider::class] = $failedJobProvider;
 
-        $queueFake->jobsToPop[] = $jobFake = new FakeJob;
-        $queue->pop();
-        $jobFake->fail();
+        $agent->pushJob();
+        $job = $queue->pop();
+        $job->fail();
         Str::createUuidsUsingSequence([Uuid::fromString('00dc709e-90c4-70c2-87c8-9b7127d20e8f')]);
         $failedJobProvider->log('cloud', 'default', ['payload' => 'here'], new RuntimeException('Whoops!'));
         Str::createUuidsNormally();
@@ -318,11 +443,11 @@ class QueueTest extends TestCase
     {
         $this->travelTo('2000-01-02 03:04:05.060708');
         $eventsFake = $this->fakeEvents();
-        [$queue, $queueFake] = $this->fakeQueue();
+        [$queue, $agent] = $this->fakeQueue();
 
-        $queueFake->jobsToPop[] = $jobFake = new FakeJob;
-        $queue->pop();
-        $jobFake->release();
+        $agent->pushJob();
+        $job = $queue->pop();
+        $job->release();
         $queue->pop();
 
         $this->assertSame([
@@ -340,6 +465,361 @@ class QueueTest extends TestCase
                 'duration_ms' => 0,
             ],
         ], $eventsFake->emitted);
+    }
+
+    public function testPopReturnsACloudJobBuiltFromTheAgentResponse()
+    {
+        $this->fakeEvents();
+        [$queue, $agent] = $this->fakeQueue();
+
+        $agent->pushJob(['messageId' => 'message-id', 'body' => 'job-body']);
+
+        $job = $queue->pop();
+
+        $this->assertInstanceOf(CloudJob::class, $job);
+        $this->assertSame('message-id', $job->getJobId());
+        $this->assertSame('job-body', $job->getRawBody());
+    }
+
+    public function testPopReturnsNullWhenTheAgentHasNoJob()
+    {
+        $this->fakeEvents();
+        [$queue] = $this->fakeQueue();
+
+        $this->assertNull($queue->pop());
+    }
+
+    public function testPopReceivesDirectlyFromSqsWhenTheAgentIsDisabled()
+    {
+        // With the agent disabled (the default) the queue receives from SQS.
+        Http::fake();
+        $this->fakeEvents();
+        [$queue, $client] = $this->mockedQueue();
+
+        $client->shouldReceive('receiveMessage')->once()->andReturn(new Result([
+            'Messages' => [[
+                'MessageId' => 'message-id',
+                'ReceiptHandle' => 'receipt-handle',
+                'Body' => 'job-body',
+                'Attributes' => ['ApproximateReceiveCount' => 1],
+            ]],
+        ]));
+
+        $job = $queue->pop();
+
+        $this->assertInstanceOf(SqsJob::class, $job);
+        $this->assertNotInstanceOf(CloudJob::class, $job);
+        $this->assertSame('message-id', $job->getJobId());
+        $this->assertSame('job-body', $job->getRawBody());
+        Http::assertNothingSent();
+    }
+
+    public function testPopReturnsNullWhenSqsHasNoMessageAndTheAgentIsDisabled()
+    {
+        $this->fakeEvents();
+        [$queue, $client] = $this->mockedQueue();
+
+        $client->shouldReceive('receiveMessage')->once()->andReturn(new Result(['Messages' => null]));
+
+        $this->assertNull($queue->pop());
+    }
+
+    public function testDeletingAJobReportsProcessedToTheAgentWithoutTouchingSqs()
+    {
+        $this->fakeEvents();
+        [$queue, $agent] = $this->fakeQueue();
+        $pushed = $agent->pushJob();
+
+        $job = $queue->pop();
+        $job->delete();
+
+        $this->assertTrue($job->isDeleted());
+        $this->assertAgentResults([
+            ['messageId' => $pushed['messageId'], 'receiptHandle' => $pushed['receiptHandle'], 'status' => 'processed'],
+        ]);
+    }
+
+    public function testFailingAJobReportsProcessedExactlyOnce()
+    {
+        $this->fakeEvents();
+        [$queue, $agent] = $this->fakeQueue();
+        $pushed = $agent->pushJob();
+
+        $job = $queue->pop();
+        $job->fail(new RuntimeException('Whoops!'));
+
+        // fail() routes through delete(), so it reports a single "processed".
+        $this->assertTrue($job->hasFailed());
+        $this->assertAgentResults([
+            ['messageId' => $pushed['messageId'], 'receiptHandle' => $pushed['receiptHandle'], 'status' => 'processed'],
+        ]);
+    }
+
+    public function testReleasingAJobReportsReleasedWithTheDelayToTheAgent()
+    {
+        $this->fakeEvents();
+        [$queue, $agent] = $this->fakeQueue();
+        $pushed = $agent->pushJob();
+
+        $job = $queue->pop();
+        $job->release(30);
+
+        $this->assertTrue($job->isReleased());
+        $this->assertAgentResults([
+            ['messageId' => $pushed['messageId'], 'receiptHandle' => $pushed['receiptHandle'], 'status' => 'released', 'delay' => 30],
+        ]);
+    }
+
+    public function testPopBuildsTheJobWithTheCloudConnectionName()
+    {
+        $this->fakeEvents();
+        [$queue, $agent] = $this->fakeQueue();
+        $agent->pushJob();
+
+        $this->assertSame('cloud', $queue->pop()->getConnectionName());
+    }
+
+    public function testPopUsesTheReceiveCountSuppliedByTheAgent()
+    {
+        $this->fakeEvents();
+        [$queue, $agent] = $this->fakeQueue();
+        $agent->pushJob(['attributes' => ['ApproximateReceiveCount' => '5']]);
+
+        $this->assertSame(5, $queue->pop()->attempts());
+    }
+
+    public function testReportingAnOutcomeOmitsTheReceiptHandleWhenTheAgentDoesNotSupplyOne()
+    {
+        $this->fakeEvents();
+        [$queue, $agent] = $this->fakeQueue();
+        // A non-string handle is treated as absent, so the result omits it and
+        // the agent falls back to matching on the message id alone.
+        $pushed = $agent->pushJob(['receiptHandle' => null]);
+
+        $queue->pop()->delete();
+
+        $this->assertAgentResults([
+            ['messageId' => $pushed['messageId'], 'status' => 'processed'],
+        ]);
+    }
+
+    public function testPopToleratesANonStringBodyFromTheAgent()
+    {
+        $this->fakeEvents();
+        [$queue, $agent] = $this->fakeQueue();
+        $agent->pushJob(['body' => ['not' => 'a-string']]);
+
+        $job = $queue->pop();
+
+        $this->assertInstanceOf(CloudJob::class, $job);
+        $this->assertSame('', $job->getRawBody());
+    }
+
+    public function testPopAcceptsAFalsyButValidMessageId()
+    {
+        $this->fakeEvents();
+        [$queue, $agent] = $this->fakeQueue();
+        // "0" is a valid, non-empty id that empty() would wrongly reject.
+        $agent->pushJob(['messageId' => '0']);
+
+        $this->assertSame('0', $queue->pop()->getJobId());
+    }
+
+    public function testARejectedResultIsReportedOnlyOnce()
+    {
+        $this->fakeEvents();
+        [$queue, $agent] = $this->fakeQueue();
+        $pushed = $agent->pushJob();
+
+        $agent->resultStatus = 422;
+
+        $job = $queue->pop();
+
+        try {
+            $job->delete();
+            $this->fail('Expected the rejected report to throw a RequestException.');
+        } catch (RequestException) {
+            //
+        }
+
+        // The agent's rejection is authoritative for this message, so only
+        // transient socket failures are retried - never the verdict itself.
+        $this->assertAgentResults([
+            ['messageId' => $pushed['messageId'], 'receiptHandle' => $pushed['receiptHandle'], 'status' => 'processed'],
+        ]);
+    }
+
+    public function testDeletingPropagatesWhenTheAgentIsUnreachable()
+    {
+        $this->fakeEvents();
+        $sqs = $this->mock(SqsClient::class);
+        [$queue, $agent] = $this->fakeQueue($sqs);
+        $agent->pushJob();
+
+        $job = $queue->pop();
+
+        // An unreachable agent propagates rather than deleting from SQS directly.
+        $agent->resultUnreachable = true;
+        $sqs->shouldNotReceive('deleteMessage');
+
+        $this->expectException(AgentUnreachableException::class);
+
+        $job->delete();
+    }
+
+    public function testReleasingPropagatesWhenTheAgentIsUnreachable()
+    {
+        $this->fakeEvents();
+        $sqs = $this->mock(SqsClient::class);
+        [$queue, $agent] = $this->fakeQueue($sqs);
+        $agent->pushJob();
+
+        $job = $queue->pop();
+
+        // An unreachable agent propagates rather than resetting visibility on SQS.
+        $agent->resultUnreachable = true;
+        $sqs->shouldNotReceive('changeMessageVisibility');
+
+        $this->expectException(AgentUnreachableException::class);
+
+        $job->release(30);
+    }
+
+    public function testReportingThrowsWhenTheAgentRejectsTheResult()
+    {
+        $this->fakeEvents();
+        $sqs = $this->mock(SqsClient::class);
+        [$queue, $agent] = $this->fakeQueue($sqs);
+        $agent->pushJob();
+
+        $job = $queue->pop();
+
+        // A client-error rejection is message-specific, so it propagates as a
+        // RequestException for the worker to report rather than deleting from
+        // SQS directly or restarting the pod.
+        $agent->resultStatus = 422;
+        $sqs->shouldNotReceive('deleteMessage');
+
+        $this->expectException(RequestException::class);
+
+        $job->delete();
+    }
+
+    public function testReportingEscalatesWhenTheAgentReturnsAServerError()
+    {
+        $this->fakeEvents();
+        $sqs = $this->mock(SqsClient::class);
+        [$queue, $agent] = $this->fakeQueue($sqs);
+        $agent->pushJob();
+
+        $job = $queue->pop();
+
+        // A server error means the agent itself is wedged, so it escalates as
+        // an unreachable fault to restart the pod rather than deleting from SQS.
+        $agent->resultStatus = 500;
+        $sqs->shouldNotReceive('deleteMessage');
+
+        $this->expectException(AgentUnreachableException::class);
+
+        $job->delete();
+    }
+
+    public function testPopThrowsWhenTheAgentReturnsAnError()
+    {
+        $this->fakeEvents();
+        [$queue, $agent] = $this->fakeQueue();
+
+        // Drive the agent's own GET /next stub so the non-200 branch is hit;
+        // a separate Http::fake() would be shadowed by the agent closure.
+        $agent->nextResponse = Http::response('error', 500);
+
+        // An error status means the agent cannot serve work, so it escalates
+        // as an unrecoverable fault rather than idling and re-polling forever.
+        $this->expectException(AgentUnreachableException::class);
+
+        $queue->pop();
+    }
+
+    public function testPopThrowsWhenTheAgentReturnsAnUnexpectedSuccessStatus()
+    {
+        $this->fakeEvents();
+        [$queue, $agent] = $this->fakeQueue();
+
+        // The agent only ever answers 200 (job) or 204 (empty); any other 2xx
+        // is off-contract, so it escalates rather than being decoded as a job.
+        $agent->nextResponse = Http::response('', 202);
+
+        $this->expectException(AgentUnreachableException::class);
+
+        $queue->pop();
+    }
+
+    public function testPopThrowsWhenTheAgentReturnsANonArrayBody()
+    {
+        $this->fakeEvents();
+        [$queue, $agent] = $this->fakeQueue();
+
+        // A 200 that decodes to a scalar is an agent fault; treat it the same
+        // as an unreachable agent rather than idling.
+        $agent->nextResponse = Http::response('"not-an-array"', 200);
+
+        $this->expectException(AgentUnreachableException::class);
+
+        $queue->pop();
+    }
+
+    public function testPopThrowsWhenTheAgentSocketIsUnreachable()
+    {
+        $this->fakeEvents();
+        [$queue] = $this->fakeQueue();
+
+        // An unreachable socket must escalate as an unrecoverable fault, not idle.
+        Http::fake(fn () => throw new ConnectionException('Connection refused'));
+
+        $this->expectException(AgentUnreachableException::class);
+
+        $queue->pop();
+    }
+
+    public function testPopFlagsTheWorkerToStopWhenTheAgentIsUnreachable()
+    {
+        $this->fakeEvents();
+        [$queue] = $this->fakeQueue();
+
+        // The shared worker singleton starts out able to keep running.
+        $this->assertFalse($this->app['queue.worker']->lostConnection);
+
+        Http::fake(fn () => throw new ConnectionException('Connection refused'));
+
+        try {
+            $queue->pop();
+            $this->fail('Expected the unreachable agent to throw an AgentUnreachableException.');
+        } catch (AgentUnreachableException) {
+            //
+        }
+
+        // This release has no injectable LostConnectionDetector, so the queue
+        // flags the running worker directly; its daemon loop exits (lost
+        // connection) on the next tick and the pod restarts.
+        $this->assertTrue($this->app['queue.worker']->lostConnection);
+    }
+
+    public function testReleasingThenFailingReportsBothOutcomesToTheAgent()
+    {
+        $this->fakeEvents();
+        [$queue, $agent] = $this->fakeQueue();
+        $pushed = $agent->pushJob();
+
+        $job = $queue->pop();
+        $job->release(30);
+        $job->fail(new RuntimeException('Whoops!'));
+
+        // CloudJob keeps no memory of prior reports, so both outcomes are
+        // reported in order; reconciling them is the agent's responsibility.
+        $this->assertAgentResults([
+            ['messageId' => $pushed['messageId'], 'receiptHandle' => $pushed['receiptHandle'], 'status' => 'released', 'delay' => 30],
+            ['messageId' => $pushed['messageId'], 'receiptHandle' => $pushed['receiptHandle'], 'status' => 'processed'],
+        ]);
     }
 
     public function testItEmitsJobQueuedEvent()
@@ -414,9 +894,9 @@ class QueueTest extends TestCase
             Cloud::configureManagedQueues($this->app);
             Cloud::bootManagedQueues($this->app);
             $eventsFake = $this->fakeEvents();
-            [$queue, $queueFake] = $this->fakeQueue();
+            [$queue, $agent] = $this->fakeQueue();
 
-            $queueFake->jobsToPop[] = new FakeJob;
+            $agent->pushJob();
             $queue->pop();
             $this->travel(2)->seconds();
 
@@ -462,10 +942,10 @@ class QueueTest extends TestCase
             Cloud::configureManagedQueues($this->app);
             Cloud::bootManagedQueues($this->app);
             $eventsFake = $this->fakeEvents();
-            [$queue, $queueFake] = $this->fakeQueue();
+            [$queue, $agent] = $this->fakeQueue();
 
             foreach ($reasons as $index => $reason) {
-                $queueFake->jobsToPop[] = new FakeJob;
+                $agent->pushJob();
                 $queue->pop();
 
                 $this->app['events']->dispatch(new WorkerStopping(0, null, $reason));
@@ -493,9 +973,9 @@ class QueueTest extends TestCase
             Cloud::configureManagedQueues($this->app);
             Cloud::bootManagedQueues($this->app);
             $eventsFake = $this->fakeEvents();
-            [$queue, $queueFake] = $this->fakeQueue();
+            [$queue, $agent] = $this->fakeQueue();
 
-            $queueFake->jobsToPop[] = new FakeJob;
+            $agent->pushJob();
             $queue->pop();
 
             $this->app['events']->dispatch(new WorkerStopping);
@@ -530,11 +1010,11 @@ class QueueTest extends TestCase
             Cloud::configureManagedQueues($this->app);
             Cloud::bootManagedQueues($this->app);
             $eventsFake = $this->fakeEvents();
-            [$queue, $queueFake] = $this->fakeQueue();
+            [$queue, $agent] = $this->fakeQueue();
 
-            $queueFake->jobsToPop[] = $jobFake = new FakeJob;
-            $queue->pop();
-            $jobFake->fail();
+            $agent->pushJob();
+            $job = $queue->pop();
+            $job->fail();
 
             $this->app['events']->dispatch(new WorkerStopping(0, null, WorkerStopReason::TimedOut));
 
@@ -554,11 +1034,11 @@ class QueueTest extends TestCase
             Cloud::configureManagedQueues($this->app);
             Cloud::bootManagedQueues($this->app);
             $eventsFake = $this->fakeEvents();
-            [$queue, $queueFake] = $this->fakeQueue();
+            [$queue, $agent] = $this->fakeQueue();
 
-            $queueFake->jobsToPop[] = $jobFake = new FakeJob;
-            $queue->pop();
-            $jobFake->release();
+            $agent->pushJob();
+            $job = $queue->pop();
+            $job->release();
 
             $this->app['events']->dispatch(new WorkerStopping(0, null, WorkerStopReason::MaxJobsExceeded));
 
@@ -598,9 +1078,9 @@ class QueueTest extends TestCase
             Cloud::configureManagedQueues($this->app);
             Cloud::bootManagedQueues($this->app);
             $eventsFake = $this->fakeEvents();
-            [$queue, $queueFake] = $this->fakeQueue();
+            [$queue, $agent] = $this->fakeQueue();
 
-            $queueFake->jobsToPop[] = new FakeJob;
+            $agent->pushJob();
             $queue->pop();
 
             $this->app['events']->dispatch(new WorkerStopping(0, null, WorkerStopReason::TimedOut));
@@ -690,9 +1170,10 @@ class QueueTest extends TestCase
     {
         $this->travelTo('2000-01-02 03:04:05.060708');
         $eventsFake = $this->fakeEvents();
-        [$queue, $queueFake] = $this->fakeQueue();
+        [$queue, $agent] = $this->fakeQueue();
 
-        $queueFake->jobsToPop = [new FakeJob, new FakeJob];
+        $agent->pushJob();
+        $agent->pushJob();
         $queue->pop();
         $this->travel(1)->second();
         $queue->pop();
@@ -708,9 +1189,9 @@ class QueueTest extends TestCase
         date_default_timezone_set('Australia/Melbourne');
         $this->travelTo(Carbon::parse('2000-01-02 03:04:05.060708', 'Australia/Melbourne'));
         $eventsFake = $this->fakeEvents();
-        [$queue, $queueFake] = $this->fakeQueue();
+        [$queue, $agent] = $this->fakeQueue();
 
-        $queueFake->jobsToPop[] = new FakeJob;
+        $agent->pushJob();
         $queue->pop();
         $this->travel(1)->second();
         $queue->pop();
@@ -933,9 +1414,8 @@ class QueueTest extends TestCase
 
         $queue->push(new FakeJob, queue: 'orders.fifo');
 
-        // The suffix is injected before the ".fifo" extension on the real SQS
-        // queue name, so the normalized name must strip it back out and keep
-        // the ".fifo" terminal rather than reporting "orders-env-....fifo".
+        // The suffix is injected before ".fifo", so it must be stripped without
+        // leaking into the normalized name.
         $this->assertSame('orders.fifo', $eventsFake->emitted[0]['queue']);
     }
 
@@ -989,17 +1469,31 @@ class QueueTest extends TestCase
     }
 
     /**
-     * @return array{Queue, object{jobsToPop: array}}
+     * Build a Cloud queue whose agent runtime socket is faked via Http::fake().
+     *
+     * The returned agent exposes pushJob() to script the next GET /next
+     * responses; once drained the agent answers 204. POST /result requests are
+     * recorded by the HTTP fake and can be asserted with Http::assertSent().
+     *
+     * @return array{Queue, object{jobs: array}}
      */
-    private function fakeQueue()
+    private function fakeQueue($sqs = null)
     {
-        $fakeQueue = new class($this->app, [], null) extends QueueFake
-        {
-            public array $jobsToPop = [];
+        // Enable the agent so pop() long-polls the faked runtime socket.
+        $this->app['config']->set('queue.connections.cloud.agent', [
+            'enabled' => true,
+            'socket' => '/tmp/cloud-agent.sock',
+        ]);
 
-            public function pop($queue = null)
+        // A real client suffices while the SQS seams stay no-ops; callers asserting
+        // direct SQS calls pass a mock instead.
+        $sqs ??= new SqsClient(['region' => 'us-east-2', 'version' => 'latest', 'credentials' => false]);
+
+        $fakeQueue = new class($this->app, $sqs) extends QueueFake
+        {
+            public function __construct($app, private $sqs)
             {
-                return array_shift($this->jobsToPop);
+                parent::__construct($app);
             }
 
             public function getQueue($queue)
@@ -1007,6 +1501,21 @@ class QueueTest extends TestCase
                 $queue ??= 'default';
 
                 return config('queue.connections.cloud.connection.prefix').'/'.$queue.config('queue.connections.cloud.connection.suffix');
+            }
+
+            public function getContainer()
+            {
+                return $this->app;
+            }
+
+            public function getSqs()
+            {
+                return $this->sqs;
+            }
+
+            public function getConnectionName()
+            {
+                return 'cloud';
             }
 
             public function setConfig(array $config)
@@ -1035,12 +1544,97 @@ class QueueTest extends TestCase
 
         $this->app['queue']->addConnector('cloud', $this->app->factory(QueueConnector::class));
 
-        return [$this->app['queue']->connection('cloud'), $fakeQueue];
+        $agent = $this->fakeAgent();
+
+        $connection = $this->app['queue']->connection('cloud');
+
+        // The agent only serves a queue:work worker popping its queue, so present
+        // as one for pop() (see usesAgent()). Set after connecting so the
+        // connector's worker wiring - which expects the cloud failed-job provider
+        // - isn't exercised here. Restored in tearDown().
+        $_SERVER['argv'] = ['artisan', 'queue:work'];
+
+        return [$connection, $agent];
+    }
+
+    /**
+     * Fake the cloud-agent runtime socket with Http::fake(): GET /next serves
+     * scripted jobs (204 once drained) and POST /result is accepted (and
+     * recorded for assertions). The returned object scripts jobs via pushJob().
+     */
+    private function fakeAgent()
+    {
+        $agent = new class
+        {
+            public array $jobs = [];
+
+            public int $resultStatus = 200;
+
+            public bool $resultUnreachable = false;
+
+            public $nextResponse = null;
+
+            public function pushJob(array $job = []): array
+            {
+                $job = array_merge([
+                    'messageId' => (string) Str::uuid(),
+                    'receiptHandle' => 'receipt-handle',
+                    // The agent always reports the SQS queue URL the message came from.
+                    'queueUrl' => 'https://sqs.us-east-1.amazonaws.com/123456789012/default',
+                    'body' => json_encode(['job' => MyJob::class, 'data' => []]),
+                    // SQS always returns ApproximateReceiveCount, so mirror it.
+                    'attributes' => ['ApproximateReceiveCount' => 1],
+                ], $job);
+
+                $this->jobs[] = $job;
+
+                return $job;
+            }
+        };
+
+        Http::fake(function ($request) use ($agent) {
+            if (str_ends_with($request->url(), '/next')) {
+                if ($agent->nextResponse !== null) {
+                    return $agent->nextResponse;
+                }
+
+                $job = array_shift($agent->jobs);
+
+                return $job === null
+                    ? Http::response('', 204)
+                    : Http::response($job, 200);
+            }
+
+            if (str_ends_with($request->url(), '/result')) {
+                if ($agent->resultUnreachable) {
+                    throw new ConnectionException('Connection refused');
+                }
+
+                return Http::response('', $agent->resultStatus);
+            }
+
+            return Http::response('', 404);
+        });
+
+        return $agent;
     }
 
     private function fakeFailer()
     {
         return new FileFailedJobProvider(tempnam(sys_get_temp_dir(), 'cloud_failed_job_test_'));
+    }
+
+    /**
+     * Assert the exact sequence of POST /result bodies sent to the agent.
+     */
+    private function assertAgentResults(array $expected): void
+    {
+        $results = Http::recorded(fn ($request) => str_ends_with($request->url(), '/result'))
+            ->map(fn ($record) => $record[0]->data())
+            ->values()
+            ->all();
+
+        $this->assertSame($expected, $results);
     }
 }
 


### PR DESCRIPTION
Backport of #60659 to `11.x`; see that PR for full context. Two adaptations for this branch:

- The large-payload overflow storage (#59734) is 13.x-only, so the `CloudJob` overflow parameter, the `SqsJob::deleteOverflowPayload()` extraction, and the two overflow tests are omitted.
- 11.x has no injectable `LostConnectionDetector` (#56493). Instead of the `AgentAwareLostConnectionDetector` + container `extend`, an unreachable agent flags the shared `queue.worker` singleton's public `$lostConnection` directly; the daemon loop then exits with `WorkerStopReason::LostConnection` on the next tick and the pod restarts — the same outcome, with no core database changes.

## What

When Laravel Cloud's managed-queue agent is enabled, a `queue:work` worker pops jobs from the in-container cloud-agent over its unix-socket runtime API instead of receiving from SQS directly. The agent long-polls SQS and owns the terminal delete/visibility operations; the worker just processes each job and reports the outcome back.

## How

- `Queue::pop()` routes to the agent (`GET /next`) only when the agent is enabled, the process is a `queue:work` worker, and the popped queue is the one that worker is serving. Every other case (other queues, non-worker contexts, non-SQS connections) pops from SQS exactly as before.
- Jobs come back as a `CloudJob` (extends `SqsJob`). Its `delete()`/`release()` don't touch SQS — they report the outcome to the agent (`POST /result`), which performs the SQS operation. The agent is the single writer to SQS.
- If the agent socket is unreachable, or returns an error/malformed response, an `AgentUnreachableException` is raised; the running worker is flagged to stop so it exits and the pod restarts rather than spinning against a dead agent. Reporting retries only transient socket failures; the agent's own 4xx verdict for a message propagates as-is.

## Notes

- Opt-in per connection via `agent.enabled`; socket path defaults to `/tmp/cloud-agent.sock` (`agent.socket`).
- `SqsJob`'s SQS calls are split into small protected methods (`deleteMessageFromSqs`, `changeMessageVisibilityInSqs`) so the delete/release flow reads clearly and stays extensible. No behavioural change to the standard SQS path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
