### PR TITLE
[13.x] Fix multibyte string handling in Str::wordWrap

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1951,7 +1951,21 @@ class Str
      */
     public static function wordWrap($string, $characters = 75, $break = "\n", $cutLongWords = false)
     {
-        return wordwrap($string, $characters, $break, $cutLongWords);
+        if (static::isAscii($string)) {
+            return wordwrap($string, $characters, $break, $cutLongWords);
+        }
+
+        $replaced = [];
+
+        $skeleton = preg_replace_callback('/[\x80-\xFF][\x80-\xBF]*|\x1A/', function ($match) use (&$replaced) {
+            $replaced[] = $match[0];
+
+            return "\x1A";
+        }, $string);
+
+        return preg_replace_callback('/\x1A/', function () use (&$replaced) {
+            return array_shift($replaced);
+        }, wordwrap($skeleton, $characters, $break, $cutLongWords));
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1955,6 +1955,10 @@ class Str
             return wordwrap($string, $characters, $break, $cutLongWords);
         }
 
+        if ($break === '') {
+            return wordwrap($string, $characters, $break, $cutLongWords);
+        }
+
         $replaced = [];
 
         $skeleton = preg_replace_callback('/[\x80-\xFF][\x80-\xBF]*|\x1A/', function ($match) use (&$replaced) {
@@ -1963,9 +1967,19 @@ class Str
             return "\x1A";
         }, $string);
 
-        return preg_replace_callback('/\x1A/', function () use (&$replaced) {
-            return array_shift($replaced);
-        }, wordwrap($skeleton, $characters, $break, $cutLongWords));
+        $breakToken = "\0";
+
+        while (str_contains($skeleton, $breakToken)) {
+            $breakToken .= "\0";
+        }
+
+        $index = 0;
+
+        return implode($break, array_map(function ($segment) use (&$replaced, &$index) {
+            return preg_replace_callback('/\x1A/', function () use (&$replaced, &$index) {
+                return $replaced[$index++];
+            }, $segment);
+        }, explode($breakToken, wordwrap($skeleton, $characters, $breakToken, $cutLongWords))));
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1506,6 +1506,7 @@ class SupportStrTest extends TestCase
         $this->assertSame("žltý\nkôň", Str::wordWrap('žltý kôň', 4, "\n", true));
         $this->assertSame("žl\ntý", Str::wordWrap('žltý', 2, "\n", true));
         $this->assertSame("😀😀\n😀😀", Str::wordWrap('😀😀😀😀', 2, "\n", true));
+        $this->assertSame("éA\x1ABé", Str::wordWrap('é é', 1, "A\x1AB"));
         $this->assertSame('❤Mu<br />lti<br />Byt<br />e☆❤<br />☆❤☆<br />❤', Str::wordWrap('❤Multi Byte☆❤☆❤☆❤', 3, '<br />', true));
     }
 

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1501,6 +1501,12 @@ class SupportStrTest extends TestCase
         $this->assertSame('Hel<br />lo<br />Wor<br />ld', Str::wordWrap('Hello World', 3, '<br />', true));
 
         $this->assertSame('❤Multi<br />Byte☆❤☆❤☆❤', Str::wordWrap('❤Multi Byte☆❤☆❤☆❤', 3, '<br />'));
+
+        $this->assertSame('žltý kôň', Str::wordWrap('žltý kôň', 8, "\n"));
+        $this->assertSame("žltý\nkôň", Str::wordWrap('žltý kôň', 4, "\n", true));
+        $this->assertSame("žl\ntý", Str::wordWrap('žltý', 2, "\n", true));
+        $this->assertSame("😀😀\n😀😀", Str::wordWrap('😀😀😀😀', 2, "\n", true));
+        $this->assertSame('❤Mu<br />lti<br />Byt<br />e☆❤<br />☆❤☆<br />❤', Str::wordWrap('❤Multi Byte☆❤☆❤☆❤', 3, '<br />', true));
     }
 
     public static function validUuidList()


### PR DESCRIPTION
`Str::wordWrap()` delegates to PHP's native `wordwrap()`, which counts bytes
rather than characters. While the rest of the `Str` class is multibyte-aware
(`limit()`, `mask()`, `length()`, `padBoth()`, ...), `wordWrap()` breaks on
multibyte input in two ways:

**1. Wrapping at wrong widths** - a 4-character word like `žltý` is counted
as 6, so lines wrap earlier than requested:

```php
Str::wordWrap('žltý kôň', 8, "\n");
// expected: "žltý kôň" (8 characters, fits on one line)
// actual:   "žltý\nkôň"
```

**2. Corrupting UTF-8 with `$cutLongWords = true`** - words are cut at byte
boundaries, which can split a multibyte character in half and produce
invalid UTF-8:

```php
$wrapped = Str::wordWrap('žltý kôň', 4, "\n", true);
mb_check_encoding($wrapped, 'UTF-8'); // false — ň is split in half
json_encode($wrapped);                // false — fails on invalid UTF-8
```

The existing multibyte test (`❤Multi Byte☆❤☆❤☆❤` at width 3) only passes
coincidentally, because those characters are exactly 3 bytes each, so the
byte-based cuts happen to land on character boundaries.

### The fix

ASCII strings keep the exact previous behavior, same native call, no
overhead. For multibyte strings, each multibyte character is temporarily
replaced with a single-byte placeholder, the native `wordwrap()` wraps this
skeleton (now counting characters correctly), and the characters are then
restored in order. Native wrapping semantics are preserved exactly; nothing
is ever cut mid-character.

All existing tests pass unchanged.