### PR TITLE
[13.x] Fake the pwnedpasswords API in ValidationPasswordRuleTest

### DIFF
--- a/tests/Validation/ValidationPasswordRuleTest.php
+++ b/tests/Validation/ValidationPasswordRuleTest.php
@@ -4,7 +4,10 @@ namespace Illuminate\Tests\Validation;
 
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Validation\Rule as RuleContract;
+use Illuminate\Http\Client\Factory as HttpFactory;
 use Illuminate\Support\Facades\Facade;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
 use Illuminate\Translation\ArrayLoader;
 use Illuminate\Translation\Translator;
 use Illuminate\Validation\Rules\Password;
@@ -118,6 +121,18 @@ class ValidationPasswordRuleTest extends TestCase
 
     public function testUncompromised()
     {
+        // These are treated as compromised, with a breach count high enough to still
+        // be considered compromised past the raised threshold used further below.
+        $this->fakePwnedPasswordsApi([
+            '123456' => 25000000,
+            'password' => 10000000,
+            'welcome' => 500000,
+            'abc123' => 300000,
+            '123456789' => 20000000,
+            '12345678' => 15000000,
+            'nuno' => 5000000,
+        ]);
+
         $this->fails(Password::min(2)->uncompromised(), [
             '123456',
             'password',
@@ -143,6 +158,30 @@ class ValidationPasswordRuleTest extends TestCase
             '7Z^k5EvqQ9g%c!Jt9$ufnNpQy#Kf',
             'NRs*Gz2@hSmB$vVBSPDfqbRtEzk4nF7ZAbM29VMW$BPD%b2U%3VmJAcrY5eZGVxP%z%apnwSX',
         ]);
+    }
+
+    /**
+     * Fake the "Have I Been Pwned" range API with deterministic responses, so the
+     * uncompromised password rule never depends on a real, flaky network call.
+     *
+     * @param  array<string, int>  $breachCountsByPassword
+     * @return void
+     */
+    protected function fakePwnedPasswordsApi(array $breachCountsByPassword): void
+    {
+        Http::fake(function ($request) use ($breachCountsByPassword) {
+            $prefix = Str::after($request->url(), '/range/');
+
+            foreach ($breachCountsByPassword as $password => $count) {
+                $hash = strtoupper(sha1($password));
+
+                if (str_starts_with($hash, $prefix)) {
+                    return Http::response(substr($hash, 5).':'.$count);
+                }
+            }
+
+            return Http::response('');
+        });
     }
 
     public function testMessagesOrder()
@@ -557,6 +596,8 @@ class ValidationPasswordRuleTest extends TestCase
                 new ArrayLoader, 'en'
             );
         });
+
+        $container->singleton(HttpFactory::class);
 
         Facade::setFacadeApplication($container);
 


### PR DESCRIPTION
This test made a real network call to https://api.pwnedpasswords.com. On the GitHub Actions Windows runners this call sometimes fails, and the error handling itself fails too (no `ExceptionHandler` bound in this test), so the real network error gets hidden and the test just fails:

- https://github.com/laravel/framework/actions/runs/30473374540/job/90648878932?pr=60926
- https://github.com/laravel/framework/actions/runs/30464648708/job/90619230765?pr=60925

This fixes it by faking the HTTP response instead of calling the real API. `ValidationNotPwnedVerifierTest` already does this with mocks, so this test was the only one still using the network.

This is not new: the test has always called the real API, since it was added in #36960. It only fails sometimes, when the network call is unreliable.