### PR TITLE
[13.x] Avoid repeated Redis prefix/connection lookups in tag-set loops

### DIFF
--- a/src/Illuminate/Cache/RedisTagSet.php
+++ b/src/Illuminate/Cache/RedisTagSet.php
@@ -20,11 +20,14 @@ class RedisTagSet extends TagSet
     {
         $ttl = is_null($ttl) ? -1 : Carbon::now()->addSeconds($ttl)->getTimestamp();
 
+        $connection = $this->store->connection();
+        $prefix = $this->store->getPrefix();
+
         foreach ($this->tagIds() as $tagKey) {
             if ($updateWhen) {
-                $this->store->connection()->zadd($this->store->getPrefix().$tagKey, $updateWhen, $ttl, $key);
+                $connection->zadd($prefix.$tagKey, $updateWhen, $ttl, $key);
             } else {
-                $this->store->connection()->zadd($this->store->getPrefix().$tagKey, $ttl, $key);
+                $connection->zadd($prefix.$tagKey, $ttl, $key);
             }
         }
     }
@@ -44,12 +47,14 @@ class RedisTagSet extends TagSet
         };
 
         return new LazyCollection(function () use ($connection, $defaultCursorValue) {
+            $prefix = $this->store->getPrefix();
+
             foreach ($this->tagIds() as $tagKey) {
                 $cursor = $defaultCursorValue;
 
                 do {
                     $results = $connection->zscan(
-                        $this->store->getPrefix().$tagKey,
+                        $prefix.$tagKey,
                         $cursor,
                         ['match' => '*', 'count' => 1000]
                     );
@@ -85,9 +90,12 @@ class RedisTagSet extends TagSet
      */
     public function flushStaleEntries()
     {
-        $flushStaleEntries = function ($pipe) {
+        $prefix = $this->store->getPrefix();
+        $now = Carbon::now()->getTimestamp();
+
+        $flushStaleEntries = function ($pipe) use ($prefix, $now) {
             foreach ($this->tagIds() as $tagKey) {
-                $pipe->zremrangebyscore($this->store->getPrefix().$tagKey, 0, Carbon::now()->getTimestamp());
+                $pipe->zremrangebyscore($prefix.$tagKey, 0, $now);
             }
         };
 

--- a/src/Illuminate/Cache/RedisTaggedCache.php
+++ b/src/Illuminate/Cache/RedisTaggedCache.php
@@ -159,8 +159,10 @@ class RedisTaggedCache extends TaggedCache
             end
         LUA;
 
+        $prefix = $this->store->getPrefix();
+
         $entries = $this->tags->entries()
-            ->map(fn (string $key) => $this->store->getPrefix().$key)
+            ->map(fn (string $key) => $prefix.$key)
             ->chunk(1000);
 
         foreach ($entries as $keysToBeDeleted) {
@@ -201,8 +203,10 @@ class RedisTaggedCache extends TaggedCache
      */
     protected function flushValues()
     {
+        $prefix = $this->store->getPrefix();
+
         $entries = $this->tags->entries()
-            ->map(fn (string $key) => $this->store->getPrefix().$key)
+            ->map(fn (string $key) => $prefix.$key)
             ->chunk(1000);
 
         $connection = $this->store->connection();


### PR DESCRIPTION
Compute the Redis connection and key prefix once before the loop instead of on every tag-set iteration in RedisTagSet and RedisTaggedCache.