### PR TITLE
[13.x] add missing() method to configuration repository

### DIFF
--- a/src/Illuminate/Config/Repository.php
+++ b/src/Illuminate/Config/Repository.php
@@ -42,6 +42,17 @@ class Repository implements ArrayAccess, ConfigContract
     }
 
     /**
+     * Determine if the given configuration value is missing.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function missing($key)
+    {
+        return ! $this->has($key);
+    }
+
+    /**
      * Get the specified configuration value.
      *
      * @param  array|string  $key

--- a/src/Illuminate/Contracts/Config/Repository.php
+++ b/src/Illuminate/Contracts/Config/Repository.php
@@ -13,6 +13,14 @@ interface Repository
     public function has($key);
 
     /**
+     * Determine if the given configuration value is missing.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function missing($key);
+
+    /**
      * Get the specified configuration value.
      *
      * @param  array|string  $key

--- a/tests/Config/RepositoryTest.php
+++ b/tests/Config/RepositoryTest.php
@@ -91,6 +91,12 @@ class RepositoryTest extends TestCase
         $this->assertFalse($this->repository->has('not-exist'));
     }
 
+    public function testMissing()
+    {
+        $this->assertFalse($this->repository->missing('foo'));
+        $this->assertTrue($this->repository->missing('not-exist'));
+    }
+
     public function testGet()
     {
         $this->assertSame('bar', $this->repository->get('foo'));


### PR DESCRIPTION
Adds `missing($key)` to _Illuminate\Config\Repository_, which returns `! $this->has($key)`

```PHP
// Before
if (! config()->has('app.key')) {
    //
}

// After
if (config()->missing('app.key')) {
    //
}
```