### PR TITLE
[13.x] Fix incorrect image dimensions for HEIC

### DIFF
--- a/src/Illuminate/Contracts/Image/Driver.php
+++ b/src/Illuminate/Contracts/Image/Driver.php
@@ -12,16 +12,16 @@ interface Driver
     public function process(string $contents, ImagePipeline $pipeline): string;
 
     /**
-     * Get the dominant (average) color of the image as a hex string.
-     */
-    public function dominantColor(string $contents): string;
-
-    /**
      * Get the dimensions of the given image contents.
      *
      * @return array{0: int, 1: int}
      */
     public function dimensions(string $contents): array;
+
+    /**
+     * Get the dominant (average) color of the image as a hex string.
+     */
+    public function dominantColor(string $contents): string;
 
     /**
      * Register a transformation handler.

--- a/src/Illuminate/Contracts/Image/Driver.php
+++ b/src/Illuminate/Contracts/Image/Driver.php
@@ -17,6 +17,13 @@ interface Driver
     public function dominantColor(string $contents): string;
 
     /**
+     * Get the dimensions of the given image contents.
+     *
+     * @return array{0: int, 1: int}
+     */
+    public function dimensions(string $contents): array;
+
+    /**
      * Register a transformation handler.
      *
      * @param  class-string<\Illuminate\Contracts\Image\Transformation>  $transformation

--- a/src/Illuminate/Image/Drivers/InterventionDriver.php
+++ b/src/Illuminate/Image/Drivers/InterventionDriver.php
@@ -144,6 +144,22 @@ abstract class InterventionDriver implements Driver
     }
 
     /**
+     * Get the dimensions of the given image contents.
+     *
+     * @return array{0: int, 1: int}
+     */
+    public function dimensions(string $contents): array
+    {
+        $image = $this->manager->decode($contents);
+
+        try {
+            return [$image->width(), $image->height()];
+        } finally {
+            unset($image);
+        }
+    }
+
+    /**
      * Resolve a background color, expanding the "dominant" sentinel when needed.
      */
     protected function resolveBackground(ImageInterface $image, ?string $background): ?string
@@ -162,22 +178,6 @@ abstract class InterventionDriver implements Driver
 
         try {
             return $this->dominantColorFrom($image);
-        } finally {
-            unset($image);
-        }
-    }
-
-    /**
-     * Get the dimensions of the given image contents.
-     *
-     * @return array{0: int, 1: int}
-     */
-    public function dimensions(string $contents): array
-    {
-        $image = $this->manager->decode($contents);
-
-        try {
-            return [$image->width(), $image->height()];
         } finally {
             unset($image);
         }

--- a/src/Illuminate/Image/Drivers/InterventionDriver.php
+++ b/src/Illuminate/Image/Drivers/InterventionDriver.php
@@ -168,6 +168,22 @@ abstract class InterventionDriver implements Driver
     }
 
     /**
+     * Get the dimensions of the given image contents.
+     *
+     * @return array{0: int, 1: int}
+     */
+    public function dimensions(string $contents): array
+    {
+        $image = $this->manager->decode($contents);
+
+        try {
+            return [$image->width(), $image->height()];
+        } finally {
+            unset($image);
+        }
+    }
+
+    /**
      * Sample the dominant color by resizing the image to a single pixel.
      */
     protected function dominantColorFrom(ImageInterface $image): string

