### PR TITLE
Revert "[13.x] Fix that retries of `ShouldBeUniqueUntilProcessing` jobs are force-releasing locks they don't own"

### DIFF
--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -139,12 +139,12 @@ class CallQueuedHandler
         return (new Pipeline($this->container))->send($command)
             ->through(array_merge(method_exists($command, 'middleware') ? $command->middleware() : [], $command->middleware ?? []))
             ->finally(function ($command) use (&$lockReleased) {
-                if (! $lockReleased && $this->commandShouldBeUniqueUntilProcessing($command) && ! $command->job->isReleased() && $command->job->attempts() <= 1) {
+                if (! $lockReleased && $this->commandShouldBeUniqueUntilProcessing($command) && ! $command->job->isReleased()) {
                     $this->ensureUniqueJobLockIsReleased($command);
                 }
             })
             ->then(function ($command) use ($job, &$lockReleased) {
-                if ($this->commandShouldBeUniqueUntilProcessing($command) && $job->attempts() <= 1) {
+                if ($this->commandShouldBeUniqueUntilProcessing($command)) {
                     $this->ensureUniqueJobLockIsReleased($command);
 
                     $lockReleased = true;

--- a/tests/Events/QueuedEventsTest.php
+++ b/tests/Events/QueuedEventsTest.php
@@ -587,7 +587,6 @@ class QueuedEventsTest extends TestCase
         $job->shouldReceive('isDeleted')->andReturn(false);
         $job->shouldReceive('isReleased')->andReturn(false);
         $job->shouldReceive('isDeletedOrReleased')->andReturn(false);
-        $job->shouldReceive('attempts')->andReturn(1);
         $job->shouldReceive('delete')->once();
 
         $handler = new CallQueuedHandler(new BusDispatcher($container), $container);

--- a/tests/Integration/Queue/UniqueJobTest.php
+++ b/tests/Integration/Queue/UniqueJobTest.php
@@ -145,31 +145,6 @@ class UniqueJobTest extends QueueTestCase
         $this->assertTrue($this->app->get(Cache::class)->lock($this->getLockKey($job), 10)->get());
     }
 
-    public function testRetryOfUniqueUntilProcessingJobDoesNotForceReleaseSubsequentLock()
-    {
-        $this->markTestSkippedWhenUsingSyncQueueDriver();
-
-        dispatch($job = new UniqueUntilProcessingRetryJob);
-
-        // Lock acquired at dispatch time.
-        $this->assertFalse($this->app->get(Cache::class)->lock($this->getLockKey($job), 10)->get());
-
-        $this->runQueueWorkerCommand(['--once' => true]); // attempt 1: releases lock, then fails
-
-        $this->assertTrue($job::$handled);
-
-        // Lock was correctly released before attempt 1 ran. Simulate a subsequent external dispatch
-        // acquiring it (asserts it was free and holds it for the rest of the test).
-        $this->assertTrue($this->app->get(Cache::class)->lock($this->getLockKey($job), 60)->get());
-
-        // Attempt 2 (the retry) must not force-release the lock it did not acquire.
-        UniqueUntilProcessingRetryJob::$handled = false;
-        $this->runQueueWorkerCommand(['--once' => true]); // attempt 2
-
-        $this->assertTrue($job::$handled);
-        $this->assertFalse($this->app->get(Cache::class)->lock($this->getLockKey($job), 10)->get());
-    }
-
     public function testLockIsReleasedOnModelNotFoundException()
     {
         UniqueTestSerializesModelsJob::$handled = false;
@@ -325,24 +300,6 @@ class UniqueTestRetryJob extends UniqueTestFailJob
 class UniqueUntilStartTestJob extends UniqueTestJob implements ShouldBeUniqueUntilProcessing
 {
     public $tries = 2;
-}
-
-class UniqueUntilProcessingRetryJob implements ShouldQueue, ShouldBeUniqueUntilProcessing
-{
-    use InteractsWithQueue, Queueable, Dispatchable;
-
-    public $tries = 2;
-
-    public static $handled = false;
-
-    public function handle()
-    {
-        static::$handled = true;
-
-        if ($this->attempts() === 1) {
-            throw new Exception('First attempt failure.');
-        }
-    }
 }
 
 class UniqueTestSerializesModelsJob extends UniqueTestJob


### PR DESCRIPTION
Reverts laravel/framework#59567