### PR TITLE
[13.x] Ability to set session prefix for Redis

### DIFF
--- a/src/Illuminate/Session/SessionManager.php
+++ b/src/Illuminate/Session/SessionManager.php
@@ -139,9 +139,13 @@ class SessionManager extends Manager
     {
         $handler = $this->createCacheHandler('redis');
 
-        $handler->getCache()->getStore()->setConnection(
-            $this->config->get('session.connection')
-        );
+        $store = $handler->getCache()->getStore();
+
+        $store->setConnection($this->config->get('session.connection'));
+
+        if ($prefix = $this->config->get('session.prefix')) {
+            $store->setPrefix($prefix);
+        }
 
         return $this->buildSession($handler);
     }

--- a/tests/Session/SessionManagerTest.php
+++ b/tests/Session/SessionManagerTest.php
@@ -2,10 +2,13 @@
 
 namespace Illuminate\Tests\Session;
 
+use Illuminate\Cache\CacheManager;
 use Illuminate\Config\Repository as Config;
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Redis\Factory as RedisFactory;
 use Illuminate\Session\SessionManager;
 use PHPUnit\Framework\TestCase;
+use Mockery as m;
 
 class SessionManagerTest extends TestCase
 {
@@ -18,6 +21,21 @@ class SessionManagerTest extends TestCase
         $manager->setDefaultDriver(SessionDriverName::Array);
 
         $this->assertSame('array', $app['config']['session.driver']);
+    }
+
+    public function testRedisDriverUsesConfiguredSessionPrefix()
+    {
+        $app = new Container;
+        $app->singleton('config', fn () => new Config([
+            'session' => ['driver' => 'redis', 'lifetime' => 120, 'prefix' => 'some_custom_prefix'],
+            'cache' => ['prefix' => 'cache_prefix', 'stores' => ['redis' => ['driver' => 'redis']]],
+        ]));
+        $app->singleton('cache', fn ($app) => new CacheManager($app));
+        $app->instance('redis', m::mock(RedisFactory::class));
+
+        $manager = new SessionManager($app);
+
+        $this->assertSame('some_custom_prefix', $manager->driver()->getHandler()->getCache()->getStore()->getPrefix());
     }
 }
 

--- a/tests/Session/SessionManagerTest.php
+++ b/tests/Session/SessionManagerTest.php
@@ -7,8 +7,8 @@ use Illuminate\Config\Repository as Config;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Redis\Factory as RedisFactory;
 use Illuminate\Session\SessionManager;
-use PHPUnit\Framework\TestCase;
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 
 class SessionManagerTest extends TestCase
 {

--- a/tests/Session/SessionManagerTest.php
+++ b/tests/Session/SessionManagerTest.php
@@ -37,6 +37,21 @@ class SessionManagerTest extends TestCase
 
         $this->assertSame('some_custom_prefix', $manager->driver()->getHandler()->getCache()->getStore()->getPrefix());
     }
+
+    public function testRedisDriverFallsBackToCachePrefixWhenNoSessionPrefix()
+    {
+        $app = new Container;
+        $app->singleton('config', fn () => new Config([
+            'session' => ['driver' => 'redis', 'lifetime' => 120],
+            'cache' => ['prefix' => 'cache_prefix', 'stores' => ['redis' => ['driver' => 'redis']]],
+        ]));
+        $app->singleton('cache', fn ($app) => new CacheManager($app));
+        $app->instance('redis', m::mock(RedisFactory::class));
+
+        $manager = new SessionManager($app);
+
+        $this->assertSame('cache_prefix', $manager->driver()->getHandler()->getCache()->getStore()->getPrefix());
+    }
 }
 
 enum SessionDriverName: string


### PR DESCRIPTION
On Redis providers like Upstash / clusters / ElastiCache  and general managed redis services, you're limited to a single keystore (db0), so you can't isolate sessions from cache by using a separate store.

Sessions currently inherit the cache prefix by default with setups like:
```
SESSION_DRIVER=redis
CACHE_STORE=redis
SCHEDULE_CACHE_DRIVER=redis
```


This makes it extremely difficult to scan and figure out what's what, between cache and sessions.  Meaning when you need to clear cache manually or clear space its complex.

This PR allows you to set a prefix, and is completely opt in, which mirrors the `session.connection` option.
it _could_ be defaulted, but i'm not sure or in charge of those executive decisions.  But, maybe this should be the default in 14.x to prevent confusion?

```php
// config/session.php
'prefix' => env('SESSION_PREFIX', Str::slug((string) env('APP_NAME', 'laravel')).'-session-'),
``` 

I can move this to 14.x if you'd prefer too

Alternatively, _we can_ do something like the below, but it was a lot less discoverable  and confusing, which is why I thought of this PR.
```php
// .env
// SESSION_STORE = sessions

// config/cache.php
  'sessions' => [
          'driver' => 'redis',
          'prefix' => '-session-',   
],
```

This PR will also assist https://github.com/laravel/framework/pull/60705