### PR TITLE
[13.x] Remove redundant m::close()

### DIFF
--- a/tests/Queue/QueueClearCommandTest.php
+++ b/tests/Queue/QueueClearCommandTest.php
@@ -14,13 +14,6 @@ use Symfony\Component\Console\Output\BufferedOutput;
 
 class QueueClearCommandTest extends TestCase
 {
-    protected function tearDown(): void
-    {
-        m::close();
-
-        parent::tearDown();
-    }
-
     public function testClearingDefaultQueue()
     {
         $queue = m::mock(ClearableQueue::class);


### PR DESCRIPTION
`Mockery::close()` is already invoked globally after every test by `AfterEachTestSubscriber` (`tests/AfterEachTestSubscriber.php`), so the local `tearDown()` in `QueueClearCommandTest` calling `m::close()` is redundant.