### PR TITLE
[13.x] Add tests for the whereUuid and whereUlid route constraints

### DIFF
--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -1257,6 +1257,26 @@ class RouteRegistrarTest extends TestCase
         }
     }
 
+    public function testWhereUlidRegistration()
+    {
+        $this->router->get('/{foo}')->whereUlid('foo');
+
+        $this->assertTrue($this->getRoute()->matches(Request::create('/01ARZ3NDEKTSV4RRFFQ69G5FAV', 'GET')));
+        $this->assertFalse($this->getRoute()->matches(Request::create('/01ARZ3NDEKTSV4RRFFQ69G5FA', 'GET')));
+        $this->assertFalse($this->getRoute()->matches(Request::create('/01ARZ3NDEKTSV4RRFFQ69G5FAI', 'GET')));
+        $this->assertFalse($this->getRoute()->matches(Request::create('/81ARZ3NDEKTSV4RRFFQ69G5FAV', 'GET')));
+    }
+
+    public function testWhereUuidRegistration()
+    {
+        $this->router->get('/{foo}')->whereUuid('foo');
+
+        $this->assertTrue($this->getRoute()->matches(Request::create('/2cd90b6d-3c34-4a0a-9d0d-9d0b7b1a2e6f', 'GET')));
+        $this->assertTrue($this->getRoute()->matches(Request::create('/2CD90B6D-3C34-4A0A-9D0D-9D0B7B1A2E6F', 'GET')));
+        $this->assertFalse($this->getRoute()->matches(Request::create('/2cd90b6d3c344a0a9d0d9d0b7b1a2e6f', 'GET')));
+        $this->assertFalse($this->getRoute()->matches(Request::create('/2cd90b6d-3c34-4a0a-9d0d-9d0b7b1a2e6', 'GET')));
+    }
+
     public function testWhereInRegistration()
     {
         $wheres = ['foo' => 'one|two', 'bar' => 'one|two'];


### PR DESCRIPTION
`CreatesRegularExpressionRouteConstraints` has six helpers. Four of them — `whereNumber()`, `whereAlpha()`, `whereAlphaNumeric()` and `whereIn()` — have tests in `RouteRegistrarTest`; `whereUuid()` and `whereUlid()` have none.

They are also the two with a non-trivial pattern, so nothing currently catches a regression in them:

```php
Route::get('/{foo}')->whereUlid('foo');  // [0-7][0-9a-hjkmnp-tv-zA-HJKMNP-TV-Z]{25}
Route::get('/{foo}')->whereUuid('foo');  // [\da-fA-F]{8}-[\da-fA-F]{4}-...
```

The added tests assert against real route matching rather than the pattern string, so they cover what the constraints are meant to guarantee: a canonical ULID matches, while one that is a character short, one containing a character excluded by Crockford's base32 alphabet, and one whose leading character overflows the 128-bit range do not; a UUID matches in either hex case, while an unhyphenated one and one with a truncated final group do not.

Tests only, no source changes.