### PR TITLE
[13.x] Index Vite manifest chunks by output file

### DIFF
--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -396,6 +396,7 @@ class Vite implements Htmlable
         }
 
         $manifest = $this->manifest($buildDirectory);
+        $chunkKeysByFile = $this->chunkKeysByFile($manifest);
 
         $tags = new Collection;
         $preloads = new Collection;
@@ -419,19 +420,20 @@ class Vite implements Htmlable
                 ]);
 
                 foreach ($manifest[$import]['css'] ?? [] as $css) {
-                    $partialManifest = (new Collection($manifest))->where('file', $css);
+                    $cssKey = $chunkKeysByFile[$css] ?? null;
+                    $cssChunk = $cssKey === null ? null : $manifest[$cssKey];
 
                     $preloads->push([
-                        $partialManifest->keys()->first(),
+                        $cssKey,
                         $this->assetPath("{$buildDirectory}/{$css}"),
-                        $partialManifest->first(),
+                        $cssChunk,
                         $manifest,
                     ]);
 
                     $tags->push($this->makeTagForChunk(
-                        $partialManifest->keys()->first(),
+                        $cssKey,
                         $this->assetPath("{$buildDirectory}/{$css}"),
-                        $partialManifest->first(),
+                        $cssChunk,
                         $manifest
                     ));
                 }
@@ -445,19 +447,20 @@ class Vite implements Htmlable
             ));
 
             foreach ($chunk['css'] ?? [] as $css) {
-                $partialManifest = (new Collection($manifest))->where('file', $css);
+                $cssKey = $chunkKeysByFile[$css] ?? null;
+                $cssChunk = $cssKey === null ? null : $manifest[$cssKey];
 
                 $preloads->push([
-                    $partialManifest->keys()->first(),
+                    $cssKey,
                     $this->assetPath("{$buildDirectory}/{$css}"),
-                    $partialManifest->first(),
+                    $cssChunk,
                     $manifest,
                 ]);
 
                 $tags->push($this->makeTagForChunk(
-                    $partialManifest->keys()->first(),
+                    $cssKey,
                     $this->assetPath("{$buildDirectory}/{$css}"),
-                    $partialManifest->first(),
+                    $cssChunk,
                     $manifest
                 ));
             }
