### PR TITLE
[13.x] Throw when traits declare conflicting class attributes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -28,6 +28,7 @@ use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection as BaseCollection;
+use Illuminate\Support\Reflector;
 use Illuminate\Support\Str;
 use Illuminate\Support\Stringable as SupportStringable;
 use Illuminate\Support\Traits\ForwardsCalls;
@@ -2674,6 +2675,8 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      * @param  string|null  $property
      * @param  string|null  $class
      * @return mixed
+     *
+     * @throws \LogicException
      */
     protected static function resolveClassAttribute(string $attributeClass, ?string $property = null, ?string $class = null)
     {
@@ -2697,16 +2700,12 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
                     return static::$classAttributes[$cacheKey] = $property ? $instance->{$property} : $instance;
                 }
 
-                foreach ($reflection->getTraits() as $trait) {
-                    $attributes = $trait->getAttributes($attributeClass);
-
-                    if (count($attributes) > 0) {
-                        $instance = $attributes[0]->newInstance();
-
-                        return static::$classAttributes[$cacheKey] = $property ? $instance->{$property} : $instance;
-                    }
+                if (! is_null($instance = Reflector::getClassAttributeFromTraits($reflection, $attributeClass))) {
+                    return static::$classAttributes[$cacheKey] = $property ? $instance->{$property} : $instance;
                 }
             } while ($reflection = $reflection->getParentClass());
+        } catch (LogicException $e) {
+            throw $e;
         } catch (Exception) {
             //
         }

--- a/src/Illuminate/Reflection/Reflector.php
+++ b/src/Illuminate/Reflection/Reflector.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Support;
 
+use LogicException;
 use ReflectionAttribute;
 use ReflectionClass;
 use ReflectionEnum;
@@ -99,6 +100,55 @@ class Reflector
         } while ($includeParents && false !== $reflectionClass = $reflectionClass->getParentClass());
 
         return $includeParents ? new Collection($attributes) : array_first($attributes);
+    }
+
+    /**
+     * Get the given attribute from traits used by the class.
+     *
+     * @template TAttribute of object
+     *
+     * @param  \ReflectionClass  $reflectionClass
+     * @param  class-string<TAttribute>  $attribute
+     * @return TAttribute|null
+     *
+     * @throws \LogicException
+     */
+    public static function getClassAttributeFromTraits(ReflectionClass $reflectionClass, $attribute)
+    {
+        $matches = [];
+
+        foreach ($reflectionClass->getTraits() as $trait) {
+            $attributes = $trait->getAttributes($attribute);
+
+            if ($attributes !== []) {
+                $matches[$trait->getName()] = $attributes[0]->newInstance();
+            }
+        }
+
+        if ($matches === []) {
+            return null;
+        }
+
+        $resolved = null;
+
+        foreach ($matches as $instance) {
+            if (is_null($resolved)) {
+                $resolved = $instance;
+
+                continue;
+            }
+
+            if ($resolved != $instance) {
+                throw new LogicException(sprintf(
+                    'Could not resolve [%s] attribute on [%s]: traits [%s] declare conflicting values.',
+                    $attribute,
+                    $reflectionClass->getName(),
+                    implode(', ', array_keys($matches))
+                ));
+            }
+        }
+
+        return $resolved;
     }
 
     /**

--- a/src/Illuminate/Support/Traits/ReadsClassAttributes.php
+++ b/src/Illuminate/Support/Traits/ReadsClassAttributes.php
@@ -3,6 +3,8 @@
 namespace Illuminate\Support\Traits;
 
 use Exception;
+use Illuminate\Support\Reflector;
+use LogicException;
 use ReflectionClass;
 
 trait ReadsClassAttributes
@@ -57,6 +59,8 @@ trait ReadsClassAttributes
      * @param  class-string  $attributeClass
      * @param  \ReflectionClass|null  $declaringClass
      * @return object|null
+     *
+     * @throws \LogicException
      */
     protected function getAttributeInstance($target, string $attributeClass, ?ReflectionClass &$declaringClass = null)
     {
@@ -72,16 +76,14 @@ trait ReadsClassAttributes
                     return $attributes[0]->newInstance();
                 }
 
-                foreach ($reflection->getTraits() as $trait) {
-                    $attributes = $trait->getAttributes($attributeClass);
+                if (! is_null($instance = Reflector::getClassAttributeFromTraits($reflection, $attributeClass))) {
+                    $declaringClass = $reflection;
 
-                    if (count($attributes) > 0) {
-                        $declaringClass = $reflection;
-
-                        return $attributes[0]->newInstance();
-                    }
+                    return $instance;
                 }
             } while ($reflection = $reflection->getParentClass());
+        } catch (LogicException $e) {
+            throw $e;
         } catch (Exception) {
             //
         }

