### PR TITLE
[13.x] Fix schedule:list timezone conversion for range, step, and wildcard cron expressions

### DIFF
--- a/src/Illuminate/Console/Scheduling/CronExpressionTimezoneConverter.php
+++ b/src/Illuminate/Console/Scheduling/CronExpressionTimezoneConverter.php
@@ -29,26 +29,13 @@ class CronExpressionTimezoneConverter
             return [$event->expression];
         }
 
-        $segments = preg_split("/\s+/", $event->expression);
-        $minuteGroups = static::shiftAndGroup($segments[0], $minuteOffset, 60);
+        $segments = preg_split("/\s+/", trim($event->expression));
 
-        $expressions = [];
-
-        foreach ($minuteGroups as $minuteCarry => $minuteValues) {
-            $hourGroups = static::shiftAndGroup($segments[1], $hourOffset + $minuteCarry, 24);
-
-            foreach ($hourGroups as $hourCarry => $hourValues) {
-                $parts = $segments;
-                $parts[0] = $minuteValues;
-                $parts[1] = $hourValues;
-
-                foreach (static::expressionsForHourCarry($segments, $parts, $hourCarry) as $expression) {
-                    $expressions[] = $expression;
-                }
-            }
+        if (count($segments) !== 5) {
+            return [$event->expression];
         }
 
-        return $expressions;
+        return static::convert($segments, $hourOffset, $minuteOffset) ?? [$event->expression];
     }
 
     /**
@@ -83,11 +70,61 @@ class CronExpressionTimezoneConverter
     }
 
     /**
+     * Convert the expression segments by the given offsets.
+     *
+     * @param  array<int, string>  $segments
+     * @param  int  $hourOffset
+     * @param  int  $minuteOffset
+     * @return array<int, string>|null
+     */
+    protected static function convert(array $segments, int $hourOffset, int $minuteOffset)
+    {
+        $daysAreWildcard = $segments[2] === '*' && $segments[3] === '*' && $segments[4] === '*';
+
+        // A carry out of a field is irrelevant when every field above it
+        // matches everything, so mixed carry groups may merge in that case.
+        $minuteGroups = static::shiftedGroups(
+            $segments[0], $minuteOffset, 0, 59,
+            mergeCarries: $daysAreWildcard && static::expand($segments[1], 0, 23) === range(0, 23),
+        );
+
+        if (is_null($minuteGroups)) {
+            return null;
+        }
+
+        $expressions = [];
+
+        foreach ($minuteGroups as $minuteCarry => $minuteValues) {
+            $hourGroups = static::shiftedGroups(
+                $segments[1], $hourOffset + $minuteCarry, 0, 23, mergeCarries: $daysAreWildcard,
+            );
+
+            if (is_null($hourGroups)) {
+                return null;
+            }
+
+            foreach ($hourGroups as $hourCarry => $hourValues) {
+                $parts = $segments;
+                $parts[0] = $minuteValues;
+                $parts[1] = $hourValues;
+
+                if (is_null($carried = static::expressionsForHourCarry($segments, $parts, $hourCarry))) {
+                    return null;
+                }
+
+                $expressions = array_merge($expressions, $carried);
+            }
+        }
+
+        return $expressions;
+    }
+
+    /**
      * Build expressions for the given hour carry direction.
      *
      * @param  array<int, string>  $segments
      * @param  array<int, string>  $parts
-     * @return array<int, string>
+     * @return array<int, string>|null
      */
     protected static function expressionsForHourCarry(array $segments, array $parts, int $hourCarry)
     {
@@ -95,9 +132,21 @@ class CronExpressionTimezoneConverter
             return [implode(' ', $parts)];
         }
 
-        $parts[4] = static::shiftField($segments[4], $hourCarry, 7);
+        if ($segments[4] !== '*') {
+            if (is_null($days = static::expand($segments[4], 0, 7))) {
+                return null;
+            }
 
-        $dayGroups = static::shiftAndGroup($segments[2], $hourCarry, 31, min: 1);
+            $parts[4] = static::collapse(static::shiftWrapped($days, $hourCarry, 7), 0, 6);
+        }
+
+        $dayGroups = $segments[2] === '*'
+            ? [0 => '*']
+            : static::shiftedGroups($segments[2], $hourCarry, 1, 31, mergeCarries: false);
+
+        if (is_null($dayGroups)) {
+            return null;
+        }
 
         $expressions = [];
 
@@ -105,8 +154,12 @@ class CronExpressionTimezoneConverter
             $dayParts = $parts;
             $dayParts[2] = $dayValues;
 
-            if ($dayCarry !== 0) {
-                $dayParts[3] = static::shiftField($segments[3], $dayCarry, 12, min: 1);
+            if ($dayCarry !== 0 && $segments[3] !== '*') {
+                if (is_null($months = static::expand($segments[3], 1, 12))) {
+                    return null;
+                }
+
+                $dayParts[3] = static::collapse(static::shiftWrapped($months, $dayCarry, 12, min: 1), 1, 12);
             }
 
             $expressions[] = implode(' ', $dayParts);
@@ -116,62 +169,195 @@ class CronExpressionTimezoneConverter
     }
 
     /**
-     * Shift values in a cron field and group them by carry direction.
+     * Shift a cron field by the given offset and group it by carry direction.
      *
      * @param  string  $field
      * @param  int  $offset
-     * @param  int  $mod
-     * @return array<int, string>
+     * @param  int  $min
+     * @param  int  $max
+     * @param  bool  $mergeCarries
+     * @return array<int, string>|null
      */
