### PR TITLE
[13.x] Fix JsonApiResource relationships resolved through a closure

### DIFF
--- a/src/Illuminate/Http/Resources/JsonApi/Concerns/ResolvesJsonApiElements.php
+++ b/src/Illuminate/Http/Resources/JsonApi/Concerns/ResolvesJsonApiElements.php
@@ -312,7 +312,7 @@ trait ResolvesJsonApiElements
             ->mapWithKeys(fn ($relationResolver) => [$relationResolver->relationName => $relationResolver])
             ->filter(fn ($value, $key) => in_array($key, array_keys($relation->getRelations())))
             ->each(function ($relationResolver, $key) use ($relation, $request) {
-                $this->compileResourceRelationshipUsingResolver($request, $relation, $relationResolver, $relation->getRelation($key));
+                $this->compileResourceRelationshipUsingResolver($request, $relation, $relationResolver, $relationResolver->handle($relation));
             });
     }
 

--- a/src/Illuminate/Http/Resources/JsonApi/RelationResolver.php
+++ b/src/Illuminate/Http/Resources/JsonApi/RelationResolver.php
@@ -14,7 +14,7 @@ class RelationResolver
     /**
      * The relation resolver.
      *
-     * @var \Closure(mixed):(\Illuminate\Database\Eloquent\Collection|\Illuminate\Database\Eloquent\Model|null)
+     * @var \Closure(mixed):(\Illuminate\Database\Eloquent\Collection|\Illuminate\Database\Eloquent\Model|\Illuminate\Http\Resources\JsonApi\JsonApiResource|\Illuminate\Http\Resources\JsonApi\AnonymousResourceCollection|null)
      */
     public Closure $relationResolver;
 
