### PR TITLE
[13.x] Fix size rules crashing on non-finite float values

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -2792,6 +2792,10 @@ trait ValidatesAttributes
         // is the size. If it is a file, we take kilobytes, and for a string the
         // entire length of the string will be considered the attribute size.
         if (is_numeric($value) && $hasNumeric) {
+            if (is_float($value) && ! is_finite($value)) {
+                throw new MathException('The value is not a finite number.');
+            }
+
             return (string) $this->ensureExponentWithinAllowedRange($attribute, $this->trim($value));
         } elseif (is_array($value)) {
             return count($value);

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -10147,6 +10147,30 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($validator->passes());
     }
 
+    #[DataProvider('nonFiniteFloatSizeRules')]
+    public function testItFailsSizeRulesForNonFiniteFloatsWithoutThrowing($value, $rule)
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $validator = new Validator($trans, ['foo' => $value], ['foo' => ['numeric', $rule]]);
+
+        $this->assertFalse($validator->passes());
+    }
+
+    public static function nonFiniteFloatSizeRules()
+    {
+        $rules = ['min:3', 'max:3', 'size:3', 'between:1,5', 'gt:0', 'lt:10', 'gte:0', 'lte:10'];
+
+        $cases = [];
+
+        foreach (['INF' => INF, '-INF' => -INF, 'NAN' => NAN] as $name => $value) {
+            foreach ($rules as $rule) {
+                $cases[$name.' '.$rule] = [$value, $rule];
+            }
+        }
+
+        return $cases;
+    }
+
     public function testMessagesDefaultWhenUsingSizeSpecificCustomMessages()
     {
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
Fixes #60681.

When a numeric attribute is a non-finite float — `INF`, `-INF` or `NAN`, such as the value PHP produces when decoding an overflowing number like `1e500` — the size comparison rules (`size`, `min`, `max`, `between`, `gt`, `lt`, `gte`, `lte`) let the value flow into `BigNumber::of()` as the string `"INF"` / `"NAN"`. `brick/math` then throws an uncaught `NumberFormatException`, so the request fails with an HTTP 500 instead of a clean validation failure.

## Reproduction

```php
use Illuminate\Support\Facades\Validator;

Validator::make(['n' => 1e500], ['n' => 'numeric|min:0'])->passes();
// Before: Brick\Math\Exception\NumberFormatException -> HTTP 500
// After:  false (validation fails cleanly)
```

## Fix

`getSize()` now detects non-finite floats and throws the framework's own `Illuminate\Support\Exceptions\MathException`, which every affected size rule already catches — so validation fails gracefully. This mirrors the existing out-of-range scientific-notation exponent guard directly below it.

The guard lives in the numeric branch of `getSize()` only, so finite numbers, strings, arrays and files are untouched — there is no behavioral change for any valid input.

## Tests

Added a data-provider test covering `INF`, `-INF` and `NAN` across all eight size rules, asserting validation fails without throwing.
