### PR TITLE
[13.x] Mark HTTP testing credentials as sensitive

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -128,7 +128,7 @@ trait MakesHttpRequests
      * @param  string  $type
      * @return $this
      */
-    public function withToken(string $token, string $type = 'Bearer')
+    public function withToken(#[\SensitiveParameter] string $token, string $type = 'Bearer')
     {
         return $this->withHeader('Authorization', $type.' '.$token);
     }
@@ -140,7 +140,7 @@ trait MakesHttpRequests
      * @param  string  $password
      * @return $this
      */
-    public function withBasicAuth(string $username, string $password)
+    public function withBasicAuth(string $username, #[\SensitiveParameter] string $password)
     {
         return $this->withToken(base64_encode("$username:$password"), 'Basic');
     }

--- a/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
+++ b/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
@@ -5,9 +5,12 @@ namespace Illuminate\Tests\Foundation\Testing\Concerns;
 use Illuminate\Contracts\Routing\Registrar;
 use Illuminate\Contracts\Routing\UrlGenerator;
 use Illuminate\Foundation\Http\Middleware\HandlePrecognitiveRequests;
+use Illuminate\Foundation\Testing\Concerns\MakesHttpRequests;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Orchestra\Testbench\TestCase;
+use ReflectionMethod;
+use SensitiveParameter;
 
 class MakesHttpRequestsTest extends TestCase
 {
@@ -83,6 +86,15 @@ class MakesHttpRequestsTest extends TestCase
 
         $this->withBasicAuth($username, $password);
         $this->assertSame('Basic '.$callback($username, $password), $this->defaultHeaders['Authorization']);
+    }
+
+    public function testAuthenticationCredentialsAreSensitiveParameters()
+    {
+        $token = (new ReflectionMethod(MakesHttpRequests::class, 'withToken'))->getParameters()[0];
+        $password = (new ReflectionMethod(MakesHttpRequests::class, 'withBasicAuth'))->getParameters()[1];
+
+        $this->assertCount(1, $token->getAttributes(SensitiveParameter::class));
+        $this->assertCount(1, $password->getAttributes(SensitiveParameter::class));
     }
 
     public function testWithoutTokenRemovesAuthorizationHeader()


### PR DESCRIPTION
Laravel's HTTP client marks authentication tokens and passwords with PHP's `#[SensitiveParameter]` attribute, preventing these values from appearing in stack traces.

The equivalent `MakesHttpRequests` testing helpers did not provide the same protection.

This change marks:
- The token passed to `withToken()`
- The password passed to `withBasicAuth()`