### PR TITLE
[13.x] Use PHPUnit requirement attributes instead of markTestSkipped()

### DIFF
--- a/tests/Console/Scheduling/ScheduleWorkCommandTest.php
+++ b/tests/Console/Scheduling/ScheduleWorkCommandTest.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Carbon;
 use Illuminate\Tests\Console\Fixtures\FakeSignalsRegistry;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Mockery as m;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -43,12 +44,9 @@ class ScheduleWorkCommandTest extends TestCase
         parent::tearDown();
     }
 
-    public function test_stop_signal_marks_the_worker_to_quit()
+    #[RequiresPhpExtension('pcntl')]
+    public function test_stop_signal_marks_the_worker_to_quit(): void
     {
-        if (! extension_loaded('pcntl')) {
-            $this->markTestSkipped('The pcntl extension is required to trap signals.');
-        }
-
         // When a handler is registered, Signals chains any handler already bound
         // to the signal (see Signals::initializeSignal). Other tests may leave
         // real handlers in place, so reset these signals to their default

--- a/tests/Image/Drivers/GdDriverTest.php
+++ b/tests/Image/Drivers/GdDriverTest.php
@@ -20,6 +20,7 @@ use Illuminate\Image\Transformations\Rotate;
 use Illuminate\Image\Transformations\Scale;
 use Illuminate\Image\Transformations\Sharpen;
 use Intervention\Image\Interfaces\ImageInterface;
+use PHPUnit\Framework\Attributes\RequiresFunction;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\TestCase;
 
@@ -85,12 +86,9 @@ class GdDriverTest extends TestCase
         $this->assertSame(IMAGETYPE_GIF, getimagesizefromstring($result)[2]);
     }
 
-    public function test_processes_optimize_to_avif()
+    #[RequiresFunction('imageavif')]
+    public function test_processes_optimize_to_avif(): void
     {
-        if (! function_exists('imageavif')) {
-            $this->markTestSkipped('The GD extension was not compiled with AVIF support.');
-        }
-
         $driver = new GdDriver;
 
         $pipeline = $this->pipeline(format: 'avif');
@@ -100,12 +98,9 @@ class GdDriverTest extends TestCase
         $this->assertSame(IMAGETYPE_AVIF, getimagesizefromstring($result)[2]);
     }
 
-    public function test_processes_avif_input()
+    #[RequiresFunction('imageavif')]
+    public function test_processes_avif_input(): void
     {
-        if (! function_exists('imageavif')) {
-            $this->markTestSkipped('The GD extension was not compiled with AVIF support.');
-        }
-
         $driver = new GdDriver;
         $contents = $driver->process($this->fakeImageContents(), $this->pipeline(format: 'avif'));
 

--- a/tests/Image/ImageTest.php
+++ b/tests/Image/ImageTest.php
@@ -19,6 +19,7 @@ use Illuminate\Image\Transformations\Resize;
 use Illuminate\Image\Transformations\Rotate;
 use Illuminate\Image\Transformations\Scale;
 use Illuminate\Image\Transformations\Sharpen;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\TestCase;
 
 class ImageTest extends TestCase
@@ -256,12 +257,9 @@ class ImageTest extends TestCase
         $this->assertSame('jpg', $image->extension());
     }
 
