### PR TITLE
[13.x] Release unique job locks by owner

### DIFF
--- a/src/Illuminate/Bus/Queueable.php
+++ b/src/Illuminate/Bus/Queueable.php
@@ -50,6 +50,13 @@ trait Queueable
     public $debounceOwner = '';
 
     /**
+     * The lock owner token held by the dispatch that acquired the unique lock.
+     *
+     * @var string
+     */
+    public $uniqueLockOwner = '';
+
+    /**
      * The number of seconds before the job should be made available.
      *
      * @var \DateTimeInterface|\DateInterval|array|int|null

--- a/src/Illuminate/Bus/UniqueLock.php
+++ b/src/Illuminate/Bus/UniqueLock.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Bus;
 
+use Illuminate\Contracts\Cache\LockProvider;
 use Illuminate\Contracts\Cache\Repository as Cache;
 use Illuminate\Queue\Attributes\ReadsQueueAttributes;
 use Illuminate\Queue\Attributes\UniqueFor;
@@ -39,11 +40,20 @@ class UniqueLock
             ? $job->uniqueFor()
             : ($this->getAttributeValue($job, UniqueFor::class, 'uniqueFor') ?? 0);
 
-        $cache = method_exists($job, 'uniqueVia')
-            ? ($job->uniqueVia() ?? $this->cache)
-            : $this->cache;
+        $cache = $this->resolveCache($job);
 
-        return (bool) $cache->lock(self::getKey($job), $uniqueFor)->get();
+        $lock = $cache->lock(self::getKey($job), $uniqueFor);
+
+        if (! $lock->get()) {
+            return false;
+        }
+
+        if (isset(class_uses_recursive($job)[Queueable::class]) &&
+            $cache->getStore() instanceof LockProvider) {
+            $job->uniqueLockOwner = $lock->owner();
+        }
+
+        return true;
     }
 
     /**
@@ -54,11 +64,34 @@ class UniqueLock
      */
     public function release($job)
     {
-        $cache = method_exists($job, 'uniqueVia')
-            ? ($job->uniqueVia() ?? $this->cache)
-            : $this->cache;
+        $cache = $this->resolveCache($job);
+
+        $owner = isset(class_uses_recursive($job)[Queueable::class])
+            ? ($job->uniqueLockOwner ?? '')
+            : '';
+
+        if (is_string($owner) && $owner !== '') {
+            if ($cache->getStore() instanceof LockProvider) {
+                $cache->restoreLock(self::getKey($job), $owner)->release();
+            }
+
+            return;
+        }
 
         $cache->lock(self::getKey($job))->forceRelease();
+    }
+
+    /**
+     * Resolve the cache repository that should be used for the given job.
+     *
+     * @param  mixed  $job
+     * @return \Illuminate\Contracts\Cache\Repository
+     */
+    private function resolveCache($job)
+    {
+        return method_exists($job, 'uniqueVia')
+            ? ($job->uniqueVia() ?? $this->cache)
+            : $this->cache;
     }
 
     /**

--- a/src/Illuminate/Foundation/Bus/PendingDispatch.php
+++ b/src/Illuminate/Foundation/Bus/PendingDispatch.php
@@ -282,22 +282,22 @@ class PendingDispatch
      */
     public function __destruct()
     {
-        $this->addUniqueJobInformationToContext($this->job);
-
         if (! $this->shouldDispatch()) {
-            $this->removeUniqueJobInformationFromContext($this->job);
-
             return;
         }
 
-        $this->acquireDebounceLock();
+        try {
+            $this->addUniqueJobInformationToContext($this->job);
 
-        if ($this->afterResponse) {
-            app(Dispatcher::class)->dispatchAfterResponse($this->job);
-        } else {
-            app(Dispatcher::class)->dispatch($this->job);
+            $this->acquireDebounceLock();
+
+            if ($this->afterResponse) {
+                app(Dispatcher::class)->dispatchAfterResponse($this->job);
+            } else {
+                app(Dispatcher::class)->dispatch($this->job);
+            }
+        } finally {
+            $this->removeUniqueJobInformationFromContext($this->job);
         }
-
-        $this->removeUniqueJobInformationFromContext($this->job);
     }
 }

