### PR TITLE
[13.x] Allow registering custom seeder paths via `loadSeedersFrom()`

### DIFF
--- a/src/Illuminate/Database/Console/Seeds/SeedCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeedCommand.php
@@ -7,6 +7,7 @@ use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Console\Prohibitable;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Seeder;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
@@ -88,7 +89,7 @@ class SeedCommand extends Command
         $class = $this->input->getArgument('class') ?? $this->input->getOption('class');
 
         if (! str_contains($class, '\\')) {
-            $class = 'Database\\Seeders\\'.$class;
+            $class = $this->resolveSeederClass($class);
         }
 
         if ($class === 'Database\\Seeders\\DatabaseSeeder' &&
@@ -99,6 +100,52 @@ class SeedCommand extends Command
         return $this->laravel->make($class)
             ->setContainer($this->laravel)
             ->setCommand($this);
+    }
+
+    /**
+     * Resolve the seeder class from the registered seeder paths.
+     *
+     * @param  string  $class
+     * @return string
+     */
+    protected function resolveSeederClass($class)
+    {
+        foreach ($this->getSeederPaths() as $path) {
+            $file = $path.DIRECTORY_SEPARATOR.$class.'.php';
+
+            if (! is_file($file)) {
+                continue;
+            }
+
+            if (preg_match('/^namespace\s+([^;]+);/m', file_get_contents($file), $matches) &&
+                class_exists($namespaced = trim($matches[1]).'\\'.$class)) {
+                return $namespaced;
+            }
+        }
+
+        return 'Database\\Seeders\\'.$class;
+    }
+
+    /**
+     * Get all of the seeder paths.
+     *
+     * @return string[]
+     */
+    protected function getSeederPaths()
+    {
+        return array_merge(
+            Seeder::paths(), [$this->getSeederPath()]
+        );
+    }
+
+    /**
+     * Get the path to the seeder directory.
+     *
+     * @return string
+     */
+    protected function getSeederPath()
+    {
+        return $this->laravel->databasePath().DIRECTORY_SEPARATOR.'seeders';
     }
 
     /**

--- a/src/Illuminate/Database/Seeder.php
+++ b/src/Illuminate/Database/Seeder.php
@@ -37,7 +37,7 @@ abstract class Seeder
      *
      * @var string[]
      */
-    protected $paths = [];
+    protected static $paths = [];
 
     /**
      * Run the given seeder class.
@@ -153,9 +153,9 @@ abstract class Seeder
      * @param  string  $path
      * @return void
      */
-    public function path($path)
+    public static function path($path)
     {
-        $this->paths = array_unique(array_merge($this->paths, [$path]));
+        static::$paths = array_unique(array_merge(static::$paths, [$path]));
     }
 
     /**
@@ -163,9 +163,19 @@ abstract class Seeder
      *
      * @return string[]
      */
