### PR TITLE
[13.x] Add assertNoRepeatedQueries test assertion

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -287,6 +287,80 @@ trait InteractsWithDatabase
     }
 
     /**
+     * Assert that no "N+1" query pattern occurs throughout the test.
+     *
+     * Detects the N+1 signature: the same normalized query shape executing
+     * more than the allowed threshold. Only SELECT statements are considered,
+     * since writes are commonly repeated intentionally (e.g. batch inserts).
+     *
+     * @param  int  $threshold
+     * @param  string|null  $connection
+     * @return $this
+     */
+    public function assertNoRepeatedQueries($threshold = 1, $connection = null)
+    {
+        $connectionInstance = $this->getConnection($connection);
+
+        $counts = [];
+
+        $connectionInstance->listen(function (QueryExecuted $event) use (&$counts, $connectionInstance, $connection) {
+            if (! is_null($connection) && $connectionInstance !== $event->connection) {
+                return;
+            }
+
+            if (! str_starts_with(strtolower(ltrim($event->sql)), 'select')) {
+                return;
+            }
+
+            $fingerprint = $this->fingerprintQuery($event->sql);
+
+            $counts[$fingerprint] = ($counts[$fingerprint] ?? 0) + 1;
+        });
+
+        $this->beforeApplicationDestroyed(function () use (&$counts, $threshold, $connectionInstance) {
+            $repeated = array_filter($counts, fn ($count) => $count > $threshold);
+
+            if (empty($repeated)) {
+                $this->assertTrue(true);
+
+                return;
+            }
+
+            $lines = [];
+
+            foreach ($repeated as $fingerprint => $count) {
+                $lines[] = "  [{$count}x] {$fingerprint}";
+            }
+
+            $this->fail(sprintf(
+                'Repeated query pattern detected on the [%s] connection (possible N+1).'.
+                'The following query shapes executed more than %d time(s):\n%s',
+                $connectionInstance->getName(),
+                $threshold,
+                implode("\n", $lines)
+            ));
+        });
+
+        return $this;
+    }
+
+    /**
+     * Normalize a SQL statement into a "shape" by removing its bound values,
+     * so that queries differing only by value collapse into a single pattern.
+     *
+     * @param  string  $sql
+     * @return string
+     */
+    protected function fingerprintQuery($sql)
+    {
+        $sql = preg_replace('/\b\d+\b/', '?', $sql);
+        $sql = preg_replace("/'[^']*'/", '?', $sql);
+        $sql = preg_replace('/in \([^)]+\)/i', 'in (?)', $sql);
+
+        return strtolower(trim($sql));
+    }
+
+    /**
      * Determine if the argument is a soft deletable model.
      *
      * @param  mixed  $model

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\DB;
 use Mockery as m;
 use Orchestra\Testbench\Concerns\CreatesApplication;
+use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
 
@@ -599,6 +600,103 @@ class FoundationInteractsWithDatabaseTest extends TestCase
 
         $case->setUp();
         $case->testExpectsDatabaseQueryCount();
+        $case->tearDown();
+    }
+
+    public function testAssertNoRepeatedQueriesPassesWhenNoQueryShapeRepeats()
+    {
+        $case = new class('foo') extends TestingTestCase
+        {
+            use CreatesApplication;
+
+            public function testAssertNoRepeatedQueries()
+            {
+                $this->assertNoRepeatedQueries();
+
+                DB::pretend(function ($db) {
+                    $db->table('teams')->limit(50)->get();
+                    $db->table('countries')->whereIn('id', [1, 2, 3])->get();
+                });
+            }
+        };
+
+        $case->setUp();
+        $case->testAssertNoRepeatedQueries();
+        $case->tearDown();
+    }
+
+    public function testAssertNoRepeatedQueriesFailsWhenAQueryShapeRepeats()
+    {
+        $case = new class('foo') extends TestingTestCase
+        {
+            use CreatesApplication;
+
+            public function testAssertNoRepeatedQueries()
+            {
+                $this->assertNoRepeatedQueries();
+
+                DB::pretend(function ($db) {
+                    $db->table('countries')->where('id', 1)->get();
+                    $db->table('countries')->where('id', 2)->get();
+                    $db->table('countries')->where('id', 3)->get();
+                });
+            }
+        };
+
+        $case->setUp();
+        $case->testAssertNoRepeatedQueries();
+
+        try {
+            $case->tearDown();
+            $this->fail();
+        } catch (AssertionFailedError $e) {
+            $this->assertStringContainsString('possible N+1', $e->getMessage());
+        }
+    }
+
+    public function testAssertNoRepeatedQueriesRespectsThreshold()
+    {
+        $case = new class('foo') extends TestingTestCase
+        {
+            use CreatesApplication;
+
+            public function testAssertNoRepeatedQueries()
+            {
+                $this->assertNoRepeatedQueries(threshold: 3);
+
+                DB::pretend(function ($db) {
+                    $db->table('countries')->where('id', 1)->get();
+                    $db->table('countries')->where('id', 2)->get();
+                    $db->table('countries')->where('id', 3)->get();
+                });
+            }
+        };
+
+        $case->setUp();
+        $case->testAssertNoRepeatedQueries();
+        $case->tearDown();
+    }
+
+    public function testAssertNoRepeatedQueriesIgnoresNonSelectStatements()
+    {
+        $case = new class('foo') extends TestingTestCase
+        {
+            use CreatesApplication;
+
+            public function testAssertNoRepeatedQueries()
+            {
+                $this->assertNoRepeatedQueries();
+
+                DB::pretend(function ($db) {
+                    $db->table('solves')->insert(['team_id' => 1]);
+                    $db->table('solves')->insert(['team_id' => 2]);
+                    $db->table('solves')->insert(['team_id' => 3]);
+                });
+            }
+        };
+
+        $case->setUp();
+        $case->testAssertNoRepeatedQueries();
         $case->tearDown();
     }
 


### PR DESCRIPTION
This adds an `assertNoRepeatedQueries()` assertion to `InteractsWithDatabase` for catching N+1 queries in tests/CI.

We already have `expectsDatabaseQueryCount()`, which is great when you know the exact number of queries an endpoint should run. But in practice you often don't want to pin an exact count — you just want to know that a relationship isn't being lazy-loaded in a loop. A hardcoded count is also brittle: it breaks any time you legitimately add a query, even when there's no N+1.

This assertion takes a different angle. It watches the queries a test runs, normalizes each one into a "shape" by stripping out bound values, and fails if the same shape runs more than a threshold. That's the actual signature of an N+1 — the same query executing over and over with different values.

```php
public function test_leaderboard_has_no_n_plus_one(): void
{
    Team::factory()->count(50)->create();

    $this->assertNoRepeatedQueries();

    $this->get('/leaderboard')->assertOk();
}
```

Only `SELECT` statements are considered, since repeated writes (batch inserts, for example) are usually intentional and not a problem. The threshold defaults to 1 but can be raised when a repeated read is expected:

```php
$this->assertNoRepeatedQueries(threshold: 3);
```

On failure it reports the offending shapes and how many times each ran: