### PR TITLE
[13.x] `beforePushing` and `afterPushing` methods on `QueueFake` class

### DIFF
--- a/src/Illuminate/Support/Facades/Queue.php
+++ b/src/Illuminate/Support/Facades/Queue.php
@@ -80,6 +80,8 @@ use Illuminate\Support\Testing\Fakes\QueueFake;
  * @method static array pushedJobs()
  * @method static array rawPushes()
  * @method static \Illuminate\Support\Testing\Fakes\QueueFake serializeAndRestore(bool $serializeAndRestore = true)
+ * @method static \Illuminate\Support\Testing\Fakes\QueueFake beforePushing(callable $callback)
+ * @method static \Illuminate\Support\Testing\Fakes\QueueFake afterPushing(callable $callback)
  * @method static void releaseUniqueJobLocks()
  * @method static void clearReserved()
  *

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -133,32 +133,6 @@ class QueueFake extends QueueManager implements Fake, Queue
     }
 
     /**
-     * Register a callback to be invoked before pushing a job.
-     *
-     * @param  callable  $callback
-     * @return $this
-     */
-    public function beforePushing(callable $callback)
-    {
-        $this->beforePushingCallback = $callback;
-
-        return $this;
-    }
-
-    /**
-     * Register a callback to be invoked after pushing a job.
-     *
-     * @param  callable  $callback
-     * @return $this
-     */
-    public function afterPushing(callable $callback)
-    {
-        $this->afterPushingCallback = $callback;
-
-        return $this;
-    }
-
-    /**
      * Assert if a job was pushed based on a truth-test callback.
      *
      * @param  string|\Closure  $job
@@ -885,6 +859,32 @@ class QueueFake extends QueueManager implements Fake, Queue
     public function clearReserved()
     {
         $this->reserved = [];
+    }
+
+    /**
+     * Register a callback to be invoked before pushing a job.
+     *
+     * @param  callable  $callback
+     * @return $this
+     */
+    public function beforePushing(callable $callback)
+    {
+        $this->beforePushingCallback = $callback;
+
+        return $this;
+    }
+
+    /**
+     * Register a callback to be invoked after pushing a job.
+     *
+     * @param  callable  $callback
+     * @return $this
+     */
+    public function afterPushing(callable $callback)
+    {
+        $this->afterPushingCallback = $callback;
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -90,6 +90,20 @@ class QueueFake extends QueueManager implements Fake, Queue
     protected bool $serializeAndRestore = false;
 
     /**
+     * The callback that should be invoked before pushing a job.
+     *
+     * @var callable|null
+     */
+    protected $beforePushingCallback;
+
+    /**
+     * The callback that should be invoked after pushing a job.
+     *
+     * @var callable|null
+     */
+    protected $afterPushingCallback;
+
+    /**
      * Create a new fake queue instance.
      *
      * @param  \Illuminate\Contracts\Foundation\Application  $app
@@ -114,6 +128,32 @@ class QueueFake extends QueueManager implements Fake, Queue
     public function except($jobsToBeQueued)
     {
         $this->jobsToBeQueued = Collection::wrap($jobsToBeQueued)->merge($this->jobsToBeQueued);
+
+        return $this;
+    }
+
+    /**
+     * Register a callback to be invoked before pushing a job.
+     *
+     * @param  callable  $callback
+     * @return $this
+     */
+    public function beforePushing(callable $callback)
+    {
+        $this->beforePushingCallback = $callback;
+
+        return $this;
+    }
+
+    /**
+     * Register a callback to be invoked after pushing a job.
+     *
+     * @param  callable  $callback
+     * @return $this
+     */
+    public function afterPushing(callable $callback)
+    {
+        $this->afterPushingCallback = $callback;
 
         return $this;
     }
@@ -596,6 +636,10 @@ class QueueFake extends QueueManager implements Fake, Queue
     {
         $queue = enum_value($queue);
 
+        if ($this->beforePushingCallback) {
+            call_user_func($this->beforePushingCallback, $job, $data, $queue);
+        }
+
         if ($this->shouldFakeJob($job)) {
             if ($job instanceof Closure) {
                 $job = CallQueuedClosure::create($job);
@@ -614,6 +658,10 @@ class QueueFake extends QueueManager implements Fake, Queue
             is_object($job) && isset($job->connection)
                 ? $this->queue->connection($job->connection)->push($job, $data, $queue)
                 : $this->queue->push($job, $data, $queue);
+        }
+
+        if ($this->afterPushingCallback) {
+            call_user_func($this->afterPushingCallback, $job, $data, $queue);
         }
     }
 

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -90,18 +90,18 @@ class QueueFake extends QueueManager implements Fake, Queue
     protected bool $serializeAndRestore = false;
 
     /**
-     * The callback that should be invoked before pushing a job.
+     * The callbacks that should be invoked before pushing a job.
      *
-     * @var callable|null
+     * @var array<int, callable>
      */
-    protected $beforePushingCallback;
+    protected $beforePushingCallbacks = [];
 
     /**
-     * The callback that should be invoked after pushing a job.
+     * The callbacks that should be invoked after pushing a job.
      *
-     * @var callable|null
+     * @var array<int, callable>
      */
-    protected $afterPushingCallback;
+    protected $afterPushingCallbacks = [];
 
     /**
      * Create a new fake queue instance.
@@ -610,8 +610,8 @@ class QueueFake extends QueueManager implements Fake, Queue
     {
         $queue = enum_value($queue);
 
-        if ($this->beforePushingCallback) {
-            call_user_func($this->beforePushingCallback, $job, $data, $queue);
+        foreach ($this->beforePushingCallbacks as $callback) {
+            call_user_func($callback, $job, $data, $queue);
         }
 
         if ($this->shouldFakeJob($job)) {
@@ -634,8 +634,8 @@ class QueueFake extends QueueManager implements Fake, Queue
                 : $this->queue->push($job, $data, $queue);
         }
 
-        if ($this->afterPushingCallback) {
-            call_user_func($this->afterPushingCallback, $job, $data, $queue);
+        foreach ($this->afterPushingCallbacks as $callback) {
+            call_user_func($callback, $job, $data, $queue);
         }
     }
 
@@ -869,7 +869,7 @@ class QueueFake extends QueueManager implements Fake, Queue
      */
     public function beforePushing(callable $callback)
     {
-        $this->beforePushingCallback = $callback;
+        $this->beforePushingCallbacks[] = $callback;
 
         return $this;
     }
@@ -882,7 +882,7 @@ class QueueFake extends QueueManager implements Fake, Queue
      */
     public function afterPushing(callable $callback)
     {
-        $this->afterPushingCallback = $callback;
+        $this->afterPushingCallbacks[] = $callback;
 
         return $this;
     }

--- a/tests/Support/SupportTestingQueueFakeTest.php
+++ b/tests/Support/SupportTestingQueueFakeTest.php
@@ -435,15 +435,25 @@ class SupportTestingQueueFakeTest extends TestCase
             $steps[] = ['before', is_object($job) ? get_class($job) : $job, $data, $queue];
         });
 
