### PR TITLE
[13.x] Prevent TypeError in Validator::validateDistinct()

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -920,7 +920,7 @@ trait ValidatesAttributes
     {
         $data = Arr::except($this->getDistinctValues($attribute), $attribute);
 
-        if (in_array('ignore_case', $parameters)) {
+        if (in_array('ignore_case', $parameters) && is_string($value)) {
             return empty(preg_grep('/^'.preg_quote($value, '/').'$/iu', $data));
         }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4550,6 +4550,9 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['foo' => ['0100', '100']], ['foo.*' => 'distinct:strict']);
         $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['users' => [['name' => ['John']], ['name' => ['john']]]], ['users.*.name' => 'distinct:ignore_case']);
+        $this->assertTrue($v->passes());
     }
 
     public function testValidateDistinctForTopLevelArrays()


### PR DESCRIPTION
Fixes a Fatal TypeError when using `distinct:ignore_case` on nested wildcards where the attribute value is non-string.

### Problem
`Validator::validateDistinct()` calls `preg_quote($value, '/')` directly whenever `ignore_case` is present in parameters. When validating nested attributes like _users.*.name_ where the value resolves to an array, preg_quote() throws a TypeError.

### Reproduction
```PHP
$validator = new Validator(app('translator'), [
    'users' => [['name' => ['John']], ['name' => ['john']]],
], ['users.*.name' => 'distinct:ignore_case']);

$validator->passes();
// Throws TypeError: preg_quote(): Argument #1 ($str) must be of type string, array given
```

### Solution
Added an `is_string($value)` check to the `ignore_case` conditional so non-string values safely fall through to standard `in_array()` validation instead of crashing `preg_quote()`.