### PR TITLE
[13.x] Fix Redis queue test passing a string to `Str::createUuidsUsing()`

### DIFF
--- a/tests/Integration/Queue/RedisQueueTest.php
+++ b/tests/Integration/Queue/RedisQueueTest.php
@@ -264,9 +264,7 @@ class RedisQueueTest extends TestCase
     #[DataProvider('redisDriverProvider')]
     public function testBlockingPopProperlyPopsExpiredJobs($driver)
     {
-        Str::createUuidsUsing(function () {
-            return 'uuid';
-        });
+        Str::freezeUuids();
 
         $default = config('queue.connections.redis.queue', 'default');
         $this->setQueue($driver, $default, null, 60, 5);


### PR DESCRIPTION
The **Redis and Redis Cluster** workflow has been failing on `13.x` since f341a885ff (#60995), so every PR currently shows red CI. All four jobs fail on the same two errors:

```
1) Illuminate\Tests\Queue\RedisQueueTest::testBlockingPopProperlyPopsExpiredJobs#0 with data ('predis')
Error: Call to a member function toString() on string

src/Illuminate/Queue/Queue.php:175
src/Illuminate/Queue/RedisQueue.php:385
tests/Integration/Queue/RedisQueueTest.php:279
```

Last green run was 14a698372; the very next commit, f341a885f, is where it starts.

### Cause

The test registered a UUID factory returning the plain string `'uuid'`:

```php
Str::createUuidsUsing(function () {
    return 'uuid';
});
```

`createUuidsUsing()` is documented as `(callable(): \Ramsey\Uuid\UuidInterface)|null`, so this always violated the contract — it merely happened to work while `Queue::createObjectPayload()` used `(string) Str::uuid()`. #60995 changed that to `Str::uuid()->toString()`, which hard-requires a `UuidInterface`:

```php
Str::createUuidsUsing(fn () => 'uuid');

(string) Str::uuid()      // 'uuid'
Str::uuid()->toString()   // Error: Call to a member function toString() on string
```

#60995 did update the other affected tests to return a UUID object (`QueueSqsQueueTest`, `Foundation/Cloud/QueueTest`, …). This one was missed because it only runs in the Redis workflow, which needs a live Redis server and is not part of the default test job — so both a local run and the standard CI job were green.

### Fix

`Str::freezeUuids()` is the idiomatic replacement: it generates a real `UuidInterface` and freezes it, so the UUID stays deterministic across both `later()` calls exactly as before, and it pairs with the `Str::createUuidsNormally()` already at the end of the test. The UUID value itself is never asserted — freezing was only for determinism.

### Verification

Run locally against a real Redis with phpredis 6.3.0, using the same command as CI:

```
REDIS_CLIENT=phpredis QUEUE_CONNECTION=redis vendor/bin/phpunit tests/Integration/Queue

before: Tests: 269, Assertions: 1151, Errors: 2, Skipped: 14
after:  Tests: 269, Assertions: 1161, Errors: 0, Skipped: 14
```

The +10 assertions are exactly the two tests now running to completion.

### One thing worth a maintainer's call

This PR only fixes the test, since the docblock makes the framework side defensible. But the 12 call sites changed in #60995 now hard-require a `UuidInterface`, so any **application** whose `createUuidsUsing()` callback returns a string — which worked before — gets a fatal on every queue dispatch, deferred callback, notification ID and `@once`/`@push` directive. If that's considered a breaking change for a patch release, hardening those call sites instead (or in addition) would be the safer route. Happy to follow up either way.