### PR TITLE
[13.x] Use enum_value() helper in a few more places

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -2,11 +2,12 @@
 
 namespace Illuminate\Database\Eloquent\Relations\Concerns;
 
-use BackedEnum;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Support\Collection as BaseCollection;
+
+use function Illuminate\Support\enum_value;
 
 trait InteractsWithPivotTable
 {
@@ -215,9 +216,7 @@ trait InteractsWithPivotTable
                 [$id, $attributes] = [$attributes, []];
             }
 
-            if ($id instanceof BackedEnum) {
-                $id = $id->value;
-            }
+            $id = enum_value($id);
 
             return [$id => $attributes];
         })->all();

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Database\Query;
 
-use BackedEnum;
 use Closure;
 use DatePeriod;
 use DateTimeInterface;
@@ -1513,7 +1512,7 @@ class Builder implements BuilderContract
         $values = Arr::flatten($values);
 
         foreach ($values as &$value) {
-            $value = (int) ($value instanceof BackedEnum ? $value->value : $value);
+            $value = (int) enum_value($value);
         }
 
         $this->wheres[] = ['type' => $type, 'column' => $column, 'values' => $values, 'boolean' => $boolean];

--- a/src/Illuminate/Routing/RouteUrlGenerator.php
+++ b/src/Illuminate/Routing/RouteUrlGenerator.php
@@ -2,11 +2,12 @@
 
 namespace Illuminate\Routing;
 
-use BackedEnum;
 use Illuminate\Contracts\Routing\UrlRoutable;
 use Illuminate\Routing\Exceptions\UrlGenerationException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
+
+use function Illuminate\Support\enum_value;
 
 class RouteUrlGenerator
 {
@@ -299,9 +300,7 @@ class RouteUrlGenerator
         })->all();
 
         array_walk_recursive($parameters, function (&$item) {
-            if ($item instanceof BackedEnum) {
-                $item = $item->value;
-            }
+            $item = enum_value($item);
         });
 
         return $this->url->formatParameters($parameters);

--- a/tests/Database/DatabaseEloquentBelongsToManyPivotEnumKeyTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyPivotEnumKeyTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Model as Eloquent;
+use Illuminate\Tests\Database\Fixtures\Enums\Bar;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseEloquentBelongsToManyPivotEnumKeyTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $db = new DB;
+
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+
+        $db->bootEloquent();
+        $db->setAsGlobal();
+
+        $this->createSchema();
+    }
+
+    protected function createSchema()
+    {
+        $this->schema()->create('users', function ($table) {
+            $table->increments('id');
+        });
+
+        $this->schema()->create('roles', function ($table) {
+            $table->increments('id');
+            $table->string('name');
+        });
+
+        $this->schema()->create('role_user', function ($table) {
+            $table->unsignedInteger('user_id');
+            $table->unsignedInteger('role_id');
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        $this->schema()->drop('users');
+        $this->schema()->drop('roles');
+        $this->schema()->drop('role_user');
+    }
+
+    public function testSyncAcceptsBackedEnumIds()
+    {
+        $user = PivotEnumKeyTestUser::create();
+        PivotEnumKeyTestRole::insert([
+            ['id' => 5, 'name' => 'editor'],
+            ['id' => 6, 'name' => 'viewer'],
+        ]);
+
+        $changes = $user->roles()->sync([Bar::FOO, 6]);
+
+        $this->assertSame([5, 6], $changes['attached']);
+        $this->assertSame(
+            ['editor', 'viewer'],
+            $user->roles->pluck('name')->all()
+        );
+    }
+
+    public function testToggleAcceptsBackedEnumIds()
+    {
+        $user = PivotEnumKeyTestUser::create();
+        PivotEnumKeyTestRole::insert([
+            ['id' => 5, 'name' => 'editor'],
+        ]);
+
+        $user->roles()->toggle([Bar::FOO]);
+
+        $this->assertSame(['editor'], $user->fresh()->roles->pluck('name')->all());
+
+        $user->roles()->toggle([Bar::FOO]);
+
+        $this->assertSame([], $user->fresh()->roles->pluck('name')->all());
+    }
+
+    protected function connection()
+    {
+        return Eloquent::getConnectionResolver()->connection();
+    }
+
+    protected function schema()
+    {
+        return $this->connection()->getSchemaBuilder();
+    }
+}
+
+class PivotEnumKeyTestUser extends Eloquent
+{
+    protected $table = 'users';
+    public $timestamps = false;
+
+    public function roles()
+    {
+        return $this->belongsToMany(PivotEnumKeyTestRole::class, 'role_user', 'user_id', 'role_id');
+    }
+}
+
+class PivotEnumKeyTestRole extends Eloquent
+{
+    protected $table = 'roles';
+    protected $fillable = ['id', 'name'];
+    public $timestamps = false;
+}

--- a/tests/Database/DatabaseEloquentBelongsToManyPivotEnumKeyTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyPivotEnumKeyTest.php
@@ -24,7 +24,7 @@ class DatabaseEloquentBelongsToManyPivotEnumKeyTest extends TestCase
         $this->createSchema();
     }
 
