### PR TITLE
[13.x] Only register pail in DevCommands when `pcntl_fork` is available

### DIFF
--- a/src/Illuminate/Foundation/DevCommands.php
+++ b/src/Illuminate/Foundation/DevCommands.php
@@ -58,7 +58,7 @@ class DevCommands
         self::artisan('serve --host=localhost', 'server');
         self::artisan('queue:listen --tries=1 --timeout=0', 'queue');
 
-        if (! windows_os()) {
+        if (function_exists('pcntl_fork')) {
             self::artisan('pail --timeout=0', 'logs');
         }
 

--- a/src/Illuminate/Foundation/DevCommands.php
+++ b/src/Illuminate/Foundation/DevCommands.php
@@ -57,7 +57,11 @@ class DevCommands
 
         self::artisan('serve --host=localhost', 'server');
         self::artisan('queue:listen --tries=1 --timeout=0', 'queue');
-        self::artisan('pail --timeout=0', 'logs');
+
+        if (! windows_os()) {
+            self::artisan('pail --timeout=0', 'logs');
+        }
+
         self::node('dev', 'vite');
     }
 

--- a/tests/Foundation/FoundationDevCommandsTest.php
+++ b/tests/Foundation/FoundationDevCommandsTest.php
@@ -6,6 +6,7 @@ use Illuminate\Foundation\Application;
 use Illuminate\Foundation\DevCommand;
 use Illuminate\Foundation\DevCommandColor;
 use Illuminate\Foundation\DevCommands;
+use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
@@ -292,6 +293,7 @@ class FoundationDevCommandsTest extends TestCase
         $this->assertSame(DevCommand::PRIORITY_USERLAND, $method->invoke(null, $trace));
     }
 
+    #[RequiresOperatingSystem('Linux|Darwin')]
     public function testRegisterDefaultsRegistersExpectedCommands()
     {
         DevCommands::registerDefaults();
@@ -305,6 +307,22 @@ class FoundationDevCommandsTest extends TestCase
         $this->assertContains('queue', $names);
         $this->assertContains('logs', $names);
         $this->assertContains('vite', $names);
+    }
+
+    #[RequiresOperatingSystem('Windows')]
+    public function testRegisterDefaultsExcludesPailOnWindows()
+    {
+        DevCommands::registerDefaults();
+
+        $commands = DevCommands::commands();
+
+        $this->assertCount(3, $commands);
+
+        $names = array_column($commands, 'name');
+        $this->assertContains('server', $names);
+        $this->assertContains('queue', $names);
+        $this->assertContains('vite', $names);
+        $this->assertNotContains('logs', $names);
     }
 
     public function testRegisteredCommandIncludesSource()


### PR DESCRIPTION
On Windows, when you run `php artisan dev` you get greeted with:


<details>

<summary> See log </summary>

```
php artisan dev

[server] php artisan serve --host=localhost
[queue]  php artisan queue:listen --tries=1 --timeout=0
[logs]   php artisan pail --timeout=0
[vite]   npm run dev

Need to install the following packages:
concurrently@10.0.3
Ok to proceed? (y) y

[vite] 
[vite] > dev
[vite] > vite
[vite] 
[queue] 
[queue]    INFO  Processing jobs from the [default] queue.  
[queue] 
[logs] 
[logs]    RuntimeException 
[logs] 
[logs]   The [pcntl] extension is required to run Pail.
[logs] 
[logs]   at vendor\laravel\pail\src\Guards\EnsurePcntlIsAvailable.php:15
[logs]      11▕      */
[logs]      12▕     public static function check(): void
[logs]      13▕     {
[logs]      14▕         if (! function_exists('pcntl_fork')) {
[logs]   ➜  15▕             throw new RuntimeException('The [pcntl] extension is required to run Pail.');
[logs]      16▕         }
[logs]      17▕     }
[logs]      18▕ }
[logs]      19▕
[logs] 
[logs]   1   vendor\laravel\pail\src\Console\Commands\PailCommand.php:46
[logs]       Laravel\Pail\Guards\EnsurePcntlIsAvailable::check()
[logs] 
[logs]   2   vendor\laravel\framework\src\Illuminate\Container\BoundMethod.php:36
[logs]       Laravel\Pail\Console\Commands\PailCommand::handle()
[logs] 
[logs] php artisan pail --timeout=0 exited with code 1
--> Sending SIGTERM to other processes..
[vite] npm run dev exited with code 1
--> Sending SIGTERM to other processes..
[server] 
[server]    INFO  Server running on [http://localhost:8000].  
[server] 
[server]   Press Ctrl+C to stop the server
[server] 
[server] php artisan serve --host=localhost exited with code 1
--> Sending SIGTERM to other processes..
[queue] php artisan queue:listen --tries=1 --timeout=0 exited with code 1
// crashes...
```
</details>

TLDR is because Windows doesnt have the pcntl extension

The installer automatically removes this bit in composer.json via  https://github.com/laravel/installer/blob/09409e6cc73eaf82bf3598aac94ca155a1848c0a/src/NewCommand.php#L1250 so, windows never suffers this when doing `composer run dev`, so we do the same for the dev script.


Tests adjusted to cover Windows, but easy enough I hope.

I went with `function_exists('pcntl_fork')` as it could technically also be disabled on Unix systems, and is [what pail's provider does](https://github.com/laravel/pail/blob/505ba235beee17cbdc65eec29f010b463082eaa8/src/Guards/EnsurePcntlIsAvailable.php#L14)🤷🏻 But, happy to adjust to just an os check if you prefer

Also closes https://github.com/laravel/framework/issues/60747

