### PR TITLE
[13.x] Adds dominant color detection to image driver

### DIFF
--- a/src/Illuminate/Contracts/Image/Driver.php
+++ b/src/Illuminate/Contracts/Image/Driver.php
@@ -12,6 +12,11 @@ interface Driver
     public function process(string $contents, ImagePipeline $pipeline): string;
 
     /**
+     * Get the dominant (average) color of the image as a hex string.
+     */
+    public function dominantColor(string $contents): string;
+
+    /**
      * Register a transformation handler.
      *
      * @param  class-string<\Illuminate\Contracts\Image\Transformation>  $transformation

--- a/src/Illuminate/Image/Drivers/InterventionDriver.php
+++ b/src/Illuminate/Image/Drivers/InterventionDriver.php
@@ -28,6 +28,7 @@ use Intervention\Image\Encoders\MediaTypeEncoder;
 use Intervention\Image\Encoders\PngEncoder;
 use Intervention\Image\Encoders\WebpEncoder;
 use Intervention\Image\ImageManager;
+use Intervention\Image\Interfaces\ImageInterface;
 
 abstract class InterventionDriver implements Driver
 {
@@ -94,10 +95,17 @@ abstract class InterventionDriver implements Driver
             $image = match (true) {
                 $transformation instanceof Orient => $image->orient(),
                 $transformation instanceof Cover => $image->cover($transformation->width, $transformation->height),
-                $transformation instanceof Contain => $image->contain($transformation->width, $transformation->height, $transformation->background),
+                $transformation instanceof Contain => $image->contain(
+                    $transformation->width,
+                    $transformation->height,
+                    $this->resolveBackground($image, $transformation->background),
+                ),
                 $transformation instanceof Crop => $image->crop($transformation->width, $transformation->height, $transformation->x, $transformation->y),
                 $transformation instanceof Resize => $image->resize($transformation->width, $transformation->height),
-                $transformation instanceof Rotate => $image->rotate($transformation->angle, $transformation->background),
+                $transformation instanceof Rotate => $image->rotate(
+                    $transformation->angle,
+                    $this->resolveBackground($image, $transformation->background),
+                ),
                 $transformation instanceof Scale => $image->scaleDown($transformation->width, $transformation->height),
                 $transformation instanceof Blur => $image->blur($transformation->amount),
                 $transformation instanceof Grayscale => $image->grayscale(),
@@ -134,6 +142,20 @@ abstract class InterventionDriver implements Driver
     }
 
     /**
+     * Get the dominant (average) color of the image as a hex string.
+     */
+    public function dominantColor(string $contents): string
+    {
+        $image = $this->manager->decode($contents);
+
+        try {
+            return $this->dominantColorFrom($image);
+        } finally {
+            unset($image);
+        }
+    }
+
+    /**
      * Register a transformation handler.
      *
      * @param  class-string<\Illuminate\Contracts\Image\Transformation>  $transformation
@@ -143,6 +165,30 @@ abstract class InterventionDriver implements Driver
         $this->transformationHandlers[$transformation] = $callback;
 
         return $this;
+    }
+
+    /**
+     * Resolve a background color, expanding the "dominant" sentinel when needed.
+     */
+    protected function resolveBackground(ImageInterface $image, ?string $background): ?string
+    {
+        return $background === 'dominant'
+            ? $this->dominantColorFrom($image)
+            : $background;
+    }
+
+    /**
+     * Sample the dominant color by resizing the image to a single pixel.
+     */
+    protected function dominantColorFrom(ImageInterface $image): string
+    {
+        $sample = clone $image;
+
+        try {
+            return $sample->resize(1, 1)->colorAt(0, 0)->toHex(true);
+        } finally {
+            unset($sample);
+        }
     }
 
     /**

--- a/src/Illuminate/Image/Drivers/InterventionDriver.php
+++ b/src/Illuminate/Image/Drivers/InterventionDriver.php
@@ -142,6 +142,16 @@ abstract class InterventionDriver implements Driver
     }
 
     /**
+     * Resolve a background color, expanding the "dominant" sentinel when needed.
+     */
+    protected function resolveBackground(ImageInterface $image, ?string $background): ?string
+    {
+        return $background === 'dominant'
+            ? $this->dominantColorFrom($image)
+            : $background;
+    }
+
+    /**
      * Get the dominant (average) color of the image as a hex string.
      */
     public function dominantColor(string $contents): string
