### PR TITLE
[13.x] Reset fake time globally after each test, drop redundant Carbon::setTestNow() cleanup

### DIFF
--- a/src/Illuminate/Queue/Failed/DynamoDbFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DynamoDbFailedJobProvider.php
@@ -71,7 +71,7 @@ class DynamoDbFailedJobProvider implements FailedJobProviderInterface
                 'payload' => ['S' => $payload],
                 'exception' => ['S' => (string) $exception],
                 'failed_at' => ['N' => (string) $failedAt->getTimestamp()],
-                'expires_at' => ['N' => (string) $failedAt->addDays(7)->getTimestamp()],
+                'expires_at' => ['N' => (string) $failedAt->addWeek()->getTimestamp()],
             ],
         ]);
 

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -545,7 +545,7 @@ class TestResponse implements ArrayAccess
         $expiresAt = Carbon::createFromTimestamp($cookie->getExpiresTime(), date_default_timezone_get());
 
         PHPUnit::withResponse($this)->assertTrue(
-            $cookie->getExpiresTime() !== 0 && $expiresAt->lessThan(Carbon::now()),
+            $cookie->getExpiresTime() !== 0 && $expiresAt->isPast(),
             "Cookie [{$cookieName}] is not expired, it expires at [{$expiresAt}]."
         );
 
@@ -568,7 +568,7 @@ class TestResponse implements ArrayAccess
         $expiresAt = Carbon::createFromTimestamp($cookie->getExpiresTime(), date_default_timezone_get());
 
         PHPUnit::withResponse($this)->assertTrue(
-            $cookie->getExpiresTime() === 0 || $expiresAt->greaterThan(Carbon::now()),
+            $cookie->getExpiresTime() === 0 || $expiresAt->isFuture(),
             "Cookie [{$cookieName}] is expired, it expired at [{$expiresAt}]."
         );
 

--- a/tests/AfterEachTestSubscriber.php
+++ b/tests/AfterEachTestSubscriber.php
@@ -4,15 +4,18 @@ declare(strict_types=1);
 
 namespace Illuminate\Tests;
 
-use PHPUnit\Event\Test\AfterTestMethodFinished;
-use PHPUnit\Event\Test\AfterTestMethodFinishedSubscriber;
+use Illuminate\Support\Carbon;
+use PHPUnit\Event\Test\Finished;
+use PHPUnit\Event\Test\FinishedSubscriber;
 
-final class AfterEachTestSubscriber implements AfterTestMethodFinishedSubscriber
+final class AfterEachTestSubscriber implements FinishedSubscriber
 {
-    public function notify(AfterTestMethodFinished $event): void
+    public function notify(Finished $event): void
     {
         if (class_exists(\Mockery::class)) {
             \Mockery::close();
         }
+
+        Carbon::setTestNow();
     }
 }

--- a/tests/Auth/AuthDatabaseTokenRepositoryTest.php
+++ b/tests/Auth/AuthDatabaseTokenRepositoryTest.php
@@ -108,8 +108,6 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
         $user->shouldReceive('getEmailForPasswordReset')->once()->andReturn('email');
 
         $this->assertTrue($repo->recentlyCreatedToken($user));
-
-        Carbon::setTestNow();
     }
 
     public function testRecentlyCreatedReturnsFalseIfValidRecordExists()
@@ -125,8 +123,6 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
         $user->shouldReceive('getEmailForPasswordReset')->once()->andReturn('email');
 
         $this->assertFalse($repo->recentlyCreatedToken($user));
-
-        Carbon::setTestNow();
     }
 
     public function testDeleteMethodDeletesByToken()

--- a/tests/Auth/AuthDatabaseTokenRepositoryTest.php
+++ b/tests/Auth/AuthDatabaseTokenRepositoryTest.php
@@ -97,12 +97,12 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
 
     public function testRecentlyCreatedReturnsTrueIfRecordIsRecentlyCreated()
     {
-        Carbon::setTestNow(Carbon::now());
+        Carbon::setTestNow($now = Carbon::now());
 
         $repo = $this->getRepo();
         $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock(stdClass::class));
         $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
-        $date = Carbon::now()->subSeconds(59)->toDateTimeString();
+        $date = $now->subSeconds(59)->toDateTimeString();
         $query->shouldReceive('first')->once()->andReturn((object) ['created_at' => $date, 'token' => 'hashed-token']);
         $user = m::mock(CanResetPassword::class);
         $user->shouldReceive('getEmailForPasswordReset')->once()->andReturn('email');
@@ -112,12 +112,12 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
 
     public function testRecentlyCreatedReturnsFalseIfValidRecordExists()
     {
-        Carbon::setTestNow(Carbon::now());
+        Carbon::setTestNow($now = Carbon::now());
 
         $repo = $this->getRepo();
         $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock(stdClass::class));
         $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
-        $date = Carbon::now()->subSeconds(61)->toDateTimeString();
+        $date = $now->subSeconds(61)->toDateTimeString();
         $query->shouldReceive('first')->once()->andReturn((object) ['created_at' => $date, 'token' => 'hashed-token']);
         $user = m::mock(CanResetPassword::class);
         $user->shouldReceive('getEmailForPasswordReset')->once()->andReturn('email');

