### PR TITLE
[13x.] Add `orderByRelation()` to Eloquent `Builder`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -847,7 +847,7 @@ trait QueriesRelationships
      * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<*>|\Illuminate\Contracts\Database\Query\Expression|string  $column
      * @param  SortDirection|'asc'|'desc'  $direction
      */
-    public function orderByRelation($relation, $column, $direction)
+    public function orderByRelation($relation, $column, $direction = 'asc')
     {
         /** @var Builder<Model> $this */
         $direction = $this->normalizeSortDirection($direction);

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -840,6 +840,45 @@ trait QueriesRelationships
     }
 
     /**
+     * Add an "order by" relationship clause to the query.
+     *
+     * @param  \Illuminate\Database\Eloquent\Relations\Relation<TRelatedModel, *, *>|string  $relation
+     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<*>|\Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  SortDirection|'asc'|'desc'  $direction
+     */
+    public function orderByRelation($relation, $column, $direction)
+    {
+        /** @var Builder<Model> $this */
+        $direction = $this->normalizeSortDirection($direction);
+
+        if (is_string($relation)) {
+            $relation = $this->getModel()->{$relation}();
+        }
+
+        return $this->orderBy(
+            $relation->getQuery()->select($column),
+            $direction,
+        );
+    }
+
+    /**
+     * @param  SortDirection|'asc'|'desc'  $direction
+     * @return 'asc'|'desc'
+     */
+    protected function normalizeSortDirection($direction)
+    {
+        return match (true) {
+            $direction instanceof SortDirection => match ($direction) {
+                SortDirection::Ascending => 'asc',
+                SortDirection::Descending => 'desc',
+            },
+            strtolower($direction) === 'asc' => 'asc',
+            strtolower($direction) === 'desc' => 'desc',
+            default => throw new InvalidArgumentException('Order direction must be a SortDirection, "asc" or "desc".'),
+        };
+    }
+
+    /**
      * Add subselect queries to include an aggregate value for a relationship.
      *
      * @param  mixed  $relations

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -16,6 +16,7 @@ use Illuminate\Database\Query\Expression;
 use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
+use SortDirection;
 
 use function Illuminate\Support\enum_value;
 

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -856,7 +856,7 @@ trait QueriesRelationships
         }
 
         return $this->orderBy(
-            $relation->getQuery()->select($column),
+            $relation->getRelationExistenceQuery($relation->getRelated()->newQuery(), $this)->select($column),
             $direction,
         );
     }

--- a/tests/Integration/Database/EloquentWhereHasTest.php
+++ b/tests/Integration/Database/EloquentWhereHasTest.php
@@ -248,6 +248,15 @@ class EloquentWhereHasTest extends DatabaseTestCase
 
         $this->assertEquals([1], $users->pluck('id')->all());
     }
+
+    public function testOrderByRelation()
+    {
+        $expectedSql = 'select "posts".*, (select count(*) from "comments" where "posts"."id" = "comments"."commentable_id" and "comments"."commentable_type" = \'Illuminate\Tests\Integration\Database\EloquentWhereHasTest\Post\') as "comments_count" from "posts" order by (select "content" from "texts" where "posts"."id" = "texts"."post_id") desc';
+        $actualSql = Post::orderByRelation('texts', 'content', 'desc')->toRawSql();
+        $this->assertSame($expectedSql, $actualSql);
+        $this->assertEquals([2, 1], Post::orderByRelation('texts', 'content', 'desc')->pluck('id')->all());
+        $this->assertEquals([1, 2], Post::orderByRelation('texts', 'content', 'asc')->pluck('id')->all());
+    }
 }
 
 class Comment extends Model

--- a/tests/Integration/Database/EloquentWhereHasTest.php
+++ b/tests/Integration/Database/EloquentWhereHasTest.php
@@ -251,9 +251,6 @@ class EloquentWhereHasTest extends DatabaseTestCase
 
     public function testOrderByRelation()
     {
-        $expectedSql = 'select "posts".*, (select count(*) from "comments" where "posts"."id" = "comments"."commentable_id" and "comments"."commentable_type" = \'Illuminate\Tests\Integration\Database\EloquentWhereHasTest\Post\') as "comments_count" from "posts" order by (select "content" from "texts" where "posts"."id" = "texts"."post_id") desc';
-        $actualSql = Post::orderByRelation('texts', 'content', 'desc')->toRawSql();
-        $this->assertSame($expectedSql, $actualSql);
         $this->assertEquals([2, 1], Post::orderByRelation('texts', 'content', 'desc')->pluck('id')->all());
         $this->assertEquals([1, 2], Post::orderByRelation('texts', 'content', 'asc')->pluck('id')->all());
     }


### PR DESCRIPTION
There's currently no built-in way to sort by a related model's column. Though workarounds exist, this would cement a common and semantic approach to this:
```php
Post::orderByRelation('texts', 'content', 'desc');
```