### PR TITLE
[13.x] Add JsonSchema::fromRules() to build a schema from validation rules

### DIFF
--- a/src/Illuminate/JsonSchema/JsonSchema.php
+++ b/src/Illuminate/JsonSchema/JsonSchema.php
@@ -30,6 +30,18 @@ class JsonSchema
     }
 
     /**
+     * Build a schema from a set of Laravel validation rules.
+     *
+     * Rules without a JSON Schema equivalent are ignored.
+     *
+     * @param  array<string, mixed>  $rules
+     */
+    public static function fromRules(array $rules): Types\ObjectType
+    {
+        return RuleDeserializer::deserialize($rules);
+    }
+
+    /**
      * Dynamically pass static methods to the schema instance.
      */
     public static function __callStatic(string $name, mixed $arguments): Type

--- a/src/Illuminate/JsonSchema/RuleDeserializer.php
+++ b/src/Illuminate/JsonSchema/RuleDeserializer.php
@@ -1,0 +1,328 @@
+<?php
+
+namespace Illuminate\JsonSchema;
+
+class RuleDeserializer
+{
+    /**
+     * The validation rules that resolve a property to a type.
+     *
+     * @var array<string, string>
+     */
+    protected const TYPES = [
+        'string' => 'string',
+        'integer' => 'integer',
+        'int' => 'integer',
+        'numeric' => 'number',
+        'decimal' => 'number',
+        'boolean' => 'boolean',
+        'bool' => 'boolean',
+        'array' => 'array',
+        'list' => 'array',
+    ];
+
+    /**
+     * The validation rules that map to a string format.
+     *
+     * @var array<string, string>
+     */
+    protected const FORMATS = [
+        'email' => 'email',
+        'url' => 'uri',
+        'uuid' => 'uuid',
+        'ipv4' => 'ipv4',
+        'ipv6' => 'ipv6',
+        'date' => 'date',
+    ];
+
+    /**
+     * Build a schema from the given set of Laravel validation rules.
+     *
+     * @param  array<string, mixed>  $rules
+     */
+    public static function deserialize(array $rules): Types\ObjectType
+    {
+        return (new static)->build(static::tree($rules));
+    }
+
+    /**
+     * Arrange the flat, "dot" notated rules into a nested tree.
+     *
+     * @param  array<string, mixed>  $rules
+     * @return array<string, array{rules: array<int, string>, children: array<string, mixed>}>
+     */
+    protected static function tree(array $rules): array
+    {
+        $tree = [];
+
+        foreach ($rules as $key => $definition) {
+            $node = &$tree;
+
+            foreach (explode('.', (string) $key) as $segment) {
+                $node[$segment] ??= ['rules' => [], 'children' => []];
+
+                $leaf = &$node[$segment];
+                $node = &$leaf['children'];
+            }
+
+            $leaf['rules'] = static::normalize($definition);
+
+            unset($node, $leaf);
+        }
+
+        return $tree;
+    }
+
+    /**
+     * Reduce a rule definition to the string rules it contains.
+     *
+     * @return array<int, string>
+     */
+    protected static function normalize(mixed $definition): array
+    {
+        $rules = match (true) {
+            is_string($definition) => explode('|', $definition),
+            is_array($definition) => $definition,
+            default => [],
+        };
+
+        // Rule objects, closures and invokable rules describe constraints that
+        // have no JSON Schema equivalent, so only the string rules are kept...
+        return array_values(array_filter($rules, 'is_string'));
+    }
+
+    /**
+     * Build the schema for a tree of properties.
+     *
+     * @param  array<string, array{rules: array<int, string>, children: array<string, mixed>}>  $tree
+     */
+    protected function build(array $tree): Types\ObjectType
+    {
+        $properties = [];
+
+        foreach ($tree as $name => $node) {
+            $properties[$name] = $this->property($node);
+        }
+
+        return new Types\ObjectType($properties);
+    }
+
+    /**
+     * Build the schema for a single property.
+     *
+     * @param  array{rules: array<int, string>, children: array<string, mixed>}  $node
+     */
+    protected function property(array $node): Types\Type
+    {
+        [$names, $parameters] = $this->parse($node['rules']);
+
+        $type = $this->resolve($names, $parameters, $node['children']);
+
+        $this->applyConstraints($type, $names, $parameters);
+
+        if (in_array('required', $names, true)) {
+            $type->required();
+        }
+
+        if (in_array('nullable', $names, true)) {
+            $type->nullable();
+        }
+
+        return $type;
+    }
+
+    /**
+     * Split the rules into their names and parameters.
+     *
+     * @param  array<int, string>  $rules
+     * @return array{0: array<int, string>, 1: array<string, string>}
+     */
+    protected function parse(array $rules): array
+    {
+        $names = [];
+        $parameters = [];
+
+        foreach ($rules as $rule) {
+            [$name, $parameter] = array_pad(explode(':', $rule, 2), 2, null);
+
+            $name = strtolower(trim($name));
+
+            $names[] = $name;
+
+            if ($parameter !== null) {
+                $parameters[$name] = $parameter;
+            }
+        }
+
+        return [$names, $parameters];
+    }
+
+    /**
+     * Resolve the type a property describes.
+     *
+     * @param  array<int, string>  $names
+     * @param  array<string, string>  $parameters
+     * @param  array<string, mixed>  $children
+     */
+    protected function resolve(array $names, array $parameters, array $children): Types\Type
+    {
+        if (isset($children['*'])) {
+            return (new Types\ArrayType)->items($this->property($children['*']));
+        }
+
+        if ($children !== []) {
+            return $this->build($children);
+        }
+
+        foreach ($names as $name) {
+            if (isset(static::TYPES[$name])) {
+                return $this->make(static::TYPES[$name]);
+            }
+        }
+
+        // A field carrying no type rule is treated as a string, matching how the
+        // validator sizes an untyped value against "min", "max" and "size"...
+        return $this->make('string');
+    }
+
+    /**
+     * Create a new type instance for the given JSON Schema type name.
+     */
+    protected function make(string $type): Types\Type
+    {
+        return match ($type) {
+            'integer' => new Types\IntegerType,
+            'number' => new Types\NumberType,
+            'boolean' => new Types\BooleanType,
+            'array' => new Types\ArrayType,
+            default => new Types\StringType,
+        };
+    }
+
+    /**
+     * Apply the constraint rules supported for the resolved type.
+     *
+     * @param  array<int, string>  $names
+     * @param  array<string, string>  $parameters
+     */
+    protected function applyConstraints(Types\Type $type, array $names, array $parameters): void
+    {
+        foreach ($names as $name) {
+            match ($name) {
+                'min' => $this->bound($type, 'min', $parameters['min'] ?? null),
+                'max' => $this->bound($type, 'max', $parameters['max'] ?? null),
+                'size' => $this->size($type, $parameters['size'] ?? null),
+                'between' => $this->between($type, $parameters['between'] ?? null),
+                'in' => $this->enum($type, $parameters['in'] ?? null),
+                'regex' => $this->pattern($type, $parameters['regex'] ?? null),
+                'multiple_of' => $this->multipleOf($type, $parameters['multiple_of'] ?? null),
+                default => $this->format($type, $name),
+            };
+        }
+    }
+
+    /**
+     * Apply a lower or upper bound in the unit the resolved type is measured in.
+     */
+    protected function bound(Types\Type $type, string $bound, ?string $value): void
+    {
+        if ($value === null || ! is_numeric($value)) {
+            return;
+        }
+
+        match (true) {
+            $type instanceof Types\StringType => $bound === 'min'
+                ? $type->min((int) $value)
+                : $type->max((int) $value),
+            $type instanceof Types\IntegerType => $bound === 'min'
+                ? $type->min((int) $value)
+                : $type->max((int) $value),
+            $type instanceof Types\NumberType => $bound === 'min'
+                ? $type->min($value + 0)
+                : $type->max($value + 0),
+            $type instanceof Types\ArrayType => $bound === 'min'
+                ? $type->min((int) $value)
+                : $type->max((int) $value),
+            default => null,
+        };
+    }
+
+    /**
+     * Apply an exact size as a matching pair of bounds.
+     */
+    protected function size(Types\Type $type, ?string $value): void
+    {
+        $this->bound($type, 'min', $value);
+        $this->bound($type, 'max', $value);
+    }
+
+    /**
+     * Apply the pair of bounds a "between" rule describes.
+     */
+    protected function between(Types\Type $type, ?string $value): void
+    {
+        [$min, $max] = array_pad(explode(',', (string) $value, 2), 2, null);
+
+        $this->bound($type, 'min', $min);
+        $this->bound($type, 'max', $max);
+    }
+
+    /**
+     * Apply the step a numeric value must be a multiple of.
+     */
+    protected function multipleOf(Types\Type $type, ?string $value): void
+    {
+        if ($value === null || ! is_numeric($value)) {
+            return;
+        }
+
+        match (true) {
+            $type instanceof Types\IntegerType => $type->multipleOf((int) $value),
+            $type instanceof Types\NumberType => $type->multipleOf($value + 0),
+            default => null,
+        };
+    }
+
+    /**
+     * Apply the set of values an "in" rule allows.
+     */
+    protected function enum(Types\Type $type, ?string $value): void
+    {
+        if ($value === null || $value === '') {
+            return;
+        }
+
+        $type->enum(array_map(
+            static fn (string $value) => trim($value, '"'),
+            explode(',', $value),
+        ));
+    }
+
+    /**
+     * Apply a regular expression, without its delimiters, as a pattern.
+     */
+    protected function pattern(Types\Type $type, ?string $value): void
+    {
+        if (! $type instanceof Types\StringType || $value === null || strlen($value) < 2) {
+            return;
+        }
+
+        $delimiter = $value[0];
+
+        if (($end = strrpos($value, $delimiter)) > 0) {
+            $value = substr($value, 1, $end - 1);
+        }
+
+        $type->pattern($value);
+    }
+
+    /**
+     * Apply the string format a rule describes, if it describes one.
+     */
+    protected function format(Types\Type $type, string $name): void
+    {
+        if ($type instanceof Types\StringType && isset(static::FORMATS[$name])) {
+            $type->format(static::FORMATS[$name]);
+        }
+    }
+}

