### PR TITLE
[13.x] Ensure `make:migration` generates collision-free, ordered timestamps prefixes

### DIFF
--- a/src/Illuminate/Database/Migrations/MigrationCreator.php
+++ b/src/Illuminate/Database/Migrations/MigrationCreator.php
@@ -176,15 +176,9 @@ class MigrationCreator
      * @param  string  $path
      * @return string
      */
-    protected function getCollisionFreePath($name, $path)
+    protected function getPath($name, $path)
     {
-        $this->currentMigrationPath = $path;
-
-        $path = $this->getPath($name, $path);
-
-        $this->currentMigrationPath = null;
-
-        return $path;
+        return $path.'/'.$this->getDatePrefix().'_'.$name.'.php';
     }
 
     /**
@@ -194,9 +188,15 @@ class MigrationCreator
      * @param  string  $path
      * @return string
      */
-    protected function getPath($name, $path)
+    protected function getCollisionFreePath($name, $path)
     {
-        return $path.'/'.$this->getDatePrefix().'_'.$name.'.php';
+        $this->currentMigrationPath = $path;
+
+        $path = $this->getPath($name, $path);
+
+        $this->currentMigrationPath = null;
+
+        return $path;
     }
 
     /**

--- a/src/Illuminate/Database/Migrations/MigrationCreator.php
+++ b/src/Illuminate/Database/Migrations/MigrationCreator.php
@@ -4,6 +4,7 @@ namespace Illuminate\Database\Migrations;
 
 use Closure;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
 
@@ -29,6 +30,13 @@ class MigrationCreator
      * @var (\Closure(string, string): void)[]
      */
     protected $postCreate = [];
+
+    /**
+     * The path given to the create method.
+     *
+     * @var string|null
+     */
+    protected $currentMigrationPath = null;
 
     /**
      * Create a new migration creator instance.
@@ -62,7 +70,7 @@ class MigrationCreator
         // various place-holders, save the file, and run the post create event.
         $stub = $this->getStub($table, $create);
 
-        $path = $this->getPath($name, $path);
+        $path = $this->getCollisionFreePath($name, $path);
 
         $this->files->ensureDirectoryExists(dirname($path));
 
@@ -168,6 +176,24 @@ class MigrationCreator
      * @param  string  $path
      * @return string
      */
