### PR TITLE
[13.x] Fix queue name parameter in Mailer::later()

### DIFF
--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -524,8 +524,12 @@ class Mailer implements MailerContract, MailQueueContract
             throw new InvalidArgumentException('Only mailables may be queued.');
         }
 
+        if (! is_null($queue)) {
+            $view->onQueue($queue);
+        }
+
         return $view->mailer($this->name)->later(
-            $delay, is_null($queue) ? $this->queue : $queue
+            $delay, $this->queue
         );
     }
 

--- a/tests/Mail/MailableQueuedTest.php
+++ b/tests/Mail/MailableQueuedTest.php
@@ -239,6 +239,40 @@ class MailableQueuedTest extends TestCase
         $this->assertEquals($mailable->deduplicationId(...), $pushedJob->deduplicator->getClosure());
     }
 
+    public function testLaterSetsQueueOnMailable(): void
+    {
+        $queueFake = new QueueFake(new Application);
+        $mailer = $this->getMockBuilder(Mailer::class)
+            ->setConstructorArgs($this->getMocks())
+            ->onlyMethods(['createMessage', 'to'])
+            ->getMock();
+        $mailer->setQueue($queueFake);
+
+        $mailable = new MailableQueueableStub;
+        $mailer->later(60, $mailable, 'emails');
+
+        $queueFake->assertPushed(SendQueuedMailable::class, function ($job) {
+            return $job->queue === 'emails';
+        });
+    }
+
+    public function testLaterWithoutQueueUsesDefault(): void
+    {
+        $queueFake = new QueueFake(new Application);
+        $mailer = $this->getMockBuilder(Mailer::class)
+            ->setConstructorArgs($this->getMocks())
+            ->onlyMethods(['createMessage', 'to'])
+            ->getMock();
+        $mailer->setQueue($queueFake);
+
+        $mailable = new MailableQueueableStub;
+        $mailer->later(60, $mailable);
+
+        $queueFake->assertPushed(SendQueuedMailable::class, function ($job) {
+            return $job->queue === null;
+        });
+    }
+
     protected function getMocks()
     {
         return ['smtp', m::mock(Factory::class), m::mock(TransportInterface::class)];


### PR DESCRIPTION
This PR fixes `Mailer::later()` when a queue name is provided for a queued mailable.

Previously `Mailer::later($delay, $mailable, $queue)` forwarded the `queue` argument directly into `Mailable::later($delay, Queue $queue)`. When the third argument was a string queue name such as `emails` it caused a type mismatch instead of treating it as the target queue.