### PR TITLE
Add none() method to Query Builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1311,6 +1311,16 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Force the query to return no results.
+     *
+     * @return $this
+     */
+    public function none()
+    {
+        return $this->whereRaw('0 = 1');
+    }
+
+    /**
      * Add a "where like" clause to the query.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1621,6 +1621,22 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1, 1 => 'foo'], $builder->getBindings());
     }
 
+    public function testNone()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->none();
+        $this->assertSame('select * from "users" where 0 = 1', $builder->toSql());
+        $this->assertSame([], $builder->getBindings());
+    }
+
+    public function testNoneWithExistingWheres()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('active', true)->none();
+        $this->assertSame('select * from "users" where "active" = ? and 0 = 1', $builder->toSql());
+        $this->assertEquals([true], $builder->getBindings());
+    }
+
     public function testBasicWhereIns()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
## Description

Adds a `none()` method to the query builder that constrains the query to return no results by applying a `WHERE 0 = 1` clause.

```php
// Before
$query->whereRaw('0 = 1');
$query->whereIn('id', []);
$query->whereKey([]);

// After
$query->none();
```

Laravel already provides expressive methods for common query intentions such as `exists()`, `doesntExist()`, `latest()`, `oldest()`, and `whereKey()`.

Returning an empty result set is another common intention, but today developers must rely on implementation details:

```php
$query->whereRaw('0 = 1');
$query->whereIn('id', []);
$query->whereKey([]);
```

A dedicated `none()` method makes this intent explicit, improves readability, and provides a framework-standard API for expressing that a query should never return any rows, while allowing Laravel to change the underlying implementation in the future if needed.

The method is implemented on `Query\Builder` and is automatically available on `Eloquent\Builder` through the existing `forwardCallTo` delegation.

## Usage

### Query filters

A filter may determine that no records should ever match, while still allowing the caller to continue composing the query.

```php
class PermissionFilter
{
    public function apply(Builder $query): void
    {
        if (! auth()->user()?->can('view-reports')) {
            $query->none();
        }
    }
}
```

```php
$query = Report::query();

$permissionFilter->apply($query);
$searchFilter->apply($query);
$sortFilter->apply($query);

return $query->paginate();
```

### Conditional scopes

```php
public function scopeVisibleTo(Builder $query, ?User $user)
{
    if (! $user) {
        return $query->none();
    }

    return $query->whereBelongsTo($user);
}
```

### Pipelines

A pipeline stage can invalidate the query without interrupting the pipeline itself.

```php
Pipeline::send(User::query())
    ->through([
        TenantFilter::class,
        PermissionFilter::class,
        SearchFilter::class,
    ])
    ->thenReturn()
    ->paginate();
```

```php
class PermissionFilter
{
    public function handle(Builder $query, Closure $next)
    {
        if (! auth()->user()?->can('view-users')) {
            $query->none();
        }

        return $next($query);
    }
}
```

### Feature flags

```php
$query = Report::query();

if (! Feature::active('reports')) {
    $query->none();
}

return $query
    ->latest()
    ->paginate();
```

### Repositories

```php
public function queryFor(User $user): Builder
{
    $query = Order::query();

    if ($user->isSuspended()) {
        return $query->none();
    }

    return $query->whereBelongsTo($user);
}
```

In all of these examples, `none()` expresses the intent directly instead of relying on implementation details such as `whereRaw('0 = 1')` or `whereKey([])`.