### PR TITLE
[13.x] Add an array_keys validation rule

### DIFF
--- a/src/Illuminate/Translation/lang/en/validation.php
+++ b/src/Illuminate/Translation/lang/en/validation.php
@@ -23,6 +23,7 @@ return [
     'alpha_num' => 'The :attribute field must only contain letters and numbers.',
     'any_of' => 'The :attribute field is invalid.',
     'array' => 'The :attribute field must be an array.',
+    'array_keys' => 'The :attribute field must only contain the following keys: :values.',
     'ascii' => 'The :attribute field must only contain single-byte alphanumeric characters and symbols.',
     'base64' => 'The :attribute field must be a valid Base64 string.',
     'before' => 'The :attribute field must be a date before :date.',

--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -365,6 +365,33 @@ trait ReplacesAttributes
     }
 
     /**
+     * Replace all place-holders for the array_keys rule.
+     *
+     * @param  string  $message
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array<int,string>  $parameters
+     * @return string
+     */
+    protected function replaceArrayKeys($message, $attribute, $rule, $parameters)
+    {
+        $message = $this->replaceIn($message, $attribute, $rule, $parameters);
+
+        $value = $this->getValue($attribute);
+
+        $unexpected = is_array($value)
+            ? array_keys(array_diff_key($value, array_fill_keys($parameters, '')))
+            : [];
+
+        $unexpected = array_map(
+            fn ($key) => $this->getDisplayableValue($attribute, $key),
+            $unexpected,
+        );
+
+        return $this->replaceWhileKeepingCase($message, ['unexpected' => implode(', ', $unexpected)]);
+    }
+
+    /**
      * Replace all place-holders for the required_array_keys rule.
      *
      * @param  string  $message

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -457,6 +457,25 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate that an array does not contain any keys other than the given keys.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array<int, int|string>  $parameters
+     * @return bool
+     */
+    public function validateArrayKeys($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(1, $parameters, 'array_keys');
+
+        if (! is_array($value)) {
+            return false;
+        }
+
+        return empty(array_diff_key($value, array_fill_keys($parameters, '')));
+    }
+
+    /**
      * Validate that an attribute is a list.
      *
      * @param  string  $attribute

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Validation\Rules\AnyOf;
+use Illuminate\Validation\Rules\ArrayKeys;
 use Illuminate\Validation\Rules\ArrayRule;
 use Illuminate\Validation\Rules\Can;
 use Illuminate\Validation\Rules\Date;
@@ -78,6 +79,17 @@ class Rule
     public static function array($keys = null)
     {
         return new ArrayRule(...func_get_args());
+    }
+
+    /**
+     * Get an array keys rule builder instance.
+     *
+     * @param  \Illuminate\Contracts\Support\Arrayable|array|string  $keys
+     * @return \Illuminate\Validation\Rules\ArrayKeys
+     */
+    public static function arrayKeys($keys)
+    {
+        return new ArrayKeys(...func_get_args());
     }
 
     /**

--- a/src/Illuminate/Validation/Rules/ArrayKeys.php
+++ b/src/Illuminate/Validation/Rules/ArrayKeys.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+use Illuminate\Contracts\Support\Arrayable;
+use Stringable;
+
+use function Illuminate\Support\enum_value;
+
+class ArrayKeys implements Stringable
+{
+    /**
+     * The accepted keys.
+     *
+     * @var array
+     */
+    protected $keys;
+
+    /**
+     * Create a new array keys rule instance.
+     *
+     * @param  \Illuminate\Contracts\Support\Arrayable|array  $keys
+     */
+    public function __construct($keys)
+    {
+        if ($keys instanceof Arrayable) {
+            $keys = $keys->toArray();
+        }
+
+        $this->keys = is_array($keys) ? $keys : func_get_args();
+    }
+
+    /**
+     * Convert the rule to a validation string.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        $keys = array_map(
+            static fn ($key) => enum_value($key),
+            $this->keys,
+        );
+
+        return 'array_keys:'.implode(',', $keys);
+    }
+}

--- a/tests/Validation/ValidationArrayKeysRuleTest.php
+++ b/tests/Validation/ValidationArrayKeysRuleTest.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\Translator;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Validator;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+include_once 'Enums.php';
+
+class ValidationArrayKeysRuleTest extends TestCase
+{
+    public function testItCorrectlyFormatsAStringVersionOfTheRule()
+    {
+        $rule = Rule::arrayKeys('key_1', 'key_2', 'key_3');
+
+        $this->assertSame('array_keys:key_1,key_2,key_3', (string) $rule);
+
+        $rule = Rule::arrayKeys(['key_1', 'key_2', 'key_3']);
+
+        $this->assertSame('array_keys:key_1,key_2,key_3', (string) $rule);
+
+        $rule = Rule::arrayKeys(collect(['key_1', 'key_2', 'key_3']));
+
+        $this->assertSame('array_keys:key_1,key_2,key_3', (string) $rule);
+
+        $rule = Rule::arrayKeys([ArrayKeys::key_1, ArrayKeys::key_2, ArrayKeys::key_3]);
+
+        $this->assertSame('array_keys:key_1,key_2,key_3', (string) $rule);
+
+        $rule = Rule::arrayKeys([ArrayKeysBacked::key_1, ArrayKeysBacked::key_2, ArrayKeysBacked::key_3]);
+
+        $this->assertSame('array_keys:key_1,key_2,key_3', (string) $rule);
+
+        $rule = Rule::arrayKeys([1, 2, 3]);
+
+        $this->assertSame('array_keys:1,2,3', (string) $rule);
+    }
+
+    public function testArrayKeysValidation()
+    {
+        $trans = new Translator(new ArrayLoader, 'en');
+
+        $v = new Validator($trans, ['foo' => ['key_1' => 'bar', 'key_3' => 'baz']], ['foo' => Rule::arrayKeys(['key_1', 'key_2'])]);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['foo' => ['bar', 'baz']], ['foo' => Rule::arrayKeys(['key_1'])]);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['foo' => 'not an array'], ['foo' => Rule::arrayKeys(['key_1'])]);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['foo' => (object) ['key_1' => 'bar']], ['foo' => Rule::arrayKeys(['key_1'])]);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['foo' => ['key_1' => 'bar', 'key_2' => '']], ['foo' => Rule::arrayKeys(['key_1', 'key_2'])]);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => ['key_1' => 'bar']], ['foo' => Rule::arrayKeys(['key_1', 'key_2'])]);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => ['key_1' => []]], ['foo' => Rule::arrayKeys(['key_1'])]);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => []], ['foo' => Rule::arrayKeys(['key_1', 'key_2'])]);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => ['bar', 'baz']], ['foo' => Rule::arrayKeys([0, 1])]);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => ['key_1' => 'bar']], ['foo' => (string) Rule::arrayKeys(['key_1'])]);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => null], ['foo' => ['nullable', Rule::arrayKeys(['key_1'])]]);
+        $this->assertTrue($v->passes());
+    }
+
+    public function testArrayKeysValidationRequiresAtLeastOneKey()
+    {
+        $trans = new Translator(new ArrayLoader, 'en');
+
+        $v = new Validator($trans, ['foo' => ['key_1' => 'bar']], ['foo' => 'array_keys']);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Validation rule array_keys requires at least 1 parameters.');
+
+        $v->passes();
+    }
+
+    public function testArrayKeysValidationErrorMessage()
+    {
+        $trans = new Translator(new ArrayLoader, 'en');
+
+        $trans->addLines([
+            'validation.array_keys' => 'The :attribute field must only contain the following keys: :values.',
+        ], 'en');
+
+        $v = new Validator($trans, ['foo' => ['key_1' => 'bar', 'key_3' => 'baz']], ['foo' => Rule::arrayKeys(['key_1', 'key_2'])]);
+
+        $this->assertTrue($v->fails());
+        $this->assertSame(
+            'The foo field must only contain the following keys: key_1, key_2.',
+            $v->messages()->first('foo')
+        );
+        $this->assertSame(['ArrayKeys' => ['key_1', 'key_2']], $v->failed()['foo']);
+    }
+
+    public function testArrayKeysValidationErrorMessageCanReferenceTheUnexpectedKeys()
+    {
+        $trans = new Translator(new ArrayLoader, 'en');
+
+        $v = new Validator(
+            $trans,
+            ['foo' => ['key_3' => 'bar', 'key_1' => 'baz', 'key_4' => 'qux']],
+            ['foo' => Rule::arrayKeys(['key_1', 'key_2'])],
+            ['foo.array_keys' => 'The :attribute field does not accept :unexpected. Accepted keys: :values.']
+        );
+
+        $this->assertTrue($v->fails());
+        $this->assertSame(
+            'The foo field does not accept key_3, key_4. Accepted keys: key_1, key_2.',
+            $v->messages()->first('foo')
+        );
+    }
+
+    public function testUnexpectedKeysArePlaceholderSafeAndEmptyForNonArrays()
+    {
+        $trans = new Translator(new ArrayLoader, 'en');
+
+        $v = new Validator(
+            $trans,
+            ['foo' => ['key_1' => 'a', ':values' => 'b', ':attribute' => 'c']],
+            ['foo' => Rule::arrayKeys(['key_1'])],
+            ['foo.array_keys' => 'Unexpected keys: :unexpected. Accepted: :values.']
+        );
+
+        $this->assertTrue($v->fails());
+        $this->assertSame('Unexpected keys: :values, :attribute. Accepted: key_1.', $v->messages()->first('foo'));
+
+        $v = new Validator(
+            $trans,
+            ['foo' => 'not an array'],
+            ['foo' => Rule::arrayKeys(['key_1'])],
+            ['foo.array_keys' => 'Unexpected keys: :unexpected.']
+        );
+
+        $this->assertTrue($v->fails());
+        $this->assertSame('Unexpected keys: .', $v->messages()->first('foo'));
+    }
+}


### PR DESCRIPTION
## Summary

Adds an `array_keys` validation rule for the common case of "this array may only contain these keys, anything else is invalid".

```php
$request->validate([
    'options' => Rule::arrayKeys(['sort', 'direction']),
]);

// or as a string
$request->validate([
    'options' => 'array_keys:sort,direction',
]);
```

Given `['sort' => 'name', 'colour' => 'red']`, this fails with:

> The options field must only contain the following keys: sort, direction.

Keys are optional, not required; the rule constrains which keys *may* appear, it does not demand they all be present. (`required_array_keys` already covers this)

## Why not just `array:key_1,key_2`?

`Rule::array()` already accepts keys and does reject unexpected ones, but it conflates two different failures under one message. Validating `['key_1' => 'bar', 'colour' => 'red']`:

| Rule | Message |
|---|---|
| `array:key_1,key_2` | The foo field must be an array. |
| `array_keys:key_1,key_2` | The foo field must only contain the following keys: key_1, key_2. |

The `array` rule answers "is this an array?" and "does it have only these keys?" with the same message, it cannot say which one failed, and there is no placeholder for the offending keys.

`$validator->failed()` reports `ArrayKeys` rather than `Array` which lets the two be composed where you want both checks reported independently:

```php
'options' => ['array', Rule::arrayKeys(['sort', 'direction'])],
```

This PR leaves `Rule::array()` and its message completely untouched.

## Custom messages

Two placeholders are available:

- `:values` - the accepted keys (used by the default message)
- `:unexpected` - the offending keys that caused the failure

`:unexpected` is not in the default message, but it is available to anyone writing their own, which is often the more useful half for an API response:

```php
$request->validate(
    ['options' => Rule::arrayKeys(['sort', 'direction'])],
    ['options.array_keys' => 'The :attribute field may not contain :unexpected.'],
);

// The options field may not contain colour.
```

## Details

- Accepts an array, `Arrayable` etc, matching `Rule::array()`.
- Requires at least one key, `array_keys` with no parameters throws.
- A non-array value fails; pair with `array` if you want the type failure reported separately.

## Backwards compatibility

This is a new rule, builder, and `array_keys` message line. No existing rule, message, or validation behaviour is modified.