-    public function test_extension_returns_avif_for_avif()
+    #[RequiresPhpExtension('imagick')]
+    public function test_extension_returns_avif_for_avif(): void
     {
-        if (! extension_loaded('imagick')) {
-            $this->markTestSkipped('The Imagick extension is not available.');
-        }
-
         $imagick = new \Imagick;
         $imagick->newImage(10, 10, 'red');
         $imagick->setImageFormat('avif');

--- a/tests/Integration/Queue/RedisQueueTest.php
+++ b/tests/Integration/Queue/RedisQueueTest.php
@@ -560,12 +560,8 @@ class RedisQueueTest extends TestCase
      * uses zadd directly (which triggers phpredis serialization) instead of a Lua
      * script (which bypasses serialization like pushRaw does).
      */
-    public function testDelayedJobsWorkWithPhpRedisSerializationEnabled()
+    public function testDelayedJobsWorkWithPhpRedisSerializationEnabled(): void
     {
-        if (! extension_loaded('redis')) {
-            $this->markTestSkipped('The redis extension is not installed.');
-        }
-
         // Get the phpredis connection and enable serialization
         $connection = $this->redis['phpredis']->connection();
         $client = $connection->client();

--- a/tests/Redis/PhpRedisConnectorTest.php
+++ b/tests/Redis/PhpRedisConnectorTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Redis;
 
 use Illuminate\Redis\Connectors\PhpRedisConnector;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\TestCase;
 
 class PhpRedisConnectorTest extends TestCase
@@ -201,12 +202,9 @@ class PhpRedisConnectorTest extends TestCase
         $this->assertSame(42, $connector->testParseBackoffAlgorithm(42));
     }
 
-    public function testParseBackoffAlgorithmParsesValidNames()
+    #[RequiresPhpExtension('redis')]
+    public function testParseBackoffAlgorithmParsesValidNames(): void
     {
-        if (! extension_loaded('redis')) {
-            $this->markTestSkipped('Requires phpredis extension.');
-        }
-
         $connector = new TestablePhpRedisConnector;
 
         $this->assertSame(\Redis::BACKOFF_ALGORITHM_DEFAULT, $connector->testParseBackoffAlgorithm('default'));

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -20,6 +20,7 @@ use IteratorAggregate;
 use LogicException;
 use Mockery as m;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\RequiresPhp;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use RuntimeException;
@@ -1612,12 +1613,9 @@ class SupportHelpersTest extends TestCase
         );
     }
 
