### PR TITLE
[14.x] Prevent duplicate kernel instances when resolving concrete kernel classes from providers

### DIFF
--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -59,14 +59,18 @@ class ApplicationBuilder
      */
     public function withKernels()
     {
-        $this->app->singleton(
-            \Illuminate\Contracts\Http\Kernel::class,
+        $this->app->singleton(\Illuminate\Foundation\Http\Kernel::class);
+
+        $this->app->alias(
             \Illuminate\Foundation\Http\Kernel::class,
+            \Illuminate\Contracts\Http\Kernel::class,
         );
 
-        $this->app->singleton(
-            \Illuminate\Contracts\Console\Kernel::class,
+        $this->app->singleton(\Illuminate\Foundation\Console\Kernel::class);
+
+        $this->app->alias(
             \Illuminate\Foundation\Console\Kernel::class,
+            \Illuminate\Contracts\Console\Kernel::class,
         );
 
         return $this;

--- a/tests/Foundation/FoundationApplicationBuilderTest.php
+++ b/tests/Foundation/FoundationApplicationBuilderTest.php
@@ -2,8 +2,10 @@
 
 namespace Illuminate\Tests\Foundation;
 
+use Illuminate\Contracts\Console\Kernel as ConsoleKernelContract;
 use Illuminate\Contracts\Http\Kernel as HttpKernelContract;
 use Illuminate\Foundation\Application;
+use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
 use Illuminate\Foundation\Http\Kernel as HttpKernel;
 use Illuminate\Http\Middleware\PrefersJsonResponses;
 use PHPUnit\Framework\TestCase;
@@ -86,6 +88,23 @@ class FoundationApplicationBuilderTest extends TestCase
         $this->assertSame(__DIR__.'/custom-storage', $app->storagePath());
     }
 
+    public function testKernelContractResolvesToSameInstanceAsConcrete()
+    {
+        $app = Application::configure()->create();
+
+        $this->assertSame($app->make(HttpKernelContract::class), $app->make(HttpKernel::class));
+        $this->assertSame($app->make(ConsoleKernelContract::class), $app->make(ConsoleKernel::class));
+    }
+
+    public function testKernelAbstractCanBeBoundToCustomConcrete()
+    {
+        $app = Application::configure()->create();
+
+        $app->singleton(HttpKernelContract::class, CustomHttpKernelStub::class);
+
+        $this->assertInstanceOf(CustomHttpKernelStub::class, $app->make(HttpKernelContract::class));
+    }
+
     public function testPrefersJsonResponsesIsFluent()
     {
         $builder = Application::configure();
@@ -139,4 +158,9 @@ class FoundationApplicationBuilderTest extends TestCase
 
         return $app->make(HttpKernelContract::class);
     }
+}
+
+class CustomHttpKernelStub extends HttpKernel
+{
+    //
 }


### PR DESCRIPTION
In one of our applications I noticed middleware had silently stopped applying, 2L of Pepsi later and much confusion, it was because one of our service providers was passing the concrete Kernel into the boot method ie.. 

```php
// Provider...
use Illuminate\Foundation\Http\Kernel; // The problem
public function boot(Kernel $kernel): void // We use it in the boot method...
{

// app.php / other providers... you get the idea
return Application::configure(basePath: dirname(__DIR__))
    ->withMiddleware(function (Middleware $middleware) {
        $middleware->append([
            SomeMiddleware::class,
        ]);

```
<details>

<summary>Tinker example </summary>

```

// Tinker just so you can clearly see the diff ids...
> app(\Illuminate\Cache\Repository::class);

= Illuminate\Cache\Repository {#587}

> app(\Illuminate\Contracts\Cache\Repository::class);

= Illuminate\Cache\Repository {#587} // same object..

> app(\Illuminate\Foundation\Http\Kernel::class);

= Illuminate\Foundation\Http\Kernel {#8386}

> app(\Illuminate\Contracts\Http\Kernel::class);

= Illuminate\Foundation\Http\Kernel {#8375} // different

```
</details>

This doesn't reveal itself at all, so the application works as normal despite missing all the middleware you'd previously set in other providers or in your app.php


This PR registers the kernels the same way as `registerCoreContainerAliases()` from my understanding, which catches future issues like this. 

This felt like a B/C, so I bring it to 14.x, but can just send it to 13.x if you're happy, I wasn't too sure the impact on it.

This may also be a terrible idea, but it caught us out so maybe you see a nicer way? Dunno. Please school me if its wrong