### PR TITLE
[13.x] Escape single quotes in Postgres JSON path attributes

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -780,9 +780,20 @@ class PostgresGrammar extends Grammar
             ->map(fn ($attribute) => $this->parseJsonPathArrayKeys($attribute))
             ->collapse()
             ->map(function ($attribute) use ($quote) {
-                return filter_var($attribute, FILTER_VALIDATE_INT) !== false
-                    ? $attribute
-                    : $quote.$attribute.$quote;
+                if (filter_var($attribute, FILTER_VALIDATE_INT) !== false) {
+                    return $attribute;
+                }
+
+                // The wrapped path is always embedded within a single quoted SQL
+                // string literal, so single quotes have to be escaped whatever
+                // character has been used to delimit the path attributes...
+                $attribute = str_replace("'", "''", $attribute);
+
+                if ($quote !== "'") {
+                    $attribute = str_replace($quote, $quote.$quote, $attribute);
+                }
+
+                return $quote.$attribute.$quote;
             })
             ->all();
     }

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -784,9 +784,6 @@ class PostgresGrammar extends Grammar
                     return $attribute;
                 }
 
-                // The wrapped path is always embedded within a single quoted SQL
-                // string literal, so single quotes have to be escaped whatever
-                // character has been used to delimit the path attributes...
                 $attribute = str_replace("'", "''", $attribute);
 
                 if ($quote !== "'") {

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -5623,6 +5623,36 @@ SQL;
         $this->assertEquals($expectedWithJsonEscaped, $builder->toSql());
     }
 
+    public function testPostgresJsonPathEscaping()
+    {
+        $builder = $this->getPostgresBuilder();
+        $builder->select("json->'))#");
+        $this->assertSame('select "json"->>\'\'\'))#\'', $builder->toSql());
+
+        $builder = $this->getPostgresBuilder();
+        $builder->select('*')->from('users')->where("json->'))#", '=', 1);
+        $this->assertSame('select * from "users" where "json"->>\'\'\'))#\' = ?', $builder->toSql());
+
+        $builder = $this->getPostgresBuilder();
+        $builder->select('*')->from('users')->orderBy("json->'))#");
+        $this->assertSame('select * from "users" order by "json"->>\'\'\'))#\' asc', $builder->toSql());
+
+        $builder = $this->getPostgresBuilder();
+        $builder->select('*')->from('users')->whereJsonLength("json->'))#", 1);
+        $this->assertSame('select * from "users" where jsonb_array_length(("json"->\'\'\'))#\')::jsonb) = ?', $builder->toSql());
+    }
+
+    public function testPostgresUpdateJsonPathEscaping()
+    {
+        // The update path delimits its attributes with double quotes, but the
+        // resulting path is still nested within a single quoted string literal,
+        // so single quotes must be escaped there as well...
+        $builder = $this->getPostgresBuilder();
+        $builder->getConnection()->shouldReceive('update')
+            ->with('update "users" set "options" = jsonb_set("options"::jsonb, \'{"\'\'))#"}\', ?)', ['"John"']);
+        $builder->from('users')->update(["options->'))#" => 'John']);
+    }
+
     public function testMySqlWrappingJson()
     {
         $builder = $this->getMySqlBuilder();


### PR DESCRIPTION
`PostgresGrammar::wrapJsonPathAttributes()` interpolates JSON path attributes into single quoted SQL string literals without escaping single quotes:

```php
return filter_var($attribute, FILTER_VALIDATE_INT) !== false
    ? $attribute
    : $quote.$attribute.$quote;
```

A single quote in a JSON path therefore terminates the literal early:

```php
DB::table('users')->select("meta->x', (select token from api_secrets limit 1) leaked, 'y")->get();
```

```sql
select "meta"->>'x', (select token from api_secrets limit 1) leaked, 'y' from "users"
```

This is inconsistent with the rest of the codebase in two ways:

1. Every other driver escapes this. MySQL, MariaDB, SQLite and SQL Server all go through `CompilesJsonPaths::wrapJsonPath()`, which has applied `preg_replace("/([\\\\]+)?\\'/", "''", $value)` since #28160. The same input is inert on those drivers. Postgres uses a separate `->`/`->>` code path that never received the equivalent treatment.

2. This grammar already escapes it elsewhere. `PostgresGrammar::compileJsonContainsKey()` uses `str_replace("'", "''", $lastSegment)`, which is exactly the escaping applied here.

I checked the sinks that reach `wrapJsonPathAttributes()` — `select`, `addSelect`, `where`/`orWhere`, `whereIn`, `whereNull`, `whereNotNull`, `whereBetween`, `whereDate`, `orderBy`, `groupBy`, `having`, `join`, `whereJsonContains`, `whereJsonLength`, `update` and `upsert` are all affected. `whereJsonContainsKey` is the only one that was already safe, via the `str_replace` above.

Note that plain (non-JSON) column names are not affected — identifier wrapping already neutralises those, e.g. `orderBy('id, (select ...)')` compiles to `order by "id, (select ...)" asc`. The JSON path is the only place where the quoting is escaped.

### On the update path

`compileJsonUpdateColumn()` passes `"` as the attribute delimiter, but the resulting path is still nested inside a `'{...}'` string literal:

```sql
update "users" set "meta" = jsonb_set("meta"::jsonb, '{"role"}', ?)
```

So escaping only the configured delimiter leaves that sink open. This PR escapes single quotes unconditionally, and additionally doubles the delimiter when it isn't a single quote.

### Tests

Added `testPostgresJsonPathEscaping` and `testPostgresUpdateJsonPathEscaping`, mirroring the existing `testJsonPathEscaping` coverage added in #28160. Both fail on the current `13.x` and pass with this change. The full `tests/Database` suite passes (2776 tests, 7659 assertions).

I appreciate that the documentation advises against letting user input dictate column names, and I'd echo the advice given on #28160 that column names should still be whitelisted. This is submitted as a consistency fix so that the JSON path behaves the same across all supported drivers.
