### PR TITLE
[13.x] Preserve zero-valued SQS identifiers

### DIFF
--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -605,7 +605,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
 
         $options['MessageDeduplicationId'] = $messageDeduplicationId;
 
-        return array_filter($options);
+        return array_filter($options, fn ($option) => $option !== null && $option !== '');
     }
 
     /**

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -534,6 +534,20 @@ class QueueSqsQueueTest extends TestCase
         $container->shouldHaveReceived('bound')->with('events')->twice();
     }
 
+    public function testQueueableOptionsPreserveZeroIdentifiers()
+    {
+        $job = $this->getMockBuilder(FakeSqsJobWithDeduplication::class)->onlyMethods(['deduplicationId'])->getMock();
+        $job->expects($this->once())->method('deduplicationId')->with($this->mockedPayload, $this->fifoQueueName)->willReturn('0');
+        $job->onGroup('0');
+
+        $queue = new SqsQueue($this->sqs, $this->fifoQueueName, $this->account);
+
+        $this->assertSame([
+            'MessageGroupId' => '0',
+            'MessageDeduplicationId' => '0',
+        ], $queue->getQueueableOptions($job, $this->fifoQueueName, $this->mockedPayload));
+    }
+
     public function testPushProperlyPushesJobObjectOntoSqsFifoQueueWithDeduplicator()
     {
         $job = $this->getMockBuilder(FakeSqsJobWithDeduplication::class)->onlyMethods(['deduplicationId'])->getMock();


### PR DESCRIPTION
Fixes #60830.

The group and deduplication IDs are already cast to strings here, but the default `array_filter()` call also removes `"0"`. This means a valid SQS identifier can disappear before the request is sent.

The filter now only removes `null` and `''`, so the existing content-based deduplication behavior stays the same. Added a regression test for both IDs.