### PR TITLE
[13.x] Add tests for the scheduler's conditional ping methods

### DIFF
--- a/tests/Integration/Console/Scheduling/EventPingTest.php
+++ b/tests/Integration/Console/Scheduling/EventPingTest.php
@@ -45,4 +45,126 @@ class EventPingTest extends TestCase
 
         $this->assertTrue($thenCalled);
     }
+
+    public function testPingBeforeIfPingsTheUrlWhenTheConditionIsTrue()
+    {
+        $mock = $this->swapHttpClientWithMock();
+
+        $event = $this->newEvent();
+
+        $event->pingBeforeIf(true, 'https://example.com/ping');
+        $event->callBeforeCallbacks($this->app->make(Container::class));
+
+        $this->assertPinged($mock);
+    }
+
+    public function testPingBeforeIfDoesNotPingTheUrlWhenTheConditionIsFalse()
+    {
+        $mock = $this->swapHttpClientWithMock();
+
+        $event = $this->newEvent();
+
+        $event->pingBeforeIf(false, 'https://example.com/ping');
+        $event->callBeforeCallbacks($this->app->make(Container::class));
+
+        $this->assertNull($mock->getLastRequest());
+    }
+
+    public function testThenPingIfPingsTheUrlWhenTheConditionIsTrue()
+    {
+        $mock = $this->swapHttpClientWithMock();
+
+        $event = $this->newEvent();
+
+        $event->thenPingIf(true, 'https://example.com/ping');
+        $event->callAfterCallbacks($this->app->make(Container::class));
+
+        $this->assertPinged($mock);
+    }
+
+    public function testThenPingIfDoesNotPingTheUrlWhenTheConditionIsFalse()
+    {
+        $mock = $this->swapHttpClientWithMock();
+
+        $event = $this->newEvent();
+
+        $event->thenPingIf(false, 'https://example.com/ping');
+        $event->callAfterCallbacks($this->app->make(Container::class));
+
+        $this->assertNull($mock->getLastRequest());
+    }
+
+    public function testPingOnSuccessIfPingsTheUrlWhenTheConditionIsTrue()
+    {
+        $mock = $this->swapHttpClientWithMock();
+
+        $event = $this->newEvent();
+        $event->exitCode = 0;
+
+        $event->pingOnSuccessIf(true, 'https://example.com/ping');
+        $event->callAfterCallbacks($this->app->make(Container::class));
+
+        $this->assertPinged($mock);
+    }
+
+    public function testPingOnSuccessIfDoesNotPingTheUrlWhenTheConditionIsFalse()
+    {
+        $mock = $this->swapHttpClientWithMock();
+
+        $event = $this->newEvent();
+        $event->exitCode = 0;
+
+        $event->pingOnSuccessIf(false, 'https://example.com/ping');
+        $event->callAfterCallbacks($this->app->make(Container::class));
+
+        $this->assertNull($mock->getLastRequest());
+    }
+
+    public function testPingOnFailureIfPingsTheUrlWhenTheConditionIsTrue()
+    {
+        $mock = $this->swapHttpClientWithMock();
+
+        $event = $this->newEvent();
+        $event->exitCode = 1;
+
+        $event->pingOnFailureIf(true, 'https://example.com/ping');
+        $event->callAfterCallbacks($this->app->make(Container::class));
+
+        $this->assertPinged($mock);
+    }
+
+    public function testPingOnFailureIfDoesNotPingTheUrlWhenTheConditionIsFalse()
+    {
+        $mock = $this->swapHttpClientWithMock();
+
+        $event = $this->newEvent();
+        $event->exitCode = 1;
+
+        $event->pingOnFailureIf(false, 'https://example.com/ping');
+        $event->callAfterCallbacks($this->app->make(Container::class));
+
+        $this->assertNull($mock->getLastRequest());
+    }
+
+    protected function swapHttpClientWithMock()
+    {
+        $mock = new MockHandler([new Psr7Response(200)]);
+
+        $this->swap(HttpClient::class, new HttpClient([
+            'handler' => HandlerStack::create($mock),
+        ]));
+
+        return $mock;
+    }
+
+    protected function newEvent()
+    {
+        return new Event(m::mock(EventMutex::class), 'php -i');
+    }
+
+    protected function assertPinged(MockHandler $mock)
+    {
+        $this->assertNotNull($mock->getLastRequest());
+        $this->assertSame('https://example.com/ping', (string) $mock->getLastRequest()->getUri());
+    }
 }


### PR DESCRIPTION
`Event` exposes four conditional ping helpers (`pingBeforeIf()`, `thenPingIf()`, `pingOnSuccessIf()`, `pingOnFailureIf()`) that ping a URL only when a condition holds. They were added in #24077 and #53795. Neither PR included tests.

`EventPingTest` currently only covers `pingBefore()`, and only to check that a failing endpoint doesn't break the event. Inverting the condition in any of the four `*If` methods doesn't fail the suite today.

This adds a case where the condition holds and one where it doesn't, for each method. The `onSuccess`/`onFailure` variants set `exitCode` explicitly, so the condition is the only thing under test.