### PR TITLE
[13.x] FIX flaky dominantColor() test

### DIFF
--- a/src/Illuminate/Image/Drivers/InterventionDriver.php
+++ b/src/Illuminate/Image/Drivers/InterventionDriver.php
@@ -175,7 +175,8 @@ abstract class InterventionDriver implements Driver
         $sample = clone $image;
 
         try {
-            return $sample->resize(1, 1)->colorAt(0, 0)->toHex(true);
+            // Interpolation during the 1x1 resize can leave alpha slightly non-opaque, so it's dropped here.
+            return substr($sample->resize(1, 1)->colorAt(0, 0)->toHex(true), 0, 7);
         } finally {
             unset($sample);
         }

--- a/tests/Image/Drivers/GdDriverTest.php
+++ b/tests/Image/Drivers/GdDriverTest.php
@@ -179,6 +179,14 @@ class GdDriverTest extends TestCase
         $this->assertSame('#0080ff', $driver->dominantColor($contents));
     }
 
+    public function test_dominant_color_ignores_alpha_channel(): void
+    {
+        $driver = new GdDriver;
+        $contents = $this->semiTransparentColorImageContents(0, 128, 255, 128);
+
+        $this->assertSame('#0080ff', $driver->dominantColor($contents));
+    }
+
     public function test_processes_crop()
     {
         $driver = new GdDriver;
@@ -485,6 +493,21 @@ class GdDriverTest extends TestCase
     {
         $image = imagecreatetruecolor($width, $height);
         $color = imagecolorallocate($image, $red, $green, $blue);
+        imagefill($image, 0, 0, $color);
+
+        ob_start();
+        imagepng($image);
+
+        return ob_get_clean();
+    }
+
+    protected function semiTransparentColorImageContents(int $red, int $green, int $blue, int $alpha, int $width = 100, int $height = 100): string
+    {
+        $image = imagecreatetruecolor($width, $height);
+        imagesavealpha($image, true);
+        // GD alpha runs 0 (opaque) to 127 (fully transparent), the inverse of a 0-255 alpha channel.
+        $gdAlpha = (int) round((255 - $alpha) / 255 * 127);
+        $color = imagecolorallocatealpha($image, $red, $green, $blue, $gdAlpha);
         imagefill($image, 0, 0, $color);
 
         ob_start();

--- a/tests/Image/Drivers/ImagickDriverTest.php
+++ b/tests/Image/Drivers/ImagickDriverTest.php
@@ -206,6 +206,14 @@ class ImagickDriverTest extends TestCase
         $this->assertSame('#0080ff', $driver->dominantColor($contents));
     }
 
+    public function test_dominant_color_ignores_alpha_channel(): void
+    {
+        $driver = new ImagickDriver;
+        $contents = $this->semiTransparentColorImageContents(0, 128, 255, 128);
+
+        $this->assertSame('#0080ff', $driver->dominantColor($contents));
+    }
+
     public function test_processes_crop()
     {
         $driver = new ImagickDriver;
@@ -495,6 +503,19 @@ class ImagickDriverTest extends TestCase
         $imagick = new \Imagick;
         $imagick->newImage($width, $height, new \ImagickPixel(sprintf('rgb(%d,%d,%d)', $red, $green, $blue)));
         $imagick->setImageAlphaChannel(\Imagick::ALPHACHANNEL_OPAQUE);
+        $imagick->setImageFormat('png');
+
+        $contents = $imagick->getImageBlob();
+        $imagick->clear();
+        $imagick->destroy();
+
+        return $contents;
+    }
+
+    protected function semiTransparentColorImageContents(int $red, int $green, int $blue, int $alpha, int $width = 100, int $height = 100): string
+    {
+        $imagick = new \Imagick;
+        $imagick->newImage($width, $height, new \ImagickPixel(sprintf('rgba(%d,%d,%d,%.2f)', $red, $green, $blue, $alpha / 255)));
         $imagick->setImageFormat('png');
 
         $contents = $imagick->getImageBlob();


### PR DESCRIPTION
Fixes flaky test seen here: https://github.com/laravel/framework/actions/runs/30786125662/job/91599886845

Resizing to 1x1 can leave alpha slightly non-opaque depending on the image library version, so `dominantColor()` occasionally returned an 8-char hex instead of 6. Alpha is now dropped.