### PR TITLE
[13.x] Allow excluding attributes from empty string to null conversion

### DIFF
--- a/src/Illuminate/Foundation/Configuration/Middleware.php
+++ b/src/Illuminate/Foundation/Configuration/Middleware.php
@@ -648,7 +648,11 @@ class Middleware
      */
     public function convertEmptyStringsToNull(array $except = [])
     {
-        (new Collection($except))->each(fn (Closure $callback) => ConvertEmptyStringsToNull::skipWhen($callback));
+        [$skipWhen, $except] = (new Collection($except))->partition(fn ($value) => $value instanceof Closure);
+
+        $skipWhen->each(fn (Closure $callback) => ConvertEmptyStringsToNull::skipWhen($callback));
+
+        ConvertEmptyStringsToNull::except($except->all());
 
         return $this;
     }

--- a/src/Illuminate/Foundation/Http/Middleware/ConvertEmptyStringsToNull.php
+++ b/src/Illuminate/Foundation/Http/Middleware/ConvertEmptyStringsToNull.php
@@ -3,9 +3,27 @@
 namespace Illuminate\Foundation\Http\Middleware;
 
 use Closure;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 
 class ConvertEmptyStringsToNull extends TransformsRequest
 {
+    /**
+     * The attributes that should not be converted.
+     *
+     * @var array<int, string>
+     */
+    protected $except = [
+        //
+    ];
+
+    /**
+     * The globally ignored attributes that should not be converted.
+     *
+     * @var array
+     */
+    protected static $neverConvert = [];
+
     /**
      * All of the registered skip callbacks.
      *
@@ -40,7 +58,38 @@ class ConvertEmptyStringsToNull extends TransformsRequest
      */
     protected function transform($key, $value)
     {
+        $except = array_merge($this->except, static::$neverConvert);
+
+        if ($this->shouldSkip($key, $except)) {
+            return $value;
+        }
+
         return $value === '' ? null : $value;
+    }
+
+    /**
+     * Determine if the given key should be skipped.
+     *
+     * @param  string  $key
+     * @param  array  $except
+     * @return bool
+     */
+    protected function shouldSkip($key, $except)
+    {
+        return Str::is($except, $key);
+    }
+
+    /**
+     * Indicate that the given attributes should never be converted.
+     *
+     * @param  array|string  $attributes
+     * @return void
+     */
+    public static function except($attributes)
+    {
+        static::$neverConvert = array_values(array_unique(
+            array_merge(static::$neverConvert, Arr::wrap($attributes))
+        ));
     }
 
     /**
@@ -61,6 +110,8 @@ class ConvertEmptyStringsToNull extends TransformsRequest
      */
     public static function flushState()
     {
+        static::$neverConvert = [];
+
         static::$skipCallbacks = [];
     }
 }

--- a/tests/Foundation/Http/Middleware/ConvertEmptyStringsToNullTest.php
+++ b/tests/Foundation/Http/Middleware/ConvertEmptyStringsToNullTest.php
@@ -25,6 +25,22 @@ class ConvertEmptyStringsToNullTest extends TestCase
         });
     }
 
+    public function testConvertsEmptyStringsToNullIgnoringExceptAttribute()
+    {
+        $middleware = new ConvertEmptyStringsToNullWithExceptAttribute;
+        $symfonyRequest = new SymfonyRequest([
+            'foo' => 'bar',
+            'baz' => '',
+        ]);
+        $symfonyRequest->server->set('REQUEST_METHOD', 'GET');
+        $request = Request::createFromBase($symfonyRequest);
+
+        $middleware->handle($request, function (Request $request) {
+            $this->assertSame('bar', $request->get('foo'));
+            $this->assertSame('', $request->get('baz'));
+        });
+    }
+
     public function testSkipConvertsEmptyStringsToNull()
     {
         $middleware = new ConvertEmptyStringsToNull;
@@ -41,4 +57,11 @@ class ConvertEmptyStringsToNullTest extends TestCase
             $this->assertSame('', $request->get('baz'));
         });
     }
+}
+
+class ConvertEmptyStringsToNullWithExceptAttribute extends ConvertEmptyStringsToNull
+{
+    protected $except = [
+        'baz',
+    ];
 }


### PR DESCRIPTION
The TrimStrings middleware allows specifying keys to be excluded from trimming, and this PR introduces the same support for the ConvertEmptyStringsToNull middleware.

Currently, you can only skip the middleware for the whole request:

```php
$middleware->convertEmptyStringsToNull(except: [
    fn (Request $request) => $request->rich_text === '',
]);
```

With these changes, you can now exclude specific keys instead:

```php
$middleware->convertEmptyStringsToNull(except: [
    'rich_text',
]);
```

I can backport the changes to 12.x once this is merged.