### PR TITLE
Extract actions/checkout into a local composite action

### DIFF
--- a/.github/actions/checkout/action.yml
+++ b/.github/actions/checkout/action.yml
@@ -1,0 +1,15 @@
+name: Checkout code
+description: Checkout the repository using a pinned version of actions/checkout.
+
+inputs:
+  persist-credentials:
+    description: Whether to configure the token in the local git config
+    default: 'false'
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout code
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: ${{ inputs.persist-credentials }}

--- a/.github/workflows/databases-nightly.yml
+++ b/.github/workflows/databases-nightly.yml
@@ -26,9 +26,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
+        uses: ./.github/actions/checkout
 
       - name: Setup PHP project
         uses: ./.github/actions/setup-php-project
@@ -59,9 +57,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
+        uses: ./.github/actions/checkout
 
       - name: Setup PHP project
         uses: ./.github/actions/setup-php-project

--- a/.github/workflows/databases.yml
+++ b/.github/workflows/databases.yml
@@ -29,9 +29,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
+        uses: ./.github/actions/checkout
 
       - name: Setup PHP project
         uses: ./.github/actions/setup-php-project
@@ -62,9 +60,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
+        uses: ./.github/actions/checkout
 
       - name: Setup PHP project
         uses: ./.github/actions/setup-php-project
@@ -94,9 +90,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
+        uses: ./.github/actions/checkout
 
       - name: Setup PHP project
         uses: ./.github/actions/setup-php-project
@@ -127,9 +121,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
+        uses: ./.github/actions/checkout
 
       - name: Setup PHP project
         uses: ./.github/actions/setup-php-project
@@ -162,9 +154,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
+        uses: ./.github/actions/checkout
 
       - name: Setup PHP project
         uses: ./.github/actions/setup-php-project
@@ -197,9 +187,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
+        uses: ./.github/actions/checkout
 
       - name: Setup PHP project
         uses: ./.github/actions/setup-php-project
@@ -230,9 +218,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
+        uses: ./.github/actions/checkout
 
       - name: Setup PHP project
         uses: ./.github/actions/setup-php-project
@@ -264,9 +250,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
+        uses: ./.github/actions/checkout
 
       - name: Setup PHP project
         uses: ./.github/actions/setup-php-project
@@ -289,9 +273,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
+        uses: ./.github/actions/checkout
 
       - name: Setup PHP project
         uses: ./.github/actions/setup-php-project

--- a/.github/workflows/facades.yml
+++ b/.github/workflows/facades.yml
@@ -19,7 +19,9 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        uses: ./.github/actions/checkout
+        with:
+          persist-credentials: true
 
       - name: Setup PHP project
         uses: ./.github/actions/setup-php-project

--- a/.github/workflows/queues.yml
+++ b/.github/workflows/queues.yml
@@ -19,9 +19,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
+        uses: ./.github/actions/checkout
 
       - name: Setup PHP project
         uses: ./.github/actions/setup-php-project
@@ -41,9 +39,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
+        uses: ./.github/actions/checkout
 
       - name: Setup PHP project
         uses: ./.github/actions/setup-php-project
@@ -76,9 +72,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
+        uses: ./.github/actions/checkout
 
       - name: Download & Extract beanstalkd
         run: curl -L https://github.com/beanstalkd/beanstalkd/archive/refs/tags/v1.13.tar.gz | tar xz

--- a/.github/workflows/redis.yml
+++ b/.github/workflows/redis.yml
@@ -31,9 +31,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
+        uses: ./.github/actions/checkout
 
       - name: Setup PHP project
         uses: ./.github/actions/setup-php-project
@@ -67,9 +65,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
+        uses: ./.github/actions/checkout
 
       - name: Setup PHP project
         uses: ./.github/actions/setup-php-project

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -23,7 +23,9 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        uses: ./.github/actions/checkout
+        with:
+          persist-credentials: true
 
       - name: Remove optional "v" prefix
         id: version

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -24,9 +24,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
+        uses: ./.github/actions/checkout
 
       - name: Setup PHP project
         uses: ./.github/actions/setup-php-project

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,9 +54,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
+        uses: ./.github/actions/checkout
 
       - name: Setup PHP project
         uses: ./.github/actions/setup-php-project
@@ -109,9 +107,7 @@ jobs:
           git config --global core.eol lf
 
       - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
+        uses: ./.github/actions/checkout
 
       - name: Setup PHP project
         uses: ./.github/actions/setup-php-project

--- a/.github/workflows/update-assets.yml
+++ b/.github/workflows/update-assets.yml
@@ -23,7 +23,9 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        uses: ./.github/actions/checkout
+        with:
+          persist-credentials: true
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:


### PR DESCRIPTION
Wraps the pinned `actions/checkout` in a local composite action (`.github/actions/checkout`), so bumping the checkout version only requires editing one file instead of 22 call sites across workflows. `persist-credentials` defaults to `false`; the three workflows that commit and push (`facades.yml`, `update-assets.yml`, `releases.yml`) opt back into `true`.