-    public function paths()
+    public static function paths()
     {
-        return $this->paths;
+        return static::$paths;
+    }
+
+    /**
+     * Flush the registered seeder paths.
+     *
+     * @return void
+     */
+    public static function flushPaths()
+    {
+        static::$paths = [];
     }
 
     /**

--- a/src/Illuminate/Database/Seeder.php
+++ b/src/Illuminate/Database/Seeder.php
@@ -33,6 +33,13 @@ abstract class Seeder
     protected static $called = [];
 
     /**
+     * The paths to seeder files.
+     *
+     * @var string[]
+     */
+    protected $paths = [];
+
+    /**
      * Run the given seeder class.
      *
      * @param  array|string  $class
@@ -138,6 +145,27 @@ abstract class Seeder
         }
 
         return $instance;
+    }
+
+    /**
+     * Register a custom seeder path.
+     *
+     * @param  string  $path
+     * @return void
+     */
+    public function path($path)
+    {
+        $this->paths = array_unique(array_merge($this->paths, [$path]));
+    }
+
+    /**
+     * Get all of the custom seeder paths.
+     *
+     * @return string[]
+     */
+    public function paths()
+    {
+        return $this->paths;
     }
 
     /**

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -292,11 +292,9 @@ abstract class ServiceProvider
      */
     protected function loadSeedersFrom($paths)
     {
-        $this->callAfterResolving(Seeder::class, function ($seeder) use ($paths) {
-            foreach ((array) $paths as $path) {
-                $seeder->path($path);
-            }
-        });
+        foreach ((array) $paths as $path) {
+            Seeder::path($path);
+        }
     }
 
     /**

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Foundation\CachesConfiguration;
 use Illuminate\Contracts\Foundation\CachesRoutes;
 use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Database\Eloquent\Factory as ModelFactory;
+use Illuminate\Database\Seeder;
 use Illuminate\View\Compilers\BladeCompiler;
 
 /**
@@ -279,6 +280,21 @@ abstract class ServiceProvider
         $this->callAfterResolving('migrator', function ($migrator) use ($paths) {
             foreach ((array) $paths as $path) {
                 $migrator->path($path);
+            }
+        });
+    }
+
+    /**
+     * Register database seeder paths.
+     *
+     * @param  array|string  $paths
+     * @return void
+     */
+    protected function loadSeedersFrom($paths)
+    {
+        $this->callAfterResolving(Seeder::class, function ($seeder) use ($paths) {
+            foreach ((array) $paths as $path) {
+                $seeder->path($path);
             }
         });
     }

--- a/tests/Database/DatabaseSeederTest.php
+++ b/tests/Database/DatabaseSeederTest.php
@@ -28,6 +28,13 @@ class TestDepsSeeder extends Seeder
 
 class DatabaseSeederTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        Seeder::flushPaths();
+
+        parent::tearDown();
+    }
+
     public function testCallResolveTheClassAndCallsRun()
     {
         $seeder = new TestSeeder;
@@ -87,22 +94,20 @@ class DatabaseSeederTest extends TestCase
 
     public function testPath()
     {
-        $seeder = new TestSeeder;
-        $seeder->path(__DIR__.'/seeders');
-        $seeder->path(__DIR__.'/modules/seeders');
+        Seeder::path(__DIR__.'/seeders');
+        Seeder::path(__DIR__.'/modules/seeders');
 
         $this->assertSame([
             __DIR__.'/seeders',
             __DIR__.'/modules/seeders',
-        ], $seeder->paths());
+        ], Seeder::paths());
     }
 
     public function testPathDoesNotRegisterDuplicates()
     {
-        $seeder = new TestSeeder;
-        $seeder->path(__DIR__.'/seeders');
-        $seeder->path(__DIR__.'/seeders');
+        Seeder::path(__DIR__.'/seeders');
+        Seeder::path(__DIR__.'/seeders');
 
-        $this->assertSame([__DIR__.'/seeders'], $seeder->paths());
+        $this->assertSame([__DIR__.'/seeders'], Seeder::paths());
     }
 }

--- a/tests/Database/DatabaseSeederTest.php
+++ b/tests/Database/DatabaseSeederTest.php
@@ -84,4 +84,25 @@ class DatabaseSeederTest extends TestCase
 
         $container->shouldHaveReceived('call')->once()->with([$seeder, 'run'], ['test1', 'test2']);
     }
+
+    public function testPath()
+    {
+        $seeder = new TestSeeder;
+        $seeder->path(__DIR__.'/seeders');
+        $seeder->path(__DIR__.'/modules/seeders');
+
+        $this->assertSame([
+            __DIR__.'/seeders',
+            __DIR__.'/modules/seeders',
+        ], $seeder->paths());
+    }
+
+    public function testPathDoesNotRegisterDuplicates()
+    {
+        $seeder = new TestSeeder;
+        $seeder->path(__DIR__.'/seeders');
+        $seeder->path(__DIR__.'/seeders');
+
+        $this->assertSame([__DIR__.'/seeders'], $seeder->paths());
+    }
 }

