### PR TITLE
[13.x] Apply rector PHPUnit assertion cleanups

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -47,12 +47,7 @@ use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertComparisonToSpecificMetho
 use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertEmptyNullableObjectToAssertInstanceofRector;
 use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertEqualsOrAssertSameFloatParameterToSpecificMethodsTypeRector;
 use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertEqualsToSameRector;
-use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertInstanceOfComparisonRector;
 use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertIssetToSpecificMethodRector;
-use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertNotOperatorRector;
-use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertSameBoolNullToSpecificMethodRector;
-use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertSameTrueFalseToAssertTrueFalseRector;
-use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertTrueFalseToSpecificMethodRector;
 use Rector\PHPUnit\CodeQuality\Rector\MethodCall\ScalarArgumentToExpectedParamTypeRector;
 use Rector\PHPUnit\CodeQuality\Rector\MethodCall\StringCastAssertStringContainsStringRector;
 use Rector\PHPUnit\CodeQuality\Rector\StmtsAwareInterface\DeclareStrictTypesTestsRector;
@@ -70,12 +65,7 @@ $skipPHPUnitSetList = [
     AssertEmptyNullableObjectToAssertInstanceofRector::class,
     AssertEqualsOrAssertSameFloatParameterToSpecificMethodsTypeRector::class,
     AssertEqualsToSameRector::class,
-    AssertInstanceOfComparisonRector::class,
     AssertIssetToSpecificMethodRector::class,
-    AssertNotOperatorRector::class,
-    AssertSameBoolNullToSpecificMethodRector::class,
-    AssertSameTrueFalseToAssertTrueFalseRector::class,
-    AssertTrueFalseToSpecificMethodRector::class,
     CreateStubOverCreateMockArgRector::class,
     DataProviderArrayItemsNewLinedRector::class,
     DeclareStrictTypesTestsRector::class,

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithExceptionHandling.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithExceptionHandling.php
@@ -233,8 +233,8 @@ trait InteractsWithExceptionHandling
             $exceptionMessage = $exception->getMessage();
         }
 
-        Assert::assertTrue(
-            ! $thrown,
+        Assert::assertFalse(
+            $thrown,
             sprintf('Unexpected exception of type %s with message %s was thrown.', $exceptionClass ?? null, $exceptionMessage ?? null)
         );
 

--- a/src/Illuminate/Queue/InteractsWithQueue.php
+++ b/src/Illuminate/Queue/InteractsWithQueue.php
@@ -122,8 +122,8 @@ trait InteractsWithQueue
     {
         $this->ensureQueueInteractionsHaveBeenFaked();
 
-        PHPUnit::assertTrue(
-            ! $this->job->isDeleted(),
+        PHPUnit::assertFalse(
+            $this->job->isDeleted(),
             'Job was unexpectedly deleted.'
         );
 
@@ -202,8 +202,8 @@ trait InteractsWithQueue
     {
         $this->ensureQueueInteractionsHaveBeenFaked();
 
-        PHPUnit::assertTrue(
-            ! $this->job->hasFailed(),
+        PHPUnit::assertFalse(
+            $this->job->hasFailed(),
             'Job was unexpectedly failed manually.'
         );
 
@@ -249,8 +249,8 @@ trait InteractsWithQueue
     {
         $this->ensureQueueInteractionsHaveBeenFaked();
 
-        PHPUnit::assertTrue(
-            ! $this->job->isReleased(),
+        PHPUnit::assertFalse(
+            $this->job->isReleased(),
             'Job was unexpectedly released.'
         );
 

--- a/src/Illuminate/Support/Testing/Fakes/ExceptionHandlerFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/ExceptionHandlerFake.php
@@ -71,8 +71,9 @@ class ExceptionHandlerFake implements ExceptionHandler, Fake
         );
 
         if (is_string($exception)) {
-            Assert::assertTrue(
-                in_array($exception, array_map(get_class(...), $this->reported), true),
+            Assert::assertContains(
+                $exception,
+                array_map(get_class(...), $this->reported),
                 $message,
             );
 

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -112,7 +112,7 @@ class AuthGuardTest extends TestCase
         });
         $events->shouldReceive('dispatch')->once()->with(m::type(Attempting::class));
         $events->shouldReceive('dispatch')->once()->with(m::type(Validated::class));
-        $user = $this->createMock(Authenticatable::class);
+        $user = $this->createStub(Authenticatable::class);
         $guard->getProvider()->shouldReceive('retrieveByCredentials')->once()->andReturn($user);
         $guard->getProvider()->shouldReceive('validateCredentials')->with($user, ['foo'])->andReturn(true);
         $guard->getProvider()->shouldReceive('rehashPasswordIfRequired')->with($user, ['foo'])->once();
@@ -192,7 +192,7 @@ class AuthGuardTest extends TestCase
         });
         $events->shouldReceive('dispatch')->once()->with(m::type(Attempting::class));
         $events->shouldReceive('dispatch')->once()->with(m::type(Validated::class));
-        $user = $this->createMock(Authenticatable::class);
+        $user = $this->createStub(Authenticatable::class);
         $guard->getProvider()->shouldReceive('retrieveByCredentials')->once()->andReturn($user);
         $guard->getProvider()->shouldReceive('validateCredentials')->with($user, ['foo'])->andReturn(true);
         $guard->getProvider()->shouldReceive('rehashPasswordIfRequired')->with($user, ['foo'])->once();
@@ -212,7 +212,7 @@ class AuthGuardTest extends TestCase
         });
         $events->shouldReceive('dispatch')->once()->with(m::type(Attempting::class));
         $events->shouldReceive('dispatch')->once()->with(m::type(Validated::class));
-        $user = $this->createMock(Authenticatable::class);
+        $user = $this->createStub(Authenticatable::class);
         $guard->getProvider()->shouldReceive('retrieveByCredentials')->once()->andReturn($user);
         $guard->getProvider()->shouldReceive('validateCredentials')->with($user, ['foo'])->andReturn(true);
         $guard->getProvider()->shouldNotReceive('rehashPasswordIfRequired');

--- a/tests/Cache/CacheRateLimiterTest.php
+++ b/tests/Cache/CacheRateLimiterTest.php
@@ -163,7 +163,7 @@ class CacheRateLimiterTest extends TestCase
             return 'foo';
         }, 1));
 
