### PR TITLE
[13.x] Improve `Collection::select` generic types

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -996,7 +996,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Select specific values from the items within the collection.
      *
-     * @param  \Illuminate\Support\Enumerable<array-key, TKey>|array<array-key, TKey>|string|null  $keys
+     * @param  \Illuminate\Support\Enumerable<int, string>|list<string>|string|null  $keys
      * @return static
      */
     public function select($keys)


### PR DESCRIPTION
The generic types do not satisfy this method correctly and fail on the basic documented way of using it, e.g., 

```php
$users = collect([
    ['name' => 'Taylor Otwell', 'role' => 'Developer', 'status' => 'active'],
    ['name' => 'Victoria Faith', 'role' => 'Researcher', 'status' => 'active'],
]);
 
$users->select(['name', 'role']);
```

The method was expecting `TKey`, but that would mean it is expect a key from the parent collection, e.g., `0` and / or `1`, but what we really want is a key from the nested value.

I have no idea how to do that, so I'm just making it actually work and make sense, e.g., pass a list of strings.