--- a/tests/Support/SupportServiceProviderTest.php
+++ b/tests/Support/SupportServiceProviderTest.php
@@ -36,6 +36,8 @@ class SupportServiceProviderTest extends TestCase
 
     protected function tearDown(): void
     {
+        Seeder::flushPaths();
+
         if (isset($this->tempFile) && file_exists($this->tempFile)) {
             @unlink($this->tempFile);
         }
@@ -200,36 +202,24 @@ class SupportServiceProviderTest extends TestCase
 
     public function testLoadSeedersFrom()
     {
-        $seeder = m::mock(Seeder::class);
-        $seeder->shouldReceive('path')->once()->with(__DIR__.'/seeders');
-
-        $this->app->shouldReceive('afterResolving')->once()->with(Seeder::class, m::on(function ($callback) use ($seeder) {
-            $callback($seeder);
-
-            return true;
-        }));
-
         $provider = new ServiceProviderForTestingOne($this->app);
         $provider->loadSeedersFrom(__DIR__.'/seeders');
+
+        $this->assertSame([__DIR__.'/seeders'], Seeder::paths());
     }
 
     public function testLoadSeedersFromWithMultiplePaths()
     {
-        $seeder = m::mock(Seeder::class);
-        $seeder->shouldReceive('path')->once()->with(__DIR__.'/seeders');
-        $seeder->shouldReceive('path')->once()->with(__DIR__.'/modules/seeders');
-
-        $this->app->shouldReceive('afterResolving')->once()->with(Seeder::class, m::on(function ($callback) use ($seeder) {
-            $callback($seeder);
-
-            return true;
-        }));
-
         $provider = new ServiceProviderForTestingOne($this->app);
         $provider->loadSeedersFrom([
             __DIR__.'/seeders',
             __DIR__.'/modules/seeders',
         ]);
+
+        $this->assertSame([
+            __DIR__.'/seeders',
+            __DIR__.'/modules/seeders',
+        ], Seeder::paths());
     }
 
     public function test_can_remove_provider()

--- a/tests/Support/SupportServiceProviderTest.php
+++ b/tests/Support/SupportServiceProviderTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Support;
 
 use Illuminate\Config\Repository as Config;
+use Illuminate\Database\Seeder;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Translation\Translator;
@@ -197,6 +198,40 @@ class SupportServiceProviderTest extends TestCase
         $provider->loadTranslationsFrom(__DIR__.'/translations', 'namespace');
     }
 
+    public function testLoadSeedersFrom()
+    {
+        $seeder = m::mock(Seeder::class);
+        $seeder->shouldReceive('path')->once()->with(__DIR__.'/seeders');
+
+        $this->app->shouldReceive('afterResolving')->once()->with(Seeder::class, m::on(function ($callback) use ($seeder) {
+            $callback($seeder);
+
+            return true;
+        }));
+
+        $provider = new ServiceProviderForTestingOne($this->app);
+        $provider->loadSeedersFrom(__DIR__.'/seeders');
+    }
+
+    public function testLoadSeedersFromWithMultiplePaths()
+    {
+        $seeder = m::mock(Seeder::class);
+        $seeder->shouldReceive('path')->once()->with(__DIR__.'/seeders');
+        $seeder->shouldReceive('path')->once()->with(__DIR__.'/modules/seeders');
+
+        $this->app->shouldReceive('afterResolving')->once()->with(Seeder::class, m::on(function ($callback) use ($seeder) {
+            $callback($seeder);
+
+            return true;
+        }));
+
+        $provider = new ServiceProviderForTestingOne($this->app);
+        $provider->loadSeedersFrom([
+            __DIR__.'/seeders',
+            __DIR__.'/modules/seeders',
+        ]);
+    }
+
     public function test_can_remove_provider()
     {
         $this->tempFile = __DIR__.'/providers.php';
@@ -263,6 +298,11 @@ class ServiceProviderForTestingOne extends ServiceProvider
         $this->callAfterResolving('translator', fn ($translator) => is_null($namespace)
             ? $translator->addPath($path)
             : $translator->addNamespace($namespace, $path));
+    }
+
+    public function loadSeedersFrom($paths)
+    {
+        parent::loadSeedersFrom($paths);
     }
 }
 


