### PR TITLE
[13.x] Sort null-key deprecation in `LazyCollection::keyBy`

### DIFF
--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -571,11 +571,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
                     $resolvedKey = enum_value($resolvedKey);
                 }
 
-                if (is_object($resolvedKey)) {
-                    $resolvedKey = (string) $resolvedKey;
-                }
-
-                if (is_null($resolvedKey)) {
+                if (is_object($resolvedKey) || is_null($resolvedKey)) {
                     $resolvedKey = (string) $resolvedKey;
                 }
 

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -575,6 +575,10 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
                     $resolvedKey = (string) $resolvedKey;
                 }
 
+                if (is_null($resolvedKey)) {
+                    $resolvedKey = (string) $resolvedKey;
+                }
+
                 yield $resolvedKey => $item;
             }
         });


### PR DESCRIPTION
Keeping an eye on failing tests, `LazyCollection::keyBy` is failing

see https://github.com/laravel/framework/actions/runs/30767053963/job/91547532838#step:5:278 & https://github.com/laravel/framework/actions/runs/30766848166/job/91547002515#step:5:278 as examples


8.5 complains `Using null as an array offset is deprecated, use an empty string instead` 

This ensures null keys turn into a string explicitly now, which is what it does it Arr:

https://github.com/laravel/framework/blob/15efd602da40375da02192231891c6f1e52012c0/src/Illuminate/Collections/Arr.php#L274-L276 