-        $this->assertSame(false, $rateLimiter->attempt('key', 1, function () {
+        $this->assertFalse($rateLimiter->attempt('key', 1, function () {
             return false;
         }, 1));
 

--- a/tests/Cache/ConcurrencyLimiterTest.php
+++ b/tests/Cache/ConcurrencyLimiterTest.php
@@ -237,7 +237,7 @@ class ConcurrencyLimiterTest extends TestCase
 
     public function testFunnelThrowsExceptionWhenStoreDoesNotSupportLocks()
     {
-        $store = $this->createMock(Store::class);
+        $store = $this->createStub(Store::class);
         $repository = new Repository($store);
 
         $this->assertNotInstanceOf(LockProvider::class, $store);

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -327,7 +327,7 @@ class ContainerTest extends TestCase
         $container = new Container;
         $instance = $container->make(ContainerClassWithDefaultValueStub::class);
         $this->assertInstanceOf(ContainerConcreteStub::class, $instance->noDefault);
-        $this->assertSame(null, $instance->default);
+        $this->assertNull($instance->default);
 
         $container->bind(ContainerConcreteStub::class, fn () => new ContainerConcreteStub);
         $instance = $container->make(ContainerClassWithDefaultValueStub::class);

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -275,7 +275,7 @@ class DatabaseConnectionTest extends TestCase
 
     public function testBeganTransactionFiresEventsIfSet()
     {
-        $pdo = $this->createMock(DatabaseConnectionTestMockPDO::class);
+        $pdo = $this->createStub(DatabaseConnectionTestMockPDO::class);
         $connection = $this->getMockConnection(['getName'], $pdo);
         $connection->method('getName')->willReturn('name');
         $connection->setEventDispatcher($events = m::mock(Dispatcher::class));
@@ -285,7 +285,7 @@ class DatabaseConnectionTest extends TestCase
 
     public function testCommittedFiresEventsIfSet()
     {
-        $pdo = $this->createMock(DatabaseConnectionTestMockPDO::class);
+        $pdo = $this->createStub(DatabaseConnectionTestMockPDO::class);
         $connection = $this->getMockConnection(['getName'], $pdo);
         $connection->method('getName')->willReturn('name');
         $connection->setEventDispatcher($events = m::mock(Dispatcher::class));
@@ -295,7 +295,7 @@ class DatabaseConnectionTest extends TestCase
 
     public function testCommittingFiresEventsIfSet()
     {
-        $pdo = $this->createMock(DatabaseConnectionTestMockPDO::class);
+        $pdo = $this->createStub(DatabaseConnectionTestMockPDO::class);
         $connection = $this->getMockConnection(['getName', 'transactionLevel'], $pdo);
         $connection->method('getName')->willReturn('name');
         $connection->method('transactionLevel')->willReturn(1);
@@ -307,7 +307,7 @@ class DatabaseConnectionTest extends TestCase
 
     public function testRollBackedFiresEventsIfSet()
     {
-        $pdo = $this->createMock(DatabaseConnectionTestMockPDO::class);
+        $pdo = $this->createStub(DatabaseConnectionTestMockPDO::class);
         $connection = $this->getMockConnection(['getName'], $pdo);
         $connection->method('getName')->willReturn('name');
         $connection->beginTransaction();
@@ -318,7 +318,7 @@ class DatabaseConnectionTest extends TestCase
 
     public function testRedundantRollBackFiresNoEvent()
     {
-        $pdo = $this->createMock(DatabaseConnectionTestMockPDO::class);
+        $pdo = $this->createStub(DatabaseConnectionTestMockPDO::class);
         $connection = $this->getMockConnection(['getName'], $pdo);
         $connection->method('getName')->willReturn('name');
         $connection->setEventDispatcher($events = m::mock(Dispatcher::class));
@@ -450,7 +450,7 @@ class DatabaseConnectionTest extends TestCase
     {
         $method = (new ReflectionClass(Connection::class))->getMethod('run');
 
-        $pdo = $this->createMock(DatabaseConnectionTestMockPDO::class);
+        $pdo = $this->createStub(DatabaseConnectionTestMockPDO::class);
         $mock = $this->getMockConnection(['tryAgainIfCausedByLostConnection'], $pdo);
         $mock->expects($this->once())->method('tryAgainIfCausedByLostConnection');
 

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -355,7 +355,7 @@ class DatabaseEloquentCollectionTest extends TestCase
             return 'not-a-model';
         });
 
-        $this->assertEquals(BaseCollection::class, get_class($c));
+        $this->assertInstanceOf(BaseCollection::class, $c);
     }
 
     public function testMapWithKeys()
@@ -384,7 +384,7 @@ class DatabaseEloquentCollectionTest extends TestCase
             return [$key++ => 'not-a-model'];
         });
 
-        $this->assertEquals(BaseCollection::class, get_class($c));
+        $this->assertInstanceOf(BaseCollection::class, $c);
     }
 
     public function testCollectionDiffsWithGivenCollection()
@@ -612,15 +612,15 @@ class DatabaseEloquentCollectionTest extends TestCase
     {
         $a = new Collection([['foo' => 'bar'], ['foo' => 'baz']]);
         $b = new Collection(['a', 'b', 'c']);
-        $this->assertEquals(BaseCollection::class, get_class($a->pluck('foo')));
-        $this->assertEquals(BaseCollection::class, get_class($a->keys()));
-        $this->assertEquals(BaseCollection::class, get_class($a->collapse()));
-        $this->assertEquals(BaseCollection::class, get_class($a->flatten()));
-        $this->assertEquals(BaseCollection::class, get_class($a->zip(['a', 'b'], ['c', 'd'])));
-        $this->assertEquals(BaseCollection::class, get_class($a->countBy('foo')));
-        $this->assertEquals(BaseCollection::class, get_class($b->flip()));
-        $this->assertEquals(BaseCollection::class, get_class($a->partition('foo', '=', 'bar')));
-        $this->assertEquals(BaseCollection::class, get_class($a->partition('foo', 'bar')));
+        $this->assertInstanceOf(BaseCollection::class, $a->pluck('foo'));
+        $this->assertInstanceOf(BaseCollection::class, $a->keys());
+        $this->assertInstanceOf(BaseCollection::class, $a->collapse());
+        $this->assertInstanceOf(BaseCollection::class, $a->flatten());
+        $this->assertInstanceOf(BaseCollection::class, $a->zip(['a', 'b'], ['c', 'd']));
+        $this->assertInstanceOf(BaseCollection::class, $a->countBy('foo'));
+        $this->assertInstanceOf(BaseCollection::class, $b->flip());
+        $this->assertInstanceOf(BaseCollection::class, $a->partition('foo', '=', 'bar'));
+        $this->assertInstanceOf(BaseCollection::class, $a->partition('foo', 'bar'));
     }
 
     public function testMakeVisibleRemovesHiddenAndIncludesVisible()

--- a/tests/Database/DatabaseEloquentHasOneOrManyWithAttributesPendingTest.php
+++ b/tests/Database/DatabaseEloquentHasOneOrManyWithAttributesPendingTest.php
@@ -293,7 +293,7 @@ class DatabaseEloquentHasOneOrManyWithAttributesPendingTest extends TestCase
         $relatedModel = $relationship->make();
 
         $this->assertSame($parentId, $relatedModel->parent_id);
-        $this->assertSame(true, $relatedModel->is_admin);
+        $this->assertTrue($relatedModel->is_admin);
     }
 }
 

--- a/tests/Database/DatabaseEloquentHasOneOrManyWithAttributesTest.php
+++ b/tests/Database/DatabaseEloquentHasOneOrManyWithAttributesTest.php
@@ -282,7 +282,7 @@ class DatabaseEloquentHasOneOrManyWithAttributesTest extends TestCase
         $relatedModel = $relationship->make();
 
         $this->assertSame($parentId, $relatedModel->parent_id);
-        $this->assertSame(true, $relatedModel->is_admin);
+        $this->assertTrue($relatedModel->is_admin);
     }
 }
 

