### PR TITLE
[13.x] Add test for the scheduler's sub-minute frequency methods

### DIFF
--- a/tests/Console/Scheduling/FrequencyTest.php
+++ b/tests/Console/Scheduling/FrequencyTest.php
@@ -27,6 +27,31 @@ class FrequencyTest extends TestCase
         $this->assertSame('* * * * *', $this->event->everyMinute()->getExpression());
     }
 
+    public function testEveryXSeconds()
+    {
+        $this->assertSame('* * * * *', $this->event->everySecond()->getExpression());
+        $this->assertSame(1, $this->event->repeatSeconds);
+        $this->assertTrue($this->event->isRepeatable());
+
+        $this->assertSame('* * * * *', $this->event->everyTwoSeconds()->getExpression());
+        $this->assertSame(2, $this->event->repeatSeconds);
+
+        $this->assertSame('* * * * *', $this->event->everyFiveSeconds()->getExpression());
+        $this->assertSame(5, $this->event->repeatSeconds);
+
+        $this->assertSame('* * * * *', $this->event->everyTenSeconds()->getExpression());
+        $this->assertSame(10, $this->event->repeatSeconds);
+
+        $this->assertSame('* * * * *', $this->event->everyFifteenSeconds()->getExpression());
+        $this->assertSame(15, $this->event->repeatSeconds);
+
+        $this->assertSame('* * * * *', $this->event->everyTwentySeconds()->getExpression());
+        $this->assertSame(20, $this->event->repeatSeconds);
+
+        $this->assertSame('* * * * *', $this->event->everyThirtySeconds()->getExpression());
+        $this->assertSame(30, $this->event->repeatSeconds);
+    }
+
     public function testEveryXMinutes()
     {
         $this->assertSame('*/2 * * * *', $this->event->everyTwoMinutes()->getExpression());


### PR DESCRIPTION
`ManagesFrequencies` has a family of sub-minute scheduling methods(`everySecond()`, `everyTwoSeconds()`, `everyFiveSeconds()`, `everyTenSeconds()`,`everyFifteenSeconds()`, `everyTwentySeconds()`, `everyThirtySeconds()`) that delegate to `repeatEvery()` and set the `repeatSeconds` property, which `Event::isRepeatable()` and `Event::shouldRepeatNow()` rely on. None of this was covered by the test suite.

This adds `testEveryXSeconds()` to `FrequencyTest`, following the same pattern as the existing `testEveryXMinutes()`/`testHourly()` tests, asserting both the resulting cron expression and the `repeatSeconds` value for each method.