### PR TITLE
[13.x] Add test for the Uri toStringable method

### DIFF
--- a/tests/Support/SupportUriTest.php
+++ b/tests/Support/SupportUriTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Support;
 
 use Illuminate\Contracts\Routing\UrlGenerator;
+use Illuminate\Support\Stringable;
 use Illuminate\Support\Uri;
 use PHPUnit\Framework\TestCase;
 
@@ -127,6 +128,17 @@ class SupportUriTest extends TestCase
         $this->assertEquals($expected, (string) $uri);
         $this->assertEquals($expected, $uri->value());
         $this->assertEquals($expected, $uri->toString());
+    }
+
+    public function test_to_stringable()
+    {
+        $uri = Uri::of('https://laravel.com/docs/installation?version=1#hello');
+
+        $stringable = $uri->toStringable();
+
+        $this->assertInstanceOf(Stringable::class, $stringable);
+        $this->assertSame('https://laravel.com/docs/installation?version=1#hello', (string) $stringable);
+        $this->assertSame($uri->value(), (string) $stringable);
     }
 
     public function test_complicated_query_string_manipulation()


### PR DESCRIPTION
`Illuminate\\Support\\Uri::toStringable()` returns the URI as an `Illuminate\\Support\\Stringable` instance, but it currently has no coverage in `SupportUriTest`.

This adds a test asserting the method returns a `Stringable` whose string value matches the URI's `value()`, locking in the behavior.