### PR TITLE
Attempt at lock fix

### DIFF
--- a/src/Illuminate/Bus/Queueable.php
+++ b/src/Illuminate/Bus/Queueable.php
@@ -50,6 +50,13 @@ trait Queueable
     public $debounceOwner = '';
 
     /**
+     * The owner of the unique job lock.
+     *
+     * @var string
+     */
+    public $uniqueLockOwner = '';
+
+    /**
      * The number of seconds before the job should be made available.
      *
      * @var \DateTimeInterface|\DateInterval|array|int|null

--- a/src/Illuminate/Bus/UniqueLock.php
+++ b/src/Illuminate/Bus/UniqueLock.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Bus;
 
+use Illuminate\Contracts\Cache\LockProvider;
 use Illuminate\Contracts\Cache\Repository as Cache;
 use Illuminate\Queue\Attributes\ReadsQueueAttributes;
 use Illuminate\Queue\Attributes\UniqueFor;
@@ -43,7 +44,18 @@ class UniqueLock
             ? ($job->uniqueVia() ?? $this->cache)
             : $this->cache;
 
-        return (bool) $cache->lock(self::getKey($job), $uniqueFor)->get();
+        $lock = $cache->lock(self::getKey($job), $uniqueFor);
+
+        if (! $lock->get()) {
+            return false;
+        }
+
+        if (isset(class_uses_recursive($job)[Queueable::class]) &&
+            $cache->getStore() instanceof LockProvider) {
+            $job->uniqueLockOwner = $lock->owner();
+        }
+
+        return true;
     }
 
     /**
@@ -57,6 +69,18 @@ class UniqueLock
         $cache = method_exists($job, 'uniqueVia')
             ? ($job->uniqueVia() ?? $this->cache)
             : $this->cache;
+
+        $owner = isset(class_uses_recursive($job)[Queueable::class])
+            ? ($job->uniqueLockOwner ?? '')
+            : '';
+
+        if (is_string($owner) && $owner !== '') {
+            if ($cache->getStore() instanceof LockProvider) {
+                $cache->restoreLock(self::getKey($job), $owner)->release();
+            }
+
+            return;
+        }
 
         $cache->lock(self::getKey($job))->forceRelease();
     }

--- a/src/Illuminate/Foundation/Bus/PendingDispatch.php
+++ b/src/Illuminate/Foundation/Bus/PendingDispatch.php
@@ -282,13 +282,11 @@ class PendingDispatch
      */
     public function __destruct()
     {
-        $this->addUniqueJobInformationToContext($this->job);
-
         if (! $this->shouldDispatch()) {
-            $this->removeUniqueJobInformationFromContext($this->job);
-
             return;
         }
+
+        $this->addUniqueJobInformationToContext($this->job);
 
         $this->acquireDebounceLock();
 

--- a/src/Illuminate/Foundation/Queue/InteractsWithUniqueJobs.php
+++ b/src/Illuminate/Foundation/Queue/InteractsWithUniqueJobs.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Queue;
 
+use Illuminate\Bus\Queueable;
 use Illuminate\Bus\UniqueLock;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Support\Facades\Context;
@@ -20,6 +21,9 @@ trait InteractsWithUniqueJobs
             Context::addHidden([
                 'laravel_unique_job_cache_store' => $this->getUniqueJobCacheStore($job),
                 'laravel_unique_job_key' => UniqueLock::getKey($job),
+                'laravel_unique_job_lock_owner' => isset(class_uses_recursive($job)[Queueable::class])
+                    ? ($job->uniqueLockOwner ?? '')
+                    : '',
             ]);
         }
     }
@@ -36,6 +40,7 @@ trait InteractsWithUniqueJobs
             Context::forgetHidden([
                 'laravel_unique_job_cache_store',
                 'laravel_unique_job_key',
+                'laravel_unique_job_lock_owner',
             ]);
         }
     }

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -6,9 +6,11 @@ use Exception;
 use Illuminate\Bus\Batchable;
 use Illuminate\Bus\BatchRepository;
 use Illuminate\Bus\DebounceLock;
