### PR TITLE
Add whereIntersects query builder methods

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1722,6 +1722,72 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Add a "where intersects" statement to the query.
+     *
+     * @param  array{\Illuminate\Contracts\Database\Query\Expression|string, \Illuminate\Contracts\Database\Query\Expression|string}  $columns
+     * @param  array{mixed, mixed}|\DatePeriod  $values
+     * @return $this
+     */
+    public function whereIntersects(array $columns, array|DatePeriod $values, bool $inclusive = true, string $boolean = 'and', bool $not = false)
+    {
+        if ($values instanceof DatePeriod) {
+            $values = $this->resolveDatePeriodBounds($values);
+        }
+
+        $periodStart = array_first($values);
+        $periodEnd = array_last($values);
+
+        return $this->whereNested(function ($query) use ($columns, $periodStart, $periodEnd, $inclusive, $not) {
+            $startColumn = array_first($columns);
+            $endColumn = array_last($columns);
+
+            if ($not) {
+                $query->where($startColumn, $inclusive ? '>' : '>=', $periodEnd)
+                    ->orWhere($endColumn, $inclusive ? '<' : '<=', $periodStart);
+            } else {
+                $query->where($startColumn, $inclusive ? '<=' : '<', $periodEnd)
+                    ->where($endColumn, $inclusive ? '>=' : '>', $periodStart);
+            }
+        }, $boolean);
+    }
+
+    /**
+     * Add an "or where intersects" statement to the query.
+     *
+     * @param  array{\Illuminate\Contracts\Database\Query\Expression|string, \Illuminate\Contracts\Database\Query\Expression|string}  $columns
+     * @param  array{mixed, mixed}|\DatePeriod  $values
+     * @return $this
+     */
+    public function orWhereIntersects(array $columns, array|DatePeriod $values, bool $inclusive = true)
+    {
+        return $this->whereIntersects($columns, $values, $inclusive, 'or');
+    }
+
+    /**
+     * Add a "where not intersects" statement to the query.
+     *
+     * @param  array{\Illuminate\Contracts\Database\Query\Expression|string, \Illuminate\Contracts\Database\Query\Expression|string}  $columns
+     * @param  array{mixed, mixed}|\DatePeriod  $values
+     * @return $this
+     */
+    public function whereNotIntersects(array $columns, array|DatePeriod $values, bool $inclusive = true, string $boolean = 'and')
+    {
+        return $this->whereIntersects($columns, $values, $inclusive, $boolean, true);
+    }
+
+    /**
+     * Add an "or where not intersects" statement to the query.
+     *
+     * @param  array{\Illuminate\Contracts\Database\Query\Expression|string, \Illuminate\Contracts\Database\Query\Expression|string}  $columns
+     * @param  array{mixed, mixed}|\DatePeriod  $values
+     * @return $this
+     */
+    public function orWhereNotIntersects(array $columns, array|DatePeriod $values, bool $inclusive = true)
+    {
+        return $this->whereNotIntersects($columns, $values, $inclusive, 'or');
+    }
+
+    /**
      * Add a "where between columns" statement using a value to the query.
      *
      * @param  mixed  $value

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1734,12 +1734,10 @@ class Builder implements BuilderContract
             $values = $this->resolveDatePeriodBounds($values);
         }
 
-        $periodStart = array_first($values);
-        $periodEnd = array_last($values);
+        [$periodStart, $periodEnd] = $values;
 
         return $this->whereNested(function ($query) use ($columns, $periodStart, $periodEnd, $inclusive, $not) {
-            $startColumn = array_first($columns);
-            $endColumn = array_last($columns);
+            [$startColumn, $endColumn] = $columns;
 
             if ($not) {
                 $query->where($startColumn, $inclusive ? '>' : '>=', $periodEnd)

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1501,6 +1501,62 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 2], $builder->getBindings());
     }
 
+    public function testWhereIntersects()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereIntersects(['started_at', 'ended_at'], ['2020-01-01 00:00:00', '2020-01-31 23:59:59']);
+        $this->assertSame('select * from "users" where ("started_at" <= ? and "ended_at" >= ?)', $builder->toSql());
+        $this->assertEquals([0 => '2020-01-31 23:59:59', 1 => '2020-01-01 00:00:00'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereIntersects(['started_at', 'ended_at'], ['2020-01-01 00:00:00', '2020-01-31 23:59:59'], inclusive: false);
+        $this->assertSame('select * from "users" where ("started_at" < ? and "ended_at" > ?)', $builder->toSql());
+        $this->assertEquals([0 => '2020-01-31 23:59:59', 1 => '2020-01-01 00:00:00'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereIntersects(['started_at', 'ended_at'], [new Raw("'2020-01-01 00:00:00'"), new Raw("'2020-01-31 23:59:59'")]);
+        $this->assertSame('select * from "users" where ("started_at" <= \'2020-01-31 23:59:59\' and "ended_at" >= \'2020-01-01 00:00:00\')', $builder->toSql());
+        $this->assertEquals([], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereIntersects(['started_at', 'ended_at'], new DatePeriod(
+            new DateTime('2020-01-01 00:00:00'),
+            new DateInterval('P30D'),
+            new DateTime('2020-01-31 00:00:00'),
+        ));
+        $this->assertSame('select * from "users" where ("started_at" <= ? and "ended_at" >= ?)', $builder->toSql());
+        $this->assertEquals([0 => new DateTime('2020-01-31 00:00:00'), 1 => new DateTime('2020-01-01 00:00:00')], $builder->getBindings());
+    }
+
+    public function testOrWhereIntersects()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('id', 2)->orWhereIntersects(['started_at', 'ended_at'], ['2020-01-01 00:00:00', '2020-01-31 23:59:59']);
+        $this->assertSame('select * from "users" where "id" = ? or ("started_at" <= ? and "ended_at" >= ?)', $builder->toSql());
+        $this->assertEquals([0 => 2, 1 => '2020-01-31 23:59:59', 2 => '2020-01-01 00:00:00'], $builder->getBindings());
+    }
+
+    public function testWhereNotIntersects()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereNotIntersects(['started_at', 'ended_at'], ['2020-01-01 00:00:00', '2020-01-31 23:59:59']);
+        $this->assertSame('select * from "users" where ("started_at" > ? or "ended_at" < ?)', $builder->toSql());
+        $this->assertEquals([0 => '2020-01-31 23:59:59', 1 => '2020-01-01 00:00:00'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereNotIntersects(['started_at', 'ended_at'], ['2020-01-01 00:00:00', '2020-01-31 23:59:59'], inclusive: false);
+        $this->assertSame('select * from "users" where ("started_at" >= ? or "ended_at" <= ?)', $builder->toSql());
+        $this->assertEquals([0 => '2020-01-31 23:59:59', 1 => '2020-01-01 00:00:00'], $builder->getBindings());
+    }
+
+    public function testOrWhereNotIntersects()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('id', 2)->orWhereNotIntersects(['started_at', 'ended_at'], ['2020-01-01 00:00:00', '2020-01-31 23:59:59']);
+        $this->assertSame('select * from "users" where "id" = ? or ("started_at" > ? or "ended_at" < ?)', $builder->toSql());
+        $this->assertEquals([0 => 2, 1 => '2020-01-31 23:59:59', 2 => '2020-01-01 00:00:00'], $builder->getBindings());
+    }
+
     public function testWhereValueBetween()
     {
         $builder = $this->getBuilder();

--- a/tests/Integration/Database/QueryBuilderTest.php
+++ b/tests/Integration/Database/QueryBuilderTest.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Tests\Integration\Database;
 
+use DateInterval;
+use DatePeriod;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\MultipleRecordsFoundException;
 use Illuminate\Database\RecordsNotFoundException;
@@ -301,6 +303,50 @@ class QueryBuilderTest extends DatabaseTestCase
         })->get();
 
         $this->assertCount(2, $results);
+    }
+
+    public function testWhereIntersects()
+    {
+        Schema::create('periods', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->date('starts_on');
+            $table->date('ends_on');
+            $table->dateTime('starts_at');
+            $table->dateTime('ends_at');
+        });
+
+        DB::table('periods')->insert([
+            ['name' => 'before', 'starts_on' => '2020-01-01', 'ends_on' => '2020-01-09', 'starts_at' => '2020-01-10 08:00:00', 'ends_at' => '2020-01-10 09:59:59'],
+            ['name' => 'touches-start', 'starts_on' => '2020-01-01', 'ends_on' => '2020-01-10', 'starts_at' => '2020-01-10 09:00:00', 'ends_at' => '2020-01-10 10:00:00'],
+            ['name' => 'inside', 'starts_on' => '2020-01-12', 'ends_on' => '2020-01-18', 'starts_at' => '2020-01-10 10:30:00', 'ends_at' => '2020-01-10 11:00:00'],
+            ['name' => 'touches-end', 'starts_on' => '2020-01-20', 'ends_on' => '2020-01-25', 'starts_at' => '2020-01-10 12:00:00', 'ends_at' => '2020-01-10 13:00:00'],
+            ['name' => 'after', 'starts_on' => '2020-01-21', 'ends_on' => '2020-01-31', 'starts_at' => '2020-01-10 12:00:01', 'ends_at' => '2020-01-10 13:00:00'],
+        ]);
+
+        $this->assertSame(
+            ['touches-start', 'inside', 'touches-end'],
+            DB::table('periods')->whereIntersects(['starts_on', 'ends_on'], ['2020-01-10', '2020-01-20'])->orderBy('id')->pluck('name')->all()
+        );
+
+        $this->assertSame(
+            ['inside'],
+            DB::table('periods')->whereIntersects(['starts_on', 'ends_on'], ['2020-01-10', '2020-01-20'], inclusive: false)->orderBy('id')->pluck('name')->all()
+        );
+
+        $this->assertSame(
+            ['before', 'after'],
+            DB::table('periods')->whereNotIntersects(['starts_on', 'ends_on'], ['2020-01-10', '2020-01-20'])->orderBy('id')->pluck('name')->all()
+        );
+
+        $this->assertSame(
+            ['touches-start', 'inside', 'touches-end'],
+            DB::table('periods')->whereIntersects(['starts_at', 'ends_at'], new DatePeriod(
+                new Carbon('2020-01-10 10:00:00'),
+                new DateInterval('PT1H'),
+                new Carbon('2020-01-10 12:00:00'),
+            ))->orderBy('id')->pluck('name')->all()
+        );
     }
 
     public function testWhereDate()


### PR DESCRIPTION
This PR adds `whereIntersects`, `orWhereIntersects`, `whereNotIntersects`, and `orWhereNotIntersects`, which query records where a stored date or date-time period intersects a given period.

The methods accept a pair of columns representing the stored period, plus either a two-item array or `DatePeriod` representing the period to compare against:

```php
DB::table('reservations')
    ->whereIntersects(['starts_at', 'ends_at'], ['2026-01-01 15:00:00', '2026-01-07 11:00:00'])
    ->get();
```

By default, periods that touch at their boundary values are considered intersecting. Passing `inclusive: false` requires a strict overlap:

```php
DB::table('reservations')
    ->whereIntersects(['starts_at', 'ends_at'], ['2026-01-01 15:00:00', '2026-01-07 11:00:00'], inclusive: false)
    ->get();
```

The negative variants return records whose stored period does not intersect the given period.

Tests cover SQL generation, binding order, inclusive and exclusive comparisons, raw expressions, `DatePeriod` inputs, and SQLite integration behavior for overlapping, boundary-touching, and non-overlapping periods.

Related docs PR: https://github.com/laravel/docs/pull/11262
