### PR TITLE
[13.x] Add `updateReturning` method to the query builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -4324,6 +4324,47 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Update records in the database and return the specified columns of the updated rows.
+     *
+     * @param  non-empty-array<non-empty-string>  $returning
+     * @return \Illuminate\Support\Collection
+     */
+    public function updateReturning(array $values, array $returning = ['*'])
+    {
+        if ($returning === []) {
+            throw new InvalidArgumentException('The returning columns must not be empty.');
+        }
+
+        $this->applyBeforeQueryCallbacks();
+
+        $values = (new Collection($values))->map(function ($value) {
+            if (! $value instanceof self && ! $value instanceof EloquentBuilder && ! $value instanceof Relation) {
+                return ['value' => $value, 'bindings' => match (true) {
+                    $value instanceof Collection => $value->all(),
+                    $value instanceof UnitEnum => enum_value($value),
+                    default => $value,
+                }];
+            }
+
+            [$query, $bindings] = $this->parseSub($value);
+
+            return ['value' => new Expression("({$query})"), 'bindings' => fn () => $bindings];
+        });
+
+        $sql = $this->grammar->compileUpdateReturning($this, $values->map(fn ($value) => $value['value'])->all(), $returning);
+
+        $result = new Collection(
+            $this->connection->selectFromWriteConnection($sql, $this->cleanBindings(
+                $this->grammar->prepareBindingsForUpdate($this->bindings, $values->map(fn ($value) => $value['bindings'])->all())
+            ))
+        );
+
+        $this->connection->recordsHaveBeenModified($result->isNotEmpty());
+
+        return $result;
+    }
+
+    /**
      * Update records in a PostgreSQL database using the update from syntax.
      *
      * @return int

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -1361,6 +1361,21 @@ class Grammar extends BaseGrammar
     }
 
     /**
+     * Compile an update statement with a returning clause into SQL.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $values
+     * @param  array  $returning
+     * @return string
+     *
+     * @throws \RuntimeException
+     */
+    public function compileUpdateReturning(Builder $query, array $values, array $returning)
+    {
+        throw new RuntimeException('This database engine does not support update with returning.');
+    }
+
+    /**
      * Compile the columns for an update statement.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -435,6 +435,19 @@ class PostgresGrammar extends Grammar
     }
 
     /**
+     * Compile an update statement with a returning clause into SQL.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $values
+     * @param  array  $returning
+     * @return string
+     */
+    public function compileUpdateReturning(Builder $query, array $values, array $returning)
+    {
+        return $this->compileUpdate($query, $values).' returning '.$this->columnize($returning);
+    }
+
+    /**
      * Compile the columns for an update statement.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -277,6 +277,19 @@ class SQLiteGrammar extends Grammar
     }
 
     /**
+     * Compile an update statement with a returning clause into SQL.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $values
+     * @param  array  $returning
+     * @return string
+     */
+    public function compileUpdateReturning(Builder $query, array $values, array $returning)
+    {
+        return $this->compileUpdate($query, $values).' returning '.$this->columnize($returning);
+    }
+
+    /**
      * Compile an insert ignore statement into SQL.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -4556,6 +4556,90 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertTrue($result->isEmpty());
     }
 
+    public function testUpdateReturningMethod()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('does not support');
+        $builder = $this->getBuilder();
+        $builder->from('users')->where('id', 1)->updateReturning(['email' => 'foo']);
+    }
+
+    public function testMySqlUpdateReturningMethod()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('does not support');
+        $builder = $this->getMySqlBuilder();
+        $builder->from('users')->where('id', 1)->updateReturning(['email' => 'foo']);
+    }
+
+    public function testSqlServerUpdateReturningMethod()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('does not support');
+        $builder = $this->getSqlServerBuilder();
+        $builder->from('users')->where('id', 1)->updateReturning(['email' => 'foo']);
+    }
+
+    public function testUpdateReturningWithEmptyReturning()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The returning columns must not be empty.');
+        $builder = $this->getPostgresBuilder();
+        $builder->from('users')->where('id', 1)->updateReturning(['email' => 'foo'], []);
+    }
+
+    public function testPostgresUpdateReturningMethod()
+    {
+        $builder = $this->getPostgresBuilder();
+        $builder->getConnection()->shouldReceive('selectFromWriteConnection')->once()->with(
+            'update "users" set "status" = ? where "id" = ? returning "id", "status"',
+            ['claimed', 1]
+        )->andReturn([['id' => 1, 'status' => 'claimed']]);
+        $builder->getConnection()->shouldReceive('recordsHaveBeenModified')->once()->with(true);
+        $result = $builder->from('users')->where('id', 1)->updateReturning(['status' => 'claimed'], ['id', 'status']);
+        $this->assertInstanceOf(Collection::class, $result);
+        $this->assertEquals([['id' => 1, 'status' => 'claimed']], $result->all());
+    }
+
+    public function testPostgresUpdateReturningMethodDefaultsToAllColumns()
+    {
+        $builder = $this->getPostgresBuilder();
+        $builder->getConnection()->shouldReceive('selectFromWriteConnection')->once()->with(
+            'update "users" set "email" = ? returning *',
+            ['foo']
+        )->andReturn([['id' => 1, 'email' => 'foo']]);
+        $builder->getConnection()->shouldReceive('recordsHaveBeenModified')->once()->with(true);
+        $result = $builder->from('users')->updateReturning(['email' => 'foo']);
+        $this->assertInstanceOf(Collection::class, $result);
+        $this->assertEquals([['id' => 1, 'email' => 'foo']], $result->all());
+    }
+
+    public function testSqliteUpdateReturningMethod()
+    {
+        $builder = $this->getSQLiteBuilder();
+        $builder->getConnection()->shouldReceive('selectFromWriteConnection')->once()->with(
+            'update "users" set "status" = ? where "id" = ? returning "id", "status"',
+            ['claimed', 1]
+        )->andReturn([['id' => 1, 'status' => 'claimed']]);
+        $builder->getConnection()->shouldReceive('recordsHaveBeenModified')->once()->with(true);
+        $result = $builder->from('users')->where('id', 1)->updateReturning(['status' => 'claimed'], ['id', 'status']);
+        $this->assertInstanceOf(Collection::class, $result);
+        $this->assertEquals([['id' => 1, 'status' => 'claimed']], $result->all());
+    }
+
+    public function testUpdateReturningDoesNotMarkRecordsModifiedWhenNoRowsWereUpdated()
+    {
+        $builder = $this->getPostgresBuilder();
+        $builder->getConnection()->shouldReceive('selectFromWriteConnection')->once()->with(
+            'update "users" set "email" = ? where "id" = ? returning *',
+            ['foo', 1]
+        )->andReturn([]);
+        $builder->getConnection()->shouldReceive('recordsHaveBeenModified')->once()->with(false);
+        $result = $builder->from('users')->where('id', 1)->updateReturning(['email' => 'foo']);
+        $this->assertInstanceOf(Collection::class, $result);
+        $this->assertTrue($result->isEmpty());
+    }
+
     public function testInsertOrIgnoreUsingMethod()
     {
         $this->expectException(RuntimeException::class);


### PR DESCRIPTION
## Problem

`update()` returns an affected row count, so there is no way to know which rows were actually updated or what their final values are. The common workaround is an `update` followed by a `select`, but the two queries are not atomic: another connection can modify or claim the same rows in between. A typical example is claiming pending rows for processing:

```php
DB::table('tasks')->where('status', 'pending')->limit(10)->update(['status' => 'claimed']);

// which rows did we actually claim? a second select can't answer this reliably
```

Postgres and SQLite (3.35+) solve this natively with the `RETURNING` clause, which returns the updated rows from the same atomic statement. The query builder currently only exposes `RETURNING` for inserts via `insertOrIgnoreReturning` (#59025).

## Solution

A new `updateReturning` method that compiles an `update ... returning` statement and returns a `Collection` of the updated rows:

```php
$claimed = DB::table('tasks')
    ->where('status', 'pending')
    ->limit(10)
    ->updateReturning(['status' => 'claimed'], ['id', 'payload']);
```

The `$returning` columns default to `['*']`. The method follows `update()` exactly for value preparation (enums, collections, subqueries) and grammar-specific binding order, and follows `insertOrIgnoreReturning` for the rest of its shape: it returns a `Collection`, reads from the write connection, and marks records as modified only when rows were actually returned.

## Why a separate method instead of extending `update`

Same reasoning as #59025: `update()` returns an `int` count. An optional `$returning` parameter that switches the return type to `Collection` would break type-hinting and static analysis, so a dedicated method with a consistent return type is the better API.

## Engine support

Same scope as #59025: PostgreSQL and SQLite compile the `returning` clause; other grammars throw a `RuntimeException` from the base implementation.

| Engine | `UPDATE ... RETURNING` | This PR | Notes |
| --- | --- | --- | --- |
| PostgreSQL | Yes | Yes | Supported since 8.2 |
| SQLite | Yes (3.35+) | Yes | Same syntax as PostgreSQL |
| MariaDB | No | No | Has `RETURNING` for `INSERT`/`DELETE` only; `UPDATE ... RETURNING` first appears in MariaDB 13.0 ([MDEV-5092](https://jira.mariadb.org/browse/MDEV-5092)), so it could be added later behind a version check |
| MySQL | No | No | No `RETURNING` clause |
| SQL Server | Via `OUTPUT` | No | Different placement and semantics (`inserted.*` / `deleted.*`), requires a different SQL structure |

Tests cover the compiled SQL and binding order for Postgres and SQLite (with and without an explicit column list), the unsupported-engine exceptions for the base, MySQL, and SQL Server grammars, the empty `$returning` validation, and that `recordsHaveBeenModified` is only flagged when rows were returned.

This change is purely additive. No existing methods or behaviors are modified.
