### PR TITLE
[13.x] Use self::SUCCESS/self::FAILURE in console commands

### DIFF
--- a/src/Illuminate/Console/MigrationGeneratorCommand.php
+++ b/src/Illuminate/Console/MigrationGeneratorCommand.php
@@ -53,7 +53,7 @@ abstract class MigrationGeneratorCommand extends Command
         if ($this->migrationExists($table)) {
             $this->components->error('Migration already exists.');
 
-            return 1;
+            return self::FAILURE;
         }
 
         $this->replaceMigrationPlaceholders(
@@ -62,7 +62,7 @@ abstract class MigrationGeneratorCommand extends Command
 
         $this->components->info('Migration created successfully.');
 
-        return 0;
+        return self::SUCCESS;
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/SchedulePauseCommand.php
+++ b/src/Illuminate/Console/Scheduling/SchedulePauseCommand.php
@@ -28,7 +28,7 @@ class SchedulePauseCommand extends Command
         if (! Schedule::$pausable) {
             $this->components->error('Schedule pausing is currently disabled.');
 
-            return 1;
+            return self::FAILURE;
         }
 
         $cache->forever('illuminate:schedule:paused', true);
@@ -37,6 +37,6 @@ class SchedulePauseCommand extends Command
 
         $this->components->info('Scheduled task processing has been paused.');
 
-        return 0;
+        return self::SUCCESS;
     }
 }

--- a/src/Illuminate/Console/Scheduling/ScheduleResumeCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleResumeCommand.php
@@ -38,6 +38,6 @@ class ScheduleResumeCommand extends Command
 
         $this->components->info('Scheduled task processing has resumed.');
 
-        return 0;
+        return self::SUCCESS;
     }
 }

--- a/src/Illuminate/Database/Console/DbCommand.php
+++ b/src/Illuminate/Database/Console/DbCommand.php
@@ -63,7 +63,7 @@ class DbCommand extends Command
             return Command::FAILURE;
         }
 
