### PR TITLE
[13.x] Add test for the Email rule's strict method

### DIFF
--- a/tests/Validation/ValidationEmailRuleTest.php
+++ b/tests/Validation/ValidationEmailRuleTest.php
@@ -166,6 +166,35 @@ class ValidationEmailRuleTest extends TestCase
         );
     }
 
+    public function testStrict()
+    {
+        $emailThatFailsInStrict = 'username@sub..example.com';
+        $emailThatPassesNonStrictButFailsInStrict = '"has space"@example.com';
+        $emailThatPassesInStrict = 'plainaddress@example.com';
+
+        $this->fails(
+            (new Email())->strict(),
+            $emailThatPassesNonStrictButFailsInStrict,
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
+        );
+
+        $this->fails(
+            Rule::email()->strict(),
+            $emailThatFailsInStrict,
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
+        );
+
+        $this->passes(
+            (new Email())->strict(),
+            $emailThatPassesInStrict
+        );
+
+        $this->passes(
+            Rule::email()->strict(),
+            $emailThatPassesInStrict
+        );
+    }
+
     #[RequiresPhpExtension('intl')]
     public function testValidateMxRecord()
     {


### PR DESCRIPTION
The `Email` validation rule exposes a `strict()` convenience method that ensures a strictly RFC-compliant email address (a shortcut for `rfcCompliant(strict: true)`). While `rfcCompliant(strict: true)` is covered, the `strict()` alias itself has no test.

This adds a `testStrict()` that mirrors `testRfcCompliantStrict()` through `->strict()`, confirming an email that only passes non-strict validation is rejected, a malformed address fails, and a plain valid address passes.