### PR TITLE
[13.x] Use static instead of self in `LoadConfiguration`

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
@@ -34,7 +34,7 @@ class LoadConfiguration
         // we will need to spin through every configuration file and load them all.
         $loadedFromCache = false;
 
-        if (self::$alwaysUseConfig !== null) {
+        if (static::$alwaysUseConfig !== null) {
             $items = $app->call(self::$alwaysUseConfig);
 
             $loadedFromCache = true;


### PR DESCRIPTION
Happened to notice this while working on something else. This will allow for extending LoadConfiguration if userland would ever want to do that. 🤷 