+    #[RequiresPhp('>= 8.4.0')]
     public function testLazy(): void
     {
-        if (version_compare(phpversion(), '8.4.0', '<')) {
-            $this->markTestSkipped();
-        }
-
         SupportLazyClass::$constructorCalled = false;
 
         $instance = lazy(SupportLazyClass::class, function (SupportLazyClass $instance) {
@@ -1632,12 +1630,9 @@ class SupportHelpersTest extends TestCase
         SupportLazyClass::$constructorCalled = false;
     }
 
+    #[RequiresPhp('>= 8.4.0')]
     public function testLazyCanAcceptShortClosure(): void
     {
-        if (version_compare(phpversion(), '8.4.0', '<')) {
-            $this->markTestSkipped();
-        }
-
         SupportLazyClass::$constructorCalled = false;
 
         $instance = lazy(SupportLazyClass::class, fn (SupportLazyClass $instance) => $instance->__construct('foo', 'bar'));
@@ -1650,12 +1645,9 @@ class SupportHelpersTest extends TestCase
         SupportLazyClass::$constructorCalled = false;
     }
 
-    public function testLazyThrowsExceptionWhenConstructorIsNotCalled()
+    #[RequiresPhp('>= 8.4.0')]
+    public function testLazyThrowsExceptionWhenConstructorIsNotCalled(): void
     {
-        if (version_compare(phpversion(), '8.4.0', '<')) {
-            $this->markTestSkipped();
-        }
-
         $instance = lazy(SupportLazyClass::class, function (SupportLazyClass $instance) {
             //
         });
@@ -1668,12 +1660,9 @@ class SupportHelpersTest extends TestCase
         $instance->first;
     }
 
+    #[RequiresPhp('>= 8.4.0')]
     public function testLazyCanAcceptHashForProperties(): void
     {
-        if (version_compare(phpversion(), '8.4.0', '<')) {
-            $this->markTestSkipped();
-        }
-
         SupportLazyClass::$constructorCalled = false;
 
         $instance = lazy(SupportLazyClass::class, fn (SupportLazyClass $instance) => [
@@ -1689,12 +1678,9 @@ class SupportHelpersTest extends TestCase
         SupportLazyClass::$constructorCalled = false;
     }
 
+    #[RequiresPhp('>= 8.4.0')]
     public function testLazyCanAcceptListForProperties(): void
     {
-        if (version_compare(phpversion(), '8.4.0', '<')) {
-            $this->markTestSkipped();
-        }
-
         SupportLazyClass::$constructorCalled = false;
 
         $instance = lazy(SupportLazyClass::class, fn (SupportLazyClass $instance) => ['foo', 'bar']);
@@ -1707,12 +1693,9 @@ class SupportHelpersTest extends TestCase
         SupportLazyClass::$constructorCalled = false;
     }
 
+    #[RequiresPhp('>= 8.4.0')]
     public function testLazyCanAcceptSingleValueForConstructor(): void
     {
-        if (version_compare(phpversion(), '8.4.0', '<')) {
-            $this->markTestSkipped();
-        }
-
         SupportLazyClassWithArrayParameter::$constructorCalled = false;
 
         $instance = lazy(SupportLazyClassWithArrayParameter::class, fn (SupportLazyClassWithArrayParameter $instance) => [['foo']]);
@@ -1724,12 +1707,9 @@ class SupportHelpersTest extends TestCase
         SupportLazyClassWithArrayParameter::$constructorCalled = false;
     }
 
+    #[RequiresPhp('>= 8.4.0')]
     public function testLazySupportsPositionAndNamedArguments(): void
     {
-        if (version_compare(phpversion(), '8.4.0', '<')) {
-            $this->markTestSkipped();
-        }
-
         SupportLazyClass::$constructorCalled = false;
 
         $instance = lazy(SupportLazyClass::class, fn (SupportLazyClass $instance) => ['foo', 'second' => 'bar']);
@@ -1742,12 +1722,9 @@ class SupportHelpersTest extends TestCase
         SupportLazyClass::$constructorCalled = false;
     }
 
+    #[RequiresPhp('>= 8.4.0')]
     public function testLazyThrowsWhenPositionalArgumentsComeAfterNamedArguments(): void
     {
-        if (version_compare(phpversion(), '8.4.0', '<')) {
-            $this->markTestSkipped();
-        }
-
         SupportLazyClass::$constructorCalled = false;
 
         $instance = lazy(SupportLazyClass::class, fn (SupportLazyClass $instance) => ['second' => 'bar', 'foo']);
@@ -1759,12 +1736,9 @@ class SupportHelpersTest extends TestCase
         $instance->first;
     }
 
+    #[RequiresPhp('>= 8.4.0')]
     public function testLazyCanReturnInitializedObject(): void
     {
-        if (version_compare(phpversion(), '8.4.0', '<')) {
-            $this->markTestSkipped();
-        }
-
         SupportLazyClass::$constructorCalled = false;
 
         $instance = lazy(SupportLazyClass::class, function (SupportLazyClass $instance) {
@@ -1781,12 +1755,9 @@ class SupportHelpersTest extends TestCase
         SupportLazyClass::$constructorCalled = false;
     }
 
+    #[RequiresPhp('>= 8.4.0')]
     public function testLazyMustInitilizeObject(): void
     {
-        if (version_compare(phpversion(), '8.4.0', '<')) {
-            $this->markTestSkipped();
-        }
-
         SupportLazyClass::$constructorCalled = false;
 
         $instance = lazy(SupportLazyClass::class, function (SupportLazyClass $instance) {
@@ -1800,12 +1771,9 @@ class SupportHelpersTest extends TestCase
         $instance->first;
     }
 
+    #[RequiresPhp('>= 8.4.0')]
     public function testLazyCanEagerlySetProperties(): void
     {
-        if (version_compare(phpversion(), '8.4.0', '<')) {
-            $this->markTestSkipped();
-        }
-
         SupportLazyClass::$constructorCalled = false;
 
         $instance = lazy(SupportLazyClass::class, fn () => ['foo', 'bar'], eager: ['eager' => 'baz']);
@@ -1820,12 +1788,9 @@ class SupportHelpersTest extends TestCase
         SupportLazyClass::$constructorCalled = false;
     }
 
+    #[RequiresPhp('>= 8.4.0')]
     public function testClosureOnlyLazy(): void
     {
-        if (version_compare(phpversion(), '8.4.0', '<')) {
-            $this->markTestSkipped();
-        }
-
         SupportLazyClass::$constructorCalled = false;
 
         $instance = lazy(function (SupportLazyClass $instance) {
@@ -1840,12 +1805,9 @@ class SupportHelpersTest extends TestCase
         SupportLazyClass::$constructorCalled = false;
     }
 
+    #[RequiresPhp('>= 8.4.0')]
     public function testClosureOnlyLazyCanAcceptShortClosure(): void
     {
-        if (version_compare(phpversion(), '8.4.0', '<')) {
-            $this->markTestSkipped();
-        }
-
         SupportLazyClass::$constructorCalled = false;
 
         $instance = lazy(fn (SupportLazyClass $instance) => $instance->__construct('foo', 'bar'));
@@ -1858,12 +1820,9 @@ class SupportHelpersTest extends TestCase
         SupportLazyClass::$constructorCalled = false;
     }
 
-    public function testClosureOnlyLazyThrowsExceptionWhenConstructorIsNotCalled()
+    #[RequiresPhp('>= 8.4.0')]
+    public function testClosureOnlyLazyThrowsExceptionWhenConstructorIsNotCalled(): void
     {
-        if (version_compare(phpversion(), '8.4.0', '<')) {
-            $this->markTestSkipped();
-        }
-
         $instance = lazy(function (SupportLazyClass $instance) {
             //
         });
@@ -1876,12 +1835,9 @@ class SupportHelpersTest extends TestCase
         $instance->first;
     }
 
-    public function testClosureOnlyLazyThrowsWhenNotClassSpecifiedInClosure()
+    #[RequiresPhp('>= 8.4.0')]
+    public function testClosureOnlyLazyThrowsWhenNotClassSpecifiedInClosure(): void
     {
-        if (version_compare(phpversion(), '8.4.0', '<')) {
-            $this->markTestSkipped();
-        }
-
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('The first parameter of the given Closure is missing a type hint.');
 
@@ -1890,12 +1846,9 @@ class SupportHelpersTest extends TestCase
         });
     }
 
+    #[RequiresPhp('>= 8.4.0')]
     public function testClosureOnlyLazyCanAcceptHashForProperties(): void
     {
-        if (version_compare(phpversion(), '8.4.0', '<')) {
-            $this->markTestSkipped();
-        }
-
         SupportLazyClass::$constructorCalled = false;
 
         $instance = lazy(fn (SupportLazyClass $instance) => [
@@ -1911,12 +1864,9 @@ class SupportHelpersTest extends TestCase
         SupportLazyClass::$constructorCalled = false;
     }
 
+    #[RequiresPhp('>= 8.4.0')]
     public function testClosureOnlyLazyCanAcceptListForProperties(): void
     {
-        if (version_compare(phpversion(), '8.4.0', '<')) {
-            $this->markTestSkipped();
-        }
-
         SupportLazyClass::$constructorCalled = false;
 
         $instance = lazy(fn (SupportLazyClass $instance) => ['foo', 'bar']);
@@ -1929,12 +1879,9 @@ class SupportHelpersTest extends TestCase
         SupportLazyClass::$constructorCalled = false;
     }
 
+    #[RequiresPhp('>= 8.4.0')]
     public function testClousureOnlyLazyCanAcceptSingleValueForConstructor(): void
     {
-        if (version_compare(phpversion(), '8.4.0', '<')) {
-            $this->markTestSkipped();
-        }
-
         SupportLazyClassWithArrayParameter::$constructorCalled = false;
 
         $instance = lazy(fn (SupportLazyClassWithArrayParameter $instance) => [['foo']]);
@@ -1946,12 +1893,9 @@ class SupportHelpersTest extends TestCase
         SupportLazyClassWithArrayParameter::$constructorCalled = false;
     }
 
+    #[RequiresPhp('>= 8.4.0')]
     public function testClosureOnlyLazySupportsPositionAndNamedArguments(): void
     {
-        if (version_compare(phpversion(), '8.4.0', '<')) {
-            $this->markTestSkipped();
-        }
-
         SupportLazyClass::$constructorCalled = false;
 
         $instance = lazy(fn (SupportLazyClass $instance) => ['foo', 'second' => 'bar']);
@@ -1964,12 +1908,9 @@ class SupportHelpersTest extends TestCase
         SupportLazyClass::$constructorCalled = false;
     }
 
+    #[RequiresPhp('>= 8.4.0')]
     public function testClosureOnlyLazyThrowsWhenPositionalArgumentsComeAfterNamedArguments(): void
     {
-        if (version_compare(phpversion(), '8.4.0', '<')) {
-            $this->markTestSkipped();
-        }
-
         SupportLazyClass::$constructorCalled = false;
 
         $instance = lazy(fn (SupportLazyClass $instance) => ['second' => 'bar', 'foo']);
@@ -1981,12 +1922,9 @@ class SupportHelpersTest extends TestCase
         $instance->first;
     }
 
+    #[RequiresPhp('>= 8.4.0')]
     public function testClosureOnlyLazyCanReturnInitializedObject(): void
     {
-        if (version_compare(phpversion(), '8.4.0', '<')) {
-            $this->markTestSkipped();
-        }
-
         SupportLazyClass::$constructorCalled = false;
 
         $instance = lazy(function (SupportLazyClass $instance) {
@@ -2003,12 +1941,9 @@ class SupportHelpersTest extends TestCase
         SupportLazyClass::$constructorCalled = false;
     }
 
+    #[RequiresPhp('>= 8.4.0')]
     public function testClosureOnlyLazyMustInitilizeObject(): void
     {
-        if (version_compare(phpversion(), '8.4.0', '<')) {
-            $this->markTestSkipped();
-        }
-
         SupportLazyClass::$constructorCalled = false;
 
         $instance = lazy(function (SupportLazyClass $instance) {
@@ -2022,12 +1957,9 @@ class SupportHelpersTest extends TestCase
         $instance->first;
     }
 
+    #[RequiresPhp('>= 8.4.0')]
     public function testProxy(): void
     {
-        if (version_compare(phpversion(), '8.4.0', '<')) {
-            $this->markTestSkipped();
-        }
-
         SupportLazyClass::$constructorCalled = false;
         $factory = fn () => new SupportLazyClass('foo', 'bar');
 
@@ -2041,12 +1973,9 @@ class SupportHelpersTest extends TestCase
         SupportLazyClass::$constructorCalled = false;
     }
 
+    #[RequiresPhp('>= 8.4.0')]
     public function testProxyCanEagerlySetProperties(): void
     {
-        if (version_compare(phpversion(), '8.4.0', '<')) {
-            $this->markTestSkipped();
-        }
-
         SupportLazyClass::$constructorCalled = false;
         $factory = fn () => new SupportLazyClass('foo', 'bar');
 
@@ -2062,12 +1991,9 @@ class SupportHelpersTest extends TestCase
         SupportLazyClass::$constructorCalled = false;
     }
 
+    #[RequiresPhp('>= 8.4.0')]
     public function testProxyCanEagerlySetPropertiesAndThenAlsoSetThemOnActualObject(): void
     {
-        if (version_compare(phpversion(), '8.4.0', '<')) {
-            $this->markTestSkipped();
-        }
-
         SupportLazyClass::$constructorCalled = false;
         $factory = fn () => new SupportLazyClass('foo', 'bar');
 
@@ -2091,12 +2017,9 @@ class SupportHelpersTest extends TestCase
         SupportLazyClass::$constructorCalled = false;
     }
 
+    #[RequiresPhp('>= 8.4.0')]
     public function testProxyCanAcceptShortClosure(): void
     {
-        if (version_compare(phpversion(), '8.4.0', '<')) {
-            $this->markTestSkipped();
-        }
-
         SupportLazyClass::$constructorCalled = false;
         $factory = fn () => new SupportLazyClass('foo', 'bar');
 
@@ -2110,12 +2033,9 @@ class SupportHelpersTest extends TestCase
         SupportLazyClass::$constructorCalled = false;
     }
 
-    public function testProxyThrowsExceptionWhenObjectIsNotReturned()
+    #[RequiresPhp('>= 8.4.0')]
+    public function testProxyThrowsExceptionWhenObjectIsNotReturned(): void
     {
-        if (version_compare(phpversion(), '8.4.0', '<')) {
-            $this->markTestSkipped();
-        }
-
         $instance = proxy(SupportLazyClass::class, function (SupportLazyClass $proxy) {
             //
         });
@@ -2128,12 +2048,9 @@ class SupportHelpersTest extends TestCase
         $instance->first;
     }
 
+    #[RequiresPhp('>= 8.4.0')]
     public function testProxyMustNotInitilizeProxy(): void
     {
-        if (version_compare(phpversion(), '8.4.0', '<')) {
-            $this->markTestSkipped();
-        }
-
         SupportLazyClass::$constructorCalled = false;
 
         $instance = proxy(SupportLazyClass::class, function (SupportLazyClass $proxy) {
@@ -2149,12 +2066,9 @@ class SupportHelpersTest extends TestCase
         $instance->first;
     }
 
+    #[RequiresPhp('>= 8.4.0')]
     public function testClosureOnlyProxy(): void
     {
-        if (version_compare(phpversion(), '8.4.0', '<')) {
-            $this->markTestSkipped();
-        }
-
         SupportLazyClass::$constructorCalled = false;
         $factory = fn () => new SupportLazyClass('foo', 'bar');
 
@@ -2170,12 +2084,9 @@ class SupportHelpersTest extends TestCase
         SupportLazyClass::$constructorCalled = false;
     }
 
+    #[RequiresPhp('>= 8.4.0')]
     public function testClosureOnlyProxyCanAcceptShortClosure(): void
     {
-        if (version_compare(phpversion(), '8.4.0', '<')) {
-            $this->markTestSkipped();
-        }
-
         SupportLazyClass::$constructorCalled = false;
         $factory = fn () => new SupportLazyClass('foo', 'bar');
 
@@ -2189,12 +2100,9 @@ class SupportHelpersTest extends TestCase
         SupportLazyClass::$constructorCalled = false;
     }
 
-    public function testClosureOnlyProxyThrowsExceptionWhenObjectIsNotReturned()
+    #[RequiresPhp('>= 8.4.0')]
+    public function testClosureOnlyProxyThrowsExceptionWhenObjectIsNotReturned(): void
     {
-        if (version_compare(phpversion(), '8.4.0', '<')) {
-            $this->markTestSkipped();
-        }
-
         $instance = proxy(function (SupportLazyClass $proxy) {
             //
         });
@@ -2207,12 +2115,9 @@ class SupportHelpersTest extends TestCase
         $instance->first;
     }
 
-    public function testClosureOnlyProxyThrowsWhenNotClassSpecifiedInClosure()
+    #[RequiresPhp('>= 8.4.0')]
+    public function testClosureOnlyProxyThrowsWhenNotClassSpecifiedInClosure(): void
     {
-        if (version_compare(phpversion(), '8.4.0', '<')) {
-            $this->markTestSkipped();
-        }
-
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('The first parameter of the given Closure is missing a type hint.');
 
@@ -2221,12 +2126,9 @@ class SupportHelpersTest extends TestCase
         });
     }
 
+    #[RequiresPhp('>= 8.4.0')]
     public function testClosureOnlyProxyMustNotInitilizeProxy(): void
     {
-        if (version_compare(phpversion(), '8.4.0', '<')) {
-            $this->markTestSkipped();
-        }
-
         SupportLazyClass::$constructorCalled = false;
 
         $instance = proxy(function (SupportLazyClass $proxy) {
@@ -2242,12 +2144,9 @@ class SupportHelpersTest extends TestCase
         $instance->first;
     }
 
+    #[RequiresPhp('>= 8.4.0')]
     public function testProxyCanUseClosureReturnTypeForClassDetection(): void
     {
-        if (version_compare(phpversion(), '8.4.0', '<')) {
-            $this->markTestSkipped();
-        }
-
         SupportLazyClass::$constructorCalled = false;
         $factory = fn () => new SupportLazyClass('foo', 'bar');
 


### PR DESCRIPTION
Replaces manual `extension_loaded()`/`version_compare()` guards with PHPUnit's `#[RequiresPhpExtension]` and `#[RequiresPhp]` attributes where the check is static.