### PR TITLE
[13.x] Support stream bodies in HTTP fake responses

### DIFF
--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -17,6 +17,7 @@ use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
 use JsonException;
 use PHPUnit\Framework\Assert as PHPUnit;
+use Psr\Http\Message\StreamInterface;
 
 /**
  * @mixin \Illuminate\Http\Client\PendingRequest
@@ -157,7 +158,7 @@ class Factory
     /**
      * Create a new response instance for use during stubbing.
      *
-     * @param  array|string|null  $body
+     * @param  \Psr\Http\Message\StreamInterface|array|string|resource|null  $body
      * @param  int  $status
      * @param  array  $headers
      * @return \GuzzleHttp\Promise\PromiseInterface
@@ -172,7 +173,7 @@ class Factory
     /**
      * Create a new PSR-7 response instance for use during stubbing.
      *
-     * @param  array|string|null  $body
+     * @param  \Psr\Http\Message\StreamInterface|array|string|resource|null  $body
      * @param  int  $status
      * @param  array<string, mixed>  $headers
      * @return \GuzzleHttp\Psr7\Response
@@ -191,8 +192,8 @@ class Factory
             $headers['Content-Type'] = 'application/json';
         }
 
-        if (! is_string($body) && ! is_null($body)) {
-            throw new InvalidArgumentException('HTTP fake response body must be a string, array, or null.');
+        if (! is_string($body) && ! is_null($body) && ! is_resource($body) && ! $body instanceof StreamInterface) {
+            throw new InvalidArgumentException('HTTP fake response body must be a string, array, resource, Psr\Http\Message\StreamInterface, or null.');
         }
 
         return new Psr7Response($status, static::normalizeResponseHeaders($headers), $body);
@@ -263,7 +264,7 @@ class Factory
     /**
      * Create a new RequestException instance for use during stubbing.
      *
-     * @param  array|string|null  $body
+     * @param  \Psr\Http\Message\StreamInterface|array|string|resource|null  $body
      * @param  int  $status
      * @param  array<string, mixed>  $headers
      * @return \Illuminate\Http\Client\RequestException

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -174,6 +174,35 @@ class HttpClientTest extends TestCase
         $this->assertSame(['foo' => 'bar'], $response->json());
     }
 
+    public function testFakeResponseSupportsPsr7StreamBody()
+    {
+        $stream = Utils::streamFor('Hello World');
+
+        $response = $this->factory::response($stream)->wait();
+
+        $this->assertSame($stream, $response->getBody());
+        $this->assertSame('Hello World', (string) $response->getBody());
+    }
+
+    public function testFakeResponseSupportsResourceBody()
+    {
+        $resource = fopen('php://temp', 'w+');
+        fwrite($resource, 'Hello World');
+        rewind($resource);
+
+        $response = $this->factory::response($resource)->wait();
+
+        $this->assertSame('Hello World', (string) $response->getBody());
+    }
+
+    public function testFakeResponseRejectsUnsupportedBody()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('HTTP fake response body must be a string, array, resource, Psr\Http\Message\StreamInterface, or null.');
+
+        $this->factory::response(new stdClass);
+    }
+
     public function testAcceptedRequest()
     {
         $this->factory->fake([


### PR DESCRIPTION
This restores support for the streaming body types accepted by Guzzle PSR-7 responses.

The validation added in #60522 rejects `StreamInterface` instances and PHP stream resources before Guzzle can handle them, although both body types worked previously. This keeps the stricter validation for unsupported values while allowing the two documented streaming types again. Existing string, array, and null handling is unchanged.

Fixes #60727.

Tests:

- Added coverage for PSR-7 streams, PHP stream resources, and unsupported objects.
- `vendor/bin/phpunit tests/Http/HttpClientTest.php --display-deprecation --fail-on-deprecation --no-coverage`
- `vendor/bin/pint --dirty --test`
- `vendor/bin/phpstan analyse --configuration=phpstan.src.neon.dist --no-progress src/Illuminate/Http/Client/Factory.php`
