### PR TITLE
[13.x] Improve vendor publish search matching

### DIFF
--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -141,10 +141,7 @@ class VendorPublishCommand extends Command
             )
             : search(
                 label: "Which provider or tag's files would you like to publish?",
-                options: fn ($search) => array_values(array_filter(
-                    $choices,
-                    fn ($choice) => str_contains(strtolower($choice), strtolower($search))
-                )),
+                options: fn ($search) => $this->searchPublishableChoices($choices, $search),
                 placeholder: 'Search...',
                 scroll: 15,
             );
@@ -154,6 +151,83 @@ class VendorPublishCommand extends Command
         }
 
         $this->parseChoice($choice);
+    }
+
+    /**
+     * Search the publishable providers and tags.
+     *
+     * @param  array<int, string>  $choices
+     * @return array<int, string>
+     */
+    protected function searchPublishableChoices(array $choices, string $search)
+    {
+        $search = $this->searchValue($search);
+
+        if ($search === '') {
+            return $choices;
+        }
+
+        return collect($choices)
+            ->mapWithKeys(function ($choice) use ($search) {
+                $value = $this->searchValue($choice);
+
+                if (str_contains(" {$value} ", " {$search} ")) {
+                    return [$choice => 100];
+                }
+
+                if (Str::length(Str::remove(' ', $search)) > 2
+                    && str_contains(Str::remove(' ', $value), Str::remove(' ', $search))) {
+                    return [$choice => 99];
+                }
+
+                if ($this->matchesSearchTerms($value, $search)) {
+                    return [$choice => 98];
+                }
+
+                return [$choice => 0];
+            })
+            ->filter()
+            ->sortDesc()
+            ->keys()
+            ->all();
+    }
+
+    /**
+     * Determine whether every search term matches a value term.
+     */
+    protected function matchesSearchTerms(string $value, string $search)
+    {
+        foreach (explode(' ', $search) as $searchTerm) {
+            $matches = false;
+
+            foreach (explode(' ', $value) as $valueTerm) {
+                similar_text($searchTerm, Str::substr($valueTerm, 0, Str::length($searchTerm)), $similarity);
+
+                if (Str::startsWith($valueTerm, $searchTerm)
+                    || (Str::length($searchTerm) > 2 && Str::contains($valueTerm, $searchTerm))
+                    || $similarity >= 70) {
+                    $matches = true;
+
+                    break;
+                }
+            }
+
+            if (! $matches) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Normalize a value for searching.
+     */
+    protected function searchValue(string $value)
+    {
+        $value = Str::snake(Str::replace('\\', ' ', strip_tags($value)), ' ');
+
+        return Str::squish(preg_replace('/[^\p{L}\p{N}\p{M}]+/u', ' ', Str::lower($value)));
     }
 
     /**

--- a/tests/Foundation/FoundationVendorPublishCommandTest.php
+++ b/tests/Foundation/FoundationVendorPublishCommandTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Illuminate\Tests\Foundation;
+
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Foundation\Console\VendorPublishCommand;
+use PHPUnit\Framework\TestCase;
+
+class FoundationVendorPublishCommandTest extends TestCase
+{
+    private const CHOICES = [
+        'All providers and tags',
+        '<fg=gray>Provider:</> Filament\Support\SupportServiceProvider',
+        '<fg=gray>Provider:</> Spatie\MediaLibrary\MediaLibraryServiceProvider',
+        '<fg=gray>Tag:</> ai-config',
+        '<fg=gray>Tag:</> air-config',
+        '<fg=gray>Tag:</> cashier-config',
+        '<fg=gray>Tag:</> config',
+        '<fg=gray>Tag:</> mail-config',
+        '<fg=gray>Tag:</> medialibrary-config',
+        '<fg=gray>Tag:</> medialibrary-migrations',
+        '<fg=gray>Tag:</> media-library-views',
+        '<fg=gray>Tag:</> mcp-config',
+        '<fg=gray>Tag:</> pail-config',
+        '<fg=gray>Tag:</> sentry-config',
+        '<fg=gray>Tag:</> 配置',
+    ];
+
+    public function testItRanksSimilarPublishableChoices(): void
+    {
+        $this->assertSame([
+            '<fg=gray>Provider:</> Spatie\MediaLibrary\MediaLibraryServiceProvider',
+            '<fg=gray>Tag:</> medialibrary-config',
+            '<fg=gray>Tag:</> medialibrary-migrations',
+            '<fg=gray>Tag:</> media-library-views',
+        ], $this->command()->searchChoices(self::CHOICES, 'me'));
+
+        $this->assertSame([
+            '<fg=gray>Tag:</> medialibrary-config',
+        ], $this->command()->searchChoices(self::CHOICES, 'media c'));
+
+        $this->assertSame([
+            '<fg=gray>Tag:</> medialibrary-config',
+        ], $this->command()->searchChoices(self::CHOICES, 'media library config'));
+
+        $this->assertSame([
+            '<fg=gray>Tag:</> medialibrary-config',
+        ], $this->command()->searchChoices(self::CHOICES, 'media config'));
+
+        $this->assertSame(
+            '<fg=gray>Tag:</> medialibrary-config',
+            $this->command()->searchChoices(self::CHOICES, 'medai library config')[0],
+        );
+
+        $this->assertSame(
+            '<fg=gray>Tag:</> ai-config',
+            $this->command()->searchChoices(self::CHOICES, 'ai')[0],
+        );
+
+        $this->assertSame(
+            '<fg=gray>Provider:</> Spatie\MediaLibrary\MediaLibraryServiceProvider',
+            $this->command()->searchChoices(self::CHOICES, 'spatie medialibrary')[0],
+        );
+
+        $this->assertSame([], $this->command()->searchChoices(self::CHOICES, 'unrelated'));
+
+        $this->assertSame([
+            '<fg=gray>Tag:</> 配置',
+        ], $this->command()->searchChoices(self::CHOICES, '配置'));
+
+        $this->assertSame(
+            'All providers and tags',
+            $this->command()->searchChoices(self::CHOICES, 'all')[0],
+        );
+
+        $this->assertSame(
+            '<fg=gray>Tag:</> medialibrary-config',
+            $this->command()->searchChoices(self::CHOICES, 'tag medialibrary')[0],
+        );
+
+        $this->assertSame(
+            '<fg=gray>Provider:</> Spatie\MediaLibrary\MediaLibraryServiceProvider',
+            $this->command()->searchChoices(self::CHOICES, 'provider spatie')[0],
+        );
+    }
+
+    public function testItReturnsEveryChoiceForAnEmptySearch(): void
+    {
+        $this->assertSame(self::CHOICES, $this->command()->searchChoices(self::CHOICES, ''));
+    }
+
+    private function command(): VendorPublishCommandTestStub
+    {
+        return new VendorPublishCommandTestStub(new Filesystem);
+    }
+}
+
+class VendorPublishCommandTestStub extends VendorPublishCommand
+{
+    public function searchChoices(array $choices, string $search): array
+    {
+        return $this->searchPublishableChoices($choices, $search);
+    }
+}


### PR DESCRIPTION
This PR improves the `vendor:publish` prompt by matching each search term against publishable providers and tags.

It prioritizes literal and compact matches, supports progressive prefixes and typos using `similar_text`, and filters unrelated choices.

This allows searches such as `me`, `media c`, and `media library config` to surface `medialibrary-config` without returning the full publishable list.