### PR TITLE
Add opt-in output forwarding for scheduled foreground commands

### DIFF
--- a/src/Illuminate/Console/Scheduling/CommandBuilder.php
+++ b/src/Illuminate/Console/Scheduling/CommandBuilder.php
@@ -32,9 +32,15 @@ class CommandBuilder
     {
         $output = ProcessUtils::escapeArgument($event->output);
 
-        return laravel_cloud()
-            ? $this->ensureCorrectUser($event, $event->command.' 2>&1 | tee '.($event->shouldAppendOutput ? '-a ' : '').$output)
-            : $this->ensureCorrectUser($event, $event->command.($event->shouldAppendOutput ? ' >> ' : ' > ').$output.' 2>&1');
+        if (laravel_cloud()) {
+            return $this->ensureCorrectUser($event, $event->command.' 2>&1 | tee '.($event->shouldAppendOutput ? '-a ' : '').$output);
+        }
+
+        if ($event->outputShouldBeForwardedToConsole || Schedule::$outputShouldBeForwardedToConsole) {
+            return $this->ensureCorrectUser($event, $event->command);
+        }
+
+        return $this->ensureCorrectUser($event, $event->command.($event->shouldAppendOutput ? ' >> ' : ' > ').$output.' 2>&1');
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -19,6 +19,7 @@ use Illuminate\Support\Traits\Macroable;
 use Illuminate\Support\Traits\ReflectsClosures;
 use Illuminate\Support\Traits\Tappable;
 use Psr\Http\Client\ClientExceptionInterface;
+use RuntimeException;
 use Symfony\Component\Process\Process;
 use Throwable;
 
@@ -46,6 +47,13 @@ class Event
      * @var bool
      */
     public $shouldAppendOutput = false;
+
+    /**
+     * The open file handle the forwarded output is streamed to while the command process is running.
+     *
+     * @var resource|null
+     */
+    protected $forwardedOutputHandle;
 
     /**
      * The array of callbacks to be run before the event is started.
@@ -213,13 +221,123 @@ class Event
     {
         $context = json_encode($container[Repository::class]->dehydrate());
 
+        $this->openForwardedOutputHandle();
+
+        try {
+            return $this->process($context)->run($this->outputForwardingCallback());
+        } finally {
+            $this->closeForwardedOutputHandle();
+        }
+    }
+
+    /**
+     * Create the process instance for the event.
+     *
+     * @param  string|false  $context
+     * @return \Symfony\Component\Process\Process
+     */
+    protected function process($context)
+    {
         return Process::fromShellCommandline(
             $this->buildCommand(), base_path(), ['__LARAVEL_CONTEXT' => $context], null, null
-        )->run(
-            laravel_cloud()
-                ? fn ($type, $line) => fwrite($type === 'out' ? STDOUT : STDERR, $line)
-                : fn () => true
         );
+    }
+
+    /**
+     * Determine if the command's output should be forwarded to the console process.
+     *
+     * Background events are never forwarded here: they are executed through a
+     * detached shell that manages its own output redirection independently of
+     * this process, so there is nothing meaningful for this process to forward.
+     *
+     * @return bool
+     */
+    protected function shouldForwardOutputToConsole()
+    {
+        return ($this->outputShouldBeForwardedToConsole || Schedule::$outputShouldBeForwardedToConsole)
+            && ! $this->runInBackground;
+    }
+
+    /**
+     * Open the file handle the event's output should be streamed to, if applicable.
+     *
+     * The command itself is built without any output redirection when forwarding is
+     * enabled outside of Laravel Cloud, so the destination is opened here in order
+     * for output to still be streamed to the event's configured destination as the
+     * process runs.
+     *
+     * @return void
+     *
+     * @throws \RuntimeException if the destination cannot be opened
+     */
+    protected function openForwardedOutputHandle()
+    {
+        if (laravel_cloud()
+            || ! $this->shouldForwardOutputToConsole()
+            || $this->output === $this->getDefaultOutput()) {
+            return;
+        }
+
+        $this->forwardedOutputHandle = @fopen($this->output, $this->shouldAppendOutput ? 'ab' : 'wb');
+
+        if ($this->forwardedOutputHandle === false) {
+            $error = error_get_last();
+
+            throw new RuntimeException(sprintf(
+                'Unable to open [%s] for the scheduled command output: %s',
+                $this->output, $error['message'] ?? 'unknown error'
+            ));
+        }
+    }
+
+    /**
+     * Close the file handle the event's output was streamed to, if one was opened.
+     *
+     * @return void
+     */
+    protected function closeForwardedOutputHandle()
+    {
+        if (is_resource($this->forwardedOutputHandle)) {
+            fclose($this->forwardedOutputHandle);
+        }
+
+        $this->forwardedOutputHandle = null;
+    }
+
+    /**
+     * Get the callback used to forward the process output to the console.
+     *
+     * @return callable
+     */
+    protected function outputForwardingCallback()
+    {
+        if (laravel_cloud()) {
+            return fn ($type, $line) => $this->forwardLineToConsole($type, $line);
+        }
+
+        if (! $this->shouldForwardOutputToConsole()) {
+            return fn () => true;
+        }
+
+        return function ($type, $line) {
+            $this->forwardLineToConsole($type, $line);
+
+            if (is_resource($this->forwardedOutputHandle)) {
+                fwrite($this->forwardedOutputHandle, $line);
+            }
+        };
+    }
+
+    /**
+     * Write a line of process output to the console's standard streams.
+     *
+     * @param  string  $type
+     * @param  string  $line
+     * @return void
+     */
+    protected function forwardLineToConsole($type, $line)
+    {
+        fwrite($type === 'out' ? STDOUT : STDERR, $line);
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/ManagesAttributes.php
+++ b/src/Illuminate/Console/Scheduling/ManagesAttributes.php
@@ -91,6 +91,13 @@ trait ManagesAttributes
     public $runInBackground = false;
 
     /**
+     * Indicates if the command's output should be forwarded to the console.
+     *
+     * @var bool
+     */
+    public $outputShouldBeForwardedToConsole = false;
+
+    /**
      * The array of filter callbacks.
      *
      * @var array
@@ -210,6 +217,18 @@ trait ManagesAttributes
     public function runInBackground()
     {
         $this->runInBackground = true;
+
+        return $this;
+    }
+
+    /**
+     * State that the command's output should be forwarded to the console.
+     *
+     * @return $this
+     */
+    public function forwardOutputToConsole()
+    {
+        $this->outputShouldBeForwardedToConsole = true;
 
         return $this;
     }

--- a/src/Illuminate/Console/Scheduling/PendingEventAttributes.php
+++ b/src/Illuminate/Console/Scheduling/PendingEventAttributes.php
@@ -121,6 +121,10 @@ class PendingEventAttributes
             $event->runInBackground();
         }
 
+        if ($this->outputShouldBeForwardedToConsole) {
+            $event->forwardOutputToConsole();
+        }
+
         foreach ($this->filters as $filter) {
             $event->when($filter);
         }

--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -116,6 +116,13 @@ class Schedule
     public static $interruptible = true;
 
     /**
+     * Indicates if the output of scheduled foreground commands should be forwarded to the console.
+     *
+     * @var bool
+     */
+    public static $outputShouldBeForwardedToConsole = false;
+
+    /**
      * Create a new schedule instance.
      *
      * @param  \DateTimeZone|string|null  $timezone
@@ -363,6 +370,18 @@ class Schedule
 
             $group->mergeAttributes($event);
         }
+    }
+
+    /**
+     * Forward the output of all scheduled foreground commands to the console.
+     *
+     * @return $this
+     */
+    public function forwardOutputToConsole()
+    {
+        static::$outputShouldBeForwardedToConsole = true;
+
+        return $this;
     }
 
     /**

--- a/tests/Console/Scheduling/EventTest.php
+++ b/tests/Console/Scheduling/EventTest.php
@@ -4,18 +4,31 @@ namespace Illuminate\Tests\Console\Scheduling;
 
 use Illuminate\Console\Scheduling\Event;
 use Illuminate\Console\Scheduling\EventMutex;
+use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Container\Container;
+use Illuminate\Events\Dispatcher;
+use Illuminate\Log\Context\Repository;
 use Illuminate\Support\ProcessUtils;
 use Illuminate\Support\Str;
 use Illuminate\Support\Stringable;
 use Mockery as m;
 use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 use PHPUnit\Framework\TestCase;
+use ReflectionFunction;
+use ReflectionMethod;
+use RuntimeException;
 
 use function Illuminate\Support\php_binary;
 
 class EventTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        Schedule::$outputShouldBeForwardedToConsole = false;
+
+        parent::tearDown();
+    }
+
     #[RequiresOperatingSystem('Linux|Darwin')]
     public function testBuildCommandUsingUnix()
     {
@@ -117,6 +130,198 @@ class EventTest extends TestCase
 
         $event->appendOutputTo('/dev/null');
         $this->assertSame("php -i >> {$quote}/dev/null{$quote} 2>&1", $event->buildCommand());
+    }
+
+    #[RequiresOperatingSystem('Linux|Darwin')]
+    public function testForwardOutputToConsoleSetsFlagAndReturnsEvent()
+    {
+        $event = new Event(m::mock(EventMutex::class), 'php -i');
+
+        $result = $event->forwardOutputToConsole();
+
+        $this->assertSame($event, $result);
+        $this->assertTrue($event->outputShouldBeForwardedToConsole);
+    }
+
+    #[RequiresOperatingSystem('Linux|Darwin')]
+    public function testForwardOutputToConsoleDoesNotUseShellRedirectionOrTee()
+    {
+        $event = new Event(m::mock(EventMutex::class), 'php -i');
+        $event->forwardOutputToConsole();
+
+        $this->assertSame('php -i', $event->buildCommand());
+    }
+
+    #[RequiresOperatingSystem('Linux|Darwin')]
+    public function testForwardOutputToConsolePreservesExitCode()
+    {
+        $event = new Event(m::mock(EventMutex::class), 'false');
+        $event->forwardOutputToConsole();
+
+        $this->assertSame('false', $event->buildCommand());
+    }
+
+    #[RequiresOperatingSystem('Windows')]
+    public function testForwardOutputToConsoleDoesNotUseTeeOnWindows()
+    {
+        $event = new Event(m::mock(EventMutex::class), 'php -i');
+        $event->forwardOutputToConsole();
+
+        $this->assertSame('php -i', $event->buildCommand());
+    }
+
+    public function testOutputIsNotForwardedByDefault()
+    {
+        $event = new Event(m::mock(EventMutex::class), 'php -i');
+
+        $this->assertFalse($event->outputShouldBeForwardedToConsole);
+    }
+
+    #[RequiresOperatingSystem('Linux|Darwin')]
+    public function testScheduleWideForwardingAppliesRegardlessOfWhenEventWasCreated()
+    {
+        $before = new Event(m::mock(EventMutex::class), 'php -i');
+
+        Schedule::$outputShouldBeForwardedToConsole = true;
+
+        $after = new Event(m::mock(EventMutex::class), 'php -i');
+
+        $this->assertFalse($before->outputShouldBeForwardedToConsole);
+        $this->assertFalse($after->outputShouldBeForwardedToConsole);
+        $this->assertSame('php -i', $before->buildCommand());
+        $this->assertSame('php -i', $after->buildCommand());
+    }
+
+    public function testExecuteUsesForwardingCallbackWhenForwardingEnabled()
+    {
+        $event = $this->silentForwardingEvent('php -i');
+        $event->forwardOutputToConsole();
+
+        $callback = (new ReflectionMethod($event, 'outputForwardingCallback'))->invoke($event);
+
+        $this->assertSame(2, (new ReflectionFunction($callback))->getNumberOfParameters());
+    }
+
+    public function testExecuteUsesNoopCallbackByDefault()
+    {
+        $event = new Event(m::mock(EventMutex::class), 'php -i');
+
+        $callback = (new ReflectionMethod($event, 'outputForwardingCallback'))->invoke($event);
+
+        $this->assertSame(0, (new ReflectionFunction($callback))->getNumberOfParameters());
+    }
+
+    public function testForwardedOutputIsStreamedToConfiguredOutputPath()
+    {
+        $path = tempnam(sys_get_temp_dir(), 'laravel-schedule-output-');
+
+        $event = $this->silentForwardingEvent('php -i');
+        $event->forwardOutputToConsole()->sendOutputTo($path);
+
+        (new ReflectionMethod($event, 'openForwardedOutputHandle'))->invoke($event);
+
+        $callback = (new ReflectionMethod($event, 'outputForwardingCallback'))->invoke($event);
+        $callback('out', "hello world\n");
+
+        (new ReflectionMethod($event, 'closeForwardedOutputHandle'))->invoke($event);
+
+        $this->assertSame("hello world\n", file_get_contents($path));
+        $this->assertSame([['out', "hello world\n"]], $event->forwardedLines);
+
+        unlink($path);
+    }
+
+    public function testForwardedOutputIsAppendedWhenConfigured()
+    {
+        $path = tempnam(sys_get_temp_dir(), 'laravel-schedule-output-');
+        file_put_contents($path, "existing\n");
+
+        $event = $this->silentForwardingEvent('php -i');
+        $event->forwardOutputToConsole()->appendOutputTo($path);
+
+        (new ReflectionMethod($event, 'openForwardedOutputHandle'))->invoke($event);
+
+        $callback = (new ReflectionMethod($event, 'outputForwardingCallback'))->invoke($event);
+        $callback('out', "new line\n");
+
+        (new ReflectionMethod($event, 'closeForwardedOutputHandle'))->invoke($event);
+
+        $this->assertSame("existing\nnew line\n", file_get_contents($path));
+
+        unlink($path);
+    }
+
+    public function testForwardedOutputIsNotStreamedForBackgroundEvents()
+    {
+        $path = tempnam(sys_get_temp_dir(), 'laravel-schedule-output-');
+        file_put_contents($path, "existing\n");
+
+        $event = $this->silentForwardingEvent('php -i');
+        $event->forwardOutputToConsole()->appendOutputTo($path)->runInBackground();
+
+        (new ReflectionMethod($event, 'openForwardedOutputHandle'))->invoke($event);
+
+        $callback = (new ReflectionMethod($event, 'outputForwardingCallback'))->invoke($event);
+        $this->assertSame(0, (new ReflectionFunction($callback))->getNumberOfParameters());
+        $callback();
+
+        (new ReflectionMethod($event, 'closeForwardedOutputHandle'))->invoke($event);
+
+        $this->assertSame([], $event->forwardedLines);
+        $this->assertSame("existing\n", file_get_contents($path));
+
+        unlink($path);
+    }
+
+    public function testOpenForwardedOutputHandleThrowsForUnwritableDestination()
+    {
+        $event = $this->silentForwardingEvent('php -i');
+        $event->forwardOutputToConsole()->sendOutputTo('/this/path/does/not/exist/output.log');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/\/this\/path\/does\/not\/exist\/output\.log/');
+
+        (new ReflectionMethod($event, 'openForwardedOutputHandle'))->invoke($event);
+    }
+
+    public function testRunReportsFailureWhenOutputDestinationCannotBeOpened()
+    {
+        $mutex = m::mock(EventMutex::class);
+        $mutex->shouldReceive('create')->andReturn(true);
+        $mutex->shouldReceive('forget');
+
+        $event = new Event($mutex, 'php -i');
+        $event->forwardOutputToConsole()->sendOutputTo('/this/path/does/not/exist/output.log');
+
+        $container = new Container;
+        $container->instance(
+            Repository::class,
+            new Repository(new Dispatcher)
+        );
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/\/this\/path\/does\/not\/exist\/output\.log/');
+
+        $event->run($container);
+    }
+
+    /**
+     * Create an event whose console output is captured instead of being written to the real STDOUT/STDERR streams.
+     *
+     * @param  string  $command
+     * @return \Illuminate\Console\Scheduling\Event
+     */
+    protected function silentForwardingEvent($command)
+    {
+        return new class(m::mock(EventMutex::class), $command) extends Event
+        {
+            public $forwardedLines = [];
+
+            protected function forwardLineToConsole($type, $line)
+            {
+                $this->forwardedLines[] = [$type, $line];
+            }
+        };
     }
 
     public function testNextRunDate()

--- a/tests/Console/Scheduling/ScheduleTest.php
+++ b/tests/Console/Scheduling/ScheduleTest.php
@@ -32,6 +32,13 @@ final class ScheduleTest extends TestCase
         $this->container->instance(SchedulingMutex::class, $schedulingMutex);
     }
 
