### PR TITLE
[13.x] Fix missing enum_value() call in RedisTaggedCache::decrement()

### DIFF
--- a/src/Illuminate/Cache/RedisTaggedCache.php
+++ b/src/Illuminate/Cache/RedisTaggedCache.php
@@ -94,6 +94,8 @@ class RedisTaggedCache extends TaggedCache
      */
     public function decrement($key, $value = 1)
     {
+        $key = enum_value($key);
+
         $this->tags->addEntry($this->itemKey($key), updateWhen: 'NX');
 
         return parent::decrement($key, $value);

--- a/tests/Integration/Cache/RedisStoreTest.php
+++ b/tests/Integration/Cache/RedisStoreTest.php
@@ -149,6 +149,20 @@ class RedisStoreTest extends TestCase
         $this->assertEquals(0, Cache::store('redis')->tags(['votes'])->get('person-1'));
     }
 
+    public function testTagEntriesCanBeDecrementedUsingEnumKeys()
+    {
+        Cache::store('redis')->clear();
+
+        Cache::store('redis')->tags(['votes'])->put(RedisTaggedCacheTestKey::PERSON_1, 2, 5);
+        Cache::store('redis')->tags(['votes'])->decrement(RedisTaggedCacheTestKey::PERSON_1);
+
+        $this->assertEquals(1, Cache::store('redis')->tags(['votes'])->get(RedisTaggedCacheTestKey::PERSON_1));
+
+        Cache::store('redis')->tags(['votes'])->flush();
+
+        $this->assertNull(Cache::store('redis')->tags(['votes'])->get(RedisTaggedCacheTestKey::PERSON_1));
+    }
+
     public function testIncrementedTagEntriesProperlyTurnStale()
     {
         Cache::store('redis')->clear();
@@ -368,4 +382,9 @@ class RedisStoreTest extends TestCase
 
         $store->flushLocks();
     }
+}
+
+enum RedisTaggedCacheTestKey: string
+{
+    case PERSON_1 = 'person-1';
 }


### PR DESCRIPTION
This PR fixes an inconsistency in `RedisTaggedCache` where `decrement()` did not normalize enum keys with `enum_value()`, unlike the other tagged write operation `increment()`.