### PR TITLE
[13.x] Use Str::uuid()->toString()

### DIFF
--- a/src/Illuminate/Bus/Batchable.php
+++ b/src/Illuminate/Bus/Batchable.php
@@ -91,7 +91,7 @@ trait Batchable
                                   ?CarbonImmutable $finishedAt = null)
     {
         $this->fakeBatch = new BatchFake(
-            empty($id) ? (string) Str::uuid() : $id,
+            empty($id) ? Str::uuid()->toString() : $id,
             $name,
             $totalJobs,
             $pendingJobs,

--- a/src/Illuminate/Bus/DatabaseBatchRepository.php
+++ b/src/Illuminate/Bus/DatabaseBatchRepository.php
@@ -94,7 +94,7 @@ class DatabaseBatchRepository implements PrunableBatchRepository
      */
     public function store(PendingBatch $batch)
     {
-        $id = (string) Str::orderedUuid();
+        $id = Str::orderedUuid()->toString();
 
         $this->connection->table($this->table)->insert([
             'id' => $id,

--- a/src/Illuminate/Bus/DynamoBatchRepository.php
+++ b/src/Illuminate/Bus/DynamoBatchRepository.php
@@ -162,7 +162,7 @@ class DynamoBatchRepository implements BatchRepository
      */
     public function store(PendingBatch $batch)
     {
-        $id = (string) Str::orderedUuid();
+        $id = Str::orderedUuid()->toString();
 
         $batch = [
             'id' => $id,

--- a/src/Illuminate/Database/Eloquent/Concerns/HasVersion4Uuids.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasVersion4Uuids.php
@@ -15,6 +15,6 @@ trait HasVersion4Uuids
      */
     public function newUniqueId()
     {
-        return (string) Str::orderedUuid();
+        return Str::orderedUuid()->toString();
     }
 }

--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -113,7 +113,7 @@ class NotificationSender
             }
 
             $this->withLocale($this->preferredLocale($notifiable, $original), function () use ($viaChannels, $notifiable, $original) {
-                $notificationId = (string) Str::uuid();
+                $notificationId = Str::uuid()->toString();
 
                 foreach ((array) $viaChannels as $channel) {
                     if (! ($notifiable instanceof AnonymousNotifiable && $channel === 'database')) {
@@ -222,7 +222,7 @@ class NotificationSender
         $original = clone $notification;
 
         foreach ($notifiables as $notifiable) {
-            $notificationId = (string) Str::uuid();
+            $notificationId = Str::uuid()->toString();
 
             foreach ((array) $original->via($notifiable) as $channel) {
                 $notification = clone $original;

--- a/src/Illuminate/Queue/Jobs/FakeJob.php
+++ b/src/Illuminate/Queue/Jobs/FakeJob.php
@@ -35,7 +35,7 @@ class FakeJob extends Job implements JobContract
      */
     public function getJobId()
     {
-        return once(fn () => (string) Str::uuid());
+        return once(fn () => Str::uuid()->toString());
     }
 
     /**

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -172,7 +172,7 @@ abstract class Queue
     protected function createObjectPayload($job, $queue)
     {
         $payload = $this->withCreatePayloadHooks($queue, [
-            'uuid' => (string) Str::uuid(),
+            'uuid' => Str::uuid()->toString(),
             'displayName' => $this->getDisplayName($job),
             'job' => 'Illuminate\Queue\CallQueuedHandler@call',
             'maxTries' => $this->getJobTries($job),
@@ -308,7 +308,7 @@ abstract class Queue
     protected function createStringPayload($job, $queue, $data)
     {
         return $this->withCreatePayloadHooks($queue, [
-            'uuid' => (string) Str::uuid(),
+            'uuid' => Str::uuid()->toString(),
             'displayName' => is_string($job) ? explode('@', $job)[0] : null,
             'job' => $job,
             'maxTries' => null,

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -532,7 +532,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
 
         $uuid = is_object($decoded) && isset($decoded->uuid)
             ? $decoded->uuid
-            : (string) Str::uuid();
+            : Str::uuid()->toString();
 
         $this->container->make('cache')->store(
             Arr::get($this->overflowStorage, 'store')
@@ -600,7 +600,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
                 $isObject && method_exists($job, 'deduplicationId') => transform(
                     $job->deduplicationId($payload, $queue), $transformToString
                 ),
-                default => (string) Str::orderedUuid(),
+                default => Str::orderedUuid()->toString(),
             };
         }
 

--- a/src/Illuminate/Support/Defer/DeferredCallback.php
+++ b/src/Illuminate/Support/Defer/DeferredCallback.php
@@ -13,7 +13,7 @@ class DeferredCallback
      */
     public function __construct(public $callback, public ?string $name = null, public bool $always = false)
     {
-        $this->name = $name ?? (string) Str::uuid();
+        $this->name = $name ?? Str::uuid()->toString();
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/BatchRepositoryFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BatchRepositoryFake.php
@@ -49,7 +49,7 @@ class BatchRepositoryFake implements BatchRepository
      */
     public function store(PendingBatch $batch)
     {
-        $id = (string) Str::orderedUuid();
+        $id = Str::orderedUuid()->toString();
 
         $this->batches[$id] = new BatchFake(
             $id,

--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -314,7 +314,7 @@ class NotificationFake implements Fake, NotificationDispatcher, NotificationFact
 
         foreach ($notifiables as $notifiable) {
             if (! $notification->id) {
-                $notification->id = (string) Str::uuid();
+                $notification->id = Str::uuid()->toString();
             }
 
             $notifiableChannels = $channels ?: $notification->via($notifiable);

--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -301,7 +301,7 @@ trait CompilesConditionals
      */
     protected function compileOnce($id = null)
     {
-        $id = $id ? $this->stripParentheses($id) : "'".(string) Str::uuid()."'";
+        $id = $id ? $this->stripParentheses($id) : "'".Str::uuid()->toString()."'";
 
         return '<?php if (! $__env->hasRenderedOnce('.$id.')): $__env->markAsRenderedOnce('.$id.'); ?>';
     }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesStacks.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesStacks.php
@@ -40,7 +40,7 @@ trait CompilesStacks
 
         [$stack, $id] = [$parts[0], $parts[1] ?? ''];
 
-        $id = trim($id) ?: "'".(string) Str::uuid()."'";
+        $id = trim($id) ?: "'".Str::uuid()->toString()."'";
 
         return '<?php if (! $__env->hasRenderedOnce('.$id.')): $__env->markAsRenderedOnce('.$id.');
 $__env->startPush('.$stack.'); ?>';
@@ -89,7 +89,7 @@ $__env->startPush('.$stack.'); ?>';
 
         [$stack, $id] = [$parts[0], $parts[1] ?? ''];
 
-        $id = trim($id) ?: "'".(string) Str::uuid()."'";
+        $id = trim($id) ?: "'".Str::uuid()->toString()."'";
 
         return '<?php if (! $__env->hasRenderedOnce('.$id.')): $__env->markAsRenderedOnce('.$id.');
 $__env->startPrepend('.$stack.'); ?>';

--- a/tests/Foundation/Cloud/QueueTest.php
+++ b/tests/Foundation/Cloud/QueueTest.php
@@ -1376,14 +1376,14 @@ class QueueTest extends TestCase
         }
     }
 
-    public function testForgetProxiesToFailerForNonUrls()
+    public function testForgetProxiesToFailerForNonUrls(): void
     {
         $eventsFake = $this->fakeEvents();
         $failer = $this->fakeFailer();
         $provider = new FailedJobProvider($failer, $eventsFake, $this->app['encrypter']);
 
         // First log a job to the failer with a UUID
-        $uuid = (string) Str::uuid();
+        $uuid = Str::uuid()->toString();
         $failer->log('database', 'default', json_encode(['uuid' => $uuid]), new \Exception('test'));
         $jobId = $failer->ids()[0];
 
@@ -1670,7 +1670,7 @@ class QueueTest extends TestCase
             public function pushJob(array $job = []): array
             {
                 $job = array_merge([
-                    'messageId' => (string) Str::uuid(),
+                    'messageId' => Str::uuid()->toString(),
                     'receiptHandle' => 'receipt-handle',
                     // The agent always reports the SQS queue URL the message came from.
                     'queueUrl' => 'https://sqs.us-east-1.amazonaws.com/123456789012/default',

--- a/tests/Integration/Validation/ValidatorTest.php
+++ b/tests/Integration/Validation/ValidatorTest.php
@@ -24,8 +24,8 @@ class ValidatorTest extends DatabaseTestCase
             $table->string('first_name');
         });
 
-        User::create(['uuid' => (string) Str::uuid(), 'first_name' => 'John']);
-        User::create(['uuid' => (string) Str::uuid(), 'first_name' => 'Jim']);
+        User::create(['uuid' => Str::uuid()->toString(), 'first_name' => 'John']);
+        User::create(['uuid' => Str::uuid()->toString(), 'first_name' => 'Jim']);
     }
 
     public function testExists(): void

--- a/tests/Queue/DatabaseFailedJobProviderTest.php
+++ b/tests/Queue/DatabaseFailedJobProviderTest.php
@@ -112,12 +112,12 @@ class DatabaseFailedJobProviderTest extends TestCase
         $this->assertSame(0, $this->failedJobsTable()->count());
     }
 
-    public function testCanProperlyLogFailedJob()
+    public function testCanProperlyLogFailedJob(): void
     {
         $uuid = Str::uuid();
         $exception = new Exception(mb_convert_encoding('ÐÑÙ0E\xE2\x�98\xA0World��7B¹!þÿ', 'ISO-8859-1', 'UTF-8'));
 
-        $this->provider->log('database', 'default', json_encode(['uuid' => (string) $uuid]), $exception);
+        $this->provider->log('database', 'default', json_encode(['uuid' => $uuid->toString()]), $exception);
 
         $exception = (string) mb_convert_encoding($exception, 'UTF-8');
 
@@ -125,50 +125,50 @@ class DatabaseFailedJobProviderTest extends TestCase
         $this->assertSame($exception, $this->failedJobsTable()->first()->exception);
     }
 
-    public function testJobsCanBeCounted()
+    public function testJobsCanBeCounted(): void
     {
         $this->assertSame(0, $this->provider->count());
 
-        $this->provider->log('database', 'default', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+        $this->provider->log('database', 'default', json_encode(['uuid' => Str::uuid()->toString()]), new RuntimeException());
         $this->assertSame(1, $this->provider->count());
 
-        $this->provider->log('database', 'default', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
-        $this->provider->log('another-connection', 'another-queue', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+        $this->provider->log('database', 'default', json_encode(['uuid' => Str::uuid()->toString()]), new RuntimeException());
+        $this->provider->log('another-connection', 'another-queue', json_encode(['uuid' => Str::uuid()->toString()]), new RuntimeException());
         $this->assertSame(3, $this->provider->count());
     }
 
-    public function testJobsCanBeCountedByConnection()
+    public function testJobsCanBeCountedByConnection(): void
     {
-        $this->provider->log('connection-1', 'default', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
-        $this->provider->log('connection-2', 'default', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+        $this->provider->log('connection-1', 'default', json_encode(['uuid' => Str::uuid()->toString()]), new RuntimeException());
+        $this->provider->log('connection-2', 'default', json_encode(['uuid' => Str::uuid()->toString()]), new RuntimeException());
         $this->assertSame(1, $this->provider->count('connection-1'));
         $this->assertSame(1, $this->provider->count('connection-2'));
 
-        $this->provider->log('connection-1', 'default', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+        $this->provider->log('connection-1', 'default', json_encode(['uuid' => Str::uuid()->toString()]), new RuntimeException());
         $this->assertSame(2, $this->provider->count('connection-1'));
         $this->assertSame(1, $this->provider->count('connection-2'));
     }
 
-    public function testJobsCanBeCountedByQueue()
+    public function testJobsCanBeCountedByQueue(): void
     {
-        $this->provider->log('database', 'queue-1', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
-        $this->provider->log('database', 'queue-2', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+        $this->provider->log('database', 'queue-1', json_encode(['uuid' => Str::uuid()->toString()]), new RuntimeException());
+        $this->provider->log('database', 'queue-2', json_encode(['uuid' => Str::uuid()->toString()]), new RuntimeException());
         $this->assertSame(1, $this->provider->count(queue: 'queue-1'));
         $this->assertSame(1, $this->provider->count(queue: 'queue-2'));
 
-        $this->provider->log('database', 'queue-1', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+        $this->provider->log('database', 'queue-1', json_encode(['uuid' => Str::uuid()->toString()]), new RuntimeException());
         $this->assertSame(2, $this->provider->count(queue: 'queue-1'));
         $this->assertSame(1, $this->provider->count(queue: 'queue-2'));
     }
 
-    public function testJobsCanBeCountedByQueueAndConnection()
+    public function testJobsCanBeCountedByQueueAndConnection(): void
     {
-        $this->provider->log('connection-1', 'queue-99', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
-        $this->provider->log('connection-1', 'queue-99', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
-        $this->provider->log('connection-2', 'queue-99', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
-        $this->provider->log('connection-1', 'queue-1', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
-        $this->provider->log('connection-2', 'queue-1', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
-        $this->provider->log('connection-2', 'queue-1', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+        $this->provider->log('connection-1', 'queue-99', json_encode(['uuid' => Str::uuid()->toString()]), new RuntimeException());
+        $this->provider->log('connection-1', 'queue-99', json_encode(['uuid' => Str::uuid()->toString()]), new RuntimeException());
+        $this->provider->log('connection-2', 'queue-99', json_encode(['uuid' => Str::uuid()->toString()]), new RuntimeException());
+        $this->provider->log('connection-1', 'queue-1', json_encode(['uuid' => Str::uuid()->toString()]), new RuntimeException());
+        $this->provider->log('connection-2', 'queue-1', json_encode(['uuid' => Str::uuid()->toString()]), new RuntimeException());
+        $this->provider->log('connection-2', 'queue-1', json_encode(['uuid' => Str::uuid()->toString()]), new RuntimeException());
 
         $this->assertSame(2, $this->provider->count('connection-1', 'queue-99'));
         $this->assertSame(1, $this->provider->count('connection-2', 'queue-99'));
@@ -232,7 +232,7 @@ class DatabaseFailedJobProviderTest extends TestCase
             ->insert(array_merge([
                 'connection' => 'database',
                 'queue' => 'default',
-                'payload' => json_encode(['uuid' => (string) Str::uuid()]),
+                'payload' => json_encode(['uuid' => Str::uuid()->toString()]),
                 'exception' => new Exception('Whoops!'),
                 'failed_at' => Carbon::now()->subDays(10),
             ], $overrides));

--- a/tests/Queue/DatabaseUuidFailedJobProviderTest.php
+++ b/tests/Queue/DatabaseUuidFailedJobProviderTest.php
@@ -120,58 +120,58 @@ class DatabaseUuidFailedJobProviderTest extends TestCase
         $this->assertEmpty($provider->all());
     }
 
-    public function testJobsCanBeCounted()
+    public function testJobsCanBeCounted(): void
     {
         $provider = $this->getFailedJobProvider();
 
         $this->assertSame(0, $provider->count());
 
-        $provider->log('connection-1', 'queue-1', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+        $provider->log('connection-1', 'queue-1', json_encode(['uuid' => Str::uuid()->toString()]), new RuntimeException());
         $this->assertSame(1, $provider->count());
 
-        $provider->log('connection-1', 'queue-1', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
-        $provider->log('connection-2', 'queue-2', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+        $provider->log('connection-1', 'queue-1', json_encode(['uuid' => Str::uuid()->toString()]), new RuntimeException());
+        $provider->log('connection-2', 'queue-2', json_encode(['uuid' => Str::uuid()->toString()]), new RuntimeException());
         $this->assertSame(3, $provider->count());
     }
 
-    public function testJobsCanBeCountedByConnection()
+    public function testJobsCanBeCountedByConnection(): void
     {
         $provider = $this->getFailedJobProvider();
 
-        $provider->log('connection-1', 'default', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
-        $provider->log('connection-2', 'default', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+        $provider->log('connection-1', 'default', json_encode(['uuid' => Str::uuid()->toString()]), new RuntimeException());
+        $provider->log('connection-2', 'default', json_encode(['uuid' => Str::uuid()->toString()]), new RuntimeException());
         $this->assertSame(1, $provider->count('connection-1'));
         $this->assertSame(1, $provider->count('connection-2'));
 
-        $provider->log('connection-1', 'default', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+        $provider->log('connection-1', 'default', json_encode(['uuid' => Str::uuid()->toString()]), new RuntimeException());
         $this->assertSame(2, $provider->count('connection-1'));
         $this->assertSame(1, $provider->count('connection-2'));
     }
 
-    public function testJobsCanBeCountedByQueue()
+    public function testJobsCanBeCountedByQueue(): void
     {
         $provider = $this->getFailedJobProvider();
 
-        $provider->log('database', 'queue-1', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
-        $provider->log('database', 'queue-2', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+        $provider->log('database', 'queue-1', json_encode(['uuid' => Str::uuid()->toString()]), new RuntimeException());
+        $provider->log('database', 'queue-2', json_encode(['uuid' => Str::uuid()->toString()]), new RuntimeException());
         $this->assertSame(1, $provider->count(queue: 'queue-1'));
         $this->assertSame(1, $provider->count(queue: 'queue-2'));
 
-        $provider->log('database', 'queue-1', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+        $provider->log('database', 'queue-1', json_encode(['uuid' => Str::uuid()->toString()]), new RuntimeException());
         $this->assertSame(2, $provider->count(queue: 'queue-1'));
         $this->assertSame(1, $provider->count(queue: 'queue-2'));
     }
 
-    public function testJobsCanBeCountedByQueueAndConnection()
+    public function testJobsCanBeCountedByQueueAndConnection(): void
     {
         $provider = $this->getFailedJobProvider();
 
-        $provider->log('connection-1', 'queue-99', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
-        $provider->log('connection-1', 'queue-99', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
-        $provider->log('connection-2', 'queue-99', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
-        $provider->log('connection-1', 'queue-1', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
-        $provider->log('connection-2', 'queue-1', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
-        $provider->log('connection-2', 'queue-1', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+        $provider->log('connection-1', 'queue-99', json_encode(['uuid' => Str::uuid()->toString()]), new RuntimeException());
+        $provider->log('connection-1', 'queue-99', json_encode(['uuid' => Str::uuid()->toString()]), new RuntimeException());
+        $provider->log('connection-2', 'queue-99', json_encode(['uuid' => Str::uuid()->toString()]), new RuntimeException());
+        $provider->log('connection-1', 'queue-1', json_encode(['uuid' => Str::uuid()->toString()]), new RuntimeException());
+        $provider->log('connection-2', 'queue-1', json_encode(['uuid' => Str::uuid()->toString()]), new RuntimeException());
+        $provider->log('connection-2', 'queue-1', json_encode(['uuid' => Str::uuid()->toString()]), new RuntimeException());
         $this->assertSame(2, $provider->count('connection-1', 'queue-99'));
         $this->assertSame(1, $provider->count('connection-2', 'queue-99'));
         $this->assertSame(1, $provider->count('connection-1', 'queue-1'));

--- a/tests/Queue/DynamoDbFailedJobProviderTest.php
+++ b/tests/Queue/DynamoDbFailedJobProviderTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
 
 class DynamoDbFailedJobProviderTest extends TestCase
 {
-    public function testCanProperlyLogFailedJob()
+    public function testCanProperlyLogFailedJob(): void
     {
         $uuid = Str::orderedUuid();
 
@@ -32,10 +32,10 @@ class DynamoDbFailedJobProviderTest extends TestCase
             'TableName' => 'table',
             'Item' => [
                 'application' => ['S' => 'application'],
-                'uuid' => ['S' => (string) $uuid],
+                'uuid' => ['S' => $uuid->toString()],
                 'connection' => ['S' => 'connection'],
                 'queue' => ['S' => 'queue'],
-                'payload' => ['S' => json_encode(['uuid' => (string) $uuid])],
+                'payload' => ['S' => json_encode(['uuid' => $uuid->toString()])],
                 'exception' => ['S' => (string) $exception],
                 'failed_at' => ['N' => (string) $now->getTimestamp()],
                 'expires_at' => ['N' => (string) $now->addWeek()->getTimestamp()],
@@ -44,7 +44,7 @@ class DynamoDbFailedJobProviderTest extends TestCase
 
         $provider = new DynamoDbFailedJobProvider($dynamoDbClient, 'application', 'table');
 
-        $provider->log('connection', 'queue', json_encode(['uuid' => (string) $uuid]), $exception);
+        $provider->log('connection', 'queue', json_encode(['uuid' => $uuid->toString()]), $exception);
 
         Str::createUuidsNormally();
     }

--- a/tests/Queue/FileFailedJobProviderTest.php
+++ b/tests/Queue/FileFailedJobProviderTest.php
@@ -70,7 +70,7 @@ class FileFailedJobProviderTest extends TestCase
         ], $failedJobs);
     }
 
-    public function testCanFindFailedJobs()
+    public function testCanFindFailedJobs(): void
     {
         [$uuid, $exception] = $this->logFailedJob();
 
@@ -80,7 +80,7 @@ class FileFailedJobProviderTest extends TestCase
             'id' => $uuid,
             'connection' => 'connection',
             'queue' => 'queue',
-            'payload' => json_encode(['uuid' => (string) $uuid]),
+            'payload' => json_encode(['uuid' => $uuid]),
             'exception' => (string) mb_convert_encoding($exception, 'UTF-8'),
             'failed_at' => $failedJob->failed_at,
             'failed_at_timestamp' => $failedJob->failed_at_timestamp,
@@ -160,7 +160,7 @@ class FileFailedJobProviderTest extends TestCase
         $this->assertEmpty($failedJobs);
     }
 
-    public function testJobsCanBeCounted()
+    public function testJobsCanBeCounted(): void
     {
         $this->assertSame(0, $this->provider->count());
 
@@ -172,7 +172,7 @@ class FileFailedJobProviderTest extends TestCase
         $this->assertSame(3, $this->provider->count());
     }
 
-    public function testJobsCanBeCountedByConnection()
+    public function testJobsCanBeCountedByConnection(): void
     {
         $this->logFailedJob('connection-1', 'default');
         $this->logFailedJob('connection-2', 'default');
@@ -184,7 +184,7 @@ class FileFailedJobProviderTest extends TestCase
         $this->assertSame(1, $this->provider->count('connection-2'));
     }
 
-    public function testJobsCanBeCountedByQueue()
+    public function testJobsCanBeCountedByQueue(): void
     {
         $this->logFailedJob('database', 'queue-1');
         $this->logFailedJob('database', 'queue-2');
@@ -196,7 +196,7 @@ class FileFailedJobProviderTest extends TestCase
         $this->assertSame(1, $this->provider->count(queue: 'queue-2'));
     }
 
-    public function testJobsCanBeCountedByQueueAndConnection()
+    public function testJobsCanBeCountedByQueueAndConnection(): void
     {
         $this->logFailedJob('connection-1', 'queue-99');
         $this->logFailedJob('connection-1', 'queue-99');
@@ -216,10 +216,10 @@ class FileFailedJobProviderTest extends TestCase
 
         $exception = new Exception("Something went wrong at job [{$uuid}].");
 
-        $this->provider->log($connection, $queue, json_encode(['uuid' => (string) $uuid]), $exception);
+        $this->provider->log($connection, $queue, json_encode(['uuid' => $uuid->toString()]), $exception);
 
         return [
-            (string) $uuid,
+            $uuid->toString(),
             $exception,
         ];
     }

--- a/tests/Queue/QueueDatabaseQueueIntegrationTest.php
+++ b/tests/Queue/QueueDatabaseQueueIntegrationTest.php
@@ -14,6 +14,7 @@ use Illuminate\Queue\Queue;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
 use PHPUnit\Framework\TestCase;
+use Ramsey\Uuid\Uuid;
 
 class QueueDatabaseQueueIntegrationTest extends TestCase
 {
@@ -266,12 +267,12 @@ class QueueDatabaseQueueIntegrationTest extends TestCase
         Queue::createPayloadUsing(null);
     }
 
-    public function testJobPayloadIsAvailableOnEvents()
+    public function testJobPayloadIsAvailableOnEvents(): void
     {
         $jobQueueingEvent = null;
         $jobQueuedEvent = null;
         Str::createUuidsUsingSequence([
-            'expected-job-uuid',
+            Uuid::fromString('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
         ]);
         $this->container['events']->listen(function (JobQueueing $e) use (&$jobQueueingEvent) {
             $jobQueueingEvent = $e;
@@ -285,9 +286,9 @@ class QueueDatabaseQueueIntegrationTest extends TestCase
         ]);
 
         $this->assertIsArray($jobQueueingEvent->payload());
-        $this->assertSame('expected-job-uuid', $jobQueueingEvent->payload()['uuid']);
+        $this->assertSame('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee', $jobQueueingEvent->payload()['uuid']);
 
         $this->assertIsArray($jobQueuedEvent->payload());
-        $this->assertSame('expected-job-uuid', $jobQueuedEvent->payload()['uuid']);
+        $this->assertSame('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee', $jobQueuedEvent->payload()['uuid']);
     }
 }

--- a/tests/Queue/QueueDatabaseQueueUnitTest.php
+++ b/tests/Queue/QueueDatabaseQueueUnitTest.php
@@ -20,16 +20,17 @@ use Illuminate\Support\Str;
 use Mockery as m;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Ramsey\Uuid\Uuid;
 use ReflectionClass;
 use stdClass;
 
 class QueueDatabaseQueueUnitTest extends TestCase
 {
     #[DataProvider('pushJobsDataProvider')]
-    public function testPushProperlyPushesJobOntoDatabase($uuid, $job, $displayNameStartsWith, $jobStartsWith)
+    public function testPushProperlyPushesJobOntoDatabase($uuid, $job, $displayNameStartsWith, $jobStartsWith): void
     {
         Str::createUuidsUsing(function () use ($uuid) {
-            return $uuid;
+            return Uuid::fromString($uuid);
         });
 
         $queue = $this->getMockBuilder(DatabaseQueue::class)->onlyMethods(['currentTime'])->setConstructorArgs([$database = m::mock(Connection::class), 'table', 'default'])->getMock();
@@ -99,9 +100,9 @@ class QueueDatabaseQueueUnitTest extends TestCase
         Str::createUuidsNormally();
     }
 
-    public function testPushIncludesBatchIdInPayloadForBatchableJob()
+    public function testPushIncludesBatchIdInPayloadForBatchableJob(): void
     {
-        $uuid = Str::uuid()->toString();
+        $uuid = Str::uuid();
 
         Str::createUuidsUsing(function () use ($uuid) {
             return $uuid;

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -419,9 +419,9 @@ class QueueSqsQueueTest extends TestCase
         $container->shouldHaveReceived('bound')->with('events')->twice();
     }
 
-    public function testPushProperlyPushesJobStringOntoSqsFifoQueue()
+    public function testPushProperlyPushesJobStringOntoSqsFifoQueue(): void
     {
-        Str::createUuidsUsing(fn () => $this->mockedDeduplicationId);
+        Str::createUuidsUsing(fn () => $this->mockedUuid($this->mockedDeduplicationId));
 
         $queue = $this->getMockBuilder(SqsQueue::class)->onlyMethods(['createPayload', 'getQueue'])->setConstructorArgs([$this->sqs, $this->fifoQueueName, $this->account])->getMock();
         $queue->setContainer($container = m::spy(Container::class));
@@ -440,9 +440,9 @@ class QueueSqsQueueTest extends TestCase
         Str::createUuidsNormally();
     }
 
-    public function testPushProperlyPushesJobObjectOntoSqsFifoQueue()
+    public function testPushProperlyPushesJobObjectOntoSqsFifoQueue(): void
     {
-        Str::createUuidsUsing(fn () => $this->mockedDeduplicationId);
+        Str::createUuidsUsing(fn () => $this->mockedUuid($this->mockedDeduplicationId));
 
         $job = (new FakeSqsJob())->onGroup($this->mockedMessageGroupId);
 
@@ -463,9 +463,9 @@ class QueueSqsQueueTest extends TestCase
         Str::createUuidsNormally();
     }
 
-    public function testPushProperlyPushesJobObjectOntoSqsFifoQueueWithMessageGroupMethod()
+    public function testPushProperlyPushesJobObjectOntoSqsFifoQueueWithMessageGroupMethod(): void
     {
-        Str::createUuidsUsing(fn () => $this->mockedDeduplicationId);
+        Str::createUuidsUsing(fn () => $this->mockedUuid($this->mockedDeduplicationId));
 
         $job = $this->getMockBuilder(FakeSqsJobWithMessageGroup::class)->onlyMethods(['messageGroup'])->getMock();
         $job->expects($this->once())->method('messageGroup')->willReturn($this->mockedMessageGroupId);
@@ -487,9 +487,9 @@ class QueueSqsQueueTest extends TestCase
         Str::createUuidsNormally();
     }
 
-    public function testPushProperlyPushesJobObjectOntoSqsFifoQueueWithMessageGroupPropertyOverridingMethod()
+    public function testPushProperlyPushesJobObjectOntoSqsFifoQueueWithMessageGroupPropertyOverridingMethod(): void
     {
-        Str::createUuidsUsing(fn () => $this->mockedDeduplicationId);
+        Str::createUuidsUsing(fn () => $this->mockedUuid($this->mockedDeduplicationId));
 
         $job = $this->getMockBuilder(FakeSqsJobWithMessageGroup::class)->onlyMethods(['messageGroup'])->getMock();
 
@@ -563,9 +563,9 @@ class QueueSqsQueueTest extends TestCase
         $container->shouldHaveReceived('bound')->with('events')->twice();
     }
 
-    public function testPendingDispatchProperlyPushesJobObjectOntoSqsFifoQueue()
+    public function testPendingDispatchProperlyPushesJobObjectOntoSqsFifoQueue(): void
     {
-        Str::createUuidsUsing(fn () => $this->mockedDeduplicationId);
+        Str::createUuidsUsing(fn () => $this->mockedUuid($this->mockedDeduplicationId));
 
         $pendingDispatch = FakeSqsJob::dispatch()->onGroup($this->mockedMessageGroupId);
 
@@ -692,9 +692,9 @@ class QueueSqsQueueTest extends TestCase
         $container->shouldHaveReceived('bound')->with('events')->twice();
     }
 
-    public function testDelayedPushProperlyPushesJobStringOntoSqsFifoQueueWithoutDelay()
+    public function testDelayedPushProperlyPushesJobStringOntoSqsFifoQueueWithoutDelay(): void
     {
-        Str::createUuidsUsing(fn () => $this->mockedDeduplicationId);
+        Str::createUuidsUsing(fn () => $this->mockedUuid($this->mockedDeduplicationId));
 
         $queue = $this->getMockBuilder(SqsQueue::class)->onlyMethods(['createPayload', 'secondsUntil', 'getQueue'])->setConstructorArgs([$this->sqs, $this->fifoQueueName, $this->account])->getMock();
         $queue->setContainer($container = m::spy(Container::class));
@@ -714,9 +714,9 @@ class QueueSqsQueueTest extends TestCase
         Str::createUuidsNormally();
     }
 
-    public function testDelayedPushProperlyPushesJobObjectOntoSqsFifoQueueWithoutDelay()
+    public function testDelayedPushProperlyPushesJobObjectOntoSqsFifoQueueWithoutDelay(): void
     {
-        Str::createUuidsUsing(fn () => $this->mockedDeduplicationId);
+        Str::createUuidsUsing(fn () => $this->mockedUuid($this->mockedDeduplicationId));
 
         $job = (new FakeSqsJob())->onGroup($this->mockedMessageGroupId);
 
@@ -738,9 +738,9 @@ class QueueSqsQueueTest extends TestCase
         Str::createUuidsNormally();
     }
 
-    public function testDelayedPendingDispatchProperlyPushesJobObjectOntoSqsFifoQueueWithoutDelay()
+    public function testDelayedPendingDispatchProperlyPushesJobObjectOntoSqsFifoQueueWithoutDelay(): void
     {
-        Str::createUuidsUsing(fn () => $this->mockedDeduplicationId);
+        Str::createUuidsUsing(fn () => $this->mockedUuid($this->mockedDeduplicationId));
 
         $pendingDispatch = FakeSqsJob::dispatch()->onGroup($this->mockedMessageGroupId)->delay($this->mockedDelay);
 
@@ -1436,5 +1436,25 @@ class QueueSqsQueueTest extends TestCase
         $job = $queue->pop($this->queueName);
 
         $this->assertInstanceOf(SqsJob::class, $job);
+    }
+
+    protected function mockedUuid(string $value)
+    {
+        return new class($value)
+        {
+            public function __construct(private readonly string $value)
+            {
+            }
+
+            public function toString(): string
+            {
+                return $this->value;
+            }
+
+            public function __toString(): string
+            {
+                return $this->value;
+            }
+        };
     }
 }

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1713,25 +1713,25 @@ class SupportStrTest extends TestCase
         $this->assertSame($expected, Str::transliterate($value, '?', true));
     }
 
-    public function testItCanFreezeUuids()
+    public function testItCanFreezeUuids(): void
     {
-        $this->assertNotSame((string) Str::uuid(), (string) Str::uuid());
+        $this->assertNotSame(Str::uuid()->toString(), Str::uuid()->toString());
         $this->assertNotSame(Str::uuid(), Str::uuid());
 
         $uuid = Str::freezeUuids();
 
         $this->assertSame($uuid, Str::uuid());
         $this->assertSame(Str::uuid(), Str::uuid());
-        $this->assertSame((string) $uuid, (string) Str::uuid());
-        $this->assertSame((string) Str::uuid(), (string) Str::uuid());
+        $this->assertSame($uuid->toString(), Str::uuid()->toString());
+        $this->assertSame(Str::uuid()->toString(), Str::uuid()->toString());
 
         Str::createUuidsNormally();
 
         $this->assertNotSame(Str::uuid(), Str::uuid());
-        $this->assertNotSame((string) Str::uuid(), (string) Str::uuid());
+        $this->assertNotSame(Str::uuid()->toString(), Str::uuid()->toString());
     }
 
-    public function testItCanFreezeUuidsInAClosure()
+    public function testItCanFreezeUuidsInAClosure(): void
     {
         $uuids = [];
 
@@ -1742,14 +1742,14 @@ class SupportStrTest extends TestCase
         });
 
         $this->assertSame($uuid, $uuids[0]);
-        $this->assertSame((string) $uuid, (string) $uuids[0]);
-        $this->assertSame((string) $uuids[0], (string) $uuids[1]);
+        $this->assertSame($uuid->toString(), $uuids[0]->toString());
+        $this->assertSame($uuids[0]->toString(), $uuids[1]->toString());
         $this->assertSame($uuids[0], $uuids[1]);
-        $this->assertSame((string) $uuids[0], (string) $uuids[1]);
+        $this->assertSame($uuids[0]->toString(), $uuids[1]->toString());
         $this->assertSame($uuids[1], $uuids[2]);
-        $this->assertSame((string) $uuids[1], (string) $uuids[2]);
+        $this->assertSame($uuids[1]->toString(), $uuids[2]->toString());
         $this->assertNotSame(Str::uuid(), Str::uuid());
-        $this->assertNotSame((string) Str::uuid(), (string) Str::uuid());
+        $this->assertNotSame(Str::uuid()->toString(), Str::uuid()->toString());
 
         Str::createUuidsNormally();
     }

--- a/tests/View/Blade/BladePrependTest.php
+++ b/tests/View/Blade/BladePrependTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\View\Blade;
 
 use Illuminate\Support\Str;
+use Ramsey\Uuid\Uuid;
 
 class BladePrependTest extends AbstractBladeTestCase
 {
@@ -32,9 +33,9 @@ test
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
-    public function testPrependOnceIsCompiledWhenIdIsMissing()
+    public function testPrependOnceIsCompiledWhenIdIsMissing(): void
     {
-        Str::createUuidsUsing(fn () => 'e60e8f77-9ac3-4f71-9f8e-a044ef481d7f');
+        Str::createUuidsUsing(fn () => Uuid::fromString('e60e8f77-9ac3-4f71-9f8e-a044ef481d7f'));
 
         $string = '@prependOnce(\'foo\')
 test

--- a/tests/View/Blade/BladePushTest.php
+++ b/tests/View/Blade/BladePushTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\View\Blade;
 
 use Illuminate\Support\Str;
+use Ramsey\Uuid\Uuid;
 
 class BladePushTest extends AbstractBladeTestCase
 {
@@ -42,9 +43,9 @@ test
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
-    public function testPushOnceIsCompiledWhenIdIsMissing()
+    public function testPushOnceIsCompiledWhenIdIsMissing(): void
     {
-        Str::createUuidsUsing(fn () => 'e60e8f77-9ac3-4f71-9f8e-a044ef481d7f');
+        Str::createUuidsUsing(fn () => Uuid::fromString('e60e8f77-9ac3-4f71-9f8e-a044ef481d7f'));
 
         $string = '@pushOnce(\'foo\')
 test


### PR DESCRIPTION
Replace `(string)` casts on UUID objects with `->toString()`.

`Str::uuid()`/`Str::orderedUuid()` are documented to return `\Ramsey\Uuid\UuidInterface`, so `->toString()` is the correct way to get the string form instead of relying on the magic `(string)` cast.

Some tests fake the UUID factory via `Str::createUuidsUsing()`/`createUuidsUsingSequence()` with a closure returning a plain string instead of a `UuidInterface`. That happened to work under `(string)` (a no-op on an already-string value) but breaks under `->toString()`, since a plain string has no such method. Those fakes are updated to wrap the value in `Ramsey\Uuid\Uuid::fromString()` so they honor the documented return type instead of quietly violating it.