### PR TITLE
[13.x] Sync property docblocks with their parent declarations

### DIFF
--- a/src/Illuminate/Cache/Console/CacheTableCommand.php
+++ b/src/Illuminate/Cache/Console/CacheTableCommand.php
@@ -18,7 +18,7 @@ class CacheTableCommand extends MigrationGeneratorCommand
     /**
      * The console command name aliases.
      *
-     * @var array
+     * @var string[]
      */
     protected $aliases = ['cache:table'];
 

--- a/src/Illuminate/Foundation/Providers/ConsoleSupportServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ConsoleSupportServiceProvider.php
@@ -11,7 +11,7 @@ class ConsoleSupportServiceProvider extends AggregateServiceProvider implements 
     /**
      * The provider class names.
      *
-     * @var string[]
+     * @var array<int, class-string<\Illuminate\Support\ServiceProvider>>
      */
     protected $providers = [
         ArtisanServiceProvider::class,

--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -41,7 +41,7 @@ class FoundationServiceProvider extends AggregateServiceProvider
     /**
      * The provider class names.
      *
-     * @var string[]
+     * @var array<int, class-string<\Illuminate\Support\ServiceProvider>>
      */
     protected $providers = [
         FormRequestServiceProvider::class,

--- a/src/Illuminate/Notifications/Console/NotificationTableCommand.php
+++ b/src/Illuminate/Notifications/Console/NotificationTableCommand.php
@@ -18,7 +18,7 @@ class NotificationTableCommand extends MigrationGeneratorCommand
     /**
      * The console command name aliases.
      *
-     * @var array
+     * @var string[]
      */
     protected $aliases = ['notifications:table'];
 

--- a/src/Illuminate/Notifications/DatabaseNotification.php
+++ b/src/Illuminate/Notifications/DatabaseNotification.php
@@ -35,7 +35,7 @@ class DatabaseNotification extends Model
     /**
      * The guarded attributes on the model.
      *
-     * @var array
+     * @var array<string>
      */
     protected $guarded = [];
 

--- a/src/Illuminate/Queue/Console/BatchesTableCommand.php
+++ b/src/Illuminate/Queue/Console/BatchesTableCommand.php
@@ -20,7 +20,7 @@ class BatchesTableCommand extends MigrationGeneratorCommand
     /**
      * The console command name aliases.
      *
-     * @var array
+     * @var string[]
      */
     protected $aliases = ['queue:batches-table'];
 

--- a/src/Illuminate/Queue/Console/FailedTableCommand.php
+++ b/src/Illuminate/Queue/Console/FailedTableCommand.php
@@ -20,7 +20,7 @@ class FailedTableCommand extends MigrationGeneratorCommand
     /**
      * The console command name aliases.
      *
-     * @var array
+     * @var string[]
      */
     protected $aliases = ['queue:failed-table'];
 

--- a/src/Illuminate/Queue/Console/TableCommand.php
+++ b/src/Illuminate/Queue/Console/TableCommand.php
@@ -20,7 +20,7 @@ class TableCommand extends MigrationGeneratorCommand
     /**
      * The console command name aliases.
      *
-     * @var array
+     * @var string[]
      */
     protected $aliases = ['queue:table'];
 

--- a/src/Illuminate/Session/Console/SessionTableCommand.php
+++ b/src/Illuminate/Session/Console/SessionTableCommand.php
@@ -20,7 +20,7 @@ class SessionTableCommand extends MigrationGeneratorCommand
     /**
      * The console command name aliases.
      *
-     * @var array
+     * @var string[]
      */
     protected $aliases = ['session:table'];
 


### PR DESCRIPTION
Nine properties are annotated more loosely than the property they override, so the child annotation throws away type information the parent already declares:

- `$aliases` on six migration generator commands (`cache:table`, `notifications:table`, `queue:table`, `queue:failed-table`, `queue:batches-table`, `session:table`) is `@var array`, while `Command::$aliases` is `@var string[]`. Each one holds a list of command name strings.
- `$providers` on `ConsoleSupportServiceProvider` and `FoundationServiceProvider` is `@var string[]`, while `AggregateServiceProvider::$providers` is `@var array<int, class-string<\Illuminate\Support\ServiceProvider>>`. Every entry in both arrays is a `ServiceProvider` subclass.
- `$guarded` on `DatabaseNotification` is `@var array`, while `Model::$guarded` is `@var array<string>`.

Docblocks only, no behavior change.