### PR TITLE
[13.x] Fix Number::forHumans() and abbreviate() scaling tiny decimals

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -302,6 +302,14 @@ class Number
 
         $numberExponent = floor(log10($number));
         $displayExponent = $numberExponent - ($numberExponent % 3);
+
+        // Values below 1 have a negative exponent that has no corresponding unit,
+        // so clamp it to zero to avoid scaling the number up without a suffix
+        // (e.g. 0.005 would otherwise be rendered as "5" instead of "0").
+        if ($displayExponent < 0) {
+            $displayExponent = 0;
+        }
+
         $number /= pow(10, $displayExponent);
 
         $formatted = static::format($number, $precision, $maxPrecision);

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -301,15 +301,7 @@ class Number
         }
 
         $numberExponent = floor(log10($number));
-        $displayExponent = $numberExponent - ($numberExponent % 3);
-
-        // Values below 1 have a negative exponent that has no corresponding unit,
-        // so clamp it to zero to avoid scaling the number up without a suffix
-        // (e.g. 0.005 would otherwise be rendered as "5" instead of "0").
-        if ($displayExponent < 0) {
-            $displayExponent = 0;
-        }
-
+        $displayExponent = max(0, $numberExponent - ($numberExponent % 3));
         $number /= pow(10, $displayExponent);
 
         $formatted = static::format($number, $precision, $maxPrecision);

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -268,6 +268,14 @@ class SupportNumberTest extends TestCase
         $this->assertSame('0', Number::forHumans(-0.4999));
         $this->assertSame('-0.40', Number::forHumans(-0.4, precision: 2));
 
+        // Values below 0.001 must not be scaled up by a negative exponent.
+        $this->assertSame('0', Number::forHumans(0.005));
+        $this->assertSame('0', Number::forHumans(0.001));
+        $this->assertSame('0', Number::forHumans(0.009));
+        $this->assertSame('0', Number::forHumans(-0.005));
+        $this->assertSame('0.005', Number::forHumans(0.005, precision: 3));
+        $this->assertSame('-0.005', Number::forHumans(-0.005, precision: 3));
+
         $this->assertSame('999 thousand', Number::forHumans(999499));
         $this->assertSame('1 million', Number::forHumans(999500));
         $this->assertSame('1 million', Number::forHumans(999999));
@@ -335,6 +343,12 @@ class SupportNumberTest extends TestCase
         // A negative magnitude that rounds down to zero must not keep the sign.
         $this->assertSame('0', Number::abbreviate(-0.4));
         $this->assertSame('0', Number::abbreviate(-0.05));
+
+        // Values below 0.001 must not be scaled up by a negative exponent.
+        $this->assertSame('0', Number::abbreviate(0.005));
+        $this->assertSame('0', Number::abbreviate(0.001));
+        $this->assertSame('0', Number::abbreviate(-0.005));
+        $this->assertSame('0.005', Number::abbreviate(0.005, precision: 3));
 
         $this->assertSame('999K', Number::abbreviate(999499));
         $this->assertSame('1M', Number::abbreviate(999500));


### PR DESCRIPTION
For values below `0.001`, `Number::forHumans()` and `Number::abbreviate()` return an incorrectly scaled number. `summarize()` computes a negative display exponent (e.g. `floor(log10(0.005)) = -3`), and since there is no unit suffix for negative exponents, the value is divided by `10^-3` and returned without a suffix:

```php
Number::forHumans(0.005);  // "5"  (expected "0")
Number::abbreviate(0.001); // "1"  (expected "0")
```

Clamping the display exponent to a minimum of `0` fixes this and keeps sub-unit values consistent with how `0.05`, `0.5`, etc. are already handled (they return `"0"`). Precision is unaffected — `Number::forHumans(0.005, precision: 3)` still returns `"0.005"`.

Added regression tests to `testForHumans()` and `testSummarize()` covering small positive and negative decimals, both with and without precision.