### PR TITLE
[13.x] Fix Relation::getMorphAlias() for zero aliases

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -519,7 +519,9 @@ abstract class Relation implements BuilderContract
      */
     public static function getMorphAlias(string $className)
     {
-        return array_search($className, static::$morphMap, strict: true) ?: $className;
+        $alias = array_search($className, static::$morphMap, strict: true);
+
+        return $alias !== false ? $alias : $className;
     }
 
     /**

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -232,9 +232,13 @@ class DatabaseEloquentRelationTest extends TestCase
 
     public function testGetMorphAlias()
     {
-        Relation::morphMap(['user' => 'App\User']);
+        Relation::morphMap([
+            'user' => 'App\User',
+            0 => 'App\Admin',
+        ]);
 
         $this->assertSame('user', Relation::getMorphAlias('App\User'));
+        $this->assertSame(0, Relation::getMorphAlias('App\Admin'));
         $this->assertSame('Does\Not\Exist', Relation::getMorphAlias('Does\Not\Exist'));
     }
 


### PR DESCRIPTION
**The Problem**

When looking up a morph map alias via `Relation::getMorphAlias()`, the method uses a shorthand ternary operator (`?:`) on the result of `array_search()`:

```php
return array_search($className, static::$morphMap) ?:$className;

```

If a model is mapped to the integer `0` (which is a common practice when using legacy databases or ultra-optimized numeric discriminators), `array_search()` correctly finds and returns `0`.

However, because PHP evaluates `0` as falsey, the shorthand ternary discards the alias and falls back to returning the full class name instead.

**The Solution**
This PR replaces the loose ternary check with an explicit type check (`!== false`) against the result of `array_search()`. This ensures that `0` is properly preserved and returned as a valid alias, making its behavior consistent with all other numeric/integer aliases (like `1` or `10`).