### PR TITLE
[13.x] Sync FilesystemAdapter return types with the filesystem contract

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -942,7 +942,7 @@ class FilesystemAdapter implements CloudFilesystemContract
      *
      * @param  string|null  $directory
      * @param  bool  $recursive
-     * @return array
+     * @return array<string>
      */
     public function files($directory = null, $recursive = false)
     {
@@ -961,7 +961,7 @@ class FilesystemAdapter implements CloudFilesystemContract
      * Get all of the files from the given directory (recursive).
      *
      * @param  string|null  $directory
-     * @return array
+     * @return array<string>
      */
     public function allFiles($directory = null)
     {
@@ -973,7 +973,7 @@ class FilesystemAdapter implements CloudFilesystemContract
      *
      * @param  string|null  $directory
      * @param  bool  $recursive
-     * @return array
+     * @return array<string>
      */
     public function directories($directory = null, $recursive = false)
     {
@@ -991,7 +991,7 @@ class FilesystemAdapter implements CloudFilesystemContract
      * Get all the directories within a given directory (recursive).
      *
      * @param  string|null  $directory
-     * @return array
+     * @return array<string>
      */
     public function allDirectories($directory = null)
     {


### PR DESCRIPTION
`Illuminate\Contracts\Filesystem\Filesystem` already declares the element type for its four directory listing methods:

```php
/**
 * @return array<string>
 */
public function files($directory = null, $recursive = false);
```

`FilesystemAdapter` — the implementation behind every `Storage` disk — re-declares the same four methods with a bare `@return array`. The implementation's docblock wins, so anything resolved through a disk loses the element type:

```php
foreach (Storage::disk('s3')->files() as $file) {
    Storage::delete($file); // $file is mixed, so nothing checks that a string is passed on
}
```

This syncs `files()`, `allFiles()`, `directories()` and `allDirectories()` to the `array<string>` their contract already declares. Each body maps the Flysystem listing through `StorageAttributes::path()`, so `array<string>` is what they actually return.

Docblock only, no behavior change.