### PR TITLE
[13.x] Add `withProxy` method to the HTTP client

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -26,6 +26,7 @@ use Illuminate\Support\Str;
 use Illuminate\Support\Stringable;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
+use Illuminate\Support\Uri;
 use InvalidArgumentException;
 use JsonSerializable;
 use Psr\Http\Message\MessageInterface;
@@ -661,11 +662,15 @@ class PendingRequest
     /**
      * Specify the proxy that the request should be sent through.
      *
-     * @param  string|array  $proxy
+     * @param  \Illuminate\Support\Uri|string|array  $proxy
      * @return $this
      */
-    public function withProxy(string|array $proxy)
+    public function withProxy(Uri|string|array $proxy)
     {
+        if ($proxy instanceof Uri) {
+            $proxy = (string) $proxy;
+        }
+
         $this->options['proxy'] = $proxy;
 
         return $this;

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -659,6 +659,19 @@ class PendingRequest
     }
 
     /**
+     * Specify the proxy that the request should be sent through.
+     *
+     * @param  string|array  $proxy
+     * @return $this
+     */
+    public function withProxy(string|array $proxy)
+    {
+        $this->options['proxy'] = $proxy;
+
+        return $this;
+    }
+
+    /**
      * Specify the number of times the request should be attempted.
      *
      * @param  array|int  $times

--- a/src/Illuminate/Support/Facades/Http.php
+++ b/src/Illuminate/Support/Facades/Http.php
@@ -60,6 +60,7 @@ use Illuminate\Http\Client\Factory;
  * @method static \Illuminate\Http\Client\PendingRequest sink(string|resource $to)
  * @method static \Illuminate\Http\Client\PendingRequest timeout(int|float $seconds)
  * @method static \Illuminate\Http\Client\PendingRequest connectTimeout(int|float $seconds)
+ * @method static \Illuminate\Http\Client\PendingRequest withProxy(string|array $proxy)
  * @method static \Illuminate\Http\Client\PendingRequest retry(array|int $times, \Closure|int $sleepMilliseconds = 0, callable|null $when = null, bool $throw = true)
  * @method static \Illuminate\Http\Client\PendingRequest withOptions(array $options)
  * @method static \Illuminate\Http\Client\PendingRequest withMiddleware(callable $middleware)

--- a/src/Illuminate/Support/Facades/Http.php
+++ b/src/Illuminate/Support/Facades/Http.php
@@ -60,7 +60,7 @@ use Illuminate\Http\Client\Factory;
  * @method static \Illuminate\Http\Client\PendingRequest sink(string|resource $to)
  * @method static \Illuminate\Http\Client\PendingRequest timeout(int|float $seconds)
  * @method static \Illuminate\Http\Client\PendingRequest connectTimeout(int|float $seconds)
- * @method static \Illuminate\Http\Client\PendingRequest withProxy(string|array $proxy)
+ * @method static \Illuminate\Http\Client\PendingRequest withProxy(\Illuminate\Support\Uri|string|array $proxy)
  * @method static \Illuminate\Http\Client\PendingRequest retry(array|int $times, \Closure|int $sleepMilliseconds = 0, callable|null $when = null, bool $throw = true)
  * @method static \Illuminate\Http\Client\PendingRequest withOptions(array $options)
  * @method static \Illuminate\Http\Client\PendingRequest withMiddleware(callable $middleware)

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -4102,6 +4102,39 @@ class HttpClientTest extends TestCase
         $this->assertSame(['connect_timeout' => 10, 'crypto_method' => 33, 'http_errors' => false, 'timeout' => 30, 'allow_redirects' => ['max' => 10]], $request->getOptions());
     }
 
+    public function testItCanSetAStringProxy(): void
+    {
+        $request = new PendingRequest($this->factory);
+
+        $request = $request->withProxy('http://proxy.example.com:8080');
+
+        $this->assertSame('http://proxy.example.com:8080', Arr::get($request->getOptions(), 'proxy'));
+    }
+
+    public function testItCanSetAnArrayProxy(): void
+    {
+        $request = new PendingRequest($this->factory);
+
+        $request = $request->withProxy([
+            'http' => 'http://http-proxy.example.com:8080',
+            'https' => 'http://https-proxy.example.com:8080',
+            'no' => ['.local', '127.0.0.1'],
+        ]);
+
+        $this->assertSame([
+            'http' => 'http://http-proxy.example.com:8080',
+            'https' => 'http://https-proxy.example.com:8080',
+            'no' => ['.local', '127.0.0.1'],
+        ], Arr::get($request->getOptions(), 'proxy'));
+    }
+
+    public function testProxyIsNotSetByDefault(): void
+    {
+        $request = new PendingRequest($this->factory);
+
+        $this->assertNull(Arr::get($request->getOptions(), 'proxy'));
+    }
+
     public function testPreventDuplicatedContentType(): void
     {
         $client = $this->factory->asJson();

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -4135,6 +4135,15 @@ class HttpClientTest extends TestCase
         $this->assertNull(Arr::get($request->getOptions(), 'proxy'));
     }
 
+    public function testItCanSetAUriProxy(): void
+    {
+        $request = new PendingRequest($this->factory);
+
+        $request = $request->withProxy(Uri::of('http://proxy.example.com:8080'));
+
+        $this->assertSame('http://proxy.example.com:8080', Arr::get($request->getOptions(), 'proxy'));
+    }
+
     public function testPreventDuplicatedContentType(): void
     {
         $client = $this->factory->asJson();


### PR DESCRIPTION
  This PR adds a `withProxy` method to `Illuminate\Http\Client\PendingRequest` that sends requests through the given proxy, wrapping Guzzle's `proxy` request option.                                                                                                               
                                                                                                                                                                                                                                                                                    
  ### Why                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                    
  Routing requests through a proxy is a routine need — corporate network egress, scraping, and geographic testing all require it — but today the only way to configure it is the lower-level `withOptions(['proxy' => ...])`, which forces every caller to know the Guzzle option   
  key. The new helper mirrors the ergonomics of the existing `withCookies`, `withToken`, `withUserAgent`, `timeout`, and `connectTimeout` methods:                                                                                                                                  
                                                                                                                                                                                                                                                                                    
  ```php                                                                                                                                                                                                                                                                            
  Http::withProxy('http://proxy.example.com:8080')->get('https://laravel.com');                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                    
  Http::withProxy([                                                                                                                                                                                                                                                                 
      'http' => 'http://http-proxy.example.com:8080',                                                                                                                                                                                                                               
      'https' => 'http://https-proxy.example.com:8080',                                                                                                                                                                                                                             
      'no' => ['.local', '127.0.0.1'],                                                                                                                                                                                                                                              
  ])->get('https://laravel.com');                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                    
  // Or a Uri instance, e.g. when the proxy URL is built fluently:                                                                                                                                                                                                                  
  Http::withProxy(Uri::of('http://proxy.example.com:8080'))->get('https://laravel.com');                                                                                                                                                                                            
  ```                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                    
  ### Behavior                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                    
  It accepts a single proxy string (applied to all schemes), an array keyed by scheme, or an `Illuminate\Support\Uri` instance — exactly matching what Guzzle's `proxy` option supports, including SOCKS proxies via a `socks5://` scheme. When a `Uri` is given it is cast to a    
  string before being stored on `options['proxy']`, since Guzzle only accepts a `string|array` there. The value is stored directly on `options['proxy']`, consistent with `timeout` and `connectTimeout`, so it does not need to be registered as a mergeable option.               
                                                                                                                                                                                                                                                                                    
  ### Why this doesn't break existing features                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                    
  - It is a **pure, backward-compatible addition** — no existing signature or behavior changes.                                                                                                                                                                                     
  - It only sets a Guzzle option key that the client already passes through; no new request-building logic.                                                                                                                                                                         
  - `withOptions(['proxy' => ...])` continues to work exactly as before.                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                    
  ### Tests                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                    
  Added 4 tests covering the string proxy form, the per-scheme array form (including the `no` exclusion list), the `Uri` instance form, and the default (no proxy) state. The full HTTP client test suite passes, Pint passes, and no new PHPStan errors are introduced.