### PR TITLE
[13.x] Job expiration based on job timeout

### DIFF
--- a/src/Illuminate/Queue/Connectors/DatabaseConnector.php
+++ b/src/Illuminate/Queue/Connectors/DatabaseConnector.php
@@ -37,7 +37,8 @@ class DatabaseConnector implements ConnectorInterface
             $config['table'],
             $config['queue'],
             $config['retry_after'] ?? 60,
-            $config['after_commit'] ?? null
+            $config['after_commit'] ?? null,
+            $config['expire_after_timeout'] ?? false
         );
     }
 }

--- a/src/Illuminate/Queue/Connectors/RedisConnector.php
+++ b/src/Illuminate/Queue/Connectors/RedisConnector.php
@@ -47,7 +47,8 @@ class RedisConnector implements ConnectorInterface
             $config['retry_after'] ?? 60,
             $config['block_for'] ?? null,
             $config['after_commit'] ?? null,
-            $config['migration_batch_size'] ?? -1
+            $config['migration_batch_size'] ?? -1,
+            $config['expire_after_timeout'] ?? false
         );
     }
 }

--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -41,7 +41,7 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
     /**
      * The expiration time of a job.
      *
-     * @var int|null
+     * @var int|string|null
      */
     protected $retryAfter = 60;
 
@@ -58,7 +58,7 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
      * @param  \Illuminate\Database\Connection  $database
      * @param  string  $table
      * @param  string  $default
