### PR TITLE
[13.x] Fix host port parsing in serve command

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -257,7 +257,7 @@ class ServeCommand extends Command
      */
     protected function getHostAndPort()
     {
-        if (preg_match('/(\[.*\]):?([0-9]+)?/', $this->input->getOption('host'), $matches) !== false) {
+        if (preg_match('/(\[.*\]):?([0-9]+)?/', $this->input->getOption('host'), $matches) === 1) {
             return [
                 $matches[1] ?? $this->input->getOption('host'),
                 $matches[2] ?? null,

--- a/tests/Foundation/Console/ServeCommandTest.php
+++ b/tests/Foundation/Console/ServeCommandTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\Console;
+
+use Illuminate\Foundation\Console\ServeCommand;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\ArrayInput;
+
+class ServeCommandTest extends TestCase
+{
+    #[DataProvider('hostAndPortProvider')]
+    public function testHostAndPortParsing($host, $expectedHost, $expectedPort)
+    {
+        $command = new class extends ServeCommand
+        {
+            public function getHostAndPortForTesting()
+            {
+                return $this->getHostAndPort();
+            }
+        };
+
+        $command->setInput(new ArrayInput(['--host' => $host], $command->getDefinition()));
+
+        $this->assertSame([$expectedHost, $expectedPort], $command->getHostAndPortForTesting());
+    }
+
+    public static function hostAndPortProvider()
+    {
+        return [
+            'hostname with port' => ['localhost:8888', 'localhost', '8888'],
+            'IPv4 address with port' => ['127.0.0.1:8888', '127.0.0.1', '8888'],
+            'IPv6 address with port' => ['[::1]:8888', '[::1]', '8888'],
+            'hostname without port' => ['localhost', 'localhost', null],
+            'IPv6 address without port' => ['[::1]', '[::1]', null],
+        ];
+    }
+}


### PR DESCRIPTION
The IPv6 host detection in the `serve` command checks whether `preg_match` returned anything other than `false`. However, `preg_match` returns `0` when the pattern does not match, causing hostname and IPv4 inputs to enter the IPv6 branch as well.

As a result, host values containing a port, such as `localhost:8888` or `127.0.0.1:8888`, are no longer split into their host and port components.

This changes the condition to require an actual regex match, restoring host-and-port parsing for hostnames and IPv4 addresses while preserving IPv6 support.