### PR TITLE
[14.x] Change `Arrayable` templates

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -38,7 +38,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Create a new collection.
      *
-     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>|null  $items
+     * @param  \Illuminate\Contracts\Support\Arrayable<array<TKey, TValue>>|iterable<TKey, TValue>|null  $items
      */
     public function __construct($items = [])
     {
@@ -254,10 +254,9 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Cross join with the given lists, returning all possible permutations.
      *
-     * @template TCrossJoinKey
      * @template TCrossJoinValue
      *
-     * @param  \Illuminate\Contracts\Support\Arrayable<TCrossJoinKey, TCrossJoinValue>|iterable<TCrossJoinKey, TCrossJoinValue>  ...$lists
+     * @param  \Illuminate\Contracts\Support\Arrayable<array<array-key, TCrossJoinValue>>|iterable<array-key, TCrossJoinValue>  ...$lists
      * @return static<int, array<int, TValue|TCrossJoinValue>>
      */
     public function crossJoin(...$lists)

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -15,7 +15,7 @@ use Traversable;
  *
  * @template-covariant TValue
  *
- * @extends \Illuminate\Contracts\Support\Arrayable<TKey, TValue>
+ * @extends \Illuminate\Contracts\Support\Arrayable<array<TKey, TValue>>
  * @extends \IteratorAggregate<TKey, TValue>
  */
 interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, JsonSerializable
@@ -26,8 +26,8 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * @template TMakeKey of array-key
      * @template TMakeValue
      *
-     * @param  \Illuminate\Contracts\Support\Arrayable<TMakeKey, TMakeValue>|iterable<TMakeKey, TMakeValue>|null  $items
-     * @return static<TMakeKey, TMakeValue>
+     * @param  \Illuminate\Contracts\Support\Arrayable<array<array-key, mixed>>|iterable<TMakeKey, TMakeValue>|null  $items
+     * @return ($items is \Illuminate\Contracts\Support\Arrayable<array<TMakeKey, TMakeValue>> ? static<TMakeKey, TMakeValue> : static<TMakeKey, TMakeValue>)
      */
     public static function make($items = []);
 
@@ -168,10 +168,9 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Cross join with the given lists, returning all possible permutations.
      *
-     * @template TCrossJoinKey
      * @template TCrossJoinValue
      *
-     * @param  \Illuminate\Contracts\Support\Arrayable<TCrossJoinKey, TCrossJoinValue>|iterable<TCrossJoinKey, TCrossJoinValue>  ...$lists
+     * @param  \Illuminate\Contracts\Support\Arrayable<array<array-key, TCrossJoinValue>>|iterable<array-key, TCrossJoinValue>  ...$lists
      * @return static<int, array<int, TValue|TCrossJoinValue>>
      */
     public function crossJoin(...$lists);

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -40,7 +40,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     /**
      * Create a new lazy collection instance.
      *
-     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>|(Closure(): \Generator<TKey, TValue, mixed, void>)|self<TKey, TValue>|array<TKey, TValue>|null  $source
+     * @param  \Illuminate\Contracts\Support\Arrayable<array<TKey, TValue>>|iterable<TKey, TValue>|(Closure(): \Generator<TKey, TValue, mixed, void>)|self<TKey, TValue>|array<TKey, TValue>|null  $source
      *
      * @throws \InvalidArgumentException
      */
@@ -62,7 +62,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     /**
      * Create a new instance of the collection.
      *
-     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>|(Closure(): \Generator<TKey, TValue, mixed, void>)|self<TKey, TValue>|array<TKey, TValue>|null  $items
+     * @param  \Illuminate\Contracts\Support\Arrayable<array<TKey, TValue>>|iterable<TKey, TValue>|(Closure(): \Generator<TKey, TValue, mixed, void>)|self<TKey, TValue>|array<TKey, TValue>|null  $items
      * @return static
      */
     protected function newInstance($items = [])
@@ -76,8 +76,8 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * @template TMakeKey of array-key
      * @template TMakeValue
      *
-     * @param  \Illuminate\Contracts\Support\Arrayable<TMakeKey, TMakeValue>|iterable<TMakeKey, TMakeValue>|(Closure(): \Generator<TMakeKey, TMakeValue, mixed, void>)|self<TMakeKey, TMakeValue>|array<TMakeKey, TMakeValue>|null  $items
-     * @return static<TMakeKey, TMakeValue>
+     * @param  \Illuminate\Contracts\Support\Arrayable<array<array-key, mixed>>|iterable<TMakeKey, TMakeValue>|(Closure(): \Generator<TMakeKey, TMakeValue, mixed, void>)|self<TMakeKey, TMakeValue>|array<TMakeKey, TMakeValue>|null  $items
+     * @return ($items is \Illuminate\Contracts\Support\Arrayable<array<TMakeKey, TMakeValue>> ? static<TMakeKey, TMakeValue> : static<TMakeKey, TMakeValue>)
      */
     public static function make($items = [], ...$args)
     {

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -113,8 +113,8 @@ trait EnumeratesValues
      * @template TMakeKey of array-key
      * @template TMakeValue
      *
-     * @param  \Illuminate\Contracts\Support\Arrayable<TMakeKey, TMakeValue>|iterable<TMakeKey, TMakeValue>|null  $items
-     * @return static<TMakeKey, TMakeValue>
+     * @param  \Illuminate\Contracts\Support\Arrayable<array<array-key, mixed>>|iterable<TMakeKey, TMakeValue>|null  $items
+     * @return ($items is \Illuminate\Contracts\Support\Arrayable<array<TMakeKey, TMakeValue>> ? static<TMakeKey, TMakeValue> : static<TMakeKey, TMakeValue>)
      */
     public static function make($items = [], ...$args)
     {

--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -10,8 +10,8 @@ if (! function_exists('collect')) {
      * @template TKey of array-key
      * @template TValue
      *
-     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>|null  $value
-     * @return \Illuminate\Support\Collection<TKey, TValue>
+     * @param  \Illuminate\Contracts\Support\Arrayable<array<array-key, mixed>>|iterable<TKey, TValue>|null  $value
+     * @return ($value is \Illuminate\Contracts\Support\Arrayable<array<TKey, TValue>> ? \Illuminate\Support\Collection<TKey, TValue> : \Illuminate\Support\Collection<TKey, TValue>)
      */
     function collect($value = []): Collection
     {

--- a/src/Illuminate/Contracts/Support/Arrayable.php
+++ b/src/Illuminate/Contracts/Support/Arrayable.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Contracts\Support;
 
 /**
- * @template TReturn of array = array<array-key, mixed>
+ * @template-covariant TReturn of array = array<array-key, mixed>
  */
 interface Arrayable
 {

--- a/src/Illuminate/Contracts/Support/Arrayable.php
+++ b/src/Illuminate/Contracts/Support/Arrayable.php
@@ -3,15 +3,14 @@
 namespace Illuminate\Contracts\Support;
 
 /**
- * @template TKey of array-key
- * @template TValue
+ * @template TReturn of array = array<array-key, mixed>
  */
 interface Arrayable
 {
     /**
      * Get the instance as an array.
      *
-     * @return array<TKey, TValue>
+     * @return TReturn
      */
     public function toArray();
 }

--- a/types/Support/Arrayable.php
+++ b/types/Support/Arrayable.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Contracts\Support\Arrayable;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * @implements Arrayable<array{id: int, name: string, tags: array<string, string>}>
+ */
+class ShapedArrayableResponse implements Arrayable
+{
+    public function toArray(): array
+    {
+        return [
+            'id' => 1,
+            'name' => 'Taylor',
+            'tags' => ['framework' => 'Laravel'],
+        ];
+    }
+}
+
+assertType('array{id: int, name: string, tags: array<string, string>}', (new ShapedArrayableResponse)->toArray());

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -5,7 +5,7 @@ use Illuminate\Support\Collection;
 
 use function PHPStan\Testing\assertType;
 
-/** @implements Arrayable<int, User> */
+/** @implements Arrayable<array<int, User>> */
 class Users implements Arrayable
 {
     public function toArray(): array

--- a/types/Support/LazyCollection.php
+++ b/types/Support/LazyCollection.php
@@ -6,7 +6,7 @@ use Illuminate\Support\LazyCollection;
 
 use function PHPStan\Testing\assertType;
 
-/** @implements Arrayable<int, User> */
+/** @implements Arrayable<array<int, User>> */
 class Users implements Arrayable
 {
     public function toArray(): array


### PR DESCRIPTION
I don't like that, as a good steward of PHPStan, I need to declare the `@implements Arrayable` doc, but then give a proper array shape to my `toArray()` method.

Take for instance something like this:

```php
/** @implements Arrayable<string, mixed> */  // <--- This is nearly meaningless
class ShopifyOrder implements Arrayable
{
    public function __construct(
        public ShopifyGid $orderId,
        public string $firstName,
        public string $lastName,
        public Money $price
    ) {
    }

    /**
     * @return array{            // <-- This is the meaningful shape
     *     order_id: string,
     *     first_name: string,
     *     last_name: string,
     *     price: array{amount: int, currency: string}
     *  }
     */
    #[Override]
    public function toArray(): array
    {
        return [
            'order_id' => $this->orderId->__toString(),
            'first_name' => $this->firstName,
            'last_name' => $this->lastName,
            'price' => [
                'amount' => $this->price->amount,
                'currency' => $this->price->currency,
            ],
        ];
    }
}
```

The iterable type of `array<string, mixed>` is basically useless, and I end up having to re-write the fuller shape in the implementation.

What if instead we did this:

```php
/** 
 * @implements Arrayable<array{
 *     order_id: string,
 *     first_name: string,
 *     last_name: string,
 *     price: array{amount: int, currency: string}
 *  }>
 */
class ShopifyOrder implements Arrayable
{
    public function __construct(
        public ShopifyGid $orderId,
        public string $firstName,
        public string $lastName,
        public Money $price
    ) {
    }

    #[Override]
    public function toArray(): array
    {
        // same as above
    }
} 
```

Now we have a more precise array shape when we phpstan declare the implements, and don't need to duplicate it for the `toArray()` method.

## Why 14.x?
Because this will likely cause a lot of folks having to modify their userland code to encode the proper generics.