### PR TITLE
[13.x] Prefer isEmpty()/isNotEmpty()/contains() over count() checks

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -126,7 +126,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      */
     public function mode($key = null)
     {
-        if ($this->count() === 0) {
+        if ($this->isEmpty()) {
             return;
         }
 

--- a/src/Illuminate/Console/Concerns/PromptsForMissingInput.php
+++ b/src/Illuminate/Console/Concerns/PromptsForMissingInput.php
@@ -103,7 +103,6 @@ trait PromptsForMissingInput
     protected function didReceiveOptions(InputInterface $input)
     {
         return (new Collection($this->getDefinition()->getOptions()))
-            ->reject(fn ($option) => $input->getOption($option->getName()) === $option->getDefault())
-            ->isNotEmpty();
+            ->contains(fn ($option) => $input->getOption($option->getName()) !== $option->getDefault());
     }
 }

--- a/src/Illuminate/Database/Console/ShowModelCommand.php
+++ b/src/Illuminate/Database/Console/ShowModelCommand.php
@@ -145,7 +145,7 @@ class ShowModelCommand extends DatabaseInspectionCommand implements PromptsForMi
 
         $this->components->twoColumnDetail('<fg=green;options=bold>Events</>');
 
-        if ($modelData->events->count()) {
+        if ($modelData->events->isNotEmpty()) {
             foreach ($modelData->events as $event) {
                 $this->components->twoColumnDetail(
                     sprintf('%s', $event['event']),
@@ -158,7 +158,7 @@ class ShowModelCommand extends DatabaseInspectionCommand implements PromptsForMi
 
         $this->components->twoColumnDetail('<fg=green;options=bold>Observers</>');
 
-        if ($modelData->observers->count()) {
+        if ($modelData->observers->isNotEmpty()) {
             foreach ($modelData->observers as $observer) {
                 $this->components->twoColumnDetail(
                     sprintf('%s', $observer['event']),

--- a/src/Illuminate/Foundation/Console/ChannelListCommand.php
+++ b/src/Illuminate/Foundation/Console/ChannelListCommand.php
@@ -48,11 +48,11 @@ class ChannelListCommand extends Command
             $this->components->warn('The [App\Providers\BroadcastServiceProvider] has not been loaded. Your private channels may not be loaded.');
         }
 
-        if (! $channels->count()) {
-            return $this->components->error("Your application doesn't have any private broadcasting channels.");
+        if ($channels->isEmpty()) {
+            $this->components->error("Your application doesn't have any private broadcasting channels.");
+        } else {
+            $this->displayChannels($channels);
         }
-
-        $this->displayChannels($channels);
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/DatabaseTransactionsManager.php
+++ b/src/Illuminate/Foundation/Testing/DatabaseTransactionsManager.php
@@ -34,7 +34,7 @@ class DatabaseTransactionsManager extends BaseManager
         // If there are no transactions, we'll run the callbacks right away. Also, we'll run it
         // right away when we're in test mode and we only have the wrapping transaction. For
         // every other case, we'll queue up the callback to run after the commit happens.
-        if ($this->callbackApplicableTransactions()->count() === 0) {
+        if ($this->callbackApplicableTransactions()->isEmpty()) {
             return $callback();
         }
 

--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -475,7 +475,7 @@ class Factory
     public function assertSent($callback)
     {
         PHPUnit::assertTrue(
-            $this->recorded($callback)->count() > 0,
+            $this->recorded($callback)->isNotEmpty(),
             'An expected request was not recorded.'
         );
     }
@@ -510,8 +510,8 @@ class Factory
      */
     public function assertNotSent($callback)
     {
-        PHPUnit::assertFalse(
-            $this->recorded($callback)->count() > 0,
+        PHPUnit::assertTrue(
+            $this->recorded($callback)->isEmpty(),
             'Unexpected request was recorded.'
         );
     }

--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -126,9 +126,9 @@ class BusFake implements Fake, QueueingDispatcher
         }
 
         PHPUnit::assertTrue(
-            $this->dispatched($command, $callback)->count() > 0 ||
-            $this->dispatchedAfterResponse($command, $callback)->count() > 0 ||
-            $this->dispatchedSync($command, $callback)->count() > 0,
+            $this->dispatched($command, $callback)->isNotEmpty() ||
+            $this->dispatchedAfterResponse($command, $callback)->isNotEmpty() ||
+            $this->dispatchedSync($command, $callback)->isNotEmpty(),
             "The expected [{$command}] job was not dispatched."
         );
     }
@@ -187,9 +187,9 @@ class BusFake implements Fake, QueueingDispatcher
         }
 
         PHPUnit::assertTrue(
-            $this->dispatched($command, $callback)->count() === 0 &&
-            $this->dispatchedAfterResponse($command, $callback)->count() === 0 &&
-            $this->dispatchedSync($command, $callback)->count() === 0,
+            $this->dispatched($command, $callback)->isEmpty() &&
+            $this->dispatchedAfterResponse($command, $callback)->isEmpty() &&
+            $this->dispatchedSync($command, $callback)->isEmpty(),
             "The unexpected [{$command}] job was dispatched."
         );
     }
@@ -226,7 +226,7 @@ class BusFake implements Fake, QueueingDispatcher
         }
 
         PHPUnit::assertTrue(
-            $this->dispatchedSync($command, $callback)->count() > 0,
+            $this->dispatchedSync($command, $callback)->isNotEmpty(),
             "The expected [{$command}] job was not dispatched synchronously."
         );
     }
@@ -295,7 +295,7 @@ class BusFake implements Fake, QueueingDispatcher
         }
 
         PHPUnit::assertTrue(
-            $this->dispatchedAfterResponse($command, $callback)->count() > 0,
+            $this->dispatchedAfterResponse($command, $callback)->isNotEmpty(),
             "The expected [{$command}] job was not dispatched after sending the response."
         );
     }
@@ -510,7 +510,7 @@ class BusFake implements Fake, QueueingDispatcher
         $callback = is_array($callback) ? fn (PendingBatchFake $batch) => $batch->hasJobs($callback) : $callback;
 
         PHPUnit::assertTrue(
-            $this->batched($callback)->count() > 0,
+            $this->batched($callback)->isNotEmpty(),
             'The expected batch was not dispatched.'
         );
     }

--- a/src/Illuminate/Support/Testing/Fakes/EventFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/EventFake.php
@@ -142,7 +142,7 @@ class EventFake implements Dispatcher, Fake
         }
 
         PHPUnit::assertTrue(
-            $this->dispatched($event, $callback)->count() > 0,
+            $this->dispatched($event, $callback)->isNotEmpty(),
             "The expected [{$event}] event was not dispatched."
         );
     }
