### PR TITLE
[13.x] Send SQS bulk batches concurrently for standard queues

### DIFF
--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -34,7 +34,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
      *
      * @var int
      */
-    const MAX_CONCURRENT_BATCH_REQUESTS = 10;
+    const MAX_CONCURRENT_BATCH_REQUESTS = 50;
 
     /**
      * The cache key prefix for extended SQS payloads.

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -318,9 +318,6 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
     /**
      * Push an array of jobs onto the queue using the SendMessageBatch API.
      *
-     * Standard queue batches are sent concurrently, while FIFO queue batches
-     * are sent one at a time so messages cannot arrive out of order.
-     *
      * @param  array  $jobs
      * @param  mixed  $data
      * @param  string|null  $queue
@@ -399,9 +396,6 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
     /**
      * Build entries, raise queueing events, dispatch chunks, and raise queued events with SQS message IDs.
      *
-     * The first failed chunk aborts the dispatch: its exception is rethrown
-     * and chunks that have not been dispatched yet will never be sent.
-     *
      * @param  array  $messages
      * @param  string|null  $queue
      * @return void
@@ -423,7 +417,6 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
 
         $chunks = $this->chunkBatchEntries($entries);
 
-        // Requests are created lazily so a failure stops any further chunks from being dispatched...
         $requests = function () use ($chunks, $queueUrl) {
             foreach ($chunks as $index => $chunk) {
                 yield $index => $this->sqs->sendMessageBatchAsync([
@@ -433,9 +426,6 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
             }
         };
 
-        // FIFO queues require ordering, so chunks are dispatched one at a time and later messages
-        // cannot arrive ahead of unsent ones. Standard queues make no ordering guarantees, so
-        // their chunks may be dispatched concurrently for much higher total throughput...
         Each::ofLimitAll(
             $requests(),
             str_ends_with($queueUrl, '.fifo') ? 1 : static::MAX_CONCURRENT_BATCH_REQUESTS,

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -399,8 +399,8 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
     /**
      * Build entries, raise queueing events, dispatch chunks, and raise queued events with SQS message IDs.
      *
-     * Once a chunk fails, no further chunks are dispatched, and the earliest
-     * failure is thrown after every in-flight request has settled.
+     * The first failed chunk aborts the dispatch: its exception is rethrown
+     * and chunks that have not been dispatched yet will never be sent.
      *
      * @param  array  $messages
      * @param  string|null  $queue
@@ -423,15 +423,9 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
 
         $chunks = $this->chunkBatchEntries($entries);
 
-        [$results, $failures, $halted] = [[], [], false];
-
         // Requests are created lazily so a failure stops any further chunks from being dispatched...
-        $requests = function () use ($chunks, $queueUrl, &$halted) {
+        $requests = function () use ($chunks, $queueUrl) {
             foreach ($chunks as $index => $chunk) {
-                if ($halted) {
-                    return;
-                }
-
                 yield $index => $this->sqs->sendMessageBatchAsync([
                     'QueueUrl' => $queueUrl,
                     'Entries' => $chunk,
@@ -442,40 +436,18 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
         // FIFO queues require ordering, so chunks are dispatched one at a time and later messages
         // cannot arrive ahead of unsent ones. Standard queues make no ordering guarantees, so
         // their chunks may be dispatched concurrently for much higher total throughput...
-        Each::ofLimit(
+        Each::ofLimitAll(
             $requests(),
             str_ends_with($queueUrl, '.fifo') ? 1 : static::MAX_CONCURRENT_BATCH_REQUESTS,
-            function ($result, $index) use (&$results, &$halted) {
-                $results[$index] = $result;
+            function ($result, $index, $aggregate) use ($chunks, $messages, $queue, $queueUrl) {
+                $this->raiseJobQueuedEventsForBatchResult($result, $messages, $queue);
 
-                $halted = $halted || ! empty($result['Failed']);
-            },
-            function ($reason, $index) use (&$failures, &$halted) {
-                $failures[$index] = $reason;
-
-                $halted = true;
+                // A batch can return HTTP 200 while rejecting entries, so surface those failures as an SqsException...
+                if (! empty($result['Failed'])) {
+                    $aggregate->reject($this->toBatchEntriesFailedException($result, $chunks[$index], $queueUrl));
+                }
             },
         )->wait();
-
-        ksort($results);
-
-        // Every message accepted by SQS raises a queued event, even when another chunk failed...
-        foreach ($results as $result) {
-            $this->raiseJobQueuedEventsForBatchResult($result, $messages, $queue);
-        }
-
-        // A batch can return HTTP 200 while rejecting entries, so surface those failures as an SqsException...
-        foreach ($results as $index => $result) {
-            if (! empty($result['Failed'])) {
-                $failures[$index] = $this->toBatchEntriesFailedException($result, $chunks[$index], $queueUrl);
-            }
-        }
-
-        if (! empty($failures)) {
-            ksort($failures);
-
-            throw reset($failures);
-        }
     }
 
     /**

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -5,6 +5,7 @@ namespace Illuminate\Queue;
 use Aws\Command;
 use Aws\Sqs\Exception\SqsException;
 use Aws\Sqs\SqsClient;
+use GuzzleHttp\Promise\Each;
 use Illuminate\Contracts\Queue\ClearableQueue;
 use Illuminate\Contracts\Queue\Queue as QueueContract;
 use Illuminate\Queue\Jobs\SqsJob;
@@ -27,6 +28,13 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
      * @var int
      */
     const MAX_MESSAGES_PER_BATCH = 10;
