### PR TITLE
[13.x] Fix Collection::mode() returning wrong results for float values

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -133,15 +133,24 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
         $collection = isset($key) ? $this->pluck($key) : $this;
 
         $counts = $this->newInstance();
+        $values = [];
 
-        $collection->each(fn ($value) => $counts[$value] = isset($counts[$value]) ? $counts[$value] + 1 : 1);
+        $collection->each(function ($value) use ($counts, &$values) {
+            $index = serialize($value);
+
+            $counts[$index] = isset($counts[$index]) ? $counts[$index] + 1 : 1;
+
+            $values[$index] = $value;
+        });
 
         $sorted = $counts->sort();
 
         $highestValue = $sorted->last();
 
         return $sorted->filter(fn ($value) => $value == $highestValue)
-            ->sort()->keys()->all();
+            ->keys()
+            ->map(fn ($index) => $values[$index])
+            ->sort()->values()->all();
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -5134,6 +5134,13 @@ class SupportCollectionTest extends TestCase
     }
 
     #[DataProvider('collectionClassProvider')]
+    public function testModeWithFloatValues($collection)
+    {
+        $data = new $collection([1.5, 1.5, 1.9, 2.9, 2.9, 2.9]);
+        $this->assertEquals([2.9], $data->mode());
+    }
+
+    #[DataProvider('collectionClassProvider')]
     public function testSliceOffset($collection)
     {
         $data = new $collection([1, 2, 3, 4, 5, 6, 7, 8]);


### PR DESCRIPTION
`Collection::mode()` (and `LazyCollection::mode()`, which just delegates to it) gives you the wrong answer when your collection has float values in it.

### Why

The method counts occurrences by using each value directly as an array key:

```php
$collection->each(fn ($value) => $counts[$value] = isset($counts[$value]) ? $counts[$value] + 1 : 1);
```

The problem is PHP silently truncates float array keys down to integers. So if you have distinct floats that happen to share the same integer part, they get lumped together into one bucket:

```php
(new Collection([1.5, 1.5, 1.9, 2.9, 2.9, 2.9]))->mode();
// Expected: [2.9] (it shows up 3 times)
// Actual:   [1, 2] (wrong, and these numbers aren't even in the original array!)
```