### PR TITLE
[13.x] Fix appended accessors receiving null in toArray()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -246,7 +246,7 @@ trait HasAttributes
         // as these attributes are not really in the attributes array, but are run
         // when we need to array or JSON the model for convenience to the coder.
         foreach ($this->getArrayableAppends() as $key) {
-            $attributes[$key] = $this->mutateAttributeForArray($key, null);
+            $attributes[$key] = $this->mutateAttributeForArray($key, $this->getAttributeFromArray($key));
         }
 
         return $attributes;

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -2566,6 +2566,15 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertSame([], $model->toArray());
     }
 
+    public function testToArrayPassesRealValueToAppendedAccessor()
+    {
+        $model = new EloquentModelAppendsWithExistingAttributeStub;
+        $model->price = 100;
+
+        $this->assertSame(100, $model->price);
+        $this->assertSame(100, $model->toArray()['price']);
+    }
+
     public function testMergeAppendsMergesAppends()
     {
         $model = new EloquentModelAppendsStub;
@@ -4304,6 +4313,18 @@ class EloquentModelAppendsStub extends Model
     public function getStudlyCasedAttribute()
     {
         return 'StudlyCased';
+    }
+}
+
+class EloquentModelAppendsWithExistingAttributeStub extends Model
+{
+    protected $guarded = [];
+
+    protected $appends = ['price'];
+
+    protected function price(): Attribute
+    {
+        return Attribute::get(fn ($value) => $value);
     }
 }
 


### PR DESCRIPTION
When an accessor is defined for an existing attribute and that attribute is also listed in `$appends`, `toArray()` returns `null` for it instead of the accessor's value:

```php
protected $appends = ['price'];

protected function price(): Attribute
{
    return Attribute::get(fn ($price) => $price);
}

$model->price;              // 100
$model->toArray()['price']; // null
```

The appends loop in `attributesToArray()` calls `mutateAttributeForArray($key, null)`, so the accessor always receives `null` no matter what is stored on the model. Reading the same attribute directly goes through `getAttributeFromArray()`, which is why `$model->price` and `$model->toArray()['price']` disagree.

This passes the raw attribute value into the accessor, the same way direct access already does. Appends that have no backing attribute still receive `null`, so their behavior is unchanged.

Fixes #60917