### PR TITLE
[13.x] Simplify `FormRequest::safe`

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -347,9 +347,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
      */
     public function safe(?array $keys = null)
     {
-        return is_array($keys)
-            ? $this->validator->safe()->only($keys)
-            : $this->validator->safe();
+        return $this->validator->safe($keys);
     }
 
     /**


### PR DESCRIPTION
This one is just a tiny obvious cleanup in `FormRequest::safe()`.

It does not add or change any functionality. It just forwards the call to the underlying validator since `Validator::safe()` does exactly the same check.

Thanks!