### PR TITLE
[13.x] Fix typos in doc blocks

### DIFF
--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -90,7 +90,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * @param  int  $from
      * @param  int  $to
      * @param  int  $step
-     * @return ($step is zero ? never : static<int, int>)
+     * @return ($step is 0 ? never : static<int, int>)
      *
      * @throws \InvalidArgumentException
      */

--- a/src/Illuminate/Contracts/Container/SelfBuilding.php
+++ b/src/Illuminate/Contracts/Container/SelfBuilding.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Contracts\Container;
 
 /**
- * @method static newInstance(): static
+ * @method static static newInstance()
  */
 interface SelfBuilding
 {

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -251,7 +251,7 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Load a relationship path for models of the given type if it is not already eager loaded.
      *
-     * @param  array<int, <string, class-string>>  $tuples
+     * @param  array<int, array<string, class-string>>  $tuples
      * @return void
      */
     public function loadMissingRelationshipChain(array $tuples)

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -212,7 +212,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * The callback that is responsible for handling lazy loading violations.
      *
-     * @var (callable(self, string))|null
+     * @var (callable(self, string): mixed)|null
      */
     protected static $lazyLoadingViolationCallback;
 
@@ -226,7 +226,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * The callback that is responsible for handling discarded attribute violations.
      *
-     * @var (callable(self, array))|null
+     * @var (callable(self, array): mixed)|null
      */
     protected static $discardedAttributeViolationCallback;
 
@@ -240,7 +240,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * The callback that is responsible for handling missing attribute violations.
      *
-     * @var (callable(self, string))|null
+     * @var (callable(self, string): mixed)|null
      */
     protected static $missingAttributeViolationCallback;
 
@@ -590,7 +590,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * Register a callback that is responsible for handling lazy loading violations.
      *
-     * @param  (callable(self, string))|null  $callback
+     * @param  (callable(self, string): mixed)|null  $callback
      * @return void
      */
     public static function handleLazyLoadingViolationUsing(?callable $callback)
@@ -612,7 +612,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * Register a callback that is responsible for handling discarded attribute violations.
      *
-     * @param  (callable(self, array))|null  $callback
+     * @param  (callable(self, array): mixed)|null  $callback
      * @return void
      */
     public static function handleDiscardedAttributeViolationUsing(?callable $callback)
@@ -634,7 +634,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * Register a callback that is responsible for handling missing attribute violations.
      *
-     * @param  (callable(self, string))|null  $callback
+     * @param  (callable(self, string): mixed)|null  $callback
      * @return void
      */
     public static function handleMissingAttributeViolationUsing(?callable $callback)

--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -388,7 +388,7 @@ class ApplicationBuilder
     /**
      * Register and configure the application's exception handler.
      *
-     * @param  callable(\Illuminate\Foundation\Configuration\Exceptions)|null  $using
+     * @param  (callable(\Illuminate\Foundation\Configuration\Exceptions): mixed)|null  $using
      * @return $this
      */
     public function withExceptions(?callable $using = null)

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -761,7 +761,7 @@ class PendingRequest
     /**
      * Add a new callback to execute after the response is built.
      *
-     * @param  (callable(\Illuminate\Http\Client\Response, \Illuminate\Http\Client\Request): \Illuminate\Http\Client\Response|null)  $callback
+     * @param  callable(\Illuminate\Http\Client\Response, \Illuminate\Http\Client\Request): (\Illuminate\Http\Client\Response|null)  $callback
      * @return $this
      */
     public function afterResponse(callable $callback)
@@ -1754,7 +1754,7 @@ class PendingRequest
      *
      * @return \Closure
      *
-     * @throws \Illuminate\Http\Client\Exceptions\StrayRequestException
+     * @throws \Illuminate\Http\Client\StrayRequestException
      */
     public function buildStubHandler()
     {

--- a/src/Illuminate/Http/Resources/JsonApi/Concerns/ResolvesJsonApiElements.php
+++ b/src/Illuminate/Http/Resources/JsonApi/Concerns/ResolvesJsonApiElements.php
@@ -37,7 +37,7 @@ trait ResolvesJsonApiElements
     /**
      * Cached loaded relationships map.
      *
-     * @var array<int, array{0: \Illuminate\Http\Resources\JsonApi\JsonApiResource, 1: string, 2: string, 3: bool}|null
+     * @var array<int, array{0: \Illuminate\Http\Resources\JsonApi\JsonApiResource, 1: string, 2: string, 3: bool}>|null
      */
     public $loadedRelationshipsMap;
 

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -1548,8 +1548,6 @@ class Mailable implements MailableContract, Renderable
     /**
      * Assert the mailable has the given attachment.
      *
-     * @param  string|\Illuminate\Contracts\Mail\Attachable|\Illuminate\Mail\Attachment  $file
-     * @param  array  $options
      * @return $this
      */
     public function assertHasNoAttachments()

--- a/src/Illuminate/Queue/Middleware/Skip.php
+++ b/src/Illuminate/Queue/Middleware/Skip.php
@@ -7,7 +7,7 @@ use Closure;
 class Skip
 {
     /**
-     * @param  bool  $param  Whether the job should be skipped.
+     * @param  bool  $skip  Whether the job should be skipped.
      */
     public function __construct(protected bool $skip = false)
     {

--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -467,7 +467,7 @@ class Password implements DataAwareRule, ImplicitRule, IteratorAggregate, Rule, 
     /**
      * Get an iterator for the password validation rules.
      *
-     * @return \ArrayIterator<TKey, TValue>
+     * @return \ArrayIterator<int, mixed>
      */
     public function getIterator(): Traversable
     {

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1643,7 +1643,7 @@ class Validator implements ValidatorContract
     /**
      * Ensure exponents are within range using the given callback.
      *
-     * @param  callable(int $scale, string $attribute, mixed $value)  $callback
+     * @param  callable(int, string, mixed): mixed  $callback
      * @return $this
      */
     public function ensureExponentWithinAllowedRangeUsing($callback)

--- a/src/Illuminate/View/DynamicComponent.php
+++ b/src/Illuminate/View/DynamicComponent.php
@@ -22,7 +22,7 @@ class DynamicComponent extends Component
     /**
      * The component tag compiler instance.
      *
-     * @var \Illuminate\View\Compilers\BladeTagCompiler
+     * @var \Illuminate\View\Compilers\ComponentTagCompiler
      */
     protected static $compiler;
 


### PR DESCRIPTION
This PR fixes some typos in doc blocks found in the framework, improving what editors and static analysis tools understand about framework code. This was done by temporarily raising the PHPStan level to 2.