### PR TITLE
[13.x] Add brightness adjustment support to Illuminate Image

### DIFF
--- a/src/Illuminate/Image/Drivers/InterventionDriver.php
+++ b/src/Illuminate/Image/Drivers/InterventionDriver.php
@@ -8,6 +8,7 @@ use Illuminate\Image\ImageException;
 use Illuminate\Image\ImageOutputOptions;
 use Illuminate\Image\ImagePipeline;
 use Illuminate\Image\Transformations\Blur;
+use Illuminate\Image\Transformations\Brightness;
 use Illuminate\Image\Transformations\Contain;
 use Illuminate\Image\Transformations\Cover;
 use Illuminate\Image\Transformations\Crop;
@@ -100,6 +101,7 @@ abstract class InterventionDriver implements Driver
                 $transformation instanceof Rotate => $image->rotate($transformation->angle, $transformation->background),
                 $transformation instanceof Scale => $image->scaleDown($transformation->width, $transformation->height),
                 $transformation instanceof Blur => $image->blur($transformation->amount),
+                $transformation instanceof Brightness => $image->brightness($transformation->amount),
                 $transformation instanceof Grayscale => $image->grayscale(),
                 $transformation instanceof Sharpen => $image->sharpen($transformation->amount),
                 $transformation instanceof FlipVertically => $image->flip(Direction::VERTICAL),

--- a/src/Illuminate/Image/Image.php
+++ b/src/Illuminate/Image/Image.php
@@ -10,6 +10,7 @@ use Illuminate\Contracts\Image\Driver;
 use Illuminate\Contracts\Image\Transformation;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Image\Transformations\Blur;
+use Illuminate\Image\Transformations\Brightness;
 use Illuminate\Image\Transformations\Contain;
 use Illuminate\Image\Transformations\Cover;
 use Illuminate\Image\Transformations\Crop;