@@ -347,12 +347,11 @@ class EventFake implements Dispatcher, Fake
         }
 
         return (new Collection($this->eventsToFake))
-            ->filter(function ($event) use ($eventName, $payload) {
+            ->contains(function ($event) use ($eventName, $payload) {
                 return $event instanceof Closure
                     ? $event($eventName, $payload)
                     : $event === $eventName;
-            })
-            ->isNotEmpty();
+            });
     }
 
     /**
@@ -387,12 +386,11 @@ class EventFake implements Dispatcher, Fake
         }
 
         return (new Collection($this->eventsToDispatch))
-            ->filter(function ($event) use ($eventName, $payload) {
+            ->contains(function ($event) use ($eventName, $payload) {
                 return $event instanceof Closure
                     ? $event($eventName, $payload)
                     : $event === $eventName;
-            })
-            ->isNotEmpty();
+            });
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -81,7 +81,7 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
                 $callback = fn ($mail) => $mail->hasTo($address);
 
                 PHPUnit::assertTrue(
-                    $this->sent($mailable, $callback)->count() > 0,
+                    $this->sent($mailable, $callback)->isNotEmpty(),
                     "The expected [{$mailable}] mailable was not sent to address [{$address}].".$suggestion
                 );
             }
@@ -90,7 +90,7 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
         }
 
         PHPUnit::assertTrue(
-            $this->sent($mailable, $callback)->count() > 0,
+            $this->sent($mailable, $callback)->isNotEmpty(),
             "The expected [{$mailable}] mailable was not sent.".$suggestion
         );
     }
@@ -204,7 +204,7 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
                 $callback = fn ($mail) => $mail->hasTo($address);
 
                 PHPUnit::assertTrue(
-                    $this->queued($mailable, $callback)->count() > 0,
+                    $this->queued($mailable, $callback)->isNotEmpty(),
                     "The expected [{$mailable}] mailable was not queued to address [{$address}]."
                 );
             }
@@ -213,7 +213,7 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
         }
 
         PHPUnit::assertTrue(
-            $this->queued($mailable, $callback)->count() > 0,
+            $this->queued($mailable, $callback)->isNotEmpty(),
             "The expected [{$mailable}] mailable was not queued."
         );
     }
@@ -361,7 +361,7 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
      */
     public function hasSent($mailable)
     {
-        return $this->mailablesOf($mailable)->count() > 0;
+        return $this->mailablesOf($mailable)->isNotEmpty();
     }
 
     /**
@@ -392,7 +392,7 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
      */
     public function hasQueued($mailable)
     {
-        return $this->queuedMailablesOf($mailable)->count() > 0;
+        return $this->queuedMailablesOf($mailable)->isNotEmpty();
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -87,7 +87,7 @@ class NotificationFake implements Fake, NotificationDispatcher, NotificationFact
         }
 
         PHPUnit::assertTrue(
-            $this->sent($notifiable, $notification, $callback)->count() > 0,
+            $this->sent($notifiable, $notification, $callback)->isNotEmpty(),
             "The expected [{$notification}] notification was not sent."
         );
     }

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -153,7 +153,7 @@ class QueueFake extends QueueManager implements Fake, Queue
         }
 
         PHPUnit::assertTrue(
-            $this->pushed($job, $callback)->count() > 0,
+            $this->pushed($job, $callback)->isNotEmpty(),
             "The expected [{$job}] job was not pushed."
         );
     }
