### PR TITLE
[13.x] Fix Artisan output assertions for zero values

### DIFF
--- a/src/Illuminate/Testing/PendingCommand.php
+++ b/src/Illuminate/Testing/PendingCommand.php
@@ -532,11 +532,11 @@ class PendingCommand
             $this->test->fail('Output does not contain "'.Arr::first($this->test->expectedOutputSubstrings).'".');
         }
 
-        if ($output = array_search(true, $this->test->unexpectedOutput)) {
+        if (($output = array_search(true, $this->test->unexpectedOutput)) !== false) {
             $this->test->fail('Output "'.$output.'" was printed.');
         }
 
-        if ($output = array_search(true, $this->test->unexpectedOutputSubstrings)) {
+        if (($output = array_search(true, $this->test->unexpectedOutputSubstrings)) !== false) {
             $this->test->fail('Output "'.$output.'" was printed.');
         }
     }

--- a/tests/Integration/Testing/ArtisanCommandTest.php
+++ b/tests/Integration/Testing/ArtisanCommandTest.php
@@ -56,6 +56,10 @@ class ArtisanCommandTest extends TestCase
             $this->line('My name is Taylor Otwell');
         });
 
+        Artisan::command('zero', function () {
+            $this->line('0');
+        });
+
         Artisan::command('new-england', function () {
             $this->line('The region of New England consists of the following states:');
             $this->info('Connecticut');
@@ -122,6 +126,26 @@ class ArtisanCommandTest extends TestCase
 
         $this->artisan('contains')
             ->doesntExpectOutputToContain('Taylor Otwell')
+            ->assertExitCode(0);
+    }
+
+    public function test_console_command_that_fails_from_zero_as_unexpected_output()
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Output "0" was printed.');
+
+        $this->artisan('zero')
+            ->doesntExpectOutput('0')
+            ->assertExitCode(0);
+    }
+
+    public function test_console_command_that_fails_from_zero_as_unexpected_output_substring()
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Output "0" was printed.');
+
+        $this->artisan('zero')
+            ->doesntExpectOutputToContain('0')
             ->assertExitCode(0);
     }
 


### PR DESCRIPTION
This PR fixes `doesntExpectOutput()` and `doesntExpectOutputToContain()` incorrectly passing when the unexpected output is `"0"`.

PHP converts the `"0"` array key to the integer `0`. When `array_search()` finds the matched expectation, it therefore returns `0`, which was previously treated as `false`.

The result of array_search() is now compared explicitly against false, preserving existing behavior for all other output while correctly handling "0".

Regression tests cover both exact output and substring expectations.