### PR TITLE
[13.x] Detect circular constructor dependencies in Container

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1157,6 +1157,11 @@ class Container implements ArrayAccess, ContainerContract
             return $this->buildSelfBuildingInstance($concrete, $reflector);
         }
 
+        // Self-building types re-enter build() for themselves once via newInstance().
+        if (count(array_keys($this->buildStack, $concrete, true)) > 1) {
+            throw new CircularDependencyException("Circular dependency detected while resolving [{$concrete}].");
+        }
+
         $this->buildStack[] = $concrete;
 
         $constructor = $reflector->getConstructor();

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -9,6 +9,7 @@ use Illuminate\Container\Attributes\Singleton;
 use Illuminate\Container\Container;
 use Illuminate\Container\EntryNotFoundException;
 use Illuminate\Contracts\Container\BindingResolutionException;
+use Illuminate\Contracts\Container\CircularDependencyException;
 use Illuminate\Contracts\Container\ContextualAttribute;
 use Illuminate\Contracts\Container\SelfBuilding;
 use PHPUnit\Framework\Attributes\RequiresPhp;
@@ -1032,13 +1033,15 @@ class ContainerTest extends TestCase
         $this->assertSame('taylor@laravel.com', $r->email);
     }
 
-    // public function testContainerCanCatchCircularDependency()
-    // {
-    //     $this->expectException(\Illuminate\Contracts\Container\CircularDependencyException::class);
+    public function testContainerCanCatchCircularDependency(): void
+    {
+        $this->expectExceptionObject(new CircularDependencyException(
+            'Circular dependency detected while resolving ['.CircularAStub::class.'].'
+        ));
 
-    //     $container = new Container;
-    //     $container->get(CircularAStub::class);
-    // }
+        $container = new Container;
+        $container->get(CircularAStub::class);
+    }
 }
 
 class CircularAStub


### PR DESCRIPTION
A genuine constructor cycle (`A` needs `B`, `B` needs `A`) recurses until the process runs out of memory instead of throwing the documented `CircularDependencyException`.

This was actually attempted in 2021 ([dd7274d](https://github.com/laravel/framework/commit/dd7274d23a9ee58cc1abdf7107403169a3994b68)) but reverted a week later ([332844e](https://github.com/laravel/framework/commit/332844e5bde34f8db91aeca4d21cd4e0925d691e)) because it broke `SelfBuilding` types, which legitimately re-enter `build()` for themselves once via `newInstance()`. This version only throws once the same concrete type shows up more than once on the build stack, so that re-entrant case still works (covered by the existing `BuildableIntegrationTest`) while real cycles are still caught.