### PR TITLE
[13.x] Use Stringable::explode() instead of new Collection(explode())

### DIFF
--- a/src/Illuminate/Database/Concerns/CompilesJsonPaths.php
+++ b/src/Illuminate/Database/Concerns/CompilesJsonPaths.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Database\Concerns;
 
-use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use Illuminate\Support\Stringable;
 
 trait CompilesJsonPaths
 {
@@ -35,7 +35,7 @@ trait CompilesJsonPaths
     {
         $value = preg_replace("/([\\\\]+)?\\'/", "''", $value);
 
-        $jsonPath = (new Collection(explode($delimiter, $value)))
+        $jsonPath = (new Stringable($value))->explode($delimiter)
             ->map(fn ($segment) => $this->wrapJsonPathSegment($segment))
             ->join('.');
 

--- a/src/Illuminate/Database/Console/MonitorCommand.php
+++ b/src/Illuminate/Database/Console/MonitorCommand.php
@@ -5,7 +5,7 @@ namespace Illuminate\Database\Console;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Database\Events\DatabaseBusy;
-use Illuminate\Support\Collection;
+use Illuminate\Support\Stringable;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'db:monitor')]
@@ -79,7 +79,7 @@ class MonitorCommand extends DatabaseInspectionCommand
      */
     protected function parseDatabases($databases)
     {
-        return (new Collection(explode(',', $databases)))->map(function ($database) {
+        return (new Stringable($databases))->explode(',')->map(function ($database) {
             if (! $database) {
                 $database = $this->laravel['config']['database.default'];
             }

--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -4,6 +4,7 @@ namespace Illuminate\Database;
 
 use Illuminate\Contracts\Database\Query\Expression;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Stringable;
 use Illuminate\Support\Traits\Macroable;
 use RuntimeException;
 
@@ -67,7 +68,7 @@ abstract class Grammar
         if (str_contains($table, '.')) {
             $table = substr_replace($table, '.'.$prefix, strrpos($table, '.'), 1);
 
-            return (new Collection(explode('.', $table)))
+            return (new Stringable($table))->explode('.')
                 ->map($this->wrapValue(...))
                 ->implode('.');
         }

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\ColumnDefinition;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Fluent;
+use Illuminate\Support\Stringable;
 use RuntimeException;
 
 class MySqlGrammar extends Grammar
@@ -743,7 +744,7 @@ class MySqlGrammar extends Grammar
     public function escapeNames($names)
     {
         return array_map(
-            fn ($name) => (new Collection(explode('.', $name)))->map($this->wrapValue(...))->implode('.'),
+            fn ($name) => (new Stringable($name))->explode('.')->map($this->wrapValue(...))->implode('.'),
             $names
         );
     }

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -4,8 +4,8 @@ namespace Illuminate\Database\Schema\Grammars;
 
 use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Collection;
 use Illuminate\Support\Fluent;
+use Illuminate\Support\Stringable;
 use LogicException;
 
 class PostgresGrammar extends Grammar
@@ -758,7 +758,7 @@ class PostgresGrammar extends Grammar
     public function escapeNames($names)
     {
         return array_map(
-            fn ($name) => (new Collection(explode('.', $name)))->map($this->wrapValue(...))->implode('.'),
+            fn ($name) => (new Stringable($name))->explode('.')->map($this->wrapValue(...))->implode('.'),
             $names
         );
     }

--- a/src/Illuminate/Foundation/Console/AboutCommand.php
+++ b/src/Illuminate/Foundation/Console/AboutCommand.php
@@ -332,7 +332,7 @@ class AboutCommand extends Command
      */
     protected function sections()
     {
-        return (new Collection(explode(',', $this->option('only') ?? '')))
+        return (new Stringable($this->option('only') ?? ''))->explode(',')
             ->filter()
             ->map(fn ($only) => $this->toSearchKeyword($only))
             ->all();

--- a/src/Illuminate/Foundation/Console/MailMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/MailMakeCommand.php
@@ -5,8 +5,8 @@ namespace Illuminate\Foundation\Console;
 use Illuminate\Console\Concerns\CreatesMatchingTest;
 use Illuminate\Console\GeneratorCommand;
 use Illuminate\Foundation\Inspiring;
-use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use Illuminate\Support\Stringable;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -168,7 +168,7 @@ class MailMakeCommand extends GeneratorCommand
         if (! $view) {
             $name = str_replace('\\', '/', $this->argument('name'));
 
-            $view = 'mail.'.(new Collection(explode('/', $name)))
+            $view = 'mail.'.(new Stringable($name))->explode('/')
                 ->map(fn ($part) => Str::kebab($part))
                 ->implode('.');
         }

--- a/src/Illuminate/Foundation/Console/NotificationMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/NotificationMakeCommand.php
@@ -4,8 +4,8 @@ namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Concerns\CreatesMatchingTest;
 use Illuminate\Console\GeneratorCommand;
-use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use Illuminate\Support\Stringable;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -153,7 +153,7 @@ class NotificationMakeCommand extends GeneratorCommand
         $wantsMarkdownView = confirm('Would you like to create a markdown view?');
 
         if ($wantsMarkdownView) {
-            $defaultMarkdownView = (new Collection(explode('/', str_replace('\\', '/', $this->argument('name')))))
+            $defaultMarkdownView = (new Stringable($this->argument('name')))->replace('\\', '/')->explode('/')
                 ->map(fn ($path) => Str::kebab($path))
                 ->prepend('mail')
                 ->implode('.');

--- a/src/Illuminate/Foundation/Console/OptimizeClearCommand.php
+++ b/src/Illuminate/Foundation/Console/OptimizeClearCommand.php
@@ -5,6 +5,7 @@ namespace Illuminate\Foundation\Console;
 use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Stringable;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'optimize:clear')]
@@ -33,7 +34,7 @@ class OptimizeClearCommand extends Command
     {
         $this->components->info('Clearing cached bootstrap files.');
 
-        $exceptions = Collection::wrap(explode(',', $this->option('except') ?? ''))
+        $exceptions = (new Stringable($this->option('except') ?? ''))->explode(',')
             ->map(fn ($except) => trim($except))
             ->filter()
             ->unique()

--- a/src/Illuminate/Foundation/Console/OptimizeCommand.php
+++ b/src/Illuminate/Foundation/Console/OptimizeCommand.php
@@ -5,6 +5,7 @@ namespace Illuminate\Foundation\Console;
 use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Stringable;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'optimize')]
@@ -33,7 +34,7 @@ class OptimizeCommand extends Command
     {
         $this->components->info('Caching framework bootstrap, configuration, and metadata.');
 
-        $exceptions = Collection::wrap(explode(',', $this->option('except') ?? ''))
+        $exceptions = (new Stringable($this->option('except') ?? ''))->explode(',')
             ->map(fn ($except) => trim($except))
             ->filter()
             ->unique()

--- a/src/Illuminate/Foundation/Console/ReloadCommand.php
+++ b/src/Illuminate/Foundation/Console/ReloadCommand.php
@@ -5,6 +5,7 @@ namespace Illuminate\Foundation\Console;
 use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Stringable;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'reload')]
@@ -33,7 +34,7 @@ class ReloadCommand extends Command
     {
         $this->components->info('Reloading services.');
 
-        $exceptions = Collection::wrap(explode(',', $this->option('except') ?? ''))
+        $exceptions = (new Stringable($this->option('except') ?? ''))->explode(',')
             ->map(fn ($except) => trim($except))
             ->filter()
             ->unique()

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -495,7 +495,7 @@ class RouteListCommand extends Command
         $actionClass = explode('@', $action)[0];
 
         if (class_exists($actionClass) && str_starts_with((new ReflectionClass($actionClass))->getFilename(), base_path('vendor'))) {
-            $actionCollection = new Collection(explode('\\', $action));
+            $actionCollection = (new Stringable($action))->explode('\\');
 
             return $name.$actionCollection->take(2)->implode('\\').'   '.$actionCollection->last();
         }

--- a/src/Illuminate/Http/Middleware/SetCacheHeaders.php
+++ b/src/Illuminate/Http/Middleware/SetCacheHeaders.php
@@ -6,6 +6,7 @@ use Closure;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use Illuminate\Support\Stringable;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
@@ -88,7 +89,7 @@ class SetCacheHeaders
      */
     protected function parseOptions($options)
     {
-        return (new Collection(explode(';', rtrim($options, ';'))))->mapWithKeys(function ($option) {
+        return (new Stringable(rtrim($options, ';')))->explode(';')->mapWithKeys(function ($option) {
             $data = explode('=', $option, 2);
 
             return [$data[0] => $data[1] ?? true];

--- a/src/Illuminate/Queue/Console/ClearCommand.php
+++ b/src/Illuminate/Queue/Console/ClearCommand.php
@@ -65,7 +65,7 @@ class ClearCommand extends Command
 
         $count = 0;
 
-        $queues = collect(explode(',', $queueName))
+        $queues = (new Stringable($queueName))->explode(',')
             ->map(fn ($queue) => trim($queue))
             ->filter()
             ->unique()

--- a/src/Illuminate/Queue/Console/MonitorCommand.php
+++ b/src/Illuminate/Queue/Console/MonitorCommand.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Queue\Factory;
 use Illuminate\Queue\Events\QueueBusy;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Stringable;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'queue:monitor')]
@@ -88,7 +89,7 @@ class MonitorCommand extends Command
      */
     protected function parseQueues($queues)
     {
-        return (new Collection(explode(',', $queues)))->map(function ($queue) {
+        return (new Stringable($queues))->explode(',')->map(function ($queue) {
             [$connection, $queue] = array_pad(explode(':', $queue, 2), 2, null);
 
             if (! isset($queue)) {

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -9,9 +9,9 @@ use Illuminate\Contracts\Routing\UrlRoutable;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
-use Illuminate\Support\Collection;
 use Illuminate\Support\InteractsWithTime;
 use Illuminate\Support\Str;
+use Illuminate\Support\Stringable;
 use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
@@ -461,7 +461,7 @@ class UrlGenerator implements UrlGeneratorContract
     {
         $url = $absolute ? $request->url() : '/'.$request->path();
 
-        $queryString = (new Collection(explode('&', (string) $request->server->get('QUERY_STRING'))))
+        $queryString = (new Stringable((string) $request->server->get('QUERY_STRING')))->explode('&')
             ->reject(function ($parameter) use ($ignoreQuery) {
                 $parameter = Str::before($parameter, '=');
 

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -790,7 +790,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
 
         if (is_null($alias)) {
             $alias = str_contains($class, '\\View\\Components\\')
-                ? (new Collection(explode('\\', Str::after($class, '\\View\\Components\\'))))
+                ? (new Stringable($class))->after('\\View\\Components\\')->explode('\\')
                     ->map(fn ($segment) => Str::kebab($segment))
                     ->implode(':')
                 : Str::kebab(class_basename($class));


### PR DESCRIPTION
Replaces `new Collection(explode(...))`, `Collection::wrap(explode(...))`, and `collect(explode(...))` with `(new Stringable(...))->explode(...)` across 17 files. Same underlying behavior, reads as splitting a string rather than wrapping an array.
