### PR TITLE
[13.x] Remove redundant Mockery::close() calls

### DIFF
--- a/tests/Bus/BusPendingDispatchTest.php
+++ b/tests/Bus/BusPendingDispatchTest.php
@@ -135,10 +135,4 @@ class BusPendingDispatchTest extends TestCase
 
         $this->pendingDispatch->unless(false, fn ($pendingDispatch) => $pendingDispatch->delay(300));
     }
-
-    protected function tearDown(): void
-    {
-        m::close();
-        parent::tearDown();
-    }
 }

--- a/tests/Cache/CacheFailoverStoreTest.php
+++ b/tests/Cache/CacheFailoverStoreTest.php
@@ -13,11 +13,6 @@ use PHPUnit\Framework\TestCase;
 
 class CacheFailoverStoreTest extends TestCase
 {
-    protected function tearDown(): void
-    {
-        m::close();
-    }
-
     public function testImplementsCanFlushLocks()
     {
         $store = $this->makeFailoverStore([]);

--- a/tests/Cache/CacheMemoizedStoreTest.php
+++ b/tests/Cache/CacheMemoizedStoreTest.php
@@ -42,11 +42,6 @@ class CacheMemoizedStoreTest extends TestCase
         (new MemoizedStore('test', new Repository($stub)))->flushLocks();
     }
 
-    protected function tearDown(): void
-    {
-        m::close();
-    }
-
     public function testHasSeparateLockStoreDelegatestoUnderlyingStore(): void
     {
         $withSeparate = new MemoizedStore('test', new Repository(new ArrayStore));

--- a/tests/Database/DatabaseMigratorTest.php
+++ b/tests/Database/DatabaseMigratorTest.php
@@ -17,8 +17,6 @@ class DatabaseMigratorTest extends TestCase
     {
         (new ReflectionProperty(Migrator::class, 'connectionResolverCallback'))->setValue(null, null);
 
-        m::close();
-
         parent::tearDown();
     }
 

--- a/tests/Image/ImageManagerTest.php
+++ b/tests/Image/ImageManagerTest.php
@@ -20,11 +20,6 @@ use PHPUnit\Framework\TestCase;
 
 class ImageManagerTest extends TestCase
 {
-    protected function tearDown(): void
-    {
-        m::close();
-    }
-
     public function test_default_driver_returns_configured_value()
     {
         $app = $this->makeApp(['image.default' => 'imagick']);

--- a/tests/Queue/ListFailedCommandTest.php
+++ b/tests/Queue/ListFailedCommandTest.php
@@ -11,13 +11,6 @@ use Symfony\Component\Console\Output\BufferedOutput;
 
 class ListFailedCommandTest extends TestCase
 {
-    protected function tearDown(): void
-    {
-        m::close();
-
-        parent::tearDown();
-    }
-
     public function testItDisplaysEmptyFailedJobsAsJson()
     {
         $output = $this->runCommandWithFailedJobs([], ['--json' => true]);

--- a/tests/Queue/QueueListFailedCommandTest.php
+++ b/tests/Queue/QueueListFailedCommandTest.php
@@ -12,11 +12,6 @@ use Symfony\Component\Console\Output\BufferedOutput;
 
 class QueueListFailedCommandTest extends TestCase
 {
-    protected function tearDown(): void
-    {
-        m::close();
-    }
-
     public function testQueuedListenerShowsUnderlyingListenerClassNotWrapper()
     {
         // CallQueuedListener is the wrapper class Laravel uses to dispatch


### PR DESCRIPTION
AfterEachTestSubscriber already closes Mockery after every test.