### PR TITLE
[13.x] Fix ReflectsClosures::firstClosureParameterTypes() returning wrong parameter's type

### DIFF
--- a/src/Illuminate/Reflection/Traits/ReflectsClosures.php
+++ b/src/Illuminate/Reflection/Traits/ReflectsClosures.php
@@ -57,19 +57,19 @@ trait ReflectsClosures
 
                 return [$parameter->getName() => Reflector::getParameterClassNames($parameter)];
             })
-            ->filter()
-            ->values()
             ->all();
 
         if (empty($types)) {
             throw new RuntimeException('The given Closure has no parameters.');
         }
 
-        if (isset($types[0]) && empty($types[0])) {
+        $first = array_values($types)[0];
+
+        if (empty($first)) {
             throw new RuntimeException('The first parameter of the given Closure is missing a type hint.');
         }
 
-        return $types[0];
+        return $first;
     }
 
     /**

--- a/src/Illuminate/Reflection/helpers.php
+++ b/src/Illuminate/Reflection/helpers.php
@@ -70,7 +70,7 @@ if (! function_exists('proxy')) {
     {
         static $closureReflector;
 
-        $closureReflector = new class
+        $closureReflector ??= new class
         {
             use ReflectsClosures;
 

--- a/tests/Support/SupportReflectsClosuresTest.php
+++ b/tests/Support/SupportReflectsClosuresTest.php
@@ -103,6 +103,15 @@ class SupportReflectsClosuresTest extends TestCase
         });
     }
 
+    public function testItThrowsWhenFirstParameterHasNoTypeHintEvenIfLaterParameterDoes(): void
+    {
+        $this->expectExceptionObject(new RuntimeException('The first parameter of the given Closure is missing a type hint.'));
+
+        ReflectsClosuresClass::reflectFirstAll(function ($a, ExampleParameter $b) {
+            //
+        });
+    }
+
     public function testClosureReturnTypesReturnsClassReturnType(): void
     {
         $this->assertSame(


### PR DESCRIPTION
`firstClosureParameterTypes()` filtered out empty/null entries and reindexed *before* reading index `0`. If the first closure parameter had no type hint but a later one did, the later parameter's types silently shifted into index `0` instead of throwing the expected `RuntimeException`.

Also fixes the `proxy()` helper, which rebuilt its reflector on every call instead of caching it like `lazy()` does.
