### PR TITLE
[13.x] Honor JSON:API sparse fieldsets for relationships

### DIFF
--- a/src/Illuminate/Http/Resources/JsonApi/Concerns/ResolvesJsonApiElements.php
+++ b/src/Illuminate/Http/Resources/JsonApi/Concerns/ResolvesJsonApiElements.php
@@ -74,7 +74,7 @@ trait ResolvesJsonApiElements
             'type' => $resourceType,
             ...(new Collection([
                 'attributes' => $this->resolveResourceAttributes($request, $resourceType),
-                'relationships' => $this->resolveResourceRelationshipIdentifiers($request),
+                'relationships' => $this->resolveResourceRelationshipIdentifiers($request, $resourceType),
                 'links' => $this->resolveResourceLinks($request),
                 'meta' => $this->resolveResourceMetaInformation($request),
             ]))->filter()->map(fn ($value) => (object) $value),
@@ -164,7 +164,7 @@ trait ResolvesJsonApiElements
      *
      * @throws \RuntimeException
      */
-    protected function resolveResourceRelationshipIdentifiers(JsonApiRequest $request): array
+    protected function resolveResourceRelationshipIdentifiers(JsonApiRequest $request, ?string $resourceType = null): array
     {
         if (! $this->resource instanceof Model) {
             return [];
@@ -172,8 +172,13 @@ trait ResolvesJsonApiElements
 
         $this->compileResourceRelationships($request);
 
+        $resourceType ??= $this->resolveResourceType($request);
+
+        $usesSparseFieldset = $this->usesRequestQueryString && $request->hasSparseFieldset($resourceType);
+
         return [
             ...(new Collection($this->filter($this->loadedRelationshipIdentifiers)))
+                ->when($usesSparseFieldset, fn ($relationships) => $relationships->only($request->sparseFields($resourceType)))
                 ->map(function ($relation) {
                     return ! is_null($relation) ? $relation : ['data' => null];
                 })->all(),

--- a/tests/Integration/Http/Resources/JsonApi/JsonApiResourceTest.php
+++ b/tests/Integration/Http/Resources/JsonApi/JsonApiResourceTest.php
@@ -64,6 +64,84 @@ class JsonApiResourceTest extends TestCase
             ->assertJsonMissing(['jsonapi', 'included']);
     }
 
+    public function testItOmitsRelationshipsNotListedInSparseFieldsets()
+    {
+        $user = User::factory()->create();
+
+        $post = Post::factory()->create([
+            'user_id' => $user->getKey(),
+        ]);
+
+        $this->getJson("/users/{$user->getKey()}?".http_build_query([
+            'include' => 'posts',
+            'fields' => ['users' => 'name'],
+        ]))
+            ->assertHeader('Content-type', 'application/vnd.api+json')
+            ->assertExactJson([
+                'data' => [
+                    'id' => (string) $user->getKey(),
+                    'type' => 'users',
+                    'attributes' => [
+                        'name' => $user->name,
+                    ],
+                ],
+                'included' => [
+                    [
+                        'id' => (string) $post->getKey(),
+                        'type' => 'posts',
+                        'attributes' => [
+                            'title' => $post->title,
+                            'content' => $post->content,
+                        ],
+                    ],
+                ],
+            ]);
+    }
+
+    public function testItRetainsRelationshipsListedInSparseFieldsets()
+    {
+        $user = User::factory()->create();
+
+        $post = Post::factory()->create([
+            'user_id' => $user->getKey(),
+        ]);
+
+        $this->getJson("/users/{$user->getKey()}?".http_build_query([
+            'include' => 'posts',
+            'fields' => ['users' => 'name,posts'],
+        ]))
+            ->assertHeader('Content-type', 'application/vnd.api+json')
+            ->assertExactJson([
+                'data' => [
+                    'id' => (string) $user->getKey(),
+                    'type' => 'users',
+                    'attributes' => [
+                        'name' => $user->name,
+                    ],
+                    'relationships' => [
+                        'posts' => [
+                            'data' => [
+                                [
+                                    'id' => (string) $post->getKey(),
+                                    'type' => 'posts',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                'included' => [
+                    [
+                        'id' => (string) $post->getKey(),
+                        'type' => 'posts',
+                        'attributes' => [
+                            'title' => $post->title,
+                            'content' => $post->content,
+                        ],
+                    ],
+                ],
+            ]);
+    }
+
     public function testItCanGenerateJsonApiResponseWithEmptyRelationshipsUsingSparseIncluded()
     {
         $user = User::factory()->create();


### PR DESCRIPTION
Sparse fieldsets are currently applied only to a resource object's `attributes`. Relationships are not filtered, so a request that restricts the fields for a type still receives that type's relationships:

```
GET /users/1?include=posts&fields[users]=name
```

```json
{
    "data": {
        "id": "1",
        "type": "users",
        "attributes": { "name": "Taylor" },
        "relationships": {
            "posts": { "data": [{ "id": "1", "type": "posts" }] }
        }
    },
    "included": [ ... ]
}
```

`posts` was not requested in `fields[users]`, so it should not appear.

The specification defines a resource object's attributes and relationships collectively as its **fields**:

> A resource object's attributes and its relationships are collectively called its "fields".
> — [Resource Objects](https://jsonapi.org/format/#document-resource-objects)

and requires that a restricted fieldset be respected:

> If a client requests a restricted set of fields for a resource type, an endpoint **MUST NOT** include additional fields in resource objects of that type in its response.
> — [Sparse Fieldsets](https://jsonapi.org/format/#fetching-sparse-fieldsets)

This applies the fieldset to relationships using the same `usesRequestQueryString` / `hasSparseFieldset` checks already used for attributes, so `ignoreFieldsAndIncludesInQueryString()` continues to opt out of both, and an empty fieldset (`fields[users]=`) drops relationships just as #59813 made it drop attributes.

After the change the response is:

```json
{
    "data": {
        "id": "1",
        "type": "users",
        "attributes": { "name": "Taylor" }
    },
    "included": [ ... ]
}
```

Requesting the relationship keeps it, as expected:

```
GET /users/1?include=posts&fields[users]=name,posts
```

**Scope notes**

- `included` is deliberately untouched. It is governed by the `include` parameter, not by `fields`, so the related resources are still returned (with their own type's fieldset applied to them).
- `resolveResourceRelationshipIdentifiers()` takes the resource type as an **optional** second parameter rather than a required one, so any application overriding this `protected` method keeps working on 13.x. `resolveResourceObject()` passes the type it has already resolved, so there is no extra work per resource.

**Tests**

Two tests added to `JsonApiResourceTest`: one asserting an unrequested relationship is omitted, one asserting a requested relationship is retained. I confirmed the first fails without the source change and passes with it.

Locally: `tests/Http` and `tests/Integration/Http` pass (770 tests, 2358 assertions), and Pint and PHPStan (`phpstan.src.neon.dist`) both report no issues.
