### PR TITLE
[13.x] Add dedicated tests for each custom exception

### DIFF
--- a/tests/Auth/Access/Exceptions/AuthorizationExceptionTest.php
+++ b/tests/Auth/Access/Exceptions/AuthorizationExceptionTest.php
@@ -9,14 +9,14 @@ use PHPUnit\Framework\TestCase;
 
 class AuthorizationExceptionTest extends TestCase
 {
-    public function testExceptionIsInstanceOfException()
+    public function testExceptionIsInstanceOfException(): void
     {
         $exception = new AuthorizationException;
 
         $this->assertInstanceOf(Exception::class, $exception);
     }
 
-    public function testExceptionDefaultsToUnauthorizedMessage()
+    public function testExceptionDefaultsToUnauthorizedMessage(): void
     {
         $exception = new AuthorizationException;
 
@@ -25,7 +25,7 @@ class AuthorizationExceptionTest extends TestCase
         $this->assertNull($exception->getPrevious());
     }
 
-    public function testExceptionHoldsMessageCodeAndPrevious()
+    public function testExceptionHoldsMessageCodeAndPrevious(): void
     {
         $previous = new Exception('previous');
 
@@ -36,7 +36,7 @@ class AuthorizationExceptionTest extends TestCase
         $this->assertSame($previous, $exception->getPrevious());
     }
 
-    public function testSetResponseIsFluentAndAssignsResponse()
+    public function testSetResponseIsFluentAndAssignsResponse(): void
     {
         $exception = new AuthorizationException;
         $response = Response::deny('Denied.');
@@ -47,7 +47,7 @@ class AuthorizationExceptionTest extends TestCase
         $this->assertSame($response, $exception->response());
     }
 
-    public function testWithStatusIsFluentAndAssignsStatus()
+    public function testWithStatusIsFluentAndAssignsStatus(): void
     {
         $exception = new AuthorizationException;
 
@@ -60,7 +60,7 @@ class AuthorizationExceptionTest extends TestCase
         $this->assertSame(404, $exception->status());
     }
 
-    public function testAsNotFoundSetsStatusTo404()
+    public function testAsNotFoundSetsStatusTo404(): void
     {
         $exception = new AuthorizationException;
 
@@ -69,7 +69,7 @@ class AuthorizationExceptionTest extends TestCase
         $this->assertSame(404, $exception->status());
     }
 
-    public function testToResponseBuildsDenyResponseWithMessageCodeAndStatus()
+    public function testToResponseBuildsDenyResponseWithMessageCodeAndStatus(): void
     {
         $exception = new AuthorizationException('Custom message.', 'ability-code');
         $exception->withStatus(403);

--- a/tests/Auth/Access/Exceptions/AuthorizationExceptionTest.php
+++ b/tests/Auth/Access/Exceptions/AuthorizationExceptionTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Illuminate\Tests\Auth\Access\Exceptions;
+
+use Exception;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Auth\Access\Response;
+use PHPUnit\Framework\TestCase;
+
+class AuthorizationExceptionTest extends TestCase
+{
+    public function testExceptionIsInstanceOfException()
+    {
+        $exception = new AuthorizationException;
+
+        $this->assertInstanceOf(Exception::class, $exception);
+    }
+
+    public function testExceptionDefaultsToUnauthorizedMessage()
+    {
+        $exception = new AuthorizationException;
+
+        $this->assertSame('This action is unauthorized.', $exception->getMessage());
+        $this->assertSame(0, $exception->getCode());
+        $this->assertNull($exception->getPrevious());
+    }
+
+    public function testExceptionHoldsMessageCodeAndPrevious()
+    {
+        $previous = new Exception('previous');
+
+        $exception = new AuthorizationException('Custom message.', 'ability-code', $previous);
+
+        $this->assertSame('Custom message.', $exception->getMessage());
+        $this->assertSame('ability-code', $exception->getCode());
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+
+    public function testSetResponseIsFluentAndAssignsResponse()
+    {
+        $exception = new AuthorizationException;
+        $response = Response::deny('Denied.');
+
+        $result = $exception->setResponse($response);
+
+        $this->assertSame($exception, $result);
+        $this->assertSame($response, $exception->response());
+    }
+
+    public function testWithStatusIsFluentAndAssignsStatus()
+    {
+        $exception = new AuthorizationException;
+
+        $this->assertFalse($exception->hasStatus());
+
+        $result = $exception->withStatus(404);
+
+        $this->assertSame($exception, $result);
+        $this->assertTrue($exception->hasStatus());
+        $this->assertSame(404, $exception->status());
+    }
+
+    public function testAsNotFoundSetsStatusTo404()
+    {
+        $exception = new AuthorizationException;
+
+        $exception->asNotFound();
+
+        $this->assertSame(404, $exception->status());
+    }
+
+    public function testToResponseBuildsDenyResponseWithMessageCodeAndStatus()
+    {
+        $exception = new AuthorizationException('Custom message.', 'ability-code');
+        $exception->withStatus(403);
+
+        $response = $exception->toResponse();
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertFalse($response->allowed());
+        $this->assertSame('Custom message.', $response->message());
+        $this->assertSame('ability-code', $response->code());
+        $this->assertSame(403, $response->status());
+    }
+}

--- a/tests/Auth/Exceptions/AuthenticationExceptionTest.php
+++ b/tests/Auth/Exceptions/AuthenticationExceptionTest.php
@@ -11,16 +11,18 @@ class AuthenticationExceptionTest extends TestCase
     protected function tearDown(): void
     {
         AuthenticationException::redirectUsing(fn () => null);
+
+        parent::tearDown();
     }
 
-    public function testExceptionIsInstanceOfException()
+    public function testExceptionIsInstanceOfException(): void
     {
         $exception = new AuthenticationException;
 
         $this->assertInstanceOf(\Exception::class, $exception);
     }
 
-    public function testExceptionDefaultsToUnauthenticatedMessageAndNoGuards()
+    public function testExceptionDefaultsToUnauthenticatedMessageAndNoGuards(): void
     {
         $exception = new AuthenticationException;
 
@@ -28,7 +30,7 @@ class AuthenticationExceptionTest extends TestCase
         $this->assertSame([], $exception->guards());
     }
 
-    public function testExceptionHoldsMessageAndGuards()
+    public function testExceptionHoldsMessageAndGuards(): void
     {
         $exception = new AuthenticationException('Custom message.', ['web', 'api']);
 
@@ -36,21 +38,21 @@ class AuthenticationExceptionTest extends TestCase
         $this->assertSame(['web', 'api'], $exception->guards());
     }
 
-    public function testRedirectToReturnsExplicitPathWhenProvided()
+    public function testRedirectToReturnsExplicitPathWhenProvided(): void
     {
         $exception = new AuthenticationException('Unauthenticated.', [], '/login');
 
         $this->assertSame('/login', $exception->redirectTo(Request::create('/')));
     }
 
-    public function testRedirectToReturnsNullWithoutPathOrCallback()
+    public function testRedirectToReturnsNullWithoutPathOrCallback(): void
     {
         $exception = new AuthenticationException;
 
         $this->assertNull($exception->redirectTo(Request::create('/')));
     }
 
-    public function testRedirectToUsesRegisteredCallbackWhenNoExplicitPath()
+    public function testRedirectToUsesRegisteredCallbackWhenNoExplicitPath(): void
     {
         AuthenticationException::redirectUsing(fn (Request $request) => '/custom-login');
 
@@ -59,7 +61,7 @@ class AuthenticationExceptionTest extends TestCase
         $this->assertSame('/custom-login', $exception->redirectTo(Request::create('/')));
     }
 
-    public function testRedirectToPrefersExplicitPathOverCallback()
+    public function testRedirectToPrefersExplicitPathOverCallback(): void
     {
         AuthenticationException::redirectUsing(fn (Request $request) => '/custom-login');
 

--- a/tests/Auth/Exceptions/AuthenticationExceptionTest.php
+++ b/tests/Auth/Exceptions/AuthenticationExceptionTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Illuminate\Tests\Auth\Exceptions;
+
+use Illuminate\Auth\AuthenticationException;
+use Illuminate\Http\Request;
+use PHPUnit\Framework\TestCase;
+
+class AuthenticationExceptionTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        AuthenticationException::redirectUsing(fn () => null);
+    }
+
+    public function testExceptionIsInstanceOfException()
+    {
+        $exception = new AuthenticationException;
+
+        $this->assertInstanceOf(\Exception::class, $exception);
+    }
+
+    public function testExceptionDefaultsToUnauthenticatedMessageAndNoGuards()
+    {
+        $exception = new AuthenticationException;
+
+        $this->assertSame('Unauthenticated.', $exception->getMessage());
+        $this->assertSame([], $exception->guards());
+    }
+
+    public function testExceptionHoldsMessageAndGuards()
+    {
+        $exception = new AuthenticationException('Custom message.', ['web', 'api']);
+
+        $this->assertSame('Custom message.', $exception->getMessage());
+        $this->assertSame(['web', 'api'], $exception->guards());
+    }
+
+    public function testRedirectToReturnsExplicitPathWhenProvided()
+    {
+        $exception = new AuthenticationException('Unauthenticated.', [], '/login');
+
+        $this->assertSame('/login', $exception->redirectTo(Request::create('/')));
+    }
+
+    public function testRedirectToReturnsNullWithoutPathOrCallback()
+    {
+        $exception = new AuthenticationException;
+
+        $this->assertNull($exception->redirectTo(Request::create('/')));
+    }
+
+    public function testRedirectToUsesRegisteredCallbackWhenNoExplicitPath()
+    {
+        AuthenticationException::redirectUsing(fn (Request $request) => '/custom-login');
+
+        $exception = new AuthenticationException;
+
+        $this->assertSame('/custom-login', $exception->redirectTo(Request::create('/')));
+    }
+
+    public function testRedirectToPrefersExplicitPathOverCallback()
+    {
+        AuthenticationException::redirectUsing(fn (Request $request) => '/custom-login');
+
+        $exception = new AuthenticationException('Unauthenticated.', [], '/login');
+
+        $this->assertSame('/login', $exception->redirectTo(Request::create('/')));
+    }
+}

--- a/tests/Broadcasting/Exceptions/BroadcastExceptionTest.php
+++ b/tests/Broadcasting/Exceptions/BroadcastExceptionTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Illuminate\Tests\Broadcasting\Exceptions;
+
+use Exception;
+use Illuminate\Broadcasting\BroadcastException;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class BroadcastExceptionTest extends TestCase
+{
+    public function testExceptionIsInstanceOfRuntimeException()
+    {
+        $exception = new BroadcastException;
+
+        $this->assertInstanceOf(RuntimeException::class, $exception);
+    }
+
+    public function testExceptionHoldsMessageCodeAndPrevious()
+    {
+        $previous = new Exception('previous');
+
+        $exception = new BroadcastException('Broadcast failed.', 42, $previous);
+
+        $this->assertSame('Broadcast failed.', $exception->getMessage());
+        $this->assertSame(42, $exception->getCode());
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+}

--- a/tests/Broadcasting/Exceptions/BroadcastExceptionTest.php
+++ b/tests/Broadcasting/Exceptions/BroadcastExceptionTest.php
@@ -9,14 +9,14 @@ use RuntimeException;
 
 class BroadcastExceptionTest extends TestCase
 {
-    public function testExceptionIsInstanceOfRuntimeException()
+    public function testExceptionIsInstanceOfRuntimeException(): void
     {
         $exception = new BroadcastException;
 
         $this->assertInstanceOf(RuntimeException::class, $exception);
     }
 
-    public function testExceptionHoldsMessageCodeAndPrevious()
+    public function testExceptionHoldsMessageCodeAndPrevious(): void
     {
         $previous = new Exception('previous');
 

--- a/tests/Cache/Exceptions/LimiterTimeoutExceptionTest.php
+++ b/tests/Cache/Exceptions/LimiterTimeoutExceptionTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Illuminate\Tests\Cache\Exceptions;
+
+use Exception;
+use Illuminate\Cache\Limiters\LimiterTimeoutException;
+use PHPUnit\Framework\TestCase;
+
+class LimiterTimeoutExceptionTest extends TestCase
+{
+    public function testExceptionIsInstanceOfException()
+    {
+        $exception = new LimiterTimeoutException;
+
+        $this->assertInstanceOf(Exception::class, $exception);
+    }
+
+    public function testExceptionHoldsMessageCodeAndPrevious()
+    {
+        $previous = new Exception('previous');
+
+        $exception = new LimiterTimeoutException('Limiter timed out.', 42, $previous);
+
+        $this->assertSame('Limiter timed out.', $exception->getMessage());
+        $this->assertSame(42, $exception->getCode());
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+}

--- a/tests/Cache/Exceptions/LimiterTimeoutExceptionTest.php
+++ b/tests/Cache/Exceptions/LimiterTimeoutExceptionTest.php
@@ -8,14 +8,14 @@ use PHPUnit\Framework\TestCase;
 
 class LimiterTimeoutExceptionTest extends TestCase
 {
-    public function testExceptionIsInstanceOfException()
+    public function testExceptionIsInstanceOfException(): void
     {
         $exception = new LimiterTimeoutException;
 
         $this->assertInstanceOf(Exception::class, $exception);
     }
 
-    public function testExceptionHoldsMessageCodeAndPrevious()
+    public function testExceptionHoldsMessageCodeAndPrevious(): void
     {
         $previous = new Exception('previous');
 

--- a/tests/Cache/Exceptions/LockTimeoutExceptionTest.php
+++ b/tests/Cache/Exceptions/LockTimeoutExceptionTest.php
@@ -8,14 +8,14 @@ use PHPUnit\Framework\TestCase;
 
 class LockTimeoutExceptionTest extends TestCase
 {
-    public function testExceptionIsInstanceOfException()
+    public function testExceptionIsInstanceOfException(): void
     {
         $exception = new LockTimeoutException;
 
         $this->assertInstanceOf(Exception::class, $exception);
     }
 
-    public function testExceptionHoldsMessageCodeAndPrevious()
+    public function testExceptionHoldsMessageCodeAndPrevious(): void
     {
         $previous = new Exception('previous');
 

--- a/tests/Cache/Exceptions/LockTimeoutExceptionTest.php
+++ b/tests/Cache/Exceptions/LockTimeoutExceptionTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Illuminate\Tests\Cache\Exceptions;
+
+use Exception;
+use Illuminate\Contracts\Cache\LockTimeoutException;
+use PHPUnit\Framework\TestCase;
+
+class LockTimeoutExceptionTest extends TestCase
+{
+    public function testExceptionIsInstanceOfException()
+    {
+        $exception = new LockTimeoutException;
+
+        $this->assertInstanceOf(Exception::class, $exception);
+    }
+
+    public function testExceptionHoldsMessageCodeAndPrevious()
+    {
+        $previous = new Exception('previous');
+
+        $exception = new LockTimeoutException('Lock timed out.', 42, $previous);
+
+        $this->assertSame('Lock timed out.', $exception->getMessage());
+        $this->assertSame(42, $exception->getCode());
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+}

--- a/tests/Console/Exceptions/ManuallyFailedExceptionTest.php
+++ b/tests/Console/Exceptions/ManuallyFailedExceptionTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Illuminate\Tests\Console\Exceptions;
+
+use Exception;
+use Illuminate\Console\ManuallyFailedException;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class ManuallyFailedExceptionTest extends TestCase
+{
+    public function testExceptionIsInstanceOfRuntimeException()
+    {
+        $exception = new ManuallyFailedException;
+
+        $this->assertInstanceOf(RuntimeException::class, $exception);
+    }
+
+    public function testExceptionHoldsMessageCodeAndPrevious()
+    {
+        $previous = new Exception('previous');
+
+        $exception = new ManuallyFailedException('Manually failed.', 42, $previous);
+
+        $this->assertSame('Manually failed.', $exception->getMessage());
+        $this->assertSame(42, $exception->getCode());
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+}

--- a/tests/Console/Exceptions/ManuallyFailedExceptionTest.php
+++ b/tests/Console/Exceptions/ManuallyFailedExceptionTest.php
@@ -9,14 +9,14 @@ use RuntimeException;
 
 class ManuallyFailedExceptionTest extends TestCase
 {
-    public function testExceptionIsInstanceOfRuntimeException()
+    public function testExceptionIsInstanceOfRuntimeException(): void
     {
         $exception = new ManuallyFailedException;
 
         $this->assertInstanceOf(RuntimeException::class, $exception);
     }
 
-    public function testExceptionHoldsMessageCodeAndPrevious()
+    public function testExceptionHoldsMessageCodeAndPrevious(): void
     {
         $previous = new Exception('previous');
 

--- a/tests/Console/Exceptions/PromptValidationExceptionTest.php
+++ b/tests/Console/Exceptions/PromptValidationExceptionTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Illuminate\Tests\Console\Exceptions;
+
+use Exception;
+use Illuminate\Console\PromptValidationException;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class PromptValidationExceptionTest extends TestCase
+{
+    public function testExceptionIsInstanceOfRuntimeException()
+    {
+        $exception = new PromptValidationException;
+
+        $this->assertInstanceOf(RuntimeException::class, $exception);
+    }
+
+    public function testExceptionHoldsMessageCodeAndPrevious()
+    {
+        $previous = new Exception('previous');
+
+        $exception = new PromptValidationException('The provided value is invalid.', 42, $previous);
+
+        $this->assertSame('The provided value is invalid.', $exception->getMessage());
+        $this->assertSame(42, $exception->getCode());
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+}

--- a/tests/Console/Exceptions/PromptValidationExceptionTest.php
+++ b/tests/Console/Exceptions/PromptValidationExceptionTest.php
@@ -9,14 +9,14 @@ use RuntimeException;
 
 class PromptValidationExceptionTest extends TestCase
 {
-    public function testExceptionIsInstanceOfRuntimeException()
+    public function testExceptionIsInstanceOfRuntimeException(): void
     {
         $exception = new PromptValidationException;
 
         $this->assertInstanceOf(RuntimeException::class, $exception);
     }
 
-    public function testExceptionHoldsMessageCodeAndPrevious()
+    public function testExceptionHoldsMessageCodeAndPrevious(): void
     {
         $previous = new Exception('previous');
 

--- a/tests/Container/Exceptions/BindingResolutionExceptionTest.php
+++ b/tests/Container/Exceptions/BindingResolutionExceptionTest.php
@@ -9,14 +9,14 @@ use Psr\Container\ContainerExceptionInterface;
 
 class BindingResolutionExceptionTest extends TestCase
 {
-    public function testExceptionImplementsContainerExceptionInterface()
+    public function testExceptionImplementsContainerExceptionInterface(): void
     {
         $exception = new BindingResolutionException;
 
         $this->assertInstanceOf(ContainerExceptionInterface::class, $exception);
     }
 
-    public function testExceptionHoldsMessageCodeAndPrevious()
+    public function testExceptionHoldsMessageCodeAndPrevious(): void
     {
         $previous = new Exception('previous');
 

--- a/tests/Container/Exceptions/BindingResolutionExceptionTest.php
+++ b/tests/Container/Exceptions/BindingResolutionExceptionTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Illuminate\Tests\Container\Exceptions;
+
+use Exception;
+use Illuminate\Contracts\Container\BindingResolutionException;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerExceptionInterface;
+
+class BindingResolutionExceptionTest extends TestCase
+{
+    public function testExceptionImplementsContainerExceptionInterface()
+    {
+        $exception = new BindingResolutionException;
+
+        $this->assertInstanceOf(ContainerExceptionInterface::class, $exception);
+    }
+
+    public function testExceptionHoldsMessageCodeAndPrevious()
+    {
+        $previous = new Exception('previous');
+
+        $exception = new BindingResolutionException('Target is not instantiable.', 42, $previous);
+
+        $this->assertSame('Target is not instantiable.', $exception->getMessage());
+        $this->assertSame(42, $exception->getCode());
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+}

--- a/tests/Container/Exceptions/CircularDependencyExceptionTest.php
+++ b/tests/Container/Exceptions/CircularDependencyExceptionTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Illuminate\Tests\Container\Exceptions;
+
+use Exception;
+use Illuminate\Contracts\Container\CircularDependencyException;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerExceptionInterface;
+
+class CircularDependencyExceptionTest extends TestCase
+{
+    public function testExceptionImplementsContainerExceptionInterface()
+    {
+        $exception = new CircularDependencyException;
+
+        $this->assertInstanceOf(ContainerExceptionInterface::class, $exception);
+    }
+
+    public function testExceptionHoldsMessageCodeAndPrevious()
+    {
+        $previous = new Exception('previous');
+
+        $exception = new CircularDependencyException('Circular dependency detected.', 42, $previous);
+
+        $this->assertSame('Circular dependency detected.', $exception->getMessage());
+        $this->assertSame(42, $exception->getCode());
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+}

--- a/tests/Container/Exceptions/CircularDependencyExceptionTest.php
+++ b/tests/Container/Exceptions/CircularDependencyExceptionTest.php
@@ -9,14 +9,14 @@ use Psr\Container\ContainerExceptionInterface;
 
 class CircularDependencyExceptionTest extends TestCase
 {
-    public function testExceptionImplementsContainerExceptionInterface()
+    public function testExceptionImplementsContainerExceptionInterface(): void
     {
         $exception = new CircularDependencyException;
 
         $this->assertInstanceOf(ContainerExceptionInterface::class, $exception);
     }
 
-    public function testExceptionHoldsMessageCodeAndPrevious()
+    public function testExceptionHoldsMessageCodeAndPrevious(): void
     {
         $previous = new Exception('previous');
 

--- a/tests/Container/Exceptions/EntryNotFoundExceptionTest.php
+++ b/tests/Container/Exceptions/EntryNotFoundExceptionTest.php
@@ -9,14 +9,14 @@ use Psr\Container\NotFoundExceptionInterface;
 
 class EntryNotFoundExceptionTest extends TestCase
 {
-    public function testExceptionImplementsNotFoundExceptionInterface()
+    public function testExceptionImplementsNotFoundExceptionInterface(): void
     {
         $exception = new EntryNotFoundException;
 
         $this->assertInstanceOf(NotFoundExceptionInterface::class, $exception);
     }
 
-    public function testExceptionHoldsMessageCodeAndPrevious()
+    public function testExceptionHoldsMessageCodeAndPrevious(): void
     {
         $previous = new Exception('previous');
 

--- a/tests/Container/Exceptions/EntryNotFoundExceptionTest.php
+++ b/tests/Container/Exceptions/EntryNotFoundExceptionTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Illuminate\Tests\Container\Exceptions;
+
+use Exception;
+use Illuminate\Container\EntryNotFoundException;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\NotFoundExceptionInterface;
+
+class EntryNotFoundExceptionTest extends TestCase
+{
+    public function testExceptionImplementsNotFoundExceptionInterface()
+    {
+        $exception = new EntryNotFoundException;
+
+        $this->assertInstanceOf(NotFoundExceptionInterface::class, $exception);
+    }
+
+    public function testExceptionHoldsMessageCodeAndPrevious()
+    {
+        $previous = new Exception('previous');
+
+        $exception = new EntryNotFoundException('Entry not found.', 42, $previous);
+
+        $this->assertSame('Entry not found.', $exception->getMessage());
+        $this->assertSame(42, $exception->getCode());
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+}

--- a/tests/Database/Exceptions/ClassMorphViolationExceptionTest.php
+++ b/tests/Database/Exceptions/ClassMorphViolationExceptionTest.php
@@ -9,14 +9,14 @@ use stdClass;
 
 class ClassMorphViolationExceptionTest extends TestCase
 {
-    public function testExceptionIsInstanceOfRuntimeException()
+    public function testExceptionIsInstanceOfRuntimeException(): void
     {
         $exception = new ClassMorphViolationException(new stdClass);
 
         $this->assertInstanceOf(RuntimeException::class, $exception);
     }
 
-    public function testExceptionHoldsModelAndMessage()
+    public function testExceptionHoldsModelAndMessage(): void
     {
         $exception = new ClassMorphViolationException(new stdClass);
 

--- a/tests/Database/Exceptions/ClassMorphViolationExceptionTest.php
+++ b/tests/Database/Exceptions/ClassMorphViolationExceptionTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Illuminate\Tests\Database\Exceptions;
+
+use Illuminate\Database\ClassMorphViolationException;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use stdClass;
+
+class ClassMorphViolationExceptionTest extends TestCase
+{
+    public function testExceptionIsInstanceOfRuntimeException()
+    {
+        $exception = new ClassMorphViolationException(new stdClass);
+
+        $this->assertInstanceOf(RuntimeException::class, $exception);
+    }
+
+    public function testExceptionHoldsModelAndMessage()
+    {
+        $exception = new ClassMorphViolationException(new stdClass);
+
+        $this->assertSame(stdClass::class, $exception->model);
+        $this->assertSame('No morph map defined for model [stdClass].', $exception->getMessage());
+        $this->assertSame(0, $exception->getCode());
+        $this->assertNull($exception->getPrevious());
+    }
+}

--- a/tests/Database/Exceptions/DeadlockExceptionTest.php
+++ b/tests/Database/Exceptions/DeadlockExceptionTest.php
@@ -9,14 +9,14 @@ use PHPUnit\Framework\TestCase;
 
 class DeadlockExceptionTest extends TestCase
 {
-    public function testExceptionIsInstanceOfPDOException()
+    public function testExceptionIsInstanceOfPDOException(): void
     {
         $exception = new DeadlockException;
 
         $this->assertInstanceOf(PDOException::class, $exception);
     }
 
-    public function testExceptionHoldsMessageCodeAndPrevious()
+    public function testExceptionHoldsMessageCodeAndPrevious(): void
     {
         $previous = new Exception('previous');
 

--- a/tests/Database/Exceptions/DeadlockExceptionTest.php
+++ b/tests/Database/Exceptions/DeadlockExceptionTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Illuminate\Tests\Database\Exceptions;
+
+use Exception;
+use Illuminate\Database\DeadlockException;
+use PDOException;
+use PHPUnit\Framework\TestCase;
+
+class DeadlockExceptionTest extends TestCase
+{
+    public function testExceptionIsInstanceOfPDOException()
+    {
+        $exception = new DeadlockException;
+
+        $this->assertInstanceOf(PDOException::class, $exception);
+    }
+
+    public function testExceptionHoldsMessageCodeAndPrevious()
+    {
+        $previous = new Exception('previous');
+
+        $exception = new DeadlockException('Deadlock found when trying to get lock.', 42, $previous);
+
+        $this->assertSame('Deadlock found when trying to get lock.', $exception->getMessage());
+        $this->assertSame(42, $exception->getCode());
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+}

--- a/tests/Database/Exceptions/LazyLoadingViolationExceptionTest.php
+++ b/tests/Database/Exceptions/LazyLoadingViolationExceptionTest.php
@@ -9,14 +9,14 @@ use stdClass;
 
 class LazyLoadingViolationExceptionTest extends TestCase
 {
-    public function testExceptionIsInstanceOfRuntimeException()
+    public function testExceptionIsInstanceOfRuntimeException(): void
     {
         $exception = new LazyLoadingViolationException(new stdClass, 'posts');
 
         $this->assertInstanceOf(RuntimeException::class, $exception);
     }
 
-    public function testExceptionHoldsModelRelationAndMessage()
+    public function testExceptionHoldsModelRelationAndMessage(): void
     {
         $exception = new LazyLoadingViolationException(new stdClass, 'posts');
 

--- a/tests/Database/Exceptions/LazyLoadingViolationExceptionTest.php
+++ b/tests/Database/Exceptions/LazyLoadingViolationExceptionTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Illuminate\Tests\Database\Exceptions;
+
+use Illuminate\Database\LazyLoadingViolationException;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use stdClass;
+
+class LazyLoadingViolationExceptionTest extends TestCase
+{
+    public function testExceptionIsInstanceOfRuntimeException()
+    {
+        $exception = new LazyLoadingViolationException(new stdClass, 'posts');
+
+        $this->assertInstanceOf(RuntimeException::class, $exception);
+    }
+
+    public function testExceptionHoldsModelRelationAndMessage()
+    {
+        $exception = new LazyLoadingViolationException(new stdClass, 'posts');
+
+        $this->assertSame(stdClass::class, $exception->model);
+        $this->assertSame('posts', $exception->relation);
+        $this->assertSame(
+            'Attempted to lazy load [posts] on model [stdClass] but lazy loading is disabled.',
+            $exception->getMessage()
+        );
+        $this->assertSame(0, $exception->getCode());
+        $this->assertNull($exception->getPrevious());
+    }
+}

--- a/tests/Database/Exceptions/LostConnectionExceptionTest.php
+++ b/tests/Database/Exceptions/LostConnectionExceptionTest.php
@@ -9,14 +9,14 @@ use PHPUnit\Framework\TestCase;
 
 class LostConnectionExceptionTest extends TestCase
 {
-    public function testExceptionIsInstanceOfLogicException()
+    public function testExceptionIsInstanceOfLogicException(): void
     {
         $exception = new LostConnectionException;
 
         $this->assertInstanceOf(LogicException::class, $exception);
     }
 
-    public function testExceptionHoldsMessageCodeAndPrevious()
+    public function testExceptionHoldsMessageCodeAndPrevious(): void
     {
         $previous = new Exception('previous');
 

--- a/tests/Database/Exceptions/LostConnectionExceptionTest.php
+++ b/tests/Database/Exceptions/LostConnectionExceptionTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Illuminate\Tests\Database\Exceptions;
+
+use Exception;
+use Illuminate\Database\LostConnectionException;
+use LogicException;
+use PHPUnit\Framework\TestCase;
+
+class LostConnectionExceptionTest extends TestCase
+{
+    public function testExceptionIsInstanceOfLogicException()
+    {
+        $exception = new LostConnectionException;
+
+        $this->assertInstanceOf(LogicException::class, $exception);
+    }
+
+    public function testExceptionHoldsMessageCodeAndPrevious()
+    {
+        $previous = new Exception('previous');
+
+        $exception = new LostConnectionException('Lost connection to the database.', 42, $previous);
+
+        $this->assertSame('Lost connection to the database.', $exception->getMessage());
+        $this->assertSame(42, $exception->getCode());
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+}

--- a/tests/Database/Exceptions/MultipleColumnsSelectedExceptionTest.php
+++ b/tests/Database/Exceptions/MultipleColumnsSelectedExceptionTest.php
@@ -9,14 +9,14 @@ use RuntimeException;
 
 class MultipleColumnsSelectedExceptionTest extends TestCase
 {
-    public function testExceptionIsInstanceOfRuntimeException()
+    public function testExceptionIsInstanceOfRuntimeException(): void
     {
         $exception = new MultipleColumnsSelectedException;
 
         $this->assertInstanceOf(RuntimeException::class, $exception);
     }
 
-    public function testExceptionHoldsMessageCodeAndPrevious()
+    public function testExceptionHoldsMessageCodeAndPrevious(): void
     {
         $previous = new Exception('previous');
 

--- a/tests/Database/Exceptions/MultipleColumnsSelectedExceptionTest.php
+++ b/tests/Database/Exceptions/MultipleColumnsSelectedExceptionTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Illuminate\Tests\Database\Exceptions;
+
+use Exception;
+use Illuminate\Database\MultipleColumnsSelectedException;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class MultipleColumnsSelectedExceptionTest extends TestCase
+{
+    public function testExceptionIsInstanceOfRuntimeException()
+    {
+        $exception = new MultipleColumnsSelectedException;
+
+        $this->assertInstanceOf(RuntimeException::class, $exception);
+    }
+
+    public function testExceptionHoldsMessageCodeAndPrevious()
+    {
+        $previous = new Exception('previous');
+
+        $exception = new MultipleColumnsSelectedException('Multiple columns selected.', 42, $previous);
+
+        $this->assertSame('Multiple columns selected.', $exception->getMessage());
+        $this->assertSame(42, $exception->getCode());
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+}

--- a/tests/Database/Exceptions/MultipleRecordsFoundExceptionTest.php
+++ b/tests/Database/Exceptions/MultipleRecordsFoundExceptionTest.php
@@ -9,14 +9,14 @@ use RuntimeException;
 
 class MultipleRecordsFoundExceptionTest extends TestCase
 {
-    public function testExceptionIsInstanceOfRuntimeException()
+    public function testExceptionIsInstanceOfRuntimeException(): void
     {
         $exception = new MultipleRecordsFoundException(2);
 
         $this->assertInstanceOf(RuntimeException::class, $exception);
     }
 
-    public function testExceptionHoldsCountAndMessage()
+    public function testExceptionHoldsCountAndMessage(): void
     {
         $exception = new MultipleRecordsFoundException(3);
 
@@ -27,7 +27,7 @@ class MultipleRecordsFoundExceptionTest extends TestCase
         $this->assertNull($exception->getPrevious());
     }
 
-    public function testExceptionHoldsCodeAndPrevious()
+    public function testExceptionHoldsCodeAndPrevious(): void
     {
         $previous = new Exception('previous');
 

--- a/tests/Database/Exceptions/MultipleRecordsFoundExceptionTest.php
+++ b/tests/Database/Exceptions/MultipleRecordsFoundExceptionTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Illuminate\Tests\Database\Exceptions;
+
+use Exception;
+use Illuminate\Database\MultipleRecordsFoundException;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class MultipleRecordsFoundExceptionTest extends TestCase
+{
+    public function testExceptionIsInstanceOfRuntimeException()
+    {
+        $exception = new MultipleRecordsFoundException(2);
+
+        $this->assertInstanceOf(RuntimeException::class, $exception);
+    }
+
+    public function testExceptionHoldsCountAndMessage()
+    {
+        $exception = new MultipleRecordsFoundException(3);
+
+        $this->assertSame(3, $exception->count);
+        $this->assertSame(3, $exception->getCount());
+        $this->assertSame('3 records were found.', $exception->getMessage());
+        $this->assertSame(0, $exception->getCode());
+        $this->assertNull($exception->getPrevious());
+    }
+
+    public function testExceptionHoldsCodeAndPrevious()
+    {
+        $previous = new Exception('previous');
+
+        $exception = new MultipleRecordsFoundException(3, 42, $previous);
+
+        $this->assertSame(42, $exception->getCode());
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+}

--- a/tests/Database/Exceptions/QueryExceptionTest.php
+++ b/tests/Database/Exceptions/QueryExceptionTest.php
@@ -9,14 +9,14 @@ use PHPUnit\Framework\TestCase;
 
 class QueryExceptionTest extends TestCase
 {
-    public function testExceptionIsInstanceOfPDOException()
+    public function testExceptionIsInstanceOfPDOException(): void
     {
         $exception = new QueryException('mysql', 'select * from users', [], new Exception('Syntax error'));
 
         $this->assertInstanceOf(PDOException::class, $exception);
     }
 
-    public function testExceptionHoldsConnectionSqlAndBindings()
+    public function testExceptionHoldsConnectionSqlAndBindings(): void
     {
         $previous = new Exception('Syntax error');
 
@@ -34,7 +34,7 @@ class QueryExceptionTest extends TestCase
         $this->assertSame($previous, $exception->getPrevious());
     }
 
-    public function testExceptionInheritsCodeFromPreviousException()
+    public function testExceptionInheritsCodeFromPreviousException(): void
     {
         $previous = new Exception('Syntax error', 1234);
 
@@ -43,7 +43,7 @@ class QueryExceptionTest extends TestCase
         $this->assertSame(1234, $exception->getCode());
     }
 
-    public function testExceptionInheritsErrorInfoFromPreviousPDOException()
+    public function testExceptionInheritsErrorInfoFromPreviousPDOException(): void
     {
         $previous = new PDOException('Syntax error');
         $previous->errorInfo = ['42S02', 1146, "Table 'db.users' doesn't exist"];
@@ -53,7 +53,7 @@ class QueryExceptionTest extends TestCase
         $this->assertSame(['42S02', 1146, "Table 'db.users' doesn't exist"], $exception->errorInfo);
     }
 
-    public function testExceptionFormatsMessageWithHostAndPort()
+    public function testExceptionFormatsMessageWithHostAndPort(): void
     {
         $exception = new QueryException('mysql', 'select 1', [], new Exception('Syntax error'), [
             'driver' => 'mysql',
@@ -74,7 +74,7 @@ class QueryExceptionTest extends TestCase
         ], $exception->getConnectionDetails());
     }
 
-    public function testExceptionFormatsMessageWithUnixSocket()
+    public function testExceptionFormatsMessageWithUnixSocket(): void
     {
         $exception = new QueryException('mysql', 'select 1', [], new Exception('Syntax error'), [
             'driver' => 'mysql',
@@ -88,7 +88,7 @@ class QueryExceptionTest extends TestCase
         );
     }
 
-    public function testExceptionFormatsMessageWithoutHostForSqliteDriver()
+    public function testExceptionFormatsMessageWithoutHostForSqliteDriver(): void
     {
         $exception = new QueryException('sqlite', 'select 1', [], new Exception('Syntax error'), [
             'driver' => 'sqlite',
@@ -101,7 +101,7 @@ class QueryExceptionTest extends TestCase
         );
     }
 
-    public function testExceptionHoldsReadWriteType()
+    public function testExceptionHoldsReadWriteType(): void
     {
         $exception = new QueryException(
             'mysql', 'select 1', [], new Exception('Syntax error'), [], 'write'

--- a/tests/Database/Exceptions/QueryExceptionTest.php
+++ b/tests/Database/Exceptions/QueryExceptionTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Illuminate\Tests\Database\Exceptions;
+
+use Exception;
+use Illuminate\Database\QueryException;
+use PDOException;
+use PHPUnit\Framework\TestCase;
+
+class QueryExceptionTest extends TestCase
+{
+    public function testExceptionIsInstanceOfPDOException()
+    {
+        $exception = new QueryException('mysql', 'select * from users', [], new Exception('Syntax error'));
+
+        $this->assertInstanceOf(PDOException::class, $exception);
+    }
+
+    public function testExceptionHoldsConnectionSqlAndBindings()
+    {
+        $previous = new Exception('Syntax error');
+
+        $exception = new QueryException(
+            'mysql', 'select * from users where id = ?', [1], $previous
+        );
+
+        $this->assertSame('mysql', $exception->getConnectionName());
+        $this->assertSame('select * from users where id = ?', $exception->getSql());
+        $this->assertSame([1], $exception->getBindings());
+        $this->assertSame(
+            'Syntax error (Connection: mysql, SQL: select * from users where id = 1)',
+            $exception->getMessage()
+        );
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+
+    public function testExceptionInheritsCodeFromPreviousException()
+    {
+        $previous = new Exception('Syntax error', 1234);
+
+        $exception = new QueryException('mysql', 'select 1', [], $previous);
+
+        $this->assertSame(1234, $exception->getCode());
+    }
+
+    public function testExceptionInheritsErrorInfoFromPreviousPDOException()
+    {
+        $previous = new PDOException('Syntax error');
+        $previous->errorInfo = ['42S02', 1146, "Table 'db.users' doesn't exist"];
+
+        $exception = new QueryException('mysql', 'select 1', [], $previous);
+
+        $this->assertSame(['42S02', 1146, "Table 'db.users' doesn't exist"], $exception->errorInfo);
+    }
+
+    public function testExceptionFormatsMessageWithHostAndPort()
+    {
+        $exception = new QueryException('mysql', 'select 1', [], new Exception('Syntax error'), [
+            'driver' => 'mysql',
+            'host' => '127.0.0.1',
+            'port' => 3306,
+            'database' => 'forge',
+        ]);
+
+        $this->assertSame(
+            'Syntax error (Connection: mysql, Host: 127.0.0.1, Port: 3306, Database: forge, SQL: select 1)',
+            $exception->getMessage()
+        );
+        $this->assertSame([
+            'driver' => 'mysql',
+            'host' => '127.0.0.1',
+            'port' => 3306,
+            'database' => 'forge',
+        ], $exception->getConnectionDetails());
+    }
+
+    public function testExceptionFormatsMessageWithUnixSocket()
+    {
+        $exception = new QueryException('mysql', 'select 1', [], new Exception('Syntax error'), [
+            'driver' => 'mysql',
+            'unix_socket' => '/var/run/mysqld/mysqld.sock',
+            'database' => 'forge',
+        ]);
+
+        $this->assertSame(
+            'Syntax error (Connection: mysql, Socket: /var/run/mysqld/mysqld.sock, Database: forge, SQL: select 1)',
+            $exception->getMessage()
+        );
+    }
+
+    public function testExceptionFormatsMessageWithoutHostForSqliteDriver()
+    {
+        $exception = new QueryException('sqlite', 'select 1', [], new Exception('Syntax error'), [
+            'driver' => 'sqlite',
+            'database' => '/database.sqlite',
+        ]);
+
+        $this->assertSame(
+            'Syntax error (Connection: sqlite, Database: /database.sqlite, SQL: select 1)',
+            $exception->getMessage()
+        );
+    }
+
+    public function testExceptionHoldsReadWriteType()
+    {
+        $exception = new QueryException(
+            'mysql', 'select 1', [], new Exception('Syntax error'), [], 'write'
+        );
+
+        $this->assertSame('write', $exception->readWriteType);
+    }
+}

--- a/tests/Database/Exceptions/RecordNotFoundExceptionTest.php
+++ b/tests/Database/Exceptions/RecordNotFoundExceptionTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Illuminate\Tests\Database\Exceptions;
+
+use Exception;
+use Illuminate\Database\RecordNotFoundException;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class RecordNotFoundExceptionTest extends TestCase
+{
+    public function testExceptionIsInstanceOfRuntimeException()
+    {
+        $exception = new RecordNotFoundException;
+
+        $this->assertInstanceOf(RuntimeException::class, $exception);
+    }
+
+    public function testExceptionHoldsMessageCodeAndPrevious()
+    {
+        $previous = new Exception('previous');
+
+        $exception = new RecordNotFoundException('No record found.', 42, $previous);
+
+        $this->assertSame('No record found.', $exception->getMessage());
+        $this->assertSame(42, $exception->getCode());
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+}

--- a/tests/Database/Exceptions/RecordNotFoundExceptionTest.php
+++ b/tests/Database/Exceptions/RecordNotFoundExceptionTest.php
@@ -9,14 +9,14 @@ use RuntimeException;
 
 class RecordNotFoundExceptionTest extends TestCase
 {
-    public function testExceptionIsInstanceOfRuntimeException()
+    public function testExceptionIsInstanceOfRuntimeException(): void
     {
         $exception = new RecordNotFoundException;
 
         $this->assertInstanceOf(RuntimeException::class, $exception);
     }
 
-    public function testExceptionHoldsMessageCodeAndPrevious()
+    public function testExceptionHoldsMessageCodeAndPrevious(): void
     {
         $previous = new Exception('previous');
 

--- a/tests/Database/Exceptions/RecordsNotFoundExceptionTest.php
+++ b/tests/Database/Exceptions/RecordsNotFoundExceptionTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Illuminate\Tests\Database\Exceptions;
+
+use Exception;
+use Illuminate\Database\RecordsNotFoundException;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class RecordsNotFoundExceptionTest extends TestCase
+{
+    public function testExceptionIsInstanceOfRuntimeException()
+    {
+        $exception = new RecordsNotFoundException;
+
+        $this->assertInstanceOf(RuntimeException::class, $exception);
+    }
+
+    public function testExceptionHoldsMessageCodeAndPrevious()
+    {
+        $previous = new Exception('previous');
+
+        $exception = new RecordsNotFoundException('No records found.', 42, $previous);
+
+        $this->assertSame('No records found.', $exception->getMessage());
+        $this->assertSame(42, $exception->getCode());
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+}

--- a/tests/Database/Exceptions/RecordsNotFoundExceptionTest.php
+++ b/tests/Database/Exceptions/RecordsNotFoundExceptionTest.php
@@ -9,14 +9,14 @@ use RuntimeException;
 
 class RecordsNotFoundExceptionTest extends TestCase
 {
-    public function testExceptionIsInstanceOfRuntimeException()
+    public function testExceptionIsInstanceOfRuntimeException(): void
     {
         $exception = new RecordsNotFoundException;
 
         $this->assertInstanceOf(RuntimeException::class, $exception);
     }
 
-    public function testExceptionHoldsMessageCodeAndPrevious()
+    public function testExceptionHoldsMessageCodeAndPrevious(): void
     {
         $previous = new Exception('previous');
 

--- a/tests/Database/Exceptions/SQLiteDatabaseDoesNotExistExceptionTest.php
+++ b/tests/Database/Exceptions/SQLiteDatabaseDoesNotExistExceptionTest.php
@@ -8,14 +8,14 @@ use PHPUnit\Framework\TestCase;
 
 class SQLiteDatabaseDoesNotExistExceptionTest extends TestCase
 {
-    public function testExceptionIsInstanceOfInvalidArgumentException()
+    public function testExceptionIsInstanceOfInvalidArgumentException(): void
     {
         $exception = new SQLiteDatabaseDoesNotExistException('/path/to/database.sqlite');
 
         $this->assertInstanceOf(InvalidArgumentException::class, $exception);
     }
 
-    public function testExceptionHoldsPathAndMessage()
+    public function testExceptionHoldsPathAndMessage(): void
     {
         $exception = new SQLiteDatabaseDoesNotExistException('/path/to/database.sqlite');
 

--- a/tests/Database/Exceptions/SQLiteDatabaseDoesNotExistExceptionTest.php
+++ b/tests/Database/Exceptions/SQLiteDatabaseDoesNotExistExceptionTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Illuminate\Tests\Database\Exceptions;
+
+use Illuminate\Database\SQLiteDatabaseDoesNotExistException;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+class SQLiteDatabaseDoesNotExistExceptionTest extends TestCase
+{
+    public function testExceptionIsInstanceOfInvalidArgumentException()
+    {
+        $exception = new SQLiteDatabaseDoesNotExistException('/path/to/database.sqlite');
+
+        $this->assertInstanceOf(InvalidArgumentException::class, $exception);
+    }
+
+    public function testExceptionHoldsPathAndMessage()
+    {
+        $exception = new SQLiteDatabaseDoesNotExistException('/path/to/database.sqlite');
+
+        $this->assertSame('/path/to/database.sqlite', $exception->path);
+        $this->assertSame(
+            'Database file at path [/path/to/database.sqlite] does not exist. Ensure this is an absolute path to the database.',
+            $exception->getMessage()
+        );
+        $this->assertSame(0, $exception->getCode());
+        $this->assertNull($exception->getPrevious());
+    }
+}

--- a/tests/Database/Exceptions/UniqueConstraintViolationExceptionTest.php
+++ b/tests/Database/Exceptions/UniqueConstraintViolationExceptionTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 class UniqueConstraintViolationExceptionTest extends TestCase
 {
-    public function testExceptionIsInstanceOfQueryException()
+    public function testExceptionIsInstanceOfQueryException(): void
     {
         $exception = new UniqueConstraintViolationException(
             'mysql', 'insert into users (email) values (?)', ['taylor@laravel.com'], new Exception('Duplicate entry')
@@ -18,7 +18,7 @@ class UniqueConstraintViolationExceptionTest extends TestCase
         $this->assertInstanceOf(QueryException::class, $exception);
     }
 
-    public function testExceptionDefaultsIndexAndColumns()
+    public function testExceptionDefaultsIndexAndColumns(): void
     {
         $exception = new UniqueConstraintViolationException(
             'mysql', 'insert into users (email) values (?)', ['taylor@laravel.com'], new Exception('Duplicate entry')
@@ -28,7 +28,7 @@ class UniqueConstraintViolationExceptionTest extends TestCase
         $this->assertSame([], $exception->columns);
     }
 
-    public function testSetIndexIsFluentAndAssignsIndex()
+    public function testSetIndexIsFluentAndAssignsIndex(): void
     {
         $exception = new UniqueConstraintViolationException(
             'mysql', 'insert into users (email) values (?)', ['taylor@laravel.com'], new Exception('Duplicate entry')
@@ -40,7 +40,7 @@ class UniqueConstraintViolationExceptionTest extends TestCase
         $this->assertSame('users_email_unique', $exception->index);
     }
 
-    public function testSetColumnsIsFluentAndAssignsColumns()
+    public function testSetColumnsIsFluentAndAssignsColumns(): void
     {
         $exception = new UniqueConstraintViolationException(
             'mysql', 'insert into users (email) values (?)', ['taylor@laravel.com'], new Exception('Duplicate entry')

--- a/tests/Database/Exceptions/UniqueConstraintViolationExceptionTest.php
+++ b/tests/Database/Exceptions/UniqueConstraintViolationExceptionTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Illuminate\Tests\Database\Exceptions;
+
+use Exception;
+use Illuminate\Database\QueryException;
+use Illuminate\Database\UniqueConstraintViolationException;
+use PHPUnit\Framework\TestCase;
+
+class UniqueConstraintViolationExceptionTest extends TestCase
+{
+    public function testExceptionIsInstanceOfQueryException()
+    {
+        $exception = new UniqueConstraintViolationException(
+            'mysql', 'insert into users (email) values (?)', ['taylor@laravel.com'], new Exception('Duplicate entry')
+        );
+
+        $this->assertInstanceOf(QueryException::class, $exception);
+    }
+
+    public function testExceptionDefaultsIndexAndColumns()
+    {
+        $exception = new UniqueConstraintViolationException(
+            'mysql', 'insert into users (email) values (?)', ['taylor@laravel.com'], new Exception('Duplicate entry')
+        );
+
+        $this->assertNull($exception->index);
+        $this->assertSame([], $exception->columns);
+    }
+
+    public function testSetIndexIsFluentAndAssignsIndex()
+    {
+        $exception = new UniqueConstraintViolationException(
+            'mysql', 'insert into users (email) values (?)', ['taylor@laravel.com'], new Exception('Duplicate entry')
+        );
+
+        $result = $exception->setIndex('users_email_unique');
+
+        $this->assertSame($exception, $result);
+        $this->assertSame('users_email_unique', $exception->index);
+    }
+
+    public function testSetColumnsIsFluentAndAssignsColumns()
+    {
+        $exception = new UniqueConstraintViolationException(
+            'mysql', 'insert into users (email) values (?)', ['taylor@laravel.com'], new Exception('Duplicate entry')
+        );
+
+        $result = $exception->setColumns(['email']);
+
+        $this->assertSame($exception, $result);
+        $this->assertSame(['email'], $exception->columns);
+    }
+}

--- a/tests/Encryption/Exceptions/DecryptExceptionTest.php
+++ b/tests/Encryption/Exceptions/DecryptExceptionTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Illuminate\Tests\Encryption\Exceptions;
+
+use Exception;
+use Illuminate\Contracts\Encryption\DecryptException;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class DecryptExceptionTest extends TestCase
+{
+    public function testExceptionIsInstanceOfRuntimeException()
+    {
+        $exception = new DecryptException;
+
+        $this->assertInstanceOf(RuntimeException::class, $exception);
+    }
+
+    public function testExceptionHoldsMessageCodeAndPrevious()
+    {
+        $previous = new Exception('previous');
+
+        $exception = new DecryptException('Could not decrypt the data.', 42, $previous);
+
+        $this->assertSame('Could not decrypt the data.', $exception->getMessage());
+        $this->assertSame(42, $exception->getCode());
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+}

--- a/tests/Encryption/Exceptions/DecryptExceptionTest.php
+++ b/tests/Encryption/Exceptions/DecryptExceptionTest.php
@@ -9,14 +9,14 @@ use RuntimeException;
 
 class DecryptExceptionTest extends TestCase
 {
-    public function testExceptionIsInstanceOfRuntimeException()
+    public function testExceptionIsInstanceOfRuntimeException(): void
     {
         $exception = new DecryptException;
 
         $this->assertInstanceOf(RuntimeException::class, $exception);
     }
 
-    public function testExceptionHoldsMessageCodeAndPrevious()
+    public function testExceptionHoldsMessageCodeAndPrevious(): void
     {
         $previous = new Exception('previous');
 

--- a/tests/Encryption/Exceptions/EncryptExceptionTest.php
+++ b/tests/Encryption/Exceptions/EncryptExceptionTest.php
@@ -9,14 +9,14 @@ use RuntimeException;
 
 class EncryptExceptionTest extends TestCase
 {
-    public function testExceptionIsInstanceOfRuntimeException()
+    public function testExceptionIsInstanceOfRuntimeException(): void
     {
         $exception = new EncryptException;
 
         $this->assertInstanceOf(RuntimeException::class, $exception);
     }
 
-    public function testExceptionHoldsMessageCodeAndPrevious()
+    public function testExceptionHoldsMessageCodeAndPrevious(): void
     {
         $previous = new Exception('previous');
 

--- a/tests/Encryption/Exceptions/EncryptExceptionTest.php
+++ b/tests/Encryption/Exceptions/EncryptExceptionTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Illuminate\Tests\Encryption\Exceptions;
+
+use Exception;
+use Illuminate\Contracts\Encryption\EncryptException;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class EncryptExceptionTest extends TestCase
+{
+    public function testExceptionIsInstanceOfRuntimeException()
+    {
+        $exception = new EncryptException;
+
+        $this->assertInstanceOf(RuntimeException::class, $exception);
+    }
+
+    public function testExceptionHoldsMessageCodeAndPrevious()
+    {
+        $previous = new Exception('previous');
+
+        $exception = new EncryptException('Could not encrypt the data.', 42, $previous);
+
+        $this->assertSame('Could not encrypt the data.', $exception->getMessage());
+        $this->assertSame(42, $exception->getCode());
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+}

--- a/tests/Encryption/Exceptions/MissingAppKeyExceptionTest.php
+++ b/tests/Encryption/Exceptions/MissingAppKeyExceptionTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Illuminate\Tests\Encryption\Exceptions;
+
+use Illuminate\Encryption\MissingAppKeyException;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class MissingAppKeyExceptionTest extends TestCase
+{
+    public function testExceptionIsInstanceOfRuntimeException()
+    {
+        $exception = new MissingAppKeyException;
+
+        $this->assertInstanceOf(RuntimeException::class, $exception);
+    }
+
+    public function testExceptionDefaultsToStandardMessage()
+    {
+        $exception = new MissingAppKeyException;
+
+        $this->assertSame('No application encryption key has been specified.', $exception->getMessage());
+    }
+
+    public function testExceptionAcceptsCustomMessage()
+    {
+        $exception = new MissingAppKeyException('Custom message.');
+
+        $this->assertSame('Custom message.', $exception->getMessage());
+    }
+}

--- a/tests/Encryption/Exceptions/MissingAppKeyExceptionTest.php
+++ b/tests/Encryption/Exceptions/MissingAppKeyExceptionTest.php
@@ -8,21 +8,21 @@ use RuntimeException;
 
 class MissingAppKeyExceptionTest extends TestCase
 {
-    public function testExceptionIsInstanceOfRuntimeException()
+    public function testExceptionIsInstanceOfRuntimeException(): void
     {
         $exception = new MissingAppKeyException;
 
         $this->assertInstanceOf(RuntimeException::class, $exception);
     }
 
-    public function testExceptionDefaultsToStandardMessage()
+    public function testExceptionDefaultsToStandardMessage(): void
     {
         $exception = new MissingAppKeyException;
 
         $this->assertSame('No application encryption key has been specified.', $exception->getMessage());
     }
 
-    public function testExceptionAcceptsCustomMessage()
+    public function testExceptionAcceptsCustomMessage(): void
     {
         $exception = new MissingAppKeyException('Custom message.');
 

--- a/tests/Filesystem/Exceptions/FileNotFoundExceptionTest.php
+++ b/tests/Filesystem/Exceptions/FileNotFoundExceptionTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Illuminate\Tests\Filesystem\Exceptions;
+
+use Exception;
+use Illuminate\Contracts\Filesystem\FileNotFoundException;
+use PHPUnit\Framework\TestCase;
+
+class FileNotFoundExceptionTest extends TestCase
+{
+    public function testExceptionIsInstanceOfException()
+    {
+        $exception = new FileNotFoundException;
+
+        $this->assertInstanceOf(Exception::class, $exception);
+    }
+
+    public function testExceptionHoldsMessageCodeAndPrevious()
+    {
+        $previous = new Exception('previous');
+
+        $exception = new FileNotFoundException('File not found.', 42, $previous);
+
+        $this->assertSame('File not found.', $exception->getMessage());
+        $this->assertSame(42, $exception->getCode());
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+}

--- a/tests/Filesystem/Exceptions/FileNotFoundExceptionTest.php
+++ b/tests/Filesystem/Exceptions/FileNotFoundExceptionTest.php
@@ -8,14 +8,14 @@ use PHPUnit\Framework\TestCase;
 
 class FileNotFoundExceptionTest extends TestCase
 {
-    public function testExceptionIsInstanceOfException()
+    public function testExceptionIsInstanceOfException(): void
     {
         $exception = new FileNotFoundException;
 
         $this->assertInstanceOf(Exception::class, $exception);
     }
 
-    public function testExceptionHoldsMessageCodeAndPrevious()
+    public function testExceptionHoldsMessageCodeAndPrevious(): void
     {
         $previous = new Exception('previous');
 

--- a/tests/Filesystem/Exceptions/LockTimeoutExceptionTest.php
+++ b/tests/Filesystem/Exceptions/LockTimeoutExceptionTest.php
@@ -8,14 +8,14 @@ use PHPUnit\Framework\TestCase;
 
 class LockTimeoutExceptionTest extends TestCase
 {
-    public function testExceptionIsInstanceOfException()
+    public function testExceptionIsInstanceOfException(): void
     {
         $exception = new LockTimeoutException;
 
         $this->assertInstanceOf(Exception::class, $exception);
     }
 
-    public function testExceptionHoldsMessageCodeAndPrevious()
+    public function testExceptionHoldsMessageCodeAndPrevious(): void
     {
         $previous = new Exception('previous');
 

--- a/tests/Filesystem/Exceptions/LockTimeoutExceptionTest.php
+++ b/tests/Filesystem/Exceptions/LockTimeoutExceptionTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Illuminate\Tests\Filesystem\Exceptions;
+
+use Exception;
+use Illuminate\Contracts\Filesystem\LockTimeoutException;
+use PHPUnit\Framework\TestCase;
+
+class LockTimeoutExceptionTest extends TestCase
+{
+    public function testExceptionIsInstanceOfException()
+    {
+        $exception = new LockTimeoutException;
+
+        $this->assertInstanceOf(Exception::class, $exception);
+    }
+
+    public function testExceptionHoldsMessageCodeAndPrevious()
+    {
+        $previous = new Exception('previous');
+
+        $exception = new LockTimeoutException('Lock timed out.', 42, $previous);
+
+        $this->assertSame('Lock timed out.', $exception->getMessage());
+        $this->assertSame(42, $exception->getCode());
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+}

--- a/tests/Foundation/Cloud/Exceptions/AgentUnreachableExceptionTest.php
+++ b/tests/Foundation/Cloud/Exceptions/AgentUnreachableExceptionTest.php
@@ -9,14 +9,14 @@ use RuntimeException;
 
 class AgentUnreachableExceptionTest extends TestCase
 {
-    public function testExceptionIsInstanceOfRuntimeException()
+    public function testExceptionIsInstanceOfRuntimeException(): void
     {
         $exception = new AgentUnreachableException;
 
         $this->assertInstanceOf(RuntimeException::class, $exception);
     }
 
-    public function testExceptionHoldsMessageCodeAndPrevious()
+    public function testExceptionHoldsMessageCodeAndPrevious(): void
     {
         $previous = new Exception('previous');
 

--- a/tests/Foundation/Cloud/Exceptions/AgentUnreachableExceptionTest.php
+++ b/tests/Foundation/Cloud/Exceptions/AgentUnreachableExceptionTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\Cloud\Exceptions;
+
+use Exception;
+use Illuminate\Foundation\Cloud\AgentUnreachableException;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class AgentUnreachableExceptionTest extends TestCase
+{
+    public function testExceptionIsInstanceOfRuntimeException()
+    {
+        $exception = new AgentUnreachableException;
+
+        $this->assertInstanceOf(RuntimeException::class, $exception);
+    }
+
+    public function testExceptionHoldsMessageCodeAndPrevious()
+    {
+        $previous = new Exception('previous');
+
+        $exception = new AgentUnreachableException('Agent unreachable.', 42, $previous);
+
+        $this->assertSame('Agent unreachable.', $exception->getMessage());
+        $this->assertSame(42, $exception->getCode());
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+}

--- a/tests/Foundation/Cloud/Exceptions/ManagedQueueNotFoundExceptionTest.php
+++ b/tests/Foundation/Cloud/Exceptions/ManagedQueueNotFoundExceptionTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\Cloud\Exceptions;
+
+use Exception;
+use Illuminate\Foundation\Cloud\ManagedQueueNotFoundException;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class ManagedQueueNotFoundExceptionTest extends TestCase
+{
+    public function testExceptionIsInstanceOfRuntimeException()
+    {
+        $exception = new ManagedQueueNotFoundException;
+
+        $this->assertInstanceOf(RuntimeException::class, $exception);
+    }
+
+    public function testExceptionHoldsMessageCodeAndPrevious()
+    {
+        $previous = new Exception('previous');
+
+        $exception = new ManagedQueueNotFoundException('Managed queue not found.', 42, $previous);
+
+        $this->assertSame('Managed queue not found.', $exception->getMessage());
+        $this->assertSame(42, $exception->getCode());
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+}

--- a/tests/Foundation/Cloud/Exceptions/ManagedQueueNotFoundExceptionTest.php
+++ b/tests/Foundation/Cloud/Exceptions/ManagedQueueNotFoundExceptionTest.php
@@ -9,14 +9,14 @@ use RuntimeException;
 
 class ManagedQueueNotFoundExceptionTest extends TestCase
 {
-    public function testExceptionIsInstanceOfRuntimeException()
+    public function testExceptionIsInstanceOfRuntimeException(): void
     {
         $exception = new ManagedQueueNotFoundException;
 
         $this->assertInstanceOf(RuntimeException::class, $exception);
     }
 
-    public function testExceptionHoldsMessageCodeAndPrevious()
+    public function testExceptionHoldsMessageCodeAndPrevious(): void
     {
         $previous = new Exception('previous');
 

--- a/tests/Foundation/Exceptions/MixFileNotFoundExceptionTest.php
+++ b/tests/Foundation/Exceptions/MixFileNotFoundExceptionTest.php
@@ -8,14 +8,14 @@ use PHPUnit\Framework\TestCase;
 
 class MixFileNotFoundExceptionTest extends TestCase
 {
-    public function testExceptionIsInstanceOfException()
+    public function testExceptionIsInstanceOfException(): void
     {
         $exception = new MixFileNotFoundException;
 
         $this->assertInstanceOf(Exception::class, $exception);
     }
 
-    public function testExceptionHoldsMessageCodeAndPrevious()
+    public function testExceptionHoldsMessageCodeAndPrevious(): void
     {
         $previous = new Exception('previous');
 

--- a/tests/Foundation/Exceptions/MixFileNotFoundExceptionTest.php
+++ b/tests/Foundation/Exceptions/MixFileNotFoundExceptionTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\Exceptions;
+
+use Exception;
+use Illuminate\Foundation\MixFileNotFoundException;
+use PHPUnit\Framework\TestCase;
+
+class MixFileNotFoundExceptionTest extends TestCase
+{
+    public function testExceptionIsInstanceOfException()
+    {
+        $exception = new MixFileNotFoundException;
+
+        $this->assertInstanceOf(Exception::class, $exception);
+    }
+
+    public function testExceptionHoldsMessageCodeAndPrevious()
+    {
+        $previous = new Exception('previous');
+
+        $exception = new MixFileNotFoundException('Mix file not found.', 42, $previous);
+
+        $this->assertSame('Mix file not found.', $exception->getMessage());
+        $this->assertSame(42, $exception->getCode());
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+}

--- a/tests/Foundation/Exceptions/MixManifestNotFoundExceptionTest.php
+++ b/tests/Foundation/Exceptions/MixManifestNotFoundExceptionTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\Exceptions;
+
+use Exception;
+use Illuminate\Foundation\MixManifestNotFoundException;
+use PHPUnit\Framework\TestCase;
+
+class MixManifestNotFoundExceptionTest extends TestCase
+{
+    public function testExceptionIsInstanceOfException()
+    {
+        $exception = new MixManifestNotFoundException;
+
+        $this->assertInstanceOf(Exception::class, $exception);
+    }
+
+    public function testExceptionHoldsMessageCodeAndPrevious()
+    {
+        $previous = new Exception('previous');
+
+        $exception = new MixManifestNotFoundException('Mix manifest not found.', 42, $previous);
+
+        $this->assertSame('Mix manifest not found.', $exception->getMessage());
+        $this->assertSame(42, $exception->getCode());
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+}

--- a/tests/Foundation/Exceptions/MixManifestNotFoundExceptionTest.php
+++ b/tests/Foundation/Exceptions/MixManifestNotFoundExceptionTest.php
@@ -8,14 +8,14 @@ use PHPUnit\Framework\TestCase;
 
 class MixManifestNotFoundExceptionTest extends TestCase
 {
-    public function testExceptionIsInstanceOfException()
+    public function testExceptionIsInstanceOfException(): void
     {
         $exception = new MixManifestNotFoundException;
 
         $this->assertInstanceOf(Exception::class, $exception);
     }
 
-    public function testExceptionHoldsMessageCodeAndPrevious()
+    public function testExceptionHoldsMessageCodeAndPrevious(): void
     {
         $previous = new Exception('previous');
 

--- a/tests/Foundation/Exceptions/ViteExceptionTest.php
+++ b/tests/Foundation/Exceptions/ViteExceptionTest.php
@@ -8,14 +8,14 @@ use PHPUnit\Framework\TestCase;
 
 class ViteExceptionTest extends TestCase
 {
-    public function testExceptionIsInstanceOfException()
+    public function testExceptionIsInstanceOfException(): void
     {
         $exception = new ViteException;
 
         $this->assertInstanceOf(Exception::class, $exception);
     }
 
-    public function testExceptionHoldsMessageCodeAndPrevious()
+    public function testExceptionHoldsMessageCodeAndPrevious(): void
     {
         $previous = new Exception('previous');
 

--- a/tests/Foundation/Exceptions/ViteExceptionTest.php
+++ b/tests/Foundation/Exceptions/ViteExceptionTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\Exceptions;
+
+use Exception;
+use Illuminate\Foundation\ViteException;
+use PHPUnit\Framework\TestCase;
+
+class ViteExceptionTest extends TestCase
+{
+    public function testExceptionIsInstanceOfException()
+    {
+        $exception = new ViteException;
+
+        $this->assertInstanceOf(Exception::class, $exception);
+    }
+
+    public function testExceptionHoldsMessageCodeAndPrevious()
+    {
+        $previous = new Exception('previous');
+
+        $exception = new ViteException('Vite error.', 42, $previous);
+
+        $this->assertSame('Vite error.', $exception->getMessage());
+        $this->assertSame(42, $exception->getCode());
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+}

--- a/tests/Foundation/Exceptions/ViteManifestNotFoundExceptionTest.php
+++ b/tests/Foundation/Exceptions/ViteManifestNotFoundExceptionTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\Exceptions;
+
+use Exception;
+use Illuminate\Foundation\ViteException;
+use Illuminate\Foundation\ViteManifestNotFoundException;
+use PHPUnit\Framework\TestCase;
+
+class ViteManifestNotFoundExceptionTest extends TestCase
+{
+    public function testExceptionIsInstanceOfViteException()
+    {
+        $exception = new ViteManifestNotFoundException;
+
+        $this->assertInstanceOf(ViteException::class, $exception);
+    }
+
+    public function testExceptionHoldsMessageCodeAndPrevious()
+    {
+        $previous = new Exception('previous');
+
+        $exception = new ViteManifestNotFoundException('Vite manifest not found.', 42, $previous);
+
+        $this->assertSame('Vite manifest not found.', $exception->getMessage());
+        $this->assertSame(42, $exception->getCode());
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+}

--- a/tests/Foundation/Exceptions/ViteManifestNotFoundExceptionTest.php
+++ b/tests/Foundation/Exceptions/ViteManifestNotFoundExceptionTest.php
@@ -9,14 +9,14 @@ use PHPUnit\Framework\TestCase;
 
 class ViteManifestNotFoundExceptionTest extends TestCase
 {
-    public function testExceptionIsInstanceOfViteException()
+    public function testExceptionIsInstanceOfViteException(): void
     {
         $exception = new ViteManifestNotFoundException;
 
         $this->assertInstanceOf(ViteException::class, $exception);
     }
 
-    public function testExceptionHoldsMessageCodeAndPrevious()
+    public function testExceptionHoldsMessageCodeAndPrevious(): void
     {
         $previous = new Exception('previous');
 

--- a/tests/Http/Client/Exceptions/BatchInProgressExceptionTest.php
+++ b/tests/Http/Client/Exceptions/BatchInProgressExceptionTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Illuminate\Tests\Http\Client\Exceptions;
+
+use Illuminate\Http\Client\BatchInProgressException;
+use Illuminate\Http\Client\HttpClientException;
+use PHPUnit\Framework\TestCase;
+
+class BatchInProgressExceptionTest extends TestCase
+{
+    public function testExceptionIsInstanceOfHttpClientException()
+    {
+        $exception = new BatchInProgressException;
+
+        $this->assertInstanceOf(HttpClientException::class, $exception);
+    }
+
+    public function testExceptionUsesFixedMessage()
+    {
+        $exception = new BatchInProgressException;
+
+        $this->assertSame(
+            'You cannot add requests to a batch that is already in progress.',
+            $exception->getMessage()
+        );
+        $this->assertSame(0, $exception->getCode());
+        $this->assertNull($exception->getPrevious());
+    }
+}

--- a/tests/Http/Client/Exceptions/BatchInProgressExceptionTest.php
+++ b/tests/Http/Client/Exceptions/BatchInProgressExceptionTest.php
@@ -8,14 +8,14 @@ use PHPUnit\Framework\TestCase;
 
 class BatchInProgressExceptionTest extends TestCase
 {
-    public function testExceptionIsInstanceOfHttpClientException()
+    public function testExceptionIsInstanceOfHttpClientException(): void
     {
         $exception = new BatchInProgressException;
 
         $this->assertInstanceOf(HttpClientException::class, $exception);
     }
 
-    public function testExceptionUsesFixedMessage()
+    public function testExceptionUsesFixedMessage(): void
     {
         $exception = new BatchInProgressException;
 

--- a/tests/Http/Client/Exceptions/ConnectionExceptionTest.php
+++ b/tests/Http/Client/Exceptions/ConnectionExceptionTest.php
@@ -9,14 +9,14 @@ use PHPUnit\Framework\TestCase;
 
 class ConnectionExceptionTest extends TestCase
 {
-    public function testExceptionIsInstanceOfHttpClientException()
+    public function testExceptionIsInstanceOfHttpClientException(): void
     {
         $exception = new ConnectionException;
 
         $this->assertInstanceOf(HttpClientException::class, $exception);
     }
 
-    public function testExceptionHoldsMessageCodeAndPrevious()
+    public function testExceptionHoldsMessageCodeAndPrevious(): void
     {
         $previous = new Exception('previous');
 

--- a/tests/Http/Client/Exceptions/ConnectionExceptionTest.php
+++ b/tests/Http/Client/Exceptions/ConnectionExceptionTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Illuminate\Tests\Http\Client\Exceptions;
+
+use Exception;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\HttpClientException;
+use PHPUnit\Framework\TestCase;
+
+class ConnectionExceptionTest extends TestCase
+{
+    public function testExceptionIsInstanceOfHttpClientException()
+    {
+        $exception = new ConnectionException;
+
+        $this->assertInstanceOf(HttpClientException::class, $exception);
+    }
+
+    public function testExceptionHoldsMessageCodeAndPrevious()
+    {
+        $previous = new Exception('previous');
+
+        $exception = new ConnectionException('Could not connect.', 42, $previous);
+
+        $this->assertSame('Could not connect.', $exception->getMessage());
+        $this->assertSame(42, $exception->getCode());
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+}

--- a/tests/Http/Client/Exceptions/HttpClientExceptionTest.php
+++ b/tests/Http/Client/Exceptions/HttpClientExceptionTest.php
@@ -8,14 +8,14 @@ use PHPUnit\Framework\TestCase;
 
 class HttpClientExceptionTest extends TestCase
 {
-    public function testExceptionIsInstanceOfException()
+    public function testExceptionIsInstanceOfException(): void
     {
         $exception = new HttpClientException;
 
         $this->assertInstanceOf(Exception::class, $exception);
     }
 
-    public function testExceptionHoldsMessageCodeAndPrevious()
+    public function testExceptionHoldsMessageCodeAndPrevious(): void
     {
         $previous = new Exception('previous');
 

--- a/tests/Http/Client/Exceptions/HttpClientExceptionTest.php
+++ b/tests/Http/Client/Exceptions/HttpClientExceptionTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Illuminate\Tests\Http\Client\Exceptions;
+
+use Exception;
+use Illuminate\Http\Client\HttpClientException;
+use PHPUnit\Framework\TestCase;
+
+class HttpClientExceptionTest extends TestCase
+{
+    public function testExceptionIsInstanceOfException()
+    {
+        $exception = new HttpClientException;
+
+        $this->assertInstanceOf(Exception::class, $exception);
+    }
+
+    public function testExceptionHoldsMessageCodeAndPrevious()
+    {
+        $previous = new Exception('previous');
+
+        $exception = new HttpClientException('Client error.', 42, $previous);
+
+        $this->assertSame('Client error.', $exception->getMessage());
+        $this->assertSame(42, $exception->getCode());
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+}

--- a/tests/Http/Client/Exceptions/RequestExceptionTest.php
+++ b/tests/Http/Client/Exceptions/RequestExceptionTest.php
@@ -24,14 +24,14 @@ class RequestExceptionTest extends TestCase
         parent::tearDown();
     }
 
-    public function testExceptionIsInstanceOfHttpClientException()
+    public function testExceptionIsInstanceOfHttpClientException(): void
     {
         $exception = new RequestException(new Response(new Psr7Response(500)));
 
         $this->assertInstanceOf(HttpClientException::class, $exception);
     }
 
-    public function testExceptionHoldsResponseAndStatusCodeAsCode()
+    public function testExceptionHoldsResponseAndStatusCodeAsCode(): void
     {
         $response = new Response(new Psr7Response(403));
 
@@ -42,7 +42,7 @@ class RequestExceptionTest extends TestCase
         $this->assertSame('HTTP request returned status code 403', $exception->getMessage());
     }
 
-    public function testExceptionAppendsBodySummaryOnReport()
+    public function testExceptionAppendsBodySummaryOnReport(): void
     {
         $response = new Response(new Psr7Response(403, [], 'Forbidden.'));
 
@@ -53,7 +53,7 @@ class RequestExceptionTest extends TestCase
         $this->assertTrue($exception->hasBeenSummarized);
     }
 
-    public function testExceptionTruncatesBodySummaryAtGlobalLimit()
+    public function testExceptionTruncatesBodySummaryAtGlobalLimit(): void
     {
         RequestException::truncateAt(5);
 
@@ -65,7 +65,7 @@ class RequestExceptionTest extends TestCase
         $this->assertSame("HTTP request returned status code 403:\nForbi (truncated...)\n", $exception->getMessage());
     }
 
-    public function testExceptionTruncatesBodySummaryAtInstanceLimit()
+    public function testExceptionTruncatesBodySummaryAtInstanceLimit(): void
     {
         $response = new Response(new Psr7Response(403, [], 'Forbidden.'));
 
@@ -75,14 +75,14 @@ class RequestExceptionTest extends TestCase
         $this->assertSame("HTTP request returned status code 403:\nForbi (truncated...)\n", $exception->getMessage());
     }
 
-    public function testDontTruncateDisablesSummaryTruncation()
+    public function testDontTruncateDisablesSummaryTruncation(): void
     {
         RequestException::dontTruncate();
 
         $this->assertFalse(RequestException::$truncateAt);
     }
 
-    public function testTruncateResetsGlobalLimitToDefault()
+    public function testTruncateResetsGlobalLimitToDefault(): void
     {
         RequestException::truncateAt(5);
         RequestException::truncate();

--- a/tests/Http/Client/Exceptions/RequestExceptionTest.php
+++ b/tests/Http/Client/Exceptions/RequestExceptionTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Illuminate\Tests\Http\Client\Exceptions;
+
+use GuzzleHttp\Psr7\Response as Psr7Response;
+use Illuminate\Http\Client\HttpClientException;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Http\Client\Response;
+use PHPUnit\Framework\TestCase;
+
+class RequestExceptionTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        RequestException::truncate();
+    }
+
+    protected function tearDown(): void
+    {
+        RequestException::truncate();
+
+        parent::tearDown();
+    }
+
+    public function testExceptionIsInstanceOfHttpClientException()
+    {
+        $exception = new RequestException(new Response(new Psr7Response(500)));
+
+        $this->assertInstanceOf(HttpClientException::class, $exception);
+    }
+
+    public function testExceptionHoldsResponseAndStatusCodeAsCode()
+    {
+        $response = new Response(new Psr7Response(403));
+
+        $exception = new RequestException($response);
+
+        $this->assertSame($response, $exception->response);
+        $this->assertSame(403, $exception->getCode());
+        $this->assertSame('HTTP request returned status code 403', $exception->getMessage());
+    }
+
+    public function testExceptionAppendsBodySummaryOnReport()
+    {
+        $response = new Response(new Psr7Response(403, [], 'Forbidden.'));
+
+        $exception = new RequestException($response);
+        $exception->report();
+
+        $this->assertSame("HTTP request returned status code 403:\nForbidden.\n", $exception->getMessage());
+        $this->assertTrue($exception->hasBeenSummarized);
+    }
+
+    public function testExceptionTruncatesBodySummaryAtGlobalLimit()
+    {
+        RequestException::truncateAt(5);
+
+        $response = new Response(new Psr7Response(403, [], 'Forbidden.'));
+
+        $exception = new RequestException($response);
+        $exception->report();
+
+        $this->assertSame("HTTP request returned status code 403:\nForbi (truncated...)\n", $exception->getMessage());
+    }
+
+    public function testExceptionTruncatesBodySummaryAtInstanceLimit()
+    {
+        $response = new Response(new Psr7Response(403, [], 'Forbidden.'));
+
+        $exception = new RequestException($response, 5);
+        $exception->report();
+
+        $this->assertSame("HTTP request returned status code 403:\nForbi (truncated...)\n", $exception->getMessage());
+    }
+
+    public function testDontTruncateDisablesSummaryTruncation()
+    {
+        RequestException::dontTruncate();
+
+        $this->assertFalse(RequestException::$truncateAt);
+    }
+
+    public function testTruncateResetsGlobalLimitToDefault()
+    {
+        RequestException::truncateAt(5);
+        RequestException::truncate();
+
+        $this->assertSame(120, RequestException::$truncateAt);
+    }
+}

--- a/tests/Http/Client/Exceptions/StrayRequestExceptionTest.php
+++ b/tests/Http/Client/Exceptions/StrayRequestExceptionTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Illuminate\Tests\Http\Client\Exceptions;
+
+use Illuminate\Http\Client\StrayRequestException;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class StrayRequestExceptionTest extends TestCase
+{
+    public function testExceptionIsInstanceOfRuntimeException()
+    {
+        $exception = new StrayRequestException('http://foo.com');
+
+        $this->assertInstanceOf(RuntimeException::class, $exception);
+    }
+
+    public function testExceptionUsesUriInMessage()
+    {
+        $exception = new StrayRequestException('http://foo.com');
+
+        $this->assertSame(
+            'Attempted request to [http://foo.com] without a matching fake.',
+            $exception->getMessage()
+        );
+        $this->assertSame(0, $exception->getCode());
+        $this->assertNull($exception->getPrevious());
+    }
+}

--- a/tests/Http/Client/Exceptions/StrayRequestExceptionTest.php
+++ b/tests/Http/Client/Exceptions/StrayRequestExceptionTest.php
@@ -8,14 +8,14 @@ use RuntimeException;
 
 class StrayRequestExceptionTest extends TestCase
 {
-    public function testExceptionIsInstanceOfRuntimeException()
+    public function testExceptionIsInstanceOfRuntimeException(): void
     {
         $exception = new StrayRequestException('http://foo.com');
 
         $this->assertInstanceOf(RuntimeException::class, $exception);
     }
 
-    public function testExceptionUsesUriInMessage()
+    public function testExceptionUsesUriInMessage(): void
     {
         $exception = new StrayRequestException('http://foo.com');
 

--- a/tests/Http/Exceptions/HttpResponseExceptionTest.php
+++ b/tests/Http/Exceptions/HttpResponseExceptionTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Illuminate\Tests\Http\Exceptions;
+
+use Exception;
+use Illuminate\Http\Exceptions\HttpResponseException;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Symfony\Component\HttpFoundation\Response;
+
+class HttpResponseExceptionTest extends TestCase
+{
+    public function testExceptionIsInstanceOfRuntimeException()
+    {
+        $exception = new HttpResponseException(new Response);
+
+        $this->assertInstanceOf(RuntimeException::class, $exception);
+    }
+
+    public function testExceptionHoldsResponse()
+    {
+        $response = new Response('body', 404);
+
+        $exception = new HttpResponseException($response);
+
+        $this->assertSame($response, $exception->getResponse());
+    }
+
+    public function testExceptionDefaultsToEmptyMessageAndCodeWithoutPrevious()
+    {
+        $exception = new HttpResponseException(new Response);
+
+        $this->assertSame('', $exception->getMessage());
+        $this->assertSame(0, $exception->getCode());
+        $this->assertNull($exception->getPrevious());
+    }
+
+    public function testExceptionInheritsMessageAndCodeFromPrevious()
+    {
+        $previous = new Exception('Something went wrong.', 42);
+
+        $exception = new HttpResponseException(new Response, $previous);
+
+        $this->assertSame('Something went wrong.', $exception->getMessage());
+        $this->assertSame(42, $exception->getCode());
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+}

--- a/tests/Http/Exceptions/HttpResponseExceptionTest.php
+++ b/tests/Http/Exceptions/HttpResponseExceptionTest.php
@@ -10,14 +10,14 @@ use Symfony\Component\HttpFoundation\Response;
 
 class HttpResponseExceptionTest extends TestCase
 {
-    public function testExceptionIsInstanceOfRuntimeException()
+    public function testExceptionIsInstanceOfRuntimeException(): void
     {
         $exception = new HttpResponseException(new Response);
 
         $this->assertInstanceOf(RuntimeException::class, $exception);
     }
 
-    public function testExceptionHoldsResponse()
+    public function testExceptionHoldsResponse(): void
     {
         $response = new Response('body', 404);
 
@@ -26,7 +26,7 @@ class HttpResponseExceptionTest extends TestCase
         $this->assertSame($response, $exception->getResponse());
     }
 
-    public function testExceptionDefaultsToEmptyMessageAndCodeWithoutPrevious()
+    public function testExceptionDefaultsToEmptyMessageAndCodeWithoutPrevious(): void
     {
         $exception = new HttpResponseException(new Response);
 
@@ -35,7 +35,7 @@ class HttpResponseExceptionTest extends TestCase
         $this->assertNull($exception->getPrevious());
     }
 
-    public function testExceptionInheritsMessageAndCodeFromPrevious()
+    public function testExceptionInheritsMessageAndCodeFromPrevious(): void
     {
         $previous = new Exception('Something went wrong.', 42);
 

--- a/tests/Http/Exceptions/MalformedUrlExceptionTest.php
+++ b/tests/Http/Exceptions/MalformedUrlExceptionTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Illuminate\Tests\Http\Exceptions;
+
+use Illuminate\Http\Exceptions\MalformedUrlException;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+class MalformedUrlExceptionTest extends TestCase
+{
+    public function testExceptionIsInstanceOfHttpException()
+    {
+        $exception = new MalformedUrlException;
+
+        $this->assertInstanceOf(HttpException::class, $exception);
+    }
+
+    public function testExceptionUsesStatusCode400AndMessage()
+    {
+        $exception = new MalformedUrlException;
+
+        $this->assertSame(400, $exception->getStatusCode());
+        $this->assertSame('Malformed URL.', $exception->getMessage());
+        $this->assertSame(0, $exception->getCode());
+        $this->assertNull($exception->getPrevious());
+    }
+}

--- a/tests/Http/Exceptions/MalformedUrlExceptionTest.php
+++ b/tests/Http/Exceptions/MalformedUrlExceptionTest.php
@@ -8,14 +8,14 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class MalformedUrlExceptionTest extends TestCase
 {
-    public function testExceptionIsInstanceOfHttpException()
+    public function testExceptionIsInstanceOfHttpException(): void
     {
         $exception = new MalformedUrlException;
 
         $this->assertInstanceOf(HttpException::class, $exception);
     }
 
-    public function testExceptionUsesStatusCode400AndMessage()
+    public function testExceptionUsesStatusCode400AndMessage(): void
     {
         $exception = new MalformedUrlException;
 

--- a/tests/Http/Exceptions/OriginMismatchExceptionTest.php
+++ b/tests/Http/Exceptions/OriginMismatchExceptionTest.php
@@ -8,14 +8,14 @@ use PHPUnit\Framework\TestCase;
 
 class OriginMismatchExceptionTest extends TestCase
 {
-    public function testExceptionIsInstanceOfException()
+    public function testExceptionIsInstanceOfException(): void
     {
         $exception = new OriginMismatchException;
 
         $this->assertInstanceOf(Exception::class, $exception);
     }
 
-    public function testExceptionHoldsMessageCodeAndPrevious()
+    public function testExceptionHoldsMessageCodeAndPrevious(): void
     {
         $previous = new Exception('previous');
 

--- a/tests/Http/Exceptions/OriginMismatchExceptionTest.php
+++ b/tests/Http/Exceptions/OriginMismatchExceptionTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Illuminate\Tests\Http\Exceptions;
+
+use Exception;
+use Illuminate\Http\Exceptions\OriginMismatchException;
+use PHPUnit\Framework\TestCase;
+
+class OriginMismatchExceptionTest extends TestCase
+{
+    public function testExceptionIsInstanceOfException()
+    {
+        $exception = new OriginMismatchException;
+
+        $this->assertInstanceOf(Exception::class, $exception);
+    }
+
+    public function testExceptionHoldsMessageCodeAndPrevious()
+    {
+        $previous = new Exception('previous');
+
+        $exception = new OriginMismatchException('The request origin does not match.', 42, $previous);
+
+        $this->assertSame('The request origin does not match.', $exception->getMessage());
+        $this->assertSame(42, $exception->getCode());
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+}

--- a/tests/Http/Exceptions/PostTooLargeExceptionTest.php
+++ b/tests/Http/Exceptions/PostTooLargeExceptionTest.php
@@ -9,21 +9,21 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class PostTooLargeExceptionTest extends TestCase
 {
-    public function testExceptionIsInstanceOfHttpException()
+    public function testExceptionIsInstanceOfHttpException(): void
     {
         $exception = new PostTooLargeException;
 
         $this->assertInstanceOf(HttpException::class, $exception);
     }
 
-    public function testExceptionUsesStatusCode413()
+    public function testExceptionUsesStatusCode413(): void
     {
         $exception = new PostTooLargeException;
 
         $this->assertSame(413, $exception->getStatusCode());
     }
 
-    public function testExceptionHoldsMessageHeadersCodeAndPrevious()
+    public function testExceptionHoldsMessageHeadersCodeAndPrevious(): void
     {
         $previous = new Exception('previous');
 

--- a/tests/Http/Exceptions/PostTooLargeExceptionTest.php
+++ b/tests/Http/Exceptions/PostTooLargeExceptionTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Illuminate\Tests\Http\Exceptions;
+
+use Exception;
+use Illuminate\Http\Exceptions\PostTooLargeException;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+class PostTooLargeExceptionTest extends TestCase
+{
+    public function testExceptionIsInstanceOfHttpException()
+    {
+        $exception = new PostTooLargeException;
+
+        $this->assertInstanceOf(HttpException::class, $exception);
+    }
+
+    public function testExceptionUsesStatusCode413()
+    {
+        $exception = new PostTooLargeException;
+
+        $this->assertSame(413, $exception->getStatusCode());
+    }
+
+    public function testExceptionHoldsMessageHeadersCodeAndPrevious()
+    {
+        $previous = new Exception('previous');
+
+        $exception = new PostTooLargeException('The POST data is too large.', $previous, ['X-Foo' => 'Bar'], 42);
+
+        $this->assertSame('The POST data is too large.', $exception->getMessage());
+        $this->assertSame(['X-Foo' => 'Bar'], $exception->getHeaders());
+        $this->assertSame(42, $exception->getCode());
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+}

--- a/tests/Http/Exceptions/ThrottleRequestsExceptionTest.php
+++ b/tests/Http/Exceptions/ThrottleRequestsExceptionTest.php
@@ -9,21 +9,21 @@ use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
 
 class ThrottleRequestsExceptionTest extends TestCase
 {
-    public function testExceptionIsInstanceOfTooManyRequestsHttpException()
+    public function testExceptionIsInstanceOfTooManyRequestsHttpException(): void
     {
         $exception = new ThrottleRequestsException;
 
         $this->assertInstanceOf(TooManyRequestsHttpException::class, $exception);
     }
 
-    public function testExceptionUsesStatusCode429()
+    public function testExceptionUsesStatusCode429(): void
     {
         $exception = new ThrottleRequestsException;
 
         $this->assertSame(429, $exception->getStatusCode());
     }
 
-    public function testExceptionHoldsMessageHeadersCodeAndPrevious()
+    public function testExceptionHoldsMessageHeadersCodeAndPrevious(): void
     {
         $previous = new Exception('previous');
 

--- a/tests/Http/Exceptions/ThrottleRequestsExceptionTest.php
+++ b/tests/Http/Exceptions/ThrottleRequestsExceptionTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Illuminate\Tests\Http\Exceptions;
+
+use Exception;
+use Illuminate\Http\Exceptions\ThrottleRequestsException;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
+
+class ThrottleRequestsExceptionTest extends TestCase
+{
+    public function testExceptionIsInstanceOfTooManyRequestsHttpException()
+    {
+        $exception = new ThrottleRequestsException;
+
+        $this->assertInstanceOf(TooManyRequestsHttpException::class, $exception);
+    }
+
+    public function testExceptionUsesStatusCode429()
+    {
+        $exception = new ThrottleRequestsException;
+
+        $this->assertSame(429, $exception->getStatusCode());
+    }
+
+    public function testExceptionHoldsMessageHeadersCodeAndPrevious()
+    {
+        $previous = new Exception('previous');
+
+        $exception = new ThrottleRequestsException('Too many attempts.', $previous, ['Retry-After' => 60], 42);
+
+        $this->assertSame('Too many attempts.', $exception->getMessage());
+        $this->assertSame(['Retry-After' => 60], $exception->getHeaders());
+        $this->assertSame(42, $exception->getCode());
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+}

--- a/tests/Http/Resources/JsonApi/Exceptions/ResourceIdentificationExceptionTest.php
+++ b/tests/Http/Resources/JsonApi/Exceptions/ResourceIdentificationExceptionTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Illuminate\Tests\Http\Resources\JsonApi\Exceptions;
+
+use Illuminate\Http\Resources\JsonApi\Exceptions\ResourceIdentificationException;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use stdClass;
+
+class ResourceIdentificationExceptionTest extends TestCase
+{
+    public function testExceptionIsInstanceOfRuntimeException()
+    {
+        $exception = ResourceIdentificationException::attemptingToDetermineIdFor(new stdClass);
+
+        $this->assertInstanceOf(RuntimeException::class, $exception);
+    }
+
+    public function testAttemptingToDetermineIdForObject()
+    {
+        $exception = ResourceIdentificationException::attemptingToDetermineIdFor(new stdClass);
+
+        $this->assertSame('Unable to resolve resource object ID for [stdClass].', $exception->getMessage());
+    }
+
+    public function testAttemptingToDetermineIdForScalar()
+    {
+        $exception = ResourceIdentificationException::attemptingToDetermineIdFor('foo');
+
+        $this->assertSame('Unable to resolve resource object ID for [string].', $exception->getMessage());
+    }
+
+    public function testAttemptingToDetermineTypeForObject()
+    {
+        $exception = ResourceIdentificationException::attemptingToDetermineTypeFor(new stdClass);
+
+        $this->assertSame('Unable to resolve resource object type for [stdClass].', $exception->getMessage());
+    }
+
+    public function testAttemptingToDetermineTypeForScalar()
+    {
+        $exception = ResourceIdentificationException::attemptingToDetermineTypeFor(42);
+
+        $this->assertSame('Unable to resolve resource object type for [integer].', $exception->getMessage());
+    }
+}

--- a/tests/Http/Resources/JsonApi/Exceptions/ResourceIdentificationExceptionTest.php
+++ b/tests/Http/Resources/JsonApi/Exceptions/ResourceIdentificationExceptionTest.php
@@ -9,35 +9,35 @@ use stdClass;
 
 class ResourceIdentificationExceptionTest extends TestCase
 {
-    public function testExceptionIsInstanceOfRuntimeException()
+    public function testExceptionIsInstanceOfRuntimeException(): void
     {
         $exception = ResourceIdentificationException::attemptingToDetermineIdFor(new stdClass);
 
         $this->assertInstanceOf(RuntimeException::class, $exception);
     }
 
-    public function testAttemptingToDetermineIdForObject()
+    public function testAttemptingToDetermineIdForObject(): void
     {
         $exception = ResourceIdentificationException::attemptingToDetermineIdFor(new stdClass);
 
         $this->assertSame('Unable to resolve resource object ID for [stdClass].', $exception->getMessage());
     }
 
-    public function testAttemptingToDetermineIdForScalar()
+    public function testAttemptingToDetermineIdForScalar(): void
     {
         $exception = ResourceIdentificationException::attemptingToDetermineIdFor('foo');
 
         $this->assertSame('Unable to resolve resource object ID for [string].', $exception->getMessage());
     }
 
-    public function testAttemptingToDetermineTypeForObject()
+    public function testAttemptingToDetermineTypeForObject(): void
     {
         $exception = ResourceIdentificationException::attemptingToDetermineTypeFor(new stdClass);
 
         $this->assertSame('Unable to resolve resource object type for [stdClass].', $exception->getMessage());
     }
 
-    public function testAttemptingToDetermineTypeForScalar()
+    public function testAttemptingToDetermineTypeForScalar(): void
     {
         $exception = ResourceIdentificationException::attemptingToDetermineTypeFor(42);
 

--- a/tests/Image/Exceptions/ImageExceptionTest.php
+++ b/tests/Image/Exceptions/ImageExceptionTest.php
@@ -9,14 +9,14 @@ use RuntimeException;
 
 class ImageExceptionTest extends TestCase
 {
-    public function testExceptionIsInstanceOfRuntimeException()
+    public function testExceptionIsInstanceOfRuntimeException(): void
     {
         $exception = new ImageException;
 
         $this->assertInstanceOf(RuntimeException::class, $exception);
     }
 
-    public function testExceptionHoldsMessageCodeAndPrevious()
+    public function testExceptionHoldsMessageCodeAndPrevious(): void
     {
         $previous = new Exception('previous');
 

--- a/tests/Image/Exceptions/ImageExceptionTest.php
+++ b/tests/Image/Exceptions/ImageExceptionTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Illuminate\Tests\Image\Exceptions;
+
+use Exception;
+use Illuminate\Image\ImageException;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class ImageExceptionTest extends TestCase
+{
+    public function testExceptionIsInstanceOfRuntimeException()
+    {
+        $exception = new ImageException;
+
+        $this->assertInstanceOf(RuntimeException::class, $exception);
+    }
+
+    public function testExceptionHoldsMessageCodeAndPrevious()
+    {
+        $previous = new Exception('previous');
+
+        $exception = new ImageException('Unable to process image.', 42, $previous);
+
+        $this->assertSame('Unable to process image.', $exception->getMessage());
+        $this->assertSame(42, $exception->getCode());
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+}

--- a/tests/Process/Exceptions/ProcessFailedExceptionTest.php
+++ b/tests/Process/Exceptions/ProcessFailedExceptionTest.php
@@ -9,7 +9,7 @@ use RuntimeException;
 
 class ProcessFailedExceptionTest extends TestCase
 {
-    public function testExceptionIsInstanceOfRuntimeException()
+    public function testExceptionIsInstanceOfRuntimeException(): void
     {
         $result = new FakeProcessResult(command: 'exit 1', exitCode: 1);
 
@@ -18,7 +18,7 @@ class ProcessFailedExceptionTest extends TestCase
         $this->assertInstanceOf(RuntimeException::class, $exception);
     }
 
-    public function testExceptionHoldsResultAndUsesExitCodeAsCode()
+    public function testExceptionHoldsResultAndUsesExitCodeAsCode(): void
     {
         $result = new FakeProcessResult(command: 'exit 1', exitCode: 1);
 
@@ -29,7 +29,7 @@ class ProcessFailedExceptionTest extends TestCase
         $this->assertSame("The command \"exit 1\" failed.\n\nExit Code: 1", $exception->getMessage());
     }
 
-    public function testExceptionMessageIncludesOutput()
+    public function testExceptionMessageIncludesOutput(): void
     {
         $result = new FakeProcessResult(command: 'ls', exitCode: 1, output: 'file.txt');
 
@@ -41,7 +41,7 @@ class ProcessFailedExceptionTest extends TestCase
         );
     }
 
-    public function testExceptionMessageIncludesErrorOutput()
+    public function testExceptionMessageIncludesErrorOutput(): void
     {
         $result = new FakeProcessResult(command: 'ls', exitCode: 1, errorOutput: 'permission denied');
 

--- a/tests/Process/Exceptions/ProcessFailedExceptionTest.php
+++ b/tests/Process/Exceptions/ProcessFailedExceptionTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Illuminate\Tests\Process\Exceptions;
+
+use Illuminate\Process\Exceptions\ProcessFailedException;
+use Illuminate\Process\FakeProcessResult;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class ProcessFailedExceptionTest extends TestCase
+{
+    public function testExceptionIsInstanceOfRuntimeException()
+    {
+        $result = new FakeProcessResult(command: 'exit 1', exitCode: 1);
+
+        $exception = new ProcessFailedException($result);
+
+        $this->assertInstanceOf(RuntimeException::class, $exception);
+    }
+
+    public function testExceptionHoldsResultAndUsesExitCodeAsCode()
+    {
+        $result = new FakeProcessResult(command: 'exit 1', exitCode: 1);
+
+        $exception = new ProcessFailedException($result);
+
+        $this->assertSame($result, $exception->result);
+        $this->assertSame(1, $exception->getCode());
+        $this->assertSame("The command \"exit 1\" failed.\n\nExit Code: 1", $exception->getMessage());
+    }
+
+    public function testExceptionMessageIncludesOutput()
+    {
+        $result = new FakeProcessResult(command: 'ls', exitCode: 1, output: 'file.txt');
+
+        $exception = new ProcessFailedException($result);
+
+        $this->assertSame(
+            "The command \"ls\" failed.\n\nExit Code: 1\n\nOutput:\n================\nfile.txt\n",
+            $exception->getMessage()
+        );
+    }
+
+    public function testExceptionMessageIncludesErrorOutput()
+    {
+        $result = new FakeProcessResult(command: 'ls', exitCode: 1, errorOutput: 'permission denied');
+
+        $exception = new ProcessFailedException($result);
+
+        $this->assertSame(
+            "The command \"ls\" failed.\n\nExit Code: 1\n\nError Output:\n================\npermission denied\n",
+            $exception->getMessage()
+        );
+    }
+}

--- a/tests/Process/Exceptions/ProcessTimedOutExceptionTest.php
+++ b/tests/Process/Exceptions/ProcessTimedOutExceptionTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Illuminate\Tests\Process\Exceptions;
+
+use Illuminate\Process\Exceptions\ProcessTimedOutException;
+use Illuminate\Process\FakeProcessResult;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\Exception\ProcessTimedOutException as SymfonyProcessTimedOutException;
+use Symfony\Component\Process\Exception\RuntimeException as SymfonyRuntimeException;
+use Symfony\Component\Process\Process;
+
+class ProcessTimedOutExceptionTest extends TestCase
+{
+    public function testExceptionIsInstanceOfSymfonyRuntimeException()
+    {
+        $exception = new ProcessTimedOutException($this->symfonyTimeoutException(), new FakeProcessResult);
+
+        $this->assertInstanceOf(SymfonyRuntimeException::class, $exception);
+    }
+
+    public function testExceptionHoldsResultAndInheritsMessageAndCodeFromOriginal()
+    {
+        $original = $this->symfonyTimeoutException();
+        $result = new FakeProcessResult;
+
+        $exception = new ProcessTimedOutException($original, $result);
+
+        $this->assertSame($result, $exception->result);
+        $this->assertSame($original->getMessage(), $exception->getMessage());
+        $this->assertSame($original->getCode(), $exception->getCode());
+        $this->assertSame($original, $exception->getPrevious());
+    }
+
+    protected function symfonyTimeoutException(): SymfonyProcessTimedOutException
+    {
+        $process = new Process(['php', '-v']);
+        $process->setTimeout(5);
+
+        return new SymfonyProcessTimedOutException($process, SymfonyProcessTimedOutException::TYPE_GENERAL);
+    }
+}

--- a/tests/Process/Exceptions/ProcessTimedOutExceptionTest.php
+++ b/tests/Process/Exceptions/ProcessTimedOutExceptionTest.php
@@ -11,14 +11,14 @@ use Symfony\Component\Process\Process;
 
 class ProcessTimedOutExceptionTest extends TestCase
 {
-    public function testExceptionIsInstanceOfSymfonyRuntimeException()
+    public function testExceptionIsInstanceOfSymfonyRuntimeException(): void
     {
         $exception = new ProcessTimedOutException($this->symfonyTimeoutException(), new FakeProcessResult);
 
         $this->assertInstanceOf(SymfonyRuntimeException::class, $exception);
     }
 
-    public function testExceptionHoldsResultAndInheritsMessageAndCodeFromOriginal()
+    public function testExceptionHoldsResultAndInheritsMessageAndCodeFromOriginal(): void
     {
         $original = $this->symfonyTimeoutException();
         $result = new FakeProcessResult;

--- a/tests/Queue/Exceptions/EntityNotFoundExceptionTest.php
+++ b/tests/Queue/Exceptions/EntityNotFoundExceptionTest.php
@@ -8,14 +8,14 @@ use PHPUnit\Framework\TestCase;
 
 class EntityNotFoundExceptionTest extends TestCase
 {
-    public function testExceptionIsInstanceOfInvalidArgumentException()
+    public function testExceptionIsInstanceOfInvalidArgumentException(): void
     {
         $exception = new EntityNotFoundException('App\\Models\\User', 1);
 
         $this->assertInstanceOf(InvalidArgumentException::class, $exception);
     }
 
-    public function testExceptionUsesTypeAndIdInMessage()
+    public function testExceptionUsesTypeAndIdInMessage(): void
     {
         $exception = new EntityNotFoundException('App\\Models\\User', 1);
 
@@ -27,7 +27,7 @@ class EntityNotFoundExceptionTest extends TestCase
         $this->assertNull($exception->getPrevious());
     }
 
-    public function testExceptionCastsIdToString()
+    public function testExceptionCastsIdToString(): void
     {
         $exception = new EntityNotFoundException('App\\Models\\User', null);
 

--- a/tests/Queue/Exceptions/EntityNotFoundExceptionTest.php
+++ b/tests/Queue/Exceptions/EntityNotFoundExceptionTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Illuminate\Tests\Queue\Exceptions;
+
+use Illuminate\Contracts\Queue\EntityNotFoundException;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+class EntityNotFoundExceptionTest extends TestCase
+{
+    public function testExceptionIsInstanceOfInvalidArgumentException()
+    {
+        $exception = new EntityNotFoundException('App\\Models\\User', 1);
+
+        $this->assertInstanceOf(InvalidArgumentException::class, $exception);
+    }
+
+    public function testExceptionUsesTypeAndIdInMessage()
+    {
+        $exception = new EntityNotFoundException('App\\Models\\User', 1);
+
+        $this->assertSame(
+            'Queueable entity [App\\Models\\User] not found for ID [1].',
+            $exception->getMessage()
+        );
+        $this->assertSame(0, $exception->getCode());
+        $this->assertNull($exception->getPrevious());
+    }
+
+    public function testExceptionCastsIdToString()
+    {
+        $exception = new EntityNotFoundException('App\\Models\\User', null);
+
+        $this->assertSame(
+            'Queueable entity [App\\Models\\User] not found for ID [].',
+            $exception->getMessage()
+        );
+    }
+}

--- a/tests/Queue/Exceptions/InvalidPayloadExceptionTest.php
+++ b/tests/Queue/Exceptions/InvalidPayloadExceptionTest.php
@@ -8,14 +8,14 @@ use PHPUnit\Framework\TestCase;
 
 class InvalidPayloadExceptionTest extends TestCase
 {
-    public function testExceptionIsInstanceOfInvalidArgumentException()
+    public function testExceptionIsInstanceOfInvalidArgumentException(): void
     {
         $exception = new InvalidPayloadException('Invalid payload.');
 
         $this->assertInstanceOf(InvalidArgumentException::class, $exception);
     }
 
-    public function testExceptionHoldsProvidedMessageAndValue()
+    public function testExceptionHoldsProvidedMessageAndValue(): void
     {
         $exception = new InvalidPayloadException('Invalid payload.', 'bad-json');
 
@@ -23,7 +23,7 @@ class InvalidPayloadExceptionTest extends TestCase
         $this->assertSame('bad-json', $exception->value);
     }
 
-    public function testExceptionFallsBackToJsonLastErrorWhenNoMessageGiven()
+    public function testExceptionFallsBackToJsonLastErrorWhenNoMessageGiven(): void
     {
         json_decode('{invalid');
 

--- a/tests/Queue/Exceptions/InvalidPayloadExceptionTest.php
+++ b/tests/Queue/Exceptions/InvalidPayloadExceptionTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Illuminate\Tests\Queue\Exceptions;
+
+use Illuminate\Queue\InvalidPayloadException;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+class InvalidPayloadExceptionTest extends TestCase
+{
+    public function testExceptionIsInstanceOfInvalidArgumentException()
+    {
+        $exception = new InvalidPayloadException('Invalid payload.');
+
+        $this->assertInstanceOf(InvalidArgumentException::class, $exception);
+    }
+
+    public function testExceptionHoldsProvidedMessageAndValue()
+    {
+        $exception = new InvalidPayloadException('Invalid payload.', 'bad-json');
+
+        $this->assertSame('Invalid payload.', $exception->getMessage());
+        $this->assertSame('bad-json', $exception->value);
+    }
+
+    public function testExceptionFallsBackToJsonLastErrorWhenNoMessageGiven()
+    {
+        json_decode('{invalid');
+
+        $exception = new InvalidPayloadException(null, 'bad-json');
+
+        $this->assertSame((string) json_last_error(), $exception->getMessage());
+        $this->assertSame('bad-json', $exception->value);
+    }
+}

--- a/tests/Queue/Exceptions/ManuallyFailedExceptionTest.php
+++ b/tests/Queue/Exceptions/ManuallyFailedExceptionTest.php
@@ -9,14 +9,14 @@ use RuntimeException;
 
 class ManuallyFailedExceptionTest extends TestCase
 {
-    public function testExceptionIsInstanceOfRuntimeException()
+    public function testExceptionIsInstanceOfRuntimeException(): void
     {
         $exception = new ManuallyFailedException;
 
         $this->assertInstanceOf(RuntimeException::class, $exception);
     }
 
-    public function testExceptionHoldsMessageCodeAndPrevious()
+    public function testExceptionHoldsMessageCodeAndPrevious(): void
     {
         $previous = new Exception('previous');
 

--- a/tests/Queue/Exceptions/ManuallyFailedExceptionTest.php
+++ b/tests/Queue/Exceptions/ManuallyFailedExceptionTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Illuminate\Tests\Queue\Exceptions;
+
+use Exception;
+use Illuminate\Queue\ManuallyFailedException;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class ManuallyFailedExceptionTest extends TestCase
+{
+    public function testExceptionIsInstanceOfRuntimeException()
+    {
+        $exception = new ManuallyFailedException;
+
+        $this->assertInstanceOf(RuntimeException::class, $exception);
+    }
+
+    public function testExceptionHoldsMessageCodeAndPrevious()
+    {
+        $previous = new Exception('previous');
+
+        $exception = new ManuallyFailedException('Manually failed.', 42, $previous);
+
+        $this->assertSame('Manually failed.', $exception->getMessage());
+        $this->assertSame(42, $exception->getCode());
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+}

--- a/tests/Queue/Exceptions/MaxAttemptsExceededExceptionTest.php
+++ b/tests/Queue/Exceptions/MaxAttemptsExceededExceptionTest.php
@@ -14,16 +14,18 @@ class MaxAttemptsExceededExceptionTest extends TestCase
     protected function tearDown(): void
     {
         m::close();
+
+        parent::tearDown();
     }
 
-    public function testExceptionIsInstanceOfRuntimeException()
+    public function testExceptionIsInstanceOfRuntimeException(): void
     {
         $exception = new MaxAttemptsExceededException;
 
         $this->assertInstanceOf(RuntimeException::class, $exception);
     }
 
-    public function testExceptionHoldsMessageCodeAndPrevious()
+    public function testExceptionHoldsMessageCodeAndPrevious(): void
     {
         $previous = new Exception('previous');
 
@@ -34,14 +36,14 @@ class MaxAttemptsExceededExceptionTest extends TestCase
         $this->assertSame($previous, $exception->getPrevious());
     }
 
-    public function testJobDefaultsToNull()
+    public function testJobDefaultsToNull(): void
     {
         $exception = new MaxAttemptsExceededException;
 
         $this->assertNull($exception->job);
     }
 
-    public function testForJobBuildsExceptionAndAssignsJob()
+    public function testForJobBuildsExceptionAndAssignsJob(): void
     {
         $job = m::mock(SyncJob::class);
         $job->shouldReceive('resolveName')->andReturn('App\\Jobs\\UnderlyingJob');

--- a/tests/Queue/Exceptions/MaxAttemptsExceededExceptionTest.php
+++ b/tests/Queue/Exceptions/MaxAttemptsExceededExceptionTest.php
@@ -11,13 +11,6 @@ use RuntimeException;
 
 class MaxAttemptsExceededExceptionTest extends TestCase
 {
-    protected function tearDown(): void
-    {
-        m::close();
-
-        parent::tearDown();
-    }
-
     public function testExceptionIsInstanceOfRuntimeException(): void
     {
         $exception = new MaxAttemptsExceededException;

--- a/tests/Queue/Exceptions/MaxAttemptsExceededExceptionTest.php
+++ b/tests/Queue/Exceptions/MaxAttemptsExceededExceptionTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Illuminate\Tests\Queue\Exceptions;
+
+use Exception;
+use Illuminate\Queue\Jobs\SyncJob;
+use Illuminate\Queue\MaxAttemptsExceededException;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class MaxAttemptsExceededExceptionTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    public function testExceptionIsInstanceOfRuntimeException()
+    {
+        $exception = new MaxAttemptsExceededException;
+
+        $this->assertInstanceOf(RuntimeException::class, $exception);
+    }
+
+    public function testExceptionHoldsMessageCodeAndPrevious()
+    {
+        $previous = new Exception('previous');
+
+        $exception = new MaxAttemptsExceededException('Attempted too many times.', 42, $previous);
+
+        $this->assertSame('Attempted too many times.', $exception->getMessage());
+        $this->assertSame(42, $exception->getCode());
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+
+    public function testJobDefaultsToNull()
+    {
+        $exception = new MaxAttemptsExceededException;
+
+        $this->assertNull($exception->job);
+    }
+
+    public function testForJobBuildsExceptionAndAssignsJob()
+    {
+        $job = m::mock(SyncJob::class);
+        $job->shouldReceive('resolveName')->andReturn('App\\Jobs\\UnderlyingJob');
+
+        $exception = MaxAttemptsExceededException::forJob($job);
+
+        $this->assertSame($job, $exception->job);
+        $this->assertSame('App\\Jobs\\UnderlyingJob has been attempted too many times.', $exception->getMessage());
+    }
+}

--- a/tests/Queue/Exceptions/TimeoutExceededExceptionTest.php
+++ b/tests/Queue/Exceptions/TimeoutExceededExceptionTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Illuminate\Tests\Queue\Exceptions;
+
+use Illuminate\Queue\Jobs\SyncJob;
+use Illuminate\Queue\MaxAttemptsExceededException;
+use Illuminate\Queue\TimeoutExceededException;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class TimeoutExceededExceptionTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    public function testExceptionIsInstanceOfMaxAttemptsExceededException()
+    {
+        $job = m::mock(SyncJob::class);
+        $job->shouldReceive('resolveName')->andReturn('App\\Jobs\\UnderlyingJob');
+
+        $exception = TimeoutExceededException::forJob($job);
+
+        $this->assertInstanceOf(MaxAttemptsExceededException::class, $exception);
+    }
+
+    public function testForJobBuildsExceptionAndAssignsJob()
+    {
+        $job = m::mock(SyncJob::class);
+        $job->shouldReceive('resolveName')->andReturn('App\\Jobs\\UnderlyingJob');
+
+        $exception = TimeoutExceededException::forJob($job);
+
+        $this->assertSame($job, $exception->job);
+        $this->assertSame('App\\Jobs\\UnderlyingJob has timed out.', $exception->getMessage());
+    }
+}

--- a/tests/Queue/Exceptions/TimeoutExceededExceptionTest.php
+++ b/tests/Queue/Exceptions/TimeoutExceededExceptionTest.php
@@ -10,13 +10,6 @@ use PHPUnit\Framework\TestCase;
 
 class TimeoutExceededExceptionTest extends TestCase
 {
-    protected function tearDown(): void
-    {
-        m::close();
-
-        parent::tearDown();
-    }
-
     public function testExceptionIsInstanceOfMaxAttemptsExceededException(): void
     {
         $job = m::mock(SyncJob::class);

--- a/tests/Queue/Exceptions/TimeoutExceededExceptionTest.php
+++ b/tests/Queue/Exceptions/TimeoutExceededExceptionTest.php
@@ -13,9 +13,11 @@ class TimeoutExceededExceptionTest extends TestCase
     protected function tearDown(): void
     {
         m::close();
+
+        parent::tearDown();
     }
 
-    public function testExceptionIsInstanceOfMaxAttemptsExceededException()
+    public function testExceptionIsInstanceOfMaxAttemptsExceededException(): void
     {
         $job = m::mock(SyncJob::class);
         $job->shouldReceive('resolveName')->andReturn('App\\Jobs\\UnderlyingJob');
@@ -25,7 +27,7 @@ class TimeoutExceededExceptionTest extends TestCase
         $this->assertInstanceOf(MaxAttemptsExceededException::class, $exception);
     }
 
-    public function testForJobBuildsExceptionAndAssignsJob()
+    public function testForJobBuildsExceptionAndAssignsJob(): void
     {
         $job = m::mock(SyncJob::class);
         $job->shouldReceive('resolveName')->andReturn('App\\Jobs\\UnderlyingJob');

--- a/tests/Redis/Exceptions/LimiterTimeoutExceptionTest.php
+++ b/tests/Redis/Exceptions/LimiterTimeoutExceptionTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Illuminate\Tests\Redis\Exceptions;
+
+use Exception;
+use Illuminate\Contracts\Redis\LimiterTimeoutException;
+use PHPUnit\Framework\TestCase;
+
+class LimiterTimeoutExceptionTest extends TestCase
+{
+    public function testExceptionIsInstanceOfException()
+    {
+        $exception = new LimiterTimeoutException;
+
+        $this->assertInstanceOf(Exception::class, $exception);
+    }
+
+    public function testExceptionHoldsMessageCodeAndPrevious()
+    {
+        $previous = new Exception('previous');
+
+        $exception = new LimiterTimeoutException('Limiter timed out.', 42, $previous);
+
+        $this->assertSame('Limiter timed out.', $exception->getMessage());
+        $this->assertSame(42, $exception->getCode());
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+}

--- a/tests/Redis/Exceptions/LimiterTimeoutExceptionTest.php
+++ b/tests/Redis/Exceptions/LimiterTimeoutExceptionTest.php
@@ -8,14 +8,14 @@ use PHPUnit\Framework\TestCase;
 
 class LimiterTimeoutExceptionTest extends TestCase
 {
-    public function testExceptionIsInstanceOfException()
+    public function testExceptionIsInstanceOfException(): void
     {
         $exception = new LimiterTimeoutException;
 
         $this->assertInstanceOf(Exception::class, $exception);
     }
 
-    public function testExceptionHoldsMessageCodeAndPrevious()
+    public function testExceptionHoldsMessageCodeAndPrevious(): void
     {
         $previous = new Exception('previous');
 

--- a/tests/Routing/Exceptions/BackedEnumCaseNotFoundExceptionTest.php
+++ b/tests/Routing/Exceptions/BackedEnumCaseNotFoundExceptionTest.php
@@ -8,14 +8,14 @@ use RuntimeException;
 
 class BackedEnumCaseNotFoundExceptionTest extends TestCase
 {
-    public function testExceptionIsInstanceOfRuntimeException()
+    public function testExceptionIsInstanceOfRuntimeException(): void
     {
         $exception = new BackedEnumCaseNotFoundException('App\\Enums\\Status', 'archived');
 
         $this->assertInstanceOf(RuntimeException::class, $exception);
     }
 
-    public function testExceptionUsesEnumClassAndCaseInMessage()
+    public function testExceptionUsesEnumClassAndCaseInMessage(): void
     {
         $exception = new BackedEnumCaseNotFoundException('App\\Enums\\Status', 'archived');
 

--- a/tests/Routing/Exceptions/BackedEnumCaseNotFoundExceptionTest.php
+++ b/tests/Routing/Exceptions/BackedEnumCaseNotFoundExceptionTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Illuminate\Tests\Routing\Exceptions;
+
+use Illuminate\Routing\Exceptions\BackedEnumCaseNotFoundException;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class BackedEnumCaseNotFoundExceptionTest extends TestCase
+{
+    public function testExceptionIsInstanceOfRuntimeException()
+    {
+        $exception = new BackedEnumCaseNotFoundException('App\\Enums\\Status', 'archived');
+
+        $this->assertInstanceOf(RuntimeException::class, $exception);
+    }
+
+    public function testExceptionUsesEnumClassAndCaseInMessage()
+    {
+        $exception = new BackedEnumCaseNotFoundException('App\\Enums\\Status', 'archived');
+
+        $this->assertSame(
+            'Case [archived] not found on Backed Enum [App\\Enums\\Status].',
+            $exception->getMessage()
+        );
+        $this->assertSame(0, $exception->getCode());
+        $this->assertNull($exception->getPrevious());
+    }
+}

--- a/tests/Routing/Exceptions/InvalidSignatureExceptionTest.php
+++ b/tests/Routing/Exceptions/InvalidSignatureExceptionTest.php
@@ -8,14 +8,14 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class InvalidSignatureExceptionTest extends TestCase
 {
-    public function testExceptionIsInstanceOfHttpException()
+    public function testExceptionIsInstanceOfHttpException(): void
     {
         $exception = new InvalidSignatureException;
 
         $this->assertInstanceOf(HttpException::class, $exception);
     }
 
-    public function testExceptionUsesStatusCode403AndMessage()
+    public function testExceptionUsesStatusCode403AndMessage(): void
     {
         $exception = new InvalidSignatureException;
 

--- a/tests/Routing/Exceptions/InvalidSignatureExceptionTest.php
+++ b/tests/Routing/Exceptions/InvalidSignatureExceptionTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Illuminate\Tests\Routing\Exceptions;
+
+use Illuminate\Routing\Exceptions\InvalidSignatureException;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+class InvalidSignatureExceptionTest extends TestCase
+{
+    public function testExceptionIsInstanceOfHttpException()
+    {
+        $exception = new InvalidSignatureException;
+
+        $this->assertInstanceOf(HttpException::class, $exception);
+    }
+
+    public function testExceptionUsesStatusCode403AndMessage()
+    {
+        $exception = new InvalidSignatureException;
+
+        $this->assertSame(403, $exception->getStatusCode());
+        $this->assertSame('Invalid signature.', $exception->getMessage());
+        $this->assertSame(0, $exception->getCode());
+        $this->assertNull($exception->getPrevious());
+    }
+}

--- a/tests/Routing/Exceptions/MissingRateLimiterExceptionTest.php
+++ b/tests/Routing/Exceptions/MissingRateLimiterExceptionTest.php
@@ -8,21 +8,21 @@ use PHPUnit\Framework\TestCase;
 
 class MissingRateLimiterExceptionTest extends TestCase
 {
-    public function testExceptionIsInstanceOfException()
+    public function testExceptionIsInstanceOfException(): void
     {
         $exception = MissingRateLimiterException::forLimiter('uploads');
 
         $this->assertInstanceOf(Exception::class, $exception);
     }
 
-    public function testForLimiter()
+    public function testForLimiter(): void
     {
         $exception = MissingRateLimiterException::forLimiter('uploads');
 
         $this->assertSame('Rate limiter [uploads] is not defined.', $exception->getMessage());
     }
 
-    public function testForLimiterAndUser()
+    public function testForLimiterAndUser(): void
     {
         $exception = MissingRateLimiterException::forLimiterAndUser('uploads', 'App\\Models\\User');
 

--- a/tests/Routing/Exceptions/MissingRateLimiterExceptionTest.php
+++ b/tests/Routing/Exceptions/MissingRateLimiterExceptionTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Illuminate\Tests\Routing\Exceptions;
+
+use Exception;
+use Illuminate\Routing\Exceptions\MissingRateLimiterException;
+use PHPUnit\Framework\TestCase;
+
+class MissingRateLimiterExceptionTest extends TestCase
+{
+    public function testExceptionIsInstanceOfException()
+    {
+        $exception = MissingRateLimiterException::forLimiter('uploads');
+
+        $this->assertInstanceOf(Exception::class, $exception);
+    }
+
+    public function testForLimiter()
+    {
+        $exception = MissingRateLimiterException::forLimiter('uploads');
+
+        $this->assertSame('Rate limiter [uploads] is not defined.', $exception->getMessage());
+    }
+
+    public function testForLimiterAndUser()
+    {
+        $exception = MissingRateLimiterException::forLimiterAndUser('uploads', 'App\\Models\\User');
+
+        $this->assertSame('Rate limiter [App\\Models\\User::uploads] is not defined.', $exception->getMessage());
+    }
+}

--- a/tests/Routing/Exceptions/StreamedResponseExceptionTest.php
+++ b/tests/Routing/Exceptions/StreamedResponseExceptionTest.php
@@ -10,14 +10,14 @@ use RuntimeException;
 
 class StreamedResponseExceptionTest extends TestCase
 {
-    public function testExceptionIsInstanceOfRuntimeException()
+    public function testExceptionIsInstanceOfRuntimeException(): void
     {
         $exception = new StreamedResponseException(new Exception('Stream failed.'));
 
         $this->assertInstanceOf(RuntimeException::class, $exception);
     }
 
-    public function testExceptionHoldsOriginalExceptionAndItsMessage()
+    public function testExceptionHoldsOriginalExceptionAndItsMessage(): void
     {
         $original = new Exception('Stream failed.');
 
@@ -28,7 +28,7 @@ class StreamedResponseExceptionTest extends TestCase
         $this->assertSame('Stream failed.', $exception->getMessage());
     }
 
-    public function testRenderReturnsEmptyResponse()
+    public function testRenderReturnsEmptyResponse(): void
     {
         $exception = new StreamedResponseException(new Exception('Stream failed.'));
 

--- a/tests/Routing/Exceptions/StreamedResponseExceptionTest.php
+++ b/tests/Routing/Exceptions/StreamedResponseExceptionTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Illuminate\Tests\Routing\Exceptions;
+
+use Exception;
+use Illuminate\Http\Response;
+use Illuminate\Routing\Exceptions\StreamedResponseException;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class StreamedResponseExceptionTest extends TestCase
+{
+    public function testExceptionIsInstanceOfRuntimeException()
+    {
+        $exception = new StreamedResponseException(new Exception('Stream failed.'));
+
+        $this->assertInstanceOf(RuntimeException::class, $exception);
+    }
+
+    public function testExceptionHoldsOriginalExceptionAndItsMessage()
+    {
+        $original = new Exception('Stream failed.');
+
+        $exception = new StreamedResponseException($original);
+
+        $this->assertSame($original, $exception->originalException);
+        $this->assertSame($original, $exception->getInnerException());
+        $this->assertSame('Stream failed.', $exception->getMessage());
+    }
+
+    public function testRenderReturnsEmptyResponse()
+    {
+        $exception = new StreamedResponseException(new Exception('Stream failed.'));
+
+        $response = $exception->render();
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertSame('', $response->getContent());
+    }
+}

--- a/tests/Routing/Exceptions/UrlGenerationExceptionTest.php
+++ b/tests/Routing/Exceptions/UrlGenerationExceptionTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 class UrlGenerationExceptionTest extends TestCase
 {
-    public function testExceptionIsInstanceOfException()
+    public function testExceptionIsInstanceOfException(): void
     {
         $route = new Route('GET', 'foo/{bar}', ['as' => 'foo']);
 
@@ -18,7 +18,7 @@ class UrlGenerationExceptionTest extends TestCase
         $this->assertInstanceOf(Exception::class, $exception);
     }
 
-    public function testForMissingParametersWithoutParameters()
+    public function testForMissingParametersWithoutParameters(): void
     {
         $route = new Route('GET', 'foo/{bar}', ['as' => 'foo']);
 
@@ -30,7 +30,7 @@ class UrlGenerationExceptionTest extends TestCase
         );
     }
 
-    public function testForMissingParametersWithParameters()
+    public function testForMissingParametersWithParameters(): void
     {
         $route = new Route('GET', 'foo/{bar}/{baz}', ['as' => 'foo']);
 
@@ -42,7 +42,7 @@ class UrlGenerationExceptionTest extends TestCase
         );
     }
 
-    public function testForMissingParametersWithSingleParameter()
+    public function testForMissingParametersWithSingleParameter(): void
     {
         $route = new Route('GET', 'foo/{bar}', ['as' => 'foo']);
 

--- a/tests/Routing/Exceptions/UrlGenerationExceptionTest.php
+++ b/tests/Routing/Exceptions/UrlGenerationExceptionTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Illuminate\Tests\Routing\Exceptions;
+
+use Exception;
+use Illuminate\Routing\Exceptions\UrlGenerationException;
+use Illuminate\Routing\Route;
+use PHPUnit\Framework\TestCase;
+
+class UrlGenerationExceptionTest extends TestCase
+{
+    public function testExceptionIsInstanceOfException()
+    {
+        $route = new Route('GET', 'foo/{bar}', ['as' => 'foo']);
+
+        $exception = UrlGenerationException::forMissingParameters($route);
+
+        $this->assertInstanceOf(Exception::class, $exception);
+    }
+
+    public function testForMissingParametersWithoutParameters()
+    {
+        $route = new Route('GET', 'foo/{bar}', ['as' => 'foo']);
+
+        $exception = UrlGenerationException::forMissingParameters($route);
+
+        $this->assertSame(
+            'Missing required parameters for [Route: foo] [URI: foo/{bar}].',
+            $exception->getMessage()
+        );
+    }
+
+    public function testForMissingParametersWithParameters()
+    {
+        $route = new Route('GET', 'foo/{bar}/{baz}', ['as' => 'foo']);
+
+        $exception = UrlGenerationException::forMissingParameters($route, ['bar', 'baz']);
+
+        $this->assertSame(
+            'Missing required parameters for [Route: foo] [URI: foo/{bar}/{baz}] [Missing parameters: bar, baz].',
+            $exception->getMessage()
+        );
+    }
+
+    public function testForMissingParametersWithSingleParameter()
+    {
+        $route = new Route('GET', 'foo/{bar}', ['as' => 'foo']);
+
+        $exception = UrlGenerationException::forMissingParameters($route, ['bar']);
+
+        $this->assertSame(
+            'Missing required parameter for [Route: foo] [URI: foo/{bar}] [Missing parameter: bar].',
+            $exception->getMessage()
+        );
+    }
+}

--- a/tests/Session/Exceptions/TokenMismatchExceptionTest.php
+++ b/tests/Session/Exceptions/TokenMismatchExceptionTest.php
@@ -8,14 +8,14 @@ use PHPUnit\Framework\TestCase;
 
 class TokenMismatchExceptionTest extends TestCase
 {
-    public function testExceptionIsInstanceOfException()
+    public function testExceptionIsInstanceOfException(): void
     {
         $exception = new TokenMismatchException;
 
         $this->assertInstanceOf(Exception::class, $exception);
     }
 
-    public function testExceptionHoldsMessageCodeAndPrevious()
+    public function testExceptionHoldsMessageCodeAndPrevious(): void
     {
         $previous = new Exception('previous');
 

--- a/tests/Session/Exceptions/TokenMismatchExceptionTest.php
+++ b/tests/Session/Exceptions/TokenMismatchExceptionTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Illuminate\Tests\Session\Exceptions;
+
+use Exception;
+use Illuminate\Session\TokenMismatchException;
+use PHPUnit\Framework\TestCase;
+
+class TokenMismatchExceptionTest extends TestCase
+{
+    public function testExceptionIsInstanceOfException()
+    {
+        $exception = new TokenMismatchException;
+
+        $this->assertInstanceOf(Exception::class, $exception);
+    }
+
+    public function testExceptionHoldsMessageCodeAndPrevious()
+    {
+        $previous = new Exception('previous');
+
+        $exception = new TokenMismatchException('CSRF token mismatch.', 42, $previous);
+
+        $this->assertSame('CSRF token mismatch.', $exception->getMessage());
+        $this->assertSame(42, $exception->getCode());
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+}

--- a/tests/Support/Exceptions/ItemNotFoundExceptionTest.php
+++ b/tests/Support/Exceptions/ItemNotFoundExceptionTest.php
@@ -9,14 +9,14 @@ use RuntimeException;
 
 class ItemNotFoundExceptionTest extends TestCase
 {
-    public function testExceptionIsInstanceOfRuntimeException()
+    public function testExceptionIsInstanceOfRuntimeException(): void
     {
         $exception = new ItemNotFoundException;
 
         $this->assertInstanceOf(RuntimeException::class, $exception);
     }
 
-    public function testExceptionHoldsMessageCodeAndPrevious()
+    public function testExceptionHoldsMessageCodeAndPrevious(): void
     {
         $previous = new Exception('previous');
 

--- a/tests/Support/Exceptions/ItemNotFoundExceptionTest.php
+++ b/tests/Support/Exceptions/ItemNotFoundExceptionTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Illuminate\Tests\Support\Exceptions;
+
+use Exception;
+use Illuminate\Support\ItemNotFoundException;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class ItemNotFoundExceptionTest extends TestCase
+{
+    public function testExceptionIsInstanceOfRuntimeException()
+    {
+        $exception = new ItemNotFoundException;
+
+        $this->assertInstanceOf(RuntimeException::class, $exception);
+    }
+
+    public function testExceptionHoldsMessageCodeAndPrevious()
+    {
+        $previous = new Exception('previous');
+
+        $exception = new ItemNotFoundException('No item found.', 42, $previous);
+
+        $this->assertSame('No item found.', $exception->getMessage());
+        $this->assertSame(42, $exception->getCode());
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+}

--- a/tests/Support/Exceptions/MathExceptionTest.php
+++ b/tests/Support/Exceptions/MathExceptionTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Illuminate\Tests\Support\Exceptions;
+
+use Exception;
+use Illuminate\Support\Exceptions\MathException;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class MathExceptionTest extends TestCase
+{
+    public function testExceptionIsInstanceOfRuntimeException()
+    {
+        $exception = new MathException;
+
+        $this->assertInstanceOf(RuntimeException::class, $exception);
+    }
+
+    public function testExceptionHoldsMessageCodeAndPrevious()
+    {
+        $previous = new Exception('previous');
+
+        $exception = new MathException('Division by zero.', 42, $previous);
+
+        $this->assertSame('Division by zero.', $exception->getMessage());
+        $this->assertSame(42, $exception->getCode());
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+}

--- a/tests/Support/Exceptions/MathExceptionTest.php
+++ b/tests/Support/Exceptions/MathExceptionTest.php
@@ -9,14 +9,14 @@ use RuntimeException;
 
 class MathExceptionTest extends TestCase
 {
-    public function testExceptionIsInstanceOfRuntimeException()
+    public function testExceptionIsInstanceOfRuntimeException(): void
     {
         $exception = new MathException;
 
         $this->assertInstanceOf(RuntimeException::class, $exception);
     }
 
-    public function testExceptionHoldsMessageCodeAndPrevious()
+    public function testExceptionHoldsMessageCodeAndPrevious(): void
     {
         $previous = new Exception('previous');
 

--- a/tests/Support/Exceptions/MultipleItemsFoundExceptionTest.php
+++ b/tests/Support/Exceptions/MultipleItemsFoundExceptionTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Illuminate\Tests\Support\Exceptions;
+
+use Exception;
+use Illuminate\Support\MultipleItemsFoundException;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class MultipleItemsFoundExceptionTest extends TestCase
+{
+    public function testExceptionIsInstanceOfRuntimeException()
+    {
+        $exception = new MultipleItemsFoundException(2);
+
+        $this->assertInstanceOf(RuntimeException::class, $exception);
+    }
+
+    public function testExceptionHoldsCountAndMessage()
+    {
+        $exception = new MultipleItemsFoundException(3);
+
+        $this->assertSame(3, $exception->count);
+        $this->assertSame(3, $exception->getCount());
+        $this->assertSame('3 items were found.', $exception->getMessage());
+        $this->assertSame(0, $exception->getCode());
+        $this->assertNull($exception->getPrevious());
+    }
+
+    public function testExceptionHoldsCodeAndPrevious()
+    {
+        $previous = new Exception('previous');
+
+        $exception = new MultipleItemsFoundException(3, 42, $previous);
+
+        $this->assertSame(42, $exception->getCode());
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+}

--- a/tests/Support/Exceptions/MultipleItemsFoundExceptionTest.php
+++ b/tests/Support/Exceptions/MultipleItemsFoundExceptionTest.php
@@ -9,14 +9,14 @@ use RuntimeException;
 
 class MultipleItemsFoundExceptionTest extends TestCase
 {
-    public function testExceptionIsInstanceOfRuntimeException()
+    public function testExceptionIsInstanceOfRuntimeException(): void
     {
         $exception = new MultipleItemsFoundException(2);
 
         $this->assertInstanceOf(RuntimeException::class, $exception);
     }
 
-    public function testExceptionHoldsCountAndMessage()
+    public function testExceptionHoldsCountAndMessage(): void
     {
         $exception = new MultipleItemsFoundException(3);
 
@@ -27,7 +27,7 @@ class MultipleItemsFoundExceptionTest extends TestCase
         $this->assertNull($exception->getPrevious());
     }
 
-    public function testExceptionHoldsCodeAndPrevious()
+    public function testExceptionHoldsCodeAndPrevious(): void
     {
         $previous = new Exception('previous');
 

--- a/tests/Testing/Exceptions/InvalidArgumentExceptionTest.php
+++ b/tests/Testing/Exceptions/InvalidArgumentExceptionTest.php
@@ -8,14 +8,14 @@ use PHPUnit\Framework\TestCase;
 
 class InvalidArgumentExceptionTest extends TestCase
 {
-    public function testExceptionIsInstanceOfPHPUnitException()
+    public function testExceptionIsInstanceOfPHPUnitException(): void
     {
         $exception = InvalidArgumentException::create(1, 'array');
 
         $this->assertInstanceOf(Exception::class, $exception);
     }
 
-    public function testCreateUsesAArticleForConsonantSoundingType()
+    public function testCreateUsesAArticleForConsonantSoundingType(): void
     {
         $exception = InvalidArgumentException::create(1, 'string');
 
@@ -25,7 +25,7 @@ class InvalidArgumentExceptionTest extends TestCase
         );
     }
 
-    public function testCreateUsesAnArticleForVowelSoundingType()
+    public function testCreateUsesAnArticleForVowelSoundingType(): void
     {
         $exception = InvalidArgumentException::create(2, 'array or ArrayAccess');
 
@@ -35,7 +35,7 @@ class InvalidArgumentExceptionTest extends TestCase
         );
     }
 
-    public function testCreateIncludesArgumentNumber()
+    public function testCreateIncludesArgumentNumber(): void
     {
         $exception = InvalidArgumentException::create(3, 'string');
 

--- a/tests/Testing/Exceptions/InvalidArgumentExceptionTest.php
+++ b/tests/Testing/Exceptions/InvalidArgumentExceptionTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Illuminate\Tests\Testing\Exceptions;
+
+use Illuminate\Testing\Exceptions\InvalidArgumentException;
+use PHPUnit\Framework\Exception;
+use PHPUnit\Framework\TestCase;
+
+class InvalidArgumentExceptionTest extends TestCase
+{
+    public function testExceptionIsInstanceOfPHPUnitException()
+    {
+        $exception = InvalidArgumentException::create(1, 'array');
+
+        $this->assertInstanceOf(Exception::class, $exception);
+    }
+
+    public function testCreateUsesAArticleForConsonantSoundingType()
+    {
+        $exception = InvalidArgumentException::create(1, 'string');
+
+        $this->assertSame(
+            self::class.'::testCreateUsesAArticleForConsonantSoundingType() must be a string',
+            $this->messageWithoutArgumentPrefix($exception)
+        );
+    }
+
+    public function testCreateUsesAnArticleForVowelSoundingType()
+    {
+        $exception = InvalidArgumentException::create(2, 'array or ArrayAccess');
+
+        $this->assertSame(
+            self::class.'::testCreateUsesAnArticleForVowelSoundingType() must be an array or ArrayAccess',
+            $this->messageWithoutArgumentPrefix($exception)
+        );
+    }
+
+    public function testCreateIncludesArgumentNumber()
+    {
+        $exception = InvalidArgumentException::create(3, 'string');
+
+        $this->assertStringStartsWith('Argument #3 of ', $exception->getMessage());
+    }
+
+    protected function messageWithoutArgumentPrefix(InvalidArgumentException $exception): string
+    {
+        return preg_replace('/^Argument #\d+ of /', '', $exception->getMessage());
+    }
+}

--- a/tests/Validation/Exceptions/UnauthorizedExceptionTest.php
+++ b/tests/Validation/Exceptions/UnauthorizedExceptionTest.php
@@ -9,14 +9,14 @@ use RuntimeException;
 
 class UnauthorizedExceptionTest extends TestCase
 {
-    public function testExceptionIsInstanceOfRuntimeException()
+    public function testExceptionIsInstanceOfRuntimeException(): void
     {
         $exception = new UnauthorizedException;
 
         $this->assertInstanceOf(RuntimeException::class, $exception);
     }
 
-    public function testExceptionHoldsMessageCodeAndPrevious()
+    public function testExceptionHoldsMessageCodeAndPrevious(): void
     {
         $previous = new Exception('previous');
 

--- a/tests/Validation/Exceptions/UnauthorizedExceptionTest.php
+++ b/tests/Validation/Exceptions/UnauthorizedExceptionTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Illuminate\Tests\Validation\Exceptions;
+
+use Exception;
+use Illuminate\Validation\UnauthorizedException;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class UnauthorizedExceptionTest extends TestCase
+{
+    public function testExceptionIsInstanceOfRuntimeException()
+    {
+        $exception = new UnauthorizedException;
+
+        $this->assertInstanceOf(RuntimeException::class, $exception);
+    }
+
+    public function testExceptionHoldsMessageCodeAndPrevious()
+    {
+        $previous = new Exception('previous');
+
+        $exception = new UnauthorizedException('This action is unauthorized.', 42, $previous);
+
+        $this->assertSame('This action is unauthorized.', $exception->getMessage());
+        $this->assertSame(42, $exception->getCode());
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+}

--- a/tests/Validation/ValidationExceptionTest.php
+++ b/tests/Validation/ValidationExceptionTest.php
@@ -2,14 +2,24 @@
 
 namespace Illuminate\Tests\Validation;
 
+use Illuminate\Container\Container;
+use Illuminate\Support\Facades\Facade;
 use Illuminate\Translation\ArrayLoader;
 use Illuminate\Translation\Translator;
+use Illuminate\Validation\Factory;
 use Illuminate\Validation\ValidationException;
 use Illuminate\Validation\Validator;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Response;
 
 class ValidationExceptionTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        Facade::clearResolvedInstances();
+        Facade::setFacadeApplication(null);
+    }
+
     public function testExceptionSummarizesZeroErrors()
     {
         $exception = $this->getException([], []);
@@ -162,6 +172,43 @@ class ValidationExceptionTest extends TestCase
         $exception = $validator->getException();
 
         $this->assertEquals(ValidationException::class, $exception);
+    }
+
+    public function testConstructorDefaultsToNullResponseAndDefaultErrorBag()
+    {
+        $exception = $this->getException([], ['foo' => 'required']);
+
+        $this->assertNull($exception->getResponse());
+        $this->assertSame('default', $exception->errorBag);
+    }
+
+    public function testConstructorAcceptsResponseAndErrorBag()
+    {
+        $validator = $this->getValidator([], ['foo' => 'required']);
+        $response = new Response;
+
+        $exception = new ValidationException($validator, $response, 'milwad');
+
+        $this->assertSame($response, $exception->getResponse());
+        $this->assertSame('milwad', $exception->errorBag);
+    }
+
+    public function testWithMessagesCreatesExceptionFromPlainArray()
+    {
+        $container = new Container;
+        $container->instance('validator', new Factory($this->getTranslator()));
+        Facade::setFacadeApplication($container);
+
+        $exception = ValidationException::withMessages([
+            'foo' => 'Foo is required.',
+            'bar' => ['Bar is required.', 'Bar must be a string.'],
+        ]);
+
+        $this->assertSame([
+            'foo' => ['Foo is required.'],
+            'bar' => ['Bar is required.', 'Bar must be a string.'],
+        ], $exception->errors());
+        $this->assertSame('Foo is required. (and 2 more errors)', $exception->getMessage());
     }
 
     protected function getException($data = [], $rules = [], $translator = null)

--- a/tests/Validation/ValidationExceptionTest.php
+++ b/tests/Validation/ValidationExceptionTest.php
@@ -18,30 +18,32 @@ class ValidationExceptionTest extends TestCase
     {
         Facade::clearResolvedInstances();
         Facade::setFacadeApplication(null);
+
+        parent::tearDown();
     }
 
-    public function testExceptionSummarizesZeroErrors()
+    public function testExceptionSummarizesZeroErrors(): void
     {
         $exception = $this->getException([], []);
 
         $this->assertSame('The given data was invalid.', $exception->getMessage());
     }
 
-    public function testExceptionSummarizesOneError()
+    public function testExceptionSummarizesOneError(): void
     {
         $exception = $this->getException([], ['foo' => 'required']);
 
         $this->assertSame('validation.required', $exception->getMessage());
     }
 
-    public function testExceptionSummarizesTwoErrors()
+    public function testExceptionSummarizesTwoErrors(): void
     {
         $exception = $this->getException([], ['foo' => 'required', 'bar' => 'required']);
 
         $this->assertSame('validation.required (and 1 more error)', $exception->getMessage());
     }
 
-    public function testExceptionSummarizesThreeOrMoreErrors()
+    public function testExceptionSummarizesThreeOrMoreErrors(): void
     {
         $exception = $this->getException([], [
             'foo' => 'required',
@@ -52,7 +54,7 @@ class ValidationExceptionTest extends TestCase
         $this->assertSame('validation.required (and 2 more errors)', $exception->getMessage());
     }
 
-    public function testExceptionTranslatedSummarizesTwoErrors()
+    public function testExceptionTranslatedSummarizesTwoErrors(): void
     {
         $translator = $this->getTranslator('uk', [
             '*' => [
@@ -73,7 +75,7 @@ class ValidationExceptionTest extends TestCase
         $this->assertSame('validation.required (та ще 1 помилка)', $exception->getMessage());
     }
 
-    public function testExceptionTranslatedSummarizesThreeOrMoreErrors()
+    public function testExceptionTranslatedSummarizesThreeOrMoreErrors(): void
     {
         $translator = $this->getTranslator('uk', [
             '*' => [
@@ -95,7 +97,7 @@ class ValidationExceptionTest extends TestCase
         $this->assertSame('validation.required (та ще 2 помилки)', $exception->getMessage());
     }
 
-    public function testExceptionTranslatedSummarizesFiveOrMoreErrors()
+    public function testExceptionTranslatedSummarizesFiveOrMoreErrors(): void
     {
         $translator = $this->getTranslator('uk', [
             '*' => [
@@ -120,21 +122,21 @@ class ValidationExceptionTest extends TestCase
         $this->assertSame('validation.required (та ще 5 помилок)', $exception->getMessage());
     }
 
-    public function testExceptionErrorZeroErrors()
+    public function testExceptionErrorZeroErrors(): void
     {
         $exception = $this->getException([], []);
 
         $this->assertSame([], $exception->errors());
     }
 
-    public function testExceptionErrorOneError()
+    public function testExceptionErrorOneError(): void
     {
         $exception = $this->getException([], ['foo' => 'required']);
 
         $this->assertSame(['foo' => ['validation.required']], $exception->errors());
     }
 
-    public function testExceptionStatusOneError()
+    public function testExceptionStatusOneError(): void
     {
         $exception = $this->getException([], ['foo' => 'required']);
         $exception->status(500);
@@ -142,7 +144,7 @@ class ValidationExceptionTest extends TestCase
         $this->assertEquals(500, $exception->status);
     }
 
-    public function testExceptionErrorBagOneError()
+    public function testExceptionErrorBagOneError(): void
     {
         $exception = $this->getException([], ['foo' => 'required']);
         $exception->errorBag('milwad');
@@ -150,7 +152,7 @@ class ValidationExceptionTest extends TestCase
         $this->assertSame('milwad', $exception->errorBag);
     }
 
-    public function testExceptionRedirectToOneError()
+    public function testExceptionRedirectToOneError(): void
     {
         $exception = $this->getException([], ['foo' => 'required']);
         $exception->redirectTo('https://google.com');
@@ -158,14 +160,14 @@ class ValidationExceptionTest extends TestCase
         $this->assertSame('https://google.com', $exception->redirectTo);
     }
 
-    public function testExceptionGetResponseOneError()
+    public function testExceptionGetResponseOneError(): void
     {
         $exception = $this->getException([], ['foo' => 'required']);
 
         $this->assertNull($exception->getResponse());
     }
 
-    public function testGetExceptionClassFromValidator()
+    public function testGetExceptionClassFromValidator(): void
     {
         $validator = $this->getValidator();
 
@@ -174,7 +176,7 @@ class ValidationExceptionTest extends TestCase
         $this->assertEquals(ValidationException::class, $exception);
     }
 
-    public function testConstructorDefaultsToNullResponseAndDefaultErrorBag()
+    public function testConstructorDefaultsToNullResponseAndDefaultErrorBag(): void
     {
         $exception = $this->getException([], ['foo' => 'required']);
 
@@ -182,7 +184,7 @@ class ValidationExceptionTest extends TestCase
         $this->assertSame('default', $exception->errorBag);
     }
 
-    public function testConstructorAcceptsResponseAndErrorBag()
+    public function testConstructorAcceptsResponseAndErrorBag(): void
     {
         $validator = $this->getValidator([], ['foo' => 'required']);
         $response = new Response;
@@ -193,7 +195,7 @@ class ValidationExceptionTest extends TestCase
         $this->assertSame('milwad', $exception->errorBag);
     }
 
-    public function testWithMessagesCreatesExceptionFromPlainArray()
+    public function testWithMessagesCreatesExceptionFromPlainArray(): void
     {
         $container = new Container;
         $container->instance('validator', new Factory($this->getTranslator()));

--- a/tests/View/Exceptions/ViewCompilationExceptionTest.php
+++ b/tests/View/Exceptions/ViewCompilationExceptionTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Illuminate\Tests\View\Exceptions;
+
+use Exception;
+use Illuminate\Contracts\View\ViewCompilationException;
+use PHPUnit\Framework\TestCase;
+
+class ViewCompilationExceptionTest extends TestCase
+{
+    public function testExceptionIsInstanceOfException()
+    {
+        $exception = new ViewCompilationException;
+
+        $this->assertInstanceOf(Exception::class, $exception);
+    }
+
+    public function testExceptionHoldsMessageCodeAndPrevious()
+    {
+        $previous = new Exception('previous');
+
+        $exception = new ViewCompilationException('Could not compile the view.', 42, $previous);
+
+        $this->assertSame('Could not compile the view.', $exception->getMessage());
+        $this->assertSame(42, $exception->getCode());
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+}

--- a/tests/View/Exceptions/ViewCompilationExceptionTest.php
+++ b/tests/View/Exceptions/ViewCompilationExceptionTest.php
@@ -8,14 +8,14 @@ use PHPUnit\Framework\TestCase;
 
 class ViewCompilationExceptionTest extends TestCase
 {
-    public function testExceptionIsInstanceOfException()
+    public function testExceptionIsInstanceOfException(): void
     {
         $exception = new ViewCompilationException;
 
         $this->assertInstanceOf(Exception::class, $exception);
     }
 
-    public function testExceptionHoldsMessageCodeAndPrevious()
+    public function testExceptionHoldsMessageCodeAndPrevious(): void
     {
         $previous = new Exception('previous');
 

--- a/tests/View/Exceptions/ViewExceptionTest.php
+++ b/tests/View/Exceptions/ViewExceptionTest.php
@@ -10,35 +10,35 @@ use PHPUnit\Framework\TestCase;
 
 class ViewExceptionTest extends TestCase
 {
-    public function testExceptionIsInstanceOfErrorException()
+    public function testExceptionIsInstanceOfErrorException(): void
     {
         $exception = new ViewException('View error.');
 
         $this->assertInstanceOf(ErrorException::class, $exception);
     }
 
-    public function testExceptionHoldsMessage()
+    public function testExceptionHoldsMessage(): void
     {
         $exception = new ViewException('View error.');
 
         $this->assertSame('View error.', $exception->getMessage());
     }
 
-    public function testReportReturnsFalseWithoutPreviousException()
+    public function testReportReturnsFalseWithoutPreviousException(): void
     {
         $exception = new ViewException('View error.');
 
         $this->assertFalse($exception->report());
     }
 
-    public function testReportReturnsFalseWhenPreviousExceptionIsNotReportable()
+    public function testReportReturnsFalseWhenPreviousExceptionIsNotReportable(): void
     {
         $exception = new ViewException('View error.', 0, 1, __FILE__, __LINE__, new Exception('previous'));
 
         $this->assertFalse($exception->report());
     }
 
-    public function testReportDelegatesToReportableePreviousException()
+    public function testReportDelegatesToReportableePreviousException(): void
     {
         $previous = new class extends Exception
         {
@@ -58,21 +58,21 @@ class ViewExceptionTest extends TestCase
         $this->assertTrue($previous->reported);
     }
 
-    public function testRenderReturnsNullWithoutPreviousException()
+    public function testRenderReturnsNullWithoutPreviousException(): void
     {
         $exception = new ViewException('View error.');
 
         $this->assertNull($exception->render(Request::create('/')));
     }
 
-    public function testRenderReturnsNullWhenPreviousExceptionIsNotRenderable()
+    public function testRenderReturnsNullWhenPreviousExceptionIsNotRenderable(): void
     {
         $exception = new ViewException('View error.', 0, 1, __FILE__, __LINE__, new Exception('previous'));
 
         $this->assertNull($exception->render(Request::create('/')));
     }
 
-    public function testRenderDelegatesToRenderablePreviousException()
+    public function testRenderDelegatesToRenderablePreviousException(): void
     {
         $previous = new class extends Exception
         {

--- a/tests/View/Exceptions/ViewExceptionTest.php
+++ b/tests/View/Exceptions/ViewExceptionTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Illuminate\Tests\View\Exceptions;
+
+use ErrorException;
+use Exception;
+use Illuminate\Http\Request;
+use Illuminate\View\ViewException;
+use PHPUnit\Framework\TestCase;
+
+class ViewExceptionTest extends TestCase
+{
+    public function testExceptionIsInstanceOfErrorException()
+    {
+        $exception = new ViewException('View error.');
+
+        $this->assertInstanceOf(ErrorException::class, $exception);
+    }
+
+    public function testExceptionHoldsMessage()
+    {
+        $exception = new ViewException('View error.');
+
+        $this->assertSame('View error.', $exception->getMessage());
+    }
+
+    public function testReportReturnsFalseWithoutPreviousException()
+    {
+        $exception = new ViewException('View error.');
+
+        $this->assertFalse($exception->report());
+    }
+
+    public function testReportReturnsFalseWhenPreviousExceptionIsNotReportable()
+    {
+        $exception = new ViewException('View error.', 0, 1, __FILE__, __LINE__, new Exception('previous'));
+
+        $this->assertFalse($exception->report());
+    }
+
+    public function testReportDelegatesToReportableePreviousException()
+    {
+        $previous = new class extends Exception
+        {
+            public bool $reported = false;
+
+            public function report()
+            {
+                $this->reported = true;
+
+                return true;
+            }
+        };
+
+        $exception = new ViewException('View error.', 0, 1, __FILE__, __LINE__, $previous);
+
+        $this->assertTrue($exception->report());
+        $this->assertTrue($previous->reported);
+    }
+
+    public function testRenderReturnsNullWithoutPreviousException()
+    {
+        $exception = new ViewException('View error.');
+
+        $this->assertNull($exception->render(Request::create('/')));
+    }
+
+    public function testRenderReturnsNullWhenPreviousExceptionIsNotRenderable()
+    {
+        $exception = new ViewException('View error.', 0, 1, __FILE__, __LINE__, new Exception('previous'));
+
+        $this->assertNull($exception->render(Request::create('/')));
+    }
+
+    public function testRenderDelegatesToRenderablePreviousException()
+    {
+        $previous = new class extends Exception
+        {
+            public function render($request)
+            {
+                return 'rendered: '.$request->path();
+            }
+        };
+
+        $exception = new ViewException('View error.', 0, 1, __FILE__, __LINE__, $previous);
+
+        $this->assertSame('rendered: foo', $exception->render(Request::create('/foo')));
+    }
+}


### PR DESCRIPTION
Adds a dedicated test class for each custom exception across the framework, covering construction, message formatting, and getters.

---

Apply the same testing coverage. cf. https://github.com/briannesbitt/Carbon/pull/2404 