### PR TITLE
[13.x] Add partial index support to the schema builder

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1760,9 +1760,15 @@ class Blueprint
         // index type, such as primary or index, which makes the index unique.
         $index = $index ?: $this->createIndexName($type, $columns);
 
-        return $this->addCommand(
-            $type, ['index' => $index, 'columns' => $columns, 'algorithm' => $algorithm, 'operatorClass' => $operatorClass]
-        );
+        $this->commands[] = $command = new IndexDefinition([
+            'name' => $type,
+            'index' => $index,
+            'columns' => $columns,
+            'algorithm' => $algorithm,
+            'operatorClass' => $operatorClass,
+        ]);
+
+        return $command;
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1760,13 +1760,16 @@ class Blueprint
         // index type, such as primary or index, which makes the index unique.
         $index = $index ?: $this->createIndexName($type, $columns);
 
-        $this->commands[] = $command = new IndexDefinition([
-            'name' => $type,
-            'index' => $index,
-            'columns' => $columns,
-            'algorithm' => $algorithm,
-            'operatorClass' => $operatorClass,
-        ]);
+        $command = new IndexDefinition(
+            $this->addCommand($type, [
+                'index' => $index,
+                'columns' => $columns,
+                'algorithm' => $algorithm,
+                'operatorClass' => $operatorClass,
+            ])->getAttributes()
+        );
+
+        $this->commands[count($this->commands) - 1] = $command;
 
         return $command;
     }

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -531,7 +531,29 @@ abstract class Grammar extends BaseGrammar
     }
 
     /**
+     * Reject partial index predicates on unsupported schema commands.
+     *
+     * @param  \Illuminate\Support\Fluent  $command
+     * @return void
+     *
+     * @throws \RuntimeException
+     */
+    protected function ensurePartialIndexCommandIsSupported(Fluent $command)
+    {
+        if (! $this->hasWhereClause($command)) {
+            return;
+        }
+
+        if (! in_array($command->name, ['unique', 'index'], true)) {
+            throw new RuntimeException("Partial indexes are not supported for [{$command->name}] commands.");
+        }
+    }
+
+    /**
      * Compile a partial index WHERE clause for the given index command.
+     *
+     * Supports structured attributes from IndexDefinition and a plain string
+     * attribute for direct / legacy attribute assignment.
      *
      * @param  \Illuminate\Support\Fluent  $command
      * @return string
@@ -543,6 +565,8 @@ abstract class Grammar extends BaseGrammar
         if (is_null($command->where)) {
             return '';
         }
+
+        $this->ensurePartialIndexCommandIsSupported($command);
 
         $where = $command->where;
 
@@ -581,7 +605,7 @@ abstract class Grammar extends BaseGrammar
         }
 
         if (is_bool($value)) {
-            return $value ? '1' : '0';
+            return $this->getDefaultValue($value);
         }
 
         if (is_numeric($value)) {

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -520,6 +520,90 @@ abstract class Grammar extends BaseGrammar
     }
 
     /**
+     * Determine if the given index command has a partial index predicate.
+     *
+     * @param  \Illuminate\Support\Fluent  $command
+     * @return bool
+     */
+    protected function hasWhereClause(Fluent $command)
+    {
+        return ! is_null($command->where);
+    }
+
+    /**
+     * Compile a partial index WHERE clause for the given index command.
+     *
+     * @param  \Illuminate\Support\Fluent  $command
+     * @return string
+     *
+     * @throws \RuntimeException
+     */
+    protected function compileWhereClause(Fluent $command)
+    {
+        if (is_null($command->where)) {
+            return '';
+        }
+
+        $where = $command->where;
+
+        if (is_string($where)) {
+            return ' where '.$where;
+        }
+
+        return match ($where['type'] ?? null) {
+            'Raw' => ' where '.$this->getValue($where['sql']),
+            'Null' => ' where '.$this->wrap($where['column']).' is null',
+            'NotNull' => ' where '.$this->wrap($where['column']).' is not null',
+            'Basic' => sprintf(
+                ' where %s %s %s',
+                $this->wrap($where['column']),
+                $where['operator'],
+                $this->quoteWhereValue($where['value'])
+            ),
+            default => throw new RuntimeException('Unsupported partial index where clause.'),
+        };
+    }
+
+    /**
+     * Quote a value for use in a partial index WHERE clause.
+     *
+     * @param  mixed  $value
+     * @return string
+     */
+    protected function quoteWhereValue($value)
+    {
+        if ($value instanceof Expression) {
+            return $this->getValue($value);
+        }
+
+        if (is_null($value)) {
+            return 'null';
+        }
+
+        if (is_bool($value)) {
+            return $value ? '1' : '0';
+        }
+
+        if (is_numeric($value)) {
+            return (string) $value;
+        }
+
+        return "'".str_replace("'", "''", (string) $value)."'";
+    }
+
+    /**
+     * Throw an exception for databases that do not support partial indexes.
+     *
+     * @return never
+     *
+     * @throws \RuntimeException
+     */
+    protected function throwMissingPartialIndexSupport()
+    {
+        throw new RuntimeException('This database driver does not support partial indexes.');
+    }
+
+    /**
      * Get the fluent commands for the grammar.
      *
      * @return array

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -445,6 +445,10 @@ class MySqlGrammar extends Grammar
      */
     public function compileUnique(Blueprint $blueprint, Fluent $command)
     {
+        if ($this->hasWhereClause($command)) {
+            $this->throwMissingPartialIndexSupport();
+        }
+
         return $this->compileKey($blueprint, $command, 'unique');
     }
 