--- a/tests/Database/DatabaseEloquentInverseRelationTest.php
+++ b/tests/Database/DatabaseEloquentInverseRelationTest.php
@@ -163,7 +163,7 @@ class DatabaseEloquentInverseRelationTest extends TestCase
 
         $relation = (new HasInverseRelationStub($builder, new HasInverseRelationParentStub, 'test_id'));
 
-        $this->assertTrue(in_array('test', $relation->exposeGetPossibleInverseRelations()));
+        $this->assertContains('test', $relation->exposeGetPossibleInverseRelations());
     }
 
     public function testProvidesPossibleRecursiveRelationsIfRelatedIsTheSameClassAsParent()
@@ -173,7 +173,7 @@ class DatabaseEloquentInverseRelationTest extends TestCase
 
         $relation = (new HasInverseRelationStub($builder, new HasInverseRelationParentStub));
 
-        $this->assertTrue(in_array('parent', $relation->exposeGetPossibleInverseRelations()));
+        $this->assertContains('parent', $relation->exposeGetPossibleInverseRelations());
     }
 
     #[DataProvider('guessedParentRelationsDataProvider')]

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3915,7 +3915,7 @@ class DatabaseEloquentModelTest extends TestCase
     {
         $model = new EloquentModelWithUseEloquentBuilderAttributeStub();
 
-        $query = $this->createMock(\Illuminate\Database\Query\Builder::class);
+        $query = $this->createStub(\Illuminate\Database\Query\Builder::class);
         $eloquentBuilder = $model->newEloquentBuilder($query);
 
         $this->assertInstanceOf(CustomBuilder::class, $eloquentBuilder);
@@ -3925,7 +3925,7 @@ class DatabaseEloquentModelTest extends TestCase
     {
         $model = new EloquentModelWithoutUseEloquentBuilderAttributeStub();
 
-        $query = $this->createMock(\Illuminate\Database\Query\Builder::class);
+        $query = $this->createStub(\Illuminate\Database\Query\Builder::class);
         $eloquentBuilder = $model->newEloquentBuilder($query);
 
         $this->assertNotInstanceOf(CustomBuilder::class, $eloquentBuilder);

--- a/tests/Database/DatabaseEloquentWithAttributesPendingTest.php
+++ b/tests/Database/DatabaseEloquentWithAttributesPendingTest.php
@@ -68,7 +68,7 @@ class DatabaseEloquentWithAttributesPendingTest extends TestCase
 
         $model = $query->make();
 
-        $this->assertSame(true, $model->is_admin);
+        $this->assertTrue($model->is_admin);
         $this->assertSame('First', $model->first_name);
         $this->assertSame('Last', $model->last_name);
         $this->assertSame(PendingAttributesEnum::internal, $model->type);
@@ -97,7 +97,7 @@ class DatabaseEloquentWithAttributesPendingTest extends TestCase
 
         $model = PendingAttributesModel::first();
 
-        $this->assertSame(true, $model->is_admin);
+        $this->assertTrue($model->is_admin);
         $this->assertSame('First', $model->first_name);
         $this->assertSame('Last', $model->last_name);
         $this->assertSame(PendingAttributesEnum::internal, $model->type);

--- a/tests/Database/DatabaseEloquentWithAttributesTest.php
+++ b/tests/Database/DatabaseEloquentWithAttributesTest.php
@@ -73,7 +73,7 @@ class DatabaseEloquentWithAttributesTest extends TestCase
 
         $model = $query->make();
 
-        $this->assertSame(true, $model->is_admin);
+        $this->assertTrue($model->is_admin);
         $this->assertSame('First', $model->first_name);
         $this->assertSame('Last', $model->last_name);
         $this->assertSame(WithAttributesEnum::internal, $model->type);
@@ -102,7 +102,7 @@ class DatabaseEloquentWithAttributesTest extends TestCase
 
         $model = WithAttributesModel::first();
 
-        $this->assertSame(true, $model->is_admin);
+        $this->assertTrue($model->is_admin);
         $this->assertSame('First', $model->first_name);
         $this->assertSame('Last', $model->last_name);
         $this->assertSame(WithAttributesEnum::internal, $model->type);

--- a/tests/Database/DatabaseMigratorIntegrationTest.php
+++ b/tests/Database/DatabaseMigratorIntegrationTest.php
@@ -92,8 +92,8 @@ class DatabaseMigratorIntegrationTest extends TestCase
         $this->assertTrue($this->db::schema()->hasTable('users'));
         $this->assertTrue($this->db::schema()->hasTable('password_resets'));
 
-        $this->assertTrue(str_contains($ran[0], 'users'));
-        $this->assertTrue(str_contains($ran[1], 'password_resets'));
+        $this->assertStringContainsString('users', $ran[0]);
+        $this->assertStringContainsString('password_resets', $ran[1]);
     }
 
     public function testMigrationsDefaultConnectionCanBeChanged()
@@ -154,8 +154,8 @@ class DatabaseMigratorIntegrationTest extends TestCase
         $this->assertFalse($this->db::schema()->hasTable('users'));
         $this->assertFalse($this->db::schema()->hasTable('password_resets'));
 
-        $this->assertTrue(str_contains($rolledBack[0], 'password_resets'));
-        $this->assertTrue(str_contains($rolledBack[1], 'users'));
+        $this->assertStringContainsString('password_resets', $rolledBack[0]);
+        $this->assertStringContainsString('users', $rolledBack[1]);
     }
 
     public function testMigrationsCanBeResetUsingAnString()
