### PR TITLE
[13.x] Add foreignUlidFor schema helper

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1095,6 +1095,24 @@ class Blueprint
     }
 
     /**
+     * Create a foreign ULID column for the given model.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model|string  $model
+     * @param  string|null  $column
+     * @return \Illuminate\Database\Schema\ForeignIdColumnDefinition
+     */
+    public function foreignUlidFor($model, $column = null)
+    {
+        if (is_string($model)) {
+            $model = new $model;
+        }
+
+        return $this->foreignUlid($column ?: $model->getForeignKey())
+            ->table($model->getTable())
+            ->referencesModelColumn($model->getKeyName());
+    }
+
+    /**
      * Create a new float column on the table.
      *
      * @param  string  $column

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -481,6 +481,19 @@ class DatabaseSchemaBlueprintTest extends TestCase
         ], $getSql('MySql'));
     }
 
+    public function testGenerateUlidRelationshipColumnWithUlidModel()
+    {
+        $getSql = function ($grammar) {
+            return $this->getBlueprint($grammar, 'posts', function ($table) {
+                $table->foreignUlidFor(Fixtures\Models\EloquentModelUsingUlid::class);
+            })->toSql();
+        };
+
+        $this->assertEquals([
+            'alter table `posts` add `model_using_ulid_id` char(26) not null',
+        ], $getSql('MySql'));
+    }
+
     public function testGenerateRelationshipConstrainedColumn()
     {
         $getSql = function ($grammar) {
@@ -506,6 +519,20 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $this->assertEquals([
             'alter table `posts` add `model_using_uuid_id` char(36) not null',
             'alter table `posts` add constraint `posts_model_using_uuid_id_foreign` foreign key (`model_using_uuid_id`) references `model` (`id`)',
+        ], $getSql('MySql'));
+    }
+
+    public function testGenerateUlidRelationshipConstrainedColumn()
+    {
+        $getSql = function ($grammar) {
+            return $this->getBlueprint($grammar, 'posts', function ($table) {
+                $table->foreignUlidFor(Fixtures\Models\EloquentModelUsingUlid::class)->constrained();
+            })->toSql();
+        };
+
+        $this->assertEquals([
+            'alter table `posts` add `model_using_ulid_id` char(26) not null',
+            'alter table `posts` add constraint `posts_model_using_ulid_id_foreign` foreign key (`model_using_ulid_id`) references `model` (`id`)',
         ], $getSql('MySql'));
     }
 


### PR DESCRIPTION
This PR adds a `foreignUlidFor` helper to schema blueprints, completing the trio alongside `foreignIdFor` and the recently added `foreignUuidFor` (#60091).

While `foreignIdFor` already supports ULID-backed Eloquent models by detecting the `HasUlids` trait, this helper provides an explicit API for migrations that intentionally want a ULID foreign key column:

```php
$table->foreignUlidFor(User::class)->constrained();
```

Like `foreignUuidFor`, the helper infers:

- the foreign key column name from the model
- the related table name
- the referenced primary key column

The change is purely additive and no existing behavior is modified. Tests mirror the existing `foreignUuidFor` tests (plain column and constrained column).
