### PR TITLE
[13.x] Remove deprecated `StaticCallOnNonStaticToInstanceCallRector` fixer rule

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -16,7 +16,6 @@ use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
 use Rector\Php56\Rector\FuncCall\PowToExpRector;
 use Rector\Php70\Rector\FuncCall\RandomFunctionRector;
 use Rector\Php70\Rector\MethodCall\ThisCallOnStaticMethodToStaticCallRector;
-use Rector\Php70\Rector\StaticCall\StaticCallOnNonStaticToInstanceCallRector;
 use Rector\Php70\Rector\Ternary\TernaryToNullCoalescingRector;
 use Rector\Php71\Rector\BinaryOp\BinaryOpBetweenNumberAndStringRector;
 use Rector\Php71\Rector\FuncCall\RemoveExtraParametersRector;
@@ -115,7 +114,6 @@ return RectorConfig::configure()
         ReadOnlyPropertyRector::class,
         RemoveExtraParametersRector::class,
         ReturnNeverTypeRector::class,
-        StaticCallOnNonStaticToInstanceCallRector::class,
         StringClassNameToClassConstantRector::class,
         StringableForToStringRector::class,
         TernaryToNullCoalescingRector::class,

--- a/rector.php
+++ b/rector.php
@@ -33,6 +33,7 @@ use Rector\Php82\Rector\Class_\ReadOnlyClassRector;
 use Rector\Php83\Rector\ClassConst\AddTypeToConstRector;
 use Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector;
 use Rector\Php83\Rector\FuncCall\DynamicClassConstFetchRector;
+use Rector\Php84\Rector\Class_\DeprecatedAnnotationToDeprecatedAttributeRector;
 use Rector\PHPUnit\CodeQuality\Rector\CallLike\DirectInstanceOverMockArgRector;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\ConstructClassMethodToSetUpTestCaseRector;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\InlineStubPropertyToCreateStubMethodCallRector;
@@ -104,6 +105,7 @@ return RectorConfig::configure()
         ClosureDelegatingCallToFirstClassCallableRector::class,
         ClosureFromCallableToFirstClassCallableRector::class,
         ClosureToArrowFunctionRector::class,
+        DeprecatedAnnotationToDeprecatedAttributeRector::class,
         DynamicClassConstFetchRector::class,
         FunctionFirstClassCallableRector::class,
         GetDebugTypeRector::class,

