### PR TITLE
Add not_email validation rule

### DIFF
--- a/src/Illuminate/Translation/lang/en/validation.php
+++ b/src/Illuminate/Translation/lang/en/validation.php
@@ -120,6 +120,7 @@ return [
     'missing_with_all' => 'The :attribute field must be missing when :values are present.',
     'multiple_of' => 'The :attribute field must be a multiple of :value.',
     'not_in' => 'The selected :attribute is invalid.',
+    'not_email' => 'The :attribute field must not be a valid email address.',
     'not_regex' => 'The :attribute field format is invalid.',
     'numeric' => 'The :attribute field must be a number.',
     'password' => [

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -985,6 +985,19 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate that an attribute is not a valid e-mail address.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array<int, int|string>  $parameters
+     * @return bool
+     */
+    public function validateNotEmail($attribute, $value, $parameters)
+    {
+        return ! $this->validateEmail($attribute, $value, $parameters);
+    }
+
+    /**
      * Validate the encoding of an attribute.
      *
      * @param  string  $attribute

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4980,6 +4980,56 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
     }
 
+    public function testValidateNotEmail()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines(['validation.not_email' => 'The :attribute field must not be a valid email address.'], 'en');
+
+        $v = new Validator($trans, ['x' => 'aslsdlks'], ['x' => 'NotEmail']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => ['not a string']], ['x' => 'NotEmail']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, [
+            'x' => new class
+            {
+                public function __toString()
+                {
+                    return 'aslsdlks';
+                }
+            },
+        ], ['x' => 'NotEmail']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, [
+            'x' => new class
+            {
+                public function __toString()
+                {
+                    return 'foo@gmail.com';
+                }
+            },
+        ], ['x' => 'NotEmail']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => 'foo@gmail.com'], ['x' => 'NotEmail']);
+        $this->assertFalse($v->passes());
+        $this->assertSame('The x field must not be a valid email address.', $v->messages()->first('x'));
+
+        $v = new Validator($trans, ['x' => "\"foo\r\nBcc: victim@example.com\"@example.com"], ['x' => 'NotEmail']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => 'foo@bar '], ['x' => 'NotEmail:strict']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, [], ['x' => 'NotEmail']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => ''], ['x' => 'NotEmail']);
+        $this->assertTrue($v->passes());
+    }
+
     public function testValidateEmailWithInternationalCharacters()
     {
         $v = new Validator($this->getIlluminateArrayTranslator(), ['x' => 'foo@gmäil.com'], ['x' => 'email']);


### PR DESCRIPTION
This pull request adds a `not_email` validation rule, which ensures that a given string is **not** a valid email address.

Currently, if developers want to prevent users from submitting email addresses, they have to rely on custom regular expressions. Writing an accurate regex for email validation is error-prone and messy

### Use cases
* **Usernames:** Preventing users from setting their username as an email address (which is especially important for apps that allow login via "Username or Email" to avoid collisions).

### Code
To respect the leanness of the framework, this feature is implemented as a single, one-line function. 

Instead of reinventing the wheel or introducing new regex overhead, I reused Laravel's existing robust `validateEmail` logic and negates the result. I am respecting keeping Laravel's codebase lean.

### Usage
Just like any other string validation rule:

```php
$request->validate([
    'username' => 'required|string|min:3|max:20|not_email|unique:users',
    'bio'      => 'nullable|string|not_email',
]);
```
### Considerations
In my opinion this does not open the floodgates for many more 'not' validation rules. The only other candidate is 'not_url' in my opinion. I respect it would be a slippery slope otherwise.

### Docs
I will submit a companion PR to the `laravel/docs` repository once this is merged.
