### PR TITLE
[13.x] Add ImageProcessed event and image origin tracking

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -11,6 +11,7 @@ use Illuminate\Http\File;
 use Illuminate\Http\Request;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Image\Image;
+use Illuminate\Image\ImageOrigin;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Conditionable;
@@ -405,7 +406,7 @@ class FilesystemAdapter implements CloudFilesystemContract
      */
     public function image(string $path): Image
     {
-        return new Image(fn () => $this->get($path));
+        return new Image(fn () => $this->get($path), origin: new ImageOrigin('storage', $path));
     }
 
     /**

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -4,6 +4,7 @@ namespace Illuminate\Http\Concerns;
 
 use Illuminate\Http\UploadedFile;
 use Illuminate\Image\Image;
+use Illuminate\Image\ImageOrigin;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Fluent;
 use Illuminate\Support\Traits\Dumpable;
@@ -256,7 +257,7 @@ trait InteractsWithInput
             return null;
         }
 
-        return new Image(fn () => $file->getContent(), $file);
+        return new Image(fn () => $file->getContent(), $file, new ImageOrigin('upload', $file->getClientOriginalName()));
     }
 
     /**

--- a/src/Illuminate/Image/Events/ImageProcessed.php
+++ b/src/Illuminate/Image/Events/ImageProcessed.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Illuminate\Image\Events;
+
+use Illuminate\Image\ImageOrigin;
+use Illuminate\Image\ImagePipeline;
+
+class ImageProcessed
+{
+    /**
+     * Create a new event instance.
+     *
+     * @param  \Illuminate\Image\ImageOrigin|null  $origin  The origin of the image.
+     * @param  string  $driver  The name of the driver that processed the image.
+     * @param  \Illuminate\Image\ImagePipeline  $pipeline  The pipeline of applied transformations.
+     * @param  int  $inputSize  The image size in bytes before processing.
+     * @param  int  $outputSize  The image size in bytes after processing.
+     * @param  float  $time  The number of milliseconds it took to process the image.
+     */
+    public function __construct(
+        public ?ImageOrigin $origin,
+        public string $driver,
+        public ImagePipeline $pipeline,
+        public int $inputSize,
+        public int $outputSize,
+        public float $time,
+    ) {
+    }
+}

--- a/src/Illuminate/Image/Image.php
+++ b/src/Illuminate/Image/Image.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Filesystem\Factory as FilesystemFactory;
 use Illuminate\Contracts\Image\Driver;
 use Illuminate\Contracts\Image\Transformation;
 use Illuminate\Http\UploadedFile;
+use Illuminate\Image\Events\ImageProcessed;
 use Illuminate\Image\Transformations\Blur;
 use Illuminate\Image\Transformations\Contain;
 use Illuminate\Image\Transformations\Cover;
@@ -57,6 +58,7 @@ class Image implements Stringable
     public function __construct(
         protected Closure|string $contents,
         protected ?UploadedFile $file = null,
+        protected ?ImageOrigin $origin = null,
     ) {
         $this->pipeline = new ImagePipeline;
     }
