### PR TITLE
[13.x] Fix resolveClassAttribute() cache key omitting the property

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2678,7 +2678,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     {
         $class ??= static::class;
 
-        $cacheKey = $class.'@'.$attributeClass;
+        $cacheKey = $class.'@'.$attributeClass.'@'.$property;
 
         if (array_key_exists($cacheKey, static::$classAttributes)) {
             return static::$classAttributes[$cacheKey];

--- a/tests/Database/DatabaseEloquentModelAttributesTest.php
+++ b/tests/Database/DatabaseEloquentModelAttributesTest.php
@@ -420,6 +420,23 @@ class DatabaseEloquentModelAttributesTest extends TestCase
         $this->assertFalse(ModelWithFillableAttribute::isIgnoringTouch());
     }
 
+    public function test_is_ignoring_touch_after_model_is_constructed(): void
+    {
+        new ModelWithTableAndTimestampsFalseAttribute;
+
+        $this->assertTrue(ModelWithTableAndTimestampsFalseAttribute::isIgnoringTouch());
+    }
+
+    public function test_table_and_timestamps_attributes_apply_after_is_ignoring_touch(): void
+    {
+        ModelWithTableAndTimestampsFalseAttribute::isIgnoringTouch();
+
+        $model = new ModelWithTableAndTimestampsFalseAttribute;
+
+        $this->assertSame('collision_table', $model->getTable());
+        $this->assertFalse($model->usesTimestamps());
+    }
+
     public function test_trait_initializer_merges_appends_with_attribute(): void
     {
         $model = new ModelWithAppendsAttributeAndTrait;
@@ -562,6 +579,12 @@ class ModelWithoutTimestampsAttribute extends Model
 class ModelWithTimestampsAttributeAndProperty extends Model
 {
     public $timestamps = false;
+}
+
+#[Table(name: 'collision_table', timestamps: false)]
+class ModelWithTableAndTimestampsFalseAttribute extends Model
+{
+    //
 }
 
 #[Table(dateFormat: 'U')]


### PR DESCRIPTION
`resolveClassAttribute()` leaves `$property` out of its cache key, so the object form and the property form of the same attribute share one cache slot. For `#[Table]` this collides `initializeModelAttributes()`, which caches the `Table` object, with `isIgnoringTouch()`, which caches the `timestamps` bool, so whichever runs first for a given model wins and `#[Table(timestamps: false)]` is silently ignored: the model is either still touched by its relations, or loses its table name and timestamps altogether, depending on call order. Adding `$property` to the key keeps the two forms apart.

Fixes #60803