--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -124,13 +124,7 @@ class Gate implements GateContract
     {
         $abilities = is_array($ability) ? $ability : func_get_args();
 
-        foreach ($abilities as $ability) {
-            if (! isset($this->abilities[enum_value($ability)])) {
-                return false;
-            }
-        }
-
-        return true;
+        return array_all($abilities, fn ($ability) => isset($this->abilities[enum_value($ability)]));
     }
 
     /**

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -556,13 +556,7 @@ class Arr
             return false;
         }
 
-        foreach ($keys as $key) {
-            if (! static::has($array, $key)) {
-                return false;
-            }
-        }
-
-        return true;
+        return array_all($keys, fn ($key) => static::has($array, $key));
     }
 
     /**
@@ -588,13 +582,7 @@ class Arr
             return false;
         }
 
-        foreach ($keys as $key) {
-            if (static::has($array, $key)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($keys, fn ($key) => static::has($array, $key));
     }
 
     /**

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -783,13 +783,7 @@ trait EnumeratesValues
     {
         return $this->filter(function ($value) use ($type) {
             if (is_array($type)) {
-                foreach ($type as $classType) {
-                    if ($value instanceof $classType) {
-                        return true;
-                    }
-                }
-
-                return false;
+                return array_any($type, fn ($classType) => $value instanceof $classType);
             }
 
             return $value instanceof $type;

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -285,13 +285,7 @@ class Builder
     {
         $tableColumns = array_map(strtolower(...), $this->getColumnListing($table));
 
-        foreach ($columns as $column) {
-            if (! in_array(strtolower($column), $tableColumns)) {
-                return false;
-            }
-        }
-
-        return true;
+        return array_all($columns, fn ($column) => in_array(strtolower($column), $tableColumns));
     }
 
     /**

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -218,13 +218,7 @@ trait InteractsWithInput
             $files = [$files];
         }
 
-        foreach ($files as $file) {
-            if ($this->isValidFile($file)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($files, fn ($file) => $this->isValidFile($file));
     }
 
     /**

--- a/src/Illuminate/Queue/Console/BatchesTableCommand.php
+++ b/src/Illuminate/Queue/Console/BatchesTableCommand.php
@@ -63,15 +63,9 @@ class BatchesTableCommand extends MigrationGeneratorCommand
             return parent::migrationExists($table);
         }
 
-        foreach ([
+        return array_any([
             join_paths($this->laravel->databasePath('migrations'), '*_*_*_*_create_'.$table.'_table.php'),
             join_paths($this->laravel->databasePath('migrations'), '0001_01_01_000002_create_jobs_table.php'),
-        ] as $path) {
-            if (count($this->files->glob($path)) !== 0) {
-                return true;
-            }
-        }
-
-        return false;
+        ], fn ($path) => count($this->files->glob($path)) !== 0);
     }
 }

--- a/src/Illuminate/Queue/Console/FailedTableCommand.php
+++ b/src/Illuminate/Queue/Console/FailedTableCommand.php
@@ -63,15 +63,9 @@ class FailedTableCommand extends MigrationGeneratorCommand
             return parent::migrationExists($table);
         }
 
-        foreach ([
+        return array_any([
             join_paths($this->laravel->databasePath('migrations'), '*_*_*_*_create_'.$table.'_table.php'),
             join_paths($this->laravel->databasePath('migrations'), '0001_01_01_000002_create_jobs_table.php'),
-        ] as $path) {
-            if (count($this->files->glob($path)) !== 0) {
-                return true;
-            }
-        }
-
-        return false;
+        ], fn ($path) => count($this->files->glob($path)) !== 0);
     }
 }

--- a/src/Illuminate/Queue/Console/TableCommand.php
+++ b/src/Illuminate/Queue/Console/TableCommand.php
@@ -63,15 +63,9 @@ class TableCommand extends MigrationGeneratorCommand
             return parent::migrationExists($table);
         }
 
-        foreach ([
+        return array_any([
             join_paths($this->laravel->databasePath('migrations'), '*_*_*_*_create_'.$table.'_table.php'),
             join_paths($this->laravel->databasePath('migrations'), '0001_01_01_000002_create_jobs_table.php'),
-        ] as $path) {
-            if (count($this->files->glob($path)) !== 0) {
-                return true;
-            }
-        }
-
-        return false;
+        ], fn ($path) => count($this->files->glob($path)) !== 0);
     }
 }

--- a/src/Illuminate/Queue/Middleware/FailOnException.php
+++ b/src/Illuminate/Queue/Middleware/FailOnException.php
@@ -37,13 +37,7 @@ class FailOnException
     protected function failForExceptions(array $exceptions)
     {
         return static function (Throwable $throwable) use ($exceptions) {
-            foreach ($exceptions as $exception) {
-                if ($throwable instanceof $exception) {
-                    return true;
-                }
-            }
-
-            return false;
+            return array_any($exceptions, fn ($exception) => $throwable instanceof $exception);
         };
     }
 

--- a/src/Illuminate/Queue/Middleware/ThrottlesExceptions.php
+++ b/src/Illuminate/Queue/Middleware/ThrottlesExceptions.php
@@ -193,13 +193,7 @@ class ThrottlesExceptions
      */
     protected function shouldDelete(Throwable $throwable): bool
     {
-        foreach ($this->deleteWhenCallbacks as $callback) {
-            if (call_user_func($callback, $throwable)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($this->deleteWhenCallbacks, fn ($callback) => call_user_func($callback, $throwable));
     }
 
     /**
@@ -210,13 +204,7 @@ class ThrottlesExceptions
      */
     protected function shouldFail(Throwable $throwable): bool
     {
-        foreach ($this->failWhenCallbacks as $callback) {
-            if (call_user_func($callback, $throwable)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($this->failWhenCallbacks, fn ($callback) => call_user_func($callback, $throwable));
     }
 
     /**

--- a/src/Illuminate/Redis/Connectors/PredisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PredisConnector.php
@@ -91,7 +91,7 @@ class PredisConnector implements Connector
             throw new InvalidArgumentException('The scheme configured in the Redis host option must match the scheme option.');
         }
 
-        $config['scheme'] = $config['scheme'] ?? $hostScheme;
+        $config['scheme'] ??= $hostScheme;
         $config['host'] = Str::after($host, "{$hostScheme}://");
 
         return $config;

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -922,13 +922,7 @@ class Route
             return false;
         }
 
-        foreach ($patterns as $pattern) {
-            if (Str::is($pattern, $routeName)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($patterns, fn ($pattern) => Str::is($pattern, $routeName));
     }
 
     /**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1307,13 +1307,7 @@ class Router implements BindingRegistrar, RegistrarContract
     {
         $names = is_array($name) ? $name : func_get_args();
 
-        foreach ($names as $value) {
-            if (! $this->routes->hasNamedRoute($value)) {
-                return false;
-            }
-        }
-
-        return true;
+        return array_all($names, fn ($value) => $this->routes->hasNamedRoute($value));
     }
 
     /**
@@ -1368,13 +1362,7 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     public function uses(...$patterns)
     {
-        foreach ($patterns as $pattern) {
-            if (Str::is($pattern, $this->currentRouteAction())) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($patterns, fn ($pattern) => Str::is($pattern, $this->currentRouteAction()));
     }
 
     /**

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -489,16 +489,10 @@ class UrlGenerator implements UrlGeneratorContract
             return false;
         }
 
-        foreach ($keys as $key) {
-            if (hash_equals(
-                hash_hmac('sha256', $original, $key),
-                $signature
-            )) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($keys, fn ($key) => hash_equals(
+            hash_hmac('sha256', $original, $key),
+            $signature
+        ));
     }
 
     /**

--- a/src/Illuminate/Session/Console/SessionTableCommand.php
+++ b/src/Illuminate/Session/Console/SessionTableCommand.php
@@ -59,15 +59,9 @@ class SessionTableCommand extends MigrationGeneratorCommand
      */
     protected function migrationExists($table)
     {
-        foreach ([
+        return array_any([
             join_paths($this->laravel->databasePath('migrations'), '*_*_*_*_create_'.$table.'_table.php'),
             join_paths($this->laravel->databasePath('migrations'), '0001_01_01_000000_create_users_table.php'),
-        ] as $path) {
-            if (count($this->files->glob($path)) !== 0) {
-                return true;
-            }
-        }
-
-        return false;
+        ], fn ($path) => count($this->files->glob($path)) !== 0);
     }
 }

--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -127,7 +127,7 @@ class MessageBag implements Jsonable, JsonSerializable, MessageBagContract, Mess
 
         $keys = is_array($key) ? $key : func_get_args();
 
-        return array_all($keys, fn ($key) => ! ($this->first($key) === ''));
+        return array_all($keys, fn ($key) => $this->first($key) !== '');
     }
 
     /**

--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -127,13 +127,7 @@ class MessageBag implements Jsonable, JsonSerializable, MessageBagContract, Mess
 
         $keys = is_array($key) ? $key : func_get_args();
 
-        foreach ($keys as $key) {
-            if ($this->first($key) === '') {
-                return false;
-            }
-        }
-
-        return true;
+        return array_all($keys, fn ($key) => ! ($this->first($key) === ''));
     }
 
     /**
@@ -150,13 +144,7 @@ class MessageBag implements Jsonable, JsonSerializable, MessageBagContract, Mess
 
         $keys = is_array($keys) ? $keys : func_get_args();
 
-        foreach ($keys as $key) {
-            if ($this->has($key)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($keys, fn ($key) => $this->has($key));
     }
 
     /**

--- a/src/Illuminate/Support/NodePackageManagers/Bun.php
+++ b/src/Illuminate/Support/NodePackageManagers/Bun.php
@@ -13,13 +13,7 @@ class Bun implements NodePackageManager
      */
     public static function matches(): bool
     {
-        foreach (['bun.lock', 'bun.lockb'] as $lockFile) {
-            if (file_exists(getcwd().'/'.$lockFile)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any(['bun.lock', 'bun.lockb'], fn ($lockFile) => file_exists(getcwd().'/'.$lockFile));
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -553,12 +553,12 @@ class QueueFake extends QueueManager implements Fake, Queue
             ->flatten(1)
             ->map(fn ($data) => new InspectedJob(
                 uuid: null,
+                queue: $data['queue'],
                 name: is_object($data['job'])
                     ? (method_exists($data['job'], 'displayName') ? $data['job']->displayName() : get_class($data['job']))
                     : $data['job'],
                 attempts: 0,
                 payload: [],
-                queue: $data['queue'],
                 createdAt: null,
             ));
     }

--- a/src/Illuminate/Support/Traits/InteractsWithData.php
+++ b/src/Illuminate/Support/Traits/InteractsWithData.php
@@ -55,13 +55,7 @@ trait InteractsWithData
 
         $data = $this->all();
 
-        foreach ($keys as $value) {
-            if (! Arr::has($data, $value)) {
-                return false;
-            }
-        }
-
-        return true;
+        return array_all($keys, fn ($value) => Arr::has($data, $value));
     }
 
     /**
@@ -113,13 +107,7 @@ trait InteractsWithData
     {
         $keys = is_array($key) ? $key : func_get_args();
 
-        foreach ($keys as $value) {
-            if ($this->isEmptyString($value)) {
-                return false;
-            }
-        }
-
-        return true;
+        return array_all($keys, fn ($value) => ! $this->isEmptyString($value));
     }
 
     /**
@@ -132,13 +120,7 @@ trait InteractsWithData
     {
         $keys = is_array($key) ? $key : func_get_args();
 
-        foreach ($keys as $value) {
-            if (! $this->isEmptyString($value)) {
-                return false;
-            }
-        }
-
-        return true;
+        return array_all($keys, fn ($value) => $this->isEmptyString($value));
     }
 
     /**
@@ -151,13 +133,7 @@ trait InteractsWithData
     {
         $keys = is_array($keys) ? $keys : func_get_args();
 
-        foreach ($keys as $key) {
-            if ($this->filled($key)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($keys, fn ($key) => $this->filled($key));
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -2570,13 +2570,7 @@ trait ValidatesAttributes
      */
     protected function anyFailingRequired(array $attributes)
     {
-        foreach ($attributes as $key) {
-            if (! $this->validateRequired($key, $this->getValue($key))) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($attributes, fn ($key) => ! $this->validateRequired($key, $this->getValue($key)));
     }
 
     /**
@@ -2587,13 +2581,7 @@ trait ValidatesAttributes
      */
     protected function allFailingRequired(array $attributes)
     {
-        foreach ($attributes as $key) {
-            if ($this->validateRequired($key, $this->getValue($key))) {
-                return false;
-            }
-        }
-
-        return true;
+        return array_all($attributes, fn ($key) => ! $this->validateRequired($key, $this->getValue($key)));
     }
 
     /**

--- a/tests/Foundation/Cloud/JsonFormatterTest.php
+++ b/tests/Foundation/Cloud/JsonFormatterTest.php
@@ -26,12 +26,12 @@ class JsonFormatterTest extends TestCase
     protected function createRecord(): LogRecord
     {
         return new LogRecord(
-            message: 'Test message',
-            level: Level::Info,
-            channel: 'test',
             datetime: new \DateTimeImmutable,
-            extra: [],
+            channel: 'test',
+            level: Level::Info,
+            message: 'Test message',
             context: [],
+            extra: [],
         );
     }
 
@@ -79,12 +79,12 @@ class JsonFormatterTest extends TestCase
         $app->instance('request', $request);
 
         $record = new LogRecord(
-            message: 'Test message',
-            level: Level::Warning,
-            channel: 'my-channel',
             datetime: new \DateTimeImmutable('2024-01-15 10:30:00'),
-            extra: ['extra_field' => 'extra_value'],
+            channel: 'my-channel',
+            level: Level::Warning,
+            message: 'Test message',
             context: ['context_field' => 'context_value'],
+            extra: ['extra_field' => 'extra_value'],
         );
 
         $formatter = new JsonFormatter;

--- a/tests/Foundation/LaravelCloudJsonFormatterTest.php
+++ b/tests/Foundation/LaravelCloudJsonFormatterTest.php
@@ -26,12 +26,12 @@ class LaravelCloudJsonFormatterTest extends TestCase
     protected function createRecord(): LogRecord
     {
         return new LogRecord(
-            message: 'Test message',
-            level: Level::Info,
-            channel: 'test',
             datetime: new \DateTimeImmutable,
-            extra: [],
+            channel: 'test',
+            level: Level::Info,
+            message: 'Test message',
             context: [],
+            extra: [],
         );
     }
 
@@ -79,12 +79,12 @@ class LaravelCloudJsonFormatterTest extends TestCase
         $app->instance('request', $request);
 
         $record = new LogRecord(
-            message: 'Test message',
-            level: Level::Warning,
-            channel: 'my-channel',
             datetime: new \DateTimeImmutable('2024-01-15 10:30:00'),
-            extra: ['extra_field' => 'extra_value'],
+            channel: 'my-channel',
+            level: Level::Warning,
+            message: 'Test message',
             context: ['context_field' => 'context_value'],
+            extra: ['extra_field' => 'extra_value'],
         );
 
         $formatter = new LaravelCloudJsonFormatter;

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -2313,7 +2313,7 @@ class RoutingRouteTest extends TestCase
 
         try {
             $route->run();
-        } catch (\Throwable $e) {
+        } catch (\Throwable) {
             //
         }
 


### PR DESCRIPTION
## Summary

This PR modernises the Rector setup and applies the updated ruleset across the codebase.

### Changes to `rector.php`

**Removed rule**

- **`StaticCallOnNonStaticToInstanceCallRector`** — deprecated in Rector and removed from both the skip list and imports.

**Skipped rule**

- **`DeprecatedAnnotationToDeprecatedAttributeRector`** — explicitly skipped. Converting `@deprecated` PHPDoc annotations to `#[\Deprecated]` attributes (PHP 8.4) causes PHP to emit real `E_DEPRECATED` notices at call-sites, which breaks the test suite under `--fail-on-deprecation`. Keeping it skipped leaves the existing annotations untouched.

### Codebase changes

`array_all()` and `array_any()` — native PHP 8.4 functions polyfilled via `symfony/polyfill-php84` — replace a number of `foreach` loops that were checking whether all or any elements of an array satisfy a condition. This produces more expressive, intention-revealing code with no behaviour changes.