### PR TITLE
[13.x] Fix RedisQueueTest.php

### DIFF
--- a/tests/Integration/Queue/RedisQueueTest.php
+++ b/tests/Integration/Queue/RedisQueueTest.php
@@ -17,6 +17,7 @@ use Mockery as m;
 use Orchestra\Testbench\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+use Ramsey\Uuid\Uuid;
 
 #[RequiresPhpExtension('redis')]
 class RedisQueueTest extends TestCase
@@ -265,7 +266,7 @@ class RedisQueueTest extends TestCase
     public function testBlockingPopProperlyPopsExpiredJobs($driver)
     {
         Str::createUuidsUsing(function () {
-            return 'uuid';
+            return Uuid::fromString('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee');
         });
 
         $default = config('queue.connections.redis.queue', 'default');


### PR DESCRIPTION
This fixes failing tests... https://github.com/laravel/framework/actions/runs/30840371593/job/91775661101#step:5:278

it was failing due to https://github.com/laravel/framework/pull/60995 which changed `(string) Str::uuid()` to `Str::uuid()->toString()` 

`Str::createUuidsUsing()` expects its factory to return a `UuidInterface` looking at the docblock so this test failed, so I've adjusted the test. 


Copied the UUID logic from 

https://github.com/laravel/framework/blob/a61f8e4809677146ecb91f273bc2f44108ed244c/tests/Queue/QueueDatabaseQueueIntegrationTest.php#L273


I'm trying my best to keep up with failures so new contributors get a nice experience, I apologize you must see my face. And finally no, I don't have a bot checking for failures it's me 😆. 


I guess the change that caused this could be considered breaking if anyone uses a string, but imo feels unlikely? Not sure what you think tho.