### PR TITLE
[13.x] Ensure validateBase64 properly validates base64

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -171,7 +171,13 @@ trait ValidatesAttributes
      */
     public function validateBase64($attribute, $value): bool
     {
-        return is_string($value) && $value !== '' && base64_decode($value, true) !== false;
+        if (! is_string($value) || $value === '') {
+            return false;
+        }
+
+        $decoded = base64_decode($value, true);
+
+        return $decoded !== false && base64_encode($decoded) === $value;
     }
 
     /**


### PR DESCRIPTION
I know this is brand new

But, I see tests failing, so I am here see:
https://github.com/laravel/framework/actions/runs/29511649712/job/87666337273#step:7:273 https://github.com/laravel/framework/actions/runs/29513165816/job/87671476329#step:7:266 

The method here should be validating its proper base64, 'YQ' by itself is not valid base64, according to the test, and specs but the method passed

Its an age old problem you can see via https://stackoverflow.com/a/10797086 ( I basically implemented this ) 

No new tests, cause it now passing proves it works