### PR TITLE
[13.x] Remove dead parent::setUp()/tearDown() calls in tests

### DIFF
--- a/tests/Auth/AuthenticateMiddlewareTest.php
+++ b/tests/Auth/AuthenticateMiddlewareTest.php
@@ -34,8 +34,6 @@ class AuthenticateMiddlewareTest extends TestCase
     protected function tearDown(): void
     {
         Container::setInstance(null);
-
-        parent::tearDown();
     }
 
     public function testItCanGenerateDefinitionViaStaticMethod()

--- a/tests/Auth/AuthorizeMiddlewareTest.php
+++ b/tests/Auth/AuthorizeMiddlewareTest.php
@@ -29,8 +29,6 @@ class AuthorizeMiddlewareTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->user = new stdClass;
 
         Container::setInstance($this->container = new Container);
@@ -51,8 +49,6 @@ class AuthorizeMiddlewareTest extends TestCase
     protected function tearDown(): void
     {
         Container::setInstance(null);
-
-        parent::tearDown();
     }
 
     public function testItCanGenerateDefinitionViaStaticMethod()

--- a/tests/Broadcasting/AblyBroadcasterTest.php
+++ b/tests/Broadcasting/AblyBroadcasterTest.php
@@ -20,8 +20,6 @@ class AblyBroadcasterTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->ably = m::mock(AblyRest::class, ['abcd:efgh']);
 
         $this->broadcaster = m::mock(AblyBroadcaster::class, [$this->ably])->makePartial();

--- a/tests/Broadcasting/BroadcasterTest.php
+++ b/tests/Broadcasting/BroadcasterTest.php
@@ -23,16 +23,12 @@ class BroadcasterTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->broadcaster = new FakeBroadcaster;
     }
 
     protected function tearDown(): void
     {
         Container::setInstance(null);
-
-        parent::tearDown();
     }
 
     public function testExtractingParametersWhileCheckingForUserAccess()

--- a/tests/Broadcasting/PusherBroadcasterTest.php
+++ b/tests/Broadcasting/PusherBroadcasterTest.php
@@ -19,8 +19,6 @@ class PusherBroadcasterTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->pusher = m::mock('Pusher\Pusher');
         $this->broadcaster = m::mock(PusherBroadcaster::class, [$this->pusher])->makePartial();
     }

--- a/tests/Broadcasting/RedisBroadcasterTest.php
+++ b/tests/Broadcasting/RedisBroadcasterTest.php
@@ -19,8 +19,6 @@ class RedisBroadcasterTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->broadcaster = m::mock(RedisBroadcaster::class)->makePartial();
         $container = Container::setInstance(new Container);
 

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -121,8 +121,6 @@ class BusBatchTest extends TestCase
         unset($_SERVER['__finally.batch'], $_SERVER['__progress.batch'], $_SERVER['__then.batch'], $_SERVER['__catch.batch'], $_SERVER['__catch.exception']);
 
         $this->schema()->drop('job_batches');
-
-        parent::tearDown();
     }
 
     public function test_jobs_can_be_added_to_the_batch()

