### PR TITLE
Make migrate command prohibitable

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Console\Migrations;
 
 use Illuminate\Console\ConfirmableTrait;
+use Illuminate\Console\Prohibitable;
 use Illuminate\Contracts\Console\Isolatable;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Events\SchemaLoaded;
@@ -20,7 +21,7 @@ use function Laravel\Prompts\confirm;
 #[AsCommand(name: 'migrate')]
 class MigrateCommand extends BaseCommand implements Isolatable
 {
-    use ConfirmableTrait;
+    use ConfirmableTrait, Prohibitable;
 
     /**
      * The name and signature of the console command.
@@ -82,7 +83,8 @@ class MigrateCommand extends BaseCommand implements Isolatable
      */
     public function handle()
     {
-        if (! $this->confirmToProceed()) {
+        if ($this->isProhibited() ||
+            ! $this->confirmToProceed()) {
             return 1;
         }
 

--- a/tests/Database/DatabaseMigrationMigrateCommandTest.php
+++ b/tests/Database/DatabaseMigrationMigrateCommandTest.php
@@ -16,6 +16,13 @@ use Symfony\Component\Console\Output\NullOutput;
 
 class DatabaseMigrationMigrateCommandTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        MigrateCommand::prohibit(false);
+
+        parent::tearDown();
+    }
+
     public function testBasicMigrationsCallMigratorWithProperArguments()
     {
         $command = new MigrateCommand($migrator = m::mock(Migrator::class), $dispatcher = m::mock(Dispatcher::class));
@@ -133,6 +140,22 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
         $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
 
         $this->runCommand($command, ['--step' => true]);
+    }
+
+    public function testMigrateCommandExitsWhenProhibited()
+    {
+        $command = new MigrateCommand($migrator = m::mock(Migrator::class), m::mock(Dispatcher::class));
+        $app = new ApplicationDatabaseMigrationStub(['path.database' => __DIR__]);
+        $app->useDatabasePath(__DIR__);
+        $command->setLaravel($app);
+
+        MigrateCommand::prohibit();
+
+        $code = $this->runCommand($command);
+
+        $this->assertSame(1, $code);
+
+        $migrator->shouldNotHaveBeenCalled();
     }
 
     protected function runCommand($command, $input = [])


### PR DESCRIPTION
This PR makes the migrate command prohibitable, consistent with other database commands such as `db:seed` and `migrate:rollback`.

This allows applications to explicitly prevent migrations from running in environments connected to production replicas or other databases where schema changes must not occur.

```php
MigrateCommand::prohibit();
```

When prohibited, the command exits before interacting with the migrator, including when --force is provided.