--- a/tests/Cache/CacheArrayStoreTest.php
+++ b/tests/Cache/CacheArrayStoreTest.php
@@ -9,13 +9,6 @@ use stdClass;
 
 class CacheArrayStoreTest extends TestCase
 {
-    protected function tearDown(): void
-    {
-        Carbon::setTestNow();
-
-        parent::tearDown();
-    }
-
     public function testItemsCanBeSetAndRetrieved()
     {
         $store = new ArrayStore;

--- a/tests/Cache/CacheArrayStoreTest.php
+++ b/tests/Cache/CacheArrayStoreTest.php
@@ -51,12 +51,12 @@ class CacheArrayStoreTest extends TestCase
 
     public function testItemsCanExpire()
     {
-        Carbon::setTestNow(Carbon::now());
+        Carbon::setTestNow($now = Carbon::now());
 
         $store = new ArrayStore;
 
         $store->put('foo', 'bar', 10);
-        Carbon::setTestNow(Carbon::now()->addSeconds(10)->addSecond());
+        Carbon::setTestNow($now->addSeconds(10)->addSecond());
         $result = $store->get('foo');
 
         $this->assertNull($result);
@@ -127,7 +127,7 @@ class CacheArrayStoreTest extends TestCase
 
     public function testNonExistingKeysCanBeIncremented()
     {
-        Carbon::setTestNow(Carbon::now());
+        Carbon::setTestNow($now = Carbon::now());
 
         $store = new ArrayStore;
         $result = $store->increment('foo');
@@ -135,18 +135,18 @@ class CacheArrayStoreTest extends TestCase
         $this->assertEquals(1, $store->get('foo'));
 
         // Will be there forever
-        Carbon::setTestNow(Carbon::now()->addYears(10));
+        Carbon::setTestNow($now->addYears(10));
         $this->assertEquals(1, $store->get('foo'));
     }
 
     public function testExpiredKeysAreIncrementedLikeNonExistingKeys()
     {
-        Carbon::setTestNow(Carbon::now());
+        Carbon::setTestNow($now = Carbon::now());
 
         $store = new ArrayStore;
 
         $store->put('foo', 999, 10);
-        Carbon::setTestNow(Carbon::now()->addSeconds(10)->addSecond());
+        Carbon::setTestNow($now->addSeconds(10)->addSecond());
         $result = $store->increment('foo');
 
         $this->assertEquals(1, $result);
@@ -214,24 +214,24 @@ class CacheArrayStoreTest extends TestCase
 
     public function testCanAcquireLockAgainAfterExpiry()
     {
-        Carbon::setTestNow(Carbon::now());
+        Carbon::setTestNow($now = Carbon::now());
 
         $store = new ArrayStore;
         $lock = $store->lock('foo', 10);
         $lock->acquire();
-        Carbon::setTestNow(Carbon::now()->addSeconds(10));
+        Carbon::setTestNow($now->addSeconds(10));
 
         $this->assertTrue($lock->acquire());
     }
 
     public function testLockExpirationLowerBoundary()
     {
-        Carbon::setTestNow(Carbon::now());
+        Carbon::setTestNow($now = Carbon::now());
 
         $store = new ArrayStore;
         $lock = $store->lock('foo', 10);
         $lock->acquire();
-        Carbon::setTestNow(Carbon::now()->addSeconds(10)->subMicrosecond());
+        Carbon::setTestNow($now->addSeconds(10)->subMicrosecond());
 
         $this->assertFalse($lock->acquire());
     }
@@ -344,13 +344,13 @@ class CacheArrayStoreTest extends TestCase
 
     public function testExpiredLockCannotBeRefreshedByPreviousOwner()
     {
-        Carbon::setTestNow(Carbon::now());
+        Carbon::setTestNow($now = Carbon::now());
 
         $store = new ArrayStore;
         $lock = $store->lock('foo', 10);
         $this->assertTrue($lock->get());
 
-        Carbon::setTestNow(Carbon::now()->addSeconds(10)->addSecond());
+        Carbon::setTestNow($now->addSeconds(10)->addSecond());
 
         $this->assertFalse($lock->refresh(20));
     }
@@ -365,39 +365,39 @@ class CacheArrayStoreTest extends TestCase
 
     public function testCanGetAll()
     {
-        Carbon::setTestNow(Carbon::now());
+        Carbon::setTestNow($now = Carbon::now());
 
         $store = new ArrayStore(false);
         $store->put('foo', 'bar', 10);
 
         $this->assertEquals([
-            'foo' => ['value' => 'bar', 'expiresAt' => Carbon::now()->addSeconds(10)->getPreciseTimestamp(3) / 1000],
+            'foo' => ['value' => 'bar', 'expiresAt' => $now->addSeconds(10)->getPreciseTimestamp(3) / 1000],
         ], $store->all());
     }
 
     public function testCanGetAllWhenSerialized()
     {
-        Carbon::setTestNow(Carbon::now());
+        Carbon::setTestNow($now = Carbon::now());
 
         $store = new ArrayStore(true);
         $store->put('foo', 'bar', 10);
         $this->assertEquals([
-            'foo' => ['value' => 'bar', 'expiresAt' => $expiresAt = (Carbon::now()->addSeconds(10)->getPreciseTimestamp(3) / 1000)],
+            'foo' => ['value' => 'bar', 'expiresAt' => $expiresAt = ($now->copy()->addSeconds(10)->getPreciseTimestamp(3) / 1000)],
         ], $store->all());
 
         // Now let's put a serializable value in there
         $store->forget('foo');
-        $store->put('foo', Carbon::now(), 10);
+        $store->put('foo', $now, 10);
 
         $this->assertEquals([
             'foo' => [
-                'value' => Carbon::now(),
+                'value' => $now,
                 'expiresAt' => $expiresAt,
             ],
         ], $store->all());
 
         $this->assertEquals(
-            serialize(Carbon::now()),
+            serialize($now),
             $store->all(false)['foo']['value']
         );
     }

--- a/tests/Cache/CacheFileStoreTest.php
+++ b/tests/Cache/CacheFileStoreTest.php
@@ -235,7 +235,7 @@ class CacheFileStoreTest extends TestCase
 
         $filePath = $this->getCachePath('foo');
         $files = $this->mockFilesystem();
-        $initialValue = ($now->getTimestamp() - 10).serialize(77);
+        $initialValue = $now->subSeconds(10)->getTimestamp().serialize(77);
         $valueAfterIncrement = '9999999999'.serialize(3);
         $store = new FileStore($files, __DIR__);
 

--- a/tests/Cache/CacheFileStoreTest.php
+++ b/tests/Cache/CacheFileStoreTest.php
@@ -231,12 +231,11 @@ class CacheFileStoreTest extends TestCase
 
     public function testIncrementExpiredKeys()
     {
-        Carbon::setTestNow(Carbon::now());
+        Carbon::setTestNow($now = Carbon::now());
 
         $filePath = $this->getCachePath('foo');
         $files = $this->mockFilesystem();
-        $now = Carbon::now()->getTimestamp();
-        $initialValue = ($now - 10).serialize(77);
+        $initialValue = ($now->getTimestamp() - 10).serialize(77);
         $valueAfterIncrement = '9999999999'.serialize(3);
         $store = new FileStore($files, __DIR__);
 
@@ -309,10 +308,10 @@ class CacheFileStoreTest extends TestCase
 
     public function testIncrementDoesNotExtendCacheLife()
     {
-        Carbon::setTestNow(Carbon::now());
+        Carbon::setTestNow($now = Carbon::now());
 
         $files = $this->mockFilesystem();
-        $expiration = Carbon::now()->addSeconds(50)->getTimestamp();
+        $expiration = $now->addSeconds(50)->getTimestamp();
         $initialValue = $expiration.serialize(1);
         $valueAfterIncrement = $expiration.serialize(2);
         $store = new FileStore($files, __DIR__);

--- a/tests/Cache/CacheFileStoreTest.php
+++ b/tests/Cache/CacheFileStoreTest.php
@@ -14,13 +14,6 @@ use RuntimeException;
 
 class CacheFileStoreTest extends TestCase
 {
-    protected function tearDown(): void
-    {
-        Carbon::setTestNow();
-
-        parent::tearDown();
-    }
-
     public function testNullIsReturnedIfFileDoesntExist()
     {
         $files = $this->mockFilesystem();

--- a/tests/Cache/CacheMemcachedStoreTest.php
+++ b/tests/Cache/CacheMemcachedStoreTest.php
@@ -57,7 +57,6 @@ class CacheMemcachedStoreTest extends TestCase
         $store = new MemcachedStore($memcache);
         $result = $store->put('foo', 'bar', 60);
         $this->assertTrue($result);
-        Carbon::setTestNow();
     }
 
     public function testTouchMethodProperlyCallsMemcache(): void

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -39,7 +39,6 @@ class CacheRepositoryTest extends TestCase
 
     protected function tearDown(): void
     {
-        Carbon::setTestNow();
         Repository::handleUnserializableClassUsing(null);
 
         parent::tearDown();

--- a/tests/Cache/CacheSessionStoreTest.php
+++ b/tests/Cache/CacheSessionStoreTest.php
@@ -53,12 +53,12 @@ class CacheSessionStoreTest extends TestCase
 
     public function testItemsCanExpire()
     {
-        Carbon::setTestNow(Carbon::now());
+        Carbon::setTestNow($now = Carbon::now());
 
         $store = new SessionStore(self::getSession());
 
         $store->put('foo', 'bar', 10);
-        Carbon::setTestNow(Carbon::now()->addSeconds(10)->addSecond());
+        Carbon::setTestNow($now->addSeconds(10)->addSecond());
         $result = $store->get('foo');
 
         $this->assertNull($result);
@@ -66,21 +66,21 @@ class CacheSessionStoreTest extends TestCase
 
     public function testTouchExtendsTtl()
     {
-        Carbon::setTestNow(Carbon::now());
+        Carbon::setTestNow($now = Carbon::now());
 
         $store = new SessionStore(self::getSession());
         $store->put('foo', 'bar', 10);
 
         // Move time forward and touch to extend TTL
-        Carbon::setTestNow(Carbon::now()->addSeconds(5));
+        Carbon::setTestNow($now->addSeconds(5));
         $this->assertTrue($store->touch('foo', 60));
 
         // Value should still exist past the original expiry
-        Carbon::setTestNow(Carbon::now()->addSeconds(10));
+        Carbon::setTestNow($now->addSeconds(10));
         $this->assertSame('bar', $store->get('foo'));
 
         // Value should expire after the new TTL
-        Carbon::setTestNow(Carbon::now()->addSeconds(50));
+        Carbon::setTestNow($now->addSeconds(50));
         $this->assertNull($store->get('foo'));
     }
 
@@ -147,12 +147,12 @@ class CacheSessionStoreTest extends TestCase
 
     public function testExpiredKeysAreIncrementedLikeNonExistingKeys()
     {
-        Carbon::setTestNow(Carbon::now());
+        Carbon::setTestNow($now = Carbon::now());
 
         $store = new SessionStore(self::getSession());
 
         $store->put('foo', 999, 10);
-        Carbon::setTestNow(Carbon::now()->addSeconds(10)->addSecond());
+        Carbon::setTestNow($now->addSeconds(10)->addSecond());
         $result = $store->increment('foo');
 
         $this->assertEquals(1, $result);
@@ -220,13 +220,13 @@ class CacheSessionStoreTest extends TestCase
 
     public function testCanGetAll()
     {
-        Carbon::setTestNow(Carbon::now());
+        Carbon::setTestNow($now = Carbon::now());
 
         $store = new SessionStore(self::getSession());
         $store->put('foo', 'bar', 10);
 
         $this->assertEquals([
-            'foo' => ['value' => 'bar', 'expiresAt' => Carbon::now()->addSeconds(10)->getPreciseTimestamp(3) / 1000],
+            'foo' => ['value' => 'bar', 'expiresAt' => $now->addSeconds(10)->getPreciseTimestamp(3) / 1000],
         ], $store->all());
     }
 

--- a/tests/Cache/CacheSessionStoreTest.php
+++ b/tests/Cache/CacheSessionStoreTest.php
@@ -11,13 +11,6 @@ use stdClass;
 
 class CacheSessionStoreTest extends TestCase
 {
-    protected function tearDown(): void
-    {
-        Carbon::setTestNow();
-
-        parent::tearDown();
-    }
-
     public function testItemsCanBeSetAndRetrieved()
     {
         $store = new SessionStore(self::getSession());

--- a/tests/Cache/CacheStorageStoreTest.php
+++ b/tests/Cache/CacheStorageStoreTest.php
@@ -10,13 +10,6 @@ use PHPUnit\Framework\TestCase;
 
 class CacheStorageStoreTest extends TestCase
 {
-    protected function tearDown(): void
-    {
-        Carbon::setTestNow();
-
-        parent::tearDown();
-    }
-
     public function testValuesCanBeStoredAndRetrieved()
     {
         $disk = new ArrayFilesystem;

--- a/tests/Cache/CacheStorageStoreTest.php
+++ b/tests/Cache/CacheStorageStoreTest.php
@@ -22,14 +22,14 @@ class CacheStorageStoreTest extends TestCase
 
     public function testExpiredItemsReturnNullAndGetDeleted()
     {
-        Carbon::setTestNow(Carbon::now());
+        Carbon::setTestNow($now = Carbon::now());
 
         $disk = new ArrayFilesystem;
         $store = new StorageStore($disk, 'cache');
 
         $store->put('foo', 'bar', 1);
 
-        Carbon::setTestNow(Carbon::now()->addSeconds(2));
+        Carbon::setTestNow($now->addSeconds(2));
 
         $this->assertNull($store->get('foo'));
         $this->assertFalse($disk->exists($store->path('foo')));
@@ -46,7 +46,7 @@ class CacheStorageStoreTest extends TestCase
 
     public function testIncrementAndDecrementRetainExpiration()
     {
-        Carbon::setTestNow(Carbon::now());
+        Carbon::setTestNow($now = Carbon::now());
 
         $store = new StorageStore(new ArrayFilesystem, 'cache');
         $store->put('foo', 5, 60);
@@ -54,23 +54,23 @@ class CacheStorageStoreTest extends TestCase
         $this->assertSame(7, $store->increment('foo', 2));
         $this->assertSame(4, $store->decrement('foo', 3));
 
-        Carbon::setTestNow(Carbon::now()->addSeconds(61));
+        Carbon::setTestNow($now->addSeconds(61));
 
         $this->assertNull($store->get('foo'));
     }
 
     public function testTouchUpdatesExpiration()
     {
-        Carbon::setTestNow(Carbon::now());
+        Carbon::setTestNow($now = Carbon::now());
 
         $store = new StorageStore(new ArrayFilesystem, 'cache');
         $store->put('foo', 'bar', 2);
 
-        Carbon::setTestNow(Carbon::now()->addSecond());
+        Carbon::setTestNow($now->addSecond());
 
         $this->assertTrue($store->touch('foo', 60));
 
-        Carbon::setTestNow(Carbon::now()->addSecond());
+        Carbon::setTestNow($now->addSecond());
 
         $this->assertSame('bar', $store->get('foo'));
     }

--- a/tests/Console/ConsoleScheduledEventTest.php
+++ b/tests/Console/ConsoleScheduledEventTest.php
@@ -27,7 +27,6 @@ class ConsoleScheduledEventTest extends TestCase
     protected function tearDown(): void
     {
         date_default_timezone_set($this->defaultTimezone);
-        Carbon::setTestNow();
 
         parent::tearDown();
     }

--- a/tests/Console/Scheduling/FrequencyTest.php
+++ b/tests/Console/Scheduling/FrequencyTest.php
@@ -123,8 +123,6 @@ class FrequencyTest extends TestCase
         Carbon::setTestNow('2020-10-10 10:10:10');
 
         $this->assertSame('0 0 31 * *', $this->event->lastDayOfMonth()->getExpression());
-
-        Carbon::setTestNow();
     }
 
     public function testTwiceMonthly()

--- a/tests/Console/Scheduling/ScheduleWorkCommandTest.php
+++ b/tests/Console/Scheduling/ScheduleWorkCommandTest.php
@@ -38,8 +38,6 @@ class ScheduleWorkCommandTest extends TestCase
 
     protected function tearDown(): void
     {
-        Carbon::setTestNow();
-
         Signals::resolveAvailabilityUsing($this->originalAvailabilityResolver);
 
         parent::tearDown();

--- a/tests/Database/DatabaseEloquentBelongsToManyCreateOrFirstTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyCreateOrFirstTest.php
@@ -26,13 +26,6 @@ class DatabaseEloquentBelongsToManyCreateOrFirstTest extends TestCase
         Carbon::setTestNow('2023-01-01 00:00:00');
     }
 
-    protected function tearDown(): void
-    {
-        Carbon::setTestNow();
-
-        parent::tearDown();
-    }
-
     #[DataProvider('createOrFirstValues')]
     public function testCreateOrFirstMethodCreatesNewRelated(Closure|array $values): void
     {

--- a/tests/Database/DatabaseEloquentBuilderCreateOrFirstTest.php
+++ b/tests/Database/DatabaseEloquentBuilderCreateOrFirstTest.php
@@ -22,13 +22,6 @@ class DatabaseEloquentBuilderCreateOrFirstTest extends TestCase
         Carbon::setTestNow('2023-01-01 00:00:00');
     }
 
-    protected function tearDown(): void
-    {
-        Carbon::setTestNow();
-
-        parent::tearDown();
-    }
-
     #[DataProvider('createOrFirstValues')]
     public function testCreateOrFirstMethodCreatesNewRecord(Closure|array $values): void
     {

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -27,13 +27,6 @@ use stdClass;
 
 class DatabaseEloquentBuilderTest extends TestCase
 {
-    protected function tearDown(): void
-    {
-        Carbon::setTestNow();
-
-        parent::tearDown();
-    }
-
     public function testFindMethod()
     {
         $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);
@@ -2696,8 +2689,6 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $result = $builder->from('table as alias')->update(['foo' => 'bar', 'alias.updated_at' => null]);
         $this->assertEquals(1, $result);
-
-        Carbon::setTestNow();
     }
 
     public function testUpsert()

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -834,8 +834,6 @@ class DatabaseEloquentFactoryTest extends TestCase
         $post = FactoryTestPostFactory::new()->trashed($deleted_at)->create();
 
         $this->assertTrue($deleted_at->equalTo($post->deleted_at));
-
-        Carbon::setTestNow();
     }
 
     public function test_dynamic_trashed_state_respects_existing_state()
@@ -845,8 +843,6 @@ class DatabaseEloquentFactoryTest extends TestCase
         $comment = FactoryTestCommentFactory::new()->trashed()->create();
 
         $this->assertTrue($comment->deleted_at->equalTo($now->subWeek()));
-
-        Carbon::setTestNow();
     }
 
     public function test_dynamic_trashed_state_throws_exception_when_not_a_softdeletes_model()

--- a/tests/Database/DatabaseEloquentHasManyCreateOrFirstTest.php
+++ b/tests/Database/DatabaseEloquentHasManyCreateOrFirstTest.php
@@ -23,13 +23,6 @@ class DatabaseEloquentHasManyCreateOrFirstTest extends TestCase
         Carbon::setTestNow('2023-01-01 00:00:00');
     }
 
-    protected function tearDown(): void
-    {
-        Carbon::setTestNow();
-
-        parent::tearDown();
-    }
-
     #[DataProvider('createOrFirstValues')]
     public function testCreateOrFirstMethodCreatesNewRecord(Closure|array $values): void
     {

--- a/tests/Database/DatabaseEloquentHasManyThroughCreateOrFirstTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughCreateOrFirstTest.php
@@ -25,13 +25,6 @@ class DatabaseEloquentHasManyThroughCreateOrFirstTest extends TestCase
         Carbon::setTestNow('2023-01-01 00:00:00');
     }
 
-    protected function tearDown(): void
-    {
-        Carbon::setTestNow();
-
-        parent::tearDown();
-    }
-
     #[DataProvider('createOrFirstValues')]
     public function testCreateOrFirstMethodCreatesNewRecord(Closure|array $values): void
     {

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -205,7 +205,6 @@ class DatabaseEloquentIntegrationTest extends TestCase
         Relation::morphMap([], false);
         Eloquent::unsetConnectionResolver();
 
-        Carbon::setTestNow();
         Str::createUuidsNormally();
         DB::flushQueryLog();
 

--- a/tests/Database/DatabaseEloquentIrregularPluralTest.php
+++ b/tests/Database/DatabaseEloquentIrregularPluralTest.php
@@ -59,8 +59,6 @@ class DatabaseEloquentIrregularPluralTest extends TestCase
         $this->schema()->drop('irregular_plural_humans');
         $this->schema()->drop('irregular_plural_human_irregular_plural_token');
 
-        Carbon::setTestNow();
-
         parent::tearDown();
     }
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -72,8 +72,6 @@ class DatabaseEloquentModelTest extends TestCase
 
     protected function tearDown(): void
     {
-        Carbon::setTestNow();
-
         Model::unsetEventDispatcher();
         Carbon::resetToStringFormat();
 

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -94,8 +94,6 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
      */
     protected function tearDown(): void
     {
-        Carbon::setTestNow();
-
         $this->schema()->drop('users');
         $this->schema()->drop('posts');
         $this->schema()->drop('comments');

--- a/tests/Database/DatabaseEloquentTimestampsTest.php
+++ b/tests/Database/DatabaseEloquentTimestampsTest.php
@@ -63,7 +63,6 @@ class DatabaseEloquentTimestampsTest extends TestCase
         $this->schema()->drop('users');
         $this->schema()->drop('users_created_at');
         $this->schema()->drop('users_updated_at');
-        Carbon::setTestNow();
 
         parent::tearDown();
     }

--- a/tests/Database/QueryDurationThresholdTest.php
+++ b/tests/Database/QueryDurationThresholdTest.php
@@ -17,13 +17,6 @@ class QueryDurationThresholdTest extends TestCase
      */
     protected $now;
 
-    protected function tearDown(): void
-    {
-        Carbon::setTestNow();
-
-        parent::tearDown();
-    }
-
     public function testItCanHandleReachingADurationThresholdInTheDb()
     {
         $connection = new Connection(new PDO('sqlite::memory:'));

--- a/tests/Foundation/FoundationInteractsWithTimeTest.php
+++ b/tests/Foundation/FoundationInteractsWithTimeTest.php
@@ -10,13 +10,6 @@ class FoundationInteractsWithTimeTest extends TestCase
 {
     use InteractsWithTime;
 
-    protected function tearDown(): void
-    {
-        Carbon::setTestNow();
-
-        parent::tearDown();
-    }
-
     public function testFreezeTimeReturnsFrozenTime()
     {
         $actual = $this->freezeTime();

--- a/tests/Integration/Console/CommandDurationThresholdTest.php
+++ b/tests/Integration/Console/CommandDurationThresholdTest.php
@@ -22,12 +22,12 @@ class CommandDurationThresholdTest extends TestCase
             $called = true;
         });
 
-        Carbon::setTestNow(Carbon::now());
+        Carbon::setTestNow($now = Carbon::now());
         $kernel->handle($input, new ConsoleOutput);
 
         $this->assertFalse($called);
 
-        Carbon::setTestNow(Carbon::now()->addSecond()->addMilliseconds(1));
+        Carbon::setTestNow($now->addSecond()->addMilliseconds(1));
         $kernel->terminate($input, 21);
 
         $this->assertTrue($called);
@@ -43,12 +43,12 @@ class CommandDurationThresholdTest extends TestCase
             $called = true;
         });
 
-        Carbon::setTestNow(Carbon::now());
+        Carbon::setTestNow($now = Carbon::now());
         $kernel->handle($input, new ConsoleOutput);
 
         $this->assertFalse($called);
 
-        Carbon::setTestNow(Carbon::now()->addSecond());
+        Carbon::setTestNow($now->addSecond());
         $kernel->terminate($input, 21);
 
         $this->assertFalse($called);
@@ -85,12 +85,12 @@ class CommandDurationThresholdTest extends TestCase
             $called = true;
         });
 
-        Carbon::setTestNow(Carbon::now());
+        Carbon::setTestNow($now = Carbon::now());
         $kernel->handle($input, new ConsoleOutput);
 
         $this->assertFalse($called);
 
-        Carbon::setTestNow(Carbon::now()->addSecond()->addMilliseconds(1));
+        Carbon::setTestNow($now->addSecond()->addMilliseconds(1));
         $kernel->terminate($input, 21);
 
         $this->assertTrue($called);
@@ -106,12 +106,12 @@ class CommandDurationThresholdTest extends TestCase
             $called = true;
         });
 
-        Carbon::setTestNow(Carbon::now());
+        Carbon::setTestNow($now = Carbon::now());
         $kernel->handle($input, new ConsoleOutput);
 
         $this->assertFalse($called);
 
-        Carbon::setTestNow(Carbon::now()->addSecond());
+        Carbon::setTestNow($now->addSecond());
         $kernel->terminate($input, 21);
 
         $this->assertFalse($called);
@@ -120,14 +120,14 @@ class CommandDurationThresholdTest extends TestCase
     public function testItCanExceedThresholdWhenSpecifyingDurationAsDateTime(): void
     {
         retry(2, function () {
-            Carbon::setTestNow(Carbon::now());
+            Carbon::setTestNow($now = Carbon::now());
 
             $input = new StringInput('foo');
             $called = false;
 
             $kernel = $this->app[Kernel::class];
             $kernel->command('foo', fn () => null);
-            $kernel->whenCommandLifecycleIsLongerThan(Carbon::now()->addSecond()->addMillisecond(), function () use (&$called) {
+            $kernel->whenCommandLifecycleIsLongerThan($now->copy()->addSecond()->addMillisecond(), function () use (&$called) {
                 $called = true;
             });
 
@@ -135,7 +135,7 @@ class CommandDurationThresholdTest extends TestCase
 
             $this->assertFalse($called);
 
-            Carbon::setTestNow(Carbon::now()->addSecond()->addMillisecond());
+            Carbon::setTestNow($now->addSecond()->addMillisecond());
 
             $kernel->terminate($input, 21);
 
@@ -145,12 +145,12 @@ class CommandDurationThresholdTest extends TestCase
 
     public function testItCanStayUnderThresholdWhenSpecifyingDurationAsDateTime(): void
     {
-        Carbon::setTestNow(Carbon::now());
+        Carbon::setTestNow($now = Carbon::now());
         $kernel = $this->app[Kernel::class];
         $kernel->command('foo', fn () => null);
         $input = new StringInput('foo');
         $called = false;
-        $kernel->whenCommandLifecycleIsLongerThan(Carbon::now()->addSecond()->addMillisecond(), function () use (&$called) {
+        $kernel->whenCommandLifecycleIsLongerThan($now->copy()->addSecond()->addMillisecond(), function () use (&$called) {
             $called = true;
         });
 
@@ -158,7 +158,7 @@ class CommandDurationThresholdTest extends TestCase
 
         $this->assertFalse($called);
 
-        Carbon::setTestNow(Carbon::now()->addSecond());
+        Carbon::setTestNow($now->addSecond());
         $kernel->terminate($input, 21);
 
         $this->assertFalse($called);
@@ -190,10 +190,10 @@ class CommandDurationThresholdTest extends TestCase
         });
 
         Config::set('app.timezone', 'Australia/Melbourne');
-        Carbon::setTestNow(Carbon::now());
+        Carbon::setTestNow($now = Carbon::now());
         $kernel->handle($input = new StringInput('foo'), new ConsoleOutput);
 
-        Carbon::setTestNow(Carbon::now()->addMinute());
+        Carbon::setTestNow($now->addMinute());
         $kernel->terminate($input, 21);
 
         $this->assertSame('Australia/Melbourne', $startedAt->timezone->getName());

--- a/tests/Integration/Console/Scheduling/ScheduleGroupTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleGroupTest.php
@@ -186,8 +186,6 @@ class ScheduleGroupTest extends TestCase
                 "[$description] $task should ".($expected[$task] ? 'run' : 'not run')
             );
         }
-
-        Carbon::setTestNow();
     }
 
     private function assertTaskExecution($event, $app, $expected, $message): void

--- a/tests/Integration/Console/Scheduling/ScheduleRunCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleRunCommandTest.php
@@ -23,13 +23,6 @@ class ScheduleRunCommandTest extends TestCase
         Carbon::setTestNow(Carbon::now());
     }
 
-    protected function tearDown(): void
-    {
-        Carbon::setTestNow();
-
-        parent::tearDown();
-    }
-
     /**
      * @throws BindingResolutionException
      */
@@ -272,7 +265,7 @@ class ScheduleRunCommandTest extends TestCase
         $reflection = new ReflectionProperty($command, 'startedAt');
         $startedAt = $reflection->getValue($command);
 
-        $originalTimestamp = $startedAt->timestamp;
+        $originalTimestamp = $startedAt->getTimestamp();
         $originalMicro = $startedAt->micro;
 
         // Call repeatEvents with an empty collection so it exits immediately
@@ -285,7 +278,7 @@ class ScheduleRunCommandTest extends TestCase
 
         // startedAt should not have been mutated to end of minute
         $startedAtAfter = (new ReflectionProperty($command, 'startedAt'))->getValue($command);
-        $this->assertEquals($originalTimestamp, $startedAtAfter->timestamp);
+        $this->assertEquals($originalTimestamp, $startedAtAfter->getTimestamp());
         $this->assertEquals($originalMicro, $startedAtAfter->micro);
     }
 }

--- a/tests/Integration/Cookie/CookieTest.php
+++ b/tests/Integration/Cookie/CookieTest.php
@@ -36,10 +36,10 @@ class CookieTest extends TestCase
             return 'hello world';
         })->middleware('web');
 
-        Carbon::setTestNow(Carbon::now());
+        Carbon::setTestNow($now = Carbon::now());
         $response = $this->get('/');
         $this->assertCount(2, $response->headers->getCookies());
-        $this->assertEquals(Carbon::now()->addMinute()->getTimestamp(), $response->headers->getCookies()[1]->getExpiresTime());
+        $this->assertEquals($now->addMinute()->getTimestamp(), $response->headers->getCookies()[1]->getExpiresTime());
     }
 
     protected function defineEnvironment($app)

--- a/tests/Integration/Database/MariaDb/EloquentCastTest.php
+++ b/tests/Integration/Database/MariaDb/EloquentCastTest.php
@@ -36,8 +36,8 @@ class EloquentCastTest extends MariaDbTestCase
 
     public function testItCastTimestampsCreatedByTheBuilderWhenTimeHasNotPassed()
     {
-        Carbon::setTestNow(Carbon::now());
-        $createdAt = Carbon::now()->getTimestamp();
+        Carbon::setTestNow($now = Carbon::now());
+        $createdAt = $now->getTimestamp();
 
         $castUser = UserWithIntTimestampsViaCasts::create([
             'email' => fake()->unique()->email,
@@ -79,8 +79,8 @@ class EloquentCastTest extends MariaDbTestCase
 
     public function testItCastTimestampsCreatedByTheBuilderWhenTimeHasPassed()
     {
-        Carbon::setTestNow(Carbon::now());
-        $createdAt = Carbon::now()->getTimestamp();
+        Carbon::setTestNow($now = Carbon::now());
+        $createdAt = $now->getTimestamp();
 
         $castUser = UserWithIntTimestampsViaCasts::create([
             'email' => fake()->unique()->email,
@@ -99,8 +99,8 @@ class EloquentCastTest extends MariaDbTestCase
         $this->assertSame($createdAt, $mutatorUser->created_at->getTimestamp());
         $this->assertSame($createdAt, $mutatorUser->updated_at->getTimestamp());
 
-        Carbon::setTestNow(Carbon::now()->addSecond());
-        $updatedAt = Carbon::now()->getTimestamp();
+        Carbon::setTestNow($now->addSecond());
+        $updatedAt = $now->getTimestamp();
 
         $castUser->update([
             'email' => fake()->unique()->email,
@@ -125,7 +125,7 @@ class EloquentCastTest extends MariaDbTestCase
 
     public function testItCastTimestampsUpdatedByAMutator()
     {
-        Carbon::setTestNow(Carbon::now());
+        Carbon::setTestNow($now = Carbon::now());
 
         $mutatorUser = UserWithUpdatedAtViaMutator::create([
             'email' => fake()->unique()->email,
@@ -133,8 +133,8 @@ class EloquentCastTest extends MariaDbTestCase
 
         $this->assertNull($mutatorUser->updated_at);
 
-        Carbon::setTestNow(Carbon::now()->addSecond());
-        $updatedAt = Carbon::now()->getTimestamp();
+        Carbon::setTestNow($now->addSecond());
+        $updatedAt = $now->getTimestamp();
 
         $mutatorUser->update([
             'email' => fake()->unique()->email,

--- a/tests/Integration/Database/MariaDb/EloquentCastTest.php
+++ b/tests/Integration/Database/MariaDb/EloquentCastTest.php
@@ -49,12 +49,12 @@ class EloquentCastTest extends MariaDbTestCase
             'email' => fake()->unique()->email,
         ]);
 
-        $this->assertSame($createdAt, $castUser->created_at->timestamp);
-        $this->assertSame($createdAt, $castUser->updated_at->timestamp);
-        $this->assertSame($createdAt, $attributeUser->created_at->timestamp);
-        $this->assertSame($createdAt, $attributeUser->updated_at->timestamp);
-        $this->assertSame($createdAt, $mutatorUser->created_at->timestamp);
-        $this->assertSame($createdAt, $mutatorUser->updated_at->timestamp);
+        $this->assertSame($createdAt, $castUser->created_at->getTimestamp());
+        $this->assertSame($createdAt, $castUser->updated_at->getTimestamp());
+        $this->assertSame($createdAt, $attributeUser->created_at->getTimestamp());
+        $this->assertSame($createdAt, $attributeUser->updated_at->getTimestamp());
+        $this->assertSame($createdAt, $mutatorUser->created_at->getTimestamp());
+        $this->assertSame($createdAt, $mutatorUser->updated_at->getTimestamp());
 
         $castUser->update([
             'email' => fake()->unique()->email,
@@ -66,15 +66,15 @@ class EloquentCastTest extends MariaDbTestCase
             'email' => fake()->unique()->email,
         ]);
 
-        $this->assertSame($createdAt, $castUser->created_at->timestamp);
-        $this->assertSame($createdAt, $castUser->updated_at->timestamp);
-        $this->assertSame($createdAt, $castUser->fresh()->updated_at->timestamp);
-        $this->assertSame($createdAt, $attributeUser->created_at->timestamp);
-        $this->assertSame($createdAt, $attributeUser->updated_at->timestamp);
-        $this->assertSame($createdAt, $attributeUser->fresh()->updated_at->timestamp);
-        $this->assertSame($createdAt, $mutatorUser->created_at->timestamp);
-        $this->assertSame($createdAt, $mutatorUser->updated_at->timestamp);
-        $this->assertSame($createdAt, $mutatorUser->fresh()->updated_at->timestamp);
+        $this->assertSame($createdAt, $castUser->created_at->getTimestamp());
+        $this->assertSame($createdAt, $castUser->updated_at->getTimestamp());
+        $this->assertSame($createdAt, $castUser->fresh()->updated_at->getTimestamp());
+        $this->assertSame($createdAt, $attributeUser->created_at->getTimestamp());
+        $this->assertSame($createdAt, $attributeUser->updated_at->getTimestamp());
+        $this->assertSame($createdAt, $attributeUser->fresh()->updated_at->getTimestamp());
+        $this->assertSame($createdAt, $mutatorUser->created_at->getTimestamp());
+        $this->assertSame($createdAt, $mutatorUser->updated_at->getTimestamp());
+        $this->assertSame($createdAt, $mutatorUser->fresh()->updated_at->getTimestamp());
     }
 
     public function testItCastTimestampsCreatedByTheBuilderWhenTimeHasPassed()
@@ -92,12 +92,12 @@ class EloquentCastTest extends MariaDbTestCase
             'email' => fake()->unique()->email,
         ]);
 
-        $this->assertSame($createdAt, $castUser->created_at->timestamp);
-        $this->assertSame($createdAt, $castUser->updated_at->timestamp);
-        $this->assertSame($createdAt, $attributeUser->created_at->timestamp);
-        $this->assertSame($createdAt, $attributeUser->updated_at->timestamp);
-        $this->assertSame($createdAt, $mutatorUser->created_at->timestamp);
-        $this->assertSame($createdAt, $mutatorUser->updated_at->timestamp);
+        $this->assertSame($createdAt, $castUser->created_at->getTimestamp());
+        $this->assertSame($createdAt, $castUser->updated_at->getTimestamp());
+        $this->assertSame($createdAt, $attributeUser->created_at->getTimestamp());
+        $this->assertSame($createdAt, $attributeUser->updated_at->getTimestamp());
+        $this->assertSame($createdAt, $mutatorUser->created_at->getTimestamp());
+        $this->assertSame($createdAt, $mutatorUser->updated_at->getTimestamp());
 
         Carbon::setTestNow(Carbon::now()->addSecond());
         $updatedAt = Carbon::now()->getTimestamp();
@@ -112,15 +112,15 @@ class EloquentCastTest extends MariaDbTestCase
             'email' => fake()->unique()->email,
         ]);
 
-        $this->assertSame($createdAt, $castUser->created_at->timestamp);
-        $this->assertSame($updatedAt, $castUser->updated_at->timestamp);
-        $this->assertSame($updatedAt, $castUser->fresh()->updated_at->timestamp);
-        $this->assertSame($createdAt, $attributeUser->created_at->timestamp);
-        $this->assertSame($updatedAt, $attributeUser->updated_at->timestamp);
-        $this->assertSame($updatedAt, $attributeUser->fresh()->updated_at->timestamp);
-        $this->assertSame($createdAt, $mutatorUser->created_at->timestamp);
-        $this->assertSame($updatedAt, $mutatorUser->updated_at->timestamp);
-        $this->assertSame($updatedAt, $mutatorUser->fresh()->updated_at->timestamp);
+        $this->assertSame($createdAt, $castUser->created_at->getTimestamp());
+        $this->assertSame($updatedAt, $castUser->updated_at->getTimestamp());
+        $this->assertSame($updatedAt, $castUser->fresh()->updated_at->getTimestamp());
+        $this->assertSame($createdAt, $attributeUser->created_at->getTimestamp());
+        $this->assertSame($updatedAt, $attributeUser->updated_at->getTimestamp());
+        $this->assertSame($updatedAt, $attributeUser->fresh()->updated_at->getTimestamp());
+        $this->assertSame($createdAt, $mutatorUser->created_at->getTimestamp());
+        $this->assertSame($updatedAt, $mutatorUser->updated_at->getTimestamp());
+        $this->assertSame($updatedAt, $mutatorUser->fresh()->updated_at->getTimestamp());
     }
 
     public function testItCastTimestampsUpdatedByAMutator()
@@ -140,8 +140,8 @@ class EloquentCastTest extends MariaDbTestCase
             'email' => fake()->unique()->email,
         ]);
 
-        $this->assertSame($updatedAt, $mutatorUser->updated_at->timestamp);
-        $this->assertSame($updatedAt, $mutatorUser->fresh()->updated_at->timestamp);
+        $this->assertSame($updatedAt, $mutatorUser->updated_at->getTimestamp());
+        $this->assertSame($updatedAt, $mutatorUser->fresh()->updated_at->getTimestamp());
     }
 }
 

--- a/tests/Integration/Database/MySql/EloquentCastTest.php
+++ b/tests/Integration/Database/MySql/EloquentCastTest.php
@@ -49,12 +49,12 @@ class EloquentCastTest extends MySqlTestCase
             'email' => fake()->unique()->email,
         ]);
 
-        $this->assertSame($createdAt, $castUser->created_at->timestamp);
-        $this->assertSame($createdAt, $castUser->updated_at->timestamp);
-        $this->assertSame($createdAt, $attributeUser->created_at->timestamp);
-        $this->assertSame($createdAt, $attributeUser->updated_at->timestamp);
-        $this->assertSame($createdAt, $mutatorUser->created_at->timestamp);
-        $this->assertSame($createdAt, $mutatorUser->updated_at->timestamp);
+        $this->assertSame($createdAt, $castUser->created_at->getTimestamp());
+        $this->assertSame($createdAt, $castUser->updated_at->getTimestamp());
+        $this->assertSame($createdAt, $attributeUser->created_at->getTimestamp());
+        $this->assertSame($createdAt, $attributeUser->updated_at->getTimestamp());
+        $this->assertSame($createdAt, $mutatorUser->created_at->getTimestamp());
+        $this->assertSame($createdAt, $mutatorUser->updated_at->getTimestamp());
 
         $castUser->update([
             'email' => fake()->unique()->email,
@@ -66,15 +66,15 @@ class EloquentCastTest extends MySqlTestCase
             'email' => fake()->unique()->email,
         ]);
 
-        $this->assertSame($createdAt, $castUser->created_at->timestamp);
-        $this->assertSame($createdAt, $castUser->updated_at->timestamp);
-        $this->assertSame($createdAt, $castUser->fresh()->updated_at->timestamp);
-        $this->assertSame($createdAt, $attributeUser->created_at->timestamp);
-        $this->assertSame($createdAt, $attributeUser->updated_at->timestamp);
-        $this->assertSame($createdAt, $attributeUser->fresh()->updated_at->timestamp);
-        $this->assertSame($createdAt, $mutatorUser->created_at->timestamp);
-        $this->assertSame($createdAt, $mutatorUser->updated_at->timestamp);
-        $this->assertSame($createdAt, $mutatorUser->fresh()->updated_at->timestamp);
+        $this->assertSame($createdAt, $castUser->created_at->getTimestamp());
+        $this->assertSame($createdAt, $castUser->updated_at->getTimestamp());
+        $this->assertSame($createdAt, $castUser->fresh()->updated_at->getTimestamp());
+        $this->assertSame($createdAt, $attributeUser->created_at->getTimestamp());
+        $this->assertSame($createdAt, $attributeUser->updated_at->getTimestamp());
+        $this->assertSame($createdAt, $attributeUser->fresh()->updated_at->getTimestamp());
+        $this->assertSame($createdAt, $mutatorUser->created_at->getTimestamp());
+        $this->assertSame($createdAt, $mutatorUser->updated_at->getTimestamp());
+        $this->assertSame($createdAt, $mutatorUser->fresh()->updated_at->getTimestamp());
     }
 
     public function testItCastTimestampsCreatedByTheBuilderWhenTimeHasPassed()
@@ -92,12 +92,12 @@ class EloquentCastTest extends MySqlTestCase
             'email' => fake()->unique()->email,
         ]);
 
-        $this->assertSame($createdAt, $castUser->created_at->timestamp);
-        $this->assertSame($createdAt, $castUser->updated_at->timestamp);
-        $this->assertSame($createdAt, $attributeUser->created_at->timestamp);
-        $this->assertSame($createdAt, $attributeUser->updated_at->timestamp);
-        $this->assertSame($createdAt, $mutatorUser->created_at->timestamp);
-        $this->assertSame($createdAt, $mutatorUser->updated_at->timestamp);
+        $this->assertSame($createdAt, $castUser->created_at->getTimestamp());
+        $this->assertSame($createdAt, $castUser->updated_at->getTimestamp());
+        $this->assertSame($createdAt, $attributeUser->created_at->getTimestamp());
+        $this->assertSame($createdAt, $attributeUser->updated_at->getTimestamp());
+        $this->assertSame($createdAt, $mutatorUser->created_at->getTimestamp());
+        $this->assertSame($createdAt, $mutatorUser->updated_at->getTimestamp());
 
         Carbon::setTestNow(Carbon::now()->addSecond());
         $updatedAt = Carbon::now()->getTimestamp();
@@ -112,15 +112,15 @@ class EloquentCastTest extends MySqlTestCase
             'email' => fake()->unique()->email,
         ]);
 
