### PR TITLE
[13.x] Add withoutHeader() and withoutHeaders() to HTTP client Pendin…

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -500,7 +500,7 @@ class PendingRequest
     /**
      * Remove the given headers from the request.
      *
-     * @param  array  $names
+     * @param  list<string>  $names
      * @return $this
      */
     public function withoutHeaders(array $names)

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -485,6 +485,34 @@ class PendingRequest
     }
 
     /**
+     * Remove the given header from the request.
+     *
+     * @param  string  $name
+     * @return $this
+     */
+    public function withoutHeader($name)
+    {
+        unset($this->options['headers'][$name]);
+
+        return $this;
+    }
+
+    /**
+     * Remove the given headers from the request.
+     *
+     * @param  array  $names
+     * @return $this
+     */
+    public function withoutHeaders(array $names)
+    {
+        foreach ($names as $name) {
+            $this->withoutHeader($name);
+        }
+
+        return $this;
+    }
+
+    /**
      * Specify the basic authentication username and password for the request.
      *
      * @param  string  $username

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -600,6 +600,28 @@ class HttpClientTest extends TestCase
         });
     }
 
+    public function testCanRemoveHeadersFromRequest()
+    {
+        $this->factory->fake();
+
+        $this->factory->withHeaders([
+            'X-Test-Header' => 'foo',
+            'X-Keep-Header' => 'bar',
+        ])->withHeader('X-Another-Header', 'baz')
+            ->withoutHeader('X-Test-Header')
+            ->withoutHeaders(['X-Another-Header', 'X-Missing-Header'])
+            ->post('http://foo.com/json', [
+                'name' => 'Taylor',
+            ]);
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://foo.com/json' &&
+                   ! $request->hasHeader('X-Test-Header') &&
+                   ! $request->hasHeader('X-Another-Header') &&
+                   $request->hasHeader('X-Keep-Header', 'bar');
+        });
+    }
+
     public function testCanSendFormData()
     {
         $this->factory->fake();


### PR DESCRIPTION
This PR adds `withoutHeader()` and `withoutHeaders()` methods to the HTTP client's `PendingRequest`, allowing removal of headers before a request is sent.

The client currently supports adding headers (`withHeader()`, `withHeaders()`, `replaceHeaders()`) but offers no fluent way to remove one. This mirrors the `withoutHeader()` method recently added to `ResponseTrait` and the existing `withCookie()`/`withoutCookie()` symmetry, completing the header API.

### Use Cases
- Removing a default header set by a base client or `Http::macro`
- Stripping a header for a single request without rebuilding the client
- Removing sensitive headers (e.g. `X-Debug`, `Authorization`) before proxying

### Usage
    Http::withHeaders(['X-Debug' => '1'])
        ->withoutHeader('X-Debug')
        ->withoutHeaders(['X-Trace', 'X-Internal'])
        ->get('https://example.com');
