### PR TITLE
[13.x] Encode object properties with numeric names as a JSON object

### DIFF
--- a/src/Illuminate/JsonSchema/Deserializer.php
+++ b/src/Illuminate/JsonSchema/Deserializer.php
@@ -164,12 +164,18 @@ class Deserializer
     {
         $properties = [];
 
-        if (isset($schema['properties']) && is_array($schema['properties'])) {
+        // A JSON object decoded without associative arrays arrives as an object, as
+        // does the "properties" a schema with numeric property names serializes to...
+        $definitions = is_object($schema['properties'] ?? null)
+            ? (array) $schema['properties']
+            : $schema['properties'] ?? null;
+
+        if (is_array($definitions)) {
             $required = is_array($schema['required'] ?? null)
                 ? array_flip(array_map('strval', $schema['required']))
                 : [];
 
-            foreach ($schema['properties'] as $key => $definition) {
+            foreach ($definitions as $key => $definition) {
                 if (! is_array($definition)) {
                     throw new InvalidArgumentException(
                         "Unable to represent the schema for property [{$key}]; boolean schemas are not supported."

--- a/src/Illuminate/JsonSchema/Serializer.php
+++ b/src/Illuminate/JsonSchema/Serializer.php
@@ -91,10 +91,17 @@ class Serializer
                     $attributes['required'] = $required;
                 }
 
-                $attributes['properties'] = array_map(
+                $properties = array_map(
                     static fn (Types\Type $property) => static::serialize($property),
                     $attributes['properties'],
                 );
+
+                // PHP casts numeric property names to integer array keys, so a schema
+                // whose property names are "0", "1", ... would otherwise encode as a
+                // JSON array rather than the object the specification requires...
+                $attributes['properties'] = array_is_list($properties)
+                    ? (object) $properties
+                    : $properties;
             }
         }
 

--- a/tests/JsonSchema/DeserializerTest.php
+++ b/tests/JsonSchema/DeserializerTest.php
@@ -180,6 +180,44 @@ class DeserializerTest extends TestCase
         $this->assertIsString($array['required'][0]);
     }
 
+    public function test_it_encodes_sequential_numeric_property_names_as_a_json_object(): void
+    {
+        $type = JsonSchema::fromArray([
+            'type' => 'object',
+            'properties' => [
+                '0' => ['type' => 'string'],
+                '1' => ['type' => 'integer'],
+            ],
+            'required' => ['0'],
+        ]);
+
+        $decoded = json_decode($type->toString());
+
+        $this->assertEquals((object) [
+            '0' => (object) ['type' => 'string'],
+            '1' => (object) ['type' => 'integer'],
+        ], $decoded->properties);
+
+        $this->assertEquals(['0'], $decoded->required);
+    }
+
+    public function test_it_round_trips_sequential_numeric_property_names(): void
+    {
+        $type = JsonSchema::fromArray([
+            'type' => 'object',
+            'properties' => [
+                '0' => ['type' => 'string'],
+                '1' => ['type' => 'integer'],
+            ],
+            'required' => ['0'],
+        ]);
+
+        $this->assertEquals(
+            $type->toArray(),
+            JsonSchema::fromArray($type->toArray())->toArray()
+        );
+    }
+
     public function test_it_disallows_additional_properties_when_false(): void
     {
         $type = JsonSchema::fromArray([

--- a/tests/JsonSchema/ObjectTypeTest.php
+++ b/tests/JsonSchema/ObjectTypeTest.php
@@ -53,6 +53,21 @@ class ObjectTypeTest extends TestCase
         ], $type->toArray());
     }
 
+    public function test_it_may_have_sequential_numeric_property_names(): void
+    {
+        $type = JsonSchema::object([
+            '0' => JsonSchema::string()->required(),
+            '1' => JsonSchema::integer(),
+        ]);
+
+        $this->assertSame(
+            '{"0":{"type":"string"},"1":{"type":"integer"}}',
+            json_encode($type->toArray()['properties'])
+        );
+
+        $this->assertSame(['0'], $type->toArray()['required']);
+    }
+
     public function test_it_may_be_initialized_with_a_closure_but_may_have_properties(): void
     {
         $type = JsonSchema::object(fn (JsonSchemaTypeFactory $schema) => [


### PR DESCRIPTION
`ObjectType` property names become array keys, and PHP casts numeric strings to integers. When a schema's property names happen to be `"0"`, `"1"`, ... the resulting array is a list, so `properties` encodes as a JSON **array** instead of the object the specification requires:

```php
use Illuminate\JsonSchema\JsonSchema;

echo JsonSchema::object([
    '0' => JsonSchema::string()->required(),
    '1' => JsonSchema::integer(),
]);
```

```json
{
    "properties": [
        { "type": "string" },
        { "type": "integer" }
    ],
    "type": "object",
    "required": ["0"]
}
```

The document is invalid, and self-contradictory on top of that: `required` still names `"0"`, but there is no longer a property that can be addressed by name. The same output comes back from `JsonSchema::fromArray()`, so a schema received from elsewhere is silently corrupted by a round trip.

`DeserializerTest::test_it_preserves_numeric_string_property_names_when_marking_required()` already covers numeric property names, but it uses `"1"` and `"4"`. Those keys are not a list, so `json_encode()` emits an object anyway and the broken case slips past.

This casts `properties` to an object when the serialized properties form a list, which is exactly when `json_encode()` would otherwise emit an array. Schemas with ordinary property names keep the plain array they have today, so nothing else in the output changes. `Deserializer::buildObject()` now also accepts an object for `properties`, which keeps `fromArray(...)` round trips working and additionally lets it read a schema that was decoded with `json_decode($json)` rather than `json_decode($json, true)`.

```json
{
    "properties": {
        "0": { "type": "string" },
        "1": { "type": "integer" }
    },
    "type": "object",
    "required": ["0"]
}
```
