### PR TITLE
[13.x] Respect after-commit dispatch when bulk pushing to DatabaseQueue

### DIFF
--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -305,19 +305,54 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
     {
         $queue = $this->getQueue($queue);
 
-        $now = $this->availableAt();
+        [$afterCommit, $immediate] = $this->partitionJobsByAfterCommit((array) $jobs);
 
-        return $this->database->table($this->table)->insert((new Collection((array) $jobs))->map(
-            function ($job) use ($queue, $data, $now) {
+        $result = null;
+
+        if (! empty($immediate) || empty($afterCommit)) {
+            $now = $this->availableAt();
+
+            $result = $this->database->table($this->table)->insert((new Collection($immediate))->map(
+                function ($job) use ($queue, $data, $now) {
+                    $delay = is_object($job) ? $this->getAttributeValue($job, Delay::class, 'delay') : null;
+
+                    return $this->buildDatabaseRecord(
+                        $queue,
+                        $this->createPayload($job, $this->getQueue($queue), $data),
+                        isset($delay) ? $this->availableAt($delay) : $now,
+                    );
+                }
+            )->all());
+        }
+
+        if (! empty($afterCommit)) {
+            foreach ($afterCommit as $job) {
+                $this->registerRollbackCallbacksForJobsThatDispatchAfterCommit($job);
+            }
+
+            $jobs = (new Collection($afterCommit))->map(function ($job) use ($queue, $data) {
                 $delay = is_object($job) ? $this->getAttributeValue($job, Delay::class, 'delay') : null;
 
-                return $this->buildDatabaseRecord(
-                    $queue,
-                    $this->createPayload($job, $this->getQueue($queue), $data),
-                    isset($delay) ? $this->availableAt($delay) : $now,
-                );
-            }
-        )->all());
+                return [
+                    'payload' => $this->createPayload($job, $this->getQueue($queue), $data),
+                    'delay' => $delay,
+                ];
+            })->all();
+
+            $this->container->make('db.transactions')->addCallback(function () use ($queue, $jobs) {
+                $now = $this->availableAt();
+
+                $this->database->table($this->table)->insert((new Collection($jobs))->map(
+                    fn ($job) => $this->buildDatabaseRecord(
+                        $queue,
+                        $job['payload'],
+                        isset($job['delay']) ? $this->availableAt($job['delay']) : $now,
+                    )
+                )->all());
+            });
+        }
+
+        return $result;
     }
 
     /**

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -407,6 +407,24 @@ abstract class Queue
     }
 
     /**
+     * Partition the given jobs by whether they should be deferred until the active database transaction commits.
+     *
+     * @param  array  $jobs
+     * @return array{0: array, 1: array}
+     */
+    protected function partitionJobsByAfterCommit(array $jobs)
+    {
+        if (! isset($this->container) || ! $this->container->bound('db.transactions')) {
+            return [[], $jobs];
+        }
+
+        return (new Collection($jobs))
+            ->partition(fn ($job) => $this->shouldDispatchAfterCommit($job))
+            ->map(fn ($jobs) => $jobs->values()->all())
+            ->all();
+    }
+
+    /**
      * Register callbacks to release locks if the current database transaction is rolled back.
      *
      * @param  \Closure|string|object  $job

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -344,24 +344,6 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
     }
 
     /**
-     * Partition the given jobs by whether they should be deferred until the active database transaction commits.
-     *
-     * @param  array  $jobs
-     * @return array{0: array, 1: array}
-     */
-    protected function partitionJobsByAfterCommit(array $jobs)
-    {
-        if (! $this->container->bound('db.transactions')) {
-            return [[], $jobs];
-        }
-
-        return (new Collection($jobs))
-            ->partition(fn ($job) => $this->shouldDispatchAfterCommit($job))
-            ->map(fn ($jobs) => $jobs->values()->all())
-            ->all();
-    }
-
-    /**
      * Create the payload for each of the given jobs.
      *
      * Payloads are created at dispatch time, even for jobs deferred until after the transaction commits.

--- a/tests/Queue/QueueDatabaseQueueUnitTest.php
+++ b/tests/Queue/QueueDatabaseQueueUnitTest.php
@@ -251,6 +251,40 @@ class QueueDatabaseQueueUnitTest extends TestCase
         $queue->bulk([new JobWithDelayAttribute], ['data'], 'queue');
     }
 
+    public function testBulkDefersAfterCommitJobsUntilTheTransactionCommits()
+    {
+        $transactions = m::mock(\Illuminate\Database\DatabaseTransactionsManager::class);
+
+        $committed = null;
+
+        $transactions->shouldReceive('addCallback')->once()->andReturnUsing(function ($callback) use (&$committed) {
+            $committed = $callback;
+        });
+
+        $container = new Container;
+        $container->instance('db.transactions', $transactions);
+
+        $database = m::mock(Connection::class);
+        $queue = new DatabaseQueue($database, 'table', 'default');
+        $queue->setContainer($container);
+
+        $inserted = false;
+
+        $database->shouldReceive('table')->with('table')->once()->andReturn($query = m::mock(stdClass::class));
+        $query->shouldReceive('insert')->once()->andReturnUsing(function () use (&$inserted) {
+            $inserted = true;
+        });
+
+        $queue->bulk([new AfterCommitJob]);
+
+        $this->assertNotNull($committed);
+        $this->assertFalse($inserted);
+
+        $committed();
+
+        $this->assertTrue($inserted);
+    }
+
     public function testBuildDatabaseRecordWithPayloadAtTheEnd()
     {
         $queue = m::mock(DatabaseQueue::class);
@@ -464,6 +498,11 @@ class MyBatchableJob
 #[Delay(15)]
 class JobWithDelayAttribute
 {
+}
+
+class AfterCommitJob implements ShouldQueue
+{
+    public $afterCommit = true;
 }
 
 #[Backoff(9)]


### PR DESCRIPTION
When bulk dispatching jobs through the database queue, jobs configured to dispatch after commit are inserted immediately because `DatabaseQueue::bulk()` bypasses the normal after-commit dispatch flow.

This PR partitions bulk jobs by their after-commit configuration. Normal jobs continue to use the existing optimized bulk insert, while after-commit jobs are inserted only once the active database transaction commits.

A regression test verifies that an after-commit job is not inserted before the transaction callback runs.