### PR TITLE
[13.x] Allow customizing the application builder used by Application::configure()

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -209,6 +209,13 @@ class Application extends Container implements ApplicationContract, CachesConfig
     protected $absoluteCachePathPrefixes = ['/', '\\'];
 
     /**
+     * The application builder class.
+     *
+     * @var class-string<Configuration\ApplicationBuilder>
+     */
+    protected static string $applicationBuilder = Configuration\ApplicationBuilder::class;
+
+    /**
      * Create a new Illuminate application instance.
      *
      * @param  string|null  $basePath
@@ -238,7 +245,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
             default => static::inferBasePath(),
         };
 
-        return (new Configuration\ApplicationBuilder(new static($basePath)))
+        return (new static::$applicationBuilder(new static($basePath)))
             ->withKernels()
             ->withEvents()
             ->withCommands()


### PR DESCRIPTION
`Application::configure()` currently hardcodes `Configuration\ApplicationBuilder`, making it impossible for frameworks extending Laravel's `Application` to customize the bootstrap builder without overriding the entire `configure()` method. This change introduces a protected extension point so subclasses can provide their own `ApplicationBuilder` while preserving the existing API and default behavior.