### PR TITLE
[12.x] Enum as queue overlap key

### DIFF
--- a/src/Illuminate/Queue/Middleware/WithoutOverlapping.php
+++ b/src/Illuminate/Queue/Middleware/WithoutOverlapping.php
@@ -6,6 +6,8 @@ use Illuminate\Container\Container;
 use Illuminate\Contracts\Cache\Repository as Cache;
 use Illuminate\Support\InteractsWithTime;
 
+use function Illuminate\Support\enum_value;
+
 class WithoutOverlapping
 {
     use InteractsWithTime;
@@ -48,13 +50,13 @@ class WithoutOverlapping
     /**
      * Create a new middleware instance.
      *
-     * @param  string  $key
+     * @param  \UnitEnum|string  $key
      * @param  \DateTimeInterface|int|null  $releaseAfter
      * @param  \DateTimeInterface|int  $expiresAfter
      */
     public function __construct($key = '', $releaseAfter = 0, $expiresAfter = 0)
     {
-        $this->key = $key;
+        $this->key = enum_value($key);
         $this->releaseAfter = $releaseAfter;
         $this->expiresAfter = $this->secondsUntil($expiresAfter);
     }

--- a/tests/Integration/Queue/WithoutOverlappingJobsTest.php
+++ b/tests/Integration/Queue/WithoutOverlappingJobsTest.php
@@ -284,4 +284,3 @@ enum BackedCategory: string
 {
     case backed = 'backed';
 }
-

--- a/tests/Integration/Queue/WithoutOverlappingJobsTest.php
+++ b/tests/Integration/Queue/WithoutOverlappingJobsTest.php
@@ -175,6 +175,26 @@ class WithoutOverlappingJobsTest extends QueueTestCase
             'prefix:key',
             (new WithoutOverlapping('key'))->withPrefix('prefix:')->shared()->getLockKey($job)
         );
+
+        $this->assertSame(
+            'prefix:'.hash('xxh128', 'App\\Actions\\WithoutOverlappingTestAction').':unit',
+            (new WithoutOverlapping(UnitCategory::unit))->withPrefix('prefix:')->getLockKey($job)
+        );
+
+        $this->assertSame(
+            'prefix:unit',
+            (new WithoutOverlapping(UnitCategory::unit))->withPrefix('prefix:')->shared()->getLockKey($job)
+        );
+
+        $this->assertSame(
+            'prefix:'.hash('xxh128', 'App\\Actions\\WithoutOverlappingTestAction').':backed',
+            (new WithoutOverlapping(BackedCategory::backed))->withPrefix('prefix:')->getLockKey($job)
+        );
+
+        $this->assertSame(
+            'prefix:backed',
+            (new WithoutOverlapping(BackedCategory::backed))->withPrefix('prefix:')->shared()->getLockKey($job)
+        );
     }
 }
 
@@ -254,3 +274,14 @@ class OverlappingTestJobWithDisplayName extends OverlappingTestJob
         return 'App\\Actions\\WithoutOverlappingTestAction';
     }
 }
+
+enum UnitCategory
+{
+    case unit;
+}
+
+enum BackedCategory: string
+{
+    case backed = 'backed';
+}
+


### PR DESCRIPTION
## This PR allows using Enum as a key for middleware WithoutOverlapping

> [!NOTE]
> The changes are fully backward compatible and do not disrupt existing applications.

```php

namespace App\Enums;

enum Category
{
    case suit;
    case dress;
}
```
```php
namespace App\Jobs;

use App\Enums\Category;
use Illuminate\Contracts\Queue\ShouldQueue;
use Illuminate\Foundation\Queue\Queueable;
use Illuminate\Queue\Middleware\WithoutOverlapping;

class UpdateCategory implements ShouldQueue
{
    use Queueable;

    public function __construct(
        protected Category $category,
    ) {}

    public function middleware(): array
    {
        return [new WithoutOverlapping($this->category)];
    }

    public function __invoke(): void
    {
        // Some code
    }
}

```

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