@@ -28,7 +28,7 @@ class RelationResolver
     /**
      * Construct a new resource relationship resolver.
      *
-     * @param  \Closure(mixed):(\Illuminate\Database\Eloquent\Collection|\Illuminate\Database\Eloquent\Model|null)|class-string<\Illuminate\Http\Resources\JsonApi\JsonApiResource>|null  $resolver
+     * @param  \Closure(mixed):(\Illuminate\Database\Eloquent\Collection|\Illuminate\Database\Eloquent\Model|\Illuminate\Http\Resources\JsonApi\JsonApiResource|\Illuminate\Http\Resources\JsonApi\AnonymousResourceCollection|null)|class-string<\Illuminate\Http\Resources\JsonApi\JsonApiResource>|null  $resolver
      */
     public function __construct(public string $relationName, Closure|string|null $resolver = null)
     {
@@ -47,7 +47,21 @@ class RelationResolver
      */
     public function handle(mixed $resource): Collection|Model|null
     {
-        return value($this->relationResolver, $resource);
+        $resolved = value($this->relationResolver, $resource);
+
+        if ($resolved instanceof AnonymousResourceCollection) {
+            $this->relationResourceClass ??= $resolved->collects;
+
+            return new Collection($resolved->collection->map->resource);
+        }
+
+        if ($resolved instanceof JsonApiResource) {
+            $this->relationResourceClass ??= $resolved::class;
+
+            return $resolved->resource;
+        }
+
+        return $resolved;
     }
 
     /**

--- a/tests/Http/Resources/JsonApi/RelationResolverTest.php
+++ b/tests/Http/Resources/JsonApi/RelationResolverTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Illuminate\Tests\Http\Resources\JsonApi;
+
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\Resources\JsonApi\JsonApiResource;
+use Illuminate\Http\Resources\JsonApi\RelationResolver;
+use PHPUnit\Framework\TestCase;
+
+class RelationResolverTest extends TestCase
+{
+    public function testResolvesClosureReturningResourceCollection()
+    {
+        $first = new RelationResolverTestModel(['id' => 1]);
+        $second = new RelationResolverTestModel(['id' => 2]);
+
+        $resolver = new RelationResolver('comments', fn () => RelationResolverTestResource::collection([$first, $second]));
+
+        $resolved = $resolver->handle(new RelationResolverTestModel);
+
+        $this->assertInstanceOf(EloquentCollection::class, $resolved);
+        $this->assertSame([$first, $second], $resolved->all());
+        $this->assertSame(RelationResolverTestResource::class, $resolver->resourceClass());
+    }
+
+    public function testResolvesClosureReturningSingleResource()
+    {
+        $model = new RelationResolverTestModel(['id' => 1]);
+
+        $resolver = new RelationResolver('author', fn () => new RelationResolverTestResource($model));
+
+        $resolved = $resolver->handle(new RelationResolverTestModel);
+
+        $this->assertSame($model, $resolved);
+        $this->assertSame(RelationResolverTestResource::class, $resolver->resourceClass());
+    }
+
+    public function testResolvesClosureReturningRawModels()
+    {
+        $model = new RelationResolverTestModel(['id' => 1]);
+
+        $resolver = new RelationResolver('comments', fn () => new EloquentCollection([$model]));
+
+        $resolved = $resolver->handle(new RelationResolverTestModel);
+
+        $this->assertInstanceOf(EloquentCollection::class, $resolved);
+        $this->assertSame([$model], $resolved->all());
+        $this->assertNull($resolver->resourceClass());
+    }
+
+    public function testResolvesClosureReturningNull()
+    {
+        $resolver = new RelationResolver('author', fn () => null);
+
+        $this->assertNull($resolver->handle(new RelationResolverTestModel));
+        $this->assertNull($resolver->resourceClass());
+    }
+}
+
+class RelationResolverTestModel extends Model
+{
+    protected $guarded = [];
+}
+
+class RelationResolverTestResource extends JsonApiResource
+{
+    //
+}

--- a/tests/Integration/Http/Resources/JsonApi/Fixtures/PostResource.php
+++ b/tests/Integration/Http/Resources/JsonApi/Fixtures/PostResource.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures;
 
+use Illuminate\Http\Request;
 use Illuminate\Http\Resources\JsonApi\JsonApiResource;
 
 class PostResource extends JsonApiResource
@@ -11,8 +12,14 @@ class PostResource extends JsonApiResource
         'content',
     ];
 
-    protected array $relationships = [
-        'author' => AuthorResource::class,
-        'comments',
-    ];
+    #[\Override]
+    public function toRelationships(Request $request)
+    {
+        return [
+            'author' => AuthorResource::class,
+            'comments' => fn () => CommentResource::collection(
+                $this->comments->where('content', '!=', 'private')
+            ),
+        ];
+    }
 }

--- a/tests/Integration/Http/Resources/JsonApi/JsonApiResourceTest.php
+++ b/tests/Integration/Http/Resources/JsonApi/JsonApiResourceTest.php
@@ -421,6 +421,39 @@ class JsonApiResourceTest extends TestCase
             ->assertJsonMissing(['jsonapi']);
     }
 
+    public function testItCanResolveNestedRelationshipThroughClosureReturningResourceCollection()
+    {
+        $user = User::factory()->create();
+
+        $publicPost = Post::factory()->create([
+            'user_id' => $user->getKey(),
+        ]);
+
+        $privatePost = Post::factory()->create([
+            'user_id' => $user->getKey(),
+        ]);
+
+        $publicComment = Comment::factory()->create([
+            'content' => 'public',
+            'post_id' => $publicPost->getKey(),
+            'user_id' => $user->getKey(),
+        ]);
+
+        $privateComment = Comment::factory()->create([
+            'content' => 'private',
+            'post_id' => $privatePost->getKey(),
+            'user_id' => $user->getKey(),
+        ]);
+
+        $response = $this->getJson("/users/{$user->getKey()}?".http_build_query(['include' => 'posts.comments']))
+            ->assertJsonPath('data.relationships.posts.data.0.id', (string) $publicPost->getKey())
+            ->assertJsonPath('included.0.relationships.comments.data.0.id', (string) $publicComment->getKey());
+
+        $this->assertFalse(collect($response->json('included'))->contains(
+            fn ($included) => $included['type'] === 'comments' && $included['id'] === (string) $privateComment->getKey()
+        ));
+    }
+
     public function testItCanResolveRelationshipWithRecursiveNestedRelationship()
     {
         $now = $this->freezeSecond();


### PR DESCRIPTION
_PR description is generated by Claude and checked by myself, just wanted to be open about that._

This PR fixes a crash when a JSON:API relationship is resolved through a closure that returns a resource:

```php
public function toRelationships(Request $request): array
{
    return [
        'author' => UserResource::class,
        'comments' => fn () => CommentResource::collection(
            $request->user()->is($this->resource)
                ? $this->comments
                : $this->comments->where('is_public', true),
        ),
    ];
}
```

This throws the following error:

```
Illuminate\Http\Resources\JsonApi\RelationResolver::handle(): Return value
must be of type Illuminate\Database\Eloquent\Collection|Illuminate\Database\Eloquent\Model|null,
Illuminate\Http\Resources\JsonApi\AnonymousResourceCollection returned
```

`RelationResolver::handle()` only accepted a raw `Collection`, `Model`, or `null`, so a closure returning `CommentResource::collection(...)` (an `AnonymousResourceCollection`) blew up on the return type before the value was ever used.

The fix stays inside `RelationResolver`. A returned resource collection already carries everything we need — the underlying models on its `collection`, and the resource class on its `collects` property — so we unwrap it back into the models and adopt that resource class. A single returned resource is unwrapped the same way. This mirrors what the resolver already does internally when you hand it a class-string; the closure form was simply arriving "pre-wrapped" and the resolver didn't know how to open it.

Closures that already return raw models or Eloquent collections keep working unchanged, so this is fully backward compatible — it only adds handling for return types that previously errored.

Tests are included covering a closure that returns a resource collection, a single resource, raw models, and `null`.

Closes #60121