### PR TITLE
[13.x] Improve return type for `Arr::prependKeysWith()`

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -721,9 +721,11 @@ class Arr
     /**
      * Prepend the key names of an associative array.
      *
-     * @param  array  $array
+     * @template TValue
+     *
+     * @param  array<TValue>  $array
      * @param  string  $prependWith
-     * @return array
+     * @return array<string, TValue>
      */
     public static function prependKeysWith($array, $prependWith)
     {

--- a/types/Support/Arr.php
+++ b/types/Support/Arr.php
@@ -205,3 +205,5 @@ assertType('array<int<0, max>, int>', Arr::whereNotNull($arr));
 
 assertType('mixed', Arr::random($array));
 assertType('array', Arr::random($array, 2));
+
+assertType('array<string, User>', Arr::prependKeysWith($array, 'user_'));


### PR DESCRIPTION
Allows tools like PHPStan to understand the return type of `Arr::prependKeysWith()`