### PR TITLE
[13.x] Fix validation stalling for minutes on large arrays

### DIFF
--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -176,11 +176,13 @@ class ValidationRuleParser
                             [$attribute => [$key]]
                         );
 
-                        $results = $this->mergeRules($results, $compiled->rules);
+                        foreach ($compiled->rules as $compiledAttribute => $compiledRules) {
+                            $this->mergeRulesForAttributeInto($results, $compiledAttribute, $compiledRules);
+                        }
                     } else {
                         $this->implicitAttributes[$attribute][] = $key;
 
-                        $results = $this->mergeRules($results, $key, $rule);
+                        $this->mergeRulesForAttributeInto($results, $key, $rule);
                     }
                 }
             }
@@ -222,13 +224,26 @@ class ValidationRuleParser
      */
     protected function mergeRulesForAttribute($results, $attribute, $rules)
     {
+        $this->mergeRulesForAttributeInto($results, $attribute, $rules);
+
+        return $results;
+    }
+
+    /**
+     * Merge additional rules into a given attribute by reference.
+     *
+     * @param  array  $results
+     * @param  string  $attribute
+     * @param  string|array  $rules
+     * @return void
+     */
+    private function mergeRulesForAttributeInto(&$results, $attribute, $rules)
+    {
         $merge = head($this->explodeRules([$rules]));
 
         $results[$attribute] = array_merge(
             isset($results[$attribute]) ? $this->explodeExplicitRule($results[$attribute], $attribute) : [], $merge
         );
-
-        return $results;
     }
 
     /**


### PR DESCRIPTION
An ordinary request body can stall a request for over a minute. Expanding `foo.*.bar` rules is quadratic in the number of expanded attributes (array items × wildcard rules), so `Validator::make()` spends that time building the rule set before a single rule runs. `post_max_size` and web server body limits never trigger, 8000 items here is only ~1.1 MB.

To reproduce, in `php artisan tinker`:

```php
$rules = ['items' => ['array']];

foreach (range(1, 17) as $i) {
    $rules["items.*.field{$i}"] = ['nullable', 'string'];
}

foreach ([500, 1000, 2000, 4000, 8000] as $count) {
    $data = ['items' => array_fill(0, $count, ['field1' => 'value'])];

    $start = microtime(true);
    Illuminate\Support\Facades\Validator::make($data, $rules)->passes();
    printf("%5d items: %7.2fs\n", $count, microtime(true) - $start);
}
```

| items | before | after |
| ----- | ------ | ----- |
| 500   | 0.29s  | 0.06s |
| 1000  | 0.98s  | 0.11s |
| 2000  | 3.80s  | 0.24s |
| 4000  | 18.59s | 0.47s |
| 8000  | 85.13s | 0.98s |

A `max` rule on the array does not help: `'items' => ['array', 'max:500']` still expands and evaluates every `items.*` rule before reporting that the array is too large.

`ValidationRuleParser::explodeWildcardRules()` accumulates into `$results` by reassigning the return value of `mergeRules()`:

```php
$results = $this->mergeRules($results, $key, $rule);
```

`mergeRulesForAttribute()` receives `$results` by value and writes to it, so copy-on-write clones the whole accumulated rule set once per expanded attribute: 68,000 copies of an array averaging 34,000 entries for 17 rules over 4000 items. `Validator::passes()` itself is linear; all of the cost is in the expansion.

The fix moves the merge body into a private method that takes `$results` by reference, and the wildcard loop calls that instead of round-tripping through the by-value `mergeRules()`.

No public or protected signatures change: `mergeRules()` is untouched and `mergeRulesForAttribute()` keeps its exact signature and return value, delegating to the new private method. `explodeWildcardRules()` no longer routes through it, so an override there no longer affects wildcard expansion. This is unavoidable, since the by-value return is the bug itself.

No new test, since the behaviour is unchanged and a timing assertion would be flaky.