@@ -348,18 +350,26 @@ class Image implements Stringable
     public function toBytes(): string
     {
         if ($this->pipeline->hasChanges() && ! $this->processed) {
+            $pipeline = $this->pipeline;
+
             try {
-                $this->contents = $this->resolveDriver()->process(
-                    value($this->contents), $this->pipeline
-                );
+                $contents = value($this->contents);
+
+                $startedAt = hrtime(true);
+
+                $this->contents = $this->resolveDriver()->process($contents, $pipeline);
             } catch (ImageException $e) {
                 throw $e;
             } catch (Throwable $e) {
-                throw new ImageException("Failed to process image: {$e->getMessage()}", 0, $e);
+                throw new ImageException("Failed to process image{$this->originContext()}: {$e->getMessage()}", 0, $e);
             }
+
+            $time = round((hrtime(true) - $startedAt) / 1_000_000, 2);
 
             $this->pipeline = new ImagePipeline;
             $this->processed = true;
+
+            $this->dispatchProcessedEvent($pipeline, strlen($contents), strlen($this->contents), $time);
         }
 
         return value($this->contents);
@@ -419,7 +429,7 @@ class Image implements Stringable
             $size = @getimagesizefromstring($this->toBytes());
 
             if ($size === false) {
-                throw new ImageException('Unable to determine the dimensions of the image.');
+                throw new ImageException("Unable to determine the dimensions of the image{$this->originContext()}.");
             }
 
             return [$size[0], $size[1]];
@@ -488,6 +498,43 @@ class Image implements Stringable
     public function file(): ?UploadedFile
     {
         return $this->file;
+    }
+
+    /**
+     * Get the origin of the image.
+     */
+    public function origin(): ?ImageOrigin
+    {
+        return $this->origin;
+    }
+
+    /**
+     * Get the image origin context for exception messages.
+     */
+    protected function originContext(): string
+    {
+        return $this->origin ? " [{$this->origin}]" : '';
+    }
+
+    /**
+     * Dispatch the image processed event.
+     */
+    protected function dispatchProcessedEvent(ImagePipeline $pipeline, int $inputSize, int $outputSize, float $time): void
+    {
+        $container = Container::getInstance();
+
+        if (! $container->bound('events')) {
+            return;
+        }
+
+        $container->make('events')->dispatch(new ImageProcessed(
+            $this->origin,
+            $this->driver ?? $container->make('image')->getDefaultDriver(),
+            $pipeline,
+            $inputSize,
+            $outputSize,
+            $time,
+        ));
     }
 
     /**

--- a/src/Illuminate/Image/ImageManager.php
+++ b/src/Illuminate/Image/ImageManager.php
@@ -26,7 +26,7 @@ class ImageManager extends Manager
      */
     public function fromBytes(string $contents): Image
     {
-        return new Image($contents);
+        return new Image($contents, origin: new ImageOrigin('bytes'));
     }
 
     /**
@@ -36,6 +36,7 @@ class ImageManager extends Manager
     {
         return new Image(
             fn () => base64_decode($base64, true) ?: throw new ImageException('Invalid base64 image data.'),
+            origin: new ImageOrigin('base64'),
         );
     }
 
@@ -46,6 +47,7 @@ class ImageManager extends Manager
     {
         return new Image(
             fn () => $this->container->make(Filesystem::class)->get($path),
+            origin: new ImageOrigin('path', $path),
         );
     }
 
@@ -56,6 +58,7 @@ class ImageManager extends Manager
     {
         return new Image(
             fn () => $this->container->make(FilesystemFactory::class)->disk($disk)->get($path),
+            origin: new ImageOrigin('storage', $path, $disk),
         );
     }
 
@@ -64,7 +67,7 @@ class ImageManager extends Manager
      */
     public function fromUpload(UploadedFile $file): Image
     {
-        return new Image(fn () => $file->getContent(), $file);
+        return new Image(fn () => $file->getContent(), $file, new ImageOrigin('upload', $file->getClientOriginalName()));
     }
 
     /**
@@ -74,6 +77,7 @@ class ImageManager extends Manager
     {
         return new Image(
             fn () => $this->container->make(HttpFactory::class)->get($url)->body(),
+            origin: new ImageOrigin('url', $url),
         );
     }
 

--- a/src/Illuminate/Image/ImageOrigin.php
+++ b/src/Illuminate/Image/ImageOrigin.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Illuminate\Image;
+
+use Stringable;
+
+class ImageOrigin implements Stringable
+{
+    /**
+     * Create a new image origin instance.
+     *
+     * @param  'path'|'url'|'storage'|'upload'|'bytes'|'base64'  $type
+     */
+    public function __construct(
+        public string $type,
+        public ?string $reference = null,
+        public ?string $disk = null,
+    ) {
+    }
+
+    /**
+     * Get the string representation of the origin.
+     */
+    public function __toString(): string
+    {
+        return implode(':', array_filter(
+            [$this->type, $this->disk, $this->reference],
+            fn ($value) => ! is_null($value),
+        ));
+    }
+}

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -214,6 +214,8 @@ class FilesystemAdapterTest extends TestCase
 
         $this->assertInstanceOf(Image::class, $image);
         $this->assertSame([100, 100], $image->dimensions());
+        $this->assertSame('storage', $image->origin()->type);
+        $this->assertSame('photo.jpg', $image->origin()->reference);
     }
 
     public function testMimeTypeNotDetected()

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -1171,7 +1171,11 @@ class HttpRequestTest extends TestCase
             ],
         ];
         $request = Request::create('/', 'GET', [], [], $files);
