### PR TITLE
[13.x] Capture concurrency exception parameters faithfully

### DIFF
--- a/src/Illuminate/Concurrency/Console/InvokeSerializedClosureCommand.php
+++ b/src/Illuminate/Concurrency/Console/InvokeSerializedClosureCommand.php
@@ -54,28 +54,58 @@ class InvokeSerializedClosureCommand extends Command
         } catch (Throwable $e) {
             report($e);
 
-            $reflection = new ReflectionClass($e);
-            $constructor = $reflection->getConstructor();
-            $parameters = [];
-
-            if ($constructor) {
-                $declaringClass = $constructor->getDeclaringClass()->getName();
-
-                if ($declaringClass === $reflection->getName()) {
-                    foreach ($constructor->getParameters() as $parameter) {
-                        $parameters[$parameter->name] = $e->{$parameter->name} ?? null;
-                    }
-                }
-            }
-
             $this->output->write(json_encode([
                 'successful' => false,
                 'exception' => get_class($e),
                 'message' => $e->getMessage(),
                 'file' => $e->getFile(),
                 'line' => $e->getLine(),
-                'parameters' => $parameters,
+                'parameters' => $this->exceptionParameters($e),
             ]));
         }
+    }
+
+    /**
+     * Get the constructor arguments that may be used to recreate the given exception.
+     *
+     * Arguments are only captured when every constructor parameter is backed by a
+     * property holding a JSON-representable value; otherwise an empty array is
+     * returned and the exception will be recreated from its message instead.
+     *
+     * @param  \Throwable  $e
+     * @return array<string, mixed>
+     */
+    protected function exceptionParameters(Throwable $e)
+    {
+        $reflection = new ReflectionClass($e);
+        $constructor = $reflection->getConstructor();
+
+        if (! $constructor || $constructor->getDeclaringClass()->getName() !== $reflection->getName()) {
+            return [];
+        }
+
+        $parameters = [];
+
+        foreach ($constructor->getParameters() as $parameter) {
+            if (! $reflection->hasProperty($parameter->name)) {
+                return [];
+            }
+
+            $property = $reflection->getProperty($parameter->name);
+
+            if ($property->isStatic() || ! $property->isInitialized($e)) {
+                return [];
+            }
+
+            $value = $property->getValue($e);
+
+            if (! is_null($value) && ! is_scalar($value) && ! is_array($value)) {
+                return [];
+            }
+
+            $parameters[$parameter->name] = $value;
+        }
+
+        return $parameters;
     }
 }

