### PR TITLE
[13.x] Support a leading "!" to mark a Command option's value as required

### DIFF
--- a/src/Illuminate/Console/Parser.php
+++ b/src/Illuminate/Console/Parser.php
@@ -97,19 +97,29 @@ class Parser
     {
         [$token, $description] = static::extractDescription($token);
 
-        preg_match('/^(?:(.*?)\s*\|\s*)?(!)?(.*)$/', $token, $matches);
+        preg_match('/^(?:(.*?)\s*\|\s*)?(!)?([^=]+?)(?:(=)(\*)?(.*))?$/', $token, $matches);
 
-        [$required, $shortcut, $token] = [$matches[2] === '!', $matches[1] !== '' ? $matches[1] : null, $matches[3]];
+        [$shortcut, $mode, $token, $array, $default] = [
+            $matches[1] !== '' ? $matches[1] : null,
+            $matches[2] === '!' ? InputOption::VALUE_REQUIRED : InputOption::VALUE_OPTIONAL,
+            $matches[3],
+            ($matches[5] ?? '') === '*',
+            $matches[6] ?? '',
+        ];
 
-        $mode = $required ? InputOption::VALUE_REQUIRED : InputOption::VALUE_OPTIONAL;
+        if (($matches[4] ?? '') !== '=') {
+            return new InputOption($token, $shortcut, InputOption::VALUE_NONE, $description);
+        }
 
-        return match (true) {
-            str_ends_with($token, '=') => new InputOption(trim($token, '='), $shortcut, $mode, $description),
-            str_ends_with($token, '=*') => new InputOption(trim($token, '=*'), $shortcut, $mode | InputOption::VALUE_IS_ARRAY, $description),
-            (bool) preg_match('/(.+)\=\*(.+)/', $token, $matches) => new InputOption($matches[1], $shortcut, $mode | InputOption::VALUE_IS_ARRAY, $description, preg_split('/,\s?/', $matches[2])),
-            (bool) preg_match('/(.+)\=(.+)/', $token, $matches) => new InputOption($matches[1], $shortcut, $mode, $description, $matches[2]),
-            default => new InputOption($token, $shortcut, InputOption::VALUE_NONE, $description),
-        };
+        if ($array) {
+            $mode |= InputOption::VALUE_IS_ARRAY;
+        }
+
+        return new InputOption($token, $shortcut, $mode, $description, match (true) {
+            $default === '' => null,
+            $array => preg_split('/,\s?/', $default),
+            default => $default,
+        });
     }
 
     /**

--- a/src/Illuminate/Console/Parser.php
+++ b/src/Illuminate/Console/Parser.php
@@ -97,20 +97,17 @@ class Parser
     {
         [$token, $description] = static::extractDescription($token);
 
-        $matches = preg_split('/\s*\|\s*/', $token, 2);
+        preg_match('/^(?:(.*?)\s*\|\s*)?(!)?(.*)$/', $token, $matches);
 
-        $shortcut = null;
+        [$required, $shortcut, $token] = [$matches[2] === '!', $matches[1] !== '' ? $matches[1] : null, $matches[3]];
 
-        if (isset($matches[1])) {
-            $shortcut = $matches[0];
-            $token = $matches[1];
-        }
+        $mode = $required ? InputOption::VALUE_REQUIRED : InputOption::VALUE_OPTIONAL;
 
         return match (true) {
-            str_ends_with($token, '=') => new InputOption(trim($token, '='), $shortcut, InputOption::VALUE_OPTIONAL, $description),
-            str_ends_with($token, '=*') => new InputOption(trim($token, '=*'), $shortcut, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, $description),
-            (bool) preg_match('/(.+)\=\*(.+)/', $token, $matches) => new InputOption($matches[1], $shortcut, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, $description, preg_split('/,\s?/', $matches[2])),
-            (bool) preg_match('/(.+)\=(.+)/', $token, $matches) => new InputOption($matches[1], $shortcut, InputOption::VALUE_OPTIONAL, $description, $matches[2]),
+            str_ends_with($token, '=') => new InputOption(trim($token, '='), $shortcut, $mode, $description),
+            str_ends_with($token, '=*') => new InputOption(trim($token, '=*'), $shortcut, $mode | InputOption::VALUE_IS_ARRAY, $description),
+            (bool) preg_match('/(.+)\=\*(.+)/', $token, $matches) => new InputOption($matches[1], $shortcut, $mode | InputOption::VALUE_IS_ARRAY, $description, preg_split('/,\s?/', $matches[2])),
+            (bool) preg_match('/(.+)\=(.+)/', $token, $matches) => new InputOption($matches[1], $shortcut, $mode, $description, $matches[2]),
             default => new InputOption($token, $shortcut, InputOption::VALUE_NONE, $description),
         };
     }

