### PR TITLE
Add strict() command for SQLite tables

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -341,6 +341,17 @@ class Blueprint
     }
 
     /**
+     * Indicate that the table should be created in strict mode.
+     * This only affects SQLite 3.37.0 and later.
+     *
+     * @return \Illuminate\Support\Fluent
+     */
+    public function strict()
+    {
+        return $this->addCommand('strict');
+    }
+
+    /**
      * Specify the storage engine that should be used for the table.
      *
      * @param  string  $engine

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -230,12 +230,13 @@ class SQLiteGrammar extends Grammar
      */
     public function compileCreate(Blueprint $blueprint, Fluent $command)
     {
-        return sprintf('%s table %s (%s%s%s)',
+        return sprintf('%s table %s (%s%s%s)%s',
             $blueprint->temporary ? 'create temporary' : 'create',
             $this->wrapTable($blueprint),
             implode(', ', $this->getColumns($blueprint)),
             $this->addForeignKeys($this->getCommandsByName($blueprint, 'foreign')),
-            $this->addPrimaryKeys($this->getCommandByName($blueprint, 'primary'))
+            $this->addPrimaryKeys($this->getCommandByName($blueprint, 'primary')),
+            $this->hasCommand($blueprint, 'strict') ? ' strict' : ''
         );
     }
 

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -54,6 +54,19 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertSame('create temporary table "users" ("id" integer primary key autoincrement not null, "email" varchar not null)', $statements[0]);
     }
 
+    public function testCreateStrictTable()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->create();
+        $blueprint->strict();
+        $blueprint->increments('id');
+        $blueprint->string('email');
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('create table "users" ("id" integer primary key autoincrement not null, "email" varchar not null) strict', $statements[0]);
+    }
+
     public function testDropTable()
     {
         $blueprint = new Blueprint($this->getConnection(), 'users');


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR adds support for creating strict tables in SQLite. By default, any value can go into any type on SQLite tables. Strict mode restricts this to only valid values for the specified data type.

It only affects the SQLite schema grammar.

Source: https://sqlite.org/stricttables.html

Inspired by: https://github.com/laravel/framework/pull/51413
