### PR TITLE
Added question mark escaping to Grammar::whereColumn()

### DIFF
--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -248,6 +248,17 @@ abstract class Grammar
     }
 
     /**
+     * Escapes any operator that contains a ? for use in PDO
+     *
+     * @param  string  $operator
+     * @return string
+     */
+    protected function escapeQuestionMark($operator)
+    {
+        return str_replace('?', '??', $operator);
+    }
+
+    /**
      * Determine if the given value is a raw expression.
      *
      * @param  mixed  $value

--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -248,17 +248,6 @@ abstract class Grammar
     }
 
     /**
-     * Escapes any operator that contains a ? for use in PDO.
-     *
-     * @param  string  $operator
-     * @return string
-     */
-    protected function escapeQuestionMark($operator)
-    {
-        return str_replace('?', '??', $operator);
-    }
-
-    /**
      * Determine if the given value is a raw expression.
      *
      * @param  mixed  $value

--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -248,7 +248,7 @@ abstract class Grammar
     }
 
     /**
-     * Escapes any operator that contains a ? for use in PDO
+     * Escapes any operator that contains a ? for use in PDO.
      *
      * @param  string  $operator
      * @return string

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -306,7 +306,7 @@ class Grammar extends BaseGrammar
     {
         $value = $this->parameter($where['value']);
 
-        $operator = str_replace('?', '??', $where['operator']);
+        $operator = $this->escapeQuestionMark($where['operator']);
 
         return $this->wrap($where['column']).' '.$operator.' '.$value;
     }
@@ -585,7 +585,9 @@ class Grammar extends BaseGrammar
      */
     protected function whereColumn(Builder $query, $where)
     {
-        return $this->wrap($where['first']).' '.$where['operator'].' '.$this->wrap($where['second']);
+        $operator = $this->escapeQuestionMark($where['operator']);
+
+        return $this->wrap($where['first']).' '.$operator.' '.$this->wrap($where['second']);
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -306,7 +306,7 @@ class Grammar extends BaseGrammar
     {
         $value = $this->parameter($where['value']);
 
-        $operator = $this->escapeQuestionMark($where['operator']);
+        $operator = str_replace('?', '??', $where['operator']);
 
         return $this->wrap($where['column']).' '.$operator.' '.$value;
     }
@@ -585,7 +585,7 @@ class Grammar extends BaseGrammar
      */
     protected function whereColumn(Builder $query, $where)
     {
-        $operator = $this->escapeQuestionMark($where['operator']);
+        $operator = str_replace('?', '??', $where['operator']);
 
         return $this->wrap($where['first']).' '.$operator.' '.$this->wrap($where['second']);
     }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -7672,6 +7672,28 @@ SQL;
         $this->assertSame('select * from "users" where "roles" ??& ?', $builder->toSql());
     }
 
+    public function testWhereColumnQuestionMarkOperatorOnPostgres()
+    {
+        $builder = $this->getPostgresBuilder();
+        $builder->select('*')->from('users')->whereColumn('foo', '?', '_foo');
+        $this->assertSame('select * from "users" where "foo" ?? "_foo"', $builder->toSql());
+
+        $builder = $this->getPostgresBuilder();
+        $builder->select('*')->from('users')->whereColumn('foo', '?|', '_foo');
+        $this->assertSame('select * from "users" where "foo" ??| "_foo"', $builder->toSql());
+
+        $builder = $this->getPostgresBuilder();
+        $builder->select('*')->from('users')->whereColumn('foo', '?&', '_foo');
+        $this->assertSame('select * from "users" where "foo" ??& "_foo"', $builder->toSql());
+    }
+
+    public function testJoinQuestionMarkOperatorOnPostgres()
+    {
+        $builder = $this->getPostgresBuilder();
+        $builder->select(['countries.*', new Raw('count(users.*) as "users"')])->from('countries')->join('users', 'users.country_codes', '?', 'countries.code');
+        $this->assertSame('select "countries".*, count(users.*) as "users" from "countries" inner join "users" on "users"."country_codes" ?? "countries"."code"', $builder->toSql());
+    }
+
     public function testUseIndexMySql()
     {
         $builder = $this->getMySqlBuilder();


### PR DESCRIPTION
Any operators that contain a question mark, like `?` or `?|` in Postgres, were already escaped in `Illuminate\Database\Query\Grammars\Grammar::whereBasic()` so PDO wouldn't assume that it was a placeholder. The same wasn't true for `whereColumn`, and therefore joins. Workarounds, as suggested in #56872, were required to use these operators. 

So, I extracted an `escapeQuestionMark` helper method into `Illuminate\Database\Grammar`, implemented it in `whereBasic` and `whereColumn` and then added test for it.