-        $this->assertSame($createdAt, $castUser->created_at->timestamp);
-        $this->assertSame($updatedAt, $castUser->updated_at->timestamp);
-        $this->assertSame($updatedAt, $castUser->fresh()->updated_at->timestamp);
-        $this->assertSame($createdAt, $attributeUser->created_at->timestamp);
-        $this->assertSame($updatedAt, $attributeUser->updated_at->timestamp);
-        $this->assertSame($updatedAt, $attributeUser->fresh()->updated_at->timestamp);
-        $this->assertSame($createdAt, $mutatorUser->created_at->timestamp);
-        $this->assertSame($updatedAt, $mutatorUser->updated_at->timestamp);
-        $this->assertSame($updatedAt, $mutatorUser->fresh()->updated_at->timestamp);
+        $this->assertSame($createdAt, $castUser->created_at->getTimestamp());
+        $this->assertSame($updatedAt, $castUser->updated_at->getTimestamp());
+        $this->assertSame($updatedAt, $castUser->fresh()->updated_at->getTimestamp());
+        $this->assertSame($createdAt, $attributeUser->created_at->getTimestamp());
+        $this->assertSame($updatedAt, $attributeUser->updated_at->getTimestamp());
+        $this->assertSame($updatedAt, $attributeUser->fresh()->updated_at->getTimestamp());
+        $this->assertSame($createdAt, $mutatorUser->created_at->getTimestamp());
+        $this->assertSame($updatedAt, $mutatorUser->updated_at->getTimestamp());
+        $this->assertSame($updatedAt, $mutatorUser->fresh()->updated_at->getTimestamp());
     }
 
     public function testItCastTimestampsUpdatedByAMutator()