-     * @param  int  $retryAfter
+     * @param  int|string  $retryAfter
      * @param  bool  $dispatchAfterCommit
      */
     public function __construct(
@@ -486,7 +486,8 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
      */
     protected function isReservedButExpired($query)
     {
-        $expiration = Carbon::now()->subSeconds($this->retryAfter)->getTimestamp();
+        // In-flight jobs have a 300-second grace period when config is switched from a fixed value to "auto"
+        $expiration = Carbon::now()->subSeconds($this->retryAfter === 'auto' ? 300 : $this->retryAfter)->getTimestamp();
 
         $query->orWhere(function ($query) use ($expiration) {
             $query->where('reserved_at', '<=', $expiration);
@@ -519,8 +520,20 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
      */
     protected function markJobAsReserved($job)
     {
+        $reservationOffset = 0;
+
+        if ($this->retryAfter === 'auto') {
+            $timeout = json_decode($job->payload, true)['timeout'] ?? null;
+
+            if (! is_numeric($timeout) || (int) $timeout <= 0) {
+                $timeout = $this->workerTimeout ?? 60;
+            }
+
+            $reservationOffset = (int) $timeout + 10 - 300;
+        }
+
         $this->database->table($this->table)->where('id', $job->id)->update([
-            'reserved_at' => $job->touch(),
+            'reserved_at' => $job->touch($reservationOffset),
             'attempts' => $job->increment(),
         ]);
 

--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -41,9 +41,16 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
     /**
      * The expiration time of a job.
      *
-     * @var int|string|null
+     * @var int|null
      */
     protected $retryAfter = 60;
+
+    /**
+     * Indicates if jobs should be reserved until their timeout instead of the retry_after value.
+     *
+     * @var bool
+     */
+    protected $expireAfterTimeout = false;
 
     /**
      * The cached lock type for popping jobs.
@@ -58,8 +65,9 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
      * @param  \Illuminate\Database\Connection  $database
      * @param  string  $table
      * @param  string  $default
-     * @param  int|string  $retryAfter
+     * @param  int  $retryAfter
      * @param  bool  $dispatchAfterCommit
+     * @param  bool  $expireAfterTimeout
      */
     public function __construct(
         Connection $database,
@@ -67,12 +75,14 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
         $default = 'default',
         $retryAfter = 60,
         $dispatchAfterCommit = false,
+        $expireAfterTimeout = false,
     ) {
         $this->table = $table;
         $this->default = $default;
         $this->database = $database;
         $this->retryAfter = $retryAfter;
         $this->dispatchAfterCommit = $dispatchAfterCommit;
+        $this->expireAfterTimeout = $expireAfterTimeout;
     }
 
     /**
@@ -486,8 +496,7 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
      */
     protected function isReservedButExpired($query)
     {
-        // In-flight jobs have a 300-second grace period when config is switched from a fixed value to "auto"
-        $expiration = Carbon::now()->subSeconds($this->retryAfter === 'auto' ? 300 : $this->retryAfter)->getTimestamp();
+        $expiration = Carbon::now()->subSeconds($this->retryAfter)->getTimestamp();
 
         $query->orWhere(function ($query) use ($expiration) {
             $query->where('reserved_at', '<=', $expiration);
@@ -522,14 +531,16 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
     {
         $reservationOffset = 0;
 
-        if ($this->retryAfter === 'auto') {
+        if ($this->expireAfterTimeout) {
             $timeout = json_decode($job->payload, true)['timeout'] ?? null;
 
             if (! is_numeric($timeout) || (int) $timeout <= 0) {
-                $timeout = $this->workerTimeout ?? 60;
+                $timeout = $this->workerTimeout;
             }
 
-            $reservationOffset = (int) $timeout + 10 - 300;
+            if (! is_null($timeout)) {
+                $reservationOffset = (int) $timeout + 10 - $this->retryAfter;
+            }
         }
 
         $this->database->table($this->table)->where('id', $job->id)->update([

--- a/src/Illuminate/Queue/Jobs/DatabaseJobRecord.php
+++ b/src/Illuminate/Queue/Jobs/DatabaseJobRecord.php
@@ -40,11 +40,12 @@ class DatabaseJobRecord
     /**
      * Update the "reserved at" timestamp of the job.
      *
+     * @param  int  $offset
      * @return int
      */
-    public function touch()
+    public function touch($offset = 0)
     {
-        $this->record->reserved_at = $this->currentTime();
+        $this->record->reserved_at = $this->currentTime() + $offset;
 
         return $this->record->reserved_at;
     }

--- a/src/Illuminate/Queue/Listener.php
+++ b/src/Illuminate/Queue/Listener.php
@@ -161,6 +161,7 @@ class Listener
             "--backoff={$options->backoff}",
             "--memory={$options->memory}",
             "--sleep={$options->sleep}",
+            "--timeout={$options->timeout}",
             "--tries={$options->maxTries}",
             $options->force ? '--force' : null,
         ], function ($value) {

--- a/src/Illuminate/Queue/LuaScripts.php
+++ b/src/Illuminate/Queue/LuaScripts.php
@@ -63,6 +63,7 @@ LUA;
      * KEYS[2] - The queue to place reserved jobs on, for example: queues:foo:reserved
      * KEYS[3] - The notify queue
      * ARGV[1] - The time at which the reserved job will expire
+     * ARGV[2] - The base time for expiring jobs based on their own timeout
      *
      * @return string
      */
@@ -77,8 +78,15 @@ if(job ~= false) then
     -- Increment the attempt count and place job on the reserved queue...
     reserved = cjson.decode(job)
     reserved['attempts'] = reserved['attempts'] + 1
+
+    local expiration = ARGV[1]
+
+    if(tonumber(ARGV[2]) and type(reserved['timeout']) == 'number' and reserved['timeout'] > 0) then
+        expiration = reserved['timeout'] + ARGV[2]
+    end
+
     reserved = cjson.encode(reserved)
-    redis.call('zadd', KEYS[2], ARGV[1], reserved)
+    redis.call('zadd', KEYS[2], expiration, reserved)
     redis.call('lpop', KEYS[3])
 end
 

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -61,6 +61,13 @@ abstract class Queue
     protected $dispatchAfterCommit;
 
     /**
+     * The job timeout set on the worker processing the queue.
+     *
+     * @var int|null
+     */
+    protected $workerTimeout;
+
+    /**
      * The create payload callbacks.
      *
      * @var callable[]
@@ -485,6 +492,19 @@ abstract class Queue
     public function setConnectionName($name)
     {
         $this->connectionName = $name;
+
+        return $this;
+    }
+
+    /**
+     * Set the job timeout of the worker processing the queue.
+     *
+     * @param  int|null  $timeout
+     * @return $this
+     */
+    public function setWorkerTimeout($timeout)
+    {
+        $this->workerTimeout = $timeout > 0 ? (int) $timeout : null;
 
         return $this;
     }

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -39,9 +39,16 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
     /**
      * The expiration time of a job.
      *
-     * @var int|string|null
+     * @var int|null
      */
     protected $retryAfter = 60;
+
+    /**
+     * Indicates if jobs should be reserved until their timeout instead of the retry_after value.
+     *
+     * @var bool
+     */
+    protected $expireAfterTimeout = false;
 
     /**
      * The maximum number of seconds to block for a job.
@@ -81,10 +88,11 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
      * @param  \Illuminate\Contracts\Redis\Factory  $redis
      * @param  string  $default
      * @param  string|null  $connection
-     * @param  int|string  $retryAfter
+     * @param  int  $retryAfter
      * @param  int|null  $blockFor
      * @param  bool  $dispatchAfterCommit
      * @param  int  $migrationBatchSize
+     * @param  bool  $expireAfterTimeout
      */
     public function __construct(
         Redis $redis,
@@ -94,6 +102,7 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
         $blockFor = null,
         $dispatchAfterCommit = false,
         $migrationBatchSize = -1,
+        $expireAfterTimeout = false,
     ) {
         $this->redis = $redis;
         $this->default = $default;
@@ -102,6 +111,7 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
         $this->retryAfter = $retryAfter;
         $this->dispatchAfterCommit = $dispatchAfterCommit;
         $this->migrationBatchSize = $migrationBatchSize;
+        $this->expireAfterTimeout = $expireAfterTimeout;
     }
 
     /**
@@ -456,8 +466,8 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
     {
         $nextJob = $this->getConnection()->eval(
             LuaScripts::pop(), 3, $queue, $queue.':reserved', $queue.':notify',
-            $this->availableAt($this->retryAfter === 'auto' ? ($this->workerTimeout ?? 60) + 10 : $this->retryAfter),
-            $this->retryAfter === 'auto' ? $this->availableAt(10) : ''
+            $this->availableAt($this->expireAfterTimeout && $this->workerTimeout ? $this->workerTimeout + 10 : $this->retryAfter),
+            $this->expireAfterTimeout ? $this->availableAt(10) : ''
         );
 
         if (empty($nextJob)) {

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -39,7 +39,7 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
     /**
      * The expiration time of a job.
      *
-     * @var int|null
+     * @var int|string|null
      */
     protected $retryAfter = 60;
 
@@ -81,7 +81,7 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
      * @param  \Illuminate\Contracts\Redis\Factory  $redis
      * @param  string  $default
      * @param  string|null  $connection
-     * @param  int  $retryAfter
+     * @param  int|string  $retryAfter
      * @param  int|null  $blockFor
      * @param  bool  $dispatchAfterCommit
      * @param  int  $migrationBatchSize
@@ -456,7 +456,8 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
     {
         $nextJob = $this->getConnection()->eval(
             LuaScripts::pop(), 3, $queue, $queue.':reserved', $queue.':notify',
-            $this->availableAt($this->retryAfter)
+            $this->availableAt($this->retryAfter === 'auto' ? ($this->workerTimeout ?? 60) + 10 : $this->retryAfter),
+            $this->retryAfter === 'auto' ? $this->availableAt(10) : ''
         );
 
         if (empty($nextJob)) {

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -219,6 +219,8 @@ class Worker
 
         $this->raiseWorkerStartingEvent($connectionName, $queue, $options);
 
+        $this->shareWorkerTimeout($connectionName, $options);
+
         while (true) {
             // Before reserving any jobs, we will make sure this queue is not paused and
             // if it is we will just pause this worker for a given amount of time and
@@ -407,6 +409,8 @@ class Worker
      */
     public function runNextJob($connectionName, $queue, WorkerOptions $options)
     {
+        $this->shareWorkerTimeout($connectionName, $options);
+
         $job = $this->getNextJob(
             $this->manager->connection($connectionName), $queue
         );
@@ -419,6 +423,22 @@ class Worker
         }
 
         $this->sleep($options->sleep);
+    }
+
+    /**
+     * Share the worker's job timeout with the given queue connection.
+     *
+     * @param  string  $connectionName
+     * @param  \Illuminate\Queue\WorkerOptions  $options
+     * @return void
+     */
+    protected function shareWorkerTimeout($connectionName, WorkerOptions $options)
+    {
+        $connection = $this->manager->connection($connectionName);
+
+        if (method_exists($connection, 'setWorkerTimeout')) {
+            $connection->setWorkerTimeout($options->timeout);
+        }
     }
 
     /**

--- a/tests/Integration/Queue/RedisQueueTest.php
+++ b/tests/Integration/Queue/RedisQueueTest.php
@@ -189,7 +189,7 @@ class RedisQueueTest extends TestCase
         $this->queue->setContainer($this->container = m::spy(Container::class));
         $redisKey = $this->getQueueRedisKey($default);
 
-        $getJobExpirationTimestamp = function () use ($driver, $default, $redisKey) {
+        $getJobExpirationTimestamp = function () use ($driver, $redisKey) {
             $this->queue->pop();
 
             $result = $this->redis[$driver]->connection()->zrangebyscore("$redisKey:reserved", -INF, INF, ['withscores' => true]);

--- a/tests/Integration/Queue/RedisQueueTest.php
+++ b/tests/Integration/Queue/RedisQueueTest.php
@@ -182,6 +182,60 @@ class RedisQueueTest extends TestCase
      * @param  string  $driver
      */
     #[DataProvider('redisDriverProvider')]
+    public function testPopReservesJobsBasedOnTheJobTimeoutWhenRetryAfterIsAuto($driver)
+    {
+        $default = config('queue.connections.redis.queue', 'default');
+        $this->queue = new RedisQueue($this->redis[$driver], $default, null, 'auto');
+        $this->queue->setContainer($this->container = m::spy(Container::class));
+        $redisKey = $this->getQueueRedisKey($default);
+
+        $getJobExpirationTimestamp = function () use ($driver, $default, $redisKey) {
+            $this->queue->pop();
+
+            $result = $this->redis[$driver]->connection()->zrangebyscore("$redisKey:reserved", -INF, INF, ['withscores' => true]);
+
+            $this->queue->clear();
+
+            return (int) $result[array_keys($result)[0]];
+        };
+
+        Carbon::setTestNow($time = Carbon::now());
+
+        // Timeout defined on the job is used
+        $job = new RedisQueueIntegrationTestJob(123);
+        $job->timeout = 25;
+        $this->queue->push($job);
+        $this->assertSame($time->getTimestamp() + 25 + 10, $getJobExpirationTimestamp());
+
+        // No timeout on the job, timeout on the queue worker wasn't shared, so the default of 60 seconds is used
+        $this->queue->push(new RedisQueueIntegrationTestJob(123));
+        $this->assertSame($time->getTimestamp() + 60 + 10, $getJobExpirationTimestamp());
+
+        // Timeout of 0 on the job, the default of 60 seconds is used
+        $job = new RedisQueueIntegrationTestJob(123);
+        $job->timeout = 0;
+        $this->queue->push($job);
+        $this->assertSame($time->getTimestamp() + 60 + 10, $getJobExpirationTimestamp());
+
+        // No timeout on the job, the queue worker's timeout is used
+        $this->queue->setWorkerTimeout(15);
+        $this->queue->push(new RedisQueueIntegrationTestJob(123));
+        $this->assertSame($time->getTimestamp() + 15 + 10, $getJobExpirationTimestamp());
+
+        // Timeout on the job takes precedence over the queue worker timeout
+        $this->queue->setWorkerTimeout(15);
+        $job = new RedisQueueIntegrationTestJob(123);
+        $job->timeout = 25;
+        $this->queue->push($job);
+        $this->assertSame($time->getTimestamp() + 25 + 10, $getJobExpirationTimestamp());
+
+        Carbon::setTestNow();
+    }
+
+    /**
+     * @param  string  $driver
+     */
+    #[DataProvider('redisDriverProvider')]
     public function testPopProperlyPopsDelayedJobOffOfRedis($driver)
     {
         $default = config('queue.connections.redis.queue', 'default');

--- a/tests/Integration/Queue/RedisQueueTest.php
+++ b/tests/Integration/Queue/RedisQueueTest.php
@@ -182,10 +182,10 @@ class RedisQueueTest extends TestCase
      * @param  string  $driver
      */
     #[DataProvider('redisDriverProvider')]
-    public function testPopReservesJobsBasedOnTheJobTimeoutWhenRetryAfterIsAuto($driver)
+    public function testPopReservesJobsBasedOnTheJobTimeoutWhenExpireAfterTimeoutIsEnabled($driver)
     {
         $default = config('queue.connections.redis.queue', 'default');
-        $this->queue = new RedisQueue($this->redis[$driver], $default, null, 'auto');
+        $this->queue = new RedisQueue($this->redis[$driver], $default, null, 90, expireAfterTimeout: true);
         $this->queue->setContainer($this->container = m::spy(Container::class));
         $redisKey = $this->getQueueRedisKey($default);
 
@@ -207,15 +207,15 @@ class RedisQueueTest extends TestCase
         $this->queue->push($job);
         $this->assertSame($time->getTimestamp() + 25 + 10, $getJobExpirationTimestamp());
 
-        // No timeout on the job, timeout on the queue worker wasn't shared, so the default of 60 seconds is used
+        // No timeout on the job, no timeout shared by the queue worker: retry_after is used
         $this->queue->push(new RedisQueueIntegrationTestJob(123));
-        $this->assertSame($time->getTimestamp() + 60 + 10, $getJobExpirationTimestamp());
+        $this->assertSame($time->getTimestamp() + 90, $getJobExpirationTimestamp());
 
-        // Timeout of 0 on the job, the default of 60 seconds is used
+        // Timeout of 0 on the job is ignored: retry_after is used
         $job = new RedisQueueIntegrationTestJob(123);
         $job->timeout = 0;
         $this->queue->push($job);
-        $this->assertSame($time->getTimestamp() + 60 + 10, $getJobExpirationTimestamp());
+        $this->assertSame($time->getTimestamp() + 90, $getJobExpirationTimestamp());
 
         // No timeout on the job, the queue worker's timeout is used
         $this->queue->setWorkerTimeout(15);

--- a/tests/Queue/QueueDatabaseQueueIntegrationTest.php
+++ b/tests/Queue/QueueDatabaseQueueIntegrationTest.php
@@ -156,6 +156,50 @@ class QueueDatabaseQueueIntegrationTest extends TestCase
         $this->assertEquals(1, $popped_job->attempts(), 'The "attempts" attribute of the Job object was not updated by pop!');
     }
 
+    public function testPoppedJobsAreReservedBasedOnTheJobTimeoutWhenRetryAfterIsAuto()
+    {
+        Carbon::setTestNow($time = Carbon::now());
+
+        $queue = new DatabaseQueue($this->connection(), $this->table, 'default', 'auto');
+        $queue->setContainer($this->container);
+
+        $getJobReservedAt = function ($timeout) use ($queue) {
+            $this->connection()->table('jobs')->insert([
+                'queue' => 'default',
+                'payload' => json_encode(['timeout' => $timeout]),
+                'attempts' => 0,
+                'reserved_at' => null,
+                'available_at' => Carbon::now()->subSecond()->getTimestamp(),
+                'created_at' => Carbon::now()->getTimestamp(),
+            ]);
+
+            $queue->pop('default');
+
+            $reservedAt = (int) $this->connection()->table('jobs')->latest()->value('reserved_at');
+
+            $queue->clear();
+
+            return $reservedAt;
+        };
+
+        // 600-second timeout on the job, + 10-second buffer - 300-second grace period
+        $this->assertSame($time->getTimestamp() + 600 + 10 - 300, $getJobReservedAt(600));
+
+        // If the job doesn't define a timeout and the worker timeout is unknown, then the 60-second default is used
+        $this->assertSame($time->getTimestamp() + 60 + 10 - 300, $getJobReservedAt(null));
+        $this->assertSame($time->getTimestamp() + 60 + 10 - 300, $getJobReservedAt(0));
+
+        // Worker timeout is used if the job doesn't define a timeout
+        $queue->setWorkerTimeout(120);
+        $this->assertSame($time->getTimestamp() + 120 + 10 - 300, $getJobReservedAt(null));
+        $this->assertSame($time->getTimestamp() + 120 + 10 - 300, $getJobReservedAt(0));
+
+        // Timeout on the job takes precedence over the queue worker timeout
+        $this->assertSame($time->getTimestamp() + 45 + 10 - 300, $getJobReservedAt(45));
+
+        Carbon::setTestNow();
+    }
+
     /**
      * Test that the queue can be cleared.
      */

--- a/tests/Queue/QueueDatabaseQueueIntegrationTest.php
+++ b/tests/Queue/QueueDatabaseQueueIntegrationTest.php
@@ -156,11 +156,11 @@ class QueueDatabaseQueueIntegrationTest extends TestCase
         $this->assertEquals(1, $popped_job->attempts(), 'The "attempts" attribute of the Job object was not updated by pop!');
     }
 
-    public function testPoppedJobsAreReservedBasedOnTheJobTimeoutWhenRetryAfterIsAuto()
+    public function testPoppedJobsAreReservedBasedOnTheJobTimeoutWhenExpireAfterTimeoutIsEnabled()
     {
         Carbon::setTestNow($time = Carbon::now());
 
-        $queue = new DatabaseQueue($this->connection(), $this->table, 'default', 'auto');
+        $queue = new DatabaseQueue($this->connection(), $this->table, 'default', 90, expireAfterTimeout: true);
         $queue->setContainer($this->container);
 
         $getJobReservedAt = function ($timeout) use ($queue) {
@@ -182,20 +182,20 @@ class QueueDatabaseQueueIntegrationTest extends TestCase
             return $reservedAt;
         };
 
-        // 600-second timeout on the job, + 10-second buffer - 300-second grace period
-        $this->assertSame($time->getTimestamp() + 600 + 10 - 300, $getJobReservedAt(600));
+        // "reserved_at" holds the expiry (job timeout + 10-second buffer) minus the retry_after window
+        $this->assertSame($time->getTimestamp() + 600 + 10 - 90, $getJobReservedAt(timeout: 600));
 
-        // If the job doesn't define a timeout and the worker timeout is unknown, then the 60-second default is used
-        $this->assertSame($time->getTimestamp() + 60 + 10 - 300, $getJobReservedAt(null));
-        $this->assertSame($time->getTimestamp() + 60 + 10 - 300, $getJobReservedAt(0));
+        // No timeout on the job, no worker timeout known
+        $this->assertSame($time->getTimestamp(), $getJobReservedAt(timeout: null));
+        $this->assertSame($time->getTimestamp(), $getJobReservedAt(timeout: 0));
 
         // Worker timeout is used if the job doesn't define a timeout
         $queue->setWorkerTimeout(120);
-        $this->assertSame($time->getTimestamp() + 120 + 10 - 300, $getJobReservedAt(null));
-        $this->assertSame($time->getTimestamp() + 120 + 10 - 300, $getJobReservedAt(0));
+        $this->assertSame($time->getTimestamp() + 120 + 10 - 90, $getJobReservedAt(timeout: null));
+        $this->assertSame($time->getTimestamp() + 120 + 10 - 90, $getJobReservedAt(timeout: 0));
 
         // Timeout on the job takes precedence over the queue worker timeout
-        $this->assertSame($time->getTimestamp() + 45 + 10 - 300, $getJobReservedAt(45));
+        $this->assertSame($time->getTimestamp() + 45 + 10 - 90, $getJobReservedAt(timeout: 45));
 
         Carbon::setTestNow();
     }

--- a/tests/Queue/QueueListenerTest.php
+++ b/tests/Queue/QueueListenerTest.php
@@ -53,7 +53,7 @@ class QueueListenerTest extends TestCase
         $this->assertInstanceOf(Process::class, $process);
         $this->assertEquals(__DIR__, $process->getWorkingDirectory());
         $this->assertEquals(3, $process->getTimeout());
-        $this->assertEquals($escape.php_binary().$escape." {$escape}{$artisanBinary}{$escape} {$escape}queue:work{$escape} {$escape}connection{$escape} {$escape}--once{$escape} {$escapeMsys}--name=default{$escapeMsys} {$escapeMsys}--queue=queue{$escapeMsys} {$escapeMsys}--backoff=1{$escapeMsys} {$escapeMsys}--memory=2{$escapeMsys} {$escapeMsys}--sleep=3{$escapeMsys} {$escapeMsys}--tries=1{$escapeMsys}", $process->getCommandLine());
+        $this->assertEquals($escape.php_binary().$escape." {$escape}{$artisanBinary}{$escape} {$escape}queue:work{$escape} {$escape}connection{$escape} {$escape}--once{$escape} {$escapeMsys}--name=default{$escapeMsys} {$escapeMsys}--queue=queue{$escapeMsys} {$escapeMsys}--backoff=1{$escapeMsys} {$escapeMsys}--memory=2{$escapeMsys} {$escapeMsys}--sleep=3{$escapeMsys} {$escapeMsys}--timeout=3{$escapeMsys} {$escapeMsys}--tries=1{$escapeMsys}", $process->getCommandLine());
     }
 
     public function testMakeProcessCorrectlyFormatsCommandLineWithAnEnvironmentSpecified()
@@ -75,7 +75,7 @@ class QueueListenerTest extends TestCase
         $this->assertInstanceOf(Process::class, $process);
         $this->assertEquals(__DIR__, $process->getWorkingDirectory());
         $this->assertEquals(3, $process->getTimeout());
-        $this->assertEquals($escape.php_binary().$escape." {$escape}{$artisanBinary}{$escape} {$escape}queue:work{$escape} {$escape}connection{$escape} {$escape}--once{$escape} {$escapeMsys}--name=default{$escapeMsys} {$escapeMsys}--queue=queue{$escapeMsys} {$escapeMsys}--backoff=1{$escapeMsys} {$escapeMsys}--memory=2{$escapeMsys} {$escapeMsys}--sleep=3{$escapeMsys} {$escapeMsys}--tries=1{$escapeMsys} {$escapeMsys}--env=test{$escapeMsys}", $process->getCommandLine());
+        $this->assertEquals($escape.php_binary().$escape." {$escape}{$artisanBinary}{$escape} {$escape}queue:work{$escape} {$escape}connection{$escape} {$escape}--once{$escape} {$escapeMsys}--name=default{$escapeMsys} {$escapeMsys}--queue=queue{$escapeMsys} {$escapeMsys}--backoff=1{$escapeMsys} {$escapeMsys}--memory=2{$escapeMsys} {$escapeMsys}--sleep=3{$escapeMsys} {$escapeMsys}--timeout=3{$escapeMsys} {$escapeMsys}--tries=1{$escapeMsys} {$escapeMsys}--env=test{$escapeMsys}", $process->getCommandLine());
     }
 
     public function testMakeProcessCorrectlyFormatsCommandLineWhenTheConnectionIsNotSpecified()
@@ -97,6 +97,6 @@ class QueueListenerTest extends TestCase
         $this->assertInstanceOf(Process::class, $process);
         $this->assertEquals(__DIR__, $process->getWorkingDirectory());
         $this->assertEquals(3, $process->getTimeout());
-        $this->assertEquals($escape.php_binary().$escape." {$escape}{$artisanBinary}{$escape} {$escape}queue:work{$escape} {$escape}--once{$escape} {$escapeMsys}--name=default{$escapeMsys} {$escapeMsys}--queue=queue{$escapeMsys} {$escapeMsys}--backoff=1{$escapeMsys} {$escapeMsys}--memory=2{$escapeMsys} {$escapeMsys}--sleep=3{$escapeMsys} {$escapeMsys}--tries=1{$escapeMsys} {$escapeMsys}--env=test{$escapeMsys}", $process->getCommandLine());
+        $this->assertEquals($escape.php_binary().$escape." {$escape}{$artisanBinary}{$escape} {$escape}queue:work{$escape} {$escape}--once{$escape} {$escapeMsys}--name=default{$escapeMsys} {$escapeMsys}--queue=queue{$escapeMsys} {$escapeMsys}--backoff=1{$escapeMsys} {$escapeMsys}--memory=2{$escapeMsys} {$escapeMsys}--sleep=3{$escapeMsys} {$escapeMsys}--timeout=3{$escapeMsys} {$escapeMsys}--tries=1{$escapeMsys} {$escapeMsys}--env=test{$escapeMsys}", $process->getCommandLine());
     }
 }


### PR DESCRIPTION
This PR adds an `expire_after_timeout` option to the Redis and database queue drivers. When enabled, jobs expire 10 seconds after their timeout, instead of naively based on `retry_after`.

Quick recap on how job timeouts, expiration, and retries work:
- Jobs with `$tries = 1` fail instantly when they time out
- Jobs with `$tries > 1` get killed when they time out. The queue starts the next attempt when the previous attempt has expired.

Currently, jobs always expire `retry_after` seconds after they're started, which causes two problems:
- `retry_after` must be longer than your longest-running job. If it's shorter, the job gets retried while it's still running, so it ends up running twice at the same time.
- I've worked on multiple projects where `retry_after` was set to 1 hour. That meant a short job that timed out would sit for a full hour before retrying. Even worse, nothing gets logged when this happens, so the job essentially disappears for an hour (which is not fun to debug).

Enabling `expire_after_timeout` fixes both these problems, and in most cases it removes the need for `retry_after` entirely. `retry_after` is now only used for jobs that run without a timeout (e.g. `$timeout = 0`).

`retry_after` and the new `expire_after_timeout` are only used by the Redis and database queue drivers:
- The Redis driver currently stores `now + retry_after` as the job expiration. With `expire_after_timeout` enabled it stores `now + timeout + 10`
- The database driver uses a `reserved_at` column that gets set to `now` when a worker picks up the job. With `expire_after_timeout` enabled it's `now + timeout + 10 - retry_after`. This works nicely with the existing query that finds expired jobs via `reserved_at <= now - retry_after` (it does make the `reserved_at` name misleading, but I think that's fine)

This PR is backwards compatible and the feature is disabled by default, nothing changes for existing applications when this is merged. A small follow-up PR for Horizon is needed to enable this flag there too.