### PR TITLE
[13.x] Respect job delays when bulk pushing to QueueFake

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -9,6 +9,8 @@ use Illuminate\Contracts\Cache\Repository as Cache;
 use Illuminate\Contracts\Queue\Queue;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Events\CallQueuedListener;
+use Illuminate\Queue\Attributes\Delay;
+use Illuminate\Queue\Attributes\ReadsQueueAttributes;
 use Illuminate\Queue\CallQueuedClosure;
 use Illuminate\Queue\Jobs\InspectedJob;
 use Illuminate\Queue\QueueManager;
@@ -25,7 +27,7 @@ use function Illuminate\Support\enum_value;
  */
 class QueueFake extends QueueManager implements Fake, Queue
 {
-    use ReflectsClosures;
+    use ReadsQueueAttributes, ReflectsClosures;
 
     /**
      * The original queue manager.
@@ -794,7 +796,13 @@ class QueueFake extends QueueManager implements Fake, Queue
     public function bulk($jobs, $data = '', $queue = null)
     {
         foreach ($jobs as $job) {
-            $this->push($job, $data, $queue);
+            $delay = is_object($job) ? $this->getAttributeValue($job, Delay::class, 'delay') : null;
+
+            if (isset($delay)) {
+                $this->later($delay, $job, $data, $queue);
+            } else {
+                $this->push($job, $data, $queue);
+            }
         }
     }
 

--- a/tests/Support/SupportTestingQueueFakeTest.php
+++ b/tests/Support/SupportTestingQueueFakeTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Support;
 use BadMethodCallException;
 use Illuminate\Bus\Queueable;
 use Illuminate\Foundation\Application;
+use Illuminate\Queue\Attributes\Delay;
 use Illuminate\Queue\CallQueuedClosure;
 use Illuminate\Queue\Jobs\InspectedJob;
 use Illuminate\Queue\QueueManager;
@@ -228,6 +229,31 @@ class SupportTestingQueueFakeTest extends TestCase
         $this->fake->assertPushedOn('foo', JobStub::class);
         $this->fake->assertPushedOn($queue, JobStub::class);
         $this->fake->assertPushed(JobStub::class, 2);
+    }
+
+    public function testBulkRespectsDelayAttribute()
+    {
+        $this->fake->bulk([
+            new JobWithDelayAttributeStub,
+            new JobStub,
+        ], ['foo' => 'bar'], 'redis');
+
+        $this->assertSame(1, $this->fake->delayedSize('redis'));
+        $this->fake->assertPushedOn('redis', JobWithDelayAttributeStub::class);
+        $this->fake->assertPushed(JobWithDelayAttributeStub::class, function ($job, $queue, $data) {
+            return $queue === 'redis' && $data === ['foo' => 'bar'];
+        });
+        $this->fake->assertPushedOn('redis', JobStub::class);
+    }
+
+    public function testBulkRespectsRuntimeDelay()
+    {
+        $job = (new JobWithRuntimeDelayStub)->delay(30);
+
+        $this->fake->bulk([$job], '', 'redis');
+
+        $this->assertSame(1, $this->fake->delayedSize('redis'));
+        $this->fake->assertPushedOn('redis', JobWithRuntimeDelayStub::class);
     }
 
     public function testPushOnAndLaterOnAcceptUnitEnums()
@@ -793,6 +819,27 @@ class JobStub
 
 class JobToFakeStub
 {
+    public function handle()
+    {
+        //
+    }
+}
+
+#[Delay(15)]
+class JobWithDelayAttributeStub
+{
+    use Queueable;
+
+    public function handle()
+    {
+        //
+    }
+}
+
+class JobWithRuntimeDelayStub
+{
+    use Queueable;
+
     public function handle()
     {
         //


### PR DESCRIPTION
  `QueueFake::bulk()` currently pushes every job immediately, regardless of
  whether the job defines a `#[Delay]` attribute or a runtime `$delay` value.
  This differs from the production queue drivers, which respect these delays
  during bulk dispatch.

  This PR updates `QueueFake::bulk()` to resolve each job's delay using the same
  attribute resolution mechanism as the production drivers. Jobs with a delay
  are passed to `later()`, while jobs without a delay continue to use `push()`.

  This keeps bulk dispatch behavior consistent between `Queue::fake()` and
  production queue connections without changing the behavior of non-delayed
  jobs. Queue names, payload data, and existing pushed-job assertions remain
  unchanged.

  Regression tests cover bulk jobs with both `#[Delay]` attributes and runtime
  delays.