+
+    /**
+     * The maximum number of concurrent SendMessageBatch requests for standard queues.
+     *
+     * @var int
+     */
+    const MAX_CONCURRENT_BATCH_REQUESTS = 10;
 
     /**
      * The cache key prefix for extended SQS payloads.
@@ -310,6 +318,9 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
     /**
      * Push an array of jobs onto the queue using the SendMessageBatch API.
      *
+     * Standard queue batches are sent concurrently, while FIFO queue batches
+     * are sent one at a time so messages cannot arrive out of order.
+     *
      * @param  array  $jobs
      * @param  mixed  $data
      * @param  string|null  $queue
@@ -388,6 +399,9 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
     /**
      * Build entries, raise queueing events, dispatch chunks, and raise queued events with SQS message IDs.
      *
+     * Once a chunk fails, no further chunks are dispatched, and the earliest
+     * failure is thrown after every in-flight request has settled.
+     *
      * @param  array  $messages
      * @param  string|null  $queue
      * @return void
@@ -407,46 +421,113 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
 
         $queueUrl = $this->getQueue($queue);
 
-        // Dispatch chunks and stop at the first failure so later messages cannot arrive ahead of unsent ones...
-        foreach ($this->chunkBatchEntries($entries) as $chunk) {
-            $result = $this->sqs->sendMessageBatch([
-                'QueueUrl' => $queueUrl,
-                'Entries' => $chunk,
-            ]);
+        $chunks = $this->chunkBatchEntries($entries);
 
-            foreach ($result['Successful'] ?? [] as $success) {
-                if (! isset($messages[$success['Id']])) {
-                    continue;
+        [$results, $failures, $halted] = [[], [], false];
+
+        // Requests are created lazily so a failure stops any further chunks from being dispatched...
+        $requests = function () use ($chunks, $queueUrl, &$halted) {
+            foreach ($chunks as $index => $chunk) {
+                if ($halted) {
+                    return;
                 }
 
-                $message = $messages[$success['Id']];
-
-                $this->raiseJobQueuedEvent(
-                    $queue, $success['MessageId'], $message['job'], $message['payload'], $message['delay']
-                );
+                yield $index => $this->sqs->sendMessageBatchAsync([
+                    'QueueUrl' => $queueUrl,
+                    'Entries' => $chunk,
+                ]);
             }
+        };
 
-            // A batch can return HTTP 200 while rejecting entries, so surface those failures as an SqsException...
+        // FIFO queues require ordering, so chunks are dispatched one at a time and later messages
+        // cannot arrive ahead of unsent ones. Standard queues make no ordering guarantees, so
+        // their chunks may be dispatched concurrently for much higher total throughput...
+        Each::ofLimit(
+            $requests(),
+            str_ends_with($queueUrl, '.fifo') ? 1 : static::MAX_CONCURRENT_BATCH_REQUESTS,
+            function ($result, $index) use (&$results, &$halted) {
+                $results[$index] = $result;
+
+                $halted = $halted || ! empty($result['Failed']);
+            },
+            function ($reason, $index) use (&$failures, &$halted) {
+                $failures[$index] = $reason;
+
+                $halted = true;
+            },
+        )->wait();
+
+        ksort($results);
+
+        // Every message accepted by SQS raises a queued event, even when another chunk failed...
+        foreach ($results as $result) {
+            $this->raiseJobQueuedEventsForBatchResult($result, $messages, $queue);
+        }
+
+        // A batch can return HTTP 200 while rejecting entries, so surface those failures as an SqsException...
+        foreach ($results as $index => $result) {
             if (! empty($result['Failed'])) {
-                $failure = $result['Failed'][0];
-
-                throw new SqsException(
-                    sprintf(
-                        'SQS SendMessageBatch rejected [%d] of [%d] messages. First failure [%s]: %s',
-                        count($result['Failed']),
-                        count($chunk),
-                        $failure['Code'] ?? 'Unknown',
-                        $failure['Message'] ?? '',
-                    ),
-                    new Command('SendMessageBatch', ['QueueUrl' => $queueUrl, 'Entries' => $chunk]),
-                    [
-                        'code' => $failure['Code'] ?? null,
-                        'message' => $failure['Message'] ?? null,
-                        'result' => $result,
-                    ],
-                );
+                $failures[$index] = $this->toBatchEntriesFailedException($result, $chunks[$index], $queueUrl);
             }
         }
+
+        if (! empty($failures)) {
+            ksort($failures);
+
+            throw reset($failures);
+        }
+    }
+
+    /**
+     * Raise the queued events for entries accepted by SQS in the given batch result.
+     *
+     * @param  \Aws\Result  $result
+     * @param  array  $messages
+     * @param  string|null  $queue
+     * @return void
+     */
+    protected function raiseJobQueuedEventsForBatchResult($result, array $messages, $queue)
+    {
+        foreach ($result['Successful'] ?? [] as $success) {
+            if (! isset($messages[$success['Id']])) {
+                continue;
+            }
+
+            $message = $messages[$success['Id']];
+
+            $this->raiseJobQueuedEvent(
+                $queue, $success['MessageId'], $message['job'], $message['payload'], $message['delay']
+            );
+        }
+    }
+
+    /**
+     * Create the exception for a batch result that was accepted with rejected entries.
+     *
+     * @param  \Aws\Result  $result
+     * @param  array  $chunk
+     * @param  string  $queueUrl
+     * @return \Aws\Sqs\Exception\SqsException
+     */
+    protected function toBatchEntriesFailedException($result, array $chunk, $queueUrl)
+    {
+        $failure = $result['Failed'][0];
+
+        return new SqsException(
+            sprintf(
+                'SQS SendMessageBatch rejected [%d] of [%d] messages. First failure [%s]: %s',
+                count($result['Failed']),
+                count($chunk),
+                $failure['Code'] ?? 'Unknown',
+                $failure['Message'] ?? '',
+            ),
+            new Command('SendMessageBatch', ['QueueUrl' => $queueUrl, 'Entries' => $chunk]),
+            [
+                'code' => $failure['Code'] ?? null,
+                'message' => $failure['Message'] ?? null,
+                'result' => $result,
+            ],
+        );
     }
 
     /**

--- a/tests/Foundation/Cloud/QueueTest.php
+++ b/tests/Foundation/Cloud/QueueTest.php
@@ -8,6 +8,7 @@ use Aws\HandlerList;
 use Aws\MockHandler;
 use Aws\Result;
 use Aws\Sqs\SqsClient;
+use GuzzleHttp\Promise\Create;
 use Illuminate\Contracts\Encryption\DecryptException;
 use Illuminate\Database\LostConnectionDetector;
 use Illuminate\Foundation\Cloud;
@@ -917,9 +918,9 @@ class QueueTest extends TestCase
         $eventsFake = $this->fakeEvents();
         [$queue, $client] = $this->mockedQueue();
         $client->shouldReceive('sendMessage')->times(5)->andReturn(new Result());
-        $client->shouldReceive('sendMessageBatch')->once()->andReturnUsing(fn ($args) => new Result([
+        $client->shouldReceive('sendMessageBatchAsync')->once()->andReturnUsing(fn ($args) => Create::promiseFor(new Result([
             'Successful' => array_map(fn ($entry) => ['Id' => $entry['Id'], 'MessageId' => 'id'], $args['Entries']),
-        ]));
+        ])));
 
         $queue->push(new FakeJob, queue: '1');
         $queue->pushOn('2', new FakeJob);
@@ -1197,9 +1198,9 @@ class QueueTest extends TestCase
         $this->app['config']->set('queue.connections.cloud.connection.after_commit', true);
         [$queue, $client] = $this->mockedQueue();
         $client->shouldReceive('sendMessage')->times(5)->andReturn(new Result());
-        $client->shouldReceive('sendMessageBatch')->once()->andReturnUsing(fn ($args) => new Result([
+        $client->shouldReceive('sendMessageBatchAsync')->once()->andReturnUsing(fn ($args) => Create::promiseFor(new Result([
             'Successful' => array_map(fn ($entry) => ['Id' => $entry['Id'], 'MessageId' => 'id'], $args['Entries']),
-        ]));
+        ])));
 
         DB::beginTransaction();
 

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Queue;
 use Aws\Result;
 use Aws\Sqs\Exception\SqsException;
 use Aws\Sqs\SqsClient;
+use GuzzleHttp\Promise\Create;
 use Illuminate\Bus\Dispatcher;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Bus\Dispatcher as DispatcherContract;
@@ -980,16 +981,16 @@ class QueueSqsQueueTest extends TestCase
 
         $captured = null;
 
-        $this->sqs->shouldReceive('sendMessageBatch')->once()->with(m::on(function ($args) use (&$captured) {
+        $this->sqs->shouldReceive('sendMessageBatchAsync')->once()->with(m::on(function ($args) use (&$captured) {
             $captured = $args;
 
             return true;
-        }))->andReturn(new Result([
+        }))->andReturn(Create::promiseFor(new Result([
             'Successful' => [
                 ['Id' => 'placeholder', 'MessageId' => 'mid-1'],
             ],
             'Failed' => [],
-        ]));
+        ])));
 
         $queue->bulk(['a', 'b', 'c'], 'data', $this->queueName);
 
@@ -1010,11 +1011,11 @@ class QueueSqsQueueTest extends TestCase
 
         $batchSizes = [];
 
-        $this->sqs->shouldReceive('sendMessageBatch')->twice()->with(m::on(function ($args) use (&$batchSizes) {
+        $this->sqs->shouldReceive('sendMessageBatchAsync')->twice()->with(m::on(function ($args) use (&$batchSizes) {
             $batchSizes[] = count($args['Entries']);
 
             return true;
-        }))->andReturn(new Result(['Successful' => [], 'Failed' => []]));
+        }))->andReturnUsing(fn () => Create::promiseFor(new Result(['Successful' => [], 'Failed' => []])));
 
         $queue->bulk(range(1, 15), 'data', $this->queueName);
 
@@ -1035,11 +1036,11 @@ class QueueSqsQueueTest extends TestCase
 
         $batchSizes = [];
 
-        $this->sqs->shouldReceive('sendMessageBatch')->twice()->with(m::on(function ($args) use (&$batchSizes) {
+        $this->sqs->shouldReceive('sendMessageBatchAsync')->twice()->with(m::on(function ($args) use (&$batchSizes) {
             $batchSizes[] = count($args['Entries']);
 
             return true;
-        }))->andReturn(new Result(['Successful' => [], 'Failed' => []]));
+        }))->andReturnUsing(fn () => Create::promiseFor(new Result(['Successful' => [], 'Failed' => []])));
 
         $queue->bulk(['a', 'b'], 'data', $this->queueName);
 
@@ -1068,14 +1069,14 @@ class QueueSqsQueueTest extends TestCase
         $queue->expects($this->once())->method('getQueue')->willReturn($this->queueUrl);
         $queue->method('createPayload')->willReturnCallback(fn ($job) => "payload-{$job}");
 
-        $this->sqs->shouldReceive('sendMessageBatch')->once()->andReturnUsing(function ($args) {
+        $this->sqs->shouldReceive('sendMessageBatchAsync')->once()->andReturnUsing(function ($args) {
             $successful = array_map(
                 fn ($entry, $i) => ['Id' => $entry['Id'], 'MessageId' => 'mid-'.$i],
                 $args['Entries'],
                 array_keys($args['Entries'])
             );
 
-            return new Result(['Successful' => $successful, 'Failed' => []]);
+            return Create::promiseFor(new Result(['Successful' => $successful, 'Failed' => []]));
         });
 
         $queue->bulk(['a', 'b'], 'data', $this->queueName);
@@ -1106,11 +1107,11 @@ class QueueSqsQueueTest extends TestCase
 
         $captured = null;
 
-        $this->sqs->shouldReceive('sendMessageBatch')->once()->with(m::on(function ($args) use (&$captured) {
+        $this->sqs->shouldReceive('sendMessageBatchAsync')->once()->with(m::on(function ($args) use (&$captured) {
             $captured = $args;
 
             return true;
-        }))->andReturn(new Result(['Successful' => [], 'Failed' => []]));
+        }))->andReturn(Create::promiseFor(new Result(['Successful' => [], 'Failed' => []])));
 
         $queue->bulk([$jobA, $jobB], 'data', $this->queueName);
 
@@ -1128,13 +1129,13 @@ class QueueSqsQueueTest extends TestCase
         $queue->expects($this->once())->method('getQueue')->willReturn($this->queueUrl);
         $queue->expects($this->once())->method('createPayload')->willReturn('payload-a');
 
-        $this->sqs->shouldReceive('sendMessageBatch')->once()->andReturnUsing(function ($args) {
-            return new Result([
+        $this->sqs->shouldReceive('sendMessageBatchAsync')->once()->andReturnUsing(function ($args) {
+            return Create::promiseFor(new Result([
                 'Successful' => [],
                 'Failed' => [
                     ['Id' => $args['Entries'][0]['Id'], 'Code' => 'InternalError', 'Message' => 'oops', 'SenderFault' => false],
                 ],
-            ]);
+            ]));
         });
 
         try {
@@ -1164,11 +1165,11 @@ class QueueSqsQueueTest extends TestCase
 
         $captured = [];
 
-        $this->sqs->shouldReceive('sendMessageBatch')->twice()->with(m::on(function ($args) use (&$captured) {
+        $this->sqs->shouldReceive('sendMessageBatchAsync')->twice()->with(m::on(function ($args) use (&$captured) {
             $captured[] = $args;
 
             return true;
-        }))->andReturn(new Result(['Successful' => [], 'Failed' => []]));
+        }))->andReturnUsing(fn () => Create::promiseFor(new Result(['Successful' => [], 'Failed' => []])));
 
         $queue->bulk(range(1, 15), 'data', $this->fifoQueueName);
 
@@ -1189,7 +1190,7 @@ class QueueSqsQueueTest extends TestCase
         $queue->method('createPayload')->willReturnCallback(fn ($job) => "payload-{$job}");
 
         // Only the first chunk is attempted; its exception propagates untouched and later chunks are not sent.
-        $this->sqs->shouldReceive('sendMessageBatch')->once()->andThrow(new RuntimeException('SQS is down'));
+        $this->sqs->shouldReceive('sendMessageBatchAsync')->once()->andReturn(Create::rejectionFor(new RuntimeException('SQS is down')));
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('SQS is down');
@@ -1225,10 +1226,10 @@ class QueueSqsQueueTest extends TestCase
 
         $sent = false;
 
-        $this->sqs->shouldReceive('sendMessageBatch')->once()->andReturnUsing(function () use (&$sent) {
+        $this->sqs->shouldReceive('sendMessageBatchAsync')->once()->andReturnUsing(function () use (&$sent) {
             $sent = true;
 
-            return new Result(['Successful' => [], 'Failed' => []]);
+            return Create::promiseFor(new Result(['Successful' => [], 'Failed' => []]));
         });
 
         $queue->bulk([$job], 'data', $this->queueName);
@@ -1294,11 +1295,11 @@ class QueueSqsQueueTest extends TestCase
 
         $captured = null;
 
-        $this->sqs->shouldReceive('sendMessageBatch')->once()->with(m::on(function ($args) use (&$captured) {
+        $this->sqs->shouldReceive('sendMessageBatchAsync')->once()->with(m::on(function ($args) use (&$captured) {
             $captured = $args;
 
             return true;
-        }))->andReturn(new Result(['Successful' => [], 'Failed' => []]));
+        }))->andReturn(Create::promiseFor(new Result(['Successful' => [], 'Failed' => []])));
 
         $queue->bulk([$job], 'data', $this->fifoQueueName);
 
@@ -1332,19 +1333,19 @@ class QueueSqsQueueTest extends TestCase
 
         $calls = 0;
 
-        $this->sqs->shouldReceive('sendMessageBatch')->twice()->andReturnUsing(function ($args) use (&$calls) {
+        $this->sqs->shouldReceive('sendMessageBatchAsync')->twice()->andReturnUsing(function ($args) use (&$calls) {
             if ($calls++ === 0) {
-                return new Result([
+                return Create::promiseFor(new Result([
                     'Successful' => array_map(
                         fn ($entry, $i) => ['Id' => $entry['Id'], 'MessageId' => 'mid-'.$i],
                         $args['Entries'],
                         array_keys($args['Entries'])
                     ),
                     'Failed' => [],
-                ]);
+                ]));
             }
 
-            throw new RuntimeException('chunk failed');
+            return Create::rejectionFor(new RuntimeException('chunk failed'));
         });
 
         try {
@@ -1355,10 +1356,170 @@ class QueueSqsQueueTest extends TestCase
             $this->assertSame('chunk failed', $e->getMessage());
         }
 
-        // The first chunk was queued before the second failed, so its queued events must already have fired.
+        // The first chunk reached SQS even though the second chunk failed, so its queued events must have fired.
         $queuedEvents = array_filter($dispatched, fn ($e) => $e instanceof \Illuminate\Queue\Events\JobQueued);
 
         $this->assertCount(10, $queuedEvents);
+    }
+
+    public function testBulkSendsStandardMultiChunkBatchesConcurrently()
+    {
+        $events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class);
+        $dispatched = [];
+        $events->shouldReceive('dispatch')->andReturnUsing(function ($event) use (&$dispatched) {
+            $dispatched[] = $event;
+        });
+
+        $container = m::mock(Container::class);
+        $container->shouldReceive('bound')->with('events')->andReturn(true);
+        $container->shouldReceive('bound')->with('db.transactions')->andReturn(false);
+        $container->shouldReceive('offsetGet')->with('events')->andReturn($events);
+
+        $queue = $this->getMockBuilder(SqsQueue::class)
+            ->onlyMethods(['getQueue', 'createPayload'])
+            ->setConstructorArgs([$this->sqs, $this->queueName, $this->account])
+            ->getMock();
+        $queue->setContainer($container);
+        $queue->setConnectionName('sqs');
+        $queue->expects($this->once())->method('getQueue')->willReturn($this->queueUrl);
+        $queue->method('createPayload')->willReturnCallback(fn ($job) => "payload-{$job}");
+
+        $this->sqs->shouldReceive('sendMessageBatchAsync')->twice()->andReturnUsing(function ($args) {
+            return Create::promiseFor(new Result([
+                'Successful' => array_map(
+                    fn ($entry) => ['Id' => $entry['Id'], 'MessageId' => 'mid-'.$entry['Id']],
+                    $args['Entries']
+                ),
+                'Failed' => [],
+            ]));
+        });
+
+        $queue->bulk(range(1, 15), 'data', $this->queueName);
+
+        // Queued events are raised in message order once every chunk has settled...
+        $queuedEvents = array_values(array_filter($dispatched, fn ($e) => $e instanceof \Illuminate\Queue\Events\JobQueued));
+
+        $this->assertCount(15, $queuedEvents);
+        $this->assertSame(
+            array_map(fn ($id) => 'mid-'.$id, range(0, 14)),
+            array_map(fn ($e) => $e->id, $queuedEvents)
+        );
+    }
+
+    public function testBulkStopsLaunchingBatchesAfterAFailureOnStandardQueues()
+    {
+        $events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class);
+        $dispatched = [];
+        $events->shouldReceive('dispatch')->andReturnUsing(function ($event) use (&$dispatched) {
+            $dispatched[] = $event;
+        });
+
+        $container = m::mock(Container::class);
+        $container->shouldReceive('bound')->with('events')->andReturn(true);
+        $container->shouldReceive('bound')->with('db.transactions')->andReturn(false);
+        $container->shouldReceive('offsetGet')->with('events')->andReturn($events);
+
+        $queue = $this->getMockBuilder(SqsQueue::class)
+            ->onlyMethods(['getQueue', 'createPayload'])
+            ->setConstructorArgs([$this->sqs, $this->queueName, $this->account])
+            ->getMock();
+        $queue->setContainer($container);
+        $queue->setConnectionName('sqs');
+        $queue->expects($this->once())->method('getQueue')->willReturn($this->queueUrl);
+        $queue->method('createPayload')->willReturnCallback(fn ($job) => "payload-{$job}");
+
+        $calls = 0;
+
+        // Eleven chunks are prepared, but only the first ten may be launched: the first request's
+        // failure must prevent the final chunk from ever being dispatched...
+        $this->sqs->shouldReceive('sendMessageBatchAsync')->times(10)->andReturnUsing(function ($args) use (&$calls) {
+            if ($calls++ === 0) {
+                return Create::rejectionFor(new RuntimeException('SQS is down'));
+            }
+
+            return Create::promiseFor(new Result([
+                'Successful' => array_map(
+                    fn ($entry) => ['Id' => $entry['Id'], 'MessageId' => 'mid-'.$entry['Id']],
+                    $args['Entries']
+                ),
+                'Failed' => [],
+            ]));
+        });
+
+        try {
+            $queue->bulk(range(1, 110), 'data', $this->queueName);
+
+            $this->fail('RuntimeException was not thrown.');
+        } catch (RuntimeException $e) {
+            $this->assertSame('SQS is down', $e->getMessage());
+        }
+
+        // The nine in-flight chunks settled successfully, so their queued events must have fired...
+        $queuedEvents = array_filter($dispatched, fn ($e) => $e instanceof \Illuminate\Queue\Events\JobQueued);
+
+        $this->assertCount(90, $queuedEvents);
+    }
+
+    public function testBulkThrowsForFailedEntriesAfterStandardChunksSettle()
+    {
+        $events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class);
+        $dispatched = [];
+        $events->shouldReceive('dispatch')->andReturnUsing(function ($event) use (&$dispatched) {
+            $dispatched[] = $event;
+        });
+
+        $container = m::mock(Container::class);
+        $container->shouldReceive('bound')->with('events')->andReturn(true);
+        $container->shouldReceive('bound')->with('db.transactions')->andReturn(false);
+        $container->shouldReceive('offsetGet')->with('events')->andReturn($events);
+
+        $queue = $this->getMockBuilder(SqsQueue::class)
+            ->onlyMethods(['getQueue', 'createPayload'])
+            ->setConstructorArgs([$this->sqs, $this->queueName, $this->account])
+            ->getMock();
+        $queue->setContainer($container);
+        $queue->setConnectionName('sqs');
+        $queue->expects($this->once())->method('getQueue')->willReturn($this->queueUrl);
+        $queue->method('createPayload')->willReturnCallback(fn ($job) => "payload-{$job}");
+
+        $calls = 0;
+
+        $this->sqs->shouldReceive('sendMessageBatchAsync')->twice()->andReturnUsing(function ($args) use (&$calls) {
+            $successful = array_map(
+                fn ($entry) => ['Id' => $entry['Id'], 'MessageId' => 'mid-'.$entry['Id']],
+                $args['Entries']
+            );
+
+            if ($calls++ === 0) {
+                $failed = array_shift($successful);
+
+                return Create::promiseFor(new Result([
+                    'Successful' => $successful,
+                    'Failed' => [
+                        ['Id' => $failed['Id'], 'Code' => 'InternalError', 'Message' => 'oops', 'SenderFault' => false],
+                    ],
+                ]));
+            }
+
+            return Create::promiseFor(new Result(['Successful' => $successful, 'Failed' => []]));
+        });
+
+        try {
+            $queue->bulk(range(1, 15), 'data', $this->queueName);
+
+            $this->fail('SqsException was not thrown.');
+        } catch (SqsException $e) {
+            $this->assertSame(
+                'SQS SendMessageBatch rejected [1] of [10] messages. First failure [InternalError]: oops',
+                $e->getMessage()
+            );
+        }
+
+        // Every accepted message raises a queued event, including the second chunk's, before the failure is thrown...
+        $queuedEvents = array_values(array_filter($dispatched, fn ($e) => $e instanceof \Illuminate\Queue\Events\JobQueued));
+
+        $this->assertCount(14, $queuedEvents);
+        $this->assertContains('mid-10', array_map(fn ($e) => $e->id, $queuedEvents));
     }
 
     public function testBulkRethrowsTheOriginalExceptionWhenASingleBatchRequestFails()
@@ -1371,7 +1532,7 @@ class QueueSqsQueueTest extends TestCase
         $queue->expects($this->once())->method('getQueue')->willReturn($this->queueUrl);
         $queue->expects($this->once())->method('createPayload')->willReturn('payload-a');
 
-        $this->sqs->shouldReceive('sendMessageBatch')->once()->andThrow(new RuntimeException('SQS is down'));
+        $this->sqs->shouldReceive('sendMessageBatchAsync')->once()->andReturn(Create::rejectionFor(new RuntimeException('SQS is down')));
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('SQS is down');
@@ -1384,7 +1545,7 @@ class QueueSqsQueueTest extends TestCase
         $queue = new SqsQueue($this->sqs, $this->queueName, $this->account);
         $queue->setContainer(m::mock(Container::class));
 
-        $this->sqs->shouldNotReceive('sendMessageBatch');
+        $this->sqs->shouldNotReceive('sendMessageBatchAsync');
 
         $queue->bulk([], 'data', $this->queueName);
     }

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -1418,9 +1418,9 @@ class QueueSqsQueueTest extends TestCase
 
         $calls = 0;
 
-        // Eleven chunks are prepared, but only the first ten may be launched: the first request's
-        // failure must prevent the final chunk from ever being dispatched...
-        $this->sqs->shouldReceive('sendMessageBatchAsync')->times(10)->andReturnUsing(function () use (&$calls) {
+        // One more chunk is prepared than the concurrency limit allows in flight: the first
+        // request's failure must prevent the final chunk from ever being dispatched...
+        $this->sqs->shouldReceive('sendMessageBatchAsync')->times(SqsQueue::MAX_CONCURRENT_BATCH_REQUESTS)->andReturnUsing(function () use (&$calls) {
             if ($calls++ === 0) {
                 return Create::rejectionFor(new RuntimeException('SQS is down'));
             }
@@ -1429,7 +1429,11 @@ class QueueSqsQueueTest extends TestCase
         });
 
         try {
-            $queue->bulk(range(1, 110), 'data', $this->queueName);
+            $queue->bulk(
+                range(1, (SqsQueue::MAX_CONCURRENT_BATCH_REQUESTS + 1) * SqsQueue::MAX_MESSAGES_PER_BATCH),
+                'data',
+                $this->queueName
+            );
 
             $this->fail('RuntimeException was not thrown.');
         } catch (RuntimeException $e) {
@@ -1437,7 +1441,7 @@ class QueueSqsQueueTest extends TestCase
         }
 
         // Only the initial concurrent window of requests may ever be launched...
-        $this->assertSame(10, $calls);
+        $this->assertSame(SqsQueue::MAX_CONCURRENT_BATCH_REQUESTS, $calls);
     }
 
     public function testBulkThrowsForFailedEntriesOnStandardQueues()

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -1396,7 +1396,7 @@ class QueueSqsQueueTest extends TestCase
 
         $queue->bulk(range(1, 15), 'data', $this->queueName);
 
-        // Queued events are raised in message order once every chunk has settled...
+        // Queued events are raised for each chunk as it settles...
         $queuedEvents = array_values(array_filter($dispatched, fn ($e) => $e instanceof \Illuminate\Queue\Events\JobQueued));
 
         $this->assertCount(15, $queuedEvents);
@@ -1408,23 +1408,11 @@ class QueueSqsQueueTest extends TestCase
 
     public function testBulkStopsLaunchingBatchesAfterAFailureOnStandardQueues()
     {
-        $events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class);
-        $dispatched = [];
-        $events->shouldReceive('dispatch')->andReturnUsing(function ($event) use (&$dispatched) {
-            $dispatched[] = $event;
-        });
-
-        $container = m::mock(Container::class);
-        $container->shouldReceive('bound')->with('events')->andReturn(true);
-        $container->shouldReceive('bound')->with('db.transactions')->andReturn(false);
-        $container->shouldReceive('offsetGet')->with('events')->andReturn($events);
-
         $queue = $this->getMockBuilder(SqsQueue::class)
             ->onlyMethods(['getQueue', 'createPayload'])
             ->setConstructorArgs([$this->sqs, $this->queueName, $this->account])
             ->getMock();
-        $queue->setContainer($container);
-        $queue->setConnectionName('sqs');
+        $queue->setContainer(m::spy(Container::class));
         $queue->expects($this->once())->method('getQueue')->willReturn($this->queueUrl);
         $queue->method('createPayload')->willReturnCallback(fn ($job) => "payload-{$job}");
 
@@ -1432,18 +1420,12 @@ class QueueSqsQueueTest extends TestCase
 
         // Eleven chunks are prepared, but only the first ten may be launched: the first request's
         // failure must prevent the final chunk from ever being dispatched...
-        $this->sqs->shouldReceive('sendMessageBatchAsync')->times(10)->andReturnUsing(function ($args) use (&$calls) {
+        $this->sqs->shouldReceive('sendMessageBatchAsync')->times(10)->andReturnUsing(function () use (&$calls) {
             if ($calls++ === 0) {
                 return Create::rejectionFor(new RuntimeException('SQS is down'));
             }
 
-            return Create::promiseFor(new Result([
-                'Successful' => array_map(
-                    fn ($entry) => ['Id' => $entry['Id'], 'MessageId' => 'mid-'.$entry['Id']],
-                    $args['Entries']
-                ),
-                'Failed' => [],
-            ]));
+            return Create::promiseFor(new Result(['Successful' => [], 'Failed' => []]));
         });
 
         try {
@@ -1454,13 +1436,11 @@ class QueueSqsQueueTest extends TestCase
             $this->assertSame('SQS is down', $e->getMessage());
         }
 
-        // The nine in-flight chunks settled successfully, so their queued events must have fired...
-        $queuedEvents = array_filter($dispatched, fn ($e) => $e instanceof \Illuminate\Queue\Events\JobQueued);
-
-        $this->assertCount(90, $queuedEvents);
+        // Only the initial concurrent window of requests may ever be launched...
+        $this->assertSame(10, $calls);
     }
 
-    public function testBulkThrowsForFailedEntriesAfterStandardChunksSettle()
+    public function testBulkThrowsForFailedEntriesOnStandardQueues()
     {
         $events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class);
         $dispatched = [];
@@ -1515,7 +1495,7 @@ class QueueSqsQueueTest extends TestCase
             );
         }
 
-        // Every accepted message raises a queued event, including the second chunk's, before the failure is thrown...
+        // Messages accepted before the failure was observed still raise queued events...
         $queuedEvents = array_values(array_filter($dispatched, fn ($e) => $e instanceof \Illuminate\Queue\Events\JobQueued));
 
         $this->assertCount(14, $queuedEvents);


### PR DESCRIPTION
Since #60645, `SqsQueue::bulk()` dispatches jobs via the `SendMessageBatch` API, splitting them into chunks of 10 messages / 1 MB and sending the chunks one at a time. Sequential dispatch is required for FIFO queues — a later chunk must not arrive ahead of an unsent one — but standard queues make no ordering guarantees, so a large bulk dispatch currently pays for hundreds of serial HTTP round-trips it doesn't need (a 10,000 job bulk is 1,000 sequential requests).

This PR dispatches the batch requests concurrently when the queue is a standard queue, while keeping FIFO dispatch strictly ordered.

## How it works

The chunk requests are yielded lazily from a generator and driven by `GuzzleHttp\Promise\Each::ofLimitAll()`, so "sequential vs. concurrent" is simply the concurrency argument:

- **FIFO queues** run at a concurrency of `1`: the next request is not created until the previous one has settled, preserving today's ordering and stop-at-first-failure behavior exactly.
- **Standard queues** run at `SqsQueue::MAX_CONCURRENT_BATCH_REQUESTS` (50), which subclasses may override.

Laziness matters here: a promise created by `sendMessageBatchAsync()` is already registered on the shared curl multi handle, and the first `wait()` transmits every registered transfer at once. Because requests only come into existence when the pool pulls them from the generator, un-launched chunks remain genuinely un-launched.

## Failure semantics

The same contract as every other driver's `bulk()`, where a failed `push()` simply throws: the first failed chunk rejects the aggregate promise, its exception is rethrown untouched, and chunks that were not yet dispatched are never sent. Entry-level failures inside an HTTP 200 response are surfaced as the same synthesized `SqsException` as before, with an unchanged message format.

As with the sequential implementation — or any driver failing mid-`bulk()` — a thrown exception means the dispatch may have partially completed: chunks accepted before the failure are on the queue and have raised their `JobQueued` events, and with concurrent dispatch up to forty-nine in-flight chunks may additionally land after the failure. SQS standard queues are at-least-once delivery, so consumers of bulk dispatch at this scale should already be idempotent.

The AWS SDK for PHP has no native handling for any of this — `sendMessageBatch` rejects more than 10 entries outright, and unlike the Java SDK's buffered SQS client (or the PHP SDK's own DynamoDB `WriteRequestBatch`), it offers no chunking or parallel dispatch for SQS.

On Guzzle handlers without `curl_multi` support (e.g. the stream handler), the standard-queue path gracefully degrades to sequential execution with identical results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

