### PR TITLE
[12.x] Allow restricting unserialized classes in DynamoBatchRepository options

### DIFF
--- a/src/Illuminate/Bus/BusServiceProvider.php
+++ b/src/Illuminate/Bus/BusServiceProvider.php
@@ -84,6 +84,7 @@ class BusServiceProvider extends ServiceProvider implements DeferrableProvider
                 $app->config->get('queue.batching.table', 'job_batches'),
                 ttl: $app->config->get('queue.batching.ttl', null),
                 ttlAttribute: $app->config->get('queue.batching.ttl_attribute', 'ttl'),
+                serializableClasses: $app->config->get('queue.batching.serializable_classes', null),
             );
         });
     }

--- a/src/Illuminate/Bus/DynamoBatchRepository.php
+++ b/src/Illuminate/Bus/DynamoBatchRepository.php
@@ -60,7 +60,16 @@ class DynamoBatchRepository implements BatchRepository
     protected $marshaler;
 
     /**
+     * The classes that are allowed to be unserialized from batch options.
+     *
+     * @var array|bool|null
+     */
+    protected $serializableClasses;
+
+    /**
      * Create a new batch repository instance.
+     *
+     * @param  array|bool|null  $serializableClasses
      */
     public function __construct(
         BatchFactory $factory,
@@ -69,6 +78,7 @@ class DynamoBatchRepository implements BatchRepository
         string $table,
         ?int $ttl,
         ?string $ttlAttribute,
+        $serializableClasses = null,
     ) {
         $this->factory = $factory;
         $this->dynamoDbClient = $dynamoDbClient;
@@ -76,6 +86,7 @@ class DynamoBatchRepository implements BatchRepository
         $this->table = $table;
         $this->ttl = $ttl;
         $this->ttlAttribute = $ttlAttribute;
+        $this->serializableClasses = $serializableClasses;
         $this->marshaler = new Marshaler;
     }
 
@@ -511,6 +522,10 @@ class DynamoBatchRepository implements BatchRepository
      */
     protected function unserialize($serialized)
     {
+        if ($this->serializableClasses !== null) {
+            return unserialize($serialized, ['allowed_classes' => $this->serializableClasses]);
+        }
+
         return unserialize($serialized);
     }
 

--- a/tests/Bus/DynamoBatchRepositoryTest.php
+++ b/tests/Bus/DynamoBatchRepositoryTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Illuminate\Tests\Bus;
+
+use __PHP_Incomplete_Class;
+use Aws\DynamoDb\DynamoDbClient;
+use Illuminate\Bus\BatchFactory;
+use Illuminate\Bus\DynamoBatchRepository;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class DynamoBatchRepositoryTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+
+        parent::tearDown();
+    }
+
+    public function testOptionsAreUnserializedWithoutRestrictionsByDefault()
+    {
+        $repository = $this->createRepository();
+
+        $options = ['name' => 'test', 'callback' => new DynamoBatchRepositoryTestCallback];
+
+        $this->assertEquals($options, $repository->unserializeValue(serialize($options)));
+    }
+
+    public function testOptionsUnserializationCanBeRestricted()
+    {
+        $repository = $this->createRepository(serializableClasses: false);
+
+        $unserialized = $repository->unserializeValue(serialize(['callback' => new DynamoBatchRepositoryTestCallback]));
+
+        $this->assertInstanceOf(__PHP_Incomplete_Class::class, $unserialized['callback']);
+    }
+
+    public function testOptionsUnserializationAllowsWhitelistedClasses()
+    {
+        $repository = $this->createRepository(serializableClasses: [DynamoBatchRepositoryTestCallback::class]);
+
+        $options = ['callback' => new DynamoBatchRepositoryTestCallback];
+
+        $this->assertEquals($options, $repository->unserializeValue(serialize($options)));
+    }
+
+    protected function createRepository($serializableClasses = null)
+    {
+        return new DynamoBatchRepositoryUnserializeStub(
+            m::mock(BatchFactory::class),
+            m::mock(DynamoDbClient::class),
+            'test',
+            'job_batches',
+            ttl: null,
+            ttlAttribute: null,
+            serializableClasses: $serializableClasses,
+        );
+    }
+}
+
+class DynamoBatchRepositoryUnserializeStub extends DynamoBatchRepository
+{
+    public function unserializeValue($serialized)
+    {
+        return $this->unserialize($serialized);
+    }
+}
+
+class DynamoBatchRepositoryTestCallback
+{
+    //
+}

