### PR TITLE
[13.x] Support `Delay` attribute when using `Bus::batch` & bulk

### DIFF
--- a/src/Illuminate/Queue/BeanstalkdQueue.php
+++ b/src/Illuminate/Queue/BeanstalkdQueue.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Queue;
 
 use Illuminate\Contracts\Queue\Queue as QueueContract;
+use Illuminate\Queue\Attributes\Delay;
 use Illuminate\Queue\Jobs\BeanstalkdJob;
 use Illuminate\Support\Collection;
 use Pheanstalk\Contract\JobIdInterface;
@@ -265,8 +266,10 @@ class BeanstalkdQueue extends Queue implements QueueContract
     public function bulk($jobs, $data = '', $queue = null)
     {
         foreach ((array) $jobs as $job) {
-            if (isset($job->delay)) {
-                $this->later($job->delay, $job, $data, $queue);
+            $delay = is_object($job) ? $this->getAttributeValue($job, Delay::class, 'delay') : null;
+
+            if (isset($delay)) {
+                $this->later($delay, $job, $data, $queue);
             } else {
                 $this->push($job, $data, $queue);
             }

--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -5,6 +5,7 @@ namespace Illuminate\Queue;
 use Illuminate\Contracts\Queue\ClearableQueue;
 use Illuminate\Contracts\Queue\Queue as QueueContract;
 use Illuminate\Database\Connection;
+use Illuminate\Queue\Attributes\Delay;
 use Illuminate\Queue\Jobs\DatabaseJob;
 use Illuminate\Queue\Jobs\DatabaseJobRecord;
 use Illuminate\Queue\Jobs\InspectedJob;
@@ -308,10 +309,12 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
 
         return $this->database->table($this->table)->insert((new Collection((array) $jobs))->map(
             function ($job) use ($queue, $data, $now) {
+                $delay = is_object($job) ? $this->getAttributeValue($job, Delay::class, 'delay') : null;
+
                 return $this->buildDatabaseRecord(
                     $queue,
                     $this->createPayload($job, $this->getQueue($queue), $data),
-                    isset($job->delay) ? $this->availableAt($job->delay) : $now,
+                    isset($delay) ? $this->availableAt($delay) : $now,
                 );
             }
         )->all());

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -5,6 +5,7 @@ namespace Illuminate\Queue;
 use Illuminate\Contracts\Queue\ClearableQueue;
 use Illuminate\Contracts\Queue\Queue as QueueContract;
 use Illuminate\Contracts\Redis\Factory as Redis;
+use Illuminate\Queue\Attributes\Delay;
 use Illuminate\Queue\Jobs\InspectedJob;
 use Illuminate\Queue\Jobs\RedisJob;
 use Illuminate\Redis\Connections\Connection;
@@ -271,8 +272,10 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
 
         $bulk = function () use ($jobs, $data, $queue) {
             foreach ((array) $jobs as $job) {
-                if (isset($job->delay)) {
-                    $this->later($job->delay, $job, $data, $queue);
+                $delay = is_object($job) ? $this->getAttributeValue($job, Delay::class, 'delay') : null;
+
+                if (isset($delay)) {
+                    $this->later($delay, $job, $data, $queue);
                 } else {
                     $this->push($job, $data, $queue);
                 }

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -7,6 +7,7 @@ use Aws\Sqs\Exception\SqsException;
 use Aws\Sqs\SqsClient;
 use Illuminate\Contracts\Queue\ClearableQueue;
 use Illuminate\Contracts\Queue\Queue as QueueContract;
+use Illuminate\Queue\Attributes\Delay;
 use Illuminate\Queue\Jobs\SqsJob;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
@@ -374,7 +375,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
     {
         return (new Collection($jobs))
             ->map(function ($job) use ($data, $queue) {
-                $delay = is_object($job) ? ($job->delay ?? null) : null;
+                $delay = is_object($job) ? $this->getAttributeValue($job, Delay::class, 'delay') : null;
 
                 return [
                     'job' => $job,

--- a/tests/Queue/Fixtures/FakeSqsJobWithDelayAttribute.php
+++ b/tests/Queue/Fixtures/FakeSqsJobWithDelayAttribute.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\Tests\Queue\Fixtures;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Queue\Attributes\Delay;
+
+#[Delay(15)]
+class FakeSqsJobWithDelayAttribute implements ShouldQueue
+{
+    use Queueable;
+
+    public function handle(): void
+    {
+        //
+    }
+}

--- a/tests/Queue/QueueBeanstalkdQueueTest.php
+++ b/tests/Queue/QueueBeanstalkdQueueTest.php
@@ -87,13 +87,10 @@ class QueueBeanstalkdQueueTest extends TestCase
     {
         $this->setQueue('default', 60);
         $pheanstalk = $this->queue->getPheanstalk();
-        $pheanstalk->shouldReceive('useTube')->twice()->with(m::type(TubeName::class));
+        $pheanstalk->shouldReceive('useTube')->once()->with(m::type(TubeName::class));
         $pheanstalk->shouldReceive('put')->once()->with(m::type('string'), Pheanstalk::DEFAULT_PRIORITY, 15, Pheanstalk::DEFAULT_TTR);
-        $pheanstalk->shouldReceive('put')->once()->with(m::type('string'), 1024, 0, 60);
 
-        $this->queue->bulk([new BeanstalkdJobWithDelayAttribute, 'foo'], ['data']);
-
-        $this->container->shouldHaveReceived('bound')->with('events')->times(4);
+        $this->queue->bulk([new BeanstalkdJobWithDelayAttribute], ['data']);
     }
 
     public function testPopProperlyPopsJobOffOfBeanstalkd()

--- a/tests/Queue/QueueBeanstalkdQueueTest.php
+++ b/tests/Queue/QueueBeanstalkdQueueTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Queue;
 
 use Illuminate\Container\Container;
+use Illuminate\Queue\Attributes\Delay;
 use Illuminate\Queue\BeanstalkdQueue;
 use Illuminate\Queue\Jobs\BeanstalkdJob;
 use Illuminate\Support\Carbon;
@@ -82,6 +83,19 @@ class QueueBeanstalkdQueueTest extends TestCase
         Str::createUuidsNormally();
     }
 
+    public function testBulkRespectsDelayAttributeWhenPushingOntoBeanstalkd()
+    {
+        $this->setQueue('default', 60);
+        $pheanstalk = $this->queue->getPheanstalk();
+        $pheanstalk->shouldReceive('useTube')->twice()->with(m::type(TubeName::class));
+        $pheanstalk->shouldReceive('put')->once()->with(m::type('string'), Pheanstalk::DEFAULT_PRIORITY, 15, Pheanstalk::DEFAULT_TTR);
+        $pheanstalk->shouldReceive('put')->once()->with(m::type('string'), 1024, 0, 60);
+
+        $this->queue->bulk([new BeanstalkdJobWithDelayAttribute, 'foo'], ['data']);
+
+        $this->container->shouldHaveReceived('bound')->with('events')->times(4);
+    }
+
     public function testPopProperlyPopsJobOffOfBeanstalkd()
     {
         $this->setQueue('default', 60);
@@ -147,4 +161,9 @@ class QueueBeanstalkdQueueTest extends TestCase
         $this->container = m::spy(Container::class);
         $this->queue->setContainer($this->container);
     }
+}
+
+#[Delay(15)]
+class BeanstalkdJobWithDelayAttribute
+{
 }

--- a/tests/Queue/QueueDatabaseQueueUnitTest.php
+++ b/tests/Queue/QueueDatabaseQueueUnitTest.php
@@ -7,6 +7,7 @@ use Illuminate\Container\Container;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Database\Connection;
 use Illuminate\Queue\Attributes\Backoff;
+use Illuminate\Queue\Attributes\Delay;
 use Illuminate\Queue\Attributes\FailOnTimeout;
 use Illuminate\Queue\Attributes\MaxExceptions;
 use Illuminate\Queue\Attributes\Timeout;
@@ -236,6 +237,22 @@ class QueueDatabaseQueueUnitTest extends TestCase
         Str::createUuidsNormally();
     }
 
+    public function testDelayAttributeIsRespectedWhenBulkPushing()
+    {
+        $database = m::mock(Connection::class);
+        $queue = $this->getMockBuilder(DatabaseQueue::class)->onlyMethods(['currentTime', 'availableAt'])->setConstructorArgs([$database, 'table', 'default'])->getMock();
+        $queue->method('currentTime')->willReturn('created');
+        $queue->method('availableAt')->willReturnCallback(function ($delay = 0) {
+            return 'available:'.$delay;
+        });
+        $database->shouldReceive('table')->with('table')->andReturn($query = m::mock(stdClass::class));
+        $query->shouldReceive('insert')->once()->andReturnUsing(function ($records) {
+            $this->assertSame('available:15', $records[0]['available_at']);
+        });
+
+        $queue->bulk([new JobWithDelayAttribute], ['data'], 'queue');
+    }
+
     public function testBuildDatabaseRecordWithPayloadAtTheEnd()
     {
         $queue = m::mock(DatabaseQueue::class);
@@ -444,6 +461,11 @@ class MyTestJob
 class MyBatchableJob
 {
     use Batchable;
+}
+
+#[Delay(15)]
+class JobWithDelayAttribute
+{
 }
 
 #[Backoff(9)]

--- a/tests/Queue/QueueRedisQueueTest.php
+++ b/tests/Queue/QueueRedisQueueTest.php
@@ -188,9 +188,8 @@ class QueueRedisQueueTest extends TestCase
             $callback();
         });
         $queue->expects($this->once())->method('later')->with(15, $this->isInstanceOf(RedisJobWithDelayAttribute::class), ['data'], null);
-        $queue->expects($this->once())->method('push')->with('foo', ['data'], null);
 
-        $queue->bulk([new RedisJobWithDelayAttribute, 'foo'], ['data']);
+        $queue->bulk([new RedisJobWithDelayAttribute], ['data']);
     }
 
     public function testGetQueueRemainsUnchangedForNonCluster()

--- a/tests/Queue/QueueRedisQueueTest.php
+++ b/tests/Queue/QueueRedisQueueTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Queue;
 
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Redis\Factory;
+use Illuminate\Queue\Attributes\Delay;
 use Illuminate\Queue\LuaScripts;
 use Illuminate\Queue\Queue;
 use Illuminate\Queue\RedisQueue;
@@ -174,6 +175,22 @@ class QueueRedisQueueTest extends TestCase
 
         Carbon::setTestNow();
         Str::createUuidsNormally();
+    }
+
+    public function testBulkRespectsDelayAttributeWhenPushingOntoRedis()
+    {
+        $queue = $this->getMockBuilder(RedisQueue::class)->onlyMethods(['later', 'push'])->setConstructorArgs([$redis = m::mock(Factory::class), 'default'])->getMock();
+        $redis->shouldReceive('connection')->once()->andReturn($redis);
+        $redis->shouldReceive('pipeline')->once()->andReturnUsing(function ($callback) {
+            $callback();
+        });
+        $redis->shouldReceive('transaction')->once()->andReturnUsing(function ($callback) {
+            $callback();
+        });
+        $queue->expects($this->once())->method('later')->with(15, $this->isInstanceOf(RedisJobWithDelayAttribute::class), ['data'], null);
+        $queue->expects($this->once())->method('push')->with('foo', ['data'], null);
+
+        $queue->bulk([new RedisJobWithDelayAttribute, 'foo'], ['data']);
     }
 
     public function testGetQueueRemainsUnchangedForNonCluster()
@@ -437,4 +454,9 @@ class TestableRedisQueue extends RedisQueue
     {
         return $this->allQueueNames();
     }
+}
+
+#[Delay(15)]
+class RedisJobWithDelayAttribute
+{
 }

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -20,6 +20,7 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
 use Illuminate\Tests\Queue\Fixtures\FakeSqsJob;
 use Illuminate\Tests\Queue\Fixtures\FakeSqsJobWithDeduplication;
+use Illuminate\Tests\Queue\Fixtures\FakeSqsJobWithDelayAttribute;
 use Illuminate\Tests\Queue\Fixtures\FakeSqsJobWithMessageGroup;
 use Laravel\SerializableClosure\SerializableClosure;
 use Mockery as m;
@@ -1115,6 +1116,31 @@ class QueueSqsQueueTest extends TestCase
         $queue->bulk([$jobA, $jobB], 'data', $this->queueName);
 
         $this->assertSame(30, $captured['Entries'][0]['DelaySeconds']);
+        $this->assertArrayNotHasKey('DelaySeconds', $captured['Entries'][1]);
+    }
+
+    public function testBulkHonoursDelayAttribute()
+    {
+        $queue = $this->getMockBuilder(SqsQueue::class)
+            ->onlyMethods(['getQueue', 'createPayload', 'secondsUntil'])
+            ->setConstructorArgs([$this->sqs, $this->queueName, $this->account])
+            ->getMock();
+        $queue->setContainer(m::spy(Container::class));
+        $queue->expects($this->once())->method('getQueue')->willReturn($this->queueUrl);
+        $queue->method('createPayload')->willReturnCallback(fn ($job, $q, $data, $delay) => 'payload-'.($delay ?? 'none'));
+        $queue->method('secondsUntil')->with(15)->willReturn(15);
+
+        $captured = null;
+
+        $this->sqs->shouldReceive('sendMessageBatch')->once()->with(m::on(function ($args) use (&$captured) {
+            $captured = $args;
+
+            return true;
+        }))->andReturn(new Result(['Successful' => [], 'Failed' => []]));
+
+        $queue->bulk([new FakeSqsJobWithDelayAttribute, new FakeSqsJob], 'data', $this->queueName);
+
+        $this->assertSame(15, $captured['Entries'][0]['DelaySeconds']);
         $this->assertArrayNotHasKey('DelaySeconds', $captured['Entries'][1]);
     }
 


### PR DESCRIPTION
Noticed this earlier [via this](https://github.com/laravel/framework/pull/60757#issuecomment-4959270639), jobs pushed via `Bus::batch()` and `Bus::bulk` already respect `$delay` as a property, but, they ignore the Delay attribute. 

This PR ensures the attribute is also covered. As I would expect the same behavior.

The SQS driver was already doing a `is_object` check, so I've replicated elsewhere.   

This mean each Queue class checks the attribute / param now basically.

This means it fixes the below:
<details>
<summary> Code example </summary>

```php
    dispatch(new DelayParamJob); // delayed 
    Bus::batch([new DelayParamJob-])->dispatch(); // delayed 
    Queue::bulk([new DelayParamJob]); // delayed 

     
    dispatch(new DelayAttrJob); // delayed 
    Bus::batch([new DelayAttrJob])->dispatch(); // not delayed
    Queue::bulk([new DelayAttrJob]); // not delayed
    
    // With the PR its delayed properly
    
    
class DelayPropertyJob implements ShouldQueue
{
    use Batchable, Queueable;

    public function __construct()
    {
        $this->delay(60);
    }
}

#[Delay(60)]
class DelayAttributeJob implements ShouldQueue
{
    use Batchable, Queueable;
}
```
</details>

This isn't officially documented, but feels odd to support only the param and not the attr? I imagine it may catch someone out when moving params -> attrs
 
I believe theres no fifo etc risk, as the drivers are already responsible for this 🫡 
 
Open to your feedback, maybe this sux?  thanks!