-    protected static function shiftAndGroup($field, $offset, $mod, $min = 0)
+    protected static function shiftedGroups(string $field, int $offset, int $min, int $max, bool $mergeCarries)
     {
-        if ($offset === 0 || ! preg_match('/^[\d,]+$/', $field)) {
+        if ($offset === 0) {
             return [0 => $field];
         }
 
-        $groups = [];
-
-        foreach (explode(',', $field) as $value) {
-            $new = (int) $value + $offset;
-            $carry = 0;
-
-            if ($new >= $mod + $min) {
-                $carry = 1;
-                $new -= $mod;
-            } elseif ($new < $min) {
-                $carry = -1;
-                $new += $mod;
-            }
-
-            $groups[$carry][] = $new;
+        if (is_null($values = static::expand($field, $min, $max))) {
+            return null;
         }
 
-        return (new Collection($groups))->map(function ($values) {
-            sort($values);
+        $groups = static::shiftAndGroupValues($values, $offset, $max - $min + 1, $min);
 
-            return implode(',', $values);
-        })->all();
+        if ($mergeCarries && count($groups) > 1) {
+            $groups = [0 => static::mergeGroups($groups)];
+        }
+
+        return array_map(fn ($group) => static::collapse($group, $min, $max), $groups);
     }
 
     /**
-     * Shift a cron field by the given offset.
+     * Expand a cron field into the sorted list of values it matches.
      *
      * @param  string  $field
+     * @param  int  $min
+     * @param  int  $max
+     * @return array<int, int>|null
+     */
+    protected static function expand(string $field, int $min, int $max)
+    {
+        if ($field === '*') {
+            return range($min, $max);
+        }
+
+        $values = [];
+
+        foreach (explode(',', $field) as $part) {
+            if (! preg_match('/^(\*|\d+(?:-\d+)?)(?:\/(\d+))?$/', $part, $matches)) {
+                return null;
+            }
+
+            $step = ($matches[2] ?? '') !== '' ? (int) $matches[2] : null;
+
+            if ($step === 0) {
+                return null;
+            }
+
+            if ($matches[1] === '*') {
+                [$start, $end] = [$min, $max];
+            } elseif (str_contains($matches[1], '-')) {
+                [$start, $end] = array_map(intval(...), explode('-', $matches[1]));
+            } else {
+                [$start, $end] = [(int) $matches[1], is_null($step) ? (int) $matches[1] : $max];
+            }
+
+            if ($start < $min || $end > $max || $start > $end) {
+                return null;
+            }
+
+            for ($value = $start; $value <= $end; $value += $step ?? 1) {
+                $values[] = $value;
+            }
+        }
+
+        $values = array_values(array_unique($values));
+
+        sort($values);
+
+        return $values;
+    }
+
+    /**
+     * Shift values in a cron field and group them by carry direction.
+     *
+     * @param  array<int, int>  $values
      * @param  int  $offset
      * @param  int  $mod
      * @param  int  $min
-     * @return string
+     * @return array<int, array<int, int>>
      */
-    protected static function shiftField($field, $offset, $mod, $min = 0)
+    protected static function shiftAndGroupValues(array $values, int $offset, int $mod, int $min = 0)
     {
-        if ($offset === 0 || ! preg_match('/^[\d,]+$/', $field)) {
-            return $field;
+        $groups = [];
+
+        foreach ($values as $value) {
+            $carry = (int) floor(($value + $offset - $min) / $mod);
+
+            $groups[$carry][] = $value + $offset - $carry * $mod;
         }
 
-        $shifted = (new Collection(explode(',', $field)))
-            ->map(fn ($v) => (((int) $v + $offset - $min) % $mod + $mod) % $mod + $min)
-            ->sort();
+        return array_map(function ($group) {
+            sort($group);
 
-        return $shifted->implode(',');
+            return $group;
+        }, $groups);
+    }
+
+    /**
+     * Shift values within a cron field, wrapping around its domain.
+     *
+     * @param  array<int, int>  $values
+     * @param  int  $offset
+     * @param  int  $mod
+     * @param  int  $min
+     * @return array<int, int>
+     */
+    protected static function shiftWrapped(array $values, int $offset, int $mod, int $min = 0)
+    {
+        $shifted = array_values(array_unique(array_map(
+            fn ($value) => (($value + $offset - $min) % $mod + $mod) % $mod + $min, $values
+        )));
+
+        sort($shifted);
+
+        return $shifted;
+    }
+
+    /**
+     * Merge grouped values into a single sorted group.
+     *
+     * @param  array<int, array<int, int>>  $groups
+     * @return array<int, int>
+     */
+    protected static function mergeGroups(array $groups)
+    {
+        $merged = array_merge(...array_values($groups));
+
+        sort($merged);
+
+        return $merged;
+    }
+
+    /**
+     * Collapse a sorted list of values into the most compact cron field syntax.
+     *
+     * @param  array<int, int>  $values
+     * @param  int  $min
+     * @param  int  $max
+     * @return string
+     */
+    protected static function collapse(array $values, int $min, int $max)
+    {
+        if ($values === range($min, $max)) {
+            return '*';
+        }
+
+        if (count($values) === 1) {
+            return (string) $values[0];
+        }
+
+        $steps = (new Collection($values))
+            ->sliding(2)
+            ->map(fn ($pair) => $pair->last() - $pair->first())
+            ->unique();
+
+        if (count($values) < 3 || $steps->count() > 1) {
+            return static::collapseRuns($values);
+        }
+
+        [$first, $last, $step] = [$values[0], end($values), $steps->first()];
+
+        if ($step === 1) {
+            return "{$first}-{$last}";
+        }
+
+        return $first === $min && $last + $step > $max
+            ? "*/{$step}"
+            : "{$first}-{$last}/{$step}";
+    }
+
+    /**
+     * Collapse consecutive runs of three or more values into ranges.
+     *
+     * @param  array<int, int>  $values
+     * @return string
+     */
+    protected static function collapseRuns(array $values)
+    {
+        return (new Collection($values))
+            ->chunkWhile(fn ($value, $key, $chunk) => $value === $chunk->last() + 1)
+            ->map(fn ($run) => $run->count() >= 3 ? $run->first().'-'.$run->last() : $run->implode(','))
+            ->implode(',');
     }
 }

--- a/src/Illuminate/Console/Scheduling/CronExpressionTimezoneConverter.php
+++ b/src/Illuminate/Console/Scheduling/CronExpressionTimezoneConverter.php
@@ -22,9 +22,15 @@ class CronExpressionTimezoneConverter
     {
         $eventTimezone = static::resolveEventTimezone($event, $timezone);
 
-        [$totalOffsetMinutes, $hourOffset, $minuteOffset] = static::offsetComponents(
+        $offsetComponents = static::offsetComponents(
             $event, $eventTimezone, $timezone
         );
+
+        if (is_null($offsetComponents)) {
+            return [$event->expression];
+        }
+
+        [$totalOffsetMinutes, $hourOffset, $minuteOffset] = $offsetComponents;
 
         if ($totalOffsetMinutes === 0) {
             return [$event->expression];
@@ -56,20 +62,29 @@ class CronExpressionTimezoneConverter
     /**
      * Get offset components between the event and display timezones.
      *
-     * @return array{int, int, int}
+     * @return array{int, int, int}|null
      */
     protected static function offsetComponents(Event $event, DateTimeZone $eventTimezone, DateTimeZone $displayTimezone)
     {
         try {
             $at = $event->nextRunDate(Carbon::now());
+            $nextAt = $event->nextRunDate(Carbon::now(), 1);
         } catch (Throwable) {
             $at = Carbon::now();
+            $nextAt = null;
         }
 
         $totalOffsetMinutes = intdiv(
             $displayTimezone->getOffset($at) - $eventTimezone->getOffset($at),
             60
         );
+
+        if ($nextAt && $totalOffsetMinutes !== intdiv(
+            $displayTimezone->getOffset($nextAt) - $eventTimezone->getOffset($nextAt),
+            60
+        )) {
+            return null;
+        }
 
         return [$totalOffsetMinutes, intdiv($totalOffsetMinutes, 60), $totalOffsetMinutes % 60];
     }
@@ -196,18 +211,23 @@ class CronExpressionTimezoneConverter
 
                 [$targetMonth, $targetDay] = [$month, $day + $carry];
 
-                if ($targetDay < 1) {
-                    $targetMonth = $month === 1 ? 12 : $month - 1;
+                while ($targetDay < 1) {
+                    $targetMonth = $targetMonth === 1 ? 12 : $targetMonth - 1;
 
                     if ($targetMonth === 2) {
                         return null;
                     }
 
-                    $targetDay = static::daysInMonth($targetMonth);
-                } elseif ($month === 2 && $targetDay > 28) {
-                    return null;
-                } elseif ($targetDay > static::daysInMonth($month)) {
-                    [$targetMonth, $targetDay] = [$month === 12 ? 1 : $month + 1, 1];
+                    $targetDay += static::daysInMonth($targetMonth);
+                }
+
+                while ($targetDay > static::daysInMonth($targetMonth)) {
+                    if ($targetMonth === 2) {
+                        return null;
+                    }
+
+                    $targetDay -= static::daysInMonth($targetMonth);
+                    $targetMonth = $targetMonth === 12 ? 1 : $targetMonth + 1;
                 }
 
                 $shifted[$targetMonth][$targetDay] = true;

--- a/src/Illuminate/Console/Scheduling/CronExpressionTimezoneConverter.php
+++ b/src/Illuminate/Console/Scheduling/CronExpressionTimezoneConverter.php
@@ -5,6 +5,7 @@ namespace Illuminate\Console\Scheduling;
 use DateTimeZone;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
+use Throwable;
 
 class CronExpressionTimezoneConverter
 {
@@ -22,7 +23,7 @@ class CronExpressionTimezoneConverter
         $eventTimezone = static::resolveEventTimezone($event, $timezone);
 
         [$totalOffsetMinutes, $hourOffset, $minuteOffset] = static::offsetComponents(
-            $eventTimezone, $timezone
+            $event, $eventTimezone, $timezone
         );
 
         if ($totalOffsetMinutes === 0) {
@@ -57,12 +58,16 @@ class CronExpressionTimezoneConverter
      *
      * @return array{int, int, int}
      */
-    protected static function offsetComponents(DateTimeZone $eventTimezone, DateTimeZone $displayTimezone)
+    protected static function offsetComponents(Event $event, DateTimeZone $eventTimezone, DateTimeZone $displayTimezone)
     {
-        $now = Carbon::now();
+        try {
+            $at = $event->nextRunDate(Carbon::now());
+        } catch (Throwable) {
+            $at = Carbon::now();
+        }
 
         $totalOffsetMinutes = intdiv(
-            $displayTimezone->getOffset($now) - $eventTimezone->getOffset($now),
+            $displayTimezone->getOffset($at) - $eventTimezone->getOffset($at),
             60
         );
 
@@ -81,8 +86,6 @@ class CronExpressionTimezoneConverter
     {
         $daysAreWildcard = $segments[2] === '*' && $segments[3] === '*' && $segments[4] === '*';
 
-        // A carry out of a field is irrelevant when every field above it
-        // matches everything, so mixed carry groups may merge in that case.
         $minuteGroups = static::shiftedGroups(
             $segments[0], $minuteOffset, 0, 59,
             mergeCarries: $daysAreWildcard && static::expand($segments[1], 0, 23) === range(0, 23),
@@ -133,39 +136,117 @@ class CronExpressionTimezoneConverter
         }
 
         if ($segments[4] !== '*') {
+            // Cron treats restricted day-of-month and day-of-week fields as an "or", so they cannot shift together...
+            if ($segments[2] !== '*' || $segments[3] !== '*') {
+                return null;
+            }
+
             if (is_null($days = static::expand($segments[4], 0, 7))) {
                 return null;
             }
 
             $parts[4] = static::collapse(static::shiftWrapped($days, $hourCarry, 7), 0, 6);
+
+            return [implode(' ', $parts)];
         }
 
-        $dayGroups = $segments[2] === '*'
-            ? [0 => '*']
-            : static::shiftedGroups($segments[2], $hourCarry, 1, 31, mergeCarries: false);
+        if ($segments[2] === '*' && $segments[3] === '*') {
+            return [implode(' ', $parts)];
+        }
 
-        if (is_null($dayGroups)) {
+        if (is_null($dayGroups = static::shiftDaysOfMonth($segments[2], $segments[3], $hourCarry))) {
             return null;
         }
 
-        $expressions = [];
+        return array_map(function ($group) use ($parts) {
+            [$parts[2], $parts[3]] = $group;
 
-        foreach ($dayGroups as $dayCarry => $dayValues) {
-            $dayParts = $parts;
-            $dayParts[2] = $dayValues;
+            return implode(' ', $parts);
+        }, $dayGroups);
+    }
 
-            if ($dayCarry !== 0 && $segments[3] !== '*') {
-                if (is_null($months = static::expand($segments[3], 1, 12))) {
+    /**
+     * Shift the day-of-month field by the given carry, respecting month lengths.
+     *
+     * @param  string  $domField
+     * @param  string  $monthField
+     * @param  int  $carry
+     * @return array<int, array{string, string}>|null
+     */
+    protected static function shiftDaysOfMonth(string $domField, string $monthField, int $carry)
+    {
+        $months = $monthField === '*' ? range(1, 12) : static::expand($monthField, 1, 12);
+        $days = $domField === '*' ? range(1, 31) : static::expand($domField, 1, 31);
+
+        if (is_null($months) || is_null($days)) {
+            return null;
+        }
+
+        $shifted = [];
+
+        foreach ($months as $month) {
+            foreach ($days as $day) {
+                if ($month === 2 && $day === 29) {
                     return null;
                 }
 
-                $dayParts[3] = static::collapse(static::shiftWrapped($months, $dayCarry, 12, min: 1), 1, 12);
-            }
+                if ($day > static::daysInMonth($month)) {
+                    continue;
+                }
 
-            $expressions[] = implode(' ', $dayParts);
+                [$targetMonth, $targetDay] = [$month, $day + $carry];
+
+                if ($targetDay < 1) {
+                    $targetMonth = $month === 1 ? 12 : $month - 1;
+
+                    if ($targetMonth === 2) {
+                        return null;
+                    }
+
+                    $targetDay = static::daysInMonth($targetMonth);
+                } elseif ($month === 2 && $targetDay > 28) {
+                    return null;
+                } elseif ($targetDay > static::daysInMonth($month)) {
+                    [$targetMonth, $targetDay] = [$month === 12 ? 1 : $month + 1, 1];
+                }
+
+                $shifted[$targetMonth][$targetDay] = true;
+            }
         }
 
-        return $expressions;
+        if ($shifted === []) {
+            return null;
+        }
+
+        $groups = [];
+
+        foreach ($shifted as $month => $days) {
+            $days = array_keys($days);
+
+            sort($days);
+
+            $groups[implode(',', $days)][] = $month;
+        }
+
+        return (new Collection($groups))->map(function ($months, $days) {
+            sort($months);
+
+            return [
+                static::collapse(array_map(intval(...), explode(',', $days)), 1, 31),
+                static::collapse($months, 1, 12),
+            ];
+        })->values()->all();
+    }
+
+    /**
+     * Get the number of days in the given month of a non-leap year.
+     *
+     * @param  int  $month
+     * @return int
+     */
+    protected static function daysInMonth(int $month)
+    {
+        return Carbon::create(2023, $month)->daysInMonth;
     }
 
     /**

--- a/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
@@ -256,13 +256,15 @@ class ScheduleListCommandTest extends TestCase
             // No conversion needed — same timezone
             'same timezone' => ['0 8 * * *', 'UTC', null, ['0 8 * * *']],
 
-            // Wildcards/steps — pass through unchanged
+            // Wildcards — shift-invariant when the day fields are wildcards
             'every minute' => ['* * * * *', 'America/New_York', null, ['* * * * *']],
             'every five minutes' => ['*/5 * * * *', 'Asia/Tokyo', null, ['*/5 * * * *']],
-            'every two hours' => ['0 */2 * * *', 'Asia/Tokyo', null, ['0 */2 * * *']],
-            'every odd hour' => ['0 1-23/2 * * *', 'Asia/Tokyo', null, ['0 1-23/2 * * *']],
-            'quarterly step month' => ['0 0 1 1-12/3 *', 'Asia/Tokyo', null, ['0 15 31 1-12/3 *']],
-            'weekdays range' => ['0 8 * * 1-5', 'Asia/Tokyo', null, ['0 23 * * 1-5']],
+
+            // Steps/ranges — expanded, shifted, and re-collapsed
+            'every two hours' => ['0 */2 * * *', 'Asia/Tokyo', null, ['0 1-23/2 * * *']],
+            'every odd hour' => ['0 1-23/2 * * *', 'Asia/Tokyo', null, ['0 */2 * * *']],
+            'quarterly step month' => ['0 0 1 1-12/3 *', 'Asia/Tokyo', null, ['0 15 31 3-12/3 *']],
+            'weekdays range' => ['0 8 * * 1-5', 'Asia/Tokyo', null, ['0 23 * * 0-4']],
 
             // Simple hour shift (no day boundary)
             'daily LA to UTC' => ['0 8 * * *', 'America/Los_Angeles', null, ['0 16 * * *']],
@@ -281,9 +283,9 @@ class ScheduleListCommandTest extends TestCase
             'twice daily Tokyo' => ['0 9,17 * * *', 'Asia/Tokyo', null, ['0 0,8 * * *']],
             'twice daily Tokyo wrapping' => ['0 13,22 * * *', 'Asia/Tokyo', null, ['0 4,13 * * *']],
 
-            // Comma-separated hours — mixed carries (splits into two entries)
-            'twice daily LA mixed carry' => ['0 13,17 * * *', 'America/Los_Angeles', null, ['0 21 * * *', '0 1 * * *']],
-            'twice daily Tokyo mixed carry' => ['0 3,20 * * *', 'Asia/Tokyo', null, ['0 18 * * *', '0 11 * * *']],
+            // Comma-separated hours — mixed carries merge when the day fields are wildcards
+            'twice daily LA mixed carry' => ['0 13,17 * * *', 'America/Los_Angeles', null, ['0 1,21 * * *']],
+            'twice daily Tokyo mixed carry' => ['0 3,20 * * *', 'Asia/Tokyo', null, ['0 11,18 * * *']],
 
             // Day-of-week shifts
             'weekly Monday night LA' => ['0 22 * * 1', 'America/Los_Angeles', null, ['0 6 * * 2']],
@@ -317,6 +319,33 @@ class ScheduleListCommandTest extends TestCase
             // Comma minutes with half-hour timezone — mixed minute carries (splits)
             // 15+(-30)=-15→45 (carry -1) and 45+(-30)=15 (no carry)
             'comma minutes Kolkata mixed carry' => ['15,45 8 * * *', 'Asia/Kolkata', null, ['45 2 * * *', '15 3 * * *']],
+
+            // Hour ranges
+            'hour range NY' => ['0 0-4 * * *', 'America/New_York', null, ['0 5-9 * * *']],
+            'hour range with minute step Amsterdam' => ['*/10 8-23 * * *', 'Europe/Amsterdam', null, ['*/10 7-22 * * *']],
+            'hour range with minute step Johannesburg' => ['*/10 8-23 * * *', 'Africa/Johannesburg', null, ['*/10 6-21 * * *']],
+            'hour range LA' => ['0 8-11 * * *', 'America/Los_Angeles', null, ['0 16-19 * * *']],
+
+            // Ranges/steps with half-hour timezone offsets
+            'minute step Kolkata' => ['*/10 * * * *', 'Asia/Kolkata', null, ['*/10 * * * *']],
+            'hour range Kolkata' => ['0 9-17 * * *', 'Asia/Kolkata', null, ['30 3-11 * * *']],
+            'hour range Kathmandu' => ['0 9-11 * * *', 'Asia/Kathmandu', null, ['15 3-5 * * *']],
+
+            // Day-of-week ranges shift with the day carry
+            'weeknights range LA' => ['0 22 * * 1-5', 'America/Los_Angeles', null, ['0 6 * * 2-6']],
+            'dow range wraps through Sunday' => ['0 3 * * 0-2', 'Asia/Tokyo', null, ['0 18 * * 0,1,6']],
+
+            // Steps/wildcards split when a day field is fixed (no merge)
+            'hour step with fixed day' => ['0 */2 15 * *', 'Asia/Tokyo', null, ['0 15-23/2 14 * *', '0 1-13/2 15 * *']],
+            'wildcard hour with fixed day' => ['30 * 15 * *', 'Asia/Tokyo', null, ['30 15-23 14 * *', '30 0-14 15 * *']],
+            'wildcard minute with half-hour offset' => ['* 8 * * *', 'Asia/Kolkata', null, ['30-59 2 * * *', '0-29 3 * * *']],
+
+            // Unsupported syntax in a field that needs shifting — unchanged
+            'named dow range needing shift' => ['0 8 * * MON-FRI', 'Asia/Tokyo', null, ['0 8 * * MON-FRI']],
+            'last day of month needing shift' => ['0 8 L * *', 'Asia/Tokyo', null, ['0 8 L * *']],
+
+            // Unsupported syntax in a field that does not need shifting — converts
+            'named dow without day carry' => ['0 14 * * MON', 'Asia/Tokyo', null, ['0 5 * * MON']],
         ];
     }
 
@@ -345,13 +374,23 @@ class ScheduleListCommandTest extends TestCase
 
     public function testDisplayScheduleCliSplitsExpressionWhenMixedCarry()
     {
-        // 13+8=21 (no carry), 17+8=1 (carry +1) — splits into two CLI rows
+        // 13+8=21 (no carry), 17+8=1 (carry +1) — the fixed day forces two CLI rows
+        $this->schedule->command('inspire')->cron('0 13,17 1 * *')->timezone('America/Los_Angeles');
+
+        $this->artisan(ScheduleListCommand::class)
+            ->assertSuccessful()
+            ->expectsOutputToContain('0 21 1 * *')
+            ->expectsOutputToContain('0 1  2 * *');
+    }
+
+    public function testDisplayScheduleCliMergesMixedCarryWhenDaysAreWildcards()
+    {
+        // 13+8=21 (no carry), 17+8=1 (carry +1) — wildcard days merge into one CLI row
         $this->schedule->command('inspire')->twiceDaily(13, 17)->timezone('America/Los_Angeles');
 
         $this->artisan(ScheduleListCommand::class)
             ->assertSuccessful()
-            ->expectsOutputToContain('0 21 * * *')
-            ->expectsOutputToContain('0 1  * * *');
+            ->expectsOutputToContain('0 1,21 * * *');
     }
 
     public function testDisplayScheduleCliConvertsExpression()

--- a/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
@@ -263,7 +263,7 @@ class ScheduleListCommandTest extends TestCase
             // Steps/ranges — expanded, shifted, and re-collapsed
             'every two hours' => ['0 */2 * * *', 'Asia/Tokyo', null, ['0 1-23/2 * * *']],
             'every odd hour' => ['0 1-23/2 * * *', 'Asia/Tokyo', null, ['0 */2 * * *']],
-            'quarterly step month' => ['0 0 1 1-12/3 *', 'Asia/Tokyo', null, ['0 15 31 3-12/3 *']],
+            'quarterly step month' => ['0 0 1 1-12/3 *', 'Asia/Tokyo', null, ['0 15 31 3,12 *', '0 15 30 6,9 *']],
             'weekdays range' => ['0 8 * * 1-5', 'Asia/Tokyo', null, ['0 23 * * 0-4']],
 
             // Simple hour shift (no day boundary)
@@ -296,18 +296,20 @@ class ScheduleListCommandTest extends TestCase
             // Day-of-month shifts
             'monthly 15th Tokyo (no day wrap)' => ['0 12 15 * *', 'Asia/Tokyo', null, ['0 3 15 * *']],
             'monthly 15th Tokyo (day wraps back)' => ['0 8 15 * *', 'Asia/Tokyo', null, ['0 23 14 * *']],
-            'monthly 1st Tokyo (day wraps to 31)' => ['0 1 1 * *', 'Asia/Tokyo', null, ['0 16 31 * *']],
+            // day 1 wraps into the previous month, whose last day varies (incl. February) — unchanged
+            'monthly 1st Tokyo (day wraps back)' => ['0 1 1 * *', 'Asia/Tokyo', null, ['0 1 1 * *']],
             'monthly 1st LA (day wraps forward)' => ['0 22 1 * *', 'America/Los_Angeles', null, ['0 6 2 * *']],
 
-            // Month shifts (day-of-month carry propagates to month)
+            // Month shifts (day-of-month carry respects month lengths)
             'yearly Jan 1 Tokyo' => ['0 1 1 1 *', 'Asia/Tokyo', null, ['0 16 31 12 *']],
-            'yearly Jul 1 Tokyo' => ['0 1 1 7 *', 'Asia/Tokyo', null, ['0 16 31 6 *']],
+            'yearly Jul 1 Tokyo' => ['0 1 1 7 *', 'Asia/Tokyo', null, ['0 16 30 6 *']],
             'yearly Dec 31 LA' => ['0 22 31 12 *', 'America/Los_Angeles', null, ['0 6 1 1 *']],
+            'dom 31 across months' => ['0 1 31 * *', 'Asia/Tokyo', null, ['0 16 30 1,3,5,7,8,10,12 *']],
 
             // Comma day-of-month
             'twice monthly Tokyo (no wrap)' => ['0 12 1,16 * *', 'Asia/Tokyo', null, ['0 3 1,16 * *']],
-            // day 1→31 (carry -1 to month) and 16→15 (no carry) — splits
-            'twice monthly Tokyo (wraps)' => ['0 1 1,16 * *', 'Asia/Tokyo', null, ['0 16 31 * *', '0 16 15 * *']],
+            // day 1 wraps into a month whose last day varies — unchanged
+            'twice monthly Tokyo (wraps)' => ['0 1 1,16 * *', 'Asia/Tokyo', null, ['0 1 1,16 * *']],
 
             // Comma day-of-week
             'weekends LA night' => ['0 22 * * 0,6', 'America/Los_Angeles', null, ['0 6 * * 0,1']],
@@ -346,6 +348,18 @@ class ScheduleListCommandTest extends TestCase
 
             // Unsupported syntax in a field that does not need shifting — converts
             'named dow without day carry' => ['0 14 * * MON', 'Asia/Tokyo', null, ['0 5 * * MON']],
+
+            // Wildcard dom with a restricted month splits at the month boundary
+            'wildcard dom restricted month' => ['0 1 * 1 *', 'Asia/Tokyo', null, ['0 16 31 12 *', '0 16 1-30 1 *']],
+
+            // Restricted dom and dow combine with "or" semantics — unchanged
+            'dom and dow both restricted' => ['0 1 1 3 1', 'Asia/Tokyo', null, ['0 1 1 3 1']],
+            'dow with restricted month' => ['0 1 * 1 1', 'Asia/Tokyo', null, ['0 1 * 1 1']],
+
+            // February's length depends on the year — unchanged
+            'into February' => ['0 1 1 3 *', 'Asia/Tokyo', null, ['0 1 1 3 *']],
+            'out of February' => ['0 23 28 2 *', 'America/Los_Angeles', null, ['0 23 28 2 *']],
+            'February 29th' => ['0 1 29 2 *', 'Asia/Tokyo', null, ['0 1 29 2 *']],
         ];
     }
 
@@ -370,6 +384,25 @@ class ScheduleListCommandTest extends TestCase
         foreach ($expectedExpressions as $index => $expected) {
             $this->assertSame($expected, $data[$index]['expression']);
         }
+    }
+
+    public function testExpressionTimezoneConversionUsesOffsetAtNextRunDate()
+    {
+        // Listed during BST (UTC+1), but both events next run after DST has
+        // ended, so they convert with the UTC+0 offset in effect when they run.
+        Carbon::setTestNow('2023-10-29');
+
+        $this->schedule->command('inspire')->cron('0 0 30 10 *')->timezone('Europe/London');
+        $this->schedule->command('inspire')->cron('0 0 30 6 *')->timezone('Europe/London');
+
+        $this->withoutMockingConsoleOutput()->artisan(ScheduleListCommand::class, [
+            '--timezone' => 'UTC',
+            '--json' => true,
+        ]);
+
+        $data = json_decode(Artisan::output(), true);
+
+        $this->assertSame(['0 0 30 10 *', '0 23 29 6 *'], array_column($data, 'expression'));
     }
 
     public function testDisplayScheduleCliSplitsExpressionWhenMixedCarry()

--- a/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
@@ -360,6 +360,11 @@ class ScheduleListCommandTest extends TestCase
             'into February' => ['0 1 1 3 *', 'Asia/Tokyo', null, ['0 1 1 3 *']],
             'out of February' => ['0 23 28 2 *', 'America/Los_Angeles', null, ['0 23 28 2 *']],
             'February 29th' => ['0 1 29 2 *', 'Asia/Tokyo', null, ['0 1 29 2 *']],
+            'wildcard dom in February' => ['0 1 * 2 *', 'Asia/Tokyo', null, ['0 1 * 2 *']],
+
+            // February shifts that do not depend on the year — convert
+            'within February' => ['0 1 15 2 *', 'Asia/Tokyo', null, ['0 16 14 2 *']],
+            'into February 1st' => ['0 22 31 1 *', 'America/Los_Angeles', null, ['0 6 1 2 *']],
         ];
     }
 

--- a/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
@@ -365,6 +365,10 @@ class ScheduleListCommandTest extends TestCase
             // February shifts that do not depend on the year — convert
             'within February' => ['0 1 15 2 *', 'Asia/Tokyo', null, ['0 16 14 2 *']],
             'into February 1st' => ['0 22 31 1 *', 'America/Los_Angeles', null, ['0 6 1 2 *']],
+
+            // The largest timezone difference can carry by two calendar days
+            'two-day carry forward' => ['0 23 31 1 *', 'Etc/GMT+12', 'Pacific/Kiritimati', ['0 1 2 2 *']],
+            'two-day carry backward' => ['0 0 1 4 *', 'Pacific/Kiritimati', 'Etc/GMT+12', ['0 22 30 3 *']],
         ];
     }
 
@@ -408,6 +412,22 @@ class ScheduleListCommandTest extends TestCase
         $data = json_decode(Artisan::output(), true);
 
         $this->assertSame(['0 0 30 10 *', '0 23 29 6 *'], array_column($data, 'expression'));
+    }
+
+    public function testExpressionTimezoneConversionFallsBackAcrossDstTransition()
+    {
+        Carbon::setTestNow('2024-10-26 22:30:00 UTC');
+
+        $this->schedule->command('inspire')->cron('0 0,2 * * *')->timezone('Europe/London');
+
+        $this->withoutMockingConsoleOutput()->artisan(ScheduleListCommand::class, [
+            '--timezone' => 'UTC',
+            '--json' => true,
+        ]);
+
+        $data = json_decode(Artisan::output(), true);
+
+        $this->assertSame(['0 0,2 * * *'], array_column($data, 'expression'));
     }
 
     public function testDisplayScheduleCliSplitsExpressionWhenMixedCarry()


### PR DESCRIPTION
This PR is a follow-up to #59286. The converter only shifts plain numeric fields, so ranges (`8-23`), steps (`*/2`), and wildcards pass through unchanged while the output still labels them with the display timezone. Anything consuming `schedule:list --json` will compute the wrong run times for those.

### Example

```php
Schedule::command('inspire')
    ->cron('*/10 8-23 * * *')
    ->timezone('Europe/Amsterdam'); // UTC+2 (CEST)
```

### Before

```
$ php artisan schedule:list --timezone UTC

  */10 8-23 * * *  php artisan inspire  Next Due: 3 minutes from now
```

```json
[
  {
    "expression": "*/10 8-23 * * *",
    "timezone": "UTC"
  }
]
```

The expression claims the task runs 08:00-23:59 UTC. It actually runs 08:00-23:59 Amsterdam time (06:00-21:59 UTC).

### After

```
$ php artisan schedule:list --timezone UTC

  */10 6-21 * * *  php artisan inspire  Next Due: 3 minutes from now
```

```json
[
  {
    "expression": "*/10 6-21 * * *",
    "timezone": "UTC"
  }
]
```

The converter now expands any field into its values, shifts them, and collapses the result back into compact syntax (`*`, `a-b`, `*/s`, `a-b/s`, or a comma list). More examples:

| Expression | Event timezone | Before (display UTC) | After |
| --- | --- | --- | --- |
| `0 0-4 * * *` | America/New_York | `0 0-4 * * *` | `0 5-9 * * *` |
| `0 */2 * * *` | Asia/Tokyo | `0 */2 * * *` | `0 1-23/2 * * *` |
| `0 8 * * 1-5` | Asia/Tokyo | `0 23 * * 1-5` | `0 23 * * 0-4` |
| `0 0 1 1-12/3 *` | Asia/Tokyo | `0 15 31 1-12/3 *` | `0 15 31 3-12/3 *` |

The last two were converted before, but wrongly. The hour was shifted across midnight while the day-of-week/month ranges stayed behind. They now shift together with the carry.

Some nastier ones, with fractional offsets and boundary crossings:

| Expression | Event timezone | Before (display UTC) | After |
| --- | --- | --- | --- |
| `0 8-17 * * 1-5` | Pacific/Chatham (UTC+12:45) | `15 8-17 * * 1-5` | `15 19-23 * * 0-4`<br>`15 0-4 * * 1-5` |
| `* * 1 1 *` | Asia/Kathmandu (UTC+5:45) | `* * 1 1 *` | `15-59 18-23 31 12 *`<br>`15-59 0-17 1 1 *`<br>`0-14 19-23 31 12 *`<br>`0-14 0-18 1 1 *` |
| `*/15 9-17 * * *` | Asia/Kathmandu | `*/15 9-17 * * *` | `15-45/15 3-11 * * *`<br>`0 4-12 * * *` |
| `0 22-23 * * 5` | America/Los_Angeles | `0 22-23 * * 5` | `0 5,6 * * 6` |

Note the Chatham case: the old code shifted the minute by the fractional offset but left the hours and weekdays alone, producing an expression that is correct in no timezone.

### Some edge-cases

Splitting still works as in #59286. When a shifted range crosses midnight and a day field is fixed, the event is split:

```
$ php artisan schedule:list --json
// 0 */2 15 * * in Asia/Tokyo

[
  { "expression": "0 15-23/2 14 * *", "timezone": "UTC" },
  { "expression": "0 1-13/2 15 * *", "timezone": "UTC" }
]
```

When the day fields are all wildcards, a day carry is irrelevant (every day matches), so mixed carries now merge into a single entry instead. `twiceDaily(13, 17)` in `America/Los_Angeles` now produces one line, `0 1,21 * * *`, where #59286 produced two.

Expressions using syntax that cannot be safely shifted (`L`, `W`, `#`, `?`, or named values like `MON`) in a field that needs shifting are returned unchanged, as before. The converter never emits a half-converted expression.

### Tests

Updated the cases that pinned the old pass-through behavior and added coverage for ranges, steps, wildcards, half-hour offsets, day carries, merging, and the fallbacks. Also verified the converted expressions produce the exact same run instants as the originals evaluated in their own timezone.
