### PR TITLE
[13.x] Sync more getter return types with their property generics

### DIFF
--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -602,7 +602,7 @@ class Kernel implements KernelContract
     /**
      * Get the application's route middleware groups.
      *
-     * @return array
+     * @return array<string, array<int, class-string|string>>
      */
     public function getMiddlewareGroups()
     {

--- a/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
@@ -90,7 +90,7 @@ class EventServiceProvider extends ServiceProvider
     /**
      * Get the events and handlers.
      *
-     * @return array
+     * @return array<string, array<int, string>>
      */
     public function listens()
     {


### PR DESCRIPTION
Syncs two getters' bare `@return array` to the generic already declared on the property each returns: `Kernel::getMiddlewareGroups()` - `array<string, array<int, class-string|string>>` and `EventServiceProvider::listens()` - `array<string, array<int, string>>`.                                                                                                                                                               

Docblock-only, no behavior change.         

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
