### PR TITLE
[12.x] Terminate default style value with a semicolon in ComponentAttributeBag::merge()

### DIFF
--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -257,6 +257,10 @@ class ComponentAttributeBag implements Arrayable, ArrayAccess, IteratorAggregate
 
             if ($key === 'style') {
                 $value = Str::finish($value, ';');
+
+                if (is_string($defaultsValue) && $defaultsValue !== '') {
+                    $defaultsValue = Str::finish($defaultsValue, ';');
+                }
             }
 
             return [$key => implode(' ', array_unique(array_filter([$defaultsValue, $value])))];

--- a/tests/View/ViewComponentAttributeBagTest.php
+++ b/tests/View/ViewComponentAttributeBagTest.php
@@ -118,6 +118,25 @@ class ViewComponentAttributeBagTest extends TestCase
         $this->assertSame('class="font-bold" id="my-id"', (string) $bag->except(['name', 'missing']));
     }
 
+    public function testMergeTerminatesDefaultStyleWithSemicolon()
+    {
+        $bag = new ComponentAttributeBag(['style' => 'color: blue']);
+
+        // The default style value is not terminated with a semicolon, so one
+        // should be added to keep the resulting declaration list valid.
+        $this->assertSame('style="font-weight: bold; color: blue;"', (string) $bag->merge(['style' => 'font-weight: bold']));
+
+        $bag = new ComponentAttributeBag(['style' => 'color: blue']);
+
+        // A default style value that already ends with a semicolon must not gain a second one.
+        $this->assertSame('style="font-weight: bold; color: blue;"', (string) $bag->merge(['style' => 'font-weight: bold;']));
+
+        // When no default style is provided the existing value should be returned untouched.
+        $bag = new ComponentAttributeBag(['style' => 'color: blue']);
+
+        $this->assertSame('style="color: blue;"', (string) $bag->merge([]));
+    }
+
     public function testAttributeRetrievalUsingDotNotation()
     {
         $bag = new ComponentAttributeBag([


### PR DESCRIPTION
`ComponentAttributeBag::merge()` treats the `style` attribute similarly to `class` by appending values. However, it only terminates the **existing** style value with a semicolon, omitting it for the **default** value being merged in front of it.

When a default style does not end with a semicolon, the two declarations run together, resulting in invalid CSS.

While the `->style()` helper mitigates this because `Arr::toCssStyles()` automatically appends a semicolon to every declaration, calling `merge(['style' => '...'])` directly with a raw string (which is fully supported and documented) is broken.

```php
$bag = new ComponentAttributeBag(['style' => 'color: blue']);

// Current Behavior (Broken)
echo (string) $bag->merge(['style' => 'font-weight: bold']);
// style="font-weight: bold color: blue;"  Invalid CSS

// Expected / New Behavior
echo (string) $bag->merge(['style' => 'font-weight: bold']);
// style="font-weight: bold; color: blue;"  Valid CSS

```