### PR TITLE
[13.x] Improve Fluent generic types

### DIFF
--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -19,6 +19,7 @@ use Traversable;
  *
  * @implements \Illuminate\Contracts\Support\Arrayable<TKey, TValue>
  * @implements \ArrayAccess<TKey, TValue>
+ * @implements \IteratorAggregate<TKey, TValue>
  */
 class Fluent implements Arrayable, ArrayAccess, IteratorAggregate, Jsonable, JsonSerializable
 {
@@ -46,8 +47,11 @@ class Fluent implements Arrayable, ArrayAccess, IteratorAggregate, Jsonable, Jso
     /**
      * Create a new fluent instance.
      *
-     * @param  iterable<TKey, TValue>  $attributes
-     * @return static
+     * @template TMakeKey of array-key
+     * @template TMakeValue
+     *
+     * @param  iterable<TMakeKey, TMakeValue>  $attributes
+     * @return static<TMakeKey, TMakeValue>
      */
     public static function make($attributes = [])
     {
@@ -100,9 +104,11 @@ class Fluent implements Arrayable, ArrayAccess, IteratorAggregate, Jsonable, Jso
     /**
      * Get an attribute from the fluent instance.
      *
-     * @param  string  $key
-     * @param  mixed  $default
-     * @return mixed
+     * @template TValueDefault
+     *
+     * @param  TKey  $key
+     * @param  TValueDefault|(\Closure(): TValueDefault)  $default
+     * @return TValue|TValueDefault
      */
     public function value($key, $default = null)
     {

--- a/types/Support/Fluent.php
+++ b/types/Support/Fluent.php
@@ -10,6 +10,7 @@ assertType("Illuminate\Support\Fluent<string, 25|'Taylor'|User>", $fluent);
 assertType('Illuminate\Support\Fluent<string, string>', new Fluent(['name' => 'Taylor']));
 assertType('Illuminate\Support\Fluent<string, int>', new Fluent(['age' => 25]));
 assertType('Illuminate\Support\Fluent<string, User>', new Fluent(['user' => new User]));
+assertType("Illuminate\Support\Fluent<string, 25|'Taylor'|User>", Fluent::make(['name' => 'Taylor', 'age' => 25, 'user' => new User]));
 
 assertType("25|'Taylor'|User|null", $fluent['name']);
 assertType("25|'Taylor'|User|null", $fluent['age']);
@@ -17,6 +18,10 @@ assertType("25|'Taylor'|User|null", $fluent['age']);
 assertType("25|'Taylor'|User|null", $fluent->get('name'));
 assertType("25|'Taylor'|User|null", $fluent->get('foobar'));
 assertType("25|'Taylor'|'zonda'|User", $fluent->get('foobar', 'zonda'));
+assertType("25|'Taylor'|User|null", $fluent->value('name'));
+assertType("25|'Taylor'|User|null", $fluent->value('foobar'));
+assertType("25|'Taylor'|'zonda'|User", $fluent->value('foobar', 'zonda'));
+assertType("25|'Taylor'|'zonda'|User", $fluent->value('foobar', fn () => 'zonda'));
 assertType("array<string, 25|'Taylor'|User>", $fluent->getAttributes());
 assertType("array<string, 25|'Taylor'|User>", $fluent->toArray());
 assertType("array<string, 25|'Taylor'|User>", $fluent->jsonSerialize());


### PR DESCRIPTION
Improve static-analysis inference for Fluent. This adds method-level templates to `Fluent::make()`, types `value()` using the attribute and default value types, and declares the existing generic IteratorAggregate implementation.