### PR TITLE
[13.x] Add test for the Request matchesType method

### DIFF
--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -1534,6 +1534,19 @@ class HttpRequestTest extends TestCase
         $this->assertFalse($request->acceptsMarkdown());
     }
 
+    public function testMatchesType()
+    {
+        $this->assertTrue(Request::matchesType('application/json', 'application/json'));
+
+        $this->assertTrue(Request::matchesType('application/json', 'application/vnd.api+json'));
+        $this->assertTrue(Request::matchesType('application/xml', 'application/atom+xml'));
+
+        $this->assertFalse(Request::matchesType('application/vnd.api+json', 'application/json'));
+        $this->assertFalse(Request::matchesType('application/json', 'application/xml'));
+        $this->assertFalse(Request::matchesType('application/json', 'text/json'));
+        $this->assertFalse(Request::matchesType('json', 'application/json'));
+    }
+
     public function testFormatReturnsAcceptsJson()
     {
         $request = Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json']);


### PR DESCRIPTION
`Request::matchesType()` is public API and backs `accepts()`, but it is the only method in `InteractsWithContentTypes` with no test coverage — the other eleven (`isJson`, `accepts`, `prefers`, `format`, the `wants*`/`accepts*` family) are all exercised.

It is also the one that does the actual work: beyond an exact comparison it matches a media type against its structured-syntax suffix variants, so `application/json` matches `application/vnd.api+json` but not the other way around, and a type without a subtype never matches:

```php
Request::matchesType('application/json', 'application/vnd.api+json'); // true
Request::matchesType('application/vnd.api+json', 'application/json'); // false
Request::matchesType('json', 'application/json');                     // false
```

None of that asymmetry is pinned down today. This adds a test covering the exact match, the `+suffix` match in both directions, a different subtype, a different top-level type, and an input with no subtype.

Test only, no source changes.