@@ -140,8 +140,8 @@ class EloquentCastTest extends MySqlTestCase
             'email' => fake()->unique()->email,
         ]);
 
-        $this->assertSame($updatedAt, $mutatorUser->updated_at->timestamp);
-        $this->assertSame($updatedAt, $mutatorUser->fresh()->updated_at->timestamp);
+        $this->assertSame($updatedAt, $mutatorUser->updated_at->getTimestamp());
+        $this->assertSame($updatedAt, $mutatorUser->fresh()->updated_at->getTimestamp());
     }
 }
 

--- a/tests/Integration/Database/MySql/EloquentCastTest.php
+++ b/tests/Integration/Database/MySql/EloquentCastTest.php
@@ -36,8 +36,8 @@ class EloquentCastTest extends MySqlTestCase
 
     public function testItCastTimestampsCreatedByTheBuilderWhenTimeHasNotPassed()
     {
-        Carbon::setTestNow(Carbon::now());
-        $createdAt = Carbon::now()->getTimestamp();
+        Carbon::setTestNow($now = Carbon::now());
+        $createdAt = $now->getTimestamp();
 
         $castUser = UserWithIntTimestampsViaCasts::create([
             'email' => fake()->unique()->email,
@@ -79,8 +79,8 @@ class EloquentCastTest extends MySqlTestCase
 
     public function testItCastTimestampsCreatedByTheBuilderWhenTimeHasPassed()
     {
-        Carbon::setTestNow(Carbon::now());
-        $createdAt = Carbon::now()->getTimestamp();
+        Carbon::setTestNow($now = Carbon::now());
+        $createdAt = $now->getTimestamp();
 
         $castUser = UserWithIntTimestampsViaCasts::create([
             'email' => fake()->unique()->email,
@@ -99,8 +99,8 @@ class EloquentCastTest extends MySqlTestCase
         $this->assertSame($createdAt, $mutatorUser->created_at->getTimestamp());
         $this->assertSame($createdAt, $mutatorUser->updated_at->getTimestamp());
 
-        Carbon::setTestNow(Carbon::now()->addSecond());
-        $updatedAt = Carbon::now()->getTimestamp();
+        Carbon::setTestNow($now->addSecond());
+        $updatedAt = $now->getTimestamp();
 
         $castUser->update([
             'email' => fake()->unique()->email,
@@ -125,7 +125,7 @@ class EloquentCastTest extends MySqlTestCase
 
     public function testItCastTimestampsUpdatedByAMutator()
     {
-        Carbon::setTestNow(Carbon::now());
+        Carbon::setTestNow($now = Carbon::now());
 
         $mutatorUser = UserWithUpdatedAtViaMutator::create([
             'email' => fake()->unique()->email,
@@ -133,8 +133,8 @@ class EloquentCastTest extends MySqlTestCase
 
         $this->assertNull($mutatorUser->updated_at);
 
-        Carbon::setTestNow(Carbon::now()->addSecond());
-        $updatedAt = Carbon::now()->getTimestamp();
+        Carbon::setTestNow($now->addSecond());
+        $updatedAt = $now->getTimestamp();
 
         $mutatorUser->update([
             'email' => fake()->unique()->email,

--- a/tests/Integration/Foundation/MaintenanceModeTest.php
+++ b/tests/Integration/Foundation/MaintenanceModeTest.php
@@ -268,8 +268,6 @@ class MaintenanceModeTest extends TestCase
 
         $expectedDate = Carbon::parse($datetime)->format(DateTimeInterface::RFC7231);
         $this->assertSame($expectedDate, $data['retry']);
-
-        Carbon::setTestNow();
     }
 
     public static function retryAfterDatetimeProvider(): array

--- a/tests/Integration/Http/RequestDurationThresholdTest.php
+++ b/tests/Integration/Http/RequestDurationThresholdTest.php
@@ -24,10 +24,10 @@ class RequestDurationThresholdTest extends TestCase
             $called = true;
         });
 
-        Carbon::setTestNow(Carbon::now());
+        Carbon::setTestNow($now = Carbon::now());
         $kernel->handle($request);
 
-        Carbon::setTestNow(Carbon::now()->addSecond()->addMillisecond());
+        Carbon::setTestNow($now->addSecond()->addMillisecond());
         $kernel->terminate($request, $response);
 
         $this->assertTrue($called);
@@ -44,10 +44,10 @@ class RequestDurationThresholdTest extends TestCase
             $called = true;
         });
 
-        Carbon::setTestNow(Carbon::now());
+        Carbon::setTestNow($now = Carbon::now());
         $kernel->handle($request);
 
-        Carbon::setTestNow(Carbon::now()->addSecond());
+        Carbon::setTestNow($now->addSecond());
         $kernel->terminate($request, $response);
 
         $this->assertFalse($called);
@@ -64,10 +64,10 @@ class RequestDurationThresholdTest extends TestCase
             $url = $request->url();
         });
 
-        Carbon::setTestNow(Carbon::now());
+        Carbon::setTestNow($now = Carbon::now());
         $kernel->handle($request);
 
-        Carbon::setTestNow(Carbon::now()->addSeconds(2));
+        Carbon::setTestNow($now->addSeconds(2));
         $kernel->terminate($request, $response);
 
         $this->assertSame('http://localhost/test-route', $url);
@@ -84,9 +84,9 @@ class RequestDurationThresholdTest extends TestCase
         });
 
         Config::set('app.timezone', 'Australia/Melbourne');
-        Carbon::setTestNow(Carbon::now()->startOfDay());
+        Carbon::setTestNow($now = Carbon::now()->startOfDay());
         $kernel->handle($request = Request::create('http://localhost/test-route'));
-        Carbon::setTestNow(Carbon::now()->addMinute());
+        Carbon::setTestNow($now->addMinute());
         $kernel->terminate($request, new Response);
 
         $this->assertSame('Australia/Melbourne', $startedAt->timezone->getName());
@@ -103,10 +103,10 @@ class RequestDurationThresholdTest extends TestCase
             $called = true;
         });
 
-        Carbon::setTestNow(Carbon::now());
+        Carbon::setTestNow($now = Carbon::now());
         $kernel->handle($request);
 
-        Carbon::setTestNow(Carbon::now()->addSecond()->addMillisecond());
+        Carbon::setTestNow($now->addSecond()->addMillisecond());
         $kernel->terminate($request, $response);
 
         $this->assertTrue($called);
@@ -123,10 +123,10 @@ class RequestDurationThresholdTest extends TestCase
             $called = true;
         });
 