@@ -167,8 +167,8 @@ class DatabaseMigratorIntegrationTest extends TestCase
         $this->assertFalse($this->db::schema()->hasTable('users'));
         $this->assertFalse($this->db::schema()->hasTable('password_resets'));
 
-        $this->assertTrue(str_contains($rolledBack[0], 'password_resets'));
-        $this->assertTrue(str_contains($rolledBack[1], 'users'));
+        $this->assertStringContainsString('password_resets', $rolledBack[0]);
+        $this->assertStringContainsString('users', $rolledBack[1]);
     }
 
     public function testMigrationsCanBeResetUsingAnArray()
@@ -180,8 +180,8 @@ class DatabaseMigratorIntegrationTest extends TestCase
         $this->assertFalse($this->db::schema()->hasTable('users'));
         $this->assertFalse($this->db::schema()->hasTable('password_resets'));
 
-        $this->assertTrue(str_contains($rolledBack[0], 'password_resets'));
-        $this->assertTrue(str_contains($rolledBack[1], 'users'));
+        $this->assertStringContainsString('password_resets', $rolledBack[0]);
+        $this->assertStringContainsString('users', $rolledBack[1]);
     }
 
     public function testNoErrorIsThrownWhenNoOutstandingMigrationsExist()

--- a/tests/Database/DatabaseMySqlSchemaStateTest.php
+++ b/tests/Database/DatabaseMySqlSchemaStateTest.php
@@ -146,7 +146,7 @@ class DatabaseMySqlSchemaStateTest extends TestCase
             new Exception('column-statistics')
         );
 
