### PR TITLE
[13.x] Add support for database generated columns on Eloquent models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Attributes/Generated.php
+++ b/src/Illuminate/Database/Eloquent/Attributes/Generated.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class Generated
+{
+    /**
+     * @var array<int, string>
+     */
+    public array $columns;
+
+    /**
+     * Create a new attribute instance.
+     *
+     * @param  array<int, string>|string  ...$columns
+     */
+    public function __construct(array|string ...$columns)
+    {
+        $this->columns = is_array($columns[0]) ? $columns[0] : $columns;
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -532,10 +532,12 @@ class Builder implements BuilderContract
 
         $this->model::unguarded(function () use (&$values) {
             foreach ($values as $key => $rowValues) {
-                $values[$key] = tap(
+                $model = tap(
                     $this->newModelInstance($rowValues),
                     fn ($model) => $model->setUniqueIds()
-                )->getAttributes();
+                );
+
+                $values[$key] = Arr::except($model->getAttributes(), $model->getGenerated());
             }
         });
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -532,16 +532,20 @@ class Builder implements BuilderContract
 
         $this->model::unguarded(function () use (&$values) {
             foreach ($values as $key => $rowValues) {
-                $model = tap(
-                    $this->newModelInstance($rowValues),
-                    fn ($model) => $model->setUniqueIds()
-                );
+                $model = $this->newModelInstance($rowValues);
 
-                $values[$key] = Arr::except($model->getAttributes(), $model->getGenerated());
+                $model->setUniqueIds();
+
+                $values[$key] = $model->getAttributes();
             }
         });
 
-        return $this->addTimestampsToUpsertValues($values);
+        $generated = $this->model->getGenerated();
+
+        return array_map(
+            fn ($rowValues) => Arr::except($rowValues, $generated),
+            $this->addTimestampsToUpsertValues($values)
+        );
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2327,7 +2327,7 @@ trait HasAttributes
      */
     protected function getDirtyForUpdate()
     {
-        return Arr::except($this->getDirty(), $this->getGenerated());
+        return $this->getDirty();
     }
 
     /**
@@ -2559,6 +2559,28 @@ trait HasAttributes
         }
 
         $this->generated = array_values(array_unique(array_merge($this->generated, $generated)));
+
+        return $this;
+    }
+
+    /**
+     * Discard any set values for the model's generated columns, since only the database may compute their values.
+     *
+     * @return $this
+     */
+    protected function discardGeneratedAttributes()
+    {
+        foreach ($this->getGenerated() as $key) {
+            if (! array_key_exists($key, $this->attributes)) {
+                continue;
+            }
+
+            if (array_key_exists($key, $this->original)) {
+                $this->attributes[$key] = $this->original[$key];
+            } else {
+                unset($this->attributes[$key]);
+            }
+        }
 
         return $this;
     }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2571,6 +2571,8 @@ trait HasAttributes
     protected function discardGeneratedAttributes()
     {
         foreach ($this->getGenerated() as $key) {
+            unset($this->attributeCastCache[$key], $this->classCastCache[$key]);
+
             if (! array_key_exists($key, $this->attributes)) {
                 continue;
             }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2059,7 +2059,7 @@ trait HasAttributes
      */
     protected function getAttributesForInsert()
     {
-        return $this->getAttributes();
+        return Arr::except($this->getAttributes(), $this->getGenerated());
     }
 
     /**
@@ -2327,7 +2327,7 @@ trait HasAttributes
      */
     protected function getDirtyForUpdate()
     {
-        return $this->getDirty();
+        return Arr::except($this->getDirty(), $this->getGenerated());
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -15,6 +15,7 @@ use Illuminate\Contracts\Database\Eloquent\CastsInboundAttributes;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Attributes\Appends;
 use Illuminate\Database\Eloquent\Attributes\DateFormat;
+use Illuminate\Database\Eloquent\Attributes\Generated;
 use Illuminate\Database\Eloquent\Attributes\Initialize;
 use Illuminate\Database\Eloquent\Attributes\Table;
 use Illuminate\Database\Eloquent\Casts\AsArrayObject;
@@ -151,6 +152,13 @@ trait HasAttributes
     protected $appends = [];
 
     /**
+     * The attributes that are computed by the database as generated columns.
+     *
+     * @var array<int, string>
+     */
+    protected $generated = [];
+
+    /**
      * Indicates whether attributes are snake cased on arrays.
      *
      * @var bool
@@ -215,6 +223,7 @@ trait HasAttributes
             ?? null;
 
         $this->mergeAppends(static::resolveClassAttribute(Appends::class, 'columns') ?? []);
+        $this->mergeGenerated(static::resolveClassAttribute(Generated::class, 'columns') ?? []);
     }
 
     /**
@@ -2512,6 +2521,46 @@ trait HasAttributes
     public function withoutAppends()
     {
         return $this->setAppends([]);
+    }
+
+    /**
+     * Get the attributes that are computed by the database as generated columns.
+     *
+     * @return array<int, string>
+     */
+    public function getGenerated()
+    {
+        return $this->generated;
+    }
+
+    /**
+     * Set the attributes that are computed by the database as generated columns.
+     *
+     * @param  array<int, string>  $generated
+     * @return $this
+     */
+    public function setGenerated(array $generated)
+    {
+        $this->generated = $generated;
+
+        return $this;
+    }
+
+    /**
+     * Merge new generated columns with existing generated columns on the model.
+     *
+     * @param  array<int, string>  $generated
+     * @return $this
+     */
+    public function mergeGenerated(array $generated)
+    {
+        if ($generated === []) {
+            return $this;
+        }
+
+        $this->generated = array_values(array_unique(array_merge($this->generated, $generated)));
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1501,6 +1501,8 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
             return false;
         }
 
+        $this->discardGeneratedAttributes();
+
         // First we need to create a fresh query instance and touch the creation and
         // update timestamp on the model which are maintained by us for developer
         // convenience. Then we will just continue saving the model instances.
@@ -1586,6 +1588,8 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
             return false;
         }
 
+        $this->discardGeneratedAttributes();
+
         // First we'll need to create a fresh query instance and touch the creation and
         // update timestamps on this model, which are maintained by us for developer
         // convenience. After, we will just continue saving these model instances.
@@ -1641,6 +1645,8 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         if ($this->fireModelEvent('creating') === false) {
             return false;
         }
+
+        $this->discardGeneratedAttributes();
 
         if ($this->usesTimestamps()) {
             $this->updateTimestamps();

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1379,6 +1379,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     public function save(array $options = [])
     {
         $this->mergeAttributesFromCachedCasts();
+        $this->discardGeneratedAttributes();
 
         $query = $this->newModelQuery();
 
@@ -1433,6 +1434,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         }
 
         $this->mergeAttributesFromCachedCasts();
+        $this->discardGeneratedAttributes();
 
         $query = $this->newModelQuery();
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1113,9 +1113,13 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     protected function incrementOrDecrement($column, $amount, $extra, $method)
     {
+        $extra = Arr::except($extra, $this->getGenerated());
+
         if (! $this->exists) {
             return $this->newQueryWithoutRelationships()->{$method}($column, $amount, $extra);
         }
+
+        $this->discardGeneratedAttributes();
 
         $this->{$column} = $this->isClassDeviable($column)
             ? $this->deviateClassCastableAttribute($method, $column, $amount)
@@ -1282,9 +1286,13 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     protected function incrementOrDecrementEach(array $columns, array $extra, string $method)
     {
+        $extra = Arr::except($extra, $this->getGenerated());
+
         if (! $this->exists) {
             return $this->newQueryWithoutRelationships()->{$method}($columns, $extra);
         }
+
+        $this->discardGeneratedAttributes();
 
         $isIncrement = $method === 'incrementEach';
         $singleMethod = $isIncrement ? 'increment' : 'decrement';

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2136,6 +2136,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
             $this->getCreatedAtColumn(),
             $this->getUpdatedAtColumn(),
             ...$this->uniqueIds(),
+            ...$this->getGenerated(),
             'laravel_through_key',
         ]));
 

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -2606,6 +2606,28 @@ class DatabaseEloquentIntegrationTest extends TestCase
         });
     }
 
+    public function testFillAndInsertExcludesGeneratedColumns()
+    {
+        $this->schema()->create('test_order_items', function (Blueprint $table) {
+            $table->increments('id');
+            $table->float('price')->nullable();
+            $table->float('total_price')->nullable();
+        });
+
+        $this->assertTrue(EloquentTestOrderItemWithGenerated::fillAndInsert([
+            ['price' => 100.0, 'total_price' => 200.0],
+            ['price' => 50.0],
+        ]));
+
+        $items = EloquentTestOrderItemWithGenerated::get();
+
+        $this->assertCount(2, $items);
+        $this->assertNull($items[0]->total_price);
+        $this->assertNull($items[1]->total_price);
+
+        $this->schema()->drop('test_order_items');
+    }
+
     public function testCanFillAndInsertWithUniqueStringIds()
     {
         Str::createUuidsUsingSequence([
@@ -2729,6 +2751,14 @@ class DatabaseEloquentIntegrationTest extends TestCase
 /**
  * Eloquent Models...
  */
+class EloquentTestOrderItemWithGenerated extends Eloquent
+{
+    public $timestamps = false;
+    protected $generated = ['total_price'];
+    protected $guarded = [];
+    protected $table = 'test_order_items';
+}
+
 class EloquentTestUser extends Eloquent
 {
     protected $table = 'users';

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -2628,6 +2628,27 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->schema()->drop('test_order_items');
     }
 
+    public function testFillAndInsertDoesNotReinjectGeneratedTimestamps()
+    {
+        $this->schema()->create('test_order_item_timestamps', function (Blueprint $table) {
+            $table->increments('id');
+            $table->float('price')->nullable();
+            $table->timestamp('created_at')->nullable();
+            $table->timestamp('updated_at')->nullable();
+        });
+
+        $this->assertTrue(EloquentTestOrderItemWithGeneratedTimestamp::fillAndInsert([
+            ['price' => 100.0],
+        ]));
+
+        $item = EloquentTestOrderItemWithGeneratedTimestamp::first();
+
+        $this->assertNotNull($item->created_at);
+        $this->assertNull($item->updated_at);
+
+        $this->schema()->drop('test_order_item_timestamps');
+    }
+
     public function testCanFillAndInsertWithUniqueStringIds()
     {
         Str::createUuidsUsingSequence([
@@ -2757,6 +2778,13 @@ class EloquentTestOrderItemWithGenerated extends Eloquent
     protected $generated = ['total_price'];
     protected $guarded = [];
     protected $table = 'test_order_items';
+}
+
+class EloquentTestOrderItemWithGeneratedTimestamp extends Eloquent
+{
+    protected $generated = ['updated_at'];
+    protected $guarded = [];
+    protected $table = 'test_order_item_timestamps';
 }
 
 class EloquentTestUser extends Eloquent

--- a/tests/Database/DatabaseEloquentModelAttributesTest.php
+++ b/tests/Database/DatabaseEloquentModelAttributesTest.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Attributes\Appends;
 use Illuminate\Database\Eloquent\Attributes\Connection;
 use Illuminate\Database\Eloquent\Attributes\DateFormat;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\Generated;
 use Illuminate\Database\Eloquent\Attributes\Guarded;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Attributes\Table;
@@ -311,6 +312,41 @@ class DatabaseEloquentModelAttributesTest extends TestCase
         $this->assertSame(['full_name', 'is_admin'], $model->getAppends());
     }
 
+    public function test_generated_attribute(): void
+    {
+        $model = new ModelWithGeneratedAttribute;
+
+        $this->assertSame(['total_price', 'search_index'], $model->getGenerated());
+    }
+
+    public function test_generated_attribute_variadic(): void
+    {
+        $model = new ModelWithGeneratedAttributeVariadic;
+
+        $this->assertSame(['total_price', 'search_index'], $model->getGenerated());
+    }
+
+    public function test_generated_property_merges_with_attribute(): void
+    {
+        $model = new ModelWithGeneratedAttributeAndProperty;
+
+        $this->assertEqualsCanonicalizing(['full_name', 'total_price', 'search_index'], $model->getGenerated());
+    }
+
+    public function test_replicate_excludes_generated_attribute_columns(): void
+    {
+        $model = new ModelWithGeneratedAttribute;
+        $model->setRawAttributes([
+            'name' => 'Order',
+            'search_index' => 'order',
+            'total_price' => 200.0,
+        ]);
+
+        $replicated = $model->replicate();
+
+        $this->assertSame(['name' => 'Order'], $replicated->getAttributes());
+    }
+
     public function test_touches_attribute(): void
     {
         $model = new ModelWithTouchesAttribute;
@@ -391,6 +427,17 @@ class DatabaseEloquentModelAttributesTest extends TestCase
         $this->assertSame($original, $model->getAppends());
     }
 
+    public function test_merge_generated_with_empty_array_is_noop(): void
+    {
+        $model = new ModelWithGeneratedAttribute;
+        $original = $model->getGenerated();
+
+        $result = $model->mergeGenerated([]);
+
+        $this->assertSame($model, $result);
+        $this->assertSame($original, $model->getGenerated());
+    }
+
     public function test_set_fillable_overrides_attribute(): void
     {
         $model = new ModelWithFillableAttribute;
@@ -463,6 +510,13 @@ class DatabaseEloquentModelAttributesTest extends TestCase
         $model = new ModelWithFillableAttributeAndTrait;
 
         $this->assertEqualsCanonicalizing(['name', 'email', 'phone'], $model->getFillable());
+    }
+
+    public function test_trait_initializer_merges_generated_with_attribute(): void
+    {
+        $model = new ModelWithGeneratedAttributeAndTrait;
+
+        $this->assertEqualsCanonicalizing(['total_price', 'search_index', 'discounted_price'], $model->getGenerated());
     }
 }
 
@@ -682,6 +736,24 @@ class ModelWithAppendsAttributeVariadic extends Model
     //
 }
 
+#[Generated(['total_price', 'search_index'])]
+class ModelWithGeneratedAttribute extends Model
+{
+    //
+}
+
+#[Generated('total_price', 'search_index')]
+class ModelWithGeneratedAttributeVariadic extends Model
+{
+    //
+}
+
+#[Generated(['total_price', 'search_index'])]
+class ModelWithGeneratedAttributeAndProperty extends Model
+{
+    protected $generated = ['full_name'];
+}
+
 #[Touches(['post', 'author'])]
 class ModelWithTouchesAttribute extends Model
 {
@@ -773,6 +845,14 @@ trait AddsPhoneFillable
     }
 }
 
+trait AddsDiscountedPriceGenerated
+{
+    protected function initializeAddsDiscountedPriceGenerated()
+    {
+        $this->mergeGenerated(['discounted_price']);
+    }
+}
+
 #[Appends(['full_name', 'is_admin'])]
 class ModelWithAppendsAttributeAndTrait extends Model
 {
@@ -795,4 +875,10 @@ class ModelWithVisibleAttributeAndTrait extends Model
 class ModelWithFillableAttributeAndTrait extends Model
 {
     use AddsPhoneFillable;
+}
+
+#[Generated(['total_price', 'search_index'])]
+class ModelWithGeneratedAttributeAndTrait extends Model
+{
+    use AddsDiscountedPriceGenerated;
 }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -2692,6 +2692,52 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertArrayNotHasKey('total_price', $replicated->getAttributes());
     }
 
+    public function testInsertExcludesGeneratedColumns()
+    {
+        $model = $this->getMockBuilder(EloquentModelWithGeneratedStub::class)->onlyMethods(['newModelQuery', 'updateTimestamps', 'refresh'])->getMock();
+        $query = m::mock(Builder::class);
+        $query->shouldReceive('insertGetId')->once()->with(['price' => 100.0, 'quantity' => 2.0], 'id')->andReturn(1);
+        $query->shouldReceive('getConnection')->once();
+        $model->expects($this->once())->method('newModelQuery')->willReturn($query);
+        $model->expects($this->once())->method('updateTimestamps');
+
+        $model::setEventDispatcher($events = m::mock(Dispatcher::class));
+        $events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
+        $events->shouldReceive('until')->once()->with('eloquent.creating: '.get_class($model), $model)->andReturn(true);
+        $events->shouldReceive('dispatch')->once()->with('eloquent.created: '.get_class($model), $model);
+        $events->shouldReceive('dispatch')->once()->with('eloquent.saved: '.get_class($model), $model);
+
+        $model->price = 100.0;
+        $model->quantity = 2.0;
+        $model->total_price = 200.0;
+        $model->exists = false;
+        $this->assertTrue($model->save());
+        $this->assertEquals(1, $model->id);
+    }
+
+    public function testUpdateExcludesGeneratedColumns()
+    {
+        $model = $this->getMockBuilder(EloquentModelWithGeneratedStub::class)->onlyMethods(['newModelQuery', 'updateTimestamps'])->getMock();
+        $query = m::mock(Builder::class);
+        $query->shouldReceive('where')->once()->with('id', '=', 1);
+        $query->shouldReceive('update')->once()->with(['price' => 150.0])->andReturn(1);
+        $model->expects($this->once())->method('newModelQuery')->willReturn($query);
+        $model->expects($this->once())->method('updateTimestamps');
+
+        $model::setEventDispatcher($events = m::mock(Dispatcher::class));
+        $events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
+        $events->shouldReceive('until')->once()->with('eloquent.updating: '.get_class($model), $model)->andReturn(true);
+        $events->shouldReceive('dispatch')->once()->with('eloquent.updated: '.get_class($model), $model)->andReturn(true);
+        $events->shouldReceive('dispatch')->once()->with('eloquent.saved: '.get_class($model), $model)->andReturn(true);
+
+        $model->id = 1;
+        $model->syncOriginal();
+        $model->price = 150.0;
+        $model->total_price = 300.0;
+        $model->exists = true;
+        $this->assertTrue($model->save());
+    }
+
     public function testIncrementOnExistingModelCallsQueryAndSetsAttribute()
     {
         $model = m::mock(EloquentModelStub::class.'[newQueryWithoutScopes]');

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -2662,6 +2662,36 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertNull($replicated->updated_at);
     }
 
+    public function testReplicateExcludesGeneratedColumns()
+    {
+        $model = new EloquentModelWithGeneratedStub;
+        $model->id = 'id';
+        $model->price = 100.0;
+        $model->quantity = 2.0;
+        $model->total_price = 200.0;
+        $replicated = $model->replicate();
+
+        $this->assertNull($replicated->id);
+        $this->assertSame(100.0, $replicated->price);
+        $this->assertSame(2.0, $replicated->quantity);
+        $this->assertNull($replicated->total_price);
+        $this->assertArrayNotHasKey('total_price', $replicated->getAttributes());
+    }
+
+    public function testReplicateExcludesGeneratedColumnsAlongsideExcept()
+    {
+        $model = new EloquentModelWithGeneratedStub;
+        $model->id = 'id';
+        $model->price = 100.0;
+        $model->quantity = 2.0;
+        $model->total_price = 200.0;
+        $replicated = $model->replicate(['quantity']);
+
+        $this->assertSame(100.0, $replicated->price);
+        $this->assertArrayNotHasKey('quantity', $replicated->getAttributes());
+        $this->assertArrayNotHasKey('total_price', $replicated->getAttributes());
+    }
+
     public function testIncrementOnExistingModelCallsQueryAndSetsAttribute()
     {
         $model = m::mock(EloquentModelStub::class.'[newQueryWithoutScopes]');
@@ -4131,6 +4161,11 @@ class EloquentModelStubWithTrait extends EloquentModelStub
 class EloquentModelCamelStub extends EloquentModelStub
 {
     public static $snakeAttributes = false;
+}
+
+class EloquentModelWithGeneratedStub extends EloquentModelStub
+{
+    protected $generated = ['total_price'];
 }
 
 class EloquentDateModelStub extends EloquentModelStub

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -2736,6 +2736,28 @@ class DatabaseEloquentModelTest extends TestCase
         $model->total_price = 300.0;
         $model->exists = true;
         $this->assertTrue($model->save());
+        $this->assertSame(['price' => 150.0], $model->getChanges());
+        $this->assertArrayNotHasKey('total_price', $model->getAttributes());
+    }
+
+    public function testSaveSkipsUpdateWhenOnlyGeneratedColumnsChanged()
+    {
+        $model = $this->getMockBuilder(EloquentModelWithGeneratedStub::class)->onlyMethods(['newModelQuery'])->getMock();
+        $query = m::mock(Builder::class);
+        $model->expects($this->once())->method('newModelQuery')->willReturn($query);
+
+        $model::setEventDispatcher($events = m::mock(Dispatcher::class));
+        $events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
+        $events->shouldReceive('dispatch')->once()->with('eloquent.saved: '.get_class($model), $model)->andReturn(true);
+
+        $model->setRawAttributes(['id' => 1, 'price' => 100.0, 'total_price' => 200.0], true);
+        $model->exists = true;
+        $model->total_price = 999.0;
+
+        $this->assertTrue($model->save());
+        $this->assertSame(200.0, $model->total_price);
+        $this->assertFalse($model->isDirty());
+        $this->assertSame([], $model->getChanges());
     }
 
     public function testIncrementOnExistingModelCallsQueryAndSetsAttribute()

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -2788,6 +2788,50 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertSame(['price' => 150.0], $model->getChanges());
     }
 
+    public function testUpdateDiscardsCastCacheForGeneratedColumns()
+    {
+        $model = $this->getMockBuilder(EloquentModelWithGeneratedCastStub::class)->onlyMethods(['newModelQuery', 'updateTimestamps'])->getMock();
+        $query = m::mock(Builder::class);
+        $query->shouldReceive('where')->once()->with('id', '=', 1);
+        $query->shouldReceive('update')->once()->with(['price' => 150.0])->andReturn(1);
+        $model->expects($this->once())->method('newModelQuery')->willReturn($query);
+        $model->expects($this->once())->method('updateTimestamps');
+
+        $model::setEventDispatcher($events = m::mock(Dispatcher::class));
+        $events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
+        $events->shouldReceive('until')->once()->with('eloquent.updating: '.get_class($model), $model)->andReturn(true);
+        $events->shouldReceive('dispatch')->once()->with('eloquent.updated: '.get_class($model), $model)->andReturn(true);
+        $events->shouldReceive('dispatch')->once()->with('eloquent.saved: '.get_class($model), $model)->andReturn(true);
+
+        $model->setRawAttributes(['id' => 1, 'price' => 100.0, 'meta' => '{"total":200}'], true);
+        $model->exists = true;
+        $model->meta['hacked'] = true;
+        $model->price = 150.0;
+
+        $this->assertTrue($model->save());
+        $this->assertSame(['price' => 150.0], $model->getChanges());
+        $this->assertSame(['total' => 200], $model->meta->toArray());
+    }
+
+    public function testIncrementExcludesGeneratedColumns()
+    {
+        $model = m::mock(EloquentModelWithGeneratedStub::class.'[newQueryWithoutScopes]');
+        $model->exists = true;
+        $model->id = 1;
+        $model->syncOriginalAttribute('id');
+        $model->quantity = 2;
+        $model->total_price = 999.0;
+
+        $model->shouldReceive('newQueryWithoutScopes')->andReturn($query = m::mock(stdClass::class));
+        $query->shouldReceive('where')->andReturn($query);
+        $query->shouldReceive('increment')->once()->with('quantity', 1, ['price' => 150.0]);
+
+        $model->publicIncrement('quantity', 1, ['price' => 150.0, 'total_price' => 300.0]);
+
+        $this->assertArrayNotHasKey('total_price', $model->getAttributes());
+        $this->assertSame(['quantity' => 3, 'price' => 150.0], $model->getChanges());
+    }
+
     public function testIncrementOnExistingModelCallsQueryAndSetsAttribute()
     {
         $model = m::mock(EloquentModelStub::class.'[newQueryWithoutScopes]');
@@ -4262,6 +4306,12 @@ class EloquentModelCamelStub extends EloquentModelStub
 class EloquentModelWithGeneratedStub extends EloquentModelStub
 {
     protected $generated = ['total_price'];
+}
+
+class EloquentModelWithGeneratedCastStub extends EloquentModelStub
+{
+    protected $casts = ['meta' => AsArrayObject::class];
+    protected $generated = ['meta'];
 }
 
 class EloquentDateModelStub extends EloquentModelStub

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -2760,6 +2760,34 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertSame([], $model->getChanges());
     }
 
+    public function testUpdateDiscardsGeneratedColumnsSetByEventListeners()
+    {
+        $model = $this->getMockBuilder(EloquentModelWithGeneratedStub::class)->onlyMethods(['newModelQuery', 'updateTimestamps'])->getMock();
+        $query = m::mock(Builder::class);
+        $query->shouldReceive('where')->once()->with('id', '=', 1);
+        $query->shouldReceive('update')->once()->with(['price' => 150.0])->andReturn(1);
+        $model->expects($this->once())->method('newModelQuery')->willReturn($query);
+        $model->expects($this->once())->method('updateTimestamps');
+
+        $model::setEventDispatcher($events = m::mock(Dispatcher::class));
+        $events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
+        $events->shouldReceive('until')->once()->with('eloquent.updating: '.get_class($model), $model)->andReturnUsing(function () use ($model) {
+            $model->total_price = 999.0;
+
+            return true;
+        });
+        $events->shouldReceive('dispatch')->once()->with('eloquent.updated: '.get_class($model), $model)->andReturn(true);
+        $events->shouldReceive('dispatch')->once()->with('eloquent.saved: '.get_class($model), $model)->andReturn(true);
+
+        $model->setRawAttributes(['id' => 1, 'price' => 100.0, 'total_price' => 200.0], true);
+        $model->exists = true;
+        $model->price = 150.0;
+
+        $this->assertTrue($model->save());
+        $this->assertSame(200.0, $model->total_price);
+        $this->assertSame(['price' => 150.0], $model->getChanges());
+    }
+
     public function testIncrementOnExistingModelCallsQueryAndSetsAttribute()
     {
         $model = m::mock(EloquentModelStub::class.'[newQueryWithoutScopes]');


### PR DESCRIPTION
Currently, saving a model whose table has a generated column (`virtualAs()` / `storedAs()`) fails whenever the column's value is present on the model, since it ends up in the INSERT or UPDATE and the database rejects it (reported in #25495). Replicating is the classic trip-wire, because `replicate()` copies every loaded attribute onto the clone:

```
SQLSTATE[HY000]: General error: 3105 The value specified for generated column
'total_price' in table 'order_items' is not allowed
```

To avoid that today, you have to remember to exclude the column at every call site, or override `replicate()` on the model:

```php
$clone = $item->replicate(['total_price']);
```

With this PR, the model declares its generated columns once and Eloquent never writes them: they are stripped from insert and update statements, and `replicate()` excludes them from clones alongside the primary key, timestamps, and unique ids:

```php
#[Generated('total_price')]
class OrderItem extends Model
{
    // or: protected $generated = ['total_price'];
}

$clone = $item->replicate();
```

Values assigned to generated columns are discarded when a save begins: reverted to the last database-loaded value, or removed when the model was never hydrated with one. They are therefore never dirty at write time, a generated-only change does not trigger the update lifecycle (no `updating` event, timestamp bump, or owner touching), and `syncOriginal()` / `getChanges()` only ever reflect what the database really holds. `fillAndInsert()` excludes the columns per row as well. The attribute itself is resolved and merged exactly like `#[Fillable]`, with `getGenerated()` / `setGenerated()` / `mergeGenerated()` accessors. Models that declare nothing are unaffected, and since only the database can compute the value, a freshly saved model has no value for these columns until refreshed.

Companion documentation PR: laravel/docs#11294.