-        Carbon::setTestNow(Carbon::now());
+        Carbon::setTestNow($now = Carbon::now());
         $kernel->handle($request);
 
-        Carbon::setTestNow(Carbon::now()->addSecond());
+        Carbon::setTestNow($now->addSecond());
         $kernel->terminate($request, $response);
 
         $this->assertFalse($called);
@@ -143,10 +143,10 @@ class RequestDurationThresholdTest extends TestCase
             $called = true;
         });
 
-        Carbon::setTestNow(Carbon::now());
+        Carbon::setTestNow($now = Carbon::now());
         $kernel->handle($request);
 
-        Carbon::setTestNow(Carbon::now()->addSecond()->addMillisecond());
+        Carbon::setTestNow($now->addSecond()->addMillisecond());
         $kernel->terminate($request, $response);
 
         $this->assertTrue($called);
@@ -163,10 +163,10 @@ class RequestDurationThresholdTest extends TestCase
             $called = true;
         });
 
-        Carbon::setTestNow(Carbon::now());
+        Carbon::setTestNow($now = Carbon::now());
         $kernel->handle($request);
 
-        Carbon::setTestNow(Carbon::now()->addSecond());
+        Carbon::setTestNow($now->addSecond());
         $kernel->terminate($request, $response);
 
         $this->assertFalse($called);
