### PR TITLE
[13.x] Fix PendingProcess losing falsy standard input values

### DIFF
--- a/src/Illuminate/Process/PendingProcess.php
+++ b/src/Illuminate/Process/PendingProcess.php
@@ -310,7 +310,7 @@ class PendingProcess
             $process->setIdleTimeout($this->idleTimeout);
         }
 
-        if ($this->input) {
+        if ($this->input !== null) {
             $process->setInput($this->input);
         }
 

--- a/tests/Process/ProcessTest.php
+++ b/tests/Process/ProcessTest.php
@@ -686,6 +686,15 @@ class ProcessTest extends TestCase
     }
 
     #[RequiresOperatingSystem('Linux|Darwin')]
+    public function testRealProcessesCanUseFalsyStandardInput()
+    {
+        $factory = new Factory();
+        $result = $factory->input(0)->run('cat');
+
+        $this->assertSame('0', $result->output());
+    }
+
+    #[RequiresOperatingSystem('Linux|Darwin')]
     public function testProcessPipe()
     {
         $factory = new Factory;


### PR DESCRIPTION
When `PendingProcess` receives a falsy standard input value, its process builder treats the value as absent and does not forward it to Symfony Process.

As a result, values such as `0`, `0.0`, and `'0'` are not written to STDIN.

This PR only skips `setInput()` when the input is `null`, preserving all supplied input values.

A regression test has been added for `input(0)`.