### PR TITLE
[13.x] Add multi-queue support to queue:clear command

### DIFF
--- a/src/Illuminate/Queue/Console/ClearCommand.php
+++ b/src/Illuminate/Queue/Console/ClearCommand.php
@@ -7,6 +7,7 @@ use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Console\Prohibitable;
 use Illuminate\Contracts\Queue\ClearableQueue;
 use Illuminate\Support\Str;
+use Illuminate\Support\Stringable;
 use ReflectionClass;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
@@ -29,7 +30,7 @@ class ClearCommand extends Command
      *
      * @var string
      */
-    protected $description = 'Delete all of the jobs from the specified queue';
+    protected $description = 'Delete all of the jobs from the specified queues';
 
     /**
      * Execute the console command.
@@ -38,8 +39,10 @@ class ClearCommand extends Command
      */
     public function handle()
     {
-        if ($this->isProhibited() ||
-            ! $this->confirmToProceed()) {
+        if (
+            $this->isProhibited() ||
+            ! $this->confirmToProceed()
+        ) {
             return 1;
         }
 
@@ -53,15 +56,28 @@ class ClearCommand extends Command
 
         $queue = $this->laravel['queue']->connection($connection);
 
-        if ($queue instanceof ClearableQueue) {
-            $count = $queue->clear($queueName);
-
-            $this->components->info('Cleared '.$count.' '.Str::plural('job', $count).' from the ['.$queueName.'] queue');
-        } else {
+        if (! $queue instanceof ClearableQueue) {
             $this->components->error('Clearing queues is not supported on ['.(new ReflectionClass($queue))->getShortName().']');
 
             return 1;
         }
+
+        $count = 0;
+
+        $queues = collect(explode(',', $queueName))
+            ->map(fn ($queue) => trim($queue))
+            ->filter()
+            ->unique()
+            ->values()
+            ->all();
+
+        foreach ($queues as $name) {
+            $count += $queue->clear($name);
+        }
+
+        $this->components->info(
+            sprintf('Cleared %s %s from the [%s] %s', $count, Str::plural('job', $count), implode(', ', $queues), (new Stringable('queue'))->plural($queues))
+        );
 
         return 0;
     }
@@ -75,7 +91,8 @@ class ClearCommand extends Command
     protected function getQueue($connection)
     {
         return $this->option('queue') ?: $this->laravel['config']->get(
-            "queue.connections.{$connection}.queue", 'default'
+            "queue.connections.{$connection}.queue",
+            'default'
         );
     }
 
@@ -99,7 +116,7 @@ class ClearCommand extends Command
     protected function getOptions()
     {
         return [
-            ['queue', null, InputOption::VALUE_OPTIONAL, 'The name of the queue to clear'],
+            ['queue', null, InputOption::VALUE_OPTIONAL, 'The names of the queues to clear'],
 
             ['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production'],
         ];

--- a/src/Illuminate/Queue/Console/ClearCommand.php
+++ b/src/Illuminate/Queue/Console/ClearCommand.php
@@ -43,7 +43,7 @@ class ClearCommand extends Command
             $this->isProhibited() ||
             ! $this->confirmToProceed()
         ) {
-            return 1;
+            return self::FAILURE;
         }
 
         $connection = $this->argument('connection')
@@ -59,7 +59,7 @@ class ClearCommand extends Command
         if (! $queue instanceof ClearableQueue) {
             $this->components->error('Clearing queues is not supported on ['.(new ReflectionClass($queue))->getShortName().']');
 
-            return 1;
+            return self::FAILURE;
         }
 
         $count = 0;
@@ -79,7 +79,7 @@ class ClearCommand extends Command
             sprintf('Cleared %s %s from the [%s] %s', $count, Str::plural('job', $count), implode(', ', $queues), (new Stringable('queue'))->plural($queues))
         );
 
-        return 0;
+        return self::SUCCESS;
     }
 
     /**

--- a/tests/Queue/QueueClearCommandTest.php
+++ b/tests/Queue/QueueClearCommandTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Illuminate\Tests\Queue;
+
+use Illuminate\Contracts\Config\Repository;
+use Illuminate\Contracts\Queue\ClearableQueue;
+use Illuminate\Foundation\Application;
+use Illuminate\Queue\Console\ClearCommand;
+use Illuminate\Queue\QueueManager;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class QueueClearCommandTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+
+        parent::tearDown();
+    }
+
+    public function testClearingDefaultQueue()
+    {
+        $queue = m::mock(ClearableQueue::class);
+        $queue->shouldReceive('clear')->with('default')->once()->andReturn(2);
+
+        $output = $this->runClearCommand($queue);
+
+        $this->assertStringContainsString('Cleared 2 jobs from the [default] queue', $output);
+    }
+
+    public function testClearingMultipleQueues()
+    {
+        $queue = m::mock(ClearableQueue::class);
+        $queue->shouldReceive('clear')->with('high')->once()->andReturn(3);
+        $queue->shouldReceive('clear')->with('low')->once()->andReturn(0);
+        $queue->shouldReceive('clear')->with('emails')->once()->andReturn(1);
+
+        $output = $this->runClearCommand($queue, ['--queue' => 'high,low,emails']);
+
+        $this->assertStringContainsString('Cleared 4 jobs from the [high, low, emails] queues', $output);
+    }
+
+    public function testClearingMultipleQueuesWithWhitespace()
+    {
+        $queue = m::mock(ClearableQueue::class);
+        $queue->shouldReceive('clear')->with('high')->once()->andReturn(3);
+        $queue->shouldReceive('clear')->with('low')->once()->andReturn(0);
+
+        $output = $this->runClearCommand($queue, ['--queue' => 'high, low']);
+
+        $this->assertStringContainsString('Cleared 3 jobs from the [high, low] queues', $output);
+    }
+
+    public function testClearingMultipleQueuesWithEmptyValues()
+    {
+        $queue = m::mock(ClearableQueue::class);
+        $queue->shouldReceive('clear')->with('high')->once()->andReturn(3);
+        $queue->shouldReceive('clear')->with('low')->once()->andReturn(0);
+
+        $output = $this->runClearCommand($queue, ['--queue' => 'high,,low']);
+
+        $this->assertStringContainsString('Cleared 3 jobs from the [high, low] queues', $output);
+    }
+
+    public function testClearingMultipleQueuesWithDuplicates()
+    {
+        $queue = m::mock(ClearableQueue::class);
+        $queue->shouldReceive('clear')->with('high')->once()->andReturn(3);
+        $queue->shouldReceive('clear')->with('low')->once()->andReturn(0);
+
+        $output = $this->runClearCommand($queue, ['--queue' => 'high,low,high']);
+
+        $this->assertStringContainsString('Cleared 3 jobs from the [high, low] queues', $output);
+    }
+
+    protected function runClearCommand($queue, array $arguments = []): string
+    {
+        $container = new Application;
+        $container['env'] = 'testing';
+
+        $config = m::mock(Repository::class, \ArrayAccess::class);
+        $config->shouldReceive('offsetGet')->with('queue.default')->andReturn('redis');
+        $config->shouldReceive('get')->with('queue.connections.redis.queue', 'default')->andReturn('default');
+
+        $container['config'] = $config;
+
+        $queueManager = m::mock(QueueManager::class);
+        $queueManager->shouldReceive('connection')->with('redis')->andReturn($queue);
+
+        $container['queue'] = $queueManager;
+
+        $command = new ClearCommand;
+        $command->setLaravel($container);
+
+        $output = new BufferedOutput();
+        $command->run(new ArrayInput($arguments), $output);
+
+        return $output->fetch();
+    }
+}


### PR DESCRIPTION
### Description
This PR adds support for comma-separated queue names to the `queue:clear` Artisan command, making it consistent with other queue commands such as `queue:work` and `queue:listen`.

Currently, `queue:clear` only accepts a single queue name via `--queue`. With this change, developers can clear multiple queues in a single execution:

```bash
php artisan queue:clear redis --queue=high,low,emails

```

### Changes

* Updated `Illuminate\Queue\Console\ClearCommand` to parse, trim, filter empty values, and deduplicate comma-separated queue names using the Collection pipeline.
* Maintained output formatting consistency using standard Laravel `Stringable` helpers.
* Created unit test suite in `tests/Queue/QueueClearCommandTest.php` covering:
* Default single queue execution.
* Multiple comma-separated queues.
* Whitespace trimming (`--queue="high, low"`).
* Empty value filtering (`--queue="high,,low"`).
* Queue deduplication (`--queue="high,low,high"`).



### Backward Compatibility

Fully backward-compatible. Passing a single queue name behaves exactly as before.