### PR TITLE
[13.x] Detect circular alias references in Container

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1667,12 +1667,24 @@ class Container implements ArrayAccess, ContainerContract
      *
      * @param  string  $abstract
      * @return string
+     *
+     * @throws \LogicException
      */
     public function getAlias($abstract)
     {
-        return isset($this->aliases[$abstract])
-            ? $this->getAlias($this->aliases[$abstract])
-            : $abstract;
+        $seen = [];
+
+        while (isset($this->aliases[$abstract])) {
+            if (isset($seen[$abstract])) {
+                throw new LogicException("Circular alias reference for [{$abstract}].");
+            }
+
+            $seen[$abstract] = true;
+
+            $abstract = $this->aliases[$abstract];
+        }
+
+        return $abstract;
     }
 
     /**

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -585,6 +585,29 @@ class ContainerTest extends TestCase
         $container->alias('name', 'name');
     }
 
+    public function testItThrowsExceptionOnCircularAliasReference(): void
+    {
+        $this->expectExceptionObject(new \LogicException('Circular alias reference for [a].'));
+
+        $container = new Container;
+        $container->alias('a', 'b');
+        $container->alias('b', 'a');
+
+        $container->getAlias('a');
+    }
+
+    public function testItThrowsExceptionOnIndirectCircularAliasReference(): void
+    {
+        $this->expectExceptionObject(new \LogicException('Circular alias reference for [a].'));
+
+        $container = new Container;
+        $container->alias('a', 'b');
+        $container->alias('b', 'c');
+        $container->alias('c', 'a');
+
+        $container->getAlias('a');
+    }
+
     public function testContainerGetFactory()
     {
         $container = new Container;


### PR DESCRIPTION
Registering two aliases that point back to each other made `getAlias()` recurse infinitely until memory exhaustion. Throw a `LogicException` instead.