@@ -285,16 +285,14 @@ class QueueFake extends QueueManager implements Fake, Queue
      */
     protected function assertPushedWithChainOfClasses($job, $expectedChain, $callback)
     {
-        $matching = $this->pushed($job, $callback)->map->chained->map(function ($chain) {
-            return (new Collection($chain))->map(function ($job) {
+        $matching = $this->pushed($job, $callback)->contains(function ($pushedJob) use ($expectedChain) {
+            return (new Collection($pushedJob->chained))->map(function ($job) {
                 return get_class(unserialize($job));
-            });
-        })->filter(function ($chain) use ($expectedChain) {
-            return $chain->all() === $expectedChain;
+            })->all() === $expectedChain;
         });
 
         PHPUnit::assertTrue(
-            $matching->isNotEmpty(), 'The expected chain was not pushed.'
+            $matching, 'The expected chain was not pushed.'
         );
     }
 

--- a/tests/Console/PromptsForMissingInputTest.php
+++ b/tests/Console/PromptsForMissingInputTest.php
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Input\InputOption;
 
 class PromptsForMissingInputTest extends TestCase
 {
-    public function testDidReceiveOptionsReturnsFalseWhenAllOptionsMatchTheirDefaults()
+    public function testDidReceiveOptionsReturnsFalseWhenAllOptionsMatchTheirDefaults(): void
     {
         $stub = $this->makeStub();
 
@@ -19,7 +19,7 @@ class PromptsForMissingInputTest extends TestCase
         $this->assertFalse($stub->didReceiveOptions($input));
     }
 
-    public function testDidReceiveOptionsReturnsTrueWhenAnOptionDiffersFromItsDefault()
+    public function testDidReceiveOptionsReturnsTrueWhenAnOptionDiffersFromItsDefault(): void
     {
         $stub = $this->makeStub();
 
@@ -36,7 +36,7 @@ class PromptsForMissingInputTest extends TestCase
                 didReceiveOptions as public;
             }
 
-            public function getDefinition()
+            public function getDefinition(): InputDefinition
             {
                 return new InputDefinition([
                     new InputOption('force', null, InputOption::VALUE_NONE),

--- a/tests/Console/PromptsForMissingInputTest.php
+++ b/tests/Console/PromptsForMissingInputTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Illuminate\Tests\Console;
+
+use Illuminate\Console\Concerns\PromptsForMissingInput;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\InputOption;
+
+class PromptsForMissingInputTest extends TestCase
+{
+    public function testDidReceiveOptionsReturnsFalseWhenAllOptionsMatchTheirDefaults()
+    {
+        $stub = $this->makeStub();
+
+        $input = new ArrayInput([], $stub->getDefinition());
+
+        $this->assertFalse($stub->didReceiveOptions($input));
+    }
+
+    public function testDidReceiveOptionsReturnsTrueWhenAnOptionDiffersFromItsDefault()
+    {
+        $stub = $this->makeStub();
+
+        $input = new ArrayInput(['--force' => true], $stub->getDefinition());
+
+        $this->assertTrue($stub->didReceiveOptions($input));
+    }
+
+    protected function makeStub()
+    {
+        return new class
+        {
+            use PromptsForMissingInput {
+                didReceiveOptions as public;
+            }
+
+            public function getDefinition()
+            {
+                return new InputDefinition([
+                    new InputOption('force', null, InputOption::VALUE_NONE),
+                    new InputOption('name', null, InputOption::VALUE_OPTIONAL, '', 'default-name'),
+                ]);
+            }
+        };
+    }
+}

--- a/tests/Foundation/Console/ChannelListCommandTest.php
+++ b/tests/Foundation/Console/ChannelListCommandTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\Console;
+
+use Illuminate\Console\Application;
+use Illuminate\Contracts\Broadcasting\Broadcaster as BroadcasterContract;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Foundation\Application as FoundationApplication;
+use Illuminate\Foundation\Console\ChannelListCommand;
+use Illuminate\Support\Collection;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class ChannelListCommandTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+
+        parent::tearDown();
+    }
+
+    public function testItDisplaysAnErrorWhenThereAreNoChannels()
+    {
+        $app = $this->makeApplication([]);
+
+        $app->call('channel:list');
+
+        $this->assertStringContainsString(
+            "doesn't have any private broadcasting channels", $app->output()
+        );
+    }
+
+    public function testItListsRegisteredChannels()
+    {
+        $app = $this->makeApplication([
+            'orders.{order}' => fn () => true,
+        ]);
+
+        $app->call('channel:list');
+
+        $output = $app->output();
+
+        $this->assertStringContainsString('orders.{order}', $output);
+        $this->assertStringContainsString('Showing [1] private channels', $output);
+    }
+
+    protected function makeApplication(array $channels)
+    {
+        $laravel = new FoundationApplication(__DIR__);
+
+        $broadcaster = m::mock(BroadcasterContract::class);
+        $broadcaster->shouldReceive('getChannels')->andReturn(new Collection($channels));
+
+        $laravel->instance(BroadcasterContract::class, $broadcaster);
+
+        $artisan = new Application(
+            $laravel,
+            m::mock(Dispatcher::class, ['dispatch' => null, 'fire' => null]),
+            'testing'
+        );
+
+        $command = new ChannelListCommand;
+        $command->setLaravel($laravel);
+
+        $artisan->addCommands([$command]);
+
+        return $artisan;
+    }
+}

--- a/tests/Foundation/Console/ChannelListCommandTest.php
+++ b/tests/Foundation/Console/ChannelListCommandTest.php
@@ -13,14 +13,7 @@ use PHPUnit\Framework\TestCase;
 
 class ChannelListCommandTest extends TestCase
 {
-    protected function tearDown(): void
-    {
-        m::close();
-
-        parent::tearDown();
-    }
-
-    public function testItDisplaysAnErrorWhenThereAreNoChannels()
+    public function testItDisplaysAnErrorWhenThereAreNoChannels(): void
     {
         $app = $this->makeApplication([]);
 
@@ -31,7 +24,7 @@ class ChannelListCommandTest extends TestCase
         );
     }
 
-    public function testItListsRegisteredChannels()
+    public function testItListsRegisteredChannels(): void
     {
         $app = $this->makeApplication([
             'orders.{order}' => fn () => true,
@@ -45,7 +38,7 @@ class ChannelListCommandTest extends TestCase
         $this->assertStringContainsString('Showing [1] private channels', $output);
     }
 
-    protected function makeApplication(array $channels)
+    protected function makeApplication(array $channels): Application
     {
         $laravel = new FoundationApplication(__DIR__);
 


### PR DESCRIPTION
- Swaps `->count()` / `->count() > 0` / `->count() === 0` used purely as a truthiness check for `->isEmpty()` / `->isNotEmpty()` across `Collection::mode()`, `DatabaseTransactionsManager`, `ShowModelCommand`, `ChannelListCommand`, `Http\Client\Factory`, and the testing Fakes (Bus, Event, Mail, Notification, Queue)
- Swaps `->filter()`/`->reject()` followed only by `->isNotEmpty()` for `->contains()` (or a negated `->contains()`), which can short-circuit on the first match instead of materializing the full filtered collection — notably `EventFake::shouldFakeEvent()`/`shouldDispatchEvent()`, which run on every event dispatch, and `PromptsForMissingInput::didReceiveOptions()`
- `QueueFake::assertPushedWithChainOfClasses()` collapses two `map()` passes plus a `filter()->isNotEmpty()` tail into a single `contains()`
