### PR TITLE
[13.x] Use array_all instead of manual foreach loops

### DIFF
--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -506,13 +506,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      */
     protected function shouldLogin($callbacks, AuthenticatableContract $user)
     {
-        foreach (Arr::wrap($callbacks) as $callback) {
-            if (! $callback($user, $this)) {
-                return false;
-            }
-        }
-
-        return true;
+        return array_all(Arr::wrap($callbacks), fn ($callback) => $callback($user, $this));
     }
 
     /**

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -112,11 +112,7 @@ trait BuildsQueries
     public function each(callable $callback, $count = 1000)
     {
         return $this->chunk($count, function ($results) use ($callback) {
-            foreach ($results as $key => $value) {
-                if ($callback($value, $key) === false) {
-                    return false;
-                }
-            }
+            return array_all($results->all(), fn ($value, $key) => $callback($value, $key) !== false);
         });
     }
 
@@ -234,11 +230,10 @@ trait BuildsQueries
     public function eachById(callable $callback, $count = 1000, $column = null, $alias = null)
     {
         return $this->chunkById($count, function ($results, $page) use ($callback, $count) {
-            foreach ($results as $key => $value) {
-                if ($callback($value, (($page - 1) * $count) + $key) === false) {
-                    return false;
-                }
-            }
+            return array_all(
+                $results->all(),
+                fn ($value, $key) => $callback($value, (($page - 1) * $count) + $key) !== false
+            );
         }, $column, $alias);
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -1092,11 +1092,10 @@ class BelongsToMany extends Relation
     public function eachById(callable $callback, $count = 1000, $column = null, $alias = null)
     {
         return $this->chunkById($count, function ($results, $page) use ($callback, $count) {
-            foreach ($results as $key => $value) {
-                if ($callback($value, (($page - 1) * $count) + $key) === false) {
-                    return false;
-                }
-            }
+            return array_all(
+                $results->all(),
+                fn ($value, $key) => $callback($value, (($page - 1) * $count) + $key) !== false
+            );
         }, $column, $alias);
     }
 
@@ -1135,11 +1134,7 @@ class BelongsToMany extends Relation
     public function each(callable $callback, $count = 1000)
     {
         return $this->chunk($count, function ($results) use ($callback) {
-            foreach ($results as $key => $value) {
-                if ($callback($value, $key) === false) {
-                    return false;
-                }
-            }
+            return array_all($results->all(), fn ($value, $key) => $callback($value, $key) !== false);
         });
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrManyThrough.php
@@ -620,11 +620,7 @@ abstract class HasOneOrManyThrough extends Relation
     public function each(callable $callback, $count = 1000)
     {
         return $this->chunk($count, function ($results) use ($callback) {
-            foreach ($results as $key => $value) {
-                if ($callback($value, $key) === false) {
-                    return false;
-                }
-            }
+            return array_all($results->all(), fn ($value, $key) => $callback($value, $key) !== false);
         });
     }
 

--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -268,10 +268,8 @@ class Encrypter implements EncrypterContract, StringEncrypter
             return false;
         }
 
-        foreach (['iv', 'value', 'mac'] as $item) {
-            if (! isset($payload[$item]) || ! is_string($payload[$item])) {
-                return false;
-            }
+        if (! array_all(['iv', 'value', 'mac'], fn ($item) => isset($payload[$item]) && is_string($payload[$item]))) {
+            return false;
         }
 
         if (isset($payload['tag']) && ! is_string($payload['tag'])) {

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1550,10 +1550,8 @@ trait ValidatesAttributes
     public function validateIn($attribute, $value, $parameters)
     {
         if (is_array($value) && $this->hasRule($attribute, 'Array')) {
-            foreach ($value as $element) {
-                if (is_array($element)) {
-                    return false;
-                }
+            if (! array_all($value, fn ($element) => ! is_array($element))) {
+                return false;
             }
 
             return array_diff($value, $parameters) === [];
@@ -2338,11 +2336,10 @@ trait ValidatesAttributes
     public function validateProhibits($attribute, $value, $parameters)
     {
         if ($this->validateRequired($attribute, $value)) {
-            foreach ($parameters as $parameter) {
-                if ($this->validateRequired($parameter, Arr::get($this->data, $parameter))) {
-                    return false;
-                }
-            }
+            return array_all(
+                $parameters,
+                fn ($parameter) => ! $this->validateRequired($parameter, Arr::get($this->data, $parameter))
+            );
         }
 
         return true;


### PR DESCRIPTION
Replace manual foreach/return-false loops with array_all in Str, Encrypter, SessionGuard, ValidatesAttributes, BuildsQueries, and relation each()/eachById() methods.