### PR TITLE
[13.x] Add metadata support to Artisan commands

### DIFF
--- a/src/Illuminate/Console/Attributes/Metadata.php
+++ b/src/Illuminate/Console/Attributes/Metadata.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Illuminate\Console\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
+class Metadata
+{
+    /**
+     * Create a new attribute instance.
+     *
+     * @param  array<array-key, mixed>  $metadata
+     */
+    public function __construct(public array $metadata)
+    {
+        //
+    }
+}

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -6,6 +6,7 @@ use Illuminate\Console\Attributes\Aliases;
 use Illuminate\Console\Attributes\Description;
 use Illuminate\Console\Attributes\Help;
 use Illuminate\Console\Attributes\Hidden;
+use Illuminate\Console\Attributes\Metadata;
 use Illuminate\Console\Attributes\Signature;
 use Illuminate\Console\Attributes\Usage;
 use Illuminate\Console\View\Components\Factory;
@@ -197,6 +198,10 @@ class Command extends SymfonyCommand
 
         if ($aliases !== []) {
             $this->aliases = $aliases[0]->newInstance()->aliases;
+        }
+
+        foreach ($reflection->getAttributes(Metadata::class) as $metadata) {
+            $this->metadata($metadata->newInstance()->metadata);
         }
     }
 

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -10,6 +10,8 @@ use Illuminate\Console\Attributes\Signature;
 use Illuminate\Console\Attributes\Usage;
 use Illuminate\Console\View\Components\Factory;
 use Illuminate\Contracts\Console\Isolatable;
+use Illuminate\Support\Arr;
+use Illuminate\Support\MetadataMerger;
 use Illuminate\Support\Traits\Macroable;
 use ReflectionClass;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
@@ -90,6 +92,13 @@ class Command extends SymfonyCommand
      * @var string[]
      */
     protected $aliases;
+
+    /**
+     * The command metadata.
+     *
+     * @var array<array-key, mixed>
+     */
+    private $commandMetadata = [];
 
     /**
      * Create a new console command instance.
@@ -379,6 +388,49 @@ class Command extends SymfonyCommand
     public function setHidden(bool $hidden = true): static
     {
         parent::setHidden($this->hidden = $hidden);
+
+        return $this;
+    }
+
+    /**
+     * Add metadata to the command.
+     *
+     * @param  array  $metadata
+     * @return $this
+     */
+    public function metadata(array $metadata)
+    {
+        $this->commandMetadata = MetadataMerger::merge(
+            $this->commandMetadata,
+            $metadata,
+        );
+
+        return $this;
+    }
+
+    /**
+     * Get metadata for the command.
+     *
+     * @param  string|null  $key
+     * @param  mixed  $default
+     * @return ($key is null ? array<array-key, mixed> : mixed)
+     */
+    public function getMetadata($key = null, $default = null)
+    {
+        return is_null($key)
+            ? $this->commandMetadata
+            : Arr::get($this->commandMetadata, $key, $default);
+    }
+
+    /**
+     * Set the metadata for the command, replacing existing metadata.
+     *
+     * @param  array  $metadata
+     * @return $this
+     */
+    public function setMetadata(array $metadata)
+    {
+        $this->commandMetadata = $metadata;
 
         return $this;
     }

--- a/src/Illuminate/Routing/RouteGroup.php
+++ b/src/Illuminate/Routing/RouteGroup.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Routing;
 
 use Illuminate\Support\Arr;
