### PR TITLE
Add Collection::lastOrFail()

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1507,6 +1507,33 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Get the last item in the collection but throw an exception if no matching items exist.
+     *
+     * @param  (callable(TValue, TKey): bool)|string|null  $key
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @return TValue
+     *
+     * @throws \Illuminate\Support\ItemNotFoundException
+     */
+    public function lastOrFail($key = null, $operator = null, $value = null)
+    {
+        $filter = func_num_args() > 1
+            ? $this->operatorForWhere(...func_get_args())
+            : $key;
+
+        $placeholder = new stdClass();
+
+        $item = $this->last($filter, $placeholder);
+
+        if ($item === $placeholder) {
+            throw new ItemNotFoundException;
+        }
+
+        return $item;
+    }
+
+    /**
      * Chunk the collection into chunks of the given size.
      *
      * @param  int  $size

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -1046,6 +1046,18 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public function firstOrFail($key = null, $operator = null, $value = null);
 
     /**
+     * Get the last item in the collection but throw an exception if no matching items exist.
+     *
+     * @param  (callable(TValue, TKey): bool)|string|null  $key
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @return TValue
+     *
+     * @throws \Illuminate\Support\ItemNotFoundException
+     */
+    public function lastOrFail($key = null, $operator = null, $value = null);
+
+    /**
      * Chunk the collection into chunks of the given size.
      *
      * @param  int  $size

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1390,6 +1390,29 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
+     * Get the last item in the collection but throw an exception if no matching items exist.
+     *
+     * @param  (callable(TValue, TKey): bool)|string|null  $key
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @return TValue
+     *
+     * @throws \Illuminate\Support\ItemNotFoundException
+     */
+    public function lastOrFail($key = null, $operator = null, $value = null)
+    {
+        $filter = func_num_args() > 1
+            ? $this->operatorForWhere(...func_get_args())
+            : $key;
+
+        return $this
+            ->unless($filter == null)
+            ->filter($filter)
+            ->collect()
+            ->lastOrFail();
+    }
+
+    /**
      * Chunk the collection into chunks of the given size.
      *
      * @param  int  $size

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -297,6 +297,66 @@ class SupportCollectionTest extends TestCase
     }
 
     #[DataProvider('collectionClassProvider')]
+    public function testLastOrFailReturnsLastItemInCollection($collection)
+    {
+        $collection = new $collection([
+            ['name' => 'foo'],
+            ['name' => 'bar'],
+        ]);
+
+        $this->assertSame(['name' => 'bar'], $collection->where('name', 'bar')->lastOrFail());
+        $this->assertSame(['name' => 'bar'], $collection->lastOrFail('name', '=', 'bar'));
+        $this->assertSame(['name' => 'bar'], $collection->lastOrFail('name', 'bar'));
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testLastOrFailThrowsExceptionIfNoItemsExist($collection)
+    {
+        $this->expectException(ItemNotFoundException::class);
+
+        $collection = new $collection([
+            ['name' => 'foo'],
+            ['name' => 'bar'],
+        ]);
+
+        $collection->where('name', 'INVALID')->lastOrFail();
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testLastOrFailReturnsLastMatchingItemInCollection($collection)
+    {
+        $collection = new $collection([
+            ['name' => 'foo'],
+            ['name' => 'bar'],
+            ['name' => 'bar'],
+        ]);
+
+        $this->assertSame(['name' => 'bar'], $collection->where('name', 'bar')->lastOrFail());
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testLastOrFailReturnsLastItemInCollectionWithCallback($collection)
+    {
+        $data = new $collection(['foo', 'bar', 'baz']);
+        $result = $data->lastOrFail(function ($value) {
+            return $value !== 'baz';
+        });
+        $this->assertSame('bar', $result);
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testLastOrFailThrowsExceptionIfNoItemsExistWithCallback($collection)
+    {
+        $this->expectException(ItemNotFoundException::class);
+
+        $data = new $collection(['foo', 'bar', 'baz']);
+
+        $data->lastOrFail(function ($value) {
+            return $value === 'invalid';
+        });
+    }
+
+    #[DataProvider('collectionClassProvider')]
     public function testFirstWhere($collection)
     {
         $data = new $collection([


### PR DESCRIPTION
## Summary
- `Collection::firstOrFail()` exists to get the first item (optionally matching a key/operator/value or callback) and throw `ItemNotFoundException` if nothing matches, but there is no equivalent for the last item.
- This PR adds `lastOrFail()` mirroring `firstOrFail()`'s implementation and signature, built on top of the existing `last()` method.
- Implemented for `Collection` and `LazyCollection`, and declared on the `Enumerable` contract, consistent with how `firstOrFail()` is implemented across all three.