### PR TITLE
Fix withBindings / withSingletons / withScopedSingletons to apply bindings immediately

### DIFF
--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -416,11 +416,11 @@ class ApplicationBuilder
      */
     public function withBindings(array $bindings)
     {
-        return $this->registered(function ($app) use ($bindings) {
-            foreach ($bindings as $abstract => $concrete) {
-                $app->bind($abstract, $concrete);
-            }
-        });
+        foreach ($bindings as $abstract => $concrete) {
+            $this->app->bind($abstract, $concrete);
+        }
+
+        return $this;
     }
 
     /**
@@ -431,15 +431,15 @@ class ApplicationBuilder
      */
     public function withSingletons(array $singletons)
     {
-        return $this->registered(function ($app) use ($singletons) {
-            foreach ($singletons as $abstract => $concrete) {
-                if (is_string($abstract)) {
-                    $app->singleton($abstract, $concrete);
-                } else {
-                    $app->singleton($concrete);
-                }
+        foreach ($singletons as $abstract => $concrete) {
+            if (is_string($abstract)) {
+                $this->app->singleton($abstract, $concrete);
+            } else {
+                $this->app->singleton($concrete);
             }
-        });
+        }
+
+        return $this;
     }
 
     /**
@@ -450,15 +450,15 @@ class ApplicationBuilder
      */
     public function withScopedSingletons(array $scopedSingletons)
     {
-        return $this->registered(function ($app) use ($scopedSingletons) {
-            foreach ($scopedSingletons as $abstract => $concrete) {
-                if (is_string($abstract)) {
-                    $app->scoped($abstract, $concrete);
-                } else {
-                    $app->scoped($concrete);
-                }
+        foreach ($scopedSingletons as $abstract => $concrete) {
+            if (is_string($abstract)) {
+                $this->app->scoped($abstract, $concrete);
+            } else {
+                $this->app->scoped($concrete);
             }
-        });
+        }
+
+        return $this;
     }
 
     /**

--- a/tests/Foundation/FoundationApplicationBuilderTest.php
+++ b/tests/Foundation/FoundationApplicationBuilderTest.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Http\Kernel as HttpKernel;
 use Illuminate\Http\Middleware\PrefersJsonResponses;
 use PHPUnit\Framework\TestCase;
+use stdClass;
 
 class FoundationApplicationBuilderTest extends TestCase
 {
@@ -120,6 +121,60 @@ class FoundationApplicationBuilderTest extends TestCase
         $app = Application::configure()->prefersJsonResponses(false)->create();
 
         $this->assertFalse($this->bootAndResolveKernel($app)->hasMiddleware(PrefersJsonResponses::class));
+    }
+
+    public function testWithBindingsBindsImmediately()
+    {
+        $app = Application::configure()
+            ->withBindings(['foo' => fn () => 'bar'])
+            ->create();
+
+        $this->assertSame('bar', $app->make('foo'));
+    }
+
+    public function testWithSingletonsBindsImmediately()
+    {
+        $app = Application::configure()
+            ->withSingletons([stdClass::class])
+            ->create();
+
+        $this->assertInstanceOf(stdClass::class, $app->make(stdClass::class));
+    }
+
+    public function testWithSingletonsWithConcreteBindsImmediately()
+    {
+        $app = Application::configure()
+            ->withSingletons(['foo' => stdClass::class])
+            ->create();
+
+        $this->assertInstanceOf(stdClass::class, $app->make('foo'));
+    }
+
+    public function testWithSingletonsMaintainsSingletonBehavior()
+    {
+        $app = Application::configure()
+            ->withSingletons(['foo' => stdClass::class])
+            ->create();
+
+        $this->assertSame($app->make('foo'), $app->make('foo'));
+    }
+
+    public function testWithScopedSingletonsBindsImmediately()
+    {
+        $app = Application::configure()
+            ->withScopedSingletons([stdClass::class])
+            ->create();
+
+        $this->assertInstanceOf(stdClass::class, $app->make(stdClass::class));
+    }
+
+    public function testWithScopedSingletonsWithConcreteBindsImmediately()
+    {
+        $app = Application::configure()
+            ->withScopedSingletons(['foo' => stdClass::class])
+            ->create();
+
+        $this->assertInstanceOf(stdClass::class, $app->make('foo'));
     }
 
     protected function bootAndResolveKernel(Application $app): HttpKernel


### PR DESCRIPTION
### Problem

`withBindings()`, `withSingletons()`, and `withScopedSingletons()` defer their bindings via `$this->registered()`, which only fires during `registerConfiguredProviders()` — well after the HTTP Kernel has been constructed. This means that bindings needed during kernel construction (like `router`) are not yet registered, causing the kernel to resolve and cache the original `Router` instance. Routes loaded by `RouteServiceProvider` end up on a separate custom Router, while the kernel dispatches through its original (empty) Router → 404.

### Root Cause

```php
// bootstrap/app.php — bindings are queued, not applied
->withSingletons(['router' => ...])

// public/index.php — kernel resolves the ORIGINAL router before the callback fires
$app->make(Kernel::class);
```

The deferred callback pattern in `ApplicationBuilder::withBindings()` and friends uses `$this->registered()`, which stores callbacks to run during provider registration. By then, the kernel has already captured its dependencies.

### Solution

Apply bindings **immediately** against `$this->app` at chain time instead of deferring via `$this->registered()`. At chain time (before `->create()`), the application is a fresh instance — no providers have registered, no kernels have been constructed. Immediate binding is safe and matches user expectations.

### Changes

**`src/Illuminate/Foundation/Configuration/ApplicationBuilder.php`**
- `withBindings()` — calls `$this->app->bind()` immediately
- `withSingletons()` — calls `$this->app->singleton()` immediately
- `withScopedSingletons()` — calls `$this->app->scoped()` immediately

**`tests/Foundation/FoundationApplicationBuilderTest.php`**
- Added 6 tests verifying that all three methods bind immediately and correctly:
  - `testWithBindingsBindsImmediately`
  - `testWithSingletonsBindsImmediately`
  - `testWithSingletonsWithConcreteBindsImmediately`
  - `testWithSingletonsMaintainsSingletonBehavior`
  - `testWithScopedSingletonsBindsImmediately`
  - `testWithScopedSingletonsWithConcreteBindsImmediately`