@@ -156,28 +166,6 @@ abstract class InterventionDriver implements Driver
     }
 
     /**
-     * Register a transformation handler.
-     *
-     * @param  class-string<\Illuminate\Contracts\Image\Transformation>  $transformation
-     */
-    public function transformUsing(string $transformation, callable $callback): static
-    {
-        $this->transformationHandlers[$transformation] = $callback;
-
-        return $this;
-    }
-
-    /**
-     * Resolve a background color, expanding the "dominant" sentinel when needed.
-     */
-    protected function resolveBackground(ImageInterface $image, ?string $background): ?string
-    {
-        return $background === 'dominant'
-            ? $this->dominantColorFrom($image)
-            : $background;
-    }
-
-    /**
      * Sample the dominant color by resizing the image to a single pixel.
      */
     protected function dominantColorFrom(ImageInterface $image): string
@@ -189,6 +177,18 @@ abstract class InterventionDriver implements Driver
         } finally {
             unset($sample);
         }
+    }
+
+    /**
+     * Register a transformation handler.
+     *
+     * @param  class-string<\Illuminate\Contracts\Image\Transformation>  $transformation
+     */
+    public function transformUsing(string $transformation, callable $callback): static
+    {
+        $this->transformationHandlers[$transformation] = $callback;
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Image/Image.php
+++ b/src/Illuminate/Image/Image.php
@@ -476,6 +476,22 @@ class Image implements Stringable
     }
 
     /**
+     * Get the dominant (average) color of the image as a hex string.
+     */
+    public function dominantColor(): string
+    {
+        return once(function () {
+            $contents = value($this->contents);
+
+            if ($this->pipeline->hasChanges() && ! $this->processed) {
+                $contents = $this->resolveDriver()->process($contents, clone $this->pipeline);
+            }
+
+            return $this->resolveDriver()->dominantColor($contents);
+        });
+    }
+
+    /**
      * Set the driver to use for processing.
      */
     public function using(string $driver): static

--- a/tests/Image/Drivers/GdDriverTest.php
+++ b/tests/Image/Drivers/GdDriverTest.php
@@ -142,6 +142,29 @@ class GdDriverTest extends TestCase
         $this->assertSame(200, $height);
     }
 
+    public function test_processes_contain_with_dominant_background()
+    {
+        $driver = new GdDriver;
+        $contents = $this->solidColorImageContents(255, 0, 0, 400, 200);
+
+        $pipeline = $this->pipeline(new Contain(200, 200, 'dominant'));
+
+        $result = $driver->process($contents, $pipeline);
+
+        [$width, $height] = getimagesizefromstring($result);
+
+        $this->assertSame(200, $width);
+        $this->assertSame(200, $height);
+    }
+
+    public function test_dominant_color_returns_hex_for_solid_image()
+    {
+        $driver = new GdDriver;
+        $contents = $this->solidColorImageContents(0, 128, 255);
+
+        $this->assertSame('#0080ff', $driver->dominantColor($contents));
+    }
+
     public function test_processes_crop()
     {
         $driver = new GdDriver;
@@ -185,6 +208,19 @@ class GdDriverTest extends TestCase
 
         $this->assertSame(50, $width);
         $this->assertSame(100, $height);
+    }
+
+    public function test_processes_rotate_with_dominant_background()
+    {
+        $driver = new GdDriver;
+        $contents = $this->solidColorImageContents(0, 255, 0, 100, 50);
+
+        $pipeline = $this->pipeline(new Rotate(45, 'dominant'));
+
+        $result = $driver->process($contents, $pipeline);
+
+        $this->assertNotEmpty($result);
+        $this->assertNotFalse(getimagesizefromstring($result));
     }
 
     public function test_processes_scale()