+    protected function tearDown(): void
+    {
+        Schedule::$outputShouldBeForwardedToConsole = false;
+
+        parent::tearDown();
+    }
+
     #[DataProvider('jobHonoursDisplayNameIfMethodExistsProvider')]
     public function testJobHonoursDisplayNameIfMethodExists(object $job, string $jobName): void
     {
@@ -115,5 +122,30 @@ final class ScheduleTest extends TestCase
 
         $this->assertSame(['team' => 'platform'], $events[0]->attributes);
         $this->assertSame([], $events[1]->attributes);
+    }
+
+    public function testForwardOutputToConsoleAppliesRegardlessOfCallOrder(): void
+    {
+        $schedule = new Schedule();
+
+        $before = $schedule->command('inspire');
+
+        $schedule->forwardOutputToConsole();
+
+        $after = $schedule->command('queue:work');
+
+        $this->assertTrue(Schedule::$outputShouldBeForwardedToConsole);
+        $this->assertStringNotContainsString('>', $before->buildCommand());
+        $this->assertStringNotContainsString('>', $after->buildCommand());
+    }
+
+    public function testForwardOutputToConsoleIsDisabledByDefault(): void
+    {
+        $schedule = new Schedule();
+
+        $event = $schedule->command('inspire');
+
+        $this->assertFalse(Schedule::$outputShouldBeForwardedToConsole);
+        $this->assertStringContainsString('>', $event->buildCommand());
     }
 }

