### PR TITLE
[13.x] Add `app.datetime_overflow` config option

### DIFF
--- a/config-stubs/app.php
+++ b/config-stubs/app.php
@@ -69,6 +69,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Date / Carbon Overflow Behavior
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify whether date and time overflow is allowed when
+    | adding or subtracting months / years using Carbon. This option is
+    | enabled by default, matching Carbon's own default behavior.
+    |
+    */
+
+    'datetime_overflow' => true,
+
+    /*
+    |--------------------------------------------------------------------------
     | Application Locale Configuration
     |--------------------------------------------------------------------------
     |

--- a/config/app.php
+++ b/config/app.php
@@ -76,6 +76,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Date / Carbon Overflow Behavior
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify whether date and time overflow is allowed when
+    | adding or subtracting months / years using Carbon. This option is
+    | enabled by default, matching Carbon's own default behavior.
+    |
+    */
+
+    'datetime_overflow' => true,
+
+    /*
+    |--------------------------------------------------------------------------
     | Application Locale Configuration
     |--------------------------------------------------------------------------
     |

--- a/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
@@ -7,6 +7,7 @@ use Illuminate\Config\Repository;
 use Illuminate\Contracts\Config\Repository as RepositoryContract;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Date;
 use SplFileInfo;
 use Symfony\Component\Finder\Finder;
 
@@ -63,6 +64,10 @@ class LoadConfiguration
         $app->resolveEnvironmentUsing($app->environment(...));
 
         date_default_timezone_set($config->get('app.timezone', 'UTC'));
+
+        $overflow = (bool) $config->get('app.datetime_overflow', true);
+        Date::useMonthsOverflow($overflow);
+        Date::useYearsOverflow($overflow);
 
         mb_internal_encoding('UTF-8');
     }


### PR DESCRIPTION
I saw a tweet recently from [Ash Allen](https://github.com/ash-jc-allen) pointing out that most developers don't know Carbon has month/year overflow behaviour (`useMonthsOverflow()` / `useYearsOverflow()`), enabled by default. 

Currently the only way to change it is calling `Date::useMonthsOverflow()` / `useYearsOverflow()` yourself in a service provider, which I have done for years in my apps.

This adds an `app.datetime_overflow` config option, wired up in `LoadConfiguration`. Defaults to `true`, matching Carbon's own default, so it's not a breaking change.

cf. https://github.com/briannesbitt/Carbon/pull/710
