### PR TITLE
[13.x] Introduce `RequestAttribute` contextual Attribute

### DIFF
--- a/src/Illuminate/Container/Attributes/RequestAttribute.php
+++ b/src/Illuminate/Container/Attributes/RequestAttribute.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Illuminate\Container\Attributes;
+
+use Attribute;
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Contracts\Container\ContextualAttribute;
+use ReflectionParameter;
+
+#[Attribute(Attribute::TARGET_PARAMETER)]
+class RequestAttribute implements ContextualAttribute
+{
+    /**
+     * Create a new class instance.
+     */
+    public function __construct(public string $parameter = null)
+    {
+    }
+
+    /**
+     * Resolve the route parameter.
+     *
+     * @param  self  $attribute
+     * @param  \Illuminate\Contracts\Container\Container  $container
+     * @return mixed
+     */
+    public static function resolve(self $attribute, Container $container, ReflectionParameter $parameter)
+    {
+        return $container->make('request')->attributes->get($attribute->parameter);
+    }
+}

--- a/src/Illuminate/Container/Attributes/RequestAttribute.php
+++ b/src/Illuminate/Container/Attributes/RequestAttribute.php
@@ -18,7 +18,7 @@ class RequestAttribute implements ContextualAttribute
     }
 
     /**
-     * Resolve the route parameter.
+     * Resolve the request attribute.
      *
      * @param  self  $attribute
      * @param  \Illuminate\Contracts\Container\Container  $container

--- a/src/Illuminate/Container/Attributes/RequestAttribute.php
+++ b/src/Illuminate/Container/Attributes/RequestAttribute.php
@@ -13,7 +13,7 @@ class RequestAttribute implements ContextualAttribute
     /**
      * Create a new class instance.
      */
-    public function __construct(public string $parameter = null)
+    public function __construct(public string $parameter)
     {
     }
 


### PR DESCRIPTION
We have middleware that sets a user's org based on their API key. We store the `Organization` model as a request attribute.

This makes it a bit simpler to resolve and not have to do so many type-juggling things.

## Example
```php
class InventoryController
{
    public function __construct(private readonly InventoryService $inventoryService) {}

    public function index(Request $request)
    {
        /** @var Organization $org */
        $org = $request->attributes->get('org');

        return $this-inventoryService->getForOrg($org);
    }

    public function newAndImprovedIndex(Request $request, #[RequestAttribute('org')] Organization $org)
    {
        return $this-inventoryService->getForOrg($org);
    }
}
```