### PR TITLE
[13.x] Add timeout minutes to workflows

### DIFF
--- a/.github/workflows/databases-nightly.yml
+++ b/.github/workflows/databases-nightly.yml
@@ -10,6 +10,7 @@ permissions:
 jobs:
   mysql_9:
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
 
     services:
       mysql:
@@ -42,6 +43,7 @@ jobs:
   mariadb:
     runs-on: ubuntu-24.04
     continue-on-error: true
+    timeout-minutes: 10
 
     services:
       mariadb:

--- a/.github/workflows/facades.yml
+++ b/.github/workflows/facades.yml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   update:
     runs-on: ubuntu-24.04
+    timeout-minutes: 5
 
     name: Facade DocBlocks
 

--- a/.github/workflows/install-nightly.yml
+++ b/.github/workflows/install-nightly.yml
@@ -15,6 +15,7 @@ jobs:
         os: [ubuntu-24.04, windows-2022]
 
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
 
     steps:
       - name: Setup PHP

--- a/.github/workflows/queues.yml
+++ b/.github/workflows/queues.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   sync:
     runs-on: ubuntu-24.04
-    timeout-minutes: 5
+    timeout-minutes: 10
 
     name: Sync Driver
 
@@ -35,7 +35,7 @@ jobs:
 
   database:
     runs-on: ubuntu-24.04
-    timeout-minutes: 5
+    timeout-minutes: 10
 
     name: Database Driver
 

--- a/.github/workflows/queues.yml
+++ b/.github/workflows/queues.yml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   sync:
     runs-on: ubuntu-24.04
+    timeout-minutes: 5
 
     name: Sync Driver
 
@@ -34,6 +35,7 @@ jobs:
 
   database:
     runs-on: ubuntu-24.04
+    timeout-minutes: 5
 
     name: Database Driver
 
@@ -59,6 +61,7 @@ jobs:
 
   beanstalkd:
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
 
     strategy:
       fail-fast: true

--- a/.github/workflows/redis.yml
+++ b/.github/workflows/redis.yml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   redis:
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
 
     services:
       redis:
@@ -55,6 +56,7 @@ jobs:
 
   redis-cluster:
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
 
     strategy:
       fail-fast: true

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
 
     name: Release ${{ inputs.version }}
 
@@ -131,6 +132,7 @@ jobs:
 
   update-changelog:
     needs: release
+    timeout-minutes: 10
 
     name: Update changelog
 

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   types:
     runs-on: ubuntu-24.04
+    timeout-minutes: 5
 
     strategy:
       fail-fast: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,7 @@ permissions:
 jobs:
   linux_tests:
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
 
     services:
       memcached:
@@ -87,6 +88,7 @@ jobs:
 
   windows_tests:
     runs-on: windows-2022
+    timeout-minutes: 10
 
     strategy:
       fail-fast: true

--- a/.github/workflows/update-assets.yml
+++ b/.github/workflows/update-assets.yml
@@ -19,6 +19,7 @@ permissions:
 jobs:
   update:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     steps:
       - name: Checkout Code


### PR DESCRIPTION
Noticed : https://github.com/laravel/framework/actions/runs/30023021536/job/89260339134  action had ran for 6 hrs

So, this PR adds some sensible timeout defaults to any workflows that didn't have a timeout set.  

I've gone through each and made sure it's more than needed- but they wont run away for hours and hours.

So if it does get stuck, it'll timeout rather than run for 6 hrs. Faster feedback loop? I guess is the right term.

Flying to Boston tomorrow, so I'll see you on the flip side 🫡 

