### PR TITLE
[12.x] Prevent fatal errors when logging deprecations fails

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -98,23 +98,23 @@ class HandleExceptions
 
         try {
             $logger = static::$app->make(LogManager::class);
-        } catch (Exception) {
+
+            $this->ensureDeprecationLoggerIsConfigured();
+
+            $options = static::$app['config']->get('logging.deprecations') ?? [];
+
+            with($logger->channel('deprecations'), function ($log) use ($message, $file, $line, $level, $options) {
+                if ($options['trace'] ?? false) {
+                    $log->warning((string) new ErrorException($message, 0, $level, $file, $line));
+                } else {
+                    $log->warning(sprintf('%s in %s on line %s',
+                        $message, $file, $line
+                    ));
+                }
+            });
+        } catch (Throwable) {
             return;
         }
-
-        $this->ensureDeprecationLoggerIsConfigured();
-
-        $options = static::$app['config']->get('logging.deprecations') ?? [];
-
-        with($logger->channel('deprecations'), function ($log) use ($message, $file, $line, $level, $options) {
-            if ($options['trace'] ?? false) {
-                $log->warning((string) new ErrorException($message, 0, $level, $file, $line));
-            } else {
-                $log->warning(sprintf('%s in %s on line %s',
-                    $message, $file, $line
-                ));
-            }
-        });
     }
 
     /**

--- a/tests/Foundation/Bootstrap/HandleExceptionsTest.php
+++ b/tests/Foundation/Bootstrap/HandleExceptionsTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Foundation\Bootstrap;
 
+use Error;
 use ErrorException;
 use Illuminate\Config\Repository as Config;
 use Illuminate\Foundation\Application;
@@ -326,6 +327,23 @@ class HandleExceptionsTest extends TestCase
     {
         $this->app->expects('runningUnitTests')->andReturn(false);
         $this->app->expects('hasBeenBootstrapped')->andReturn(true);
+
+        $this->handleExceptions()->handleError(
+            E_DEPRECATED,
+            'str_contains(): Passing null to parameter #2 ($needle) of type string is deprecated',
+            '/home/user/laravel/routes/web.php',
+            17
+        );
+    }
+
+    public function testIgnoreDeprecationIfLoggingFails()
+    {
+        $logger = m::mock(LogManager::class);
+        $this->app->instance(LogManager::class, $logger);
+        $this->app->expects('runningUnitTests')->andReturn(false);
+        $this->app->expects('hasBeenBootstrapped')->andReturn(true);
+
+        $logger->expects('channel')->with('deprecations')->andThrow(new Error('Class "Monolog\Logger" not found'));
 
         $this->handleExceptions()->handleError(
             E_DEPRECATED,


### PR DESCRIPTION
This is a backport of #60893 to the 12.x branch. Reporting a deprecation should never be able to crash the application, but the logging attempt in HandleExceptions::handleDeprecationError() was only guarded against an Exception thrown while resolving the LogManager. Any Throwable raised while building or using the deprecations channel, such as an Error triggered when a deprecation fires while Monolog's Logger class is still mid-autoload on PHP 8.4, would fatal the process. The vulnerable code on 12.x is identical to what was fixed on 13.x, and 12.x supports the same PHP 8.4 and Monolog 3.x combinations, so the whole logging attempt is now wrapped so that any failure is ignored.