### PR TITLE
[13.x] Add valueOrFail() method to query builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3544,6 +3544,21 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Get a single column's value from the first result of the query or throw an exception.
+     *
+     * @param  string  $column
+     * @return mixed
+     *
+     * @throws \Illuminate\Database\RecordNotFoundException
+     */
+    public function valueOrFail($column)
+    {
+        $result = (array) $this->firstOrFail([$column]);
+
+        return array_first($result);
+    }
+
+    /**
      * Execute the query as a "select" statement.
      *
      * @param  string|\Illuminate\Contracts\Database\Query\Expression|array<string|\Illuminate\Contracts\Database\Query\Expression>  $columns

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -4101,6 +4101,27 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertSame('bar', $results);
     }
 
+    public function testValueOrFailMethodReturnsSingleColumn()
+    {
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('select')->once()->with('select "foo" from "users" where "id" = ? limit 1', [1], true, [])->andReturn([['foo' => 'bar']]);
+        $builder->getProcessor()->shouldReceive('processSelect')->once()->with($builder, [['foo' => 'bar']])->andReturn([['foo' => 'bar']]);
+        $results = $builder->from('users')->where('id', '=', 1)->valueOrFail('foo');
+        $this->assertSame('bar', $results);
+    }
+
+    public function testValueOrFailMethodThrowsRecordNotFoundException()
+    {
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('select')->once()->with('select "foo" from "users" where "id" = ? limit 1', [1], true, [])->andReturn([]);
+        $builder->getProcessor()->shouldReceive('processSelect')->once()->with($builder, [])->andReturn([]);
+
+        $this->expectException(RecordNotFoundException::class);
+        $this->expectExceptionMessage('No record found for the given query.');
+
+        $builder->from('users')->where('id', '=', 1)->valueOrFail('foo');
+    }
+
     public function testRawValueMethodReturnsSingleColumn()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
  ## Summary
  Adds `valueOrFail()` to the query builder so `DB::table()` callers get the same "single column or throw" helper the Eloquent Builder already has.
  ```php
  // Before
  $id = DB::table('users')->where('email', $email)->value('id');

  if (is_null($id)) {
      throw new RecordNotFoundException(...);
  }

  // After
  $id = DB::table('users')->where('email', $email)->valueOrFail('id');
```

  ## Why
  The query builder already has `value()` and `soleValue()`, and Eloquent already has `valueOrFail()`. Without this method, query-builder code has to null-check `value()` manually, which is verbose and ambiguous when the column itself can be `null`.
  
  ## Backwards compatibility
  New method only. No existing behavior changed.
  ## Tests
  - Returns the column when a row exists
  - Throws `RecordNotFoundException` when no row matches