### PR TITLE
[13.x] Fix the ModelMakeCommand handle return type

### DIFF
--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -56,7 +56,7 @@ class ModelMakeCommand extends GeneratorCommand
     /**
      * Execute the console command.
      *
-     * @return void
+     * @return bool|null
      */
     public function handle()
     {


### PR DESCRIPTION
`ModelMakeCommand::handle()` is annotated `@return void`, but it returns `false` when the model already exists and the user declines to generate the additional components.

`GeneratorCommand::handle()`, which it overrides, is annotated `@return bool|null`, and `ProviderMakeCommand` already carries that same annotation on its own override.

PHPStan reports three errors on the file as it stands:

```
Return type (void) of method ModelMakeCommand::handle() should be compatible with
return type (bool|null) of method GeneratorCommand::handle()

Method ModelMakeCommand::handle() with return type void returns false but should not return anything.
Method ModelMakeCommand::handle() with return type void returns false but should not return anything.
```

Syncing the annotation with the parent's resolves all three, and makes the command analysable when it is extended in an application. Docblock only, no behavior change.
