### PR TITLE
[13.x] Memoize TestResponse::decodeResponseJson()

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -69,6 +69,13 @@ class TestResponse implements ArrayAccess
     protected $streamedContent;
 
     /**
+     * The decoded response JSON.
+     *
+     * @var \Illuminate\Testing\AssertableJsonString|null
+     */
+    protected $decodedResponseJson;
+
+    /**
      * Create a new test response instance.
      *
      * @param  TResponse  $response
@@ -1265,6 +1272,10 @@ class TestResponse implements ArrayAccess
      */
     public function decodeResponseJson()
     {
+        if (! is_null($this->decodedResponseJson)) {
+            return $this->decodedResponseJson;
+        }
+
         if ($this->baseResponse instanceof StreamedResponse ||
             $this->baseResponse instanceof StreamedJsonResponse) {
             $testJson = new AssertableJsonString($this->streamedContent());
@@ -1282,7 +1293,7 @@ class TestResponse implements ArrayAccess
             }
         }
 
-        return $testJson;
+        return $this->decodedResponseJson = $testJson;
     }
 
     /**


### PR DESCRIPTION
Chaining JSON assertions (`assertJson()`, `assertJsonPath()`, `assertJsonCount()`, `json()`, etc.) on the same response re-decodes the response body from scratch every time. This caches the result the first time, the same way `streamedContent()` already does on this same class.