### PR TITLE
[13.x] Add model contract mapping for eloquent relationships

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -219,13 +219,15 @@ trait HasRelationships
      *
      * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
      *
-     * @param  class-string<TRelatedModel>  $related
+     * @param  class-string<TRelatedModel>  $related  The related model class or a mapped contract
      * @param  string|null  $foreignKey
      * @param  string|null  $localKey
      * @return \Illuminate\Database\Eloquent\Relations\HasOne<TRelatedModel, $this>
      */
     public function hasOne($related, $foreignKey = null, $localKey = null)
     {
+        $related = Relation::getModelForContract($related) ?? $related;
+
         $instance = $this->newRelatedInstance($related);
 
         $foreignKey = $foreignKey ?: $this->getForeignKey();
@@ -258,8 +260,8 @@ trait HasRelationships
      * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
      * @template TIntermediateModel of \Illuminate\Database\Eloquent\Model
      *
-     * @param  class-string<TRelatedModel>  $related
-     * @param  class-string<TIntermediateModel>  $through
+     * @param  class-string<TRelatedModel>  $related  The related model class or a mapped contract
+     * @param  class-string<TIntermediateModel>  $through  The intermediate model class or a mapped contract
      * @param  string|null  $firstKey
      * @param  string|null  $secondKey
      * @param  string|null  $localKey
@@ -268,6 +270,9 @@ trait HasRelationships
      */
     public function hasOneThrough($related, $through, $firstKey = null, $secondKey = null, $localKey = null, $secondLocalKey = null)
     {
+        $related = Relation::getModelForContract($related) ?? $related;
+        $through = Relation::getModelForContract($through) ?? $through;
+
         $through = $this->newRelatedThroughInstance($through);
 
         $firstKey = $firstKey ?: $this->getForeignKey();
@@ -311,7 +316,7 @@ trait HasRelationships
      *
      * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
      *
-     * @param  class-string<TRelatedModel>  $related
+     * @param  class-string<TRelatedModel>  $related  The related model class or a mapped contract
      * @param  string  $name
      * @param  string|null  $type
      * @param  string|null  $id
@@ -320,6 +325,8 @@ trait HasRelationships
      */
     public function morphOne($related, $name, $type = null, $id = null, $localKey = null)
     {
+        $related = Relation::getModelForContract($related) ?? $related;
+
         $instance = $this->newRelatedInstance($related);
 
         [$type, $id] = $this->getMorphs($name, $type, $id);
@@ -352,7 +359,7 @@ trait HasRelationships
      *
      * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
      *
-     * @param  class-string<TRelatedModel>  $related
+     * @param  class-string<TRelatedModel>  $related  The related model class or a mapped contract
      * @param  string|null  $foreignKey
      * @param  string|null  $ownerKey
      * @param  string|null  $relation
@@ -366,6 +373,8 @@ trait HasRelationships
         if (is_null($relation)) {
             $relation = $this->guessBelongsToRelation();
         }
+
+        $related = Relation::getModelForContract($related) ?? $related;
 
         $instance = $this->newRelatedInstance($related);
 
@@ -541,13 +550,15 @@ trait HasRelationships
      *
      * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
      *
-     * @param  class-string<TRelatedModel>  $related
+     * @param  class-string<TRelatedModel>  $related  The related model class or a mapped contract
      * @param  string|null  $foreignKey
      * @param  string|null  $localKey
      * @return \Illuminate\Database\Eloquent\Relations\HasMany<TRelatedModel, $this>
      */
     public function hasMany($related, $foreignKey = null, $localKey = null)
     {
+        $related = Relation::getModelForContract($related) ?? $related;
+
         $instance = $this->newRelatedInstance($related);
 
         $foreignKey = $foreignKey ?: $this->getForeignKey();
@@ -582,8 +593,8 @@ trait HasRelationships
      * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
      * @template TIntermediateModel of \Illuminate\Database\Eloquent\Model
      *
-     * @param  class-string<TRelatedModel>  $related
-     * @param  class-string<TIntermediateModel>  $through
+     * @param  class-string<TRelatedModel>  $related  The related model class or a mapped contract
+     * @param  class-string<TIntermediateModel>  $through  The intermediate model class or a mapped contract
      * @param  string|null  $firstKey
      * @param  string|null  $secondKey
      * @param  string|null  $localKey
@@ -592,6 +603,9 @@ trait HasRelationships
      */
     public function hasManyThrough($related, $through, $firstKey = null, $secondKey = null, $localKey = null, $secondLocalKey = null)
     {
+        $related = Relation::getModelForContract($related) ?? $related;
+        $through = Relation::getModelForContract($through) ?? $through;
+
         $through = $this->newRelatedThroughInstance($through);
 
         $firstKey = $firstKey ?: $this->getForeignKey();
@@ -635,7 +649,7 @@ trait HasRelationships
      *
      * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
      *
-     * @param  class-string<TRelatedModel>  $related
+     * @param  class-string<TRelatedModel>  $related  The related model class or a mapped contract
      * @param  string  $name
      * @param  string|null  $type
      * @param  string|null  $id
@@ -644,6 +658,8 @@ trait HasRelationships
      */
     public function morphMany($related, $name, $type = null, $id = null, $localKey = null)
     {
+        $related = Relation::getModelForContract($related) ?? $related;
+
         $instance = $this->newRelatedInstance($related);
 
         // Here we will gather up the morph type and ID for the relationship so that we
@@ -681,7 +697,7 @@ trait HasRelationships
      * @template TPivotModel of \Illuminate\Database\Eloquent\Relations\Pivot = \Illuminate\Database\Eloquent\Relations\Pivot
      * @template TPivotTable of string|null
      *
-     * @param  class-string<TRelatedModel>  $related
+     * @param  class-string<TRelatedModel>  $related  The related model class or a mapped contract
      * @param  class-string<TPivotModel>|TPivotTable  $table
      * @param  string|null  $foreignPivotKey
      * @param  string|null  $relatedPivotKey
@@ -709,6 +725,8 @@ trait HasRelationships
         // First, we'll need to determine the foreign key and "other key" for the
         // relationship. Once we have determined the keys we'll make the query
         // instances as well as the relationship instances we need for this.
+        $related = Relation::getModelForContract($related) ?? $related;
+
         $instance = $this->newRelatedInstance($related);
 
         $foreignPivotKey = $foreignPivotKey ?: $this->getForeignKey();
@@ -768,7 +786,7 @@ trait HasRelationships
      *
      * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
      *
-     * @param  class-string<TRelatedModel>  $related
+     * @param  class-string<TRelatedModel>  $related  The related model class or a mapped contract
      * @param  string  $name
      * @param  string|null  $table
      * @param  string|null  $foreignPivotKey
@@ -791,6 +809,8 @@ trait HasRelationships
         $inverse = false,
     ) {
         $relation = $relation ?: $this->guessBelongsToManyRelation();
+
+        $related = Relation::getModelForContract($related) ?? $related;
 
         // First, we will need to determine the foreign key and "other key" for the
         // relationship. Once we have determined the keys we will make the query
@@ -875,7 +895,7 @@ trait HasRelationships
      *
      * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
      *
-     * @param  class-string<TRelatedModel>  $related
+     * @param  class-string<TRelatedModel>  $related  The related model class or a mapped contract
      * @param  string  $name
      * @param  string|null  $table
      * @param  string|null  $foreignPivotKey

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -13,6 +13,7 @@ use Illuminate\Database\Query\Expression;
 use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Support\Traits\ForwardsCalls;
 use Illuminate\Support\Traits\Macroable;
+use InvalidArgumentException;
 
 /**
  * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
@@ -68,6 +69,13 @@ abstract class Relation implements BuilderContract
      * @var array<string, class-string<\Illuminate\Database\Eloquent\Model>>
      */
     public static $morphMap = [];
+
+    /**
+     * An array to map model contracts to their concrete model classes.
+     *
+     * @var array<class-string, class-string<\Illuminate\Database\Eloquent\Model>>
+     */
+    public static $modelContractMap = [];
 
     /**
      * Prevents morph relationships without a morph map.
@@ -481,6 +489,55 @@ abstract class Relation implements BuilderContract
         }
 
         return static::$morphMap;
+    }
+
+    /**
+     * Set or get the map of model contracts to concrete model classes.
+     *
+     * @param  array<class-string, class-string<\Illuminate\Database\Eloquent\Model>>|null  $map
+     * @param  bool  $merge
+     * @return array<class-string, class-string<\Illuminate\Database\Eloquent\Model>>
+     *
+     * @throws \InvalidArgumentException
+     */
+    public static function contractMap(?array $map = null, $merge = true)
+    {
+        if (is_array($map)) {
+            $eloquentModelClass = Model::class;
+
+            foreach ($map as $contract => $model) {
+                if (! is_string($contract) || ! interface_exists($contract)) {
+                    throw new InvalidArgumentException("Model contract [{$contract}] must be an interface.");
+                }
+
+                if (! is_string($model) || ! is_subclass_of($model, $eloquentModelClass)) {
+                    $model = is_string($model) ? $model : get_debug_type($model);
+
+                    throw new InvalidArgumentException("Model [{$model}] mapped to contract [{$contract}] must extend [{$eloquentModelClass}].");
+                }
+
+                if (! is_a($model, $contract, true)) {
+                    throw new InvalidArgumentException("Model [{$model}] mapped to contract [{$contract}] must implement [{$contract}].");
+                }
+            }
+
+            static::$modelContractMap = $merge && static::$modelContractMap
+                ? $map + static::$modelContractMap
+                : $map;
+        }
+
+        return static::$modelContractMap;
+    }
+
+    /**
+     * Get the model associated with a model contract.
+     *
+     * @param  class-string  $contract
+     * @return class-string<\Illuminate\Database\Eloquent\Model>|null
+     */
+    public static function getModelForContract($contract)
+    {
+        return static::$modelContractMap[$contract] ?? null;
     }
 
     /**

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -10,11 +10,19 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Carbon;
+use InvalidArgumentException;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
 class DatabaseEloquentRelationTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        Relation::contractMap([], false);
+
+        parent::tearDown();
+    }
+
     public function testSetRelationFail()
     {
         $parent = new EloquentRelationResetModelStub;
@@ -238,6 +246,67 @@ class DatabaseEloquentRelationTest extends TestCase
         $this->assertSame('Does\Not\Exist', Relation::getMorphAlias('Does\Not\Exist'));
     }
 
+    public function testContractMapCanBeRegisteredLookedUpMergedReplacedAndReset()
+    {
+        $this->assertSame([], Relation::contractMap());
+
+        Relation::contractMap([
+            EloquentRelationContractStub::class => EloquentRelationContractModelStub::class,
+        ]);
+
+        $this->assertSame(EloquentRelationContractModelStub::class, Relation::getModelForContract(EloquentRelationContractStub::class));
+        $this->assertNull(Relation::getModelForContract(EloquentRelationOtherContractStub::class));
+
+        Relation::contractMap([
+            EloquentRelationOtherContractStub::class => EloquentRelationOtherContractModelStub::class,
+        ]);
+
+        $this->assertSame([
+            EloquentRelationOtherContractStub::class => EloquentRelationOtherContractModelStub::class,
+            EloquentRelationContractStub::class => EloquentRelationContractModelStub::class,
+        ], Relation::contractMap());
+
+        Relation::contractMap([
+            EloquentRelationContractStub::class => EloquentRelationContractModelStub::class,
+        ], false);
+
+        $this->assertSame([
+            EloquentRelationContractStub::class => EloquentRelationContractModelStub::class,
+        ], Relation::contractMap());
+
+        $this->assertSame([], Relation::contractMap([], false));
+    }
+
+    public function testContractMapRejectsNonInterfaceKeys()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Model contract ['.EloquentRelationResetModelStub::class.'] must be an interface.');
+
+        Relation::contractMap([
+            EloquentRelationResetModelStub::class => EloquentRelationContractModelStub::class,
+        ]);
+    }
+
+    public function testContractMapRejectsValuesThatAreNotModels()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Model ['.EloquentRelationNonModelStub::class.'] mapped to contract ['.EloquentRelationContractStub::class.'] must extend ['.Model::class.'].');
+
+        Relation::contractMap([
+            EloquentRelationContractStub::class => EloquentRelationNonModelStub::class,
+        ]);
+    }
+
+    public function testContractMapRejectsModelsThatDoNotImplementTheContract()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Model ['.EloquentRelationResetModelStub::class.'] mapped to contract ['.EloquentRelationContractStub::class.'] must implement ['.EloquentRelationContractStub::class.'].');
+
+        Relation::contractMap([
+            EloquentRelationContractStub::class => EloquentRelationResetModelStub::class,
+        ]);
+    }
+
     public function testWithoutRelations()
     {
         $original = new EloquentNoTouchingModelStub;
@@ -397,4 +466,29 @@ class EloquentRelationAndAttributeModelStub extends Model
     {
         return $this->belongsTo(self::class);
     }
+}
+
+interface EloquentRelationContractStub
+{
+    //
+}
+
+interface EloquentRelationOtherContractStub
+{
+    //
+}
+
+class EloquentRelationContractModelStub extends Model implements EloquentRelationContractStub
+{
+    //
+}
+
+class EloquentRelationOtherContractModelStub extends Model implements EloquentRelationOtherContractStub
+{
+    //
+}
+
+class EloquentRelationNonModelStub implements EloquentRelationContractStub
+{
+    //
 }

--- a/tests/Database/DatabaseEloquentRelationshipsTest.php
+++ b/tests/Database/DatabaseEloquentRelationshipsTest.php
@@ -15,6 +15,7 @@ use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Query\Builder as BaseBuilder;
 use Illuminate\Database\Query\Grammars\Grammar;
 use Illuminate\Database\Query\Processors\Processor;
@@ -23,6 +24,13 @@ use PHPUnit\Framework\TestCase;
 
 class DatabaseEloquentRelationshipsTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        Relation::contractMap([], false);
+
+        parent::tearDown();
+    }
+
     public function testStandardRelationships()
     {
         $post = new Post;
@@ -53,6 +61,36 @@ class DatabaseEloquentRelationshipsTest extends TestCase
         $this->assertInstanceOf(CustomHasOneThrough::class, $post->contract());
         $this->assertInstanceOf(CustomMorphToMany::class, $post->tags());
         $this->assertInstanceOf(CustomMorphTo::class, $post->postable());
+    }
+
+    public function testRelationshipHelpersResolveMappedContractsBeforeProtectedExtensionPoints()
+    {
+        Relation::contractMap([
+            RelatedContract::class => ContractModel::class,
+            ThroughContract::class => ContractThroughModel::class,
+        ]);
+
+        $post = new ContractPost;
+
+        $relations = Relation::noConstraints(fn () => [
+            $post->hasOne(RelatedContract::class),
+            $post->hasMany(RelatedContract::class),
+            $post->belongsTo(RelatedContract::class),
+            $post->hasOneThrough(RelatedContract::class, ThroughContract::class),
+            $post->hasManyThrough(RelatedContract::class, ThroughContract::class),
+            $post->morphOne(RelatedContract::class, 'contractable'),
+            $post->morphMany(RelatedContract::class, 'contractable'),
+            $post->belongsToMany(RelatedContract::class),
+            $post->morphToMany(RelatedContract::class, 'contractable'),
+            $post->morphedByMany(RelatedContract::class, 'contractable'),
+        ]);
+
+        foreach ($relations as $relation) {
+            $this->assertInstanceOf(ContractModel::class, $relation->getRelated());
+        }
+
+        $this->assertSame(array_fill(0, 10, ContractModel::class), $post->relatedClasses);
+        $this->assertSame(array_fill(0, 2, ContractThroughModel::class), $post->throughClasses);
     }
 
     public function testAlwaysUnsetBelongsToRelationWhenReceivedModelId()
@@ -263,6 +301,55 @@ class DatabaseEloquentRelationshipsTest extends TestCase
 class FakeRelationship extends Model
 {
     //
+}
+
+interface RelatedContract
+{
+    //
+}
+
+interface ThroughContract
+{
+    //
+}
+
+class ContractConnectionModel extends Model
+{
+    public function getConnection()
+    {
+        return new Connection(null);
+    }
+}
+
+class ContractModel extends ContractConnectionModel implements RelatedContract
+{
+    //
+}
+
+class ContractThroughModel extends ContractConnectionModel implements ThroughContract
+{
+    //
+}
+
+class ContractPost extends ContractConnectionModel
+{
+    public $relatedClasses = [];
+
+    public $throughClasses = [];
+
+    protected function newRelatedInstance($class)
+    {
+        $this->relatedClasses[] = $class;
+
+        return parent::newRelatedInstance($class);
+    }
+
+    protected function newRelatedThroughInstance($class)
+    {
+        $this->throughClasses[] = $class;
+
+        return parent::newRelatedThroughInstance($class);
+    }
 }
 
 class Post extends Model


### PR DESCRIPTION
## Summary

This PR allows eloquent relationship targets to be declared as interfaces, with applications mapping those contracts to concrete eloquent model classes during application boot. This is particularly useful for packages that need to define relationships to application owned models, but don't want to depend on the application model namespace.

A package can define a relationship without depending on the consuming application model:

```php
return $this->belongsTo(UserContract::class);
```

The application can then register its concrete implementation in a service provider:

```php
Relation::contractMap([
    UserContract::class => App\Models\User::class,
]);
```

## Motivation

Packages commonly need to define relationships to application owned models. Referencing a concrete model class couples the package to the application namespace and model implementation, while resolving models through the container or config helpers during every relationship construction introduces additional runtime behavior.

Contract maps provide an explicit, upfront configuration point. Packages can depend on stable interfaces, while applications retain control over the concrete eloquent models used by those relationships.

Checking some of the more popular laravel packages on github and the following (or similar) implemention is common, which is slower to resolve and harder to verify with static analysis:

```php
return $this->belongsTo(config('auth.providers.users.model'));
```

## Implementation

This adds the following APIs to `Relation`:

```php
Relation::contractMap(?array $map = null, $merge = true);
Relation::getModelForContract($contract);
```

`contractMap()` follows the existing `morphMap()` conventions:

- calling it without a map returns the current mappings.
- new mappings are merged by default.
- passing `false` as the second argument replaces the existing mappings.
- passing an empty array with `false` resets the map.

Mappings are validated when registered:

- keys must reference interfaces.
- values must extend eloquent's `Model`.
- values must implement their mapped interfaces.
- invalid mappings throw descriptive `InvalidArgumentException` instances.

Contract targets are resolved before eloquent calls its existing `newRelatedInstance()` or `newRelatedThroughInstance()` extension points. This ensures applications overriding those protected methods receive the resolved concrete model class.

Resolution applies to explicitly supplied related and through targets for:

- `hasOne`
- `hasMany`
- `belongsTo`
- `hasOneThrough`
- `hasManyThrough`
- `morphOne`
- `morphMany`
- `belongsToMany`
- `morphToMany`
- `morphedByMany` through its existing delegation

I also implemented it a few different ways (not included in this PR), and benchmarked each of them, with the current implementation being the fastest and most backwards compatible:

- using the service container to resolve the model from the interface like any other dependency
- changing the newRelatedInstance() and newRelatedThroughInstance() methods to resolve the model from the contract map

## Backward Compatibility

Existing relationships that reference concrete model classes continue to use the same model construction path.

Concrete model classes are not resolved through the container, reflected upon, or validated during relationship construction. If no contract mapping exists, the supplied class is passed directly to the existing protected construction methods as before.

Contract resolution is limited to relationship helpers where a developer explicitly supplies a related or through target. Other eloquent model resolution behavior is unchanged.

## Tests

Tests cover:

- registration and lookup
- merging existing maps
- replacement and reset behavior
- rejection of non-interface keys
- rejection of values that do not extend `Model`
- rejection of models that do not implement their mapped contract
- resolution across every supported relationship helper
- resolution before protected model-construction extension points

## Possible Improvements

- look at merging the contract map with the morph map?
- improve the type defintion on some relatioship methods like `@param  class-string<TRelatedModel>  $related` to allow for interfaces?
- a ModelInterface contract that all models must implement instead of checking for the Model?
- interface to concrete model guessing from the interface name?