+    protected function getCollisionFreePath($name, $path)
+    {
+        $this->currentMigrationPath = $path;
+
+        $path = $this->getPath($name, $path);
+
+        $this->currentMigrationPath = null;
+
+        return $path;
+    }
+
+    /**
+     * Get the full path to the migration.
+     *
+     * @param  string  $name
+     * @param  string  $path
+     * @return string
+     */
     protected function getPath($name, $path)
     {
         return $path.'/'.$this->getDatePrefix().'_'.$name.'.php';
@@ -205,7 +231,19 @@ class MigrationCreator
      */
     protected function getDatePrefix()
     {
-        return date('Y_m_d_His');
+        $path = $this->currentMigrationPath;
+
+        if ($path === null) {
+            return date('Y_m_d_His');
+        }
+
+        $date = Date::now();
+
+        while ($this->files->glob($path.'/'.$date->format('Y_m_d_His').'_*.php')) {
+            $date = $date->addSecond();
+        }
+
+        return $date->format('Y_m_d_His');
     }
 
     /**

--- a/tests/Database/DatabaseMigrationCreatorTest.php
+++ b/tests/Database/DatabaseMigrationCreatorTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Database;
 
 use Illuminate\Database\Migrations\MigrationCreator;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Carbon;
 use InvalidArgumentException;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -91,6 +92,69 @@ class DatabaseMigrationCreatorTest extends TestCase
         $creator->getFilesystem()->shouldReceive('requireOnce')->once()->with('foo/foo_create_bar.php');
 
         $creator->create('migration_creator_fake_migration', 'foo');
+    }
+
+    public function testMigrationsCreatedWithinTheSameSecondHaveIncreasingDatePrefixes()
+    {
+        Carbon::setTestNow('2026-07-13 14:41:22');
+
+        $files = new Filesystem;
+        $path = sys_get_temp_dir().'/laravel-migration-creator-'.uniqid();
+
+        try {
+            $creator = new MigrationCreator($files, $path.'/stubs');
+
+            $first = $creator->create('create_bs_table', $path, 'bs', true);
+            $second = $creator->create('create_as_table', $path, 'as', true);
+
+            $this->assertSame($path.'/2026_07_13_144122_create_bs_table.php', $first);
+            $this->assertSame($path.'/2026_07_13_144123_create_as_table.php', $second);
+        } finally {
+            Carbon::setTestNow();
+            $files->deleteDirectory($path);
+        }
+    }
+
+    public function testOverriddenDatePrefixRetainsExistingBehavior()
+    {
+        $files = new Filesystem;
+        $path = sys_get_temp_dir().'/laravel-migration-creator-'.uniqid();
+        $creator = new class($files, $path.'/stubs') extends MigrationCreator
+        {
+            protected function getDatePrefix()
+            {
+                return 'custom_prefix';
+            }
+        };
+
+        try {
+            $first = $creator->create('create_bs_table', $path, 'bs', true);
+            $second = $creator->create('create_as_table', $path, 'as', true);
+
+            $this->assertSame($path.'/custom_prefix_create_bs_table.php', $first);
+            $this->assertSame($path.'/custom_prefix_create_as_table.php', $second);
+        } finally {
+            $files->deleteDirectory($path);
+        }
+    }
+
+    public function testOverriddenCreateMethodRetainsExistingDatePrefixBehavior()
+    {
+        $files = m::mock(Filesystem::class);
+        $files->shouldNotReceive('glob');
+
+        $creator = new class($files, 'stubs') extends MigrationCreator
+        {
+            public function create($name, $path, $table = null, $create = false)
+            {
+                return $this->getPath($name, $path);
+            }
+        };
+
+        $this->assertMatchesRegularExpression(
+            '/^foo\/\d{4}_\d{2}_\d{2}_\d{6}_create_bar\.php$/',
+            $creator->create('create_bar', 'foo'),
+        );
     }
 
     protected function getCreator()

--- a/tests/Integration/Generators/ModelMakeCommandTest.php
+++ b/tests/Integration/Generators/ModelMakeCommandTest.php
@@ -2,16 +2,22 @@
 
 namespace Illuminate\Tests\Integration\Generators;
 
+use Illuminate\Support\Carbon;
+
 class ModelMakeCommandTest extends TestCase
 {
     protected $files = [
         'app/Models/Foo.php',
         'app/Models/Foo/Bar.php',
+        'app/Models/Aaa.php',
+        'app/Models/Xxx.php',
         'app/Http/Controllers/FooController.php',
         'app/Http/Controllers/BarController.php',
         'database/factories/FooFactory.php',
         'database/factories/Foo/BarFactory.php',
+        'database/migrations/*_create_aaas_table.php',
         'database/migrations/*_create_foos_table.php',
+        'database/migrations/*_create_xxxes_table.php',
         'database/seeders/FooSeeder.php',
         'tests/Feature/Models/FooTest.php',
     ];
@@ -192,6 +198,20 @@ class ModelMakeCommandTest extends TestCase
         $this->assertFilenameNotExists('app/Http/Controllers/FooController.php');
         $this->assertFilenameNotExists('database/factories/FooFactory.php');
         $this->assertFilenameNotExists('database/seeders/FooSeeder.php');
+    }
+
+    public function testItPreservesMigrationGenerationOrderForModelsCreatedWithinTheSameSecond()
+    {
+        Carbon::setTestNow('2026-07-13 15:54:55');
+
+        $this->artisan('make:model', ['name' => 'Xxx', '--migration' => true])
+            ->assertExitCode(0);
+
+        $this->artisan('make:model', ['name' => 'Aaa', '--migration' => true])
+            ->assertExitCode(0);
+
+        $this->assertFilenameExists('database/migrations/2026_07_13_155455_create_xxxes_table.php');
+        $this->assertFilenameExists('database/migrations/2026_07_13_155456_create_aaas_table.php');
     }
 
     public function testItCanGenerateModelFileWithSeederption()


### PR DESCRIPTION
Ironically, this is basically the same as https://github.com/laravel/framework/pull/60770, but this one should be non-breaking for potentially existing subclasses. @pushpak1300 and I apparently started working on the same problem [triggered by Povilas 's tweet](https://x.com/PovilasKorop/status/2076638534996218326) yesterday. :)

**Running:**
```shell
php artisan make:model Xxx -m && php artisan make:model Aaa  -m
```

or

```
php artisan make:model Xxx -m 
php artisan make:model Aaa  -m
```

**Current Result:**
```
2026_07_13_155455_create_aaas_table.php
2026_07_13_155455_create_xxxes_table.php
```
Without maintaining the given generation order as given by the command order, references between migrations can cause:

> SQLSTATE[HY000]: General error: 1824 Failed to open the referenced table

**Expected Result:**
```
2026_07_13_155455_create_xxxes_table.php // X before A 
2026_07_13_155456_create_aaas_table.php
```

Solution is to add a pseudo-second to avoid collisions. This way we do not need to switch to more verbose timestamped prefixes with microseconds -- which would probably be breaking for some ecosystem stuff, too.

For completeness, Pushpaks PR will break userland implementations that already solved the timestamp collision problem on their own (or just use custom `getDatePrefix` for other reasons) by extending `MigrationCreator`:

> Fatal error: Declaration of ChildMigrationCreator::getDatePrefix() must be compatible with MigrationCreator::getDatePrefix($path = null)