### PR TITLE
[13.x] Use exception handler contract when configuring exceptions

### DIFF
--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -400,7 +400,7 @@ class ApplicationBuilder
 
         if ($using !== null) {
             $this->app->afterResolving(
-                \Illuminate\Foundation\Exceptions\Handler::class,
+                \Illuminate\Contracts\Debug\ExceptionHandler::class,
                 fn ($handler) => $using(new Exceptions($handler)),
             );
         }


### PR DESCRIPTION

Currently `withExceptions()` registers the exception configuration callback using `Illuminate\Foundation\Exceptions\Handler::class`.

This prevents custom exception handlers bound to `Illuminate\Contracts\Debug\ExceptionHandler` from receiving the configuration callback.

Resolve the handler through the contract instead, allowing applications to replace the exception handler implementation while keeping `withExceptions()` behavior.