### PR TITLE
[13.x] Fix return value of Auth::logoutOtherDevices()

### DIFF
--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -774,6 +774,8 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
         $this->provider->rehashPasswordIfRequired(
             $user, ['password' => $password], force: true
         );
+
+        return $user;
     }
 
     /**


### PR DESCRIPTION
Calling `Auth::logoutOtherDevices()` currently returns _null_ instead of returning the authenticated user instance, despite the `@return \Illuminate\Contracts\Auth\Authenticatable|null` docblock contract.

### Cause
`SessionGuard::logoutOtherDevices()` returns the result of `$this->rehashUserPasswordForDeviceLogout($password)`, but `rehashUserPasswordForDeviceLogout()` was missing a `return $user;` statement.

```PHP
// Before: returns null even on success
$user = Auth::logoutOtherDevices($password); 
dump($user); // null

// After: correctly returns the user instance
$user = Auth::logoutOtherDevices($password);
dump($user); // User model instance
```