### PR TITLE
[13.x] Fix iterable support in Arr::last()

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -329,6 +329,8 @@ class Arr
      */
     public static function last($array, ?callable $callback = null, $default = null)
     {
+        $array = static::from($array);
+
         if (is_null($callback)) {
             return empty($array) ? value($default) : array_last($array);
         }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Support;
 
+use ArrayIterator;
 use ArrayObject;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
@@ -502,6 +503,15 @@ class SupportArrTest extends TestCase
         $this->assertSame('bar', $value3);
         $this->assertSame('baz', $value4);
         $this->assertEquals(200, $value5);
+    }
+
+    public function testLastAcceptsIterables()
+    {
+        $items = new ArrayIterator(['first' => 100, 'second' => 200, 'third' => 300]);
+
+        $this->assertSame(300, Arr::last($items));
+        $this->assertSame(200, Arr::last($items, fn ($value, $key) => $key !== 'third'));
+        $this->assertSame('default', Arr::last(new ArrayIterator, default: 'default'));
     }
 
     public function testFlatten()


### PR DESCRIPTION
`Arr::last()` documents support for iterable values, but currently passes its input directly to array-only functions such as `array_last()` and `array_reverse()`.

Passing an `ArrayIterator`, generator, or another non-array iterable therefore results in a `TypeError`. 
This change normalizes the input through `Arr::from()` before applying the existing logic.