### PR TITLE
[13.x] Use immutable timestamps in batch testing fakes

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/BatchFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BatchFake.php
@@ -5,7 +5,6 @@ namespace Illuminate\Support\Testing\Fakes;
 use Carbon\CarbonImmutable;
 use Illuminate\Bus\Batch;
 use Illuminate\Bus\UpdatedBatchJobCounts;
-use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Throwable;
 
@@ -151,7 +150,7 @@ class BatchFake extends Batch
     #[\Override]
     public function cancel(?Throwable $exception = null)
     {
-        $this->cancelledAt = Carbon::now();
+        $this->cancelledAt = CarbonImmutable::now();
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/BatchRepositoryFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BatchRepositoryFake.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Support\Testing\Fakes;
 
-use Carbon\Carbon;
 use Carbon\CarbonImmutable;
 use Closure;
 use Illuminate\Bus\BatchRepository;
@@ -113,7 +112,7 @@ class BatchRepositoryFake implements BatchRepository
     public function markAsFinished(string $batchId)
     {
         if (isset($this->batches[$batchId])) {
-            $this->batches[$batchId]->finishedAt = Carbon::now();
+            $this->batches[$batchId]->finishedAt = CarbonImmutable::now();
         }
     }
 

--- a/tests/Support/SupportTestingBusFakeTest.php
+++ b/tests/Support/SupportTestingBusFakeTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Support;
 
+use Carbon\CarbonImmutable;
 use Illuminate\Bus\Batch;
 use Illuminate\Bus\Queueable;
 use Illuminate\Container\Container;
@@ -777,6 +778,28 @@ class SupportTestingBusFakeTest extends TestCase
         $batch->cancel();
 
         $this->assertTrue($batch->cancelled());
+    }
+
+    public function testCancelledBatchesHaveImmutableCancelledAtTimestamp()
+    {
+        $batch = $this->fake->batch([])->dispatch();
+
+        $batch->cancel();
+
+        $this->assertInstanceOf(CarbonImmutable::class, $batch->cancelledAt);
+    }
+
+    public function testFinishedBatchesHaveImmutableFinishedAtTimestamp()
+    {
+        $batchRepository = new BatchRepositoryFake;
+
+        $fake = new BusFake(m::mock(QueueingDispatcher::class), [], $batchRepository);
+
+        $batch = $fake->batch([])->dispatch();
+
+        $batchRepository->markAsFinished($batch->id);
+
+        $this->assertInstanceOf(CarbonImmutable::class, $batch->finishedAt);
     }
 
     public function testDispatchFakeBatch()


### PR DESCRIPTION
`Illuminate\Bus\Batch` declares its timestamps as `CarbonImmutable`, and both `DatabaseBatchRepository` and `DynamoBatchRepository` hydrate them accordingly. The testing fakes, however, assign mutable `Carbon` instances:

* `BatchFake::cancel()` assigns `Carbon::now()` to `cancelledAt`
* `BatchRepositoryFake::markAsFinished()` assigns `Carbon::now()` to `finishedAt`

This makes faked batches behave differently from real ones. Code that touches these timestamps (for example `$batch->cancelledAt->addDay()`) mutates the value in place under `Bus::fake()`, while in production the same call returns a new instance and leaves the batch untouched. Assertions written against a faked batch can therefore pass or fail for reasons that do not reproduce outside of tests.

This PR assigns `CarbonImmutable::now()` in both places, matching the property type declared on `Batch` and the value already used by `BatchRepositoryFake::store()` for `createdAt`. No public API changes; the only behavioral difference is the timestamp type, which now matches what the framework documents and what production repositories return.

Two regression tests are added to `SupportTestingBusFakeTest` asserting that `cancelledAt` and `finishedAt` are `CarbonImmutable` instances on faked batches.

