### PR TITLE
[13.x] Fix Actions remove `imagedestroy` from tests

### DIFF
--- a/tests/Image/Drivers/GdDriverTest.php
+++ b/tests/Image/Drivers/GdDriverTest.php
@@ -475,7 +475,6 @@ class GdDriverTest extends TestCase
 
         ob_start();
         imagepng($image);
-        imagedestroy($image);
 
         return ob_get_clean();
     }

--- a/tests/Integration/Image/ImageTest.php
+++ b/tests/Integration/Image/ImageTest.php
@@ -804,7 +804,6 @@ class ImageTest extends TestCase
 
         ob_start();
         imagepng($image);
-        imagedestroy($image);
 
         return ob_get_clean();
     }


### PR DESCRIPTION
Actions are failing due to deprecations

Currently, this function does nothing... as we test from 8.3 upwards. see https://github.com/laravel/framework/actions/runs/30638969760/job/91183738795#step:5:278

```
Function imagedestroy() is deprecated since 8.5, as it has no effect since PHP 8.0
```