### PR TITLE
feat: add support for QUERY method in routing as defined in RFC 10008

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -394,7 +394,7 @@ class RouteListCommand extends Command
         $routes = $routes->map(
             fn ($route) => array_merge($route, [
                 'action' => $this->formatActionForCli($route),
-                'method' => $route['method'] === 'GET|HEAD|POST|PUT|PATCH|DELETE|OPTIONS' ? 'ANY' : $route['method'],
+                'method' => $route['method'] === 'GET|HEAD|QUERY|POST|PUT|PATCH|DELETE|OPTIONS' ? 'ANY' : $route['method'],
                 'uri' => $route['domain'] ? ($route['domain'].'/'.ltrim($route['uri'], '/')) : $route['uri'],
             ]),
         );

--- a/src/Illuminate/Foundation/Http/Middleware/PreventRequestForgery.php
+++ b/src/Illuminate/Foundation/Http/Middleware/PreventRequestForgery.php
@@ -119,7 +119,7 @@ class PreventRequestForgery
      */
     protected function isReading($request)
     {
-        return in_array($request->method(), ['HEAD', 'GET', 'OPTIONS']);
+        return in_array($request->method(), ['HEAD', 'GET', 'QUERY', 'OPTIONS']);
     }
 
     /**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -298,7 +298,7 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     public function view($uri, $view, $data = [], $status = 200, array $headers = [])
     {
-        return $this->match(['GET', 'HEAD'], $uri, '\Illuminate\Routing\ViewController')
+        return $this->match(['GET', 'HEAD', 'QUERY'], $uri, '\Illuminate\Routing\ViewController')
             ->setDefaults([
                 'view' => $view,
                 'data' => $data,

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -133,7 +133,7 @@ class Router implements BindingRegistrar, RegistrarContract
      *
      * @var string[]
      */
-    public static $verbs = ['GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'];
+    public static $verbs = ['GET', 'HEAD', 'QUERY', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'];
 
     /**
      * Create a new Router instance.
@@ -157,7 +157,19 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     public function get($uri, $action = null)
     {
-        return $this->addRoute(['GET', 'HEAD'], $uri, $action);
+        return $this->addRoute(['GET', 'HEAD', 'QUERY'], $uri, $action);
+    }
+
+    /**
+     * Register a new QUERY route with the router.
+     *
+     * @param  string  $uri
+     * @param  array|string|callable|null  $action
+     * @return \Illuminate\Routing\Route
+     */
+    public function query($uri, $action = null)
+    {
+        return $this->addRoute('QUERY', $uri, $action);
     }
 
     /**

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -540,7 +540,7 @@ class RoutingRouteTest extends TestCase
         $response = $router->dispatch(Request::create('foo/bar', 'OPTIONS'));
 
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertSame('GET,HEAD,POST', $response->headers->get('Allow'));
+        $this->assertSame('GET,HEAD,QUERY,POST', $response->headers->get('Allow'));
     }
 
     public function testHeadDispatcher()

--- a/tests/Testing/Console/RouteListCommandTest.php
+++ b/tests/Testing/Console/RouteListCommandTest.php
@@ -136,7 +136,7 @@ class RouteListCommandTest extends TestCase
         $this->withoutDeprecationHandling();
 
         RouteListCommand::resolveTerminalWidthUsing(function () {
-            return 82;
+            return 87;
         });
 
         $this->router->get('/', function () {
@@ -148,10 +148,10 @@ class RouteListCommandTest extends TestCase
             ->assertSuccessful()
             ->expectsOutput('')
             ->expectsOutput(
-                '  GET|HEAD       foo/{user} Illuminate\Tests\Testing\Console\FooController@show'
+                '  GET|HEAD|QUERY       foo/{user} Illuminate\Tests\Testing\Console\FooController@show'
             )->expectsOutput('')
             ->expectsOutput(
-                '                                                              Showing [1] routes'
+                '                                                                   Showing [1] routes'
             )
             ->expectsOutput('');
     }
@@ -223,9 +223,9 @@ class RouteListCommandTest extends TestCase
         $this->artisan(RouteListCommand::class, ['-v' => true, '--except-vendor' => true])
             ->assertSuccessful()
             ->expectsOutput('')
-            ->expectsOutput('  GET|HEAD       foo/{user} Illuminate\Tests\Testing\Console\FooController@show')
-            ->expectsOutput('  ANY            redirect .... Illuminate\Routing\RedirectController')
-            ->expectsOutput('  GET|HEAD       view .............................................. ')
+            ->expectsOutput('  GET|HEAD|QUERY       foo/{user} Illuminate\Tests\Testing\Console\FooController@show')
+            ->expectsOutput('  ANY                   redirect Illuminate\Routing\RedirectController')
+            ->expectsOutput('  GET|HEAD|QUERY       view ........................................ ')
             ->expectsOutput('')
             ->expectsOutput('                                                  Showing [3] routes')
             ->expectsOutput('');

--- a/tests/Testing/Console/RouteListCommandTest.php
+++ b/tests/Testing/Console/RouteListCommandTest.php
@@ -224,7 +224,7 @@ class RouteListCommandTest extends TestCase
             ->assertSuccessful()
             ->expectsOutput('')
             ->expectsOutput('  GET|HEAD|QUERY       foo/{user} Illuminate\Tests\Testing\Console\FooController@show')
-            ->expectsOutput('  ANY                   redirect Illuminate\Routing\RedirectController')
+            ->expectsOutput('  ANY                  redirect Illuminate\Routing\RedirectController')
             ->expectsOutput('  GET|HEAD|QUERY       view ........................................ ')
             ->expectsOutput('')
             ->expectsOutput('                                                  Showing [3] routes')


### PR DESCRIPTION
Add the QUERY HTTP method as defined in RFC 10008. QUERY is a safe, idempotent method similar to GET but designed for retrieving information without modifying state — intended as a replacement for GET-with-body patterns.
