### PR TITLE
[13.x] Fix multibyte case-insensitive matching in Str::replace and Str::remove

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1286,7 +1286,50 @@ class Str
 
         return $caseSensitive
             ? str_replace($search, $replace, $subject)
-            : str_ireplace($search, $replace, $subject);
+            : static::replaceIgnoreCase($search, $replace, $subject);
+    }
+
+    /**
+     * Replace the given value in the given string regardless of case.
+     *
+     * @param  string|iterable<string>  $search
+     * @param  string|iterable<string>  $replace
+     * @param  string|iterable<string>  $subject
+     * @return string|string[]
+     */
+    protected static function replaceIgnoreCase($search, $replace, $subject)
+    {
+        $searches = is_array($search) ? array_values($search) : [$search];
+
+        if (static::isAscii(implode('', $searches))) {
+            return str_ireplace($search, $replace, $subject);
+        }
+
+        foreach ((array) $subject as $value) {
+            if (! preg_match('//u', (string) $value)) {
+                return str_ireplace($search, $replace, $subject);
+            }
+        }
+
+        $replacements = is_array($replace)
+            ? array_values($replace)
+            : array_fill(0, count($searches), $replace);
+
+        foreach ($searches as $index => $term) {
+            if ((string) $term === '') {
+                continue;
+            }
+
+            $replacement = (string) ($replacements[$index] ?? '');
+
+            $subject = preg_replace_callback(
+                '/'.preg_quote((string) $term, '/').'/iu',
+                fn () => $replacement,
+                $subject
+            );
+        }
+
+        return $subject;
     }
 
     /**
@@ -1419,7 +1462,7 @@ class Str
 
         return $caseSensitive
             ? str_replace($search, '', $subject)
-            : str_ireplace($search, '', $subject);
+            : static::replaceIgnoreCase($search, '', $subject);
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1292,9 +1292,9 @@ class Str
     /**
      * Replace the given value in the given string regardless of case.
      *
-     * @param  string|iterable<string>  $search
-     * @param  string|iterable<string>  $replace
-     * @param  string|iterable<string>  $subject
+     * @param  array|string  $search
+     * @param  array|string  $replace
+     * @param  array|string  $subject
      * @return string|string[]
      */
     protected static function replaceIgnoreCase($search, $replace, $subject)

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1292,9 +1292,9 @@ class Str
     /**
      * Replace the given value in the given string regardless of case.
      *
-     * @param  array|string  $search
-     * @param  array|string  $replace
-     * @param  array|string  $subject
+     * @param  string|string[]  $search
+     * @param  string|string[]  $replace
+     * @param  string|string[]  $subject
      * @return string|string[]
      */
     protected static function replaceIgnoreCase($search, $replace, $subject)

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1305,28 +1305,28 @@ class Str
             return str_ireplace($search, $replace, $subject);
         }
 