+use Illuminate\Support\MetadataMerger;
 
 class RouteGroup
 {
@@ -69,30 +70,7 @@ class RouteGroup
      */
     public static function mergeMetadata(array $old, array $new)
     {
-        foreach ($new as $key => $value) {
-            if (isset($old[$key]) && static::mergableMetadata($old[$key], $value)) {
-                $value = static::mergeMetadata($old[$key], $value);
-            }
-
-            $old[$key] = $value;
-        }
-
-        return $old;
-    }
-
-    /**
-     * Determine if the given metadata values should be merged.
-     *
-     * @param  mixed  $old
-     * @param  mixed  $new
-     * @return bool
-     */
-    protected static function mergableMetadata($old, $new)
-    {
-        return is_array($old) &&
-            is_array($new) &&
-            Arr::isAssoc($old) &&
-            Arr::isAssoc($new);
+        return MetadataMerger::merge($old, $new);
     }
 
     /**

--- a/src/Illuminate/Support/MetadataMerger.php
+++ b/src/Illuminate/Support/MetadataMerger.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Illuminate\Support;
+
+/**
+ * @internal
+ */
+class MetadataMerger
+{
+    /**
+     * Merge the given metadata.
+     *
+     * Associative array values are merged recursively, while all other values, including lists, replace the existing value entirely.
+     *
+     * @param  array  $existing
+     * @param  array  $incoming
+     * @return array
+     */
+    public static function merge(array $existing, array $incoming): array
+    {
+        foreach ($incoming as $key => $value) {
+            if (isset($existing[$key]) && static::mergeable($existing[$key], $value)) {
+                $value = static::merge($existing[$key], $value);
+            }
+
+            $existing[$key] = $value;
+        }
+
+        return $existing;
+    }
+
+    /**
+     * Determine if the given metadata values should be merged.
+     *
+     * @param  mixed  $existing
+     * @param  mixed  $incoming
+     * @return bool
+     */
+    protected static function mergeable($existing, $incoming)
+    {
+        return is_array($existing) &&
+            is_array($incoming) &&
+            Arr::isAssoc($existing) &&
+            Arr::isAssoc($incoming);
+    }
+}

--- a/tests/Console/CommandTest.php
+++ b/tests/Console/CommandTest.php
@@ -4,8 +4,10 @@ namespace Illuminate\Tests\Console;
 
 use Illuminate\Console\Application;
 use Illuminate\Console\Attributes\Aliases;
+use Illuminate\Console\Attributes\Description;
 use Illuminate\Console\Attributes\Help;
 use Illuminate\Console\Attributes\Hidden;
+use Illuminate\Console\Attributes\Metadata as CommandMetadata;
 use Illuminate\Console\Attributes\Signature;
 use Illuminate\Console\Attributes\Usage;
 use Illuminate\Console\Command;
@@ -459,6 +461,63 @@ class CommandTest extends TestCase
 
         $this->assertSame(['foo:bar 1', 'foo:bar 1 --force'], $command->getUsages());
     }
+
+    public function testMetadataAttributeConfiguresCommandMetadata()
+    {
+        $command = new MetadataCommand;
+
+        $this->assertSame([
+            'operations' => [
+                'owner' => 'finance',
+            ],
+        ], $command->getMetadata());
+    }
+
+    public function testRepeatableMetadataAttributesMergeInDeclarationOrder()
+    {
+        $command = new RepeatableMetadataCommand;
+
+        $this->assertSame([
+            'operations' => [
+                'owner' => 'finance',
+                'criticality' => 'low',
+                'monitoring' => [
+                    'enabled' => true,
+                    'channel' => 'finance-alerts',
+                ],
+            ],
+        ], $command->getMetadata());
+    }
+
+    public function testConstructorMetadataIsMergedAfterAttributeMetadata()
+    {
+        $command = new ConstructorMetadataCommand;
+
+        $this->assertSame([
+            'operations' => [
+                'owner' => 'finance',
+                'criticality' => 'high',
+            ],
+        ], $command->getMetadata());
+    }
+
+    public function testMetadataAttributesAreNotInheritedFromParentCommands()
+    {
+        $this->assertSame([], (new ChildMetadataCommand)->getMetadata());
+    }
+
+    public function testMetadataAttributeDoesNotAffectOtherCommandAttributes()
+    {
+        $command = new MetadataWithCommandAttributesCommand;
+
+        $this->assertSame('metadata:attributes', $command->getName());
+        $this->assertSame('Command with metadata', $command->getDescription());
+        $this->assertSame('Extended metadata command help.', $command->getHelp());
+        $this->assertSame(['metadata:alias'], $command->getAliases());
+        $this->assertSame(['metadata:attributes --force'], $command->getUsages());
+        $this->assertTrue($command->isHidden());
+        $this->assertSame(['domain' => 'testing'], $command->getMetadata());
+    }
 }
 
 enum CommandInputType: string
@@ -515,6 +574,97 @@ class AliasesAttributeCommand extends Command
 #[Signature('foo:bar', aliases: ['ignored:alias'])]
 #[Aliases(['override:alias'])]
 class AliasesAttributeOverridesSignatureCommand extends Command
