### PR TITLE
[13.x] Respect job delays when bulk pushing to FailoverQueue

### DIFF
--- a/src/Illuminate/Queue/FailoverQueue.php
+++ b/src/Illuminate/Queue/FailoverQueue.php
@@ -163,27 +163,6 @@ class FailoverQueue extends Queue implements QueueContract
     }
 
     /**
-     * Push an array of jobs onto the queue.
-     *
-     * @param  array  $jobs
-     * @param  mixed  $data
-     * @param  string|null  $queue
-     * @return void
-     */
-    public function bulk($jobs, $data = '', $queue = null)
-    {
-        foreach ((array) $jobs as $job) {
-            $delay = is_object($job) ? $this->getAttributeValue($job, Delay::class, 'delay') : null;
-
-            if (isset($delay)) {
-                $this->later($delay, $job, $data, $queue);
-            } else {
-                $this->push($job, $data, $queue);
-            }
-        }
-    }
-
-    /**
      * Push a raw payload onto the queue.
      *
      * @param  string  $payload
@@ -207,6 +186,27 @@ class FailoverQueue extends Queue implements QueueContract
     public function later($delay, $job, $data = '', $queue = null)
     {
         return $this->attemptOnAllConnections(__FUNCTION__, func_get_args(), $job);
+    }
+
+    /**
+     * Push an array of jobs onto the queue.
+     *
+     * @param  array  $jobs
+     * @param  mixed  $data
+     * @param  string|null  $queue
+     * @return void
+     */
+    public function bulk($jobs, $data = '', $queue = null)
+    {
+        foreach ((array) $jobs as $job) {
+            $delay = is_object($job) ? $this->getAttributeValue($job, Delay::class, 'delay') : null;
+
+            if (isset($delay)) {
+                $this->later($delay, $job, $data, $queue);
+            } else {
+                $this->push($job, $data, $queue);
+            }
+        }
     }
 
     /**

--- a/src/Illuminate/Queue/FailoverQueue.php
+++ b/src/Illuminate/Queue/FailoverQueue.php
@@ -4,6 +4,7 @@ namespace Illuminate\Queue;
 
 use Illuminate\Contracts\Events\Dispatcher as EventDispatcher;
 use Illuminate\Contracts\Queue\Queue as QueueContract;
+use Illuminate\Queue\Attributes\Delay;
 use Illuminate\Queue\Events\QueueFailedOver;
 use Illuminate\Support\Collection;
 use RuntimeException;
@@ -159,6 +160,27 @@ class FailoverQueue extends Queue implements QueueContract
     public function push($job, $data = '', $queue = null)
     {
         return $this->attemptOnAllConnections(__FUNCTION__, func_get_args(), $job);
+    }
+
+    /**
+     * Push an array of jobs onto the queue.
+     *
+     * @param  array  $jobs
+     * @param  mixed  $data
+     * @param  string|null  $queue
+     * @return void
+     */
+    public function bulk($jobs, $data = '', $queue = null)
+    {
+        foreach ((array) $jobs as $job) {
+            $delay = is_object($job) ? $this->getAttributeValue($job, Delay::class, 'delay') : null;
+
+            if (isset($delay)) {
+                $this->later($delay, $job, $data, $queue);
+            } else {
+                $this->push($job, $data, $queue);
+            }
+        }
     }
 
     /**

--- a/tests/Queue/FailoverQueueTest.php
+++ b/tests/Queue/FailoverQueueTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Queue;
 
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Queue\Attributes\Delay;
 use Illuminate\Queue\FailoverQueue;
 use Illuminate\Queue\QueueManager;
 use Mockery as m;
@@ -43,4 +44,29 @@ class FailoverQueueTest extends TestCase
 
         $failover->push('some-job');
     }
+
+    public function test_bulk_respects_job_delays()
+    {
+        $failover = new FailoverQueue($queue = m::mock(QueueManager::class), m::mock(Dispatcher::class), ['sync']);
+
+        $queue->shouldReceive('connection')->times(3)->with('sync')->andReturn(
+            $sync = m::mock('stdClass'),
+        );
+
+        $sync->shouldReceive('later')->once()->with(15, m::type(FailoverJobWithDelayAttribute::class), '', null);
+        $sync->shouldReceive('later')->once()->with(30, m::type(FailoverJobWithDelayProperty::class), '', null);
+        $sync->shouldReceive('push')->once()->with('regular-job', '', null);
+
+        $failover->bulk([new FailoverJobWithDelayAttribute, new FailoverJobWithDelayProperty, 'regular-job']);
+    }
+}
+
+#[Delay(15)]
+class FailoverJobWithDelayAttribute
+{
+}
+
+class FailoverJobWithDelayProperty
+{
+    public $delay = 30;
 }


### PR DESCRIPTION
When bulk dispatching jobs through a failover queue connection, delayed jobs are pushed immediately because `FailoverQueue` inherits the base `bulk()` method, which always calls `push()`.

This PR makes `FailoverQueue::bulk()` resolve each job's delay and call `later()` when a delay is configured.

This preserves both `#[Delay]` attributes and the existing `$delay` property fallback, while non-delayed jobs continue to use `push()`.

A regression test has been added to cover delayed and non-delayed bulk jobs.