--- a/tests/JsonSchema/RuleDeserializerTest.php
+++ b/tests/JsonSchema/RuleDeserializerTest.php
@@ -1,0 +1,257 @@
+<?php
+
+namespace Illuminate\Tests\JsonSchema;
+
+use Illuminate\JsonSchema\JsonSchema;
+use PHPUnit\Framework\TestCase;
+
+class RuleDeserializerTest extends TestCase
+{
+    public function test_it_maps_the_scalar_type_rules(): void
+    {
+        $type = JsonSchema::fromRules([
+            'name' => 'string',
+            'age' => 'integer',
+            'score' => 'numeric',
+            'active' => 'boolean',
+            'tags' => 'array',
+        ]);
+
+        $this->assertEquals([
+            'type' => 'object',
+            'properties' => [
+                'name' => ['type' => 'string'],
+                'age' => ['type' => 'integer'],
+                'score' => ['type' => 'number'],
+                'active' => ['type' => 'boolean'],
+                'tags' => ['type' => 'array'],
+            ],
+        ], $type->toArray());
+    }
+
+    public function test_it_accepts_rules_given_as_arrays(): void
+    {
+        $type = JsonSchema::fromRules([
+            'name' => ['required', 'string', 'max:50'],
+        ]);
+
+        $this->assertEquals([
+            'type' => 'object',
+            'properties' => [
+                'name' => ['maxLength' => 50, 'type' => 'string'],
+            ],
+            'required' => ['name'],
+        ], $type->toArray());
+    }
+
+    public function test_it_marks_required_and_nullable_properties(): void
+    {
+        $type = JsonSchema::fromRules([
+            'name' => 'required|string',
+            'nickname' => 'nullable|string',
+        ])->toArray();
+
+        $this->assertSame(['name'], $type['required']);
+        $this->assertSame(['string', 'null'], $type['properties']['nickname']['type']);
+    }
+
+    public function test_it_resolves_size_rules_against_the_resolved_type(): void
+    {
+        $type = JsonSchema::fromRules([
+            'name' => 'string|min:2|max:50',
+            'age' => 'integer|min:0|max:120',
+            'score' => 'numeric|min:0.5',
+            'tags' => 'array|min:1|max:5',
+        ]);
+
+        $this->assertEquals([
+            'name' => ['minLength' => 2, 'maxLength' => 50, 'type' => 'string'],
+            'age' => ['minimum' => 0, 'maximum' => 120, 'type' => 'integer'],
+            'score' => ['minimum' => 0.5, 'type' => 'number'],
+            'tags' => ['minItems' => 1, 'maxItems' => 5, 'type' => 'array'],
+        ], $type->toArray()['properties']);
+    }
+
+    public function test_it_treats_an_untyped_field_as_a_string(): void
+    {
+        $type = JsonSchema::fromRules(['name' => 'required|max:10']);
+
+        $this->assertEquals(
+            ['maxLength' => 10, 'type' => 'string'],
+            $type->toArray()['properties']['name']
+        );
+    }
+
+    public function test_it_maps_between_and_size_rules(): void
+    {
+        $type = JsonSchema::fromRules([
+            'age' => 'integer|between:18,65',
+            'code' => 'string|size:6',
+            'tags' => 'array|size:3',
+        ]);
+
+        $this->assertEquals([
+            'age' => ['minimum' => 18, 'maximum' => 65, 'type' => 'integer'],
+            'code' => ['minLength' => 6, 'maxLength' => 6, 'type' => 'string'],
+            'tags' => ['minItems' => 3, 'maxItems' => 3, 'type' => 'array'],
+        ], $type->toArray()['properties']);
+    }
+
+    public function test_it_maps_the_in_rule_to_an_enum(): void
+    {
+        $type = JsonSchema::fromRules(['role' => 'in:admin,editor,viewer']);
+
+        $this->assertSame(
+            ['admin', 'editor', 'viewer'],
+            $type->toArray()['properties']['role']['enum']
+        );
+    }
+
+    public function test_it_maps_string_formats_and_patterns(): void
+    {
+        $type = JsonSchema::fromRules([
+            'email' => 'email',
+            'website' => 'url',
+            'identifier' => 'uuid',
+            'born' => 'date',
+            'host' => 'ipv4',
+            'slug' => 'regex:/^[a-z]+$/',
+        ]);
+
+        $this->assertEquals([
+            'email' => ['format' => 'email', 'type' => 'string'],
+            'website' => ['format' => 'uri', 'type' => 'string'],
+            'identifier' => ['format' => 'uuid', 'type' => 'string'],
+            'born' => ['format' => 'date', 'type' => 'string'],
+            'host' => ['format' => 'ipv4', 'type' => 'string'],
+            'slug' => ['pattern' => '^[a-z]+$', 'type' => 'string'],
+        ], $type->toArray()['properties']);
+    }
+
+    public function test_it_maps_the_multiple_of_rule(): void
+    {
+        $type = JsonSchema::fromRules([
+            'quantity' => 'integer|multiple_of:5',
+            'price' => 'numeric|multiple_of:0.25',
+        ]);
+
+        $this->assertEquals([
+            'quantity' => ['multipleOf' => 5, 'type' => 'integer'],
+            'price' => ['multipleOf' => 0.25, 'type' => 'number'],
+        ], $type->toArray()['properties']);
+    }
+
+    public function test_it_ignores_formats_it_cannot_represent_exactly(): void
+    {
+        // Laravel's "ip" accepts either version and a ULID is not a UUID, so
+        // neither has an exact JSON Schema format to map onto...
+        $type = JsonSchema::fromRules(['host' => 'ip', 'identifier' => 'ulid']);
+
+        $this->assertEquals([
+            'host' => ['type' => 'string'],
+            'identifier' => ['type' => 'string'],
+        ], $type->toArray()['properties']);
+    }
+
+    public function test_it_nests_properties_written_in_dot_notation(): void
+    {
+        $type = JsonSchema::fromRules([
+            'user' => 'required',
+            'user.name' => 'required|string',
+            'user.address.city' => 'string',
+        ]);
+
+        $this->assertEquals([
+            'type' => 'object',
+            'properties' => [
+                'user' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'name' => ['type' => 'string'],
+                        'address' => [
+                            'type' => 'object',
+                            'properties' => ['city' => ['type' => 'string']],
+                        ],
+                    ],
+                    'required' => ['name'],
+                ],
+            ],
+            'required' => ['user'],
+        ], $type->toArray());
+    }
+
+    public function test_it_maps_wildcard_rules_to_array_items(): void
+    {
+        $type = JsonSchema::fromRules([
+            'tags' => 'required|array|min:1',
+            'tags.*' => 'string|max:20',
+        ]);
+
+        $this->assertEquals([
+            'items' => ['maxLength' => 20, 'type' => 'string'],
+            'minItems' => 1,
+            'type' => 'array',
+        ], $type->toArray()['properties']['tags']);
+    }
+
+    public function test_it_maps_wildcard_rules_describing_objects(): void
+    {
+        $type = JsonSchema::fromRules([
+            'users' => 'array',
+            'users.*.name' => 'required|string',
+            'users.*.age' => 'integer',
+        ]);
+
+        $this->assertEquals([
+            'items' => [
+                'type' => 'object',
+                'properties' => [
+                    'name' => ['type' => 'string'],
+                    'age' => ['type' => 'integer'],
+                ],
+                'required' => ['name'],
+            ],
+            'type' => 'array',
+        ], $type->toArray()['properties']['users']);
+    }
+
+    public function test_it_infers_an_array_from_a_wildcard_without_its_own_rules(): void
+    {
+        $type = JsonSchema::fromRules(['tags.*' => 'string']);
+
+        $this->assertEquals(
+            ['items' => ['type' => 'string'], 'type' => 'array'],
+            $type->toArray()['properties']['tags']
+        );
+    }
+
+    public function test_it_ignores_rules_it_cannot_represent(): void
+    {
+        $type = JsonSchema::fromRules([
+            'password' => 'required|string|confirmed|not_in:secret',
+            'avatar' => 'image|mimes:jpg,png',
+        ]);
+
+        $this->assertEquals([
+            'password' => ['type' => 'string'],
+            'avatar' => ['type' => 'string'],
+        ], $type->toArray()['properties']);
+    }
+
+    public function test_it_ignores_rule_objects_and_closures(): void
+    {
+        $type = JsonSchema::fromRules([
+            'name' => ['required', 'string', fn () => true, new \stdClass],
+        ]);
+
+        $this->assertEquals(
+            ['type' => 'string'],
+            $type->toArray()['properties']['name']
+        );
+    }
+
+    public function test_it_returns_an_empty_object_for_no_rules(): void
+    {
+        $this->assertSame(['type' => 'object'], JsonSchema::fromRules([])->toArray());
+    }
+}


