### PR TITLE
[13.x] Add `concurrent` to `Arr`

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -4,12 +4,14 @@ namespace Illuminate\Support;
 
 use ArgumentCountError;
 use ArrayAccess;
+use ArrayIterator;
 use Closure;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
 use JsonSerializable;
+use MultipleIterator;
 use Random\Randomizer;
 use SortDirection;
 use Traversable;
@@ -1306,6 +1308,17 @@ class Arr
     public static function whereNotNull($array)
     {
         return static::where($array, fn ($value) => ! is_null($value));
+    }
+
+    public static function concurrent(array ...$arguments)
+    {
+        $multipleIterator = new MultipleIterator(MultipleIterator::MIT_NEED_ALL|MultipleIterator::MIT_KEYS_ASSOC);
+        
+        foreach ($arguments as $idx => $array) {
+            $multipleIterator->attachIterator(new ArrayIterator($array), $idx);
+        }
+        
+        return $multipleIterator;
     }
 
     /**

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -1312,7 +1312,10 @@ class Arr
 
     public static function concurrent(array ...$arguments)
     {
-        $multipleIterator = new MultipleIterator(MultipleIterator::MIT_NEED_ALL|MultipleIterator::MIT_KEYS_ASSOC);
+        $typeFlag = array_all($arguments, fn ($value) => array_is_list($value))
+            ? MultipleIterator::MIT_KEYS_ASSOC
+            : MultipleIterator::MIT_KEYS_NUMERIC;
+        $multipleIterator = new MultipleIterator(MultipleIterator::MIT_NEED_ALL|$typeFlag);
         
         foreach ($arguments as $idx => $array) {
             $multipleIterator->attachIterator(new ArrayIterator($array), $idx);

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -1315,7 +1315,7 @@ class Arr
         $typeFlag = array_all($arguments, fn ($value) => array_is_list($value))
             ? MultipleIterator::MIT_KEYS_ASSOC
             : MultipleIterator::MIT_KEYS_NUMERIC;
-        $multipleIterator = new MultipleIterator(MultipleIterator::MIT_NEED_ALL|$typeFlag);
+        $multipleIterator = new MultipleIterator(MultipleIterator::MIT_NEED_ANY|$typeFlag);
         
         foreach ($arguments as $idx => $array) {
             $multipleIterator->attachIterator(new ArrayIterator($array), $idx);

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -1315,7 +1315,7 @@ class Arr
         $typeFlag = array_all($arguments, fn ($value) => array_is_list($value))
             ? MultipleIterator::MIT_KEYS_ASSOC
             : MultipleIterator::MIT_KEYS_NUMERIC;
-        $multipleIterator = new MultipleIterator(MultipleIterator::MIT_NEED_ANY|$typeFlag);
+        $multipleIterator = new MultipleIterator(MultipleIterator::MIT_NEED_ANY | $typeFlag);
 
         foreach ($arguments as $idx => $array) {
             $multipleIterator->attachIterator(new ArrayIterator($array), $idx);

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -1316,11 +1316,11 @@ class Arr
             ? MultipleIterator::MIT_KEYS_ASSOC
             : MultipleIterator::MIT_KEYS_NUMERIC;
         $multipleIterator = new MultipleIterator(MultipleIterator::MIT_NEED_ANY|$typeFlag);
-        
+
         foreach ($arguments as $idx => $array) {
             $multipleIterator->attachIterator(new ArrayIterator($array), $idx);
         }
-        
+
         return $multipleIterator;
     }
 

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1964,8 +1964,8 @@ class SupportArrTest extends TestCase
         $this->assertEquals([[0 => 'John', 1 => 'Jane'], [2 => 'Greg']], $result);
     }
 
-    #[TestWith([[[1, 2], [3, 4]], [2, 4, 6, 8]])]
-    #[TestWith([[['a' => 1, 'b' => 2], ['c' => 3, 'd' => 4]], [2, 4, 6, 8]])]
+    #[TestWith([[[1, 2], [3, 4]], [2, 6, 4, 8]])]
+    #[TestWith([[['a' => 1, 'b' => 2], ['c' => 3, 'd' => 4]], [2, 6, 4, 8]])]
     public function testConcurrent(array $input, array $output)
     {
         $result = [];

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1971,7 +1971,7 @@ class SupportArrTest extends TestCase
         $result = [];
 
         foreach (Arr::concurrent(...$input) as $key => [$c, $d]) {
-            array_push($result, ...array_map(fn ($value) => $value * 2), [$c, $d]);
+            array_push($result, $c * 2, $d * 2);
         }
 
         $this->assertEquals($output, $result);

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1973,7 +1973,7 @@ class SupportArrTest extends TestCase
         foreach (Arr::concurrent(...$input) as $key => [$c, $d]) {
             array_push($result, ...array_map(fn ($value) => $value * 2), [$c, $d]);
         }
-        
+
         $this->assertEquals($output, $result);
     }
 }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -11,6 +11,7 @@ use Illuminate\Support\ItemNotFoundException;
 use Illuminate\Support\MultipleItemsFoundException;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 use WeakMap;
@@ -1961,5 +1962,18 @@ class SupportArrTest extends TestCase
         $result = Arr::partition($array, fn (string $value) => str_contains($value, 'J'));
 
         $this->assertEquals([[0 => 'John', 1 => 'Jane'], [2 => 'Greg']], $result);
+    }
+
+    #[TestWith([[[1, 2], [3, 4]], [2, 4, 6, 8]])]
+    #[TestWith([[['a' => 1, 'b' => 2], ['c' => 3, 'd' => 4]], [2, 4, 6, 8]])]
+    public function testConcurrent(array $input, array $output)
+    {
+        $result = [];
+
+        foreach (Arr::concurrent(...$input) as $key => [$c, $d]) {
+            array_push($result, ...array_map(fn ($value) => $value * 2), [$c, $d])
+        }
+        
+        $this->assertEquals($output, $result);
     }
 }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1971,7 +1971,7 @@ class SupportArrTest extends TestCase
         $result = [];
 
         foreach (Arr::concurrent(...$input) as $key => [$c, $d]) {
-            array_push($result, ...array_map(fn ($value) => $value * 2), [$c, $d])
+            array_push($result, ...array_map(fn ($value) => $value * 2), [$c, $d]);
         }
         
         $this->assertEquals($output, $result);


### PR DESCRIPTION
# Current
Looping over multiple arrays in parallel can be cumbersome or even imperformant when done poorly.
```php
$foo = [1, 2];
$bar = [3, 4];

foreach ($foo as $fooKey => $fooValue) {
	foreach ($bar as $barKey => $barValue) {
		//
	}
}

// or

foreach ($foo as $fooKey => $fooValue) {
	$barValue = $bar[$fooKey];
	//
}
```

# Proposed
```php
$foo = [1, 2];
$bar = [3, 4];
$baz = Arr::concurrent($foo, $bar);

foreach ($baz as $key => [$fooValue, $barValue]) {
	//
}
```

This is especially helpful when having more than just two arrays.