### PR TITLE
[13.x] Fix default handling in `CookieJar::queued()`

### DIFF
--- a/src/Illuminate/Cookie/CookieJar.php
+++ b/src/Illuminate/Cookie/CookieJar.php
@@ -41,9 +41,9 @@ class CookieJar implements JarContract
     protected $sameSite = 'lax';
 
     /**
-     * All of the cookies queued for sending.
+     * All of the cookies queued for sending, keyed by name and then by path.
      *
-     * @var \Symfony\Component\HttpFoundation\Cookie[]
+     * @var array<string, array<string, \Symfony\Component\HttpFoundation\Cookie>>
      */
     protected $queued = [];
 
@@ -116,20 +116,26 @@ class CookieJar implements JarContract
     /**
      * Get a queued cookie instance.
      *
+     * @template TQueuedDefault
+     *
      * @param  string  $key
-     * @param  mixed  $default
+     * @param  TQueuedDefault|(\Closure(): TQueuedDefault)  $default
      * @param  string|null  $path
-     * @return \Symfony\Component\HttpFoundation\Cookie|null
+     * @return \Symfony\Component\HttpFoundation\Cookie|TQueuedDefault
      */
     public function queued($key, $default = null, $path = null)
     {
-        $queued = Arr::get($this->queued, $key, $default);
+        $queued = $this->queued[$key] ?? null;
+
+        if ($queued === null) {
+            return value($default);
+        }
 
         if ($path === null) {
             return Arr::last($queued, null, $default);
         }
 
-        return Arr::get($queued, $path, $default);
+        return $queued[$path] ?? value($default);
     }
 
     /**

--- a/tests/Cookie/CookieTest.php
+++ b/tests/Cookie/CookieTest.php
@@ -130,6 +130,54 @@ class CookieTest extends TestCase
         $this->assertEquals($cookieTwo, $cookieJar->queued('foo'));
     }
 
+    public function testQueuedReturnsTheDefaultWhenTheCookieIsNotQueued(): void
+    {
+        $cookieJar = $this->getCreator();
+        $fallback = $cookieJar->make('fallback', 'bar');
+        $cookieJar->queue($cookieJar->make('foo', 'bar', 0, '/path'));
+
+        $this->assertNull($cookieJar->queued('nonexistent'));
+        $this->assertSame($fallback, $cookieJar->queued('nonexistent', $fallback));
+        $this->assertSame('bar', $cookieJar->queued('nonexistent', 'bar'));
+        $this->assertSame('bar', $cookieJar->queued('nonexistent', fn () => 'bar'));
+        $this->assertSame($fallback, $cookieJar->queued('nonexistent', $fallback, '/path'));
+        $this->assertSame($fallback, $cookieJar->queued('foo', $fallback, '/wrongPath'));
+    }
+
+    public function testQueuedResolvesADefaultClosureOnlyOnce(): void
+    {
+        $cookieJar = $this->getCreator();
+        $invocations = 0;
+        $default = function () use (&$invocations) {
+            $invocations++;
+
+            return 'bar';
+        };
+
+        $this->assertSame('bar', $cookieJar->queued('nonexistent', $default, '/path'));
+        $this->assertSame(1, $invocations);
+    }
+
+    public function testQueuedDoesNotResolveCookieNamesUsingDotNotation(): void
+    {
+        $cookieJar = $this->getCreator();
+        $cookieJar->queue($cookieJar->make('foo', 'bar', 0, 'path'));
+
+        $this->assertNull($cookieJar->queued('foo.path'));
+        $this->assertSame('fallback', $cookieJar->queued('foo.path', 'fallback'));
+        $this->assertFalse($cookieJar->hasQueued('foo.path'));
+    }
+
+    public function testQueuedFindsCookieNamesContainingDots(): void
+    {
+        $cookieJar = $this->getCreator();
+        $cookie = $cookieJar->make('foo.path', 'bar');
+        $cookieJar->queue($cookie);
+
+        $this->assertSame($cookie, $cookieJar->queued('foo.path'));
+        $this->assertTrue($cookieJar->hasQueued('foo.path'));
+    }
+
     public function testHasQueued(): void
     {
         $cookieJar = $this->getCreator();


### PR DESCRIPTION
`CookieJar::queued()` uses `$default` for two different jobs. It is the fallback for the `Arr::get()` lookup, and then whatever that lookup returned is treated as the queue bucket:

```php
$queued = Arr::get($this->queued, $key, $default); // fallback return value

if ($path === null) {
    return Arr::last($queued, null, $default);     // now treated as array<path, Cookie>
}

return Arr::get($queued, $path, $default);
```

`$this->queued` is `array<name, array<path, Cookie>>`, so when the name is not queued the caller's default goes straight into `Arr::last()` as if it were a bucket of cookies. On `13.x` today, with #60887 already applied:

```php
$jar->queued('missing', new Cookie('fallback', 'x')); // bool(false)
$jar->queued('missing', 'fallback');                  // InvalidArgumentException
$jar->queued('missing', fn () => 'fallback');         // InvalidArgumentException
```

The `bool(false)` is `Cookie::$partitioned`, the last property left after `Arr::from()` casts the object with `(array)`. The scalar and `Closure` cases still throw `Items cannot be represented by a scalar value.`, because #60887 guarded `Arr::last()` against `null` only and `Arr::from()` rejects every other scalar. A `Closure` default is also resolved twice when `$path` is passed, since both `Arr::get()` calls run `value()` on it.

Only a `null` default ever worked, which is why nobody hit this. `hasQueued()` passes `null`, and so does every first-party caller. That case broke too in v13.22.0 and #60887 fixed it, but every other default is still broken on 13.x today. This PR fixes the `queued()` bug underneath, so `CookieJar` no longer depends on that guard.

Both lookups also go through `Arr::get()`, which falls back to segment traversal when the exact key is missing. Cookie names and paths are opaque strings, not key paths:

```php
$jar->queue($jar->make('foo', 'x', 0, 'bar')); // name "foo", path "bar"

$jar->queued('foo.bar');    // the cookie queued as "foo", not null
$jar->hasQueued('foo.bar'); // true
```

That is also how `$queued` can hold a `Cookie` instead of a bucket and reach `Arr::last()` as a non-array. Both levels now read literal keys, and `$default` is resolved once, in one place.

A cookie whose name really does contain a dot is unaffected. `Arr::get()` checks the exact key before it splits on dots, so `queued('foo.bar')` already returned the cookie queued under the literal name `foo.bar` and still does. Only the accidental traversal fallback goes away, and `testQueuedFindsCookieNamesContainingDots` locks that in.

Docblocks: `@return` becomes `Cookie|TQueuedDefault`, since the method has always returned whatever `$default` was while documenting `Cookie|null`. `@var` on `$queued` becomes `array<string, array<string, Cookie>>`; the current `Cookie[]` describes a flat shape the property has not had since paths were added.

## Compatibility

Nothing that previously returned a usable value changes. With a `null` default every branch returns exactly what it returned before. Any other default previously produced a wrong value or threw.
