### PR TITLE
[13.x] Support null for shortcut field in return type array for HasParameters::getOptions (#60723)

### DIFF
--- a/src/Illuminate/Console/Concerns/HasParameters.php
+++ b/src/Illuminate/Console/Concerns/HasParameters.php
@@ -58,7 +58,7 @@ trait HasParameters
      *
      * @return (InputOption|array{
      *    0: non-empty-string,
-     *    1?: string|non-empty-array<string>,
+     *    1?: string|non-empty-array<string>|null,
      *    2?: int-mask-of<InputOption::VALUE_*>,
      *    3?: string,
      *    4?: mixed,


### PR DESCRIPTION
#60723 
