### PR TITLE
Fix accessor receiving null when attribute is both cast and appended

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -246,7 +246,14 @@ trait HasAttributes
         // as these attributes are not really in the attributes array, but are run
         // when we need to array or JSON the model for convenience to the coder.
         foreach ($this->getArrayableAppends() as $key) {
-            $attributes[$key] = $this->mutateAttributeForArray($key, null);
+           // If the attribute already exists and was already mutated above, it has
+           // already received its real, underlying value. Re-running the mutator
+           // here with a "null" placeholder would discard that computed value.
+           if (array_key_exists($key, $attributes) && in_array($key, $mutatedAttributes)) {
+               continue;
+           }
+
+           $attributes[$key] = $this->mutateAttributeForArray($key, $attributes[$key] ?? null);
         }
 
         return $attributes;

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -2566,6 +2566,15 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertSame([], $model->toArray());
     }
 
+    public function testAppendingAnAttributeThatAlreadyHasAnAccessorUsesItsRealValue()
+    {
+        $model = new EloquentModelAppendsRealAttributeStub;
+        $model->setRawAttributes(['price' => 50]);
+
+        $this->assertSame(100, $model->price);
+        $this->assertSame(100, $model->toArray()['price']);
+    }
+
     public function testMergeAppendsMergesAppends()
     {
         $model = new EloquentModelAppendsStub;
@@ -4304,6 +4313,18 @@ class EloquentModelAppendsStub extends Model
     public function getStudlyCasedAttribute()
     {
         return 'StudlyCased';
+    }
+}
+
+class EloquentModelAppendsRealAttributeStub extends Model
+{
+    protected $appends = ['price'];
+
+    protected function price(): Attribute
+    {
+        return Attribute::make(
+            get: fn ($value) => $value * 2,
+        );
     }
 }
 


### PR DESCRIPTION
## Description

  `Model::attributesToArray()` handles two categories of attributes separately: real attributes with accessors (mutated using their real, underlying value via
  `addMutatedAttributesToArray()`), and appended attributes (computed via `getArrayableAppends()`).

  The appends loop unconditionally re-runs the mutator for every appended key using a hardcoded `null` as the raw value:

  ```php
  foreach ($this->getArrayableAppends() as $key) {
      $attributes[$key] = $this->mutateAttributeForArray($key, null);
  }

  This is fine for purely virtual appended attributes with no backing column (e.g. full_name). But if an attribute has both an accessor and is listed in $appends at the same time (a real,
  reported scenario, not misuse), that attribute already has a correct, real value computed a few lines earlier. The appends loop then overwrites that correct value by re-running the
  accessor with null instead of the real value, silently producing wrong output.

  Example: a model with a price column and an Attribute::make(get: fn ($value) => $value * 2) accessor, with price also in $appends:

  $model->price;              // 100 (correct)
  $model->toArray()['price']; // null-derived result (wrong)

  Direct property access and array/JSON serialization silently disagree, with no error or warning.

  Fix

  Skip appended keys that were already mutated by the earlier step (checked via the already-in-scope $mutatedAttributes list), and otherwise fall back to the existing raw attribute value
  instead of a hardcoded null:

  foreach ($this->getArrayableAppends() as $key) {
      if (array_key_exists($key, $attributes) && in_array($key, $mutatedAttributes)) {
          continue;
      }

      $attributes[$key] = $this->mutateAttributeForArray($key, $attributes[$key] ?? null);
  }

  Purely virtual appends (no backing attribute) are unaffected: they still receive null exactly as before.

  Why this is safe

  - No breaking change for the common case (appends with no backing attribute).
  - Fixes a real data-correctness bug: toArray()/JSON output now matches direct property access.
  - Verified against the full tests/Database suite (2780 tests), no regressions.

  Tests

  Added testAppendingAnAttributeThatAlreadyHasAnAccessorUsesItsRealValue in tests/Database/DatabaseEloquentModelTest.php, with a new fixture model EloquentModelAppendsRealAttributeStub.
  Confirmed the test fails on unmodified code (0 !== 100) and passes with the fix.
  ```