+{
+    public function handle()
+    {
+    }
+}
+
+#[CommandMetadata([
+    'operations' => [
+        'owner' => 'finance',
+    ],
+])]
+class MetadataCommand extends Command
+{
+    public function handle()
+    {
+    }
+}
+
+#[CommandMetadata([
+    'operations' => [
+        'owner' => 'platform',
+        'criticality' => 'low',
+        'monitoring' => [
+            'enabled' => true,
+            'channel' => 'operations',
+        ],
+    ],
+])]
+#[CommandMetadata([
+    'operations' => [
+        'owner' => 'finance',
+        'monitoring' => [
+            'channel' => 'finance-alerts',
+        ],
+    ],
+])]
+class RepeatableMetadataCommand extends Command
+{
+    public function handle()
+    {
+    }
+}
+
+#[CommandMetadata([
+    'operations' => [
+        'owner' => 'platform',
+        'criticality' => 'low',
+    ],
+])]
+class ConstructorMetadataCommand extends Command
+{
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->metadata([
+            'operations' => [
+                'owner' => 'finance',
+                'criticality' => 'high',
+            ],
+        ]);
+    }
+
+    public function handle()
+    {
+    }
+}
+
+#[CommandMetadata(['inherited' => true])]
+class ParentMetadataCommand extends Command
+{
+    public function handle()
+    {
+    }
+}
+
+class ChildMetadataCommand extends ParentMetadataCommand
+{
+    public function handle()
+    {
+    }
+}
+
+#[Signature('metadata:attributes', aliases: ['ignored:alias'])]
+#[Description('Command with metadata')]
+#[Help('Extended metadata command help.')]
+#[Usage('metadata:attributes --force')]
+#[Aliases(['metadata:alias'])]
+#[Hidden]
+#[CommandMetadata(['domain' => 'testing'])]
+class MetadataWithCommandAttributesCommand extends Command
 {
     public function handle()
     {

--- a/tests/Console/CommandTest.php
+++ b/tests/Console/CommandTest.php
@@ -24,6 +24,143 @@ use Symfony\Component\Console\Question\ChoiceQuestion;
 
 class CommandTest extends TestCase
 {
+    public function testMetadataDefaultsToAnEmptyArray()
+    {
+        $this->assertSame([], (new Command)->getMetadata());
+    }
+
+    public function testMetadataMergesAssociativeValuesAndSupportsDotNotation()
+    {
+        $command = new Command;
+
+        $this->assertSame($command, $command->metadata([
+            'operations' => [
+                'owner' => 'platform',
+                'monitoring' => [
+                    'enabled' => true,
+                ],
+            ],
+        ]));
+
+        $command->metadata([
+            'operations' => [
+                'owner' => 'finance',
+                'monitoring' => [
+                    'channel' => 'finance-alerts',
+                ],
+            ],
+        ]);
+
+        $this->assertSame([
+            'operations' => [
+                'owner' => 'finance',
+                'monitoring' => [
+                    'enabled' => true,
+                    'channel' => 'finance-alerts',
+                ],
+            ],
+        ], $command->getMetadata());
+        $this->assertSame('finance', $command->getMetadata('operations.owner'));
+        $this->assertSame('Not configured', $command->getMetadata('operations.runbook', 'Not configured'));
+    }
+
+    public function testMetadataReplacesListsScalarsAndValueTypes()
+    {
+        $command = (new Command)->metadata([
+            'roles' => ['operator', 'administrator'],
+            'criticality' => 'low',
+            'monitoring' => ['enabled' => true],
+        ]);
+
+        $command->metadata([
+            'roles' => ['finance'],
+            'criticality' => 'high',
+            'monitoring' => false,
+        ]);
+
+        $this->assertSame([
+            'roles' => ['finance'],
+            'criticality' => 'high',
+            'monitoring' => false,
+        ], $command->getMetadata());
+    }
+
+    public function testMetadataCanBeReplaced()
+    {
+        $command = (new Command)->metadata([
+            'owner' => 'platform',
+            'criticality' => 'high',
+        ]);
+
+        $this->assertSame($command, $command->setMetadata([
+            'owner' => 'finance',
+        ]));
+        $this->assertSame(['owner' => 'finance'], $command->getMetadata());
+    }
+
+    public function testMetadataDoesNotAlterTheCommandDefinition()
+    {
+        $command = new class extends Command
+        {
+            protected $signature = 'test:metadata {argument?} {--option=}';
+
+            protected $description = 'Test command metadata';
+        };
+
+        $command->metadata([
+            'name' => 'other:name',
+            'description' => 'Other description',
+            'arguments' => [],
+            'options' => [],
+            'hidden' => true,
+        ]);
+
+        $this->assertSame('test:metadata', $command->getName());
+        $this->assertSame('Test command metadata', $command->getDescription());
+        $this->assertTrue($command->getDefinition()->hasArgument('argument'));
+        $this->assertTrue($command->getDefinition()->hasOption('option'));
+        $this->assertFalse($command->isHidden());
+    }
+
+    public function testMetadataStorageDoesNotConflictWithUserlandMetadataProperties()
+    {
+        $commandWithPrivateProperty = new class extends Command
+        {
+            private $metadata = ['userland' => true];
+        };
+
+        $commandWithTypedProperty = new class extends Command
+        {
+            protected array $metadata = ['userland' => true];
+        };
+
+        $commandWithPrivateProperty->metadata(['framework' => 'private']);
+        $commandWithTypedProperty->metadata(['framework' => 'typed']);
+
+        $this->assertSame(['framework' => 'private'], $commandWithPrivateProperty->getMetadata());
+        $this->assertSame(['framework' => 'typed'], $commandWithTypedProperty->getMetadata());
+    }
+
+    public function testConcreteMetadataMethodTakesPrecedenceOverCommandMacro()
+    {
+        $macroCalled = false;
+
+        Command::macro('metadata', function () use (&$macroCalled) {
+            $macroCalled = true;
+
+            return $this;
+        });
+
+        try {
+            $command = (new Command)->metadata(['owner' => 'finance']);
+
+            $this->assertFalse($macroCalled);
+            $this->assertSame(['owner' => 'finance'], $command->getMetadata());
+        } finally {
+            Command::flushMacros();
+        }
+    }
+
     public function testCallingClassCommandResolveCommandViaApplicationResolution()
     {
         $command = new class extends Command

--- a/tests/Integration/Console/ConsoleApplicationTest.php
+++ b/tests/Integration/Console/ConsoleApplicationTest.php
@@ -3,13 +3,19 @@
 namespace Illuminate\Tests\Integration\Console;
 
 use Illuminate\Console\Application as Artisan;
+use Illuminate\Console\Attributes\Metadata;
 use Illuminate\Console\Command;
+use Illuminate\Console\ContainerCommandLoader;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Foundation\Console\QueuedCommand;
 use Illuminate\Support\Facades\Queue;
 use Orchestra\Testbench\TestCase;
+use ReflectionProperty;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command as SymfonyCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 
 class ConsoleApplicationTest extends TestCase
 {
@@ -20,6 +26,8 @@ class ConsoleApplicationTest extends TestCase
                 FooCommandStub::class,
                 ZondaCommandStub::class,
             ]);
+
+            $artisan->add(new SymfonyCommandStub);
         });
 
         parent::setUp();
@@ -108,6 +116,81 @@ class ConsoleApplicationTest extends TestCase
             return $job->displayName() === 'foo:bar';
         });
     }