@@ -144,6 +145,16 @@ class Image implements Stringable
     public function orient(): static
     {
         return $this->transform(new Orient);
+    }
+
+    /**
+     * Adjust the image brightness.
+     *
+     * @param  int<-100, 100>  $amount
+     */
+    public function brightness(int $amount = 10): static
+    {
+        return $this->transform(new Brightness(max(-100, min(100, $amount))));
     }
 
     /**

--- a/src/Illuminate/Image/Transformations/Brightness.php
+++ b/src/Illuminate/Image/Transformations/Brightness.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Illuminate\Image\Transformations;
+
+use Illuminate\Contracts\Image\Transformation;
+
+class Brightness implements Transformation
+{
+    public function __construct(
+        public readonly int $amount
+    ) {
+        //
+    }
+}

--- a/tests/Image/Drivers/GdDriverTest.php
+++ b/tests/Image/Drivers/GdDriverTest.php
@@ -8,6 +8,7 @@ use Illuminate\Image\Drivers\GdDriver;
 use Illuminate\Image\ImageException;
 use Illuminate\Image\ImagePipeline;
 use Illuminate\Image\Transformations\Blur;
+use Illuminate\Image\Transformations\Brightness;
 use Illuminate\Image\Transformations\Contain;
 use Illuminate\Image\Transformations\Cover;
 use Illuminate\Image\Transformations\Crop;
@@ -305,6 +306,19 @@ class GdDriverTest extends TestCase
         $this->assertNotSame($contents, $result);
     }
 
+    public function test_processes_brightness()
+    {
+        $driver = new GdDriver;
+        $contents = $this->fakeImageContents(100, 100);
+
+        $pipeline = $this->pipeline(new Brightness(10));
+
+        $result = $driver->process($contents, $pipeline);
+
+        $this->assertNotEmpty($result);
+        $this->assertNotSame($contents, $result);
+    }
+
     public function test_processes_grayscale()
     {
         $driver = new GdDriver;
@@ -358,7 +372,8 @@ class GdDriverTest extends TestCase
     public function test_processes_custom_transformation()
     {
         $driver = new GdDriver;
-        $transformation = new class implements Transformation {
+        $transformation = new class implements Transformation
+        {
             //
         };
         $received = null;

--- a/tests/Image/Drivers/GdDriverTest.php
+++ b/tests/Image/Drivers/GdDriverTest.php
@@ -372,8 +372,7 @@ class GdDriverTest extends TestCase
     public function test_processes_custom_transformation()
     {
         $driver = new GdDriver;
-        $transformation = new class implements Transformation
-        {
+        $transformation = new class implements Transformation {
             //
         };
         $received = null;

--- a/tests/Image/Drivers/ImagickDriverTest.php
+++ b/tests/Image/Drivers/ImagickDriverTest.php
@@ -7,6 +7,7 @@ use Illuminate\Http\UploadedFile;
 use Illuminate\Image\Drivers\ImagickDriver;
 use Illuminate\Image\ImagePipeline;
 use Illuminate\Image\Transformations\Blur;
+use Illuminate\Image\Transformations\Brightness;
 use Illuminate\Image\Transformations\Contain;
 use Illuminate\Image\Transformations\Cover;
 use Illuminate\Image\Transformations\Crop;
@@ -308,6 +309,19 @@ class ImagickDriverTest extends TestCase
         $contents = $this->fakeImageContents(100, 100);
 
         $pipeline = $this->pipeline(new Blur(10));
+
+        $result = $driver->process($contents, $pipeline);
+
+        $this->assertNotEmpty($result);
+        $this->assertNotSame($contents, $result);
+    }
+
+    public function test_processes_brightness()
+    {
+        $driver = new ImagickDriver;
+        $contents = $this->fakeImageContents(100, 100);
+
+        $pipeline = $this->pipeline(new Brightness(10));
 
         $result = $driver->process($contents, $pipeline);
 

--- a/tests/Image/ImageTest.php
+++ b/tests/Image/ImageTest.php
@@ -8,6 +8,7 @@ use Illuminate\Image\ImageException;
 use Illuminate\Image\ImageOutputOptions;
 use Illuminate\Image\ImagePipeline;
 use Illuminate\Image\Transformations\Blur;
+use Illuminate\Image\Transformations\Brightness;
 use Illuminate\Image\Transformations\Contain;
 use Illuminate\Image\Transformations\Cover;
 use Illuminate\Image\Transformations\Crop;
@@ -456,6 +457,41 @@ class ImageTest extends TestCase
         $this->assertSame(10, $this->getOptions($image->sharpen())->sharpen);
     }
 
+    public function test_brightness_returns_new_instance()
+    {
+        $image = $this->makeImage();
+
+        $this->assertNotSame($image, $image->brightness());
+    }
+
+    public function test_brightness_sets_option()
+    {
+        $image = $this->makeImage();
+
+        $this->assertSame(20, $this->getOptions($image->brightness(20))->brightness);
+    }
+
+    public function test_brightness_has_default()
+    {
+        $image = $this->makeImage();
+
+        $this->assertSame(10, $this->getOptions($image->brightness())->brightness);
+    }
+
+    public function test_brightness_clamps_low_value()
+    {
+        $image = $this->makeImage();
+
+        $this->assertSame(-100, $this->getOptions($image->brightness(-200))->brightness);
+    }
+
+    public function test_brightness_clamps_high_value()
+    {
+        $image = $this->makeImage();
+
+        $this->assertSame(100, $this->getOptions($image->brightness(200))->brightness);
+    }
+
     public function test_flip_vertically_returns_new_instance()
     {
         $image = $this->makeImage();
@@ -745,6 +781,14 @@ class ImageTest extends TestCase
     {
         $pipeline = new ImagePipeline;
         $pipeline->add(new Sharpen(0));
+
+        $this->assertTrue($pipeline->hasChanges());
+    }
+
+    public function test_image_pipeline_has_changes_with_zero_brightness()
+    {
+        $pipeline = new ImagePipeline;
+        $pipeline->add(new Brightness(0));
 
         $this->assertTrue($pipeline->hasChanges());
     }
@@ -1049,6 +1093,7 @@ class ImageTest extends TestCase
             'scaleHeight' => null,
             'orient' => null,
             'blur' => null,
+            'brightness' => null,
             'grayscale' => null,
             'sharpen' => null,
             'flipVertically' => null,
@@ -1067,6 +1112,7 @@ class ImageTest extends TestCase
                 $transformation instanceof Scale => [$options->scaleWidth, $options->scaleHeight] = [$transformation->width, $transformation->height],
                 $transformation instanceof Orient => $options->orient = true,
                 $transformation instanceof Blur => $options->blur = $transformation->amount,
+                $transformation instanceof Brightness => $options->brightness = $transformation->amount,
                 $transformation instanceof Grayscale => $options->grayscale = true,
                 $transformation instanceof Sharpen => $options->sharpen = $transformation->amount,
                 $transformation instanceof FlipVertically => $options->flipVertically = true,

--- a/tests/Integration/Image/ImageTest.php
+++ b/tests/Integration/Image/ImageTest.php
@@ -121,6 +121,26 @@ class ImageTest extends TestCase
         $this->assertNotSame($contents, $result);
     }
 
+    public function test_brightness_and_to_bytes()
+    {
+        $contents = $this->fakeImageContents(100, 100);
+        $image = new Image($contents);
+
+        $result = $image->brightness(50)->toBytes();
+
+        $this->assertNotSame($contents, $result);
+    }
+
+    public function test_brightness_does_not_change_dimensions()
+    {
+        $image = new Image($this->fakeImageContents(200, 150));
+
+        $result = $image->brightness(30);
+
+        $this->assertSame(200, $result->width());
+        $this->assertSame(150, $result->height());
+    }
+
     public function test_immutability_with_variants()
     {
         $image = new Image($this->fakeImageContents(400, 400));


### PR DESCRIPTION
This PR adds a `brightness()` adjustment method to `Illuminate\Image`.

The new method follows the same pattern as the existing image adjustment helpers such as `blur()`, `grayscale()`, and `sharpen()`. It introduces a brightness transformation, wires it into the image pipeline, and maps it through the Intervention driver processing flow.
