### PR TITLE
[13.x] Fix Cache::touch() expiration handling

### DIFF
--- a/src/Illuminate/Cache/ArrayStore.php
+++ b/src/Illuminate/Cache/ArrayStore.php
@@ -181,6 +181,14 @@ class ArrayStore extends TaggableStore implements CanFlushLocks, LockProvider
             return false;
         }
 
+        $expiresAt = $item['expiresAt'] ?? 0;
+
+        if ($expiresAt !== 0 && (Carbon::now()->getPreciseTimestamp(3) / 1000) >= $expiresAt) {
+            $this->forget($key);
+
+            return false;
+        }
+
         $item['expiresAt'] = $this->calculateExpiration($seconds);
 
         $this->storage = array_merge($this->storage, [$key => $item]);

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -692,7 +692,13 @@ class Repository implements ArrayAccess, CacheContract
     {
         $key = enum_value($key);
 
-        return $this->store->touch($this->itemKey($key), $this->getSeconds($ttl));
+        $seconds = $this->getSeconds($ttl);
+
+        if ($seconds <= 0) {
+            return $this->forget($key);
+        }
+
+        return $this->store->touch($this->itemKey($key), $seconds);
     }
 
     /**

--- a/tests/Cache/CacheArrayStoreTest.php
+++ b/tests/Cache/CacheArrayStoreTest.php
@@ -79,6 +79,19 @@ class CacheArrayStoreTest extends TestCase
         $this->assertSame($value, $store->get($key));
     }
 
+    public function testTouchDoesNotRestoreExpiredItem(): void
+    {
+        Carbon::setTestNow($now = Carbon::now());
+
+        $store = new ArrayStore;
+        $store->put('key', 'value', 30);
+
+        Carbon::setTestNow($now->addSeconds(30));
+
+        $this->assertFalse($store->touch('key', 60));
+        $this->assertNull($store->get('key'));
+    }
+
     public function testStoreItemForeverProperlyStoresInArray()
     {
         $mock = $this->getMockBuilder(ArrayStore::class)->onlyMethods(['put'])->getMock();

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -537,6 +537,16 @@ class CacheRepositoryTest extends TestCase
         $this->assertTrue($repo->touch($key, DateInterval::createFromDateString("$ttl seconds")));
     }
 
+    public function testTouchWithDatetimeInPastOrZeroSecondsRemovesOldItem(): void
+    {
+        $repo = $this->getRepository();
+        $repo->getStore()->shouldReceive('touch')->never();
+        $repo->getStore()->shouldReceive('forget')->twice()->with('key')->andReturn(true);
+
+        $this->assertTrue($repo->touch('key', Carbon::now()->subMinute()));
+        $this->assertTrue($repo->touch('key', 0));
+    }
+
     public function testTouchWorksWithEnumKey(): void
     {
         $ttl = 60;


### PR DESCRIPTION
`Cache::touch()` normalizes past or non-positive TTL values to zero. Some cache stores interpret zero as an indefinite TTL, which can unexpectedly make an item permanent instead of expiring it.

Additionally, `ArrayStore::touch()` reads directly from its internal storage without checking the existing expiration, allowing an expired item to be restored with a new TTL.