### PR TITLE
[13.x] Add  InteractsWithData `plainString` method to retrieve data as a string

### DIFF
--- a/src/Illuminate/Support/Traits/InteractsWithData.php
+++ b/src/Illuminate/Support/Traits/InteractsWithData.php
@@ -269,7 +269,7 @@ trait InteractsWithData
      *
      * @param  string  $key
      * @param  mixed  $default
-     * @return string
+     * @return string|null
      */
     public function plainString($key, $default = null)
     {

--- a/src/Illuminate/Support/Traits/InteractsWithData.php
+++ b/src/Illuminate/Support/Traits/InteractsWithData.php
@@ -265,6 +265,22 @@ trait InteractsWithData
     }
 
     /**
+     * Retrieve data from the instance as a string.
+     *
+     * @param  string  $key
+     * @param  mixed  $default
+     * @return string
+     */
+    public function plainString($key, $default = null)
+    {
+        if ($this->isNotFilled($key)) {
+            return value($default);
+        }
+
+        return (string) $this->data($key);
+    }
+
+    /**
      * Retrieve data as a boolean value.
      *
      * Returns true when value is "1", "true", "on", and "yes". Otherwise, returns false.

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -683,6 +683,31 @@ class HttpRequestTest extends TestCase
         $this->assertSame('', $request->string('unknown_key')->value());
     }
 
+    public function testPlainStringMethod()
+    {
+        $request = Request::create('/', 'GET', [
+            'int' => 123,
+            'int_str' => '456',
+            'float' => 123.456,
+            'float_str' => '123.456',
+            'float_zero' => 0.000,
+            'float_str_zero' => '0.000',
+            'str' => 'abc',
+            'empty_str' => '',
+            'null' => null,
+        ]);
+        $this->assertSame('123', $request->plainString('int'));
+        $this->assertSame('456', $request->plainString('int_str'));
+        $this->assertSame('123.456', $request->plainString('float'));
+        $this->assertSame('123.456', $request->plainString('float_str'));
+        $this->assertSame('0', $request->plainString('float_zero'));
+        $this->assertSame('0.000', $request->plainString('float_str_zero'));
+        $this->assertSame(null, $request->plainString('empty_str'));
+        $this->assertSame(null, $request->plainString('null'));
+        $this->assertSame(null, $request->plainString('unknown_key'));
+        $this->assertSame('default', $request->plainString('unknown_key', 'default'));
+    }
+
     public function testBooleanMethod()
     {
         $request = Request::create('/', 'GET', ['with_trashed' => 'false', 'download' => true, 'checked' => 1, 'unchecked' => '0', 'with_on' => 'on', 'with_yes' => 'yes']);


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

I believe the `string` method in `InteractsWithData` should be returning actual PHP strings instead of a Stringable instance, while we keep `str` for that purpose because there are genuine cases where I want a nullable string, but Stringable would have already converted it to an empty string so we end up having to check for empty string or go back to using the `input` method. Still, since it has been used that way and changing the behaviour is a breaking change, it is only fair for us to have a way to retrieve typed data, just as there is for other types like integer, boolean, enums, arrays, etc.