### PR TITLE
Support publishing to Reverb over an internal host with a custom Host header

### DIFF
--- a/config/broadcasting.php
+++ b/config/broadcasting.php
@@ -35,11 +35,12 @@ return [
             'key' => env('REVERB_APP_KEY'),
             'secret' => env('REVERB_APP_SECRET'),
             'app_id' => env('REVERB_APP_ID'),
+            'host_header' => env('REVERB_HOST'),
             'options' => [
-                'host' => env('REVERB_HOST'),
-                'port' => env('REVERB_PORT', 443),
-                'scheme' => env('REVERB_SCHEME', 'https'),
-                'useTLS' => env('REVERB_SCHEME', 'https') === 'https',
+                'host' => env('REVERB_INTERNAL_HOST', env('REVERB_HOST')),
+                'port' => env('REVERB_INTERNAL_PORT', env('REVERB_PORT', 443)),
+                'scheme' => env('REVERB_INTERNAL_SCHEME', env('REVERB_SCHEME', 'https')),
+                'useTLS' => env('REVERB_INTERNAL_SCHEME', env('REVERB_SCHEME', 'https')) === 'https',
             ],
             'client_options' => [
                 // Guzzle client options: https://docs.guzzlephp.org/en/stable/request-options.html

--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -5,6 +5,8 @@ namespace Illuminate\Broadcasting;
 use Ably\AblyRest;
 use Closure;
 use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
 use Illuminate\Broadcasting\Broadcasters\AblyBroadcaster;
 use Illuminate\Broadcasting\Broadcasters\LogBroadcaster;
 use Illuminate\Broadcasting\Broadcasters\NullBroadcaster;
@@ -24,6 +26,7 @@ use Illuminate\Queue\Attributes\ReadsQueueAttributes;
 use Illuminate\Support\Queue\Concerns\ResolvesQueueRoutes;
 use Illuminate\Support\RebindsCallbacksToSelf;
 use InvalidArgumentException;
+use Psr\Http\Message\RequestInterface;
 use Psr\Log\LoggerInterface;
 use Pusher\Pusher;
 use ReflectionException;
@@ -361,16 +364,7 @@ class BroadcastManager implements FactoryContract
      */
     public function pusher(array $config)
     {
-        $guzzleClient = new GuzzleClient(
-            array_merge(
-                [
-                    'connect_timeout' => 10,
-                    'crypto_method' => STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT,
-                    'timeout' => 30,
-                ],
-                $config['client_options'] ?? [],
-            ),
-        );
+        $guzzleClient = new GuzzleClient($this->pusherClientOptions($config));
 
         $pusher = new Pusher(
             $config['key'],
@@ -385,6 +379,56 @@ class BroadcastManager implements FactoryContract
         }
 
         return $pusher;
+    }
+
+    /**
+     * Get the Guzzle client options for the Pusher SDK.
+     *
+     * @param  array  $config
+     * @return array
+     */
+    protected function pusherClientOptions(array $config)
+    {
+        $clientOptions = array_merge(
+            [
+                'connect_timeout' => 10,
+                'crypto_method' => STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT,
+                'timeout' => 30,
+            ],
+            $config['client_options'] ?? [],
+        );
+
+        $hostHeader = $config['host_header'] ?? null;
+
+        if (! empty($hostHeader) && $hostHeader !== ($config['options']['host'] ?? null)) {
+            $clientOptions = $this->withHostHeaderClientOptions($clientOptions, $hostHeader);
+        }
+
+        return $clientOptions;
+    }
+
+    /**
+     * Configure the Guzzle client to send a custom Host header.
+     *
+     * @param  array  $clientOptions
+     * @param  string  $hostHeader
+     * @return array
+     */
+    protected function withHostHeaderClientOptions(array $clientOptions, string $hostHeader)
+    {
+        $handler = $clientOptions['handler'] ?? null;
+        $handlerStack = $handler instanceof HandlerStack ? $handler : HandlerStack::create($handler);
+
+        $handlerStack->push(
+            Middleware::mapRequest(
+                static fn (RequestInterface $request): RequestInterface => $request->withHeader('Host', $hostHeader),
+            ),
+            'broadcasting-host-header',
+        );
+
+        $clientOptions['handler'] = $handlerStack;
+
+        return $clientOptions;
     }
 
     /**

--- a/tests/Integration/Broadcasting/BroadcastManagerTest.php
+++ b/tests/Integration/Broadcasting/BroadcastManagerTest.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Tests\Integration\Broadcasting;
 
+use GuzzleHttp\Promise\Create;
+use GuzzleHttp\Psr7\Response;
 use Illuminate\Broadcasting\BroadcastEvent;
 use Illuminate\Broadcasting\BroadcastManager;
 use Illuminate\Broadcasting\UniqueBroadcastEvent;
@@ -17,7 +19,9 @@ use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Queue;
 use InvalidArgumentException;
 use Orchestra\Testbench\TestCase;
+use Psr\Http\Message\RequestInterface;
 use Psr\Log\LoggerInterface;
+use Pusher\Pusher;
 use RuntimeException;
 use stdClass;
 
@@ -293,6 +297,110 @@ class BroadcastManagerTest extends TestCase
         $instance2 = $manager->connection(BroadcastConnectionName::Log);
 
         $this->assertNotSame($instance1, $instance2);
+    }
+
+    public function testPusherClientOverridesHostHeaderWhenConfigured()
+    {
+        if (! class_exists(Pusher::class)) {
+            $this->markTestSkipped('Pusher PHP SDK not installed.');
+        }
+
+        $requests = [];
+        $manager = new BroadcastManager($this->getApp([]));
+
+        $pusher = $manager->pusher([
+            'key' => 'test-key',
+            'secret' => 'test-secret',
+            'app_id' => 'test-app',
+            'host_header' => 'public-reverb.example.test',
+            'options' => [
+                'host' => '10.0.0.1',
+                'port' => 8080,
+                'scheme' => 'http',
+                'useTLS' => false,
+            ],
+            'client_options' => [
+                'handler' => function (RequestInterface $request) use (&$requests) {
+                    $requests[] = $request;
+
+                    return Create::promiseFor(new Response(200, [], '{}'));
+                },
+            ],
+        ]);
+
+        $pusher->get('/channels');
+
+        $this->assertCount(1, $requests);
+        $this->assertSame('public-reverb.example.test', $requests[0]->getHeaderLine('Host'));
+    }
+
+    public function testPusherClientDoesNotOverrideHostHeaderWhenHostHeaderMatchesConnectionHost()
+    {
+        if (! class_exists(Pusher::class)) {
+            $this->markTestSkipped('Pusher PHP SDK not installed.');
+        }
+
+        $requests = [];
+        $manager = new BroadcastManager($this->getApp([]));
+
+        $pusher = $manager->pusher([
+            'key' => 'test-key',
+            'secret' => 'test-secret',
+            'app_id' => 'test-app',
+            'host_header' => 'reverb.example.test',
+            'options' => [
+                'host' => 'reverb.example.test',
+                'port' => 8080,
+                'scheme' => 'http',
+                'useTLS' => false,
+            ],
+            'client_options' => [
+                'handler' => function (RequestInterface $request) use (&$requests) {
+                    $requests[] = $request;
+
+                    return Create::promiseFor(new Response(200, [], '{}'));
+                },
+            ],
+        ]);
+
+        $pusher->get('/channels');
+
+        $this->assertCount(1, $requests);
+        $this->assertSame('reverb.example.test', $requests[0]->getHeaderLine('Host'));
+    }
+
+    public function testPusherClientDoesNotOverrideHostHeaderWhenNotConfigured()
+    {
+        if (! class_exists(Pusher::class)) {
+            $this->markTestSkipped('Pusher PHP SDK not installed.');
+        }
+
+        $requests = [];
+        $manager = new BroadcastManager($this->getApp([]));
+
+        $pusher = $manager->pusher([
+            'key' => 'test-key',
+            'secret' => 'test-secret',
+            'app_id' => 'test-app',
+            'options' => [
+                'host' => '10.0.0.1',
+                'port' => 8080,
+                'scheme' => 'http',
+                'useTLS' => false,
+            ],
+            'client_options' => [
+                'handler' => function (RequestInterface $request) use (&$requests) {
+                    $requests[] = $request;
+
+                    return Create::promiseFor(new Response(200, [], '{}'));
+                },
+            ],
+        ]);
+
+        $pusher->get('/channels');
+
+        $this->assertCount(1, $requests);
+        $this->assertSame('10.0.0.1', $requests[0]->getHeaderLine('Host'));
     }
 
     protected function getApp(array $userConfig)

--- a/tests/Integration/Broadcasting/BroadcastManagerTest.php
+++ b/tests/Integration/Broadcasting/BroadcastManagerTest.php
@@ -366,7 +366,7 @@ class BroadcastManagerTest extends TestCase
         $pusher->get('/channels');
 
         $this->assertCount(1, $requests);
-        $this->assertSame('reverb.example.test', $requests[0]->getHeaderLine('Host'));
+        $this->assertSame('reverb.example.test:8080', $requests[0]->getHeaderLine('Host'));
     }
 
     public function testPusherClientDoesNotOverrideHostHeaderWhenNotConfigured()
@@ -400,7 +400,7 @@ class BroadcastManagerTest extends TestCase
         $pusher->get('/channels');
 
         $this->assertCount(1, $requests);
-        $this->assertSame('10.0.0.1', $requests[0]->getHeaderLine('Host'));
+        $this->assertSame('10.0.0.1:8080', $requests[0]->getHeaderLine('Host'));
     }
 
     protected function getApp(array $userConfig)

--- a/tests/Integration/Broadcasting/BroadcastManagerTest.php
+++ b/tests/Integration/Broadcasting/BroadcastManagerTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Broadcasting;
 
+use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\Promise\Create;
 use GuzzleHttp\Psr7\Response;
 use Illuminate\Broadcasting\BroadcastEvent;
@@ -21,7 +22,7 @@ use InvalidArgumentException;
 use Orchestra\Testbench\TestCase;
 use Psr\Http\Message\RequestInterface;
 use Psr\Log\LoggerInterface;
-use Pusher\Pusher;
+use ReflectionMethod;
 use RuntimeException;
 use stdClass;
 
@@ -301,23 +302,14 @@ class BroadcastManagerTest extends TestCase
 
     public function testPusherClientOverridesHostHeaderWhenConfigured()
     {
-        if (! class_exists(Pusher::class)) {
-            $this->markTestSkipped('Pusher PHP SDK not installed.');
-        }
-
         $requests = [];
         $manager = new BroadcastManager($this->getApp([]));
 
-        $pusher = $manager->pusher([
-            'key' => 'test-key',
-            'secret' => 'test-secret',
-            'app_id' => 'test-app',
+        $client = $this->pusherGuzzleClient($manager, [
             'host_header' => 'public-reverb.example.test',
             'options' => [
                 'host' => '10.0.0.1',
                 'port' => 8080,
-                'scheme' => 'http',
-                'useTLS' => false,
             ],
             'client_options' => [
                 'handler' => function (RequestInterface $request) use (&$requests) {
@@ -328,7 +320,7 @@ class BroadcastManagerTest extends TestCase
             ],
         ]);
 
-        $pusher->get('/channels');
+        $client->get('http://10.0.0.1:8080/test');
 
         $this->assertCount(1, $requests);
         $this->assertSame('public-reverb.example.test', $requests[0]->getHeaderLine('Host'));
@@ -336,23 +328,14 @@ class BroadcastManagerTest extends TestCase
 
     public function testPusherClientDoesNotOverrideHostHeaderWhenHostHeaderMatchesConnectionHost()
     {
-        if (! class_exists(Pusher::class)) {
-            $this->markTestSkipped('Pusher PHP SDK not installed.');
-        }
-
         $requests = [];
         $manager = new BroadcastManager($this->getApp([]));
 
-        $pusher = $manager->pusher([
-            'key' => 'test-key',
-            'secret' => 'test-secret',
-            'app_id' => 'test-app',
+        $client = $this->pusherGuzzleClient($manager, [
             'host_header' => 'reverb.example.test',
             'options' => [
                 'host' => 'reverb.example.test',
                 'port' => 8080,
-                'scheme' => 'http',
-                'useTLS' => false,
             ],
             'client_options' => [
                 'handler' => function (RequestInterface $request) use (&$requests) {
@@ -363,7 +346,7 @@ class BroadcastManagerTest extends TestCase
             ],
         ]);
 
-        $pusher->get('/channels');
+        $client->get('http://reverb.example.test:8080/test');
 
         $this->assertCount(1, $requests);
         $this->assertSame('reverb.example.test:8080', $requests[0]->getHeaderLine('Host'));
@@ -371,22 +354,13 @@ class BroadcastManagerTest extends TestCase
 
     public function testPusherClientDoesNotOverrideHostHeaderWhenNotConfigured()
     {
-        if (! class_exists(Pusher::class)) {
-            $this->markTestSkipped('Pusher PHP SDK not installed.');
-        }
-
         $requests = [];
         $manager = new BroadcastManager($this->getApp([]));
 
-        $pusher = $manager->pusher([
-            'key' => 'test-key',
-            'secret' => 'test-secret',
-            'app_id' => 'test-app',
+        $client = $this->pusherGuzzleClient($manager, [
             'options' => [
                 'host' => '10.0.0.1',
                 'port' => 8080,
-                'scheme' => 'http',
-                'useTLS' => false,
             ],
             'client_options' => [
                 'handler' => function (RequestInterface $request) use (&$requests) {
@@ -397,10 +371,17 @@ class BroadcastManagerTest extends TestCase
             ],
         ]);
 
-        $pusher->get('/channels');
+        $client->get('http://10.0.0.1:8080/test');
 
         $this->assertCount(1, $requests);
         $this->assertSame('10.0.0.1:8080', $requests[0]->getHeaderLine('Host'));
+    }
+
+    protected function pusherGuzzleClient(BroadcastManager $manager, array $config): GuzzleClient
+    {
+        $method = new ReflectionMethod($manager, 'pusherClientOptions');
+
+        return new GuzzleClient($method->invoke($manager, $config));
     }
 
     protected function getApp(array $userConfig)


### PR DESCRIPTION
  ## Summary
  When Laravel publishes broadcast events to Reverb, it uses the Pusher PHP SDK over HTTP. That SDK uses a single `host` option for both the TCP connection target and the HTTP `Host` header.
  In production deployments, those two values often need to differ:
  - **Browsers** connect to Reverb over a public hostname (e.g. `reverb.example.com` on port 443).
  - **Application servers** publish events over a private network (e.g. a private IP, Docker service name, or `127.0.0.1:8080`). Without a way to decouple them, teams must either publish through the public endpoint (extra TLS/latency overhead) or register a custom broadcaster that injects Guzzle middleware to override the `Host` header.  This PR adds first-class support for that split.
  ## Changes
  - Add an optional `host_header` broadcasting connection option. When set and different from `options.host`, the Pusher/Reverb Guzzle client sends that value as the HTTP `Host` header.
  - Update the default `reverb` connection in `config/broadcasting.php` to support internal publish targets via `REVERB_INTERNAL_HOST`, `REVERB_INTERNAL_PORT`, and `REVERB_INTERNAL_SCHEME`, while keeping `REVERB_HOST` as the public hostname used for the `Host` header.
  - Extract `pusherClientOptions()` / `withHostHeaderClientOptions()` in `BroadcastManager` so the logic is shared by both the `reverb` and `pusher` drivers.
  - Add integration tests covering the three relevant cases.
  ## Example configuration
  ```env
  # Public hostname used by browsers (and as the HTTP Host header when publishing)
  REVERB_HOST=reverb.example.com
  REVERB_PORT=443
  REVERB_SCHEME=https

# Private path used by web/worker servers to publish events
  REVERB_INTERNAL_HOST=10.0.0.5
  REVERB_INTERNAL_PORT=8080
  REVERB_INTERNAL_SCHEME=http
```
  ## Why this helps end users
  - Supports a common multi-server Reverb deployment pattern without custom broadcaster classes.
  - Lets apps publish over HTTP on a private network while still sending the public virtual hostname expected by Reverb or a reverse proxy.
  - Removes the need to hand-roll Guzzle `client_options` middleware, which is easy to miss and hard to discover.
  
## Backward compatibility
  - `REVERB_INTERNAL_*` variables fall back to the existing `REVERB_*` values, so single-server/local setups behave exactly as before.
  - The `Host` header middleware is only applied when `host_header` is non-empty **and** differs from `options.host`, so there is no behavior change when both values are the same.
  - Connections that do not define `host_header` are unchanged.
  - This only affects server-side event publishing over HTTP; browser WebSocket connections are unaffected.

 ## Test plan
  - [x] `testPusherClientOverridesHostHeaderWhenConfigured`
  - [x] `testPusherClientDoesNotOverrideHostHeaderWhenHostHeaderMatchesConnectionHost`
  - [x] `testPusherClientDoesNotOverrideHostHeaderWhenNotConfigured`
