### PR TITLE
[13.x] Add Http::assertSentJson() assertion helper

### DIFF
--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -502,6 +502,35 @@ class Factory
     }
 
     /**
+     * Assert that a request was sent with the given JSON data.
+     *
+     * @param  array|(\Closure(array, \Illuminate\Http\Client\Request): bool)  $data
+     * @return void
+     */
+    public function assertSentJson($data)
+    {
+        $this->assertSent(function ($request) use ($data) {
+            if (! $request->isJson()) {
+                return false;
+            }
+
+            $json = $request->data();
+
+            if ($data instanceof Closure) {
+                return $data($json, $request) === true;
+            }
+
+            foreach ($data as $key => $value) {
+                if (data_get($json, $key) !== $value) {
+                    return false;
+                }
+            }
+
+            return true;
+        });
+    }
+
+    /**
      * Assert that a request / response pair was not recorded matching a given truth test.
      *
      * @param  callable|(\Closure(\Illuminate\Http\Client\Request, \Illuminate\Http\Client\Response|null): bool)  $callback

--- a/src/Illuminate/Support/Facades/Http.php
+++ b/src/Illuminate/Support/Facades/Http.php
@@ -20,6 +20,7 @@ use Illuminate\Http\Client\Factory;
  * @method static void recordRequestResponsePair(\Illuminate\Http\Client\Request $request, \Illuminate\Http\Client\Response|null $response)
  * @method static void assertSent(callable|\Closure $callback)
  * @method static void assertSentInOrder(array $callbacks)
+ * @method static void assertSentJson(array|\Closure $data)
  * @method static void assertNotSent(callable|\Closure $callback)
  * @method static void assertNothingSent()
  * @method static void assertSentCount(int $count)

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -4872,6 +4872,77 @@ class HttpClientTest extends TestCase
         $response->json();
         $this->assertSame(1, $response->bodyCallCount);
     }
+
+    public function testAssertSentJsonWithSubsetMatch()
+    {
+        $this->factory->fake();
+
+        $this->factory->post('http://laravel.com/json', [
+            'email' => 'user@example.com',
+            'name' => 'Taylor',
+        ]);
+
+        $this->factory->assertSentJson([
+            'email' => 'user@example.com',
+        ]);
+    }
+
+    public function testAssertSentJsonWithClosure()
+    {
+        $this->factory->fake();
+
+        $this->factory->post('http://laravel.com/json', [
+            'status' => 'active',
+        ]);
+
+        $this->factory->assertSentJson(function (array $json, Request $request) {
+            return $json['status'] === 'active'
+                && $request->url() === 'http://laravel.com/json';
+        });
+    }
+
+    public function testAssertSentJsonWithNestedDotNotationKeys()
+    {
+        $this->factory->fake();
+
+        $this->factory->post('http://laravel.com/json', [
+            'user' => ['name' => 'Taylor', 'email' => 'user@example.com'],
+        ]);
+
+        $this->factory->assertSentJson([
+            'user.email' => 'user@example.com',
+        ]);
+    }
+
+    public function testAssertSentJsonFailsWhenNoMatchingJsonRequestWasSent()
+    {
+        $this->factory->fake();
+
+        $this->factory->post('http://laravel.com/json', [
+            'email' => 'user@example.com',
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+
+        $this->factory->assertSentJson([
+            'email' => 'other@example.com',
+        ]);
+    }
+
+    public function testAssertSentJsonDoesNotMatchNonJsonRequests()
+    {
+        $this->factory->fake();
+
+        $this->factory->asForm()->post('http://laravel.com/form', [
+            'email' => 'user@example.com',
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+
+        $this->factory->assertSentJson([
+            'email' => 'user@example.com',
+        ]);
+    }
 }
 
 class CustomFactory extends Factory


### PR DESCRIPTION
Testing outbound JSON payloads currently requires a custom `Http::assertSent()` closure. This PR adds a new `Http::assertSentJson()` assertion helper to make that common case more direct and readable.