--- a/tests/Bus/BusPendingDispatchTest.php
+++ b/tests/Bus/BusPendingDispatchTest.php
@@ -29,8 +29,6 @@ class BusPendingDispatchTest extends TestCase
     {
         $this->job = m::mock(stdClass::class);
         $this->pendingDispatch = new PendingDispatchWithoutDestructor($this->job);
-
-        parent::setUp();
     }
 
     public function testOnConnection()

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -32,16 +32,12 @@ class CacheRepositoryTest extends TestCase
 {
     protected function setUp(): void
     {
-        parent::setUp();
-
         Carbon::setTestNow(Carbon::parse(self::getTestDate()));
     }
 
     protected function tearDown(): void
     {
         Repository::handleUnserializableClassUsing(null);
-
-        parent::tearDown();
     }
 
     public function testGetReturnsValueFromCache()

--- a/tests/Cache/CacheSpyMemoTest.php
+++ b/tests/Cache/CacheSpyMemoTest.php
@@ -16,8 +16,6 @@ class CacheSpyMemoTest extends TestCase
 {
     protected function setUp(): void
     {
-        parent::setUp();
-
         $container = new Container;
 
         $container->instance('config', new ConfigRepository([
@@ -40,8 +38,6 @@ class CacheSpyMemoTest extends TestCase
     {
         Facade::clearResolvedInstances();
         Facade::setFacadeApplication(null);
-
-        parent::tearDown();
     }
 
     public function test_cache_spy_works_with_memoized_cache()

--- a/tests/Cache/ClearCommandTest.php
+++ b/tests/Cache/ClearCommandTest.php
@@ -41,8 +41,6 @@ class ClearCommandTest extends TestCase
      */
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->cacheManager = m::mock(CacheManager::class);
         $this->files = m::mock(Filesystem::class);
         $this->cacheRepository = m::mock(Repository::class);

--- a/tests/Cache/ConcurrencyLimiterTest.php
+++ b/tests/Cache/ConcurrencyLimiterTest.php
@@ -19,8 +19,6 @@ class ConcurrencyLimiterTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->repository = new Repository(new ArrayStore);
     }
 

--- a/tests/Config/RepositoryTest.php
+++ b/tests/Config/RepositoryTest.php
@@ -45,8 +45,6 @@ class RepositoryTest extends TestCase
                 'b.c' => 'd',
             ],
         ]);
-
-        parent::setUp();
     }
 
     public function testGetValueWhenKeyContainDot()

--- a/tests/Console/ConsoleApplicationTest.php
+++ b/tests/Console/ConsoleApplicationTest.php
@@ -33,8 +33,6 @@ class ConsoleApplicationTest extends TestCase
     protected function tearDown(): void
     {
         $this->tearDownTheTestEnvironmentUsingMockery();
-
-        parent::tearDown();
     }
 
     public function testAddSetsLaravelInstance()

--- a/tests/Console/ConsoleEventSchedulerTest.php
+++ b/tests/Console/ConsoleEventSchedulerTest.php
@@ -22,8 +22,6 @@ class ConsoleEventSchedulerTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $container = Container::getInstance();
 
         $container->instance(EventMutex::class, m::mock(CacheEventMutex::class));

--- a/tests/Console/ConsoleScheduledEventTest.php
+++ b/tests/Console/ConsoleScheduledEventTest.php
@@ -27,8 +27,6 @@ class ConsoleScheduledEventTest extends TestCase
     protected function tearDown(): void
     {
         date_default_timezone_set($this->defaultTimezone);
-
-        parent::tearDown();
     }
 
     public function testBasicCronCompilation()

--- a/tests/Console/Scheduling/CacheEventMutexTest.php
+++ b/tests/Console/Scheduling/CacheEventMutexTest.php
@@ -34,8 +34,6 @@ class CacheEventMutexTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->cacheFactory = m::mock(Factory::class);
         $this->cacheRepository = m::mock(Repository::class);
         $this->cacheFactory->shouldReceive('store')->andReturn($this->cacheRepository);

--- a/tests/Console/Scheduling/CacheSchedulingMutexTest.php
+++ b/tests/Console/Scheduling/CacheSchedulingMutexTest.php
@@ -41,8 +41,6 @@ class CacheSchedulingMutexTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->cacheFactory = m::mock(Factory::class);
         $this->cacheRepository = m::mock(Repository::class);
         $this->cacheFactory->shouldReceive('store')->andReturn($this->cacheRepository);

--- a/tests/Console/Scheduling/ScheduleTest.php
+++ b/tests/Console/Scheduling/ScheduleTest.php
@@ -22,8 +22,6 @@ final class ScheduleTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->container = new Container;
         Container::setInstance($this->container);
         $eventMutex = m::mock(EventMutex::class);

--- a/tests/Console/Scheduling/ScheduleWorkCommandTest.php
+++ b/tests/Console/Scheduling/ScheduleWorkCommandTest.php
@@ -28,8 +28,6 @@ class ScheduleWorkCommandTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->originalAvailabilityResolver = (new ReflectionProperty(Signals::class, 'availabilityResolver'))
             ->getValue();
 
@@ -39,8 +37,6 @@ class ScheduleWorkCommandTest extends TestCase
     protected function tearDown(): void
     {
         Signals::resolveAvailabilityUsing($this->originalAvailabilityResolver);
-
-        parent::tearDown();
     }
 
     public function test_stop_signal_marks_the_worker_to_quit()

--- a/tests/Console/SignalsTest.php
+++ b/tests/Console/SignalsTest.php
@@ -23,8 +23,6 @@ class SignalsTest extends TestCase
     protected function tearDown(): void
     {
         $this->state = null;
-
-        parent::tearDown();
     }
 
     public function testRegister()

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -21,8 +21,6 @@ class ContainerTest extends TestCase
 {
     protected function setUp(): void
     {
-        parent::setUp();
-
         if (version_compare(PHP_VERSION, '8.5.0', '>=')) {
             require_once __DIR__.'/Fixtures/ContainerBindWhenFixtures.php';
         }
@@ -31,8 +29,6 @@ class ContainerTest extends TestCase
     protected function tearDown(): void
     {
         Container::setInstance(null);
-
-        parent::tearDown();
     }
 
     public function testContainerSingleton()

--- a/tests/Cookie/Middleware/EncryptCookiesTest.php
+++ b/tests/Cookie/Middleware/EncryptCookiesTest.php
@@ -34,8 +34,6 @@ class EncryptCookiesTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->container = new Container;
         $this->container->singleton(EncrypterContract::class, function () {
             return new Encrypter(str_repeat('a', 16));

--- a/tests/Database/DatabaseConcernsPreventsCircularRecursionTest.php
+++ b/tests/Database/DatabaseConcernsPreventsCircularRecursionTest.php
@@ -10,8 +10,6 @@ class DatabaseConcernsPreventsCircularRecursionTest extends TestCase
 {
     protected function setUp(): void
     {
-        parent::setUp();
-
         PreventsCircularRecursionWithRecursiveMethod::$globalStack = 0;
     }
 

--- a/tests/Database/DatabaseEloquentAsBinaryCastTest.php
+++ b/tests/Database/DatabaseEloquentAsBinaryCastTest.php
@@ -17,8 +17,6 @@ class DatabaseEloquentAsBinaryCastTest extends TestCase
         $reflection = new \ReflectionClass(BinaryCodec::class);
         $property = $reflection->getProperty('customCodecs');
         $property->setValue(null, []);
-
-        parent::tearDown();
     }
 
     public function testCastThrowsWhenFormatMissing()

--- a/tests/Database/DatabaseEloquentBelongsToManyAggregateTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyAggregateTest.php
@@ -103,8 +103,6 @@ class DatabaseEloquentBelongsToManyAggregateTest extends TestCase
     {
         $this->schema()->drop('orders');
         $this->schema()->drop('products');
-
-        parent::tearDown();
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBelongsToManyChunkByIdTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyChunkByIdTest.php
@@ -90,8 +90,6 @@ class DatabaseEloquentBelongsToManyChunkByIdTest extends TestCase
         $this->schema()->drop('users');
         $this->schema()->drop('articles');
         $this->schema()->drop('article_user');
-
-        parent::tearDown();
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBelongsToManyEachByIdTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyEachByIdTest.php
@@ -74,8 +74,6 @@ class DatabaseEloquentBelongsToManyEachByIdTest extends TestCase
         $this->schema()->drop('users');
         $this->schema()->drop('articles');
         $this->schema()->drop('article_user');
-
-        parent::tearDown();
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBelongsToManyExpressionTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyExpressionTest.php
@@ -106,8 +106,6 @@ class DatabaseEloquentBelongsToManyExpressionTest extends TestCase
         $this->schema()->drop('posts');
         $this->schema()->drop('tags');
         $this->schema()->drop('taggables');
-
-        parent::tearDown();
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBelongsToManyLazyByIdTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyLazyByIdTest.php
@@ -73,8 +73,6 @@ class DatabaseEloquentBelongsToManyLazyByIdTest extends TestCase
         $this->schema()->drop('users');
         $this->schema()->drop('articles');
         $this->schema()->drop('article_user');
-
-        parent::tearDown();
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBelongsToManySyncReturnValueTypeTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManySyncReturnValueTypeTest.php
@@ -61,8 +61,6 @@ class DatabaseEloquentBelongsToManySyncReturnValueTypeTest extends TestCase
         $this->schema()->drop('users');
         $this->schema()->drop('articles');
         $this->schema()->drop('article_user');
-
-        parent::tearDown();
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBelongsToManySyncTouchesParentTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManySyncTouchesParentTest.php
@@ -65,8 +65,6 @@ class DatabaseEloquentBelongsToManySyncTouchesParentTest extends TestCase
         $this->schema()->drop('users');
         $this->schema()->drop('articles');
         $this->schema()->drop('article_user');
-
-        parent::tearDown();
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBelongsToManyWithAttributesPendingTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyWithAttributesPendingTest.php
@@ -177,8 +177,6 @@ class DatabaseEloquentBelongsToManyWithAttributesPendingTest extends TestCase
         $this->schema()->drop('pending_attributes_posts');
         $this->schema()->drop('pending_attributes_tags');
         $this->schema()->drop('pending_attributes_pivot');
-
-        parent::tearDown();
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBelongsToManyWithAttributesTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyWithAttributesTest.php
@@ -184,8 +184,6 @@ class DatabaseEloquentBelongsToManyWithAttributesTest extends TestCase
         $this->schema()->drop('with_attributes_posts');
         $this->schema()->drop('with_attributes_tags');
         $this->schema()->drop('with_attributes_pivot');
-
-        parent::tearDown();
     }
 
     /**

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -63,8 +63,6 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->schema()->drop('users');
         $this->schema()->drop('articles');
         $this->schema()->drop('comments');
-
-        parent::tearDown();
     }
 
     public function testAddingItemsToCollection()

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -105,8 +105,6 @@ class DatabaseEloquentFactoryTest extends TestCase
         $this->schema()->drop('users');
 
         Container::setInstance(null);
-
-        parent::tearDown();
     }
 
     public function test_basic_model_can_be_created()

--- a/tests/Database/DatabaseEloquentGlobalScopesTest.php
+++ b/tests/Database/DatabaseEloquentGlobalScopesTest.php
@@ -13,8 +13,6 @@ class DatabaseEloquentGlobalScopesTest extends TestCase
 {
     protected function setUp(): void
     {
-        parent::setUp();
-
         tap(new DB)->addConnection([
             'driver' => 'sqlite',
             'database' => ':memory:',
@@ -24,8 +22,6 @@ class DatabaseEloquentGlobalScopesTest extends TestCase
     protected function tearDown(): void
     {
         Model::unsetConnectionResolver();
-
-        parent::tearDown();
     }
 
     public function testGlobalScopeIsApplied()

--- a/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
@@ -70,8 +70,6 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
         $this->schema()->drop('users');
         $this->schema()->drop('posts');
         $this->schema()->drop('countries');
-
-        parent::tearDown();
     }
 
     public function testItLoadsAHasManyThroughRelationWithCustomKeys()

--- a/tests/Database/DatabaseEloquentHasOneOfManyTest.php
+++ b/tests/Database/DatabaseEloquentHasOneOfManyTest.php
@@ -69,8 +69,6 @@ class DatabaseEloquentHasOneOfManyTest extends TestCase
         $this->schema()->drop('logins');
         $this->schema()->drop('states');
         $this->schema()->drop('prices');
-
-        parent::tearDown();
     }
 
     public function testItGuessesRelationName()

--- a/tests/Database/DatabaseEloquentHasOneThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasOneThroughIntegrationTest.php
@@ -68,8 +68,6 @@ class DatabaseEloquentHasOneThroughIntegrationTest extends TestCase
         $this->schema()->drop('users');
         $this->schema()->drop('contracts');
         $this->schema()->drop('positions');
-
-        parent::tearDown();
     }
 
     public function testItLoadsAHasOneThroughRelationWithCustomKeys()

--- a/tests/Database/DatabaseEloquentHasOneThroughOfManyTest.php
+++ b/tests/Database/DatabaseEloquentHasOneThroughOfManyTest.php
@@ -67,8 +67,6 @@ class DatabaseEloquentHasOneThroughOfManyTest extends TestCase
         $this->schema()->drop('logins');
         $this->schema()->drop('states');
         $this->schema()->drop('prices');
-
-        parent::tearDown();
     }
 
     public function testItGuessesRelationName(): void

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -207,8 +207,6 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
         Str::createUuidsNormally();
         DB::flushQueryLog();
-
-        parent::tearDown();
     }
 
     /**

--- a/tests/Database/DatabaseEloquentIntegrationWithTablePrefixTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationWithTablePrefixTest.php
@@ -76,8 +76,6 @@ class DatabaseEloquentIntegrationWithTablePrefixTest extends TestCase
         }
 
         Relation::morphMap([], false);
-
-        parent::tearDown();
     }
 
     public function testBasicModelHydration()

--- a/tests/Database/DatabaseEloquentInverseRelationHasManyTest.php
+++ b/tests/Database/DatabaseEloquentInverseRelationHasManyTest.php
@@ -56,8 +56,6 @@ class DatabaseEloquentInverseRelationHasManyTest extends TestCase
     {
         $this->schema()->drop('test_users');
         $this->schema()->drop('test_posts');
-
-        parent::tearDown();
     }
 
     public function testHasManyInverseRelationIsProperlySetToParentWhenLazyLoaded()

--- a/tests/Database/DatabaseEloquentInverseRelationHasOneTest.php
+++ b/tests/Database/DatabaseEloquentInverseRelationHasOneTest.php
@@ -55,8 +55,6 @@ class DatabaseEloquentInverseRelationHasOneTest extends TestCase
     {
         $this->schema()->drop('test_parent');
         $this->schema()->drop('test_child');
-
-        parent::tearDown();
     }
 
     public function testHasOneInverseRelationIsProperlySetToParentWhenLazyLoaded()

--- a/tests/Database/DatabaseEloquentInverseRelationMorphManyTest.php
+++ b/tests/Database/DatabaseEloquentInverseRelationMorphManyTest.php
@@ -56,8 +56,6 @@ class DatabaseEloquentInverseRelationMorphManyTest extends TestCase
     {
         $this->schema()->drop('test_posts');
         $this->schema()->drop('test_comments');
-
-        parent::tearDown();
     }
 
     public function testMorphManyInverseRelationIsProperlySetToParentWhenLazyLoaded()

--- a/tests/Database/DatabaseEloquentInverseRelationMorphOneTest.php
+++ b/tests/Database/DatabaseEloquentInverseRelationMorphOneTest.php
@@ -55,8 +55,6 @@ class DatabaseEloquentInverseRelationMorphOneTest extends TestCase
     {
         $this->schema()->drop('test_posts');
         $this->schema()->drop('test_images');
-
-        parent::tearDown();
     }
 
     public function testMorphOneInverseRelationIsProperlySetToParentWhenLazyLoaded()

--- a/tests/Database/DatabaseEloquentIrregularPluralTest.php
+++ b/tests/Database/DatabaseEloquentIrregularPluralTest.php
@@ -58,8 +58,6 @@ class DatabaseEloquentIrregularPluralTest extends TestCase
         $this->schema()->drop('irregular_plural_tokens');
         $this->schema()->drop('irregular_plural_humans');
         $this->schema()->drop('irregular_plural_human_irregular_plural_token');
-
-        parent::tearDown();
     }
 
     protected function schema()

--- a/tests/Database/DatabaseEloquentLocalScopesTest.php
+++ b/tests/Database/DatabaseEloquentLocalScopesTest.php
@@ -10,8 +10,6 @@ class DatabaseEloquentLocalScopesTest extends TestCase
 {
     protected function setUp(): void
     {
-        parent::setUp();
-
         tap(new DB)->addConnection([
             'driver' => 'sqlite',
             'database' => ':memory:',
@@ -21,8 +19,6 @@ class DatabaseEloquentLocalScopesTest extends TestCase
     protected function tearDown(): void
     {
         Model::unsetConnectionResolver();
-
-        parent::tearDown();
     }
 
     public function testCanCheckExistenceOfLocalScope()

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -75,8 +75,6 @@ class DatabaseEloquentModelTest extends TestCase
     {
         Model::unsetEventDispatcher();
         Carbon::resetToStringFormat();
-
-        parent::tearDown();
     }
 
     public function testAttributeManipulation()

--- a/tests/Database/DatabaseEloquentMorphOneOfManyTest.php
+++ b/tests/Database/DatabaseEloquentMorphOneOfManyTest.php
@@ -51,8 +51,6 @@ class DatabaseEloquentMorphOneOfManyTest extends TestCase
     {
         $this->schema()->drop('products');
         $this->schema()->drop('states');
-
-        parent::tearDown();
     }
 
     public function testEagerLoadingAppliesConstraintsToInnerJoinSubQuery()

--- a/tests/Database/DatabaseEloquentMorphTest.php
+++ b/tests/Database/DatabaseEloquentMorphTest.php
@@ -19,8 +19,6 @@ class DatabaseEloquentMorphTest extends TestCase
     protected function tearDown(): void
     {
         Relation::morphMap([], false);
-
-        parent::tearDown();
     }
 
     public function testMorphOneSetsProperConstraints()

--- a/tests/Database/DatabaseEloquentPolymorphicIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentPolymorphicIntegrationTest.php
@@ -71,8 +71,6 @@ class DatabaseEloquentPolymorphicIntegrationTest extends TestCase
         $this->schema()->drop('users');
         $this->schema()->drop('posts');
         $this->schema()->drop('comments');
-
-        parent::tearDown();
     }
 
     public function testItLoadsRelationshipsAutomatically()

--- a/tests/Database/DatabaseEloquentPolymorphicRelationsIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentPolymorphicRelationsIntegrationTest.php
@@ -68,8 +68,6 @@ class DatabaseEloquentPolymorphicRelationsIntegrationTest extends TestCase
         }
 
         Relation::morphMap([], false);
-
-        parent::tearDown();
     }
 
     public function testCreation()

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -21,8 +21,6 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
 {
     protected function setUp(): void
     {
-        parent::setUp();
-
         $db = new DB;
 
         $db->addConnection([
@@ -97,8 +95,6 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $this->schema()->drop('users');
         $this->schema()->drop('posts');
         $this->schema()->drop('comments');
-
-        parent::tearDown();
     }
 
     /**

--- a/tests/Database/DatabaseEloquentStrictMorphsTest.php
+++ b/tests/Database/DatabaseEloquentStrictMorphsTest.php
@@ -12,8 +12,6 @@ class DatabaseEloquentStrictMorphsTest extends TestCase
 {
     protected function setUp(): void
     {
-        parent::setUp();
-
         Relation::requireMorphMap();
     }
 
@@ -72,8 +70,6 @@ class DatabaseEloquentStrictMorphsTest extends TestCase
     {
         Relation::morphMap([], false);
         Relation::requireMorphMap(false);
-
-        parent::tearDown();
     }
 }
 

--- a/tests/Database/DatabaseEloquentTimestampsTest.php
+++ b/tests/Database/DatabaseEloquentTimestampsTest.php
@@ -12,8 +12,6 @@ class DatabaseEloquentTimestampsTest extends TestCase
 {
     protected function setUp(): void
     {
-        parent::setUp();
-
         $db = new DB;
 
         $db->addConnection([
@@ -63,8 +61,6 @@ class DatabaseEloquentTimestampsTest extends TestCase
         $this->schema()->drop('users');
         $this->schema()->drop('users_created_at');
         $this->schema()->drop('users_updated_at');
-
-        parent::tearDown();
     }
 
     /**

--- a/tests/Database/DatabaseEloquentWithAttributesPendingTest.php
+++ b/tests/Database/DatabaseEloquentWithAttributesPendingTest.php
@@ -25,8 +25,6 @@ class DatabaseEloquentWithAttributesPendingTest extends TestCase
     protected function tearDown(): void
     {
         $this->schema()->dropIfExists((new PendingAttributesModel)->getTable());
-
-        parent::tearDown();
     }
 
     public function testAddsAttributes(): void

--- a/tests/Database/DatabaseEloquentWithAttributesTest.php
+++ b/tests/Database/DatabaseEloquentWithAttributesTest.php
@@ -25,8 +25,6 @@ class DatabaseEloquentWithAttributesTest extends TestCase
     protected function tearDown(): void
     {
         $this->schema()->dropIfExists((new WithAttributesModel)->getTable());
-
-        parent::tearDown();
     }
 
     public function testAddsAttributes(): void

--- a/tests/Database/DatabaseEloquentWithCastsTest.php
+++ b/tests/Database/DatabaseEloquentWithCastsTest.php
@@ -13,8 +13,6 @@ class DatabaseEloquentWithCastsTest extends TestCase
 {
     protected function setUp(): void
     {
-        parent::setUp();
-
         $db = new DB;
 
         $db->addConnection([

--- a/tests/Database/DatabaseMigrationRefreshCommandTest.php
+++ b/tests/Database/DatabaseMigrationRefreshCommandTest.php
@@ -20,8 +20,6 @@ class DatabaseMigrationRefreshCommandTest extends TestCase
     protected function tearDown(): void
     {
         RefreshCommand::prohibit(false);
-
-        parent::tearDown();
     }
 
     public function testRefreshCommandCallsCommandsWithProperArguments()

--- a/tests/Database/DatabaseMigrationResetCommandTest.php
+++ b/tests/Database/DatabaseMigrationResetCommandTest.php
@@ -16,8 +16,6 @@ class DatabaseMigrationResetCommandTest extends TestCase
     protected function tearDown(): void
     {
         ResetCommand::prohibit(false);
-
-        parent::tearDown();
     }
 
     public function testResetCommandCallsMigratorWithProperArguments()

--- a/tests/Database/DatabaseMigratorIntegrationTest.php
+++ b/tests/Database/DatabaseMigratorIntegrationTest.php
@@ -81,8 +81,6 @@ class DatabaseMigratorIntegrationTest extends TestCase
     {
         Facade::clearResolvedInstances();
         Facade::setFacadeApplication(null);
-
-        parent::tearDown();
     }
 
     public function testBasicMigrationOfSingleFolder()

--- a/tests/Database/DatabaseMigratorTest.php
+++ b/tests/Database/DatabaseMigratorTest.php
@@ -16,8 +16,6 @@ class DatabaseMigratorTest extends TestCase
     protected function tearDown(): void
     {
         (new ReflectionProperty(Migrator::class, 'connectionResolverCallback'))->setValue(null, null);
-
-        parent::tearDown();
     }
 
     public function testResolveConnectionUsesDirectVariantWhenConfigured()

--- a/tests/Database/DatabaseSQLiteBuilderTest.php
+++ b/tests/Database/DatabaseSQLiteBuilderTest.php
@@ -27,8 +27,6 @@ class DatabaseSQLiteBuilderTest extends TestCase
     {
         Container::setInstance(null);
         Facade::setFacadeApplication(null);
-
-        parent::tearDown();
     }
 
     public function testCreateDatabase()

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -16,8 +16,6 @@ class DatabaseSchemaBlueprintTest extends TestCase
     protected function tearDown(): void
     {
         Builder::$defaultMorphKeyType = 'int';
-
-        parent::tearDown();
     }
 
     public function testToSqlRunsCommandsFromBlueprint()

--- a/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
@@ -38,8 +38,6 @@ class DatabaseSchemaBuilderIntegrationTest extends TestCase
     {
         Facade::clearResolvedInstances();
         Facade::setFacadeApplication(null);
-
-        parent::tearDown();
     }
 
     public function testHasColumnWithTablePrefix()

--- a/tests/Database/DatabaseTransactionsTest.php
+++ b/tests/Database/DatabaseTransactionsTest.php
@@ -56,8 +56,6 @@ class DatabaseTransactionsTest extends TestCase
         foreach (['default', 'second_connection'] as $connection) {
             $this->schema($connection)->drop('users');
         }
-
-        parent::tearDown();
     }
 
     public function testTransactionIsRecordedAndCommitted()

--- a/tests/Database/EloquentModelCustomCastingTest.php
+++ b/tests/Database/EloquentModelCustomCastingTest.php
@@ -78,8 +78,6 @@ class EloquentModelCustomCastingTest extends TestCase
         $this->schema()->drop('casting_table');
         $this->schema()->drop('members');
         $this->schema()->drop('documents');
-
-        parent::tearDown();
     }
 
     #[RequiresPhpExtension('gmp')]

--- a/tests/Database/PruneCommandTest.php
+++ b/tests/Database/PruneCommandTest.php
@@ -20,8 +20,6 @@ class PruneCommandTest extends TestCase
 {
     protected function setUp(): void
     {
-        parent::setUp();
-
         Application::setInstance($container = new Application(__DIR__.'/Pruning'));
 
         Closure::bind(
@@ -269,7 +267,5 @@ class PruneCommandTest extends TestCase
     protected function tearDown(): void
     {
         Application::setInstance(null);
-
-        parent::tearDown();
     }
 }

--- a/tests/Database/SeedCommandTest.php
+++ b/tests/Database/SeedCommandTest.php
@@ -138,8 +138,6 @@ class SeedCommandTest extends TestCase
         SeedCommand::prohibit(false);
 
         Model::unsetEventDispatcher();
-
-        parent::tearDown();
     }
 }
 

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -47,8 +47,6 @@ class FilesystemAdapterTest extends TestCase
         $filesystem->deleteDirectory(basename($this->tempDir));
 
         unset($this->tempDir, $this->filesystem, $this->adapter);
-
-        parent::tearDown();
     }
 
     public function testResponse()

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -39,8 +39,6 @@ class FilesystemTest extends TestCase
     {
         $files = new Filesystem;
         $files->deleteDirectory(self::$tempDir, $preserve = true);
-
-        parent::tearDown();
     }
 
     public function testGetRetrievesFiles()

--- a/tests/Foundation/Bootstrap/HandleExceptionsTest.php
+++ b/tests/Foundation/Bootstrap/HandleExceptionsTest.php
@@ -38,8 +38,6 @@ class HandleExceptionsTest extends TestCase
     {
         Application::setInstance(null);
         HandleExceptions::flushState($this);
-
-        parent::tearDown();
     }
 
     public function testPhpDeprecations()

--- a/tests/Foundation/Bootstrap/LoadEnvironmentVariablesTest.php
+++ b/tests/Foundation/Bootstrap/LoadEnvironmentVariablesTest.php
@@ -13,8 +13,6 @@ class LoadEnvironmentVariablesTest extends TestCase
     {
         unset($_ENV['FOO'], $_SERVER['FOO']);
         putenv('FOO');
-
-        parent::tearDown();
     }
 
     protected function getAppMock($file)

--- a/tests/Foundation/Cloud/JsonFormatterTest.php
+++ b/tests/Foundation/Cloud/JsonFormatterTest.php
@@ -13,14 +13,12 @@ class JsonFormatterTest extends TestCase
 {
     protected function setUp(): void
     {
-        parent::setUp();
         Container::setInstance(new Container);
     }
 
     protected function tearDown(): void
     {
         Container::setInstance(null);
-        parent::tearDown();
     }
 
     protected function createRecord(): LogRecord

--- a/tests/Foundation/Configuration/MiddlewareTest.php
+++ b/tests/Foundation/Configuration/MiddlewareTest.php
@@ -39,8 +39,6 @@ class MiddlewareTest extends TestCase
         foreach ([Authenticate::class, AuthenticateSession::class, AuthenticationException::class, RedirectIfAuthenticated::class] as $class) {
             (new ReflectionClass($class))->getProperty('redirectToCallback')->setValue(null, null);
         }
-
-        parent::tearDown();
     }
 
     public function testConvertEmptyStringsToNull()

--- a/tests/Foundation/Console/CliDumperTest.php
+++ b/tests/Foundation/Console/CliDumperTest.php
@@ -233,7 +233,5 @@ class CliDumperTest extends TestCase
     protected function tearDown(): void
     {
         CliDumper::resolveDumpSourceUsing(null);
-
-        parent::tearDown();
     }
 }

--- a/tests/Foundation/Console/RouteListCommandTest.php
+++ b/tests/Foundation/Console/RouteListCommandTest.php
@@ -16,8 +16,6 @@ class RouteListCommandTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->app = new Application(
             $laravel = new \Illuminate\Foundation\Application(__DIR__),
             m::mock(Dispatcher::class, ['dispatch' => null, 'fire' => null]),

--- a/tests/Foundation/FoundationAliasLoaderTest.php
+++ b/tests/Foundation/FoundationAliasLoaderTest.php
@@ -9,8 +9,6 @@ class FoundationAliasLoaderTest extends TestCase
 {
     public function setUp(): void
     {
-        parent::setUp();
-
         AliasLoader::setInstance(null);
         AliasLoader::setFacadeNamespace('Facades\\');
     }

--- a/tests/Foundation/FoundationApplicationBuilderTest.php
+++ b/tests/Foundation/FoundationApplicationBuilderTest.php
@@ -13,8 +13,6 @@ class FoundationApplicationBuilderTest extends TestCase
     protected function tearDown(): void
     {
         unset($_ENV['APP_BASE_PATH'], $_ENV['LARAVEL_STORAGE_PATH'], $_SERVER['LARAVEL_STORAGE_PATH']);
-
-        parent::tearDown();
     }
 
     public function testBaseDirectoryWithArg()

--- a/tests/Foundation/FoundationAuthorizesRequestsTraitTest.php
+++ b/tests/Foundation/FoundationAuthorizesRequestsTraitTest.php
@@ -15,8 +15,6 @@ class FoundationAuthorizesRequestsTraitTest extends TestCase
     protected function tearDown(): void
     {
         Container::setInstance(null);
-
-        parent::tearDown();
     }
 
     public function testBasicGateCheck()

--- a/tests/Foundation/FoundationDevCommandsTest.php
+++ b/tests/Foundation/FoundationDevCommandsTest.php
@@ -14,8 +14,6 @@ class FoundationDevCommandsTest extends TestCase
 {
     protected function setUp(): void
     {
-        parent::setUp();
-
         $ref = new ReflectionClass(DevCommands::class);
 
         foreach (['commands', 'except', 'only'] as $prop) {

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -81,8 +81,6 @@ class FoundationExceptionsHandlerTest extends TestCase
     protected function tearDown(): void
     {
         Container::setInstance(null);
-
-        parent::tearDown();
     }
 
     public function testHandlerReportsExceptionAsContext()

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -33,8 +33,6 @@ class FoundationFormRequestTest extends TestCase
         Container::setInstance(null);
 
         $this->mocks = [];
-
-        parent::tearDown();
     }
 
     public function testValidatedMethodReturnsTheValidatedData()

--- a/tests/Foundation/Http/HtmlDumperTest.php
+++ b/tests/Foundation/Http/HtmlDumperTest.php
@@ -289,7 +289,5 @@ class HtmlDumperTest extends TestCase
     {
         HtmlDumper::resolveDumpSourceUsing(null);
         Container::setInstance(null);
-
-        parent::tearDown();
     }
 }

--- a/tests/Foundation/LaravelCloudJsonFormatterTest.php
+++ b/tests/Foundation/LaravelCloudJsonFormatterTest.php
@@ -13,14 +13,12 @@ class LaravelCloudJsonFormatterTest extends TestCase
 {
     protected function setUp(): void
     {
-        parent::setUp();
         Container::setInstance(new Container);
     }
 
     protected function tearDown(): void
     {
         Container::setInstance(null);
-        parent::tearDown();
     }
 
     protected function createRecord(): LogRecord

--- a/tests/Foundation/Testing/DatabaseMigrationsTest.php
+++ b/tests/Foundation/Testing/DatabaseMigrationsTest.php
@@ -47,8 +47,6 @@ class DatabaseMigrationsTest extends TestCase
         $this->tearDownTheApplicationTestingHooks();
 
         RefreshDatabaseState::$migrated = false;
-
-        parent::tearDown();
     }
 
     protected function refreshApplication()

--- a/tests/Foundation/Testing/DatabaseTruncationTest.php
+++ b/tests/Foundation/Testing/DatabaseTruncationTest.php
@@ -23,8 +23,6 @@ class DatabaseTruncationTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->app['config'] = new Repository([
             'database' => [
                 'migrations' => [
@@ -40,8 +38,6 @@ class DatabaseTruncationTest extends TestCase
         static::$allTables = [];
         $this->tablesToTruncate = null;
         $this->exceptTables = null;
-
-        parent::tearDown();
     }
 
     public function testTruncateTables()

--- a/tests/Foundation/Testing/RefreshDatabaseTest.php
+++ b/tests/Foundation/Testing/RefreshDatabaseTest.php
@@ -37,8 +37,6 @@ class RefreshDatabaseTest extends TestCase
         $this->tearDownTheApplicationTestingHooks();
 
         RefreshDatabaseState::$migrated = false;
-
-        parent::tearDown();
     }
 
     protected function refreshApplication()

--- a/tests/Foundation/Testing/WormholeTest.php
+++ b/tests/Foundation/Testing/WormholeTest.php
@@ -13,8 +13,6 @@ class WormholeTest extends TestCase
     protected function tearDown(): void
     {
         Date::useDefault();
-
-        parent::tearDown();
     }
 
     public function testCanTravelBackToPresent()

--- a/tests/Hashing/HasherTest.php
+++ b/tests/Hashing/HasherTest.php
@@ -18,8 +18,6 @@ class HasherTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $container = Container::setInstance(new Container);
         $container->singleton('config', fn () => new Config());
 

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -65,8 +65,6 @@ class HttpClientTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->factory = new Factory;
 
         RequestException::truncate();

--- a/tests/Http/Middleware/PreventRequestForgeryTest.php
+++ b/tests/Http/Middleware/PreventRequestForgeryTest.php
@@ -18,8 +18,6 @@ class PreventRequestForgeryTest extends TestCase
     protected function tearDown(): void
     {
         PreventRequestForgery::flushState();
-
-        parent::tearDown();
     }
 
     public function test_same_origin_header_passes()

--- a/tests/Http/Middleware/VitePreloadingTest.php
+++ b/tests/Http/Middleware/VitePreloadingTest.php
@@ -17,8 +17,6 @@ class VitePreloadingTest extends TestCase
     {
         Facade::setFacadeApplication(null);
         Facade::clearResolvedInstances();
-
-        parent::tearDown();
     }
 
     public function testItDoesNotSetLinkTagWhenNoTagsHaveBeenPreloaded()

--- a/tests/Http/Resources/JsonApi/JsonApiResourceTest.php
+++ b/tests/Http/Resources/JsonApi/JsonApiResourceTest.php
@@ -13,8 +13,6 @@ class JsonApiResourceTest extends TestCase
     {
         JsonResource::flushState();
         JsonApiResource::flushState();
-
-        parent::tearDown();
     }
 
     public function testResponseWrapperIsHardCodedToData()

--- a/tests/Integration/Cache/PhpRedisBackoffTest.php
+++ b/tests/Integration/Cache/PhpRedisBackoffTest.php
@@ -19,7 +19,6 @@ class PhpRedisBackoffTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
         $this->setUpRedis();
 
         $client = $this->redis['phpredis']->connection()->client();
@@ -31,8 +30,6 @@ class PhpRedisBackoffTest extends TestCase
     protected function tearDown(): void
     {
         $this->tearDownRedis();
-
-        parent::tearDown();
     }
 
     #[DataProvider('phpRedisBackoffAlgorithmsProvider')]

--- a/tests/Integration/Cache/RedisCacheIntegrationTest.php
+++ b/tests/Integration/Cache/RedisCacheIntegrationTest.php
@@ -17,15 +17,12 @@ class RedisCacheIntegrationTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
         $this->setUpRedis();
     }
 
     protected function tearDown(): void
     {
         $this->tearDownRedis();
-
-        parent::tearDown();
     }
 
     /**

--- a/tests/Mail/MailMailerTest.php
+++ b/tests/Mail/MailMailerTest.php
@@ -20,8 +20,6 @@ class MailMailerTest extends TestCase
     protected function tearDown(): void
     {
         unset($_SERVER['__mailer.test']);
-
-        parent::tearDown();
     }
 
     public function testMailerSendSendsMessageWithProperViewContent(): void

--- a/tests/Mail/MailMessageTest.php
+++ b/tests/Mail/MailMessageTest.php
@@ -19,8 +19,6 @@ class MailMessageTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->message = new Message(new Email());
     }
 

--- a/tests/Notifications/NotificationChannelManagerTest.php
+++ b/tests/Notifications/NotificationChannelManagerTest.php
@@ -28,8 +28,6 @@ class NotificationChannelManagerTest extends TestCase
     protected function tearDown(): void
     {
         Container::setInstance(null);
-
-        parent::tearDown();
     }
 
     public function testNotificationCanBeDispatchedToDriver()

--- a/tests/Notifications/NotificationMailMessageTest.php
+++ b/tests/Notifications/NotificationMailMessageTest.php
@@ -22,8 +22,6 @@ class NotificationMailMessageTest extends TestCase
             $this->deleteDirectory($this->filesystemRoot);
             $this->filesystemRoot = null;
         }
-
-        parent::tearDown();
     }
 
     public function testTemplate()

--- a/tests/Notifications/NotificationRoutesNotificationsTest.php
+++ b/tests/Notifications/NotificationRoutesNotificationsTest.php
@@ -16,8 +16,6 @@ class NotificationRoutesNotificationsTest extends TestCase
     protected function tearDown(): void
     {
         Container::setInstance(null);
-
-        parent::tearDown();
     }
 
     public function testNotificationCanBeDispatched()

--- a/tests/Pagination/LengthAwarePaginatorTest.php
+++ b/tests/Pagination/LengthAwarePaginatorTest.php
@@ -26,8 +26,6 @@ class LengthAwarePaginatorTest extends TestCase
     protected function tearDown(): void
     {
         unset($this->p);
-
-        parent::tearDown();
     }
 
     public function testLengthAwarePaginatorGetAndSetPageName()

--- a/tests/Pipeline/HubTest.php
+++ b/tests/Pipeline/HubTest.php
@@ -14,8 +14,6 @@ class HubTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->hub = new Hub(new Container);
     }
 

--- a/tests/Queue/DatabaseFailedJobProviderTest.php
+++ b/tests/Queue/DatabaseFailedJobProviderTest.php
@@ -19,7 +19,6 @@ class DatabaseFailedJobProviderTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
         $this->createDatabaseWithFailedJobTable()
             ->createProvider();
     }

--- a/tests/Queue/FailoverQueueTest.php
+++ b/tests/Queue/FailoverQueueTest.php
@@ -14,8 +14,6 @@ class FailoverQueueTest extends TestCase
     protected function tearDown(): void
     {
         Container::setInstance(null);
-
-        parent::tearDown();
     }
 
     public function test_push_fails_over_on_exception()

--- a/tests/Queue/QueueClearCommandTest.php
+++ b/tests/Queue/QueueClearCommandTest.php
@@ -17,8 +17,6 @@ class QueueClearCommandTest extends TestCase
     protected function tearDown(): void
     {
         m::close();
-
-        parent::tearDown();
     }
 
     public function testClearingDefaultQueue()

--- a/tests/Queue/QueueDatabaseQueueIntegrationTest.php
+++ b/tests/Queue/QueueDatabaseQueueIntegrationTest.php
@@ -105,8 +105,6 @@ class QueueDatabaseQueueIntegrationTest extends TestCase
     protected function tearDown(): void
     {
         $this->schema()->drop('jobs');
-
-        parent::tearDown();
     }
 
     /**

--- a/tests/Queue/QueuePauseResumeTest.php
+++ b/tests/Queue/QueuePauseResumeTest.php
@@ -20,8 +20,6 @@ class QueuePauseResumeTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->cache = new Repository(new ArrayStore);
 
         // Mock the cache facade to return our cache repository

--- a/tests/Queue/QueueSyncQueueTest.php
+++ b/tests/Queue/QueueSyncQueueTest.php
@@ -22,8 +22,6 @@ class QueueSyncQueueTest extends TestCase
     protected function tearDown(): void
     {
         Container::setInstance(null);
-
-        parent::tearDown();
     }
 
     public function testPushShouldFireJobInstantly()

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -48,8 +48,6 @@ class QueueWorkerTest extends TestCase
     protected function tearDown(): void
     {
         Container::setInstance();
-
-        parent::tearDown();
     }
 
     public function testJobCanBeFired()

--- a/tests/Redis/ConcurrentLimiterTest.php
+++ b/tests/Redis/ConcurrentLimiterTest.php
@@ -15,16 +15,12 @@ class ConcurrentLimiterTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->setUpRedis();
     }
 
     protected function tearDown(): void
     {
         $this->tearDownRedis();
-
-        parent::tearDown();
     }
 
     public function testItLocksTasksWhenNoSlotAvailable()

--- a/tests/Redis/DurationLimiterTest.php
+++ b/tests/Redis/DurationLimiterTest.php
@@ -14,16 +14,12 @@ class DurationLimiterTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->setUpRedis();
     }
 
     protected function tearDown(): void
     {
         $this->tearDownRedis();
-
-        parent::tearDown();
     }
 
     public function testItLocksTasksWhenNoSlotAvailable()

--- a/tests/Redis/RedisConnectionTest.php
+++ b/tests/Redis/RedisConnectionTest.php
@@ -19,15 +19,12 @@ class RedisConnectionTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
         $this->setUpRedis();
     }
 
     protected function tearDown(): void
     {
         $this->tearDownRedis();
-
-        parent::tearDown();
     }
 
     public function testItSetsValuesWithExpiry()

--- a/tests/Redis/RedisConnectorTest.php
+++ b/tests/Redis/RedisConnectorTest.php
@@ -14,15 +14,12 @@ class RedisConnectorTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
         $this->setUpRedis();
     }
 
     protected function tearDown(): void
     {
         $this->tearDownRedis();
-
-        parent::tearDown();
     }
 
     public function testDefaultConfiguration()

--- a/tests/Redis/RedisManagerExtensionTest.php
+++ b/tests/Redis/RedisManagerExtensionTest.php
@@ -17,8 +17,6 @@ class RedisManagerExtensionTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->redis = new RedisManager(new Application, 'my_custom_driver', [
             'default' => [
                 'host' => 'some-host',

--- a/tests/Routing/RouteCollectionTest.php
+++ b/tests/Routing/RouteCollectionTest.php
@@ -21,8 +21,6 @@ class RouteCollectionTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->routeCollection = new RouteCollection;
     }
 

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -24,8 +24,6 @@ class RouteRegistrarTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->router = new Router(m::mock(Dispatcher::class), Container::getInstance());
     }
 

--- a/tests/Session/CacheBasedSessionHandlerTest.php
+++ b/tests/Session/CacheBasedSessionHandlerTest.php
@@ -15,7 +15,6 @@ class CacheBasedSessionHandlerTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
         $this->cacheMock = m::mock(CacheContract::class);
         $this->sessionHandler = new CacheBasedSessionHandler(cache: $this->cacheMock, minutes: 10);
     }

--- a/tests/Support/DateFacadeTest.php
+++ b/tests/Support/DateFacadeTest.php
@@ -17,8 +17,6 @@ class DateFacadeTest extends TestCase
     protected function tearDown(): void
     {
         DateFactory::use(Carbon::class);
-
-        parent::tearDown();
     }
 
     protected static function assertBetweenStartAndNow($start, $actual)

--- a/tests/Support/LotteryTest.php
+++ b/tests/Support/LotteryTest.php
@@ -11,8 +11,6 @@ class LotteryTest extends TestCase
     protected function tearDown(): void
     {
         Lottery::determineResultNormally();
-
-        parent::tearDown();
     }
 
     public function testItCanWin()

--- a/tests/Support/OnceTest.php
+++ b/tests/Support/OnceTest.php
@@ -11,8 +11,6 @@ class OnceTest extends TestCase
     {
         Once::flush();
         Once::enable();
-
-        parent::tearDown();
     }
 
     public function testResultMemoization()

--- a/tests/Support/SleepTest.php
+++ b/tests/Support/SleepTest.php
@@ -17,8 +17,6 @@ class SleepTest extends TestCase
     protected function tearDown(): void
     {
         Sleep::fake(false);
-
-        parent::tearDown();
     }
 
     public function testItSleepsForSeconds()

--- a/tests/Support/SupportBinaryCodecTest.php
+++ b/tests/Support/SupportBinaryCodecTest.php
@@ -16,8 +16,6 @@ class SupportBinaryCodecTest extends TestCase
         $reflection = new \ReflectionClass(BinaryCodec::class);
         $property = $reflection->getProperty('customCodecs');
         $property->setValue(null, []);
-
-        parent::tearDown();
     }
 
     public function testFormatsReturnsDefaultFormats()

--- a/tests/Support/SupportCarbonTest.php
+++ b/tests/Support/SupportCarbonTest.php
@@ -18,16 +18,12 @@ class SupportCarbonTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         Carbon::setTestNow($this->now = Carbon::create(2017, 6, 27, 13, 14, 15, 'UTC'));
     }
 
     protected function tearDown(): void
     {
         Carbon::serializeUsing(null);
-
-        parent::tearDown();
     }
 
     public function testInstance()

--- a/tests/Support/SupportFacadesEventTest.php
+++ b/tests/Support/SupportFacadesEventTest.php
@@ -27,8 +27,6 @@ class SupportFacadesEventTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->events = m::mock(Dispatcher::class);
 
         $container = new Container;
@@ -44,8 +42,6 @@ class SupportFacadesEventTest extends TestCase
     {
         Facade::clearResolvedInstances();
         Facade::setFacadeApplication(null);
-
-        parent::tearDown();
     }
 
     public function testFakeFor()

--- a/tests/Support/SupportFacadesQueueTest.php
+++ b/tests/Support/SupportFacadesQueueTest.php
@@ -17,8 +17,6 @@ class SupportFacadesQueueTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->queueManager = m::mock(Factory::class);
 
         $container = new Container;
@@ -32,8 +30,6 @@ class SupportFacadesQueueTest extends TestCase
     {
         Queue::clearResolvedInstance();
         Queue::setFacadeApplication(null);
-
-        parent::tearDown();
     }
 
     public function testFakeFor()

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -31,8 +31,6 @@ class SupportHelpersTest extends TestCase
     protected function setUp(): void
     {
         mkdir(__DIR__.'/tmp');
-
-        parent::setUp();
     }
 
     protected function tearDown(): void
@@ -40,8 +38,6 @@ class SupportHelpersTest extends TestCase
         if (is_dir(__DIR__.'/tmp')) {
             (new Filesystem)->deleteDirectory(__DIR__.'/tmp');
         }
-
-        parent::tearDown();
     }
 
     public function testE()

--- a/tests/Support/SupportServiceProviderTest.php
+++ b/tests/Support/SupportServiceProviderTest.php
@@ -38,8 +38,6 @@ class SupportServiceProviderTest extends TestCase
         if (isset($this->tempFile) && file_exists($this->tempFile)) {
             @unlink($this->tempFile);
         }
-
-        parent::tearDown();
     }
 
     public function testPublishableServiceProviders()

--- a/tests/Support/SupportTestingBusFakeTest.php
+++ b/tests/Support/SupportTestingBusFakeTest.php
@@ -23,7 +23,6 @@ class SupportTestingBusFakeTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
         $this->fake = new BusFake(m::mock(QueueingDispatcher::class));
     }
 

--- a/tests/Support/SupportTestingEventFakeTest.php
+++ b/tests/Support/SupportTestingEventFakeTest.php
@@ -14,7 +14,6 @@ class SupportTestingEventFakeTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
         $this->fake = new EventFake(m::mock(Dispatcher::class));
     }
 

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -30,7 +30,6 @@ class SupportTestingMailFakeTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
         $this->mailManager = m::mock(MailManager::class, function ($mock) {
             $mock->shouldReceive('getDefaultDriver')
                 ->andReturn('smtp');

--- a/tests/Support/SupportTestingNotificationFakeTest.php
+++ b/tests/Support/SupportTestingNotificationFakeTest.php
@@ -33,8 +33,6 @@ class SupportTestingNotificationFakeTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->fake = new NotificationFake;
         $this->notification = new NotificationStub;
         $this->user = new UserStub;

--- a/tests/Support/SupportTestingQueueFakeTest.php
+++ b/tests/Support/SupportTestingQueueFakeTest.php
@@ -29,7 +29,6 @@ class SupportTestingQueueFakeTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
         $this->fake = new QueueFake(new Application);
         $this->job = new JobStub;
     }

--- a/tests/Testing/Concerns/InteractsWithDeprecationHandlingTest.php
+++ b/tests/Testing/Concerns/InteractsWithDeprecationHandlingTest.php
@@ -15,8 +15,6 @@ class InteractsWithDeprecationHandlingTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         set_error_handler(function () {
             $this->deprecationsFound = true;
         });
@@ -27,8 +25,6 @@ class InteractsWithDeprecationHandlingTest extends TestCase
         $this->deprecationsFound = false;
 
         HandleExceptions::flushHandlersState($this);
-
-        parent::tearDown();
     }
 
     public function testWithDeprecationHandling()

--- a/tests/Testing/Concerns/TestCachesTest.php
+++ b/tests/Testing/Concerns/TestCachesTest.php
@@ -18,8 +18,6 @@ class TestCachesTest extends TestCase
 {
     protected function setUp(): void
     {
-        parent::setUp();
-
         Container::setInstance($container = new Container);
 
         Facade::setFacadeApplication($container);
@@ -57,8 +55,6 @@ class TestCachesTest extends TestCase
         };
 
         (new ReflectionProperty($instance::class, 'originalCachePrefix'))->setValue(null, null);
-
-        parent::tearDown();
     }
 
     #[DataProvider('cachePrefixes')]

--- a/tests/Testing/Concerns/TestDatabasesTest.php
+++ b/tests/Testing/Concerns/TestDatabasesTest.php
@@ -15,8 +15,6 @@ class TestDatabasesTest extends TestCase
 {
     protected function setUp(): void
     {
-        parent::setUp();
-
         Container::setInstance($container = new Container);
 
         $container->singleton('config', function () {
@@ -103,7 +101,5 @@ class TestDatabasesTest extends TestCase
         DB::setFacadeApplication(null);
 
         unset($_SERVER['LARAVEL_PARALLEL_TESTING']);
-
-        parent::tearDown();
     }
 }

--- a/tests/Testing/Concerns/TestViewsTest.php
+++ b/tests/Testing/Concerns/TestViewsTest.php
@@ -19,8 +19,6 @@ class TestViewsTest extends TestCase
 {
     protected function setUp(): void
     {
-        parent::setUp();
-
         Container::setInstance($container = new Container);
 
         Facade::setFacadeApplication($container);
@@ -43,8 +41,6 @@ class TestViewsTest extends TestCase
         Facade::setFacadeApplication(null);
 
         unset($_SERVER['LARAVEL_PARALLEL_TESTING']);
-
-        parent::tearDown();
     }
 
     public function testCompiledViewPathAppendsToken()

--- a/tests/Testing/ParallelTestingTest.php
+++ b/tests/Testing/ParallelTestingTest.php
@@ -11,8 +11,6 @@ class ParallelTestingTest extends TestCase
 {
     protected function setUp(): void
     {
-        parent::setUp();
-
         Container::setInstance(new Container);
 
         $_SERVER['LARAVEL_PARALLEL_TESTING'] = 1;
@@ -102,7 +100,5 @@ class ParallelTestingTest extends TestCase
         Container::setInstance(null);
 
         unset($_SERVER['LARAVEL_PARALLEL_TESTING']);
-
-        parent::tearDown();
     }
 }

--- a/tests/Validation/ValidationAnyOfRuleTest.php
+++ b/tests/Validation/ValidationAnyOfRuleTest.php
@@ -377,8 +377,6 @@ class ValidationAnyOfRuleTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $container = Container::getInstance();
         $container->bind('translator', function () {
             return new Translator(
@@ -398,7 +396,5 @@ class ValidationAnyOfRuleTest extends TestCase
         Container::setInstance(null);
         Facade::clearResolvedInstances();
         Facade::setFacadeApplication(null);
-
-        parent::tearDown();
     }
 }

--- a/tests/Validation/ValidationEmailRuleTest.php
+++ b/tests/Validation/ValidationEmailRuleTest.php
@@ -933,7 +933,5 @@ class ValidationEmailRuleTest extends TestCase
         Facade::clearResolvedInstances();
 
         Facade::setFacadeApplication(null);
-
-        parent::tearDown();
     }
 }

--- a/tests/Validation/ValidationEnumRuleTest.php
+++ b/tests/Validation/ValidationEnumRuleTest.php
@@ -346,7 +346,5 @@ class ValidationEnumRuleTest extends TestCase
         Facade::clearResolvedInstances();
 
         Facade::setFacadeApplication(null);
-
-        parent::tearDown();
     }
 }

--- a/tests/Validation/ValidationExcludeUnlessRuleTest.php
+++ b/tests/Validation/ValidationExcludeUnlessRuleTest.php
@@ -15,8 +15,6 @@ class ValidationExcludeUnlessRuleTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->translator = new Translator(new ArrayLoader, 'en');
     }
 

--- a/tests/Validation/ValidationExistsRuleTest.php
+++ b/tests/Validation/ValidationExistsRuleTest.php
@@ -309,8 +309,6 @@ class ValidationExistsRuleTest extends TestCase
     protected function tearDown(): void
     {
         $this->schema('default')->drop('users');
-
-        parent::tearDown();
     }
 
     public function getIlluminateArrayTranslator()

--- a/tests/Validation/ValidationFactoryTest.php
+++ b/tests/Validation/ValidationFactoryTest.php
@@ -16,8 +16,6 @@ class ValidationFactoryTest extends TestCase
     protected function tearDown(): void
     {
         Validator::flushState();
-
-        parent::tearDown();
     }
 
     public function testMakeMethodCreatesValidValidator()

--- a/tests/Validation/ValidationFileRuleTest.php
+++ b/tests/Validation/ValidationFileRuleTest.php
@@ -504,7 +504,5 @@ class ValidationFileRuleTest extends TestCase
         Facade::clearResolvedInstances();
 
         Facade::setFacadeApplication(null);
-
-        parent::tearDown();
     }
 }

--- a/tests/Validation/ValidationImageFileRuleTest.php
+++ b/tests/Validation/ValidationImageFileRuleTest.php
@@ -166,8 +166,6 @@ class ValidationImageFileRuleTest extends TestCase
         Facade::clearResolvedInstances();
 
         Facade::setFacadeApplication(null);
-
-        parent::tearDown();
     }
 }
 

--- a/tests/Validation/ValidationNotPwnedVerifierTest.php
+++ b/tests/Validation/ValidationNotPwnedVerifierTest.php
@@ -16,8 +16,6 @@ class ValidationNotPwnedVerifierTest extends TestCase
     protected function tearDown(): void
     {
         Container::setInstance(null);
-
-        parent::tearDown();
     }
 
     public function testEmptyValues()

--- a/tests/Validation/ValidationPasswordRuleTest.php
+++ b/tests/Validation/ValidationPasswordRuleTest.php
@@ -613,7 +613,5 @@ class ValidationPasswordRuleTest extends TestCase
         Facade::setFacadeApplication(null);
 
         Password::$defaultCallback = null;
-
-        parent::tearDown();
     }
 }

--- a/tests/Validation/ValidationProhibitedUnlessRuleTest.php
+++ b/tests/Validation/ValidationProhibitedUnlessRuleTest.php
@@ -15,8 +15,6 @@ class ValidationProhibitedUnlessRuleTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->translator = new Translator(new ArrayLoader, 'en');
     }
 

--- a/tests/Validation/ValidationRequiredUnlessRuleTest.php
+++ b/tests/Validation/ValidationRequiredUnlessRuleTest.php
@@ -15,8 +15,6 @@ class ValidationRequiredUnlessRuleTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->translator = new Translator(new ArrayLoader, 'en');
     }
 

--- a/tests/Validation/ValidationRuleCanTest.php
+++ b/tests/Validation/ValidationRuleCanTest.php
@@ -22,8 +22,6 @@ class ValidationRuleCanTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->user = new stdClass;
 
         Container::setInstance($this->container = new Container);
@@ -52,8 +50,6 @@ class ValidationRuleCanTest extends TestCase
         Facade::clearResolvedInstances();
 
         Facade::setFacadeApplication(null);
-
-        parent::tearDown();
     }
 
     public function testValidationFails()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -45,8 +45,6 @@ class ValidationValidatorTest extends TestCase
     protected function tearDown(): void
     {
         Validator::flushState();
-
-        parent::tearDown();
     }
 
     public function testNestedErrorMessagesAreRetrievedFromLocalArray()

--- a/tests/View/Blade/AbstractBladeTestCase.php
+++ b/tests/View/Blade/AbstractBladeTestCase.php
@@ -18,8 +18,6 @@ abstract class AbstractBladeTestCase extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->compiler = new BladeCompiler($this->getFiles(), __DIR__);
     }
 
@@ -29,8 +27,6 @@ abstract class AbstractBladeTestCase extends TestCase
         Component::flushCache();
         Component::forgetComponentsResolver();
         Component::forgetFactory();
-
-        parent::tearDown();
     }
 
     protected function getFiles()

--- a/tests/View/ComponentTest.php
+++ b/tests/View/ComponentTest.php
@@ -25,8 +25,6 @@ class ComponentTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->config = m::mock(Config::class);
 
         $container = new Container;
@@ -48,8 +46,6 @@ class ComponentTest extends TestCase
         Container::setInstance(null);
         Component::flushCache();
         Component::forgetFactory();
-
-        parent::tearDown();
     }
 
     public function testInlineViewsGetCreated()


### PR DESCRIPTION
PHPUnit's own `TestCase::setUp()`/`tearDown()` are empty, so calling `parent::setUp()`/`parent::tearDown()` in tests that extend it directly does nothing. Removed those dead calls.

Left classes extending a custom base (Testbench, `AbstractBladeTestCase` subclasses, `DatabaseTestCase`, etc.) alone, since those parents do real work.