### PR TITLE
[13.x] Clarify 'requests' option for FormRequest generation

### DIFF
--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -295,7 +295,7 @@ class ControllerMakeCommand extends GeneratorCommand
             ['model', 'm', InputOption::VALUE_OPTIONAL, 'Generate a resource controller for the given model'],
             ['parent', 'p', InputOption::VALUE_OPTIONAL, 'Generate a nested resource controller class'],
             ['resource', 'r', InputOption::VALUE_NONE, 'Generate a resource controller class'],
-            ['requests', 'R', InputOption::VALUE_NONE, 'Generate FormRequest classes for store and update'],
+            ['requests', 'R', InputOption::VALUE_NONE, 'Generate FormRequest classes for store and update [Model Required]'],
             ['singleton', 's', InputOption::VALUE_NONE, 'Generate a singleton resource controller class'],
             ['creatable', null, InputOption::VALUE_NONE, 'Indicate that a singleton resource should be creatable'],
         ];


### PR DESCRIPTION
Updated the description for the 'requests' option to indicate that a model is required for generating FormRequest classes.

It's ambigue to have `--requests` option but no `--model` option mentioned (required to have it).

Already discussed in #60820 and I think it need a few clarification beside the docs already mention the command:

`php artisan make:controller PhotoController --model=Photo --resource --requests`