### PR TITLE
[13.x] Add boolean version of soft deletes

### DIFF
--- a/src/Illuminate/Database/Eloquent/SoftDeletesBoolean.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletesBoolean.php
@@ -1,0 +1,290 @@
+<?php
+
+namespace Illuminate\Database\Eloquent;
+
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Support\Collection as BaseCollection;
+
+/**
+ * @method static \Illuminate\Database\Eloquent\Builder<static> withTrashed(bool $withTrashed = true)
+ * @method static \Illuminate\Database\Eloquent\Builder<static> onlyTrashed()
+ * @method static \Illuminate\Database\Eloquent\Builder<static> withoutTrashed()
+ * @method static static restoreOrCreate(array<string, mixed> $attributes = [], array<string, mixed> $values = [])
+ * @method static static createOrRestore(array<string, mixed> $attributes = [], array<string, mixed> $values = [])
+ */
+trait SoftDeletesBoolean
+{
+    /**
+     * Indicates if the model is currently force deleting.
+     *
+     * @var bool
+     */
+    protected $forceDeleting = false;
+
+    /**
+     * Boot the soft deleting trait for a model.
+     */
+    public static function bootSoftDeletesBoolean(): void
+    {
+        static::addGlobalScope(new SoftDeletingBooleanScope);
+    }
+
+    /**
+     * Initialize the soft deleting trait for an instance.
+     *
+     * @return void
+     */
+    public function initializeSoftDeletes()
+    {
+        if (! isset($this->casts[$this->getIsDeletedColumn()])) {
+            $this->casts[$this->getIsDeletedColumn()] = 'boolean';
+        }
+    }
+
+    /**
+     * Force a hard delete on a soft deleted model.
+     *
+     * @return bool|null
+     */
+    public function forceDelete()
+    {
+        if ($this->fireModelEvent('forceDeleting') === false) {
+            return false;
+        }
+
+        $this->forceDeleting = true;
+
+        return tap($this->delete(), function ($deleted) {
+            $this->forceDeleting = false;
+
+            if ($deleted) {
+                $this->fireModelEvent('forceDeleted', false);
+            }
+        });
+    }
+
+    /**
+     * Force a hard delete on a soft deleted model without raising any events.
+     *
+     * @return bool|null
+     */
+    public function forceDeleteQuietly()
+    {
+        return static::withoutEvents(fn () => $this->forceDelete());
+    }
+
+    /**
+     * Destroy the models for the given IDs.
+     *
+     * @param  \Illuminate\Support\Collection|array|int|string  $ids
+     * @return int
+     */
+    public static function forceDestroy($ids)
+    {
+        if ($ids instanceof EloquentCollection) {
+            $ids = $ids->modelKeys();
+        }
+
+        if ($ids instanceof BaseCollection) {
+            $ids = $ids->all();
+        }
+
+        $ids = is_array($ids) ? $ids : func_get_args();
+
+        if ($ids === []) {
+            return 0;
+        }
+
+        // We will actually pull the models from the database table and call delete on
+        // each of them individually so that their events get fired properly with a
+        // correct set of attributes in case the developers wants to check these.
+        $key = ($instance = new static)->getKeyName();
+
+        $count = 0;
+
+        foreach ($instance::withTrashed()->whereIn($key, $ids)->get() as $model) {
+            if ($model->forceDelete()) {
+                $count++;
+            }
+        }
+
+        return $count;
+    }
+
+    /**
+     * Perform the actual delete query on this model instance.
+     *
+     * @return mixed
+     */
+    protected function performDeleteOnModel()
+    {
+        if ($this->forceDeleting) {
+            return tap($this->setKeysForSaveQuery($this->newModelQuery())->forceDelete(), function () {
+                $this->exists = false;
+            });
+        }
+
+        return $this->runSoftDelete();
+    }
+
+    /**
+     * Perform the actual delete query on this model instance.
+     *
+     * @return void
+     */
+    protected function runSoftDelete()
+    {
+        $query = $this->setKeysForSaveQuery($this->newModelQuery());
+
+        $time = $this->freshTimestamp();
+
+        $columns = [$this->getIsDeletedColumn() => true];
+
+        $this->{$this->getIsDeletedColumn()} = true;
+
+        if ($this->usesTimestamps() && ! is_null($this->getUpdatedAtColumn())) {
+            $this->{$this->getUpdatedAtColumn()} = $time;
+
+            $columns[$this->getUpdatedAtColumn()] = $this->fromDateTime($time);
+        }
+
+        $query->update($columns);
+
+        $this->syncOriginalAttributes(array_keys($columns));
+
+        $this->fireModelEvent('trashed', false);
+    }
+
+    /**
+     * Restore a soft-deleted model instance.
+     *
+     * @return bool
+     */
+    public function restore()
+    {
+        // If the restoring event does not return false, we will proceed with this
+        // restore operation. Otherwise, we bail out so the developer will stop
+        // the restore totally. We will clear the deleted timestamp and save.
+        if ($this->fireModelEvent('restoring') === false) {
+            return false;
+        }
+
+        $this->{$this->getIsDeletedColumn()} = false;
+
+        // Once we have saved the model, we will fire the "restored" event so this
+        // developer will do anything they need to after a restore operation is
+        // totally finished. Then we will return the result of the save call.
+        $this->exists = true;
+
+        $result = $this->save();
+
+        if ($result) {
+            $this->fireModelEvent('restored', false);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Restore a soft-deleted model instance without raising any events.
+     *
+     * @return bool
+     */
+    public function restoreQuietly()
+    {
+        return static::withoutEvents(fn () => $this->restore());
+    }
+
+    /**
+     * Determine if the model instance has been soft-deleted.
+     */
+    public function trashed(): bool
+    {
+        return (bool) $this->{$this->getIsDeletedColumn()};
+    }
+
+    /**
+     * Register a "softDeleted" model event callback with the dispatcher.
+     *
+     * @param  \Illuminate\Events\QueuedClosure|callable|class-string  $callback
+     * @return void
+     */
+    public static function softDeleted($callback)
+    {
+        static::registerModelEvent('trashed', $callback);
+    }
+
+    /**
+     * Register a "restoring" model event callback with the dispatcher.
+     *
+     * @param  \Illuminate\Events\QueuedClosure|callable|class-string  $callback
+     * @return void
+     */
+    public static function restoring($callback)
+    {
+        static::registerModelEvent('restoring', $callback);
+    }
+
+    /**
+     * Register a "restored" model event callback with the dispatcher.
+     *
+     * @param  \Illuminate\Events\QueuedClosure|callable|class-string  $callback
+     * @return void
+     */
+    public static function restored($callback)
+    {
+        static::registerModelEvent('restored', $callback);
+    }
+
+    /**
+     * Register a "forceDeleting" model event callback with the dispatcher.
+     *
+     * @param  \Illuminate\Events\QueuedClosure|callable|class-string  $callback
+     * @return void
+     */
+    public static function forceDeleting($callback)
+    {
+        static::registerModelEvent('forceDeleting', $callback);
+    }
+
+    /**
+     * Register a "forceDeleted" model event callback with the dispatcher.
+     *
+     * @param  \Illuminate\Events\QueuedClosure|callable|class-string  $callback
+     * @return void
+     */
+    public static function forceDeleted($callback)
+    {
+        static::registerModelEvent('forceDeleted', $callback);
+    }
+
+    /**
+     * Determine if the model is currently force deleting.
+     *
+     * @return bool
+     */
+    public function isForceDeleting()
+    {
+        return $this->forceDeleting;
+    }
+
+    /**
+     * Get the name of the "is deleted" column.
+     *
+     * @return string
+     */
+    public function getIsDeletedColumn()
+    {
+        return defined(static::class.'::IS_DELETED') ? static::IS_DELETED : 'is_deleted';
+    }
+
+    /**
+     * Get the fully-qualified "deleted at" column.
+     *
+     * @return string
+     */
+    public function getQualifiedIsDeletedColumn()
+    {
+        return $this->qualifyColumn($this->getIsDeletedColumn());
+    }
+}

--- a/src/Illuminate/Database/Eloquent/SoftDeletingBooleanScope.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletingBooleanScope.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace Illuminate\Database\Eloquent;
+
+/**
+ * @template TModel of \Illuminate\Database\Eloquent\Model
+ *
+ * @implements \Illuminate\Database\Eloquent\Scope<TModel>
+ */
+class SoftDeletingBooleanScope implements Scope
+{
+    /**
+     * All of the extensions to be added to the builder.
+     *
+     * @var string[]
+     */
+    protected $extensions = ['Restore', 'RestoreOrCreate', 'CreateOrRestore', 'WithTrashed', 'WithoutTrashed', 'OnlyTrashed'];
+
+    /**
+     * Apply the scope to a given Eloquent query builder.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder<TModel>  $builder
+     * @param  TModel  $model
+     * @return void
+     */
+    public function apply(Builder $builder, Model $model)
+    {
+        $builder->where($model->getQualifiedIsDeletedColumn(), false);
+    }
+
+    /**
+     * Extend the query builder with the needed functions.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder<*>  $builder
+     * @return void
+     */
+    public function extend(Builder $builder)
+    {
+        foreach ($this->extensions as $extension) {
+            $this->{"add{$extension}"}($builder);
+        }
+
+        $builder->onDelete(function (Builder $builder) {
+            $column = $this->getIsDeletedColumn($builder);
+
+            return $builder->update([
+                $column => true,
+            ]);
+        });
+    }
+
+    /**
+     * Get the "deleted at" column for the builder.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder<*>  $builder
+     * @return string
+     */
+    protected function getIsDeletedColumn(Builder $builder)
+    {
+        if ((array) $builder->getQuery()->joins !== []) {
+            return $builder->getModel()->getQualifiedIsDeletedColumn();
+        }
+
+        return $builder->getModel()->getIsDeletedColumn();
+    }
+
+    /**
+     * Add the restore extension to the builder.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder<*>  $builder
+     * @return void
+     */
+    protected function addRestore(Builder $builder): void
+    {
+        $builder->macro('restore', function (Builder $builder) {
+            $builder->withTrashed();
+
+            return $builder->update([$builder->getModel()->getIsDeletedColumn() => false]);
+        });
+    }
+
+    /**
+     * Add the restore-or-create extension to the builder.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder<*>  $builder
+     * @return void
+     */
+    protected function addRestoreOrCreate(Builder $builder)
+    {
+        $builder->macro('restoreOrCreate', function (Builder $builder, array $attributes = [], array $values = []) {
+            $builder->withTrashed();
+
+            return tap($builder->firstOrCreate($attributes, $values), function ($instance) {
+                $instance->restore();
+            });
+        });
+    }
+
+    /**
+     * Add the create-or-restore extension to the builder.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder<*>  $builder
+     * @return void
+     */
+    protected function addCreateOrRestore(Builder $builder)
+    {
+        $builder->macro('createOrRestore', function (Builder $builder, array $attributes = [], array $values = []) {
+            $builder->withTrashed();
+
+            return tap($builder->createOrFirst($attributes, $values), function ($instance) {
+                $instance->restore();
+            });
+        });
+    }
+
+    /**
+     * Add the with-trashed extension to the builder.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder<*>  $builder
+     * @return void
+     */
+    protected function addWithTrashed(Builder $builder)
+    {
+        $builder->macro('withTrashed', function (Builder $builder, $withTrashed = true) {
+            if (! $withTrashed) {
+                return $builder->withoutTrashed();
+            }
+
+            return $builder->withoutGlobalScope($this);
+        });
+    }
+
+    /**
+     * Add the without-trashed extension to the builder.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder<*>  $builder
+     * @return void
+     */
+    protected function addWithoutTrashed(Builder $builder)
+    {
+        $builder->macro('withoutTrashed', function (Builder $builder) {
+            $model = $builder->getModel();
+
+            $builder->withoutGlobalScope($this)->where(
+                $model->getQualifiedIsDeletedColumn(),
+                false
+            );
+
+            return $builder;
+        });
+    }
+
+    /**
+     * Add the only-trashed extension to the builder.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder<*>  $builder
+     * @return void
+     */
+    protected function addOnlyTrashed(Builder $builder)
+    {
+        $builder->macro('onlyTrashed', function (Builder $builder) {
+            $model = $builder->getModel();
+
+            $builder->withoutGlobalScope($this)->whereNot(
+                $model->getQualifiedIsDeletedColumn(),
+                false
+            );
+
+            return $builder;
+        });
+    }
+}

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -604,6 +604,17 @@ class Blueprint
     }
 
     /**
+     * Indicate that the soft delete column should be dropped.
+     *
+     * @param  string  $column
+     * @return void
+     */
+    public function dropSoftDeletesBoolean($column = 'is_deleted')
+    {
+        $this->dropColumn($column);
+    }
+
+    /**
      * Indicate that the remember token column should be dropped.
      *
      * @return void
@@ -1386,6 +1397,17 @@ class Blueprint
     public function softDeletesDatetime($column = 'deleted_at', $precision = null)
     {
         return $this->dateTime($column, $precision)->nullable();
+    }
+
+    /**
+     * Add an "is deleted" boolean for the table.
+     *
+     * @param  string  $column
+     * @return \Illuminate\Database\Schema\ColumnDefinition
+     */
+    public function softDeletesBoolean($column = 'is_deleted')
+    {
+        return $this->boolean($column);
     }
 
     /**


### PR DESCRIPTION
This pull request adds a boolean version of soft deletes to Laravel. Next to `deleted_at`, the column `is_deleted` is also oftenly used for soft deleting database rows. Previously, developers used https://github.com/tenantcloud/laravel-boolean-softdeletes, but this project is unmaintained. With this pull request adding `SoftDeletesBoolean` to Laravel, this is no longer needed.