@@ -429,6 +465,19 @@ class GdDriverTest extends TestCase
         $file = UploadedFile::fake()->image('test.jpg', $width, $height);
 
         return file_get_contents($file->getRealPath());
+    }
+
+    protected function solidColorImageContents(int $red, int $green, int $blue, int $width = 100, int $height = 100): string
+    {
+        $image = imagecreatetruecolor($width, $height);
+        $color = imagecolorallocate($image, $red, $green, $blue);
+        imagefill($image, 0, 0, $color);
+
+        ob_start();
+        imagepng($image);
+        imagedestroy($image);
+
+        return ob_get_clean();
     }
 
     protected function pipeline(?Transformation $transformation = null, ?string $format = null, ?int $quality = null): ImagePipeline

--- a/tests/Image/Drivers/ImagickDriverTest.php
+++ b/tests/Image/Drivers/ImagickDriverTest.php
@@ -152,6 +152,29 @@ class ImagickDriverTest extends TestCase
         $this->assertSame(200, $height);
     }
 
+    public function test_processes_contain_with_dominant_background()
+    {
+        $driver = new ImagickDriver;
+        $contents = $this->solidColorImageContents(255, 0, 0, 400, 200);
+
+        $pipeline = $this->pipeline(new Contain(200, 200, 'dominant'));
+
+        $result = $driver->process($contents, $pipeline);
+
+        [$width, $height] = getimagesizefromstring($result);
+
+        $this->assertSame(200, $width);
+        $this->assertSame(200, $height);
+    }
+
+    public function test_dominant_color_returns_hex_for_solid_image()
+    {
+        $driver = new ImagickDriver;
+        $contents = $this->solidColorImageContents(0, 128, 255);
+
+        $this->assertSame('#0080ff', $driver->dominantColor($contents));
+    }
+
     public function test_processes_crop()
     {
         $driver = new ImagickDriver;
@@ -195,6 +218,19 @@ class ImagickDriverTest extends TestCase
 
         $this->assertSame(50, $width);
         $this->assertSame(100, $height);
+    }
+
+    public function test_processes_rotate_with_dominant_background()
+    {
+        $driver = new ImagickDriver;
+        $contents = $this->solidColorImageContents(0, 255, 0, 100, 50);
+
+        $pipeline = $this->pipeline(new Rotate(45, 'dominant'));
+
+        $result = $driver->process($contents, $pipeline);
+
+        $this->assertNotEmpty($result);
+        $this->assertNotFalse(getimagesizefromstring($result));
     }
 
     public function test_processes_scale()
@@ -406,6 +442,19 @@ class ImagickDriverTest extends TestCase
         $file = UploadedFile::fake()->image('test.jpg', $width, $height);
 
         return file_get_contents($file->getRealPath());
+    }
+
+    protected function solidColorImageContents(int $red, int $green, int $blue, int $width = 100, int $height = 100): string
+    {
+        $imagick = new \Imagick;
+        $imagick->newImage($width, $height, new \ImagickPixel(sprintf('rgb(%d,%d,%d)', $red, $green, $blue)));
+        $imagick->setImageFormat('png');
+
+        $contents = $imagick->getImageBlob();
+        $imagick->clear();
+        $imagick->destroy();
+
+        return $contents;
     }
 
     protected function pipeline(?Transformation $transformation = null, ?string $format = null, ?int $quality = null): ImagePipeline

--- a/tests/Image/ImageManagerTest.php
+++ b/tests/Image/ImageManagerTest.php
@@ -321,6 +321,11 @@ class ImageManagerTest extends TestCase
                 return $contents;
             }
 
