### PR TITLE
[13.x] Add support for Vite's chunk import map

### DIFF
--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -56,6 +56,13 @@ class Vite implements Htmlable
     protected $manifestFilename = 'manifest.json';
 
     /**
+     * The name of the import map file.
+     *
+     * @var string
+     */
+    protected $importMapFilename = 'importmap.json';
+
+    /**
      * The custom asset path resolver.
      *
      * @var callable|null
@@ -96,6 +103,13 @@ class Vite implements Htmlable
      * @var array
      */
     protected static $manifests = [];
+
+    /**
+     * The cached import map files.
+     *
+     * @var array
+     */
+    protected static $importMaps = [];
 
     /**
      * The ViteFonts instance.
@@ -212,6 +226,19 @@ class Vite implements Htmlable
     public function useManifestFilename($filename)
     {
         $this->manifestFilename = $filename;
+
+        return $this;
+    }
+
+    /**
+     * Set the filename for the import map file.
+     *
+     * @param  string  $filename
+     * @return $this
+     */
+    public function useImportMapFilename($filename)
+    {
+        $this->importMapFilename = $filename;
 
         return $this;
     }
@@ -470,6 +497,13 @@ class Vite implements Htmlable
             ->map(fn ($args) => $this->makePreloadTagForChunk(...$args));
 
         $base = $preloads->join('').$stylesheets->join('').$scripts->join('');
