### PR TITLE
[13.x] Add license and workflow to illuminate/image

### DIFF
--- a/src/Illuminate/Image/.gitattributes
+++ b/src/Illuminate/Image/.gitattributes
@@ -1,0 +1,2 @@
+/.github export-ignore
+.gitattributes export-ignore

--- a/src/Illuminate/Image/.github/workflows/close-pull-request.yml
+++ b/src/Illuminate/Image/.github/workflows/close-pull-request.yml
@@ -1,0 +1,13 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: "Thank you for your pull request. However, you have submitted this PR on the Illuminate organization which is a read-only sub split of `laravel/framework`. Please submit your PR on the https://github.com/laravel/framework repository.<br><br>Thanks!"

--- a/src/Illuminate/Image/LICENSE.md
+++ b/src/Illuminate/Image/LICENSE.md
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) Taylor Otwell
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Illuminate/Image/composer.json
+++ b/src/Illuminate/Image/composer.json
@@ -22,6 +22,7 @@
         "illuminate/support": "^13.0"
     },
     "suggest": {
+        "ext-fileinfo": "Required to use the Image class.",
         "intervention/image": "Required to use the GD and Imagick image drivers (^4.0)."
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
Since we can access it via https://github.com/illuminate/image 

This PR ensures the license.md, workflow, and .gitattributes are inline with all the other illuminate bits.

Also, while I was here, noticed the composer.json had no suggestion for ext-fileinfo, which is used https://github.com/laravel/framework/blob/89d5f0a3d96c6067bf2f724d40fe75ac78439b36/src/Illuminate/Image/Drivers/InterventionDriver.php#L79 (afaik both drivers use process, but i went with suggest to mirror filesystem)

I spend a few hours every day just going through stuff and super old prs, just out of curiosity, so, hell yea and sorry
