### PR TITLE
[13.x] Add `isJson` and `transferTime` methods to HTTP client response

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -125,6 +125,16 @@ class Response implements ArrayAccess, Stringable
     }
 
     /**
+     * Determine if the response is JSON.
+     *
+     * @return bool
+     */
+    public function isJson()
+    {
+        return str_contains($this->header('Content-Type'), 'json');
+    }
+
+    /**
      * Get the decoded JSON body of the response as an object.
      *
      * @param  int-mask<JSON_BIGINT_AS_STRING, JSON_INVALID_UTF8_IGNORE, JSON_INVALID_UTF8_SUBSTITUTE, JSON_OBJECT_AS_ARRAY, JSON_THROW_ON_ERROR>|null  $flags
@@ -305,6 +315,16 @@ class Response implements ArrayAccess, Stringable
     public function handlerStats()
     {
         return $this->transferStats?->getHandlerStats() ?? [];
+    }
+
+    /**
+     * Get the transfer time of the response in seconds.
+     *
+     * @return float|null
+     */
+    public function transferTime()
+    {
+        return $this->transferStats?->getTransferTime();
     }
 
     /**

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -393,6 +393,42 @@ class HttpClientTest extends TestCase
         $this->assertSame(['foo' => 'bar'], $response['result']);
     }
 
+    public function testResponseIsJson()
+    {
+        $this->factory->fake([
+            '*' => $this->factory::response(['foo' => 'bar'], 200, ['Content-Type' => 'application/json']),
+        ]);
+
+        $this->assertTrue($this->factory->get('http://foo.com/api')->isJson());
+    }
+
+    public function testResponseIsJsonWithCharset()
+    {
+        $this->factory->fake([
+            '*' => $this->factory::response(['foo' => 'bar'], 200, ['Content-Type' => 'application/json; charset=utf-8']),
+        ]);
+
+        $this->assertTrue($this->factory->get('http://foo.com/api')->isJson());
+    }
+
+    public function testResponseIsNotJson()
+    {
+        $this->factory->fake([
+            '*' => $this->factory::response('foo', 200, ['Content-Type' => 'text/plain']),
+        ]);
+
+        $this->assertFalse($this->factory->get('http://foo.com/api')->isJson());
+    }
+
+    public function testResponseIsNotJsonWithoutContentType()
+    {
+        $this->factory->fake([
+            '*' => $this->factory::response('foo'),
+        ]);
+
+        $this->assertFalse($this->factory->get('http://foo.com/api')->isJson());
+    }
+
     public function testResponseObjectAsArray()
     {
         $this->factory->fake([
@@ -2420,6 +2456,28 @@ class HttpClientTest extends TestCase
         $effectiveUri = $this->factory->get('https://example.com')->effectiveUri();
 
         $this->assertSame('https://example.com', (string) $effectiveUri);
+    }
+
+    public function testTransferTimeCanBeRetrieved()
+    {
+        $response = new Response(new Psr7Response());
+        $response->transferStats = new TransferStats(new GuzzleRequest('GET', 'http://example.com'), null, 1.234);
+
+        $this->assertSame(1.234, $response->transferTime());
+    }
+
+    public function testTransferTimeIsNullWhenNoTransferStatsAreAvailable()
+    {
+        $response = new Response(new Psr7Response());
+
+        $this->assertNull($response->transferTime());
+    }
+
+    public function testTransferTimeIsNullWhenFakingTheRequest()
+    {
+        $this->factory->fake(['https://example.com' => ['world' => 'Hello world']]);
+
+        $this->assertNull($this->factory->get('https://example.com')->transferTime());
     }
 
     public function testClonedClientsWorkSuccessfullyWithTheRequestObject()


### PR DESCRIPTION
This PR adds two small, fully backward-compatible accessor methods to the `Illuminate\Http\Client\Response` class.                                                                                                                                                                
                                                                                                                                                                                                                                                                                    
### `isJson()`
Determines whether the response carries a JSON content type, mirroring the existing `Request::isJson()` helper.                                                                                                                                                                   
                                                                                                                                                                                                                                                                                    
  ```php                                                                                                                                                                                                                                                                            
  if ($response->isJson()) {                                                                                                                                                                                                                                                        
      return $response->json();                                                                                                                                                                                                                                                     
  }                                                                                                                                                                                                                                                                                 
  ```                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                    
  Today, developers must manually write `str_contains($response->header('Content-Type'), 'json')` before calling `json()` / `collect()`. The `Request` object already exposes `isJson()`, `isForm()`, and `isMultipart()`, but `Response` had no equivalent — this fills that       
  symmetry gap and removes the boilerplate. It safely returns `false` when no `Content-Type` header is present.                                                                                                                                                                     
                                                                                                                                                                                                                                                                                    
  ### `transferTime()`                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                    
  Returns the transfer time of the response in seconds, delegating to Guzzle's `TransferStats::getTransferTime()`:                                                                                                                                                                  
                                                                                                                                                                                                                                                                              
  ```php                                                                                                                                                                                                                                                                            
  Log::info('Upstream API call', ['seconds' => $response->transferTime()]);                                                                                                                                                                                                         
  ```                                                                      
 The `Response` class already exposes `effectiveUri()` and `handlerStats()` over its `transferStats` property, but had no accessor for the transfer duration — a commonly requested value for logging and slow-response alerting. The method name follows the established          
  `effectiveUri` / `handlerStats` convention (wrapping Guzzle's `getEffectiveUri` / `getHandlerStats`). It returns `null` when transfer stats are unavailable (e.g. when responses are faked), consistent with `effectiveUri()`.                                                    
                                                                                                                                                                                                                                                                                    
  ### Why this doesn't break existing features                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                    
  - Both methods are **pure additions** — no existing signatures or behavior change.                                                                                                                                                                                                
  - The names do not collide with any method on the underlying PSR response (they are not proxied via `__call`).                                                                                                                                                                    
  - Fully backward compatible: neither method existed before, so no caller is affected.                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                    
  ### Tests                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                    
  Added 7 tests covering the happy path and edge cases:                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                    
  - `testResponseIsJson`, `testResponseIsJsonWithCharset`, `testResponseIsNotJson`, `testResponseIsNotJsonWithoutContentType`                                                                                                                                                       
  - `testTransferTimeCanBeRetrieved`, `testTransferTimeIsNullWhenNoTransferStatsAreAvailable`, `testTransferTimeIsNullWhenFakingTheRequest`                                                                                                                                         
                                                                                                                                                                                                                                                                                 