-        return 0;
+        return self::SUCCESS;
     }
 
     /**

--- a/src/Illuminate/Database/Console/DbCommand.php
+++ b/src/Illuminate/Database/Console/DbCommand.php
@@ -44,7 +44,7 @@ class DbCommand extends Command
             $this->line('  Use the <options=bold>[--read]</> and <options=bold>[--write]</> options to specify a read or write connection.');
             $this->newLine();
 
-            return Command::FAILURE;
+            return self::FAILURE;
         }
 
         try {
@@ -60,7 +60,7 @@ class DbCommand extends Command
 
             $this->error("{$command} not found in path.");
 
-            return Command::FAILURE;
+            return self::FAILURE;
         }
 
         return self::SUCCESS;

--- a/src/Illuminate/Database/Console/DumpCommand.php
+++ b/src/Illuminate/Database/Console/DumpCommand.php
@@ -46,7 +46,7 @@ class DumpCommand extends Command
     public function handle(ConnectionResolverInterface $connections, Dispatcher $dispatcher)
     {
         if ($this->isProhibited()) {
-            return Command::FAILURE;
+            return self::FAILURE;
         }
 
         $connection = $connections->connection($database = $this->input->getOption('database'));

--- a/src/Illuminate/Database/Console/Migrations/FreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/FreshCommand.php
@@ -57,9 +57,8 @@ class FreshCommand extends Command
      */
     public function handle()
     {
-        if ($this->isProhibited() ||
-            ! $this->confirmToProceed()) {
-            return Command::FAILURE;
+        if ($this->isProhibited() || ! $this->confirmToProceed()) {
+            return self::FAILURE;
         }
 
         $database = $this->input->getOption('database');

--- a/src/Illuminate/Database/Console/Migrations/FreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/FreshCommand.php
@@ -104,7 +104,7 @@ class FreshCommand extends Command
             $this->runSeeder($database);
         }
 
-        return 0;
+        return self::SUCCESS;
     }
 
     /**

--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -83,7 +83,7 @@ class MigrateCommand extends BaseCommand implements Isolatable
     public function handle()
     {
         if (! $this->confirmToProceed()) {
-            return 1;
+            return self::FAILURE;
         }
 
         try {
@@ -92,13 +92,13 @@ class MigrateCommand extends BaseCommand implements Isolatable
             if ($this->option('graceful')) {
                 $this->components->warn($e->getMessage());
 
-                return 0;
+                return self::SUCCESS;
             }
 
             throw $e;
         }
 
-        return 0;
+        return self::SUCCESS;
     }
 
     /**

--- a/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
@@ -79,7 +79,7 @@ class RefreshCommand extends Command
             $this->runSeeder($database);
         }
 
-        return 0;
+        return self::SUCCESS;
     }
 
     /**

--- a/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
@@ -36,9 +36,8 @@ class RefreshCommand extends Command
      */
     public function handle()
     {
-        if ($this->isProhibited() ||
-            ! $this->confirmToProceed()) {
-            return Command::FAILURE;
+        if ($this->isProhibited() || ! $this->confirmToProceed()) {
+            return self::FAILURE;
         }
 
         // Next we'll gather some of the options so that we can have the right options

--- a/src/Illuminate/Database/Console/Migrations/ResetCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/ResetCommand.php
@@ -54,9 +54,8 @@ class ResetCommand extends BaseCommand
      */
     public function handle()
     {
-        if ($this->isProhibited() ||
-            ! $this->confirmToProceed()) {
-            return Command::FAILURE;
+        if ($this->isProhibited() || ! $this->confirmToProceed()) {
+            return self::FAILURE;
         }
 
         return $this->migrator->usingConnection($this->option('database'), function () {

--- a/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
@@ -69,7 +69,7 @@ class RollbackCommand extends BaseCommand
             );
         });
 
-        return 0;
+        return self::SUCCESS;
     }
 
     /**

--- a/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
@@ -54,9 +54,8 @@ class RollbackCommand extends BaseCommand
      */
     public function handle()
     {
-        if ($this->isProhibited() ||
-            ! $this->confirmToProceed()) {
-            return Command::FAILURE;
+        if ($this->isProhibited() || ! $this->confirmToProceed()) {
+            return self::FAILURE;
         }
 
         $this->migrator->usingConnection($this->option('database'), function () {

--- a/src/Illuminate/Database/Console/Migrations/StatusCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/StatusCommand.php
@@ -55,7 +55,7 @@ class StatusCommand extends BaseCommand
             if (! $this->migrator->repositoryExists()) {
                 $this->components->error('Migration table not found.');
 
-                return 1;
+                return self::FAILURE;
             }
 
             $ran = $this->migrator->getRepository()->getRan();

--- a/src/Illuminate/Database/Console/Seeds/SeedCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeedCommand.php
@@ -75,7 +75,7 @@ class SeedCommand extends Command
             $this->resolver->setDefaultConnection($previousConnection);
         }
 
-        return 0;
+        return self::SUCCESS;
     }
 
     /**

--- a/src/Illuminate/Database/Console/Seeds/SeedCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeedCommand.php
@@ -56,9 +56,8 @@ class SeedCommand extends Command
      */
     public function handle()
     {
-        if ($this->isProhibited() ||
-            ! $this->confirmToProceed()) {
-            return Command::FAILURE;
+        if ($this->isProhibited() || ! $this->confirmToProceed()) {
+            return self::FAILURE;
         }
 
         $this->components->info('Seeding database.');

--- a/src/Illuminate/Database/Console/ShowCommand.php
+++ b/src/Illuminate/Database/Console/ShowCommand.php
@@ -67,7 +67,7 @@ class ShowCommand extends DatabaseInspectionCommand
 
         $this->display($data);
 
-        return 0;
+        return self::SUCCESS;
     }
 
     /**

--- a/src/Illuminate/Database/Console/ShowModelCommand.php
+++ b/src/Illuminate/Database/Console/ShowModelCommand.php
@@ -56,12 +56,12 @@ class ShowModelCommand extends DatabaseInspectionCommand implements PromptsForMi
         } catch (BindingResolutionException $e) {
             $this->components->error($e->getMessage());
 
-            return 1;
+            return self::FAILURE;
         }
 
         $this->display($info);
 
-        return 0;
+        return self::SUCCESS;
     }
 
     /**

--- a/src/Illuminate/Database/Console/TableCommand.php
+++ b/src/Illuminate/Database/Console/TableCommand.php
@@ -70,7 +70,7 @@ class TableCommand extends DatabaseInspectionCommand
         if (! $table) {
             $this->components->warn("Table [{$tableName}] doesn't exist.");
 
-            return 1;
+            return self::FAILURE;
         }
 
         [$columns, $indexes, $foreignKeys] = $connection->withoutTablePrefix(function ($connection) use ($table) {
@@ -102,7 +102,7 @@ class TableCommand extends DatabaseInspectionCommand
 
         $this->display($data);
 
-        return 0;
+        return self::SUCCESS;
     }
 
     /**

--- a/src/Illuminate/Database/Console/WipeCommand.php
+++ b/src/Illuminate/Database/Console/WipeCommand.php
@@ -60,7 +60,7 @@ class WipeCommand extends Command
 
         $this->flushDatabaseConnection($database);
 
-        return 0;
+        return self::SUCCESS;
     }
 
     /**

--- a/src/Illuminate/Database/Console/WipeCommand.php
+++ b/src/Illuminate/Database/Console/WipeCommand.php
@@ -35,9 +35,8 @@ class WipeCommand extends Command
      */
     public function handle()
     {
-        if ($this->isProhibited() ||
-            ! $this->confirmToProceed()) {
-            return Command::FAILURE;
+        if ($this->isProhibited() || ! $this->confirmToProceed()) {
+            return self::FAILURE;
         }
 
         $database = $this->input->getOption('database');

--- a/src/Illuminate/Foundation/Console/AboutCommand.php
+++ b/src/Illuminate/Foundation/Console/AboutCommand.php
@@ -99,7 +99,7 @@ class AboutCommand extends Command
 
         $this->newLine();
 
-        return 0;
+        return self::SUCCESS;
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/ConfigPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigPublishCommand.php
@@ -54,7 +54,7 @@ class ConfigPublishCommand extends Command
         if (! is_null($name) && ! isset($config[$name])) {
             $this->components->error('Unrecognized configuration file.');
 
-            return 1;
+            return self::FAILURE;
         }
 
         $this->publish($name, $config[$name], $this->laravel->configPath().'/'.$name.'.php');

--- a/src/Illuminate/Foundation/Console/ConfigShowCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigShowCommand.php
@@ -40,7 +40,7 @@ class ConfigShowCommand extends Command
         $this->render($config);
         $this->newLine();
 
-        return Command::SUCCESS;
+        return self::SUCCESS;
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/DocsCommand.php
+++ b/src/Illuminate/Foundation/Console/DocsCommand.php
@@ -117,7 +117,7 @@ class DocsCommand extends Command
 
         $this->refreshDocs();
 
-        return Command::SUCCESS;
+        return self::SUCCESS;
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/DownCommand.php
+++ b/src/Illuminate/Foundation/Console/DownCommand.php
@@ -74,7 +74,7 @@ class DownCommand extends Command
                 $e->getMessage(),
             ));
 
-            return 1;
+            return self::FAILURE;
         }
     }
 

--- a/src/Illuminate/Foundation/Console/UpCommand.php
+++ b/src/Illuminate/Foundation/Console/UpCommand.php
@@ -35,7 +35,7 @@ class UpCommand extends Command
             if (! $this->laravel->maintenanceMode()->active()) {
                 $this->components->info('Application is already up.');
 
-                return 0;
+                return self::SUCCESS;
             }
 
             $this->laravel->maintenanceMode()->deactivate();
@@ -55,9 +55,9 @@ class UpCommand extends Command
                 $e->getMessage(),
             ));
 
-            return 1;
+            return self::FAILURE;
         }
 
