### PR TITLE
[13.x] Default route group controller action to __invoke for invokable controllers

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -566,6 +566,9 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     protected function createRoute($methods, $uri, $action)
     {
+        // If no action was provided for the route we will check the group
+        // for an invokable controller and use it as the default action
+        // so the controller doesn't need to be given on each route.
         if (is_null($action)) {
             $action = $this->groupControllerAsDefaultAction();
         }

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -566,6 +566,10 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     protected function createRoute($methods, $uri, $action)
     {
+        if (is_null($action)) {
+            $action = $this->groupControllerAsDefaultAction();
+        }
+
         // If the route is routing to a controller we will parse the route action into
         // an acceptable array format before registering it and creating this route
         // instance itself. We need to build the Closure that will call this out.
@@ -670,6 +674,24 @@ class Router implements BindingRegistrar, RegistrarContract
         }
 
         return $group['controller'].'@'.$class;
+    }
+
+    /**
+     * Use the group controller as the route action if the controller is invokable.
+     *
+     * @return string|null
+     */
+    protected function groupControllerAsDefaultAction()
+    {
+        if (! $this->hasGroupStack()) {
+            return null;
+        }
+
+        $controller = array_last($this->groupStack)['controller'] ?? null;
+
+        return is_string($controller) && method_exists($controller, '__invoke')
+            ? $controller
+            : null;
     }
 
     /**

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
 use Illuminate\Routing\RouteRegistrar;
+use Illuminate\Routing\RoutingServiceProvider;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Stringable;
@@ -26,7 +27,10 @@ class RouteRegistrarTest extends TestCase
     {
         parent::setUp();
 
-        $this->router = new Router(m::mock(Dispatcher::class), Container::getInstance());
+        $container = new Container();
+        (new RoutingServiceProvider($container))->register();
+
+        $this->router = new Router(m::mock(Dispatcher::class), $container);
     }
 
     public function testMiddlewareFluentRegistration()

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -10,6 +10,7 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
 use Illuminate\Routing\RouteRegistrar;
 use Illuminate\Routing\RoutingServiceProvider;
+use LogicException;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Stringable;
@@ -430,6 +431,41 @@ class RouteRegistrarTest extends TestCase
             RouteRegistrarControllerStub::class.'@index',
             $this->getRoute()->getAction()['uses']
         );
+    }
+
+    public function testCanRegisterGroupWithInvokableControllerAsDefaultAction()
+    {
+        $this->router->controller(InvokableRouteRegistrarControllerStub::class)
+            ->group(function ($router) {
+                $router->get('users');
+            });
+
+        $this->seeResponse('controller', Request::create('users', 'GET'));
+        $this->assertSame(
+            InvokableRouteRegistrarControllerStub::class.'@__invoke',
+            $this->getRoute()->getAction()['uses']
+        );
+    }
+
+    public function testGroupWithNonInvokableControllerStillRequiresAction()
+    {
+        $this->router->controller(RouteRegistrarControllerStub::class)
+            ->group(function ($router) {
+                $router->get('users');
+            });
+
+        $this->expectException(LogicException::class);
+
+        $this->router->dispatch(Request::create('users', 'GET'));
+    }
+
+    public function testRouteWithNoActionAndNoGroupStillRequiresAction()
+    {
+        $this->router->get('users');
+
+        $this->expectException(LogicException::class);
+
+        $this->router->dispatch(Request::create('users', 'GET'));
     }
 
     public function testCanOverrideGroupControllerWithStringSyntax()


### PR DESCRIPTION
This PR calls `__invoke` by default for invokable controllers in route groups, a behavior that is [currently not supported](https://github.com/laravel/framework/pull/40276#issuecomment-1060686597).

**Context**
Currently, a route group with an invokable controller needs to tack on '__invoke' in all its routes which deviates from the syntax of an individual route with an invokable controller. 

This PR adds another path in the `Router::createRoute()` to call '__invoke' when as the default action.

example code from my own saas:

let BarExamController be an invokable controller

before
```php
Route::prefix('bar-exam')
    ->controller(BarExamController::class)
    ->group(function () {
        Route::get('/2026/remedial', '__invoke')->name('bar-exam.remedial');
        Route::get('/2026/taxation', '__invoke')->name('bar-exam.taxation');
        Route::get('/2026/civil', '__invoke')->name('bar-exam.civil');
});
```

with this PR
```php
Route::prefix('bar-exam')
    ->controller(BarExamController::class)
    ->group(function () {
        Route::get('/2026/remedial')->name('bar-exam.remedial');
        Route::get('/2026/taxation')->name('bar-exam.taxation');
        Route::get('/2026/civil')->name('bar-exam.civil');
});
```

this syntax is more intuitive and uses a sensible default

**Backwards compatibility**
Invokable group controller w no action              =>       Route works (`Controller@__invoke`)
Non-invokable group controller w no action      =>       LogicException; works the same


A null action inside a controller group is today a guaranteed request-time exception. No working application code can be relying on it. Giving it a working meaning breaks nothing. Group `namespace` interaction is unchanged relative
to writing `Route::get('/x', Controller::class)` inside the same group.



also fixed `RouteRegistrarTest.php` to use own Container. that way, we could run the test in isolation                
i.e. `vendor/bin/phpunit tests/Routing/RouteRegistrarTest.php`