### PR TITLE
[13.x] Use array_any/array_find instead of manual foreach loops

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2281,16 +2281,7 @@ trait HasAttributes
             return count($changes) > 0;
         }
 
-        // Here we will spin through every attribute and see if this is in the array of
-        // dirty attributes. If it is, we will return true and if we make it through
-        // all of the attributes for the entire array we will return false at end.
-        foreach (Arr::wrap($attributes) as $attribute) {
-            if (array_key_exists($attribute, $changes)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any(Arr::wrap($attributes), fn ($attribute) => array_key_exists($attribute, $changes));
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -176,13 +176,10 @@ class Builder
             return (bool) $this->connection->scalar($sql);
         }
 
-        foreach ($this->getTables($schema ?? $this->getCurrentSchemaName()) as $value) {
-            if (strtolower($table) === strtolower($value['name'])) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any(
+            $this->getTables($schema ?? $this->getCurrentSchemaName()),
+            fn ($value) => strtolower($table) === strtolower($value['name'])
+        );
     }
 
     /**
@@ -197,13 +194,10 @@ class Builder
 
         $view = $this->connection->getTablePrefix().$view;
 
-        foreach ($this->getViews($schema ?? $this->getCurrentSchemaName()) as $value) {
-            if (strtolower($view) === strtolower($value['name'])) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any(
+            $this->getViews($schema ?? $this->getCurrentSchemaName()),
+            fn ($value) => strtolower($view) === strtolower($value['name'])
+        );
     }
 
     /**
@@ -468,13 +462,10 @@ class Builder
      */
     public function hasForeignKey($table, $foreignKey)
     {
-        foreach ($this->getForeignKeys($table) as $value) {
-            if ($value['name'] === $foreignKey || $value['columns'] === $foreignKey) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any(
+            $this->getForeignKeys($table),
+            fn ($value) => $value['name'] === $foreignKey || $value['columns'] === $foreignKey
+        );
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -447,13 +447,7 @@ abstract class Grammar extends BaseGrammar
      */
     protected function hasCommand(Blueprint $blueprint, $name)
     {
-        foreach ($blueprint->getCommands() as $command) {
-            if ($command->name === $name) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($blueprint->getCommands(), fn ($command) => $command->name === $name);
     }
 
     /**

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -520,10 +520,8 @@ class Handler implements ExceptionHandlerContract
             return true;
         }
 
-        foreach ($this->dontReportCallbacks as $dontReportCallback) {
-            if ($dontReportCallback($e) === true) {
-                return true;
-            }
+        if (array_any($this->dontReportCallbacks, fn ($dontReportCallback) => $dontReportCallback($e) === true)) {
+            return true;
         }
 
         return rescue(fn () => with($this->throttle($e), function ($throttle) use ($e) {

--- a/src/Illuminate/Foundation/Exceptions/ReportableHandler.php
+++ b/src/Illuminate/Foundation/Exceptions/ReportableHandler.php
@@ -58,13 +58,7 @@ class ReportableHandler
      */
     public function handles(Throwable $e)
     {
-        foreach ($this->firstClosureParameterTypes($this->callback) as $type) {
-            if (is_a($e, $type)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($this->firstClosureParameterTypes($this->callback), fn ($type) => is_a($e, $type));
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/RefreshDatabase.php
+++ b/src/Illuminate/Foundation/Testing/RefreshDatabase.php
@@ -34,13 +34,7 @@ trait RefreshDatabase
      */
     protected function usingInMemoryDatabases()
     {
-        foreach ($this->connectionsToTransact() as $name) {
-            if ($this->usingInMemoryDatabase($name)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($this->connectionsToTransact(), fn ($name) => $this->usingInMemoryDatabase($name));
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -313,21 +313,17 @@ class Str
             $haystack = mb_strtolower($haystack);
         }
 
-        if (! is_iterable($needles)) {
-            $needles = (array) $needles;
+        if (! is_array($needles)) {
+            $needles = $needles instanceof Traversable ? iterator_to_array($needles) : (array) $needles;
         }
 
-        foreach ($needles as $needle) {
+        return array_any($needles, function ($needle) use ($haystack, $ignoreCase) {
             if ($ignoreCase) {
                 $needle = mb_strtolower($needle);
             }
 
-            if ($needle !== '' && str_contains($haystack, $needle)) {
-                return true;
-            }
-        }
-
-        return false;
+            return $needle !== '' && str_contains($haystack, $needle);
+        });
     }
 
     /**
@@ -424,17 +420,11 @@ class Str
             return false;
         }
 
-        if (! is_iterable($needles)) {
-            $needles = (array) $needles;
+        if (! is_array($needles)) {
+            $needles = $needles instanceof Traversable ? iterator_to_array($needles) : (array) $needles;
         }
 
-        foreach ($needles as $needle) {
-            if ((string) $needle !== '' && str_ends_with($haystack, $needle)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($needles, fn ($needle) => (string) $needle !== '' && str_ends_with($haystack, $needle));
     }
 
     /**
@@ -920,19 +910,11 @@ class Str
     {
         $value = (string) $value;
 
-        if (! is_iterable($pattern)) {
-            $pattern = [$pattern];
+        if (! is_array($pattern)) {
+            $pattern = $pattern instanceof Traversable ? iterator_to_array($pattern) : [$pattern];
         }
 
-        foreach ($pattern as $pattern) {
-            $pattern = (string) $pattern;
-
-            if (preg_match($pattern, $value) === 1) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($pattern, fn ($pattern) => preg_match((string) $pattern, $value) === 1);
     }
 
     /**
@@ -1754,17 +1736,11 @@ class Str
             return false;
         }
 
-        if (! is_iterable($needles)) {
-            $needles = [$needles];
+        if (! is_array($needles)) {
+            $needles = $needles instanceof Traversable ? iterator_to_array($needles) : [$needles];
         }
 
-        foreach ($needles as $needle) {
-            if ((string) $needle !== '' && str_starts_with($haystack, $needle)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($needles, fn ($needle) => (string) $needle !== '' && str_starts_with($haystack, $needle));
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -187,13 +187,10 @@ trait FormatsMessages
      */
     protected function getWildcardCustomMessages($messages, $search, $default)
     {
-        foreach ($messages as $key => $message) {
-            if ($search === $key || (Str::contains($key, ['*']) && Str::is($key, $search))) {
-                return $message;
-            }
-        }
-
-        return $default;
+        return array_find(
+            $messages,
+            fn ($message, $key) => $search === $key || (Str::contains($key, ['*']) && Str::is($key, $search))
+        ) ?? $default;
     }
 
     /**


### PR DESCRIPTION
Use array_any/array_find instead of manual foreach loops in Str, Schema Builder/Grammar, HasAttributes, exception handlers, RefreshDatabase, and validation message formatting.