### PR TITLE
[13.x] Add base64 validation rule

### DIFF
--- a/src/Illuminate/Translation/lang/en/validation.php
+++ b/src/Illuminate/Translation/lang/en/validation.php
@@ -24,6 +24,7 @@ return [
     'any_of' => 'The :attribute field is invalid.',
     'array' => 'The :attribute field must be an array.',
     'ascii' => 'The :attribute field must only contain single-byte alphanumeric characters and symbols.',
+    'base64' => 'The :attribute field must be a valid Base64 string.',
     'before' => 'The :attribute field must be a date before :date.',
     'before_or_equal' => 'The :attribute field must be a date before or equal to :date.',
     'between' => [

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -171,11 +171,7 @@ trait ValidatesAttributes
      */
     public function validateBase64($attribute, $value): bool
     {
-        if (! is_string($value) || $value === '') {
-            return false;
-        }
-
-        return preg_match('/^(?:[a-z\d+\/]{4})*(?:[a-z\d+\/]{2}==|[a-z\d+\/]{3}=|[a-z\d+\/]{4})$/i', $value) === 1;
+        return is_string($value) && $value !== '' && base64_decode($value, true) !== false;
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -163,6 +163,22 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate that an attribute is a valid Base64 string.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function validateBase64($attribute, $value): bool
+    {
+        if (! is_string($value) || $value === '') {
+            return false;
+        }
+
+        return preg_match('/^(?:[a-z\d+\/]{4})*(?:[a-z\d+\/]{2}==|[a-z\d+\/]{3}=|[a-z\d+\/]{4})$/i', $value) === 1;
+    }
+
+    /**
      * "Break" on first validation fail.
      *
      * Always returns true, just lets us put "bail" in rules.

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1117,7 +1117,8 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['name' => ''], ['name' => 'required']);
 
-        $exception = new class($v) extends ValidationException {
+        $exception = new class($v) extends ValidationException
+        {
         };
         $v->setException($exception);
 
@@ -2379,6 +2380,21 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
     }
 
+    public function testValidateBase64(): void
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['value' => base64_encode('Laravel')], ['value' => 'base64']);
+        $this->assertTrue($v->passes());
+        $v = new Validator($trans, ['value' => ''], ['value' => 'required|base64']);
+        $this->assertFalse($v->passes());
+        $v = new Validator($trans, ['value' => 'not-base64!'], ['value' => 'base64']);
+        $this->assertFalse($v->passes());
+        $v = new Validator($trans, ['value' => 'YQ'], ['value' => 'base64']);
+        $this->assertFalse($v->passes());
+        $v = new Validator($trans, ['value' => 'YQ=='], ['value' => 'base64']);
+        $this->assertTrue($v->passes());
+    }
+
     public function testValidateConfirmed()
     {
         $trans = $this->getIlluminateArrayTranslator();
@@ -3300,6 +3316,13 @@ class ValidationValidatorTest extends TestCase
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['x' => ['array']], ['x' => 'hex_color']);
+        $this->assertFalse($v->passes());
+    }
+
+    public function testValidateBase64DoesNotThrowOnNonStringValue(): void
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['x' => ['array']], ['x' => 'base64']);
         $this->assertFalse($v->passes());
     }
 


### PR DESCRIPTION
Adds a `base64` validation rule (RFC 4648), a common format check offered by other validation libraries such as Zod's `.base64()` but currently missing from Laravel.