### PR TITLE
[13.x] Respect zero password confirmation timeout

### DIFF
--- a/src/Illuminate/Auth/Middleware/RequirePassword.php
+++ b/src/Illuminate/Auth/Middleware/RequirePassword.php
@@ -41,7 +41,7 @@ class RequirePassword
     {
         $this->responseFactory = $responseFactory;
         $this->urlGenerator = $urlGenerator;
-        $this->passwordTimeout = $passwordTimeout ?: 10800;
+        $this->passwordTimeout = $passwordTimeout ?? 10800;
     }
 
     /**

--- a/tests/Integration/Auth/Middleware/RequirePasswordTest.php
+++ b/tests/Integration/Auth/Middleware/RequirePasswordTest.php
@@ -155,4 +155,27 @@ class RequirePasswordTest extends TestCase
         $response->assertStatus(302);
         $response->assertRedirect($this->app->make(UrlGenerator::class)->route('password.confirm'));
     }
+
+    public function testAuthPasswordTimeoutMayBeZero()
+    {
+        $this->withoutExceptionHandling();
+
+        /** @var \Illuminate\Contracts\Routing\Registrar $router */
+        $router = $this->app->make(Registrar::class);
+
+        $router->get('password-confirm', function (): Response {
+            return new Response('foo');
+        })->name('password.confirm');
+
+        $router->get('test-route', function (): Response {
+            return new Response('foobar');
+        })->middleware([StartSession::class, RequirePassword::class]);
+
+        $this->app->make(Repository::class)->set('auth.password_timeout', 0);
+
+        $response = $this->withSession(['auth.password_confirmed_at' => time() - 1])->get('test-route');
+
+        $response->assertStatus(302);
+        $response->assertRedirect($this->app->make(UrlGenerator::class)->route('password.confirm'));
+    }
 }


### PR DESCRIPTION
This PR ensures a configured `auth.password_timeout` value of `0` is respected. Previously, the `RequirePassword` middleware used the shorthand ternary operator, causing zero to fall back to the default 10,800-second timeout.
The fallback now only applies when the timeout is `null`.