### PR TITLE
[13.x] Avoid redundant Collection passes in map/filter/reject chains

### DIFF
--- a/src/Illuminate/Console/Concerns/PromptsForMissingInput.php
+++ b/src/Illuminate/Console/Concerns/PromptsForMissingInput.php
@@ -40,8 +40,7 @@ trait PromptsForMissingInput
     protected function promptForMissingArguments(InputInterface $input, OutputInterface $output)
     {
         $prompted = (new Collection($this->getDefinition()->getArguments()))
-            ->reject(fn (InputArgument $argument) => $argument->getName() === 'command')
-            ->filter(fn (InputArgument $argument) => $argument->isRequired() && match (true) {
+            ->filter(fn (InputArgument $argument) => $argument->getName() !== 'command' && $argument->isRequired() && match (true) {
                 $argument->isArray() => empty($input->getArgument($argument->getName())),
                 default => is_null($input->getArgument($argument->getName())),
             })

--- a/src/Illuminate/Foundation/PackageManifest.php
+++ b/src/Illuminate/Foundation/PackageManifest.php
@@ -134,8 +134,8 @@ class PackageManifest
         })->each(function ($configuration) use (&$ignore) {
             $ignore = array_merge($ignore, $configuration['dont-discover'] ?? []);
         })->reject(function ($configuration, $package) use ($ignore, $ignoreAll) {
-            return $ignoreAll || in_array($package, $ignore);
-        })->filter()->all());
+            return $ignoreAll || in_array($package, $ignore) || empty($configuration);
+        })->all());
     }
 
     /**

--- a/src/Illuminate/Reflection/Traits/ReflectsClosures.php
+++ b/src/Illuminate/Reflection/Traits/ReflectsClosures.php
@@ -117,8 +117,7 @@ trait ReflectsClosures
             : [$reflection->getReturnType()];
 
         return (new Collection($types))
-            ->reject(fn ($type) => $type->isBuiltin())
-            ->reject(fn ($type) => in_array($type->getName(), ['static', 'self']))
+            ->reject(fn ($type) => $type->isBuiltin() || in_array($type->getName(), ['static', 'self']))
             ->map(fn ($type) => $type->getName())
             ->values()
             ->all();

--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -241,8 +241,7 @@ abstract class Component
             $reflection = new ReflectionClass($this);
 
             static::$propertyCache[$class] = (new Collection($reflection->getProperties(ReflectionProperty::IS_PUBLIC)))
-                ->reject(fn (ReflectionProperty $property) => $property->isStatic())
-                ->reject(fn (ReflectionProperty $property) => $this->shouldIgnore($property->getName()))
+                ->reject(fn (ReflectionProperty $property) => $property->isStatic() || $this->shouldIgnore($property->getName()))
                 ->map(fn (ReflectionProperty $property) => $property->getName())
                 ->all();
         }

--- a/src/Illuminate/View/DynamicComponent.php
+++ b/src/Illuminate/View/DynamicComponent.php
@@ -123,8 +123,8 @@ EOF;
     protected function compileSlots(array $slots)
     {
         return (new Collection($slots))
-            ->map(fn ($slot, $name) => $name === '__default' ? null : '<x-slot name="'.$name.'" '.((string) $slot->attributes).'>{{ $'.$name.' }}</x-slot>')
-            ->filter()
+            ->reject(fn ($slot, $name) => $name === '__default')
+            ->map(fn ($slot, $name) => '<x-slot name="'.$name.'" '.((string) $slot->attributes).'>{{ $'.$name.' }}</x-slot>')
             ->implode(PHP_EOL);
     }
 

--- a/tests/Support/SupportReflectsClosuresTest.php
+++ b/tests/Support/SupportReflectsClosuresTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Support;
 
+use Closure;
 use Illuminate\Support\Traits\ReflectsClosures;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
@@ -102,6 +103,57 @@ class SupportReflectsClosuresTest extends TestCase
         });
     }
 
+    public function testClosureReturnTypesReturnsClassReturnType(): void
+    {
+        $this->assertSame(
+            [ExampleParameter::class],
+            ReflectsClosuresClass::reflectReturnTypes(fn (): ExampleParameter => new ExampleParameter)
+        );
+    }
+
+    public function testClosureReturnTypesExcludesBuiltinReturnType(): void
+    {
+        $this->assertSame(
+            [],
+            ReflectsClosuresClass::reflectReturnTypes(fn (): string => 'foo')
+        );
+    }
+
+    public function testClosureReturnTypesReturnsEmptyArrayWhenNoReturnType(): void
+    {
+        $this->assertSame(
+            [],
+            ReflectsClosuresClass::reflectReturnTypes(fn () => 'foo')
+        );
+    }
+
+    public function testClosureReturnTypesExcludesSelfAndStaticReturnTypes(): void
+    {
+        $this->assertSame([], ReflectsClosuresClass::reflectReturnTypes(ReflectsClosuresClass::closureWithSelfReturnType()));
+        $this->assertSame([], ReflectsClosuresClass::reflectReturnTypes(ReflectsClosuresClass::closureWithStaticReturnType()));
+    }
+
+    public function testClosureReturnTypesKeepsOnlyClassTypesFromUnionReturnType(): void
+    {
+        $this->assertSame(
+            [ExampleParameter::class],
+            ReflectsClosuresClass::reflectReturnTypes(fn (): ExampleParameter|string => new ExampleParameter)
+        );
+
+        $this->assertSame(
+            [ExampleParameter::class, AnotherExampleParameter::class],
+            ReflectsClosuresClass::reflectReturnTypes(fn (): ExampleParameter|AnotherExampleParameter => new ExampleParameter)
+        );
+    }
+
+    public function testClosureReturnTypesReturnsEmptyArrayForIntersectionReturnType(): void
+    {
+        $this->assertSame(
+            [],
+            ReflectsClosuresClass::reflectReturnTypes(fn (): ReflectsClosuresInterfaceOne&ReflectsClosuresInterfaceTwo => new ReflectsClosuresBothInterfaces)
+        );
+    }
+
     private function assertParameterTypes($expected, $closure)
     {
         $types = ReflectsClosuresClass::reflect($closure);
@@ -128,6 +180,25 @@ class ReflectsClosuresClass
     {
         return (new static)->firstClosureParameterTypes($closure);
     }
+
+    public static function reflectReturnTypes($closure)
+    {
+        return (new static)->closureReturnTypes($closure);
+    }
+
+    public static function closureWithSelfReturnType(): Closure
+    {
+        return function (): self {
+            return new self;
+        };
+    }
+
+    public static function closureWithStaticReturnType(): Closure
+    {
+        return function (): static {
+            return new static;
+        };
+    }
 }
 
 class ExampleParameter
@@ -136,6 +207,21 @@ class ExampleParameter
 }
 
 class AnotherExampleParameter
+{
+    //
+}
+
+interface ReflectsClosuresInterfaceOne
+{
+    //
+}
+
+interface ReflectsClosuresInterfaceTwo
+{
+    //
+}
+
+class ReflectsClosuresBothInterfaces implements ReflectsClosuresInterfaceOne, ReflectsClosuresInterfaceTwo
 {
     //
 }

--- a/tests/View/ComponentTest.php
+++ b/tests/View/ComponentTest.php
@@ -366,6 +366,31 @@ class ComponentTest extends TestCase
         $this->assertTrue((bool) $anotherSlot->hasActualContent());
         $this->assertTrue((bool) $moreComplexSlot->hasActualContent());
     }
+
+    public function testDataOnlyIncludesNonStaticNonIgnoredPublicProperties(): void
+    {
+        $component = new TestComponentWithStaticAndIgnoredProperties;
+
+        $data = $component->data();
+
+        $this->assertSame('bar', $data['visible']);
+        $this->assertArrayNotHasKey('staticProp', $data);
+        $this->assertArrayNotHasKey('__hidden', $data);
+    }
+}
+
+class TestComponentWithStaticAndIgnoredProperties extends Component
+{
+    public static $staticProp = 'static';
+
+    public $__hidden = 'hidden';
+
+    public $visible = 'bar';
+
+    public function render()
+    {
+        return 'Hello';
+    }
 }
 
 class TestInlineViewComponent extends Component

--- a/tests/View/DynamicComponentTest.php
+++ b/tests/View/DynamicComponentTest.php
@@ -9,7 +9,7 @@ use ReflectionMethod;
 
 class DynamicComponentTest extends TestCase
 {
-    public function testCompileSlotsExcludesDefaultSlot()
+    public function testCompileSlotsExcludesDefaultSlot(): void
     {
         $component = new DynamicComponent('alert');
 
@@ -24,7 +24,7 @@ class DynamicComponentTest extends TestCase
         $this->assertStringContainsString('{{ $title }}', $result);
     }
 
-    public function testCompileSlotsReturnsEmptyStringWhenOnlyDefaultSlotIsPresent()
+    public function testCompileSlotsReturnsEmptyStringWhenOnlyDefaultSlotIsPresent(): void
     {
         $component = new DynamicComponent('alert');
 

--- a/tests/View/DynamicComponentTest.php
+++ b/tests/View/DynamicComponentTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Illuminate\Tests\View;
+
+use Illuminate\View\ComponentAttributeBag;
+use Illuminate\View\DynamicComponent;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+class DynamicComponentTest extends TestCase
+{
+    public function testCompileSlotsExcludesDefaultSlot()
+    {
+        $component = new DynamicComponent('alert');
+
+        $method = new ReflectionMethod(DynamicComponent::class, 'compileSlots');
+        $result = $method->invoke($component, [
+            '__default' => (object) ['attributes' => new ComponentAttributeBag],
+            'title' => (object) ['attributes' => new ComponentAttributeBag],
+        ]);
+
+        $this->assertStringNotContainsString('__default', $result);
+        $this->assertStringContainsString('<x-slot name="title"', $result);
+        $this->assertStringContainsString('{{ $title }}', $result);
+    }
+
+    public function testCompileSlotsReturnsEmptyStringWhenOnlyDefaultSlotIsPresent()
+    {
+        $component = new DynamicComponent('alert');
+
+        $method = new ReflectionMethod(DynamicComponent::class, 'compileSlots');
+        $result = $method->invoke($component, [
+            '__default' => (object) ['attributes' => new ComponentAttributeBag],
+        ]);
+
+        $this->assertSame('', $result);
+    }
+}


### PR DESCRIPTION
A few places chained two filter-family operations back to back (`reject()->reject()`, `reject()->filter()`, or `map()->map()`) where a single pass over the collection is enough:

- `ReflectsClosures::closureReturnTypes()` rejected twice
- `View\Component::extractPublicProperties()` rejected twice
- `Console\PromptsForMissingInput::promptForMissingArguments()` rejected then filtered
- `Foundation\PackageManifest::build()` rejected then filtered
- `View\DynamicComponent::compileSlots()` mapped a `__default` slot to `null` just to filter it back out — reordered to reject first instead
