### PR TITLE
[13.x] Add `query` and `queryJson` HTTP testing helpers

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -549,6 +549,37 @@ trait MakesHttpRequests
     }
 
     /**
+     * Visit the given URI with a QUERY request.
+     *
+     * @param  \Illuminate\Support\Uri|string  $uri
+     * @param  array  $data
+     * @param  array  $headers
+     * @return \Illuminate\Testing\TestResponse
+     */
+    public function query($uri, array $data = [], array $headers = [])
+    {
+        $server = $this->transformHeadersToServerVars($headers);
+
+        $cookies = $this->prepareCookiesForRequest();
+
+        return $this->call('QUERY', $uri, $data, $cookies, [], $server);
+    }
+
+    /**
+     * Visit the given URI with a QUERY request, expecting a JSON response.
+     *
+     * @param  \Illuminate\Support\Uri|string  $uri
+     * @param  array  $data
+     * @param  array  $headers
+     * @param  int  $options
+     * @return \Illuminate\Testing\TestResponse
+     */
+    public function queryJson($uri, array $data = [], array $headers = [], $options = 0)
+    {
+        return $this->json('QUERY', $uri, $data, $headers, $options);
+    }
+
+    /**
      * Call the given URI with a JSON request.
      *
      * @param  string  $method

--- a/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
+++ b/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Routing\Registrar;
 use Illuminate\Contracts\Routing\UrlGenerator;
 use Illuminate\Foundation\Http\Middleware\HandlePrecognitiveRequests;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
 use Orchestra\Testbench\TestCase;
 
 class MakesHttpRequestsTest extends TestCase
@@ -225,6 +226,50 @@ class MakesHttpRequestsTest extends TestCase
         $this->followingRedirects()->get('from');
 
         $this->assertEquals(['from', 'to'], $callOrder);
+    }
+
+    public function testQuerySendsRequestBodyUsingQueryMethod()
+    {
+        $router = $this->app->make(Registrar::class);
+
+        $router->match(['QUERY'], 'search', function (Request $request) {
+            return [
+                'method' => $request->method(),
+                'filter' => $request->input('filter'),
+                'post' => $request->post('filter'),
+                'query' => $request->query('filter'),
+            ];
+        });
+
+        $this->query('search', ['filter' => 'active'])
+            ->assertOk()
+            ->assertExactJson([
+                'method' => 'QUERY',
+                'filter' => 'active',
+                'post' => 'active',
+                'query' => null,
+            ]);
+    }
+
+    public function testQueryJsonSendsJsonRequestBodyUsingQueryMethod()
+    {
+        $router = $this->app->make(Registrar::class);
+
+        $router->match(['QUERY'], 'search', function (Request $request) {
+            return [
+                'method' => $request->method(),
+                'isJson' => $request->isJson(),
+                'filter' => $request->input('filter'),
+            ];
+        });
+
+        $this->queryJson('search', ['filter' => 'active'])
+            ->assertOk()
+            ->assertExactJson([
+                'method' => 'QUERY',
+                'isJson' => true,
+                'filter' => 'active',
+            ]);
     }
 
     public function testWithPrecognition()


### PR DESCRIPTION
With the HTTP `QUERY` method gaining first-class routing support (#60655) — and `Route::match(['QUERY'], ...)` already working today — there is currently no fluent way to test such routes: `MakesHttpRequests` offers helpers for every other verb but not QUERY.

This PR adds `$this->query($uri, $data, $headers)` and `$this->queryJson(...)`, mirroring the existing `delete()`/`deleteJson()` helpers since QUERY is a safe method that carries its query in the request body:

```php
Route::match(['QUERY'], '/search', fn () => request()->input('filter'));

$this->queryJson('/search', ['filter' => 'active'])->assertOk();
```

Symfony HttpFoundation ≥ 7.4 (Laravel 13's minimum) natively supports QUERY in `Request::create()`, placing test data in the request body just like POST/PUT/DELETE — the tests assert this explicitly (`$request->post('filter')` is set, `$request->query('filter')` is not).

Fully backward compatible — purely additive, no contracts changed. Tests cover both helpers end-to-end through the router.

🤖 Generated with [Claude Code](https://claude.com/claude-code)