### PR TITLE
[12.x] Fix Factory::insert() with a count of zero

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -485,6 +485,10 @@ abstract class Factory
             ? $made
             : $this->newModel()->newCollection([$made]);
 
+        if ($madeCollection->isEmpty()) {
+            return;
+        }
+
         $model = $madeCollection->first();
 
         if (isset($this->connection)) {

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -1076,6 +1076,13 @@ class DatabaseEloquentFactoryTest extends TestCase
         $this->assertCount(1, $users->where('name', 'shaedrich'));
     }
 
+    public function test_factory_can_insert_zero_models()
+    {
+        (new FactoryTestPostFactory())->count(0)->insert();
+
+        $this->assertCount(0, FactoryTestPost::all());
+    }
+
     public function test_factory_can_insert_with_hidden()
     {
         (new FactoryTestUserFactory())->forEachSequence(['name' => Name::Taylor, 'options' => 'abc'])->insert();


### PR DESCRIPTION
Calling `insert()` on a factory with a count of zero throws an error:

```php
User::factory()->count(0)->insert();

// Error: Call to a member function newQueryWithoutScopes() on null
```

`Factory::insert()` assumes `make()` always returns at least one model. With a count of zero, `make()` intentionally returns an empty collection, so `first()` returns `null` and the following calls dereference it.

A count of zero is already a supported no-op elsewhere in the factory API. `make()`, `create()`, `makeMany(0)` and `createMany(0)` all handle it without error, so `insert()` behaving differently is inconsistent.

This adds an explicit empty-collection guard so `insert()` returns early instead of relying on a downstream empty database insert. Behavior for single-model and non-empty counted factories is unchanged.

This is useful when the count comes from a variable or configuration value that can legitimately be zero, which currently forces callers to guard every `insert()` call themselves.

A regression test was added alongside the existing `insert()` tests.