### PR TITLE
[13.x] Implement `creationTimeOfOldestPendingJob` on the QueueFake

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -12,6 +12,7 @@ use Illuminate\Events\CallQueuedListener;
 use Illuminate\Queue\CallQueuedClosure;
 use Illuminate\Queue\Jobs\InspectedJob;
 use Illuminate\Queue\QueueManager;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\ReflectsClosures;
@@ -573,7 +574,7 @@ class QueueFake extends QueueManager implements Fake, Queue
                     : $data['job'],
                 attempts: 0,
                 payload: [],
-                createdAt: null,
+                createdAt: isset($data['createdAt']) ? Carbon::createFromTimestamp($data['createdAt']) : null,
             ));
     }
 
@@ -595,7 +596,10 @@ class QueueFake extends QueueManager implements Fake, Queue
      */
     public function creationTimeOfOldestPendingJob($queue = null)
     {
-        return null;
+        return (new Collection($this->jobs))
+            ->flatten(1)
+            ->whereStrict('queue', enum_value($queue))
+            ->min('createdAt');
     }
 
     /**
@@ -623,6 +627,7 @@ class QueueFake extends QueueManager implements Fake, Queue
                 'job' => $this->serializeAndRestore ? $this->serializeAndRestoreJob($job) : $job,
                 'queue' => $queue,
                 'data' => $data,
+                'createdAt' => Carbon::now()->getTimestamp(),
             ];
 
             if ($job instanceof ShouldBeUnique) {
@@ -711,6 +716,7 @@ class QueueFake extends QueueManager implements Fake, Queue
             $this->delayed[is_object($job) ? get_class($job) : $job][] = [
                 'job' => $job,
                 'queue' => enum_value($queue),
+                'createdAt' => Carbon::now()->getTimestamp(),
             ];
         }
 
@@ -762,6 +768,7 @@ class QueueFake extends QueueManager implements Fake, Queue
         $this->reserved[is_object($job) ? get_class($job) : $job][] = [
             'job' => $this->serializeAndRestore ? $this->serializeAndRestoreJob($job) : $job,
             'queue' => $queue,
+            'createdAt' => Carbon::now()->getTimestamp(),
         ];
     }
 

--- a/tests/Support/SupportTestingQueueFakeTest.php
+++ b/tests/Support/SupportTestingQueueFakeTest.php
@@ -8,6 +8,7 @@ use Illuminate\Foundation\Application;
 use Illuminate\Queue\CallQueuedClosure;
 use Illuminate\Queue\Jobs\InspectedJob;
 use Illuminate\Queue\QueueManager;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Testing\Fakes\QueueFake;
 use Mockery as m;
 use PHPUnit\Framework\ExpectationFailedException;
@@ -648,6 +649,21 @@ class SupportTestingQueueFakeTest extends TestCase
         $this->fake->later(10, $this->job, '', 'foo');
 
         $this->fake->assertPushedOn('foo', JobStub::class);
+    }
+
+    public function testCreationTimeOfOldestPendingJob()
+    {
+        Carbon::setTestNow($now = Carbon::now());
+
+        $this->assertNull($this->fake->creationTimeOfOldestPendingJob('foo'));
+
+        $this->fake->push($this->job, '', 'foo');
+
+        Carbon::setTestNow($now->copy()->addMinutes(5));
+
+        $this->fake->push(new JobToFakeStub, '', 'foo');
+
+        $this->assertSame($now->getTimestamp(), $this->fake->creationTimeOfOldestPendingJob('foo'));
     }
 
     public function testReservedJobs()


### PR DESCRIPTION

The PR ensures `creationTimeOfOldestPendingJob` works on the fake, this means when we use it in commands / jobs, we can test it properly, it also means all the `InspectedJob` classes have a createdAt set, which is what would happen on the real drivers, which is very useful for tests etc. 

The fake methods includes delayed jobs, as there's no real "delay" happening cos that's how pushed works atm too.

This now means, **all** the queue metrics/inspection methods are covered by the fake 🥳