--- a/src/Illuminate/Foundation/Queue/InteractsWithUniqueJobs.php
+++ b/src/Illuminate/Foundation/Queue/InteractsWithUniqueJobs.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Queue;
 
+use Illuminate\Bus\Queueable;
 use Illuminate\Bus\UniqueLock;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Support\Facades\Context;
@@ -20,6 +21,9 @@ trait InteractsWithUniqueJobs
             Context::addHidden([
                 'laravel_unique_job_cache_store' => $this->getUniqueJobCacheStore($job),
                 'laravel_unique_job_key' => UniqueLock::getKey($job),
+                'laravel_unique_job_lock_owner' => isset(class_uses_recursive($job)[Queueable::class])
+                    ? ($job->uniqueLockOwner ?? '')
+                    : '',
             ]);
         }
     }
@@ -36,6 +40,7 @@ trait InteractsWithUniqueJobs
             Context::forgetHidden([
                 'laravel_unique_job_cache_store',
                 'laravel_unique_job_key',
+                'laravel_unique_job_lock_owner',
             ]);
         }
     }

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -6,9 +6,11 @@ use Exception;
 use Illuminate\Bus\Batchable;
 use Illuminate\Bus\BatchRepository;
 use Illuminate\Bus\DebounceLock;
+use Illuminate\Bus\Queueable;
 use Illuminate\Bus\UniqueLock;
 use Illuminate\Contracts\Bus\Dispatcher;
 use Illuminate\Contracts\Cache\Factory as CacheFactory;
+use Illuminate\Contracts\Cache\LockProvider;
 use Illuminate\Contracts\Cache\Repository as Cache;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Encryption\Encrypter;