+        $this->fake->beforePushing(function ($job, $data, $queue) use (&$steps) {
+            $steps[] = ['before again', is_object($job) ? get_class($job) : $job, $data, $queue];
+        });
+
         $this->fake->afterPushing(function ($job, $data, $queue) use (&$steps) {
             $steps[] = ['after', is_object($job) ? get_class($job) : $job, $data, $queue];
+        });
+
+        $this->fake->afterPushing(function ($job, $data, $queue) use (&$steps) {
+            $steps[] = ['after again', is_object($job) ? get_class($job) : $job, $data, $queue];
         });
 
         $this->fake->push($this->job, ['foo' => 'bar'], 'redis');
 
         $this->assertSame([
             ['before', JobStub::class, ['foo' => 'bar'], 'redis'],
+            ['before again', JobStub::class, ['foo' => 'bar'], 'redis'],
             ['after', JobStub::class, ['foo' => 'bar'], 'redis'],
+            ['after again', JobStub::class, ['foo' => 'bar'], 'redis'],
         ], $steps);
     }
 
@@ -462,15 +472,23 @@ class SupportTestingQueueFakeTest extends TestCase
             ->beforePushing(function ($job, $data, $queue) use (&$steps) {
                 $steps[] = ['before', is_object($job) ? get_class($job) : $job, $data, $queue];
             })
+            ->beforePushing(function ($job, $data, $queue) use (&$steps) {
+                $steps[] = ['before again', is_object($job) ? get_class($job) : $job, $data, $queue];
+            })
             ->afterPushing(function ($job, $data, $queue) use (&$steps) {
                 $steps[] = ['after', is_object($job) ? get_class($job) : $job, $data, $queue];
+            })
+            ->afterPushing(function ($job, $data, $queue) use (&$steps) {
+                $steps[] = ['after again', is_object($job) ? get_class($job) : $job, $data, $queue];
             });
 
         $fake->push($job, ['foo' => 'bar'], 'redis');
 
         $this->assertSame([
             ['before', JobStub::class, ['foo' => 'bar'], 'redis'],
+            ['before again', JobStub::class, ['foo' => 'bar'], 'redis'],
             ['after', JobStub::class, ['foo' => 'bar'], 'redis'],
+            ['after again', JobStub::class, ['foo' => 'bar'], 'redis'],
         ], $steps);
     }
 

--- a/tests/Support/SupportTestingQueueFakeTest.php
+++ b/tests/Support/SupportTestingQueueFakeTest.php
@@ -427,6 +427,53 @@ class SupportTestingQueueFakeTest extends TestCase
         );
     }
 
