### PR TITLE
[13.x] Fix PHP extensions in sqlite workflow job

### DIFF
--- a/.github/workflows/databases.yml
+++ b/.github/workflows/databases.yml
@@ -401,7 +401,7 @@ jobs:
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: 8.3
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, sqlsrv, pdo, pdo_sqlsrv, odbc, pdo_odbc, :php-psr
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, :php-psr
           tools: composer:v2
           coverage: none
 


### PR DESCRIPTION
The `sqlite` job in `.github/workflows/databases.yml` was set up with the `sqlsrv`/`pdo_sqlsrv`/`odbc`/`pdo_odbc` PHP extensions (copied from the SQL Server job) instead of `sqlite`/`pdo_sqlite`.