### PR TITLE
[13.x] Adjust ImagickDriverTest

### DIFF
--- a/tests/Image/Drivers/ImagickDriverTest.php
+++ b/tests/Image/Drivers/ImagickDriverTest.php
@@ -448,6 +448,7 @@ class ImagickDriverTest extends TestCase
     {
         $imagick = new \Imagick;
         $imagick->newImage($width, $height, new \ImagickPixel(sprintf('rgb(%d,%d,%d)', $red, $green, $blue)));
+        $imagick->setImageAlphaChannel(\Imagick::ALPHACHANNEL_OPAQUE);
         $imagick->setImageFormat('png');
 
         $contents = $imagick->getImageBlob();


### PR DESCRIPTION
This would return inconsistent results see https://github.com/laravel/framework/actions/runs/30767405341/job/91548465744?pr=60987#step:5:284  

This basically sets the alpha channel to opaque which ensures the test is consistent for CI 