+
+    public function testArtisanAllResolvesCommandMetadataThroughTheLazyLoader(): void
+    {
+        $commands = $this->app[Kernel::class]->all();
+
+        $this->assertSame('artisan-command-metadata-owner', $commands['zonda']->getMetadata('owner'));
+        $this->assertSame($commands['zonda'], $commands['app:zonda']);
+
+        $kernel = $this->app[Kernel::class];
+        $artisan = (new ReflectionProperty($kernel, 'artisan'))->getValue($kernel);
+        $commandMap = (new ReflectionProperty($artisan, 'commandMap'))->getValue($artisan);
+        $commandLoader = (new ReflectionProperty(\Symfony\Component\Console\Application::class, 'commandLoader'))->getValue($artisan);
+
+        $this->assertSame(ZondaCommandStub::class, $commandMap['zonda']);
+        $this->assertNotContains('artisan-command-metadata-owner', $commandMap, true);
+        $this->assertInstanceOf(ContainerCommandLoader::class, $commandLoader);
+
+        $loaderMap = (new ReflectionProperty($commandLoader, 'commandMap'))->getValue($commandLoader);
+
+        $this->assertSame(ZondaCommandStub::class, $loaderMap['zonda']);
+        $this->assertNotContains('artisan-command-metadata-owner', $loaderMap, true);
+    }
+
+    public function testMixedCommandCatalogsCanBeFilteredToLaravelCommands(): void
+    {
+        $commands = $this->app[Kernel::class]->all();
+        $laravelCommands = array_filter(
+            $commands,
+            fn (SymfonyCommand $command) => $command instanceof Command,
+        );
+
+        $this->assertArrayHasKey('zonda', $laravelCommands);
+        $this->assertArrayHasKey('symfony:metadata-control', $commands);
+        $this->assertArrayNotHasKey('symfony:metadata-control', $laravelCommands);
+        $this->assertFalse(method_exists($commands['symfony:metadata-control'], 'getMetadata'));
+    }
+
+    public function testDirectSymfonyCommandsRemainListableAndExecutable(): void
+    {
+        $this->artisan('list')
+            ->expectsOutputToContain('symfony:metadata-control')
+            ->doesntExpectOutputToContain('artisan-command-metadata-owner');
+
+        $this->artisan('symfony:metadata-control')
+            ->expectsOutput('Symfony command ran')
+            ->assertExitCode(0);
+    }
+
+    public function testCommandMetadataIsNotIncludedInHelpOutput(): void
+    {
+        $this->artisan('help', ['command_name' => 'zonda'])
+            ->expectsOutputToContain('Zonda command description')
+            ->doesntExpectOutputToContain('artisan-command-metadata-owner');
+    }
+
+    public function testCommandMetadataIsNotCopiedToQueuedCommandPayloads(): void
+    {
+        Queue::fake();
+
+        $this->app[Kernel::class]->queue('zonda', ['id' => 1]);
+
+        Queue::assertPushed(QueuedCommand::class, function ($job) {
+            return $job->displayName() === 'zonda'
+                && ! str_contains(serialize($job), 'artisan-command-metadata-owner');
+        });
+    }
+
+    public function testCommandMetadataIsNotCopiedToScheduledEvents(): void
+    {
+        $event = $this->app->make(Schedule::class)->command(ZondaCommandStub::class, ['id' => 1]);
+
+        $this->assertSame([], $event->attributes);
+        $this->assertSame('Zonda command description', $event->description);
+        $this->assertStringNotContainsString('artisan-command-metadata-owner', $event->command);
+    }
 }
 
 class FooCommandStub extends Command
