### PR TITLE
[13.x] Fix `Arr::forget()` removing the wrong element

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -424,6 +424,9 @@ class Arr
         }
 
         foreach ($keys as $key) {
+            // clean up before each pass
+            $array = &$original;
+
             // if the exact key exists in the top-level, remove it
             if (static::exists($array, $key)) {
                 unset($array[$key]);
@@ -432,9 +435,6 @@ class Arr
             }
 
             $parts = explode('.', $key);
-
-            // clean up before each pass
-            $array = &$original;
 
             while (count($parts) > 1) {
                 $part = array_shift($parts);

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1728,9 +1728,9 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['products' => ['desk' => []]], $array);
 
         // A "dot" key following a deeper "dot" key is also resolved from the top level
-        $array = ['a' => ['b' => ['c' => 1, 'd' => 2]], 'e' => ['d' => 3]];
+        $array = ['a' => ['b' => ['c' => 1, 'e.d' => 'literal']], 'e' => ['d' => 3]];
         Arr::forget($array, ['a.b.c', 'e.d']);
-        $this->assertEquals(['a' => ['b' => ['d' => 2]], 'e' => []], $array);
+        $this->assertEquals(['a' => ['b' => ['e.d' => 'literal']], 'e' => []], $array);
     }
 
     public function testFrom()

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1717,6 +1717,20 @@ class SupportArrTest extends TestCase
         $array = [2 => [1 => 'products', 3 => 'users']];
         Arr::forget($array, 2.3);
         $this->assertEquals([2 => [1 => 'products']], $array);
+
+        // A top-level key following a "dot" key is resolved against the top-level array
+        $array = ['users' => ['name' => 'Joe', 'id' => 1], 'id' => 99];
+        Arr::forget($array, ['users.name', 'id']);
+        $this->assertEquals(['users' => ['id' => 1]], $array);
+
+        $array = ['products' => ['desk' => ['price' => 100]], 'desk' => 'top-level'];
+        Arr::forget($array, ['products.desk.price', 'desk']);
+        $this->assertEquals(['products' => ['desk' => []]], $array);
+
+        // A "dot" key following a deeper "dot" key is also resolved from the top level
+        $array = ['a' => ['b' => ['c' => 1, 'd' => 2]], 'e' => ['d' => 3]];
+        Arr::forget($array, ['a.b.c', 'e.d']);
+        $this->assertEquals(['a' => ['b' => ['d' => 2]], 'e' => []], $array);
     }
 
     public function testFrom()


### PR DESCRIPTION
`Arr::forget()` resets its working reference back to the top-level array (`$array = &$original`) only *after* the shortcut that unsets an exact top-level key. When a "dot" key is processed, the reference is left pointing at a nested array, so the **next** key in the list is resolved against that nested array instead of the top level.

```php
$array = ['users' => ['name' => 'Joe', 'id' => 1], 'id' => 99];

Arr::forget($array, ['users.name', 'id']);

// before: ['users' => [], 'id' => 99]   <- removed users.id, kept the top-level id
// after:  ['users' => ['id' => 1]]
```

The wrong element is removed and the requested one is kept, silently. Two dotted keys in a row are affected the same way:

```php
$array = ['a' => ['b' => ['c' => 1, 'd' => 2]], 'e' => ['d' => 3]];

Arr::forget($array, ['a.b.c', 'e.d']);

// before: ['a' => ['b' => ['d' => 2]], 'e' => ['d' => 3]]  <- e.d never removed
// after:  ['a' => ['b' => ['d' => 2]], 'e' => []]
```

Moving the reset to the top of the loop makes every key resolve from the top-level array, which is what the existing `// clean up before each pass` comment intends.

This also affects everything that delegates here: `Arr::except()`, `Collection::except()`, `data_forget()` and `Uri::withoutQuery()`.

Tests covering both orderings are added to the existing `testForget()`.