@@ -481,7 +484,7 @@ class Vite implements Htmlable
             ->flatMap(fn ($entrypoint) => (new Collection($manifest[$entrypoint]['dynamicImports'] ?? []))
                 ->map(fn ($import) => $manifest[$import])
                 ->filter(fn ($chunk) => str_ends_with($chunk['file'], '.js') || str_ends_with($chunk['file'], '.css'))
-                ->flatMap($f = function ($chunk) use (&$f, $manifest, &$discoveredImports) {
+                ->flatMap($f = function ($chunk) use (&$f, $manifest, $chunkKeysByFile, &$discoveredImports) {
                     return (new Collection([...$chunk['imports'] ?? [], ...$chunk['dynamicImports'] ?? []]))
                         ->reject(function ($import) use (&$discoveredImports) {
                             if (isset($discoveredImports[$import])) {
@@ -495,9 +498,9 @@ class Vite implements Htmlable
                                 $f($manifest[$import])
                             ), new Collection([$chunk]))
                         ->merge((new Collection($chunk['css'] ?? []))->map(
-                            fn ($css) => (new Collection($manifest))->first(fn ($chunk) => $chunk['file'] === $css) ?? [
-                                'file' => $css,
-                            ],
+                            fn ($css) => isset($chunkKeysByFile[$css])
+                                ? $manifest[$chunkKeysByFile[$css]]
+                                : ['file' => $css],
                         ));
                 })
                 ->map(function ($chunk) use ($buildDirectory, $manifest) {
@@ -964,6 +967,25 @@ class Vite implements Htmlable
         }
 
         return static::$manifests[$path];
+    }
+
+    /**
+     * Index the given manifest's chunk keys by their output file.
+     *
+     * @param  array  $manifest
+     * @return array<string, string>
+     */
+    protected function chunkKeysByFile($manifest)
+    {
+        $index = [];
+
+        foreach ($manifest as $key => $chunk) {
+            if (isset($chunk['file']) && ! isset($index[$chunk['file']])) {
+                $index[$chunk['file']] = $key;
+            }
+        }
+
+        return $index;
     }
 
     /**

--- a/tests/Foundation/FoundationViteTest.php
+++ b/tests/Foundation/FoundationViteTest.php
@@ -115,6 +115,101 @@ class FoundationViteTest extends TestCase
         $this->cleanViteManifest($buildDir);
     }
 
+    public function testViteResolvesCssChunksReachedThroughNestedImports()
+    {
+        $buildDir = Str::random();
+        $this->makeViteManifest([
+            'resources/js/app.js' => [
+                'src' => 'resources/js/app.js',
+                'file' => 'assets/app.versioned.js',
+                'imports' => [
+                    '_layout.js',
+                ],
+            ],
+            '_layout.js' => [
+                'file' => 'assets/layout.versioned.js',
+                'css' => [
+                    'assets/layout.versioned.css',
+                ],
+                'imports' => [
+                    '_header.js',
+                ],
+            ],
+            '_header.js' => [
+                'file' => 'assets/header.versioned.js',
+                'css' => [
+                    'assets/header.versioned.css',
+                ],
+            ],
+            // The CSS reached through the nested imports above has its own
+            // manifest entries, which must be resolved back from the file name.
+            'resources/css/layout.css' => [
+                'src' => 'resources/css/layout.css',
+                'file' => 'assets/layout.versioned.css',
+            ],
+            'resources/css/header.css' => [
+                'src' => 'resources/css/header.css',
+                'file' => 'assets/header.versioned.css',
+            ],
+        ], $buildDir);
+
+        $vite = app(Vite::class);
+        $result = $vite(['resources/js/app.js'], $buildDir);
+
+        $this->assertSame(
+            '<link rel="preload" as="style" href="https://example.com/'.$buildDir.'/assets/layout.versioned.css" />'
+            .'<link rel="preload" as="style" href="https://example.com/'.$buildDir.'/assets/header.versioned.css" />'
+            .'<link rel="modulepreload" as="script" href="https://example.com/'.$buildDir.'/assets/app.versioned.js" />'
+            .'<link rel="modulepreload" as="script" href="https://example.com/'.$buildDir.'/assets/layout.versioned.js" />'
+            .'<link rel="modulepreload" as="script" href="https://example.com/'.$buildDir.'/assets/header.versioned.js" />'
+            .'<link rel="stylesheet" href="https://example.com/'.$buildDir.'/assets/layout.versioned.css" />'
+            .'<link rel="stylesheet" href="https://example.com/'.$buildDir.'/assets/header.versioned.css" />'
+            .'<script type="module" src="https://example.com/'.$buildDir.'/assets/app.versioned.js"></script>',
+            $result->toHtml()
+        );
+
+        $this->assertSame([
+            'https://example.com/'.$buildDir.'/assets/layout.versioned.css',
+            'https://example.com/'.$buildDir.'/assets/header.versioned.css',
+            'https://example.com/'.$buildDir.'/assets/app.versioned.js',
+            'https://example.com/'.$buildDir.'/assets/layout.versioned.js',
+            'https://example.com/'.$buildDir.'/assets/header.versioned.js',
+        ], array_keys($vite->preloadedAssets()));
+
+        $this->cleanViteManifest($buildDir);
+    }
+
+    public function testViteUsesTheFirstManifestEntryWhenTwoChunksShareAnOutputFile()
+    {
+        $buildDir = Str::random();
+        $this->makeViteManifest([
+            'resources/js/app.js' => [
+                'src' => 'resources/js/app.js',
+                'file' => 'assets/app.versioned.js',
+                'css' => [
+                    'assets/shared.versioned.css',
+                ],
+            ],
+            'resources/css/first.css' => [
+                'src' => 'resources/css/first.css',
+                'file' => 'assets/shared.versioned.css',
+                'integrity' => 'first-integrity',
+            ],
+            'resources/css/second.css' => [
+                'src' => 'resources/css/second.css',
+                'file' => 'assets/shared.versioned.css',
+                'integrity' => 'second-integrity',
+            ],
+        ], $buildDir);
+
+        $result = app(Vite::class)(['resources/js/app.js'], $buildDir);
+
+        $this->assertStringContainsString('integrity="first-integrity"', $result->toHtml());
+        $this->assertStringNotContainsString('second-integrity', $result->toHtml());
+
+        $this->cleanViteManifest($buildDir);
+    }
+
     public function testViteHotModuleReplacementWithJsOnly()
     {
         $this->makeViteHotFile();


### PR DESCRIPTION
Resolving a CSS file back to its manifest entry currently scans the whole manifest, once per CSS reference, inside the recursive walk over dynamic imports. Three sites do it, two via `where('file', $css)` and one via `first(fn ($chunk) => $chunk['file'] === $css)`.

Cost is entries × css_refs × imports. On the manifest I hit this on (434 entries, 145 CSS references, an entrypoint declaring 125 dynamic imports) that's roughly 63k comparisons per render, paid on every request that renders `@vite(...)`. I found it on Lambda where the call was taking ~54ms.

This builds the `file` -> `key` index once per render and looks chunks up directly.

The index is a plain local, not a static cache. All of the win comes from reusing it across the ~145 lookups within one render, so persisting it between requests measured no faster and would have meant a second never-cleared static next to `$manifests`. `chunkKeysByFile()` keeps the first match on a duplicate `file` value, matching `where(...)->first()`.

## Benchmarks

Real `Illuminate\Foundation\Vite`, 430 entry manifest, 30 iterations, median. There's no benchmark suite in the repo so this is a standalone script, happy to share it.

| Case | Before | After | Speedup |
| --- | --- | --- | --- |
| entrypoint, 125 dynamic imports | 2.170 ms | 0.175 ms | 12.4x |
| entrypoint, 142 dynamic imports | 3.566 ms | 0.214 ms | 16.7x |
| all four entrypoints | 11.317 ms | 0.419 ms | 27.0x |

## Output is unchanged

Rendered HTML plus `preloadedAssets()` across 5 entrypoint combinations × 3 prefetch strategies, diffed against a pristine copy of the class: 498,317 bytes, byte identical. The fixture includes a duplicate `file` value to cover the first-match rule.

Two tests added, both passing before and after, there to lock in existing behaviour rather than demonstrate a fix. One asserts tags and preloads for CSS reached through nested imports (the existing `testViteWithNestedCssImport` only covers CSS with no manifest entry of its own, and doesn't check preloads). The other pins the first-match behaviour.
