### PR TITLE
[13.x] Add a monthly log driver

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "league/flysystem": "^3.25.1",
         "league/flysystem-local": "^3.25.1",
         "league/uri": "^7.5.1",
-        "monolog/monolog": "^3.0",
+        "monolog/monolog": "^3.4",
         "nesbot/carbon": "^3.8.4",
         "nunomaduro/termwind": "^2.0",
         "psr/container": "^1.1.1 || ^2.0.1",

--- a/config/logging.php
+++ b/config/logging.php
@@ -45,7 +45,7 @@ return [
     | utilizes the Monolog PHP logging library, which includes a variety
     | of powerful log handlers and formatters that you're free to use.
     |
-    | Available drivers: "single", "daily", "slack", "syslog",
+    | Available drivers: "single", "daily", "monthly", "slack", "syslog",
     |                    "errorlog", "monolog", "custom", "stack"
     |
     */

--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -325,10 +325,43 @@ class LogManager implements LoggerInterface
      */
     protected function createDailyDriver(array $config)
     {
+        return $this->createRotatingDriver(
+            $config,
+            RotatingFileHandler::FILE_PER_DAY,
+            $config['max_files'] ?? $config['days'] ?? 7,
+        );
+    }
+
+    /**
+     * Create an instance of the monthly file log driver.
+     *
+     * @param  array  $config
+     * @return \Psr\Log\LoggerInterface
+     */
+    protected function createMonthlyDriver(array $config)
+    {
+        return $this->createRotatingDriver(
+            $config,
+            RotatingFileHandler::FILE_PER_MONTH,
+            $config['max_files'] ?? 3,
+        );
+    }
+
+    /**
+     * Create an instance of a rotating file log driver.
+     *
+     * @param  array  $config
+     * @param  string  $dateFormat
+     * @param  int  $maxFiles
+     * @return \Psr\Log\LoggerInterface
+     */
+    protected function createRotatingDriver(array $config, string $dateFormat, $maxFiles)
+    {
         return new Monolog($this->parseChannel($config), [
             $this->prepareHandler(new RotatingFileHandler(
-                $config['path'], $config['days'] ?? 7, $this->level($config),
-                $config['bubble'] ?? true, $config['permission'] ?? null, $config['locking'] ?? false
+                $config['path'], $maxFiles, $this->level($config),
+                $config['bubble'] ?? true, $config['permission'] ?? null, $config['locking'] ?? false,
+                $dateFormat,
             ), $config),
         ], $config['replace_placeholders'] ?? false ? [new PsrLogMessageProcessor()] : []);
     }

--- a/src/Illuminate/Log/composer.json
+++ b/src/Illuminate/Log/composer.json
@@ -17,7 +17,7 @@
         "php": "^8.3",
         "illuminate/contracts": "^13.0",
         "illuminate/support": "^13.0",
-        "monolog/monolog": "^3.0",
+        "monolog/monolog": "^3.4",
         "psr/log": "^1.0 || ^2.0 || ^3.0"
     },
     "provide": {

--- a/tests/Log/LogManagerTest.php
+++ b/tests/Log/LogManagerTest.php
@@ -11,6 +11,7 @@ use Monolog\Handler\FingersCrossedHandler;
 use Monolog\Handler\LogEntriesHandler;
 use Monolog\Handler\NewRelicHandler;
 use Monolog\Handler\NullHandler;
+use Monolog\Handler\RotatingFileHandler;
 use Monolog\Handler\StreamHandler;
 use Monolog\Handler\SyslogHandler;
 use Monolog\Level;
@@ -19,6 +20,7 @@ use Monolog\Processor\MemoryUsageProcessor;
 use Monolog\Processor\PsrLogMessageProcessor;
 use Monolog\Processor\UidProcessor;
 use Orchestra\Testbench\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LoggerTrait;
 use ReflectionProperty;
@@ -362,7 +364,7 @@ class LogManagerTest extends TestCase
         $handler = $logger->getLogger()->getHandlers()[0];
         $formatter = $handler->getFormatter();
 
-        $this->assertInstanceOf(StreamHandler::class, $handler);
+        $this->assertInstanceOf(RotatingFileHandler::class, $handler);
         $this->assertInstanceOf(LineFormatter::class, $formatter);
         $this->assertInstanceOf(PsrLogMessageProcessor::class, $logger->getLogger()->getProcessors()[1]);
 
@@ -381,13 +383,66 @@ class LogManagerTest extends TestCase
         $handler = $logger->getLogger()->getHandlers()[0];
         $formatter = $handler->getFormatter();
 
-        $this->assertInstanceOf(StreamHandler::class, $handler);
+        $this->assertInstanceOf(RotatingFileHandler::class, $handler);
         $this->assertInstanceOf(HtmlFormatter::class, $formatter);
         $this->assertCount(1, $logger->getLogger()->getProcessors());
 
         $dateFormat = new ReflectionProperty(get_class($formatter), 'dateFormat');
 
         $this->assertSame('Y/m/d--test', $dateFormat->getValue($formatter));
+    }
+
+    public static function rotatingFileDriverDataProvider()
+    {
+        return [
+            'daily' => ['daily', 'Y-m-d', ['2026-01-01', '2026-01-02', '2026-01-03']],
+            'monthly' => ['monthly', 'Y-m', ['2026-01', '2026-02', '2026-03']],
+        ];
+    }
+
+    #[DataProvider('rotatingFileDriverDataProvider')]
+    public function testRotatingFileDriversLogToADateStampedFileAndPruneOldOnes($driver, $dateFormat, $staleDates)
+    {
+        foreach (glob(storage_path("logs/rotating-$driver-*.log")) as $file) {
+            unlink($file);
+        }
+
+        $stalePaths = array_map(fn ($date) => storage_path("logs/rotating-$driver-$date.log"), $staleDates);
+
+        foreach ($stalePaths as $stalePath) {
+            file_put_contents($stalePath, 'stale');
+        }
+
+        $this->app['config']->set("logging.channels.rotating-$driver", [
+            'driver' => $driver,
+            'path' => storage_path("logs/rotating-$driver.log"),
+            'level' => 'warning',
+            'max_files' => 3,
+        ]);
+
+        $logger = (new LogManager($this->app))->channel("rotating-$driver");
+
+        $logger->warning('Something went wrong');
+
+        $handler = $logger->getLogger()->getHandlers()[0];
+
+        $handler->close();
+
+        $expectedPath = storage_path("logs/rotating-$driver-".date($dateFormat).'.log');
+
+        $this->assertInstanceOf(RotatingFileHandler::class, $handler);
+        $this->assertSame(Level::Warning, $handler->getLevel());
+        $this->assertFileExists($expectedPath);
+        $this->assertSame($expectedPath, $handler->getUrl());
+        $this->assertStringContainsString('WARNING: Something went wrong', file_get_contents($expectedPath));
+
+        $this->assertFileDoesNotExist($stalePaths[0]);
+        $this->assertFileExists($stalePaths[1]);
+        $this->assertFileExists($stalePaths[2]);
+
+        unlink($expectedPath);
+        unlink($stalePaths[1]);
+        unlink($stalePaths[2]);
     }
 
     public function testLogManagerCreateSyslogDriverWithConfiguredFormatter()

--- a/tests/Log/LogManagerTest.php
+++ b/tests/Log/LogManagerTest.php
@@ -436,6 +436,7 @@ class LogManagerTest extends TestCase
         $this->assertSame($expectedPath, $handler->getUrl());
         $this->assertStringContainsString('WARNING: Something went wrong', file_get_contents($expectedPath));
 
+        // max_files = 3, the oldest 4th file was deleted
         $this->assertFileDoesNotExist($stalePaths[0]);
         $this->assertFileExists($stalePaths[1]);
         $this->assertFileExists($stalePaths[2]);


### PR DESCRIPTION
The daily log driver is great because it has log rotation, but a file per day is overkill for smaller applications, you end up with a lot of nearly empty log files.

This PR adds a monthly log driver, which creates files called `laravel-2026-05.log`, `laravel-2026-06.log`, etc:
```
'monthly' => [
    'driver' => 'monthly',
    'path' => storage_path('logs/laravel.log'),
    'max_files' => 3,
],
```

For reference, [Monolog's `RotatingFileHandler`](https://github.com/Seldaek/monolog/blob/57eb1028342134e701e77c617565d51b6e5a2a53/src/Monolog/Handler/RotatingFileHandler.php#L31-L34) also supports hourly and yearly log rotation.