### PR TITLE
[13.x] Ensure withoutEagerLoad removes eager loads from builder state

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -2071,9 +2071,7 @@ class Builder implements BuilderContract
      */
     public function withoutEagerLoad(array $relations)
     {
-        $relations = array_diff(array_keys($this->model->getRelations()), $relations);
-
-        return $this->with($relations);
+        return $this->without($relations);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -835,6 +835,30 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals(['foo'], $results);
     }
 
+    public function testWithoutEagerLoadRemovesOnlySpecifiedRelationsFromTheBuilderState()
+    {
+        $builder = m::mock(Builder::class.'[eagerLoadRelation]', [$this->getMockQueryBuilder()]);
+        $builder->setEagerLoads([
+            'comments' => function () {
+                return 'comments';
+            },
+            'posts' => function () {
+                return 'posts';
+            },
+        ]);
+
+        $model = m::mock(Model::class);
+        $model->shouldReceive('getRelations')->zeroOrMoreTimes()->andReturn([]);
+        $model->shouldReceive('getTable')->once()->andReturn('table');
+        $builder->getQuery()->shouldReceive('from')->once()->with('table');
+        $builder->setModel($model);
+
+        $builder->withoutEagerLoad(['comments']);
+
+        $this->assertArrayNotHasKey('comments', $builder->getEagerLoads());
+        $this->assertArrayHasKey('posts', $builder->getEagerLoads());
+    }
+
     public function testEagerLoadRelationsCanBeFlushed()
     {
         $builder = m::mock(Builder::class.'[eagerLoadRelation]', [$this->getMockQueryBuilder()]);


### PR DESCRIPTION
## Summary
Fix a bug where Eloquent queries could still load a relationship even after calling withoutEagerLoad().. what I noticed was that the query builder was not removing the given relationship from its own eager-loading settings correctly.

## Changes
- Updated Builder::withoutEagerLoad() to remove the requested relations from the existing eager-loaded configuration
- Added a regression test to ensure only the specified relation is removed while other eager loads remain intact

## Testing
- phpunit --filter testWithoutEagerLoadRemovesOnlySpecifiedRelationsFromTheBuilderState DatabaseEloquentBuilderTest.php
- phpunit DatabaseEloquentBuilderTest.php

## Example

- a query that calls `with(['comments', 'author'])` and then `withoutEagerLoad(['comments'])` should only retain `author` in the eager-load configuration.

Here is a snippet:

```php
$query = Post::query()->with(['comments', 'author']);

$query->withoutEagerLoad(['comments']);

assert(array_key_exists('author', $query->getEagerLoads()));
assert(! array_key_exists('comments', $query->getEagerLoads()));
```

Before this change, comments could still be eager-loaded even though $query->withoutEagerLoad(['comments']) was called.