### PR TITLE
Fix BelongsToMany::touch() when related key is not `id`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -1327,7 +1327,7 @@ class BelongsToMany extends Relation
         // the related model's timestamps, to make sure these all reflect the changes
         // to the parent models. This will help us keep any caching synced up here.
         if (count($ids = $this->allRelatedIds()) > 0) {
-            $this->getRelated()->newQueryWithoutRelationships()->whereKey($ids)->update($columns);
+            $this->getRelated()->newQueryWithoutRelationships()->whereIn($this->getQualifiedRelatedKeyName(), $ids)->update($columns);
         }
     }
 


### PR DESCRIPTION
Currently, `BelongsToMany::touch()` uses the related key to retrieve which records to touch (`allRelatedIds()`), but uses the primary key of the related model to perform the touch (`whereKey()`). Therefore if the user specified a related key other than `id`, the touch will fail.

This PR changes `touch()` to use the related key to align with `allRelatedIds()`.