### PR TITLE
[13.x] Restore iterable support to Arr::every() and Arr::some()

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -594,7 +594,17 @@ class Arr
      */
     public static function every($array, callable $callback)
     {
-        return array_all($array, $callback);
+        if (is_array($array)) {
+            return array_all($array, $callback);
+        }
+
+        foreach ($array as $key => $value) {
+            if (! $callback($value, $key)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**
@@ -606,7 +616,17 @@ class Arr
      */
     public static function some($array, callable $callback)
     {
-        return array_any($array, $callback);
+        if (is_array($array)) {
+            return array_any($array, $callback);
+        }
+
+        foreach ($array as $key => $value) {
+            if ($callback($value, $key)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Support;
 
+use ArrayIterator;
 use ArrayObject;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
@@ -860,11 +861,25 @@ class SupportArrTest extends TestCase
         $this->assertTrue(Arr::every(['foo', 'bar'], fn ($value, $key) => is_string($value)));
     }
 
+    public function testEveryAcceptsIterables()
+    {
+        $items = new ArrayIterator(['first' => 1, 'second' => 2]);
+
+        $this->assertTrue(Arr::every($items, fn ($value, $key) => is_string($key) && $value > 0));
+    }
+
     public function testSome()
     {
         $this->assertFalse(Arr::some([1, 2], fn ($value, $key) => is_string($value)));
         $this->assertTrue(Arr::some(['foo', 2], fn ($value, $key) => is_string($value)));
         $this->assertTrue(Arr::some(['foo', 'bar'], fn ($value, $key) => is_string($value)));
+    }
+
+    public function testSomeAcceptsIterables()
+    {
+        $items = new ArrayIterator(['first' => 1, 'second' => 2]);
+
+        $this->assertTrue(Arr::some($items, fn ($value, $key) => $key === 'second' && $value === 2));
     }
 
     public function testIsAssoc()


### PR DESCRIPTION
`Arr::every()` and `Arr::some()` document support for iterable values, but currently pass them directly to `array_all()` and `array_any()`, which only accept arrays.
As a result, passing an `ArrayIterator`, generator, or other non-array iterable throws a `TypeError`.
This change retains the native PHP helpers for arrays while restoring the original short-circuiting iteration behavior for other iterables.
Regression tests also ensure callback values and keys are passed correctly.