### PR TITLE
[13.x] Fix pagination edge cases

### DIFF
--- a/src/Illuminate/Pagination/CursorPaginator.php
+++ b/src/Illuminate/Pagination/CursorPaginator.php
@@ -70,8 +70,10 @@ class CursorPaginator extends AbstractCursorPaginator implements Arrayable, Arra
         $this->items = $this->items->slice(0, $this->perPage);
 
         if (! is_null($this->cursor) && $this->cursor->pointsToPreviousItems()) {
-            $this->items = $this->items->reverse()->values();
+            $this->items = $this->items->reverse();
         }
+
+        $this->items = $this->items->values();
     }
 
     /**

--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -58,7 +58,7 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
 
         $this->total = $total;
         $this->perPage = (int) $perPage;
-        $this->lastPage = max((int) ceil($total / $perPage), 1);
+        $this->lastPage = max((int) ceil($total / max($this->perPage, 1)), 1);
         $this->path = $this->path !== '/' ? rtrim($this->path, '/') : $this->path;
         $this->currentPage = $this->setCurrentPage($currentPage, $this->pageName);
         $this->items = $items instanceof Collection ? $items : new Collection($items);

--- a/tests/Pagination/CursorPaginatorTest.php
+++ b/tests/Pagination/CursorPaginatorTest.php
@@ -97,6 +97,24 @@ class CursorPaginatorTest extends TestCase
         $this->assertTrue($paginator->onLastPage());
     }
 
+    public function testItemsAreConsistentlyReindexedForNextAndPreviousPages(): void
+    {
+        $next = new CursorPaginator([['id' => 1], ['id' => 2], ['id' => 3]], 2, null, [
+            'parameters' => ['id'],
+        ]);
+
+        $this->assertSame([0, 1], array_keys($next->items()));
+
+        $cursor = new Cursor(['id' => 5], false);
+
+        $previous = new CursorPaginator([['id' => 4], ['id' => 3], ['id' => 2]], 2, $cursor, [
+            'parameters' => ['id'],
+        ]);
+
+        $this->assertSame([0, 1], array_keys($previous->items()));
+        $this->assertSame([['id' => 3], ['id' => 4]], $previous->items());
+    }
+
     public function testReturnEmptyCursorWhenItemsAreEmpty()
     {
         $cursor = new Cursor(['id' => 25], true);

--- a/tests/Pagination/LengthAwarePaginatorTest.php
+++ b/tests/Pagination/LengthAwarePaginatorTest.php
@@ -58,6 +58,14 @@ class LengthAwarePaginatorTest extends TestCase
         $this->assertEmpty($paginator->items());
     }
 
+    public function testLengthAwarePaginatorDoesNotDivideByZeroWhenPerPageIsZero(): void
+    {
+        $paginator = new LengthAwarePaginator(['item1', 'item2', 'item3', 'item4'], 4, 0, 1);
+
+        $this->assertSame(4, $paginator->lastPage());
+        $this->assertSame(0, $paginator->perPage());
+    }
+
     public function testLengthAwarePaginatorOnFirstAndLastPage()
     {
         $paginator = new LengthAwarePaginator(['1', '2', '3', '4'], 4, 2, 2);


### PR DESCRIPTION
- Guard against division by zero in `LengthAwarePaginator` when `perPage` is 0
- Make `CursorPaginator` reindex items consistently on both next and previous pages

