### PR TITLE
[12.x] Fix contextual bindings resolving against stale build stack during construction

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1157,16 +1157,18 @@ class Container implements ArrayAccess, ContainerContract
 
         // Once we have all the constructor's parameters we can create each of the
         // dependency instances and then use the reflection instances to make a
-        // new instance of this class, injecting the created dependencies in.
+        // new instance of this class, injecting the created dependencies in. The
+        // concrete stays on the build stack until the constructor has finished
+        // running so contextual bindings resolve against the class being built.
         try {
             $instances = $this->resolveDependencies($dependencies);
+
+            $this->fireAfterResolvingAttributeCallbacks(
+                $reflector->getAttributes(), $instance = new $concrete(...$instances)
+            );
         } finally {
             array_pop($this->buildStack);
         }
-
-        $this->fireAfterResolvingAttributeCallbacks(
-            $reflector->getAttributes(), $instance = new $concrete(...$instances)
-        );
 
         return $instance;
     }

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -345,6 +345,45 @@ class ContainerTest extends TestCase
         $this->assertInstanceOf(ContainerConcreteStub::class, $instance->default);
     }
 
+    public function testContextualBindingsDoNotLeakIntoNestedDependencyConstructors()
+    {
+        $container = new Container;
+
+        $container->bind(IContainerContractStub::class, ContainerImplementationStub::class);
+
+        $container->when(ContainerNestedContextualParentStub::class)
+            ->needs(IContainerContractStub::class)
+            ->give(ContainerImplementationStubTwo::class);
+
+        ContainerNestedContextualChildStub::$onConstruct = function () use ($container) {
+            return $container->make(IContainerContractStub::class);
+        };
+
+        $instance = $container->make(ContainerNestedContextualParentStub::class);
+
+        $this->assertInstanceOf(ContainerImplementationStubTwo::class, $instance->contract);
+        $this->assertInstanceOf(ContainerImplementationStub::class, ContainerNestedContextualChildStub::$resolved);
+    }
+
+    public function testContextualBindingsAreAppliedInsideConstructorBody()
+    {
+        $container = new Container;
+
+        $container->bind(IContainerContractStub::class, ContainerImplementationStub::class);
+
+        $container->when(ContainerNestedContextualChildStub::class)
+            ->needs(IContainerContractStub::class)
+            ->give(ContainerImplementationStubTwo::class);
+
+        ContainerNestedContextualChildStub::$onConstruct = function () use ($container) {
+            return $container->make(IContainerContractStub::class);
+        };
+
+        $container->make(ContainerNestedContextualChildStub::class);
+
+        $this->assertInstanceOf(ContainerImplementationStubTwo::class, ContainerNestedContextualChildStub::$resolved);
+    }
+
     public function testBound()
     {
         $container = new Container;
@@ -974,6 +1013,29 @@ class ContainerImplementationStub implements IContainerContractStub
 class ContainerImplementationStubTwo implements IContainerContractStub
 {
     //
+}
+
+class ContainerNestedContextualParentStub
+{
+    public function __construct(
+        public IContainerContractStub $contract,
+        public ContainerNestedContextualChildStub $child,
+    ) {
+    }
+}
+
+class ContainerNestedContextualChildStub
+{
+    public static $onConstruct;
+
+    public static $resolved;
+
+    public function __construct()
+    {
+        if (static::$onConstruct) {
+            static::$resolved = (static::$onConstruct)();
+        }
+    }
 }
 
 class ContainerDependentStub


### PR DESCRIPTION
Fixes #55435

## Problem

When the container builds a class, the concrete is popped off the `buildStack` **before** its constructor runs:

```php
try {
    $instances = $this->resolveDependencies($dependencies);
} finally {
    array_pop($this->buildStack); // popped here...
}

$instance = new $concrete(...$instances); // ...but the constructor runs here
```

So while a constructor body executes, `end($this->buildStack)` still points at the *parent* class (or is empty). Any container resolution triggered from inside a constructor — directly, or indirectly, e.g. by the framework's error handler when a deprecation is raised — resolves contextual bindings (`when()->needs()->give()`) registered for the wrong class.

The scenario from #55435: with `when(InjectedClass)->needs(LoggerInterface::class)->give(...)` registered, a dependency's constructor triggers a deprecation warning. The error handler calls `$app->make(LogManager::class)`, and because `InjectedClass` is still incorrectly on top of the build stack, the contextual binding for `LoggerInterface` (an alias of `log`) leaks in. The handler receives a `Monolog\Logger` instead of the `LogManager` and fatals on `$logger->channel('deprecations')` — masking the original deprecation entirely.

## Fix

Keep the concrete on the build stack until its constructor has finished running. The container now treats a class as "being built" for the entire duration of its constructor, which matches the mental model of contextual binding:

- Resolutions inside a dependency's constructor no longer see the parent's contextual bindings (the reported bug).
- As a side effect, resolutions inside a class' own constructor body now consistently see that class' contextual bindings — previously they silently did not, even though the same bindings apply to its constructor parameters.

## Tests

- `testContextualBindingsDoNotLeakIntoNestedDependencyConstructors` — regression test for the reported bug.
- `testContextualBindingsAreAppliedInsideConstructorBody` — documents the corrected, consistent behavior for constructor-body resolutions.

Suites green: `tests/Container` (192 tests), `tests/Foundation`, `tests/Log`, `tests/Integration/Container`, `tests/Integration/Foundation`, and the full suite (the only 2 failures are pre-existing `ValidationEmailRuleTest` environment issues, also failing on a clean `12.x`).

Also verified end-to-end against the reproduction repository linked in #55435: HTTP 500 `Call to undefined method Monolog\Logger::channel()` before the fix, HTTP 200 after.

## Backward compatibility

The change only affects which class sits on top of the build stack *while a constructor body executes*. Constructor parameter resolution, exception messages that include the build stack, and singleton/instance caching are untouched.