-    protected function createSchema()
+    protected function createSchema(): void
     {
         $this->schema()->create('users', function ($table) {
             $table->increments('id');
@@ -81,7 +81,7 @@ class DatabaseEloquentBelongsToManyPivotEnumKeyTest extends TestCase
         $this->assertSame([], $user->fresh()->roles->pluck('name')->all());
     }
 
-    protected function connection()
+    protected function connection(): \Illuminate\Database\ConnectionInterface
     {
         return Eloquent::getConnectionResolver()->connection();
     }
@@ -97,7 +97,7 @@ class PivotEnumKeyTestUser extends Eloquent
     protected $table = 'users';
     public $timestamps = false;
 
-    public function roles()
+    public function roles(): \Illuminate\Database\Eloquent\Relations\BelongsToMany
     {
         return $this->belongsToMany(PivotEnumKeyTestRole::class, 'role_user', 'user_id', 'role_id');
     }

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -923,6 +923,35 @@ class RoutingUrlGeneratorTest extends TestCase
         );
     }
 
+    public function testRouteGenerationWithUnitEnums():void
+    {
+        $url = new UrlGenerator(
+            $routes = new RouteCollection,
+            Request::create('http://www.foo.com/')
+        );
+
+        $namedRoute = new Route(['GET'], '/foo/{bar}', ['as' => 'foo.bar']);
+        $routes->add($namedRoute);
+
+        $this->assertSame('http://www.foo.com/foo/Fruits', $url->route('foo.bar', CategoryEnum::Fruits));
+    }
+
+    public function testRouteGenerationWithNestedUnitEnums():void
+    {
+        $url = new UrlGenerator(
+            $routes = new RouteCollection,
+            Request::create('http://www.foo.com/')
+        );
+
+        $namedRoute = new Route(['GET'], '/foo', ['as' => 'foo']);
+        $routes->add($namedRoute);
+
+        $this->assertSame(
+            'http://www.foo.com/foo?filter%5B0%5D=People&filter%5B1%5D=Fruits',
+            $url->route('foo', ['filter' => [CategoryEnum::People, CategoryEnum::Fruits]]),
+        );
+    }
+
     public function testSignedUrlWithKeyResolver()
     {
         $url = new UrlGenerator(

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -923,7 +923,7 @@ class RoutingUrlGeneratorTest extends TestCase
         );
     }
 
-    public function testRouteGenerationWithUnitEnums():void
+    public function testRouteGenerationWithUnitEnums(): void
     {
         $url = new UrlGenerator(
             $routes = new RouteCollection,
@@ -936,7 +936,7 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertSame('http://www.foo.com/foo/Fruits', $url->route('foo.bar', CategoryEnum::Fruits));
     }
 
-    public function testRouteGenerationWithNestedUnitEnums():void
+    public function testRouteGenerationWithNestedUnitEnums(): void
     {
         $url = new UrlGenerator(
             $routes = new RouteCollection,


### PR DESCRIPTION
A few spots were still manually unwrapping enums with `$value instanceof BackedEnum ? $value->value : $value` instead of using the `enum_value()` helper we already use elsewhere (`PendingBroadcast`, `Grammar::getDefaultValue`, `Js::encode`, `Collection::keyBy`).

Swapped it in:
- `InteractsWithPivotTable::formatRecordsList()`
- `Query\Builder::whereIntegerInRaw()`
- `RouteUrlGenerator::formatParameters()`

Behavior's the same for backed enums. Bonus: these now also accept plain `UnitEnum` values instead of erroring on them, same as the other call sites.

Didn't touch the route name/domain spots (`UrlGenerator::route()`, `Route::domain()`/`name()`, `RouteRegistrar`) since those deliberately throw for non-string-backed enums, and `enum_value()` doesn't have that restriction.

Added tests for the pivot and route-parameter cases.