### PR TITLE
[13.x] Fix Factory::recycle ignoring additional arguments when the first argument is a collection

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -775,8 +775,7 @@ abstract class Factory
             'recycle' => $this->recycle
                 ->flatten()
                 ->merge(
-                    Collection::wrap($model instanceof Model ? func_get_args() : $model)
-                        ->flatten()
+                    Collection::wrap(func_get_args())->flatten()
                 )->groupBy(fn ($model) => get_class($model)),
         ]);
     }

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -951,6 +951,25 @@ class DatabaseEloquentFactoryTest extends TestCase
         $this->assertSame(3, FactoryTestPost::count());
     }
 
+    public function test_recycle_accepts_mixed_collection_and_models()
+    {
+        Factory::guessFactoryNamesUsing(function ($model) {
+            return $model.'Factory';
+        });
+
+        $users = FactoryTestUserFactory::new()->count(3)->create();
+        $posts = FactoryTestPostFactory::new()->count(2)->create();
+
+        $comments = FactoryTestCommentFactory::new()
+            ->count(10)
+            ->recycle($users, $posts)
+            ->create();
+
+        $this->assertTrue(
+            $comments->every(fn ($comment) => $posts->contains('id', $comment->commentable_id))
+        );
+    }
+
     public function test_no_models_can_be_provided_to_recycle()
     {
         Factory::guessFactoryNamesUsing(function ($model) {


### PR DESCRIPTION
### Summary

When the first argument passed to `Factory::recycle()` is a `Collection` (or array), any subsequent arguments are silently ignored.

This PR updates `recycle()` to process all provided arguments consistently, allowing `Model`, `Collection`, and arrays to be mixed.

### Changes

- Process all variadic arguments passed to `recycle()`
- Add a regression test covering mixed `Collection` and `Model` arguments