@@ -457,6 +461,10 @@ class MySqlGrammar extends Grammar
      */
     public function compileIndex(Blueprint $blueprint, Fluent $command)
     {
+        if ($this->hasWhereClause($command)) {
+            $this->throwMissingPartialIndexSupport();
+        }
+
         return $this->compileKey($blueprint, $command, 'index');
     }
 

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -428,6 +428,8 @@ class MySqlGrammar extends Grammar
      */
     public function compilePrimary(Blueprint $blueprint, Fluent $command)
     {
+        $this->ensurePartialIndexCommandIsSupported($command);
+
         return sprintf('alter table %s add primary key %s(%s)%s',
             $this->wrapTable($blueprint),
             $command->algorithm ? 'using '.$command->algorithm : '',
@@ -477,6 +479,8 @@ class MySqlGrammar extends Grammar
      */
     public function compileFullText(Blueprint $blueprint, Fluent $command)
     {
+        $this->ensurePartialIndexCommandIsSupported($command);
+
         return $this->compileKey($blueprint, $command, 'fulltext');
     }
 
@@ -489,6 +493,8 @@ class MySqlGrammar extends Grammar
      */
     public function compileSpatialIndex(Blueprint $blueprint, Fluent $command)
     {
+        $this->ensurePartialIndexCommandIsSupported($command);
+
         return $this->compileKey($blueprint, $command, 'spatial index');
     }
 

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -673,6 +673,12 @@ class PostgresGrammar extends Grammar
      */
     protected function uniqueIsConstraint(Blueprint $blueprint, $index)
     {
+        // Grammar SQL-generation tests may attach this grammar to a non-Postgres
+        // connection. Only introspect against a live PostgreSQL connection.
+        if ($this->connection->getDriverName() !== 'pgsql') {
+            return true;
+        }
+
         [$schema, $table] = $this->connection->getSchemaBuilder()->parseSchemaAndTable($blueprint->getTable());
 
         $table = $this->connection->getTablePrefix().$table;

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Fluent;
 use Illuminate\Support\Stringable;
 use LogicException;
+use RuntimeException;
 
 class PostgresGrammar extends Grammar
 {
@@ -318,6 +319,8 @@ class PostgresGrammar extends Grammar
      */
     public function compilePrimary(Blueprint $blueprint, Fluent $command)
     {
+        $this->ensurePartialIndexCommandIsSupported($command);
+
         $columns = $this->columnize($command->columns);
 
         return 'alter table '.$this->wrapTable($blueprint)." add primary key ({$columns})";
@@ -326,21 +329,37 @@ class PostgresGrammar extends Grammar
     /**
      * Compile a unique key command.
      *
+     * Partial unique indexes are created via CREATE UNIQUE INDEX (not as table
+     * constraints). Drop them with dropIndex() rather than dropUnique().
+     *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
      * @param  \Illuminate\Support\Fluent  $command
-     * @return string[]
+     * @return string|string[]
+     *
+     * @throws \RuntimeException
      */
     public function compileUnique(Blueprint $blueprint, Fluent $command)
     {
         // Partial unique indexes must be created as indexes; PostgreSQL unique
         // constraints do not support WHERE predicates.
         if ($this->hasWhereClause($command)) {
-            return sprintf('create unique index %s%s on %s%s (%s)%s',
+            if (! is_null($command->deferrable) || ! is_null($command->initiallyImmediate)) {
+                throw new RuntimeException('Partial unique indexes may not be deferrable.');
+            }
+
+            $nullsDistinct = '';
+
+            if (! is_null($command->nullsNotDistinct)) {
+                $nullsDistinct = ' nulls '.($command->nullsNotDistinct ? 'not distinct' : 'distinct');
+            }
+
+            return sprintf('create unique index %s%s on %s%s (%s)%s%s',
                 $command->online ? 'concurrently ' : '',
                 $this->wrap($command->index),
                 $this->wrapTable($blueprint),
                 $command->algorithm ? ' using '.$command->algorithm : '',
                 $this->columnize($command->columns),
+                $nullsDistinct,
                 $this->compileWhereClause($command)
             );
         }
@@ -416,6 +435,8 @@ class PostgresGrammar extends Grammar
      */
     public function compileFulltext(Blueprint $blueprint, Fluent $command)
     {
+        $this->ensurePartialIndexCommandIsSupported($command);
+
         $language = $command->language ?: 'english';
 
         $columns = array_map(function ($column) use ($language) {
@@ -439,6 +460,8 @@ class PostgresGrammar extends Grammar
      */
     public function compileSpatialIndex(Blueprint $blueprint, Fluent $command)
     {
+        $this->ensurePartialIndexCommandIsSupported($command);
+
         $command->algorithm = 'gist';
 
         if (! is_null($command->operatorClass)) {
@@ -457,6 +480,8 @@ class PostgresGrammar extends Grammar
      */
     public function compileVectorIndex(Blueprint $blueprint, Fluent $command)
     {
+        $this->ensurePartialIndexCommandIsSupported($command);
+
         return $this->compileIndexWithOperatorClass($blueprint, $command);
     }
 

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -332,6 +332,19 @@ class PostgresGrammar extends Grammar
      */
     public function compileUnique(Blueprint $blueprint, Fluent $command)
     {
+        // Partial unique indexes must be created as indexes; PostgreSQL unique
+        // constraints do not support WHERE predicates.
+        if ($this->hasWhereClause($command)) {
+            return sprintf('create unique index %s%s on %s%s (%s)%s',
+                $command->online ? 'concurrently ' : '',
+                $this->wrap($command->index),
+                $this->wrapTable($blueprint),
+                $command->algorithm ? ' using '.$command->algorithm : '',
+                $this->columnize($command->columns),
+                $this->compileWhereClause($command)
+            );
+        }
+
         $uniqueStatement = 'unique';
 
         if (! is_null($command->nullsNotDistinct)) {
@@ -382,12 +395,13 @@ class PostgresGrammar extends Grammar
      */
     public function compileIndex(Blueprint $blueprint, Fluent $command)
     {
-        return sprintf('create index %s%s on %s%s (%s)',
+        return sprintf('create index %s%s on %s%s (%s)%s',
             $command->online ? 'concurrently ' : '',
             $this->wrap($command->index),
             $this->wrapTable($blueprint),
             $command->algorithm ? ' using '.$command->algorithm : '',
-            $this->columnize($command->columns)
+            $this->columnize($command->columns),
+            $this->compileWhereClause($command)
         );
     }
 

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -330,7 +330,7 @@ class PostgresGrammar extends Grammar
      * Compile a unique key command.
      *
      * Partial unique indexes are created via CREATE UNIQUE INDEX (not as table
-     * constraints). Drop them with dropIndex() rather than dropUnique().
+     * constraints). dropUnique() detects this and falls back to DROP INDEX.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
      * @param  \Illuminate\Support\Fluent  $command
@@ -645,15 +645,51 @@ class PostgresGrammar extends Grammar
     /**
      * Compile a drop unique key command.
      *
+     * Partial unique indexes are created via CREATE UNIQUE INDEX and are not
+     * table constraints. When the named unique is not a constraint, fall back
+     * to DROP INDEX so dropUnique() works for both forms.
+     *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
      * @param  \Illuminate\Support\Fluent  $command
      * @return string
      */
     public function compileDropUnique(Blueprint $blueprint, Fluent $command)
     {
+        if (! $this->uniqueIsConstraint($blueprint, $command->index)) {
+            return $this->compileDropIndex($blueprint, $command);
+        }
+
         $index = $this->wrap($command->index);
 
         return "alter table {$this->wrapTable($blueprint)} drop constraint {$index}";
+    }
+
+    /**
+     * Determine whether the given unique name is a table constraint.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  string  $index
+     * @return bool
+     */
+    protected function uniqueIsConstraint(Blueprint $blueprint, $index)
+    {
+        [$schema, $table] = $this->connection->getSchemaBuilder()->parseSchemaAndTable($blueprint->getTable());
+
+        $table = $this->connection->getTablePrefix().$table;
+
+        $result = $this->connection->selectOne(sprintf(
+            'select exists ('
+            .'select 1 from pg_constraint c '
+            .'join pg_class t on c.conrelid = t.oid '
+            .'join pg_namespace n on n.oid = t.relnamespace '
+            ."where c.contype = 'u' and c.conname = %s and t.relname = %s and n.nspname = %s"
+            .') as "exists"',
+            $this->quoteString($index),
+            $this->quoteString($table),
+            $schema ? $this->quoteString($schema) : 'current_schema()'
+        ));
+
+        return (bool) ($result->exists ?? false);
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -399,11 +399,12 @@ class SQLiteGrammar extends Grammar
     {
         [$schema, $table] = $this->connection->getSchemaBuilder()->parseSchemaAndTable($blueprint->getTable());
 
-        return sprintf('create unique index %s%s on %s (%s)',
+        return sprintf('create unique index %s%s on %s (%s)%s',
             $schema ? $this->wrapValue($schema).'.' : '',
             $this->wrap($command->index),
             $this->wrapTable($table),
-            $this->columnize($command->columns)
+            $this->columnize($command->columns),
+            $this->compileWhereClause($command)
         );
     }
 
@@ -418,11 +419,12 @@ class SQLiteGrammar extends Grammar
     {
         [$schema, $table] = $this->connection->getSchemaBuilder()->parseSchemaAndTable($blueprint->getTable());
 
-        return sprintf('create index %s%s on %s (%s)',
+        return sprintf('create index %s%s on %s (%s)%s',
             $schema ? $this->wrapValue($schema).'.' : '',
             $this->wrap($command->index),
             $this->wrapTable($table),
-            $this->columnize($command->columns)
+            $this->columnize($command->columns),
+            $this->compileWhereClause($command)
         );
     }
 

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -385,6 +385,8 @@ class SQLiteGrammar extends Grammar
      */
     public function compilePrimary(Blueprint $blueprint, Fluent $command)
     {
+        $this->ensurePartialIndexCommandIsSupported($command);
+
         // Handled on table creation or alteration...
     }
 

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -256,6 +256,8 @@ class SqlServerGrammar extends Grammar
      */
     public function compilePrimary(Blueprint $blueprint, Fluent $command)
     {
+        $this->ensurePartialIndexCommandIsSupported($command);
+
         return sprintf('alter table %s add constraint %s primary key (%s)',
             $this->wrapTable($blueprint),
             $this->wrap($command->index),
@@ -308,6 +310,8 @@ class SqlServerGrammar extends Grammar
      */
     public function compileSpatialIndex(Blueprint $blueprint, Fluent $command)
     {
+        $this->ensurePartialIndexCommandIsSupported($command);
+
         return sprintf('create spatial index %s on %s (%s)',
             $this->wrap($command->index),
             $this->wrapTable($blueprint),

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -272,10 +272,11 @@ class SqlServerGrammar extends Grammar
      */
     public function compileUnique(Blueprint $blueprint, Fluent $command)
     {
-        return sprintf('create unique index %s on %s (%s)%s',
+        return sprintf('create unique index %s on %s (%s)%s%s',
             $this->wrap($command->index),
             $this->wrapTable($blueprint),
             $this->columnize($command->columns),
+            $this->compileWhereClause($command),
             $command->online ? ' with (online = on)' : ''
         );
     }
@@ -289,10 +290,11 @@ class SqlServerGrammar extends Grammar
      */
     public function compileIndex(Blueprint $blueprint, Fluent $command)
     {
-        return sprintf('create index %s on %s (%s)%s',
+        return sprintf('create index %s on %s (%s)%s%s',
             $this->wrap($command->index),
             $this->wrapTable($blueprint),
             $this->columnize($command->columns),
+            $this->compileWhereClause($command),
             $command->online ? ' with (online = on)' : ''
         );
     }

--- a/src/Illuminate/Database/Schema/IndexDefinition.php
+++ b/src/Illuminate/Database/Schema/IndexDefinition.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Schema;
 
 use Illuminate\Support\Fluent;
+use InvalidArgumentException;
 
 /**
  * @method $this algorithm(string $algorithm) Specify an algorithm for the index (MySQL/PostgreSQL)
@@ -16,38 +17,49 @@ use Illuminate\Support\Fluent;
 class IndexDefinition extends Fluent
 {
     /**
+     * The valid operators for partial index where clauses.
+     *
+     * @var list<string>
+     */
+    protected $operators = ['=', '<', '>', '<=', '>=', '<>', '!=', '<=>'];
+
+    /**
      * Specify a partial index predicate.
      *
-     * Supported by PostgreSQL, SQLite, and SQL Server. MySQL and MariaDB do not
-     * support partial indexes and will throw a RuntimeException when compiling.
+     * Semantics match the query builder where possible:
      *
-     * When a single argument is provided, it is treated as a raw SQL fragment:
-     *
-     *     $table->unique('email')->where('deleted_at is null');
-     *
-     * Column / operator / value forms are also supported:
-     *
+     *     $table->unique('email')->where('deleted_at');          // IS NULL
+     *     $table->unique('email')->where('deleted_at', null);    // IS NULL
      *     $table->index('status')->where('active', true);
      *     $table->index('status')->where('active', '=', 1);
+     *
+     * Use whereRaw() for raw SQL predicates. Partial indexes are supported by
+     * PostgreSQL, SQLite, and SQL Server. On PostgreSQL, drop partial unique
+     * indexes with dropIndex() rather than dropUnique().
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return $this
+     *
+     * @throws \InvalidArgumentException
      */
     public function where($column, $operator = null, $value = null)
     {
         if (func_num_args() === 1) {
-            $this->attributes['where'] = [
-                'type' => 'Raw',
-                'sql' => $column,
-            ];
-
-            return $this;
+            return $this->whereNull($column);
         }
 
         if (func_num_args() === 2) {
             [$value, $operator] = [$operator, '='];
+        } elseif ($this->invalidOperator($operator)) {
+            throw new InvalidArgumentException('Illegal operator for partial index where clause.');
+        }
+
+        if (is_null($value)) {
+            return in_array($operator, ['=', '<=>'], true)
+                ? $this->whereNull($column)
+                : $this->whereNotNull($column);
         }
 
         $this->attributes['where'] = [
@@ -61,11 +73,33 @@ class IndexDefinition extends Fluent
     }
 
     /**
+     * Specify a raw partial index predicate.
+     *
+     *     $table->unique('email')->whereRaw('deleted_at is null');
+     *
+     * On PostgreSQL, drop partial unique indexes with dropIndex() rather than dropUnique().
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $expression
+     * @return $this
+     */
+    public function whereRaw($expression)
+    {
+        $this->attributes['where'] = [
+            'type' => 'Raw',
+            'sql' => $expression,
+        ];
+
+        return $this;
+    }
+
+    /**
      * Specify a partial index "where null" predicate.
      *
      * Useful for soft-delete-aware unique indexes:
      *
      *     $table->unique(['user_id', 'slug'])->whereNull('deleted_at');
+     *
+     * On PostgreSQL, drop partial unique indexes with dropIndex() rather than dropUnique().
      *
      * @param  string  $column
      * @return $this
@@ -94,5 +128,16 @@ class IndexDefinition extends Fluent
         ];
 
         return $this;
+    }
+
+    /**
+     * Determine if the given operator is supported.
+     *
+     * @param  mixed  $operator
+     * @return bool
+     */
+    protected function invalidOperator($operator)
+    {
+        return ! is_string($operator) || ! in_array(strtolower($operator), $this->operators, true);
     }
 }

--- a/src/Illuminate/Database/Schema/IndexDefinition.php
+++ b/src/Illuminate/Database/Schema/IndexDefinition.php
@@ -34,8 +34,8 @@ class IndexDefinition extends Fluent
      *     $table->index('status')->where('active', '=', 1);
      *
      * Use whereRaw() for raw SQL predicates. Partial indexes are supported by
-     * PostgreSQL, SQLite, and SQL Server. On PostgreSQL, drop partial unique
-     * indexes with dropIndex() rather than dropUnique().
+     * PostgreSQL, SQLite, and SQL Server. On PostgreSQL, dropUnique() detects
+     * whether the unique is a constraint or a partial index.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
      * @param  mixed  $operator
@@ -77,8 +77,6 @@ class IndexDefinition extends Fluent
      *
      *     $table->unique('email')->whereRaw('deleted_at is null');
      *
-     * On PostgreSQL, drop partial unique indexes with dropIndex() rather than dropUnique().
-     *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $expression
      * @return $this
      */
@@ -98,8 +96,6 @@ class IndexDefinition extends Fluent
      * Useful for soft-delete-aware unique indexes:
      *
      *     $table->unique(['user_id', 'slug'])->whereNull('deleted_at');
-     *
-     * On PostgreSQL, drop partial unique indexes with dropIndex() rather than dropUnique().
      *
      * @param  string  $column
      * @return $this

--- a/src/Illuminate/Database/Schema/IndexDefinition.php
+++ b/src/Illuminate/Database/Schema/IndexDefinition.php
@@ -15,5 +15,84 @@ use Illuminate\Support\Fluent;
  */
 class IndexDefinition extends Fluent
 {
-    //
+    /**
+     * Specify a partial index predicate.
+     *
+     * Supported by PostgreSQL, SQLite, and SQL Server. MySQL and MariaDB do not
+     * support partial indexes and will throw a RuntimeException when compiling.
+     *
+     * When a single argument is provided, it is treated as a raw SQL fragment:
+     *
+     *     $table->unique('email')->where('deleted_at is null');
+     *
+     * Column / operator / value forms are also supported:
+     *
+     *     $table->index('status')->where('active', true);
+     *     $table->index('status')->where('active', '=', 1);
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function where($column, $operator = null, $value = null)
+    {
+        if (func_num_args() === 1) {
+            $this->attributes['where'] = [
+                'type' => 'Raw',
+                'sql' => $column,
+            ];
+
+            return $this;
+        }
+
+        if (func_num_args() === 2) {
+            [$value, $operator] = [$operator, '='];
+        }
+
+        $this->attributes['where'] = [
+            'type' => 'Basic',
+            'column' => $column,
+            'operator' => $operator,
+            'value' => $value,
+        ];
+
+        return $this;
+    }
+
+    /**
+     * Specify a partial index "where null" predicate.
+     *
+     * Useful for soft-delete-aware unique indexes:
+     *
+     *     $table->unique(['user_id', 'slug'])->whereNull('deleted_at');
+     *
+     * @param  string  $column
+     * @return $this
+     */
+    public function whereNull($column)
+    {
+        $this->attributes['where'] = [
+            'type' => 'Null',
+            'column' => $column,
+        ];
+
+        return $this;
+    }
+
+    /**
+     * Specify a partial index "where not null" predicate.
+     *
+     * @param  string  $column
+     * @return $this
+     */
+    public function whereNotNull($column)
+    {
+        $this->attributes['where'] = [
+            'type' => 'NotNull',
+            'column' => $column,
+        ];
+
+        return $this;
+    }
 }

--- a/tests/Database/DatabaseMariaDbSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMariaDbSchemaGrammarTest.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Schema\MariaDbBuilder;
 use Illuminate\Tests\Database\Fixtures\Enums\Foo;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 class DatabaseMariaDbSchemaGrammarTest extends TestCase
 {
@@ -365,6 +366,16 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add unique `bar`(`foo`)', $statements[0]);
+    }
+
+    public function testAddingPartialUniqueKeyThrowsException()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('This database driver does not support partial indexes.');
+
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->unique('email')->whereNull('deleted_at');
+        $blueprint->toSql();
     }
 
     public function testAddingIndex()

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Schema\MySqlBuilder;
 use Illuminate\Tests\Database\Fixtures\Enums\Foo;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 class DatabaseMySqlSchemaGrammarTest extends TestCase
 {
@@ -364,6 +365,26 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add unique `bar`(`foo`)', $statements[0]);
+    }
+
+    public function testAddingPartialUniqueKeyThrowsException()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('This database driver does not support partial indexes.');
+
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->unique('email')->whereNull('deleted_at');
+        $blueprint->toSql();
+    }
+
+    public function testAddingPartialIndexThrowsException()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('This database driver does not support partial indexes.');
+
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->index('email')->whereNull('deleted_at');
+        $blueprint->toSql();
     }
 
     public function testAddingIndex()

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -343,6 +343,56 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertSame('alter table "users" add constraint "users_foo_unique" unique using index "users_foo_unique"', $statements[1]);
     }
 
+    public function testAddingPartialUniqueKeyWithWhereNull()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->unique(['user_id', 'slug'])->whereNull('deleted_at');
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('create unique index "users_user_id_slug_unique" on "users" ("user_id", "slug") where "deleted_at" is null', $statements[0]);
+    }
+
+    public function testAddingPartialUniqueKeyWithWhereNotNull()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->unique('email', 'users_email_active_unique')->whereNotNull('email');
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('create unique index "users_email_active_unique" on "users" ("email") where "email" is not null', $statements[0]);
+    }
+
+    public function testAddingPartialUniqueKeyWithRawWhere()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->unique('email')->where('deleted_at is null');
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('create unique index "users_email_unique" on "users" ("email") where deleted_at is null', $statements[0]);
+    }
+
+    public function testAddingPartialUniqueKeyWithBasicWhere()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->unique('email')->where('active', true);
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('create unique index "users_email_unique" on "users" ("email") where "active" = 1', $statements[0]);
+    }
+
+    public function testAddingPartialUniqueKeyOnline()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->unique('email')->whereNull('deleted_at')->online();
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('create unique index concurrently "users_email_unique" on "users" ("email") where "deleted_at" is null', $statements[0]);
+    }
+
     public function testAddingIndex()
     {
         $blueprint = new Blueprint($this->getConnection(), 'users');
@@ -351,6 +401,16 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
         $this->assertCount(1, $statements);
         $this->assertSame('create index "baz" on "users" ("foo", "bar")', $statements[0]);
+    }
+
+    public function testAddingPartialIndexWithWhereNull()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->index('email')->whereNull('deleted_at');
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('create index "users_email_index" on "users" ("email") where "deleted_at" is null', $statements[0]);
     }
 
     public function testAddingIndexWithAlgorithm()

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -460,7 +460,6 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertSame('create unique index concurrently "users_email_unique" on "users" ("email") where "deleted_at" is null', $statements[0]);
     }
 
-
     public function testAddingIndex()
     {
         $blueprint = new Blueprint($this->getConnection(), 'users');

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -204,12 +204,28 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testDropUnique()
     {
-        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $connection = $this->getConnection();
+        $connection->shouldReceive('selectOne')->once()->andReturn((object) ['exists' => true]);
+
+        $blueprint = new Blueprint($connection, 'users');
         $blueprint->dropUnique('foo');
         $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" drop constraint "foo"', $statements[0]);
+    }
+
+    public function testDropUniqueFallsBackToDropIndexForPartialUnique()
+    {
+        $connection = $this->getConnection();
+        $connection->shouldReceive('selectOne')->once()->andReturn((object) ['exists' => false]);
+
+        $blueprint = new Blueprint($connection, 'users');
+        $blueprint->dropUnique('users_email_unique');
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('drop index "users_email_unique"', $statements[0]);
     }
 
     public function testDropIndex()
@@ -444,15 +460,6 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertSame('create unique index concurrently "users_email_unique" on "users" ("email") where "deleted_at" is null', $statements[0]);
     }
 
-    public function testDroppingPartialUniqueUsesDropIndex()
-    {
-        $blueprint = new Blueprint($this->getConnection(), 'users');
-        $blueprint->dropIndex('users_email_unique');
-        $statements = $blueprint->toSql();
-
-        $this->assertCount(1, $statements);
-        $this->assertSame('drop index "users_email_unique"', $statements[0]);
-    }
 
     public function testAddingIndex()
     {
@@ -1515,6 +1522,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         return $connection
             ->shouldReceive('getSchemaGrammar')->andReturn($grammar)
             ->shouldReceive('getSchemaBuilder')->andReturn($builder)
+            ->shouldReceive('selectOne')->andReturn((object) ['exists' => true])->byDefault()
             ->getMock();
     }
 
@@ -1525,7 +1533,11 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function getBuilder()
     {
-        return mock(PostgresBuilder::class);
+        return mock(PostgresBuilder::class, function ($mock) {
+            $mock->shouldReceive('parseSchemaAndTable')->andReturnUsing(
+                fn ($table) => [null, last(explode('.', $table))]
+            )->byDefault();
+        });
     }
 
     /** @return list<array{method: string, type: string, user: int|null, grammar: false|int|null, expected: int|null}> */

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -14,6 +14,7 @@ use Mockery as m;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 class DatabasePostgresSchemaGrammarTest extends TestCase
 {
@@ -363,10 +364,30 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertSame('create unique index "users_email_active_unique" on "users" ("email") where "email" is not null', $statements[0]);
     }
 
+    public function testAddingPartialUniqueKeyWithOneArgumentWhere()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->unique('email')->where('deleted_at');
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('create unique index "users_email_unique" on "users" ("email") where "deleted_at" is null', $statements[0]);
+    }
+
+    public function testAddingPartialUniqueKeyWithNullValueWhere()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->unique('email')->where('deleted_at', null);
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('create unique index "users_email_unique" on "users" ("email") where "deleted_at" is null', $statements[0]);
+    }
+
     public function testAddingPartialUniqueKeyWithRawWhere()
     {
         $blueprint = new Blueprint($this->getConnection(), 'users');
-        $blueprint->unique('email')->where('deleted_at is null');
+        $blueprint->unique('email')->whereRaw('deleted_at is null');
         $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
@@ -380,7 +401,37 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
-        $this->assertSame('create unique index "users_email_unique" on "users" ("email") where "active" = 1', $statements[0]);
+        $this->assertSame('create unique index "users_email_unique" on "users" ("email") where "active" = \'1\'', $statements[0]);
+    }
+
+    public function testAddingPartialUniqueKeyWithNullsNotDistinct()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->unique('email')->whereNull('deleted_at')->nullsNotDistinct();
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('create unique index "users_email_unique" on "users" ("email") nulls not distinct where "deleted_at" is null', $statements[0]);
+    }
+
+    public function testAddingPartialUniqueKeyWithDeferrableThrowsException()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Partial unique indexes may not be deferrable.');
+
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->unique('email')->whereNull('deleted_at')->deferrable();
+        $blueprint->toSql();
+    }
+
+    public function testAddingPartialPrimaryKeyThrowsException()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Partial indexes are not supported for [primary] commands.');
+
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->primary('id')->whereNull('deleted_at');
+        $blueprint->toSql();
     }
 
     public function testAddingPartialUniqueKeyOnline()
@@ -391,6 +442,16 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
         $this->assertCount(1, $statements);
         $this->assertSame('create unique index concurrently "users_email_unique" on "users" ("email") where "deleted_at" is null', $statements[0]);
+    }
+
+    public function testDroppingPartialUniqueUsesDropIndex()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->dropIndex('users_email_unique');
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('drop index "users_email_unique"', $statements[0]);
     }
 
     public function testAddingIndex()

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -1522,6 +1522,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         return $connection
             ->shouldReceive('getSchemaGrammar')->andReturn($grammar)
             ->shouldReceive('getSchemaBuilder')->andReturn($builder)
+            ->shouldReceive('getDriverName')->andReturn('pgsql')->byDefault()
             ->shouldReceive('selectOne')->andReturn((object) ['exists' => true])->byDefault()
             ->getMock();
     }

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -221,6 +221,26 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertSame('create unique index "bar" on "users" ("foo")', $statements[0]);
     }
 
+    public function testAddingPartialUniqueKeyWithWhereNull()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->unique(['user_id', 'slug'])->whereNull('deleted_at');
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('create unique index "users_user_id_slug_unique" on "users" ("user_id", "slug") where "deleted_at" is null', $statements[0]);
+    }
+
+    public function testAddingPartialIndexWithWhereNull()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->index('email')->whereNull('deleted_at');
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('create index "users_email_index" on "users" ("email") where "deleted_at" is null', $statements[0]);
+    }
+
     public function testAddingIndex()
     {
         $blueprint = new Blueprint($this->getConnection(), 'users');

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -231,6 +231,36 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertSame('create unique index "users_user_id_slug_unique" on "users" ("user_id", "slug") where "deleted_at" is null', $statements[0]);
     }
 
+    public function testAddingPartialUniqueKeyWithRawWhere()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->unique('email')->whereRaw('deleted_at is null');
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('create unique index "users_email_unique" on "users" ("email") where deleted_at is null', $statements[0]);
+    }
+
+    public function testAddingPartialUniqueKeyWithBasicWhere()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->unique('email')->where('active', true);
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('create unique index "users_email_unique" on "users" ("email") where "active" = \'1\'', $statements[0]);
+    }
+
+    public function testAddingPartialUniqueKeyWithNullValueWhere()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->unique('email')->where('deleted_at', null);
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('create unique index "users_email_unique" on "users" ("email") where "deleted_at" is null', $statements[0]);
+    }
+
     public function testAddingPartialIndexWithWhereNull()
     {
         $blueprint = new Blueprint($this->getConnection(), 'users');

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -288,6 +288,36 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertSame('create unique index "bar" on "users" ("foo") with (online = on)', $statements[0]);
     }
 