@@ -123,15 +206,29 @@ class FooCommandStub extends Command
 }
 
 #[AsCommand(name: 'zonda', aliases: ['app:zonda'])]
+#[Metadata(['owner' => 'artisan-command-metadata-owner'])]
 class ZondaCommandStub extends Command
 {
     protected $signature = 'zonda {id}';
 
     protected $aliases = ['app:zonda'];
 
+    protected $description = 'Zonda command description';
+
     public function handle()
     {
         //
+    }
+}
+
+#[AsCommand(name: 'symfony:metadata-control', description: 'Direct Symfony command')]
+class SymfonyCommandStub extends SymfonyCommand
+{
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $output->writeln('Symfony command ran');
+
+        return self::SUCCESS;
     }
 }
 

--- a/tests/Integration/Foundation/Console/ClosureCommandTest.php
+++ b/tests/Integration/Foundation/Console/ClosureCommandTest.php
@@ -2,7 +2,10 @@
 
 namespace Illuminate\Tests\Integration\Foundation\Console;
 
+use Illuminate\Console\Scheduling\Event;
+use Illuminate\Foundation\Console\ClosureCommand;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Schedule;
 use Orchestra\Testbench\TestCase;
 
 class ClosureCommandTest extends TestCase
@@ -13,11 +16,54 @@ class ClosureCommandTest extends TestCase
     {
         Artisan::command('inspire', function () {
             $this->comment('We must ship. - Taylor Otwell');
-        })->purpose('Display an inspiring quote');
+        })->purpose('Display an inspiring quote')->metadata([
+            'operations' => [
+                'owner' => 'framework',
+            ],
+        ]);
     }
 
     public function testItCanRunClosureCommand()
     {
         $this->artisan('inspire')->expectsOutput('We must ship. - Taylor Otwell');
+    }
+
+    public function testClosureCommandSupportsMetadataWithoutCreatingAScheduledEvent()
+    {
+        $command = new ClosureCommand('metadata:test', fn () => null);
+
+        $this->assertSame($command, $command->metadata(['owner' => 'finance']));
+        $this->assertSame(['owner' => 'finance'], $command->getMetadata());
+        $this->assertSame([], Schedule::events());
+    }
+
+    public function testConcreteMetadataMethodTakesPrecedenceOverScheduledEventMacro()
+    {
+        $macroCalled = false;
+
+        Event::macro('metadata', function () use (&$macroCalled) {
+            $macroCalled = true;
+
+            return $this;
+        });
+
+        try {
+            $command = (new ClosureCommand('metadata:test', fn () => null))
+                ->metadata(['owner' => 'finance']);
+
+            $this->assertFalse($macroCalled);
+            $this->assertSame(['owner' => 'finance'], $command->getMetadata());
+            $this->assertSame([], Schedule::events());
+        } finally {
+            Event::flushMacros();
+        }
+    }
+
+    public function testClosureCommandContinuesToForwardSchedulingMethods()
+    {
+        $event = (new ClosureCommand('metadata:test', fn () => null))->daily();
+
+        $this->assertInstanceOf(Event::class, $event);
+        $this->assertSame('0 0 * * *', $event->expression);
     }
 }

