### PR TITLE
Add PHPDoc about Builder::findMany([])

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -590,6 +590,10 @@ class Builder implements BuilderContract
     /**
      * Find multiple models by their primary keys.
      *
+     * It is safe to provide an empty array of primary keys:
+     * in that case you obtain an empty collection, and no
+     * database query is executed.
+     *
      * @param  \Illuminate\Contracts\Support\Arrayable|array  $ids
      * @param  array|string  $columns
      * @return \Illuminate\Database\Eloquent\Collection<int, TModel>


### PR DESCRIPTION
Add documentation about already-existing good logic involving findMany() with an empty array.

Using findMany([]) with an empty array is occasionally very useful for "don't care" situations, to just return an empty collection and without causing any additional database query, which is good for your performances, and is good for your code. I believe this behavior is really good and better than other frameworks, and deserves a little mention.

In particular, with an empty array, the findMany() never returns all items by mistake, and it never executes a nonsense query by mistake. Thanks Laravel!

To understand why this change is useful, consider this "cautious" code I recommend in production, so to only rely on documented features:

```php
$ids = $request->input('ids', []);
$products = [];
if ($ids) {
    $products = Product::findMany($ids);
}
```

And enjoy the equivalent feature, now documented:

```php
$ids = $request->input('ids', []);
$products = Product::findMany($ids);
```
