### PR TITLE
[13.x] Invoke callable on_stats handlers

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -1337,7 +1337,7 @@ class PendingRequest
         $laravelData = $this->parseRequestData($method, $url, $options);
 
         $onStats = function ($transferStats) {
-            if (($callback = ($this->options['on_stats'] ?? false)) instanceof Closure) {
+            if (is_callable($callback = ($this->options['on_stats'] ?? false))) {
                 $transferStats = $callback($transferStats) ?: $transferStats;
             }
 

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -7,6 +7,7 @@ use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException as GuzzleRequestException;
 use GuzzleHttp\Exception\TooManyRedirectsException;
+use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Middleware;
 use GuzzleHttp\Promise\Create;
 use GuzzleHttp\Promise\PromiseInterface;
@@ -4225,6 +4226,26 @@ class HttpClientTest extends TestCase
             ->handlerStats();
 
         $this->assertTrue($onStatsFunctionCalled);
+    }
+
+    public function testTheTransferStatsCanBeCustomizedWithACallable(): void
+    {
+        $collector = new class
+        {
+            public $called = false;
+
+            public function collect(TransferStats $stats): void
+            {
+                $this->called = true;
+            }
+        };
+
+        $this->factory->createPendingRequest()
+            ->setHandler(new MockHandler([new Psr7Response(200)]))
+            ->withOptions(['on_stats' => [$collector, 'collect']])
+            ->get('https://example.com');
+
+        $this->assertTrue($collector->called);
     }
 
     public function testItCanAddGlobalMiddleware()


### PR DESCRIPTION
Laravel wraps Guzzle's `on_stats` option to retain transfer statistics on the response. However, the wrapper only invokes configured closures, silently ignoring other valid PHP callables such as callable arrays and invokable objects.

This PR uses `is_callable()` so all valid `on_stats` callbacks are invoked.

A regression test verifies that a callable-array handler runs through the HTTP client's normal request path.

Existing closure callbacks and requests without an `on_stats` option are unchanged.