### PR TITLE
[13.x] Remove unregistered skipped rector rule

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -27,7 +27,6 @@ use Rector\Php80\Rector\FuncCall\ClassOnObjectRector;
 use Rector\Php80\Rector\Switch_\ChangeSwitchToMatchRector;
 use Rector\Php80\Rector\Ternary\GetDebugTypeRector;
 use Rector\Php81\Rector\Array_\ArrayToFirstClassCallableRector;
-use Rector\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector;
 use Rector\Php81\Rector\Property\ReadOnlyPropertyRector;
 use Rector\Php83\Rector\ClassConst\AddTypeToConstRector;
 use Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector;
@@ -89,7 +88,6 @@ return RectorConfig::configure()
         DynamicClassConstFetchRector::class,
         FunctionFirstClassCallableRector::class,
         GetDebugTypeRector::class,
-        NullToStrictStringFuncCallArgRector::class,
         RandomFunctionRector::class,
         ReadOnlyPropertyRector::class,
         RemoveExtraParametersRector::class,


### PR DESCRIPTION
Removes an unregistered rule from rector.php's `withSkip()` — `vendor/bin/rector --rules-summary` flags it as dead.