### PR TITLE
[13.x] Prevent Str::headline() from dropping numeric '0'

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1485,7 +1485,7 @@ class Str
 
         $collapsed = static::replace(['-', '_', ' '], '_', implode('_', $parts));
 
-        return implode(' ', array_filter(explode('_', $collapsed)));
+        return implode(' ', array_filter(explode('_', $collapsed), 'strlen'));
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -93,6 +93,10 @@ class SupportStrTest extends TestCase
         $this->assertSame('Orwell 1984', Str::headline(' orwell_- 1984 '));
 
         $this->assertSame('Laravel Rocks!', Str::headline('laravel rocks!'));
+
+        $this->assertSame('Field 0', Str::headline('field 0'));
+        $this->assertSame('User 0 Name', Str::headline('user_0_name'));
+        $this->assertSame('Version 0 0 1', Str::headline('version_0_0_1'));
     }
 
     public function testStringInitials()


### PR DESCRIPTION
Under the hood, `Str::headline()` uses `array_filter(explode('_', $collapsed))` to clean up extra or empty spaces/delimiters between string segments.

Because `array_filter() `was called without a callback, PHP defaults to boolean conversion. In PHP, `(bool) "0"` evaluates to false, which caused numeric '0' segments (e.g. 'field 0' or 'user_0_name') to be mistakenly stripped out.

```PHP
// Before
Str::headline('field 0');     // 'Field'
Str::headline('user_0_name'); // 'User Name'

// After
Str::headline('field 0');     // 'Field 0'
Str::headline('user_0_name'); // 'User 0 Name'
```