### PR TITLE
[13.x] Allow faking DNS lookups in validation rules

### DIFF
--- a/src/Illuminate/Support/Facades/Validator.php
+++ b/src/Illuminate/Support/Facades/Validator.php
@@ -11,6 +11,7 @@ namespace Illuminate\Support\Facades;
  * @method static void replacer(string $rule, \Closure|string $replacer)
  * @method static void includeUnvalidatedArrayKeys()
  * @method static void excludeUnvalidatedArrayKeys()
+ * @method static void fakeDnsLookups(bool $value = true)
  * @method static void resolver(\Closure $resolver)
  * @method static \Illuminate\Contracts\Translation\Translator getTranslator()
  * @method static \Illuminate\Validation\PresenceVerifierInterface getPresenceVerifier()

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -147,6 +147,10 @@ trait ValidatesAttributes
      */
     protected function getDnsRecords($hostname, $type)
     {
+        if (static::$fakeDnsLookups) {
+            return [['host' => $hostname, 'class' => 'IN', 'ttl' => 60, 'type' => 'A', 'ip' => '127.0.0.1']];
+        }
+
         return dns_get_record($hostname, $type);
     }
 
@@ -959,13 +963,14 @@ trait ValidatesAttributes
             ->unique()
             ->map(fn ($validation) => match (true) {
                 $validation === 'strict' => new NoRFCWarningsValidation(),
-                $validation === 'dns' => new DNSCheckValidation(),
+                $validation === 'dns' => static::$fakeDnsLookups ? null : new DNSCheckValidation(),
                 $validation === 'spoof' => new SpoofCheckValidation(),
                 $validation === 'filter' => new FilterEmailValidation(),
                 $validation === 'filter_unicode' => FilterEmailValidation::unicode(),
                 is_string($validation) && class_exists($validation) => $this->container->make($validation),
                 default => new RFCValidation(),
             })
+            ->filter()
             ->values()
             ->all() ?: [new RFCValidation];
 

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -22,6 +22,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Exceptions\MathException;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Str;
+use Illuminate\Validation\FakeDnsGetRecordWrapper;
 use Illuminate\Validation\Rules\Exists;
 use Illuminate\Validation\Rules\Unique;
 use Illuminate\Validation\ValidationData;
