### PR TITLE
[13.x] Add `toHtml()` to `Image`

### DIFF
--- a/src/Illuminate/Image/Image.php
+++ b/src/Illuminate/Image/Image.php
@@ -430,7 +430,7 @@ class Image implements Htmlable, Stringable
                     return [$value => true];
                 }
 
-                if (is_string($key) && (is_string($value) || $value instanceof Stringable || $value === true)) {
+                if (is_string($key) && (is_scalar($value) || $value instanceof Stringable || $value === true)) {
                     return [$key => $value];
                 }
             }))

--- a/src/Illuminate/Image/Image.php
+++ b/src/Illuminate/Image/Image.php
@@ -8,6 +8,7 @@ use Illuminate\Container\Container;
 use Illuminate\Contracts\Filesystem\Factory as FilesystemFactory;
 use Illuminate\Contracts\Image\Driver;
 use Illuminate\Contracts\Image\Transformation;
+use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Image\Transformations\Blur;
 use Illuminate\Image\Transformations\Contain;
@@ -27,7 +28,7 @@ use Illuminate\Support\Traits\Macroable;
 use Stringable;
 use Throwable;
 
-class Image implements Stringable
+class Image implements Htmlable, Stringable
 {
     use Conditionable, Macroable;
 

--- a/src/Illuminate/Image/Image.php
+++ b/src/Illuminate/Image/Image.php
@@ -402,7 +402,7 @@ class Image implements Htmlable, Stringable
                     return [$key => $value];
                 }
             }))
-            ->map(fn ($value, $key) => sprintf('%s="%s"', e($key), e($value)));
+            ->map(fn ($value, $key) => $value === true ? e($key) : sprintf('%s="%s"', e($key), e($value)));
 
         return '<img '.$attributes->join(' ').'>';
     }

--- a/src/Illuminate/Image/Image.php
+++ b/src/Illuminate/Image/Image.php
@@ -433,6 +433,8 @@ class Image implements Htmlable, Stringable
                 if (is_string($key) && (is_scalar($value) || $value instanceof Stringable || $value === true)) {
                     return [$key => $value];
                 }
+
+                return [];
             }))
             ->map(fn ($value, $key) => $value === true ? e($key) : sprintf('%s="%s"', e($key), e($value)));
 

--- a/src/Illuminate/Image/Image.php
+++ b/src/Illuminate/Image/Image.php
@@ -384,7 +384,7 @@ class Image implements Htmlable, Stringable
     }
 
     /**
-     * @param  array<string, scalar|\Stringable|bool>&string[]  $attributes
+     * @param  array<string, scalar|\Stringable|true>&string[]  $attributes
      */
     public function toHtml(array $attributes = []): string
     {
@@ -398,7 +398,7 @@ class Image implements Htmlable, Stringable
                     return [$value => true];
                 }
 
-                if (is_string($key) && (is_string($value) || $value instanceof Stringable || is_bool($value))) {
+                if (is_string($key) && (is_string($value) || $value instanceof Stringable || $value === true)) {
                     return [$key => $value];
                 }
             }))

--- a/src/Illuminate/Image/Image.php
+++ b/src/Illuminate/Image/Image.php
@@ -394,6 +394,7 @@ class Image implements Htmlable, Stringable
         ])
             ->merge($attributes)
             ->map(fn ($value, $key) => sprintf('%s="%s"', $key, $value));
+
         return '<img '.$attributes->join(' ').'>';
     }
 

--- a/src/Illuminate/Image/Image.php
+++ b/src/Illuminate/Image/Image.php
@@ -382,6 +382,21 @@ class Image implements Stringable
     }
 
     /**
+     * @param  array<string, scalar|\Stringable>  $attributes
+     */
+    public function toHtml(array $attributes = []): string
+    {
+        $attributes = collect([
+            'src' => $this->toDataUri(),
+            'width' => $this->width(),
+            'height' => $this->height(),
+        ])
+            ->merge($attributes)
+            ->map(fn ($value, $key) => sprintf('%s="%s"', $key, $value));
+        return '<img '.$attributes->join(' ').'>';
+    }
+
+    /**
      * Get the file extension based on the MIME type.
      */
     public function extension(): string

--- a/src/Illuminate/Image/Image.php
+++ b/src/Illuminate/Image/Image.php
@@ -393,7 +393,7 @@ class Image implements Htmlable, Stringable
             'height' => $this->height(),
         ])
             ->merge($attributes)
-            ->map(fn ($value, $key) => sprintf('%s="%s"', $key, $value));
+            ->map(fn ($value, $key) => sprintf('%s="%s"', e($key), e($value)));
 
         return '<img '.$attributes->join(' ').'>';
     }

--- a/src/Illuminate/Image/Image.php
+++ b/src/Illuminate/Image/Image.php
@@ -22,6 +22,7 @@ use Illuminate\Image\Transformations\Resize;
 use Illuminate\Image\Transformations\Rotate;
 use Illuminate\Image\Transformations\Scale;
 use Illuminate\Image\Transformations\Sharpen;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
