### PR TITLE
[13.x] Allow mail config options without name

### DIFF
--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -514,7 +514,7 @@ class MailManager implements FactoryContract
         $address = Arr::get($config, $type, $this->app['config']['mail.'.$type]);
 
         if (is_array($address) && isset($address['address'])) {
-            $mailer->{'always'.Str::studly($type)}($address['address'], $address['name']);
+            $mailer->{'always'.Str::studly($type)}($address['address'], $address['name'] ?? null);
         }
     }
 

--- a/tests/Mail/MailManagerTest.php
+++ b/tests/Mail/MailManagerTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Mail;
 
 use InvalidArgumentException;
+use Orchestra\Testbench\Attributes\WithConfig;
 use Orchestra\Testbench\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\TestWith;
@@ -175,14 +176,10 @@ class MailManagerTest extends TestCase
         $this->assertNotSame($mailer1, $mailer2);
     }
 
+    #[WithConfig('mail.mailers.array', ['transport' => 'array'])]
+    #[WithConfig('mail.to', ['address' => 'taylor@laravel.com'])]
     public function testGlobalToAddressWithoutName(): void
     {
-        $this->app['config']->set('mail.mailers.array', [
-            'transport' => 'array',
-        ]);
-
-        $this->app['config']->set('mail.to', ['address' => 'taylor@laravel.com']);
-
         $mailer = $this->app['mail.manager']->mailer('array');
 
         $sentMessage = $mailer->raw('Hello World', function ($message) {

--- a/tests/Mail/MailManagerTest.php
+++ b/tests/Mail/MailManagerTest.php
@@ -175,6 +175,23 @@ class MailManagerTest extends TestCase
         $this->assertNotSame($mailer1, $mailer2);
     }
 
+    public function testGlobalToAddressWithoutName(): void
+    {
+        $this->app['config']->set('mail.mailers.array', [
+            'transport' => 'array',
+        ]);
+
+        $this->app['config']->set('mail.to', ['address' => 'taylor@laravel.com']);
+
+        $mailer = $this->app['mail.manager']->mailer('array');
+
+        $sentMessage = $mailer->raw('Hello World', function ($message) {
+            $message->to('jack@laravel.com');
+        });
+
+        $this->assertStringContainsString('To: taylor@laravel.com', $sentMessage->toString());
+    }
+
     public static function emptyTransportConfigDataProvider()
     {
         return [


### PR DESCRIPTION
Closes https://github.com/laravel/framework/issues/60666

All of the `always` mail facade methods IE `mailAlwaysFrom`, `mailAlwaysTo` etc allow the name to be null in the signature.

```php
    if ($this->app->environment('local')) {
        Mail::alwaysFrom('dev@example.com');
    }
```
If you set your own `from`, in the config, without a name  (or set any of the others like to, without a name) **while using these methods**,
```
    'from' => [
       'address' => env('MAIL_TO_ADDRESS', 'hello@example.com'),
   ],

```

You get an exception:
```
   ErrorException 

  Undefined array key "name"

  at C:\Users\Jack\Documents\GitHub\secret-weapon\vendor\laravel\framework\src\Illuminate\Mail\MailManager.php:516
    512▕     protected function setGlobalAddress($mailer, array $config, string $type)
    513▕     {
    514▕         $address = Arr::get($config, $type, $this->app['config']['mail.'.$type]);
    515▕         if (is_array($address) && isset($address['address'])) {
  ➜ 516▕             $mailer->{'always'.Str::studly($type)}($address['address'], $address['name']);
    517▕         }
    518▕     }
    519▕ 
    520▕     /**

  1   C:\Users\Jack\Documents\GitHub\secret-weapon\vendor\laravel\framework\src\Illuminate\Mail\MailManager.php:516
      Illuminate\Foundation\Bootstrap\HandleExceptions::{closure:Illuminate\Foundation\Bootstrap\HandleExceptions::forwardsTo():262}()

  2   C:\Users\Jack\Documents\GitHub\secret-weapon\vendor\laravel\framework\src\Illuminate\Mail\MailManager.php:131
      Illuminate\Mail\MailManager::setGlobalAddress()
```

This PR allows people to drop the name from the config by defaulting it to null as the methods already allow. 

Thought I'd give this a go as the methods already allow null :) 


