### PR TITLE
Fix null handling in Arr::last() method

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -329,6 +329,10 @@ class Arr
      */
     public static function last($array, ?callable $callback = null, $default = null)
     {
+        if ($array === null) {
+            return value($default);
+        }
+
         $array = static::from($array);
 
         if (is_null($callback)) {

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -326,7 +326,6 @@ class Arr
      * @param  (callable(TValue, TKey): bool)|null  $callback
      * @param  TLastDefault|(\Closure(): TLastDefault)  $default
      * @return TValue|TLastDefault
-     * @phpstan-result ($array is null ? TLastDefault : TValue|TLastDefault)
      */
     public static function last($array, ?callable $callback = null, $default = null)
     {

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -326,6 +326,7 @@ class Arr
      * @param  (callable(TValue, TKey): bool)|null  $callback
      * @param  TLastDefault|(\Closure(): TLastDefault)  $default
      * @return TValue|TLastDefault
+     * @phpstan-result ($array is null ? TLastDefault : TValue|TLastDefault)
      */
     public static function last($array, ?callable $callback = null, $default = null)
     {


### PR DESCRIPTION
## Summary

This PR adds a simple null check to `Arr::last()`.

Currently, passing `null` relies on `Arr::from()` to handle the value. By returning the default value immediately when the input is `null`, the method becomes more explicit and avoids unnecessary processing.

### Before

```php
Arr::last(null, default: 'fallback');
```

The method passes `null` through `Arr::from()` before returning the default value.

### After

```php
Arr::last(null, default: 'fallback');
```

The method immediately returns the default value without further processing.

## Changes

```php
if ($array === null) {
    return value($default);
}
```

This preserves the existing behavior while making the intent clearer and avoiding an unnecessary call to `Arr::from()`.

## Backward Compatibility

* ✅ No breaking changes
* ✅ Existing behavior is preserved
* ✅ Adds a small optimization for `null` input


Issue: #60881