### PR TITLE
[13.x] Fix TrustProxies at:* when multiple proxies are used

### DIFF
--- a/src/Illuminate/Http/Middleware/TrustProxies.php
+++ b/src/Illuminate/Http/Middleware/TrustProxies.php
@@ -4,6 +4,7 @@ namespace Illuminate\Http\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\HeaderUtils;
 
 class TrustProxies
 {
@@ -112,14 +113,46 @@ class TrustProxies
     }
 
     /**
-     * Set the trusted proxy to be the IP address calling this servers.
+     * Set the trusted proxies to all IP addresses in the forwarded chain + the calling IP.
      *
      * @param  \Illuminate\Http\Request  $request
      * @return void
      */
     protected function setTrustedProxyIpAddressesToTheCallingIp(Request $request)
     {
-        $request->setTrustedProxies([$request->server->get('REMOTE_ADDR')], $this->getTrustedHeaderNames());
+        $trustedIps = collect($this->gatherProxyIpAddresses($request))
+            ->concat([$request->server->get('REMOTE_ADDR')])
+            ->unique()
+            ->values()
+            ->all();
+        $request->setTrustedProxies($trustedIps, $this->getTrustedHeaderNames());
+    }
+
+    /**
+     * Gather a list of IP addresses from the X-FORWARDED-FOR/X-FORWARDED headers.
+     *
+     * @param  Request  $request
+     * @return array
+     */
+    private function gatherProxyIpAddresses(Request $request)
+    {
+        $forwardedForIps = collect(explode(',', $request->headers->get('X-FORWARDED-FOR', '')))
+            ->map(fn ($v) => trim($v))
+            ->filter(fn ($v) => ! empty($v))
+            ->values()
+            ->all();
+        $forwardedIps = [];
+
+        $forwarded = $request->header('FORWARDED', '');
+        $parts = HeaderUtils::split($forwarded, ',;=');
+        foreach ($parts as $subParts) {
+            if (null === $v = HeaderUtils::combine($subParts)['for'] ?? null) {
+                continue;
+            }
+            $forwardedIps[] = trim($v);
+        }
+
+        return array_merge($forwardedIps, $forwardedForIps);
     }
 
     /**

--- a/src/Illuminate/Http/Middleware/TrustProxies.php
+++ b/src/Illuminate/Http/Middleware/TrustProxies.php
@@ -112,7 +112,7 @@ class TrustProxies
     }
 
     /**
-     * Set the trusted proxies to all IP addresses in the forwarded chain + the calling IP.
+     * Set the trusted proxies to catchall addresses for IPv4 and IPv6.
      *
      * @param  \Illuminate\Http\Request  $request
      * @return void

--- a/src/Illuminate/Http/Middleware/TrustProxies.php
+++ b/src/Illuminate/Http/Middleware/TrustProxies.php
@@ -4,7 +4,6 @@ namespace Illuminate\Http\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
-use Symfony\Component\HttpFoundation\HeaderUtils;
 
 class TrustProxies
 {
@@ -120,39 +119,7 @@ class TrustProxies
      */
     protected function setTrustedProxyIpAddressesToTheCallingIp(Request $request)
     {
-        $trustedIps = collect($this->gatherProxyIpAddresses($request))
-            ->concat([$request->server->get('REMOTE_ADDR')])
-            ->unique()
-            ->values()
-            ->all();
-        $request->setTrustedProxies($trustedIps, $this->getTrustedHeaderNames());
-    }
-
-    /**
-     * Gather a list of IP addresses from the X-FORWARDED-FOR/X-FORWARDED headers.
-     *
-     * @param  Request  $request
-     * @return array
-     */
-    private function gatherProxyIpAddresses(Request $request)
-    {
-        $forwardedForIps = collect(explode(',', $request->headers->get('X-FORWARDED-FOR', '')))
-            ->map(fn ($v) => trim($v))
-            ->filter(fn ($v) => ! empty($v))
-            ->values()
-            ->all();
-        $forwardedIps = [];
-
-        $forwarded = $request->header('FORWARDED', '');
-        $parts = HeaderUtils::split($forwarded, ',;=');
-        foreach ($parts as $subParts) {
-            if (null === $v = HeaderUtils::combine($subParts)['for'] ?? null) {
-                continue;
-            }
-            $forwardedIps[] = trim($v);
-        }
-
-        return array_merge($forwardedIps, $forwardedForIps);
+        $request->setTrustedProxies(['0.0.0.0/0', '::/0'], $this->getTrustedHeaderNames());
     }
 
     /**

--- a/tests/Http/Middleware/TrustProxiesTest.php
+++ b/tests/Http/Middleware/TrustProxiesTest.php
@@ -80,6 +80,24 @@ class TrustProxiesTest extends TestCase
     }
 
     /**
+     * Test that the wildcard trusts proxies in an IPv6 forwarded chain, so the
+     * left-most client IP is returned rather than an intermediate IPv6 proxy.
+     */
+    public function test_trusted_proxy_sets_trusted_proxies_with_wildcard_and_ipv6_chain()
+    {
+        $trustedProxy = $this->createTrustedProxy($this->headerAll, '*');
+        $request = $this->createProxiedRequest([
+            'REMOTE_ADDR' => '2001:db8::1',
+            'HTTP_X_FORWARDED_FOR' => '173.174.200.38, 2001:db8::2, 2001:db8::3',
+        ]);
+
+        $trustedProxy->handle($request, function ($request) {
+            $this->assertSame('173.174.200.38', $request->getClientIp(),
+                'Assert IPv6 proxies in the forwarded chain are trusted with wildcard proxy setting');
+        });
+    }
+
+    /**
      * Test the next most typical usage of TrustedProxies:
      * Trusted X-Forwarded-For header, REMOTE_ADDR for TrustedProxies.
      */