--- a/src/Illuminate/Image/Image.php
+++ b/src/Illuminate/Image/Image.php
@@ -462,12 +462,12 @@ class Image implements Stringable
         return once(function () {
             $contents = $this->toBytes();
 
-            // getimagesize() misreports HEIC's coded/padded frame size, so read HEIC via the driver.
+            // getimagesize() misreports HEIC's coded / padded frame size, so read HEIC via the driver...
             if (in_array($this->mimeType(), ['image/heic', 'image/heif', 'image/x-heic'], true)) {
                 try {
                     return $this->resolveDriver()->dimensions($contents);
                 } catch (Throwable) {
-                    // The driver can't decode this image; fall back to the native reader below.
+                    // The driver can't decode this image; fall back to the native reader below...
                 }
             }
 

--- a/src/Illuminate/Image/Image.php
+++ b/src/Illuminate/Image/Image.php
@@ -460,7 +460,18 @@ class Image implements Stringable
     public function dimensions(): array
     {
         return once(function () {
-            $size = @getimagesizefromstring($this->toBytes());
+            $contents = $this->toBytes();
+
+            // getimagesize() misreports HEIC's coded/padded frame size, so read HEIC via the driver.
+            if (in_array($this->mimeType(), ['image/heic', 'image/heif', 'image/x-heic'], true)) {
+                try {
+                    return $this->resolveDriver()->dimensions($contents);
+                } catch (Throwable) {
+                    // The driver can't decode this image; fall back to the native reader below.
+                }
+            }
+
+            $size = @getimagesizefromstring($contents);
 
             if ($size === false) {
                 throw new ImageException('Unable to determine the dimensions of the image.');

--- a/tests/Image/Drivers/GdDriverTest.php
+++ b/tests/Image/Drivers/GdDriverTest.php
@@ -477,6 +477,14 @@ class GdDriverTest extends TestCase
         $this->assertTrue(true);
     }
 
+    public function test_dimensions_returns_the_decoded_size()
+    {
+        $driver = new GdDriver;
+        $contents = $driver->process($this->fakeImageContents(320, 240), $this->pipeline(new Cover(200, 150), format: 'png'));
+
+        $this->assertSame([200, 150], $driver->dimensions($contents));
+    }
+
     protected function fakeImageContents(int $width = 100, int $height = 100): string
     {
         $file = UploadedFile::fake()->image('test.jpg', $width, $height);

--- a/tests/Image/Drivers/ImagickDriverTest.php
+++ b/tests/Image/Drivers/ImagickDriverTest.php
@@ -2,9 +2,13 @@
 
 namespace Illuminate\Tests\Image\Drivers;
 
+use Illuminate\Config\Repository;
+use Illuminate\Container\Container;
 use Illuminate\Contracts\Image\Transformation;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Image\Drivers\ImagickDriver;
+use Illuminate\Image\Image;
+use Illuminate\Image\ImageManager;
 use Illuminate\Image\ImagePipeline;
 use Illuminate\Image\Transformations\Blur;
 use Illuminate\Image\Transformations\Contain;
@@ -139,6 +143,49 @@ class ImagickDriverTest extends TestCase
         $result = $driver->process($result, $this->pipeline(format: 'jpg'));
 
         $this->assertSame([50, 25], array_slice(getimagesizefromstring($result), 0, 2));
+    }
+
+    public function test_dimensions_returns_the_decoded_size()
+    {
+        $driver = new ImagickDriver;
+        $contents = $driver->process($this->fakeImageContents(320, 240), $this->pipeline(new Cover(200, 150), format: 'png'));
+
+        $this->assertSame([200, 150], $driver->dimensions($contents));
+    }
+
+    public function test_dimensions_returns_the_display_size_for_heic()
+    {
+        $this->ensureImageFormatCanBeEncoded('heic');
+
+        $driver = new ImagickDriver;
+
+        // 137x73 is a size where HEIC's coded/padded frame differs from the display size, which
+        // getimagesize() misreports; the driver must return the true display size.
+        $contents = $driver->process($this->fakeImageContents(400, 300), $this->pipeline(new Cover(137, 73), format: 'heic'));
+
+        $this->assertSame([137, 73], $driver->dimensions($contents));
+    }
+
+    public function test_image_dimensions_are_correct_for_real_heic_through_public_api()
+    {
+        $this->ensureImageFormatCanBeEncoded('heic');
+
+        // End-to-end through the public Image API on a real HEIC; fails pre-fix (getimagesize returns 138x74).
+        $heic = (new ImagickDriver)->process(
+            $this->fakeImageContents(400, 300),
+            $this->pipeline(new Cover(137, 73), format: 'heic')
+        );
+
+        $container = new Container;
+        $container->instance('config', new Repository(['images' => ['default' => 'imagick']]));
+        $container->instance('image', new ImageManager($container));
+        Container::setInstance($container);
+
+        try {
+            $this->assertSame([137, 73], (new Image($heic))->dimensions());
+        } finally {
+            Container::setInstance(null);
+        }
     }
 
     public function test_processes_optimize_to_bmp()
@@ -489,11 +536,18 @@ class ImagickDriverTest extends TestCase
             $this->markTestSkipped("The Imagick extension was not compiled with {$format} support.");
         }
 
-        $imagick = new \Imagick;
-        $imagick->newImage(1, 1, 'white');
-        $imagick->setImageFormat($format);
+        try {
+            $imagick = new \Imagick;
+            $imagick->newImage(1, 1, 'white');
+            $imagick->setImageFormat($format);
+            $encoded = $imagick->getImageBlob();
+        } catch (\ImagickException) {
+            // Some builds ship the HEIC decode delegate but no encoder, in which case encoding
+            // raises instead of returning an empty blob. Either way, encoding is unavailable.
+            $encoded = '';
+        }
 
-        if ($imagick->getImageBlob() === '') {
+        if ($encoded === '') {
             $this->markTestSkipped("The Imagick extension cannot encode {$format} images.");
         }
     }

--- a/tests/Image/ImageManagerTest.php
+++ b/tests/Image/ImageManagerTest.php
@@ -326,6 +326,11 @@ class ImageManagerTest extends TestCase
                 return '#000000';
             }
 
+            public function dimensions(string $contents): array
+            {
+                return [0, 0];
+            }
+
             public function transformUsing(string $transformation, callable $callback): static
             {
                 $this->handlers[$transformation] = $callback;
@@ -360,6 +365,11 @@ class ImageManagerTest extends TestCase
             public function dominantColor(string $contents): string
             {
                 return '#000000';
+            }
+
+            public function dimensions(string $contents): array
+            {
+                return [0, 0];
             }
 
             public function transformUsing(string $transformation, callable $callback): static

--- a/tests/Image/ImageTest.php
+++ b/tests/Image/ImageTest.php
@@ -2,9 +2,13 @@
 
 namespace Illuminate\Tests\Image;
 
+use Illuminate\Config\Repository;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Image\Driver;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Image\Image;
 use Illuminate\Image\ImageException;
+use Illuminate\Image\ImageManager;
 use Illuminate\Image\ImageOutputOptions;
 use Illuminate\Image\ImagePipeline;
 use Illuminate\Image\Transformations\Blur;
@@ -289,6 +293,94 @@ class ImageTest extends TestCase
         $this->expectExceptionMessage('Unable to determine the dimensions of the image.');
 
         $image->dimensions();
+    }
+
+    public function test_dimensions_defers_to_the_driver_for_heic_images()
+    {
+        $container = new Container;
+        $container->instance('config', new Repository(['images' => ['default' => 'fake']]));
+
+        $manager = new ImageManager($container);
+        $manager->extend('fake', fn () => new class implements Driver
+        {
+            public function process(string $contents, ImagePipeline $pipeline): string
+            {
+                // Bytes that finfo reports as image/heic but getimagesizefromstring() cannot read.
+                return "\x00\x00\x00\x18ftypheic\x00\x00\x00\x00mif1heic";
+            }
+
+            public function dimensions(string $contents): array
+            {
+                return [123, 45];
+            }
+
+            public function dominantColor(string $contents): string
+            {
+                return '#000000';
+            }
+
+            public function transformUsing(string $transformation, callable $callback): static
+            {
+                return $this;
+            }
+        });
+        $container->instance('image', $manager);
+
+        Container::setInstance($container);
+
+        try {
+            $image = (new Image($this->fakeImageContents()))->using('fake')->cover(1, 1);
+
+            $this->assertSame([123, 45], $image->dimensions());
+            $this->assertSame(123, $image->width());
+            $this->assertSame(45, $image->height());
+        } finally {
+            Container::setInstance(null);
+        }
+    }
+
+    public function test_dimensions_falls_back_to_native_reader_when_the_driver_cannot_decode_heic()
+    {
+        $container = new Container;
+        $container->instance('config', new Repository(['images' => ['default' => 'fake']]));
+
+        $manager = new ImageManager($container);
+        $manager->extend('fake', fn () => new class implements Driver
+        {
+            public function process(string $contents, ImagePipeline $pipeline): string
+            {
+                return "\x00\x00\x00\x18ftypheic\x00\x00\x00\x00mif1heic";
+            }
+
+            public function dimensions(string $contents): array
+            {
+                throw new ImageException('The driver cannot decode this image.');
+            }
+
+            public function dominantColor(string $contents): string
+            {
+                return '#000000';
+            }
+
+            public function transformUsing(string $transformation, callable $callback): static
+            {
+                return $this;
+            }
+        });
+        $container->instance('image', $manager);
+
+        Container::setInstance($container);
+
+        try {
+            $image = (new Image($this->fakeImageContents()))->using('fake')->cover(1, 1);
+
+            $this->expectException(ImageException::class);
+            $this->expectExceptionMessage('Unable to determine the dimensions of the image.');
+
+            $image->dimensions();
+        } finally {
+            Container::setInstance(null);
+        }
     }
 
     public function test_hash_name_returns_name_with_extension()


### PR DESCRIPTION
`Image::dimensions()`, `width()` and `height()` read the size with `getimagesizefromstring()`, which misreads HEIC — it either fails outright or reports the coded/padded frame size instead of the image's true display size:

| HEIC | `getimagesize` (current) | actual display size |
|------|--------------------------|---------------------|
| iPhone photo (large)* | `false` → **throws** | 3024×4032 |
| small single-tile     | **138×74**           | 137×73 |

<sub>\* Large HEICs are stored as a grid of smaller tiles; `getimagesize` can't resolve the assembled size and returns `false` ([php-src #20863](https://github.com/php/php-src/issues/20863)).</sub>

So on an ordinary iPhone upload `->width()` throws today, and on smaller HEICs it silently returns the wrong number. (The conversion pipeline is fine — it goes through the driver, not `getimagesize()`; only the dimension inspectors are affected, which is what upload validation, aspect-ratio checks, and stored metadata rely on.)

```php
Image::fromStorage('uploads/iphone-photo.heic')->width();
// before: ImageException "Unable to determine the dimensions of the image"
// after:  3024

$request->image('avatar')->cover(137, 73)->toHeic()->width();
// before: 138   after: 137
```

## Fix

Follow-up to #60922, which added HEIC input/output support; `dimensions()` was left reading via `getimagesizefromstring()`. For HEIC/HEIF, dimensions are now read from the driver, which decodes the image and reports its true display size; every other format keeps its existing behaviour. HEIC requires the Imagick driver, so if the driver can't decode the image (e.g. GD) we fall back to the previous `getimagesize()` path — **the default GD driver is unaffected**.

Adds `dimensions(string $contents): array` to the `Image\Driver` contract and `InterventionDriver`, mirroring `dominantColor()` (#60932). Tests cover the driver routing, the GD fallback, and real-HEIC dimensions.
