### PR TITLE
[13.x] Add tests for the Number currency helpers

### DIFF
--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -169,6 +169,28 @@ class SupportNumberTest extends TestCase
         $this->assertSame('1 234,56 $US', Number::currency(1234.56, 'USD', 'fr'));
     }
 
+    #[RequiresPhpExtension('intl')]
+    public function testToCurrencyWithAppCurrency()
+    {
+        $this->assertSame('$1.00', Number::currency(1));
+
+        Number::useCurrency('EUR');
+
+        $this->assertSame('EUR', Number::defaultCurrency());
+        $this->assertSame('€1.00', Number::currency(1));
+
+        Number::useCurrency('USD');
+    }
+
+    #[RequiresPhpExtension('intl')]
+    public function testToCurrencyWithCurrency()
+    {
+        $this->assertSame('€1.00', Number::withCurrency('EUR', fn () => Number::currency(1)));
+
+        $this->assertSame('USD', Number::defaultCurrency());
+        $this->assertSame('$1.00', Number::currency(1));
+    }
+
     public function testBytesToHuman()
     {
         $this->assertSame('0 B', Number::fileSize(0));


### PR DESCRIPTION
`Number::useCurrency()` and `Number::withCurrency()` have no coverage, while their locale counterparts `Number::useLocale()` and `Number::withLocale()` are both exercised in `SupportNumberTest`.

This adds the two missing cases: setting the default currency through `useCurrency()`, and formatting inside a callback run under a temporary currency with `withCurrency()` — including the restoration of the previous currency once the callback has finished.

Tests only, no production code is touched.