--- a/src/Illuminate/Concurrency/ProcessDriver.php
+++ b/src/Illuminate/Concurrency/ProcessDriver.php
@@ -63,7 +63,7 @@ class ProcessDriver implements Driver
 
             if (! $result['successful']) {
                 throw new $result['exception'](
-                    ...(! empty(array_filter($result['parameters'], fn ($parameter) => ! is_null($parameter)))
+                    ...(! empty($result['parameters'])
                         ? $result['parameters']
                         : [$result['message']])
                 );

--- a/tests/Concurrency/InvokeSerializedClosureCommandTest.php
+++ b/tests/Concurrency/InvokeSerializedClosureCommandTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Illuminate\Tests\Concurrency;
+
+use Exception;
+use Illuminate\Concurrency\Console\InvokeSerializedClosureCommand;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Throwable;
+
+class InvokeSerializedClosureCommandTest extends TestCase
+{
+    public function testItCapturesParametersBackedByProperties()
+    {
+        $parameters = $this->parametersFor(new CapturableParametersException('https://example.com', 400));
+
+        $this->assertSame(['uri' => 'https://example.com', 'statusCode' => 400], $parameters);
+    }
+
+    public function testItCapturesNullAndFalseyParameterValues()
+    {
+        $this->assertSame(['status' => null], $this->parametersFor(new NullableParameterException(null)));
+        $this->assertSame(['status' => 0], $this->parametersFor(new NullableParameterException(0)));
+    }
+
+    public function testItCapturesTheBaseExceptionConstructorParameters()
+    {
+        $parameters = $this->parametersFor(new Exception('boom', 42));
+
+        $this->assertSame(['message' => 'boom', 'code' => 42, 'previous' => null], $parameters);
+    }
+
+    public function testItCapturesNothingWhenAParameterIsNotBackedByAProperty()
+    {
+        $this->assertSame([], $this->parametersFor(new UnbackedParameterException('payments')));
+    }
+
+    public function testItCapturesNothingWhenAParameterValueIsNotJsonRepresentable()
+    {
+        $this->assertSame([], $this->parametersFor(new Exception('boom', 0, new RuntimeException('previous'))));
+    }
+
+    public function testItCapturesNothingWhenTheConstructorIsInherited()
+    {
+        $this->assertSame([], $this->parametersFor(new InheritedConstructorException('boom')));
+    }
+
+    protected function parametersFor(Throwable $e): array
+    {
+        $command = new class extends InvokeSerializedClosureCommand
+        {
+            public function parametersFor(Throwable $e): array
+            {
+                return $this->exceptionParameters($e);
+            }
+        };
+
+        return $command->parametersFor($e);
+    }
+}
+
+class CapturableParametersException extends Exception
+{
+    public function __construct(public string $uri, public int $statusCode)
+    {
+        parent::__construct("Request to {$uri} failed with status {$statusCode}");
+    }
+}
+
+class NullableParameterException extends RuntimeException
+{
+    public function __construct(public ?int $status = null)
+    {
+        parent::__construct('Exception with nullable parameter');
+    }
+}
+
+class UnbackedParameterException extends Exception
+{
+    public function __construct(string $context)
+    {
+        parent::__construct("Failed in {$context}");
+    }
+}
+
+class InheritedConstructorException extends Exception
+{
+}

--- a/tests/Concurrency/ProcessDriverTest.php
+++ b/tests/Concurrency/ProcessDriverTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Illuminate\Tests\Concurrency;
+
+use Exception;
+use Illuminate\Concurrency\ProcessDriver;
+use Illuminate\Container\Container;
+use Illuminate\Foundation\Application;
+use Illuminate\Process\Factory;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class ProcessDriverTest extends TestCase
+{
+    public function testRunRecreatesExceptionsFromCapturedParametersIncludingNulls()
+    {
+        try {
+            $this->runWithFakeResult([
+                'successful' => false,
+                'exception' => DriverNullableParameterException::class,
+                'message' => 'Exception with nullable parameter',
+                'parameters' => ['status' => null],
+            ]);
+
+            $this->fail('The expected exception was not thrown.');
+        } catch (DriverNullableParameterException $e) {
+            $this->assertNull($e->status);
+        }
+    }
+
+    public function testRunRecreatesExceptionsFromTheMessageWhenNoParametersWereCaptured()
+    {
+        try {
+            $this->runWithFakeResult([
+                'successful' => false,
+                'exception' => DriverUnbackedParameterException::class,
+                'message' => 'Failed in payments',
+                'parameters' => [],
+            ]);
+
+            $this->fail('The expected exception was not thrown.');
+        } catch (DriverUnbackedParameterException $e) {
+            $this->assertStringContainsString('Failed in payments', $e->getMessage());
+        }
+    }
+
+    protected function runWithFakeResult(array $result): void
+    {
+        $factory = new Factory;
+
+        $factory->fake(fn () => $factory->result(json_encode($result)));
+
+        $previousContainer = Container::getInstance();
+
+        Container::setInstance(new Application(__DIR__));
+
+        try {
+            (new ProcessDriver($factory))->run(fn () => null);
+        } finally {
+            Container::setInstance($previousContainer);
+        }
+    }
+}
+
+class DriverNullableParameterException extends RuntimeException
+{
+    public function __construct(public ?int $status = null)
+    {
+        parent::__construct('Exception with nullable parameter');
+    }
+}
+
+class DriverUnbackedParameterException extends Exception
+{
+    public function __construct(string $context)
+    {
+        parent::__construct("Failed in {$context}");
+    }
+}

--- a/tests/Integration/Concurrency/ConcurrencyTest.php
+++ b/tests/Integration/Concurrency/ConcurrencyTest.php
@@ -177,6 +177,47 @@ PHP);
         ];
     }
 
