### PR TITLE
[13.x] Add `Image` to facade workflow

### DIFF
--- a/.github/workflows/facades.yml
+++ b/.github/workflows/facades.yml
@@ -63,6 +63,7 @@ jobs:
             Illuminate\\Support\\Facades\\Gate \
             Illuminate\\Support\\Facades\\Hash \
             Illuminate\\Support\\Facades\\Http \
+            Illuminate\\Support\\Facades\\Image \
             Illuminate\\Support\\Facades\\Lang \
             Illuminate\\Support\\Facades\\Log \
             Illuminate\\Support\\Facades\\Mail \


### PR DESCRIPTION
Morning!

I was poking the Image facade locally and realised it wasnt hinting methods that the manager had ... which led to me this PR. 

(For those that don't know, this workflow is responsible for keeping the docblocks in sync, which is cool)

See https://github.com/jackbayliss/framework/commit/463a364ade17928426d6e3495b19cab7d8506425 to prove it adds methods 🫡 