### PR DESCRIPTION
`Illuminate\JsonSchema` can only be driven by hand today — every property, constraint and required flag has to be spelled out a second time. Applications have already described that same shape once, in the validation rules of a form request, so this reads them:

```php
JsonSchema::fromRules([
    'title'  => 'required|string|min:3|max:120',
    'status' => 'required|in:draft,published,archived',
    'author.name'  => 'required|string|max:50',
    'author.email' => 'required|email',
    'rating' => 'nullable|numeric|between:0,5|multiple_of:0.5',
    'tags'   => 'array|max:5',
    'tags.*' => 'string|max:20',
]);
```

```json
{
    "properties": {
        "title": { "minLength": 3, "maxLength": 120, "type": "string" },
        "status": { "enum": ["draft", "published", "archived"], "type": "string" },
        "author": {
            "properties": {
                "name": { "maxLength": 50, "type": "string" },
                "email": { "format": "email", "type": "string" }
            },
            "type": "object",
            "required": ["name", "email"]
        },
        "rating": { "minimum": 0, "maximum": 5, "multipleOf": 0.5, "type": ["number", "null"] },
        "tags": { "maxItems": 5, "items": { "maxLength": 20, "type": "string" }, "type": "array" }
    },
    "type": "object",
    "required": ["title", "status", "author"]
}
```