-        $mockOutput = $this->createMock(\stdClass::class);
+        $mockOutput = $this->createStub(\stdClass::class);
         $mockVariables = [];
 
         $schemaState = $this->getMockBuilder(MySqlSchemaState::class)

--- a/tests/Filesystem/FilesystemManagerTest.php
+++ b/tests/Filesystem/FilesystemManagerTest.php
@@ -208,7 +208,7 @@ class FilesystemManagerTest extends TestCase
             ]);
 
             $scoped->put('dirname/filename.txt', 'file content');
-            $this->assertTrue(is_dir(__DIR__.'/../../to-be-scoped/path-prefix'));
+            $this->assertDirectoryExists(__DIR__.'/../../to-be-scoped/path-prefix');
             $this->assertSame('file content', file_get_contents(__DIR__.'/../../to-be-scoped/path-prefix/dirname/filename.txt'));
         } finally {
             unlink(__DIR__.'/../../to-be-scoped/path-prefix/dirname/filename.txt');

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -502,8 +502,8 @@ class FoundationInteractsWithDatabaseTest extends TestCase
 
     public function testGetTableConnectionNameFromModel()
     {
-        $this->assertSame(null, $this->getTableConnection(ProductStub::class));
-        $this->assertSame(null, $this->getTableConnection(new ProductStub));
+        $this->assertNull($this->getTableConnection(ProductStub::class));
+        $this->assertNull($this->getTableConnection(new ProductStub));
         $this->assertSame('mysql', $this->getTableConnection((new ProductStub)->setConnection('mysql')));
     }
 

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -11,7 +11,6 @@ use Illuminate\Routing\Route;
 use Illuminate\Session\Store;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Stringable;
 use Illuminate\Tests\Database\Fixtures\Models\Money\Price;
 use InvalidArgumentException;
 use Mockery as m;
@@ -671,8 +670,8 @@ class HttpRequestTest extends TestCase
             'empty_str' => '',
             'null' => null,
         ]);
-        $this->assertTrue($request->string('int') instanceof Stringable);
-        $this->assertTrue($request->string('unknown_key') instanceof Stringable);
+        $this->assertInstanceOf(\Illuminate\Support\Stringable::class, $request->string('int'));
+        $this->assertInstanceOf(\Illuminate\Support\Stringable::class, $request->string('unknown_key'));
         $this->assertSame('123', $request->string('int')->value());
         $this->assertSame('456', $request->string('int_str')->value());
         $this->assertSame('123.456', $request->string('float')->value());

--- a/tests/Integration/View/BladeAnonymousComponentTest.php
+++ b/tests/Integration/View/BladeAnonymousComponentTest.php
@@ -16,9 +16,9 @@ class BladeAnonymousComponentTest extends TestCase
 
         $view = View::make('page')->render();
 
-        $this->assertTrue(str_contains($view, 'Panel content.'));
-        $this->assertTrue(str_contains($view, 'class="app-layout"'));
-        $this->assertTrue(str_contains($view, 'class="danger-button"'));
+        $this->assertStringContainsString('Panel content.', $view);
+        $this->assertStringContainsString('class="app-layout"', $view);
+        $this->assertStringContainsString('class="danger-button"', $view);
     }
 
     public function test_anonymous_components_with_custom_paths_cant_be_rendered_as_normal_views()

--- a/tests/Log/ContextTest.php
+++ b/tests/Log/ContextTest.php
@@ -166,10 +166,10 @@ class ContextTest extends TestCase
         Context::hydrate($dehydrated);
 
         $this->assertSame('string', Context::get('string'));
-        $this->assertSame(false, Context::get('bool'));
+        $this->assertFalse(Context::get('bool'));
         $this->assertSame(5, Context::get('int'));
         $this->assertSame(5.5, Context::get('float'));
-        $this->assertSame(null, Context::get('null'));
+        $this->assertNull(Context::get('null'));
         $this->assertSame([1, 2, 3], Context::get('array'));
         $this->assertSame(['foo' => 'bar'], Context::get('hash'));
         $this->assertEquals(Context::get('object'), (object) ['foo' => 'bar']);

--- a/tests/Pipeline/PipelineTest.php
+++ b/tests/Pipeline/PipelineTest.php
@@ -328,7 +328,7 @@ class PipelineTest extends TestCase
                 return $piped;
             });
 
-        $this->assertSame(null, $result);
+        $this->assertNull($result);
         $this->assertSame('foo', $_SERVER['__test.pipe.one']);
         $this->assertSame('foo', $_SERVER['__test.pipe.two']);
         $this->assertSame('foo', $_SERVER['__test.pipe.finally']);
