### PR TITLE
[13.x] Replace manual all/any foreach loops with array_all/array_any

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -349,19 +349,8 @@ class Event
     {
         $this->lastChecked = Date::now();
 
-        foreach ($this->filters as $callback) {
-            if (! $this->callEventCallback($app, $callback)) {
-                return false;
-            }
-        }
-
-        foreach ($this->rejects as $callback) {
-            if ($this->callEventCallback($app, $callback)) {
-                return false;
-            }
-        }
-
-        return true;
+        return array_all($this->filters, fn ($callback) => $this->callEventCallback($app, $callback))
+            && array_all($this->rejects, fn ($callback) => ! $this->callEventCallback($app, $callback));
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
@@ -250,12 +250,6 @@ trait HasTimestamps
     {
         $class ??= static::class;
 
-        foreach (static::$ignoreTimestampsOn as $ignoredClass) {
-            if ($class === $ignoredClass || is_subclass_of($class, $ignoredClass)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any(static::$ignoreTimestampsOn, fn ($ignoredClass) => $class === $ignoredClass || is_subclass_of($class, $ignoredClass));
     }
 }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -549,13 +549,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
             return true;
         }
 
-        foreach (static::$ignoreOnTouch as $ignoredClass) {
-            if ($class === $ignoredClass || is_subclass_of($class, $ignoredClass)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any(static::$ignoreOnTouch, fn ($ignoredClass) => $class === $ignoredClass || is_subclass_of($class, $ignoredClass));
     }
 
     /**

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -181,13 +181,7 @@ class Dispatcher implements DispatcherContract
      */
     public function hasWildcardListeners($eventName)
     {
-        foreach ($this->wildcards as $key => $listeners) {
-            if (Str::is($key, $eventName)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($this->wildcards, fn ($listeners, $key) => Str::is($key, $eventName));
     }
 
     /**

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -382,13 +382,7 @@ class Handler implements ExceptionHandlerContract
             return true;
         }
 
-        foreach ($this->dontRetryCallbacks as $dontRetryCallback) {
-            if ($dontRetryCallback($e) === true) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($this->dontRetryCallbacks, fn ($dontRetryCallback) => $dontRetryCallback($e) === true);
     }
 
     /**

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -1946,13 +1946,7 @@ class PendingRequest
             return true;
         }
 
-        foreach ($this->allowedStrayRequestUrls as $pattern) {
-            if (Str::is($pattern, $url)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($this->allowedStrayRequestUrls, fn ($pattern) => Str::is($pattern, $url));
     }
 
     /**

--- a/src/Illuminate/Http/Client/Request.php
+++ b/src/Illuminate/Http/Client/Request.php
@@ -107,13 +107,7 @@ class Request implements ArrayAccess
             $headers = [$headers => null];
         }
 
-        foreach ($headers as $key => $value) {
-            if (! $this->hasHeader($key, $value)) {
-                return false;
-            }
-        }
-
-        return true;
+        return array_all($headers, fn ($value, $key) => $this->hasHeader($key, $value));
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -453,13 +453,7 @@ trait ValidatesAttributes
             return false;
         }
 
-        foreach ($parameters as $param) {
-            if (! Arr::exists($value, $param)) {
-                return false;
-            }
-        }
-
-        return true;
+        return array_all($parameters, fn ($param) => Arr::exists($value, $param));
     }
 
     /**
@@ -529,13 +523,7 @@ trait ValidatesAttributes
             return false;
         }
 
-        foreach ($parameters as $parameter) {
-            if (! in_array($parameter, $value)) {
-                return false;
-            }
-        }
-
-        return true;
+        return array_all($parameters, fn ($parameter) => in_array($parameter, $value));
     }
 
     /**
@@ -552,13 +540,7 @@ trait ValidatesAttributes
             return false;
         }
 
-        foreach ($parameters as $parameter) {
-            if (in_array($parameter, $value)) {
-                return false;
-            }
-        }
-
-        return true;
+        return array_all($parameters, fn ($parameter) => ! in_array($parameter, $value));
     }
 
     /**
@@ -1574,13 +1556,7 @@ trait ValidatesAttributes
             return false;
         }
 
-        foreach ($parameters as $param) {
-            if (Arr::exists($value, $param)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($parameters, fn ($param) => Arr::exists($value, $param));
     }
 
     /**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -564,14 +564,8 @@ class Validator implements ValidatorContract
      */
     protected function shouldBeExcluded($attribute)
     {
-        foreach ($this->excludeAttributes as $excludeAttribute) {
-            if ($attribute === $excludeAttribute ||
-                Str::startsWith($attribute, $excludeAttribute.'.')) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($this->excludeAttributes, fn ($excludeAttribute) => $attribute === $excludeAttribute ||
+            Str::startsWith($attribute, $excludeAttribute.'.'));
     }
 
     /**

--- a/tests/Cache/CacheEventsTest.php
+++ b/tests/Cache/CacheEventsTest.php
@@ -317,13 +317,7 @@ class CacheEventsTest extends TestCase
                 return false;
             }
 
-            foreach ($properties as $name => $value) {
-                if ($value != $event->$name) {
-                    return false;
-                }
-            }
-
-            return true;
+            return array_all($properties, fn ($value, $name) => $value == $event->$name);
         });
     }
 

--- a/tests/Integration/Migration/MigratorTest.php
+++ b/tests/Integration/Migration/MigratorTest.php
@@ -284,13 +284,7 @@ class MigratorTest extends TestCase
     protected function expectBulletList($elements): void
     {
         $this->output->shouldReceive('writeln')->once()->with(m::on(function ($argument) use ($elements) {
-            foreach ($elements as $element) {
-                if (! (new Stringable($argument))->contains("⇂ $element")) {
-                    return false;
-                }
-            }
-
-            return true;
+            return array_all($elements, fn ($element) => (new Stringable($argument))->contains("⇂ $element"));
         }), m::any());
     }
 


### PR DESCRIPTION
Replaces hand-rolled foreach-with-early-return loops that check "all match" or "any match" with the `array_all`/`array_any` helpers, matching the pattern already used elsewhere in the codebase (e.g. `Arr::has`, `Gate::any`, `MessageBag`).

Only converts loops iterating over plain arrays (not `Traversable`/lazy iterables), to avoid changing behavior for non-array inputs.
