### PR TITLE
[13.x] Fix PHP 8.5 null array offset deprecation in `Relation::getMorphedModel()`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -576,11 +576,15 @@ abstract class Relation implements BuilderContract
     /**
      * Get the model associated with a custom polymorphic type.
      *
-     * @param  string  $alias
+     * @param  string|int|null  $alias
      * @return class-string<\Illuminate\Database\Eloquent\Model>|null
      */
     public static function getMorphedModel($alias)
     {
+        if (is_null($alias)) {
+            return null;
+        }
+
         return static::$morphMap[$alias] ?? null;
     }
 

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -230,6 +230,18 @@ class DatabaseEloquentRelationTest extends TestCase
         Relation::morphMap([], false);
     }
 
+    public function testGetMorphedModel()
+    {
+        Relation::morphMap(['user' => 'App\User', 1 => 'App\Team']);
+
+        $this->assertSame('App\User', Relation::getMorphedModel('user'));
+        $this->assertSame('App\Team', Relation::getMorphedModel(1));
+        $this->assertNull(Relation::getMorphedModel('does_not_exist'));
+        $this->assertNull(Relation::getMorphedModel(null));
+
+        Relation::morphMap([], false);
+    }
+
     public function testGetMorphAlias()
     {
         Relation::morphMap(['user' => 'App\User']);


### PR DESCRIPTION
On PHP 8.5 `Relation::getMorphedModel()` emits a deprecation when the alias is `null`:

      Deprecated: Using null as an array offset is deprecated, use an empty string instead
      in .../Database/Eloquent/Relations/Relation.php

  `??` doesn't help here, the offset is still evaluated first.

  The alias normally comes straight from a nullable `*_type` column, so `null` ends up here
  whenever a record has no related model. `whereHasMorph()` runs the same call for every
  type it's given.

  I used an early return rather than coercing `null` to `''`, since a null morph type
  already means "no related model" elsewhere (see `HasRelationships::morphTo()`). Any alias
  that can actually be registered resolves exactly as before.

  `@param` is widened to `string|int|null` since integer aliases are supported. I left the
  parameter untyped because the method is `public static` and may be overridden.