### PR TITLE
[13.x] Fix Bus::bulk() ignoring per-job Delay

### DIFF
--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -165,15 +165,30 @@ class Dispatcher implements QueueingDispatcher
                 ?? $this->resolveQueueFromQueueRoute($job)
                 ?? null;
 
-            $groups[$connection.':'.$queue]['connection'] = $connection;
-            $groups[$connection.':'.$queue]['queue'] = $queue;
-            $groups[$connection.':'.$queue]['jobs'][] = $job;
+            $groupId = $connection.':'.$queue;
+
+            $groups[$groupId]['connection'] = $connection;
+            $groups[$groupId]['queue'] = $queue;
+
+            $delay = $this->getAttributeValue($job, Delay::class, 'delay');
+
+            if (isset($delay)) {
+                $groups[$groupId]['delayed'][] = [$job, $delay];
+            } else {
+                $groups[$groupId]['jobs'][] = $job;
+            }
         }
 
         foreach ($groups as $group) {
-            ($this->queueResolver)($group['connection'])->bulk(
-                $group['jobs'], '', $group['queue']
-            );
+            $queue = ($this->queueResolver)($group['connection']);
+
+            if (! empty($group['jobs'])) {
+                $queue->bulk($group['jobs'], '', $group['queue']);
+            }
+
+            foreach ($group['delayed'] ?? [] as [$job, $delay]) {
+                $queue->later($delay, $job, '', $group['queue']);
+            }
         }
     }
 

--- a/tests/Bus/BusDispatcherTest.php
+++ b/tests/Bus/BusDispatcherTest.php
@@ -15,6 +15,13 @@ use RuntimeException;
 
 class BusDispatcherTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        Container::setInstance(null);
+    }
+
     public function testCommandsThatShouldQueueIsQueued()
     {
         $container = new Container;
@@ -30,8 +37,6 @@ class BusDispatcherTest extends TestCase
         });
 
         $dispatcher->dispatch(m::mock(ShouldQueue::class));
-
-        Container::setInstance(null);
     }
 
     public function testCommandsThatShouldQueueIsQueuedUsingCustomHandler()
@@ -49,8 +54,6 @@ class BusDispatcherTest extends TestCase
         });
 
         $dispatcher->dispatch(new BusDispatcherTestCustomQueueCommand);
-
-        Container::setInstance(null);
     }
 
     public function testCommandsThatShouldQueueIsQueuedUsingCustomQueueAndDelay()
@@ -68,8 +71,6 @@ class BusDispatcherTest extends TestCase
         });
 
         $dispatcher->dispatch(new BusDispatcherTestSpecificQueueAndDelayCommand);
-
-        Container::setInstance(null);
     }
 
     public function testCommandsAreDispatchedWithQueueRoute()
@@ -87,8 +88,6 @@ class BusDispatcherTest extends TestCase
         });
 
         $dispatcher->dispatch(new BusDispatcherQueueable);
-
-        Container::setInstance(null);
     }
 
     public function testDispatchNowShouldNeverQueue()
@@ -146,8 +145,6 @@ class BusDispatcherTest extends TestCase
         $job = (new ShouldNotBeDispatched)->onConnection('null');
 
         $dispatcher->dispatch($job);
-
-        Container::setInstance(null);
     }
 
     public function testDispatchBulk()
@@ -169,8 +166,30 @@ class BusDispatcherTest extends TestCase
             new BusDispatcherQueueable,
             new BusDispatcherTestSpecificQueueCommand,
         ]);
+    }
 
-        Container::setInstance(null);
+    public function testDispatchBulkHonorsPerJobDelay(): void
+    {
+        $container = new Container;
+        $container->instance('queue.routes', $queueRoutes = m::mock());
+        $queueRoutes->shouldReceive('getQueue')->andReturn(null);
+        $queueRoutes->shouldReceive('getConnection')->andReturn(null);
+        Container::setInstance($container);
+
+        $mock = m::mock(Queue::class);
+        $mock->shouldReceive('bulk')->once()->with(
+            m::on(fn ($jobs) => count($jobs) === 1), '', null
+        );
+        $mock->shouldReceive('later')->once()->with(
+            10, m::type(BusDispatcherTestSpecificQueueAndDelayCommand::class), '', 'foo'
+        );
+
+        $dispatcher = new Dispatcher($container, fn () => $mock);
+
+        $dispatcher->bulk([
+            new BusDispatcherQueueable,
+            new BusDispatcherTestSpecificQueueAndDelayCommand,
+        ]);
     }
 }
 


### PR DESCRIPTION
`Bus::dispatch()` honors a job's `Delay` attribute/property by pushing it via `Queue::later()`, but `Bus::bulk()` grouped every job into a plain `Queue::bulk()` call regardless, so delayed jobs fired immediately when dispatched in bulk instead of respecting their delay.

Delayed jobs are now pushed individually via `later()`, while the rest of the batch still goes through the existing grouped `bulk()` call.