### PR TITLE
[13.x] Fix undefined index in Hub::pipe()

### DIFF
--- a/src/Illuminate/Pipeline/Hub.php
+++ b/src/Illuminate/Pipeline/Hub.php
@@ -5,6 +5,7 @@ namespace Illuminate\Pipeline;
 use Closure;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Pipeline\Hub as HubContract;
+use InvalidArgumentException;
 
 class Hub implements HubContract
 {
@@ -65,6 +66,10 @@ class Hub implements HubContract
     public function pipe($object, $pipeline = null)
     {
         $pipeline = $pipeline ?: 'default';
+
+        if (! isset($this->pipelines[$pipeline])) {
+            throw new InvalidArgumentException("Pipeline [{$pipeline}] is not defined.");
+        }
 
         return call_user_func(
             $this->pipelines[$pipeline], new Pipeline($this->container), $object

--- a/tests/Pipeline/HubTest.php
+++ b/tests/Pipeline/HubTest.php
@@ -10,33 +10,37 @@ use PHPUnit\Framework\TestCase;
 
 class HubTest extends TestCase
 {
-    public function testPipeSendsObjectThroughDefaultPipeline()
-    {
-        $hub = new Hub(new Container);
+    private Hub $hub;
 
-        $hub->defaults(function (Pipeline $pipeline, $object) {
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->hub = new Hub(new Container);
+    }
+
+    public function testPipeSendsObjectThroughDefaultPipeline(): void
+    {
+        $this->hub->defaults(function (Pipeline $pipeline, $object) {
             return $pipeline->send($object)->through([])->thenReturn();
         });
 
-        $this->assertSame('foo', $hub->pipe('foo'));
+        $this->assertSame('foo', $this->hub->pipe('foo'));
     }
 
-    public function testPipeSendsObjectThroughNamedPipeline()
+    public function testPipeSendsObjectThroughNamedPipeline(): void
     {
-        $hub = new Hub(new Container);
-
-        $hub->pipeline('named', function (Pipeline $pipeline, $object) {
+        $this->hub->pipeline('named', function (Pipeline $pipeline, $object) {
             return $pipeline->send($object)->through([])->thenReturn();
         });
 
-        $this->assertSame('foo', $hub->pipe('foo', 'named'));
+        $this->assertSame('foo', $this->hub->pipe('foo', 'named'));
     }
 
-    public function testPipeThrowsExceptionForUndefinedPipeline()
+    public function testPipeThrowsExceptionForUndefinedPipeline(): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Pipeline [missing] is not defined.');
+        $this->expectExceptionObject(new InvalidArgumentException('Pipeline [missing] is not defined.'));
 
-        (new Hub(new Container))->pipe('foo', 'missing');
+        $this->hub->pipe('foo', 'missing');
     }
 }

--- a/tests/Pipeline/HubTest.php
+++ b/tests/Pipeline/HubTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Illuminate\Tests\Pipeline;
+
+use Illuminate\Container\Container;
+use Illuminate\Pipeline\Hub;
+use Illuminate\Pipeline\Pipeline;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+class HubTest extends TestCase
+{
+    public function testPipeSendsObjectThroughDefaultPipeline()
+    {
+        $hub = new Hub(new Container);
+
+        $hub->defaults(function (Pipeline $pipeline, $object) {
+            return $pipeline->send($object)->through([])->thenReturn();
+        });
+
+        $this->assertSame('foo', $hub->pipe('foo'));
+    }
+
+    public function testPipeSendsObjectThroughNamedPipeline()
+    {
+        $hub = new Hub(new Container);
+
+        $hub->pipeline('named', function (Pipeline $pipeline, $object) {
+            return $pipeline->send($object)->through([])->thenReturn();
+        });
+
+        $this->assertSame('foo', $hub->pipe('foo', 'named'));
+    }
+
+    public function testPipeThrowsExceptionForUndefinedPipeline()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Pipeline [missing] is not defined.');
+
+        (new Hub(new Container))->pipe('foo', 'missing');
+    }
+}


### PR DESCRIPTION
Throws a clear `InvalidArgumentException` instead of a `TypeError` when the named pipeline is undefined.