### PR TITLE
Add trans() method to Stringable

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -924,6 +924,18 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
+     * Translate the string and get a new stringable object.
+     *
+     * @param  array  $replace
+     * @param  string|null  $locale
+     * @return static
+     */
+    public function trans($replace = [], $locale = null)
+    {
+        return new static(Str::trans($this->value, $replace, $locale));
+    }
+
+    /**
      * Transliterate a string to its closest ASCII representation.
      *
      * @param  string|null  $unknown

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -634,6 +634,30 @@ class SupportStringableTest extends TestCase
         $this->assertSame('Hello', (string) $this->stringable('🎂')->transliterate('Hello'));
     }
 
+    public function testTrans()
+    {
+        $originalContainer = Container::getInstance();
+
+        Container::setInstance($container = new Container);
+
+        $container->instance('translator', new class
+        {
+            public function get($key, array $replace = [], $locale = null)
+            {
+                return str_replace(':name', $replace['name'], $key).' '.$locale;
+            }
+        });
+
+        try {
+            $string = $this->stringable('Hello :name')->trans(['name' => 'Taylor'], 'en');
+        } finally {
+            Container::setInstance($originalContainer);
+        }
+
+        $this->assertInstanceOf(Stringable::class, $string);
+        $this->assertSame('hello taylor en', (string) $string->lower());
+    }
+
     public function testNewLine()
     {
         $this->assertSame('Laravel'.PHP_EOL, (string) $this->stringable('Laravel')->newLine());


### PR DESCRIPTION
## Summary
- Adds a new `trans()` method to the Stringable class
- Enables convenient string translation with optional replace parameters and locale specification
- Returns a new stringable instance with the translated string

## Test plan
- [x] Unit tests added for the `trans()` method
- [x] Verifies translation works with replacement parameters and locale