### PR TITLE
Preserve falsy values in Can validation rule

### DIFF
--- a/src/Illuminate/Validation/Rules/Can.php
+++ b/src/Illuminate/Validation/Rules/Can.php
@@ -54,7 +54,9 @@ class Can implements Rule, ValidatorAwareRule
 
         $model = array_shift($arguments);
 
-        return Gate::allows($this->ability, array_filter([$model, ...$arguments, $value]));
+        return Gate::allows($this->ability, array_filter(
+            [$model, ...$arguments, $value], fn ($argument) => ! is_null($argument)
+        ));
     }
 
     /**

--- a/tests/Validation/ValidationRuleCanTest.php
+++ b/tests/Validation/ValidationRuleCanTest.php
@@ -92,6 +92,23 @@ class ValidationRuleCanTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
+    public function testValidationPassesFalseyArguments()
+    {
+        $this->gate()->define('update-company', function ($user, ...$arguments) {
+            $this->assertSame([\App\Models\Company::class, 0, false, '0', 0], $arguments);
+
+            return true;
+        });
+
+        $v = new Validator(
+            resolve('translator'),
+            ['company' => 0],
+            ['company' => new Can('update-company', [\App\Models\Company::class, 0, false, '0'])]
+        );
+
+        $this->assertTrue($v->passes());
+    }
+
     public function testCustomMessageUsingDotNotationAndFqcnWorks()
     {
         $v = new Validator(


### PR DESCRIPTION
**The Problem**

When using the `Rule::can()` validation rule, the framework prepares the arguments for `Gate::allows()` using `array_filter()` without a callback:

```php
return Gate::allows($this->ability, array_filter([$model, ...$arguments,$value]));

```

Because PHP's default `array_filter` removes *all* falsey values, any legitimate argument that happens to be `0`, `"0"`, `false`, or `""` (empty string) gets silently dropped.

This leads to two frustrating issues:

1. The validated field itself is omitted if its value is falsey (e.g., an ID of `0` or a boolean setting).
2. If you pass extra arguments to the rule, any falsey argument disappears, which shifts the position of subsequent arguments and completely breaks the signature of your policy or gate method.

### The Solution
This PR updates the filter callback to strictly target and remove only `null` values. This preserves the original intent of the filter which is to cleanly guard against unresolved optional models while ensuring that valid, meaningful falsey values are safely passed through to the gate.