### PR TITLE
[13.x] Solve another PHP 8.5 null index deprecation

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -589,6 +589,10 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
                 $resolvedKey = (string) $resolvedKey;
             }
 
+            if (is_null($resolvedKey)) {
+                $resolvedKey = (string) $resolvedKey;
+            }
+
             $results[$resolvedKey] = $item;
         }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3751,6 +3751,19 @@ class SupportCollectionTest extends TestCase
     }
 
     #[DataProvider('collectionClassProvider')]
+    public function testGroupByNull($collection)
+    {
+        $data = new $collection($payload = [
+            ['name' => 'a', 'url' => '1'],
+            ['name' => 'b', 'url' => null],
+            ['name' => 'c', 'url' => null],
+        ]);
+
+        $result = $data->groupBy('url');
+        $this->assertEquals(['1' => [$payload[0]], 'null' => [$payload[1], $payload[2]]], $result->toArray());
+    }
+
+    #[DataProvider('collectionClassProvider')]
     public function testKeyByAttribute($collection)
     {
         $data = new $collection([['rating' => 1, 'name' => '1'], ['rating' => 2, 'name' => '2'], ['rating' => 3, 'name' => '3']]);
@@ -3808,6 +3821,15 @@ class SupportCollectionTest extends TestCase
             '[0,"Taylor","Otwell"]' => ['firstname' => 'Taylor', 'lastname' => 'Otwell', 'locale' => 'US'],
             '[1,"Lucas","Michot"]' => ['firstname' => 'Lucas', 'lastname' => 'Michot', 'locale' => 'FR'],
         ], $result->all());
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testKeyByNull($collection)
+    {
+        $data = new $collection([['rating' => 1, 'name' => '1'], ['rating' => 2, 'name' => null]]);
+
+        $result = $data->keyBy('name');
+        $this->assertEquals(['1' => ['rating' => 1, 'name' => '1'], 'null' => ['rating' => 2, 'name' => null]], $result->all());
     }
 
     #[DataProvider('collectionClassProvider')]

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3760,7 +3760,7 @@ class SupportCollectionTest extends TestCase
         ]);
 
         $result = $data->groupBy('url');
-        $this->assertEquals(['1' => [$payload[0]], 'null' => [$payload[1], $payload[2]]], $result->toArray());
+        $this->assertEquals(['1' => [$payload[0]], '' => [$payload[1], $payload[2]]], $result->toArray());
     }
 
     #[DataProvider('collectionClassProvider')]
@@ -3829,7 +3829,7 @@ class SupportCollectionTest extends TestCase
         $data = new $collection([['rating' => 1, 'name' => '1'], ['rating' => 2, 'name' => null]]);
 
         $result = $data->keyBy('name');
-        $this->assertEquals(['1' => ['rating' => 1, 'name' => '1'], 'null' => ['rating' => 2, 'name' => null]], $result->all());
+        $this->assertEquals(['1' => ['rating' => 1, 'name' => '1'], '' => ['rating' => 2, 'name' => null]], $result->all());
     }
 
     #[DataProvider('collectionClassProvider')]


### PR DESCRIPTION
There have been [a few fixes](https://github.com/laravel/framework/pulls?q=Using+null+as+an+array+offset+is+deprecated%2C+use+an+empty+string+instead+in+) already. On two cases I'm still encountering warnings:

- `$collection->keyBy('someKey')` emits a warning if some values in `someKey` are `null`.
- `$collection[$offset]` emits a warning if `$offset = null`.

I propose to solve the `Collection::keyBy` issue by doing a cast to string (effectively replacing it with an empty string) because that's
- how it used to work and still works
- what `Collection::groupBy` does since solving the same issue in #57137 

I think it should be solved in framework for convenience, backwards compatibility and parity with the `Collection::groupBy` behaviour. I am also adding a simple test for both `keyBy` and `groupBy` to make this behaviour more locked in.

## What about `$collection[$offset]`?

That warning is easier to solve on your own and it forces you to focus the attention on auto-cast in exactly the way that the warning was intended to do. So I haven't tried to solve it yet. But I've done some research:

- `collect(['a' => 1, '' => 3])->has(null)` is `true`
- `collect(['a' => 1, '' => 3])->get(null)` returns `3`
- `collect(['a' => 1, '' => 3])[null­]` returns `3` and emits the warning

So maybe we should make `->get(null)` and `[null]` work the same while we're at it? Is dropping the warning the correct direction here?

By the way
- `Arr::exists(['a' => 1, '' => 3], null)` is `true`
- `Arr::has(['a' => 1, '' => 3], null)` is `false` 🙃
- `Arr::get(['a' => 1, '' => 3], null)` returns `['a' => 1, '' => 3]` (the whole array)