--- a/tests/Console/ConsoleParserTest.php
+++ b/tests/Console/ConsoleParserTest.php
@@ -146,6 +146,41 @@ class ConsoleParserTest extends TestCase
         $this->assertSame('default', $results[2][0]->getDefault());
     }
 
+    public function testRequiredOptionValueParsing()
+    {
+        $results = Parser::parse('command:name {--!option= : The option description.}');
+
+        $this->assertSame('option', $results[2][0]->getName());
+        $this->assertSame('The option description.', $results[2][0]->getDescription());
+        $this->assertTrue($results[2][0]->acceptValue());
+        $this->assertTrue($results[2][0]->isValueRequired());
+        $this->assertFalse($results[2][0]->isValueOptional());
+        $this->assertNull($results[2][0]->getDefault());
+
+        $results = Parser::parse('command:name {--o|!option=}');
+
+        $this->assertSame('o', $results[2][0]->getShortcut());
+        $this->assertSame('option', $results[2][0]->getName());
+        $this->assertTrue($results[2][0]->isValueRequired());
+
+        $results = Parser::parse('command:name {--!option=*}');
+
+        $this->assertSame('option', $results[2][0]->getName());
+        $this->assertTrue($results[2][0]->isArray());
+        $this->assertTrue($results[2][0]->isValueRequired());
+
+        $results = Parser::parse('command:name {--!option=*defaultOptionValue1,defaultOptionValue2}');
+
+        $this->assertTrue($results[2][0]->isArray());
+        $this->assertTrue($results[2][0]->isValueRequired());
+        $this->assertEquals(['defaultOptionValue1', 'defaultOptionValue2'], $results[2][0]->getDefault());
+
+        $results = Parser::parse('command:name {--!option=defaultOptionValue}');
+
+        $this->assertTrue($results[2][0]->isValueRequired());
+        $this->assertSame('defaultOptionValue', $results[2][0]->getDefault());
+    }
+
     public function testNameIsSpacesException()
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Console/ConsoleParserTest.php
+++ b/tests/Console/ConsoleParserTest.php
@@ -146,7 +146,7 @@ class ConsoleParserTest extends TestCase
         $this->assertSame('default', $results[2][0]->getDefault());
     }
 
-    public function testRequiredOptionValueParsing()
+    public function testRequiredOptionValueParsing(): void
     {
         $results = Parser::parse('command:name {--!option= : The option description.}');
 
@@ -173,7 +173,7 @@ class ConsoleParserTest extends TestCase
 
         $this->assertTrue($results[2][0]->isArray());
         $this->assertTrue($results[2][0]->isValueRequired());
-        $this->assertEquals(['defaultOptionValue1', 'defaultOptionValue2'], $results[2][0]->getDefault());
+        $this->assertSame(['defaultOptionValue1', 'defaultOptionValue2'], $results[2][0]->getDefault());
 
         $results = Parser::parse('command:name {--!option=defaultOptionValue}');
 


### PR DESCRIPTION
Adds a leading `!` marker to the CLI command signature's option DSL (e.g. `--!option=`) to mark an option's value as required (`VALUE_REQUIRED`) instead of the default optional (`VALUE_OPTIONAL`), so `--option` alone with no value is rejected.