@@ -352,7 +352,7 @@ class PipelineTest extends TestCase
                 return $piped;
             });
 
-        $this->assertSame(null, $result);
+        $this->assertNull($result);
         $this->assertSame('foo', $_SERVER['__test.pipe.one']);
         $this->assertSame('foo', $_SERVER['__test.pipe.two']);
         $this->assertSame('foo', $_SERVER['__test.pipe.finally']);

--- a/tests/Process/ProcessTest.php
+++ b/tests/Process/ProcessTest.php
@@ -23,7 +23,7 @@ class ProcessTest extends TestCase
         $this->assertTrue($result->successful());
         $this->assertFalse($result->failed());
         $this->assertEquals(0, $result->exitCode());
-        $this->assertTrue(str_contains($result->output(), 'ProcessTest.php'));
+        $this->assertStringContainsString('ProcessTest.php', $result->output());
         $this->assertSame('', $result->errorOutput());
 
         $result->throw();
@@ -46,8 +46,8 @@ class ProcessTest extends TestCase
         $this->assertTrue($results[0]->successful());
         $this->assertTrue($results[1]->successful());
 
-        $this->assertTrue(str_contains($results[0]->output(), 'ProcessTest.php'));
-        $this->assertTrue(str_contains($results[1]->output(), 'ProcessTest.php'));
+        $this->assertStringContainsString('ProcessTest.php', $results[0]->output());
+        $this->assertStringContainsString('ProcessTest.php', $results[1]->output());
 
         $this->assertTrue($results->successful());
     }
@@ -110,8 +110,8 @@ class ProcessTest extends TestCase
         $this->assertTrue($output[1]['out'] !== []);
         $this->assertInstanceOf(ProcessResult::class, $poolResults[0]);
         $this->assertInstanceOf(ProcessResult::class, $poolResults[1]);
-        $this->assertTrue(str_contains($poolResults[0]->output(), 'ProcessTest.php'));
-        $this->assertTrue(str_contains($poolResults[1]->output(), 'ProcessTest.php'));
+        $this->assertStringContainsString('ProcessTest.php', $poolResults[0]->output());
+        $this->assertStringContainsString('ProcessTest.php', $poolResults[1]->output());
     }
 
     public function testProcessPoolResultsCanBeEvaluatedByName()
@@ -128,8 +128,8 @@ class ProcessTest extends TestCase
         $this->assertTrue($pool['first']->successful());
         $this->assertTrue($pool['second']->successful());
 
-        $this->assertTrue(str_contains($pool['first']->output(), 'ProcessTest.php'));
-        $this->assertTrue(str_contains($pool['second']->output(), 'ProcessTest.php'));
+        $this->assertStringContainsString('ProcessTest.php', $pool['first']->output());
+        $this->assertStringContainsString('ProcessTest.php', $pool['second']->output());
     }
 
     public function testOutputCanBeRetrievedViaStartCallback()
@@ -144,7 +144,7 @@ class ProcessTest extends TestCase
 
         $process->wait();
 
-        $this->assertTrue(str_contains(implode('', $output), 'ProcessTest.php'));
+        $this->assertStringContainsString('ProcessTest.php', implode('', $output));
     }
 
     public function testOutputCanBeRetrievedViaWaitCallback()
@@ -159,7 +159,7 @@ class ProcessTest extends TestCase
             $output[] = $buffer;
         });
 
-        $this->assertTrue(str_contains(implode('', $output), 'ProcessTest.php'));
+        $this->assertStringContainsString('ProcessTest.php', implode('', $output));
     }
 
     public function testBasicProcessFake()
@@ -445,7 +445,7 @@ class ProcessTest extends TestCase
         ]);
 
         $result = $factory->path(__DIR__)->run($this->ls());
-        $this->assertTrue(str_contains($result->output(), 'ProcessTest.php'));
+        $this->assertStringContainsString('ProcessTest.php', $result->output());
     }
 
     public function testProcessFakeThrowShorthand()

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -289,13 +289,13 @@ class SessionStoreTest extends TestCase
         $session->flash('foo', 'bar');
         $session->put('fu', 'baz');
         $session->put('_flash.old', ['qu']);
-        $this->assertNotFalse(array_search('foo', $session->get('_flash.new')));
-        $this->assertFalse(array_search('fu', $session->get('_flash.new')));
+        $this->assertContains('foo', $session->get('_flash.new'));
+        $this->assertNotContains('fu', $session->get('_flash.new'));
         $session->keep(['fu', 'qu']);
-        $this->assertNotFalse(array_search('foo', $session->get('_flash.new')));
-        $this->assertNotFalse(array_search('fu', $session->get('_flash.new')));
-        $this->assertNotFalse(array_search('qu', $session->get('_flash.new')));
-        $this->assertFalse(array_search('qu', $session->get('_flash.old')));
+        $this->assertContains('foo', $session->get('_flash.new'));
+        $this->assertContains('fu', $session->get('_flash.new'));
+        $this->assertContains('qu', $session->get('_flash.new'));
+        $this->assertNotContains('qu', $session->get('_flash.old'));
     }
 
     public function testReflash()
