### PR TITLE
[13.x] Fix zero size overrides on fake uploaded files

### DIFF
--- a/src/Illuminate/Http/Testing/File.php
+++ b/src/Illuminate/Http/Testing/File.php
@@ -23,7 +23,7 @@ class File extends UploadedFile
     /**
      * The "size" to report.
      *
-     * @var int
+     * @var int|null
      */
     public $sizeToReport;
 
@@ -108,7 +108,7 @@ class File extends UploadedFile
      */
     public function getSize(): int
     {
-        return $this->sizeToReport ?: parent::getSize();
+        return $this->sizeToReport ?? parent::getSize();
     }
 
     /**

--- a/tests/Http/HttpTestingFileFactoryTest.php
+++ b/tests/Http/HttpTestingFileFactoryTest.php
@@ -119,6 +119,13 @@ class HttpTestingFileFactoryTest extends TestCase
         );
     }
 
+    public function testSizeCanBeSetToZero()
+    {
+        $file = (new FileFactory)->createWithContent('test.txt', 'content')->size(0);
+
+        $this->assertSame(0, $file->getSize());
+    }
+
     #[DataProvider('generateImageDataProvider')]
     public function testCallingCreateWithoutGDLoadedThrowsAnException(string $fileExtension, string $driver)
     {


### PR DESCRIPTION
Fake uploaded files currently ignore an explicitly configured size of zero because getSize() uses a truthiness fallback. This changes the fallback to null coalescing, allowing size(0) to report zero while preserving the underlying file-size fallback when no override exists.
A regression test has been added for a non-empty fake file overridden to zero bytes.
