### PR TITLE
[13.x] Fix `DumpCommand` return type.

### DIFF
--- a/src/Illuminate/Database/Console/DumpCommand.php
+++ b/src/Illuminate/Database/Console/DumpCommand.php
@@ -41,7 +41,7 @@ class DumpCommand extends Command
      *
      * @param  \Illuminate\Database\ConnectionResolverInterface  $connections
      * @param  \Illuminate\Contracts\Events\Dispatcher  $dispatcher
-     * @return void
+     * @return int
      */
     public function handle(ConnectionResolverInterface $connections, Dispatcher $dispatcher)
     {
@@ -70,6 +70,8 @@ class DumpCommand extends Command
         }
 
         $this->components->info($info.' successfully.');
+
+        return Command::SUCCESS;
     }
 
     /**


### PR DESCRIPTION
This PR changes `DumpCommand::handle()` to return `Command::SUCCESS` on success and updates its DocBlock from `@return void` to `@return int`.

Since the method already returned `Command::FAILURE` in some cases, the previous `@return void` annotation was incorrect. No native return type has been added, so this introduces no breaking change.

We encountered this while overriding `DumpCommand` in our project. The incorrect DocBlock causes PHPStan to report an incompatible method signature, and this change resolves that inconsistency.
