### PR TITLE
[13.x] Use reduce() instead of foreach accumulator loops

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -571,15 +571,8 @@ trait InteractsWithPivotTable
      */
     protected function detachUsingCustomClass($ids)
     {
-        $results = 0;
-
-        $records = $this->getCurrentlyAttachedPivotsForIds($ids);
-
-        foreach ($records as $record) {
-            $results += $record->delete();
-        }
-
-        return $results;
+        return $this->getCurrentlyAttachedPivotsForIds($ids)
+            ->reduce(fn ($carry, $record) => $carry + $record->delete(), 0);
     }
 
     /**

--- a/src/Illuminate/Queue/Console/ClearCommand.php
+++ b/src/Illuminate/Queue/Console/ClearCommand.php
@@ -63,21 +63,15 @@ class ClearCommand extends Command
             return self::FAILURE;
         }
 
-        $count = 0;
-
         $queues = (new Stringable($queueName))->explode(',')
             ->map(fn ($queue) => trim($queue))
             ->filter()
-            ->unique()
-            ->values()
-            ->all();
+            ->unique();
 
-        foreach ($queues as $name) {
-            $count += $queue->clear($name);
-        }
+        $count = $queues->reduce(fn ($carry, $name) => $carry + $queue->clear($name), 0);
 
         $this->components->info(
-            sprintf('Cleared %s %s from the [%s] %s', $count, Str::plural('job', $count), implode(', ', $queues), (new Stringable('queue'))->plural($queues))
+            sprintf('Cleared %s %s from the [%s] %s', $count, Str::plural('job', $count), $queues->implode(', '), Str::plural('queue', $queues->count()))
         );
 
         return self::SUCCESS;


### PR DESCRIPTION
Simplify ClearCommand and InteractsWithPivotTable::detachUsingCustomClass to use Collection::reduce() instead of a manual foreach accumulator.