### PR TITLE
[13.x] Add a UniqueJobSkipped event

### DIFF
--- a/src/Illuminate/Foundation/Bus/PendingDispatch.php
+++ b/src/Illuminate/Foundation/Bus/PendingDispatch.php
@@ -12,6 +12,7 @@ use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Foundation\Queue\InteractsWithUniqueJobs;
 use Illuminate\Queue\Attributes\DebounceFor;
 use Illuminate\Queue\Attributes\ReadsQueueAttributes;
+use Illuminate\Queue\Events\UniqueJobSkipped;
 use Illuminate\Support\Traits\Conditionable;
 use LogicException;
 
@@ -215,8 +216,19 @@ class PendingDispatch
             return true;
         }
 
-        return (new UniqueLock(Container::getInstance()->make(Cache::class)))
-            ->acquire($this->job);
+        $container = Container::getInstance();
+
+        $lockAcquired = (new UniqueLock($container->make(Cache::class)))->acquire($this->job);
+
+        if ($lockAcquired) {
+            return true;
+        }
+
+        if ($container->bound('events')) {
+            $container->make('events')->dispatch(new UniqueJobSkipped($this->job));
+        }
+
+        return false;
     }
 
     /**

--- a/src/Illuminate/Queue/Events/UniqueJobSkipped.php
+++ b/src/Illuminate/Queue/Events/UniqueJobSkipped.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Illuminate\Queue\Events;
+
+class UniqueJobSkipped
+{
+    /**
+     * Create a new event instance.
+     *
+     * @param  mixed  $job  The job that was not dispatched.
+     */
+    public function __construct(
+        public $job,
+    ) {
+    }
+}

--- a/tests/Integration/Queue/UniqueJobTest.php
+++ b/tests/Integration/Queue/UniqueJobTest.php
@@ -13,9 +13,11 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Auth\User;
 use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\Events\UniqueJobSkipped;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Queue;
 use Orchestra\Testbench\Attributes\WithMigration;
 use Orchestra\Testbench\Factories\UserFactory;
@@ -52,6 +54,26 @@ class UniqueJobTest extends QueueTestCase
         $this->assertFalse(
             $this->app->get(Cache::class)->lock($this->getLockKey(UniqueTestJob::class), 10)->get()
         );
+    }
+
+    public function testUniqueJobEmitsEventWhenAlreadyAcquired()
+    {
+        Bus::fake();
+
+        $skipped = [];
+
+        Event::listen(UniqueJobSkipped::class, function ($event) use (&$skipped) {
+            $skipped[] = $event->job;
+        });
+
+        UniqueTestJob::dispatch();
+
+        $this->assertSame([], $skipped);
+
+        UniqueTestJob::dispatch();
+
+        $this->assertCount(1, $skipped);
+        $this->assertInstanceOf(UniqueTestJob::class, $skipped[0]);
     }
 
     public function testUniqueJobWithViaDispatched()

--- a/tests/Integration/Queue/UniqueJobTest.php
+++ b/tests/Integration/Queue/UniqueJobTest.php
@@ -56,7 +56,7 @@ class UniqueJobTest extends QueueTestCase
         );
     }
 
-    public function testUniqueJobEmitsEventWhenAlreadyAcquired()
+    public function testUniqueJobEmitsUniqueJobSkippedEventWhenAlreadyAcquired()
     {
         Bus::fake();
 


### PR DESCRIPTION
Currently, if a job doesn't get dispatched because it's unique there's no way to know 

I'd like the ability to see if there's any unique jobs being dropped just to help with debugging and general observability, for example a job can still be sat on the  queue holding the lock, so the next dispatch silently never happens. 

Or maybe its never hit.. and its therefore pointless making the job unique. Those kind of things :) 

Debounced jobs have an event when they're debounced ie `JobDebounced`, so thought I'd give this a go. 

You may see a nicer name, so open to adjusting the event etc. I placed it alongside JobDebounced.

Also open to the idea of this being terrible, so let me know if it sux