### PR TITLE
[13.x] Fix ShouldBeUniqueUntilProcessing lock leak on retry after being released by middleware

### DIFF
--- a/src/Illuminate/Bus/Queueable.php
+++ b/src/Illuminate/Bus/Queueable.php
@@ -50,6 +50,13 @@ trait Queueable
     public $debounceOwner = '';
 
     /**
+     * The lock owner token for the "unique until processing" lock.
+     *
+     * @var string
+     */
+    public $uniqueLockOwner = '';
+
+    /**
      * The number of seconds before the job should be made available.
      *
      * @var \DateTimeInterface|\DateInterval|array|int|null

--- a/src/Illuminate/Bus/UniqueLock.php
+++ b/src/Illuminate/Bus/UniqueLock.php
@@ -5,6 +5,7 @@ namespace Illuminate\Bus;
 use Illuminate\Contracts\Cache\Repository as Cache;
 use Illuminate\Queue\Attributes\ReadsQueueAttributes;
 use Illuminate\Queue\Attributes\UniqueFor;
+use Illuminate\Support\Str;
 
 class UniqueLock
 {
@@ -43,11 +44,24 @@ class UniqueLock
             ? ($job->uniqueVia() ?? $this->cache)
             : $this->cache;
 
-        return (bool) $cache->lock(self::getKey($job), $uniqueFor)->get();
+        $owner = Str::random(40);
+
+        $acquired = (bool) $cache->lock(self::getKey($job), $uniqueFor, $owner)->get();
+
+        if ($acquired && property_exists($job, 'uniqueLockOwner')) {
+            $job->uniqueLockOwner = $owner;
+        }
+
+        return $acquired;
     }
 
     /**
      * Release the lock for the given job.
+     *
+     * Releases by owner when the job carries one, so a dispatch that never
+     * released its own lock (e.g. a retry after being released back to the
+     * queue by another middleware) can't release a lock a newer, unrelated
+     * dispatch has since legitimately acquired.
      *
      * @param  mixed  $job
      * @return void
@@ -57,6 +71,14 @@ class UniqueLock
         $cache = method_exists($job, 'uniqueVia')
             ? ($job->uniqueVia() ?? $this->cache)
             : $this->cache;
+
+        $owner = property_exists($job, 'uniqueLockOwner') ? $job->uniqueLockOwner : '';
+
+        if (! empty($owner)) {
+            $cache->restoreLock(self::getKey($job), $owner)->release();
+
+            return;
+        }
 
         $cache->lock(self::getKey($job))->forceRelease();
     }

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -139,12 +139,12 @@ class CallQueuedHandler
         return (new Pipeline($this->container))->send($command)
             ->through(array_merge(method_exists($command, 'middleware') ? $command->middleware() : [], $command->middleware ?? []))
             ->finally(function ($command) use (&$lockReleased) {
-                if (! $lockReleased && $this->commandShouldBeUniqueUntilProcessing($command) && ! $command->job->isReleased() && $command->job->attempts() <= 1) {
+                if (! $lockReleased && $this->commandShouldBeUniqueUntilProcessing($command) && ! $command->job->isReleased()) {
                     $this->ensureUniqueJobLockIsReleased($command);
                 }
             })
             ->then(function ($command) use ($job, &$lockReleased) {
-                if ($this->commandShouldBeUniqueUntilProcessing($command) && $job->attempts() <= 1) {
+                if ($this->commandShouldBeUniqueUntilProcessing($command)) {
                     $this->ensureUniqueJobLockIsReleased($command);
 
                     $lockReleased = true;

--- a/tests/Events/QueuedEventsTest.php
+++ b/tests/Events/QueuedEventsTest.php
@@ -476,7 +476,7 @@ class QueuedEventsTest extends TestCase
 
         $cache->shouldReceive('lock')
             ->once()
-            ->with($expectedKey, 60)
+            ->with($expectedKey, 60, m::type('string'))
             ->andReturn($lock);
         $lock->shouldReceive('get')->once()->andReturn(true);
 
@@ -510,7 +510,7 @@ class QueuedEventsTest extends TestCase
 
         $uniqueCache->shouldReceive('lock')
             ->once()
-            ->with($expectedKey, 60)
+            ->with($expectedKey, 60, m::type('string'))
             ->andReturn($lock);
         $lock->shouldReceive('get')->once()->andReturn(true);
 

--- a/tests/Integration/Queue/UniqueUntilProcessingJobTest.php
+++ b/tests/Integration/Queue/UniqueUntilProcessingJobTest.php
@@ -48,6 +48,26 @@ class UniqueUntilProcessingJobTest extends QueueTestCase
         UniqueUntilProcessingJobThatReleases::dispatch();
         $this->assertDatabaseCount('jobs', 1);
     }
+
+    public function testShouldBeUniqueUntilProcessingReleasesLockWhenRetryAfterBeingReleasedByMiddlewareSucceeds()
+    {
+        UniqueUntilProcessingJobThatReleasesOnlyOnFirstAttempt::dispatch();
+        $this->assertNotNull(DB::table('cache_locks')->first());
+
+        // Attempt #1: middleware releases the job back to the queue without processing it.
+        $this->runQueueWorkerCommand(['--once' => true, '--tries' => 2]);
+        $this->assertFalse(UniqueUntilProcessingJobThatReleasesOnlyOnFirstAttempt::$handled);
+        $this->assertNotNull(DB::table('cache_locks')->first());
+
+        // Attempt #2: middleware lets it through this time, and the job actually runs.
+        $this->runQueueWorkerCommand(['--once' => true, '--tries' => 2]);
+        $this->assertTrue(UniqueUntilProcessingJobThatReleasesOnlyOnFirstAttempt::$handled);
+        $this->assertNull(DB::table('cache_locks')->first());
+
+        // The lock should be free again for a fresh dispatch.
+        UniqueUntilProcessingJobThatReleasesOnlyOnFirstAttempt::dispatch();
+        $this->assertDatabaseCount('jobs', 1);
+    }
 }
 
 class UniqueTestJobThatDoesNotRelease implements ShouldQueue, ShouldBeUniqueUntilProcessing
@@ -85,5 +105,26 @@ class UniqueUntilProcessingJobThatReleases extends UniqueTestJobThatDoesNotRelea
     public function uniqueId()
     {
         return 100;
+    }
+}
+
+class UniqueUntilProcessingJobThatReleasesOnlyOnFirstAttempt extends UniqueTestJobThatDoesNotRelease
+{
+    public function middleware()
+    {
+        return [
+            function ($job, $next) {
+                if ($job->attempts() === 1) {
+                    return $job->release(0);
+                }
+
+                return $next($job);
+            },
+        ];
+    }
+
+    public function uniqueId()
+    {
+        return 200;
     }
 }


### PR DESCRIPTION
Fixes #60042

## Summary

`CallQueuedHandler::dispatchThroughMiddleware()` only releases the "unique in queue" lock when `job->attempts() <= 1`:

```php
->finally(function ($command) use (&$lockReleased) {
    if (! $lockReleased && $this->commandShouldBeUniqueUntilProcessing($command) && ! $command->job->isReleased() && $command->job->attempts() <= 1) {
        $this->ensureUniqueJobLockIsReleased($command);
    }
})
->then(function ($command) use ($job, &$lockReleased) {
    if ($this->commandShouldBeUniqueUntilProcessing($command) && $job->attempts() <= 1) {
        $this->ensureUniqueJobLockIsReleased($command);
        $lockReleased = true;
    }
    ...
});
```

This works fine when the first attempt runs the job all the way to `then()`. It breaks when a middleware (most commonly `WithoutOverlapping`) releases the job back to the queue *before* it ever reaches `then()`:

1. Job is dispatched, holding the "no duplicate in queue" unique lock.
2. A worker picks it up. `WithoutOverlapping` sees another job with the same key already running, so it calls `$job->release()` and doesn't call `$next()`. The lock is correctly *not* released here (`finally()`'s `! $command->job->isReleased()` check prevents it) - the job is effectively still pending, so the lock should stay held.
3. Later, a worker picks up the retry. This time there's no overlap, so it reaches `then()` and runs successfully. But `job->attempts()` is now `2`, so `attempts() <= 1` is false - the lock is **never released**, on either path.
4. The lock now sits in the cache until its TTL (or forever, if unset). Every future dispatch of that job, until the lock expires, is silently dropped.

## Why `attempts() <= 1` was there

It was guarding against a different, real bug: releasing the lock unconditionally on every retry could delete a lock that a *newer, unrelated* dispatch has since legitimately acquired (if this dispatch's first attempt already released its own lock via the normal `then()` path, then failed later and got retried for an unrelated reason). The `attempts()` check was a coarse proxy for "have I already released".

## Fix

Replace the attempt-count heuristic with actual lock ownership, mirroring the existing `debounceOwner` pattern already used by `DebounceLock` for the exact same class of problem:

- `Queueable` trait gets a new `$uniqueLockOwner` property (same shape as the existing `$debounceOwner`).
- `UniqueLock::acquire()` generates an owner token, acquires the lock with it, and stores it on the job *before* it's first serialized into the queue payload - so the token survives every retry, since a retry replays the original payload rather than a freshly re-serialized object.
- `UniqueLock::release()` now does an ownership-checked release via `restoreLock($key, $owner)->release()` instead of an unconditional `forceRelease()` (falls back to the old `forceRelease()` behavior if the job doesn't carry an owner token, e.g. non-`Queueable` callers).
- The `attempts() <= 1` guards in `CallQueuedHandler` are removed entirely - it's now safe to always attempt the release once a dispatch reaches the point where it's really running, since an ownership mismatch (someone else's lock) is simply a no-op instead of an incorrect deletion.

This fixes the regression without reintroducing the bug the `attempts()` check was added for.

## Tests

- Extended the existing `UniqueUntilProcessingJobTest` with a new end-to-end test against the real `database` queue/cache driver: attempt #1 is released by middleware (lock correctly stays held), attempt #2 is let through and completes, and the lock is now actually released. Fails against the current code, passes with the fix.
- Updated two `QueuedEventsTest` Mockery expectations that asserted `lock()` was called with exactly 2 arguments - it now always receives an explicit owner as a 3rd argument.

## Test plan

- [x] New regression test in `UniqueUntilProcessingJobTest` (fails before fix, passes after)
- [x] `tests/Bus`, `tests/Queue`, `tests/Integration/Queue`, `tests/Events`, `tests/Broadcasting`, `tests/Integration/Console` - 1095 tests, 0 failures (covers every call site of `UniqueLock::acquire()`/`release()`: queue dispatch, `BroadcastManager`, `Events\Dispatcher::queueHandler`, `Console\Scheduling\Schedule`, `QueueFake`)
- [x] Full suite (`vendor/bin/phpunit`, 14359 tests): the only failures are pre-existing and unrelated (confirmed identical on unmodified `13.x`), none introduced by this change

## Why this does not break existing behavior

- Non-`Queueable` callers of `UniqueLock` fall back to the previous `forceRelease()` behavior.
- The only behavioral change for `Queueable` jobs is *when* the lock is released (now correctly released once the job actually starts running, on any attempt, instead of only on attempt 1) and *how* it's released (ownership-checked instead of unconditional) - both strictly more correct than before.
- No public API changes.