### PR TITLE
[13.x] Add illuminate/concurrency subsplit

### DIFF
--- a/bin/release.sh
+++ b/bin/release.sh
@@ -52,7 +52,7 @@ git tag $VERSION
 git push origin --tags
 
 # Tag Components
-for REMOTE in auth broadcasting bus cache collections conditionable config console container contracts cookie database encryption events filesystem hashing http image json-schema log macroable mail notifications pagination pipeline process queue reflection redis routing session support testing translation validation view
+for REMOTE in auth broadcasting bus cache collections concurrency conditionable config console container contracts cookie database encryption events filesystem hashing http image json-schema log macroable mail notifications pagination pipeline process queue reflection redis routing session support testing translation validation view
 do
     echo ""
     echo ""

--- a/bin/split.sh
+++ b/bin/split.sh
@@ -24,6 +24,7 @@ remote bus git@github.com:illuminate/bus.git
 remote cache git@github.com:illuminate/cache.git
 remote collections git@github.com:illuminate/collections.git
 remote conditionable git@github.com:illuminate/conditionable.git
+remote concurrency git@github.com:illuminate/concurrency.git
 remote config git@github.com:illuminate/config.git
 remote console git@github.com:illuminate/console.git
 remote container git@github.com:illuminate/container.git
@@ -61,6 +62,7 @@ split 'src/Illuminate/Bus' bus
 split 'src/Illuminate/Cache' cache
 split 'src/Illuminate/Collections' collections
 split 'src/Illuminate/Conditionable' conditionable
+split 'src/Illuminate/Concurrency' concurrency
 split 'src/Illuminate/Config' config
 split 'src/Illuminate/Console' console
 split 'src/Illuminate/Container' container

--- a/src/Illuminate/Concurrency/.github/workflows/close-pull-request.yml
+++ b/src/Illuminate/Concurrency/.github/workflows/close-pull-request.yml
@@ -1,0 +1,13 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: "Thank you for your pull request. However, you have submitted this PR on the Illuminate organization which is a read-only sub split of `laravel/framework`. Please submit your PR on the https://github.com/laravel/framework repository.<br><br>Thanks!"


### PR DESCRIPTION
This PR adds concurrency to the split and release sh scripts and adds the auto close workflow while I was here.

Noticed it was missing from poking image

This could of not been done for a reason? But, it has a license.md etc & it's the only one not subsplit so felt odd? 