--- a/tests/Integration/Console/Scheduling/ScheduleRunCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleRunCommandTest.php
@@ -27,6 +27,8 @@ class ScheduleRunCommandTest extends TestCase
     {
         Carbon::setTestNow();
 
+        Schedule::$outputShouldBeForwardedToConsole = false;
+
         parent::tearDown();
     }
 
@@ -260,6 +262,130 @@ class ScheduleRunCommandTest extends TestCase
         Event::assertDispatched(ScheduledTaskStarting::class);
         Event::assertDispatched(ScheduledTaskFinished::class);
         Event::assertNotDispatched(ScheduledTaskFailed::class);
+    }
+
+    /**
+     * @throws BindingResolutionException
+     */
+    public function test_forward_output_to_console_preserves_failing_exit_code()
+    {
+        Event::fake([
+            ScheduledTaskStarting::class,
+            ScheduledTaskFinished::class,
+            ScheduledTaskFailed::class,
+        ]);
+
+        $schedule = $this->app->make(Schedule::class);
+        $task = $schedule->exec('exit 1')
+            ->everyMinute()
+            ->forwardOutputToConsole();
+
+        $task->when(function () {
+            return true;
+        });
+
+        $this->artisan('schedule:run');
+
+        Event::assertDispatched(ScheduledTaskFailed::class, function ($event) use ($task) {
+            return $event->task === $task;
+        });
+    }
+
+    /**
+     * @throws BindingResolutionException
+     */
+    public function test_forward_output_to_console_writes_output_to_configured_destination()
+    {
+        $path = tempnam(sys_get_temp_dir(), 'laravel-schedule-output-');
+
+        $schedule = $this->app->make(Schedule::class);
+        $command = PHP_OS_FAMILY === 'Windows' ? 'echo hello world' : "echo 'hello world'";
+        $task = $schedule->exec($command)
+            ->everyMinute()
+            ->forwardOutputToConsole()
+            ->sendOutputTo($path);
+
+        $task->when(function () {
+            return true;
+        });
+
+        $this->artisan('schedule:run');
+
+        $this->assertSame('hello world', trim(file_get_contents($path)));
+
+        unlink($path);
+    }
+
+    /**
+     * @throws BindingResolutionException
+     */
+    public function test_forward_output_to_console_does_not_affect_background_events()
+    {
+        Event::fake([
+            ScheduledTaskStarting::class,
+            ScheduledTaskFinished::class,
+            ScheduledTaskFailed::class,
+        ]);
+
+        $path = tempnam(sys_get_temp_dir(), 'laravel-schedule-output-');
+        file_put_contents($path, "existing\n");
+
+        $schedule = $this->app->make(Schedule::class);
+        $command = PHP_OS_FAMILY === 'Windows' ? 'echo hello world' : "echo 'hello world'";
+        $task = $schedule->exec($command)
+            ->everyMinute()
+            ->forwardOutputToConsole()
+            ->appendOutputTo($path)
+            ->runInBackground();
+
+        $task->when(function () {
+            return true;
+        });
+
+        $this->artisan('schedule:run');
+
+        // Give the detached background process a moment to finish writing its own output.
+        usleep(300000);
+
+        Event::assertNotDispatched(ScheduledTaskFailed::class);
+        $this->assertStringContainsString('hello world', file_get_contents($path));
+
+        unlink($path);
+    }
+
+    /**
+     * @throws BindingResolutionException
+     */
+    public function test_schedule_wide_forward_output_to_console_applies_to_events_created_before_and_after()
+    {
+        $schedule = $this->app->make(Schedule::class);
+
+        $beforePath = tempnam(sys_get_temp_dir(), 'laravel-schedule-output-');
+        $afterPath = tempnam(sys_get_temp_dir(), 'laravel-schedule-output-');
+
+        $before = $schedule->exec("echo 'before'")
+            ->everyMinute()
+            ->sendOutputTo($beforePath);
+
+        $schedule->forwardOutputToConsole();
+
+        $after = $schedule->exec("echo 'after'")
+            ->everyMinute()
+            ->sendOutputTo($afterPath);
+
+        foreach ([$before, $after] as $task) {
+            $task->when(function () {
+                return true;
+            });
+        }
+
+        $this->artisan('schedule:run');
+
+        $this->assertSame('before', trim(file_get_contents($beforePath)));
+        $this->assertSame('after', trim(file_get_contents($afterPath)));
+
+        unlink($beforePath);
+        unlink($afterPath);
     }
 
     public function test_repeat_events_does_not_mutate_started_at()


