### PR TITLE
[14.x] feat: add optional context array to report helpers

### DIFF
--- a/src/Illuminate/Contracts/Debug/ExceptionHandler.php
+++ b/src/Illuminate/Contracts/Debug/ExceptionHandler.php
@@ -13,11 +13,12 @@ interface ExceptionHandler
      * Report or log an exception.
      *
      * @param  \Throwable  $e
+     * @param  array<string, mixed>  $context
      * @return void
      *
      * @throws \Throwable
      */
-    public function report(Throwable $e);
+    public function report(Throwable $e, array $context = []);
 
     /**
      * Determine if the exception should be reported.

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -636,9 +636,9 @@ class Kernel implements KernelContract
      * @param  \Throwable  $e
      * @return void
      */
-    protected function reportException(Throwable $e)
+    protected function reportException(Throwable $e, array $context = [])
     {
-        $this->app[ExceptionHandler::class]->report($e);
+        $this->app[ExceptionHandler::class]->report($e, $context);
     }
 
     /**

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -234,7 +234,7 @@ class Handler implements ExceptionHandlerContract
     /**
      * Register a reportable callback.
      *
-     * @param  callable  $reportUsing
+     * @param  callable(Throwable, array): ?bool  $reportUsing
      * @return \Illuminate\Foundation\Exceptions\ReportableHandler
      */
     public function reportable(callable $reportUsing)
@@ -424,11 +424,12 @@ class Handler implements ExceptionHandlerContract
      * Report or log an exception.
      *
      * @param  \Throwable  $e
+     * @param  array<string, mixed>  $context
      * @return void
      *
      * @throws \Throwable
      */
-    public function report(Throwable $e)
+    public function report(Throwable $e, array $context = [])
     {
         $e = $this->mapException($e);
 
@@ -436,18 +437,19 @@ class Handler implements ExceptionHandlerContract
             return;
         }
 
-        $this->reportThrowable($e);
+        $this->reportThrowable($e, $context);
     }
 
     /**
      * Reports error based on report method on exception or to logger.
      *
      * @param  \Throwable  $e
+     * @param  array<string, mixed>  $context
      * @return void
      *
      * @throws \Throwable
      */
-    protected function reportThrowable(Throwable $e): void
+    protected function reportThrowable(Throwable $e, array $context = []): void
     {
         $this->reportedExceptionMap[$e] = true;
 
@@ -456,8 +458,10 @@ class Handler implements ExceptionHandlerContract
             return;
         }
 
