### PR TITLE
[13.x] Enable additional Rector rules

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -27,6 +27,7 @@ use Rector\Php80\Rector\Ternary\GetDebugTypeRector;
 use Rector\Php81\Rector\Array_\ArrayToFirstClassCallableRector;
 use Rector\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector;
 use Rector\Php81\Rector\Property\ReadOnlyPropertyRector;
+use Rector\Php83\Rector\ClassConst\AddTypeToConstRector;
 use Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector;
 use Rector\Php83\Rector\FuncCall\DynamicClassConstFetchRector;
 use Rector\Php84\Rector\Class_\DeprecatedAnnotationToDeprecatedAttributeRector;
@@ -71,6 +72,7 @@ return RectorConfig::configure()
     ->withSkip([
         ...$skipPHPUnitSetList,
         AddOverrideAttributeToOverriddenMethodsRector::class,
+        AddTypeToConstRector::class,
         ArrayToFirstClassCallableRector::class,
         ArrowFunctionDelegatingCallToFirstClassCallableRector::class,
         BinaryOpBetweenNumberAndStringRector::class,

--- a/rector.php
+++ b/rector.php
@@ -7,14 +7,11 @@ use Rector\CodeQuality\Rector\FuncCall\SortCallLikeNamedArgsRector;
 use Rector\CodeQuality\Rector\Identical\StrlenZeroToIdenticalEmptyStringRector;
 use Rector\CodingStyle\Rector\ArrowFunction\ArrowFunctionDelegatingCallToFirstClassCallableRector;
 use Rector\CodingStyle\Rector\Closure\ClosureDelegatingCallToFirstClassCallableRector;
-use Rector\CodingStyle\Rector\FuncCall\ClosureFromCallableToFirstClassCallableRector;
 use Rector\CodingStyle\Rector\FuncCall\CountArrayToEmptyArrayComparisonRector;
 use Rector\CodingStyle\Rector\FuncCall\FunctionFirstClassCallableRector;
 use Rector\Config\RectorConfig;
 use Rector\Php55\Rector\Class_\ClassConstantToSelfClassRector;
-use Rector\Php55\Rector\ClassConstFetch\StaticToSelfOnFinalClassRector;
 use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
-use Rector\Php56\Rector\FuncCall\PowToExpRector;
 use Rector\Php70\Rector\FuncCall\RandomFunctionRector;
 use Rector\Php70\Rector\MethodCall\ThisCallOnStaticMethodToStaticCallRector;
 use Rector\Php70\Rector\Ternary\TernaryToNullCoalescingRector;
@@ -30,50 +27,35 @@ use Rector\Php80\Rector\Ternary\GetDebugTypeRector;
 use Rector\Php81\Rector\Array_\ArrayToFirstClassCallableRector;
 use Rector\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector;
 use Rector\Php81\Rector\Property\ReadOnlyPropertyRector;
-use Rector\Php82\Rector\Class_\ReadOnlyClassRector;
-use Rector\Php83\Rector\ClassConst\AddTypeToConstRector;
 use Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector;
 use Rector\Php83\Rector\FuncCall\DynamicClassConstFetchRector;
 use Rector\Php84\Rector\Class_\DeprecatedAnnotationToDeprecatedAttributeRector;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\NarrowUnusedSetUpDefinedPropertyRector;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\YieldDataProviderRector;
-use Rector\PHPUnit\CodeQuality\Rector\ClassMethod\AddInstanceofAssertForNullableArgumentRector;
 use Rector\PHPUnit\CodeQuality\Rector\ClassMethod\AddInstanceofAssertForNullableInstanceRector;
-use Rector\PHPUnit\CodeQuality\Rector\ClassMethod\DataProviderArrayItemsNewLinedRector;
 use Rector\PHPUnit\CodeQuality\Rector\ClassMethod\NoSetupWithParentCallOverrideRector;
-use Rector\PHPUnit\CodeQuality\Rector\Expression\AssertArrayCastedObjectToAssertSameRector;
-use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertCompareOnCountableWithMethodToAssertCountRector;
 use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertComparisonToSpecificMethodRector;
 use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertEmptyNullableObjectToAssertInstanceofRector;
 use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertEqualsOrAssertSameFloatParameterToSpecificMethodsTypeRector;
 use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertEqualsToSameRector;
 use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertIssetToSpecificMethodRector;
-use Rector\PHPUnit\CodeQuality\Rector\MethodCall\ScalarArgumentToExpectedParamTypeRector;
 use Rector\PHPUnit\CodeQuality\Rector\MethodCall\StringCastAssertStringContainsStringRector;
 use Rector\PHPUnit\CodeQuality\Rector\StmtsAwareInterface\DeclareStrictTypesTestsRector;
-use Rector\PHPUnit\PHPUnit120\Rector\CallLike\CreateStubOverCreateMockArgRector;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\Privatization\Rector\Class_\FinalizeTestCaseClassRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnNeverTypeRector;
 
 $skipPHPUnitSetList = [
-    AddInstanceofAssertForNullableArgumentRector::class,
     AddInstanceofAssertForNullableInstanceRector::class,
-    AssertArrayCastedObjectToAssertSameRector::class,
-    AssertCompareOnCountableWithMethodToAssertCountRector::class,
     AssertComparisonToSpecificMethodRector::class,
     AssertEmptyNullableObjectToAssertInstanceofRector::class,
     AssertEqualsOrAssertSameFloatParameterToSpecificMethodsTypeRector::class,
     AssertEqualsToSameRector::class,
     AssertIssetToSpecificMethodRector::class,
-    CreateStubOverCreateMockArgRector::class,
-    DataProviderArrayItemsNewLinedRector::class,
     DeclareStrictTypesTestsRector::class,
     FinalizeTestCaseClassRector::class,
     NarrowUnusedSetUpDefinedPropertyRector::class,
     NoSetupWithParentCallOverrideRector::class,
-    ScalarArgumentToExpectedParamTypeRector::class,
-    StaticToSelfOnFinalClassRector::class,
     StringCastAssertStringContainsStringRector::class,
     YieldDataProviderRector::class,
 ];
@@ -89,7 +71,6 @@ return RectorConfig::configure()
     ->withSkip([
         ...$skipPHPUnitSetList,
         AddOverrideAttributeToOverriddenMethodsRector::class,
-        AddTypeToConstRector::class,
         ArrayToFirstClassCallableRector::class,
         ArrowFunctionDelegatingCallToFirstClassCallableRector::class,
         BinaryOpBetweenNumberAndStringRector::class,
@@ -99,16 +80,13 @@ return RectorConfig::configure()
         ClassOnThisVariableObjectRector::class,
         ClassPropertyAssignToConstructorPromotionRector::class,
         ClosureDelegatingCallToFirstClassCallableRector::class,
-        ClosureFromCallableToFirstClassCallableRector::class,
         ClosureToArrowFunctionRector::class,
         DeprecatedAnnotationToDeprecatedAttributeRector::class,
         DynamicClassConstFetchRector::class,
         FunctionFirstClassCallableRector::class,
         GetDebugTypeRector::class,
         NullToStrictStringFuncCallArgRector::class,
-        PowToExpRector::class,
         RandomFunctionRector::class,
-        ReadOnlyClassRector::class,
         ReadOnlyPropertyRector::class,
         RemoveExtraParametersRector::class,
         ReturnNeverTypeRector::class,

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -302,7 +302,7 @@ class Number
 
         $numberExponent = floor(log10($number));
         $displayExponent = max(0, $numberExponent - ($numberExponent % 3));
-        $number /= pow(10, $displayExponent);
+        $number /= 10 ** $displayExponent;
 
         $formatted = static::format($number, $precision, $maxPrecision);
 

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -749,7 +749,7 @@ class BusBatchTest extends TestCase
         $factory->shouldReceive('make')
             ->withSomeOfArgs($batch, '', '', '', '', '', '', $options);
 
-        $batch->find(1);
+        $batch->find('1');
     }
 
     /**

--- a/tests/Cache/RateLimiterTest.php
+++ b/tests/Cache/RateLimiterTest.php
@@ -28,7 +28,7 @@ class RateLimiterTest extends TestCase
     {
         $reflectedLimitersProperty = new ReflectionProperty(RateLimiter::class, 'limiters');
 
-        $rateLimiter = new RateLimiter($this->createMock(Cache::class));
+        $rateLimiter = new RateLimiter($this->createStub(Cache::class));
         $rateLimiter->for($name, fn () => Limit::perMinute(100));
 
         $limiters = $reflectedLimitersProperty->getValue($rateLimiter);

--- a/tests/Container/AfterResolvingAttributeCallbackTest.php
+++ b/tests/Container/AfterResolvingAttributeCallbackTest.php
@@ -75,10 +75,10 @@ class AfterResolvingAttributeCallbackTest extends TestCase
 }
 
 #[Attribute(Attribute::TARGET_PARAMETER)]
-final class ContainerTestOnTenant
+final readonly class ContainerTestOnTenant
 {
     public function __construct(
-        public readonly Tenant $tenant
+        public Tenant $tenant
     ) {
     }
 }
@@ -99,29 +99,29 @@ final class HasTenantImpl
     }
 }
 
-final class ContainerTestHasTenantImplPropertyWithTenantA
+final readonly class ContainerTestHasTenantImplPropertyWithTenantA
 {
     public function __construct(
         #[ContainerTestOnTenant(Tenant::TenantA)]
-        public readonly HasTenantImpl $property
+        public HasTenantImpl $property
     ) {
     }
 }
 
-final class ContainerTestHasTenantImplPropertyWithTenantB
+final readonly class ContainerTestHasTenantImplPropertyWithTenantB
 {
     public function __construct(
         #[ContainerTestOnTenant(Tenant::TenantB)]
-        public readonly HasTenantImpl $property
+        public HasTenantImpl $property
     ) {
     }
 }
 
 #[Attribute(Attribute::TARGET_CLASS)]
-final class ContainerTestConfiguresClass
+final readonly class ContainerTestConfiguresClass
 {
     public function __construct(
-        public readonly string $value
+        public string $value
     ) {
     }
 }

--- a/tests/Container/ContextualAttributeBindingTest.php
+++ b/tests/Container/ContextualAttributeBindingTest.php
@@ -459,29 +459,29 @@ final class ContainerTestImplB implements ContainerTestContract
 {
 }
 
-final class ContainerTestHasAttributeThatResolvesToImplA
+final readonly class ContainerTestHasAttributeThatResolvesToImplA
 {
     public function __construct(
         #[ContainerTestAttributeThatResolvesContractImpl('A')]
-        public readonly ContainerTestContract $property
+        public ContainerTestContract $property
     ) {
     }
 }
 
-final class ContainerTestHasAttributeThatResolvesToImplB
+final readonly class ContainerTestHasAttributeThatResolvesToImplB
 {
     public function __construct(
         #[ContainerTestAttributeThatResolvesContractImpl('B')]
-        public readonly ContainerTestContract $property
+        public ContainerTestContract $property
     ) {
     }
 }
 
 #[Attribute(Attribute::TARGET_PARAMETER)]
-final class ContainerTestConfigValue implements ContextualAttribute
+final readonly class ContainerTestConfigValue implements ContextualAttribute
 {
     public function __construct(
-        public readonly string $key
+        public string $key
     ) {
     }
 }
@@ -496,10 +496,10 @@ final class ContainerTestHasConfigValueProperty
 }
 
 #[Attribute(Attribute::TARGET_PARAMETER)]
-final class ContainerTestConfigValueWithResolve implements ContextualAttribute
+final readonly class ContainerTestConfigValueWithResolve implements ContextualAttribute
 {
     public function __construct(
-        public readonly string $key
+        public string $key
     ) {
     }
 
@@ -561,7 +561,7 @@ final class ComplexDependency implements ContainerTestContract
     }
 }
 
-final class AuthedTest
+final readonly class AuthedTest
 {
     public function __construct(
         #[Authenticated('foo')] AuthenticatableContract $foo,
@@ -572,7 +572,7 @@ final class AuthedTest
     }
 }
 
-final class CacheTest
+final readonly class CacheTest
 {
     public function __construct(
         #[Cache('foo')] CacheRepository $foo,
@@ -585,35 +585,35 @@ final class CacheTest
     }
 }
 
-final class ConfigTest
+final readonly class ConfigTest
 {
     public function __construct(#[Config('foo')] string $foo, #[Config('bar')] string $bar)
     {
     }
 }
 
-final class ContextTest
+final readonly class ContextTest
 {
     public function __construct(#[Context('foo')] string $foo)
     {
     }
 }
 
-final class ContextHiddenTest
+final readonly class ContextHiddenTest
 {
     public function __construct(#[Context('bar', hidden: true)] string $foo)
     {
     }
 }
 
-final class DatabaseTest
+final readonly class DatabaseTest
 {
     public function __construct(#[Database('foo')] Connection $foo, #[Database('bar')] Connection $bar)
     {
     }
 }
 
-final class GuardTest
+final readonly class GuardTest
 {
     public function __construct(
         #[Auth('foo')] GuardContract $foo,
@@ -624,28 +624,28 @@ final class GuardTest
     }
 }
 
-final class LogTest
+final readonly class LogTest
 {
     public function __construct(#[Log('foo')] LoggerInterface $foo, #[Log('bar')] LoggerInterface $bar)
     {
     }
 }
 
-final class RouteParameterTest
+final readonly class RouteParameterTest
 {
     public function __construct(#[RouteParameter('foo')] Model $foo, #[RouteParameter('bar')] string $bar)
     {
     }
 }
 
-final class RouteParameterTestWithoutParameterName
+final readonly class RouteParameterTestWithoutParameterName
 {
     public function __construct(#[RouteParameter] Model $foo, #[RouteParameter] string $bar)
     {
     }
 }
 
-final class StorageTest
+final readonly class StorageTest
 {
     public function __construct(
         #[Storage('foo')] Filesystem $foo,
@@ -656,46 +656,46 @@ final class StorageTest
     }
 }
 
-final class GiveTestSimple
+final readonly class GiveTestSimple
 {
     public function __construct(
         #[Give(SimpleDependency::class)]
-        public readonly ContainerTestContract $dependency
+        public ContainerTestContract $dependency
     ) {
     }
 }
 
-final class GiveTestComplex
+final readonly class GiveTestComplex
 {
     public function __construct(
         #[Give(ComplexDependency::class, ['param' => true])]
-        public readonly ContainerTestContract $dependency
+        public ContainerTestContract $dependency
     ) {
     }
 }
 
-final class TimezoneObject
+final readonly class TimezoneObject
 {
     public function __construct(
-        #[Config('app.timezone')] public readonly ?string $timezone
-    ) {
-        //
-    }
-}
-
-final class LocaleObject
-{
-    public function __construct(
-        #[Config('app.locale')] public readonly ?string $locale
+        #[Config('app.timezone')] public ?string $timezone
     ) {
         //
     }
 }
 
-final class HasParameterAwareAttribute
+final readonly class LocaleObject
 {
     public function __construct(
-        #[ContainerTestParameterAwareAttribute] public readonly ?string $name,
+        #[Config('app.locale')] public ?string $locale
+    ) {
+        //
+    }
+}
+
+final readonly class HasParameterAwareAttribute
+{
+    public function __construct(
+        #[ContainerTestParameterAwareAttribute] public ?string $name,
     ) {
         //
     }

--- a/tests/Database/DatabaseEloquentBelongsToManyWithDefaultAttributesTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyWithDefaultAttributesTest.php
@@ -54,6 +54,16 @@ class DatabaseEloquentBelongsToManyWithDefaultAttributesTest extends TestCase
         $builder->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock(stdClass::class));
         $mockQueryBuilder->shouldReceive('getGrammar')->andReturn(m::mock(Grammar::class, ['isExpression' => false]));
 
-        return [$builder, $parent, 'club_user', 'club_id', 'user_id', 'id', 'id', null, false];
+        return [
+            $builder,
+            $parent,
+            'club_user',
+            'club_id',
+            'user_id',
+            'id',
+            'id',
+            null,
+            false,
+        ];
     }
 }

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -1104,9 +1104,9 @@ class DatabaseEloquentFactoryTest extends TestCase
             ->insert();
         $this->assertCount(5, $posts = FactoryTestPost::query()->where('title', 'hello')->get());
         $this->assertEquals(strtoupper($posts[0]->user->name), $posts[0]->upper_case_name);
-        $this->assertEquals(
+        $this->assertCount(
             2,
-            ($users = FactoryTestUser::query()->get())->count()
+            $users = FactoryTestUser::query()->get()
         );
         $this->assertCount(1, $users->where('name', 'totwell'));
         $this->assertCount(1, $users->where('name', 'shaedrich'));

--- a/tests/Database/DatabaseEloquentMorphToManyTest.php
+++ b/tests/Database/DatabaseEloquentMorphToManyTest.php
@@ -132,7 +132,18 @@ class DatabaseEloquentMorphToManyTest extends TestCase
             m::mock(stdClass::class, ['getGrammar' => $grammar])
         );
 
-        return [$builder, $parent, 'taggable', 'taggables', 'taggable_id', 'tag_id', 'id', 'id', 'relation_name', false];
+        return [
+            $builder,
+            $parent,
+            'taggable',
+            'taggables',
+            'taggable_id',
+            'tag_id',
+            'id',
+            'id',
+            'relation_name',
+            false,
+        ];
     }
 }
 

--- a/tests/Integration/Cache/RedisStoreTest.php
+++ b/tests/Integration/Cache/RedisStoreTest.php
@@ -114,7 +114,7 @@ class RedisStoreTest extends TestCase
         Cache::store('redis')->tags(['people', 'author'])->flush();
 
         $keyCount = Cache::store('redis')->connection()->keys('*');
-        $this->assertEquals(0, count($keyCount));
+        $this->assertCount(0, $keyCount);
     }
 
     public function testTagEntriesCanBeStoredForever()
@@ -130,7 +130,7 @@ class RedisStoreTest extends TestCase
         Cache::store('redis')->tags(['people', 'author'])->flush();
 
         $keyCount = Cache::store('redis')->connection()->keys('*');
-        $this->assertEquals(0, count($keyCount));
+        $this->assertCount(0, $keyCount);
     }
 
     public function testTagEntriesCanBeIncremented()
@@ -176,7 +176,7 @@ class RedisStoreTest extends TestCase
         Cache::store('redis')->tags(['votes'])->flushStale();
 
         $keyCount = Cache::store('redis')->connection()->keys('*');
-        $this->assertEquals(0, count($keyCount));
+        $this->assertCount(0, $keyCount);
     }
 
     public function testPastTtlTagEntriesAreNotAdded()
@@ -189,7 +189,7 @@ class RedisStoreTest extends TestCase
         $this->assertNull($value);
 
         $keyCount = Cache::store('redis')->connection()->keys('*');
-        $this->assertEquals(0, count($keyCount));
+        $this->assertCount(0, $keyCount);
     }
 
     public function testPutPastTtlTagEntriesProperlyTurnStale()
@@ -200,7 +200,7 @@ class RedisStoreTest extends TestCase
         Cache::store('redis')->tags(['votes'])->flushStale();
 
         $keyCount = Cache::store('redis')->connection()->keys('*');
-        $this->assertEquals(0, count($keyCount));
+        $this->assertCount(0, $keyCount);
     }
 
     public function testTagsCanBeFlushedBySingleKey()
@@ -216,7 +216,7 @@ class RedisStoreTest extends TestCase
         $this->assertNull(Cache::store('redis')->tags(['people', 'artist'])->get('person-2'));
 
         $keyCount = Cache::store('redis')->connection()->keys('*');
-        $this->assertEquals(3, count($keyCount)); // Sets for people, authors, and actual entry for Sally
+        $this->assertCount(3, $keyCount); // Sets for people, authors, and actual entry for Sally
     }
 
     public function testStaleEntriesCanBeFlushed()
@@ -234,7 +234,7 @@ class RedisStoreTest extends TestCase
         Cache::store('redis')->tags(['people'])->flushStale();
 
         $keyCount = Cache::store('redis')->connection()->keys('*');
-        $this->assertEquals(4, count($keyCount)); // Sets for people, authors, and artists + individual entry for Jennifer
+        $this->assertCount(4, $keyCount); // Sets for people, authors, and artists + individual entry for Jennifer
     }
 
     public function testMultipleItemsCanBeSetAndRetrieved()

--- a/tests/Integration/Console/JobSchedulingTest.php
+++ b/tests/Integration/Console/JobSchedulingTest.php
@@ -60,25 +60,25 @@ class JobSchedulingTest extends TestCase
             $event->run($this->app);
         }
 
-        $this->assertSame(1, Queue::pushed(JobWithDefaultConnection::class, function (JobWithDefaultConnection $job, $pushedQueue) {
+        $this->assertCount(1, Queue::pushed(JobWithDefaultConnection::class, function (JobWithDefaultConnection $job, $pushedQueue) {
             return $job->connection === 'test-connection';
-        })->count());
+        }));
 
-        $this->assertSame(1, Queue::pushed(JobWithDefaultConnection::class, function (JobWithDefaultConnection $job, $pushedQueue) {
+        $this->assertCount(1, Queue::pushed(JobWithDefaultConnection::class, function (JobWithDefaultConnection $job, $pushedQueue) {
             return $job->connection === 'foo';
-        })->count());
+        }));
 
-        $this->assertSame(0, Queue::pushed(JobWithDefaultConnection::class, function (JobWithDefaultConnection $job, $pushedQueue) {
+        $this->assertCount(0, Queue::pushed(JobWithDefaultConnection::class, function (JobWithDefaultConnection $job, $pushedQueue) {
             return $job->connection === null;
-        })->count());
+        }));
 
-        $this->assertSame(1, Queue::pushed(JobWithoutDefaultConnection::class, function (JobWithoutDefaultConnection $job, $pushedQueue) {
+        $this->assertCount(1, Queue::pushed(JobWithoutDefaultConnection::class, function (JobWithoutDefaultConnection $job, $pushedQueue) {
             return $job->connection === null;
-        })->count());
+        }));
 
-        $this->assertSame(1, Queue::pushed(JobWithoutDefaultConnection::class, function (JobWithoutDefaultConnection $job, $pushedQueue) {
+        $this->assertCount(1, Queue::pushed(JobWithoutDefaultConnection::class, function (JobWithoutDefaultConnection $job, $pushedQueue) {
             return $job->connection === 'bar';
-        })->count());
+        }));
     }
 
     public function testJobQueuingRespectsQueueRoutes(): void

--- a/tests/Integration/Database/EloquentCursorPaginateTest.php
+++ b/tests/Integration/Database/EloquentCursorPaginateTest.php
@@ -67,7 +67,7 @@ class EloquentCursorPaginateTest extends DatabaseTestCase
 
         $query = TestPost::query()->distinct();
 
-        $this->assertEquals(6, $query->get()->count());
+        $this->assertCount(6, $query->get());
         $this->assertEquals(6, $query->count());
         $this->assertCount(6, $query->cursorPaginate()->items());
     }
@@ -82,7 +82,7 @@ class EloquentCursorPaginateTest extends DatabaseTestCase
 
         $query = TestPost::query()->whereNull('user_id');
 
-        $this->assertEquals(3, $query->get()->count());
+        $this->assertCount(3, $query->get());
         $this->assertEquals(3, $query->count());
         $this->assertCount(3, $query->cursorPaginate()->items());
     }
@@ -100,7 +100,7 @@ class EloquentCursorPaginateTest extends DatabaseTestCase
 
         $query = TestUser::query()->has('posts');
 
-        $this->assertEquals(2, $query->get()->count());
+        $this->assertCount(2, $query->get());
         $this->assertEquals(2, $query->count());
         $this->assertCount(2, $query->cursorPaginate()->items());
     }
@@ -119,7 +119,7 @@ class EloquentCursorPaginateTest extends DatabaseTestCase
             $query->where('title', 'Howdy');
         });
 
-        $this->assertEquals(1, $query->get()->count());
+        $this->assertCount(1, $query->get());
         $this->assertEquals(1, $query->count());
         $this->assertCount(1, $query->cursorPaginate()->items());
     }
@@ -140,7 +140,7 @@ class EloquentCursorPaginateTest extends DatabaseTestCase
                 ->whereColumn('test_posts.user_id', 'test_users.id');
         });
 
-        $this->assertEquals(2, $query->get()->count());
+        $this->assertCount(2, $query->get());
         $this->assertEquals(2, $query->count());
         $this->assertCount(2, $query->cursorPaginate()->items());
     }
@@ -243,7 +243,7 @@ class EloquentCursorPaginateTest extends DatabaseTestCase
         $clonedQuery = $query->clone();
         $anotherQuery = $query->clone();
 
-        $this->assertEquals(6, $query->get()->count());
+        $this->assertCount(6, $query->get());
         $this->assertEquals(6, $query->count());
         $this->assertCount(6, $query->cursorPaginate()->items());
         $this->assertCount(3, $clonedQuery->cursorPaginate(3)->items());
@@ -264,7 +264,7 @@ class EloquentCursorPaginateTest extends DatabaseTestCase
 
         $query = TestPost::query()->orderBy('title')->distinct('title')->select('title');
 
-        $this->assertEquals(2, $query->get()->count());
+        $this->assertCount(2, $query->get());
         $this->assertEquals(2, $query->count());
         $this->assertCount(2, $query->cursorPaginate()->items());
     }
@@ -288,7 +288,7 @@ class EloquentCursorPaginateTest extends DatabaseTestCase
         $query = TestUser::query()->join('test_posts', 'test_posts.user_id', '=', 'test_users.id')
             ->distinct('test_users.id')->select('test_users.*');
 
-        $this->assertEquals(5, $query->get()->count());
+        $this->assertCount(5, $query->get());
         $this->assertEquals(5, $query->count());
         $this->assertCount(5, $query->cursorPaginate()->items());
     }

--- a/tests/Integration/Database/EloquentPaginateTest.php
+++ b/tests/Integration/Database/EloquentPaginateTest.php
@@ -43,7 +43,7 @@ class EloquentPaginateTest extends DatabaseTestCase
 
         $query = Post::query()->distinct();
 
-        $this->assertEquals(6, $query->get()->count());
+        $this->assertCount(6, $query->get());
         $this->assertEquals(6, $query->count());
         $this->assertEquals(6, $query->paginate()->total());
     }
@@ -58,7 +58,7 @@ class EloquentPaginateTest extends DatabaseTestCase
 
         $query = Post::query()->distinct()->select('title');
 
-        $this->assertEquals(2, $query->get()->count());
+        $this->assertCount(2, $query->get());
         $this->assertEquals(6, $query->count());
         $this->assertEquals(6, $query->paginate()->total());
     }
@@ -72,7 +72,7 @@ class EloquentPaginateTest extends DatabaseTestCase
 
         $query = Post::query()->distinct('title')->select('title');
 
-        $this->assertEquals(2, $query->get()->count());
+        $this->assertCount(2, $query->get());
         $this->assertEquals(2, $query->count());
         $this->assertEquals(2, $query->paginate()->total());
     }
@@ -92,7 +92,7 @@ class EloquentPaginateTest extends DatabaseTestCase
         $query = User::query()->join('posts', 'posts.user_id', '=', 'users.id')
             ->distinct('users.id')->select('users.*');
 
-        $this->assertEquals(5, $query->get()->count());
+        $this->assertCount(5, $query->get());
         $this->assertEquals(5, $query->count());
         $this->assertEquals(5, $query->paginate()->total());
     }

--- a/tests/Integration/Database/EloquentWhereHasTest.php
+++ b/tests/Integration/Database/EloquentWhereHasTest.php
@@ -143,7 +143,10 @@ class EloquentWhereHasTest extends DatabaseTestCase
                 $builder->selectRaw('id')->where('public', $value);
             };
 
-            return [$callbackEloquent, $callbackQuery];
+            return [
+                $callbackEloquent,
+                $callbackQuery,
+            ];
         };
 
         return [

--- a/tests/Integration/Support/Fixtures/MultipleInstanceManager.php
+++ b/tests/Integration/Support/Fixtures/MultipleInstanceManager.php
@@ -73,28 +73,23 @@ class MultipleInstanceManager extends BaseMultipleInstanceManager
      */
     public function getInstanceConfig($name)
     {
-        switch ($name) {
-            case 'foo':
-                return [
-                    'driver' => 'foo',
-                    'foo-option' => 'option-value',
-                ];
-            case 'bar':
-                return [
-                    'driver' => 'bar',
-                    'bar-option' => 'option-value',
-                ];
-            case 'mysql_database-connection':
-                return [
-                    'driver' => 'mysql_database-connection',
-                    'mysql_database-connection-option' => 'option-value',
-                ];
-            case 'custom':
-                return [
-                    'driver' => 'custom',
-                ];
-            default:
-                return [];
-        }
+        return match ($name) {
+            'foo' => [
+                'driver' => 'foo',
+                'foo-option' => 'option-value',
+            ],
+            'bar' => [
+                'driver' => 'bar',
+                'bar-option' => 'option-value',
+            ],
+            'mysql_database-connection' => [
+                'driver' => 'mysql_database-connection',
+                'mysql_database-connection-option' => 'option-value',
+            ],
+            'custom' => [
+                'driver' => 'custom',
+            ],
+            default => [],
+        };
     }
 }

--- a/tests/Mail/MailManagerTest.php
+++ b/tests/Mail/MailManagerTest.php
@@ -192,7 +192,9 @@ class MailManagerTest extends TestCase
     public static function emptyTransportConfigDataProvider()
     {
         return [
-            [null], [''], [' '],
+            [null],
+            [''],
+            [' '],
         ];
     }
 }

--- a/tests/Mail/MailableAlternativeSyntaxTest.php
+++ b/tests/Mail/MailableAlternativeSyntaxTest.php
@@ -35,9 +35,9 @@ class MailableAlternativeSyntaxTest extends TestCase
 
         $this->assertSame('test-view', $mailable->view);
         $this->assertEquals(['test-data-key' => 'test-data-value'], $mailable->viewData);
-        $this->assertEquals(2, count($mailable->to));
-        $this->assertEquals(1, count($mailable->cc));
-        $this->assertEquals(1, count($mailable->bcc));
+        $this->assertCount(2, $mailable->to);
+        $this->assertCount(1, $mailable->cc);
+        $this->assertCount(1, $mailable->bcc);
     }
 
     public function testEnvelopesCanReceiveAdditionalRecipients(): void