@@ -179,9 +179,9 @@ class RequestDurationThresholdTest extends TestCase
         $request = Request::create('http://localhost/test-route');
         $response = new Response();
 
-        Carbon::setTestNow(Carbon::now());
+        Carbon::setTestNow($now = Carbon::now());
         $kernel->handle($request);
-        $this->assertTrue(Carbon::now()->eq($kernel->requestStartedAt()));
+        $this->assertTrue($now->eq($kernel->requestStartedAt()));
 
         $kernel->terminate($request, $response);
         $this->assertNull($kernel->requestStartedAt());

--- a/tests/Integration/Mail/SendingMailWithLocaleTest.php
+++ b/tests/Integration/Mail/SendingMailWithLocaleTest.php
@@ -78,8 +78,6 @@ class SendingMailWithLocaleTest extends TestCase
         );
 
         $this->assertSame('en', Carbon::getLocale());
-
-        Carbon::setTestNow();
     }
 
     public function testLocaleIsSentWithModelPreferredLocale()

--- a/tests/Integration/Notifications/SendingNotificationsWithLocaleTest.php
+++ b/tests/Integration/Notifications/SendingNotificationsWithLocaleTest.php
@@ -142,8 +142,6 @@ class SendingNotificationsWithLocaleTest extends TestCase
         $this->assertTrue($this->app->isLocale('en'));
 
         $this->assertSame('en', Carbon::getLocale());
