### PR TITLE
[13.x] Re-evaluate unmatched BindWhen attributes

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1008,7 +1008,8 @@ class Container implements ArrayAccess, ContainerContract
         $concrete = $this->resolveConcreteFromAttributes($reflected);
 
         if ($concrete === null) {
-            if ($this->environmentResolver === null && $reflected->getAttributes(Bind::class) !== []) {
+            if ($reflected->getAttributes(BindWhen::class) !== [] ||
+                ($this->environmentResolver === null && $reflected->getAttributes(Bind::class) !== [])) {
                 unset($this->checkedForAttributeBindings[$abstract]);
             }
 

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -934,6 +934,24 @@ class ContainerTest extends TestCase
     }
 
     #[RequiresPhp('>= 8.5.0')]
+    public function testBindWhenIsReevaluatedAfterAnInitialMiss(): void
+    {
+        $container = new Container;
+
+        try {
+            $container->make(BindWhenConditionalInterface::class);
+
+            $this->fail('Expected binding resolution to fail when the BindWhen condition does not match.');
+        } catch (BindingResolutionException) {
+            // Continue after the expected first resolution failure.
+        }
+
+        $container->instance(BindWhenCondition::class, new BindWhenCondition);
+
+        $this->assertInstanceOf(BindWhenConditionalConcrete::class, $container->make(BindWhenConditionalInterface::class));
+    }
+
+    #[RequiresPhp('>= 8.5.0')]
     public function testBindWhenTakesPrecedenceOverBind(): void
     {
         $container = new Container;

--- a/tests/Container/Fixtures/ContainerBindWhenFixtures.php
+++ b/tests/Container/Fixtures/ContainerBindWhenFixtures.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Container;
 use Illuminate\Container\Attributes\Bind;
 use Illuminate\Container\Attributes\BindWhen;
 use Illuminate\Container\Attributes\Singleton;
+use Illuminate\Contracts\Container\Container as ContainerContract;
 
 #[BindWhen(BindWhenFalseConcrete::class, static function () {
     return false;
@@ -44,6 +45,21 @@ interface BindWhenNoMatchInterface
 }
 
 class BindWhenNoMatchConcrete implements BindWhenNoMatchInterface
+{
+}
+
+#[BindWhen(BindWhenConditionalConcrete::class, static function (ContainerContract $container) {
+    return $container->bound(BindWhenCondition::class);
+})]
+interface BindWhenConditionalInterface
+{
+}
+
+class BindWhenCondition
+{
+}
+
+class BindWhenConditionalConcrete implements BindWhenConditionalInterface
 {
 }
 


### PR DESCRIPTION
When no `#[BindWhen]` condition matches, the container marks the abstract as having already checked its binding attributes.

This prevents the attributes from being evaluated again if the condition depends on container state that changes after the initial resolution attempt.

This PR clears the attribute-binding cache when an abstract has `#[BindWhen]` attributes but none match, allowing a subsequent resolution to evaluate the conditions again.

A regression test has been added to cover resolving an interface after its `#[BindWhen]` condition becomes true.