### PR TITLE
[13.x] Wipe all connections used by pending migrations in migrate:fresh

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/FreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/FreshCommand.php
@@ -69,6 +69,10 @@ class FreshCommand extends BaseCommand
             $this->migrator->getConnectionsForMigrations($this->getMigrationPaths())
         ))));
 
+        if (empty($connections)) {
+            $connections = [$database];
+        }
+
         $this->migrator->usingConnection($database, function () use ($connections) {
             try {
                 $repositoryExists = $this->migrator->repositoryExists();

--- a/src/Illuminate/Database/Console/Migrations/FreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/FreshCommand.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Throwable;
 
 #[AsCommand(name: 'migrate:fresh')]
-class FreshCommand extends Command
+class FreshCommand extends BaseCommand
 {
     use ConfirmableTrait, Prohibitable;
 
@@ -64,7 +64,12 @@ class FreshCommand extends Command
 
         $database = $this->input->getOption('database');
 
-        $this->migrator->usingConnection($database, function () use ($database) {
+        $connections = array_values(array_unique(array_filter(array_merge(
+            [$database],
+            $this->migrator->getConnectionsForPendingMigrations($this->getMigrationPaths())
+        ))));
+
+        $this->migrator->usingConnection($database, function () use ($connections) {
             try {
                 $repositoryExists = $this->migrator->repositoryExists();
             } catch (Throwable) {
@@ -74,12 +79,17 @@ class FreshCommand extends Command
             if ($repositoryExists) {
                 $this->newLine();
 
-                $this->components->task('Dropping all tables', fn () => $this->callSilent('db:wipe', array_filter([
-                    '--database' => $database,
-                    '--drop-views' => $this->option('drop-views'),
-                    '--drop-types' => $this->option('drop-types'),
-                    '--force' => true,
-                ])) == 0);
+                foreach ($connections as $connection) {
+                    $this->components->task(
+                        "Dropping all tables [{$connection}]",
+                        fn () => $this->callSilent('db:wipe', array_filter([
+                                '--database' => $connection,
+                                '--drop-views' => $this->option('drop-views'),
+                                '--drop-types' => $this->option('drop-types'),
+                                '--force' => true,
+                            ])) == 0
+                    );
+                }
             }
         });
 

--- a/src/Illuminate/Database/Console/Migrations/FreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/FreshCommand.php
@@ -83,11 +83,11 @@ class FreshCommand extends BaseCommand
                     $this->components->task(
                         "Dropping all tables [{$connection}]",
                         fn () => $this->callSilent('db:wipe', array_filter([
-                                '--database' => $connection,
-                                '--drop-views' => $this->option('drop-views'),
-                                '--drop-types' => $this->option('drop-types'),
-                                '--force' => true,
-                            ])) == 0
+                            '--database' => $connection,
+                            '--drop-views' => $this->option('drop-views'),
+                            '--drop-types' => $this->option('drop-types'),
+                            '--force' => true,
+                        ])) == 0
                     );
                 }
             }

--- a/src/Illuminate/Database/Console/Migrations/FreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/FreshCommand.php
@@ -66,7 +66,7 @@ class FreshCommand extends BaseCommand
 
         $connections = array_values(array_unique(array_filter(array_merge(
             [$database],
-            $this->migrator->getConnectionsForPendingMigrations($this->getMigrationPaths())
+            $this->migrator->getConnectionsForMigrations($this->getMigrationPaths())
         ))));
 
         $this->migrator->usingConnection($database, function () use ($connections) {

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -870,4 +870,26 @@ class Migrator
     {
         $this->events?->dispatch($event);
     }
+
+    /**
+     * Get connections from migrations
+     *
+     * @param  array  $paths
+     * @return  array
+     */
+    public function getConnectionsForPendingMigrations(array $paths): array
+    {
+        $files = $this->getMigrationFiles($paths);
+
+        $this->requireFiles($migrations = $this->pendingMigrations(
+            $files, $this->repository->getRan()
+        ));
+
+        return collect($migrations)
+            ->map(fn ($file) => $this->resolvePath($file))
+            ->map(fn ($migration) => $migration->getConnection() ?: $this->resolver->getDefaultConnection())
+            ->unique()
+            ->values()
+            ->all();
+    }
 }

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -884,7 +884,7 @@ class Migrator
         $files = $this->getMigrationFiles($paths);
 
         foreach ($files as $file) {
-            $migration = $this->resolve($file);
+            $migration = $this->resolvePath($file);
 
             $connectionName = $migration->getConnection()
                 ?: $this->connection

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -872,24 +872,27 @@ class Migrator
     }
 
     /**
-     * Get connections from migrations.
+     * Get the unique database connection names used by the migration files.
      *
      * @param  array  $paths
      * @return array
      */
-    public function getConnectionsForPendingMigrations(array $paths): array
+    public function getConnectionsForMigrations(array $paths): array
     {
+        $connections = [];
+
         $files = $this->getMigrationFiles($paths);
 
-        $this->requireFiles($migrations = $this->pendingMigrations(
-            $files, $this->repository->getRan()
-        ));
+        foreach ($files as $file) {
+            $migration = $this->resolve($file);
 
-        return collect($migrations)
-            ->map(fn ($file) => $this->resolvePath($file))
-            ->map(fn ($migration) => $migration->getConnection() ?: $this->resolver->getDefaultConnection())
-            ->unique()
-            ->values()
-            ->all();
+            $connectionName = $migration->getConnection()
+                ?: $this->connection
+                    ?: $this->resolver->getDefaultConnection();
+
+            $connections[] = $connectionName;
+        }
+
+        return array_values(array_unique($connections));
     }
 }

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -872,10 +872,10 @@ class Migrator
     }
 
     /**
-     * Get connections from migrations
+     * Get connections from migrations.
      *
      * @param  array  $paths
-     * @return  array
+     * @return array
      */
     public function getConnectionsForPendingMigrations(array $paths): array
     {

--- a/tests/Database/DatabaseMigrationFreshCommandMultiConnectionTest.php
+++ b/tests/Database/DatabaseMigrationFreshCommandMultiConnectionTest.php
@@ -49,7 +49,7 @@ class DatabaseMigrationFreshCommandMultiConnectionTest extends TestCase
             ->once()
             ->andReturn(true);
 
-        $migrator->shouldReceive('getConnectionsForPendingMigrations')
+        $migrator->shouldReceive('getConnectionsForMigrations')
             ->once()
             ->andReturn(['mysql', 'mysql2']);
 

--- a/tests/Database/DatabaseMigrationFreshCommandMultiConnectionTest.php
+++ b/tests/Database/DatabaseMigrationFreshCommandMultiConnectionTest.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Database\Console\Migrations\FreshCommand;
+use Illuminate\Database\Console\Migrations\MigrateCommand;
+use Illuminate\Database\Console\WipeCommand;
+use Illuminate\Database\Events\DatabaseRefreshed;
+use Illuminate\Database\Migrations\Migrator;
+use Illuminate\Foundation\Application;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application as ConsoleApplication;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+
+class DatabaseMigrationFreshCommandMultiConnectionTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        FreshCommand::prohibit(false);
+
+        parent::tearDown();
+    }
+
+    public function testFreshWipesEveryConnectionUsedByPendingMigrations()
+    {
+        $command = new FreshCommand($migrator = m::mock(Migrator::class));
+
+        $app = new ApplicationDatabaseFreshMultiConnStub(['path.database' => __DIR__]);
+        $dispatcher = $app->instance(Dispatcher::class, m::mock());
+
+        $console = m::mock(ConsoleApplication::class)->makePartial();
+        $console->__construct();
+
+        $command->setLaravel($app);
+        $command->setApplication($console);
+
+        $migrator->shouldReceive('paths')->once()->andReturn([]);
+
+        $migrator->shouldReceive('usingConnection')
+            ->once()
+            ->andReturnUsing(function ($name, $callback) {
+                return $callback();
+            });
+
+        $migrator->shouldReceive('repositoryExists')
+            ->once()
+            ->andReturn(true);
+
+        $migrator->shouldReceive('getConnectionsForPendingMigrations')
+            ->once()
+            ->andReturn(['mysql', 'mysql2']);
+
+        $wipeCommand = m::mock(WipeCommand::class);
+        $migrateCommand = m::mock(MigrateCommand::class);
+
+        $console->shouldReceive('find')->with('db:wipe')->andReturn($wipeCommand);
+        $console->shouldReceive('find')->with('migrate')->andReturn($migrateCommand);
+
+        $wipeCommand->shouldReceive('run')
+            ->with(
+                m::on(function (ArrayInput $input) {
+                    $string = (string) $input;
+
+                    return str_contains($string, 'db:wipe')
+                        && str_contains($string, '--force')
+                        && str_contains($string, '--database=mysql')
+                        && ! str_contains($string, '--database=mysql2');
+                }),
+                m::any()
+            )
+            ->once()
+            ->andReturn(0);
+
+        $wipeCommand->shouldReceive('run')
+            ->with(
+                m::on(function (ArrayInput $input) {
+                    $string = (string) $input;
+
+                    return str_contains($string, 'db:wipe')
+                        && str_contains($string, '--force')
+                        && str_contains($string, '--database=mysql2');
+                }),
+                m::any()
+            )
+            ->once()
+            ->andReturn(0);
+
+        $migrateCommand->shouldReceive('run')
+            ->with(
+                m::on(function ($input) {
+                    $string = (string) $input;
+
+                    return str_contains($string, 'migrate') && str_contains($string, '--force');
+                }),
+                m::any()
+            )
+            ->once()
+            ->andReturn(0);
+
+        $dispatcher->shouldReceive('dispatch')
+            ->once()
+            ->with(m::type(DatabaseRefreshed::class));
+
+        $this->runCommand($command);
+    }
+
+    protected function runCommand($command, $input = [])
+    {
+        return $command->run(new ArrayInput($input), new NullOutput);
+    }
+}
+
+class ApplicationDatabaseFreshMultiConnStub extends Application
+{
+    public function __construct(array $data = [])
+    {
+        parent::__construct();
+
+        foreach ($data as $abstract => $instance) {
+            $this->instance($abstract, $instance);
+        }
+    }
+
+    public function environment(...$environments)
+    {
+        return 'development';
+    }
+}