Dot notation becomes nested objects and `*` becomes array items, including `attachments.*.url`, which describes an array of objects.

## What is mapped

Only rules with an exact JSON Schema counterpart:

- **Types** — `string`, `integer`, `numeric`, `boolean`, `array`, `list`, `decimal`
- **Presence** — `required`, `nullable`
- **Bounds** — `min`, `max`, `size`, `between`, resolved in the unit the type is measured in, so `min` is `minLength` on a string, `minimum` on a number and `minItems` on an array, exactly as the validator sizes a value
- **Numbers** — `multiple_of`
- **Values** — `in`, `regex`
- **Formats** — `email`, `url`, `uuid`, `ipv4`, `ipv6`, `date`

A field with no type rule is treated as a string, which is how the validator sizes an untyped value.

Anything else is ignored rather than approximated: `confirmed` and `exists` have no schema equivalent, `ip` accepts either version so it matches neither `ipv4` nor `ipv6`, and a ULID is not a UUID. Rule objects, closures and invokable rules are skipped. This mirrors how `fromArray()` already handles the subset of JSON Schema the component supports.

## Notes

`illuminate/json-schema` still requires nothing but `illuminate/contracts`. Rule strings are parsed syntactically, so no dependency on `illuminate/validation` is introduced and the package stays standalone.

17 tests added. The `tests/JsonSchema` suite passes (297 tests) and the full suite shows no regressions against the same commit.