@@ -304,8 +304,8 @@ class SessionStoreTest extends TestCase
         $session->flash('foo', 'bar');
         $session->put('_flash.old', ['foo']);
         $session->reflash();
-        $this->assertNotFalse(array_search('foo', $session->get('_flash.new')));
-        $this->assertFalse(array_search('foo', $session->get('_flash.old')));
+        $this->assertContains('foo', $session->get('_flash.new'));
+        $this->assertNotContains('foo', $session->get('_flash.old'));
     }
 
     public function testReflashWithNow()
@@ -313,8 +313,8 @@ class SessionStoreTest extends TestCase
         $session = $this->getSession();
         $session->now('foo', 'bar');
         $session->reflash();
-        $this->assertNotFalse(array_search('foo', $session->get('_flash.new')));
-        $this->assertFalse(array_search('foo', $session->get('_flash.old')));
+        $this->assertContains('foo', $session->get('_flash.new'));
+        $this->assertNotContains('foo', $session->get('_flash.old'));
     }
 
     public function testOnly()

--- a/tests/Support/DateFacadeTest.php
+++ b/tests/Support/DateFacadeTest.php
@@ -35,41 +35,41 @@ class DateFacadeTest extends TestCase
     public function testUseClosure()
     {
         $start = Carbon::now()->getTimestamp();
-        $this->assertSame(Carbon::class, get_class(Date::now()));
+        $this->assertInstanceOf(Carbon::class, Date::now());
         self::assertBetweenStartAndNow($start, Date::now()->getTimestamp());
         DateFactory::use(function (Carbon $date) {
             return new DateTime($date->format('Y-m-d H:i:s.u'), $date->getTimezone());
         });
         $start = Carbon::now()->getTimestamp();
-        $this->assertSame(DateTime::class, get_class(Date::now()));
+        $this->assertInstanceOf(DateTime::class, Date::now());
         self::assertBetweenStartAndNow($start, Date::now()->getTimestamp());
     }
 
     public function testUseClassName()
     {
         $start = Carbon::now()->getTimestamp();
-        $this->assertSame(Carbon::class, get_class(Date::now()));
+        $this->assertInstanceOf(Carbon::class, Date::now());
         self::assertBetweenStartAndNow($start, Date::now()->getTimestamp());
         DateFactory::use(DateTime::class);
         $start = Carbon::now()->getTimestamp();
-        $this->assertSame(DateTime::class, get_class(Date::now()));
+        $this->assertInstanceOf(DateTime::class, Date::now());
         self::assertBetweenStartAndNow($start, Date::now()->getTimestamp());
     }
 
     public function testCarbonImmutable()
     {
         DateFactory::use(CarbonImmutable::class);
-        $this->assertSame(CarbonImmutable::class, get_class(Date::now()));
+        $this->assertInstanceOf(CarbonImmutable::class, Date::now());
         DateFactory::use(Carbon::class);
-        $this->assertSame(Carbon::class, get_class(Date::now()));
+        $this->assertInstanceOf(Carbon::class, Date::now());
         DateFactory::use(function (Carbon $date) {
             return $date->toImmutable();
         });
-        $this->assertSame(CarbonImmutable::class, get_class(Date::now()));
+        $this->assertInstanceOf(CarbonImmutable::class, Date::now());
         DateFactory::use(function ($date) {
             return $date;
         });
-        $this->assertSame(Carbon::class, get_class(Date::now()));
+        $this->assertInstanceOf(Carbon::class, Date::now());
 
         DateFactory::use(new Factory([
             'locale' => 'fr',

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -710,13 +710,13 @@ class SupportArrTest extends TestCase
         $test_array = ['string' => 'foo bar',  'boolean' => true];
 
         // Test boolean values are returned as booleans
-        $this->assertSame(
-            true, Arr::boolean($test_array, 'boolean')
+        $this->assertTrue(
+            Arr::boolean($test_array, 'boolean')
         );
 
         // Test that default boolean values are returned for missing keys
-        $this->assertSame(
-            true, Arr::boolean($test_array, 'missing_key', true)
+        $this->assertTrue(
+            Arr::boolean($test_array, 'missing_key', true)
         );
 
         // Test that an exception is raised if the value is not a boolean

--- a/tests/Support/SupportFluentTest.php
+++ b/tests/Support/SupportFluentTest.php
@@ -6,7 +6,6 @@ use ArrayIterator;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Fluent;
-use Illuminate\Support\Stringable;
 use InvalidArgumentException;
 use IteratorAggregate;
 use PHPUnit\Framework\TestCase;
@@ -181,8 +180,8 @@ class SupportFluentTest extends TestCase
             'empty_str' => '',
             'null' => null,
         ]);
-        $this->assertTrue($fluent->string('int') instanceof Stringable);
-        $this->assertTrue($fluent->string('unknown_key') instanceof Stringable);
+        $this->assertInstanceOf(\Illuminate\Support\Stringable::class, $fluent->string('int'));
+        $this->assertInstanceOf(\Illuminate\Support\Stringable::class, $fluent->string('unknown_key'));
         $this->assertSame('123', $fluent->string('int')->value());
         $this->assertSame('456', $fluent->string('int_str')->value());
         $this->assertSame('123.456', $fluent->string('float')->value());

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1762,16 +1762,16 @@ class SupportStrTest extends TestCase
         $this->assertSame((string) $first, (string) $retrieved);
 
         $retrieved = Str::uuid();
-        $this->assertFalse(in_array($retrieved, [$zeroth, $first, $third], true));
-        $this->assertFalse(in_array((string) $retrieved, [(string) $zeroth, (string) $first, (string) $third], true));
+        $this->assertNotContains($retrieved, [$zeroth, $first, $third]);
+        $this->assertNotContains((string) $retrieved, [(string) $zeroth, (string) $first, (string) $third]);
 
         $retrieved = Str::uuid();
         $this->assertSame($third, $retrieved);
         $this->assertSame((string) $third, (string) $retrieved);
 
         $retrieved = Str::uuid();
-        $this->assertFalse(in_array($retrieved, [$zeroth, $first, $third], true));
-        $this->assertFalse(in_array((string) $retrieved, [(string) $zeroth, (string) $first, (string) $third], true));
+        $this->assertNotContains($retrieved, [$zeroth, $first, $third]);
+        $this->assertNotContains((string) $retrieved, [(string) $zeroth, (string) $first, (string) $third]);
 
         Str::createUuidsNormally();
     }
@@ -1864,16 +1864,16 @@ class SupportStrTest extends TestCase
         $this->assertSame((string) $first, (string) $retrieved);
 
         $retrieved = Str::ulid();
-        $this->assertFalse(in_array($retrieved, [$zeroth, $first, $third], true));
-        $this->assertFalse(in_array((string) $retrieved, [(string) $zeroth, (string) $first, (string) $third], true));
+        $this->assertNotContains($retrieved, [$zeroth, $first, $third]);
+        $this->assertNotContains((string) $retrieved, [(string) $zeroth, (string) $first, (string) $third]);
 
         $retrieved = Str::ulid();
         $this->assertSame($third, $retrieved);
         $this->assertSame((string) $third, (string) $retrieved);
 
         $retrieved = Str::ulid();
-        $this->assertFalse(in_array($retrieved, [$zeroth, $first, $third], true));
-        $this->assertFalse(in_array((string) $retrieved, [(string) $zeroth, (string) $first, (string) $third], true));
+        $this->assertNotContains($retrieved, [$zeroth, $first, $third]);
+        $this->assertNotContains((string) $retrieved, [(string) $zeroth, (string) $first, (string) $third]);
 
         Str::createUlidsNormally();
     }

--- a/tests/Support/ValidatedInputTest.php
+++ b/tests/Support/ValidatedInputTest.php
@@ -5,7 +5,6 @@ namespace Illuminate\Tests\Support;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Stringable;
 use Illuminate\Support\ValidatedInput;
 use Illuminate\Tests\Support\Fixtures\StringBackedEnum;
 use PHPUnit\Framework\TestCase;
@@ -338,7 +337,7 @@ class ValidatedInputTest extends TestCase
         $input = new ValidatedInput(['name' => 'Fatih', 'surname' => 'AYDIN', 'foo' => ['bar' => null, 'baz' => '']]);
 
         $this->assertSame('Fatih', $input->input('name'));
-        $this->assertSame(null, $input->input('foo.bar'));
+        $this->assertNull($input->input('foo.bar'));
         $this->assertSame('test', $input->input('foo.bat', 'test'));
     }
 
@@ -356,9 +355,9 @@ class ValidatedInputTest extends TestCase
             'null' => null,
         ]);
 
