### PR TITLE
[13.x] Fix containsStrict callback matching null values

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -208,7 +208,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Determine if an item exists, using strict comparison.
      *
-     * @param  (callable(TValue): bool)|TValue|array-key  $key
+     * @param  (callable(TValue, TKey): bool)|TValue|array-key  $key
      * @param  TValue|null  $value
      * @return bool
      */
@@ -219,7 +219,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
         }
 
         if ($this->useAsCallable($key)) {
-            return ! is_null($this->first($key));
+            return array_any($this->items, $key);
         }
 
         return in_array($key, $this->items, true);

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -131,7 +131,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Determine if an item exists, using strict comparison.
      *
-     * @param  (callable(TValue): bool)|TValue|array-key  $key
+     * @param  (callable(TValue, TKey): bool)|TValue|array-key  $key
      * @param  TValue|null  $value
      * @return bool
      */

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -268,7 +268,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     /**
      * Determine if an item exists, using strict comparison.
      *
-     * @param  (callable(TValue): bool)|TValue|array-key  $key
+     * @param  (callable(TValue, TKey): bool)|TValue|array-key  $key
      * @param  TValue|null  $value
      * @return bool
      */
@@ -279,7 +279,9 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
         }
 
         if ($this->useAsCallable($key)) {
-            return ! is_null($this->first($key));
+            $placeholder = new stdClass;
+
+            return $this->first($key, $placeholder) !== $placeholder;
         }
 
         foreach ($this as $item) {

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -4063,6 +4063,7 @@ class SupportCollectionTest extends TestCase
 
         $c = new $collection([1, null]);
         $this->assertTrue($c->containsStrict(null));
+        $this->assertTrue($c->containsStrict(fn ($value) => is_null($value)));
         $this->assertFalse($c->containsStrict(0));
         $this->assertFalse($c->containsStrict(false));
 

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -109,7 +109,8 @@ assertType('bool', $collection->some(function ($user) {
 }));
 assertType('bool', $collection::make(['string'])->some('string', '=', 'string'));
 
-assertType('bool', $collection->containsStrict(function ($user) {
+assertType('bool', $collection->containsStrict(function ($user, $int) {
+    assertType('int', $int);
     assertType('User', $user);
 
     return true;

--- a/types/Support/LazyCollection.php
+++ b/types/Support/LazyCollection.php
@@ -102,7 +102,8 @@ assertType('bool', $collection->some(function ($user) {
 }));
 assertType('bool', $collection::make(['string'])->some('string', '=', 'string'));
 
-assertType('bool', $collection->containsStrict(function ($user) {
+assertType('bool', $collection->containsStrict(function ($user, $int) {
+    assertType('int', $int);
     assertType('User', $user);
 
     return true;


### PR DESCRIPTION
fix` containsStrict()` returning false when its callback matches a null item. The previous implementation used the matched value to determine whether an item existed, conflating a matched null with no match. Eager collections now use `array_any()`, while lazy collections use a sentinel value.