-        $this->assertInstanceOf(Image::class, $request->image('avatar'));
+        $image = $request->image('avatar');
+
+        $this->assertInstanceOf(Image::class, $image);
+        $this->assertSame('upload', $image->origin()->type);
+        $this->assertSame('avatar.jpg', $image->origin()->reference);
     }
 
     public function testImageMethodReturnsNullForMissingKey()

--- a/tests/Image/ImageManagerTest.php
+++ b/tests/Image/ImageManagerTest.php
@@ -351,6 +351,58 @@ class ImageManagerTest extends TestCase
         return file_get_contents($file->getRealPath());
     }
 
+    public function test_from_bytes_sets_origin()
+    {
+        $origin = (new ImageManager($this->makeApp([])))->fromBytes('contents')->origin();
+
+        $this->assertSame('bytes', $origin->type);
+        $this->assertNull($origin->reference);
+    }
+
+    public function test_from_base64_sets_origin()
+    {
+        $origin = (new ImageManager($this->makeApp([])))->fromBase64('contents')->origin();
+
+        $this->assertSame('base64', $origin->type);
+        $this->assertNull($origin->reference);
+    }
+
+    public function test_from_path_sets_origin()
+    {
+        $origin = (new ImageManager($this->makeApp([])))->fromPath('/tmp/photo.jpg')->origin();
+
+        $this->assertSame('path', $origin->type);
+        $this->assertSame('/tmp/photo.jpg', $origin->reference);
+        $this->assertNull($origin->disk);
+    }
+
+    public function test_from_storage_sets_origin()
+    {
+        $origin = (new ImageManager($this->makeApp([])))->fromStorage('photos/avatar.jpg', 's3')->origin();
+
+        $this->assertSame('storage', $origin->type);
+        $this->assertSame('photos/avatar.jpg', $origin->reference);
+        $this->assertSame('s3', $origin->disk);
+    }
+
+    public function test_from_upload_sets_origin()
+    {
+        $file = UploadedFile::fake()->image('test.jpg');
+
+        $origin = (new ImageManager($this->makeApp([])))->fromUpload($file)->origin();
+
+        $this->assertSame('upload', $origin->type);
+        $this->assertSame('test.jpg', $origin->reference);
+    }
+
+    public function test_from_url_sets_origin()
+    {
+        $origin = (new ImageManager($this->makeApp([])))->fromUrl('https://example.com/photo.jpg')->origin();
+
+        $this->assertSame('url', $origin->type);
+        $this->assertSame('https://example.com/photo.jpg', $origin->reference);
+    }
+
     protected function makeApp(array $config): Application
     {
         $app = m::mock(Application::class, \ArrayAccess::class);

--- a/tests/Image/ImageOriginTest.php
+++ b/tests/Image/ImageOriginTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Illuminate\Tests\Image;
+
+use Illuminate\Image\ImageOrigin;
+use PHPUnit\Framework\TestCase;
+
+class ImageOriginTest extends TestCase
+{
+    public function test_to_string_with_type_only()
+    {
+        $this->assertSame('bytes', (string) new ImageOrigin('bytes'));
+    }
+
+    public function test_to_string_with_reference()
+    {
+        $this->assertSame('path:/tmp/photo.jpg', (string) new ImageOrigin('path', '/tmp/photo.jpg'));
+    }
+
+    public function test_to_string_with_disk_and_reference()
+    {
+        $this->assertSame('storage:s3:photos/avatar.jpg', (string) new ImageOrigin('storage', 'photos/avatar.jpg', 's3'));
+    }
+}

--- a/tests/Image/ImageTest.php
+++ b/tests/Image/ImageTest.php
@@ -2,9 +2,16 @@
 
 namespace Illuminate\Tests\Image;
 
+use Illuminate\Config\Repository;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Image\Driver;
+use Illuminate\Events\Dispatcher;
 use Illuminate\Http\UploadedFile;
+use Illuminate\Image\Events\ImageProcessed;
 use Illuminate\Image\Image;
 use Illuminate\Image\ImageException;
+use Illuminate\Image\ImageManager;
+use Illuminate\Image\ImageOrigin;
 use Illuminate\Image\ImageOutputOptions;
 use Illuminate\Image\ImagePipeline;
 use Illuminate\Image\Transformations\Blur;
@@ -23,6 +30,13 @@ use PHPUnit\Framework\TestCase;
 
 class ImageTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        Container::setInstance(null);
+
+        parent::tearDown();
+    }
+
     public function test_cover_returns_new_instance()
     {
         $image = $this->makeImage();
@@ -934,9 +948,143 @@ class ImageTest extends TestCase
         $this->assertInstanceOf(\RuntimeException::class, $exception);
     }
 
