### PR TITLE
[13.x] Use strict comparisons for int-to-int checks

### DIFF
--- a/src/Illuminate/Cache/MemcachedStore.php
+++ b/src/Illuminate/Cache/MemcachedStore.php
@@ -57,7 +57,7 @@ class MemcachedStore extends TaggableStore implements LockProvider
     {
         $value = $this->memcached->get($this->prefix.$key);
 
-        if ($this->memcached->getResultCode() == 0) {
+        if ($this->memcached->getResultCode() === 0) {
             return $value;
         }
     }
@@ -84,7 +84,7 @@ class MemcachedStore extends TaggableStore implements LockProvider
             $values = $this->memcached->getMulti($prefixedKeys, $null, Memcached::GET_PRESERVE_ORDER);
         }
 
-        if ($this->memcached->getResultCode() != 0) {
+        if ($this->memcached->getResultCode() !== 0) {
             return array_fill_keys($keys, null);
         }
 

--- a/src/Illuminate/Console/Concerns/CreatesMatchingTest.php
+++ b/src/Illuminate/Console/Concerns/CreatesMatchingTest.php
@@ -41,6 +41,6 @@ trait CreatesMatchingTest
             '--pest' => $this->option('pest'),
             '--phpunit' => $this->option('phpunit'),
             '--force' => $this->hasOption('force') && $this->option('force'),
-        ]) == 0;
+        ]) === 0;
     }
 }

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -50,7 +50,7 @@ trait BuildsQueries
 
             $limit = is_null($remaining) ? $count : min($count, $remaining);
 
