### PR TITLE
[13.x] Use a timing-safe comparison for the maintenance mode bypass secret

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/maintenance-mode.stub
+++ b/src/Illuminate/Foundation/Console/stubs/maintenance-mode.stub
@@ -52,7 +52,7 @@ if (isset($data['except'])) {
 }
 
 // Allow framework to handle maintenance mode bypass route...
-if (isset($data['secret']) && $_SERVER['REQUEST_URI'] === '/'.$data['secret']) {
+if (isset($data['secret']) && hash_equals('/'.$data['secret'], $_SERVER['REQUEST_URI'] ?? '')) {
     return;
 }
 

--- a/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
+++ b/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
@@ -72,7 +72,7 @@ class PreventRequestsDuringMaintenance
                 throw $exception;
             }
 
-            if (isset($data['secret']) && $request->path() === $data['secret']) {
+            if (is_string($data['secret'] ?? null) && hash_equals($data['secret'], $request->path())) {
                 return $this->bypassResponse($data['secret']);
             }
 


### PR DESCRIPTION
`PreventRequestsDuringMaintenance` compares the bypass secret to the request path with a plain string comparison:

```php
if (isset($data['secret']) && $request->path() === $data['secret']) {
    return $this->bypassResponse($data['secret']);
}
```

The cookie that this branch issues is already validated with `hash_equals()` in `MaintenanceModeBypassCookie::isValid()`, so the two halves of the same bypass flow currently use different comparison styles. This makes them consistent.

The same comparison exists in `stubs/maintenance-mode.stub`, eleven lines above the `hash_equals()` call that validates the bypass cookie, so this changes both (thanks @GrahamCampbell for pointing that one out). That path runs before the framework boots.

To be clear about the scope: I am **not** reporting an exploitable vulnerability. No usable timing oracle exists here — `===` compares lengths before content, so wrong-length guesses never reach `memcmp`, and a short secret is a single vectorized compare with no per-byte gradient to climb. This is a defense-in-depth/consistency change in the same spirit as #21320, where the `remember_me` comparison was moved to `hash_equals()`.

There is no behavior change in either file, for any input:

- **Middleware:** the `isset()` guard becomes `is_string()`, because the original `===` is strict and would never have matched a non-string secret. Without the guard, `hash_equals()` would raise a `TypeError` where the old code returned `false`.
- **Stub:** the `isset()` guard is kept, because there the secret is concatenated onto `'/'` before the comparison, so a non-string secret is already coerced to a string and continues to match exactly as before.

| `$data['secret']` | request | before | after |
| --- | --- | --- | --- |
| `'foo'` | `'foo'` | `true` | `true` |
| `'foo'` | `'bar'` | `false` | `false` |
| not set | `'foo'` | `false` | `false` |
| `123` (middleware) | `'123'` | `false` | `false` |
| `123` (stub) | `'/123'` | `true` | `true` |

The existing maintenance mode tests in `tests/Integration/Foundation/MaintenanceModeTest.php` continue to describe the expected behavior.