@@ -139,12 +141,16 @@ class CallQueuedHandler
         return (new Pipeline($this->container))->send($command)
             ->through(array_merge(method_exists($command, 'middleware') ? $command->middleware() : [], $command->middleware ?? []))
             ->finally(function ($command) use (&$lockReleased) {
-                if (! $lockReleased && $this->commandShouldBeUniqueUntilProcessing($command) && ! $command->job->isReleased() && $command->job->attempts() <= 1) {
+                if (! $lockReleased &&
+                    $this->commandShouldBeUniqueUntilProcessing($command) &&
+                    ! $command->job->isReleased() &&
+                    $this->uniqueJobLockShouldBeReleased($command->job, $command)) {
                     $this->ensureUniqueJobLockIsReleased($command);
                 }
             })
             ->then(function ($command) use ($job, &$lockReleased) {
-                if ($this->commandShouldBeUniqueUntilProcessing($command) && $job->attempts() <= 1) {
+                if ($this->commandShouldBeUniqueUntilProcessing($command) &&
+                    $this->uniqueJobLockShouldBeReleased($job, $command)) {
                     $this->ensureUniqueJobLockIsReleased($command);
 
                     $lockReleased = true;
@@ -233,6 +239,21 @@ class CallQueuedHandler
         if ($this->commandShouldBeUnique($command)) {
             (new UniqueLock($this->container->make(Cache::class)))->release($command);
         }
+    }
+
+    /**
+     * Determine if the unique job lock can be safely released.
+     *
+     * @param  \Illuminate\Contracts\Queue\Job  $job
+     * @param  mixed  $command
+     * @return bool
+     */
+    private function uniqueJobLockShouldBeReleased(Job $job, $command)
+    {
+        return $job->attempts() <= 1 ||
+            (isset(class_uses_recursive($command)[Queueable::class]) &&
+             is_string($command->uniqueLockOwner ?? null) &&
+             $command->uniqueLockOwner !== '');
     }
 
     /**
@@ -333,16 +354,20 @@ class CallQueuedHandler
 
         $context = $this->container->make(ContextRepository::class);
 
-        [$store, $key] = [
+        [$store, $key, $owner] = [
             $context->getHidden('laravel_unique_job_cache_store'),
             $context->getHidden('laravel_unique_job_key'),
+            $context->getHidden('laravel_unique_job_lock_owner'),
         ];
 
         if ($store && $key) {
-            $this->container->make(CacheFactory::class)
-                ->store($store)
-                ->lock($key)
-                ->forceRelease();
+            $cache = $this->container->make(CacheFactory::class)->store($store);
+
+            if (is_string($owner) && $owner !== '' && $cache->getStore() instanceof LockProvider) {
+                $cache->restoreLock($key, $owner)->release();
+            } elseif (is_null($owner) || $owner === '') {
+                $cache->lock($key)->forceRelease();
+            }
         }
     }
 

--- a/tests/Bus/BusUniqueLockTest.php
+++ b/tests/Bus/BusUniqueLockTest.php
@@ -1,0 +1,254 @@
+<?php
+
+namespace Illuminate\Tests\Bus;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Bus\UniqueLock;
+use Illuminate\Cache\ArrayStore;
+use Illuminate\Cache\Repository;
+use Illuminate\Contracts\Cache\Lock;
+use Illuminate\Contracts\Cache\Repository as Cache;
+use Illuminate\Contracts\Cache\Store;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class BusUniqueLockTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+
+        parent::tearDown();
+    }
+
+    public function test_acquire_records_the_owner_of_the_lock_on_the_job()
+    {
+        $cache = new Repository(new ArrayStore);
+
+        $job = new UniqueLockTestJob;
+
+        $this->assertTrue((new UniqueLock($cache))->acquire($job));
+
+        $this->assertNotSame('', $job->uniqueLockOwner);
+
+        // The recorded token is the real owner of the lock, so restoring the
+        // lock with it releases the lock...
+        $this->assertTrue(
+            $cache->restoreLock(UniqueLock::getKey($job), $job->uniqueLockOwner)->release()
+        );
+        $this->assertTrue((new UniqueLock($cache))->acquire(new UniqueLockTestJob));
+    }
+
+    public function test_acquire_does_not_record_an_owner_when_the_lock_is_not_acquired()
+    {
+        $cache = new Repository(new ArrayStore);
+
+        $this->assertTrue((new UniqueLock($cache))->acquire(new UniqueLockTestJob));
+
+        $second = new UniqueLockTestJob;
+
+        $this->assertFalse((new UniqueLock($cache))->acquire($second));
+        $this->assertSame('', $second->uniqueLockOwner);
+    }
+
+    public function test_release_does_not_release_a_lock_owned_by_another_dispatch()
+    {
+        $cache = new Repository(new ArrayStore);
+
+        $lock = new UniqueLock($cache);
+
+        // The first dispatch acquires the lock and its own owner token...
+        $stale = new UniqueLockTestJob;
+        $this->assertTrue($lock->acquire($stale));
+
+        // The lock is released before processing, and a replacement dispatch
+        // acquires it with a brand new owner token...
+        $lock->release($stale);
+        $replacement = new UniqueLockTestJob;
+        $this->assertTrue($lock->acquire($replacement));
+
+        // A stale delivery of the first dispatch must not release the
+        // replacement's lock...
+        $lock->release($stale);
+
+        $this->assertFalse($lock->acquire(new UniqueLockTestJob));
+
+        // ...and the replacement is still able to release its own lock.
+        $lock->release($replacement);
+
+        $this->assertTrue($lock->acquire(new UniqueLockTestJob));
+    }
+
+    public function test_release_force_releases_payloads_that_have_no_recorded_owner()
+    {
+        $cache = new Repository(new ArrayStore);
+
+        $lock = new UniqueLock($cache);
+
+        $this->assertTrue($lock->acquire(new UniqueLockTestJob));
+
+        // Payloads queued before an upgrade carry no owner token, so they must
+        // keep the previous force release behaviour...
+        $legacy = new UniqueLockTestJob;
+        $this->assertSame('', $legacy->uniqueLockOwner);
+
+        $lock->release($legacy);
+
+        $this->assertTrue($cache->lock(UniqueLock::getKey($legacy))->get());
+    }
+
+    public function test_release_force_releases_a_payload_serialized_before_the_owner_property_existed()
+    {
+        $cache = new Repository(new ArrayStore);
+
+        $lock = new UniqueLock($cache);
+
+        $this->assertTrue($lock->acquire(new UniqueLockTestJob));
+
+        $class = UniqueLockTestJob::class;
+        $legacy = unserialize(sprintf('O:%d:"%s":0:{}', strlen($class), $class));
+
+        $this->assertInstanceOf(UniqueLockTestJob::class, $legacy);
+        $this->assertSame('', $legacy->uniqueLockOwner);
+
+        $lock->release($legacy);
+
+        $this->assertTrue($cache->lock(UniqueLock::getKey($legacy))->get());
+    }
+
+    public function test_release_force_releases_when_the_store_does_not_provide_locks()
+    {
+        $cacheLock = m::mock(Lock::class);
+        $cacheLock->shouldReceive('get')->once()->andReturn(true);
+        $cacheLock->shouldNotReceive('owner');
+        $cacheLock->shouldReceive('forceRelease')->once();
+
+        $store = m::mock(Store::class);
+        $store->shouldReceive('lock')->twice()->andReturn($cacheLock);
+
+        $job = new UniqueLockTestJob;
+
+        $lock = new UniqueLock(new Repository($store));
+
+        $this->assertTrue($lock->acquire($job));
+        $this->assertSame('', $job->uniqueLockOwner);
+
+        $lock->release($job);
+    }
+
+    public function test_acquire_does_not_create_dynamic_properties_on_jobs_without_the_owner_property()
+    {
+        $cache = new Repository(new ArrayStore);
+
+        $job = new UniqueLockTestJobWithoutQueueable;
+
+        $this->assertTrue((new UniqueLock($cache))->acquire($job));
+        $this->assertFalse(property_exists($job, 'uniqueLockOwner'));
+    }
+
+    public function test_jobs_without_queueable_may_define_their_own_owner_property()
+    {
+        foreach ([
+            new UniqueLockTestJobWithPrivateOwner,
+            new UniqueLockTestJobWithProtectedOwner,
+            new UniqueLockTestJobWithReadonlyOwner,
+        ] as $job) {
+            $cache = new Repository(new ArrayStore);
+            $lock = new UniqueLock($cache);
+
+            $this->assertTrue($lock->acquire($job));
+            $this->assertSame('application-owner', $job->ownerValue());
+
+            $lock->release($job);
+
+            $this->assertTrue($cache->lock(UniqueLock::getKey($job))->get());
+        }
+    }
+
+    public function test_unique_via_is_used_when_releasing_by_owner()
+    {
+        $default = new Repository(new ArrayStore);
+        $alternate = new Repository(new ArrayStore);
+
+        UniqueViaLockTestJob::$cache = $alternate;
+
+        $job = new UniqueViaLockTestJob;
+        $lock = new UniqueLock($default);
+
+        $this->assertTrue($lock->acquire($job));
+
+        $defaultLock = $default->lock(UniqueLock::getKey($job));
+        $this->assertTrue($defaultLock->get());
+        $this->assertFalse($alternate->lock(UniqueLock::getKey($job))->get());
+
+        $lock->release($job);
+
+        $this->assertTrue($alternate->lock(UniqueLock::getKey($job))->get());
+
+        $defaultLock->release();
+    }
+}
+
+class UniqueLockTestJob implements ShouldBeUnique
+{
+    use Queueable;
+
+    public function uniqueId()
+    {
+        return 'unique-id';
+    }
+}
+
+class UniqueLockTestJobWithoutQueueable implements ShouldBeUnique
+{
+    public function uniqueId()
+    {
+        return 'unique-id';
+    }
+}
+
+class UniqueLockTestJobWithPrivateOwner extends UniqueLockTestJobWithoutQueueable
+{
+    private $uniqueLockOwner = 'application-owner';
+
+    public function ownerValue()
+    {
+        return $this->uniqueLockOwner;
+    }
+}
+
+class UniqueLockTestJobWithProtectedOwner extends UniqueLockTestJobWithoutQueueable
+{
+    protected $uniqueLockOwner = 'application-owner';
+
+    public function ownerValue()
+    {
+        return $this->uniqueLockOwner;
+    }
+}
+
+class UniqueLockTestJobWithReadonlyOwner extends UniqueLockTestJobWithoutQueueable
+{
+    public readonly string $uniqueLockOwner;
+
+    public function __construct()
+    {
+        $this->uniqueLockOwner = 'application-owner';
+    }
+
+    public function ownerValue()
+    {
+        return $this->uniqueLockOwner;
+    }
+}
+
+class UniqueViaLockTestJob extends UniqueLockTestJob
+{
+    public static $cache;
+
+    public function uniqueVia(): Cache
+    {
+        return static::$cache;
+    }
+}

--- a/tests/Events/QueuedEventsTest.php
+++ b/tests/Events/QueuedEventsTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Events;
 use Illuminate\Bus\Dispatcher as BusDispatcher;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Cache\Lock;
+use Illuminate\Contracts\Cache\LockProvider;
 use Illuminate\Contracts\Cache\Repository as Cache;
 use Illuminate\Contracts\Queue\Job;
 use Illuminate\Contracts\Queue\Queue;
@@ -354,7 +355,9 @@ class QueuedEventsTest extends TestCase
         $container->instance(Cache::class, $cache);
 
         $cache->shouldReceive('lock')->once()->andReturn($lock);
+        $cache->shouldReceive('getStore')->once()->andReturn(m::mock(LockProvider::class));
         $lock->shouldReceive('get')->once()->andReturn(true);
+        $lock->shouldReceive('owner')->andReturn('unique-lock-owner');
 
         $d->setQueueResolver(function () use ($fakeQueue) {
             return $fakeQueue;
@@ -407,7 +410,9 @@ class QueuedEventsTest extends TestCase
         $container->instance(Cache::class, $cache);
 
         $cache->shouldReceive('lock')->once()->andReturn($lock);
+        $cache->shouldReceive('getStore')->once()->andReturn(m::mock(LockProvider::class));
         $lock->shouldReceive('get')->once()->andReturn(true);
+        $lock->shouldReceive('owner')->andReturn('unique-lock-owner');
 
         $d->setQueueResolver(function () use ($fakeQueue) {
             return $fakeQueue;
@@ -434,7 +439,9 @@ class QueuedEventsTest extends TestCase
         $container->instance(Cache::class, $cache);
 
         $cache->shouldReceive('lock')->once()->andReturn($lock);
+        $cache->shouldReceive('getStore')->once()->andReturn(m::mock(LockProvider::class));
         $lock->shouldReceive('get')->once()->andReturn(true);
+        $lock->shouldReceive('owner')->andReturn('unique-lock-owner');
 
         $d->setQueueResolver(function () use ($fakeQueue) {
             return $fakeQueue;
@@ -478,7 +485,9 @@ class QueuedEventsTest extends TestCase
             ->once()
             ->with($expectedKey, 60)
             ->andReturn($lock);
+        $cache->shouldReceive('getStore')->once()->andReturn(m::mock(LockProvider::class));
         $lock->shouldReceive('get')->once()->andReturn(true);
+        $lock->shouldReceive('owner')->andReturn('unique-lock-owner');
 
         $d->setQueueResolver(function () use ($fakeQueue) {
             return $fakeQueue;
@@ -512,7 +521,9 @@ class QueuedEventsTest extends TestCase
             ->once()
             ->with($expectedKey, 60)
             ->andReturn($lock);
+        $uniqueCache->shouldReceive('getStore')->once()->andReturn(m::mock(LockProvider::class));
         $lock->shouldReceive('get')->once()->andReturn(true);
+        $lock->shouldReceive('owner')->andReturn('unique-lock-owner');
 
         $d->setQueueResolver(function () use ($fakeQueue) {
             return $fakeQueue;

--- a/tests/Integration/Queue/JobDispatchingTest.php
+++ b/tests/Integration/Queue/JobDispatchingTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Integration\Queue;
 
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Bus\Dispatcher;
 use Illuminate\Contracts\Cache\Repository;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -13,7 +14,10 @@ use Illuminate\Queue\Events\JobQueueing;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Context;
+use Mockery as m;
 use Orchestra\Testbench\Attributes\WithMigration;
+use RuntimeException;
 
 #[WithMigration]
 #[WithMigration('queue')]
@@ -138,6 +142,44 @@ class JobDispatchingTest extends QueueTestCase
         UniqueJob::dispatchAfterResponse('test');
         $this->app->terminate();
         $this->assertFalse(UniqueJob::$ran);
+    }
+
+    public function testUniqueJobContextIsRemovedWhenDispatchThrows()
+    {
+        $job = new UniqueJob('context-failure');
+
+        $dispatcher = m::mock(Dispatcher::class);
+        $dispatcher->shouldReceive('dispatch')->once()->with($job)->andReturnUsing(function () use ($job) {
+            $this->assertSame(
+                config('cache.default'),
+                Context::getHidden('laravel_unique_job_cache_store')
+            );
+            $this->assertSame(
+                'laravel_unique_job:'.UniqueJob::class.':context-failure',
+                Context::getHidden('laravel_unique_job_key')
+            );
+            $this->assertSame(
+                $job->uniqueLockOwner,
+                Context::getHidden('laravel_unique_job_lock_owner')
+            );
+            $this->assertNotSame('', $job->uniqueLockOwner);
+
+            throw new RuntimeException('Dispatch failed.');
+        });
+
+        $this->app->instance(Dispatcher::class, $dispatcher);
+
+        try {
+            dispatch($job);
+
+            $this->fail('Expected the dispatcher to throw.');
+        } catch (RuntimeException $e) {
+            $this->assertSame('Dispatch failed.', $e->getMessage());
+        }
+
+        $this->assertNull(Context::getHidden('laravel_unique_job_cache_store'));
+        $this->assertNull(Context::getHidden('laravel_unique_job_key'));
+        $this->assertNull(Context::getHidden('laravel_unique_job_lock_owner'));
     }
 
     public function testQueueMayBeNullForJobQueueingAndJobQueuedEvent()

--- a/tests/Integration/Queue/UniqueJobTest.php
+++ b/tests/Integration/Queue/UniqueJobTest.php
@@ -170,6 +170,26 @@ class UniqueJobTest extends QueueTestCase
         $this->assertFalse($this->app->get(Cache::class)->lock($this->getLockKey($job), 10)->get());
     }
 
+    public function testRetryOfOwnerlessUniqueUntilProcessingJobDoesNotForceReleaseSubsequentLock()
+    {
+        $this->markTestSkippedWhenUsingSyncQueueDriver();
+
+        dispatch($job = new OwnerlessUniqueUntilProcessingRetryJob);
+
+        $cache = $this->app->get(Cache::class);
+
+        $this->runQueueWorkerCommand(['--once' => true]);
+
+        $this->assertTrue($job::$handled);
+        $this->assertTrue($cache->lock($this->getLockKey($job), 60)->get());
+
+        OwnerlessUniqueUntilProcessingRetryJob::$handled = false;
+        $this->runQueueWorkerCommand(['--once' => true]);
+
+        $this->assertTrue($job::$handled);
+        $this->assertFalse($cache->lock($this->getLockKey($job), 10)->get());
+    }
+
     public function testLockIsReleasedOnModelNotFoundException()
     {
         UniqueTestSerializesModelsJob::$handled = false;
@@ -190,6 +210,34 @@ class UniqueJobTest extends QueueTestCase
             $this->assertModelMissing($user);
             $this->assertTrue($this->app->get(Cache::class)->lock($this->getLockKey($job), 10)->get());
         }
+    }
+
+    public function testModelNotFoundExceptionOnlyReleasesTheLockOwnedByTheMissingJob()
+    {
+        $this->markTestSkippedWhenUsingSyncQueueDriver();
+
+        UniqueTestSerializesModelsJob::$handled = false;
+
+        /** @var \Illuminate\Foundation\Auth\User */
+        $user = UserFactory::new()->create();
+        $job = new UniqueTestSerializesModelsJob($user);
+        $cache = $this->app->get(Cache::class);
+        $lock = new UniqueLock($cache);
+
+        dispatch($job);
+
+        $lock->release($job);
+
+        $replacement = new UniqueTestSerializesModelsJob($user);
+        $this->assertTrue($lock->acquire($replacement));
+
+        $user->delete();
+        $this->runQueueWorkerCommand(['--once' => true]);
+
+        $this->assertFalse($job::$handled);
+        $this->assertFalse($cache->lock($this->getLockKey($job), 10)->get());
+
+        $lock->release($replacement);
     }
 
     public function testQueueFakeReleasesUniqueJobLocksBetweenFakes()
@@ -330,6 +378,24 @@ class UniqueUntilStartTestJob extends UniqueTestJob implements ShouldBeUniqueUnt
 class UniqueUntilProcessingRetryJob implements ShouldQueue, ShouldBeUniqueUntilProcessing
 {
     use InteractsWithQueue, Queueable, Dispatchable;
+
+    public $tries = 2;
+
+    public static $handled = false;
+
+    public function handle()
+    {
+        static::$handled = true;
+
+        if ($this->attempts() === 1) {
+            throw new Exception('First attempt failure.');
+        }
+    }
+}
+
+class OwnerlessUniqueUntilProcessingRetryJob implements ShouldQueue, ShouldBeUniqueUntilProcessing
+{
+    use InteractsWithQueue, Dispatchable;
 
     public $tries = 2;
 

--- a/tests/Integration/Queue/UniqueUntilProcessingJobTest.php
+++ b/tests/Integration/Queue/UniqueUntilProcessingJobTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Queue;
 
+use Exception;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldBeUniqueUntilProcessing;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -48,6 +49,41 @@ class UniqueUntilProcessingJobTest extends QueueTestCase
         UniqueUntilProcessingJobThatReleases::dispatch();
         $this->assertDatabaseCount('jobs', 1);
     }
+
+    public function testShouldBeUniqueUntilProcessingReleasesLockOnTheAttemptThatIsProcessed()
+    {
+        UniqueUntilProcessingJobThatReleasesOnce::dispatch();
+
+        $this->assertNotNull(DB::table('cache_locks')->first());
+
+        // Attempt 1: a middleware releases the job before it is handled, so the
+        // lock must be retained -- the job is still pending on the queue...
+        $this->runQueueWorkerCommand(['--once' => true]);
+
+        $this->assertFalse(UniqueUntilProcessingJobThatReleasesOnce::$handled);
+        $this->assertNotNull(DB::table('cache_locks')->first());
+
+        // Attempt 2: the middleware lets the job through, so the lock must be
+        // released before the job is handled...
+        $this->runQueueWorkerCommand(['--once' => true]);
+
+        $this->assertTrue(UniqueUntilProcessingJobThatReleasesOnce::$handled);
+        $this->assertNull(DB::table('cache_locks')->first());
+    }
+
+    public function testShouldBeUniqueUntilProcessingReleasesLockFromFinallyOnALaterAttempt()
+    {
+        UniqueUntilProcessingJobThatThrowsFromMiddleware::dispatch();
+
+        $this->runQueueWorkerCommand(['--once' => true]);
+
+        $this->assertNotNull(DB::table('cache_locks')->first());
+
+        $this->runQueueWorkerCommand(['--once' => true]);
+
+        $this->assertFalse(UniqueUntilProcessingJobThatThrowsFromMiddleware::$handled);
+        $this->assertNull(DB::table('cache_locks')->first());
+    }
 }
 
 class UniqueTestJobThatDoesNotRelease implements ShouldQueue, ShouldBeUniqueUntilProcessing
@@ -85,5 +121,55 @@ class UniqueUntilProcessingJobThatReleases extends UniqueTestJobThatDoesNotRelea
     public function uniqueId()
     {
         return 100;
+    }
+}
+
+class UniqueUntilProcessingJobThatReleasesOnce extends UniqueTestJobThatDoesNotRelease
+{
+    public $tries = 3;
+
+    public function middleware()
+    {
+        return [
+            function ($job, $next) {
+                if ($job->attempts() === 1) {
+                    static::$released = true;
+
+                    return $job->release();
+                }
+
+                return $next($job);
+            },
+        ];
+    }
+
+    public function uniqueId()
+    {
+        return 200;
+    }
+}
+
+class UniqueUntilProcessingJobThatThrowsFromMiddleware extends UniqueTestJobThatDoesNotRelease
+{
+    public $tries = 3;
+
+    public function middleware()
+    {
+        return [
+            function ($job) {
+                if ($job->attempts() === 1) {
+                    static::$released = true;
+
+                    return $job->release();
+                }
+
+                throw new Exception('Middleware failure.');
+            },
+        ];
+    }
+
+    public function uniqueId()
+    {
+        return 300;
     }
 }


### PR DESCRIPTION
Fixes #60042.

`ShouldBeUniqueUntilProcessing` jobs normally release their unique lock immediately before the handler runs. When middleware releases the job on its first attempt, `CallQueuedHandler` correctly skips that release because the job was released. On the later delivery, however, the existing `attempts() <= 1` guard prevents the lock from ever being released, so the job can remain unique for its full TTL even after it is eventually processed.

This change records the owner token when a `Queueable` job acquires its unique lock and uses that token to release the same lock owner on later attempts. It also:

- releases owner-aware locks through `restoreLock(...)->release()` so a stale payload cannot remove a replacement owner's lock;
- retains the existing attempt-one behavior for legacy or otherwise ownerless payloads;
- honors `uniqueVia()` and records owners only for stores that expose `LockProvider`;
- carries the owner through the missing-model context cleanup path; and
- always removes hidden unique-job context when pending dispatch throws.

## Relation to #60846

#60846 identified the same root cause and proposed the same owner-token direction. This version additionally preserves the attempt-one guard for ownerless and legacy payloads, makes the missing-model context release owner-aware, limits owner recording to `Queueable` jobs backed by `LockProvider`, and covers replacement owners, alternate stores, listeners, and legacy payloads.

No existing public method or interface signature changes. Old serialized payloads have the default empty owner and keep the existing guarded behavior. Stores without owner-aware lock support also retain the existing behavior.

The regression coverage includes middleware release followed by a later attempt, alternate cache stores, ordinary `ShouldBeUnique` retries, old payloads, queued listeners, missing models, expired and replacement locks, dispatch rollback, and mutations that release by key instead of owner.

Local validation covered the complete Linux base, queue, Redis, MySQL 8, and PostgreSQL 16 matrix. It introduced no test failures or errors, no new PHPStan findings, and the complete PHP diff passes Pint.
