### PR TITLE
[13.x] Remove never-executed nested relationship compilation in JSON:API resources

### DIFF
--- a/src/Illuminate/Http/Resources/JsonApi/Concerns/ResolvesJsonApiElements.php
+++ b/src/Illuminate/Http/Resources/JsonApi/Concerns/ResolvesJsonApiElements.php
@@ -255,10 +255,8 @@ trait ResolvesJsonApiElements
 
                 return transform(
                     [$relatedResource->resolveResourceType($request), $relatedResource->resolveResourceIdentifier($request)],
-                    function ($uniqueKey) use ($request, $relatedModel, $relatedResource, $isUnique) {
+                    function ($uniqueKey) use ($relatedResource, $isUnique) {
                         $this->loadedRelationshipsMap[] = [$relatedResource, ...$uniqueKey, $isUnique];
-
-                        $this->compileIncludedNestedRelationshipsMap($request, $relatedModel, $relatedResource);
 
                         return [
                             'id' => $uniqueKey[1],
@@ -289,10 +287,8 @@ trait ResolvesJsonApiElements
 
         yield $relationName => ['data' => transform(
             [$relatedResource->resolveResourceType($request), $relatedResource->resolveResourceIdentifier($request)],
-            function ($uniqueKey) use ($relatedModel, $relatedResource, $request) {
+            function ($uniqueKey) use ($relatedResource) {
                 $this->loadedRelationshipsMap[] = [$relatedResource, ...$uniqueKey, true];
-
-                $this->compileIncludedNestedRelationshipsMap($request, $relatedModel, $relatedResource);
 
                 return [
                     'id' => $uniqueKey[1],
@@ -300,20 +296,6 @@ trait ResolvesJsonApiElements
                 ];
             }
         )];
-    }
-
-    /**
-     * Compile included relationships map.
-     */
-    protected function compileIncludedNestedRelationshipsMap(JsonApiRequest $request, Model $relation, JsonApiResource $resource): void
-    {
-        (new Collection($resource->toRelationships($request)))
-            ->transform(fn ($value, $key) => is_int($key) ? new RelationResolver($value) : new RelationResolver($key, $value))
-            ->mapWithKeys(fn ($relationResolver) => [$relationResolver->relationName => $relationResolver])
-            ->filter(fn ($value, $key) => in_array($key, array_keys($relation->getRelations())))
-            ->each(function ($relationResolver, $key) use ($relation, $request) {
-                $this->compileResourceRelationshipUsingResolver($request, $relation, $relationResolver, $relationResolver->handle($relation));
-            });
     }
 
     /**

--- a/tests/Integration/Http/Resources/JsonApi/Fixtures/PostResource.php
+++ b/tests/Integration/Http/Resources/JsonApi/Fixtures/PostResource.php
@@ -7,6 +7,11 @@ use Illuminate\Http\Resources\JsonApi\JsonApiResource;
 
 class PostResource extends JsonApiResource
 {
+    /**
+     * The number of times the "comments" relationship closure has been resolved.
+     */
+    public static int $commentsResolutionCount = 0;
+
     protected array $attributes = [
         'title',
         'content',
@@ -17,9 +22,13 @@ class PostResource extends JsonApiResource
     {
         return [
             'author' => AuthorResource::class,
-            'comments' => fn () => CommentResource::collection(
-                $this->comments->where('content', '!=', 'private')
-            ),
+            'comments' => function () {
+                static::$commentsResolutionCount++;
+
+                return CommentResource::collection(
+                    $this->comments->where('content', '!=', 'private')
+                );
+            },
         ];
     }
 }

--- a/tests/Integration/Http/Resources/JsonApi/JsonApiResourceTest.php
+++ b/tests/Integration/Http/Resources/JsonApi/JsonApiResourceTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Integration\Http\Resources\JsonApi;
 use Illuminate\Http\Resources\JsonApi\JsonApiResource;
 use Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures\Comment;
 use Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures\Post;
+use Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures\PostResource;
 use Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures\Profile;
 use Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures\Team;
 use Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures\User;
@@ -452,6 +453,31 @@ class JsonApiResourceTest extends TestCase
         $this->assertFalse(collect($response->json('included'))->contains(
             fn ($included) => $included['type'] === 'comments' && $included['id'] === (string) $privateComment->getKey()
         ));
+    }
+
+    public function testItResolvesEachRelationshipClosureOnceWhenIncludingNestedRelationships()
+    {
+        $user = User::factory()->create();
+
+        $posts = Post::factory()->count(2)->create([
+            'user_id' => $user->getKey(),
+        ]);
+
+        foreach ($posts as $post) {
+            Comment::factory()->create([
+                'content' => 'public',
+                'post_id' => $post->getKey(),
+                'user_id' => $user->getKey(),
+            ]);
+        }
+
+        PostResource::$commentsResolutionCount = 0;
+
+        $this->getJson("/users/{$user->getKey()}?".http_build_query(['include' => 'posts.comments']))
+            ->assertJsonPath('data.relationships.posts.data.0.id', (string) $posts[0]->getKey());
+
+        // The "comments" closure should be resolved once per included post, not multiple times...
+        $this->assertSame(2, PostResource::$commentsResolutionCount);
     }
 
     public function testItCanResolveRelationshipWithRecursiveNestedRelationship()


### PR DESCRIPTION
`compileIncludedNestedRelationshipsMap()` calls `compileResourceRelationshipUsingResolver()` — which is a generator — without ever iterating the result:

```php
->each(function ($relationResolver, $key) use ($relation, $request) {
    $this->compileResourceRelationshipUsingResolver($request, $relation, $relationResolver, $relationResolver->handle($relation));
});
```

Since a generator's body only runs when iterated, this call never executes and has no effect on the response. Its only observable behavior is the eagerly evaluated `$relationResolver->handle($relation)` argument, which re-resolves every nested relationship — running user-defined relationship closures a second time, including any queries they perform — and discards the result.

Nested included relationships are actually compiled in `resolveIncludedResourceObjects()`, which resolves each included resource and appends its `loadedRelationshipsMap` to the processing queue. Removing the dead path therefore changes no output; it just avoids the duplicate work. (Iterating the generator instead is not an option — the circular-reference guard only exists in `resolveIncludedResourceObjects()`, and executing this path causes runaway recursion on bidirectional `chaperone()` relationships.)

With the method and its two call sites removed, the full JSON:API test suite passes unchanged. Also added a regression test asserting that a relationship closure is resolved exactly once per included resource — on the previous code it was resolved twice (`4` instead of `2` for two posts with `include=posts.comments`).