### PR TITLE
[13.x] Add beforeApplicationBooted() test hook

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
@@ -59,6 +59,13 @@ trait InteractsWithTestCaseLifecycle
     protected $app;
 
     /**
+     * The callbacks that should be run while the application is booting.
+     *
+     * @var array
+     */
+    protected $beforeApplicationBootedCallbacks = [];
+
+    /**
      * The callbacks that should be run after the application is created.
      *
      * @var array
@@ -169,6 +176,7 @@ trait InteractsWithTestCaseLifecycle
 
         $this->afterApplicationCreatedCallbacks = [];
         $this->beforeApplicationDestroyedCallbacks = [];
+        $this->beforeApplicationBootedCallbacks = [];
 
         if (property_exists($this, 'originalExceptionHandler')) {
             $this->originalExceptionHandler = null;
@@ -300,6 +308,17 @@ trait InteractsWithTestCaseLifecycle
         if ($this->setUpHasRun) {
             $callback();
         }
+    }
+
+    /**
+     * Register a callback to be run while the application is booting.
+     *
+     * @param  callable  $callback
+     * @return void
+     */
+    protected function beforeApplicationBooted(callable $callback)
+    {
+        $this->beforeApplicationBootedCallbacks[] = $callback;
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -56,6 +56,10 @@ abstract class TestCase extends BaseTestCase
             $app->booting(fn () => $this->markRoutesCached($app));
         }
 
+        foreach ($this->beforeApplicationBootedCallbacks as $callback) {
+            $app->booting($callback);
+        }
+
         $app->make(Kernel::class)->bootstrap();
 
         return $app;


### PR DESCRIPTION
This will register application booting life-cycle hooks to allow tests to run code before the application is booted.

It is possible to do this currently by overriding createApplication() in your application's TestCase, but there are other side-effects in createApplication() that you have to replicate and keep in sync with upstream.

Let me know if you want a test case for this.  I looked at some options for testing, but they were all awkward and the code itself is fairly trivial. There were not any other tests for InteractsWithTestCaseLifecycle to model after.