### PR TITLE
[13.x] Preserve failed jobs with invalid JSON payloads

### DIFF
--- a/src/Illuminate/Queue/Failed/DatabaseUuidFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseUuidFailedJobProvider.php
@@ -8,6 +8,8 @@ use Illuminate\Support\Facades\Date;
 
 class DatabaseUuidFailedJobProvider implements CountableFailedJobProvider, FailedJobProviderInterface, PrunableFailedJobProvider
 {
+    use ExtractsFailedJobUuid;
+
     /**
      * The connection resolver implementation.
      *
@@ -55,7 +57,7 @@ class DatabaseUuidFailedJobProvider implements CountableFailedJobProvider, Faile
     public function log($connection, $queue, $payload, $exception)
     {
         $this->getTable()->insert([
-            'uuid' => $uuid = json_decode($payload, true)['uuid'],
+            'uuid' => $uuid = $this->extractUuid($payload),
             'connection' => $connection,
             'queue' => $queue,
             'payload' => $payload,

--- a/src/Illuminate/Queue/Failed/DynamoDbFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DynamoDbFailedJobProvider.php
@@ -11,6 +11,8 @@ use Illuminate\Support\Facades\Date;
 
 class DynamoDbFailedJobProvider implements FailedJobProviderInterface
 {
+    use ExtractsFailedJobUuid;
+
     /**
      * The DynamoDB client instance.
      *
@@ -57,7 +59,7 @@ class DynamoDbFailedJobProvider implements FailedJobProviderInterface
      */
     public function log($connection, $queue, $payload, $exception)
     {
-        $id = json_decode($payload, true)['uuid'];
+        $id = $this->extractUuid($payload);
 
         $failedAt = Date::now();
 

--- a/src/Illuminate/Queue/Failed/ExtractsFailedJobUuid.php
+++ b/src/Illuminate/Queue/Failed/ExtractsFailedJobUuid.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Illuminate\Queue\Failed;
+
+use Illuminate\Support\Str;
+
+trait ExtractsFailedJobUuid
+{
+    /**
+     * Extract the UUID from the given failed job payload.
+     *
+     * @param  string  $payload
+     * @return string
+     */
+    protected function extractUuid($payload)
+    {
+        $decoded = json_validate($payload)
+            ? json_decode($payload, true, flags: JSON_THROW_ON_ERROR)
+            : null;
+
+        if (is_array($decoded) && is_string($decoded['uuid'] ?? null) && $decoded['uuid'] !== '') {
+            return $decoded['uuid'];
+        }
+
+        return (string) Str::uuid();
+    }
+}

--- a/src/Illuminate/Queue/Failed/FileFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/FileFailedJobProvider.php
@@ -9,6 +9,8 @@ use Illuminate\Support\Facades\Date;
 
 class FileFailedJobProvider implements CountableFailedJobProvider, FailedJobProviderInterface, PrunableFailedJobProvider
 {
+    use ExtractsFailedJobUuid;
+
     /**
      * The file path where the failed job file should be stored.
      *
@@ -56,7 +58,7 @@ class FileFailedJobProvider implements CountableFailedJobProvider, FailedJobProv
     public function log($connection, $queue, $payload, $exception)
     {
         return $this->lock(function () use ($connection, $queue, $payload, $exception) {
-            $id = json_decode($payload, true)['uuid'];
+            $id = $this->extractUuid($payload);
 
             $jobs = $this->read();
 

--- a/tests/Queue/DatabaseUuidFailedJobProviderTest.php
+++ b/tests/Queue/DatabaseUuidFailedJobProviderTest.php
@@ -26,6 +26,17 @@ class DatabaseUuidFailedJobProviderTest extends TestCase
         $this->assertSame(['uuid-3', 'uuid-4'], $provider->ids('queue-2'));
     }
 
+    public function testLoggingFailedJobWithInvalidPayload()
+    {
+        $provider = $this->getFailedJobProvider();
+        $payload = '{invalid';
+
+        $id = $provider->log('connection', 'queue', $payload, new RuntimeException());
+
+        $this->assertTrue(Str::isUuid($id));
+        $this->assertSame($payload, $provider->find($id)->payload);
+    }
+
     public function testGettingAllFailedJobs()
     {
         $provider = $this->getFailedJobProvider();

--- a/tests/Queue/DynamoDbFailedJobProviderTest.php
+++ b/tests/Queue/DynamoDbFailedJobProviderTest.php
@@ -49,6 +49,40 @@ class DynamoDbFailedJobProviderTest extends TestCase
         Str::createUuidsNormally();
     }
 
+    public function testCanLogFailedJobWithInvalidPayload()
+    {
+        $uuid = Str::orderedUuid();
+
+        Str::createUuidsUsing(fn () => $uuid);
+
+        Carbon::setTestNow($now = CarbonImmutable::now());
+
+        $exception = new Exception('Something went wrong.');
+        $payload = '{invalid';
+
+        $dynamoDbClient = m::mock(DynamoDbClient::class);
+
+        $dynamoDbClient->shouldReceive('putItem')->once()->with([
+            'TableName' => 'table',
+            'Item' => [
+                'application' => ['S' => 'application'],
+                'uuid' => ['S' => (string) $uuid],
+                'connection' => ['S' => 'connection'],
+                'queue' => ['S' => 'queue'],
+                'payload' => ['S' => $payload],
+                'exception' => ['S' => (string) $exception],
+                'failed_at' => ['N' => (string) $now->getTimestamp()],
+                'expires_at' => ['N' => (string) $now->addWeek()->getTimestamp()],
+            ],
+        ]);
+
+        $provider = new DynamoDbFailedJobProvider($dynamoDbClient, 'application', 'table');
+
+        $this->assertSame((string) $uuid, $provider->log('connection', 'queue', $payload, $exception));
+
+        Str::createUuidsNormally();
+    }
+
     public function testCanRetrieveAllFailedJobs()
     {
         $dynamoDbClient = m::mock(DynamoDbClient::class);

--- a/tests/Queue/FileFailedJobProviderTest.php
+++ b/tests/Queue/FileFailedJobProviderTest.php
@@ -39,6 +39,16 @@ class FileFailedJobProviderTest extends TestCase
         ], $failedJobs);
     }
 
+    public function testCanLogFailedJobsWithInvalidPayload()
+    {
+        $payload = '{invalid';
+
+        $id = $this->provider->log('connection', 'queue', $payload, new Exception('Something went wrong.'));
+
+        $this->assertTrue(Str::isUuid($id));
+        $this->assertSame($payload, $this->provider->find($id)->payload);
+    }
+
     public function testCanRetrieveAllFailedJobs()
     {
         Carbon::setTestNow(Carbon::now());


### PR DESCRIPTION
Right now, the file, database UUID, and DynamoDB failed job providers assume every payload is valid JSON containing a UUID. When that assumption doesn't hold, say the payload is malformed or just missing a UUID. the provider throws before it can even save the failure record. So the one thing that's supposed to happen when a job fails (recording that it failed) doesn't happen.

This PR adds a validation step before decoding, so a bad payload no longer takes down the failure-logging path itself:

- If the payload is invalid or has no UUID, we generate one instead of failing outright.
- If it's valid, we use the UUID from the payload as before; no behavior change there.
- The original payload is kept around either way, so it's still there for debugging.
- All three providers (file, database UUID, DynamoDB) now handle this the same way, instead of each having its own assumptions.