### PR TITLE
[13.x] Fix ProcessDriver masking child exceptions with non-standard constructors

### DIFF
--- a/src/Illuminate/Concurrency/ProcessDriver.php
+++ b/src/Illuminate/Concurrency/ProcessDriver.php
@@ -12,6 +12,7 @@ use Illuminate\Process\Pool;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Defer\DeferredCallback;
 use Laravel\SerializableClosure\SerializableClosure;
+use Throwable;
 
 use function Illuminate\Support\defer;
 
@@ -62,11 +63,17 @@ class ProcessDriver implements Driver
             $result = json_decode($output, true);
 
             if (! $result['successful']) {
-                throw new $result['exception'](
-                    ...(! empty(array_filter($result['parameters'], fn ($parameter) => ! is_null($parameter)))
-                        ? $result['parameters']
-                        : [$result['message']])
-                );
+                try {
+                    $exception = new $result['exception'](
+                        ...(! empty(array_filter($result['parameters'], fn ($parameter) => ! is_null($parameter)))
+                            ? $result['parameters']
+                            : [$result['message']])
+                    );
+                } catch (Throwable) {
+                    $exception = new Exception($result['exception'].': '.$result['message']);
+                }
+
+                throw $exception;
             }
 
             return [$key => unserialize($result['result'])];

--- a/tests/Integration/Concurrency/ConcurrencyTest.php
+++ b/tests/Integration/Concurrency/ConcurrencyTest.php
@@ -5,10 +5,12 @@ namespace Illuminate\Tests\Integration\Concurrency;
 use Exception;
 use Illuminate\Concurrency\ProcessDriver;
 use Illuminate\Concurrency\SyncDriver;
+use Illuminate\Database\QueryException;
 use Illuminate\Foundation\Application;
 use Illuminate\Process\Factory as ProcessFactory;
 use Illuminate\Support\Facades\Concurrency;
 use Orchestra\Testbench\TestCase;
+use PDOException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 
@@ -150,6 +152,22 @@ PHP);
                 'Invalid payload'
             ),
         ]);
+    }
+
+    public function testRunHandlerProcessErrorWithNonStandardConstructorException()
+    {
+        try {
+            Concurrency::run([
+                fn () => throw new QueryException('mariadb', 'insert into t values (1)', [], new PDOException('dup')),
+            ]);
+        } catch (Exception $e) {
+            $this->assertStringContainsString(QueryException::class, $e->getMessage());
+            $this->assertStringContainsString('dup', $e->getMessage());
+
+            return;
+        }
+
+        $this->fail('The expected exception was not thrown.');
     }
 
     #[DataProvider('falseyExceptionParameters')]


### PR DESCRIPTION
## Problem

When a task running under `Concurrency::run()` (process driver) throws an exception whose constructor cannot be rebuilt from the parameters captured by the child process, the parent process fails while *reconstructing* the exception and masks the original one.

The child (`InvokeSerializedClosureCommand`) captures constructor parameters by reading same-named public properties. For exceptions like `Illuminate\Database\QueryException` (constructor: `($connectionName, $sql, array $bindings, $previous, ...)`, with most of them protected or not properties at all) the captured parameters are mostly `null`. The parent then attempts:

```php
throw new $result['exception'](...$result['parameters']);
```

which fails with:

```
ArgumentCountError: Too few arguments to function Illuminate\Database\QueryException::__construct(), 1 passed in ProcessDriver.php on line 65 and at least 4 expected
```

(or a `TypeError` on `$bindings`, depending on which parameters survive).

**Effect:** any SQL error inside a concurrent task (unique constraint violation, deadlock, lock wait timeout) reaches the parent as an unrecognizable `ArgumentCountError`/`TypeError` — the real cause is lost, both in production and in tests.

## Reproduction

```php
use Illuminate\Support\Facades\Concurrency;
use Illuminate\Database\QueryException;

Concurrency::run([
    fn () => throw new QueryException('mariadb', 'insert into t values (1)', [], new PDOException('dup')),
]);
```

Expected: the parent surfaces the original `QueryException` (or at least its class + message intact). Actual: masking `ArgumentCountError`/`TypeError`.

## Fix

Make the reconstruction defensive: if the exception class cannot be rebuilt from the available parameters, fall back to a generic `Exception` that carries the original exception class and message (`QueryException: SQLSTATE[...] ...`), so the real cause is never lost. Behavior for exceptions with standard/reconstructible constructors is unchanged.

A regression test covering the `QueryException` scenario is included.
