### PR TITLE
Add storage:create-bucket Artisan command

### DIFF
--- a/src/Illuminate/Filesystem/Console/CreateBucketCommand.php
+++ b/src/Illuminate/Filesystem/Console/CreateBucketCommand.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Illuminate\Filesystem\Console;
+
+use Illuminate\Console\Command;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(name: 'storage:create-bucket')]
+class CreateBucketCommand extends Command
+{
+    /**
+     * The console command signature.
+     *
+     * @var string
+     */
+    protected $signature = 'storage:create-bucket
+                {name? : The name of the bucket to create}
+                {--disk=s3 : The S3 filesystem disk to use}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a bucket for an S3 filesystem disk';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $diskName = $this->option('disk');
+        $config = $this->laravel['config']->get("filesystems.disks.{$diskName}", []);
+
+        if (($config['driver'] ?? null) !== 's3') {
+            $this->components->error("The [{$diskName}] disk does not use the S3 driver.");
+
+            return static::FAILURE;
+        }
+
+        $bucket = $this->argument('name') ?: ($config['bucket'] ?? null);
+
+        if (! $bucket) {
+            $this->components->error("The [{$diskName}] disk does not have a configured bucket.");
+
+            return static::FAILURE;
+        }
+
+        $disk = $this->laravel['filesystem']->disk($diskName);
+
+        $disk->getClient()->createBucket(['Bucket' => $bucket]);
+
+        $this->components->info("Bucket [{$bucket}] created successfully.");
+
+        return static::SUCCESS;
+    }
+}

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -30,6 +30,7 @@ use Illuminate\Database\Console\ShowCommand;
 use Illuminate\Database\Console\ShowModelCommand;
 use Illuminate\Database\Console\TableCommand as DatabaseTableCommand;
 use Illuminate\Database\Console\WipeCommand;
+use Illuminate\Filesystem\Console\CreateBucketCommand;
 use Illuminate\Foundation\Console\AboutCommand;
 use Illuminate\Foundation\Console\ApiInstallCommand;
 use Illuminate\Foundation\Console\BroadcastingInstallCommand;
@@ -182,6 +183,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'SchedulePause' => SchedulePauseCommand::class,
         'ScheduleResume' => ScheduleResumeCommand::class,
         'ShowModel' => ShowModelCommand::class,
+        'StorageCreateBucket' => CreateBucketCommand::class,
         'StorageLink' => StorageLinkCommand::class,
         'StorageUnlink' => StorageUnlinkCommand::class,
         'Up' => UpCommand::class,

--- a/tests/Filesystem/Console/CreateBucketCommandTest.php
+++ b/tests/Filesystem/Console/CreateBucketCommandTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Illuminate\Tests\Filesystem\Console;
+
+use Aws\CommandInterface;
+use Aws\MockHandler;
+use Aws\Result;
+use Closure;
+use Orchestra\Testbench\TestCase;
+use Psr\Http\Message\RequestInterface;
+
+class CreateBucketCommandTest extends TestCase
+{
+    public function testItCreatesTheConfiguredBucket(): void
+    {
+        $this->fakeS3Disk('s3', [
+            'bucket' => 'configured-bucket',
+            'region' => 'us-east-1',
+        ], function (CommandInterface $command) {
+            $this->assertSame('configured-bucket', $command['Bucket']);
+            $this->assertArrayNotHasKey('CreateBucketConfiguration', $command->toArray());
+
+            return new Result();
+        });
+
+        $this->artisan('storage:create-bucket')
+            ->expectsOutputToContain('Bucket [configured-bucket] created successfully.')
+            ->assertSuccessful();
+    }
+
+    public function testItCanCreateAnExplicitBucketUsingAnotherDisk(): void
+    {
+        $this->fakeS3Disk('minio', [
+            'bucket' => 'configured-bucket',
+            'endpoint' => 'http://minio.test:9000',
+            'region' => 'us-east-1',
+            'use_path_style_endpoint' => true,
+        ], function (CommandInterface $command, RequestInterface $request) {
+            $this->assertSame('explicit-bucket', $command['Bucket']);
+            $this->assertArrayNotHasKey('CreateBucketConfiguration', $command->toArray());
+            $this->assertSame('minio.test', $request->getUri()->getHost());
+            $this->assertSame(9000, $request->getUri()->getPort());
+            $this->assertSame('/explicit-bucket', $request->getUri()->getPath());
+
+            return new Result();
+        });
+
+        $this->artisan('storage:create-bucket', [
+            'name' => 'explicit-bucket',
+            '--disk' => 'minio',
+        ])->assertSuccessful();
+    }
+
+    public function testItUsesTheConfiguredAwsRegionAsTheLocationConstraint(): void
+    {
+        $this->fakeS3Disk('s3', [
+            'bucket' => 'regional-bucket',
+            'region' => 'eu-west-1',
+        ], function (CommandInterface $command) {
+            $this->assertSame([
+                'LocationConstraint' => 'eu-west-1',
+            ], $command['CreateBucketConfiguration']);
+
+            return new Result();
+        });
+
+        $this->artisan('storage:create-bucket')->assertSuccessful();
+    }
+
+    public function testItFailsWhenTheDiskDoesNotUseTheS3Driver(): void
+    {
+        $this->app['config']->set('filesystems.disks.local', [
+            'driver' => 'local',
+            'root' => __DIR__,
+        ]);
+
+        $this->artisan('storage:create-bucket', ['--disk' => 'local'])
+            ->expectsOutputToContain('The [local] disk does not use the S3 driver.')
+            ->assertFailed();
+    }
+
+    public function testItFailsWhenNoBucketNameIsAvailable(): void
+    {
+        $this->app['config']->set('filesystems.disks.s3', [
+            'driver' => 's3',
+        ]);
+
+        $this->artisan('storage:create-bucket')
+            ->expectsOutputToContain('The [s3] disk does not have a configured bucket.')
+            ->assertFailed();
+    }
+
+    protected function fakeS3Disk(string $name, array $config, Closure $handler): void
+    {
+        $mock = new MockHandler();
+        $mock->append($handler);
+
+        $this->app['config']->set("filesystems.disks.{$name}", array_merge([
+            'driver' => 's3',
+            'credentials' => false,
+            'handler' => $mock,
+        ], $config));
+    }
+}


### PR DESCRIPTION
This adds a `storage:create-bucket` command for creating the bucket used by an S3 filesystem disk. It defaults to the configured `s3` disk and bucket while allowing another disk or bucket name to be selected.

The command uses the disk's existing S3 client, preserving its credentials, region, endpoint, path-style behavior, and other client options. This is additive and does not change existing filesystem behavior.

### Verification

- `php vendor/bin/phpunit tests/Filesystem` — 150 tests, 295 assertions, 1 Windows-only skip
- `php vendor/bin/pint --test src/Illuminate/Filesystem/Console/CreateBucketCommand.php src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php tests/Filesystem/Console/CreateBucketCommandTest.php`

### Manual QA

- Created the configured bucket against a disposable MinIO endpoint using the command's default arguments.
- Created an explicitly named bucket and verified both buckets through the S3 API.
- Confirmed selecting a non-S3 disk reports an actionable error and exits with status 1.

Written by GPT-5.6 Sol.
