### PR TITLE
[13.x] Fix Number::forHumans() and abbreviate() returning "-0" for tiny negative values

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -292,7 +292,7 @@ class Number
             case $number < 0:
                 $summary = static::summarize(abs($number), $precision, $maxPrecision, $units);
 
-                // Avoid a spurious "-0" when the magnitude rounds down to zero at the given precision.
+                // Avoid a spurious "-0" when the magnitude rounds down to zero at the given precision...
                 return $summary === static::summarize(0, $precision, $maxPrecision, $units)
                     ? $summary
                     : sprintf('-%s', $summary);

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -290,7 +290,12 @@ class Number
             case (float) $number === 0.0:
                 return $precision > 0 ? static::format(0, $precision, $maxPrecision) : '0';
             case $number < 0:
-                return sprintf('-%s', static::summarize(abs($number), $precision, $maxPrecision, $units));
+                $summary = static::summarize(abs($number), $precision, $maxPrecision, $units);
+
+                // Avoid a spurious "-0" when the magnitude rounds down to zero at the given precision.
+                return $summary === static::summarize(0, $precision, $maxPrecision, $units)
+                    ? $summary
+                    : sprintf('-%s', $summary);
             case $number >= 1e15:
                 return sprintf('%s'.end($units), static::summarize($number / 1e15, $precision, $maxPrecision, $units));
         }

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -262,6 +262,12 @@ class SupportNumberTest extends TestCase
         $this->assertSame('-1 quadrillion', Number::forHumans(-1000000000000000));
         $this->assertSame('-1 thousand quadrillion', Number::forHumans(-1000000000000000000));
 
+        // A negative magnitude that rounds down to zero must not keep the sign.
+        $this->assertSame('0', Number::forHumans(-0.4));
+        $this->assertSame('0', Number::forHumans(-0.05));
+        $this->assertSame('0', Number::forHumans(-0.4999));
+        $this->assertSame('-0.40', Number::forHumans(-0.4, precision: 2));
+
         $this->assertSame('999 thousand', Number::forHumans(999499));
         $this->assertSame('1 million', Number::forHumans(999500));
         $this->assertSame('1 million', Number::forHumans(999999));
@@ -325,6 +331,10 @@ class SupportNumberTest extends TestCase
         $this->assertSame('-1.1T', Number::abbreviate(-1100000000000, maxPrecision: 1));
         $this->assertSame('-1Q', Number::abbreviate(-1000000000000000));
         $this->assertSame('-1KQ', Number::abbreviate(-1000000000000000000));
+
+        // A negative magnitude that rounds down to zero must not keep the sign.
+        $this->assertSame('0', Number::abbreviate(-0.4));
+        $this->assertSame('0', Number::abbreviate(-0.05));
 
         $this->assertSame('999K', Number::abbreviate(999499));
         $this->assertSame('1M', Number::abbreviate(999500));


### PR DESCRIPTION
`Number::forHumans()` and `Number::abbreviate()` return `"-0"` for a negative number whose magnitude rounds down to zero at the requested precision:

```php
Number::forHumans(-0.4);    // "-0"  (expected "0")
Number::abbreviate(-0.05);  // "-0"  (expected "0")
```

`summarize()` handles negatives by recursing on `abs($number)` and prepending a `-` sign unconditionally. When the magnitude rounds to zero (e.g. `0.4` formatted at precision `0` becomes `"0"`), the sign is still prepended, producing `"-0"`. The zero shortcut at the top of the method never fires, because the value only collapses to zero *after* rounding inside the recursion.

This PR prepends the sign only when the summarized magnitude differs from the zero representation, so a value that rounds to zero renders as `"0"`. Non-zero negatives (including sub-unit values kept by a higher precision) are unaffected:

```php
Number::forHumans(-0.4);                // "0"
Number::forHumans(-0.4, precision: 2);  // "-0.40"        (unchanged)
Number::forHumans(-1500);               // "-2 thousand"  (unchanged)
```

Tests were added for the negative-rounds-to-zero cases in both `forHumans()` and `abbreviate()`.
