### PR TITLE
[13.x] Bump `monolog/monolog` constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "league/flysystem": "^3.25.1",
         "league/flysystem-local": "^3.25.1",
         "league/uri": "^7.5.1",
-        "monolog/monolog": "^3.4",
+        "monolog/monolog": "^3.10",
         "nesbot/carbon": "^3.8.4",
         "nunomaduro/termwind": "^2.0",
         "psr/container": "^1.1.1 || ^2.0.1",

--- a/src/Illuminate/Log/composer.json
+++ b/src/Illuminate/Log/composer.json
@@ -17,7 +17,7 @@
         "php": "^8.3",
         "illuminate/contracts": "^13.0",
         "illuminate/support": "^13.0",
-        "monolog/monolog": "^3.4",
+        "monolog/monolog": "^3.10",
         "psr/log": "^1.0 || ^2.0 || ^3.0"
     },
     "provide": {


### PR DESCRIPTION
Bunch of CI Tests are blowing up, which I noticed from a bunch of PRs see: 
https://github.com/laravel/framework/actions/runs/30223863316/job/89850797259#step:5:345
https://github.com/laravel/framework/actions/runs/30203611247/job/89797743945#step:5:275
https://github.com/laravel/framework/actions/runs/30223267704/job/89849265120#step:5:275

From my understanding, as its  currently set as 3.4.0 Monologs  addRecord method, the  `$datetime` param [isn't declared nullable](https://github.com/Seldaek/monolog/blob/3.4.0/src/Monolog/Logger.php#L321) meaning it triggers a deprecation while its autoloading that Laravel's deprecation handler is trying to pick up causing nukes in CI

  Monolog's changelog shows this was fixed through various releases:
  - [3.6.0](https://github.com/Seldaek/monolog/releases#release-3.6.0)  Fixed PHP 8.4 deprecation warnings
  - [3.8.0](https://github.com/Seldaek/monolog/releases#release-3.8.0)  Fixed PHP 8.4 deprecation notices
  - [3.10.0](https://github.com/Seldaek/monolog/releases#release-3.10.0) Fixed PHP 8.5 deprecation warnings 

  Since Laravel's tests matrix is up to PHP 8.5, I set it as 3.10.0 to cover it all which afaik means up to 3.10.0, which is fine from my understanding as it's "up to" 
  
Maybe this is a crazy idea? But seems fine to my brain

 Thx!