-
-        Carbon::setTestNow();
     }
 
     public function testLocaleIsSentWithNotifiablePreferredLocale()

--- a/tests/Integration/Session/DatabaseSessionHandlerTest.php
+++ b/tests/Integration/Session/DatabaseSessionHandlerTest.php
@@ -59,18 +59,18 @@ class DatabaseSessionHandlerTest extends DatabaseTestCase
         $connection = $this->app['db']->connection();
 
         $handler = new DatabaseSessionHandler($connection, 'sessions', 1, $this->app);
-        Carbon::setTestNow(Carbon::now());
+        Carbon::setTestNow($now = Carbon::now());
         $handler->write('simple_id_1', 'abcd');
         $this->assertEquals(0, $handler->gc(1));
 
-        Carbon::setTestNow(Carbon::now()->addSeconds(2));
+        Carbon::setTestNow($now->addSeconds(2));
 
         $handler = new DatabaseSessionHandler($connection, 'sessions', 1, $this->app);
         $handler->write('simple_id_2', 'abcd');
         $this->assertEquals(1, $handler->gc(2));
         $this->assertEquals(1, $connection->table('sessions')->count());
 
-        Carbon::setTestNow(Carbon::now()->addSeconds(2));
+        Carbon::setTestNow($now->addSeconds(2));
 
         $this->assertEquals(1, $handler->gc(1));
         $this->assertEquals(0, $connection->table('sessions')->count());

--- a/tests/Notifications/NotificationDatabaseChannelTest.php
+++ b/tests/Notifications/NotificationDatabaseChannelTest.php
@@ -18,13 +18,6 @@ class NotificationDatabaseChannelTest extends TestCase
         Carbon::setTestNow(Carbon::now());
     }
 
-    protected function tearDown(): void
-    {
-        Carbon::setTestNow();
-
-        parent::tearDown();
-    }
-
     public function testDatabaseChannelCreatesDatabaseRecordWithProperData()
     {
         $notification = new NotificationDatabaseChannelTestNotification;

--- a/tests/Queue/FileFailedJobProviderTest.php
+++ b/tests/Queue/FileFailedJobProviderTest.php
@@ -41,37 +41,33 @@ class FileFailedJobProviderTest extends TestCase
 
     public function testCanRetrieveAllFailedJobs()
     {
-        try {
-            Carbon::setTestNow(Carbon::now());
+        Carbon::setTestNow(Carbon::now());
 
-            [$uuidOne, $exceptionOne] = $this->logFailedJob();
-            [$uuidTwo, $exceptionTwo] = $this->logFailedJob();
+        [$uuidOne, $exceptionOne] = $this->logFailedJob();
+        [$uuidTwo, $exceptionTwo] = $this->logFailedJob();
 
-            $failedJobs = $this->provider->all();
+        $failedJobs = $this->provider->all();
 
-            $this->assertEquals([
-                (object) [
-                    'id' => $uuidTwo,
-                    'connection' => 'connection',
-                    'queue' => 'queue',
-                    'payload' => json_encode(['uuid' => $uuidTwo]),
-                    'exception' => (string) mb_convert_encoding($exceptionTwo, 'UTF-8'),
-                    'failed_at' => $failedJobs[1]->failed_at,
-                    'failed_at_timestamp' => $failedJobs[1]->failed_at_timestamp,
-                ],
-                (object) [
-                    'id' => $uuidOne,
-                    'connection' => 'connection',
-                    'queue' => 'queue',
-                    'payload' => json_encode(['uuid' => $uuidOne]),
-                    'exception' => (string) mb_convert_encoding($exceptionOne, 'UTF-8'),
-                    'failed_at' => $failedJobs[0]->failed_at,
-                    'failed_at_timestamp' => $failedJobs[0]->failed_at_timestamp,
-                ],
-            ], $failedJobs);
-        } finally {
-            Carbon::setTestNow();
-        }
+        $this->assertEquals([
+            (object) [
+                'id' => $uuidTwo,
+                'connection' => 'connection',
+                'queue' => 'queue',
+                'payload' => json_encode(['uuid' => $uuidTwo]),
+                'exception' => (string) mb_convert_encoding($exceptionTwo, 'UTF-8'),
+                'failed_at' => $failedJobs[1]->failed_at,
+                'failed_at_timestamp' => $failedJobs[1]->failed_at_timestamp,
+            ],
+            (object) [
+                'id' => $uuidOne,
+                'connection' => 'connection',
+                'queue' => 'queue',
+                'payload' => json_encode(['uuid' => $uuidOne]),
+                'exception' => (string) mb_convert_encoding($exceptionOne, 'UTF-8'),
+                'failed_at' => $failedJobs[0]->failed_at,
+                'failed_at_timestamp' => $failedJobs[0]->failed_at_timestamp,
+            ],
+        ], $failedJobs);
     }
 
     public function testCanFindFailedJobs()

--- a/tests/Queue/QueueBeanstalkdQueueTest.php
+++ b/tests/Queue/QueueBeanstalkdQueueTest.php
@@ -52,7 +52,6 @@ class QueueBeanstalkdQueueTest extends TestCase
 
         $this->container->shouldHaveReceived('bound')->with('events')->times(4);
 
-        Carbon::setTestNow();
         Str::createUuidsNormally();
     }
 
