### PR TITLE
[13.x] Add NumberPrompt fallback

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "guzzlehttp/guzzle": "^7.8.2",
         "guzzlehttp/promises": "^2.0.3",
         "guzzlehttp/uri-template": "^1.0",
-        "laravel/prompts": "^0.3.0",
+        "laravel/prompts": "^0.3.11",
         "laravel/serializable-closure": "^2.0.10",
         "league/commonmark": "^2.8.1",
         "league/flysystem": "^3.25.1",

--- a/src/Illuminate/Console/Concerns/ConfiguresPrompts.php
+++ b/src/Illuminate/Console/Concerns/ConfiguresPrompts.php
@@ -6,6 +6,7 @@ use Illuminate\Console\PromptValidationException;
 use Laravel\Prompts\ConfirmPrompt;
 use Laravel\Prompts\MultiSearchPrompt;
 use Laravel\Prompts\MultiSelectPrompt;
+use Laravel\Prompts\NumberPrompt;
 use Laravel\Prompts\PasswordPrompt;
 use Laravel\Prompts\PausePrompt;
 use Laravel\Prompts\Prompt;
@@ -43,6 +44,16 @@ trait ConfiguresPrompts
 
         TextareaPrompt::fallbackUsing(fn (TextareaPrompt $prompt) => $this->promptUntilValid(
             fn () => $this->components->ask($prompt->label, $prompt->default ?: null, multiline: true) ?? '',
+            $prompt->required,
+            $prompt->validate
+        ));
+
+        NumberPrompt::fallbackUsing(fn (NumberPrompt $prompt) => $this->promptUntilValid(
+            function () use ($prompt) {
+                $answer = $this->components->ask($prompt->label, $prompt->default ?: null) ?? '';
+
+                return is_numeric($answer) ? (int) $answer : $answer;
+            },
             $prompt->required,
             $prompt->validate
         ));

--- a/src/Illuminate/Console/composer.json
+++ b/src/Illuminate/Console/composer.json
@@ -21,7 +21,7 @@
         "illuminate/macroable": "^13.0",
         "illuminate/support": "^13.0",
         "illuminate/view": "^13.0",
-        "laravel/prompts": "^0.3.0",
+        "laravel/prompts": "^0.3.11",
         "nunomaduro/termwind": "^2.0",
         "symfony/console": "^7.4.0 || ^8.0.0",
         "symfony/polyfill-php84": "^1.37",

--- a/tests/Integration/Console/PromptsAssertionTest.php
+++ b/tests/Integration/Console/PromptsAssertionTest.php
@@ -9,6 +9,7 @@ use Orchestra\Testbench\TestCase;
 use function Laravel\Prompts\confirm;
 use function Laravel\Prompts\multisearch;
 use function Laravel\Prompts\multiselect;
+use function Laravel\Prompts\number;
 use function Laravel\Prompts\password;
 use function Laravel\Prompts\pause;
 use function Laravel\Prompts\search;
@@ -86,6 +87,28 @@ class PromptsAssertionTest extends TestCase
             ->artisan('test:textarea')
             ->expectsQuestion('What is your name?', 'Jane')
             ->expectsOutput('Jane');
+    }
+
+    public function testAssertionForNumberPrompt(): void
+    {
+        $this->app[Kernel::class]->registerCommand(
+            new class extends Command
+            {
+                protected $signature = 'test:number';
+
+                public function handle()
+                {
+                    $count = number('How many people?');
+
+                    $this->line("There are {$count} people.");
+                }
+            }
+        );
+
+        $this
+            ->artisan('test:number')
+            ->expectsQuestion('How many people?', 5)
+            ->expectsOutput('There are 5 people.');
     }
 
     public function testAssertionForSuggestPrompt(): void


### PR DESCRIPTION
Fixes #60958

This PR adds a fallback for `\Laravel\Prompts\NumberPrompt` to `Illuminate\Console\Concerns\ConfiguresPrompts`, falling back to a Symfony console question.

`NumberPrompt` is currently the only prompt type without a registered fallback, so whenever prompts fall back to plain console I/O — on Windows, in non-interactive contexts, or in tests — a `number()` prompt throws `RuntimeException: No fallback implementation registered for [Laravel\Prompts\NumberPrompt]` instead of degrading gracefully. This also means `number()` can't be used with `expectsQuestion()` in tests.

The fallback mirrors `NumberPrompt::value()`'s `is_numeric($answer) ? (int) $answer : $answer` cast, so it returns the same `int|string` the interactive path returns, and passes `$prompt->validate` through so the prompt's built-in `min`/`max` validation still applies.

This mirrors #53660, which added the same missing fallback for `PausePrompt`.

This also bumps the `laravel/prompts` constraint from `^0.3.0` to `^0.3.11` (in both the root and `illuminate/console` manifests). `NumberPrompt` was introduced in `laravel/prompts` v0.3.11, so referencing it requires that as the minimum; the previous `^0.3.0` floor allowed versions without the class. It stays within the same `0.3` line (current is `0.3.21`).

There is no behavior change for any existing prompt; the only effect is that `number()` now degrades gracefully instead of throwing. A `testAssertionForNumberPrompt` test is added alongside the existing prompt assertion tests.
