### PR TITLE
[13.x] Add Arr::missing() method

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -542,6 +542,18 @@ class Arr
     }
 
     /**
+     * Check if an item or one of the items does not exist in an array using "dot" notation.
+     *
+     * @param  \ArrayAccess|array  $array
+     * @param  string|array  $keys
+     * @return bool
+     */
+    public static function missing($array, $keys)
+    {
+        return ! static::has($array, $keys);
+    }
+
+    /**
      * Determine if all keys exist in an array using "dot" notation.
      *
      * @param  \ArrayAccess|array  $array

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -808,6 +808,69 @@ class SupportArrTest extends TestCase
         $this->assertFalse(Arr::has([], ['']));
     }
 
+    public function testMissing()
+    {
+        $array = ['products.desk' => ['price' => 100]];
+        $this->assertFalse(Arr::missing($array, 'products.desk'));
+
+        $array = ['products' => ['desk' => ['price' => 100]]];
+        $this->assertFalse(Arr::missing($array, 'products.desk'));
+        $this->assertFalse(Arr::missing($array, 'products.desk.price'));
+        $this->assertTrue(Arr::missing($array, 'products.foo'));
+        $this->assertTrue(Arr::missing($array, 'products.desk.foo'));
+
+        $array = ['foo' => null, 'bar' => ['baz' => null]];
+        $this->assertFalse(Arr::missing($array, 'foo'));
+        $this->assertFalse(Arr::missing($array, 'bar.baz'));
+
+        $array = new ArrayObject(['foo' => 10, 'bar' => new ArrayObject(['baz' => 10])]);
+        $this->assertFalse(Arr::missing($array, 'foo'));
+        $this->assertFalse(Arr::missing($array, 'bar'));
+        $this->assertFalse(Arr::missing($array, 'bar.baz'));
+        $this->assertTrue(Arr::missing($array, 'xxx'));
+        $this->assertTrue(Arr::missing($array, 'xxx.yyy'));
+        $this->assertTrue(Arr::missing($array, 'foo.xxx'));
+        $this->assertTrue(Arr::missing($array, 'bar.xxx'));
+
+        $array = new ArrayObject(['foo' => null, 'bar' => new ArrayObject(['baz' => null])]);
+        $this->assertFalse(Arr::missing($array, 'foo'));
+        $this->assertFalse(Arr::missing($array, 'bar.baz'));
+
+        $array = ['foo', 'bar'];
+        $this->assertTrue(Arr::missing($array, null));
+
+        $this->assertTrue(Arr::missing(null, 'foo'));
+        $this->assertTrue(Arr::missing(false, 'foo'));
+
+        $this->assertTrue(Arr::missing(null, null));
+        $this->assertTrue(Arr::missing([], null));
+
+        $array = ['products' => ['desk' => ['price' => 100]]];
+        $this->assertFalse(Arr::missing($array, ['products.desk']));
+        $this->assertFalse(Arr::missing($array, ['products.desk', 'products.desk.price']));
+        $this->assertFalse(Arr::missing($array, ['products', 'products']));
+        $this->assertTrue(Arr::missing($array, ['foo']));
+        $this->assertTrue(Arr::missing($array, []));
+        $this->assertTrue(Arr::missing($array, ['products.desk', 'products.price']));
+
+        $array = [
+            'products' => [
+                ['name' => 'desk'],
+            ],
+        ];
+        $this->assertFalse(Arr::missing($array, 'products.0.name'));
+        $this->assertTrue(Arr::missing($array, 'products.0.price'));
+
+        $this->assertTrue(Arr::missing([], [null]));
+        $this->assertTrue(Arr::missing(null, [null]));
+
+        $this->assertFalse(Arr::missing(['' => 'some'], ''));
+        $this->assertFalse(Arr::missing(['' => 'some'], ['']));
+        $this->assertTrue(Arr::missing([''], ''));
+        $this->assertTrue(Arr::missing([], ''));
+        $this->assertTrue(Arr::missing([], ['']));
+    }
+
     public function testHasAllMethod()
     {
         $array = ['name' => 'Taylor', 'age' => '', 'city' => null];


### PR DESCRIPTION
`Arr::has()` is a super important method. So I am pretty confident that it's inverse proposed in this PR could be very helpful.

For example, a number of API providers are still weird. They provide a 200 response for every request, successful or failed. We have to examine the response to know if the request is successful or failed.

We are using the KYC service named Sumsub, with the following `POST https://api.sumsub.com/resources/applicants` to create a new customer profile. If the response does not contain an `id` (or something like `response.data.id` in other services) field, that means the request has failed.

```php
$response = $sumSubApiClient->createApplicant(...);

if (Arr::missing($response, 'id')) {
    // Handle failure.
}
```
I also noticed that a similar PR has been rejected: https://github.com/laravel/framework/pull/55813

But this PR:

- Provides test cases.
- Hold off the `missingAny` method. I believe this `missing` method has already done the job of missing any.