+            public function dominantColor(string $contents): string
+            {
+                return '#000000';
+            }
+
             public function transformUsing(string $transformation, callable $callback): static
             {
                 $this->handlers[$transformation] = $callback;
@@ -350,6 +355,11 @@ class ImageManagerTest extends TestCase
             public function process(string $contents, ImagePipeline $pipeline): string
             {
                 return $contents;
+            }
+
+            public function dominantColor(string $contents): string
+            {
+                return '#000000';
             }
 
             public function transformUsing(string $transformation, callable $callback): static

--- a/tests/Image/ImageTest.php
+++ b/tests/Image/ImageTest.php
@@ -788,6 +788,18 @@ class ImageTest extends TestCase
         $this->assertSame('#ffffff', $options->containBackground);
     }
 
+    public function test_contain_sets_dominant_background()
+    {
+        $image = $this->makeImage();
+        $result = $image->contain(1200, 800, 'dominant');
+
+        $options = $this->getOptions($result);
+
+        $this->assertSame(1200, $options->containWidth);
+        $this->assertSame(800, $options->containHeight);
+        $this->assertSame('dominant', $options->containBackground);
+    }
+
     public function test_crop_sets_dimensions_and_position()
     {
         $image = $this->makeImage();
@@ -851,6 +863,17 @@ class ImageTest extends TestCase
 
         $this->assertSame(90.0, $options->rotateAngle);
         $this->assertSame('#ffffff', $options->rotateBackground);
+    }
+
+    public function test_rotate_sets_dominant_background()
+    {
+        $image = $this->makeImage();
+        $result = $image->rotate(45, 'dominant');
+
+        $options = $this->getOptions($result);
+
+        $this->assertSame(45.0, $options->rotateAngle);
+        $this->assertSame('dominant', $options->rotateBackground);
     }
 
     public function test_scale_sets_width_only()

--- a/tests/Integration/Image/ImageTest.php
+++ b/tests/Integration/Image/ImageTest.php
@@ -47,6 +47,25 @@ class ImageTest extends TestCase
         $this->assertSame(200, $height);
     }
 
+    public function test_contain_with_dominant_background()
+    {
+        $image = new Image($this->solidColorImageContents(255, 0, 0, 400, 200));
+
+        $result = $image->contain(200, 200, 'dominant')->toBytes();
+
+        [$width, $height] = getimagesizefromstring($result);
+
+        $this->assertSame(200, $width);
+        $this->assertSame(200, $height);
+    }
+
+    public function test_dominant_color_returns_hex()
+    {
+        $image = new Image($this->solidColorImageContents(0, 128, 255));
+
+        $this->assertSame('#0080ff', $image->dominantColor());
+    }
+
     public function test_crop_and_to_bytes()
     {
         $image = new Image($this->fakeImageContents(400, 200));
@@ -81,6 +100,16 @@ class ImageTest extends TestCase
 
         $this->assertSame(50, $width);
         $this->assertSame(100, $height);
+    }
+
+    public function test_rotate_with_dominant_background()
+    {
+        $image = new Image($this->solidColorImageContents(0, 255, 0, 100, 50));
+
+        $result = $image->rotate(45, 'dominant')->toBytes();
+
+        $this->assertNotEmpty($result);
+        $this->assertNotFalse(getimagesizefromstring($result));
     }
 
     public function test_to_png_and_to_bytes()
@@ -765,5 +794,18 @@ class ImageTest extends TestCase
         $file = UploadedFile::fake()->image('test.jpg', $width, $height);
 
         return file_get_contents($file->getRealPath());
+    }
+
+    protected function solidColorImageContents(int $red, int $green, int $blue, int $width = 100, int $height = 100): string
+    {
+        $image = imagecreatetruecolor($width, $height);
+        $color = imagecolorallocate($image, $red, $green, $blue);
+        imagefill($image, 0, 0, $color);
+
+        ob_start();
+        imagepng($image);
+        imagedestroy($image);
+
+        return ob_get_clean();
     }
 }


### PR DESCRIPTION
Introduces support for using the dominant (average) color of an image as a background option in image transformations, computed by downsampling image to a 1x1 pixel.

Adds a new method `dominantColor()` method to the `Driver` contract and `Image` class returning the average color of an image as a hex string.

Also adds a `'dominant'` value for the `background` parameter of `contain()` and `rotate()` transformations, which automatically fills letterbox/rotation areas with the image's dominant color.