+    public function testItCanInvokeCallbacksBeforeAndAfterPushingFakedJobs()
+    {
+        $steps = [];
+
+        $this->fake->beforePushing(function ($job, $data, $queue) use (&$steps) {
+            $steps[] = ['before', is_object($job) ? get_class($job) : $job, $data, $queue];
+        });
+
+        $this->fake->afterPushing(function ($job, $data, $queue) use (&$steps) {
+            $steps[] = ['after', is_object($job) ? get_class($job) : $job, $data, $queue];
+        });
+
+        $this->fake->push($this->job, ['foo' => 'bar'], 'redis');
+
+        $this->assertSame([
+            ['before', JobStub::class, ['foo' => 'bar'], 'redis'],
+            ['after', JobStub::class, ['foo' => 'bar'], 'redis'],
+        ], $steps);
+    }
+
+    public function testItCanInvokeCallbacksBeforeAndAfterPushingDispatchedJobs()
+    {
+        $job = new JobStub;
+        $steps = [];
+
+        $manager = m::mock(QueueManager::class);
+        $manager->shouldReceive('push')->once()->withArgs(function ($passedJob, $passedData, $passedQueue) use ($job) {
+            return $passedJob === $job && $passedData === ['foo' => 'bar'] && $passedQueue === 'redis';
+        });
+
+        $fake = (new QueueFake(new Application, [], $manager))
+            ->except(JobStub::class)
+            ->beforePushing(function ($job, $data, $queue) use (&$steps) {
+                $steps[] = ['before', is_object($job) ? get_class($job) : $job, $data, $queue];
+            })
+            ->afterPushing(function ($job, $data, $queue) use (&$steps) {
+                $steps[] = ['after', is_object($job) ? get_class($job) : $job, $data, $queue];
+            });
+
+        $fake->push($job, ['foo' => 'bar'], 'redis');
+
+        $this->assertSame([
+            ['before', JobStub::class, ['foo' => 'bar'], 'redis'],
+            ['after', JobStub::class, ['foo' => 'bar'], 'redis'],
+        ], $steps);
+    }
+
     public function testItCanFakePushedJobsWithClassAndPayload()
     {
         $fake = new QueueFake(new Application, ['JobStub']);


### PR DESCRIPTION
In a test, I wanted to manipulate the current time after a specific job was dispatched. Currently, to do that, you have to extend the `QueueFake` class and override the `push()` method.
```php
// the job we want to test

class UpdateAllUsersJob implements ShouldQueue
{
	public function __construct(
        public ?int $lastProcessedUserId = null,
    ) {
    }

	public function handle() : void
    {
        User::query()
            ->when($this->lastProcessedUserId)->where('id', '>', $this->lastProcessedUserId)
            ->lazyById()
            ->takeUntilTimeout(now()->addSeconds(55), function (?User $user) {
				// This is the part we want to test:
				// When 55 seconds have passed since the job started
				// then the job should stop, and it should append a new instance of itself to its chain
                if ($user !== null) {
                    $this->appendToChain(new static($user->id));
                }
            })
            ->each(function (User $user) {
                UpdateSpecificUserJob::dispatch($user);
            });
    }
}
```

```php
// the test

$firstUser = User::factory()->create();
$secondUser = User::factory()->create();
$thirdUser = User::factory()->create();

Queue::swap(
    (new class(Queue::getFacadeApplication(), [], Queue::getFacadeRoot(), $secondUser) extends QueueFake {
        public User $secondUser;

        public function __construct($app, $jobsToFake, $queue, User $secondUser)
        {
            parent::__construct($app, $jobsToFake, $queue);

            $this->secondUser = $secondUser;
        }

        public function push($job, $data = '', $queue = null)
        {
            parent::push($job, $data, $queue);

			//To test the usage of 'takeUntilTimeout' in the job, we need to override
			// the push method and add the following code here: 
            if ($job instanceof UpdateSpecificUserJob && $job->user->is($this->secondUser)) {
                Carbon::setTestNow(now()->addSeconds(55));
            }
        }
    })
);

($job = new UpdateAllUsersJob())->handle();

$job->assertHasChain([
    new UpdateSpecificUserJob($secondUser->id),
]);

Queue::assertPushedTimes(UpdateSpecificUserJob::class, 2)
Queue::assertPushed(fn (UpdateSpecificUserJob $job) => $job->user->is($firstUser));
Queue::assertPushed(fn (UpdateSpecificUserJob $job) => $job->user->is($secondUser));
```

That is a lot of code to do that. With the `beforePushing` or `afterPushing` method, that becomes a lot easier:

```php
// the test after using the new 'afterPushing' method

$firstUser = User::factory()->create();
$secondUser = User::factory()->create();
$thirdUser = User::factory()->create();

Queue::fake()->afterPushing(function (UpdateSpecificUserJob $job) use ($secondUser) {
    if ($job->user->is($secondUser)) {
        Carbon::setTestNow(now()->addSeconds(55));
    }
});

($job = new UpdateAllUsersJob())->handle();

$job->assertHasChain([
    new UpdateSpecificUserJob($secondUser->id),
]);

Queue::assertPushedTimes(UpdateSpecificUserJob::class, 2)
Queue::assertPushed(fn (UpdateSpecificUserJob $job) => $job->user->is($firstUser));
Queue::assertPushed(fn (UpdateSpecificUserJob $job) => $job->user->is($secondUser));
```