--- a/tests/Database/DatabaseMigratorTwoConnectionsTest.php
+++ b/tests/Database/DatabaseMigratorTwoConnectionsTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Container\Container;
+use Illuminate\Database\Connection;
+use Illuminate\Database\ConnectionResolverInterface;
+use Illuminate\Database\Migrations\MigrationRepositoryInterface;
+use Illuminate\Database\Migrations\Migrator;
+use Illuminate\Database\Schema\Builder as SchemaBuilder;
+use Illuminate\Database\Schema\Grammars\MySqlGrammar;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Facades\Facade;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseMigratorTwoConnectionsTest extends TestCase
+{
+    protected $tmpMigrationsPath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->tmpMigrationsPath = sys_get_temp_dir().'/migrator_two_conn_test_'.uniqid();
+        mkdir($this->tmpMigrationsPath);
+
+        file_put_contents(
+            $this->tmpMigrationsPath.'/2024_01_01_000000_create_secondary_table.php',
+            <<<'PHP'
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    protected $connection = 'mysql2';
+
+    public function up(): void
+    {
+        Schema::connection($this->connection)->create('secondary_table', function ($table) {
+            $table->id();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::connection($this->connection)->dropIfExists('secondary_table');
+    }
+};
+PHP
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        array_map('unlink', glob($this->tmpMigrationsPath.'/*'));
+        rmdir($this->tmpMigrationsPath);
+
+        m::close();
+
+        parent::tearDown();
+    }
+
+    public function testFreshOnOneConnectionDoesNotTouchTheOther()
+    {
+        $files = new Filesystem;
+
+        $repository = m::mock(MigrationRepositoryInterface::class);
+        $repository->shouldReceive('getRan')->andReturn([]);
+        $repository->shouldReceive('getNextBatchNumber')->andReturn(1);
+        $repository->shouldReceive('log')->zeroOrMoreTimes();
+        $repository->shouldReceive('setSource')->zeroOrMoreTimes();
+
+        $mysqlSchema = m::mock(SchemaBuilder::class);
+        $mysql2Schema = m::mock(SchemaBuilder::class);
+
+        $mysqlConnection = m::mock(Connection::class);
+        $mysqlConnection->shouldReceive('getSchemaBuilder')->andReturn($mysqlSchema);
+        $mysqlConnection->shouldReceive('getSchemaGrammar')->andReturn(new MySqlGrammar($mysqlConnection));
+        $mysqlConnection->shouldReceive('getName')->andReturn('mysql');
+        $mysqlConnection->shouldReceive('hasDirectConnection')->once()->andReturn(false);
+
+        $mysql2Connection = m::mock(Connection::class);
+        $mysql2Connection->shouldReceive('getSchemaBuilder')->andReturn($mysql2Schema);
+        $mysql2Connection->shouldReceive('getSchemaGrammar')->andReturn(new MySqlGrammar($mysql2Connection));
+        $mysql2Connection->shouldReceive('getName')->andReturn('mysql2');
+        $mysql2Connection->shouldReceive('hasDirectConnection')->once()->andReturn(false);
+        $mysql2Connection->shouldReceive('getNameWithReadWriteType')->once()->andReturn('mysql::direct');
+
+        $resolver = m::mock(ConnectionResolverInterface::class);
+        $resolver->shouldReceive('connection')->with('mysql')->andReturn($mysqlConnection);
+        $resolver->shouldReceive('connection')->with('mysql2')->andReturn($mysql2Connection);
+        $resolver->shouldReceive('setDefaultConnection');
+        $resolver->shouldReceive('getDefaultConnection')->andReturn('mysql');
+
+        $container = new Container;
+        $container->instance('db', $resolver);
+        Facade::setFacadeApplication($container);
+
+        $migrator = new Migrator($repository, $resolver, $files);
+
+        $mysql2Schema->shouldReceive('create')->once();
+
+        $migrator->usingConnection('mysql', function () use ($migrator) {
+            $migrator->run([$this->tmpMigrationsPath]);
+        });
+    }
+}

--- a/tests/Database/DatabaseMigratorTwoConnectionsTest.php
+++ b/tests/Database/DatabaseMigratorTwoConnectionsTest.php
@@ -58,6 +58,9 @@ PHP
         array_map('unlink', glob($this->tmpMigrationsPath.'/*'));
         rmdir($this->tmpMigrationsPath);
 
+        Facade::clearResolvedInstances();
+        Facade::setFacadeApplication(null);
+
         m::close();
 
         parent::tearDown();


### PR DESCRIPTION
### Problem

`migrate:fresh` (and the underlying `db:wipe`) only drops tables from the
connection passed via `--database` (or the app's default connection).
However, an individual migration may target a different connection via its
`$connection` property (or `Schema::connection('...')` inside `up()`), and
that connection's tables are never wiped by `migrate:fresh`.

This means that on a second `migrate:fresh` run, migrations for that other
connection can fail (e.g. "table already exists"), or leave stale data
behind - `migrate:fresh` no longer guarantees a truly fresh state, only for
the connection you happened to pass to `--database`.

Fixes https://github.com/laravel/framework/issues/55194

### Solution

- Added `Migrator::getConnectionsForMigrations(array $paths): array`,
  which inspects the connection declared on each pending migration
  (`$migration->getConnection()`), falling back to the default connection
  for migrations that don't override it.
- `FreshCommand::handle()` now wipes every connection returned by that method. 
   The connection passed via `--database` (or the app default) is still wiped as a fallback 
   when no pending migrations declare a connection, so commands with no migration files at all keep working as before.
- `migrate` is still invoked exactly once, unchanged - it already resolves
  each migration's own connection correctly; only the *wipe* step was
  missing coverage.

### Behavior change / backward compatibility

If a migration declares a `$connection` different from the one passed to
`--database`, `migrate:fresh` will now also wipe that connection. Previously
it silently left it untouched. This is a behavior change for anyone relying
on the old (arguably buggy) behavior of leaving other connections alone -
happy to gate this behind a flag (e.g. `--single-database`) if maintainers
prefer opt-in instead of default-on.

### Tests

- `DatabaseMigratorTwoConnectionsTest` - verifies a migration whose
  `$connection` differs from the one passed to `usingConnection()` is still
  correctly run against its own connection (unchanged, legitimate behavior).
- `DatabaseMigrationFreshCommandMultiConnectionTest` - verifies
  `migrate:fresh` calls `db:wipe` once per connection used by pending
  migrations, and `migrate` exactly once.