### PR TITLE
Fix Stringable nullable constructor documentation

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -26,7 +26,7 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     /**
      * Create a new instance of the class.
      *
-     * @param  string  $value
+     * @param  string|null  $value
      */
     public function __construct($value = '')
     {

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -1478,6 +1478,7 @@ class SupportStringableTest extends TestCase
     {
         $this->assertSame('foo', $this->stringable('foo')->value());
         $this->assertSame('foo', $this->stringable('foo')->toString());
+        $this->assertSame('', $this->stringable(null)->value());
     }
 
     public function testExactly()


### PR DESCRIPTION
## Summary

- Update the `Stringable` constructor PHPDoc to allow `null`, which is cast to an empty string.
- Add a regression assertion for `new Stringable(null)`.

## Testing

- `php -l src/Illuminate/Support/Stringable.php`
- `php -l tests/Support/SupportStringableTest.php`
- `git diff --check`
- `./vendor/bin/phpunit tests/Support/SupportStringableTest.php` (128 tests, 692 assertions)