### PR TITLE
Fix route cache mutating live route instances during serialization

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteCacheCommand.php
@@ -5,6 +5,7 @@ namespace Illuminate\Foundation\Console;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Console\Kernel as ConsoleKernelContract;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Routing\Route;
 use Illuminate\Routing\RouteCollection;
 use Symfony\Component\Console\Attribute\AsCommand;
 
@@ -59,15 +60,28 @@ class RouteCacheCommand extends Command
             return $this->components->error("Your application doesn't have any routes.");
         }
 
-        foreach ($routes as $route) {
-            $route->prepareForSerialization();
-        }
+        $routes = $this->prepareRoutes($routes);
 
         $this->files->put(
             $this->laravel->getCachedRoutesPath(), $this->buildRouteCacheFile($routes)
         );
 
         $this->components->info('Routes cached successfully.');
+    }
+
+    protected function prepareRoutes(RouteCollection $routes)
+    {
+        $collection = new RouteCollection;
+
+        foreach ($routes as $route) {
+            $collection->add(transform(clone $route, static function (Route $route) {
+                $route->prepareForSerialization();
+
+                return $route;
+            }));
+        }
+
+        return $collection;
     }
 
     /**

--- a/tests/Integration/Foundation/Console/Fixtures/app.php
+++ b/tests/Integration/Foundation/Console/Fixtures/app.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Foundation\Console\Fixtures;
+
+use Illuminate\Foundation\Application;
+
+if (! class_exists(AppCache::class)) {
+    class AppCache
+    {
+        public static $app;
+    }
+}
+
+if (isset($refresh)) {
+    return AppCache::$app = Application::configure(basePath: __DIR__)->create();
+}
+
+return AppCache::$app ??= Application::configure(basePath: __DIR__)->create();

--- a/tests/Integration/Foundation/Console/Fixtures/bootstrap/cache/.gitignore
+++ b/tests/Integration/Foundation/Console/Fixtures/bootstrap/cache/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/Integration/Foundation/Console/Fixtures/cache/.gitignore
+++ b/tests/Integration/Foundation/Console/Fixtures/cache/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/Integration/Foundation/Console/RouteCacheCommandTest.php
+++ b/tests/Integration/Foundation/Console/RouteCacheCommandTest.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Foundation\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\ServiceProvider;
+use Illuminate\Tests\Integration\Foundation\Console\Fixtures\AppCache;
+use Illuminate\Tests\Integration\Generators\TestCase;
+use LogicException;
+use Orchestra\Testbench\Concerns\InteractsWithPublishedFiles;
+
+class RouteCacheCommandTest extends TestCase
+{
+    use InteractsWithPublishedFiles;
+
+    protected $files = [
+        'cache/routes-v7.php',
+    ];
+
+    protected function tearDown(): void
+    {
+        @unlink(__DIR__.'/Fixtures/cache/routes-v7.php');
+
+        parent::tearDown();
+    }
+
+    public function testRoutesRemainAnalyzableAfterCaching(): void
+    {
+        $this->app->useBootstrapPath(__DIR__.'/Fixtures');
+
+        $app = (static function () {
+            $refresh = true;
+
+            return require __DIR__.'/Fixtures/app.php';
+        })();
+
+        $app['router']->get('/posts', [RouteCacheCommandTestController::class, 'index'])->name('posts.index');
+
+        $this->artisan('route:cache')
+            ->assertSuccessful()
+            ->expectsOutputToContain('Routes cached successfully.');
+
+        $this->assertFileExists(__DIR__.'/Fixtures/cache/routes-v7.php');
+
+        foreach ($app['router']->getRoutes() as $route) {
+            try {
+                $route->getController();
+                $route->gatherMiddleware();
+            } catch (LogicException $exception) {
+                $this->fail(sprintf(
+                    'Route [%s] is no longer analyzable after route:cache: %s',
+                    $route->uri(),
+                    $exception->getMessage(),
+                ));
+            }
+        }
+    }
+
+    public function testOptimizeCanRunTasksThatAnalyzeRoutesAfterRouteCache(): void
+    {
+        $this->withoutDeprecationHandling();
+
+        $this->app->useBootstrapPath(__DIR__.'/Fixtures');
+
+        $app = (static function () {
+            $refresh = true;
+
+            return require __DIR__.'/Fixtures/app.php';
+        })();
+
+        $app['router']->get('/posts', [RouteCacheCommandTestController::class, 'index'])->name('posts.index');
+
+        $this->app->register(RouteAnalysisOptimizeServiceProvider::class);
+
+        $this->artisan('optimize', ['--except' => 'config,events,views'])
+            ->assertSuccessful()
+            ->expectsOutputToContain('route analysis succeeded');
+    }
+}
+
+class RouteCacheCommandTestController extends Controller
+{
+    public function index(): string
+    {
+        return 'posts';
+    }
+}
+
+class RouteAnalysisOptimizeServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        $this->commands([
+            RouteAnalysisOptimizeCommand::class,
+        ]);
+
+        $this->optimizes(
+            optimize: 'test:route-analysis',
+            key: 'route-analysis',
+        );
+    }
+}
+
+class RouteAnalysisOptimizeCommand extends Command
+{
+    protected $signature = 'test:route-analysis';
+
+    protected $description = 'Analyze routes after route:cache';
+
+    public function handle(): int
+    {
+        foreach (AppCache::$app['router']->getRoutes() as $route) {
+            $route->gatherMiddleware();
+        }
+
+        $this->components->info('route analysis succeeded');
+
+        return self::SUCCESS;
+    }
+}


### PR DESCRIPTION
Fixes #60758

## Summary

`route:cache` was calling `prepareForSerialization()` directly on live route instances. That method intentionally removes `router` and `container` from a route, which makes those instances unusable for any further analysis in the same PHP process.

This becomes a problem during `php artisan optimize`, which runs `route:cache` before commands registered via `ServiceProvider::optimizes()`. Any package that registers an optimize task needing to analyze routes (for example, to cache generated metadata) can fail with `LogicException: Route is not bound.`

This PR clones each route before preparing it for serialization, and writes the route cache file from the cloned collection. Live route instances are left untouched.

## Reproduction

https://github.com/hosni-labs/laravel-optimize-command-bug

## Changes

- Extract route preparation into `prepareRoutes()`
- Clone each `Route` before calling `prepareForSerialization()`
- Build the route cache file from a new collection of prepared clones
- Add integration tests covering `route:cache` and the `optimize` flow

## Benefit to end users

Packages can safely register optimize tasks via `$this->optimizes()` that need to analyze application routes after `route:cache` has run. This makes `php artisan optimize` a reliable single command for deployment workflows that combine framework caching with package-level metadata caching.

## Why this does not break existing behavior

- The generated route cache file is still built from the same route data, passed through `prepareForSerialization()` and `compile()`, only the source instances are cloned first.
- `route:cache` behavior is unchanged from the perspective of cached route loading on subsequent requests.
- No public API changes.

## Test plan

- [x] Added `RouteCacheCommandTest` with regression coverage
- [x] Routes remain analyzable after `route:cache` in the same process
- [x] `optimize` can run custom tasks that analyze routes after `route:cache`
- [x] Verified tests fail when the clone fix is reverted

```bash
vendor/bin/phpunit tests/Integration/Foundation/Console/RouteCacheCommandTest.php