### PR TITLE
[13.x] Fix undefined array key when `logging.deprecations` omits `channel`

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -145,7 +145,7 @@ class HandleExceptions
 
         $this->ensureNullLogDriverIsConfigured();
 
-        $driver = (is_array($options = $config->get('logging.deprecations')) ? $options['channel'] : $options) ?? 'null';
+        $driver = (is_array($options = $config->get('logging.deprecations')) ? $options['channel'] ?? null : $options) ?? 'null';
 
         $config->set('logging.channels.deprecations', $config->get("logging.channels.{$driver}"));
     }

--- a/tests/Foundation/Bootstrap/HandleExceptionsTest.php
+++ b/tests/Foundation/Bootstrap/HandleExceptionsTest.php
@@ -130,6 +130,47 @@ class HandleExceptionsTest extends TestCase
         ], $this->config->get('logging.channels.deprecations'));
     }
 
+    public function testMissingChannelKeyUsesNullDriverWithoutRaisingAWarning()
+    {
+        $logger = m::mock(LogManager::class);
+        $this->app->instance(LogManager::class, $logger);
+        $this->app->expects('runningUnitTests')->andReturn(false);
+        $this->app->expects('hasBeenBootstrapped')->andReturn(true);
+
+        $this->config->set('logging.deprecations', [
+            'trace' => false,
+        ]);
+
+        $logger->expects('channel')->with('deprecations')->andReturnSelf();
+        $logger->expects('warning');
+
+        $warnings = [];
+
+        set_error_handler(function ($level, $message) use (&$warnings) {
+            $warnings[] = $message;
+
+            return true;
+        }, E_WARNING);
+
+        try {
+            $this->handleExceptions()->handleError(
+                E_DEPRECATED,
+                'str_contains(): Passing null to parameter #2 ($needle) of type string is deprecated',
+                '/home/user/laravel/routes/web.php',
+                17
+            );
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertSame([], $warnings);
+
+        $this->assertEquals([
+            'driver' => 'monolog',
+            'handler' => NullHandler::class,
+        ], $this->config->get('logging.channels.deprecations'));
+    }
+
     public function testUserDeprecations()
     {
         $logger = m::mock(LogManager::class);


### PR DESCRIPTION
The rector rewrite in 0754bff2c6 (#60930, `SimplifyIfElseToTernaryRector`) collapsed the if/else that resolves the deprecations log channel into a ternary. That moved the `??` guard off the array access and onto the ternary's *result*:

```php
// before
if (is_array($options = $config->get('logging.deprecations'))) {
    $driver = $options['channel'] ?? 'null';
} else {
    $driver = $options ?? 'null';
}

// after
$driver = (is_array($options = $config->get('logging.deprecations')) ? $options['channel'] : $options) ?? 'null';
```

`??` only suppresses the warning when it directly wraps the offset expression, so `$options['channel']` is now read unconditionally and raises `Undefined array key "channel"` whenever `logging.deprecations` is an array without a `channel` key — e.g. `'deprecations' => ['trace' => true]`.

The consequence is worse than a stray warning. `HandleExceptions::bootstrap()` sets `error_reporting(-1)` and installs itself as the error handler, so that warning re-enters `handleError()` and is rethrown as an `ErrorException`. That aborts `ensureDeprecationLoggerIsConfigured()` *before* it can run `$config->set('logging.channels.deprecations', ...)`, and the exception is then swallowed by the `catch (Throwable) { return; }` in `handleDeprecationError()`.

So the deprecation is never logged — and because `logging.channels.deprecations` never gets written, the early-return guard at the top of the method never kicks in, so **every subsequent deprecation is silently dropped too**.

Restoring the guard on the offset itself fixes it.

The added test asserts both that no warning is raised and that the channel falls back to the null driver. It fails on `13.x` with:

```
Failed asserting that two arrays are equal.
+    0 => 'Undefined array key "channel"',
```

Note the existing `testNullValueAsChannelUsesNullDriver` covers `'channel' => null`, which is a different path — an explicit null value already worked; an absent key is what broke.