### PR TITLE
[13.x] Add domains()/notDomains() to the Email validation rule

### DIFF
--- a/src/Illuminate/Validation/Rules/Email.php
+++ b/src/Illuminate/Validation/Rules/Email.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Contracts\Validation\ValidatorAwareRule;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Stringable;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
@@ -35,6 +36,20 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
      * @var array
      */
     protected $data;
+
+    /**
+     * The list of domains the email address must belong to.
+     *
+     * @var array|null
+     */
+    protected $allowedDomains = [];
+
+    /**
+     * The list of domains the email address must not belong to.
+     *
+     * @var array|null
+     */
+    protected $excludedDomains = [];
 
     /**
      * An array of custom rules that will be merged into the validation rules.
@@ -165,6 +180,32 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
     }
 
     /**
+     * Restrict the email address to the given domain(s).
+     *
+     * @param  string|array  $domains
+     * @return $this
+     */
+    public function domains($domains)
+    {
+        $this->allowedDomains = array_merge($this->allowedDomains, Arr::wrap($domains));
+
+        return $this;
+    }
+
+    /**
+     * Prevent the email address from belonging to the given domain(s).
+     *
+     * @param  string|array  $domains
+     * @return $this
+     */
+    public function notDomains($domains)
+    {
+        $this->excludedDomains = array_merge($this->excludedDomains, Arr::wrap($domains));
+
+        return $this;
+    }
+
+    /**
      * Specify additional validation rules that should be merged with the default rules during validation.
      *
      * @param  string|array  $rules
@@ -193,7 +234,31 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
             [$attribute => $this->buildValidationRules()],
             $this->validator->customMessages,
             $this->validator->customAttributes
-        );
+        )->after(function ($validator) use ($attribute, $value): void {
+            if ($this->allowedDomains === [] && $this->excludedDomains === []) {
+                return;
+            }
+
+            if (! is_string($value) && ! (is_object($value) && method_exists($value, '__toString'))) {
+                return;
+            }
+
+            $domain = new Stringable((string) $value);
+
+            if ($domain->doesntContain('@')) {
+                return;
+            }
+
+            $domain = $domain->lower()->afterLast('@');
+
+            $isAllowed = $this->allowedDomains === [] || $domain->is($this->allowedDomains, ignoreCase: true);
+
+            $isExcluded = $this->excludedDomains !== [] && $domain->is($this->excludedDomains, ignoreCase: true);
+
+            if (! $isAllowed || $isExcluded) {
+                $validator->addFailure($attribute, 'email');
+            }
+        });
 
         if ($validator->fails()) {
             $this->messages = array_merge($this->messages, $validator->messages()->all());

--- a/tests/Validation/ValidationEmailRuleTest.php
+++ b/tests/Validation/ValidationEmailRuleTest.php
@@ -799,6 +799,64 @@ class ValidationEmailRuleTest extends TestCase
         );
     }
 
+    public function testDomains(): void
+    {
+        $this->passes(
+            (new Email)->domains('laravel.com'),
+            'taylor@laravel.com'
+        );
+
+        $this->passes(
+            Rule::email()->domains(['laravel.com', 'example.com']),
+            'taylor@example.com'
+        );
+
+        $this->fails(
+            (new Email)->domains('laravel.com'),
+            'taylor@example.com',
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
+        );
+
+        $this->fails(
+            Rule::email()->domains(['laravel.com', 'example.com']),
+            'taylor@other.com',
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
+        );
+
+        // domain matching is case-insensitive.
+        $this->passes(
+            (new Email)->domains('Laravel.com'),
+            'taylor@laravel.com'
+        );
+    }
+
+    public function testNotDomains(): void
+    {
+        $this->passes(
+            (new Email)->notDomains('spam.com'),
+            'taylor@laravel.com'
+        );
+
+        $this->fails(
+            (new Email)->notDomains('spam.com'),
+            'taylor@spam.com',
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
+        );
+
+        $this->fails(
+            Rule::email()->notDomains(['spam.com', 'junk.com']),
+            'taylor@junk.com',
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
+        );
+
+        // domain matching is case-insensitive.
+        $this->fails(
+            (new Email)->notDomains('Spam.com'),
+            'taylor@spam.com',
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
+        );
+    }
+
     public function testMacro()
     {
         Email::macro('laravelEmployee', function () {


### PR DESCRIPTION
Adds `domains()` and `notDomains()` to `Rule::email()`, restricting (or excluding) which domains are accepted:

```php
Rule::email()->domains('laravel.com');
Rule::email()->notDomains('spam.com', 'junk.com');
```

Matching is case-insensitive.