### PR TITLE
[13.x] add the exception to JobReleasedAfterException

### DIFF
--- a/src/Illuminate/Queue/Events/JobReleasedAfterException.php
+++ b/src/Illuminate/Queue/Events/JobReleasedAfterException.php
@@ -10,11 +10,13 @@ class JobReleasedAfterException
      * @param  string  $connectionName  The connection name.
      * @param  \Illuminate\Contracts\Queue\Job  $job  The job instance.
      * @param  int|null  $backoff  The backoff delay.
+     * @param  \Throwable|null  $exception  The exception that caused the job to be released.
      */
     public function __construct(
         public $connectionName,
         public $job,
-        public $backoff = null
+        public $backoff = null,
+        public $exception = null,
     ) {
     }
 }

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -614,7 +614,7 @@ class Worker
                 $job->release($backoff);
 
                 $this->events->dispatch(new JobReleasedAfterException(
-                    $connectionName, $job, $backoff
+                    $connectionName, $job, $backoff, $e
                 ));
             }
         }

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -624,11 +624,12 @@ class QueueWorkerTest extends TestCase
         $worker = $this->getWorker('default', ['queue' => [$job]]);
         $worker->runNextJob('default', 'queue', $this->workerOptions(['backoff' => 10]));
 
-        $this->events->shouldHaveReceived('dispatch')->with(m::on(function ($event) use ($job) {
+        $this->events->shouldHaveReceived('dispatch')->with(m::on(function ($event) use ($job, $e) {
             return $event instanceof JobReleasedAfterException
                 && $event->connectionName === 'default'
                 && $event->job === $job
-                && $event->backoff === 10;
+                && $event->backoff === 10
+                && $event->exception === $e;
         }))->once();
     }
 


### PR DESCRIPTION
would be nice to see the exception during this event, rather than having to piece it together via `JobExceptionOccurred`  etc.