+
+        // When the build uses Vite's "chunkImportMap" option, chunks import one
+        // another through stable identifiers that only resolve via an import map,
+        // which must be output before the module scripts that depend on it.
+        if ($scripts->isNotEmpty() && ($importMap = $this->importMap($buildDirectory)) !== null) {
+            $base = $this->makeImportMapTag($importMap).$base;
+        }
 
         if ($this->prefetchStrategy === null || $this->isRunningHot()) {
             return new HtmlString($base);
@@ -975,6 +1009,49 @@ class Vite implements Htmlable
     protected function manifestPath($buildDirectory)
     {
         return public_path($buildDirectory.'/'.$this->manifestFilename);
+    }
+
+    /**
+     * Get the import map for the given build directory, or null if there is none.
+     *
+     * @param  string  $buildDirectory
+     * @return array|null
+     */
+    protected function importMap($buildDirectory)
+    {
+        $path = $this->importMapPath($buildDirectory);
+
+        if (! array_key_exists($path, static::$importMaps)) {
+            static::$importMaps[$path] = is_file($path)
+                ? json_decode(file_get_contents($path), true)
+                : null;
+        }
+
+        return static::$importMaps[$path];
+    }
+
+    /**
+     * Get the path to the import map file for the given build directory.
+     *
+     * @param  string  $buildDirectory
+     * @return string
+     */
+    protected function importMapPath($buildDirectory)
+    {
+        return public_path($buildDirectory.'/'.$this->importMapFilename);
+    }
+
+    /**
+     * Make the import map script tag for the given import map.
+     *
+     * @param  array  $importMap
+     * @return string
+     */
+    protected function makeImportMapTag($importMap)
+    {
+        return '<script type="importmap"'.$this->nonceAttribute().'>'
+            .json_encode($importMap, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG)
+            .'</script>';
     }
 
     /**

--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -498,9 +498,7 @@ class Vite implements Htmlable
 
         $base = $preloads->join('').$stylesheets->join('').$scripts->join('');
 
-        // When the build uses Vite's "chunkImportMap" option, chunks import one
-        // another through stable identifiers that only resolve via an import map,
-        // which must be output before the module scripts that depend on it.
+        // When using import mapping, chunks import one another through stable identifiers...
         if ($scripts->isNotEmpty() && ($importMap = $this->importMap($buildDirectory)) !== null) {
             $base = $this->makeImportMapTag($importMap).$base;
         }
@@ -1012,6 +1010,27 @@ class Vite implements Htmlable
     }
 
     /**
+     * Get a unique hash representing the current manifest, or null if there is no manifest.
+     *
+     * @param  string|null  $buildDirectory
+     * @return string|null
+     */
+    public function manifestHash($buildDirectory = null)
+    {
+        $buildDirectory ??= $this->buildDirectory;
+
+        if ($this->isRunningHot()) {
+            return null;
+        }
+
+        if (! is_file($path = $this->manifestPath($buildDirectory))) {
+            return null;
+        }
+
+        return md5_file($path) ?: null;
+    }
+
+    /**
      * Get the import map for the given build directory, or null if there is none.
      *
      * @param  string  $buildDirectory
@@ -1052,27 +1071,6 @@ class Vite implements Htmlable
         return '<script type="importmap"'.$this->nonceAttribute().'>'
             .json_encode($importMap, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG)
             .'</script>';
-    }
-
-    /**
-     * Get a unique hash representing the current manifest, or null if there is no manifest.
-     *
-     * @param  string|null  $buildDirectory
-     * @return string|null
-     */
-    public function manifestHash($buildDirectory = null)
-    {
-        $buildDirectory ??= $this->buildDirectory;
-
-        if ($this->isRunningHot()) {
-            return null;
-        }
-
-        if (! is_file($path = $this->manifestPath($buildDirectory))) {
-            return null;
-        }
-
-        return md5_file($path) ?: null;
     }
 
     /**

--- a/tests/Foundation/FoundationViteTest.php
+++ b/tests/Foundation/FoundationViteTest.php
@@ -1762,6 +1762,79 @@ class FoundationViteTest extends TestCase
         $this->assertCount(0, app(Vite::class)->preloadedAssets());
     }
 
+    public function testViteInjectsTheImportMapWhenPresent()
+    {
+        $buildDir = Str::random();
+        $this->makeViteManifest(null, $buildDir);
+        $this->makeViteImportMap(null, $buildDir);
+
+        $result = app(Vite::class)('resources/js/app.js', $buildDir)->toHtml();
+
+        $this->assertStringStartsWith(
+            '<script type="importmap">{"imports":{"/'.$buildDir.'/assets/app.stable.js":"/'.$buildDir.'/assets/app.versioned.js"}}</script>',
+            $result
+        );
+        // The import map must come before the module scripts it resolves.
+        $this->assertLessThan(
+            strpos($result, '<script type="module"'),
+            strpos($result, '<script type="importmap"')
+        );
+        $this->assertStringEndsWith(
+            '<script type="module" src="https://example.com/'.$buildDir.'/assets/app.versioned.js"></script>',
+            $result
+        );
+
+        $this->cleanViteImportMap($buildDir);
+        $this->cleanViteManifest($buildDir);
+    }
+
+    public function testViteDoesNotInjectAnImportMapWhenItIsMissing()
+    {
+        $buildDir = Str::random();
+        $this->makeViteManifest(null, $buildDir);
+
+        $result = app(Vite::class)('resources/js/app.js', $buildDir)->toHtml();
+
+        $this->assertStringNotContainsString('type="importmap"', $result);
+
+        $this->cleanViteManifest($buildDir);
+    }
+
+    public function testViteImportMapReceivesTheCspNonce()
+    {
+        $buildDir = Str::random();
+        $this->makeViteManifest(null, $buildDir);
+        $this->makeViteImportMap(null, $buildDir);
+
+        ViteFacade::useCspNonce('expected-nonce');
+        $result = app(Vite::class)('resources/js/app.js', $buildDir)->toHtml();
+
+        $this->assertStringStartsWith('<script type="importmap" nonce="expected-nonce">', $result);
+
+        $this->cleanViteImportMap($buildDir);
+        $this->cleanViteManifest($buildDir);
+    }
+
+    public function testItCanConfigureTheImportMapFilename()
+    {
+        $buildDir = Str::random();
+        $this->makeViteManifest(null, $buildDir);
+
+        file_put_contents(
+            public_path("{$buildDir}/custom-importmap.json"),
+            json_encode(['imports' => ["/{$buildDir}/x.stable.js" => "/{$buildDir}/x.versioned.js"]])
+        );
+
+        ViteFacade::useImportMapFilename('custom-importmap.json');
+        $result = app(Vite::class)('resources/js/app.js', $buildDir)->toHtml();
+
+        $this->assertStringStartsWith('<script type="importmap">', $result);
+        $this->assertStringContainsString("/{$buildDir}/x.versioned.js", $result);
+
+        unlink(public_path("{$buildDir}/custom-importmap.json"));
+        $this->cleanViteManifest($buildDir);
+    }
+
     protected function cleanViteManifest($path = 'build')
     {
         if (file_exists(public_path("{$path}/manifest.json"))) {
@@ -1770,6 +1843,30 @@ class FoundationViteTest extends TestCase
 
         if (file_exists(public_path($path))) {
             rmdir(public_path($path));
+        }
+    }
+
+    protected function makeViteImportMap($contents = null, $path = 'build')
+    {
+        app()->usePublicPath(__DIR__);
+
+        if (! file_exists(public_path($path))) {
+            mkdir(public_path($path));
+        }
+
+        $importMap = json_encode($contents ?? [
+            'imports' => [
+                "/{$path}/assets/app.stable.js" => "/{$path}/assets/app.versioned.js",
+            ],
+        ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+
+        file_put_contents(public_path("{$path}/importmap.json"), $importMap);
+    }
+
+    protected function cleanViteImportMap($path = 'build')
+    {
+        if (file_exists(public_path("{$path}/importmap.json"))) {
+            unlink(public_path("{$path}/importmap.json"));
         }
     }
 


### PR DESCRIPTION
Adds support for Vite's `build.chunkImportMap` [option](https://vite.dev/config/build-options#build-chunkimportmap).

With `chunkImportMap` enabled, Vite makes generated chunks import one another through stable identifiers instead of hashed filenames, and emits an `importmap.json` mapping those identifiers to the real files. This improves long-term caching: changing one chunk no longer cascades new hashes onto every chunk that imports it.

For it to work, a `<script type="importmap">` must appear before the module scripts. Vite injects it when it controls the HTML, but Laravel renders its own tags from the manifest. Currently, enabling `chunkImportMap` silently breaks module resolution.

This PR adds import-map injection to the `Vite` class:

- When `public/build/importmap.json` exists, `@vite` emits `<script type="importmap">…</script>` ahead of the modulepreload links and module scripts.
- Fully opt-in and backward compatible. Nothing changes unless that file is present (i.e. you turned on `chunkImportMap`).
- The tag honors the configured CSP nonce.
- Adds `Vite::useImportMapFilename()` for parity with `useManifestFilename()`, in case the file is renamed in the Vite config.

Usage:

```js
// vite.config.js
export default defineConfig({
  build: {
    chunkImportMap: true,
  },
});
```

Tests cover injection, ordering (import map before the module scripts), the CSP nonce, and the custom filename.

Note: `chunkImportMap` is still marked experimental in Vite.