### PR TITLE
[13.x] Add Image facade to defaultAliases

### DIFF
--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -295,6 +295,7 @@ abstract class Facade
             'Gate' => Gate::class,
             'Hash' => Hash::class,
             'Http' => Http::class,
+            'Image' => Image::class,
             'Js' => Js::class,
             'Lang' => Lang::class,
             'Log' => Log::class,


### PR DESCRIPTION
Sorry, missed this earlier..

Went to use Image in Tinker, but you cant as you need to do `Illuminate\Support\Facades\Image::fromBase64('xxx')`  otherwise, ya get

```
> Image::fromBase64('....');                                                                                                      

   Error  Class "Image" not found.
```

So, I bring this PR for an easier life, as imagine people may reach for the same, Concurrency & all the real facades are here so made sense to me. 

But, I may be wrong, I am but one man.