### PR DESCRIPTION
## Summary

Laravel currently forwards scheduled command output (stdout/stderr) to the parent `schedule:run` process only when running on Laravel Cloud (#53623). On self-hosted/containerized deployments (Docker, Kubernetes), scheduled command output is redirected to a file or `/dev/null` by default, so log lines written by scheduled commands (e.g. `LOG_CHANNEL=stderr`) never reach `docker logs` / `kubectl logs`, even though the parent "Running [...]" line does. Discussion #47448 tracks demand for this; a previous attempt (#56611) added default forwarding and was closed because the implementation wasn't loved.

This PR generalizes the existing Laravel Cloud capability into an explicit, opt-in API instead of changing default behavior:

```php
// Per event
$schedule->command('foo')->everyMinute()->forwardOutputToConsole();

// Or for every foreground event on the schedule, regardless of call order
$schedule->forwardOutputToConsole();
$schedule->command('foo')->everyMinute();
$schedule->command('bar')->hourly();
```

- `Event::forwardOutputToConsole()` opts a single event in.
- `Schedule::forwardOutputToConsole()` is a schedule-wide static toggle (mirrors `Schedule::$pausable`/`$interruptible`/`useCache()`) — it applies to every foreground event regardless of whether it's called before or after `command()`/`exec()`.
- Output is streamed to the event's configured destination (`sendOutputTo`/`appendOutputTo`) via the Symfony `Process` output callback instead of shell redirection (`tee`), so:
  - the scheduled command's real exit code is preserved (a failing command isn't masked by a successful `tee`),
  - memory stays bounded for long-running/chatty commands (streamed, not buffered),
  - it works on Windows without a `tee` dependency.
