### PR TITLE
[13.x] Add valueOr method to Eloquent Builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -844,6 +844,24 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Get a single column's value from the first result of a query or call a callback.
+     *
+     * @template TValue
+     *
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  (\Closure(): TValue)|null  $callback
+     * @return mixed|TValue
+     */
+    public function valueOr($column, ?Closure $callback = null)
+    {
+        if (! is_null($value = $this->value($column))) {
+            return $value;
+        }
+
+        return $callback === null ? null : $callback();
+    }
+
+    /**
      * Get a single column's value from the first result of a query if it's the sole matching record.
      *
      * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -375,6 +375,36 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertNull($builder->value('name'));
     }
 
+    public function testValueOrMethodWithModelFound()
+    {
+        $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);
+        $mockModel = new stdClass;
+        $mockModel->name = 'foo';
+        $builder->shouldReceive('first')->with(['name'])->andReturn($mockModel);
+
+        $this->assertSame('foo', $builder->valueOr('name', function () {
+            return 'bar';
+        }));
+    }
+
+    public function testValueOrMethodWithModelNotFoundCallsCallback()
+    {
+        $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);
+        $builder->shouldReceive('first')->with(['name'])->andReturn(null);
+
+        $this->assertSame('bar', $builder->valueOr('name', function () {
+            return 'bar';
+        }));
+    }
+
+    public function testValueOrMethodWithModelNotFoundAndNoCallbackReturnsNull()
+    {
+        $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);
+        $builder->shouldReceive('first')->with(['name'])->andReturn(null);
+
+        $this->assertNull($builder->valueOr('name'));
+    }
+
     public function testValueOrFailMethodWithModelFound()
     {
         $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);


### PR DESCRIPTION
This PR adds a `valueOr` method to the Eloquent query `Builder`.

It returns a single column's value from the first result of the query, or invokes the given callback when the value is `null` — mirroring the existing `firstOr` behavior at the column level (and complementing `value`, `valueOrFail`, and `soleValue`).

```php
// Returns the user's name, or "Guest" when no matching record exists.
$name = User::where('id', $id)->valueOr('name', fn () => 'Guest');
```

When no callback is provided, it falls back to returning `null`, matching `value()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)