### PR TITLE
[13.x] Fix parameter name in SyncQueue docblock

### DIFF
--- a/src/Illuminate/Queue/SyncQueue.php
+++ b/src/Illuminate/Queue/SyncQueue.php
@@ -239,7 +239,7 @@ class SyncQueue extends Queue implements QueueContract
      * Raise the job attempted event.
      *
      * @param  \Illuminate\Contracts\Queue\Job  $job
-     * @param  \Throwable|null  $exception
+     * @param  \Throwable|null  $exceptionOccurred
      * @return void
      */
     protected function raiseJobAttemptedEvent(Job $job, ?Throwable $exceptionOccurred = null)


### PR DESCRIPTION
The docblock for `SyncQueue::raiseJobAttemptedEvent()` references
`$exception`, but the parameter is named `$exceptionOccurred`. Mismatched
`@param` names break IDE parameter hints and static analysis tooling that
matches docblocks to parameters by name. No behavior changes.
