### PR TITLE
[12.x] Fix getMigrationBatches return type annotation

### DIFF
--- a/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
+++ b/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
@@ -99,7 +99,7 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
     /**
      * Get the completed migrations with their batch numbers.
      *
-     * @return array<int, string>[]
+     * @return array<string, int>
      */
     public function getMigrationBatches()
     {

--- a/src/Illuminate/Database/Migrations/MigrationRepositoryInterface.php
+++ b/src/Illuminate/Database/Migrations/MigrationRepositoryInterface.php
@@ -37,7 +37,7 @@ interface MigrationRepositoryInterface
     /**
      * Get the completed migrations with their batch numbers.
      *
-     * @return array<int, string>[]
+     * @return array<string, int>
      */
     public function getMigrationBatches();
 


### PR DESCRIPTION
The existing return type is wrong, causing [static analysis to false report errors](https://github.com/wouterj/WouterJEloquentBundle/actions/runs/30745546212/job/91490401866#step:9:27). This change is a backport of #59876:

> The current annotation `array<int, string>[]` is incorrect in two ways:
>
> 1. The keys and values are swapped — migration names are the keys (string), batch numbers are the values (int)
> 2. The trailing `[]` is extraneous — the return is a flat associative array, not an array of arrays

The faulty type was introduced in the 12.x branch by #58561, as such I think this bug should have been fixed it the 12.x branch instead of only in 13.x.