--- a/tests/Database/DatabaseEloquentModelAttributesTest.php
+++ b/tests/Database/DatabaseEloquentModelAttributesTest.php
@@ -16,6 +16,7 @@ use Illuminate\Database\Eloquent\Attributes\Visible;
 use Illuminate\Database\Eloquent\Attributes\WithoutIncrementing;
 use Illuminate\Database\Eloquent\Attributes\WithoutTimestamps;
 use Illuminate\Database\Eloquent\Model;
+use LogicException;
 use PHPUnit\Framework\TestCase;
 
 class DatabaseEloquentModelAttributesTest extends TestCase
@@ -478,6 +479,28 @@ class DatabaseEloquentModelAttributesTest extends TestCase
 
         $this->assertSame('primary', $model->getConnectionName());
     }
+
+    public function test_identical_trait_attributes_are_allowed(): void
+    {
+        $model = new ModelWithIdenticalTraitTableAttributes;
+
+        $this->assertSame('shared_table', $model->getTable());
+    }
+
+    public function test_conflicting_trait_attributes_throw_logic_exception(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('declare conflicting values');
+
+        new ModelWithConflictingTraitTableAttributes;
+    }
+
+    public function test_class_attribute_takes_precedence_over_conflicting_traits(): void
+    {
+        $model = new ModelOverridingConflictingTraitTableAttributes;
+
+        $this->assertSame('from_class', $model->getTable());
+    }
 }
 
 enum ConnectionUnitEnum
@@ -830,4 +853,40 @@ trait TraitUsingConnectionAttribute
 class ModelOverridingTraitConnectionAttribute extends Model
 {
     use TraitUsingConnectionAttribute;
+}
+
+#[Table(name: 'from_alpha')]
+trait TraitCarryingAlphaTableAttribute
+{
+}
+
+#[Table(name: 'from_beta')]
+trait TraitCarryingBetaTableAttribute
+{
+}
+
+#[Table(name: 'shared_table')]
+trait TraitCarryingSharedTableAttributeA
+{
+}
+
+#[Table(name: 'shared_table')]
+trait TraitCarryingSharedTableAttributeB
+{
+}
+
+class ModelWithConflictingTraitTableAttributes extends Model
+{
+    use TraitCarryingAlphaTableAttribute, TraitCarryingBetaTableAttribute;
+}
+
+class ModelWithIdenticalTraitTableAttributes extends Model
+{
+    use TraitCarryingSharedTableAttributeA, TraitCarryingSharedTableAttributeB;
+}
+
+#[Table(name: 'from_class')]
+class ModelOverridingConflictingTraitTableAttributes extends Model
+{
+    use TraitCarryingAlphaTableAttribute, TraitCarryingBetaTableAttribute;
 }

--- a/tests/Support/Fixtures/ClassesWithAttributes.php
+++ b/tests/Support/Fixtures/ClassesWithAttributes.php
@@ -39,3 +39,38 @@ class ParentClass
 class ChildClass extends ParentClass
 {
 }
+
+#[StrAttr('from_alpha')]
+trait TraitWithAlphaStrAttr
+{
+}
+
+#[StrAttr('from_beta')]
+trait TraitWithBetaStrAttr
+{
+}
+
+#[StrAttr('same')]
+trait TraitWithSameStrAttrA
+{
+}
+
+#[StrAttr('same')]
+trait TraitWithSameStrAttrB
+{
+}
+
+class ClassWithConflictingTraitAttributes
+{
+    use TraitWithAlphaStrAttr, TraitWithBetaStrAttr;
+}
+
+class ClassWithIdenticalTraitAttributes
+{
+    use TraitWithSameStrAttrA, TraitWithSameStrAttrB;
+}
+
+class ClassWithSingleTraitAttribute
+{
+    use TraitWithAlphaStrAttr;
+}