+use Illuminate\Bus\Queueable;
 use Illuminate\Bus\UniqueLock;
 use Illuminate\Contracts\Bus\Dispatcher;
 use Illuminate\Contracts\Cache\Factory as CacheFactory;
+use Illuminate\Contracts\Cache\LockProvider;
 use Illuminate\Contracts\Cache\Repository as Cache;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Encryption\Encrypter;
@@ -139,12 +141,12 @@ class CallQueuedHandler
         return (new Pipeline($this->container))->send($command)
             ->through(array_merge(method_exists($command, 'middleware') ? $command->middleware() : [], $command->middleware ?? []))
             ->finally(function ($command) use (&$lockReleased) {
-                if (! $lockReleased && $this->commandShouldBeUniqueUntilProcessing($command) && ! $command->job->isReleased()) {
+                if (! $lockReleased && $this->commandShouldBeUniqueUntilProcessing($command) && ! $command->job->isReleased() && $this->uniqueJobLockShouldBeReleased($command->job, $command)) {
                     $this->ensureUniqueJobLockIsReleased($command);
                 }
             })
             ->then(function ($command) use ($job, &$lockReleased) {
-                if ($this->commandShouldBeUniqueUntilProcessing($command)) {
+                if ($this->commandShouldBeUniqueUntilProcessing($command) && $this->uniqueJobLockShouldBeReleased($job, $command)) {
                     $this->ensureUniqueJobLockIsReleased($command);
 
                     $lockReleased = true;
@@ -233,6 +235,21 @@ class CallQueuedHandler
         if ($this->commandShouldBeUnique($command)) {
             (new UniqueLock($this->container->make(Cache::class)))->release($command);
         }
+    }
+
+    /**
+     * Determine if the unique job lock can be safely released.
+     *
+     * @param  \Illuminate\Contracts\Queue\Job  $job
+     * @param  mixed  $command
+     * @return bool
+     */
+    protected function uniqueJobLockShouldBeReleased(Job $job, $command)
+    {
+        return $job->attempts() <= 1 ||
+            (isset(class_uses_recursive($command)[Queueable::class]) &&
+             is_string($command->uniqueLockOwner ?? null) &&
+             $command->uniqueLockOwner !== '');
     }
 
     /**
@@ -333,16 +350,20 @@ class CallQueuedHandler
 
         $context = $this->container->make(ContextRepository::class);
 
-        [$store, $key] = [
+        [$store, $key, $owner] = [
             $context->getHidden('laravel_unique_job_cache_store'),
             $context->getHidden('laravel_unique_job_key'),
+            $context->getHidden('laravel_unique_job_lock_owner'),
         ];
 
         if ($store && $key) {
-            $this->container->make(CacheFactory::class)
-                ->store($store)
-                ->lock($key)
-                ->forceRelease();
+            $cache = $this->container->make(CacheFactory::class)->store($store);
+
+            if (is_string($owner) && $owner !== '' && $cache->getStore() instanceof LockProvider) {
+                $cache->restoreLock($key, $owner)->release();
+            } elseif (is_null($owner) || $owner === '') {
+                $cache->lock($key)->forceRelease();
+            }
         }
     }
 

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -225,19 +225,6 @@ class CallQueuedHandler
     }
 
     /**
-     * Ensure the lock for a unique job is released.
-     *
-     * @param  mixed  $command
-     * @return void
-     */
-    protected function ensureUniqueJobLockIsReleased($command)
-    {
-        if ($this->commandShouldBeUnique($command)) {
-            (new UniqueLock($this->container->make(Cache::class)))->release($command);
-        }
-    }
-
-    /**
      * Determine if the unique job lock can be safely released.
      *
      * @param  \Illuminate\Contracts\Queue\Job  $job
@@ -250,6 +237,19 @@ class CallQueuedHandler
             (isset(class_uses_recursive($command)[Queueable::class]) &&
              is_string($command->uniqueLockOwner ?? null) &&
              $command->uniqueLockOwner !== '');
+    }
+
+    /**
+     * Ensure the lock for a unique job is released.
+     *
+     * @param  mixed  $command
+     * @return void
+     */
+    protected function ensureUniqueJobLockIsReleased($command)
+    {
+        if ($this->commandShouldBeUnique($command)) {
+            (new UniqueLock($this->container->make(Cache::class)))->release($command);
+        }
     }
 
     /**

--- a/tests/Events/QueuedEventsTest.php
+++ b/tests/Events/QueuedEventsTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Events;
 use Illuminate\Bus\Dispatcher as BusDispatcher;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Cache\Lock;
+use Illuminate\Contracts\Cache\LockProvider;
 use Illuminate\Contracts\Cache\Repository as Cache;
 use Illuminate\Contracts\Queue\Job;
 use Illuminate\Contracts\Queue\Queue;
@@ -354,7 +355,9 @@ class QueuedEventsTest extends TestCase
         $container->instance(Cache::class, $cache);
 
         $cache->shouldReceive('lock')->once()->andReturn($lock);
+        $cache->shouldReceive('getStore')->once()->andReturn(m::mock(LockProvider::class));
         $lock->shouldReceive('get')->once()->andReturn(true);
+        $lock->shouldReceive('owner')->once()->andReturn('unique-lock-owner');
 
         $d->setQueueResolver(function () use ($fakeQueue) {
             return $fakeQueue;
@@ -407,7 +410,9 @@ class QueuedEventsTest extends TestCase
         $container->instance(Cache::class, $cache);
 
         $cache->shouldReceive('lock')->once()->andReturn($lock);
+        $cache->shouldReceive('getStore')->once()->andReturn(m::mock(LockProvider::class));
         $lock->shouldReceive('get')->once()->andReturn(true);
+        $lock->shouldReceive('owner')->once()->andReturn('unique-lock-owner');
 
         $d->setQueueResolver(function () use ($fakeQueue) {
             return $fakeQueue;
@@ -434,7 +439,9 @@ class QueuedEventsTest extends TestCase
         $container->instance(Cache::class, $cache);
 
         $cache->shouldReceive('lock')->once()->andReturn($lock);
+        $cache->shouldReceive('getStore')->once()->andReturn(m::mock(LockProvider::class));
         $lock->shouldReceive('get')->once()->andReturn(true);
+        $lock->shouldReceive('owner')->once()->andReturn('unique-lock-owner');
 
         $d->setQueueResolver(function () use ($fakeQueue) {
             return $fakeQueue;
@@ -478,7 +485,9 @@ class QueuedEventsTest extends TestCase
             ->once()
             ->with($expectedKey, 60)
             ->andReturn($lock);
+        $cache->shouldReceive('getStore')->once()->andReturn(m::mock(LockProvider::class));
         $lock->shouldReceive('get')->once()->andReturn(true);
+        $lock->shouldReceive('owner')->once()->andReturn('unique-lock-owner');
 
         $d->setQueueResolver(function () use ($fakeQueue) {
             return $fakeQueue;
@@ -512,7 +521,9 @@ class QueuedEventsTest extends TestCase
             ->once()
             ->with($expectedKey, 60)
             ->andReturn($lock);
+        $uniqueCache->shouldReceive('getStore')->once()->andReturn(m::mock(LockProvider::class));
         $lock->shouldReceive('get')->once()->andReturn(true);
+        $lock->shouldReceive('owner')->once()->andReturn('unique-lock-owner');
 
         $d->setQueueResolver(function () use ($fakeQueue) {
             return $fakeQueue;
@@ -587,6 +598,7 @@ class QueuedEventsTest extends TestCase
         $job->shouldReceive('isDeleted')->andReturn(false);
         $job->shouldReceive('isReleased')->andReturn(false);
         $job->shouldReceive('isDeletedOrReleased')->andReturn(false);
+        $job->shouldReceive('attempts')->andReturn(1);
         $job->shouldReceive('delete')->once();
 
         $handler = new CallQueuedHandler(new BusDispatcher($container), $container);

--- a/tests/Integration/Queue/UniqueJobTest.php
+++ b/tests/Integration/Queue/UniqueJobTest.php
@@ -145,6 +145,41 @@ class UniqueJobTest extends QueueTestCase
         $this->assertTrue($this->app->get(Cache::class)->lock($this->getLockKey($job), 10)->get());
     }
 
+    public function testRetryOfUniqueUntilProcessingJobDoesNotReleaseSubsequentLock()
+    {
+        $this->markTestSkippedWhenUsingSyncQueueDriver();
+
+        dispatch($job = new UniqueUntilProcessingRetryJob);
+
+        $this->assertFalse($this->app->get(Cache::class)->lock($this->getLockKey($job), 10)->get());
+
+        $this->runQueueWorkerCommand(['--once' => true]);
+
+        $this->assertTrue($job::$handled);
+        $this->assertTrue($this->app->get(Cache::class)->lock($this->getLockKey($job), 60)->get());
+
+        UniqueUntilProcessingRetryJob::$handled = false;
+        $this->runQueueWorkerCommand(['--once' => true]);
+
+        $this->assertTrue($job::$handled);
+        $this->assertFalse($this->app->get(Cache::class)->lock($this->getLockKey($job), 10)->get());
+    }
+
+    public function testRetryOfOwnerlessUniqueUntilProcessingJobDoesNotReleaseSubsequentLock()
+    {
+        $this->markTestSkippedWhenUsingSyncQueueDriver();
+
+        dispatch($job = new OwnerlessUniqueUntilProcessingRetryJob);
+
+        $this->runQueueWorkerCommand(['--once' => true]);
+
+        $this->assertTrue($this->app->get(Cache::class)->lock($this->getLockKey($job), 60)->get());
+
+        $this->runQueueWorkerCommand(['--once' => true]);
+
+        $this->assertFalse($this->app->get(Cache::class)->lock($this->getLockKey($job), 10)->get());
+    }
+
     public function testLockIsReleasedOnModelNotFoundException()
     {
         UniqueTestSerializesModelsJob::$handled = false;
@@ -165,6 +200,31 @@ class UniqueJobTest extends QueueTestCase
             $this->assertModelMissing($user);
             $this->assertTrue($this->app->get(Cache::class)->lock($this->getLockKey($job), 10)->get());
         }
+    }
+
+    public function testModelNotFoundExceptionDoesNotReleaseSubsequentLock()
+    {
+        $this->markTestSkippedWhenUsingSyncQueueDriver();
+
+        /** @var \Illuminate\Foundation\Auth\User */
+        $user = UserFactory::new()->create();
+        $job = new UniqueTestSerializesModelsJob($user);
+        $cache = $this->app->get(Cache::class);
+        $lock = new UniqueLock($cache);
+
+        dispatch($job);
+
+        $lock->release($job);
+
+        $replacement = new UniqueTestSerializesModelsJob($user);
+        $this->assertTrue($lock->acquire($replacement));
+
+        $user->delete();
+        $this->runQueueWorkerCommand(['--once' => true]);
+
+        $this->assertFalse($cache->lock($this->getLockKey($job), 10)->get());
+
+        $lock->release($replacement);
     }
 
     public function testQueueFakeReleasesUniqueJobLocksBetweenFakes()
@@ -300,6 +360,38 @@ class UniqueTestRetryJob extends UniqueTestFailJob
 class UniqueUntilStartTestJob extends UniqueTestJob implements ShouldBeUniqueUntilProcessing
 {
     public $tries = 2;
+}
+
+class UniqueUntilProcessingRetryJob implements ShouldQueue, ShouldBeUniqueUntilProcessing
+{
+    use InteractsWithQueue, Queueable, Dispatchable;
+
+    public $tries = 2;
+
+    public static $handled = false;
+
+    public function handle()
+    {
+        static::$handled = true;
+
+        if ($this->attempts() === 1) {
+            throw new Exception('First attempt failure.');
+        }
+    }
+}
+
+class OwnerlessUniqueUntilProcessingRetryJob implements ShouldQueue, ShouldBeUniqueUntilProcessing
+{
+    use InteractsWithQueue, Dispatchable;
+
+    public $tries = 2;
+
+    public function handle()
+    {
+        if ($this->attempts() === 1) {
+            throw new Exception('First attempt failure.');
+        }
+    }
 }
 
 class UniqueTestSerializesModelsJob extends UniqueTestJob

--- a/tests/Integration/Queue/UniqueUntilProcessingJobTest.php
+++ b/tests/Integration/Queue/UniqueUntilProcessingJobTest.php
@@ -48,6 +48,23 @@ class UniqueUntilProcessingJobTest extends QueueTestCase
         UniqueUntilProcessingJobThatReleases::dispatch();
         $this->assertDatabaseCount('jobs', 1);
     }
+
+    public function testShouldBeUniqueUntilProcessingReleasesLockWhenLaterAttemptIsProcessed()
+    {
+        UniqueUntilProcessingJobThatReleasesOnce::dispatch();
+
+        $this->assertNotNull(DB::table('cache_locks')->first());
+
+        $this->runQueueWorkerCommand(['--once' => true]);
+
+        $this->assertFalse(UniqueUntilProcessingJobThatReleasesOnce::$handled);
+        $this->assertNotNull(DB::table('cache_locks')->first());
+
+        $this->runQueueWorkerCommand(['--once' => true]);
+
+        $this->assertTrue(UniqueUntilProcessingJobThatReleasesOnce::$handled);
+        $this->assertNull(DB::table('cache_locks')->first());
+    }
 }
 
 class UniqueTestJobThatDoesNotRelease implements ShouldQueue, ShouldBeUniqueUntilProcessing
@@ -85,5 +102,28 @@ class UniqueUntilProcessingJobThatReleases extends UniqueTestJobThatDoesNotRelea
     public function uniqueId()
     {
         return 100;
+    }
+}
+
+class UniqueUntilProcessingJobThatReleasesOnce extends UniqueTestJobThatDoesNotRelease
+{
+    public $tries = 2;
+
+    public function middleware()
+    {
+        return [
+            function ($job, $next) {
+                if ($job->attempts() === 1) {
+                    return $job->release();
+                }
+
+                return $next($job);
+            },
+        ];
+    }
+
+    public function uniqueId()
+    {
+        return 200;
     }
 }


### PR DESCRIPTION
Fixes #60042.

ShouldBeUniqueUntilProcessing jobs need to handle two different retry scenarios:

- If the unique lock was released before handling and the job later fails, a retry must not release a lock acquired by a newer dispatch.
- If middleware releases the job before handling, the unique lock remains held and must be released when a later attempt is eventually processed.

Using attempts() <= 1 cannot distinguish these scenarios. It prevents retries from releasing newer locks, but also causes middleware-released jobs to retain their original lock indefinitely.

This change tracks the actual unique lock owner on Queueable jobs and uses ownership-aware lock release:

- Records the cache lock owner when the unique lock is acquired.
- Serializes the owner with the queued job so it survives retries.
- Releases the lock through restoreLock(...)->release().
- Allows later attempts to release a lock when they carry its owner.
- Retains the first-attempt guard for legacy and ownerless payloads.
- Propagates the owner through hidden job context so missing-model cleanup cannot release a replacement lock.
- Supports queued listeners and custom uniqueVia() stores.