### PR TITLE
[13.x] Remove deprecated imagedestroy() calls from image tests

### DIFF
--- a/tests/Image/Drivers/GdDriverTest.php
+++ b/tests/Image/Drivers/GdDriverTest.php
@@ -475,7 +475,6 @@ class GdDriverTest extends TestCase
 
         ob_start();
         imagepng($image);
-        imagedestroy($image);
 
         return ob_get_clean();
     }

--- a/tests/Integration/Image/ImageTest.php
+++ b/tests/Integration/Image/ImageTest.php
@@ -804,7 +804,6 @@ class ImageTest extends TestCase
 
         ob_start();
         imagepng($image);
-        imagedestroy($image);
 
         return ob_get_clean();
     }


### PR DESCRIPTION
`imagedestroy()` is deprecated as of PHP 8.5, so the image tests emit a deprecation there. Because the test workflow runs PHPUnit with `--fail-on-deprecation`, every PHP 8.5 job fails, and `fail-fast` cancels the rest of the matrix. `13.x` is currently red for this reason.

```
1) tests/Image/Drivers/GdDriverTest.php:478
Function imagedestroy() is deprecated since 8.5, as it has no effect since PHP 8.0

Triggered by:

* Illuminate\Tests\Image\Drivers\GdDriverTest::test_dominant_color_returns_hex_for_solid_image
* Illuminate\Tests\Image\Drivers\GdDriverTest::test_processes_contain_with_dominant_background
* Illuminate\Tests\Image\Drivers\GdDriverTest::test_processes_rotate_with_dominant_background
```

The call has had no effect since PHP 8.0, where `GdImage` became a garbage collected object, and the framework already requires PHP 8.3, so the calls can simply go. `$image` is not used afterwards in either helper.

The same helper is duplicated in `tests/Integration/Image/ImageTest.php`, so this removes it in both places.

Verified on PHP 8.5.9 with GD: `vendor/bin/phpunit --display-deprecation --fail-on-deprecation --no-coverage tests/Image tests/Integration/Image` reports the deprecation before the change and exits 0 after it.
