### PR TITLE
[13.x] Fix Str::apa() capitalization for initial hyphenated minor words

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1537,11 +1537,15 @@ class Str
             if (str_contains($lowercaseWord, '-')) {
                 $hyphenatedWords = explode('-', $lowercaseWord);
 
-                $hyphenatedWords = array_map(function ($part) use ($minorWords) {
-                    return (in_array($part, $minorWords) && mb_strlen($part) <= 3)
-                        ? $part
-                        : mb_strtoupper(mb_substr($part, 0, 1)).mb_substr($part, 1);
-                }, $hyphenatedWords);
+                $isFirstWord = $i === 0 || in_array(mb_substr($words[$i - 1], -1), $endPunctuation);
+
+                $hyphenatedWords = array_map(function ($part, $index) use ($minorWords, $isFirstWord) {
+                    if (in_array($part, $minorWords) && mb_strlen($part) <= 3 && ! ($isFirstWord && $index === 0)) {
+                        return $part;
+                    }
+
+                    return mb_strtoupper(mb_substr($part, 0, 1)).mb_substr($part, 1);
+                }, $hyphenatedWords, array_keys($hyphenatedWords));
 
                 $words[$i] = implode('-', $hyphenatedWords);
             } else {

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -135,6 +135,12 @@ class SupportStrTest extends TestCase
         $this->assertSame('Self-Report', Str::apa('Self-report'));
         $this->assertSame('Self-Report', Str::apa('SELF-REPORT'));
 
+        $this->assertSame('In-Depth Analysis', Str::apa('in-depth analysis'));
+        $this->assertSame('In-Depth Analysis', Str::apa('IN-DEPTH ANALYSIS'));
+        $this->assertSame('In-Depth Analysis', Str::apa('In-Depth Analysis'));
+        $this->assertSame('The in-Depth Analysis', Str::apa('the in-depth analysis'));
+        $this->assertSame('Introduction. In-Depth Analysis', Str::apa('introduction. in-depth analysis'));
+
         $this->assertSame('As the World Turns, So Are the Days of Our Lives', Str::apa('as the world turns, so are the days of our lives'));
         $this->assertSame('As the World Turns, So Are the Days of Our Lives', Str::apa('AS THE WORLD TURNS, SO ARE THE DAYS OF OUR LIVES'));
         $this->assertSame('As the World Turns, So Are the Days of Our Lives', Str::apa('As The World Turns, So Are The Days Of Our Lives'));


### PR DESCRIPTION
Fixes an issue where `Str::apa()` fails to capitalize a minor word at the beginning of a title if it is part of a hyphenated word.

```PHP
// Before
Str::apa('in-depth analysis'); 
// Output: 'in-Depth Analysis'

//After
Str::apa('in-depth analysis'); 
// Output: 'In-Depth Analysis'
```