--- a/tests/Queue/FileFailedJobProviderTest.php
+++ b/tests/Queue/FileFailedJobProviderTest.php
@@ -218,6 +218,9 @@ class FileFailedJobProviderTest extends TestCase
 
         $this->provider->log($connection, $queue, json_encode(['uuid' => (string) $uuid]), $exception);
 
-        return [(string) $uuid, $exception];
+        return [
+            (string) $uuid,
+            $exception,
+        ];
     }
 }

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -2727,10 +2727,10 @@ class ExampleMiddleware implements ExampleMiddlewareContract
 }
 
 #[Attribute(Attribute::TARGET_PARAMETER)]
-final class RoutingTestOnTenant
+final readonly class RoutingTestOnTenant
 {
     public function __construct(
-        public readonly RoutingTestTenant $tenant
+        public RoutingTestTenant $tenant
     ) {
     }
 }

--- a/tests/Support/SupportUriTest.php
+++ b/tests/Support/SupportUriTest.php
@@ -280,15 +280,15 @@ class SupportUriTest extends TestCase
 
         $uri = Uri::of('https://laravel.com/one/two/three?foo=bar');
 
-        $this->assertEquals(3, $uri->pathSegments()->count());
+        $this->assertCount(3, $uri->pathSegments());
 
         $uri = Uri::of('https://laravel.com/one/two/three/?foo=bar');
 
