### PR TITLE
Add #[RouteKey] class attribute to Eloquent models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Attributes/RouteKey.php
+++ b/src/Illuminate/Database/Eloquent/Attributes/RouteKey.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class RouteKey
+{
+    /**
+     * Create a new attribute instance.
+     */
+    public function __construct(
+        public string $key
+    ) {
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2446,6 +2446,13 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function getRouteKeyName()
     {
+        $reflection = new ReflectionClass($this);
+        $attributes = $reflection->getAttributes(\Illuminate\Database\Eloquent\Attributes\RouteKey::class);
+
+        if (! empty($attributes)) {
+            return $attributes[0]->newInstance()->key;
+        }
+
         return $this->getKeyName();
     }
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -16,6 +16,7 @@ use Illuminate\Database\ConnectionResolverInterface as Resolver;
 use Illuminate\Database\Eloquent\Attributes\Boot;
 use Illuminate\Database\Eloquent\Attributes\Connection;
 use Illuminate\Database\Eloquent\Attributes\Initialize;
+use Illuminate\Database\Eloquent\Attributes\RouteKey;
 use Illuminate\Database\Eloquent\Attributes\Scope as LocalScope;
 use Illuminate\Database\Eloquent\Attributes\Table;
 use Illuminate\Database\Eloquent\Attributes\UseEloquentBuilder;
@@ -2446,14 +2447,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function getRouteKeyName()
     {
-        $reflection = new ReflectionClass($this);
-        $attributes = $reflection->getAttributes(\Illuminate\Database\Eloquent\Attributes\RouteKey::class);
-
-        if (! empty($attributes)) {
-            return $attributes[0]->newInstance()->key;
-        }
-
-        return $this->getKeyName();
+        return static::resolveClassAttribute(RouteKey::class, 'key') ?? $this->getKeyName();
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3939,11 +3939,11 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertSame('slug', $model->getRouteKeyName());
     }
 
-    public function testRouteKeyFallsBackToDefaultWhenAttributeIsMissing()
+    public function testRouteKeyAttributeIsInherited()
     {
-        $model = new EloquentModelStub;
+        $model = new EloquentModelInheritingRouteKeyAttributeStub;
 
-        $this->assertSame('id', $model->getRouteKeyName());
+        $this->assertSame('slug', $model->getRouteKeyName());
     }
 }
 
@@ -4955,6 +4955,11 @@ class EloquentModelIncrementEachQueryStub
 
 #[RouteKey('slug')]
 class EloquentModelWithRouteKeyAttributeStub extends Model
+{
+    //
+}
+
+class EloquentModelInheritingRouteKeyAttributeStub extends EloquentModelWithRouteKeyAttributeStub
 {
     //
 }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -16,6 +16,7 @@ use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
 use Illuminate\Database\Eloquent\Attributes\CollectedBy;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
+use Illuminate\Database\Eloquent\Attributes\RouteKey;
 use Illuminate\Database\Eloquent\Attributes\UseFactory;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\ArrayObject;
@@ -3930,6 +3931,20 @@ class DatabaseEloquentModelTest extends TestCase
 
         $this->assertNotInstanceOf(CustomBuilder::class, $eloquentBuilder);
     }
+
+    public function testRouteKeyCanBeResolvedFromAttribute()
+    {
+        $model = new EloquentModelWithRouteKeyAttributeStub;
+
+        $this->assertSame('slug', $model->getRouteKeyName());
+    }
+
+    public function testRouteKeyFallsBackToDefaultWhenAttributeIsMissing()
+    {
+        $model = new EloquentModelStub;
+
+        $this->assertSame('id', $model->getRouteKeyName());
+    }
 }
 
 class CustomBuilder extends Builder
@@ -4936,4 +4951,10 @@ class EloquentModelIncrementEachQueryStub
     {
         throw new \BadMethodCallException($name);
     }
+}
+
+#[RouteKey('slug')]
+class EloquentModelWithRouteKeyAttributeStub extends Model
+{
+    //
 }


### PR DESCRIPTION

This pull request introduces a native `#[RouteKey]` class-level PHP attribute for Eloquent models. 

Currently, modifying the default route binding key (from `id` to columns like `slug` or `uuid`) requires overriding the `getRouteKeyName()` method on every model. Following the framework's adoption of native PHP attributes for model configurations (similar to `#[ObservedBy]` or `#[ScopedBy]`), this PR provides a declarative way to accomplish the same behavior directly on the class definition.

### Usage

Instead of overriding the method:

```php
class Post extends Model
{
    public function getRouteKeyName()
    {
        return 'slug';
    }
}

```

Developers can now cleanly declare it via the attribute:

```php
use Illuminate\Database\Eloquent\Attributes\RouteKey;

#[RouteKey('slug')]
class Post extends Model
{
    // ...
}

```

### Implementation Details

* Added the new `Illuminate\Database\Eloquent\Attributes\RouteKey` attribute class.
* Updated `Model::getRouteKeyName()` to use PHP Reflection to look for the `RouteKey` attribute on instantiation, falling back to `$this->getKeyName()` if it is not present.
* Added comprehensive unit tests in `DatabaseEloquentModelTest` validating both the attribute resolution and the default fallback functionality.
