### PR TITLE
[13.x] Preserve falsey concurrency exception parameters

### DIFF
--- a/src/Illuminate/Concurrency/ProcessDriver.php
+++ b/src/Illuminate/Concurrency/ProcessDriver.php
@@ -63,7 +63,7 @@ class ProcessDriver implements Driver
 
             if (! $result['successful']) {
                 throw new $result['exception'](
-                    ...(! empty(array_filter($result['parameters']))
+                    ...(! empty(array_filter($result['parameters'], fn ($parameter) => ! is_null($parameter)))
                         ? $result['parameters']
                         : [$result['message']])
                 );

--- a/tests/Integration/Concurrency/ConcurrencyTest.php
+++ b/tests/Integration/Concurrency/ConcurrencyTest.php
@@ -152,6 +152,31 @@ PHP);
         ]);
     }
 
+    #[DataProvider('falseyExceptionParameters')]
+    public function testRunHandlerProcessErrorWithFalseyParam(int|bool|string $value)
+    {
+        try {
+            Concurrency::run([
+                fn () => throw new ExceptionWithFalseyParam($value),
+            ]);
+        } catch (ExceptionWithFalseyParam $e) {
+            $this->assertSame($value, $e->value);
+
+            return;
+        }
+
+        $this->fail('The expected exception was not thrown.');
+    }
+
+    public static function falseyExceptionParameters(): array
+    {
+        return [
+            'zero' => [0],
+            'false' => [false],
+            'empty string' => [''],
+        ];
+    }
+
     public static function getConcurrencyDrivers(): array
     {
         return [
@@ -207,5 +232,13 @@ class ExceptionWithParam extends Exception
         public string|array $responseBody = '',
     ) {
         parent::__construct("API request to {$uri} failed with status $statusCode $reason");
+    }
+}
+
+class ExceptionWithFalseyParam extends Exception
+{
+    public function __construct(public int|bool|string $value)
+    {
+        parent::__construct('Exception with falsey parameter');
     }
 }


### PR DESCRIPTION
**The Problem**

When a concurrent task fails while using the `ProcessDriver`, the framework captures the exception in the child process, serializes it, and reconstructs it in the parent process. 

However, during the reconstruction process in `ProcessDriver.php`, the driver uses `array_filter()` without a callback to check if custom constructor parameters were captured:

```php
...(! empty(array_filter($result['parameters']))
    ? $result['parameters']
    : [$result['message']])

```

Because PHP's default `array_filter` strips out all falsey values, legitimate arguments like `0`, `false`, or `""` (empty string) are treated as completely absent. As a result, the framework incorrectly falls back to passing the exception's string message into the constructor instead of the actual arguments.

If you throw a custom exception that expects a falsey integer or boolean value:

```php
class RetryAfterException extends Exception
{
    public function __construct(public int $seconds)
    {
        parent::__construct("Retry after {$seconds} seconds.");
    }
}

Concurrency::run([
    fn () => throw new RetryAfterException(0),
]);

```

The `0` parameter is discarded because it's falsey. When the driver attempts to reconstruct the exception, it passes the string message into the constructor instead of the integer `0`, which immediately crashes the application with a `TypeError`.

**After this PR**

The reconstructed exception faithfully retains its original constructor parameters:

```php
// Works perfectly now:
$exception->seconds; // 0

```

The presence check now explicitly filters out only `null` values. Valid non-falsey parameters remain unaffected, and the message fallback still cleanly handles cases where no constructor parameters could be captured at all.