### PR TITLE
[13.x] Normalize HTTP client request header lookups

### DIFF
--- a/src/Illuminate/Http/Client/Request.php
+++ b/src/Illuminate/Http/Client/Request.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Http\Client;
 
 use ArrayAccess;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Support\Uri;
@@ -83,19 +82,17 @@ class Request implements ArrayAccess
      */
     public function hasHeader($key, $value = null)
     {
-        if (is_null($value)) {
-            return ! empty($this->request->getHeaders()[$key]);
+        if (! $this->request->hasHeader($key)) {
+            return false;
         }
 
-        $headers = $this->headers();
-
-        if (! Arr::has($headers, $key)) {
-            return false;
+        if (is_null($value)) {
+            return true;
         }
 
         $value = is_array($value) ? $value : [$value];
 
-        return empty(array_diff($value, $headers[$key]));
+        return empty(array_diff($value, $this->request->getHeader($key)));
     }
 
     /**
@@ -127,7 +124,7 @@ class Request implements ArrayAccess
      */
     public function header($key)
     {
-        return Arr::get($this->headers(), $key, []);
+        return $this->request->getHeader($key);
     }
 
     /**

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -829,6 +829,37 @@ class HttpClientTest extends TestCase
         });
     }
 
+    public function testRequestHeadersAreCheckedCaseInsensitively()
+    {
+        $this->factory->fake();
+
+        $this->factory->withHeaders([
+            'foo' => 'Bar',
+        ])->post('http://foo.com/json');
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->hasHeader('Foo')
+                && $request->hasHeader('Foo', 'Bar')
+                && $request->header('Foo') === ['Bar'];
+        });
+    }
+
+    public function testContentTypeHeadersAreCheckedCaseInsensitively()
+    {
+        $this->factory->fake();
+
+        $this->factory->send('POST', 'http://foo.com/json', [
+            'headers' => ['content-type' => 'application/json'],
+            'body' => '{"name":"Taylor"}',
+        ]);
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->hasHeader('Content-Type')
+                && $request->header('Content-Type') === ['application/json']
+                && $request->isJson();
+        });
+    }
+
     public function testCanSendFormDataWithStringable()
     {
         $this->factory->fake();


### PR DESCRIPTION
This PR fixes case sensitive header lookups in `Illuminate\Http\Client\Request`. 

`hasHeader()` and `header()` were reading from the raw header array, so lookups depended on the stored key casing. This switches them to the PSR-7 header accessors, which are case insensitive.