--- a/tests/Integration/Foundation/Console/ClosureCommandTest.php
+++ b/tests/Integration/Foundation/Console/ClosureCommandTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Foundation\Console;
 
+use Illuminate\Console\Command;
 use Illuminate\Console\Scheduling\Event;
 use Illuminate\Foundation\Console\ClosureCommand;
 use Illuminate\Support\Facades\Artisan;
@@ -26,6 +27,14 @@ class ClosureCommandTest extends TestCase
     public function testItCanRunClosureCommand()
     {
         $this->artisan('inspire')->expectsOutput('We must ship. - Taylor Otwell');
+    }
+
+    public function testClosureCommandMetadataRemainsInspectableAfterRegistration()
+    {
+        $command = Artisan::all()['inspire'];
+
+        $this->assertInstanceOf(Command::class, $command);
+        $this->assertSame('framework', $command->getMetadata('operations.owner'));
     }
 
     public function testClosureCommandSupportsMetadataWithoutCreatingAScheduledEvent()

--- a/tests/Support/SupportMetadataMergerTest.php
+++ b/tests/Support/SupportMetadataMergerTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use Illuminate\Support\MetadataMerger;
+use PHPUnit\Framework\TestCase;
+
+class SupportMetadataMergerTest extends TestCase
+{
+    public function testItMergesAssociativeArraysRecursively()
+    {
+        $this->assertSame([
+            'operations' => [
+                'owner' => 'finance',
+                'monitoring' => [
+                    'enabled' => true,
+                    'channel' => 'finance-alerts',
+                ],
+            ],
+        ], MetadataMerger::merge(
+            [
+                'operations' => [
+                    'owner' => 'platform',
+                    'monitoring' => [
+                        'enabled' => true,
+                        'channel' => 'operations',
+                    ],
+                ],
+            ],
+            [
+                'operations' => [
+                    'owner' => 'finance',
+                    'monitoring' => [
+                        'channel' => 'finance-alerts',
+                    ],
+                ],
+            ],
+        ));
+    }
+
+    public function testItReplacesListValues()
+    {
+        $this->assertSame([
+            'roles' => ['finance'],
+        ], MetadataMerger::merge(
+            ['roles' => ['operator', 'administrator']],
+            ['roles' => ['finance']],
+        ));
+    }
+
+    public function testItReplacesScalarValues()
+    {
+        $this->assertSame([
+            'enabled' => false,
+        ], MetadataMerger::merge(
+            ['enabled' => true],
+            ['enabled' => false],
+        ));
+    }
+
+    public function testItAllowsValueTypeChanges()
+    {
+        $this->assertSame([
+            'monitoring' => false,
+        ], MetadataMerger::merge(
+            ['monitoring' => ['enabled' => true]],
+            ['monitoring' => false],
+        ));
+    }
+
+    public function testItReplacesAssociativeValuesWithEmptyLists()
+    {
+        $this->assertSame([
+            'operations' => [],
+        ], MetadataMerger::merge(
+            ['operations' => ['owner' => 'finance']],
+            ['operations' => []],
+        ));
+    }
+
+    public function testItPreservesExistingMetadataForAnEmptyIncomingArray()
+    {
+        $this->assertSame(
+            ['enabled' => true],
+            MetadataMerger::merge(['enabled' => true], []),
+        );
+    }
+
+    public function testItMergesIntoAnEmptyExistingArray()
+    {
+        $this->assertSame(
+            ['enabled' => true],
+            MetadataMerger::merge([], ['enabled' => true]),
+        );
+    }
+
+    public function testItPreservesNumericRootKeyBehavior()
+    {
+        $this->assertSame(
+            [4, 2, 3],
+            MetadataMerger::merge([1, 2, 3], [4]),
+        );
+    }
+}