--- a/tests/Http/Middleware/TrustProxiesTest.php
+++ b/tests/Http/Middleware/TrustProxiesTest.php
@@ -163,9 +163,9 @@ class TrustProxiesTest extends TestCase
 
         $forwardedFor = [
             '192.0.2.2',
-            '192.0.2.199, 192.0.2.2',
-            '192.0.2.199,192.0.2.2',
-            '99.99.99.99,192.0.2.199,192.0.2.2',
+            '192.0.2.2, 192.0.2.199',
+            '192.0.2.2,192.0.2.199',
+            '192.0.2.2,99.99.99.99,192.0.2.199',
         ];
 
         foreach ($forwardedFor as $forwardedForHeader) {
@@ -173,6 +173,28 @@ class TrustProxiesTest extends TestCase
 
             $trustedProxy->handle($request, function ($request) use ($forwardedForHeader) {
                 $this->assertSame('192.0.2.2', $request->getClientIp(), 'Assert sets the '.$forwardedForHeader);
+            });
+        }
+    }
+
+    /**
+     * Test Forwarded header with multiple IP addresses, with * wildcard trusting of all proxies.
+     */
+    public function test_get_client_ip_with_multiple_ip_addresses_all_proxies_are_trusted_using_forwarded_header()
+    {
+        $trustedProxy = $this->createTrustedProxy(Request::HEADER_FORWARDED, '*');
+
+        $forwarded = [
+            'for=192.0.2.2',
+            'for=192.0.2.2,for=192.0.2.199',
+            'for=192.0.2.2,for=99.99.99.99,for=192.0.2.199',
+        ];
+
+        foreach ($forwarded as $forwardedHeader) {
+            $request = $this->createProxiedRequest(['HTTP_FORWARDED' => $forwardedHeader, 'HTTP_X_FORWARDED_FOR' => '']);
+
+            $trustedProxy->handle($request, function ($request) use ($forwardedHeader) {
+                $this->assertSame('192.0.2.2', $request->getClientIp(), 'Assert sets the '.$forwardedHeader);
             });
         }
     }


### PR DESCRIPTION
Update TrustProxies to trust a catchall address for IPv4 and IPv6 when trust all proxies is specified

Currently, only the remote address is trusted when using TrustProxies:*. If there are multiple proxies this results in the most recent proxy being treated as the original client IP.

There are tests for this however they were incorrect, treating the last IP in the X-Forwarded-For or Forwarded header list as the original, however it should be the first one (https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Forwarded-For)

Resolves https://github.com/laravel/framework/issues/60725 