+    public function test_to_bytes_dispatches_image_processed_event()
+    {
+        $events = [];
+
+        $this->captureProcessedEvents($events);
+
+        $contents = $this->fakeImageContents();
+        $image = (new Image($contents, origin: new ImageOrigin('bytes')))->cover(50, 50);
+
+        $processed = $image->toBytes();
+
+        $this->assertCount(1, $events);
+        $this->assertSame('bytes', $events[0]->origin->type);
+        $this->assertSame('fake', $events[0]->driver);
+        $this->assertCount(1, $events[0]->pipeline->transformations);
+        $this->assertSame(strlen($contents), $events[0]->inputSize);
+        $this->assertSame(strlen($processed), $events[0]->outputSize);
+        $this->assertGreaterThanOrEqual(0, $events[0]->time);
+    }
+
+    public function test_to_bytes_without_changes_does_not_dispatch_event()
+    {
+        $events = [];
+
+        $this->captureProcessedEvents($events);
+
+        (new Image($this->fakeImageContents()))->toBytes();
+
+        $this->assertCount(0, $events);
+    }
+
+    public function test_to_bytes_dispatches_event_only_once()
+    {
+        $events = [];
+
+        $this->captureProcessedEvents($events);
+
+        $image = (new Image($this->fakeImageContents()))->cover(50, 50);
+
+        $image->toBytes();
+        $image->toBytes();
+
+        $this->assertCount(1, $events);
+    }
+
+    public function test_to_bytes_processes_without_event_dispatcher()
+    {
+        $this->makeProcessingContainer(withEvents: false);
+
+        $image = (new Image($this->fakeImageContents()))->cover(50, 50);
+
+        $this->assertNotEmpty($image->toBytes());
+    }
+
+    public function test_driver_exception_message_contains_origin()
+    {
+        $image = new Image($this->fakeImageContents(), origin: new ImageOrigin('storage', 'photos/avatar.jpg', 's3'));
+
+        $this->expectException(ImageException::class);
+        $this->expectExceptionMessage('Failed to process image [storage:s3:photos/avatar.jpg]:');
+
+        $image->using('nonexistent')->cover(100, 100)->toBytes();
+    }
+
+    public function test_loader_exception_is_wrapped_in_image_exception()
+    {
+        $image = (new Image(fn () => throw new \RuntimeException('File missing.')))->cover(10, 10);
+
+        $this->expectException(ImageException::class);
+        $this->expectExceptionMessage('Failed to process image: File missing.');
+
+        $image->toBytes();
+    }
+
+    public function test_dimensions_exception_message_contains_origin()
+    {
+        $image = new Image('not-an-image', origin: new ImageOrigin('path', '/tmp/photo.jpg'));
+
+        $this->expectException(ImageException::class);
+        $this->expectExceptionMessage('Unable to determine the dimensions of the image [path:/tmp/photo.jpg].');
+
+        $image->dimensions();
+    }
+
+    public function test_origin_is_preserved_on_clones()
+    {
+        $origin = new ImageOrigin('bytes');
+        $image = new Image($this->fakeImageContents(), origin: $origin);
+
+        $this->assertSame($origin, $image->cover(100, 100)->origin());
+    }
+
     protected function makeImage(): Image
     {
         return new Image($this->fakeImageContents());
+    }
+
+    /**
+     * @param  array<int, \Illuminate\Image\Events\ImageProcessed>  $events
+     */
+    protected function captureProcessedEvents(array &$events): void
+    {
+        $container = $this->makeProcessingContainer();
+
+        $container->make('events')->listen(ImageProcessed::class, function (ImageProcessed $event) use (&$events) {
+            $events[] = $event;
+        });
+    }
+
+    protected function makeProcessingContainer(bool $withEvents = true): Container
+    {
+        $container = new Container;
+        $container->instance('config', new Repository(['image' => ['default' => 'fake']]));
+
+        if ($withEvents) {
+            $container->instance('events', new Dispatcher($container));
+        }
+
+        $manager = new ImageManager($container);
+        $manager->extend('fake', fn () => new class implements Driver
+        {
+            public function process(string $contents, ImagePipeline $pipeline): string
+            {
+                return $contents.'-processed';
+            }
+
+            public function transformUsing(string $transformation, callable $callback): static
+            {
+                return $this;
+            }
+        });
+
+        $container->instance('image', $manager);
+
+        Container::setInstance($container);
+
+        return $container;
     }
 
     protected function fakeImageContents(int $width = 100, int $height = 100): string


