### PR TITLE
[13.x] Allow RateLimiter to be Macroable

### DIFF
--- a/src/Illuminate/Cache/RateLimiter.php
+++ b/src/Illuminate/Cache/RateLimiter.php
@@ -7,12 +7,13 @@ use Illuminate\Contracts\Cache\Repository as Cache;
 use Illuminate\Redis\Connections\PhpRedisConnection;
 use Illuminate\Support\Collection;
 use Illuminate\Support\InteractsWithTime;
+use Illuminate\Support\Traits\Macroable;
 
 use function Illuminate\Support\enum_value;
 
 class RateLimiter
 {
-    use InteractsWithTime;
+    use InteractsWithTime, Macroable;
 
     /**
      * The cache store implementation.

--- a/tests/Cache/RateLimiterTest.php
+++ b/tests/Cache/RateLimiterTest.php
@@ -66,6 +66,15 @@ class RateLimiterTest extends TestCase
         $this->assertNotSame($limiterForUser1[0]->key, $limiterForUser2[0]->key);
         $this->assertNotSame($limiterForUser1[1]->key, $limiterForUser2[1]->key);
     }
+
+    public function testMacroable(): void
+    {
+        RateLimiter::macro('foo', fn () => 'bar');
+
+        $rateLimiter = new RateLimiter($this->createStub(Cache::class));
+
+        $this->assertSame('bar', $rateLimiter->foo());
+    }
 }
 
 enum BackedEnumNamedRateLimiter: string


### PR DESCRIPTION
I see many blocks of rate limiters that look like the below: 
 
```php
RateLimiter::for('foo', fn (Request $request) => Limit::perMinute(5)->by($request->ip()));
RateLimiter::for('bar', fn (Request $request) => Limit::perMinute(60)->by($request->user()?->id ?: $request->ip()));
RateLimiter::for('baz', fn (Request $request) => Limit::perSecond(1)->by($request->user()?->id ?: $request->ip()));
RateLimiter::for('qux', fn (SendQueuedJob $job) => Limit::perMinutes(10, 1)->by($job->model->id));
RateLimiter::for('quux', fn (SendQueuedJob $job) => Limit::perDay(1)->by($job->model->id));
// there is so many more
  ``` 
I want to make it nicer for us locally, so...  this PR allows us to use the macro method so I can make a method that accepts an array.

I figured this PR is easier than making `for` accept an array, as that opens a can of worms for all the other facades etc. 

Thanks!!