--- a/tests/Integration/Queue/DynamoBatchRepositoryWiringTest.php
+++ b/tests/Integration/Queue/DynamoBatchRepositoryWiringTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Queue;
+
+use Illuminate\Bus\DynamoBatchRepository;
+use Orchestra\Testbench\TestCase;
+use ReflectionProperty;
+
+class DynamoBatchRepositoryWiringTest extends TestCase
+{
+    public function test_serializable_classes_config_is_passed_to_the_repository()
+    {
+        $this->app['config']->set('queue.batching', [
+            'driver' => 'dynamodb',
+            'region' => 'us-west-2',
+            'key' => 'key',
+            'secret' => 'secret',
+            'serializable_classes' => [self::class],
+        ]);
+
+        $repository = $this->app->make(DynamoBatchRepository::class);
+
+        $this->assertSame(
+            [self::class],
+            (new ReflectionProperty($repository, 'serializableClasses'))->getValue($repository)
+        );
+    }
+
+    public function test_serializable_classes_default_to_no_restrictions()
+    {
+        $this->app['config']->set('queue.batching', [
+            'driver' => 'dynamodb',
+            'region' => 'us-west-2',
+            'key' => 'key',
+            'secret' => 'secret',
+        ]);
+
+        $repository = $this->app->make(DynamoBatchRepository::class);
+
+        $this->assertNull(
+            (new ReflectionProperty($repository, 'serializableClasses'))->getValue($repository)
+        );
+    }
+}


### PR DESCRIPTION
Fixes #59361

## Problem

`DynamoBatchRepository::unserialize()` calls PHP's `unserialize()` without the `allowed_classes` option when reading batch `options` back from DynamoDB (`toBatch()`). If an attacker is able to write to the DynamoDB batches table, this allows PHP object injection via gadget chains.

The cache stores (`FileStore`, `RedisStore`, `DatabaseStore`, `DynamoDbStore`, `ArrayStore`) were hardened against the same issue previously. This PR applies the same, already-established pattern to the DynamoDB batch repository.

## Change

Following the cache store implementation:

- `DynamoBatchRepository` accepts a new optional `$serializableClasses` constructor argument (`array|bool|null`, default `null`).
- When `null` (the default), behavior is unchanged — `unserialize($serialized)` exactly as before, so this is fully backward compatible.
- When set, options are unserialized with `['allowed_classes' => $this->serializableClasses]`, allowing applications to restrict (`false`) or whitelist specific classes.
- `BusServiceProvider` wires the value from a new `queue.batching.serializable_classes` config key, mirroring the existing `cache.serializable_classes` convention.

The opt-in design matters here because batch options may legitimately contain user objects and `SerializableClosure` instances (batch callbacks), so a blanket restriction would break existing applications — the same trade-off that was accepted for the cache stores.

## Tests

- `tests/Bus/DynamoBatchRepositoryTest.php` — default behavior unchanged, restriction works (`allowed_classes: false`), whitelisted classes still unserialize.
- `tests/Integration/Queue/DynamoBatchRepositoryWiringTest.php` — the `queue.batching.serializable_classes` config value reaches the repository; defaults to no restrictions.

`tests/Bus` (80 tests) and the Queue/Foundation suites are green.

## Note

`DatabaseBatchRepository::unserialize()` has the same unrestricted `unserialize()` call. I kept this PR focused on the reported issue (#59361), but I'm happy to follow up with the same treatment there if the maintainers would like.