### PR DESCRIPTION
## Summary

The new Image component is a great addition, but image processing is currently invisible to monitoring and debugging tools. Processing may be triggered *implicitly* — `mimeType()`, `dimensions()`, and `__toString()` all call `toBytes()` under the hood — so there is no reliable call site where an application could measure it on its own.

This PR adds observability to the component:

- A new `ImageProcessed` event is dispatched whenever an image pipeline is actually processed, carrying the driver name, the executed pipeline, input/output sizes in bytes, and the processing time in milliseconds.
- A new `ImageOrigin` value object describes where an image was loaded from, so the event (and exception messages) can answer *which* image was slow or broken.
- `ImageException` messages now include the origin context instead of being contextless.

## The `ImageProcessed` event

```php
use Illuminate\Image\Events\ImageProcessed;
use Illuminate\Support\Facades\Event;

Event::listen(function (ImageProcessed $event) {
    Log::info("Processed image [{$event->origin}] using [{$event->driver}] in {$event->time}ms", [
        'transformations' => count($event->pipeline->transformations),
        'input' => $event->inputSize,
        'output' => $event->outputSize,
    ]);
});
```

| Property | Description |
| --- | --- |
| `origin` | `ImageOrigin\|null` — where the image was loaded from |
| `driver` | The driver name that processed the image (`gd`, `imagick`, or a custom driver) |
| `pipeline` | The executed `ImagePipeline` (transformations + output options) |
| `inputSize` | Image size in bytes before processing |
| `outputSize` | Image size in bytes after processing |
| `time` | Processing time in milliseconds (measured with `hrtime()`, excludes lazy-loading I/O) |

The event is only dispatched when actual processing happens: once per instance, never for images without transformations, and never for repeated `toBytes()` calls on an already processed instance.

## Image origins

Every factory method now records where the image came from, and the origin travels through the immutable clone chain:

```php
Image::fromUpload($request->file('avatar'))->origin();   // upload:avatar.jpg
Image::fromStorage('photos/a.jpg', 's3')->origin();      // storage:s3:photos/a.jpg
Storage::disk('s3')->image('photos/a.jpg')->origin();    // storage:photos/a.jpg
Image::fromPath('/tmp/photo.jpg')->origin();             // path:/tmp/photo.jpg
Image::fromUrl('https://example.com/a.jpg')->origin();   // url:https://example.com/a.jpg
Image::fromBytes($bytes)->origin();                      // bytes
Image::fromBase64($base64)->origin();                    // base64
$request->image('avatar')->origin();                     // upload:avatar.jpg
```

## Exception messages with context

Failures now identify the affected image, which makes corrupt uploads and broken assets much easier to trace in logs:

```
// Before
Failed to process image: Unable to decode input

// After
Failed to process image [upload:avatar.jpg]: Unable to decode input
Unable to determine the dimensions of the image [storage:s3:photos/a.jpg].
```

Messages for images constructed directly via `new Image(...)` are unchanged.

## Example: Pulse recorder

The main motivation is enabling tooling. With this event, a "slow image processing" recorder for Laravel Pulse (or any custom telemetry) becomes trivial — analogous to how `SlowQueries` consumes `QueryExecuted`:

```php
class SlowImageProcessing
{
    public string $listen = ImageProcessed::class;

    public function record(ImageProcessed $event): void
    {
        if ($event->time < 2_000) {
            return;
        }

        Pulse::record(
            type: 'slow_image',
            key: (string) ($event->origin ?? 'unknown'),
            value: (int) $event->time,
        )->max()->count();
    }
}
```

Thanks for considering, and happy to adjust anything — naming, the event payload, or splitting the origin tracking into a separate PR if that is preferred. If this gets merged, I'll gladly follow up with a PR to laravel/docs documenting the event and origin tracking.
