### PR TITLE
[13.x] Add `#[SensitiveParameter]` to parameters carrying secrets

### DIFF
--- a/src/Illuminate/Auth/Passwords/CacheTokenRepository.php
+++ b/src/Illuminate/Auth/Passwords/CacheTokenRepository.php
@@ -21,6 +21,7 @@ class CacheTokenRepository implements TokenRepositoryInterface
     public function __construct(
         protected Repository $cache,
         protected HasherContract $hasher,
+        #[\SensitiveParameter]
         protected string $hashKey,
         protected int $expires = 3600,
         protected int $throttle = 60,

--- a/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
+++ b/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
@@ -20,6 +20,7 @@ class DatabaseTokenRepository implements TokenRepositoryInterface
         protected ConnectionInterface $connection,
         protected HasherContract $hasher,
         protected string $table,
+        #[\SensitiveParameter]
         protected string $hashKey,
         protected int $expires = 3600,
         protected int $throttle = 60,

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -268,7 +268,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      * @param  array  $credentials
      * @return bool
      */
-    public function once(array $credentials = [])
+    public function once(#[\SensitiveParameter] array $credentials = [])
     {
         $this->fireAttemptEvent($credentials);
 
@@ -308,7 +308,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      * @param  array  $credentials
      * @return bool
      */
-    public function validate(array $credentials = [])
+    public function validate(#[\SensitiveParameter] array $credentials = [])
     {
         return $this->timebox->call(function ($timebox) use ($credentials) {
             $this->lastAttempted = $user = $this->provider->retrieveByCredentials($credentials);
@@ -416,7 +416,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      * @param  bool  $remember
      * @return bool
      */
-    public function attempt(array $credentials = [], $remember = false)
+    public function attempt(#[\SensitiveParameter] array $credentials = [], $remember = false)
     {
         return $this->timebox->call(function ($timebox) use ($credentials, $remember) {
             $this->fireAttemptEvent($credentials, $remember);
@@ -453,7 +453,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      * @param  bool  $remember
      * @return bool
      */
-    public function attemptWhen(array $credentials = [], $callbacks = null, $remember = false)
+    public function attemptWhen(#[\SensitiveParameter] array $credentials = [], $callbacks = null, $remember = false)
     {
         return $this->timebox->call(function ($timebox) use ($credentials, $callbacks, $remember) {
             $this->fireAttemptEvent($credentials, $remember);
@@ -486,7 +486,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      * @param  array  $credentials
      * @return bool
      */
-    protected function hasValidCredentials($user, $credentials)
+    protected function hasValidCredentials($user, #[\SensitiveParameter] $credentials)
     {
         $validated = ! is_null($user) && $this->provider->validateCredentials($user, $credentials);
 
@@ -737,7 +737,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      *
      * @throws \Illuminate\Auth\AuthenticationException
      */
-    public function logoutOtherDevices($password)
+    public function logoutOtherDevices(#[\SensitiveParameter] $password)
     {
         if (! $this->user()) {
             return;
@@ -763,7 +763,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      *
      * @throws \InvalidArgumentException
      */
-    protected function rehashUserPasswordForDeviceLogout($password)
+    protected function rehashUserPasswordForDeviceLogout(#[\SensitiveParameter] $password)
     {
         $user = $this->user();
 
@@ -794,7 +794,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      * @param  bool  $remember
      * @return void
      */
-    protected function fireAttemptEvent(array $credentials, $remember = false)
+    protected function fireAttemptEvent(#[\SensitiveParameter] array $credentials, $remember = false)
     {
         $this->events?->dispatch(new Attempting($this->name, $credentials, $remember));
     }
@@ -851,7 +851,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      * @param  array  $credentials
      * @return void
      */
-    protected function fireFailedEvent($user, array $credentials)
+    protected function fireFailedEvent($user, #[\SensitiveParameter] array $credentials)
     {
         $this->events?->dispatch(new Failed($this->name, $user, $credentials));
     }

--- a/src/Illuminate/Auth/TokenGuard.php
+++ b/src/Illuminate/Auth/TokenGuard.php
@@ -108,7 +108,7 @@ class TokenGuard implements Guard
      * @param  array  $credentials
      * @return bool
      */
-    public function validate(array $credentials = [])
+    public function validate(#[\SensitiveParameter] array $credentials = [])
     {
         if (empty($credentials[$this->inputKey])) {
             return false;

--- a/src/Illuminate/Cache/MemcachedConnector.php
+++ b/src/Illuminate/Cache/MemcachedConnector.php
@@ -15,7 +15,7 @@ class MemcachedConnector
      * @param  array  $credentials
      * @return \Memcached
      */
-    public function connect(array $servers, $connectionId = null, array $options = [], array $credentials = [])
+    public function connect(array $servers, $connectionId = null, array $options = [], #[\SensitiveParameter] array $credentials = [])
     {
         $memcached = $this->getMemcached(
             $connectionId, $credentials, $options
@@ -43,7 +43,7 @@ class MemcachedConnector
      * @param  array  $options
      * @return \Memcached
      */
-    protected function getMemcached($connectionId, array $credentials, array $options)
+    protected function getMemcached($connectionId, #[\SensitiveParameter] array $credentials, array $options)
     {
         $memcached = $this->createMemcachedInstance($connectionId);
 
@@ -76,7 +76,7 @@ class MemcachedConnector
      * @param  array  $credentials
      * @return void
      */
-    protected function setCredentials($memcached, $credentials)
+    protected function setCredentials($memcached, #[\SensitiveParameter] $credentials)
     {
         [$username, $password] = $credentials;
 

--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -51,7 +51,7 @@ class Encrypter implements EncrypterContract, StringEncrypter
      *
      * @throws \RuntimeException
      */
-    public function __construct($key, $cipher = 'aes-128-cbc')
+    public function __construct(#[\SensitiveParameter] $key, $cipher = 'aes-128-cbc')
     {
         $key = (string) $key;
 
@@ -72,7 +72,7 @@ class Encrypter implements EncrypterContract, StringEncrypter
      * @param  string  $cipher
      * @return bool
      */
-    public static function supported($key, $cipher)
+    public static function supported(#[\SensitiveParameter] $key, $cipher)
     {
         if (! isset(self::$supportedCiphers[strtolower($cipher)])) {
             return false;
@@ -299,7 +299,7 @@ class Encrypter implements EncrypterContract, StringEncrypter
      * @param  string  $key
      * @return bool
      */
-    protected function validMacForKey(#[\SensitiveParameter] $payload, $key)
+    protected function validMacForKey(#[\SensitiveParameter] $payload, #[\SensitiveParameter] $key)
     {
         return hash_equals(
             $this->hash($payload['iv'], $payload['value'], $key), $payload['mac']
@@ -397,7 +397,7 @@ class Encrypter implements EncrypterContract, StringEncrypter
      *
      * @throws \RuntimeException
      */
-    public function previousKeys(array $keys)
+    public function previousKeys(#[\SensitiveParameter] array $keys)
     {
         foreach ($keys as $key) {
             if (! static::supported($key, $this->cipher)) {

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -491,7 +491,7 @@ class PendingRequest
      * @param  string  $password
      * @return $this
      */
-    public function withBasicAuth(string $username, string $password)
+    public function withBasicAuth(string $username, #[\SensitiveParameter] string $password)
     {
         $this->options['auth'] = [$username, $password];
 
@@ -505,7 +505,7 @@ class PendingRequest
      * @param  string  $password
      * @return $this
      */
-    public function withDigestAuth($username, $password)
+    public function withDigestAuth($username, #[\SensitiveParameter] $password)
     {
         $this->options['auth'] = [$username, $password, 'digest'];
 
@@ -519,7 +519,7 @@ class PendingRequest
      * @param  string  $password
      * @return $this
      */
-    public function withNtlmAuth($username, $password)
+    public function withNtlmAuth($username, #[\SensitiveParameter] $password)
     {
         $this->options['auth'] = [$username, $password, 'ntlm'];
 
@@ -533,7 +533,7 @@ class PendingRequest
      * @param  string  $type
      * @return $this
      */
-    public function withToken($token, $type = 'Bearer')
+    public function withToken(#[\SensitiveParameter] $token, $type = 'Bearer')
     {
         $this->options['headers']['Authorization'] = trim($type.' '.$token);
 


### PR DESCRIPTION
This PR is essentially a follow-up to #51940, adding this attribute to these parameters prevents them from showing up in stack traces.