- Background events (`runInBackground()`) are intentionally unaffected — they already run through a detached shell that owns its own output redirection via `schedule:finish`, so there is nothing for this process to forward. Covered explicitly by tests rather than attempting to support it.
- If the configured output destination can't be opened, the event now throws a descriptive exception (surfaced as `ScheduledTaskFailed` + reported) instead of silently succeeding.
- Defaults are unchanged. Laravel Cloud's existing behavior (`laravel_cloud()`) is untouched.

This avoids application-level workarounds like writing to a temp file and using `after()` to `fwrite` it out.

## Test plan

- [x] `Event::forwardOutputToConsole()` sets the flag and returns `$this`
- [x] Foreground command is built without shell redirection/`tee` when forwarding is enabled (including a failing command, to verify exit code preservation)
- [x] `Event::execute()` uses the forwarding callback when enabled, and the no-op callback by default
- [x] Output is still written to an explicitly configured destination (`sendOutputTo`/`appendOutputTo`), both truncating and appending
- [x] Background events are unaffected by forwarding (unit + integration test)
- [x] `Schedule::forwardOutputToConsole()` applies to events created before *and* after the call (integration test through real `schedule:run` execution)
- [x] Unwritable output destination throws a descriptive exception instead of silently succeeding
- [x] Existing default behavior (shell redirection, Laravel Cloud `tee` path) is unchanged
- [x] Full `tests/Console` and `tests/Integration/Console` suites pass; Pint and PHPStan clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)