### PR TITLE
[13.x] Add test for the scheduler's quarterlyOn method

### DIFF
--- a/tests/Console/Scheduling/FrequencyTest.php
+++ b/tests/Console/Scheduling/FrequencyTest.php
@@ -202,6 +202,11 @@ class FrequencyTest extends TestCase
         $this->assertSame('0 0 1 1-12/3 *', $this->event->quarterly()->getExpression());
     }
 
+    public function testQuarterlyOn()
+    {
+        $this->assertSame('0 15 4 1-12/3 *', $this->event->quarterlyOn(4, '15:00')->getExpression());
+    }
+
     public function testYearly()
     {
         $this->assertSame('0 0 1 1 *', $this->event->yearly()->getExpression());


### PR DESCRIPTION
`ManagesFrequencies::quarterlyOn()` is the only frequency helper on the scheduler that has no test coverage. Every one of its siblings is asserted in `FrequencyTest` — `quarterly()`, `monthlyOn()`, `twiceMonthly()`, `yearlyOn()` — so the day-of-quarter and time arguments it splices into the cron expression are currently unverified.

This adds the missing assertion, mirroring the existing `testMonthlyOn()` (same arguments, so the only difference in the expected expression is the month field):

```php
public function testQuarterlyOn()
{
    $this->assertSame('0 15 4 1-12/3 *', $this->event->quarterlyOn(4, '15:00')->getExpression());
}
```

Test-only change, no behavior is modified.