### PR TITLE
[13.x] fix: providesTemporaryUploadUrls should return true for s3 driver

### DIFF
--- a/src/Illuminate/Filesystem/AwsS3V3Adapter.php
+++ b/src/Illuminate/Filesystem/AwsS3V3Adapter.php
@@ -68,6 +68,16 @@ class AwsS3V3Adapter extends FilesystemAdapter
     }
 
     /**
+     * Determine if temporary upload URLs can be generated.
+     *
+     * @return bool
+     */
+    public function providesTemporaryUploadUrls()
+    {
+        return true;
+    }
+
+    /**
      * Get a temporary URL for the file at the given path.
      *
      * @param  string  $path

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -835,6 +835,17 @@ class FilesystemAdapterTest extends TestCase
         $this->assertTrue($filesystemAdapter->providesTemporaryUploadUrls());
     }
 
+    public function testProvidesTemporaryUploadUrlsForS3Adapter()
+    {
+        $filesystem = new FilesystemManager(new Application);
+        $filesystemAdapter = $filesystem->createS3Driver([
+            'region' => 'us-west-1',
+            'bucket' => 'laravel',
+        ]);
+
+        $this->assertTrue($filesystemAdapter->providesTemporaryUploadUrls());
+    }
+
     public function testProvidesTemporaryUploadUrlsForAdapterWithoutTemporaryUploadUrlSupport()
     {
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);


### PR DESCRIPTION
The S3 adapter's capability check for temporary upload URLs returns `false` even though the feature is fully implemented and functional at runtime. This mismatch occurs because:
- The guard check in `FilesystemAdapter::providesTemporaryUploadUrls()` (line 836) inspects the inner League Flysystem adapter for a `temporaryUploadUrl` method
- S3 upload signing is implemented on Laravel's outer `AwsS3V3Adapter`, not on the inner League adapter
- So the capability detection returns false while the operation itself succeeds

This PR add a `providesTemporaryUploadUrls()` override in `AwsS3V3Adapter` that returns `true`, mirroring the existing pattern already in place for `providesTemporaryUrls()` on the same class. I've added a test as well - without this fix, the provided test will fail.