-        $this->assertTrue($input->str('int') instanceof Stringable);
-        $this->assertTrue($input->str('int') instanceof Stringable);
-        $this->assertTrue($input->str('unknown_key') instanceof Stringable);
+        $this->assertInstanceOf(\Illuminate\Support\Stringable::class, $input->str('int'));
+        $this->assertInstanceOf(\Illuminate\Support\Stringable::class, $input->str('int'));
+        $this->assertInstanceOf(\Illuminate\Support\Stringable::class, $input->str('unknown_key'));
         $this->assertSame('123', $input->str('int')->value());
         $this->assertSame('456', $input->str('int_str')->value());
         $this->assertSame('123.456', $input->str('float')->value());
@@ -384,9 +383,9 @@ class ValidatedInputTest extends TestCase
             'null' => null,
         ]);
 
-        $this->assertTrue($input->string('int') instanceof Stringable);
-        $this->assertTrue($input->string('int') instanceof Stringable);
-        $this->assertTrue($input->string('unknown_key') instanceof Stringable);
+        $this->assertInstanceOf(\Illuminate\Support\Stringable::class, $input->string('int'));
+        $this->assertInstanceOf(\Illuminate\Support\Stringable::class, $input->string('int'));
+        $this->assertInstanceOf(\Illuminate\Support\Stringable::class, $input->string('unknown_key'));
         $this->assertSame('123', $input->string('int')->value());
         $this->assertSame('456', $input->string('int_str')->value());
         $this->assertSame('123.456', $input->string('float')->value());


### PR DESCRIPTION
Runs a batch of rector PHPUnit assertion rules and removes them from `rector.php`.