### PR TITLE
[13.x] Add monthly channel to logging config

### DIFF
--- a/config/logging.php
+++ b/config/logging.php
@@ -69,7 +69,15 @@ return [
             'driver' => 'daily',
             'path' => storage_path('logs/laravel.log'),
             'level' => env('LOG_LEVEL', 'debug'),
-            'days' => env('LOG_DAILY_DAYS', 14),
+            'max_files' => env('LOG_DAILY_DAYS', 14),
+            'replace_placeholders' => true,
+        ],
+
+        'monthly' => [
+            'driver' => 'monthly',
+            'path' => storage_path('logs/laravel.log'),
+            'level' => env('LOG_LEVEL', 'debug'),
+            'max_files' => 3,
             'replace_placeholders' => true,
         ],
 


### PR DESCRIPTION
Follow-up to #60892, which added the `monthly` log driver and updated the driver list comment in `config/logging.php`, while the matching channel entry was only added to the `laravel/laravel` skeleton.

This brings the framework's `config/logging.php` back in sync with the skeleton:

- Adds the `monthly` channel definition (same values as the skeleton).
- Uses the `max_files` option for the `daily` channel, matching the skeleton and the option name preferred by `LogManager`.

No behavior change: `LogManager` resolves `max_files ?? days ?? 7` for the daily driver, and the `LOG_DAILY_DAYS` environment variable is unchanged.