### PR TITLE
[13.x] Allow ->using(...) in ->change() migrations for PostgreSQL compatibility

### DIFF
--- a/src/Illuminate/Database/Schema/ColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ColumnDefinition.php
@@ -31,6 +31,7 @@ use Illuminate\Support\Fluent;
  * @method $this type(string $type) Specify a type for the column
  * @method $this unique(bool|string $indexName = null) Add a unique index
  * @method $this unsigned(bool $value = true) Set the INTEGER column as UNSIGNED if value is true (MySQL)
+ * @method $this using(string|\Illuminate\Contracts\Database\Query\Expression $expression) Specify a casting expression when changing the column type (PostgreSQL)
  * @method $this useCurrent() Set the TIMESTAMP column to use CURRENT_TIMESTAMP as default value
  * @method $this useCurrentOnUpdate() Set the TIMESTAMP column to use CURRENT_TIMESTAMP when updating (MySQL)
  * @method $this virtualAs(string|\Illuminate\Contracts\Database\Query\Expression $expression) Create a virtual generated column (MySQL/PostgreSQL/SQLite)

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -1355,8 +1355,8 @@ class PostgresGrammar extends Grammar
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
-     protected function getUsing($column)
-     {
-         return $column?->using ? ' using '.$column->using : '';
-     }
+    protected function getUsing($column)
+    {
+        return $column?->using ? ' using '.$column->using : '';
+    }
 }

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -287,7 +287,7 @@ class PostgresGrammar extends Grammar
     {
         $column = $command->column;
 
-        $changes = ['type '.$this->getType($column).$this->modifyCollate($blueprint, $column)];
+        $changes = ['type '.$this->getType($column).$this->modifyCollate($blueprint, $column).$this->getUsing($column)];
 
         foreach ($this->modifiers as $modifier) {
             if ($modifier === 'Collate') {
@@ -1348,4 +1348,15 @@ class PostgresGrammar extends Grammar
 
         return $sql;
     }
+
+    /**
+     * get USING keyword, if it's available.
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string
+     */
+     protected function getUsing($column)
+     {
+         return $column?->using ? ' using '.$column->using : '';
+     }
 }

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -287,7 +287,7 @@ class PostgresGrammar extends Grammar
     {
         $column = $command->column;
 
-        $changes = ['type '.$this->getType($column).$this->modifyCollate($blueprint, $column).$this->getUsing($column)];
+        $changes = ['type '.$this->getType($column).$this->modifyCollate($blueprint, $column).($column->using ? ' using '.$column->using : '')];
 
         foreach ($this->modifiers as $modifier) {
             if ($modifier === 'Collate') {
@@ -1347,16 +1347,5 @@ class PostgresGrammar extends Grammar
         }
 
         return $sql;
-    }
-
-    /**
-     * get USING keyword, if it's available.
-     *
-     * @param  \Illuminate\Support\Fluent  $column
-     * @return string
-     */
-    protected function getUsing($column)
-    {
-        return $column?->using ? ' using '.$column->using : '';
     }
 }

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -1366,6 +1366,18 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertStringNotContainsString('a.attgenerated', $statement);
     }
 
+    public function testAddUsingKeywordToColumnOnChange()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'currency_rates');
+        $blueprint->date('name')->using('name::date')->change();
+        $statements = $blueprint->toSql();
+
+        $this->assertSame(
+            'alter table "currency_rates" alter column "name" type date using name::date, alter column "name" set not null, alter column "name" drop default, alter column "name" drop identity if exists',
+            $statements[0]
+        );
+    }
+
     protected function getConnection(
         ?PostgresGrammar $grammar = null,
         ?PostgresBuilder $builder = null,


### PR DESCRIPTION
This enables the use of `->using(...)` for the function `->change()` in migrations so that they will work in PostgreSQL.

PostgreSQL can't automatically convert some data types to others when altering the data type of a column via `ALTER TABLE .. ALTER COLUMN`.
The `USING` keyword can be used to tell PostgreSQL how to covert the data.

This PR adds that capability.

I don't think the other supported databases have the need for `USING` so it's just ignored in them in this fix.

For reference on the discussion:
- https://github.com/laravel/framework/issues/28963
- https://github.com/tpetry/laravel-postgresql-enhanced#using

Here's an example of a migration that needs it: https://github.com/aureuserp/aureuserp/blob/master/plugins/webkul/support/database/migrations/2025_11_14_102615_alter_currency_rates_table.php
Without it, it errors out with:
```
❌ Failed to wipe database: SQLSTATE[42804]: Datatype mismatch: 7 ERROR:  column "name" cannot be cast automatically to type date
HINT:  You might need to specify "USING name::date". (Connection: pgsql, Host: 127.0.0.1, Port: 5432, Database: aerp, SQL: alter table "currency_rates" alter column "name" type date, alter column "name" set not null, alter column "name" drop default, alter column "name" drop identity if exists)
Please manually drop your database and create a new one before proceeding.
```
when running `php artisan erp:install` when reinstalling it.

Below is the code where it shows the `->using(...)` keyword added to make it work in PostgreSQL too:

```php
<?php

use Illuminate\Database\Migrations\Migration;
use Illuminate\Database\Schema\Blueprint;
use Illuminate\Support\Facades\Schema;

return new class extends Migration
{
    public function up()
    {
        Schema::table('currency_rates', function (Blueprint $table) {
            $table->date('name')->using('name::date')->change();
        });
    }

    public function down()
    {
        Schema::table('currency_rates', function (Blueprint $table) {
            $table->string('name')->using('name::string')->change();
        });
    }
};
```

The benefit is that other Laravel Web Apps, which may be build for perhaps MySQL or SQLite, can be used with PostgreSQL as long as they use Laravel's Database Classes with some compatiblity fixes like this PR provides.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