@@ -78,7 +77,6 @@ class QueueBeanstalkdQueueTest extends TestCase
 
         $this->container->shouldHaveReceived('bound')->with('events')->times(4);
 
-        Carbon::setTestNow();
         Str::createUuidsNormally();
     }
 

--- a/tests/Queue/QueueDatabaseQueueUnitTest.php
+++ b/tests/Queue/QueueDatabaseQueueUnitTest.php
@@ -95,7 +95,6 @@ class QueueDatabaseQueueUnitTest extends TestCase
 
         $container->shouldHaveReceived('bound')->with('events')->twice();
 
-        Carbon::setTestNow();
         Str::createUuidsNormally();
     }
 
@@ -232,7 +231,6 @@ class QueueDatabaseQueueUnitTest extends TestCase
 
         $queue->bulk(['foo', 'bar'], ['data'], 'queue');
 
-        Carbon::setTestNow();
         Str::createUuidsNormally();
     }
 

--- a/tests/Queue/QueuePauseResumeTest.php
+++ b/tests/Queue/QueuePauseResumeTest.php
@@ -50,7 +50,6 @@ class QueuePauseResumeTest extends TestCase
 
     public function testPauseQueueWithTTL()
     {
-        Carbon::setTestNow();
         $this->manager->pauseFor('redis', 'default', 30);
 
         $this->assertTrue($this->manager->isPaused('redis', 'default'));
@@ -61,7 +60,6 @@ class QueuePauseResumeTest extends TestCase
 
     public function testPauseQueueIndefinitely()
     {
-        Carbon::setTestNow();
         $this->manager->pause('redis', 'default');
 
         $this->assertTrue($this->manager->isPaused('redis', 'default'));

--- a/tests/Queue/QueueRedisQueueTest.php
+++ b/tests/Queue/QueueRedisQueueTest.php
@@ -38,7 +38,6 @@ class QueueRedisQueueTest extends TestCase
         $this->assertSame('foo', $id);
         $container->shouldHaveReceived('bound')->with('events')->twice();
 
-        Carbon::setTestNow();
         Str::createUuidsNormally();
     }
 
@@ -70,7 +69,6 @@ class QueueRedisQueueTest extends TestCase
 
         Queue::createPayloadUsing(null);
 
-        Carbon::setTestNow();
         Str::createUuidsNormally();
     }
 
@@ -106,7 +104,6 @@ class QueueRedisQueueTest extends TestCase
 
         Queue::createPayloadUsing(null);
 
-        Carbon::setTestNow();
         Str::createUuidsNormally();
     }
 
@@ -140,7 +137,6 @@ class QueueRedisQueueTest extends TestCase
         $this->assertSame('foo', $id);
         $container->shouldHaveReceived('bound')->with('events')->twice();
 
-        Carbon::setTestNow();
         Str::createUuidsNormally();
     }
 
@@ -172,7 +168,6 @@ class QueueRedisQueueTest extends TestCase
         $queue->later($date->addSeconds(5), 'foo', ['data']);
         $container->shouldHaveReceived('bound')->with('events')->twice();
 
-        Carbon::setTestNow();
         Str::createUuidsNormally();
     }
 
@@ -322,7 +317,6 @@ class QueueRedisQueueTest extends TestCase
 
         $queue->push('foo', ['data']);
 
-        Carbon::setTestNow();
         Str::createUuidsNormally();
     }
 
@@ -358,7 +352,6 @@ class QueueRedisQueueTest extends TestCase
         $this->assertSame('queues:default', $receivedQueue);
 
         Queue::createPayloadUsing(null);
-        Carbon::setTestNow();
         Str::createUuidsNormally();
     }
 

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -47,8 +47,6 @@ class QueueWorkerTest extends TestCase
 
     protected function tearDown(): void
     {
-        Carbon::setTestNow();
-
         Container::setInstance();
 
         parent::tearDown();

--- a/tests/Session/ArraySessionHandlerTest.php
+++ b/tests/Session/ArraySessionHandlerTest.php
@@ -9,13 +9,6 @@ use SessionHandlerInterface;
 
 class ArraySessionHandlerTest extends TestCase
 {
-    protected function tearDown(): void
-    {
-        Carbon::setTestNow();
-
-        parent::tearDown();
-    }
-
     public function test_it_implements_the_session_handler_interface()
     {
         $this->assertInstanceOf(SessionHandlerInterface::class, new ArraySessionHandler(10));

--- a/tests/Session/ArraySessionHandlerTest.php
+++ b/tests/Session/ArraySessionHandlerTest.php
@@ -41,10 +41,10 @@ class ArraySessionHandlerTest extends TestCase
     {
         $handler = new ArraySessionHandler(10);
 
-        Carbon::setTestNow(Carbon::now());
+        Carbon::setTestNow($now = Carbon::now());
         $handler->write('foo', 'bar');
 
-        Carbon::setTestNow(Carbon::now()->addMinutes(10));
+        Carbon::setTestNow($now->addMinutes(10));
         $this->assertSame('bar', $handler->read('foo'));
     }
 
@@ -52,10 +52,10 @@ class ArraySessionHandlerTest extends TestCase
     {
         $handler = new ArraySessionHandler(10);
 
-        Carbon::setTestNow(Carbon::now());
+        Carbon::setTestNow($now = Carbon::now());
         $handler->write('foo', 'bar');
 
-        Carbon::setTestNow(Carbon::now()->addMinutes(10)->addSecond());
+        Carbon::setTestNow($now->addMinutes(10)->addSecond());
         $this->assertSame('', $handler->read('foo'));
     }
 
@@ -95,16 +95,16 @@ class ArraySessionHandlerTest extends TestCase
 
         $this->assertSame(0, $handler->gc(300));
 
-        Carbon::setTestNow(Carbon::now());
+        Carbon::setTestNow($now = Carbon::now());
         $handler->write('foo', 'bar');
         $this->assertSame(0, $handler->gc(300));
         $this->assertSame('bar', $handler->read('foo'));
 
-        Carbon::setTestNow(Carbon::now()->addSecond());
+        Carbon::setTestNow($now->addSecond());
 
         $handler->write('baz', 'qux');
 
-        Carbon::setTestNow(Carbon::now()->addMinutes(5));
+        Carbon::setTestNow($now->addMinutes(5));
 
         $this->assertSame(1, $handler->gc(300));
         $this->assertSame('', $handler->read('foo'));

--- a/tests/Support/SleepTest.php
+++ b/tests/Support/SleepTest.php
@@ -18,8 +18,6 @@ class SleepTest extends TestCase
     {
         Sleep::fake(false);
 
-        Carbon::setTestNow();
-
         parent::tearDown();
     }
 

--- a/tests/Support/SupportCarbonTest.php
+++ b/tests/Support/SupportCarbonTest.php
@@ -25,7 +25,6 @@ class SupportCarbonTest extends TestCase
 
     protected function tearDown(): void
     {
-        Carbon::setTestNow();
         Carbon::serializeUsing(null);
 
         parent::tearDown();

--- a/tests/Support/SupportLazyCollectionTest.php
+++ b/tests/Support/SupportLazyCollectionTest.php
@@ -278,7 +278,6 @@ class SupportLazyCollectionTest extends TestCase
         $this->assertSame([1, 2, 3], $data);
 
         Sleep::fake(false);
-        Carbon::setTestNow();
     }
 
     public function testUniqueDoubleEnumeration()
@@ -509,8 +508,6 @@ class SupportLazyCollectionTest extends TestCase
             ],
             $output->all(),
         );
-
-        Carbon::setTestNow();
     }
 
     public function testRandomPreservesKeys()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -42,13 +42,6 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 class ValidationValidatorTest extends TestCase
 {
-    protected function tearDown(): void
-    {
-        Carbon::setTestNow();
-
-        parent::tearDown();
-    }
-
     public function testNestedErrorMessagesAreRetrievedFromLocalArray()
     {
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
Centralizes `Carbon::setTestNow()` resetting into `AfterEachTestSubscriber`, removes ~53 now-redundant per-test resets, and tidies a few non-idiomatic Carbon calls (`->timestamp` → `->getTimestamp()`, `addDays(7)` → `addWeek()`, manual now()-comparisons → `isPast()`/`isFuture()`).