### PR TITLE
[13.x] Fix operator precedence in SqsQueue size fallbacks

### DIFF
--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -133,7 +133,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
             'AttributeNames' => ['ApproximateNumberOfMessages'],
         ]);
 
-        return (int) $response['Attributes']['ApproximateNumberOfMessages'] ?? 0;
+        return (int) ($response['Attributes']['ApproximateNumberOfMessages'] ?? 0);
     }
 
     /**
@@ -149,7 +149,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
             'AttributeNames' => ['ApproximateNumberOfMessagesDelayed'],
         ]);
 
-        return (int) $response['Attributes']['ApproximateNumberOfMessagesDelayed'] ?? 0;
+        return (int) ($response['Attributes']['ApproximateNumberOfMessagesDelayed'] ?? 0);
     }
 
     /**
@@ -165,7 +165,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
             'AttributeNames' => ['ApproximateNumberOfMessagesNotVisible'],
         ]);
 
-        return (int) $response['Attributes']['ApproximateNumberOfMessagesNotVisible'] ?? 0;
+        return (int) ($response['Attributes']['ApproximateNumberOfMessagesNotVisible'] ?? 0);
     }
 
     /**

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -201,6 +201,87 @@ class QueueSqsQueueTest extends TestCase
         $this->assertEquals(6, $size); // 1 + 2 + 3
     }
 
+    public function testPendingSizeProperlyReadsSqsQueuePendingSize()
+    {
+        $queue = $this->getMockBuilder(SqsQueue::class)->onlyMethods(['getQueue'])->setConstructorArgs([$this->sqs, $this->queueName, $this->account])->getMock();
+        $queue->expects($this->exactly(2))->method('getQueue')->with($this->queueName)->willReturn($this->queueUrl);
+
+        $this->sqs->shouldReceive('getQueueAttributes')->once()->with([
+            'QueueUrl' => $this->queueUrl,
+            'AttributeNames' => ['ApproximateNumberOfMessages'],
+        ])->andReturn(new Result([
+            'Attributes' => [
+                'ApproximateNumberOfMessages' => 1,
+            ],
+        ]));
+
+        $this->assertEquals(1, $queue->pendingSize($this->queueName));
+
+        // Test missing attribute fallback
+        $this->sqs->shouldReceive('getQueueAttributes')->once()->with([
+            'QueueUrl' => $this->queueUrl,
+            'AttributeNames' => ['ApproximateNumberOfMessages'],
+        ])->andReturn(new Result([
+            'Attributes' => [],
+        ]));
+
+        $this->assertEquals(0, $queue->pendingSize($this->queueName));
+    }
+
+    public function testDelayedSizeProperlyReadsSqsQueueDelayedSize()
+    {
+        $queue = $this->getMockBuilder(SqsQueue::class)->onlyMethods(['getQueue'])->setConstructorArgs([$this->sqs, $this->queueName, $this->account])->getMock();
+        $queue->expects($this->exactly(2))->method('getQueue')->with($this->queueName)->willReturn($this->queueUrl);
+
+        $this->sqs->shouldReceive('getQueueAttributes')->once()->with([
+            'QueueUrl' => $this->queueUrl,
+            'AttributeNames' => ['ApproximateNumberOfMessagesDelayed'],
+        ])->andReturn(new Result([
+            'Attributes' => [
+                'ApproximateNumberOfMessagesDelayed' => 2,
+            ],
+        ]));
+
+        $this->assertEquals(2, $queue->delayedSize($this->queueName));
+
+        // Test missing attribute fallback
+        $this->sqs->shouldReceive('getQueueAttributes')->once()->with([
+            'QueueUrl' => $this->queueUrl,
+            'AttributeNames' => ['ApproximateNumberOfMessagesDelayed'],
+        ])->andReturn(new Result([
+            'Attributes' => [],
+        ]));
+
+        $this->assertEquals(0, $queue->delayedSize($this->queueName));
+    }
+
+    public function testReservedSizeProperlyReadsSqsQueueReservedSize()
+    {
+        $queue = $this->getMockBuilder(SqsQueue::class)->onlyMethods(['getQueue'])->setConstructorArgs([$this->sqs, $this->queueName, $this->account])->getMock();
+        $queue->expects($this->exactly(2))->method('getQueue')->with($this->queueName)->willReturn($this->queueUrl);
+
+        $this->sqs->shouldReceive('getQueueAttributes')->once()->with([
+            'QueueUrl' => $this->queueUrl,
+            'AttributeNames' => ['ApproximateNumberOfMessagesNotVisible'],
+        ])->andReturn(new Result([
+            'Attributes' => [
+                'ApproximateNumberOfMessagesNotVisible' => 3,
+            ],
+        ]));
+
+        $this->assertEquals(3, $queue->reservedSize($this->queueName));
+
+        // Test missing attribute fallback
+        $this->sqs->shouldReceive('getQueueAttributes')->once()->with([
+            'QueueUrl' => $this->queueUrl,
+            'AttributeNames' => ['ApproximateNumberOfMessagesNotVisible'],
+        ])->andReturn(new Result([
+            'Attributes' => [],
+        ]));
+
+        $this->assertEquals(0, $queue->reservedSize($this->queueName));
+    }
+
     public function testGetQueueProperlyResolvesUrlWithPrefix()
     {
         $queue = new SqsQueue($this->sqs, $this->queueName, $this->prefix);


### PR DESCRIPTION
The `pendingSize()`, `delayedSize()`, and `reservedSize()` methods currently cast SQS attributes before the null coalescing fallback is applied:

```php
return (int) $response['Attributes']['ApproximateNumberOfMessages'] ?? 0;
```

Due to PHP operator precedence, the attribute access happens before the `?? 0` fallback can handle a missing value. This can result in an undefined array key warning when the expected attribute is absent.

This updates the expression so the fallback is applied before casting:

```php
return (int) ($response['Attributes']['ApproximateNumberOfMessages'] ?? 0);
```

Existing behavior remains unchanged when the attribute exists.

Added tests covering the SQS queue size methods when the expected attributes are missing.