### PR TITLE
 [13.x] Include job name and queue in InvalidPayloadException message  

### DIFF
--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -137,7 +137,7 @@ abstract class Queue
         if (json_last_error() !== JSON_ERROR_NONE) {
             throw new InvalidPayloadException(
                 sprintf('Unable to JSON encode payload for job [%s] on queue [%s]. Error (%d): %s',
-                    $value['displayName'] ?? 'unknown', $queue ?? 'default', json_last_error(), json_last_error_msg()
+                    $value['displayName'] ?? 'unknown', $queue, json_last_error(), json_last_error_msg()
                 ), $value
             );
         }

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -136,7 +136,9 @@ abstract class Queue
 
         if (json_last_error() !== JSON_ERROR_NONE) {
             throw new InvalidPayloadException(
-                'Unable to JSON encode payload. Error ('.json_last_error().'): '.json_last_error_msg(), $value
+                sprintf('Unable to JSON encode payload for job [%s] on queue [%s]. Error (%d): %s',
+                    $value['displayName'] ?? 'unknown', $queue ?? 'default', json_last_error(), json_last_error_msg()
+                ), $value
             );
         }
 


### PR DESCRIPTION
  ## What?                                                                                                                                                                                                               
Improves the `InvalidPayloadException` message thrown from `Queue::createPayload()` to include the job's display name and the queue it was dispatched to.                                                              
                                                                                                                                                                                                                         
  ## Why?                                                                                                                                                                                                                
                                                                                                                                                                                                                         
  Currently, when a job payload fails to JSON encode (e.g. because it contains malformed UTF-8 or non-encodable values), the exception message only reports the JSON error code and message:                             
                                                                                                                                                                                                                         
  > Unable to JSON encode payload. Error (5): Malformed UTF-8 characters, possibly incorrectly encoded                                                                                                                   
                                                                                                                                                                                                                         
  In applications dispatching many different jobs, this gives no clue about *which* job caused the failure, making it painful to debug — especially in production logs.                                                  
                                                                                                                                                                                                                         
  ## After this change                                                                                                                                                                                                   
                                                                                                                                                                                                                         
  > Unable to JSON encode payload for job [App\Jobs\ProcessPodcast] on queue [default]. Error (5): Malformed UTF-8 characters, possibly incorrectly encoded                                                              
                                                                                                                                                                                                                         
  The job name falls back to `unknown` if `displayName` is not present in the payload, and the queue falls back to `default` when `null`. This is a message-only change with no behavioral impact — the exception type   
  and the payload passed to it are unchanged.                               