### PR DESCRIPTION
## Summary

This PR adds a `loadSeedersFrom()` method to `ServiceProvider`, mirroring the existing `loadMigrationsFrom()` API, so packages and modular applications can register custom seeder paths from a service provider. `db:seed` then resolves short class names from those paths, the same way `migrate` uses paths from `loadMigrationsFrom()`.

### The problem

In modular applications, seeders often live outside `database/seeders`. For example:

```
App\Modules\HR\Database\Seeders\EmployeeSeeder
App\Modules\Finance\Database\Seeders\InvoiceSeeder
App\Modules\Inventory\Database\Seeders\ProductSeeder
```

Today, `db:seed --class=EmployeeSeeder` always resolves to `Database\Seeders\EmployeeSeeder`, which does not exist:

```bash
php artisan db:seed --class=EmployeeSeeder
# Target class [Database\Seeders\EmployeeSeeder] does not exist.
```

The workaround is to pass the fully qualified class name every time:

```bash
php artisan db:seed --class="App\\Modules\\HR\\Database\\Seeders\\EmployeeSeeder"
```

That becomes cumbersome across many modules: easy to mistype, hard to remember, and inconsistent with how migrations already work for the same modular layout via `loadMigrationsFrom()`.

### The solution

Register seeder paths from a module/package service provider, just like migrations:

```php
public function boot(): void
{
    $this->loadMigrationsFrom(__DIR__.'/../Database/Migrations');
    $this->loadSeedersFrom(__DIR__.'/../Database/Seeders');
}
```

Then this works:

```bash
php artisan db:seed --class=EmployeeSeeder
```

**Service provider:**

```php
protected function loadSeedersFrom($paths)
{
    foreach ((array) $paths as $path) {
        Seeder::path($path);
    }
}
```

**Seeder** gains static `path()` / `paths()` methods to register and retrieve custom seeder paths.

**SeedCommand** gains `getSeederPaths()` analogous to `MigrateCommand`'s `getMigrationPaths()`, and resolves short `--class` names by scanning the registered paths (plus the default `database/seeders` path).

### Why not `callAfterResolving` like `loadMigrationsFrom`?

`loadMigrationsFrom()` uses `callAfterResolving('migrator', ...)` because the migrator is a container singleton. It is resolved when `MigrateCommand` is constructed (injected), so paths are registered on that instance before `getMigrationPaths()` runs.

Seeders do not work that way:

1. `Seeder` is an abstract class, not a container singleton. There is no single "seeder" service to attach paths to.
2. `db:seed` must know the registered paths *before* resolving the target seeder class, so it can map a short name like `EmployeeSeeder` to `App\Modules\HR\Database\Seeders\EmployeeSeeder`.
3. If paths were only registered inside `callAfterResolving(Seeder::class, ...)`, they would be applied too late: only after a seeder instance is already being resolved from the container.

So paths are registered immediately via static `Seeder::path()` / `Seeder::paths()`, and `SeedCommand` reads them the same way `MigrateCommand` reads `$this->migrator->paths()`.

### Prior art

A similar change was previously proposed in https://github.com/laravel/framework/pull/47315 and closed with the feedback that developers can pass a seeder class name directly.

That works well for a single app-level seeder under `Database\Seeders`. It is much less ergonomic for modular apps and packages where seeders intentionally live under namespaces like `App\Modules\*\Database\Seeders\...`. Those projects already rely on `loadMigrationsFrom()` for the same reason; this brings seeders in line with that pattern, including command-level path resolution like `migrate`.

## Tests

- ✅  `tests/Support/SupportServiceProviderTest.php` - `loadSeedersFrom` registers paths
- ✅  `tests/Database/DatabaseSeederTest.php` - `path()` / `paths()` behavior (including duplicate paths)
