### PR TITLE
[13.x] Simplify unlink for maintenance mode files

### DIFF
--- a/src/Illuminate/Foundation/Console/UpCommand.php
+++ b/src/Illuminate/Foundation/Console/UpCommand.php
@@ -40,9 +40,7 @@ class UpCommand extends Command
 
             $this->laravel->maintenanceMode()->deactivate();
 
-            if (is_file(storage_path('framework/maintenance.php'))) {
-                unlink(storage_path('framework/maintenance.php'));
-            }
+            @unlink(storage_path('framework/maintenance.php'));
 
             $this->laravel->get('events')->dispatch(new MaintenanceModeDisabled());
 

--- a/src/Illuminate/Foundation/FileBasedMaintenanceMode.php
+++ b/src/Illuminate/Foundation/FileBasedMaintenanceMode.php
@@ -27,9 +27,7 @@ class FileBasedMaintenanceMode implements MaintenanceModeContract
      */
     public function deactivate(): void
     {
-        if ($this->active()) {
-            unlink($this->path());
-        }
+        @unlink($this->path());
     }
 
     /**


### PR DESCRIPTION
Use `@unlink()` instead of a separate existence check, matching the pattern already used elsewhere in the codebase.