### PR TITLE
Make MailFake::assertQueuedTimes() public

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -225,7 +225,7 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
      * @param  int  $times
      * @return void
      */
-    protected function assertQueuedTimes($mailable, $times = 1)
+    public function assertQueuedTimes($mailable, $times = 1)
     {
         $count = $this->queued($mailable)->count();
 

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -260,6 +260,21 @@ class SupportTestingMailFakeTest extends TestCase
         $this->fake->assertQueued(MailableStub::class, 2);
     }
 
+    public function testAssertQueuedTimesCalledDirectly()
+    {
+        $this->fake->to('taylor@laravel.com')->queue($this->mailable);
+        $this->fake->to('taylor@laravel.com')->queue($this->mailable);
+
+        try {
+            $this->fake->assertQueuedTimes(MailableStub::class, 1);
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringContainsString('The expected [Illuminate\Tests\Support\MailableStub] mailable was queued 2 times instead of 1 time.', $e->getMessage());
+        }
+
+        $this->fake->assertQueuedTimes(MailableStub::class, 2);
+    }
+
     public function testAssertNotQueuedWithString()
     {
         $this->fake->assertNotQueued(MailableStub::class, 'taylor@laravel.com');


### PR DESCRIPTION
## Summary
- `MailFake::assertQueuedTimes()` was left `protected`, while its sent-mail counterpart `assertSentTimes()` is `public`.
- This means `Mail::assertSentTimes(...)` can be called directly in tests, but the queued equivalent cannot — even though `assertQueued()` internally calls `assertQueuedTimes()` when passed a numeric `$times` argument.
- This PR simply changes the visibility to `public` to match `assertSentTimes()`, and adds a test that calls `assertQueuedTimes()` directly.