### PR TITLE
[13.x] Fix config:cache selecting the wrong environment file

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
@@ -12,6 +12,20 @@ use Symfony\Component\Console\Output\ConsoleOutput;
 class LoadEnvironmentVariables
 {
     /**
+     * The environment defined outside of the environment files.
+     *
+     * @var string|null
+     */
+    protected static $externalEnvironment;
+
+    /**
+     * Indicates if the external environment has been resolved.
+     *
+     * @var bool
+     */
+    protected static $externalEnvironmentResolved = false;
+
+    /**
      * Bootstrap the given application.
      *
      * @param  \Illuminate\Contracts\Foundation\Application  $app
@@ -46,14 +60,17 @@ class LoadEnvironmentVariables
             return;
         }
 
-        $environment = Env::get('APP_ENV');
+        if (! static::$externalEnvironmentResolved) {
+            static::$externalEnvironment = Env::get('APP_ENV');
+            static::$externalEnvironmentResolved = true;
+        }
 
-        if (! $environment) {
+        if (! static::$externalEnvironment) {
             return;
         }
 
         $this->setEnvironmentFilePath(
-            $app, $app->environmentFile().'.'.$environment
+            $app, $app->environmentFile().'.'.static::$externalEnvironment
         );
     }
 
@@ -106,5 +123,17 @@ class LoadEnvironmentVariables
         http_response_code(500);
 
         exit(1);
+    }
+
+    /**
+     * Flush the bootstrapper's global state.
+     *
+     * @return void
+     */
+    public static function flushState()
+    {
+        static::$externalEnvironment = null;
+
+        static::$externalEnvironmentResolved = false;
     }
 }

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Migrations\Migrator;
 use Illuminate\Foundation\Bootstrap\HandleExceptions;
+use Illuminate\Foundation\Bootstrap\LoadEnvironmentVariables;
 use Illuminate\Foundation\Bootstrap\RegisterProviders;
 use Illuminate\Foundation\Console\AboutCommand;
 use Illuminate\Foundation\Http\FormRequest;
@@ -192,6 +193,7 @@ trait InteractsWithTestCaseLifecycle
         HandleExceptions::flushState($this);
         JsonApiResource::flushState();
         JsonResource::flushState();
+        LoadEnvironmentVariables::flushState();
         Lottery::determineResultsNormally();
         Markdown::flushState();
         Migrator::withoutMigrations([]);

--- a/tests/Foundation/Bootstrap/LoadEnvironmentVariablesTest.php
+++ b/tests/Foundation/Bootstrap/LoadEnvironmentVariablesTest.php
@@ -9,10 +9,22 @@ use PHPUnit\Framework\TestCase;
 
 class LoadEnvironmentVariablesTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        unset($_ENV['APP_ENV'], $_SERVER['APP_ENV']);
+        putenv('APP_ENV');
+
+        LoadEnvironmentVariables::flushState();
+    }
+
     protected function tearDown(): void
     {
-        unset($_ENV['FOO'], $_SERVER['FOO']);
+        unset($_ENV['FOO'], $_SERVER['FOO'], $_ENV['APP_ENV'], $_SERVER['APP_ENV'], $_ENV['ENVIRONMENT_FILE'], $_SERVER['ENVIRONMENT_FILE']);
         putenv('FOO');
+        putenv('APP_ENV');
+        putenv('ENVIRONMENT_FILE');
+
+        LoadEnvironmentVariables::flushState();
     }
 
     protected function getAppMock($file)
@@ -48,5 +60,29 @@ class LoadEnvironmentVariablesTest extends TestCase
         $this->expectOutputString('');
 
         (new LoadEnvironmentVariables)->bootstrap($this->getAppMock('BAD_FILE'));
+    }
+
+    public function testDoesNotUseEnvironmentDefinedByAPreviouslyLoadedFile()
+    {
+        $this->expectOutputString('');
+
+        $file = '.env.custom';
+
+        $app = m::mock(Application::class);
+
+        $app->shouldReceive('configurationIsCached')->andReturn(false);
+        $app->shouldReceive('runningInConsole')->andReturn(false);
+        $app->shouldReceive('environmentPath')->andReturn(__DIR__.'/../fixtures');
+        $app->shouldReceive('environmentFile')->andReturnUsing(function () use (&$file) {
+            return $file;
+        });
+        $app->shouldReceive('loadEnvironmentFrom')->andReturnUsing(function ($value) use (&$file) {
+            $file = $value;
+        });
+
+        (new LoadEnvironmentVariables)->bootstrap($app);
+        (new LoadEnvironmentVariables)->bootstrap($app);
+
+        $this->assertSame('custom', env('ENVIRONMENT_FILE'));
     }
 }

--- a/tests/Foundation/fixtures/.env.custom
+++ b/tests/Foundation/fixtures/.env.custom
@@ -1,0 +1,2 @@
+APP_ENV=specific
+ENVIRONMENT_FILE=custom

--- a/tests/Foundation/fixtures/.env.custom.specific
+++ b/tests/Foundation/fixtures/.env.custom.specific
@@ -1,0 +1,1 @@
+ENVIRONMENT_FILE=specific


### PR DESCRIPTION
`config:cache` boots a second application to build the fresh configuration, and that bootstrap runs `LoadEnvironmentVariables` again in the same process. By then the first bootstrap has already loaded `.env`, so `Env::get('APP_ENV')` returns whatever `.env` defines, and the fresh application switches to `.env.{APP_ENV}` and caches those values instead.

With an `.env` containing `APP_ENV=local` and an `.env.local` next to it:

```bash
php artisan config:clear
php artisan config:show app.key   # value from .env
php artisan config:cache
php artisan config:show app.key   # value from .env.local
php artisan config:cache
php artisan config:show app.key   # value from .env
```

The second `config:cache` gives a different result because the config is already cached at that point, so the outer bootstrap skips the environment file and nothing defines `APP_ENV` before the fresh application boots.

`.env.{APP_ENV}` is meant to be used when `APP_ENV` is set outside of the environment files, so that value is now resolved once per process, before any file has had the chance to define it. `route:cache` boots a fresh application the same way and was affected too.

Fixes #61042