### PR TITLE
Fix timezone conversion for stepped cron expressions

### DIFF
--- a/src/Illuminate/Console/Scheduling/CronExpressionTimezoneConverter.php
+++ b/src/Illuminate/Console/Scheduling/CronExpressionTimezoneConverter.php
@@ -125,13 +125,19 @@ class CronExpressionTimezoneConverter
      */
     protected static function shiftAndGroup($field, $offset, $mod, $min = 0)
     {
-        if ($offset === 0 || ! preg_match('/^[\d,]+$/', $field)) {
+        if ($offset === 0) {
+            return [0 => $field];
+        }
+
+        $values = static::expandField($field, $mod, $min);
+
+        if ($values === null) {
             return [0 => $field];
         }
 
         $groups = [];
 
-        foreach (explode(',', $field) as $value) {
+        foreach ($values as $value) {
             $new = (int) $value + $offset;
             $carry = 0;
 
@@ -151,6 +157,35 @@ class CronExpressionTimezoneConverter
 
             return implode(',', $values);
         })->all();
+    }
+
+    /**
+     * Expand a cron field containing stepped values.
+     *
+     * @param  string  $field
+     * @param  int  $mod
+     * @param  int  $min
+     * @return array<int>|null
+     */
+    protected static function expandField($field, $mod, $min = 0)
+    {
+        if (preg_match('/^[\d,]+$/', $field)) {
+            return array_map('intval', explode(',', $field));
+        }
+
+        if (! preg_match('/^(?<start>\*|\d+)(?:-(?<end>\d+))?\/(?<step>\d+)$/', $field, $matches)) {
+            return null;
+        }
+
+        $start = $matches['start'] === '*' ? $min : (int) $matches['start'];
+        $end = $matches['end'] !== '' ? (int) $matches['end'] : $mod + $min - 1;
+        $step = (int) $matches['step'];
+
+        if ($step === 0 || $start < $min || $end >= $mod + $min || $start > $end) {
+            return null;
+        }
+
+        return range($start, $end, $step);
     }
 
     /**

--- a/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
@@ -256,13 +256,15 @@ class ScheduleListCommandTest extends TestCase
             // No conversion needed — same timezone
             'same timezone' => ['0 8 * * *', 'UTC', null, ['0 8 * * *']],
 
-            // Wildcards/steps — pass through unchanged
+            // Wildcards and unsupported ranges — pass through unchanged
             'every minute' => ['* * * * *', 'America/New_York', null, ['* * * * *']],
             'every five minutes' => ['*/5 * * * *', 'Asia/Tokyo', null, ['*/5 * * * *']],
-            'every two hours' => ['0 */2 * * *', 'Asia/Tokyo', null, ['0 */2 * * *']],
-            'every odd hour' => ['0 1-23/2 * * *', 'Asia/Tokyo', null, ['0 1-23/2 * * *']],
             'quarterly step month' => ['0 0 1 1-12/3 *', 'Asia/Tokyo', null, ['0 15 31 1-12/3 *']],
             'weekdays range' => ['0 8 * * 1-5', 'Asia/Tokyo', null, ['0 23 * * 1-5']],
+
+            // Stepped hours
+            'every two hours' => ['0 */2 * * *', 'Asia/Tokyo', null, ['0 15,17,19,21,23 * * *', '0 1,3,5,7,9,11,13 * * *']],
+            'every odd hour' => ['0 1-23/2 * * *', 'Asia/Tokyo', null, ['0 16,18,20,22 * * *', '0 0,2,4,6,8,10,12,14 * * *']],
 
             // Simple hour shift (no day boundary)
             'daily LA to UTC' => ['0 8 * * *', 'America/Los_Angeles', null, ['0 16 * * *']],
@@ -341,6 +343,25 @@ class ScheduleListCommandTest extends TestCase
         foreach ($expectedExpressions as $index => $expected) {
             $this->assertSame($expected, $data[$index]['expression']);
         }
+    }
+
+    public function testExpressionTimezoneConversionHandlesSteppedHours()
+    {
+        Carbon::setTestNow('2023-07-01');
+
+        $this->schedule->command('inspire')->everyFourHours()->timezone('Europe/London');
+
+        $this->withoutMockingConsoleOutput()->artisan(ScheduleListCommand::class, [
+            '--timezone' => 'UTC',
+            '--json' => true,
+        ]);
+
+        $data = json_decode(Artisan::output(), true);
+
+        $this->assertSame([
+            '0 23 * * *',
+            '0 3,7,11,15,19 * * *',
+        ], array_column($data, 'expression'));
     }
 
     public function testDisplayScheduleCliSplitsExpressionWhenMixedCarry()


### PR DESCRIPTION
## Summary

- Expand stepped cron hour fields before applying timezone offsets.
- Preserve the existing carry-aware grouping when converted values cross midnight.
- Add coverage for `everyFourHours()` during British Summer Time and update the existing stepped-hour cases.

## Background

`schedule:list` currently passes stepped fields such as `*/4` and `1-23/2` through timezone conversion unchanged. This changes the real execution times when the event timezone differs from the display timezone.

For example, `0 */4 * * *` in `Europe/London` during British Summer Time should be represented in UTC as:

```text
0 23 * * *
0 3,7,11,15,19 * * *
```

Instead, it is currently returned as `0 */4 * * *`. Consumers of the JSON schedule can therefore invoke the scheduler at the wrong UTC hours, after which Laravel's timezone-aware due check rejects the event.

This change expands supported numeric step syntax into explicit values before passing those values through the converter's existing offset and carry logic. Plain numeric fields retain their current behavior, while unsupported cron syntax continues to pass through unchanged.

## Tests

- `vendor/bin/phpunit tests/Integration/Console/Scheduling/ScheduleListCommandTest.php`
- `vendor/bin/pint src/Illuminate/Console/Scheduling/CronExpressionTimezoneConverter.php tests/Integration/Console/Scheduling/ScheduleListCommandTest.php`
