### PR TITLE
[12.x] Ensure make:migration generates unique timestamp prefixes

### DIFF
--- a/src/Illuminate/Database/Migrations/MigrationCreator.php
+++ b/src/Illuminate/Database/Migrations/MigrationCreator.php
@@ -4,6 +4,7 @@ namespace Illuminate\Database\Migrations;
 
 use Closure;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
 
@@ -170,7 +171,7 @@ class MigrationCreator
      */
     protected function getPath($name, $path)
     {
-        return $path.'/'.$this->getDatePrefix().'_'.$name.'.php';
+        return $path.'/'.$this->getDatePrefix($path).'_'.$name.'.php';
     }
 
     /**
@@ -201,11 +202,20 @@ class MigrationCreator
     /**
      * Get the date prefix for the migration.
      *
+     * @param  string|null  $path
      * @return string
      */
-    protected function getDatePrefix()
+    protected function getDatePrefix($path = null)
     {
-        return date('Y_m_d_His');
+        $date = Carbon::now();
+
+        if (! empty($path)) {
+            while (! empty($this->files->glob($path.'/'.$date->format('Y_m_d_His').'_*.php'))) {
+                $date = $date->addSecond();
+            }
+        }
+
+        return $date->format('Y_m_d_His');
     }
 
     /**

--- a/tests/Database/DatabaseMigrationCreatorTest.php
+++ b/tests/Database/DatabaseMigrationCreatorTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Database;
 
 use Illuminate\Database\Migrations\MigrationCreator;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Carbon;
 use InvalidArgumentException;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -78,6 +79,25 @@ class DatabaseMigrationCreatorTest extends TestCase
         $creator->getFilesystem()->shouldReceive('requireOnce')->once()->with('foo/foo_create_bar.php');
 
         $creator->create('create_bar', 'foo', 'baz', true);
+    }
+
+    public function testDatePrefixIsBumpedWhenMigrationWithSamePrefixAlreadyExists()
+    {
+        Carbon::setTestNow(Carbon::create(2026, 7, 14, 12, 0, 0));
+
+        $creator = new MigrationCreator(m::mock(Filesystem::class), 'stubs');
+
+        $creator->getFilesystem()->shouldReceive('glob')->once()->with('foo/2026_07_14_120000_*.php')->andReturn(['foo/2026_07_14_120000_create_bar.php']);
+        $creator->getFilesystem()->shouldReceive('glob')->once()->with('foo/2026_07_14_120001_*.php')->andReturn([]);
+        $creator->getFilesystem()->shouldReceive('glob')->once()->with('foo/*.php')->andReturn([]);
+        $creator->getFilesystem()->shouldReceive('exists')->once()->with('stubs/migration.stub')->andReturn(false);
+        $creator->getFilesystem()->shouldReceive('get')->once()->with($creator->stubPath().'/migration.stub')->andReturn('return new class');
+        $creator->getFilesystem()->shouldReceive('ensureDirectoryExists')->once()->with('foo');
+        $creator->getFilesystem()->shouldReceive('put')->once()->with('foo/2026_07_14_120001_create_baz.php', 'return new class');
+
+        $this->assertSame('foo/2026_07_14_120001_create_baz.php', $creator->create('create_baz', 'foo'));
+
+        Carbon::setTestNow();
     }
 
     public function testTableUpdateMigrationWontCreateDuplicateClass()


### PR DESCRIPTION
### The papercut

Coding agents routinely scaffold models by chaining generator commands:

```
php artisan make:model ABC -m && php artisan make:model XYZ -m
```

These run within the same second, so both migrations get an identical `Y_m_d_His` timestamp prefix.

Migrations are ordered by that prefix, which only has one-second resolution. When prefixes tie, execution order falls back to the file name (alphabetical), which is not the creation order. This is harmless on **SQLite** — so test suites pass and the problem stays hidden — but on **MySQL** and **Postgres** it's a real bug: if `XYZ`'s migration depends on a table created by `ABC`'s migration, the alphabetical fallback can run them in the wrong order and the migration fails.

Anonymous migration classes (#37598) fixed the *class name* collision, but not the *ordering* collision — two anonymous migrations can still share a prefix.

### Why fix it in the framework

Laravel Boost already instructs agents to avoid generating migrations this way, but that's guidance, not a guarantee — any tool or script that scaffolds two migrations in one second reintroduces it. Handling it directly in the framework closes the papercut for good, regardless of how the migrations are generated.

### Fix

`MigrationCreator::getDatePrefix()` now checks the target migration directory for an existing file using the computed prefix. If one exists, it nudges the timestamp forward one second at a time until it finds a free prefix, guaranteeing a deterministic order on every driver.

Because `A && B` runs as two sequential processes, the first migration is written to disk before the second globs, so the collision is reliably detected. A test covers the bump.
