### PR TITLE
[13.x] Update install-nightly workflow to also check Windows

### DIFF
--- a/.github/workflows/install-nightly.yml
+++ b/.github/workflows/install-nightly.yml
@@ -9,14 +9,19 @@ permissions:
 
 jobs:
   install:
-    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, windows-2022]
+
+    runs-on: ${{ matrix.os }}
 
     steps:
       - name: Setup PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: 8.3
-          extensions: dom, curl, libxml, mbstring, zip, pcntl
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, fileinfo
           tools: composer:v2
           coverage: none
 
@@ -25,6 +30,7 @@ jobs:
         with:
           timeout_minutes: 5
           max_attempts: 5
+          shell: bash
           # rm -rf app ensures each retry starts clean in case it previously fails...
           command: rm -rf app && composer create-project laravel/laravel app --no-install --no-scripts --no-interaction
 
@@ -37,6 +43,7 @@ jobs:
         with:
           timeout_minutes: 5
           max_attempts: 5
+          shell: bash
           command: cd app && composer update --with-all-dependencies --no-interaction --no-progress
 
       - name: Boot the application


### PR DESCRIPTION
This PR ensures the install workflow verifies Linux and Windows work as expected.  

Since I did https://github.com/laravel/framework/pull/60749 I realised we could benefit from covering windows too, as I wanted to make sure there's no chance any regression can happen to any OS.

See the job I ran to make sure it works: https://github.com/jackbayliss/framework/actions/runs/29318824384/job/87038952276
