### PR TITLE
[13.x] Prevent 500 with size rules when JSON decoding overflows to INF

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -2935,6 +2935,10 @@ trait ValidatesAttributes
     {
         $stringValue = (string) $value;
 
+        if ($value === 'INF' || $value === '-INF') {
+            throw new MathException('Unsupported numeric value.');
+        }
+
         if (! is_numeric($value) || ! Str::contains($stringValue, 'e', ignoreCase: true)) {
             return $value;
         }


### PR DESCRIPTION
Add an additional check for values that are decoded to INF and -INF and throw a MathException for values that would result in a unsuported comparaison.