-        $this->assertEquals(3, $uri->pathSegments()->count());
+        $this->assertCount(3, $uri->pathSegments());
 
         $uri = Uri::of('https://laravel.com/one/two/three/#foo=bar');
 
-        $this->assertEquals(3, $uri->pathSegments()->count());
+        $this->assertCount(3, $uri->pathSegments());
     }
 
     public function test_macroable()

--- a/tests/Validation/ValidationEmailRuleTest.php
+++ b/tests/Validation/ValidationEmailRuleTest.php
@@ -17,8 +17,8 @@ use PHPUnit\Framework\TestCase;
 
 class ValidationEmailRuleTest extends TestCase
 {
-    private const string ATTRIBUTE = 'my_email';
-    private const string ATTRIBUTE_REPLACED = 'my email';
+    private const ATTRIBUTE = 'my_email';
+    private const ATTRIBUTE_REPLACED = 'my email';
 
     public function testBasic()
     {

--- a/tests/Validation/ValidationEmailRuleTest.php
+++ b/tests/Validation/ValidationEmailRuleTest.php
@@ -17,8 +17,8 @@ use PHPUnit\Framework\TestCase;
 
 class ValidationEmailRuleTest extends TestCase
 {
-    private const ATTRIBUTE = 'my_email';
-    private const ATTRIBUTE_REPLACED = 'my email';
+    private const string ATTRIBUTE = 'my_email';
+    private const string ATTRIBUTE_REPLACED = 'my email';
 
     public function testBasic()
     {

--- a/tests/Validation/ValidationPasswordRuleTest.php
+++ b/tests/Validation/ValidationPasswordRuleTest.php
@@ -57,6 +57,7 @@ class ValidationPasswordRuleTest extends TestCase
         $rule = (new Password(8))->when($is_privileged_user, function ($rule) {
             $rule->symbols();
         });
+        $this->assertInstanceOf(Password::class, $rule);
 
         $this->fails($rule, ['aaaaaaaa', '11111111'], [
             'validation.password.symbols',
@@ -66,6 +67,7 @@ class ValidationPasswordRuleTest extends TestCase
         $rule = (new Password(8))->when($is_privileged_user, function ($rule) {
             $rule->symbols();
         });
+        $this->assertInstanceOf(Password::class, $rule);
 
         $this->passes($rule, ['aaaaaaaa', '11111111']);
     }
@@ -458,7 +460,7 @@ class ValidationPasswordRuleTest extends TestCase
         $v = \Illuminate\Support\Facades\Validator::make(
             [],
             [
-                'password' => [\Illuminate\Validation\Rules\Password::required()],
+                'password' => [Password::required()],
             ]
         );
 


### PR DESCRIPTION
Enables the following previously-skipped Rector rules and applies their changes:

- `ClassOnThisVariableObjectRector` (5)
- `StaticToSelfOnFinalClassRector` (2)
- `DataProviderArrayItemsNewLinedRector` (2)
- `AssertCompareOnCountableWithMethodToAssertCountRector` (2)
- `ClosureFromCallableToFirstClassCallableRector` (1)
- `PowToExpRector` (1)
- `CreateStubOverCreateMockArgRector` (1)
- `ScalarArgumentToExpectedParamTypeRector` (1)
- `AssertArrayCastedObjectToAssertSameRector` (1)
- `AddInstanceofAssertForNullableArgumentRector` (1)
- `ReadOnlyClassRector` (1)