+    public function testRunHandlerProcessErrorWithNullParam()
+    {
+        try {
+            Concurrency::run([
+                fn () => throw new ExceptionWithNullableParam(null),
+            ]);
+        } catch (ExceptionWithNullableParam $e) {
+            $this->assertNull($e->status);
+
+            return;
+        }
+
+        $this->fail('The expected exception was not thrown.');
+    }
+
+    public function testRunHandlerProcessErrorWithParamNotBackedByProperty()
+    {
+        $this->expectException(ExceptionWithUnbackedParam::class);
+        $this->expectExceptionMessage('payments');
+
+        Concurrency::run([
+            fn () => throw new ExceptionWithUnbackedParam('payments'),
+        ]);
+    }
+
+    public function testRunHandlerProcessErrorPreservesDefaultExceptionCode()
+    {
+        try {
+            Concurrency::run([
+                fn () => throw new Exception('This exception has a code', 42),
+            ]);
+        } catch (Exception $e) {
+            $this->assertSame('This exception has a code', $e->getMessage());
+            $this->assertSame(42, $e->getCode());
+
+            return;
+        }
+
+        $this->fail('The expected exception was not thrown.');
+    }
+
     public static function getConcurrencyDrivers(): array
     {
         return [
@@ -240,5 +281,21 @@ class ExceptionWithFalseyParam extends Exception
     public function __construct(public int|bool|string $value)
     {
         parent::__construct('Exception with falsey parameter');
+    }
+}
+
+class ExceptionWithNullableParam extends Exception
+{
+    public function __construct(public ?int $status = null)
+    {
+        parent::__construct('Exception with nullable parameter');
+    }
+}
+
+class ExceptionWithUnbackedParam extends Exception
+{
+    public function __construct(string $context)
+    {
+        parent::__construct("Failed in {$context}");
     }
 }


### PR DESCRIPTION
The `invoke-serialized-closure` command captures a failed task's exception constructor arguments with `$e->{$parameter->name} ?? null`, which reads protected and private properties — including `Exception`'s own `$message` and `$code` — as `null`. The parent process therefore cannot tell "argument was genuinely `null`" apart from "argument could not be recovered", and works around it by falling back to the exception message whenever every captured value is `null` (#60822 narrowed this from falsey to null, but the ambiguity remains).

That fallback breaks exceptions whose constructor arguments really are `null`:

```php
class OrderException extends Exception
{
    public function __construct(public ?int $orderId = null)
    {
        parent::__construct('Order failed');
    }
}

Concurrency::run([fn () => throw new OrderException(null)]);
// TypeError: Argument #1 ($orderId) must be of type ?int, string given
```

This change captures arguments through reflection instead, and only when every constructor parameter is backed by an initialized property holding a JSON-representable value; otherwise nothing is captured and the parent keeps falling back to the message, exactly as before. Since a non-empty parameter array is now always faithful, the parent spreads it as-is, so genuine `null` values survive the round trip. As a side effect, base `Exception` instances are now recreated with their original `code` instead of losing it, since reflection can read the protected property.

Existing behavior is preserved for the other shapes: plain exceptions, exceptions with an inherited constructor, constructor arguments not stored as properties, falsey values (#60822), and exceptions carrying a `$previous` all reconstruct the same way they do today.

Added unit tests for the capture rules and the driver's reconstruction (including the preserved-`null` case), plus integration tests covering the nullable parameter, an argument without a backing property, and the now-preserved exception code.