### PR TITLE
[13.x] Optimize by using contains or doesntContain 

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -457,12 +457,10 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
      */
     protected function isReservedName($name)
     {
-        return in_array(
-            strtolower($name),
-            (new Collection($this->reservedNames))
-                ->transform(fn ($name) => strtolower($name))
-                ->all()
-        );
+        $name = strtolower($name);
+
+        return (new Collection($this->reservedNames))
+            ->contains(fn ($reservedName) => strtolower($reservedName) === $name);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -937,7 +937,7 @@ class Collection extends BaseCollection implements QueueableCollection
 
         $class = get_class($model);
 
-        if ($this->reject(fn ($model) => $model instanceof $class)->isNotEmpty()) {
+        if ($this->contains(fn ($model) => ! $model instanceof $class)) {
             throw new LogicException('Unable to create query for collection with mixed types.');
         }
 

--- a/src/Illuminate/Http/Client/Request.php
+++ b/src/Illuminate/Http/Client/Request.php
@@ -161,11 +161,11 @@ class Request implements ArrayAccess
             return false;
         }
 
-        return (new Collection($this->data))->reject(function ($file) use ($name, $value, $filename) {
-            return $file['name'] != $name ||
-                ($value && $file['contents'] != $value) ||
-                ($filename && $file['filename'] != $filename);
-        })->count() > 0;
+        return (new Collection($this->data))->contains(function ($file) use ($name, $value, $filename) {
+            return $file['name'] == $name &&
+                (! $value || $file['contents'] == $value) &&
+                (! $filename || $file['filename'] == $filename);
+        });
     }
 
     /**

--- a/src/Illuminate/Process/Factory.php
+++ b/src/Illuminate/Process/Factory.php
@@ -185,9 +185,9 @@ class Factory
         $callback = is_string($callback) ? fn ($process) => $process->command === $callback : $callback;
 
         PHPUnit::assertTrue(
-            (new Collection($this->recorded))->filter(function ($pair) use ($callback) {
+            (new Collection($this->recorded))->contains(function ($pair) use ($callback) {
                 return $callback($pair[0], $pair[1]);
-            })->count() > 0,
+            }),
             'An expected process was not invoked.'
         );
 
@@ -228,9 +228,9 @@ class Factory
         $callback = is_string($callback) ? fn ($process) => $process->command === $callback : $callback;
 
         PHPUnit::assertTrue(
-            (new Collection($this->recorded))->filter(function ($pair) use ($callback) {
+            (new Collection($this->recorded))->doesntContain(function ($pair) use ($callback) {
                 return $callback($pair[0], $pair[1]);
-            })->count() === 0,
+            }),
             'An unexpected process was invoked.'
         );
 

--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -318,9 +318,9 @@ class Store implements Session
      */
     public function hasAny($key)
     {
-        return (new Collection(is_array($key) ? $key : func_get_args()))->filter(function ($key) {
+        return (new Collection(is_array($key) ? $key : func_get_args()))->contains(function ($key) {
             return ! is_null($this->get($key));
-        })->count() >= 1;
+        });
     }
 
     /**

--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -281,7 +281,7 @@ class Store implements Session
     {
         $placeholder = new stdClass;
 
-        return ! (new Collection(is_array($key) ? $key : func_get_args()))->contains(function ($key) use ($placeholder) {
+        return (new Collection(is_array($key) ? $key : func_get_args()))->doesntContain(function ($key) use ($placeholder) {
             return $this->get($key, $placeholder) === $placeholder;
         });
     }
@@ -305,7 +305,7 @@ class Store implements Session
      */
     public function has($key)
     {
-        return ! (new Collection(is_array($key) ? $key : func_get_args()))->contains(function ($key) {
+        return (new Collection(is_array($key) ? $key : func_get_args()))->doesntContain(function ($key) {
             return is_null($this->get($key));
         });
     }

--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -448,7 +448,7 @@ class BusFake implements Fake, QueueingDispatcher
         $chain = $expectedChain;
 
         PHPUnit::assertTrue(
-            $this->dispatched($command, $callback)->filter(function ($job) use ($chain) {
+            $this->dispatched($command, $callback)->contains(function ($job) use ($chain) {
                 if (count($chain) !== count($job->chained)) {
                     return false;
                 }
@@ -483,7 +483,7 @@ class BusFake implements Fake, QueueingDispatcher
                 }
 
                 return true;
-            })->isNotEmpty(),
+            }),
             'The expected chain was not dispatched.'
         );
     }
@@ -826,11 +826,11 @@ class BusFake implements Fake, QueueingDispatcher
         }
 
         return (new Collection($this->jobsToFake))
-            ->filter(function ($job) use ($command) {
+            ->contains(function ($job) use ($command) {
                 return $job instanceof Closure
                     ? $job($command)
                     : $job === get_class($command);
-            })->isNotEmpty();
+            });
     }
 
     /**
@@ -842,11 +842,11 @@ class BusFake implements Fake, QueueingDispatcher
     protected function shouldDispatchCommand($command)
     {
         return (new Collection($this->jobsToDispatch))
-            ->filter(function ($job) use ($command) {
+            ->contains(function ($job) use ($command) {
                 return $job instanceof Closure
                     ? $job($command)
                     : $job === get_class($command);
-            })->isNotEmpty();
+            });
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -325,7 +325,7 @@ class QueueFake extends QueueManager implements Fake, Queue
      */
     protected function isChainOfObjects($chain)
     {
-        return ! (new Collection($chain))->contains(fn ($job) => ! is_object($job));
+        return (new Collection($chain))->doesntContain(fn ($job) => ! is_object($job));
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -267,7 +267,7 @@ class QueueFake extends QueueManager implements Fake, Queue
         $chain = (new Collection($expectedChain))->map(fn ($job) => serialize($job))->all();
 
         PHPUnit::assertTrue(
-            $this->pushed($job, $callback)->filter(fn ($job) => $job->chained == $chain)->isNotEmpty(),
+            $this->pushed($job, $callback)->contains(fn ($job) => $job->chained == $chain),
             'The expected chain was not pushed.'
         );
     }

--- a/src/Illuminate/Testing/Fluent/Concerns/Matching.php
+++ b/src/Illuminate/Testing/Fluent/Concerns/Matching.php
@@ -217,7 +217,7 @@ trait Matching
                 return $actual->containsStrict($search);
             });
 
-        if ($missing->whereInstanceOf('Closure')->isNotEmpty()) {
+        if ($missing->contains(fn ($search) => $search instanceof Closure)) {
             PHPUnit::assertEmpty(
                 $missing->toArray(),
                 sprintf(


### PR DESCRIPTION
Optimizes several `filter()`/`reject()` chains ending in `count()`/`isEmpty()`/`isNotEmpty()` to use `contains()`/`doesntContain()` instead, which short-circuits on the first match instead of iterating the whole collection.