### PR TITLE
[13.x] Fix guessResourceName() namespace collision when class name is a substring of a parent namespace segment

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/TransformsToResource.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/TransformsToResource.php
@@ -65,7 +65,7 @@ trait TransformsToResource
         $relativeNamespace = Str::after($modelClass, '\\Models\\');
 
         $relativeNamespace = Str::contains($relativeNamespace, '\\')
-            ? Str::before($relativeNamespace, '\\'.class_basename($modelClass))
+            ? Str::beforeLast($relativeNamespace, '\\'.class_basename($modelClass))
             : '';
 
         $potentialResource = sprintf(


### PR DESCRIPTION
Fixes #60706

Issue was found and tested on 13.7, confirmed on 13.8

If your model exists in a directory with a name that includes the model name (EX Jumping/Jump) the resource resolves to the model's path but excludes the directory. This should fix that by using Str::beforeLast instead of Str::before so it grabs the last instance of the model name in the full path when guessing the resource name. 

I didn't add a test for this. I was hoping it was small enough to not need one. 

Test case failure

Create these models
App/Models/BAM/Jumping/Jump
App/Models/BAM/Jumping/Hop

Then in tinker do guessResourceName() for each and it gives the wrong path for Jump:
```

> Jump::guessResourceName()

= [
    "App\\Http\\Resources\\BAM\\JumpResource",
    "App\\Http\\Resources\\BAM\\Jump",
  ]

> Hop::guessResourceName()

= [
    "App\\Http\\Resources\\BAM\\Jumping\\HopResource",
    "App\\Http\\Resources\\BAM\\Jumping\\Hop",
  ]
```

Test case success

Create this model
App/Models/BAM/Jumping/Jump

Then in tinker do guessResourceName() for Jump
```
> Jump::guessResourceName()

= [
    "App\\Http\\Resources\\BAM\\Jumping\\JumpResource",
    "App\\Http\\Resources\\BAM\\Jumping\\Jump",
  ]
```