@@ -383,7 +384,7 @@ class Image implements Htmlable, Stringable
     }
 
     /**
-     * @param  array<string, scalar|\Stringable>  $attributes
+     * @param  array<string, scalar|\Stringable|bool>&string[]  $attributes
      */
     public function toHtml(array $attributes = []): string
     {
@@ -392,7 +393,15 @@ class Image implements Htmlable, Stringable
             'width' => $this->width(),
             'height' => $this->height(),
         ])
-            ->merge($attributes)
+            ->merge(Arr::mapWithKeys($attributes, function ($value, $key) {
+                if (is_int($key) && is_string($value)) {
+                    return [$value => true];
+                }
+
+                if (is_string($key) && (is_string($value) || $value instanceof Stringable || is_bool($value))) {
+                    return [$key => $value];
+                }
+            }))
             ->map(fn ($value, $key) => sprintf('%s="%s"', e($key), e($value)));
 
         return '<img '.$attributes->join(' ').'>';

--- a/tests/Image/ImageTest.php
+++ b/tests/Image/ImageTest.php
@@ -822,10 +822,12 @@ class ImageTest extends TestCase
     public function test_to_html()
     {
         $image = $this->makeImage();
-        $this->assertSame('<img src="" width="100" height="100">', $image->toHtml());
+        $this->assertStringStartsWith('<img src="');
+        $this->assertStringEndsWith('" width="100" height="100">', $image->toHtml());
 
         $result = $image->scale(400, 400);
-        $this->assertSame('<img src="" width="100" height="100">', $image->toHtml());
+        $this->assertStringStartsWith('<img src="');
+        $this->assertStringEndsWith('" width="100" height="100">', $image->toHtml());
     }
 
     public function test_to_html_with_additional_attributes()

--- a/tests/Image/ImageTest.php
+++ b/tests/Image/ImageTest.php
@@ -930,7 +930,7 @@ class ImageTest extends TestCase
         $image = $this->makeImage();
 
         $result = $image->scale(400, 400);
-        $html = $image->toHtml(['height' => 42])
+        $html = $image->toHtml(['height' => 42]);
         $this->assertStringStartsWith('<img src="', $html);
         $this->assertStringEndsWith('" width="100" height="42">', $html);
     }

--- a/tests/Image/ImageTest.php
+++ b/tests/Image/ImageTest.php
@@ -819,6 +819,23 @@ class ImageTest extends TestCase
         $this->assertSame(90, $options->quality);
     }
 
+    public function test_to_html()
+    {
+        $image = $this->makeImage();
+        $this->assertSame('<img src="" width="100" height="100">', $options->image->toHtml());
+
+        $result = $image->scale(400, 400);
+        $this->assertSame('<img src="" width="100" height="100">', $options->image->toHtml());
+    }
+
+    public function test_to_html_with_additional_attributes()
+    {
+        $image = $this->makeImage();
+
+        $result = $image->scale(400, 400);
+        $this->assertSame('<img src="" width="100" height="100" alt="My avatar">', $options->image->toHtml(['alt' => 'My avatar']));
+    }
+
     public function test_optimize_throws_for_gif()
     {
         $this->expectException(ImageException::class);

--- a/tests/Image/ImageTest.php
+++ b/tests/Image/ImageTest.php
@@ -835,7 +835,7 @@ class ImageTest extends TestCase
         $image = $this->makeImage();
 
         $result = $image->scale(400, 400);
-        $this->assertSame('<img src="" width="100" height="100" alt="My avatar">', $image->toHtml(['alt' => 'My avatar']));
+        $this->assertSame('<img src="" width="100" height="100" alt="My avatar" hidden>', $image->toHtml(['alt' => 'My avatar', 'hidden']));
     }
 
     public function test_optimize_throws_for_gif()

--- a/tests/Image/ImageTest.php
+++ b/tests/Image/ImageTest.php
@@ -905,12 +905,14 @@ class ImageTest extends TestCase
     public function test_to_html()
     {
         $image = $this->makeImage();
-        $this->assertStringStartsWith('<img src="');
-        $this->assertStringEndsWith('" width="100" height="100">', $image->toHtml());
+        $html = $image->toHtml();
+        $this->assertStringStartsWith('<img src="', $html);
+        $this->assertStringEndsWith('" width="100" height="100">', $html);
 
         $result = $image->scale(400, 400);
-        $this->assertStringStartsWith('<img src="');
-        $this->assertStringEndsWith('" width="100" height="100">', $image->toHtml());
+        $html = $image->toHtml();
+        $this->assertStringStartsWith('<img src="', $html);
+        $this->assertStringEndsWith('" width="100" height="100">', $html);
     }
 
     public function test_to_html_with_additional_attributes()
