### PR TITLE
[13.x] Replace manual match+loop+str_replace with preg_replace_callback

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Renderer/Mappers/BladeMapper.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/Mappers/BladeMapper.php
@@ -266,6 +266,9 @@ class BladeMapper
      */
     protected function addLineNumbers(string $value, string $pattern)
     {
+        // The "?? $value" falls back to the original string if the pattern hits
+        // the PCRE recursion/backtrack limit, in which case preg_replace_callback()
+        // returns null instead of throwing.
         return preg_replace_callback($pattern, function ($match) use ($value) {
             $position = mb_strlen(substr($value, 0, $match[0][1]));
 

--- a/src/Illuminate/Foundation/Exceptions/Renderer/Mappers/BladeMapper.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/Mappers/BladeMapper.php
@@ -210,13 +210,7 @@ class BladeMapper
             // Matches {{ $value }}, {!! $value !!} and  {{{ $value }}} depending on $pair
             $pattern = sprintf('/(@)?%s\s*(.+?)\s*%s(\r?\n)?/s', $pair[0], $pair[1]);
 
-            if (preg_match_all($pattern, $value, $matches, PREG_OFFSET_CAPTURE)) {
-                foreach (array_reverse($matches[0]) as $match) {
-                    $position = mb_strlen(substr($value, 0, $match[1]));
-
-                    $value = $this->insertLineNumberAtPosition($position, $value);
-                }
-            }
+            $value = $this->addLineNumbers($value, $pattern);
         }
 
         return $value;
@@ -230,22 +224,10 @@ class BladeMapper
      */
     protected function addStatementLineNumbers(string $value)
     {
-        $shouldInsertLineNumbers = preg_match_all(
-            '/\B@(@?\w+(?:::\w+)?)([ \t]*)(\( ( (?>[^()]+) | (?3) )* \))?/x',
+        return $this->addLineNumbers(
             $value,
-            $matches,
-            PREG_OFFSET_CAPTURE
+            '/\B@(@?\w+(?:::\w+)?)([ \t]*)(\( ( (?>[^()]+) | (?3) )* \))?/x'
         );
-
-        if ($shouldInsertLineNumbers) {
-            foreach (array_reverse($matches[0]) as $match) {
-                $position = mb_strlen(substr($value, 0, $match[1]));
-
-                $value = $this->insertLineNumberAtPosition($position, $value);
-            }
-        }
-
-        return $value;
     }
 
     /**
@@ -256,22 +238,7 @@ class BladeMapper
      */
     protected function addBladeComponentLineNumbers(string $value)
     {
-        $shouldInsertLineNumbers = preg_match_all(
-            '/<\s*x[-:]([\w\-:.]*)/mx',
-            $value,
-            $matches,
-            PREG_OFFSET_CAPTURE
-        );
-
-        if ($shouldInsertLineNumbers) {
-            foreach (array_reverse($matches[0]) as $match) {
-                $position = mb_strlen(substr($value, 0, $match[1]));
-
-                $value = $this->insertLineNumberAtPosition($position, $value);
-            }
-        }
-
-        return $value;
+        return $this->addLineNumbers($value, '/<\s*x[-:]([\w\-:.]*)/mx');
     }
 
     /**
@@ -288,6 +255,24 @@ class BladeMapper
         $lineNumber = count(explode("\n", $before));
 
         return mb_substr($value, 0, $position)."|---LINE:{$lineNumber}---|".mb_substr($value, $position);
+    }
+
+    /**
+     * Prefix each match of the given pattern with its originating line number.
+     *
+     * @param  string  $value
+     * @param  string  $pattern
+     * @return string
+     */
+    protected function addLineNumbers(string $value, string $pattern)
+    {
+        return preg_replace_callback($pattern, function ($match) use ($value) {
+            $position = mb_strlen(substr($value, 0, $match[0][1]));
+
+            $lineNumber = count(explode("\n", mb_substr($value, 0, $position)));
+
+            return "|---LINE:{$lineNumber}---|".$match[0][0];
+        }, $value, -1, $count, PREG_OFFSET_CAPTURE) ?? $value;
     }
 
     /**

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -267,6 +267,9 @@ class Mailer implements MailerContract, MailQueueContract
      */
     protected function replaceEmbeddedAttachments(string $renderedView, array $attachments)
     {
+        // The "?? $renderedView" falls back to the original view if the pattern hits
+        // the PCRE recursion/backtrack limit, in which case preg_replace_callback()
+        // returns null instead of throwing.
         return preg_replace_callback('/<img.+?src=[\'"]cid:([^\'"]+)[\'"].*?>/is', function ($matches) use ($attachments) {
             foreach ($attachments as $attachment) {
                 if ($attachment->getContentId() === $matches[1] || $attachment->getFilename() === $matches[1]) {

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -267,23 +267,19 @@ class Mailer implements MailerContract, MailQueueContract
      */
     protected function replaceEmbeddedAttachments(string $renderedView, array $attachments)
     {
-        if (preg_match_all('/<img.+?src=[\'"]cid:([^\'"]+)[\'"].*?>/is', $renderedView, $matches)) {
-            foreach (array_unique($matches[1]) as $image) {
-                foreach ($attachments as $attachment) {
-                    if ($attachment->getContentId() === $image || $attachment->getFilename() === $image) {
-                        $renderedView = str_replace(
-                            'cid:'.$image,
-                            'data:'.$attachment->getContentType().';base64,'.$attachment->bodyToString(),
-                            $renderedView
-                        );
-
-                        break;
-                    }
+        return preg_replace_callback('/<img.+?src=[\'"]cid:([^\'"]+)[\'"].*?>/is', function ($matches) use ($attachments) {
+            foreach ($attachments as $attachment) {
+                if ($attachment->getContentId() === $matches[1] || $attachment->getFilename() === $matches[1]) {
+                    return str_replace(
+                        'cid:'.$matches[1],
+                        'data:'.$attachment->getContentType().';base64,'.$attachment->bodyToString(),
+                        $matches[0]
+                    );
                 }
             }
-        }
 
-        return $renderedView;
+            return $matches[0];
+        }, $renderedView) ?? $renderedView;
     }
 
     /**

--- a/src/Illuminate/Routing/RouteUri.php
+++ b/src/Illuminate/Routing/RouteUri.php
@@ -38,23 +38,21 @@ class RouteUri
      */
     public static function parse($uri)
     {
-        preg_match_all('/\{([\w\:]+?)\??\}/', $uri, $matches);
-
         $bindingFields = [];
 
-        foreach ($matches[0] as $match) {
-            if (! str_contains($match, ':')) {
-                continue;
+        $uri = preg_replace_callback('/\{([\w:]+?)\??}/', function ($match) use (&$bindingFields) {
+            if (! str_contains($match[0], ':')) {
+                return $match[0];
             }
 
-            $segments = explode(':', trim($match, '{}?'));
+            $segments = explode(':', trim($match[0], '{}?'));
 
             $bindingFields[$segments[0]] = $segments[1];
 
-            $uri = str_contains($match, '?')
-                ? str_replace($match, '{'.$segments[0].'?}', $uri)
-                : str_replace($match, '{'.$segments[0].'}', $uri);
-        }
+            return str_contains($match[0], '?')
+                ? '{'.$segments[0].'?}'
+                : '{'.$segments[0].'}';
+        }, $uri);
 
         return new static($uri, $bindingFields);
     }

--- a/tests/Foundation/Exceptions/Renderer/Mappers/BladeMapperTest.php
+++ b/tests/Foundation/Exceptions/Renderer/Mappers/BladeMapperTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\Exceptions\Renderer\Mappers;
+
+use Illuminate\Contracts\View\Factory;
+use Illuminate\Foundation\Exceptions\Renderer\Mappers\BladeMapper;
+use Illuminate\View\Compilers\BladeCompiler;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+class BladeMapperTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+
+        parent::tearDown();
+    }
+
+    public function testAddLineNumbersPrefixesEachMatchWithItsLineNumber(): void
+    {
+        $mapper = new BladeMapper(m::mock(Factory::class), m::mock(BladeCompiler::class));
+
+        $value = "line one\n{{ \$foo }}\nline three\n{{ \$bar }}";
+
+        $result = $this->addLineNumbers($mapper, $value, '/\{\{\s*(.+?)\s*\}\}/s');
+
+        $this->assertSame(
+            "line one\n|---LINE:2---|{{ \$foo }}\nline three\n|---LINE:4---|{{ \$bar }}",
+            $result
+        );
+    }
+
+    public function testAddLineNumbersReturnsOriginalValueUnchangedWhenNothingMatches(): void
+    {
+        $mapper = new BladeMapper(m::mock(Factory::class), m::mock(BladeCompiler::class));
+
+        $value = 'plain text with no blade syntax';
+
+        $result = $this->addLineNumbers($mapper, $value, '/\{\{\s*(.+?)\s*\}\}/s');
+
+        $this->assertSame($value, $result);
+    }
+
+    public function testAddLineNumbersReturnsOriginalValueWhenThePatternFailsToCompile(): void
+    {
+        $mapper = new BladeMapper(m::mock(Factory::class), m::mock(BladeCompiler::class));
+
+        $previousLimit = ini_get('pcre.backtrack_limit');
+        ini_set('pcre.backtrack_limit', 1);
+
+        try {
+            // Classic catastrophic-backtracking pattern: exhausts the backtrack
+            // limit above and makes preg_replace_callback() return null.
+            $value = str_repeat('a', 200).'!';
+
+            $result = $this->addLineNumbers($mapper, $value, '/^(a+)+$/');
+
+            $this->assertSame($value, $result);
+        } finally {
+            ini_set('pcre.backtrack_limit', $previousLimit);
+        }
+    }
+
+    protected function addLineNumbers(BladeMapper $mapper, string $value, string $pattern): string
+    {
+        return (new ReflectionMethod($mapper, 'addLineNumbers'))->invoke($mapper, $value, $pattern);
+    }
+}

--- a/tests/Foundation/Exceptions/Renderer/Mappers/BladeMapperTest.php
+++ b/tests/Foundation/Exceptions/Renderer/Mappers/BladeMapperTest.php
@@ -11,13 +11,6 @@ use ReflectionMethod;
 
 class BladeMapperTest extends TestCase
 {
-    protected function tearDown(): void
-    {
-        m::close();
-
-        parent::tearDown();
-    }
-
     public function testAddLineNumbersPrefixesEachMatchWithItsLineNumber(): void
     {
         $mapper = new BladeMapper(m::mock(Factory::class), m::mock(BladeCompiler::class));

--- a/tests/Foundation/Exceptions/Renderer/Mappers/BladeMapperTest.php
+++ b/tests/Foundation/Exceptions/Renderer/Mappers/BladeMapperTest.php
@@ -11,13 +11,18 @@ use ReflectionMethod;
 
 class BladeMapperTest extends TestCase
 {
+    protected BladeMapper $mapper;
+
+    protected function setUp(): void
+    {
+        $this->mapper = new BladeMapper(m::mock(Factory::class), m::mock(BladeCompiler::class));
+    }
+
     public function testAddLineNumbersPrefixesEachMatchWithItsLineNumber(): void
     {
-        $mapper = new BladeMapper(m::mock(Factory::class), m::mock(BladeCompiler::class));
-
         $value = "line one\n{{ \$foo }}\nline three\n{{ \$bar }}";
 
-        $result = $this->addLineNumbers($mapper, $value, '/\{\{\s*(.+?)\s*\}\}/s');
+        $result = $this->addLineNumbers($value, '/\{\{\s*(.+?)\s*\}\}/s');
 
         $this->assertSame(
             "line one\n|---LINE:2---|{{ \$foo }}\nline three\n|---LINE:4---|{{ \$bar }}",
@@ -27,37 +32,15 @@ class BladeMapperTest extends TestCase
 
     public function testAddLineNumbersReturnsOriginalValueUnchangedWhenNothingMatches(): void
     {
-        $mapper = new BladeMapper(m::mock(Factory::class), m::mock(BladeCompiler::class));
-
         $value = 'plain text with no blade syntax';
 
-        $result = $this->addLineNumbers($mapper, $value, '/\{\{\s*(.+?)\s*\}\}/s');
+        $result = $this->addLineNumbers($value, '/\{\{\s*(.+?)\s*\}\}/s');
 
         $this->assertSame($value, $result);
     }
 
-    public function testAddLineNumbersReturnsOriginalValueWhenThePatternFailsToCompile(): void
+    protected function addLineNumbers(string $value, string $pattern): string
     {
-        $mapper = new BladeMapper(m::mock(Factory::class), m::mock(BladeCompiler::class));
-
-        $previousLimit = ini_get('pcre.backtrack_limit');
-        ini_set('pcre.backtrack_limit', 1);
-
-        try {
-            // Classic catastrophic-backtracking pattern: exhausts the backtrack
-            // limit above and makes preg_replace_callback() return null.
-            $value = str_repeat('a', 200).'!';
-
-            $result = $this->addLineNumbers($mapper, $value, '/^(a+)+$/');
-
-            $this->assertSame($value, $result);
-        } finally {
-            ini_set('pcre.backtrack_limit', $previousLimit);
-        }
-    }
-
-    protected function addLineNumbers(BladeMapper $mapper, string $value, string $pattern): string
-    {
-        return (new ReflectionMethod($mapper, 'addLineNumbers'))->invoke($mapper, $value, $pattern);
+        return (new ReflectionMethod($this->mapper, 'addLineNumbers'))->invoke($this->mapper, $value, $pattern);
     }
 }

--- a/tests/Mail/MailMailerTest.php
+++ b/tests/Mail/MailMailerTest.php
@@ -127,6 +127,40 @@ class MailMailerTest extends TestCase
         $this->assertStringContainsString('<p>Hello World</p>', $sentMessage->toString());
     }
 
+    public function testRenderReplacesEmbeddedAttachmentCidsWithDataUris(): void
+    {
+        $view = m::mock(Factory::class);
+        $view->shouldReceive('make')->never();
+
+        $mailer = new Mailer('array', $view, new ArrayTransport);
+
+        $rendered = $mailer->render(function ($data) {
+            $cid = $data['message']->embedData('fake-image-bytes', 'logo.png', 'image/png');
+
+            return new HtmlString('<p>Hello</p><img src="'.$cid.'">');
+        });
+
+        $this->assertStringNotContainsString('cid:', $rendered);
+        $this->assertStringContainsString(
+            'data:image/png;base64,'.base64_encode('fake-image-bytes'),
+            $rendered
+        );
+    }
+
+    public function testRenderLeavesUnmatchedEmbeddedCidsUntouched(): void
+    {
+        $view = m::mock(Factory::class);
+        $view->shouldReceive('make')->never();
+
+        $mailer = new Mailer('array', $view, new ArrayTransport);
+
+        $rendered = $mailer->render(function ($data) {
+            return new HtmlString('<img src="cid:unknown-image">');
+        });
+
+        $this->assertStringContainsString('<img src="cid:unknown-image">', $rendered);
+    }
+
     public function testMailerSendSendsMessageWithProperPlainViewContent(): void
     {
         $view = m::mock(Factory::class);

--- a/tests/Routing/RouteUriTest.php
+++ b/tests/Routing/RouteUriTest.php
@@ -67,6 +67,16 @@ class RouteUriTest extends TestCase
                 '/foo/{bar}/baz/{qux?}/{test?}',
                 ['qux' => 'slug', 'test' => 'id'],
             ],
+            [
+                '/foo/{bar:slug}/{bar:slug}',
+                '/foo/{bar}/{bar}',
+                ['bar' => 'slug'],
+            ],
+            [
+                '/foo/{bar:slug}{baz:id}',
+                '/foo/{bar}{baz}',
+                ['bar' => 'slug', 'baz' => 'id'],
+            ],
         ];
     }
 }


### PR DESCRIPTION
A few spots (`RouteUri::parse`, `Mailer::replaceEmbeddedAttachments`, and `BladeMapper`'s line-number tagging) were doing a manual `preg_match_all` + loop + `str_replace` to rewrite matches in a string. `preg_replace_callback` does this in one pass and reads simpler.

Kept the old `BladeMapper::insertLineNumberAtPosition` method around unused, just in case anyone extended the class and overrode it.

Covered by existing tests plus a few new ones for the edge cases (duplicate/adjacent route bindings, unmatched embedded image cids, and the regex-failure fallback).