### PR TITLE
[13.x] Add a JSON helper for exception-safe encoding and decoding

### DIFF
--- a/src/Illuminate/Support/Json.php
+++ b/src/Illuminate/Support/Json.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Illuminate\Support;
+
+use JsonException;
+use stdClass;
+
+class Json
+{
+    /**
+     * Encode the given value as JSON.
+     *
+     * @throws JsonException
+     */
+    public static function encode(mixed $value, int $flags = 0): string
+    {
+        return json_encode($value, JSON_THROW_ON_ERROR | $flags);
+    }
+
+    /**
+     * Decode the given JSON string into an array.
+     *
+     * @return array<array-key, mixed>
+     *
+     * @throws JsonException
+     */
+    public static function decodeToArray(string $json, int $flags = 0): array
+    {
+        $decoded = json_decode($json, true, 512, JSON_THROW_ON_ERROR | $flags);
+
+        if (! is_array($decoded)) {
+            throw new JsonException('Expected a JSON object or array.');
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * Decode the given JSON string into an object.
+     *
+     * @throws JsonException
+     */
+    public static function decodeToObject(string $json, int $flags = 0): stdClass
+    {
+        $decoded = json_decode($json, false, 512, JSON_THROW_ON_ERROR | $flags);
+
+        if (! $decoded instanceof stdClass) {
+            throw new JsonException('Expected a JSON object.');
+        }
+
+        return $decoded;
+    }
+}


### PR DESCRIPTION
This PR introduces an `Illuminate\Support\Json` helper that provides a small, consistent API for encoding and decoding JSON.

It includes:

* `encode` for encoding values with `JSON_THROW_ON_ERROR`
* `decodeToArray` for decoding JSON objects or arrays into arrays
* `decodeToObject` for decoding JSON objects into `stdClass` instances
* explicit exceptions when the decoded value does not match the expected type
* support for passing additional JSON flags to each operation

The helper removes repeated `json_encode` and `json_decode` configuration from application and framework code while making the expected return type explicit at the call site.

```php
Json::encode($value);

Json::decodeToArray($json);

Json::decodeToObject($json);
```

All methods use PHP’s native JSON implementation and preserve its exception behavior through `JsonException`.
