### PR TITLE
[13.x] Use new Stringable(...) instead of Str::of()/str() internally

### DIFF
--- a/src/Illuminate/Console/QuestionHelper.php
+++ b/src/Illuminate/Console/QuestionHelper.php
@@ -77,7 +77,7 @@ class QuestionHelper extends SymfonyQuestionHelper
      */
     protected function ensureEndsWithPunctuation($string)
     {
-        if (! (new Stringable($string))->endsWith(['?', ':', '!', '.'])) {
+        if ((new Stringable($string))->doesntEndWith(['?', ':', '!', '.'])) {
             return "$string:";
         }
 

--- a/src/Illuminate/Console/View/Components/Mutators/EnsurePunctuation.php
+++ b/src/Illuminate/Console/View/Components/Mutators/EnsurePunctuation.php
@@ -14,7 +14,7 @@ class EnsurePunctuation
      */
     public function __invoke($string)
     {
-        if (! (new Stringable($string))->endsWith(['.', '?', '!', ':'])) {
+        if ((new Stringable($string))->doesntEndWith(['.', '?', '!', ':'])) {
             return "$string.";
         }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -24,6 +24,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\LazyCollection;
 use Illuminate\Support\Str;
+use Illuminate\Support\Stringable;
 use Illuminate\Support\Traits\ForwardsCalls;
 use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
@@ -503,7 +504,7 @@ class Builder implements BuilderContract
         $this->ensureConnectionSupportsVectors();
 
         if (is_string($vector)) {
-            $vector = Str::of($vector)->toEmbeddings(cache: true);
+            $vector = (new Stringable($vector))->toEmbeddings(cache: true);
         }
 
         $this->addBinding(
@@ -1222,7 +1223,7 @@ class Builder implements BuilderContract
     public function whereVectorSimilarTo($column, $vector, $minSimilarity = 0.6, $order = true)
     {
         if (is_string($vector)) {
-            $vector = Str::of($vector)->toEmbeddings(cache: true);
+            $vector = (new Stringable($vector))->toEmbeddings(cache: true);
         }
 
         $this->whereVectorDistanceLessThan($column, $vector, 1 - $minSimilarity);
@@ -1250,7 +1251,7 @@ class Builder implements BuilderContract
         $this->ensureConnectionSupportsVectors();
 
         if (is_string($vector)) {
-            $vector = Str::of($vector)->toEmbeddings(cache: true);
+            $vector = (new Stringable($vector))->toEmbeddings(cache: true);
         }
 
         return $this->whereRaw(
@@ -3047,7 +3048,7 @@ class Builder implements BuilderContract
         $this->ensureConnectionSupportsVectors();
 
         if (is_string($vector)) {
-            $vector = Str::of($vector)->toEmbeddings(cache: true);
+            $vector = (new Stringable($vector))->toEmbeddings(cache: true);
         }
 
         $this->addBinding(

--- a/src/Illuminate/Foundation/Cloud/Queue.php
+++ b/src/Illuminate/Foundation/Cloud/Queue.php
@@ -9,7 +9,7 @@ use Illuminate\Foundation\Application;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
-use Illuminate\Support\Str;
+use Illuminate\Support\Stringable;
 use Illuminate\Support\Traits\ForwardsCalls;
 use Symfony\Component\Console\Input\ArgvInput;
 
@@ -517,7 +517,7 @@ class Queue implements QueueContract, ClearableQueue
         $prefix = $this->config['connection']['prefix'] ?? null;
         $suffix = $this->config['connection']['suffix'] ?? null;
 
-        return Str::of($this->queue->getQueue($queue))
+        return (new Stringable($this->queue->getQueue($queue)))
             ->when($prefix, fn ($str) => $str->chopStart($prefix.'/'))
             ->when($suffix, fn ($str) => $str->endsWith('.fifo')
                 ? $str->chopEnd('.fifo')->chopEnd($suffix)->append('.fifo')

--- a/src/Illuminate/Foundation/Console/AboutCommand.php
+++ b/src/Illuminate/Foundation/Console/AboutCommand.php
@@ -173,7 +173,7 @@ class AboutCommand extends Command
             'Composer Version' => $this->composer->getVersion() ?? '<fg=yellow;options=bold>-</>',
             'Environment' => $this->laravel->environment(),
             'Debug Mode' => static::format(config('app.debug'), console: $formatEnabledStatus),
-            'URL' => Str::of(config('app.url'))->replace(['http://', 'https://'], ''),
+            'URL' => (new Stringable(config('app.url')))->replace(['http://', 'https://'], ''),
             'Maintenance Mode' => static::format($this->laravel->isDownForMaintenance(), console: $formatEnabledStatus),
             'Timezone' => config('app.timezone'),
             'Locale' => config('app.locale'),

--- a/src/Illuminate/Foundation/Console/DevListCommand.php
+++ b/src/Illuminate/Foundation/Console/DevListCommand.php
@@ -5,6 +5,7 @@ namespace Illuminate\Foundation\Console;
 use Illuminate\Console\Command;
 use Illuminate\Foundation\DevCommand;
 use Illuminate\Foundation\DevCommands;
+use Illuminate\Support\Stringable;
 use Laravel\Prompts\Prompt;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;
@@ -80,7 +81,7 @@ class DevListCommand extends Command
                     $columns - mb_strwidth($label) - mb_strwidth($command) - mb_strwidth($dots) - $spaceBuffer
                 );
 
-                $source = str($source)->limit($availableSourceWidth - 1, '…')->toString();
+                $source = (new Stringable($source))->limit($availableSourceWidth - 1, '…')->value();
             }
 
             $this->line(

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -6,6 +6,7 @@ use Illuminate\Console\Concerns\CreatesMatchingTest;
 use Illuminate\Console\GeneratorCommand;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use Illuminate\Support\Stringable;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -262,7 +263,7 @@ class ModelMakeCommand extends GeneratorCommand
         $replacements = [];
 
         if ($this->option('factory') || $this->option('all')) {
-            $modelPath = Str::of($this->argument('name'))->studly()->replace('/', '\\')->toString();
+            $modelPath = (new Stringable($this->argument('name')))->studly()->replace('/', '\\')->toString();
 
             $factoryNamespace = '\\Database\\Factories\\'.$modelPath.'Factory';
 

--- a/src/Illuminate/Foundation/Console/ViewMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewMakeCommand.php
@@ -116,7 +116,7 @@ class ViewMakeCommand extends GeneratorCommand
     protected function getTestPath()
     {
         return base_path(
-            Str::of($this->testClassFullyQualifiedName())
+            (new Stringable($this->testClassFullyQualifiedName()))
                 ->replace('\\', '/')
                 ->replaceFirst('Tests/Feature', 'tests/Feature')
                 ->append('Test.php')
@@ -157,7 +157,7 @@ class ViewMakeCommand extends GeneratorCommand
      */
     protected function testNamespace()
     {
-        return Str::of($this->testClassFullyQualifiedName())
+        return (new Stringable($this->testClassFullyQualifiedName()))
             ->beforeLast('\\')
             ->value();
     }
@@ -169,7 +169,7 @@ class ViewMakeCommand extends GeneratorCommand
      */
     protected function testClassName()
     {
-        return Str::of($this->testClassFullyQualifiedName())
+        return (new Stringable($this->testClassFullyQualifiedName()))
             ->afterLast('\\')
             ->append('Test')
             ->value();
@@ -182,15 +182,15 @@ class ViewMakeCommand extends GeneratorCommand
      */
     protected function testClassFullyQualifiedName()
     {
-        $name = Str::of(Str::lower($this->getNameInput()))->replace('.'.$this->option('extension'), '');
+        $name = (new Stringable(Str::lower($this->getNameInput())))->replace('.'.$this->option('extension'), '');
 
-        $namespacedName = Str::of(
+        $namespacedName = (new Stringable(
             (new Stringable($name))
                 ->replace('/', ' ')
                 ->explode(' ')
                 ->map(fn ($part) => (new Stringable($part))->ucfirst())
                 ->implode('\\')
-        )
+        ))
             ->replace(['-', '_'], ' ')
             ->explode(' ')
             ->map(fn ($part) => (new Stringable($part))->ucfirst())
@@ -220,7 +220,7 @@ class ViewMakeCommand extends GeneratorCommand
      */
     protected function testViewName()
     {
-        return Str::of($this->getNameInput())
+        return (new Stringable($this->getNameInput()))
             ->replace('/', '.')
             ->lower()
             ->value();

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -32,7 +32,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Lottery;
 use Illuminate\Support\Reflector;
-use Illuminate\Support\Str;
+use Illuminate\Support\Stringable;
 use Illuminate\Support\Traits\ReflectsClosures;
 use Illuminate\Support\ViewErrorBag;
 use Illuminate\Validation\ValidationException;
@@ -1145,7 +1145,7 @@ class Handler implements ExceptionHandlerContract
     public function renderForConsole($output, Throwable $e)
     {
         if ($e instanceof CommandNotFoundException) {
-            $message = Str::of($e->getMessage())->explode('.')->first();
+            $message = (new Stringable($e->getMessage()))->explode('.')->first();
 
             if (! empty($alternatives = $e->getAlternatives())) {
                 $message .= '. Did you mean one of these?';

--- a/src/Illuminate/Http/Resources/JsonApi/Concerns/ResolvesJsonApiElements.php
+++ b/src/Illuminate/Http/Resources/JsonApi/Concerns/ResolvesJsonApiElements.php
@@ -19,6 +19,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\LazyCollection;
 use Illuminate\Support\Str;
+use Illuminate\Support\Stringable;
 use JsonSerializable;
 use WeakMap;
 
@@ -112,7 +113,7 @@ trait ResolvesJsonApiElements
         }
 
         if (static::class !== JsonApiResource::class) {
-            return Str::of(static::class)->classBasename()->basename('Resource')->snake()->pluralStudly();
+            return (new Stringable(static::class))->classBasename()->basename('Resource')->snake()->pluralStudly();
         }
 
         if (! $this->resource instanceof Model) {
@@ -123,9 +124,9 @@ trait ResolvesJsonApiElements
 
         $morphMap = Relation::getMorphAlias($modelClassName);
 
-        return Str::of(
+        return (new Stringable(
             $morphMap !== $modelClassName ? $morphMap : class_basename($modelClassName)
-        )->snake()->pluralStudly();
+        ))->snake()->pluralStudly();
     }
 
     /**

--- a/src/Illuminate/Mail/Mailables/Headers.php
+++ b/src/Illuminate/Mail/Mailables/Headers.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Mail\Mailables;
 
 use Illuminate\Support\Collection;
-use Illuminate\Support\Str;
+use Illuminate\Support\Stringable;
 use Illuminate\Support\Traits\Conditionable;
 
 class Headers
@@ -94,7 +94,7 @@ class Headers
     public function referencesString(): string
     {
         return (new Collection($this->references))
-            ->map(fn ($messageId) => Str::of($messageId)->start('<')->finish('>')->value())
+            ->map(fn ($messageId) => (new Stringable($messageId))->start('<')->finish('>')->value())
             ->implode(' ');
     }
 }

--- a/src/Illuminate/Mail/Transport/LogTransport.php
+++ b/src/Illuminate/Mail/Transport/LogTransport.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Mail\Transport;
 
-use Illuminate\Support\Str;
+use Illuminate\Support\Stringable as SupportStringable;
 use Psr\Log\LoggerInterface;
 use Stringable;
 use Symfony\Component\Mailer\Envelope;
@@ -34,7 +34,7 @@ class LogTransport implements Stringable, TransportInterface
      */
     public function send(RawMessage $message, ?Envelope $envelope = null): ?SentMessage
     {
-        $string = Str::of($message->toString());
+        $string = new SupportStringable($message->toString());
 
         if ($string->contains('Content-Type: multipart/')) {
             $boundary = $string

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -523,12 +523,13 @@ abstract class ServiceProvider
      */
     protected function getProviderKey(?string $key = null): string
     {
-        $key ??= (string) Str::of(get_class($this))
+        $key ??= (new Stringable(get_class($this)))
             ->classBasename()
             ->before('ServiceProvider')
             ->kebab()
             ->lower()
-            ->trim();
+            ->trim()
+            ->value();
 
         if (empty($key)) {
             $key = class_basename(get_class($this));

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -470,14 +470,14 @@ class Str
 
         $start = ltrim($matches[1]);
 
-        $start = Str::of(mb_substr($start, max(mb_strlen($start, 'UTF-8') - $radius, 0), $radius, 'UTF-8'))->ltrim()->unless(
+        $start = (new Stringable(mb_substr($start, max(mb_strlen($start, 'UTF-8') - $radius, 0), $radius, 'UTF-8')))->ltrim()->unless(
             fn ($startWithRadius) => $startWithRadius->exactly($start),
             fn ($startWithRadius) => $startWithRadius->prepend($omission),
         );
 
         $end = rtrim($matches[3]);
 
-        $end = Str::of(mb_substr($end, 0, $radius, 'UTF-8'))->rtrim()->unless(
+        $end = (new Stringable(mb_substr($end, 0, $radius, 'UTF-8')))->rtrim()->unless(
             fn ($endWithRadius) => $endWithRadius->exactly($end),
             fn ($endWithRadius) => $endWithRadius->append($omission),
         );

--- a/src/Illuminate/Support/Traits/InteractsWithData.php
+++ b/src/Illuminate/Support/Traits/InteractsWithData.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Number;
-use Illuminate\Support\Str;
+use Illuminate\Support\Stringable;
 use stdClass;
 
 use function Illuminate\Support\enum_value;
@@ -261,7 +261,7 @@ trait InteractsWithData
      */
     public function string($key, $default = null)
     {
-        return Str::of($this->data($key, $default));
+        return new Stringable($this->data($key, $default));
     }
 
     /**

--- a/src/Illuminate/Support/Uri.php
+++ b/src/Illuminate/Support/Uri.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Routing\UrlRoutable;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Stringable as SupportStringable;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Dumpable;
 use Illuminate\Support\Traits\Macroable;
@@ -357,7 +358,7 @@ class Uri implements Htmlable, JsonSerializable, Responsable, Stringable
      */
     public function toStringable()
     {
-        return Str::of($this->value());
+        return new SupportStringable($this->value());
     }
 
     /**

--- a/src/Illuminate/View/Engines/CompilerEngine.php
+++ b/src/Illuminate/View/Engines/CompilerEngine.php
@@ -6,7 +6,7 @@ use Illuminate\Database\RecordNotFoundException;
 use Illuminate\Database\RecordsNotFoundException;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Http\Exceptions\HttpResponseException;
-use Illuminate\Support\Str;
+use Illuminate\Support\Stringable;
 use Illuminate\View\Compilers\CompilerInterface;
 use Illuminate\View\ViewException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -75,7 +75,7 @@ class CompilerEngine extends PhpEngine
         try {
             $results = $this->evaluatePath($this->compiler->getCompiledPath($path), $data);
         } catch (ViewException $e) {
-            if (! Str::of($e->getMessage())->contains(['No such file or directory', 'File does not exist at path'])) {
+            if ((new Stringable($e->getMessage()))->doesntContain(['No such file or directory', 'File does not exist at path'])) {
                 throw $e;
             }
 


### PR DESCRIPTION
Replaces internal `Str::of()`/`str()` calls with `new Stringable(...)` across the framework source.