### PR TITLE
[13.x] Prevent fatal errors when logging deprecations fails

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -98,23 +98,23 @@ class HandleExceptions
 
         try {
             $logger = static::$app->make(LogManager::class);
-        } catch (Exception) {
+
+            $this->ensureDeprecationLoggerIsConfigured();
+
+            $options = static::$app['config']->get('logging.deprecations') ?? [];
+
+            with($logger->channel('deprecations'), function ($log) use ($message, $file, $line, $level, $options) {
+                if ($options['trace'] ?? false) {
+                    $log->warning((string) new ErrorException($message, 0, $level, $file, $line));
+                } else {
+                    $log->warning(sprintf('%s in %s on line %s',
+                        $message, $file, $line
+                    ));
+                }
+            });
+        } catch (Throwable) {
             return;
         }
-
-        $this->ensureDeprecationLoggerIsConfigured();
-
-        $options = static::$app['config']->get('logging.deprecations') ?? [];
-
-        with($logger->channel('deprecations'), function ($log) use ($message, $file, $line, $level, $options) {
-            if ($options['trace'] ?? false) {
-                $log->warning((string) new ErrorException($message, 0, $level, $file, $line));
-            } else {
-                $log->warning(sprintf('%s in %s on line %s',
-                    $message, $file, $line
-                ));
-            }
-        });
     }
 
     /**

--- a/tests/Foundation/Bootstrap/HandleExceptionsTest.php
+++ b/tests/Foundation/Bootstrap/HandleExceptionsTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Foundation\Bootstrap;
 
+use Error;
 use ErrorException;
 use Illuminate\Config\Repository as Config;
 use Illuminate\Foundation\Application;
@@ -326,6 +327,23 @@ class HandleExceptionsTest extends TestCase
     {
         $this->app->expects('runningUnitTests')->andReturn(false);
         $this->app->expects('hasBeenBootstrapped')->andReturn(true);
+
+        $this->handleExceptions()->handleError(
+            E_DEPRECATED,
+            'str_contains(): Passing null to parameter #2 ($needle) of type string is deprecated',
+            '/home/user/laravel/routes/web.php',
+            17
+        );
+    }
+
+    public function testIgnoreDeprecationIfLoggingFails()
+    {
+        $logger = m::mock(LogManager::class);
+        $this->app->instance(LogManager::class, $logger);
+        $this->app->expects('runningUnitTests')->andReturn(false);
+        $this->app->expects('hasBeenBootstrapped')->andReturn(true);
+
+        $logger->expects('channel')->with('deprecations')->andThrow(new Error('Class "Monolog\Logger" not found'));
 
         $this->handleExceptions()->handleError(
             E_DEPRECATED,


### PR DESCRIPTION
The prefer-lowest builds on 13.x are currently failing because PHP 8.4 raises an implicit-nullable deprecation while compiling Monolog 3.4's Logger class. The deprecation handler then attempts to log through Monolog while that class is still mid-autoload, and the process fatals with a "Class Monolog\Logger not found" error. This is what kills the Concurrency child processes on Linux and the ExceptionHandler subprocess on Windows. Reporting a deprecation should never be able to crash the application, so the logging attempt now ignores any failure that occurs while building or using the deprecations channel.