-        return 0;
+        return self::SUCCESS;
     }
 }

--- a/src/Illuminate/Queue/Console/ForgetFailedCommand.php
+++ b/src/Illuminate/Queue/Console/ForgetFailedCommand.php
@@ -34,7 +34,7 @@ class ForgetFailedCommand extends Command
         } else {
             $this->components->error('No failed job matches the given ID.');
 
-            return 1;
+            return self::FAILURE;
         }
     }
 }

--- a/src/Illuminate/Queue/Console/PauseCommand.php
+++ b/src/Illuminate/Queue/Console/PauseCommand.php
@@ -39,13 +39,13 @@ class PauseCommand extends Command
         if (! Worker::$pausable) {
             $this->components->error('Queue pausing is currently disabled.');
 
-            return 1;
+            return self::FAILURE;
         }
 
         $manager->pause($connection, $queue);
 
         $this->components->info("Job processing on queue [{$connection}:{$queue}] has been paused.");
 
-        return 0;
+        return self::SUCCESS;
     }
 }

--- a/src/Illuminate/Queue/Console/PruneFailedJobsCommand.php
+++ b/src/Illuminate/Queue/Console/PruneFailedJobsCommand.php
@@ -39,7 +39,7 @@ class PruneFailedJobsCommand extends Command
         } else {
             $this->components->error('The ['.class_basename($failer).'] failed job storage driver does not support pruning.');
 
-            return 1;
+            return self::FAILURE;
         }
 
         $this->components->info("{$count} entries deleted.");

--- a/src/Illuminate/Queue/Console/ResumeCommand.php
+++ b/src/Illuminate/Queue/Console/ResumeCommand.php
@@ -46,6 +46,6 @@ class ResumeCommand extends Command
 
         $this->components->info("Job processing on queue [{$connection}:{$queue}] has been resumed.");
 
-        return 0;
+        return self::SUCCESS;
     }
 }


### PR DESCRIPTION
Replaces literal `0`/`1` exit codes in `handle()` with `self::SUCCESS`/`self::FAILURE`, matching commands that already use these constants.