### PR TITLE
[13.x] Fix stale transformations being reapplied when branching an Image after toBytes()

### DIFF
--- a/src/Illuminate/Image/Image.php
+++ b/src/Illuminate/Image/Image.php
@@ -358,6 +358,7 @@ class Image implements Stringable
                 throw new ImageException("Failed to process image: {$e->getMessage()}", 0, $e);
             }
 
+            $this->pipeline = new ImagePipeline;
             $this->processed = true;
         }
 
@@ -524,7 +525,6 @@ class Image implements Stringable
 
     /**
      * Prevent serialization of the image.
-     *
      *
      * @throws ImageException
      */

--- a/tests/Integration/Image/ImageTest.php
+++ b/tests/Integration/Image/ImageTest.php
@@ -477,6 +477,21 @@ class ImageTest extends TestCase
         $this->assertSame(100, $height);
     }
 
+    public function test_branching_after_to_bytes_does_not_reapply_stale_transformations(): void
+    {
+        $image = new Image($this->fakeImageContents(100, 50));
+
+        $rotatedOnce = $image->rotate(90);
+        $rotatedOnce->toBytes();
+
+        $rotatedTwice = $rotatedOnce->rotate(90);
+
+        [$width, $height] = getimagesizefromstring($rotatedTwice->toBytes());
+
+        $this->assertSame(100, $width);
+        $this->assertSame(50, $height);
+    }
+
     public function test_store_as_with_name_only()
     {
         Storage::fake('local');


### PR DESCRIPTION
After calling `toBytes()`, the pipeline was not cleared. Branching a new transformation from that image reapplied the old transformations on top of the already-processed bytes.