+    public function testAddingPartialUniqueKeyWithWhereNull()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->unique(['user_id', 'slug'])->whereNull('deleted_at');
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('create unique index "users_user_id_slug_unique" on "users" ("user_id", "slug") where "deleted_at" is null', $statements[0]);
+    }
+
+    public function testAddingPartialUniqueKeyOnlineWithWhereNull()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->unique('email', 'users_email_unique')->whereNull('deleted_at')->online();
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('create unique index "users_email_unique" on "users" ("email") where "deleted_at" is null with (online = on)', $statements[0]);
+    }
+
+    public function testAddingPartialIndexWithWhereNull()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->index('email')->whereNull('deleted_at');
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('create index "users_email_index" on "users" ("email") where "deleted_at" is null', $statements[0]);
+    }
+
     public function testAddingIndex()
     {
         $blueprint = new Blueprint($this->getConnection(), 'users');

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -298,6 +298,26 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertSame('create unique index "users_user_id_slug_unique" on "users" ("user_id", "slug") where "deleted_at" is null', $statements[0]);
     }
 
+    public function testAddingPartialUniqueKeyWithRawWhere()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->unique('email')->whereRaw('deleted_at is null');
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('create unique index "users_email_unique" on "users" ("email") where deleted_at is null', $statements[0]);
+    }
+
+    public function testAddingPartialUniqueKeyWithBasicWhere()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->unique('email')->where('active', true);
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('create unique index "users_email_unique" on "users" ("email") where "active" = \'1\'', $statements[0]);
+    }
+
     public function testAddingPartialUniqueKeyOnlineWithWhereNull()
     {
         $blueprint = new Blueprint($this->getConnection(), 'users');

--- a/tests/Integration/Database/SchemaPartialUniqueIndexTest.php
+++ b/tests/Integration/Database/SchemaPartialUniqueIndexTest.php
@@ -102,7 +102,7 @@ class SchemaPartialUniqueIndexTest extends DatabaseTestCase
     public function testPartialUniqueIndexCanBeDropped()
     {
         Schema::table('posts', function (Blueprint $table) {
-            $table->dropIndex('posts_user_id_slug_unique');
+            $table->dropUnique('posts_user_id_slug_unique');
         });
 
         DB::table('posts')->insert([

--- a/tests/Integration/Database/SchemaPartialUniqueIndexTest.php
+++ b/tests/Integration/Database/SchemaPartialUniqueIndexTest.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Database\QueryException;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Orchestra\Testbench\Attributes\RequiresDatabase;
+
+#[RequiresDatabase(['sqlite', 'pgsql', 'sqlsrv'])]
+class SchemaPartialUniqueIndexTest extends DatabaseTestCase
+{
+    protected function defineDatabaseMigrationsAfterDatabaseRefreshed()
+    {
+        Schema::create('posts', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('user_id');
+            $table->string('slug');
+            $table->softDeletes();
+            $table->unique(['user_id', 'slug'])->whereNull('deleted_at');
+        });
+    }
+
+    protected function destroyDatabaseMigrations()
+    {
+        Schema::dropIfExists('posts');
+    }
+
+    public function testActiveDuplicateFails()
+    {
+        DB::table('posts')->insert([
+            'user_id' => 1,
+            'slug' => 'hello',
+            'deleted_at' => null,
+        ]);
+
+        $this->expectException(QueryException::class);
+
+        DB::table('posts')->insert([
+            'user_id' => 1,
+            'slug' => 'hello',
+            'deleted_at' => null,
+        ]);
+    }
+
+    public function testDuplicateAllowedAfterSoftDelete()
+    {
+        DB::table('posts')->insert([
+            'user_id' => 1,
+            'slug' => 'hello',
+            'deleted_at' => now(),
+        ]);
+
+        DB::table('posts')->insert([
+            'user_id' => 1,
+            'slug' => 'hello',
+            'deleted_at' => null,
+        ]);
+
+        $this->assertSame(2, DB::table('posts')->count());
+    }
+
+    public function testMultipleSoftDeletedRowsWithSameKeyAllowed()
+    {
+        DB::table('posts')->insert([
+            'user_id' => 1,
+            'slug' => 'hello',
+            'deleted_at' => now()->subDay(),
+        ]);
+
+        DB::table('posts')->insert([
+            'user_id' => 1,
+            'slug' => 'hello',
+            'deleted_at' => now(),
+        ]);
+
+        $this->assertSame(2, DB::table('posts')->whereNotNull('deleted_at')->count());
+    }
+
+    public function testRestoreFailsWhenActiveDuplicateExists()
+    {
+        DB::table('posts')->insert([
+            'user_id' => 1,
+            'slug' => 'hello',
+            'deleted_at' => now(),
+        ]);
+
+        DB::table('posts')->insert([
+            'user_id' => 1,
+            'slug' => 'hello',
+            'deleted_at' => null,
+        ]);
+
+        $this->expectException(QueryException::class);
+
+        DB::table('posts')
+            ->whereNotNull('deleted_at')
+            ->update(['deleted_at' => null]);
+    }
+
+    public function testPartialUniqueIndexCanBeDropped()
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->dropIndex('posts_user_id_slug_unique');
+        });
+
+        DB::table('posts')->insert([
+            'user_id' => 1,
+            'slug' => 'hello',
+            'deleted_at' => null,
+        ]);
+
+        DB::table('posts')->insert([
+            'user_id' => 1,
+            'slug' => 'hello',
+            'deleted_at' => null,
+        ]);
+
+        $this->assertSame(2, DB::table('posts')->count());
+    }
+}


