### PR TITLE
Fix PendingProcess losing falsy command strings on run()/start()

### DIFF
--- a/src/Illuminate/Process/PendingProcess.php
+++ b/src/Illuminate/Process/PendingProcess.php
@@ -244,7 +244,7 @@ class PendingProcess
      */
     public function run(array|string|null $command = null, ?callable $output = null)
     {
-        $this->command = $command ?: $this->command;
+        $this->command = $command ?? $this->command;
 
         $process = $this->toSymfonyProcess($command);
 
@@ -274,7 +274,7 @@ class PendingProcess
      */
     public function start(array|string|null $command = null, ?callable $output = null)
     {
-        $this->command = $command ?: $this->command;
+        $this->command = $command ?? $this->command;
 
         $process = $this->toSymfonyProcess($command);
 

--- a/tests/Process/ProcessTest.php
+++ b/tests/Process/ProcessTest.php
@@ -1057,6 +1057,30 @@ class ProcessTest extends TestCase
         });
     }
 
+    public function testAssertRanWithFalsyCommandString(): void
+    {
+        $factory = new Factory;
+
+        $factory->fake();
+
+        $factory->run('0');
+
+        $factory->assertRan('0');
+        $factory->assertRanTimes('0', 1);
+        $factory->assertNotRan('ls -la');
+    }
+
+    public function testAssertRanWithFalsyStartedCommandString(): void
+    {
+        $factory = new Factory;
+
+        $factory->fake();
+
+        $factory->start('0')->wait();
+
+        $factory->assertRan('0');
+    }
+
     public function testAssertingThatNothingRan()
     {
         $factory = new Factory;


### PR DESCRIPTION
Uses `??` instead of `?:` so an explicit falsy command (e.g. `'0'`) isn't silently replaced, which was causing `Process::assertRan()` to fail for such commands.