### PR TITLE
[13.x] Fix TypeError when passing an enum to LogManager::forgetChannel()

### DIFF
--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -617,12 +617,12 @@ class LogManager implements LoggerInterface
     /**
      * Unset the given channel instance.
      *
-     * @param  string|null  $driver
+     * @param  \UnitEnum|string|null  $driver
      * @return void
      */
     public function forgetChannel($driver = null)
     {
-        $driver = $this->parseDriver($driver);
+        $driver = $this->parseDriver(enum_value($driver));
 
         if (isset($this->channels[$driver])) {
             unset($this->channels[$driver]);

--- a/tests/Log/LogManagerTest.php
+++ b/tests/Log/LogManagerTest.php
@@ -801,6 +801,18 @@ class LogManagerTest extends TestCase
 
         $this->assertSame('single', $this->app['config']['logging.default']);
     }
+
+    public function testForgetChannelAcceptsBackedEnum(): void
+    {
+        $manager = new LogManager($this->app);
+        $logger = $manager->channel(LogChannelName::Single);
+
+        $this->assertSame($logger, $manager->channel('single'));
+
+        $manager->forgetChannel(LogChannelName::Single);
+
+        $this->assertNotSame($logger, $manager->channel('single'));
+    }
 }
 
 class CustomizeFormatter


### PR DESCRIPTION
`forgetChannel()` didn't unwrap enum values, unlike `channel()`, `driver()`, and `setDefaultDriver()`, so passing an enum channel name threw a `TypeError`.