### PR TITLE
[13.x] Add `modelKeys()` to Eloquent query builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1108,7 +1108,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Get the array of primary keys from the query result.
+     * Get an array of primary keys from the query result.
      *
      * @return array<int, array-key>
      */

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1108,6 +1108,16 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Get the array of primary keys from the query result.
+     *
+     * @return array<int, array-key>
+     */
+    public function modelKeys()
+    {
+        return $this->pluck($this->model->getQualifiedKeyName())->all();
+    }
+
+    /**
      * Paginate the given query.
      *
      * @param  int|null|\Closure  $perPage

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -1030,7 +1030,39 @@ class DatabaseEloquentIntegrationTest extends TestCase
             ['id' => 2, 'email' => 'abigailotwell@gmail.com'],
         ]);
 
-        $this->assertEquals([1, 2], EloquentTestUser::oldest('id')->modelKeys());
+        $this->assertSame([1, 2], EloquentTestUser::oldest('id')->modelKeys());
+    }
+
+    public function testModelKeysCastsThePrimaryKey()
+    {
+        EloquentTestUserWithStringCastId::insert([
+            ['id' => 1, 'email' => 'taylorotwell@gmail.com'],
+            ['id' => 2, 'email' => 'abigailotwell@gmail.com'],
+        ]);
+
+        $this->assertSame(['1', '2'], EloquentTestUserWithStringCastId::oldest('id')->modelKeys());
+    }
+
+    public function testModelKeysWithCustomPrimaryKey()
+    {
+        EloquentTestUniqueUserWithCustomKey::insert([
+            ['screen_name' => 'first', 'email' => 'taylorotwell@gmail.com'],
+            ['screen_name' => 'second', 'email' => 'abigailotwell@gmail.com'],
+        ]);
+
+        $this->assertSame(['first', 'second'], EloquentTestUniqueUserWithCustomKey::orderBy('screen_name')->modelKeys());
+    }
+
+    public function testModelKeysRespectsQueryConstraints()
+    {
+        EloquentTestUser::insert([
+            ['id' => 1, 'email' => 'taylorotwell@gmail.com'],
+            ['id' => 2, 'email' => 'abigailotwell@gmail.com'],
+            ['id' => 3, 'email' => 'foo@gmail.com'],
+        ]);
+
+        $this->assertSame([2, 3], EloquentTestUser::where('id', '>', 1)->oldest('id')->modelKeys());
+        $this->assertSame([1], EloquentTestUser::oldest('id')->take(1)->modelKeys());
     }
 
     public function testModelKeysWithRelationshipAndJoin()
@@ -2879,6 +2911,13 @@ class EloquentTestUniqueUser extends Eloquent
     protected $table = 'unique_users';
     protected $casts = ['birthday' => 'datetime'];
     protected $guarded = [];
+}
+
+class EloquentTestUniqueUserWithCustomKey extends EloquentTestUniqueUser
+{
+    protected $primaryKey = 'screen_name';
+    public $incrementing = false;
+    protected $keyType = 'string';
 }
 
 class EloquentTestPost extends Eloquent

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -1033,7 +1033,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertSame([1, 2], EloquentTestUser::oldest('id')->modelKeys());
     }
 
-    public function testModelKeysCastsThePrimaryKey()
+    public function testModelKeysWithCastPrimaryKey()
     {
         EloquentTestUserWithStringCastId::insert([
             ['id' => 1, 'email' => 'taylorotwell@gmail.com'],
@@ -1053,7 +1053,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertSame(['first', 'second'], EloquentTestUniqueUserWithCustomKey::orderBy('screen_name')->modelKeys());
     }
 
-    public function testModelKeysRespectsQueryConstraints()
+    public function testModelKeysWithQueryConstraints()
     {
         EloquentTestUser::insert([
             ['id' => 1, 'email' => 'taylorotwell@gmail.com'],

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -1023,6 +1023,32 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals([1 => 'taylorotwell@gmail.com', 2 => 'abigailotwell@gmail.com'], $keyed);
     }
 
+    public function testModelKeys()
+    {
+        EloquentTestUser::insert([
+            ['id' => 1, 'email' => 'taylorotwell@gmail.com'],
+            ['id' => 2, 'email' => 'abigailotwell@gmail.com'],
+        ]);
+
+        $this->assertEquals([1, 2], EloquentTestUser::oldest('id')->modelKeys());
+    }
+
+    public function testModelKeysWithRelationshipAndJoin()
+    {
+        $user1 = EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
+        $user2 = EloquentTestUser::create(['id' => 2, 'email' => 'abigailotwell@gmail.com']);
+
+        $user1->posts()->create(['id' => 1, 'name' => 'First post']);
+        $user1->posts()->create(['id' => 2, 'name' => 'Second post']);
+        $user2->posts()->create(['id' => 3, 'name' => 'Third post']);
+
+        $this->assertEquals([1, 2], $user1->posts()->oldest('id')->modelKeys());
+
+        $join = EloquentTestUser::join('posts', 'users.id', '=', 'posts.user_id')->where('users.id', 1);
+
+        $this->assertEquals([1, 1], $join->modelKeys());
+    }
+
     public function testFindOrFail()
     {
         EloquentTestUser::insert([


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR adds a `modelKeys()` method to the Eloquent query builder, similar to what collections have:

```php
Posts::query()->where(...)->modelKeys(); // [1, 2, 3]
```

I prefer to avoid hardcoding primary key field names in code if possible (I see `pluck('id')` a lot), and it's an inconsistency when compared to being able to get the keys from a model (`$model->getKey()`) or collection (`$models->modelKeys()`). It's would also be quite handy for testing too tbh.