@@ -918,8 +920,9 @@ class ImageTest extends TestCase
         $image = $this->makeImage();
 
         $result = $image->scale(400, 400);
-        $this->assertStringStartsWith('<img src="');
-        $this->assertStringEndsWith('" width="100" height="100" alt="My avatar" hidden>', $image->toHtml(['alt' => 'My avatar', 'hidden']));
+        $html = $image->toHtml(['alt' => 'My avatar', 'hidden']);
+        $this->assertStringStartsWith('<img src="', $html);
+        $this->assertStringEndsWith('" width="100" height="100" alt="My avatar" hidden>', $html);
     }
 
     public function test_to_html_attributes_are_overwritable()
@@ -927,8 +930,9 @@ class ImageTest extends TestCase
         $image = $this->makeImage();
 
         $result = $image->scale(400, 400);
-        $this->assertStringStartsWith('<img src="');
-        $this->assertStringEndsWith('" width="100" height="42">', $image->toHtml(['height' => 42]));
+        $html = $image->toHtml(['height' => 42])
+        $this->assertStringStartsWith('<img src="', $html);
+        $this->assertStringEndsWith('" width="100" height="42">', $html);
     }
 
     public function test_optimize_allows_gif()

--- a/tests/Image/ImageTest.php
+++ b/tests/Image/ImageTest.php
@@ -928,7 +928,7 @@ class ImageTest extends TestCase
 
         $result = $image->scale(400, 400);
         $this->assertStringStartsWith('<img src="');
-        $this->assertStringEndsWith('" width="100" height="42">', $image->toHtml(['height' => 42));
+        $this->assertStringEndsWith('" width="100" height="42">', $image->toHtml(['height' => 42]));
     }
 
     public function test_optimize_allows_gif()

--- a/tests/Image/ImageTest.php
+++ b/tests/Image/ImageTest.php
@@ -822,10 +822,10 @@ class ImageTest extends TestCase
     public function test_to_html()
     {
         $image = $this->makeImage();
-        $this->assertSame('<img src="" width="100" height="100">', $options->image->toHtml());
+        $this->assertSame('<img src="" width="100" height="100">', $image->toHtml());
 
         $result = $image->scale(400, 400);
-        $this->assertSame('<img src="" width="100" height="100">', $options->image->toHtml());
+        $this->assertSame('<img src="" width="100" height="100">', $image->toHtml());
     }
 
     public function test_to_html_with_additional_attributes()
@@ -833,7 +833,7 @@ class ImageTest extends TestCase
         $image = $this->makeImage();
 
         $result = $image->scale(400, 400);
-        $this->assertSame('<img src="" width="100" height="100" alt="My avatar">', $options->image->toHtml(['alt' => 'My avatar']));
+        $this->assertSame('<img src="" width="100" height="100" alt="My avatar">', $image->toHtml(['alt' => 'My avatar']));
     }
 
     public function test_optimize_throws_for_gif()

--- a/tests/Image/ImageTest.php
+++ b/tests/Image/ImageTest.php
@@ -835,7 +835,17 @@ class ImageTest extends TestCase
         $image = $this->makeImage();
 
         $result = $image->scale(400, 400);
-        $this->assertSame('<img src="" width="100" height="100" alt="My avatar" hidden>', $image->toHtml(['alt' => 'My avatar', 'hidden']));
+        $this->assertStringStartsWith('<img src="');
+        $this->assertStringEndsWith('" width="100" height="100" alt="My avatar" hidden>', $image->toHtml(['alt' => 'My avatar', 'hidden']));
+    }
+
+    public function test_to_html_attributes_are_overwritable()
+    {
+        $image = $this->makeImage();
+
+        $result = $image->scale(400, 400);
+        $this->assertStringStartsWith('<img src="');
+        $this->assertStringEndsWith('" width="100" height="42">', $image->toHtml(['height' => 42));
     }
 
     public function test_optimize_throws_for_gif()


### PR DESCRIPTION
# Current
```php
use Illuminate\Support\Facades\Image;

$image = Image::fromStorage('avatars/photo.jpg', 'public')
    ->cover(400, 400)
    ->toWebp()
    ->quality(80);
```
```blade
<img width="400" height="400" src="{{ $image->toDataUrl() }}">
```

As you can see, information that have already been given above (`cover(400, 400)`) have to be mirrored/duplicated within blade (`width="400" height="400"`), which can result in a lot of boilerplate.

# Proposed
```php
use Illuminate\Support\Facades\Image;

$path = Image::fromStorage('avatars/photo.jpg', 'public')
    ->cover(400, 400)
    ->toWebp()
    ->quality(80);
```
```blade
{!! $image->toHtml() !!}
```

This makes `Image` usable ergonomically within Blade as if it is a first-class citizen, just reusing what it already knows with the option to add more attributes:

```blade
{!! $image->toHtml(['alt' => 'My avatar']) !!}
<!-- Results in: <img width="400" height="400" src="data:…" alt="My avatar"> -->
```