### PR DESCRIPTION
## Summary

Soft-deleted rows remain in the table, so a normal `$table->unique(...)` still blocks recreating the same business key after soft delete. Apps currently resort to raw SQL / dialect-specific partial indexes.

This PR adds first-class **partial index** support to the schema builder:

```php
$table->unique(['user_id', 'slug'])->whereNull('deleted_at');
$table->index('status')->where('active', true);
$table->unique('email')->whereRaw('deleted_at is null');
```

Existing `$table->unique()` behavior is unchanged. Soft-deleted rows are not silently restored; new inserts create new rows.

### Related prior art

- Closed soft-delete-specific PR: https://github.com/laravel/framework/pull/42948 (`uniqueIgnoreTrashed`) — Taylor: *"No plans to modify or add any behavior around this at the moment."*
- This PR takes the more general, BC-safe approach (partial / conditional indexes) with soft deletes as the motivating example, rather than a soft-delete-only helper or generated-column magic.
- Related discussion: https://github.com/laravel/framework/discussions/59674 (upsert + partial indexes)

### DB support matrix

| Driver | Support | Notes |
|--------|---------|-------|
| PostgreSQL | ✅ | `CREATE UNIQUE INDEX ... WHERE ...` (constraints cannot be partial) |
| SQLite | ✅ | `CREATE UNIQUE INDEX ... WHERE ...` |
| SQL Server | ✅ | Filtered indexes |
| MySQL / MariaDB | ❌ (v1) | Throws `RuntimeException` — no native partial indexes |

On PostgreSQL, `dropUnique()` detects whether the unique is a constraint or a partial index and emits `DROP CONSTRAINT` or `DROP INDEX` accordingly.

### Alternatives considered

1. **Silent restore-on-conflict** — rejected; restore must stay explicit.
2. **`softDeletingUnique()` only** — less general; can be sugar later.
3. **Generated columns for MySQL** — deferred; riskier and less reusable than partial indexes.
4. **Auto-apply when `softDeletes()` present** — BC risk; kept explicit.

### Breaking changes

None. `$table->unique()` without a where clause is unchanged.

### Tests

- Grammar SQL assertions for Postgres / SQLite / SQL Server / MySQL / MariaDB
- Integration behavior (`SchemaPartialUniqueIndexTest`) on SQLite / pgsql / sqlsrv

### Docs

https://github.com/laravel/docs/pull/11316

## Test plan

- [x] `Database*SchemaGrammarTest` (partial + unique coverage)
- [x] Full schema grammar suites
- [x] `SchemaPartialUniqueIndexTest` integration (SQLite)
- [ ] CI on PostgreSQL / SQL Server jobs
- [x] Docs PR linked