@@ -148,6 +149,12 @@ trait ValidatesAttributes
     protected function getDnsRecords($hostname, $type)
     {
         if (static::$fakeDnsLookups) {
+            $hostname = rtrim($hostname, '.');
+
+            if (filter_var($hostname, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME) === false || filter_var($hostname, FILTER_VALIDATE_IP) !== false) {
+                return false;
+            }
+
             return [['host' => $hostname, 'class' => 'IN', 'ttl' => 60, 'type' => 'A', 'ip' => '127.0.0.1']];
         }
 
@@ -963,15 +970,13 @@ trait ValidatesAttributes
             ->unique()
             ->map(fn ($validation) => match (true) {
                 $validation === 'strict' => new NoRFCWarningsValidation(),
-                $validation === 'dns' => static::$fakeDnsLookups ? null : new DNSCheckValidation(),
+                $validation === 'dns' => new DNSCheckValidation(static::$fakeDnsLookups ? new FakeDnsGetRecordWrapper : null),
                 $validation === 'spoof' => new SpoofCheckValidation(),
                 $validation === 'filter' => new FilterEmailValidation(),
                 $validation === 'filter_unicode' => FilterEmailValidation::unicode(),
                 is_string($validation) && class_exists($validation) => $this->container->make($validation),
                 default => new RFCValidation(),
             })
-            ->filter()
-            ->values()
             ->all() ?: [new RFCValidation];
 
         $emailValidator = Container::getInstance()->make(EmailValidator::class);

--- a/src/Illuminate/Validation/Factory.php
+++ b/src/Illuminate/Validation/Factory.php
@@ -268,6 +268,17 @@ class Factory implements FactoryContract
     }
 
     /**
+     * Fake the DNS lookups performed by validation rules so they always succeed.
+     *
+     * @param  bool  $value
+     * @return void
+     */
+    public function fakeDnsLookups($value = true)
+    {
+        Validator::fakeDnsLookups($value);
+    }
+
+    /**
      * Set the Validator instance resolver.
      *
      * @param  \Closure  $resolver

--- a/src/Illuminate/Validation/FakeDnsGetRecordWrapper.php
+++ b/src/Illuminate/Validation/FakeDnsGetRecordWrapper.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Illuminate\Validation;
+
+use Egulias\EmailValidator\Validation\DNSGetRecordWrapper;
+use Egulias\EmailValidator\Validation\DNSRecords;
+
+class FakeDnsGetRecordWrapper extends DNSGetRecordWrapper
+{
+    /**
+     * Get a synthetic DNS record for the given host.
+     *
+     * @param  string  $host
+     * @param  int  $type
+     * @return \Egulias\EmailValidator\Validation\DNSRecords
+     */
+    public function getRecords(string $host, int $type): DNSRecords
+    {
+        return new DNSRecords([['type' => 'A']]);
+    }
+}

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -315,6 +315,13 @@ class Validator implements ValidatorContract
     protected static $placeholderHash;
 
     /**
+     * Indicates if DNS lookups performed by validation rules should be faked to always succeed.
+     *
+     * @var bool
+     */
+    protected static $fakeDnsLookups = false;
+
+    /**
      * The exception to throw upon failure.
      *
      * @var class-string<\Illuminate\Validation\ValidationException>
@@ -1740,6 +1747,17 @@ class Validator implements ValidatorContract
     }
 
     /**
+     * Fake the DNS lookups performed by validation rules so they always succeed.
+     *
+     * @param  bool  $value
+     * @return void
+     */
+    public static function fakeDnsLookups($value = true)
+    {
+        static::$fakeDnsLookups = $value;
+    }
+
+    /**
      * Flush the validator's global state.
      *
      * @return void
@@ -1747,6 +1765,7 @@ class Validator implements ValidatorContract
     public static function flushState()
     {
         static::$placeholderHash = null;
+        static::$fakeDnsLookups = false;
     }
 
     /**

--- a/tests/Validation/ValidationFactoryTest.php
+++ b/tests/Validation/ValidationFactoryTest.php
@@ -9,9 +9,17 @@ use Illuminate\Validation\PresenceVerifierInterface;
 use Illuminate\Validation\Validator;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
 
 class ValidationFactoryTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        Validator::flushState();
+
+        parent::tearDown();
+    }
+
     public function testMakeMethodCreatesValidValidator()
     {
         $translator = m::mock(TranslatorInterface::class);
@@ -145,5 +153,12 @@ class ValidationFactoryTest extends TestCase
         $this->assertNull($factory->getContainer());
 
         $this->assertSame($container, $factory->setContainer($container)->getContainer());
+    }
+
+    public function testFakeDnsLookupsDelegatesToTheValidator()
+    {
+        (new Factory(m::mock(TranslatorInterface::class)))->fakeDnsLookups();
+
+        $this->assertTrue((new ReflectionProperty(Validator::class, 'fakeDnsLookups'))->getValue());
     }
 }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -5381,6 +5381,12 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['x' => ['not-a-string']], ['x' => 'active_url']);
         $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => 'http://foo..com'], ['x' => 'active_url']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => 'http://127.0.0.1'], ['x' => 'active_url']);
+        $this->assertFalse($v->passes());
     }
 
     public function testValidateEmailWithDnsCheckWithFakedDnsLookups()
@@ -5389,13 +5395,19 @@ class ValidationValidatorTest extends TestCase
 
         $trans = $this->getIlluminateArrayTranslator();
 
-        $v = new Validator($trans, ['x' => 'taylor@this-domain-does-not-exist.invalid'], ['x' => 'email:dns']);
+        $v = new Validator($trans, ['x' => 'taylor@this-domain-does-not-exist.com'], ['x' => 'email:dns']);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans, ['x' => 'taylor@this-domain-does-not-exist.invalid'], ['x' => 'email:rfc,dns']);
+        $v = new Validator($trans, ['x' => 'taylor@this-domain-does-not-exist.com'], ['x' => 'email:rfc,dns']);
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['x' => 'not-an-email'], ['x' => 'email:dns']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => '.invalid@gmail.com'], ['x' => 'email:dns']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => 'taylor@this-domain-does-not-exist.invalid'], ['x' => 'email:dns']);
         $this->assertFalse($v->passes());
     }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -35,6 +35,7 @@ use Mockery\MockInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
 use RuntimeException;
 use stdClass;
 use Symfony\Component\HttpFoundation\File\File;
@@ -42,6 +43,13 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 class ValidationValidatorTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        Validator::flushState();
+
+        parent::tearDown();
+    }
+
     public function testNestedErrorMessagesAreRetrievedFromLocalArray()
     {
         $trans = $this->getIlluminateArrayTranslator();
@@ -5366,6 +5374,53 @@ class ValidationValidatorTest extends TestCase
                 true,
             ],
         ];
+    }
+
+    public function testValidateActiveUrlWithFakedDnsLookups()
+    {
+        Validator::fakeDnsLookups();
+
+        $trans = $this->getIlluminateArrayTranslator();
+
+        $v = new Validator($trans, ['x' => 'https://this-domain-does-not-exist.invalid'], ['x' => 'active_url']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => 'aslsdlks'], ['x' => 'active_url']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => ['not-a-string']], ['x' => 'active_url']);
+        $this->assertFalse($v->passes());
+    }
+
+    public function testValidateEmailWithDnsCheckWithFakedDnsLookups()
+    {
+        Validator::fakeDnsLookups();
+
+        $trans = $this->getIlluminateArrayTranslator();
+
+        $v = new Validator($trans, ['x' => 'taylor@this-domain-does-not-exist.invalid'], ['x' => 'email:dns']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => 'taylor@this-domain-does-not-exist.invalid'], ['x' => 'email:rfc,dns']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => 'not-an-email'], ['x' => 'email:dns']);
+        $this->assertFalse($v->passes());
+    }
+
+    public function testFakedDnsLookupsCanBeToggledAndAreFlushed()
+    {
+        $property = new ReflectionProperty(Validator::class, 'fakeDnsLookups');
+
+        Validator::fakeDnsLookups();
+        $this->assertTrue($property->getValue());
+
+        Validator::fakeDnsLookups(false);
+        $this->assertFalse($property->getValue());
+
+        Validator::fakeDnsLookups();
+        Validator::flushState();
+        $this->assertFalse($property->getValue());
     }
 
     public function testValidateImage()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -31,7 +31,6 @@ use Illuminate\Validation\ValidationException;
 use Illuminate\Validation\Validator;
 use InvalidArgumentException;
 use Mockery as m;
-use Mockery\MockInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\TestCase;
@@ -5335,18 +5334,10 @@ class ValidationValidatorTest extends TestCase
     #[DataProvider('activeUrlDataProvider')]
     public function testValidateActiveUrl($data, $outcome)
     {
+        Validator::fakeDnsLookups();
+
         $trans = $this->getIlluminateArrayTranslator();
-        $v = m::mock(
-            new Validator($trans, $data, ['x' => 'active_url']),
-            function (MockInterface $mock) {
-                $mock
-                    ->shouldAllowMockingProtectedMethods()
-                    ->shouldReceive('getDnsRecords')
-                    ->withAnyArgs()
-                    ->zeroOrMoreTimes()
-                    ->andReturn(['hit']);
-            }
-        );
+        $v = new Validator($trans, $data, ['x' => 'active_url']);
         $this->assertEquals($outcome, $v->passes());
     }
 


### PR DESCRIPTION
Some of our tests are flaky because the `active_url` validation rule does a real DNS lookup that can randomly fail (even for a reliable domain like google.com). There is currently no straightforward way to fake these DNS lookups.

This PR adds `Validator::fakeDnsLookups()`, which makes `active_url` and `email:dns` skip the DNS lookup and treat it as successful. Everything else about these rules keeps working: malformed URLs and emails still fail.