-        foreach ((array) $subject as $value) {
+        $replacements = is_array($replace)
+            ? array_values($replace)
+            : array_fill(0, count($searches), $replace);
+
+        foreach ([...$searches, ...$replacements, ...(array) $subject] as $value) {
             if (! preg_match('//u', (string) $value)) {
                 return str_ireplace($search, $replace, $subject);
             }
         }
 
-        $replacements = is_array($replace)
-            ? array_values($replace)
-            : array_fill(0, count($searches), $replace);
-
         foreach ($searches as $index => $term) {
-            if ((string) $term === '') {
+            $term = (string) $term;
+
+            if ($term === '') {
                 continue;
             }
 
             $replacement = (string) ($replacements[$index] ?? '');
 
-            $subject = preg_replace_callback(
-                '/'.preg_quote((string) $term, '/').'/iu',
-                fn () => $replacement,
-                $subject
-            );
+            $subject = static::isAscii($term)
+                ? str_ireplace($term, $replacement, $subject)
+                : preg_replace_callback('/'.preg_quote($term, '/').'/iu', fn () => $replacement, $subject);
         }
 
         return $subject;

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1286,7 +1286,7 @@ class Str
 
         return $caseSensitive
             ? str_replace($search, $replace, $subject)
-            : static::replaceIgnoreCase($search, $replace, $subject);
+            : static::replaceWhileIgnoringCase($search, $replace, $subject);
     }
 
     /**
@@ -1297,7 +1297,7 @@ class Str
      * @param  string|string[]  $subject
      * @return string|string[]
      */
-    protected static function replaceIgnoreCase($search, $replace, $subject)
+    protected static function replaceWhileIgnoringCase($search, $replace, $subject)
     {
         if (! is_array($search) && is_array($replace)) {
             return str_ireplace($search, $replace, $subject);
@@ -1466,7 +1466,7 @@ class Str
 
         return $caseSensitive
             ? str_replace($search, '', $subject)
-            : static::replaceIgnoreCase($search, '', $subject);
+            : static::replaceWhileIgnoringCase($search, '', $subject);
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1299,6 +1299,10 @@ class Str
      */
     protected static function replaceIgnoreCase($search, $replace, $subject)
     {
+        if (! is_array($search) && is_array($replace)) {
+            return str_ireplace($search, $replace, $subject);
+        }
+
         $searches = is_array($search) ? array_values($search) : [$search];
 
         if (array_all($searches, static::isAscii(...))) {

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1301,7 +1301,7 @@ class Str
     {
         $searches = is_array($search) ? array_values($search) : [$search];
 
-        if (static::isAscii(implode('', $searches))) {
+        if (array_all($searches, static::isAscii(...))) {
             return str_ireplace($search, $replace, $subject);
         }
 

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -945,6 +945,11 @@ class SupportStrTest extends TestCase
         $this->assertSame('foo/bar/baz', Str::replace(' ', '/', 'foo bar baz'));
         $this->assertSame('foo bar baz', Str::replace(['?1', '?2', '?3'], ['foo', 'bar', 'baz'], '?1 ?2 ?3'));
         $this->assertSame(['foo', 'bar', 'baz'], Str::replace(collect(['?1', '?2', '?3']), collect(['foo', 'bar', 'baz']), collect(['?1', '?2', '?3'])));
+
+        $this->assertSame('Xltý kôň', Str::replace('ž', 'X', 'Žltý kôň', false));
+        $this->assertSame('žltý pes', Str::replace('KÔŇ', 'pes', 'žltý kôň', false));
+        $this->assertSame('Xltý pes', Str::replace(['ž', 'KÔŇ'], ['X', 'pes'], 'Žltý kôň', false));
+        $this->assertSame(['Xltý', 'kôň'], Str::replace('ž', 'X', ['Žltý', 'kôň'], false));
     }
 
     public function testReplaceArray()
@@ -1026,6 +1031,9 @@ class SupportStrTest extends TestCase
         $this->assertSame('Fooar', Str::remove(['f', 'b'], 'Foobar'));
         $this->assertSame('ooar', Str::remove(['f', 'b'], 'Foobar', false));
         $this->assertSame('Foobar', Str::remove(['f', '|'], 'Foo|bar'));
+
+        $this->assertSame('ltý', Str::remove('ž', 'Žltý', false));
+        $this->assertSame('žltý ', Str::remove('KÔŇ', 'žltý kôň', false));
     }
 
     public function testReverse()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -954,6 +954,13 @@ class SupportStrTest extends TestCase
         $this->assertSame("caf\xC3 X", Str::replace('ž', 'X', "caf\xC3 ž", false));
     }
 
+    public function testReplaceThrowsForScalarSearchAndArrayReplacement()
+    {
+        $this->expectException(\TypeError::class);
+
+        Str::replace('ž', ['X'], 'Ž', false);
+    }
+
     public function testReplaceArray()
     {
         $this->assertSame('foo/bar/baz', Str::replaceArray('?', ['foo', 'bar', 'baz'], '?/?/?'));

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -950,6 +950,8 @@ class SupportStrTest extends TestCase
         $this->assertSame('žltý pes', Str::replace('KÔŇ', 'pes', 'žltý kôň', false));
         $this->assertSame('Xltý pes', Str::replace(['ž', 'KÔŇ'], ['X', 'pes'], 'Žltý kôň', false));
         $this->assertSame(['Xltý', 'kôň'], Str::replace('ž', 'X', ['Žltý', 'kôň'], false));
+        $this->assertSame('ſ Yito X', Str::replace(['s', 'ž'], ['X', 'Y'], 'ſ žito s', false));
+        $this->assertSame("caf\xC3 X", Str::replace('ž', 'X', "caf\xC3 ž", false));
     }
 
     public function testReplaceArray()


### PR DESCRIPTION
`Str::replace()` and `Str::remove()` with `$caseSensitive = false` delegate
to `str_ireplace()`, which only case-folds ASCII characters. Multibyte
characters are never matched case-insensitively:

```php
Str::replace('ž', 'X', 'Žltý kôň', false);     // "Žltý kôň" — nothing replaced
Str::replace('KÔŇ', 'pes', 'žltý kôň', false); // "žltý kôň" — nothing replaced
Str::remove('ž', 'Žltý', false);               // "Žltý" — nothing removed
```

This is inconsistent within the class itself -> `Str::contains()` considers
the same strings a case-insensitive match:

```php
Str::contains('Žltý', 'ž', ignoreCase: true); // true
```

ASCII-only search terms keep using `str_ireplace()` exactly as before.
Multibyte terms are matched via `preg_quote` + `/iu` patterns with a callback
replacement, replicating `str_ireplace()` array pairing and sequential
semantics. Subjects that are not valid UTF-8 fall back to `str_ireplace()`,
preserving the previous behavior.