-            if ($limit == 0) {
+            if ($limit === 0) {
                 break;
             }
 
@@ -58,7 +58,7 @@ trait BuildsQueries
 
             $countResults = $results->count();
 
-            if ($countResults == 0) {
+            if ($countResults === 0) {
                 break;
             }
 
@@ -179,7 +179,7 @@ trait BuildsQueries
 
             $limit = is_null($remaining) ? $count : min($count, $remaining);
 
-            if ($limit == 0) {
+            if ($limit === 0) {
                 break;
             }
 
@@ -193,7 +193,7 @@ trait BuildsQueries
 
             $countResults = $results->count();
 
-            if ($countResults == 0) {
+            if ($countResults === 0) {
                 break;
             }
 

--- a/src/Illuminate/Database/Concerns/ManagesTransactions.php
+++ b/src/Illuminate/Database/Concerns/ManagesTransactions.php
@@ -49,7 +49,7 @@ trait ManagesTransactions
             $levelBeingCommitted = $this->transactions;
 
             try {
-                if ($this->transactions == 1) {
+                if ($this->transactions === 1) {
                     $this->fireConnectionEvent('committing');
                     $this->getPdo()->commit();
                 }
@@ -147,7 +147,7 @@ trait ManagesTransactions
      */
     protected function createTransaction()
     {
-        if ($this->transactions == 0) {
+        if ($this->transactions === 0) {
             $this->reconnectIfMissingConnection();
 
             try {
@@ -202,7 +202,7 @@ trait ManagesTransactions
      */
     public function commit()
     {
-        if ($this->transactionLevel() == 1) {
+        if ($this->transactionLevel() === 1) {
             $this->fireConnectionEvent('committing');
             $this->getPdo()->commit();
         }
@@ -299,7 +299,7 @@ trait ManagesTransactions
      */
     protected function performRollBack($toLevel)
     {
-        if ($toLevel == 0) {
+        if ($toLevel === 0) {
             $pdo = $this->getPdo();
 
             if ($pdo->inTransaction()) {

--- a/src/Illuminate/Database/Console/Migrations/FreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/FreshCommand.php
@@ -87,7 +87,7 @@ class FreshCommand extends Command
                     '--drop-views' => $this->option('drop-views'),
                     '--drop-types' => $this->option('drop-types'),
                     '--force' => true,
-                ])) == 0);
+                ])) === 0);
             }
         });
 

--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -145,7 +145,7 @@ class MigrateCommand extends BaseCommand implements Isolatable
             $this->components->task('Creating migration table', function () {
                 return $this->callSilent('migrate:install', array_filter([
                     '--database' => $this->option('database'),
-                ])) == 0;
+                ])) === 0;
             });
 
             $this->newLine();

--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -143,7 +143,7 @@ abstract class Grammar
     protected function wrapSegments($segments)
     {
         return (new Collection($segments))->map(function ($segment, $key) use ($segments) {
-            return $key == 0 && count($segments) > 1
+            return $key === 0 && count($segments) > 1
                 ? $this->wrapTable($segment)
                 : $this->wrapValue($segment);
         })->implode('.');

--- a/src/Illuminate/Foundation/Console/OptimizeClearCommand.php
+++ b/src/Illuminate/Foundation/Console/OptimizeClearCommand.php
@@ -45,7 +45,7 @@ class OptimizeClearCommand extends Command
             ->toArray();
 
         foreach ($tasks as $description => $command) {
-            $this->components->task($description, fn () => $this->callSilently($command) == 0);
+            $this->components->task($description, fn () => $this->callSilently($command) === 0);
         }
 
         $this->newLine();

--- a/src/Illuminate/Foundation/Console/OptimizeCommand.php
+++ b/src/Illuminate/Foundation/Console/OptimizeCommand.php
@@ -45,7 +45,7 @@ class OptimizeCommand extends Command
             ->toArray();
 
         foreach ($tasks as $description => $command) {
-            $this->components->task($description, fn () => $this->callSilently($command) == 0);
+            $this->components->task($description, fn () => $this->callSilently($command) === 0);
         }
 
         $this->newLine();

--- a/src/Illuminate/Foundation/Console/ReloadCommand.php
+++ b/src/Illuminate/Foundation/Console/ReloadCommand.php
@@ -45,7 +45,7 @@ class ReloadCommand extends Command
             ->toArray();
 
         foreach ($tasks as $description => $command) {
-            $this->components->task($description, fn () => $this->callSilently($command) == 0);
+            $this->components->task($description, fn () => $this->callSilently($command) === 0);
         }
 
         $this->newLine();

--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -225,7 +225,7 @@ trait ConditionallyLoadsAttributes
      */
     protected function whenNull($value, $default = new MissingValue)
     {
-        $arguments = func_num_args() == 1 ? [$value] : [$value, $default];
+        $arguments = func_num_args() === 1 ? [$value] : [$value, $default];
 
         return $this->when(is_null($value), ...$arguments);
     }
@@ -239,7 +239,7 @@ trait ConditionallyLoadsAttributes
      */
     protected function whenNotNull($value, $default = new MissingValue)
     {
-        $arguments = func_num_args() == 1 ? [$value] : [$value, $default];
+        $arguments = func_num_args() === 1 ? [$value] : [$value, $default];
 
         return $this->when(! is_null($value), ...$arguments);
     }

--- a/src/Illuminate/Queue/Console/RetryBatchCommand.php
+++ b/src/Illuminate/Queue/Console/RetryBatchCommand.php
@@ -52,7 +52,7 @@ class RetryBatchCommand extends Command implements Isolatable
             foreach ($batch->failedJobIds as $failedJobId) {
                 $this->components->task(
                     $failedJobId,
-                    fn () => $this->callSilent('queue:retry', ['id' => $failedJobId]) == 0
+                    fn () => $this->callSilent('queue:retry', ['id' => $failedJobId]) === 0
                 );
             }
 

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -399,11 +399,11 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
     {
         $this->migrate($prefixed = $this->getQueueRedisKey($queue));
 
-        $block = ! $this->secondaryQueueHadJob && $index == 0;
+        $block = ! $this->secondaryQueueHadJob && $index === 0;
 
         [$job, $reserved] = $this->retrieveNextJob($prefixed, $block);
 
-        if ($index == 0) {
+        if ($index === 0) {
             $this->secondaryQueueHadJob = false;
         }
 

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1125,7 +1125,7 @@ trait ValidatesAttributes
 
         return $verifier->getCount(
             $table, $column, $value, $id, $idColumn, $extra
-        ) == 0;
+        ) === 0;
     }
 
     /**

--- a/src/Illuminate/View/Concerns/ManagesLoops.php
+++ b/src/Illuminate/View/Concerns/ManagesLoops.php
@@ -34,7 +34,7 @@ trait ManagesLoops
             'remaining' => $length ?? null,
             'count' => $length,
             'first' => true,
-            'last' => isset($length) ? $length == 1 : null,
+            'last' => isset($length) ? $length === 1 : null,
             'odd' => false,
             'even' => true,
             'depth' => count($this->loopsStack) + 1,
@@ -54,7 +54,7 @@ trait ManagesLoops
         $this->loopsStack[$index] = array_merge($this->loopsStack[$index], [
             'iteration' => $loop['iteration'] + 1,
             'index' => $loop['iteration'],
-            'first' => $loop['iteration'] == 0,
+            'first' => $loop['iteration'] === 0,
             'odd' => ! $loop['odd'],
             'even' => ! $loop['even'],
             'remaining' => isset($loop['count']) ? $loop['remaining'] - 1 : null,

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -387,7 +387,7 @@ class Factory implements FactoryContract
      */
     public function doneRendering()
     {
-        return $this->renderCount == 0;
+        return $this->renderCount === 0;
     }
 
     /**


### PR DESCRIPTION
Tighten several `==`/`!=` comparisons to `===`/`!==` where both operands are verifiably int (exit codes, counts, indices, iteration state).