+        $context = $this->buildExceptionContext($e, $context);
+
         foreach ($this->reportCallbacks as $reportCallback) {
-            if ($reportCallback->handles($e) && $reportCallback($e) === false) {
+            if ($reportCallback->handles($e) && $reportCallback($e, $context) === false) {
                 return;
             }
         }
@@ -475,8 +479,6 @@ class Handler implements ExceptionHandlerContract
         $this->currentlyReporting = $e;
 
         try {
-            $context = $this->buildExceptionContext($e);
-
             method_exists($logger, $level)
                 ? $logger->{$level}($e->getMessage(), $context)
                 : $logger->log($level, $e->getMessage(), $context);
@@ -617,13 +619,15 @@ class Handler implements ExceptionHandlerContract
      * Create the context array for logging the given exception.
      *
      * @param  \Throwable  $e
+     * @param  array<string, mixed>  $context
      * @return array
      */
-    protected function buildExceptionContext(Throwable $e)
+    protected function buildExceptionContext(Throwable $e, array $context = [])
     {
         return array_merge(
             $this->buildContextForException($e),
             $this->context(),
+            $context,
             ['exception' => $e]
         );
     }
@@ -678,7 +682,7 @@ class Handler implements ExceptionHandlerContract
     /**
      * Register a closure that should be used to build exception context data.
      *
-     * @param  \Closure  $contextCallback
+     * @param  \Closure(\Throwable, array): array  $contextCallback
      * @return $this
      */
     public function buildContextUsing(Closure $contextCallback)

--- a/src/Illuminate/Foundation/Exceptions/ReportableHandler.php
+++ b/src/Illuminate/Foundation/Exceptions/ReportableHandler.php
@@ -12,7 +12,7 @@ class ReportableHandler
     /**
      * The underlying callback.
      *
-     * @var callable
+     * @var callable(Throwable, array): ?bool
      */
     protected $callback;
 
@@ -26,7 +26,7 @@ class ReportableHandler
     /**
      * Create a new reportable handler instance.
      *
-     * @param  callable  $callback
+     * @param  callable(\Throwable, array): ?bool  $callback
      */
     public function __construct(callable $callback)
     {
@@ -37,11 +37,12 @@ class ReportableHandler
      * Invoke the handler.
      *
      * @param  \Throwable  $e
+     * @param  array<string, mixed>  $context
      * @return bool
      */
-    public function __invoke(Throwable $e)
+    public function __invoke(Throwable $e, array $context = [])
     {
-        $result = call_user_func($this->callback, $e);
+        $result = call_user_func($this->callback, $e, $context);
 
         if ($result === false) {
             return false;

--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -557,9 +557,9 @@ class Kernel implements KernelContract
      * @param  \Throwable  $e
      * @return void
      */
-    protected function reportException(Throwable $e)
+    protected function reportException(Throwable $e, array $context = [])
     {
-        $this->app[ExceptionHandler::class]->report($e);
+        $this->app[ExceptionHandler::class]->report($e, $context);
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithExceptionHandling.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithExceptionHandling.php
@@ -100,11 +100,12 @@ trait InteractsWithExceptionHandling
              * Report or log an exception.
              *
              * @param  \Throwable  $e
+             * @param  array<string, mixed>  $context
              * @return void
              *
              * @throws \Exception
              */
-            public function report(Throwable $e)
+            public function report(Throwable $e, array $context = [])
             {
                 //
             }

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -719,14 +719,15 @@ if (! function_exists('report')) {
      * Report an exception.
      *
      * @param  \Throwable|string  $exception
+     * @param  array<string, mixed>  $context
      */
-    function report($exception): void
+    function report($exception, array $context = []): void
     {
         if (is_string($exception)) {
             $exception = new Exception($exception);
         }
 
-        app(ExceptionHandler::class)->report($exception);
+        app(ExceptionHandler::class)->report($exception, $context);
     }
 }
 
@@ -736,11 +737,12 @@ if (! function_exists('report_if')) {
      *
      * @param  bool  $boolean
      * @param  \Throwable|string  $exception
+     * @param  array<string, mixed>  $context
      */
-    function report_if($boolean, $exception): void
+    function report_if($boolean, $exception, array $context = []): void
     {
         if ($boolean) {
-            report($exception);
+            report($exception, $context);
         }
     }
 }
@@ -751,11 +753,12 @@ if (! function_exists('report_unless')) {
      *
      * @param  bool  $boolean
      * @param  \Throwable|string  $exception
+     * @param  array<string, mixed>  $context
      */
-    function report_unless($boolean, $exception): void
+    function report_unless($boolean, $exception, array $context = []): void
     {
         if (! $boolean) {
-            report($exception);
+            report($exception, $context);
         }
     }
 }

--- a/src/Illuminate/Support/Facades/Exceptions.php
+++ b/src/Illuminate/Support/Facades/Exceptions.php
@@ -19,7 +19,7 @@ use Illuminate\Support\Testing\Fakes\ExceptionHandlerFake;
  * @method static bool shouldStopRetries(\Throwable $e)
  * @method static \Illuminate\Foundation\Exceptions\Handler dontFlash(array|string $attributes)
  * @method static \Illuminate\Foundation\Exceptions\Handler level(string $type, string $level)
- * @method static void report(\Throwable $e)
+ * @method static void report(\Throwable $e, array<string, mixed> $context = [])
  * @method static bool isReporting(\Throwable $e)
  * @method static bool shouldReport(\Throwable $e)
  * @method static \Illuminate\Foundation\Exceptions\Handler throttleUsing(callable $throttleUsing)

--- a/src/Illuminate/Support/Testing/Fakes/ExceptionHandlerFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/ExceptionHandlerFake.php
@@ -145,14 +145,15 @@ class ExceptionHandlerFake implements ExceptionHandler, Fake
      * Report or log an exception.
      *
      * @param  \Throwable  $e
+     * @param  array<string, mixed>  $context
      * @return void
      *
      * @throws \Throwable
      */
-    public function report($e)
+    public function report($e, array $context = [])
     {
         if (! $this->isFakedException($e)) {
-            $this->handler->report($e);
+            $this->handler->report($e, $context);
 
             return;
         }

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -103,6 +103,48 @@ class FoundationExceptionsHandlerTest extends TestCase
         $this->handler->report(new ContextProvidingException('Exception message'));
     }
 
+    public function testHandlerMergesInlineContextIntoLogContext()
+    {
+        $logger = m::mock(LoggerInterface::class);
+        $this->container->instance(LoggerInterface::class, $logger);
+        $logger->shouldReceive('error')->withArgs(['Exception message', m::subset(['from' => 'user@example.com', 'subject' => 'Hello'])])->once();
+
+        $this->handler->report(new RuntimeException('Exception message'), [
+            'from' => 'user@example.com',
+            'subject' => 'Hello',
+        ]);
+    }
+
+    public function testHandlerInlineContextOverridesExceptionContext()
+    {
+        $logger = m::mock(LoggerInterface::class);
+        $this->container->instance(LoggerInterface::class, $logger);
+        $logger->shouldReceive('error')->withArgs(['Exception message', m::subset(['foo' => 'overridden'])])->once();
+
+        $this->handler->report(new ContextProvidingException('Exception message'), [
+            'foo' => 'overridden',
+        ]);
+    }
+
+    public function testReportableCallbackReceivesInlineContext()
+    {
+        $receivedContext = null;
+
+        $this->handler->reportable(function (\Throwable $e, array $context) use (&$receivedContext) {
+            $receivedContext = $context;
+
+            return false;
+        });
+
+        $this->handler->report(new RuntimeException('Exception message'), [
+            'from' => 'user@example.com',
+        ]);
+
+        $this->assertIsArray($receivedContext);
+        $this->assertSame('user@example.com', $receivedContext['from']);
+        $this->assertArrayHasKey('exception', $receivedContext);
+    }
+
     public function testHandlerReportsExceptionWhenUnReportable()
     {
         $logger = m::mock(LoggerInterface::class);

--- a/tests/Integration/Queue/ThrottlesExceptionsTest.php
+++ b/tests/Integration/Queue/ThrottlesExceptionsTest.php
@@ -354,7 +354,7 @@ class ThrottlesExceptionsTest extends TestCase
         $this->spy(ExceptionHandler::class)
             ->shouldReceive('report')
             ->twice()
-            ->with(m::type(RuntimeException::class));
+            ->with(m::type(RuntimeException::class), []);
 
         $job = new class
         {

--- a/tests/Integration/Queue/ThrottlesExceptionsWithRedisTest.php
+++ b/tests/Integration/Queue/ThrottlesExceptionsWithRedisTest.php
@@ -126,7 +126,7 @@ class ThrottlesExceptionsWithRedisTest extends TestCase
         $this->spy(ExceptionHandler::class)
             ->shouldReceive('report')
             ->twice()
-            ->with(m::type(RuntimeException::class));
+            ->with(m::type(RuntimeException::class), []);
 
         $job = new class
         {

--- a/tests/Log/ContextTest.php
+++ b/tests/Log/ContextTest.php
@@ -699,6 +699,91 @@ class ContextTest extends TestCase
         Context::rememberHidden('foo', $closure);
         $this->assertSame(1, $closureRunCount);
     }
+
+    public function test_report_helper_adds_context_to_exception_context()
+    {
+        $path = storage_path('logs/laravel.log');
+        file_put_contents($path, '');
+
+        report(new Exception('Whoops!'), ['foo' => 'bar', 'baz' => 123]);
+
+        $log = Str::after(file_get_contents($path), '] ');
+
+        $this->assertStringContainsString('"foo":"bar"', $log);
+        $this->assertStringContainsString('"baz":123', $log);
+
+        file_put_contents($path, '');
+    }
+
+    public function test_report_context_is_separate_from_global_context()
+    {
+        $path = storage_path('logs/laravel.log');
+        file_put_contents($path, '');
+
+        Context::add('global_key', 'global_value');
+
+        report(new Exception('Whoops!'), ['report_key' => 'report_value']);
+
+        $log = Str::after(file_get_contents($path), '] ');
+
+        // Report context is in exception context (before the global context extra)
+        $this->assertStringContainsString('"report_key":"report_value"', $log);
+        // Global context is in extra (at the end of the log line)
+        $this->assertStringEndsWith(' {"global_key":"global_value"}', trim($log));
+
+        file_put_contents($path, '');
+        Context::flush();
+    }
+
+    public function test_report_helper_without_context_does_not_add_context()
+    {
+        $path = storage_path('logs/laravel.log');
+        file_put_contents($path, '');
+
+        report(new Exception('Whoops!'));
+
+        $log = Str::after(file_get_contents($path), '] ');
+
+        $this->assertStringNotContainsString('"foo"', $log);
+        $this->assertStringNotContainsString('"bar"', $log);
+
+        file_put_contents($path, '');
+    }
+
+    public function test_report_if_helper_adds_context_when_condition_is_true()
+    {
+        $path = storage_path('logs/laravel.log');
+        file_put_contents($path, '');
+
+        report_if(true, new Exception('Whoops!'), ['foo' => 'bar']);
+
+        $log = Str::after(file_get_contents($path), '] ');
+
+        $this->assertStringContainsString('"foo":"bar"', $log);
+
+        file_put_contents($path, '');
+    }
+
+    public function test_report_unless_helper_adds_context_when_condition_is_false()
+    {
+        $path = storage_path('logs/laravel.log');
+        file_put_contents($path, '');
+
+        report_unless(false, new Exception('Whoops!'), ['foo' => 'bar']);
+
+        $log = Str::after(file_get_contents($path), '] ');
+
+        $this->assertStringContainsString('"foo":"bar"', $log);
+
+        file_put_contents($path, '');
+    }
+
+    public function test_report_context_does_not_leak_to_global_context()
+    {
+        report(new Exception('Whoops!'), ['leaked' => 'value']);
+
+        $this->assertNull(Context::get('leaked'));
+    }
 }
 
 enum Suit

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -797,7 +797,7 @@ class BrokenQueueConnection
 
 class ShouldntRetryExceptionHandler implements ExceptionHandler
 {
-    public function report(\Throwable $e)
+    public function report(\Throwable $e, array $context = [])
     {
         //
     }

--- a/tests/Validation/ValidationNotPwnedVerifierTest.php
+++ b/tests/Validation/ValidationNotPwnedVerifierTest.php
@@ -158,7 +158,7 @@ class ValidationNotPwnedVerifierTest extends TestCase
         $exception = new ConnectionException();
 
         $exceptionHandler = m::mock(ExceptionHandler::class);
-        $exceptionHandler->shouldReceive('report')->once()->with($exception);
+        $exceptionHandler->shouldReceive('report')->once()->with($exception, []);
         $container->bind(ExceptionHandler::class, function () use ($exceptionHandler) {
             return $exceptionHandler;
         });


### PR DESCRIPTION
Hello!

Hello! Oftentimes I want to report an exception with some addition, local context and there's currently not a nice way to do it, what I'm after is an api like:

```php
try {
    // something risky
} catch (Throwable $throwable) {
    report($throwable, [/** some context */]);
}
```

Thanks!