--- a/tests/Support/SupportReadsClassAttributesTest.php
+++ b/tests/Support/SupportReadsClassAttributesTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use Attribute;
+use Illuminate\Support\Traits\ReadsClassAttributes;
+use LogicException;
+use PHPUnit\Framework\TestCase;
+
+class SupportReadsClassAttributesTest extends TestCase
+{
+    public function test_trait_attribute_is_resolved()
+    {
+        $reader = new class
+        {
+            use ReadsClassAttributes;
+
+            public function read($target)
+            {
+                return $this->getAttributeValue($target, ReadsClassAttributesTestAttr::class, 'value');
+            }
+        };
+
+        $this->assertSame('from_trait', $reader->read(new ReadsClassAttributesTestWithTrait));
+    }
+
+    public function test_identical_trait_attributes_are_allowed()
+    {
+        $reader = new class
+        {
+            use ReadsClassAttributes;
+
+            public function read($target)
+            {
+                return $this->getAttributeValue($target, ReadsClassAttributesTestAttr::class, 'value');
+            }
+        };
+
+        $this->assertSame('same', $reader->read(new ReadsClassAttributesTestWithIdenticalTraits));
+    }
+
+    public function test_conflicting_trait_attributes_throw_logic_exception()
+    {
+        $reader = new class
+        {
+            use ReadsClassAttributes;
+
+            public function read($target)
+            {
+                return $this->getAttributeValue($target, ReadsClassAttributesTestAttr::class, 'value');
+            }
+        };
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('declare conflicting values');
+
+        $reader->read(new ReadsClassAttributesTestWithConflictingTraits);
+    }
+
+    public function test_class_attribute_takes_precedence_over_conflicting_traits()
+    {
+        $reader = new class
+        {
+            use ReadsClassAttributes;
+
+            public function read($target)
+            {
+                return $this->getAttributeValue($target, ReadsClassAttributesTestAttr::class, 'value');
+            }
+        };
+
+        $this->assertSame('from_class', $reader->read(new ReadsClassAttributesTestOverridingConflictingTraits));
+    }
+}
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class ReadsClassAttributesTestAttr
+{
+    public function __construct(public string $value)
+    {
+    }
+}
+
+#[ReadsClassAttributesTestAttr('from_alpha')]
+trait ReadsClassAttributesTestAlphaTrait
+{
+}
+
+#[ReadsClassAttributesTestAttr('from_beta')]
+trait ReadsClassAttributesTestBetaTrait
+{
+}
+
+#[ReadsClassAttributesTestAttr('same')]
+trait ReadsClassAttributesTestSameTraitA
+{
+}
+
+#[ReadsClassAttributesTestAttr('same')]
+trait ReadsClassAttributesTestSameTraitB
+{
+}
+
+#[ReadsClassAttributesTestAttr('from_trait')]
+trait ReadsClassAttributesTestSingleTrait
+{
+}
+
+class ReadsClassAttributesTestWithTrait
+{
+    use ReadsClassAttributesTestSingleTrait;
+}
+
+class ReadsClassAttributesTestWithIdenticalTraits
+{
+    use ReadsClassAttributesTestSameTraitA, ReadsClassAttributesTestSameTraitB;
+}
+
+class ReadsClassAttributesTestWithConflictingTraits
+{
+    use ReadsClassAttributesTestAlphaTrait, ReadsClassAttributesTestBetaTrait;
+}
+
+#[ReadsClassAttributesTestAttr('from_class')]
+class ReadsClassAttributesTestOverridingConflictingTraits
+{
+    use ReadsClassAttributesTestAlphaTrait, ReadsClassAttributesTestBetaTrait;
+}

--- a/tests/Support/SupportReflectorTest.php
+++ b/tests/Support/SupportReflectorTest.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Reflector;
 use Illuminate\Support\Testing\Fakes\BusFake;
 use Illuminate\Support\Testing\Fakes\MailFake;
 use Illuminate\Support\Testing\Fakes\PendingMailFake;
+use LogicException;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
@@ -131,6 +132,34 @@ class SupportReflectorTest extends TestCase
         $this->assertSame('quick', Reflector::getClassAttribute(Fixtures\ChildClass::class, Fixtures\StrAttr::class)->string);
         $this->assertSame('quick', Reflector::getClassAttribute(Fixtures\ChildClass::class, Fixtures\StrAttr::class, true)->string);
         $this->assertSame('lazy', Reflector::getClassAttribute(Fixtures\ParentClass::class, Fixtures\StrAttr::class)->string);
+    }
+
+    public function testGetClassAttributeFromTraits()
+    {
+        require_once __DIR__.'/Fixtures/ClassesWithAttributes.php';
+
+        $this->assertNull(Reflector::getClassAttributeFromTraits(
+            new ReflectionClass(Fixtures\ChildClass::class),
+            Fixtures\StrAttr::class
+        ));
+
+        $this->assertSame('from_alpha', Reflector::getClassAttributeFromTraits(
+            new ReflectionClass(Fixtures\ClassWithSingleTraitAttribute::class),
+            Fixtures\StrAttr::class
+        )->string);
+
+        $this->assertSame('same', Reflector::getClassAttributeFromTraits(
+            new ReflectionClass(Fixtures\ClassWithIdenticalTraitAttributes::class),
+            Fixtures\StrAttr::class
+        )->string);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('declare conflicting values');
+
+        Reflector::getClassAttributeFromTraits(
+            new ReflectionClass(Fixtures\ClassWithConflictingTraitAttributes::class),
+            Fixtures\StrAttr::class
+        );
     }
 }
 


### PR DESCRIPTION
Fixes #60953

After #60566 / #60519, class attributes like `#[Table]` and `#[Connection]` can live on traits. That works fine, but if two traits on the same class declare the same attribute with different values, we just picked the first trait in the `use` list and moved on.

That means something as harmless as reordering imports / traits can change runtime behaviour, which feels a bit nasty.

This PR makes that conflict explicit instead:

- if multiple traits declare the same attribute with **different** values → throw a `LogicException`
- if they declare the **same** value → still fine
- class-level attributes still win over traits (unchanged)

Shared the trait lookup in `Reflector::getClassAttributeFromTraits()` and wired it into both `Model::resolveClassAttribute()` and `ReadsClassAttributes` so Eloquent and queue attributes stay consistent.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
