### PR TITLE
[13.x] Check the class before calling relationLoaded in loadMissingRelationshipChain

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -260,8 +260,8 @@ class Collection extends BaseCollection implements QueueableCollection
 
         $this->filter(function ($model) use ($relation, $class) {
             return ! is_null($model) &&
-                ! $model->relationLoaded($relation) &&
-                $model::class === $class;
+                $model::class === $class &&
+                ! $model->relationLoaded($relation);
         })->load($relation);
 
         if (empty($tuples)) {

--- a/tests/Integration/Database/EloquentModelRelationAutoloadTest.php
+++ b/tests/Integration/Database/EloquentModelRelationAutoloadTest.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
@@ -124,6 +125,51 @@ class EloquentModelRelationAutoloadTest extends DatabaseTestCase
         Model::automaticallyEagerLoadRelationships(false);
 
         DB::disableQueryLog();
+    }
+
+    public function testRelationAutoloadChainLoadsModelsOfTheGivenClass()
+    {
+        $post = Post::create();
+        $comment = $post->comments()->create(['parent_id' => null]);
+        $comment->likes()->create();
+        $comment->likes()->create();
+
+        $posts = Post::get();
+
+        $posts->loadMissingRelationshipChain([
+            ['comments', Post::class],
+            ['likes', Comment::class],
+        ]);
+
+        $this->assertTrue($posts[0]->relationLoaded('comments'));
+        $this->assertTrue($posts[0]->comments[0]->relationLoaded('likes'));
+        $this->assertCount(2, $posts[0]->comments[0]->likes);
+    }
+
+    public function testRelationAutoloadChainSkipsNonModelRelationValues()
+    {
+        $post = Post::create();
+        $comment = $post->comments()->create(['parent_id' => null]);
+        $comment->likes()->create();
+
+        $posts = Post::get();
+
+        // A relation is not required to hold a model or a collection of models.
+        // Packages such as Lighthouse put a paginator there to represent a paginated relation.
+        foreach ($posts as $each) {
+            $each->setRelation('comments', new LengthAwarePaginator($each->comments()->get(), 1, 10));
+        }
+
+        $posts->loadMissingRelationshipChain([
+            ['comments', Post::class],
+            ['likes', Comment::class],
+        ]);
+
+        $paginator = $posts[0]->getRelation('comments');
+
+        // The paginator is left as it was found rather than being loaded into.
+        $this->assertInstanceOf(LengthAwarePaginator::class, $paginator);
+        $this->assertFalse($paginator->items()[0]->relationLoaded('likes'));
     }
 
     public function testRelationAutoloadWithCircularRelations()


### PR DESCRIPTION
`loadMissingRelationshipChain()` calls `relationLoaded()` on a value before it checks what that value is:

```php
$this->filter(function ($model) use ($relation, $class) {
    return ! is_null($model) &&
        ! $model->relationLoaded($relation) &&
        $model::class === $class;
})->load($relation);
```

A relation doesn't have to hold a model or a collection of models. If it holds something else, that value isn't null and isn't a `BaseCollection`, so it gets past the filter, doesn't get collapsed by the check below, and the recursive call ends up calling `relationLoaded()` on it.

I hit this with a paginator. `AbstractPaginator` forwards unknown calls to the collection underneath it, so it comes out as:

```
BadMethodCallException: Method Illuminate\Database\Eloquent\Collection::relationLoaded does not exist.
```

Lighthouse sets a `LengthAwarePaginator` as the relation value when it resolves a paginated GraphQL relation:

https://github.com/nuwave/lighthouse/blob/master/src/Execution/ModelsLoader/PaginatedModelsLoader.php#L191

so any app using that hits this once `Model::automaticallyEagerLoadRelationships()` is turned on. It's reported there as https://github.com/nuwave/lighthouse/issues/2679.

Swapping the two conditions makes the class check short circuit first. It's still an exact class comparison rather than `instanceof`, so anything that matched before still matches — the only change is that a value of some other type gets skipped instead of called into.

For anyone using a package that does this, automatic eager loading currently can't be turned on at all: the request 500s instead of rendering. After this they can use the feature, and relations holding something other than a model are simply left alone rather than crashing the request.

Nothing existing changes. The filter still matches the same models it did before, and the only values affected are ones that would have thrown.

Two tests. One walks a normal chain and checks the relations still get loaded — it passes before and after, so it shows the reorder doesn't change which models are matched. The other puts a paginator in a relation and walks a two step chain over it — that one fails on 13.x with the exception above and passes with this change.

```diff
         $this->filter(function ($model) use ($relation, $class) {
             return ! is_null($model) &&
-                ! $model->relationLoaded($relation) &&
-                $model::class === $class;
+                $model::class === $class &&
+                ! $model->relationLoaded($relation);
         })->load($relation);
```