### PR TITLE
[13.x] Ensure Container::call cleans up build stack after exceptions

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -797,13 +797,13 @@ class Container implements ArrayAccess, ContainerContract
             $pushedToBuildStack = true;
         }
 
-        $result = BoundMethod::call($this, $callback, $parameters, $defaultMethod);
-
-        if ($pushedToBuildStack) {
-            array_pop($this->buildStack);
+        try {
+            return BoundMethod::call($this, $callback, $parameters, $defaultMethod);
+        } finally {
+            if ($pushedToBuildStack) {
+                array_pop($this->buildStack);
+            }
         }
-
-        return $result;
     }
 
     /**

--- a/tests/Container/ContainerCallTest.php
+++ b/tests/Container/ContainerCallTest.php
@@ -7,6 +7,7 @@ use Error;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 use stdClass;
 
 class ContainerCallTest extends TestCase
@@ -228,6 +229,28 @@ class ContainerCallTest extends TestCase
         });
     }
 
+    public function testCallCleansUpBuildStackAfterException()
+    {
+        $container = new Container;
+
+        $container->when(ContainerCallFailingStub::class)
+            ->needs(ContainerCallConcreteStub::class)
+            ->give(ContainerCallContextualConcreteStub::class);
+
+        try {
+            $container->call([new ContainerCallFailingStub, 'handle']);
+
+            $this->fail('Expected the callback to throw an exception.');
+        } catch (RuntimeException) {
+            // Expected.
+        }
+
+        $dependency = $container->make(ContainerCallConcreteStub::class);
+
+        $this->assertInstanceOf(ContainerCallConcreteStub::class, $dependency);
+        $this->assertNotInstanceOf(ContainerCallContextualConcreteStub::class, $dependency);
+    }
+
     public function testCallWithNullableClassParameterDefaultValue()
     {
         $container = new Container;
@@ -273,6 +296,19 @@ class ContainerTestCallStub
 class ContainerCallConcreteStub
 {
     //
+}
+
+class ContainerCallContextualConcreteStub extends ContainerCallConcreteStub
+{
+    //
+}
+
+class ContainerCallFailingStub
+{
+    public function handle(ContainerCallConcreteStub $stub)
+    {
+        throw new RuntimeException('Expected.');
+    }
 }
 
 function containerTestInject(ContainerCallConcreteStub $stub, $default = 'taylor')


### PR DESCRIPTION
When an object callback passed to `Container::call()` throws, its class remains on the container's build stack.

If the exception is handled and the container is used again, subsequent resolutions may incorrectly apply contextual bindings registered for the failed callback.

This PR ensures the build stack is cleaned up in a `finally` block and adds a regression test covering a subsequent root-level resolution.