### PR TITLE
Release timed out jobs back onto the queue with backoff via #[ReleaseOnTimeout]

### DIFF
--- a/src/Illuminate/Queue/Attributes/ReleaseOnTimeout.php
+++ b/src/Illuminate/Queue/Attributes/ReleaseOnTimeout.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Illuminate\Queue\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class ReleaseOnTimeout
+{
+    //
+}

--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -317,6 +317,16 @@ abstract class Job
     }
 
     /**
+     * Determine if the job should be released back onto the queue when it times out.
+     *
+     * @return bool
+     */
+    public function shouldReleaseOnTimeout()
+    {
+        return $this->payload()['releaseOnTimeout'] ?? false;
+    }
+
+    /**
      * The number of seconds to wait before retrying a job that encountered an uncaught exception.
      *
      * @return int|int[]|null

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -17,6 +17,7 @@ use Illuminate\Queue\Attributes\DeleteWhenMissingModels;
 use Illuminate\Queue\Attributes\FailOnTimeout;
 use Illuminate\Queue\Attributes\MaxExceptions;
 use Illuminate\Queue\Attributes\ReadsQueueAttributes;
+use Illuminate\Queue\Attributes\ReleaseOnTimeout;
 use Illuminate\Queue\Attributes\Timeout;
 use Illuminate\Queue\Attributes\Tries;
 use Illuminate\Queue\Events\JobQueued;
@@ -178,6 +179,7 @@ abstract class Queue
             'maxTries' => $this->getJobTries($job),
             'maxExceptions' => $this->getAttributeValue($job, MaxExceptions::class, 'maxExceptions'),
             'failOnTimeout' => $this->getAttributeValue($job, FailOnTimeout::class, 'failOnTimeout') ?? false,
+            'releaseOnTimeout' => $this->getAttributeValue($job, ReleaseOnTimeout::class, 'releaseOnTimeout') ?? false,
             'backoff' => $this->getJobBackoff($job),
             'timeout' => $this->getAttributeValue($job, Timeout::class, 'timeout'),
             'retryUntil' => $this->getJobExpiration($job),

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -295,34 +295,7 @@ class Worker
         // process if it is running too long because it has frozen. This uses the async
         // signals supported in recent versions of PHP to accomplish it conveniently.
         pcntl_signal(SIGALRM, function () use ($job, $options) {
-            if ($job) {
-                $this->markJobAsFailedIfWillExceedMaxAttempts(
-                    $job->getConnectionName(), $job, (int) $options->maxTries, $e = $this->timeoutExceededException($job)
-                );
-
-                $this->markJobAsFailedIfWillExceedMaxExceptions(
-                    $job->getConnectionName(), $job, $e
-                );
-
-                $this->markJobAsFailedIfItShouldFailOnTimeout(
-                    $job->getConnectionName(), $job, $e
-                );
-
-                if ($this->shouldReleaseJobOnTimeout($job)) {
-                    $backoff = $this->calculateBackoff($job, $options);
-                    $job->release($backoff);
-
-                    $this->events->dispatch(new JobReleasedAfterException(
-                        $job->getConnectionName(), $job, $backoff, $e
-                    ));
-                } else {
-                    $this->events->dispatch(new JobTimedOut(
-                        $job->getConnectionName(), $job
-                    ));
-                }
-            }
-
-            $this->kill(static::$timedOutExitCode ?? static::EXIT_ERROR, $options, WorkerStopReason::TimedOut);
+            $this->handleWorkerTimeout($job, $options);
         }, true);
 
         pcntl_alarm(
@@ -338,6 +311,50 @@ class Worker
     protected function resetTimeoutHandler()
     {
         pcntl_alarm(0);
+    }
+
+    /**
+     * Handle a worker timeout by failing or releasing the job, then killing the worker.
+     *
+     * The worker is killed unconditionally, even if handling the job above throws,
+     * since the process may be in a corrupted state after having been frozen.
+     *
+     * @param  \Illuminate\Contracts\Queue\Job|null  $job
+     * @return void
+     */
+    protected function handleWorkerTimeout($job, WorkerOptions $options)
+    {
+        try {
+            if ($job) {
+                $this->markJobAsFailedIfWillExceedMaxAttempts(
+                    $job->getConnectionName(), $job, (int) $options->maxTries, $e = $this->timeoutExceededException($job)
+                );
+
+                $this->markJobAsFailedIfWillExceedMaxExceptions(
+                    $job->getConnectionName(), $job, $e
+                );
+
+                $this->markJobAsFailedIfItShouldFailOnTimeout(
+                    $job->getConnectionName(), $job, $e
+                );
+
+                if ($this->shouldReleaseJobOnTimeout($job)) {
+                    $backoff = $this->calculateBackoff($job, $options);
+
+                    $job->release($backoff);
+
+                    $this->events->dispatch(new JobReleasedAfterException(
+                        $job->getConnectionName(), $job, $backoff, $e
+                    ));
+                } else {
+                    $this->events->dispatch(new JobTimedOut(
+                        $job->getConnectionName(), $job
+                    ));
+                }
+            }
+        } finally {
+            $this->kill(static::$timedOutExitCode ?? static::EXIT_ERROR, $options, WorkerStopReason::TimedOut);
+        }
     }
 
     /**

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -308,9 +308,18 @@ class Worker
                     $job->getConnectionName(), $job, $e
                 );
 
-                $this->events->dispatch(new JobTimedOut(
-                    $job->getConnectionName(), $job
-                ));
+                if ($this->shouldReleaseJobOnTimeout($job)) {
+                    $backoff = $this->calculateBackoff($job, $options);
+                    $job->release($backoff);
+
+                    $this->events->dispatch(new JobReleasedAfterException(
+                        $job->getConnectionName(), $job, $backoff, $e
+                    ));
+                } else {
+                    $this->events->dispatch(new JobTimedOut(
+                        $job->getConnectionName(), $job
+                    ));
+                }
             }
 
             $this->kill(static::$timedOutExitCode ?? static::EXIT_ERROR, $options, WorkerStopReason::TimedOut);
@@ -329,6 +338,20 @@ class Worker
     protected function resetTimeoutHandler()
     {
         pcntl_alarm(0);
+    }
+
+    /**
+     * Determine if the given job should be released back onto the queue after timing out.
+     *
+     * @param  \Illuminate\Contracts\Queue\Job  $job
+     * @return bool
+     */
+    protected function shouldReleaseJobOnTimeout($job)
+    {
+        return (method_exists($job, 'shouldReleaseOnTimeout') ? $job->shouldReleaseOnTimeout() : false)
+            && ! $job->isDeleted()
+            && ! $job->isReleased()
+            && ! $job->hasFailed();
     }
 
     /**

--- a/tests/Queue/QueueDatabaseQueueUnitTest.php
+++ b/tests/Queue/QueueDatabaseQueueUnitTest.php
@@ -10,6 +10,7 @@ use Illuminate\Queue\Attributes\Backoff;
 use Illuminate\Queue\Attributes\Delay;
 use Illuminate\Queue\Attributes\FailOnTimeout;
 use Illuminate\Queue\Attributes\MaxExceptions;
+use Illuminate\Queue\Attributes\ReleaseOnTimeout;
 use Illuminate\Queue\Attributes\Timeout;
 use Illuminate\Queue\Attributes\Tries;
 use Illuminate\Queue\DatabaseQueue;
@@ -161,6 +162,38 @@ class QueueDatabaseQueueUnitTest extends TestCase
         });
 
         $queue->push(new JobWithAttributesAndDefaultProperties, ['data']);
+
+        $container->shouldHaveReceived('bound')->with('events')->twice();
+    }
+
+    public function testPushDefaultsReleaseOnTimeoutToFalse()
+    {
+        $queue = new DatabaseQueue($database = m::mock(Connection::class), 'table', 'default');
+        $queue->setContainer($container = m::spy(Container::class));
+        $database->shouldReceive('table')->with('table')->andReturn($query = m::mock(stdClass::class));
+        $query->shouldReceive('insertGetId')->once()->andReturnUsing(function ($array) {
+            $payload = json_decode($array['payload'], true);
+
+            $this->assertFalse($payload['releaseOnTimeout']);
+        });
+
+        $queue->push(new JobWithAttributesAndDefaultProperties, ['data']);
+
+        $container->shouldHaveReceived('bound')->with('events')->twice();
+    }
+
+    public function testPushIncludesReleaseOnTimeoutFromAttribute()
+    {
+        $queue = new DatabaseQueue($database = m::mock(Connection::class), 'table', 'default');
+        $queue->setContainer($container = m::spy(Container::class));
+        $database->shouldReceive('table')->with('table')->andReturn($query = m::mock(stdClass::class));
+        $query->shouldReceive('insertGetId')->once()->andReturnUsing(function ($array) {
+            $payload = json_decode($array['payload'], true);
+
+            $this->assertTrue($payload['releaseOnTimeout']);
+        });
+
+        $queue->push(new JobWithReleaseOnTimeoutAttribute, ['data']);
 
         $container->shouldHaveReceived('bound')->with('events')->twice();
     }
@@ -504,4 +537,9 @@ class JobWithAttributesAndDefaultProperties implements ShouldQueue
     public $timeout = 1700;
 
     public $tries = 7;
+}
+
+#[ReleaseOnTimeout]
+class JobWithReleaseOnTimeoutAttribute implements ShouldQueue
+{
 }

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -15,6 +15,7 @@ use Illuminate\Queue\Events\JobPopping;
 use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Queue\Events\JobProcessing;
 use Illuminate\Queue\Events\JobReleasedAfterException;
+use Illuminate\Queue\Events\JobTimedOut;
 use Illuminate\Queue\Events\WorkerIdle;
 use Illuminate\Queue\Events\WorkerStarting;
 use Illuminate\Queue\Events\WorkerStopping;
@@ -729,6 +730,25 @@ class QueueWorkerTest extends TestCase
         }
 
         $this->assertTrue($worker->killed);
+    }
+
+    public function testFailOnTimeoutTakesPriorityOverReleaseOnTimeout()
+    {
+        $job = new WorkerFakeJob;
+        $job->shouldFailOnTimeout = true;
+        $job->shouldReleaseOnTimeout = true;
+
+        $worker = $this->getWorker();
+
+        (new \ReflectionMethod($worker, 'handleWorkerTimeout'))->invoke(
+            $worker, $job, $this->workerOptions(['maxTries' => 4, 'backoff' => 10])
+        );
+
+        $this->assertTrue($job->failed);
+        $this->assertFalse($job->released);
+
+        $this->events->shouldHaveReceived('dispatch')->with(m::type(JobTimedOut::class))->once();
+        $this->events->shouldNotHaveReceived('dispatch', [m::type(JobReleasedAfterException::class)]);
     }
 
     public function testInterruptibleJobIsNotifiedOnSignal()

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -695,6 +695,42 @@ class QueueWorkerTest extends TestCase
         return $method->invoke($worker, $job);
     }
 
+    public function testWorkerIsKilledAfterHandlingTimeoutNormally()
+    {
+        $job = new WorkerFakeJob;
+        $job->shouldReleaseOnTimeout = true;
+
+        $worker = $this->getWorker();
+
+        (new \ReflectionMethod($worker, 'handleWorkerTimeout'))->invoke(
+            $worker, $job, $this->workerOptions(['backoff' => 10])
+        );
+
+        $this->assertTrue($job->released);
+        $this->assertTrue($worker->killed);
+    }
+
+    public function testWorkerIsStillKilledWhenReleaseThrowsDuringTimeout()
+    {
+        $job = new WorkerFakeJob;
+        $job->shouldReleaseOnTimeout = true;
+        $job->releaseThrows = new RuntimeException('redis connection lost');
+
+        $worker = $this->getWorker();
+
+        try {
+            (new \ReflectionMethod($worker, 'handleWorkerTimeout'))->invoke(
+                $worker, $job, $this->workerOptions(['backoff' => 10])
+            );
+
+            $this->fail('Expected exception was not thrown.');
+        } catch (RuntimeException $e) {
+            $this->assertSame('redis connection lost', $e->getMessage());
+        }
+
+        $this->assertTrue($worker->killed);
+    }
+
     public function testInterruptibleJobIsNotifiedOnSignal()
     {
         $interruptible = new class implements Interruptible
@@ -795,6 +831,16 @@ class InsomniacWorker extends Worker
     public function memoryExceeded($memoryLimit)
     {
         return $this->stopOnMemoryExceeded;
+    }
+
+    public $killed = false;
+
+    public $killedWith = [];
+
+    public function kill($status = 0, $options = null, $reason = null)
+    {
+        $this->killed = true;
+        $this->killedWith = [$status, $options, $reason];
     }
 }
 
@@ -898,6 +944,7 @@ class WorkerFakeJob implements QueueJobContract
     public $shouldFailOnTimeout = false;
 
     public $shouldReleaseOnTimeout = false;
+    public $releaseThrows;
     public $uuid;
     public $backoff;
     public $retryUntil;
@@ -979,6 +1026,10 @@ class WorkerFakeJob implements QueueJobContract
 
     public function release($delay = 0)
     {
+        if ($this->releaseThrows) {
+            throw $this->releaseThrows;
+        }
+
         $this->released = true;
 
         $this->releaseAfter = $delay;

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -633,6 +633,68 @@ class QueueWorkerTest extends TestCase
         }))->once();
     }
 
+    public function testShouldReleaseJobOnTimeoutIsTrueWhenAttributeEnabledAndJobIsStillActive()
+    {
+        $job = new WorkerFakeJob;
+        $job->shouldReleaseOnTimeout = true;
+
+        $this->assertTrue($this->callShouldReleaseJobOnTimeout($job));
+    }
+
+    public function testShouldReleaseJobOnTimeoutIsFalseWhenReleaseOnTimeoutIsDisabled()
+    {
+        $job = new WorkerFakeJob;
+        $job->shouldReleaseOnTimeout = false;
+
+        $this->assertFalse($this->callShouldReleaseJobOnTimeout($job));
+    }
+
+    public function testShouldReleaseJobOnTimeoutIsFalseWhenJobIsAlreadyDeleted()
+    {
+        $job = new WorkerFakeJob;
+        $job->shouldReleaseOnTimeout = true;
+        $job->deleted = true;
+
+        $this->assertFalse($this->callShouldReleaseJobOnTimeout($job));
+    }
+
+    public function testShouldReleaseJobOnTimeoutIsFalseWhenJobIsAlreadyReleased()
+    {
+        $job = new WorkerFakeJob;
+        $job->shouldReleaseOnTimeout = true;
+        $job->released = true;
+
+        $this->assertFalse($this->callShouldReleaseJobOnTimeout($job));
+    }
+
+    public function testShouldReleaseJobOnTimeoutIsFalseWhenJobHasAlreadyFailed()
+    {
+        $job = new WorkerFakeJob;
+        $job->shouldReleaseOnTimeout = true;
+        $job->failed = true;
+
+        $this->assertFalse($this->callShouldReleaseJobOnTimeout($job));
+    }
+
+    public function testShouldReleaseJobOnTimeoutIsFalseWhenJobDoesNotImplementTheMethod()
+    {
+        $job = $this->createStub(QueueJobContract::class);
+        $job->method('isDeleted')->willReturn(false);
+        $job->method('isReleased')->willReturn(false);
+        $job->method('hasFailed')->willReturn(false);
+
+        $this->assertFalse($this->callShouldReleaseJobOnTimeout($job));
+    }
+
+    private function callShouldReleaseJobOnTimeout($job)
+    {
+        $worker = $this->getWorker();
+
+        $method = new \ReflectionMethod($worker, 'shouldReleaseJobOnTimeout');
+
+        return $method->invoke($worker, $job);
+    }
+
     public function testInterruptibleJobIsNotifiedOnSignal()
     {
         $interruptible = new class implements Interruptible
@@ -834,6 +896,8 @@ class WorkerFakeJob implements QueueJobContract
     public $maxTries;
     public $maxExceptions;
     public $shouldFailOnTimeout = false;
+
+    public $shouldReleaseOnTimeout = false;
     public $uuid;
     public $backoff;
     public $retryUntil;
@@ -881,6 +945,11 @@ class WorkerFakeJob implements QueueJobContract
     public function shouldFailOnTimeout()
     {
         return $this->shouldFailOnTimeout;
+    }
+
+    public function shouldReleaseOnTimeout()
+    {
+        return $this->shouldReleaseOnTimeout;
     }
 
     public function uuid()


### PR DESCRIPTION
Currently, when a job times out, the worker unconditionally dispatches JobTimedOut and kills the process. Whether the job runs again depends entirely on the queue driver's own retry_after/visibility timeout — completely disconnected from the job's own backoff(). This PR adds an opt-in #[ReleaseOnTimeout] attribute so a timed-out job is released back onto the queue using the same backoff resolution already used for exception-based retries, instead of relying on the driver's retry window.

```php
#[ReleaseOnTimeout]
class ProcessPodcast implements ShouldQueue
{
    public $tries = 3;
    public $backoff = 30;
    public $timeout = 60;
}
```

The final allowed attempt is unaffected — the job still fails and JobTimedOut still fires as before. This is opt-in and has no effect unless the job allows more than one attempt, so existing jobs behave exactly as they do today.

Two things worth flagging for reviewers:

dontRetry()/shouldStopRetries() (#60552) is not consulted on timeout — pre-existing, unrelated to this change.
Jobs combining this with WithoutOverlapping should set ->expireAfter() no longer than their backoff, since a stale lock from a killed worker won't release itself before the faster retry lands.

Related discussion: #59177