### PR TITLE
[14.x] Remove unused 'composer' property from MigrateMakeCommand

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -4,7 +4,6 @@ namespace Illuminate\Database\Console\Migrations;
 
 use Illuminate\Contracts\Console\PromptsForMissingInput;
 use Illuminate\Database\Migrations\MigrationCreator;
-use Illuminate\Support\Composer;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Attribute\AsCommand;
 
@@ -38,26 +37,13 @@ class MigrateMakeCommand extends BaseCommand implements PromptsForMissingInput
     protected $creator;
 
     /**
-     * The Composer instance.
-     *
-     * @var \Illuminate\Support\Composer
-     *
-     * @deprecated Will be removed in a future Laravel version.
-     */
-    protected $composer;
-
-    /**
      * Create a new migration install command instance.
-     *
-     * @param  \Illuminate\Database\Migrations\MigrationCreator  $creator
-     * @param  \Illuminate\Support\Composer  $composer
      */
-    public function __construct(MigrationCreator $creator, Composer $composer)
+    public function __construct(MigrationCreator $creator)
     {
         parent::__construct();
 
         $this->creator = $creator;
-        $this->composer = $composer;
     }
 
     /**

--- a/src/Illuminate/Database/MigrationServiceProvider.php
+++ b/src/Illuminate/Database/MigrationServiceProvider.php
@@ -157,14 +157,16 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
     protected function registerMigrateMakeCommand()
     {
         $this->app->singleton(MigrateMakeCommand::class, function ($app) {
-            // Once we have the migration creator registered, we will create the command
-            // and inject the creator. The creator is responsible for the actual file
-            // creation of the migrations, and may be extended by these developers.
+            /**
+             * Once we have the migration creator registered, we will create the command
+             * and inject the creator. The creator is responsible for the actual file
+             * creation of the migrations, and may be extended by these developers.
+             *
+             * @var MigrationCreator
+             */
             $creator = $app['migration.creator'];
 
-            $composer = $app['composer'];
-
-            return new MigrateMakeCommand($creator, $composer);
+            return new MigrateMakeCommand($creator);
         });
     }
 

--- a/tests/Database/DatabaseMigrationMakeCommandTest.php
+++ b/tests/Database/DatabaseMigrationMakeCommandTest.php
@@ -5,7 +5,6 @@ namespace Illuminate\Tests\Database;
 use Illuminate\Database\Console\Migrations\MigrateMakeCommand;
 use Illuminate\Database\Migrations\MigrationCreator;
 use Illuminate\Foundation\Application;
-use Illuminate\Support\Composer;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -17,7 +16,6 @@ class DatabaseMigrationMakeCommandTest extends TestCase
     {
         $command = new MigrateMakeCommand(
             $creator = m::mock(MigrationCreator::class),
-            $composer = m::mock(Composer::class)
         );
         $app = new Application;
         $app->useDatabasePath(__DIR__);
@@ -33,7 +31,6 @@ class DatabaseMigrationMakeCommandTest extends TestCase
     {
         $command = new MigrateMakeCommand(
             $creator = m::mock(MigrationCreator::class),
-            m::mock(Composer::class)->shouldIgnoreMissing()
         );
         $app = new Application;
         $app->useDatabasePath(__DIR__);
@@ -49,7 +46,6 @@ class DatabaseMigrationMakeCommandTest extends TestCase
     {
         $command = new MigrateMakeCommand(
             $creator = m::mock(MigrationCreator::class),
-            m::mock(Composer::class)->shouldIgnoreMissing()
         );
         $app = new Application;
         $app->useDatabasePath(__DIR__);
@@ -65,7 +61,6 @@ class DatabaseMigrationMakeCommandTest extends TestCase
     {
         $command = new MigrateMakeCommand(
             $creator = m::mock(MigrationCreator::class),
-            m::mock(Composer::class)->shouldIgnoreMissing()
         );
         $app = new Application;
         $app->useDatabasePath(__DIR__);
@@ -81,7 +76,6 @@ class DatabaseMigrationMakeCommandTest extends TestCase
     {
         $command = new MigrateMakeCommand(
             $creator = m::mock(MigrationCreator::class),
-            m::mock(Composer::class)->shouldIgnoreMissing()
         );
         $app = new Application;
         $app->useDatabasePath(__DIR__);
@@ -97,7 +91,6 @@ class DatabaseMigrationMakeCommandTest extends TestCase
     {
         $command = new MigrateMakeCommand(
             $creator = m::mock(MigrationCreator::class),
-            m::mock(Composer::class)->shouldIgnoreMissing()
         );
         $app = new Application;
         $command->setLaravel($app);


### PR DESCRIPTION
This PR removes the deprecated `$composer` property from `MigrateMakeCommand`.

### Background

The `$composer` property was originally used by the `migrate:make` command, but it has not been used since it was removed in PR #46215 by @timacdonald.

At the time, @ankurk91 suggested removing the `Composer` dependency from the constructor as well because it was no longer used. Tim replied:

> I didn't remove the dependency as I thought a user-land class may be extending these and potentially interacting with the `$composer` property - so removing it may be a breaking change.
>
> I might deprecate it, though 💡

As a result, the property was kept and marked as deprecated:

```php
/**
 * The Composer instance.
 *
 * @var \Illuminate\Support\Composer
 *
 * @deprecated Will be removed in a future Laravel version.
 */
protected $composer;
```

The property has remained unused ever since, and should be removed in V11.x

### Why target the master branch?

Removing the property is a breaking change because user-land classes may extend `MigrateMakeCommand` and access the protected `$composer` property.

Since Laravel 13 has already been released, this change is more appropriate for the next major version, v14.x (master branch), rather than the `13.x` branch.

This PR completes the deprecation that was introduced after PR #46215 by removing the now-unused property.