### PR DESCRIPTION
  ## Summary

  This PR adds first-party metadata support to Laravel Artisan commands using the same API and merge semantics as route metadata.

  Laravel commands now expose:

  ```php
  $command->metadata([...]);
  $command->getMetadata();
  $command->getMetadata('operations.owner', $default);
  $command->setMetadata([...]);
 ```

  Class-based commands may also declare metadata using a repeatable `#[Metadata]` attribute:

```php
  use Illuminate\Console\Attributes\Metadata;
  use Illuminate\Console\Command;

  #[Metadata([
      'domain' => 'billing',
      'operations' => [
          'owner' => 'finance',
          'criticality' => 'high',
      ],
  ])]
  class ReconcileBilling extends Command
  {
      protected $signature = 'billing:reconcile';
  }

```
  Closure commands support the same API:

```php
  Artisan::command('billing:reconcile', function () {
      // ...
  })->metadata([
      'operations' => [
          'owner' => 'finance',
      ],
  ]);

```

  Registered commands may be inspected through the normal Artisan lifecycle:

```php
  $command = Artisan::all()['billing:reconcile'];

  $owner = $command->getMetadata('operations.owner');
```

  ## Motivation

  Commands already expose structured invocation information such as signatures, descriptions, arguments, options, aliases, and help text. However, applications and packages
  currently have no framework-standard place to attach arbitrary descriptive information to a command.

  Potential uses include:

  - operational ownership and application domains;
  - destructive-operation classification;
  - runbook and documentation references;
  - permission or role identifiers;
  - automation eligibility;
  - expected duration and deployment restrictions;
  - deprecation and service-level information.

  Keeping this information on the resolved command object allows packages to inspect it alongside the existing command definition without maintaining a separate registry.

  ## Merge behavior

  Command metadata follows the existing route metadata contract:

  - nested associative arrays are merged recursively;
  - lists are replaced;
  - scalar values are replaced;
  - value type changes are allowed;
  - `setMetadata()` replaces the complete metadata collection;
  - `getMetadata()` supports dot notation and default values.

  The existing route merge algorithm has been extracted into an internal-purpose `MetadataMerger`, ensuring routes and commands retain identical behavior without coupling the console
  component to routing.

  Route metadata continues to use its existing public API and remains stored under `action['metadata']`.

  ## Compatibility

  Metadata is stored privately on `Illuminate\Console\Command` and does not affect:

  - command names, signatures, aliases, arguments, or options;
  - descriptions, help text, usage, or visibility;
  - command execution or exit codes;
  - artisan list or command help output;
  - queued command payloads;
  - scheduled events or scheduled command strings;
  - the command map or lazy command loader map.

  Closure commands inherit the API from `Illuminate\Console\Command`. Calling `metadata()` on a closure command configures the command and does not create a scheduled event; existing
  scheduling method forwarding remains unchanged.

  Commands extending Symfony's base command class directly are not modified. Mixed command catalogs can safely select metadata-bearing commands using:

```php
  $commands = collect(Artisan::all())
      ->filter(fn ($command) => $command instanceof \Illuminate\Console\Command);
```

  The `#[Metadata]` attribute follows PHP's normal class-attribute behavior and is not automatically inherited from parent command classes.

  ## Testing

  This PR adds 30 tests covering:

  - route-compatible merge semantics;
  - runtime command metadata configuration and retrieval;
  - repeatable #[Metadata] declarations and precedence;
  - constructor and attribute metadata interaction;
  - user-defined metadata property compatibility;
  - closure command behavior;
  - normal and lazy Artisan registration;
  - canonical-name and alias resolution;
  - mixed Laravel and Symfony command catalogs;
  - queue and scheduler isolation;
  - list and help output compatibility;
  - direct Symfony command registration and execution.

  Formatting, targeted static analysis, and the affected Support, Routing, Console, and Integration test suites pass.