### PR TITLE
[12.x] Add capitalize parameter to Stringable::initials()

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -894,11 +894,12 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     /**
      * Convert the given string to only its initials.
      *
+     * @param  bool  $capitalize
      * @return static
      */
-    public function initials()
+    public function initials($capitalize = false)
     {
-        return new static(Str::initials($this->value));
+        return new static(Str::initials($this->value, $capitalize));
     }
 
     /**

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -1484,6 +1484,9 @@ class SupportStringableTest extends TestCase
     public function testInitials()
     {
         $this->assertSame('TO', $this->stringable('Taylor Otwell')->initials()->value());
+        $this->assertSame('to', $this->stringable('taylor otwell')->initials()->value());
+        $this->assertSame('TO', $this->stringable('taylor otwell')->initials(capitalize: true)->value());
+        $this->assertSame('JB', $this->stringable('james bond')->initials(capitalize: true)->value());
     }
 
     public function testToInteger()


### PR DESCRIPTION
- Forward the missing `$capitalize` parameter from `Stringable::initials()` to `Str::initials()`
- Add tests covering default and capitalized initials behavior Fixes #60732

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
