### PR TITLE
Use expectExceptionMessageIs() instead of the deprecated expectExceptionMessage()

### DIFF
--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -664,7 +664,7 @@ class AuthAccessGateTest extends TestCase
     public function testAuthorizeThrowsUnauthorizedException()
     {
         $this->expectException(AuthorizationException::class);
-        $this->expectExceptionMessage('You are not an admin.');
+        $this->expectExceptionMessageIs('You are not an admin.');
         $this->expectExceptionCode(0);
 
         $gate = $this->getBasicGate();
@@ -677,7 +677,7 @@ class AuthAccessGateTest extends TestCase
     public function testAuthorizeThrowsUnauthorizedExceptionWithCustomStatusCode()
     {
         $this->expectException(AuthorizationException::class);
-        $this->expectExceptionMessage('Not allowed to view as it is not published.');
+        $this->expectExceptionMessageIs('Not allowed to view as it is not published.');
         $this->expectExceptionCode('unpublished');
 
         $gate = $this->getBasicGate();
@@ -690,7 +690,7 @@ class AuthAccessGateTest extends TestCase
     public function testAuthorizeWithPolicyThatReturnsDeniedResponseObjectThrowsException()
     {
         $this->expectException(AuthorizationException::class);
-        $this->expectExceptionMessage('Not allowed.');
+        $this->expectExceptionMessageIs('Not allowed.');
         $this->expectExceptionCode('some_code');
 
         $gate = $this->getBasicGate();
@@ -854,7 +854,7 @@ class AuthAccessGateTest extends TestCase
     public function testAllowIfThrowsExceptionWhenCallbackFalse()
     {
         $this->expectException(AuthorizationException::class);
-        $this->expectExceptionMessage('foo');
+        $this->expectExceptionMessageIs('foo');
         $this->expectExceptionCode('bar');
 
         $this->getBasicGate()->allowIf(function () {
@@ -865,7 +865,7 @@ class AuthAccessGateTest extends TestCase
     public function testAllowIfThrowsExceptionWhenResponseDenied()
     {
         $this->expectException(AuthorizationException::class);
-        $this->expectExceptionMessage('foo');
+        $this->expectExceptionMessageIs('foo');
         $this->expectExceptionCode('bar');
 
         $this->getBasicGate()->allowIf(Response::deny('foo', 'bar'));
@@ -874,7 +874,7 @@ class AuthAccessGateTest extends TestCase
     public function testAllowIfThrowsExceptionWhenCallbackResponseDenied()
     {
         $this->expectException(AuthorizationException::class);
-        $this->expectExceptionMessage('quz');
+        $this->expectExceptionMessageIs('quz');
         $this->expectExceptionCode('qux');
 
         $this->getBasicGate()->allowIf(function () {
@@ -885,7 +885,7 @@ class AuthAccessGateTest extends TestCase
     public function testAllowIfThrowsExceptionIfUnauthenticated()
     {
         $this->expectException(AuthorizationException::class);
-        $this->expectExceptionMessage('foo');
+        $this->expectExceptionMessageIs('foo');
         $this->expectExceptionCode('bar');
 
         $gate = $this->getBasicGate()->forUser(null);
@@ -898,7 +898,7 @@ class AuthAccessGateTest extends TestCase
     public function testAllowIfThrowsExceptionIfAuthUserExpectedWhenGuest()
     {
         $this->expectException(AuthorizationException::class);
-        $this->expectExceptionMessage('foo');
+        $this->expectExceptionMessageIs('foo');
         $this->expectExceptionCode('bar');
 
         $gate = $this->getBasicGate()->forUser(null);
@@ -992,7 +992,7 @@ class AuthAccessGateTest extends TestCase
     public function testDenyIfThrowsExceptionWhenCallbackTrue()
     {
         $this->expectException(AuthorizationException::class);
-        $this->expectExceptionMessage('foo');
+        $this->expectExceptionMessageIs('foo');
         $this->expectExceptionCode('bar');
 
         $this->getBasicGate()->denyIf(function () {
@@ -1003,7 +1003,7 @@ class AuthAccessGateTest extends TestCase
     public function testDenyIfThrowsExceptionWhenResponseDenied()
     {
         $this->expectException(AuthorizationException::class);
-        $this->expectExceptionMessage('foo');
+        $this->expectExceptionMessageIs('foo');
         $this->expectExceptionCode('bar');
 
         $this->getBasicGate()->denyIf(Response::deny('foo', 'bar'));
@@ -1012,7 +1012,7 @@ class AuthAccessGateTest extends TestCase
     public function testDenyIfThrowsExceptionWhenCallbackResponseDenied()
     {
         $this->expectException(AuthorizationException::class);
-        $this->expectExceptionMessage('quz');
+        $this->expectExceptionMessageIs('quz');
         $this->expectExceptionCode('qux');
 
         $this->getBasicGate()->denyIf(function () {
@@ -1023,7 +1023,7 @@ class AuthAccessGateTest extends TestCase
     public function testDenyIfThrowsExceptionIfUnauthenticated()
     {
         $this->expectException(AuthorizationException::class);
-        $this->expectExceptionMessage('foo');
+        $this->expectExceptionMessageIs('foo');
         $this->expectExceptionCode('bar');
 
         $gate = $this->getBasicGate()->forUser(null);
@@ -1036,7 +1036,7 @@ class AuthAccessGateTest extends TestCase
     public function testDenyIfThrowsExceptionIfAuthUserExpectedWhenGuest()
     {
         $this->expectException(AuthorizationException::class);
-        $this->expectExceptionMessage('foo');
+        $this->expectExceptionMessageIs('foo');
         $this->expectExceptionCode('bar');
 
         $gate = $this->getBasicGate()->forUser(null);

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -297,7 +297,7 @@ class AuthGuardTest extends TestCase
     public function testAuthenticateThrowsWhenUserIsNull()
     {
         $this->expectException(AuthenticationException::class);
-        $this->expectExceptionMessage('Unauthenticated.');
+        $this->expectExceptionMessageIs('Unauthenticated.');
 
         $guard = $this->getGuard();
         $guard->getSession()->shouldReceive('get')->once()->andReturn(null);

--- a/tests/Auth/AuthPasswordBrokerTest.php
+++ b/tests/Auth/AuthPasswordBrokerTest.php
@@ -37,7 +37,7 @@ class AuthPasswordBrokerTest extends TestCase
     public function testGetUserThrowsExceptionIfUserDoesntImplementCanResetPassword()
     {
         $this->expectException(UnexpectedValueException::class);
-        $this->expectExceptionMessage('User must implement CanResetPassword interface.');
+        $this->expectExceptionMessageIs('User must implement CanResetPassword interface.');
 
         $broker = $this->getBroker($mocks = $this->getMocks());
         $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with(['foo'])->andReturn('bar');

--- a/tests/Auth/AuthenticateMiddlewareTest.php
+++ b/tests/Auth/AuthenticateMiddlewareTest.php
@@ -63,7 +63,7 @@ class AuthenticateMiddlewareTest extends TestCase
     public function testDefaultUnauthenticatedThrows()
     {
         $this->expectException(AuthenticationException::class);
-        $this->expectExceptionMessage('Unauthenticated.');
+        $this->expectExceptionMessageIs('Unauthenticated.');
 
         $this->registerAuthDriver('default', false);
 
@@ -108,7 +108,7 @@ class AuthenticateMiddlewareTest extends TestCase
     public function testMultipleDriversUnauthenticatedThrows()
     {
         $this->expectException(AuthenticationException::class);
-        $this->expectExceptionMessage('Unauthenticated.');
+        $this->expectExceptionMessageIs('Unauthenticated.');
 
         $this->registerAuthDriver('default', false);
 

--- a/tests/Auth/AuthorizeMiddlewareTest.php
+++ b/tests/Auth/AuthorizeMiddlewareTest.php
@@ -66,7 +66,7 @@ class AuthorizeMiddlewareTest extends TestCase
     public function testSimpleAbilityUnauthorized()
     {
         $this->expectException(AuthorizationException::class);
-        $this->expectExceptionMessage('This action is unauthorized.');
+        $this->expectExceptionMessageIs('This action is unauthorized.');
 
         $this->gate()->define('view-dashboard', function ($user, $additional = null) {
             $this->assertNull($additional);
@@ -228,7 +228,7 @@ class AuthorizeMiddlewareTest extends TestCase
     public function testModelTypeUnauthorized()
     {
         $this->expectException(AuthorizationException::class);
-        $this->expectExceptionMessage('This action is unauthorized.');
+        $this->expectExceptionMessageIs('This action is unauthorized.');
 
         $this->gate()->define('create', function ($user, $model) {
             $this->assertSame('App\User', $model);
@@ -269,7 +269,7 @@ class AuthorizeMiddlewareTest extends TestCase
     public function testModelUnauthorized()
     {
         $this->expectException(AuthorizationException::class);
-        $this->expectExceptionMessage('This action is unauthorized.');
+        $this->expectExceptionMessageIs('This action is unauthorized.');
 
         $post = new stdClass;
 

--- a/tests/Cache/CacheManagerTest.php
+++ b/tests/Cache/CacheManagerTest.php
@@ -312,7 +312,7 @@ class CacheManagerTest extends TestCase
     public function testThrowExceptionWhenUnknownDriverIsUsed()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Driver [unknown_taxi_driver] is not supported.');
+        $this->expectExceptionMessageIs('Driver [unknown_taxi_driver] is not supported.');
 
         $userConfig = [
             'cache' => [
@@ -334,7 +334,7 @@ class CacheManagerTest extends TestCase
     public function testThrowExceptionWhenUnknownStoreIsUsed()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Cache store [alien_store] is not defined.');
+        $this->expectExceptionMessageIs('Cache store [alien_store] is not defined.');
 
         $userConfig = [
             'cache' => [

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -699,7 +699,7 @@ class CacheRepositoryTest extends TestCase
     public function testItThrowsExceptionWhenGettingNonStringAsString()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Cache value for key [foo] must be a string, integer given.');
+        $this->expectExceptionMessageIs('Cache value for key [foo] must be a string, integer given.');
 
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('get')->once()->with('foo')->andReturn(123);
@@ -730,7 +730,7 @@ class CacheRepositoryTest extends TestCase
     public function testItThrowsExceptionWhenGettingNonIntegerAsInteger()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Cache value for key [foo] must be an integer, string given.');
+        $this->expectExceptionMessageIs('Cache value for key [foo] must be an integer, string given.');
 
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('get')->once()->with('foo')->andReturn('bar');
@@ -740,7 +740,7 @@ class CacheRepositoryTest extends TestCase
     public function testItThrowsExceptionWhenGettingFloatStringAsInteger()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Cache value for key [foo] must be an integer, string given.');
+        $this->expectExceptionMessageIs('Cache value for key [foo] must be an integer, string given.');
 
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('get')->once()->with('foo')->andReturn('1.5');
@@ -771,7 +771,7 @@ class CacheRepositoryTest extends TestCase
     public function testItThrowsExceptionWhenGettingNonFloatAsFloat()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Cache value for key [foo] must be a float, string given.');
+        $this->expectExceptionMessageIs('Cache value for key [foo] must be a float, string given.');
 
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('get')->once()->with('foo')->andReturn('bar');
@@ -795,7 +795,7 @@ class CacheRepositoryTest extends TestCase
     public function testItThrowsExceptionWhenGettingNonBooleanAsBoolean()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Cache value for key [foo] must be a boolean, string given.');
+        $this->expectExceptionMessageIs('Cache value for key [foo] must be a boolean, string given.');
 
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('get')->once()->with('foo')->andReturn('bar');
@@ -819,7 +819,7 @@ class CacheRepositoryTest extends TestCase
     public function testItThrowsExceptionWhenGettingNonArrayAsArray()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Cache value for key [foo] must be an array, string given.');
+        $this->expectExceptionMessageIs('Cache value for key [foo] must be an array, string given.');
 
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('get')->once()->with('foo')->andReturn('bar');

--- a/tests/Cache/ConcurrencyLimiterTest.php
+++ b/tests/Cache/ConcurrencyLimiterTest.php
@@ -241,7 +241,7 @@ class ConcurrencyLimiterTest extends TestCase
         $this->assertNotInstanceOf(LockProvider::class, $store);
 
         $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage('This cache store does not support locks.');
+        $this->expectExceptionMessageIs('This cache store does not support locks.');
 
         $repository->funnel('test');
     }

--- a/tests/Config/RepositoryTest.php
+++ b/tests/Config/RepositoryTest.php
@@ -298,7 +298,7 @@ class RepositoryTest extends TestCase
     public function testItThrowsAnExceptionWhenTryingToGetNonStringValueAsString(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('#^Configuration value for key \[a\] must be a string, (.*) given.#');
+        $this->expectExceptionMessageIsMatches('#^Configuration value for key \[a\] must be a string, (.*) given.#');
 
         $this->repository->string('a');
     }
@@ -313,7 +313,7 @@ class RepositoryTest extends TestCase
     public function testItThrowsAnExceptionWhenTryingToGetNonArrayValueAsArray(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('#Configuration value for key \[a.b\] must be an array, (.*) given.#');
+        $this->expectExceptionMessageIsMatches('#Configuration value for key \[a.b\] must be an array, (.*) given.#');
 
         $this->repository->array('a.b');
     }
@@ -336,7 +336,7 @@ class RepositoryTest extends TestCase
     public function testItThrowsAnExceptionWhenTryingToGetNonBooleanValueAsBoolean(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('#Configuration value for key \[a.b\] must be a boolean, (.*) given.#');
+        $this->expectExceptionMessageIsMatches('#Configuration value for key \[a.b\] must be a boolean, (.*) given.#');
 
         $this->repository->boolean('a.b');
     }
@@ -351,7 +351,7 @@ class RepositoryTest extends TestCase
     public function testItThrowsAnExceptionWhenTryingToGetNonIntegerValueAsInteger(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('#Configuration value for key \[a.b\] must be an integer, (.*) given.#');
+        $this->expectExceptionMessageIsMatches('#Configuration value for key \[a.b\] must be an integer, (.*) given.#');
 
         $this->repository->integer('a.b');
     }
@@ -366,7 +366,7 @@ class RepositoryTest extends TestCase
     public function testItThrowsAnExceptionWhenTryingToGetNonFloatValueAsFloat(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('#^Configuration value for key \[a.b\] must be a float, (.*) given.#');
+        $this->expectExceptionMessageIsMatches('#^Configuration value for key \[a.b\] must be a float, (.*) given.#');
 
         $this->repository->float('a.b');
     }

--- a/tests/Console/ConsoleParserTest.php
+++ b/tests/Console/ConsoleParserTest.php
@@ -149,7 +149,7 @@ class ConsoleParserTest extends TestCase
     public function testNameIsSpacesException()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Unable to determine command name from signature.');
+        $this->expectExceptionMessageIs('Unable to determine command name from signature.');
 
         Parser::parse(" \t\n\r\x0B\f");
     }
@@ -157,7 +157,7 @@ class ConsoleParserTest extends TestCase
     public function testNameInEmptyException()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Unable to determine command name from signature.');
+        $this->expectExceptionMessageIs('Unable to determine command name from signature.');
 
         Parser::parse('');
     }

--- a/tests/Container/ContainerCallTest.php
+++ b/tests/Container/ContainerCallTest.php
@@ -14,7 +14,7 @@ class ContainerCallTest extends TestCase
     public function testCallWithAtSignBasedClassReferencesWithoutMethodThrowsException()
     {
         $this->expectException(Error::class);
-        $this->expectExceptionMessage('Call to undefined function ContainerTestCallStub()');
+        $this->expectExceptionMessageIs('Call to undefined function ContainerTestCallStub()');
 
         $container = new Container;
         $container->call('ContainerTestCallStub');
@@ -202,7 +202,7 @@ class ContainerCallTest extends TestCase
     public function testCallWithoutRequiredParamsThrowsException()
     {
         $this->expectException(BindingResolutionException::class);
-        $this->expectExceptionMessage('Unable to resolve dependency [Parameter #0 [ <required> $foo ]] in class Illuminate\Tests\Container\ContainerTestCallStub');
+        $this->expectExceptionMessageIs('Unable to resolve dependency [Parameter #0 [ <required> $foo ]] in class Illuminate\Tests\Container\ContainerTestCallStub');
 
         $container = new Container;
         $container->call(ContainerTestCallStub::class.'@unresolvable');
@@ -211,7 +211,7 @@ class ContainerCallTest extends TestCase
     public function testCallWithUnnamedParametersThrowsException()
     {
         $this->expectException(BindingResolutionException::class);
-        $this->expectExceptionMessage('Unable to resolve dependency [Parameter #0 [ <required> $foo ]] in class Illuminate\Tests\Container\ContainerTestCallStub');
+        $this->expectExceptionMessageIs('Unable to resolve dependency [Parameter #0 [ <required> $foo ]] in class Illuminate\Tests\Container\ContainerTestCallStub');
 
         $container = new Container;
         $container->call([new ContainerTestCallStub, 'unresolvable'], ['foo', 'bar']);
@@ -220,7 +220,7 @@ class ContainerCallTest extends TestCase
     public function testCallWithoutRequiredParamsOnClosureThrowsException()
     {
         $this->expectException(BindingResolutionException::class);
-        $this->expectExceptionMessage('Unable to resolve dependency [Parameter #0 [ <required> $foo ]] in class Illuminate\Tests\Container\ContainerCallTest');
+        $this->expectExceptionMessageIs('Unable to resolve dependency [Parameter #0 [ <required> $foo ]] in class Illuminate\Tests\Container\ContainerCallTest');
 
         $container = new Container;
         $container->call(function ($foo, $bar = 'default') {

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -439,7 +439,7 @@ class ContainerTest extends TestCase
     public function testInternalClassWithDefaultParameters()
     {
         $this->expectException(BindingResolutionException::class);
-        $this->expectExceptionMessage('Unresolvable dependency resolving [Parameter #0 [ <required> $first ]] in class Illuminate\Tests\Container\ContainerMixedPrimitiveStub');
+        $this->expectExceptionMessageIs('Unresolvable dependency resolving [Parameter #0 [ <required> $first ]] in class Illuminate\Tests\Container\ContainerMixedPrimitiveStub');
 
         $container = new Container;
         $container->make(ContainerMixedPrimitiveStub::class, []);
@@ -448,7 +448,7 @@ class ContainerTest extends TestCase
     public function testBindingResolutionExceptionMessage()
     {
         $this->expectException(BindingResolutionException::class);
-        $this->expectExceptionMessage('Target [Illuminate\Tests\Container\IContainerContractStub] is not instantiable.');
+        $this->expectExceptionMessageIs('Target [Illuminate\Tests\Container\IContainerContractStub] is not instantiable.');
 
         $container = new Container;
         $container->make(IContainerContractStub::class, []);
@@ -457,7 +457,7 @@ class ContainerTest extends TestCase
     public function testBindingResolutionExceptionMessageIncludesBuildStack()
     {
         $this->expectException(BindingResolutionException::class);
-        $this->expectExceptionMessage('Target [Illuminate\Tests\Container\IContainerContractStub] is not instantiable while building [Illuminate\Tests\Container\ContainerDependentStub].');
+        $this->expectExceptionMessageIs('Target [Illuminate\Tests\Container\IContainerContractStub] is not instantiable while building [Illuminate\Tests\Container\ContainerDependentStub].');
 
         $container = new Container;
         $container->make(ContainerDependentStub::class, []);
@@ -466,7 +466,7 @@ class ContainerTest extends TestCase
     public function testBindingResolutionExceptionMessageWhenClassDoesNotExist()
     {
         $this->expectException(BindingResolutionException::class);
-        $this->expectExceptionMessage('Target class [Foo\Bar\Baz\DummyClass] does not exist.');
+        $this->expectExceptionMessageIs('Target class [Foo\Bar\Baz\DummyClass] does not exist.');
 
         $container = new Container;
         $container->build('Foo\Bar\Baz\DummyClass');
@@ -575,7 +575,7 @@ class ContainerTest extends TestCase
     public function testItThrowsExceptionWhenAbstractIsSameAsAlias()
     {
         $this->expectException('LogicException');
-        $this->expectExceptionMessage('[name] is aliased to itself.');
+        $this->expectExceptionMessageIs('[name] is aliased to itself.');
 
         $container = new Container;
         $container->alias('name', 'name');

--- a/tests/Database/DatabaseConnectionFactoryTest.php
+++ b/tests/Database/DatabaseConnectionFactoryTest.php
@@ -342,7 +342,7 @@ class DatabaseConnectionFactoryTest extends TestCase
     public function testIfDriverIsntSetExceptionIsThrown()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('A driver must be specified.');
+        $this->expectExceptionMessageIs('A driver must be specified.');
 
         $factory = new ConnectionFactory($container = m::mock(Container::class));
         $factory->createConnector(['foo']);
@@ -351,7 +351,7 @@ class DatabaseConnectionFactoryTest extends TestCase
     public function testExceptionIsThrownOnUnsupportedDriver()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Unsupported driver [foo]');
+        $this->expectExceptionMessageIs('Unsupported driver [foo]');
 
         $factory = new ConnectionFactory($container = m::mock(Container::class));
         $container->shouldReceive('bound')->once()->andReturn(false);

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -361,7 +361,7 @@ class DatabaseConnectionTest extends TestCase
     public function testTransactionRetriesOnSerializationFailure()
     {
         $this->expectException(PDOException::class);
-        $this->expectExceptionMessage('Serialization failure');
+        $this->expectExceptionMessageIs('Serialization failure');
 
         $pdo = $this->getMockBuilder(DatabaseConnectionTestMockPDO::class)->onlyMethods(['inTransaction', 'beginTransaction', 'commit', 'rollBack'])->getMock();
         $mock = $this->getMockConnection([], $pdo);
@@ -376,7 +376,7 @@ class DatabaseConnectionTest extends TestCase
     public function testTransactionMethodRetriesOnDeadlock()
     {
         $this->expectException(QueryException::class);
-        $this->expectExceptionMessage('Deadlock found when trying to get lock (Connection: conn, SQL: )');
+        $this->expectExceptionMessageIs('Deadlock found when trying to get lock (Connection: conn, SQL: )');
 
         $pdo = $this->getMockBuilder(DatabaseConnectionTestMockPDO::class)->onlyMethods(['inTransaction', 'beginTransaction', 'commit', 'rollBack'])->getMock();
         $mock = $this->getMockConnection([], $pdo);
@@ -410,7 +410,7 @@ class DatabaseConnectionTest extends TestCase
     public function testOnLostConnectionPDOIsNotSwappedWithinATransaction()
     {
         $this->expectException(QueryException::class);
-        $this->expectExceptionMessage('server has gone away (Connection: , Host: , Port: , Database: , SQL: foo)');
+        $this->expectExceptionMessageIs('server has gone away (Connection: , Host: , Port: , Database: , SQL: foo)');
 
         $pdo = m::mock(PDO::class);
         $pdo->shouldReceive('beginTransaction')->once();
@@ -462,7 +462,7 @@ class DatabaseConnectionTest extends TestCase
     public function testRunMethodNeverRetriesIfWithinTransaction()
     {
         $this->expectException(QueryException::class);
-        $this->expectExceptionMessage('(Connection: conn, SQL: ) (Connection: , Host: , Port: , Database: , SQL: )');
+        $this->expectExceptionMessageIs('(Connection: conn, SQL: ) (Connection: , Host: , Port: , Database: , SQL: )');
 
         $method = (new ReflectionClass(Connection::class))->getMethod('run');
 
@@ -512,7 +512,7 @@ class DatabaseConnectionTest extends TestCase
     public function testBeforeExecutingHooksCanBeRegistered()
     {
         $this->expectException(Exception::class);
-        $this->expectExceptionMessage('The callback was fired');
+        $this->expectExceptionMessageIs('The callback was fired');
 
         $connection = $this->getMockConnection();
         $connection->beforeExecuting(function () {
@@ -524,7 +524,7 @@ class DatabaseConnectionTest extends TestCase
     public function testBeforeStartingTransactionHooksCanBeRegistered()
     {
         $this->expectException(Exception::class);
-        $this->expectExceptionMessage('The callback was fired');
+        $this->expectExceptionMessageIs('The callback was fired');
 
         $connection = $this->getMockConnection();
         $connection->beforeStartingTransaction(function () {

--- a/tests/Database/DatabaseEloquentAsBinaryCastTest.php
+++ b/tests/Database/DatabaseEloquentAsBinaryCastTest.php
@@ -22,7 +22,7 @@ class DatabaseEloquentAsBinaryCastTest extends TestCase
     public function testCastThrowsWhenFormatMissing()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The binary codec format is required.');
+        $this->expectExceptionMessageIs('The binary codec format is required.');
 
         $model = new AsBinaryTestModel;
         $model->setRawAttributes(['no_format' => 'value']);
@@ -32,7 +32,7 @@ class DatabaseEloquentAsBinaryCastTest extends TestCase
     public function testCastThrowsOnInvalidFormat()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Unsupported binary codec format [invalid]. Allowed formats are: uuid, ulid.');
+        $this->expectExceptionMessageIs('Unsupported binary codec format [invalid]. Allowed formats are: uuid, ulid.');
 
         $model = new AsBinaryTestModel;
         $model->setRawAttributes(['invalid_format' => 'value']);

--- a/tests/Database/DatabaseEloquentBelongsToManyExpressionTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyExpressionTest.php
@@ -62,7 +62,7 @@ class DatabaseEloquentBelongsToManyExpressionTest extends TestCase
             static fn () => throw new Exception('Default global scope.')
         );
 
-        $this->expectExceptionMessage('Default global scope.');
+        $this->expectExceptionMessageIs('Default global scope.');
         $post->tags()->get();
     }
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -799,7 +799,7 @@ class DatabaseEloquentBuilderTest extends TestCase
     public function testMissingStaticMacrosThrowsProperException()
     {
         $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage('Call to undefined method Illuminate\Database\Eloquent\Builder::missingMacro()');
+        $this->expectExceptionMessageIs('Call to undefined method Illuminate\Database\Eloquent\Builder::missingMacro()');
 
         Builder::missingMacro();
     }

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -256,7 +256,7 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertCount(2, $c->findOrFail([1, 2]));
 
         $this->expectException(ModelNotFoundException::class);
-        $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Database\TestEloquentCollectionModel] 3');
+        $this->expectExceptionMessageIs('No query results for model [Illuminate\Tests\Database\TestEloquentCollectionModel] 3');
 
         $c->findOrFail([1, 2, 3]);
     }
@@ -268,7 +268,7 @@ class DatabaseEloquentCollectionTest extends TestCase
         $c = new Collection([$model]);
 
         $this->expectException(ModelNotFoundException::class);
-        $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Database\TestEloquentCollectionModel] 2');
+        $this->expectExceptionMessageIs('No query results for model [Illuminate\Tests\Database\TestEloquentCollectionModel] 2');
 
         $c->findOrFail(2);
     }
@@ -278,7 +278,7 @@ class DatabaseEloquentCollectionTest extends TestCase
         $c = new Collection();
 
         $this->expectException(ModelNotFoundException::class);
-        $this->expectExceptionMessage('');
+        $this->expectExceptionMessageIs('');
 
         $c->findOrFail(1);
     }
@@ -654,7 +654,7 @@ class DatabaseEloquentCollectionTest extends TestCase
     public function testQueueableCollectionImplementationThrowsExceptionOnMultipleModelTypes()
     {
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('Queueing collections with multiple model types is not supported.');
+        $this->expectExceptionMessageIs('Queueing collections with multiple model types is not supported.');
 
         $c = new Collection([new TestEloquentCollectionModel, (object) ['id' => 'something']]);
         $c->getQueueableClass();

--- a/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
@@ -170,7 +170,7 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
     public function testFirstOrFailThrowsAnException()
     {
         $this->expectException(ModelNotFoundException::class);
-        $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Database\HasManyThroughTestPost].');
+        $this->expectExceptionMessageIs('No query results for model [Illuminate\Tests\Database\HasManyThroughTestPost].');
 
         HasManyThroughTestCountry::create(['id' => 1, 'name' => 'United States of America', 'shortname' => 'us'])
             ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us']);
@@ -181,7 +181,7 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
     public function testFindOrFailThrowsAnException()
     {
         $this->expectException(ModelNotFoundException::class);
-        $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Database\HasManyThroughTestPost] 1');
+        $this->expectExceptionMessageIs('No query results for model [Illuminate\Tests\Database\HasManyThroughTestPost] 1');
 
         HasManyThroughTestCountry::create(['id' => 1, 'name' => 'United States of America', 'shortname' => 'us'])
             ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us']);
@@ -192,7 +192,7 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
     public function testFindOrFailWithManyThrowsAnException()
     {
         $this->expectException(ModelNotFoundException::class);
-        $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Database\HasManyThroughTestPost] 1, 2');
+        $this->expectExceptionMessageIs('No query results for model [Illuminate\Tests\Database\HasManyThroughTestPost] 1, 2');
 
         HasManyThroughTestCountry::create(['id' => 1, 'name' => 'United States of America', 'shortname' => 'us'])
             ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us'])
@@ -204,7 +204,7 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
     public function testFindOrFailWithManyUsingCollectionThrowsAnException()
     {
         $this->expectException(ModelNotFoundException::class);
-        $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Database\HasManyThroughTestPost] 1, 2');
+        $this->expectExceptionMessageIs('No query results for model [Illuminate\Tests\Database\HasManyThroughTestPost] 1, 2');
 
         HasManyThroughTestCountry::create(['id' => 1, 'name' => 'United States of America', 'shortname' => 'us'])
             ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us'])

--- a/tests/Database/DatabaseEloquentHasOneOfManyTest.php
+++ b/tests/Database/DatabaseEloquentHasOneOfManyTest.php
@@ -153,7 +153,7 @@ class DatabaseEloquentHasOneOfManyTest extends TestCase
     public function testItFailsWhenUsingInvalidAggregate()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid aggregate [count] used within ofMany relation. Available aggregates: MIN, MAX');
+        $this->expectExceptionMessageIs('Invalid aggregate [count] used within ofMany relation. Available aggregates: MIN, MAX');
         $user = HasOneOfManyTestUser::make();
         $user->latest_login_with_invalid_aggregate();
     }

--- a/tests/Database/DatabaseEloquentHasOneThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasOneThroughIntegrationTest.php
@@ -131,7 +131,7 @@ class DatabaseEloquentHasOneThroughIntegrationTest extends TestCase
     public function testFirstOrFailThrowsAnException()
     {
         $this->expectException(ModelNotFoundException::class);
-        $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Database\HasOneThroughTestContract].');
+        $this->expectExceptionMessageIs('No query results for model [Illuminate\Tests\Database\HasOneThroughTestContract].');
 
         HasOneThroughTestPosition::create(['id' => 1, 'name' => 'President', 'shortname' => 'ps'])
             ->user()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'position_short' => 'ps']);

--- a/tests/Database/DatabaseEloquentHasOneThroughOfManyTest.php
+++ b/tests/Database/DatabaseEloquentHasOneThroughOfManyTest.php
@@ -156,7 +156,7 @@ class DatabaseEloquentHasOneThroughOfManyTest extends TestCase
     public function testItFailsWhenUsingInvalidAggregate(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid aggregate [count] used within ofMany relation. Available aggregates: MIN, MAX');
+        $this->expectExceptionMessageIs('Invalid aggregate [count] used within ofMany relation. Available aggregates: MIN, MAX');
         $user = HasOneThroughOfManyTestUser::make();
         $user->latest_login_with_invalid_aggregate();
     }

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -1099,7 +1099,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
     public function testFindOrFailWithSingleIdThrowsModelNotFoundException()
     {
         $this->expectException(ModelNotFoundException::class);
-        $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Database\EloquentTestUser] 1');
+        $this->expectExceptionMessageIs('No query results for model [Illuminate\Tests\Database\EloquentTestUser] 1');
         $this->expectExceptionObject(
             (new ModelNotFoundException())->setModel(EloquentTestUser::class, [1]),
         );
@@ -1110,7 +1110,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
     public function testFindOrFailWithMultipleIdsThrowsModelNotFoundException()
     {
         $this->expectException(ModelNotFoundException::class);
-        $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Database\EloquentTestUser] 2, 3');
+        $this->expectExceptionMessageIs('No query results for model [Illuminate\Tests\Database\EloquentTestUser] 2, 3');
         $this->expectExceptionObject(
             (new ModelNotFoundException())->setModel(EloquentTestUser::class, [2, 3]),
         );
@@ -1122,7 +1122,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
     public function testFindOrFailWithMultipleIdsUsingCollectionThrowsModelNotFoundException()
     {
         $this->expectException(ModelNotFoundException::class);
-        $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Database\EloquentTestUser] 2, 3');
+        $this->expectExceptionMessageIs('No query results for model [Illuminate\Tests\Database\EloquentTestUser] 2, 3');
         $this->expectExceptionObject(
             (new ModelNotFoundException())->setModel(EloquentTestUser::class, [2, 3]),
         );
@@ -1795,7 +1795,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
     public function testSaveOrFailWithDuplicatedEntry()
     {
         $this->expectException(QueryException::class);
-        $this->expectExceptionMessage('SQLSTATE[23000]:');
+        $this->expectExceptionMessageIs('SQLSTATE[23000]:');
 
         $date = '1970-01-01';
         EloquentTestPost::create([

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1908,7 +1908,7 @@ class DatabaseEloquentModelTest extends TestCase
     public function testGlobalGuarded()
     {
         $this->expectException(MassAssignmentException::class);
-        $this->expectExceptionMessage('name');
+        $this->expectExceptionMessageIs('name');
 
         $model = new EloquentModelStub;
         $model->guard(['*']);
@@ -2484,7 +2484,7 @@ class DatabaseEloquentModelTest extends TestCase
     public function testGetModelAttributeMethodThrowsExceptionIfNotRelation()
     {
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('Illuminate\Tests\Database\EloquentModelStub::incorrectRelationStub must return a relationship instance.');
+        $this->expectExceptionMessageIs('Illuminate\Tests\Database\EloquentModelStub::incorrectRelationStub must return a relationship instance.');
 
         $model = new EloquentModelStub;
         $model->incorrectRelationStub;
@@ -3128,7 +3128,7 @@ class DatabaseEloquentModelTest extends TestCase
     public function testModelAttributeCastingFailsOnUnencodableData()
     {
         $this->expectException(JsonEncodingException::class);
-        $this->expectExceptionMessage('Unable to encode attribute [objectAttribute] for model [Illuminate\Tests\Database\EloquentModelCastingStub] to JSON: Malformed UTF-8 characters, possibly incorrectly encoded.');
+        $this->expectExceptionMessageIs('Unable to encode attribute [objectAttribute] for model [Illuminate\Tests\Database\EloquentModelCastingStub] to JSON: Malformed UTF-8 characters, possibly incorrectly encoded.');
 
         $model = new EloquentModelCastingStub;
         $model->objectAttribute = ['foo' => "b\xF8r"];
@@ -3142,7 +3142,7 @@ class DatabaseEloquentModelTest extends TestCase
     public function testModelJsonCastingFailsOnUnencodableData()
     {
         $this->expectException(JsonEncodingException::class);
-        $this->expectExceptionMessage('Unable to encode attribute [jsonAttribute] for model [Illuminate\Tests\Database\EloquentModelCastingStub] to JSON: Malformed UTF-8 characters, possibly incorrectly encoded.');
+        $this->expectExceptionMessageIs('Unable to encode attribute [jsonAttribute] for model [Illuminate\Tests\Database\EloquentModelCastingStub] to JSON: Malformed UTF-8 characters, possibly incorrectly encoded.');
 
         $model = new EloquentModelCastingStub;
         $model->jsonAttribute = ['foo' => "b\xF8r"];
@@ -3153,7 +3153,7 @@ class DatabaseEloquentModelTest extends TestCase
     public function testModelAttributeCastingFailsOnUnencodableDataWithUnicode()
     {
         $this->expectException(JsonEncodingException::class);
-        $this->expectExceptionMessage('Unable to encode attribute [jsonAttributeWithUnicode] for model [Illuminate\Tests\Database\EloquentModelCastingStub] to JSON: Malformed UTF-8 characters, possibly incorrectly encoded.');
+        $this->expectExceptionMessageIs('Unable to encode attribute [jsonAttributeWithUnicode] for model [Illuminate\Tests\Database\EloquentModelCastingStub] to JSON: Malformed UTF-8 characters, possibly incorrectly encoded.');
 
         $model = new EloquentModelCastingStub;
         $model->jsonAttributeWithUnicode = ['foo' => "b\xF8r"];
@@ -3746,7 +3746,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model = new EloquentModelCastingStub;
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The cast object for the something attribute must implement Stringable.');
+        $this->expectExceptionMessageIs('The cast object for the something attribute must implement Stringable.');
 
         $model->mergeCasts([
             'something' => (object) [],
@@ -3906,7 +3906,7 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testNestedModelBootingIsDisallowed()
     {
-        $this->expectExceptionMessageMatches('/The \[(.+)] method may not be called on model \[(.+)\] while it is being booted\./');
+        $this->expectExceptionMessageIsMatches('/The \[(.+)] method may not be called on model \[(.+)\] while it is being booted\./');
 
         $model = new class extends Model
         {

--- a/tests/Database/DatabaseEloquentResourceCollectionTest.php
+++ b/tests/Database/DatabaseEloquentResourceCollectionTest.php
@@ -29,7 +29,7 @@ class DatabaseEloquentResourceCollectionTest extends TestCase
     public function testItThrowsExceptionWhenResourceCannotBeFound()
     {
         $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('Failed to find resource class for model [Illuminate\Tests\Database\Fixtures\Models\EloquentResourceCollectionTestModel].');
+        $this->expectExceptionMessageIs('Failed to find resource class for model [Illuminate\Tests\Database\Fixtures\Models\EloquentResourceCollectionTestModel].');
 
         $collection = new Collection([
             new EloquentResourceCollectionTestModel(),

--- a/tests/Database/DatabaseEloquentResourceModelTest.php
+++ b/tests/Database/DatabaseEloquentResourceModelTest.php
@@ -22,7 +22,7 @@ class DatabaseEloquentResourceModelTest extends TestCase
     public function testItThrowsExceptionWhenResourceCannotBeFound()
     {
         $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('Failed to find resource class for model [Illuminate\Tests\Database\Fixtures\Models\EloquentResourceTestResourceModel].');
+        $this->expectExceptionMessageIs('Failed to find resource class for model [Illuminate\Tests\Database\Fixtures\Models\EloquentResourceTestResourceModel].');
 
         $model = new EloquentResourceTestResourceModel();
         $model->toResource();

--- a/tests/Database/DatabaseMigrationCreatorTest.php
+++ b/tests/Database/DatabaseMigrationCreatorTest.php
@@ -84,7 +84,7 @@ class DatabaseMigrationCreatorTest extends TestCase
     public function testTableUpdateMigrationWontCreateDuplicateClass()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('A MigrationCreatorFakeMigration class already exists.');
+        $this->expectExceptionMessageIs('A MigrationCreatorFakeMigration class already exists.');
 
         $creator = $this->getCreator();
 

--- a/tests/Database/DatabaseMySqlSchemaStateTest.php
+++ b/tests/Database/DatabaseMySqlSchemaStateTest.php
@@ -157,7 +157,7 @@ class DatabaseMySqlSchemaStateTest extends TestCase
         $schemaState->method('makeProcess')->willReturn($mockProcess);
 
         $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Dump execution exceeded maximum depth of 30.');
+        $this->expectExceptionMessageIs('Dump execution exceeded maximum depth of 30.');
 
         // test executeDumpProcess
         $method = new ReflectionMethod(get_class($schemaState), 'executeDumpProcess');

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -3360,7 +3360,7 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testIncrementManyArgumentValidation1()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Non-numeric value passed as increment amount for column: \'col\'.');
+        $this->expectExceptionMessageIs('Non-numeric value passed as increment amount for column: \'col\'.');
         $builder = $this->getBuilder();
         $builder->from('users')->incrementEach(['col' => 'a']);
     }
@@ -3368,7 +3368,7 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testIncrementManyArgumentValidation2()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Non-associative array passed to incrementEach method.');
+        $this->expectExceptionMessageIs('Non-associative array passed to incrementEach method.');
         $builder = $this->getBuilder();
         $builder->from('users')->incrementEach([11 => 11]);
     }
@@ -4036,7 +4036,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->getProcessor()->shouldReceive('processSelect')->once()->with($builder, [])->andReturn([]);
 
         $this->expectException(RecordNotFoundException::class);
-        $this->expectExceptionMessage('No record found for the given query.');
+        $this->expectExceptionMessageIs('No record found for the given query.');
 
         $builder->from('users')->where('id', '=', 1)->firstOrFail();
     }
@@ -4340,7 +4340,7 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testInsertOrIgnoreMethod()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('does not support');
+        $this->expectExceptionMessageIs('does not support');
         $builder = $this->getBuilder();
         $builder->from('users')->insertOrIgnore(['email' => 'foo']);
     }
@@ -4372,7 +4372,7 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testSqlServerInsertOrIgnoreMethod()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('does not support');
+        $this->expectExceptionMessageIs('does not support');
         $builder = $this->getSqlServerBuilder();
         $builder->from('users')->insertOrIgnore(['email' => 'foo']);
     }
@@ -4380,7 +4380,7 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testInsertOrIgnoreReturningMethod()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('does not support');
+        $this->expectExceptionMessageIs('does not support');
         $builder = $this->getBuilder();
         $builder->from('users')->insertOrIgnoreReturning(['email' => 'foo']);
     }
@@ -4396,7 +4396,7 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testMySqlInsertOrIgnoreReturningMethod()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('does not support');
+        $this->expectExceptionMessageIs('does not support');
         $builder = $this->getMySqlBuilder();
         $builder->from('users')->insertOrIgnoreReturning(['email' => 'foo']);
     }
@@ -4514,7 +4514,7 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testSqlServerInsertOrIgnoreReturningMethod()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('does not support');
+        $this->expectExceptionMessageIs('does not support');
         $builder = $this->getSqlServerBuilder();
         $builder->from('users')->insertOrIgnoreReturning(['email' => 'foo']);
     }
@@ -4522,7 +4522,7 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testInsertOrIgnoreReturningWithEmptyUniqueByArray()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The unique columns must not be empty.');
+        $this->expectExceptionMessageIs('The unique columns must not be empty.');
         $builder = $this->getPostgresBuilder();
         $builder->from('users')->insertOrIgnoreReturning(['email' => 'foo'], ['*'], []);
     }
@@ -4530,7 +4530,7 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testInsertOrIgnoreReturningWithEmptyUniqueByString()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The unique columns must not be empty.');
+        $this->expectExceptionMessageIs('The unique columns must not be empty.');
         $builder = $this->getPostgresBuilder();
         $builder->from('users')->insertOrIgnoreReturning(['email' => 'foo'], ['*'], '');
     }
@@ -4538,7 +4538,7 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testInsertOrIgnoreReturningWithEmptyReturning()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The returning columns must not be empty.');
+        $this->expectExceptionMessageIs('The returning columns must not be empty.');
         $builder = $this->getPostgresBuilder();
         $builder->from('users')->insertOrIgnoreReturning(['email' => 'foo'], []);
     }
@@ -4559,7 +4559,7 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testInsertOrIgnoreUsingMethod()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('does not support');
+        $this->expectExceptionMessageIs('does not support');
         $builder = $this->getBuilder();
         $builder->from('users')->insertOrIgnoreUsing(['email' => 'foo'], 'bar');
     }
@@ -4567,7 +4567,7 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testSqlServerInsertOrIgnoreUsingMethod()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('does not support');
+        $this->expectExceptionMessageIs('does not support');
         $builder = $this->getSqlServerBuilder();
         $builder->from('users')->insertOrIgnoreUsing(['email' => 'foo'], 'bar');
     }
@@ -4818,7 +4818,7 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testUpsertMethodWithEmptyUniqueByArray()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The unique columns must not be empty.');
+        $this->expectExceptionMessageIs('The unique columns must not be empty.');
         $builder = $this->getPostgresBuilder();
         $builder->from('users')->upsert([['email' => 'foo', 'name' => 'bar']], []);
     }
@@ -4826,7 +4826,7 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testUpsertMethodWithEmptyUniqueByString()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The unique columns must not be empty.');
+        $this->expectExceptionMessageIs('The unique columns must not be empty.');
         $builder = $this->getPostgresBuilder();
         $builder->from('users')->upsert([['email' => 'foo', 'name' => 'bar']], '');
     }
@@ -5847,7 +5847,7 @@ SQL;
     public function testPrepareValueAndOperatorExpectException()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Illegal operator and value combination.');
+        $this->expectExceptionMessageIs('Illegal operator and value combination.');
 
         $builder = $this->getBuilder();
         $builder->prepareValueAndOperator(null, 'like');
@@ -7224,7 +7224,7 @@ SQL;
     public function testWhereRowValuesArityMismatch()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The number of columns must match the number of values');
+        $this->expectExceptionMessageIs('The number of columns must match the number of values');
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('orders')->whereRowValues(['last_update'], '<', [1, 2]);

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -134,7 +134,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
     public function testDropSpatialIndex()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('The database driver in use does not support spatial indexes.');
+        $this->expectExceptionMessageIs('The database driver in use does not support spatial indexes.');
 
         $blueprint = new Blueprint($this->getConnection(), 'geo');
         $blueprint->dropSpatialIndex(['coordinates']);
@@ -250,7 +250,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
     public function testAddingSpatialIndex()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('The database driver in use does not support spatial indexes.');
+        $this->expectExceptionMessageIs('The database driver in use does not support spatial indexes.');
 
         $blueprint = new Blueprint($this->getConnection(), 'geo');
         $blueprint->spatialIndex('coordinates');
@@ -260,7 +260,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
     public function testAddingFluentSpatialIndex()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('The database driver in use does not support spatial indexes.');
+        $this->expectExceptionMessageIs('The database driver in use does not support spatial indexes.');
 
         $blueprint = new Blueprint($this->getConnection(), 'geo');
         $blueprint->geometry('coordinates')->spatialIndex();

--- a/tests/Database/EloquentModelCustomCastingTest.php
+++ b/tests/Database/EloquentModelCustomCastingTest.php
@@ -128,7 +128,7 @@ class EloquentModelCustomCastingTest extends TestCase
         ]);
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The given value is not an Address instance.');
+        $this->expectExceptionMessageIs('The given value is not an Address instance.');
         $model->address = 'single_string';
 
         // Ensure model values remain unchanged
@@ -147,7 +147,7 @@ class EloquentModelCustomCastingTest extends TestCase
         ]);
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The given value is not an Address instance.');
+        $this->expectExceptionMessageIs('The given value is not an Address instance.');
         $model->address = null;
 
         // Ensure model values remain unchanged

--- a/tests/Database/PruneCommandTest.php
+++ b/tests/Database/PruneCommandTest.php
@@ -40,7 +40,7 @@ class PruneCommandTest extends TestCase
     public function testPrunableModelAndExceptWithEachOther(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('The --model and --except options cannot be combined.');
+        $this->expectExceptionMessageIs('The --model and --except options cannot be combined.');
 
         $this->artisan([
             '--model' => Pruning\Models\PrunableTestModelWithPrunableRecords::class,

--- a/tests/Encryption/EncrypterTest.php
+++ b/tests/Encryption/EncrypterTest.php
@@ -134,7 +134,7 @@ class EncrypterTest extends TestCase
         $data = json_decode(base64_decode($encrypted));
 
         $this->expectException(DecryptException::class);
-        $this->expectExceptionMessage('Could not decrypt the data.');
+        $this->expectExceptionMessageIs('Could not decrypt the data.');
 
         $data->tag = substr($data->tag, 0, 4);
         $encrypted = base64_encode(json_encode($data));
@@ -148,7 +148,7 @@ class EncrypterTest extends TestCase
         $data = json_decode(base64_decode($encrypted));
 
         $this->expectException(DecryptException::class);
-        $this->expectExceptionMessage('Could not decrypt the data.');
+        $this->expectExceptionMessageIs('Could not decrypt the data.');
 
         $data->tag[0] = $data->tag[0] === 'A' ? 'B' : 'A';
         $encrypted = base64_encode(json_encode($data));
@@ -168,7 +168,7 @@ class EncrypterTest extends TestCase
     public function testDoNoAllowLongerKey()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unsupported cipher or incorrect key length. Supported ciphers are: aes-128-cbc, aes-256-cbc, aes-128-gcm, aes-256-gcm.');
+        $this->expectExceptionMessageIs('Unsupported cipher or incorrect key length. Supported ciphers are: aes-128-cbc, aes-256-cbc, aes-128-gcm, aes-256-gcm.');
 
         new Encrypter(str_repeat('z', 32));
     }
@@ -176,7 +176,7 @@ class EncrypterTest extends TestCase
     public function testWithBadKeyLength()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unsupported cipher or incorrect key length. Supported ciphers are: aes-128-cbc, aes-256-cbc, aes-128-gcm, aes-256-gcm.');
+        $this->expectExceptionMessageIs('Unsupported cipher or incorrect key length. Supported ciphers are: aes-128-cbc, aes-256-cbc, aes-128-gcm, aes-256-gcm.');
 
         new Encrypter(str_repeat('a', 5));
     }
@@ -184,7 +184,7 @@ class EncrypterTest extends TestCase
     public function testWithBadKeyLengthAlternativeCipher()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unsupported cipher or incorrect key length. Supported ciphers are: aes-128-cbc, aes-256-cbc, aes-128-gcm, aes-256-gcm.');
+        $this->expectExceptionMessageIs('Unsupported cipher or incorrect key length. Supported ciphers are: aes-128-cbc, aes-256-cbc, aes-128-gcm, aes-256-gcm.');
 
         new Encrypter(str_repeat('a', 16), 'AES-256-GCM');
     }
@@ -192,7 +192,7 @@ class EncrypterTest extends TestCase
     public function testWithUnsupportedCipher()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unsupported cipher or incorrect key length. Supported ciphers are: aes-128-cbc, aes-256-cbc, aes-128-gcm, aes-256-gcm.');
+        $this->expectExceptionMessageIs('Unsupported cipher or incorrect key length. Supported ciphers are: aes-128-cbc, aes-256-cbc, aes-128-gcm, aes-256-gcm.');
 
         new Encrypter(str_repeat('c', 16), 'AES-256-CFB8');
     }
@@ -200,7 +200,7 @@ class EncrypterTest extends TestCase
     public function testExceptionThrownWhenPayloadIsInvalid()
     {
         $this->expectException(DecryptException::class);
-        $this->expectExceptionMessage('The payload is invalid.');
+        $this->expectExceptionMessageIs('The payload is invalid.');
 
         $e = new Encrypter(str_repeat('a', 16));
         $payload = $e->encrypt('foo');
@@ -211,7 +211,7 @@ class EncrypterTest extends TestCase
     public function testDecryptionExceptionIsThrownWhenUnexpectedTagIsAdded()
     {
         $this->expectException(DecryptException::class);
-        $this->expectExceptionMessage('Unable to use tag because the cipher algorithm does not support AEAD.');
+        $this->expectExceptionMessageIs('Unable to use tag because the cipher algorithm does not support AEAD.');
 
         $e = new Encrypter(str_repeat('a', 16));
         $payload = $e->encrypt('foo');
@@ -223,7 +223,7 @@ class EncrypterTest extends TestCase
     public function testExceptionThrownWithDifferentKey()
     {
         $this->expectException(DecryptException::class);
-        $this->expectExceptionMessage('The MAC is invalid.');
+        $this->expectExceptionMessageIs('The MAC is invalid.');
 
         $a = new Encrypter(str_repeat('a', 16));
         $b = new Encrypter(str_repeat('b', 16));
@@ -233,7 +233,7 @@ class EncrypterTest extends TestCase
     public function testExceptionThrownWhenIvIsTooLong()
     {
         $this->expectException(DecryptException::class);
-        $this->expectExceptionMessage('The payload is invalid.');
+        $this->expectExceptionMessageIs('The payload is invalid.');
 
         $e = new Encrypter(str_repeat('a', 16));
         $payload = $e->encrypt('foo');
@@ -275,7 +275,7 @@ class EncrypterTest extends TestCase
     public function testTamperedPayloadWillGetRejected($payload)
     {
         $this->expectException(DecryptException::class);
-        $this->expectExceptionMessage('The payload is invalid.');
+        $this->expectExceptionMessageIs('The payload is invalid.');
 
         $enc = new Encrypter(str_repeat('x', 16));
         $enc->decrypt(base64_encode(json_encode($payload)));

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -711,7 +711,7 @@ class EventsDispatcherTest extends TestCase
         $d->listen('myEvent', TestListenerLean::class);
 
         $this->expectException(Error::class);
-        $this->expectExceptionMessage('Call to undefined method '.TestListenerLean::class.'::__invoke()');
+        $this->expectExceptionMessageIs('Call to undefined method '.TestListenerLean::class.'::__invoke()');
 
         $d->dispatch('myEvent', 'somePayload');
 

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -864,7 +864,7 @@ class FilesystemAdapterTest extends TestCase
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
 
         $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('Disk is not empty.');
+        $this->expectExceptionMessageIs('Disk is not empty.');
 
         $filesystemAdapter->assertEmpty();
     }

--- a/tests/Filesystem/FilesystemManagerTest.php
+++ b/tests/Filesystem/FilesystemManagerTest.php
@@ -17,7 +17,7 @@ class FilesystemManagerTest extends TestCase
     public function testExceptionThrownOnUnsupportedDriver()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Disk [local] does not have a configured driver.');
+        $this->expectExceptionMessageIs('Disk [local] does not have a configured driver.');
 
         $filesystem = new FilesystemManager(tap(new Application, function ($app) {
             $app['config'] = ['filesystems.disks.local' => null];

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -78,7 +78,7 @@ class FilesystemTest extends TestCase
     public function testLinesThrowsExceptionNonexisitingFile()
     {
         $this->expectException(FileNotFoundException::class);
-        $this->expectExceptionMessage('File does not exist at path '.__DIR__.'/unknown-file.txt.');
+        $this->expectExceptionMessageIs('File does not exist at path '.__DIR__.'/unknown-file.txt.');
 
         (new Filesystem)->lines(__DIR__.'/unknown-file.txt');
     }
@@ -331,7 +331,7 @@ class FilesystemTest extends TestCase
     public function testGetThrowsExceptionNonexisitingFile()
     {
         $this->expectException(FileNotFoundException::class);
-        $this->expectExceptionMessage('File does not exist at path '.self::$tempDir.'/unknown-file.txt.');
+        $this->expectExceptionMessageIs('File does not exist at path '.self::$tempDir.'/unknown-file.txt.');
 
         (new Filesystem)->get(self::$tempDir.'/unknown-file.txt');
     }
@@ -346,7 +346,7 @@ class FilesystemTest extends TestCase
     public function testGetRequireThrowsExceptionNonExistingFile()
     {
         $this->expectException(FileNotFoundException::class);
-        $this->expectExceptionMessage('File does not exist at path '.self::$tempDir.'/unknown-file.txt.');
+        $this->expectExceptionMessageIs('File does not exist at path '.self::$tempDir.'/unknown-file.txt.');
 
         (new Filesystem)->getRequire(self::$tempDir.'/unknown-file.txt');
     }
@@ -589,7 +589,7 @@ class FilesystemTest extends TestCase
     public function testRequireOnceThrowsExceptionNonexisitingFile()
     {
         $this->expectException(FileNotFoundException::class);
-        $this->expectExceptionMessage('File does not exist at path '.__DIR__.'/unknown-file.txt.');
+        $this->expectExceptionMessageIs('File does not exist at path '.__DIR__.'/unknown-file.txt.');
 
         (new Filesystem)->requireOnce(__DIR__.'/unknown-file.txt');
     }

--- a/tests/Foundation/Bootstrap/HandleExceptionsTest.php
+++ b/tests/Foundation/Bootstrap/HandleExceptionsTest.php
@@ -197,7 +197,7 @@ class HandleExceptionsTest extends TestCase
         $logger->shouldNotReceive('warning');
 
         $this->expectException(ErrorException::class);
-        $this->expectExceptionMessage('Something went wrong');
+        $this->expectExceptionMessageIs('Something went wrong');
 
         $this->handleExceptions()->handleError(
             E_ERROR,

--- a/tests/Foundation/Cloud/QueueTest.php
+++ b/tests/Foundation/Cloud/QueueTest.php
@@ -204,7 +204,7 @@ class QueueTest extends TestCase
         Cloud::bootManagedQueues($this->app);
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The [cloud] queue connection has not been configured.');
+        $this->expectExceptionMessageIs('The [cloud] queue connection has not been configured.');
         $this->app['queue']->connection('cloud');
     }
 
@@ -1477,7 +1477,7 @@ class QueueTest extends TestCase
         $queue = $this->app['queue']->connection('cloud');
 
         $this->expectException(ManagedQueueNotFoundException::class);
-        $this->expectExceptionMessage('Managed queue [missing-queue] does not exist.');
+        $this->expectExceptionMessageIs('Managed queue [missing-queue] does not exist.');
 
         $queue->push(new FakeJob, queue: 'missing-queue');
     }

--- a/tests/Foundation/Console/ServeCommandLogParserTest.php
+++ b/tests/Foundation/Console/ServeCommandLogParserTest.php
@@ -33,7 +33,7 @@ class ServeCommandLogParserTest extends TestCase
         $line = '[Mon Nov 19 10:30:45 2024] Info';
 
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Failed to extract the request port. Ensure the log line contains a valid port: [Mon Nov 19 10:30:45 2024] Info');
+        $this->expectExceptionMessageIs('Failed to extract the request port. Ensure the log line contains a valid port: [Mon Nov 19 10:30:45 2024] Info');
 
         ServeCommand::getRequestPortFromLine($line);
     }
@@ -43,7 +43,7 @@ class ServeCommandLogParserTest extends TestCase
         $line = '[Mon Nov 19 10:30:45 2024] :abcd Info';
 
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Failed to extract the request port. Ensure the log line contains a valid port: [Mon Nov 19 10:30:45 2024] :abcd Info');
+        $this->expectExceptionMessageIs('Failed to extract the request port. Ensure the log line contains a valid port: [Mon Nov 19 10:30:45 2024] :abcd Info');
 
         ServeCommand::getRequestPortFromLine($line);
     }
@@ -51,7 +51,7 @@ class ServeCommandLogParserTest extends TestCase
     public function testExtractRequestPortWithEmptyLogLine()
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Failed to extract the request port. Ensure the log line contains a valid port: ');
+        $this->expectExceptionMessageIs('Failed to extract the request port. Ensure the log line contains a valid port: ');
 
         ServeCommand::getRequestPortFromLine('');
     }
@@ -59,7 +59,7 @@ class ServeCommandLogParserTest extends TestCase
     public function testExtractRequestPortWithWhitespaceOnlyLine()
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Failed to extract the request port. Ensure the log line contains a valid port: ');
+        $this->expectExceptionMessageIs('Failed to extract the request port. Ensure the log line contains a valid port: ');
 
         ServeCommand::getRequestPortFromLine('   ');
     }
@@ -69,7 +69,7 @@ class ServeCommandLogParserTest extends TestCase
         $line = 'Random log entry without port';
 
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Failed to extract the request port. Ensure the log line contains a valid port: Random log entry without port');
+        $this->expectExceptionMessageIs('Failed to extract the request port. Ensure the log line contains a valid port: Random log entry without port');
 
         ServeCommand::getRequestPortFromLine($line);
     }

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -583,7 +583,7 @@ class FoundationApplicationTest extends TestCase
     public function testAbortThrowsNotFoundHttpException()
     {
         $this->expectException(NotFoundHttpException::class);
-        $this->expectExceptionMessage('Page was not found');
+        $this->expectExceptionMessageIs('Page was not found');
 
         $app = new Application();
         $app->abort(404, 'Page was not found');
@@ -592,7 +592,7 @@ class FoundationApplicationTest extends TestCase
     public function testAbortThrowsHttpException()
     {
         $this->expectException(HttpException::class);
-        $this->expectExceptionMessage('Request is bad');
+        $this->expectExceptionMessageIs('Request is bad');
 
         $app = new Application();
         $app->abort(400, 'Request is bad');

--- a/tests/Foundation/FoundationAuthorizesRequestsTraitTest.php
+++ b/tests/Foundation/FoundationAuthorizesRequestsTraitTest.php
@@ -56,7 +56,7 @@ class FoundationAuthorizesRequestsTraitTest extends TestCase
     public function testExceptionIsThrownIfGateCheckFails()
     {
         $this->expectException(AuthorizationException::class);
-        $this->expectExceptionMessage('This action is unauthorized.');
+        $this->expectExceptionMessageIs('This action is unauthorized.');
 
         $gate = $this->getBasicGate();
 

--- a/tests/Foundation/FoundationDocsCommandTest.php
+++ b/tests/Foundation/FoundationDocsCommandTest.php
@@ -175,7 +175,7 @@ class FoundationDocsCommandTest extends TestCase
         putenv('ARTISAN_DOCS_ASK_STRATEGY='.__DIR__.'/fixtures/exception-throwing-strategy.php');
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('strategy failed');
+        $this->expectExceptionMessageIs('strategy failed');
 
         $this->artisan('docs');
     }
@@ -187,13 +187,13 @@ class FoundationDocsCommandTest extends TestCase
         $this->expectException(ProcessFailedException::class);
 
         if (PHP_OS_FAMILY === 'Windows') {
-            $this->expectExceptionMessage('The command "expected-command" failed.
+            $this->expectExceptionMessageIs('The command "expected-command" failed.
 
 Exit Code: 1(General error)
 
 Working directory: expected-working-directory');
         } else {
-            $this->expectExceptionMessage('The command "\'expected-command\'" failed.
+            $this->expectExceptionMessageIs('The command "\'expected-command\'" failed.
 
 Exit Code: 1(General error)
 

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -521,7 +521,7 @@ class FoundationExceptionsHandlerTest extends TestCase
         // the error view as the debug handler should handle this gracefully.
 
         $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('Rendering this view throws an exception');
+        $this->expectExceptionMessageIs('Rendering this view throws an exception');
         $this->executeScenarioWhereErrorViewThrowsWhileRenderingAndDebugIs(true);
     }
 

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -114,7 +114,7 @@ class FoundationFormRequestTest extends TestCase
     public function testValidateMethodThrowsWhenAuthorizationFails()
     {
         $this->expectException(AuthorizationException::class);
-        $this->expectExceptionMessage('This action is unauthorized.');
+        $this->expectExceptionMessageIs('This action is unauthorized.');
 
         $this->createRequest([], FoundationTestFormRequestForbiddenStub::class)->validateResolved();
     }
@@ -122,7 +122,7 @@ class FoundationFormRequestTest extends TestCase
     public function testValidateThrowsExceptionFromAuthorizationResponse()
     {
         $this->expectException(AuthorizationException::class);
-        $this->expectExceptionMessage('foo');
+        $this->expectExceptionMessageIs('foo');
 
         $this->createRequest([], FoundationTestFormRequestForbiddenWithResponseStub::class)->validateResolved();
     }

--- a/tests/Foundation/FoundationHelpersTest.php
+++ b/tests/Foundation/FoundationHelpersTest.php
@@ -105,7 +105,7 @@ class FoundationHelpersTest extends TestCase
     public function testMixMissingManifestThrowsException()
     {
         $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Mix manifest not found');
+        $this->expectExceptionMessageIs('Mix manifest not found');
 
         mix('unversioned.css', 'missing');
     }

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -79,7 +79,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
     public function testSeeInDatabaseDoesNotFindResults()
     {
         $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('The table is empty.');
+        $this->expectExceptionMessageIs('The table is empty.');
 
         $builder = $this->mockCountBuilder(false);
 
@@ -92,7 +92,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
     {
         $this->expectException(ExpectationFailedException::class);
 
-        $this->expectExceptionMessage('Found similar results: '.json_encode([['title' => 'Forge']], JSON_PRETTY_PRINT));
+        $this->expectExceptionMessageIs('Found similar results: '.json_encode([['title' => 'Forge']], JSON_PRETTY_PRINT));
 
         $builder = $this->mockCountBuilder(false);
 
@@ -106,7 +106,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
     {
         $this->expectException(ExpectationFailedException::class);
 
-        $this->expectExceptionMessage('Found similar results: '.json_encode(['data', 'data', 'data'], JSON_PRETTY_PRINT).' and 2 others.');
+        $this->expectExceptionMessageIs('Found similar results: '.json_encode(['data', 'data', 'data'], JSON_PRETTY_PRINT).' and 2 others.');
 
         $builder = $this->mockCountBuilder(false, countResult: [5, 5]);
 
@@ -210,7 +210,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
     public function testAssertTableEntriesCountWrong()
     {
         $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('Failed asserting that table [products] matches expected entries count of 3. Entries found: 1.');
+        $this->expectExceptionMessageIs('Failed asserting that table [products] matches expected entries count of 3. Entries found: 1.');
         $this->mockCountBuilder(true);
 
         $this->assertDatabaseCount($this->table, 3);
@@ -346,7 +346,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
     public function testAssertSoftDeletedInDatabaseDoesNotFindResults()
     {
         $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('The table is empty.');
+        $this->expectExceptionMessageIs('The table is empty.');
 
         $builder = $this->mockCountBuilder(false);
 
@@ -358,7 +358,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
     public function testAssertSoftDeletedInDatabaseDoesNotFindModelResults()
     {
         $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('The table is empty.');
+        $this->expectExceptionMessageIs('The table is empty.');
 
         $this->data = ['id' => 1];
 
@@ -372,7 +372,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
     public function testAssertSoftDeletedInDatabaseDoesNotFindModelWithCustomColumnResults()
     {
         $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('The table is empty.');
+        $this->expectExceptionMessageIs('The table is empty.');
 
         $model = new CustomProductStub(['id' => 1, 'name' => 'Laravel']);
         $this->data = ['id' => 1, 'name' => 'Tailwind'];
@@ -387,7 +387,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
     public function testAssertSoftDeletedInDatabaseDoesNotFindModePassedViaFcnWithCustomColumnResults()
     {
         $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('The table is empty.');
+        $this->expectExceptionMessageIs('The table is empty.');
 
         $model = new CustomProductStub(['id' => 1, 'name' => 'Laravel']);
         $this->data = ['id' => 1];
@@ -416,7 +416,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
     public function testAssertNotSoftDeletedOnlyFindsMatchingModels()
     {
         $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('Failed asserting that any existing row');
+        $this->expectExceptionMessageIs('Failed asserting that any existing row');
 
         $builder = $this->mockCountBuilder(false);
 
@@ -428,7 +428,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
     public function testAssertNotSoftDeletedInDatabaseDoesNotFindResults()
     {
         $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('The table is empty.');
+        $this->expectExceptionMessageIs('The table is empty.');
 
         $builder = $this->mockCountBuilder(false);
 
@@ -440,7 +440,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
     public function testAssertNotSoftDeletedInDatabaseDoesNotFindModelResults()
     {
         $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('The table is empty.');
+        $this->expectExceptionMessageIs('The table is empty.');
 
         $this->data = ['id' => 1];
 
@@ -454,7 +454,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
     public function testAssertNotSoftDeletedInDatabaseDoesNotFindModelWithCustomColumnResults()
     {
         $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('The table is empty.');
+        $this->expectExceptionMessageIs('The table is empty.');
 
         $model = new CustomProductStub(['id' => 1, 'name' => 'Laravel']);
         $this->data = ['id' => 1, 'name' => 'Tailwind'];
@@ -469,7 +469,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
     public function testAssertNotSoftDeletedInDatabaseDoesNotFindModelPassedViaFcnWithCustomColumnResults()
     {
         $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('The table is empty.');
+        $this->expectExceptionMessageIs('The table is empty.');
 
         $model = new CustomProductStub(['id' => 1, 'name' => 'Laravel']);
         $this->data = ['id' => 1];

--- a/tests/Foundation/FoundationProviderRepositoryTest.php
+++ b/tests/Foundation/FoundationProviderRepositoryTest.php
@@ -88,7 +88,7 @@ class FoundationProviderRepositoryTest extends TestCase
     public function testWriteManifestThrowsExceptionIfManifestDirDoesntExist()
     {
         $this->expectException(Exception::class);
-        $this->expectExceptionMessageMatches('/^The (.*) directory must be present and writable.$/');
+        $this->expectExceptionMessageIsMatches('/^The (.*) directory must be present and writable.$/');
 
         $repo = new ProviderRepository(m::mock(ApplicationContract::class), $files = m::mock(Filesystem::class), __DIR__.'/cache/services.php');
         $files->shouldReceive('replace')->never();

--- a/tests/Foundation/FoundationViteFontsTest.php
+++ b/tests/Foundation/FoundationViteFontsTest.php
@@ -350,7 +350,7 @@ class FoundationViteFontsTest extends TestCase
         file_put_contents(public_path('build/fonts-manifest.json'), 'not-valid-json{');
 
         $this->expectException(ViteException::class);
-        $this->expectExceptionMessage('not valid JSON');
+        $this->expectExceptionMessageIs('not valid JSON');
 
         app(Vite::class)->fonts();
     }
@@ -360,7 +360,7 @@ class FoundationViteFontsTest extends TestCase
         $this->makeFontsManifest(['version' => 99, 'families' => []]);
 
         $this->expectException(ViteException::class);
-        $this->expectExceptionMessage('Unsupported font manifest version [99]. Supported versions: 1.');
+        $this->expectExceptionMessageIs('Unsupported font manifest version [99]. Supported versions: 1.');
 
         app(Vite::class)->fonts();
     }
@@ -370,7 +370,7 @@ class FoundationViteFontsTest extends TestCase
         $this->makeFontsManifest(['style' => ['inline' => ''], 'families' => []]);
 
         $this->expectException(ViteException::class);
-        $this->expectExceptionMessage('missing the [version] key');
+        $this->expectExceptionMessageIs('missing the [version] key');
 
         app(Vite::class)->fonts();
     }
@@ -380,7 +380,7 @@ class FoundationViteFontsTest extends TestCase
         $this->makeFontsManifest(['version' => 1]);
 
         $this->expectException(ViteException::class);
-        $this->expectExceptionMessage('missing the [families] key');
+        $this->expectExceptionMessageIs('missing the [families] key');
 
         app(Vite::class)->fonts();
     }
@@ -390,7 +390,7 @@ class FoundationViteFontsTest extends TestCase
         $this->makeFontsManifest();
 
         $this->expectException(ViteException::class);
-        $this->expectExceptionMessage('Unable to locate font CSS file');
+        $this->expectExceptionMessageIs('Unable to locate font CSS file');
 
         app(Vite::class)->fonts();
     }
@@ -407,7 +407,7 @@ class FoundationViteFontsTest extends TestCase
         ]);
 
         $this->expectException(ViteException::class);
-        $this->expectExceptionMessage('Font alias [display] is not defined in the font manifest. Available aliases: sans.');
+        $this->expectExceptionMessageIs('Font alias [display] is not defined in the font manifest. Available aliases: sans.');
 
         app(Vite::class)->fonts(['display']);
     }
@@ -426,7 +426,7 @@ class FoundationViteFontsTest extends TestCase
         ]);
 
         $this->expectException(ViteException::class);
-        $this->expectExceptionMessage('preload entry [0] is missing the [alias] key');
+        $this->expectExceptionMessageIs('preload entry [0] is missing the [alias] key');
 
         app(Vite::class)->fonts();
     }
@@ -445,7 +445,7 @@ class FoundationViteFontsTest extends TestCase
         ]);
 
         $this->expectException(ViteException::class);
-        $this->expectExceptionMessage('preload entry [0] for alias [sans] is missing the [file] key');
+        $this->expectExceptionMessageIs('preload entry [0] for alias [sans] is missing the [file] key');
 
         app(Vite::class)->fonts();
     }
@@ -465,7 +465,7 @@ class FoundationViteFontsTest extends TestCase
         ]);
 
         $this->expectException(ViteException::class);
-        $this->expectExceptionMessage('preload entry [0] for alias [sans] is missing the [url] key');
+        $this->expectExceptionMessageIs('preload entry [0] for alias [sans] is missing the [url] key');
 
         app(Vite::class)->fonts();
     }
@@ -586,7 +586,7 @@ class FoundationViteFontsTest extends TestCase
         $this->makeFontsCssFile('build', 'assets/fonts-abc123.css', "@font-face { font-family: 'Inter'; }");
 
         $this->expectException(ViteException::class);
-        $this->expectExceptionMessage('keyed by alias');
+        $this->expectExceptionMessageIs('keyed by alias');
 
         app(Vite::class)->fonts(['sans']);
     }
@@ -608,7 +608,7 @@ class FoundationViteFontsTest extends TestCase
         $this->makeFontsCssFile('build', 'assets/fonts-abc123.css', "@font-face { font-family: 'Inter'; }");
 
         $this->expectException(ViteException::class);
-        $this->expectExceptionMessage('keyed by alias');
+        $this->expectExceptionMessageIs('keyed by alias');
 
         app(Vite::class)->fonts(['sans']);
     }

--- a/tests/Foundation/FoundationViteTest.php
+++ b/tests/Foundation/FoundationViteTest.php
@@ -607,7 +607,7 @@ class FoundationViteTest extends TestCase
     public function testItThrowsWhenUnableToFindAssetManifestInBuildMode()
     {
         $this->expectException(ViteException::class);
-        $this->expectExceptionMessage('Vite manifest not found at: '.public_path('build/manifest.json'));
+        $this->expectExceptionMessageIs('Vite manifest not found at: '.public_path('build/manifest.json'));
 
         ViteFacade::asset('resources/js/app.js');
     }
@@ -615,7 +615,7 @@ class FoundationViteTest extends TestCase
     public function testItThrowsDeprecatedExecptionWhenUnableToFindAssetManifestInBuildMode()
     {
         $this->expectException(ViteManifestNotFoundException::class);
-        $this->expectExceptionMessage('Vite manifest not found at: '.public_path('build/manifest.json'));
+        $this->expectExceptionMessageIs('Vite manifest not found at: '.public_path('build/manifest.json'));
 
         ViteFacade::asset('resources/js/app.js');
     }
@@ -625,7 +625,7 @@ class FoundationViteTest extends TestCase
         $this->makeViteManifest();
 
         $this->expectException(ViteException::class);
-        $this->expectExceptionMessage('Unable to locate file in Vite manifest: resources/js/missing.js');
+        $this->expectExceptionMessageIs('Unable to locate file in Vite manifest: resources/js/missing.js');
 
         ViteFacade::asset('resources/js/missing.js');
     }
@@ -1300,7 +1300,7 @@ class FoundationViteTest extends TestCase
         $this->makeViteManifest();
 
         $this->expectException(ViteException::class);
-        $this->expectExceptionMessage('Unable to locate file from Vite manifest: '.public_path('build/assets/app.versioned.js'));
+        $this->expectExceptionMessageIs('Unable to locate file from Vite manifest: '.public_path('build/assets/app.versioned.js'));
 
         ViteFacade::content('resources/js/app.js');
     }

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -136,7 +136,7 @@ class HttpClientTest extends TestCase
     public function testInvalidFakeResponseHeaderValuesAreRejected($value)
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('HTTP fake response header values must be scalar, null, Laravel Stringable, or arrays of scalar, null, or Laravel Stringable values.');
+        $this->expectExceptionMessageIs('HTTP fake response header values must be scalar, null, Laravel Stringable, or arrays of scalar, null, or Laravel Stringable values.');
 
         $this->factory::response('OK', 200, ['X-Test' => $value]);
     }
@@ -196,7 +196,7 @@ class HttpClientTest extends TestCase
     public function testFakeResponseRejectsUnsupportedBody()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('HTTP fake response body must be a string, array, resource, Psr\Http\Message\StreamInterface, or null.');
+        $this->expectExceptionMessageIs('HTTP fake response body must be a string, array, resource, Psr\Http\Message\StreamInterface, or null.');
 
         $this->factory::response(new stdClass);
     }
@@ -836,7 +836,7 @@ class HttpClientTest extends TestCase
         $this->factory->fake();
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('HTTP header values must be scalar, null, Laravel Stringable, or arrays of scalar, null, or Laravel Stringable values.');
+        $this->expectExceptionMessageIs('HTTP header values must be scalar, null, Laravel Stringable, or arrays of scalar, null, or Laravel Stringable values.');
 
         $this->factory->withHeaders(['X-Test' => $value])->post('http://foo.com/json');
     }
@@ -1087,7 +1087,7 @@ class HttpClientTest extends TestCase
         $this->factory->fake();
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Multipart header values must be scalar, null, or Laravel Stringable.');
+        $this->expectExceptionMessageIs('Multipart header values must be scalar, null, or Laravel Stringable.');
 
         $this->factory->asMultipart()->post('http://foo.com/multipart', [
             [
@@ -1671,7 +1671,7 @@ class HttpClientTest extends TestCase
     public function testRequestExceptionSummary()
     {
         $this->expectException(RequestException::class);
-        $this->expectExceptionMessage('{"error":{"code":403,"message":"The Request can not be completed"}}');
+        $this->expectExceptionMessageIs('{"error":{"code":403,"message":"The Request can not be completed"}}');
 
         $error = [
             'error' => [
@@ -1688,7 +1688,7 @@ class HttpClientTest extends TestCase
     public function testRequestExceptionTruncatedSummary()
     {
         $this->expectException(RequestException::class);
-        $this->expectExceptionMessage('{"error":{"code":403,"message":"The Request can not be completed because quota limit was exceeded. Please, check our sup (truncated...)');
+        $this->expectExceptionMessageIs('{"error":{"code":403,"message":"The Request can not be completed because quota limit was exceeded. Please, check our sup (truncated...)');
 
         $error = [
             'error' => [
@@ -1706,7 +1706,7 @@ class HttpClientTest extends TestCase
         RequestException::dontTruncate();
 
         $this->expectException(RequestException::class);
-        $this->expectExceptionMessage('{"error":{"code":403,"message":"The Request can not be completed because quota limit was exceeded. Please, check our support team to increase your limit');
+        $this->expectExceptionMessageIs('{"error":{"code":403,"message":"The Request can not be completed because quota limit was exceeded. Please, check our support team to increase your limit');
 
         $error = [
             'error' => [
@@ -1724,7 +1724,7 @@ class HttpClientTest extends TestCase
         RequestException::truncateAt(60);
 
         $this->expectException(RequestException::class);
-        $this->expectExceptionMessage('{"error":{"code":403,"message":"The Request can not be compl (truncated...)');
+        $this->expectExceptionMessageIs('{"error":{"code":403,"message":"The Request can not be compl (truncated...)');
 
         $error = [
             'error' => [
@@ -1827,7 +1827,7 @@ class HttpClientTest extends TestCase
     public function testRequestExceptionEmptyBody()
     {
         $this->expectException(RequestException::class);
-        $this->expectExceptionMessageMatches('/HTTP request returned status code 403$/');
+        $this->expectExceptionMessageIsMatches('/HTTP request returned status code 403$/');
 
         $response = new Psr7Response(403);
 
@@ -3202,7 +3202,7 @@ class HttpClientTest extends TestCase
         });
 
         $this->expectException(ConnectionException::class);
-        $this->expectExceptionMessage('cURL error 60: SSL certificate problem: unable to get local issuer certificate');
+        $this->expectExceptionMessageIs('cURL error 60: SSL certificate problem: unable to get local issuer certificate');
 
         $this->factory->head('https://ssl-error.laravel.example');
     }
@@ -3210,7 +3210,7 @@ class HttpClientTest extends TestCase
     public function testConnectExceptionIsConvertedToConnectionExceptionEvenWhenWithoutFactory()
     {
         $this->expectException(ConnectionException::class);
-        $this->expectExceptionMessage('cURL error 60: SSL certificate problem');
+        $this->expectExceptionMessageIs('cURL error 60: SSL certificate problem');
 
         $pendingRequest = new PendingRequest();
 
@@ -3227,7 +3227,7 @@ class HttpClientTest extends TestCase
     public function testRequestExceptionWithoutResponseIsConvertedToConnectionExceptionEvenWhenWithoutFactory()
     {
         $this->expectException(ConnectionException::class);
-        $this->expectExceptionMessage('cURL error 28: Operation timed out');
+        $this->expectExceptionMessageIs('cURL error 28: Operation timed out');
 
         $pendingRequest = new PendingRequest();
 
@@ -3244,7 +3244,7 @@ class HttpClientTest extends TestCase
     public function testRequestExceptionWithResponseIsConvertedToConnectionExceptionEvenWhenWithoutFactory()
     {
         $this->expectException(ConnectionException::class);
-        $this->expectExceptionMessage('cURL error 28: Operation timed out');
+        $this->expectExceptionMessageIs('cURL error 28: Operation timed out');
 
         $pendingRequest = new PendingRequest();
 
@@ -3262,7 +3262,7 @@ class HttpClientTest extends TestCase
     public function testTooManyRedirectsExceptionIsConvertedToConnectionExceptionEvenWhenWithoutFactory()
     {
         $this->expectException(ConnectionException::class);
-        $this->expectExceptionMessage('Maximum number of redirects (5) exceeded');
+        $this->expectExceptionMessageIs('Maximum number of redirects (5) exceeded');
 
         $pendingRequest = new PendingRequest();
 
@@ -3291,7 +3291,7 @@ class HttpClientTest extends TestCase
         });
 
         $this->expectException(ConnectionException::class);
-        $this->expectExceptionMessage('Maximum number of redirects (5) exceeded');
+        $this->expectExceptionMessageIs('Maximum number of redirects (5) exceeded');
 
         $this->factory->maxRedirects(5)->get('https://redirect.laravel.example');
     }
@@ -4070,7 +4070,7 @@ class HttpClientTest extends TestCase
         $this->assertSame(['ok', 'ok'], $responses);
 
         $this->expectException(StrayRequestException::class);
-        $this->expectExceptionMessage('Attempted request to [https://laravel.com] without a matching fake.');
+        $this->expectExceptionMessageIs('Attempted request to [https://laravel.com] without a matching fake.');
 
         $this->factory->get('https://laravel.com');
     }

--- a/tests/Http/HttpRedirectResponseTest.php
+++ b/tests/Http/HttpRedirectResponseTest.php
@@ -212,7 +212,7 @@ class HttpRedirectResponseTest extends TestCase
     public function testMagicCallException()
     {
         $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage('Call to undefined method Illuminate\Http\RedirectResponse::doesNotExist()');
+        $this->expectExceptionMessageIs('Call to undefined method Illuminate\Http\RedirectResponse::doesNotExist()');
 
         $response = new RedirectResponse('foo.bar');
         $response->doesNotExist('bar');

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -1730,7 +1730,7 @@ class HttpRequestTest extends TestCase
     public function testSessionMethod()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Session store not set on request.');
+        $this->expectExceptionMessageIs('Session store not set on request.');
 
         $request = Request::create('/');
         $request->session();
@@ -1765,7 +1765,7 @@ class HttpRequestTest extends TestCase
     public function testGetSessionMethodWithoutLaravelSession()
     {
         $this->expectException(SessionNotFoundException::class);
-        $this->expectExceptionMessage('There is currently no session available.');
+        $this->expectExceptionMessageIs('There is currently no session available.');
 
         $request = Request::create('/');
 
@@ -1797,7 +1797,7 @@ class HttpRequestTest extends TestCase
     public function testFingerprintWithoutRoute()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unable to generate fingerprint. Route unavailable.');
+        $this->expectExceptionMessageIs('Unable to generate fingerprint. Route unavailable.');
 
         $request = Request::create('/', 'GET', [], [], [], []);
         $request->fingerprint();

--- a/tests/Http/HttpResponseTest.php
+++ b/tests/Http/HttpResponseTest.php
@@ -256,7 +256,7 @@ class HttpResponseTest extends TestCase
     public function testMagicCallException()
     {
         $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage('Call to undefined method Illuminate\Http\RedirectResponse::doesNotExist()');
+        $this->expectExceptionMessageIs('Call to undefined method Illuminate\Http\RedirectResponse::doesNotExist()');
 
         $response = new RedirectResponse('foo.bar');
         $response->doesNotExist('bar');

--- a/tests/Http/Resources/JsonApi/JsonApiResourceTest.php
+++ b/tests/Http/Resources/JsonApi/JsonApiResourceTest.php
@@ -25,7 +25,7 @@ class JsonApiResourceTest extends TestCase
     public function testUnableToSetWrapper()
     {
         $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage('Using Illuminate\Http\Resources\JsonApi\JsonApiResource::wrap() method is not allowed.');
+        $this->expectExceptionMessageIs('Using Illuminate\Http\Resources\JsonApi\JsonApiResource::wrap() method is not allowed.');
 
         JsonApiResource::wrap('laravel');
     }
@@ -33,7 +33,7 @@ class JsonApiResourceTest extends TestCase
     public function testUnableToUnsetWrapper()
     {
         $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage('Using Illuminate\Http\Resources\JsonApi\JsonApiResource::withoutWrapping() method is not allowed.');
+        $this->expectExceptionMessageIs('Using Illuminate\Http\Resources\JsonApi\JsonApiResource::withoutWrapping() method is not allowed.');
 
         JsonApiResource::withoutWrapping();
     }

--- a/tests/Image/Drivers/GdDriverTest.php
+++ b/tests/Image/Drivers/GdDriverTest.php
@@ -436,7 +436,7 @@ class GdDriverTest extends TestCase
         $driver = new GdDriver;
 
         $this->expectException(ImageException::class);
-        $this->expectExceptionMessage('The image format [text/plain] is not supported.');
+        $this->expectExceptionMessageIs('The image format [text/plain] is not supported.');
 
         $driver->process('not-an-image', new ImagePipeline);
     }

--- a/tests/Image/ImageManagerTest.php
+++ b/tests/Image/ImageManagerTest.php
@@ -76,7 +76,7 @@ class ImageManagerTest extends TestCase
         $manager = new ImageManager($app);
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Image driver [nonexistent] is not supported.');
+        $this->expectExceptionMessageIs('Image driver [nonexistent] is not supported.');
 
         $manager->driver('nonexistent');
     }
@@ -274,7 +274,7 @@ class ImageManagerTest extends TestCase
         $manager = new ImageManager($app);
 
         $this->expectException(ImageException::class);
-        $this->expectExceptionMessage('Invalid base64 image data.');
+        $this->expectExceptionMessageIs('Invalid base64 image data.');
 
         $manager->fromBase64('!!!not-base64!!!')->toBytes();
     }

--- a/tests/Image/ImageTest.php
+++ b/tests/Image/ImageTest.php
@@ -286,7 +286,7 @@ class ImageTest extends TestCase
         $image = new Image('not-an-image');
 
         $this->expectException(ImageException::class);
-        $this->expectExceptionMessage('Unable to determine the dimensions of the image.');
+        $this->expectExceptionMessageIs('Unable to determine the dimensions of the image.');
 
         $image->dimensions();
     }
@@ -351,7 +351,7 @@ class ImageTest extends TestCase
         $image = $this->makeImage();
 
         $this->expectException(ImageException::class);
-        $this->expectExceptionMessage('The [tiff] format is not supported.');
+        $this->expectExceptionMessageIs('The [tiff] format is not supported.');
 
         $image->optimize('tiff');
     }
@@ -532,7 +532,7 @@ class ImageTest extends TestCase
         $image = new Image($this->fakeImageContents());
 
         $this->expectException(ImageException::class);
-        $this->expectExceptionMessage('Failed to process image:');
+        $this->expectExceptionMessageIs('Failed to process image:');
 
         // Trigger a driver error by using a non-existent driver
         $image->using('nonexistent')->cover(100, 100)->toBytes();
@@ -708,7 +708,7 @@ class ImageTest extends TestCase
         $image = $this->makeImage();
 
         $this->expectException(ImageException::class);
-        $this->expectExceptionMessage('The [jpge] format is not supported.');
+        $this->expectExceptionMessageIs('The [jpge] format is not supported.');
 
         $image->optimize('jpge');
     }
@@ -725,7 +725,7 @@ class ImageTest extends TestCase
         $image = new Image($this->fakeImageContents());
 
         $this->expectException(ImageException::class);
-        $this->expectExceptionMessage('Images cannot be serialized. Store the image first and serialize the path instead.');
+        $this->expectExceptionMessageIs('Images cannot be serialized. Store the image first and serialize the path instead.');
 
         serialize($image);
     }
@@ -861,7 +861,7 @@ class ImageTest extends TestCase
     public function test_resize_requires_at_least_one_dimension()
     {
         $this->expectException(ImageException::class);
-        $this->expectExceptionMessage('At least one resize dimension must be specified.');
+        $this->expectExceptionMessageIs('At least one resize dimension must be specified.');
 
         $this->makeImage()->resize();
     }
@@ -913,7 +913,7 @@ class ImageTest extends TestCase
     public function test_scale_requires_at_least_one_dimension()
     {
         $this->expectException(ImageException::class);
-        $this->expectExceptionMessage('At least one scale dimension must be specified.');
+        $this->expectExceptionMessageIs('At least one scale dimension must be specified.');
 
         $this->makeImage()->scale();
     }

--- a/tests/Integration/Auth/ApiAuthenticationWithEloquentTest.php
+++ b/tests/Integration/Auth/ApiAuthenticationWithEloquentTest.php
@@ -43,7 +43,7 @@ class ApiAuthenticationWithEloquentTest extends TestCase
 
         $this->expectException(QueryException::class);
 
-        $this->expectExceptionMessage("Access denied for user 'root'@");
+        $this->expectExceptionMessageIs("Access denied for user 'root'@");
 
         try {
             $this->withoutExceptionHandling()->get('/auth', ['Authorization' => 'Bearer whatever']);

--- a/tests/Integration/Auth/AuthenticationTest.php
+++ b/tests/Integration/Auth/AuthenticationTest.php
@@ -221,7 +221,7 @@ class AuthenticationTest extends TestCase
     public function testPasswordMustBeValidToLogOutOtherDevices()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('current password');
+        $this->expectExceptionMessageIs('current password');
 
         $this->app['auth']->loginUsingId(1);
 

--- a/tests/Integration/Auth/ForgotPasswordWithoutDefaultRoutesTest.php
+++ b/tests/Integration/Auth/ForgotPasswordWithoutDefaultRoutesTest.php
@@ -42,7 +42,7 @@ class ForgotPasswordWithoutDefaultRoutesTest extends TestCase
     public function testItCannotSendForgotPasswordEmail()
     {
         $this->expectException('Symfony\Component\Routing\Exception\RouteNotFoundException');
-        $this->expectExceptionMessage('Route [password.reset] not defined.');
+        $this->expectExceptionMessageIs('Route [password.reset] not defined.');
 
         Notification::fake();
 

--- a/tests/Integration/Broadcasting/BroadcastManagerTest.php
+++ b/tests/Integration/Broadcasting/BroadcastManagerTest.php
@@ -124,7 +124,7 @@ class BroadcastManagerTest extends TestCase
     public function testThrowExceptionWhenUnknownStoreIsUsed()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Broadcast connection [alien_connection] is not defined.');
+        $this->expectExceptionMessageIs('Broadcast connection [alien_connection] is not defined.');
 
         $userConfig = [
             'broadcasting' => [

--- a/tests/Integration/Cache/PhpRedisBackoffTest.php
+++ b/tests/Integration/Cache/PhpRedisBackoffTest.php
@@ -94,7 +94,7 @@ class PhpRedisBackoffTest extends TestCase
     public function testItFailsWithAnInvalidPhpRedisAlgorithm()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Algorithm [foo] is not a valid PhpRedis backoff algorithm');
+        $this->expectExceptionMessageIs('Algorithm [foo] is not a valid PhpRedis backoff algorithm');
 
         $host = Env::get('REDIS_HOST', '127.0.0.1');
         $port = Env::get('REDIS_PORT', 6379);

--- a/tests/Integration/Concurrency/ConcurrencyTest.php
+++ b/tests/Integration/Concurrency/ConcurrencyTest.php
@@ -120,7 +120,7 @@ PHP);
     public function testRunHandlerProcessErrorWithDefaultExceptionWithoutParam()
     {
         $this->expectException(Exception::class);
-        $this->expectExceptionMessage('This is a different exception');
+        $this->expectExceptionMessageIs('This is a different exception');
 
         Concurrency::run([
             fn () => throw new Exception(
@@ -132,7 +132,7 @@ PHP);
     public function testRunHandlerProcessErrorWithCustomExceptionWithoutParam()
     {
         $this->expectException(ExceptionWithoutParam::class);
-        $this->expectExceptionMessage('Test');
+        $this->expectExceptionMessageIs('Test');
         Concurrency::run([
             fn () => throw new ExceptionWithoutParam('Test'),
         ]);
@@ -141,7 +141,7 @@ PHP);
     public function testRunHandlerProcessErrorWithCustomExceptionWithParam()
     {
         $this->expectException(ExceptionWithParam::class);
-        $this->expectExceptionMessage('API request to https://api.example.com failed with status 400 Bad Request');
+        $this->expectExceptionMessageIs('API request to https://api.example.com failed with status 400 Bad Request');
         Concurrency::run([
             fn () => throw new ExceptionWithParam(
                 'https://api.example.com',

--- a/tests/Integration/Console/CommandManualFailTest.php
+++ b/tests/Integration/Console/CommandManualFailTest.php
@@ -28,7 +28,7 @@ class CommandManualFailTest extends TestCase
     public function testCreatesAnExceptionFromString(): void
     {
         $this->expectException(ManuallyFailedException::class);
-        $this->expectExceptionMessage('Whoops!');
+        $this->expectExceptionMessageIs('Whoops!');
         $command = new Command;
         $command->fail('Whoops!');
     }
@@ -36,7 +36,7 @@ class CommandManualFailTest extends TestCase
     public function testCreatesAnExceptionFromNull(): void
     {
         $this->expectException(ManuallyFailedException::class);
-        $this->expectExceptionMessage('Command failed manually.');
+        $this->expectExceptionMessageIs('Command failed manually.');
         $command = new Command;
         $command->fail();
     }

--- a/tests/Integration/Database/DatabaseLockTest.php
+++ b/tests/Integration/Database/DatabaseLockTest.php
@@ -202,7 +202,7 @@ class DatabaseLockTest extends DatabaseTestCase
             $this->assertTrue($lock->release());
         } else {
             $this->expectException(QueryException::class);
-            $this->expectExceptionMessage($message);
+            $this->expectExceptionMessageIs($message);
             $lock->release();
         }
     }

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -483,7 +483,7 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
     public function testFindOrFailMethod()
     {
         $this->expectException(ModelNotFoundException::class);
-        $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Integration\Database\EloquentBelongsToManyTest\Tag] 10');
+        $this->expectExceptionMessageIs('No query results for model [Illuminate\Tests\Integration\Database\EloquentBelongsToManyTest\Tag] 10');
 
         $post = Post::create(['title' => Str::random()]);
 
@@ -497,7 +497,7 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
     public function testFindOrFailMethodWithMany()
     {
         $this->expectException(ModelNotFoundException::class);
-        $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Integration\Database\EloquentBelongsToManyTest\Tag] 10, 11');
+        $this->expectExceptionMessageIs('No query results for model [Illuminate\Tests\Integration\Database\EloquentBelongsToManyTest\Tag] 10, 11');
 
         $post = Post::create(['title' => Str::random()]);
 
@@ -511,7 +511,7 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
     public function testFindOrFailMethodWithManyUsingCollection()
     {
         $this->expectException(ModelNotFoundException::class);
-        $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Integration\Database\EloquentBelongsToManyTest\Tag] 10, 11');
+        $this->expectExceptionMessageIs('No query results for model [Illuminate\Tests\Integration\Database\EloquentBelongsToManyTest\Tag] 10, 11');
 
         $post = Post::create(['title' => Str::random()]);
 

--- a/tests/Integration/Database/EloquentMassPrunableTest.php
+++ b/tests/Integration/Database/EloquentMassPrunableTest.php
@@ -46,7 +46,7 @@ class EloquentMassPrunableTest extends DatabaseTestCase
     public function testPrunableMethodMustBeImplemented()
     {
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionMessageIs(
             'Please implement',
         );
 

--- a/tests/Integration/Database/EloquentModelEnumCastingTest.php
+++ b/tests/Integration/Database/EloquentModelEnumCastingTest.php
@@ -276,7 +276,7 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
         $model = new EloquentModelEnumCastingTestModel;
 
         $this->expectException(ValueError::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionMessageIs(
             sprintf('Value [%s] is not of the expected enum type [%s].', var_export(ArrayableStatus::pending, true), StringStatus::class)
         );
 
@@ -288,7 +288,7 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
         $model = new EloquentModelEnumCastingTestModel;
 
         $this->expectException(ValueError::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionMessageIs(
             sprintf('"unexpected_value" is not a valid backing value for enum %s', StringStatus::class)
         );
 

--- a/tests/Integration/Database/EloquentModelHashedCastingTest.php
+++ b/tests/Integration/Database/EloquentModelHashedCastingTest.php
@@ -75,7 +75,7 @@ class EloquentModelHashedCastingTest extends DatabaseTestCase
         Config::set('hashing.bcrypt.rounds', 10);
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage("Could not verify the hashed value's configuration.");
+        $this->expectExceptionMessageIs("Could not verify the hashed value's configuration.");
 
         $subject = HashedCast::create([
             // "password"; 13 rounds; bcrypt;
@@ -106,7 +106,7 @@ class EloquentModelHashedCastingTest extends DatabaseTestCase
         Config::set('hashing.bcrypt.rounds', 13);
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage("Could not verify the hashed value's configuration.");
+        $this->expectExceptionMessageIs("Could not verify the hashed value's configuration.");
 
         $subject = HashedCast::create([
             // "password"; argon2id;
@@ -181,7 +181,7 @@ class EloquentModelHashedCastingTest extends DatabaseTestCase
         Config::set('hashing.argon.time', 7);
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage("Could not verify the hashed value's configuration.");
+        $this->expectExceptionMessageIs("Could not verify the hashed value's configuration.");
 
         $subject = HashedCast::create([
             // "password"; 2345 memory; 2 threads; 7 time; argon2i;
@@ -197,7 +197,7 @@ class EloquentModelHashedCastingTest extends DatabaseTestCase
         Config::set('hashing.argon.time', 7);
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage("Could not verify the hashed value's configuration.");
+        $this->expectExceptionMessageIs("Could not verify the hashed value's configuration.");
 
         $subject = HashedCast::create([
             // "password"; 1234 memory; 2 threads; 8 time; argon2i;
@@ -213,7 +213,7 @@ class EloquentModelHashedCastingTest extends DatabaseTestCase
         Config::set('hashing.argon.time', 7);
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage("Could not verify the hashed value's configuration.");
+        $this->expectExceptionMessageIs("Could not verify the hashed value's configuration.");
 
         $subject = HashedCast::create([
             // "password"; 1234 memory; 3 threads; 7 time; argon2i;
@@ -284,7 +284,7 @@ class EloquentModelHashedCastingTest extends DatabaseTestCase
         Config::set('hashing.bcrypt.rounds', 13);
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage("Could not verify the hashed value's configuration.");
+        $this->expectExceptionMessageIs("Could not verify the hashed value's configuration.");
 
         $subject = HashedCast::create([
             // "password"; bcrypt;
@@ -300,7 +300,7 @@ class EloquentModelHashedCastingTest extends DatabaseTestCase
         Config::set('hashing.argon.time', 7);
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage("Could not verify the hashed value's configuration.");
+        $this->expectExceptionMessageIs("Could not verify the hashed value's configuration.");
 
         $subject = HashedCast::create([
             // "password"; 2345 memory; 2 threads; 7 time; argon2i;

--- a/tests/Integration/Database/EloquentPrunableTest.php
+++ b/tests/Integration/Database/EloquentPrunableTest.php
@@ -38,7 +38,7 @@ class EloquentPrunableTest extends DatabaseTestCase
     public function testPrunableMethodMustBeImplemented()
     {
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionMessageIs(
             'Please implement',
         );
 

--- a/tests/Integration/Database/EloquentStrictLoadingTest.php
+++ b/tests/Integration/Database/EloquentStrictLoadingTest.php
@@ -40,7 +40,7 @@ class EloquentStrictLoadingTest extends DatabaseTestCase
     public function testStrictModeThrowsAnExceptionOnLazyLoading()
     {
         $this->expectException(LazyLoadingViolationException::class);
-        $this->expectExceptionMessage('Attempted to lazy load');
+        $this->expectExceptionMessageIs('Attempted to lazy load');
 
         EloquentStrictLoadingTestModel1::create();
         EloquentStrictLoadingTestModel1::create();
@@ -104,7 +104,7 @@ class EloquentStrictLoadingTest extends DatabaseTestCase
     public function testStrictModeThrowsAnExceptionOnLazyLoadingInRelations()
     {
         $this->expectException(LazyLoadingViolationException::class);
-        $this->expectExceptionMessage('Attempted to lazy load');
+        $this->expectExceptionMessageIs('Attempted to lazy load');
 
         $model1 = EloquentStrictLoadingTestModel1::create();
         EloquentStrictLoadingTestModel2::create(['model_1_id' => $model1->id]);
@@ -136,7 +136,7 @@ class EloquentStrictLoadingTest extends DatabaseTestCase
     public function testStrictModeWithOverriddenHandlerOnLazyLoading()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Violated');
+        $this->expectExceptionMessageIs('Violated');
 
         EloquentStrictLoadingTestModel1WithCustomHandler::create();
         EloquentStrictLoadingTestModel1WithCustomHandler::create();

--- a/tests/Integration/Database/Sqlite/DatabaseSchemaBlueprintTest.php
+++ b/tests/Integration/Database/Sqlite/DatabaseSchemaBlueprintTest.php
@@ -497,7 +497,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
     public function testItEnsuresDroppingForeignKeyIsAvailable()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('This database driver does not support dropping foreign keys by name.');
+        $this->expectExceptionMessageIs('This database driver does not support dropping foreign keys by name.');
 
         Schema::table('users', function (Blueprint $table) {
             $table->dropForeign('something');

--- a/tests/Integration/Filesystem/FilesystemServiceProviderTest.php
+++ b/tests/Integration/Filesystem/FilesystemServiceProviderTest.php
@@ -11,7 +11,7 @@ class FilesystemServiceProviderTest extends TestCase
     public function test_it_throws_when_served_disks_have_conflicting_uris(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The [other] disk conflicts with the [local] disk at [/storage]. Each served disk must have a unique URL.');
+        $this->expectExceptionMessageIs('The [other] disk conflicts with the [local] disk at [/storage]. Each served disk must have a unique URL.');
 
         config(['filesystems.disks' => [
             'local' => [

--- a/tests/Integration/Foundation/Console/ConfigCacheCommandTest.php
+++ b/tests/Integration/Foundation/Console/ConfigCacheCommandTest.php
@@ -72,7 +72,7 @@ class ConfigCacheCommandTest extends TestCase
         );
 
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('Your configuration files could not be serialized because the value at "testconfig.closure" is non-serializable.');
+        $this->expectExceptionMessageIs('Your configuration files could not be serialized because the value at "testconfig.closure" is non-serializable.');
 
         $this->artisan('config:cache');
     }
@@ -96,7 +96,7 @@ class ConfigCacheCommandTest extends TestCase
         );
 
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('Your configuration files could not be serialized because the value at "testconfig.nested.deep.closure" is non-serializable.');
+        $this->expectExceptionMessageIs('Your configuration files could not be serialized because the value at "testconfig.nested.deep.closure" is non-serializable.');
 
         $this->artisan('config:cache');
     }

--- a/tests/Integration/Foundation/FoundationHelpersTest.php
+++ b/tests/Integration/Foundation/FoundationHelpersTest.php
@@ -82,7 +82,7 @@ class FoundationHelpersTest extends TestCase
     public function testMixThrowsExceptionWhenAssetIsMissingFromManifestWhenInDebugMode()
     {
         $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Unable to locate Mix file: /missing.js.');
+        $this->expectExceptionMessageIs('Unable to locate Mix file: /missing.js.');
 
         $manifest = $this->makeManifest();
 

--- a/tests/Integration/Http/JsonResponseTest.php
+++ b/tests/Integration/Http/JsonResponseTest.php
@@ -13,7 +13,7 @@ class JsonResponseTest extends TestCase
     public function testResponseWithInvalidJsonThrowsException()
     {
         $this->expectException('InvalidArgumentException');
-        $this->expectExceptionMessage('Malformed UTF-8 characters, possibly incorrectly encoded');
+        $this->expectExceptionMessageIs('Malformed UTF-8 characters, possibly incorrectly encoded');
 
         Route::get('/response', function () {
             return new JsonResponse(new class implements JsonSerializable

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -1449,7 +1449,7 @@ class ResourceTest extends TestCase
         ]);
 
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('must collect');
+        $this->expectExceptionMessageIs('must collect');
 
         new PostModelCollectionResource($posts);
     }
@@ -1573,7 +1573,7 @@ class ResourceTest extends TestCase
         $post->handle($request, fn () => null);
 
         $this->expectException(PostTooLargeException::class);
-        $this->expectExceptionMessage('The POST data is too large.');
+        $this->expectExceptionMessageIs('The POST data is too large.');
 
         $request = new Request(server: ['CONTENT_LENGTH' => '2147483640']);
         $post = new ValidatePostSize;

--- a/tests/Integration/Http/ResponseTest.php
+++ b/tests/Integration/Http/ResponseTest.php
@@ -12,7 +12,7 @@ class ResponseTest extends TestCase
     public function testResponseWithInvalidJsonThrowsException()
     {
         $this->expectException('InvalidArgumentException');
-        $this->expectExceptionMessage('Malformed UTF-8 characters, possibly incorrectly encoded');
+        $this->expectExceptionMessageIs('Malformed UTF-8 characters, possibly incorrectly encoded');
 
         Route::get('/response', function () {
             return (new Response())->setContent(new class implements JsonSerializable

--- a/tests/Integration/Http/ThrottleRequestsTest.php
+++ b/tests/Integration/Http/ThrottleRequestsTest.php
@@ -327,7 +327,7 @@ class ThrottleRequestsTest extends TestCase
     public function testItFailsIfNamedLimiterDoesNotExist()
     {
         $this->expectException(MissingRateLimiterException::class);
-        $this->expectExceptionMessage('Rate limiter [test] is not defined.');
+        $this->expectExceptionMessageIs('Rate limiter [test] is not defined.');
 
         Route::get('/', fn () => 'ok')->middleware(ThrottleRequests::using('test'));
 
@@ -337,7 +337,7 @@ class ThrottleRequestsTest extends TestCase
     public function testItFailsIfNamedLimiterDoesNotExistAndAuthenticatedUserDoesNotHaveFallbackProperty()
     {
         $this->expectException(MissingRateLimiterException::class);
-        $this->expectExceptionMessage('Rate limiter ['.User::class.'::rateLimiting] is not defined.');
+        $this->expectExceptionMessageIs('Rate limiter ['.User::class.'::rateLimiting] is not defined.');
 
         Route::get('/', fn () => 'ok')->middleware(['auth', ThrottleRequests::using('rateLimiting')]);
 

--- a/tests/Integration/Log/ContextIntegrationTest.php
+++ b/tests/Integration/Log/ContextIntegrationTest.php
@@ -98,7 +98,7 @@ class ContextIntegrationTest extends TestCase
         ];
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Value is incomplete class: {"__PHP_Incomplete_Class_Name":"App\\\\MyContextClass"}');
+        $this->expectExceptionMessageIs('Value is incomplete class: {"__PHP_Incomplete_Class_Name":"App\\\\MyContextClass"}');
 
         Context::hydrate($dehydrated);
     }
@@ -113,7 +113,7 @@ class ContextIntegrationTest extends TestCase
         ];
 
         $this->expectException(ErrorException::class);
-        $this->expectExceptionMessage('unserialize(): Error at offset 0 of 8 bytes');
+        $this->expectExceptionMessageIs('unserialize(): Error at offset 0 of 8 bytes');
 
         Context::hydrate($dehydrated);
     }

--- a/tests/Integration/Queue/DebouncedJobTest.php
+++ b/tests/Integration/Queue/DebouncedJobTest.php
@@ -120,7 +120,7 @@ class DebouncedJobTest extends QueueTestCase
     public function testDebouncedAndUniqueThrowsLogicException()
     {
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('debounced job cannot also implement ShouldBeUnique');
+        $this->expectExceptionMessageIs('debounced job cannot also implement ShouldBeUnique');
 
         DebouncedAndUniqueTestJob::dispatch('entity-1');
     }

--- a/tests/Integration/Queue/JobEncryptionTest.php
+++ b/tests/Integration/Queue/JobEncryptionTest.php
@@ -51,7 +51,7 @@ class JobEncryptionTest extends DatabaseTestCase
         Bus::dispatch(new JobEncryptionTestNonEncryptedJob);
 
         $this->expectException(DecryptException::class);
-        $this->expectExceptionMessage('The payload is invalid');
+        $this->expectExceptionMessageIs('The payload is invalid');
 
         $this->assertInstanceOf(JobEncryptionTestNonEncryptedJob::class,
             unserialize(json_decode(DB::table('jobs')->first()->payload)->data->command)

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -139,7 +139,7 @@ class ModelSerializationTest extends TestCase
     public function testItFailsIfModelsOnMultiConnections()
     {
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('Queueing collections with multiple model connections is not supported.');
+        $this->expectExceptionMessageIs('Queueing collections with multiple model connections is not supported.');
 
         $user = ModelSerializationTestUser::on('custom')->create([
             'email' => 'mohamed@laravel.com',

--- a/tests/Integration/Routing/UrlSigningTest.php
+++ b/tests/Integration/Routing/UrlSigningTest.php
@@ -70,7 +70,7 @@ class UrlSigningTest extends TestCase
     public function testTemporarySignedUrlsWithExpiresParameter()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('reserved');
+        $this->expectExceptionMessageIs('reserved');
 
         Route::get('/foo/{id}', function (Request $request, $id) {
             return $request->hasValidSignature() ? 'valid' : 'invalid';

--- a/tests/Integration/Support/ExceptionsFacadeTest.php
+++ b/tests/Integration/Support/ExceptionsFacadeTest.php
@@ -54,7 +54,7 @@ class ExceptionsFacadeTest extends TestCase
         report(new RuntimeException('test 2'));
 
         $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('The total number of exceptions reported was 2 instead of 1.');
+        $this->expectExceptionMessageIs('The total number of exceptions reported was 2 instead of 1.');
 
         Exceptions::assertReportedCount(1);
     }
@@ -80,7 +80,7 @@ class ExceptionsFacadeTest extends TestCase
     public function testFakeAssertReportedAsStringMayFail()
     {
         $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('The expected [InvalidArgumentException] exception was not reported.');
+        $this->expectExceptionMessageIs('The expected [InvalidArgumentException] exception was not reported.');
 
         Exceptions::fake();
 
@@ -93,7 +93,7 @@ class ExceptionsFacadeTest extends TestCase
     public function testFakeAssertReportedAsClosureMayFail()
     {
         $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('The expected [InvalidArgumentException] exception was not reported.');
+        $this->expectExceptionMessageIs('The expected [InvalidArgumentException] exception was not reported.');
 
         Exceptions::fake();
 
@@ -106,7 +106,7 @@ class ExceptionsFacadeTest extends TestCase
     public function testFakeAssertReportedWithFakedExceptionsMayFail()
     {
         $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('The expected [RuntimeException] exception was not reported.');
+        $this->expectExceptionMessageIs('The expected [RuntimeException] exception was not reported.');
 
         Exceptions::fake(InvalidArgumentException::class);
 
@@ -148,7 +148,7 @@ class ExceptionsFacadeTest extends TestCase
     public function testFakeAssertNotReportedMayFail()
     {
         $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('The expected [RuntimeException] exception was reported.');
+        $this->expectExceptionMessageIs('The expected [RuntimeException] exception was reported.');
 
         Exceptions::fake();
 
@@ -160,7 +160,7 @@ class ExceptionsFacadeTest extends TestCase
     public function testFakeAssertNotReportedAsClosureMayFail()
     {
         $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('The expected [RuntimeException] exception was reported.');
+        $this->expectExceptionMessageIs('The expected [RuntimeException] exception was reported.');
 
         Exceptions::fake();
 
@@ -198,7 +198,7 @@ class ExceptionsFacadeTest extends TestCase
     public function testFakeAssertNothingReportedMayFail()
     {
         $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('The following exceptions were reported: RuntimeException, RuntimeException, InvalidArgumentException.');
+        $this->expectExceptionMessageIs('The following exceptions were reported: RuntimeException, RuntimeException, InvalidArgumentException.');
 
         Exceptions::fake();
 
@@ -252,7 +252,7 @@ class ExceptionsFacadeTest extends TestCase
         Exceptions::fake()->throwOnReport();
 
         $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Test exception');
+        $this->expectExceptionMessageIs('Test exception');
 
         report(new Exception('Test exception'));
     }
@@ -287,7 +287,7 @@ class ExceptionsFacadeTest extends TestCase
         });
 
         $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Test exception');
+        $this->expectExceptionMessageIs('Test exception');
 
         $this->get('/');
     }
@@ -303,7 +303,7 @@ class ExceptionsFacadeTest extends TestCase
         });
 
         $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Test exception');
+        $this->expectExceptionMessageIs('Test exception');
 
         $this->get('/');
     }
@@ -322,7 +322,7 @@ class ExceptionsFacadeTest extends TestCase
         });
 
         $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Test exception');
+        $this->expectExceptionMessageIs('Test exception');
 
         $this->get('/');
     }
@@ -341,7 +341,7 @@ class ExceptionsFacadeTest extends TestCase
         });
 
         $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Test exception');
+        $this->expectExceptionMessageIs('Test exception');
 
         $this->get('/');
     }
@@ -379,7 +379,7 @@ class ExceptionsFacadeTest extends TestCase
         Exceptions::fake()->throwOnReport();
 
         $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Test exception');
+        $this->expectExceptionMessageIs('Test exception');
 
         report(new Exception('Test exception'));
     }
@@ -406,7 +406,7 @@ class ExceptionsFacadeTest extends TestCase
         Exceptions::fake([RuntimeException::class])->throwOnReport();
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('My exception message');
+        $this->expectExceptionMessageIs('My exception message');
 
         report(new Exception('My exception message'));
     }
@@ -416,7 +416,7 @@ class ExceptionsFacadeTest extends TestCase
         Exceptions::fake();
 
         $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Test exception');
+        $this->expectExceptionMessageIs('Test exception');
 
         report(new Exception('Test exception'));
 
@@ -428,7 +428,7 @@ class ExceptionsFacadeTest extends TestCase
         Exceptions::fake([InvalidArgumentException::class]);
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Test exception');
+        $this->expectExceptionMessageIs('Test exception');
 
         report(new RuntimeException('Test exception'));
         report(new InvalidArgumentException('Test exception'));

--- a/tests/Integration/Testing/ArtisanCommandTest.php
+++ b/tests/Integration/Testing/ArtisanCommandTest.php
@@ -79,7 +79,7 @@ class ArtisanCommandTest extends TestCase
     public function test_console_command_that_fails()
     {
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Expected status code 0 but received 1.');
+        $this->expectExceptionMessageIs('Expected status code 0 but received 1.');
 
         $this->artisan('exit', ['code' => 1])->assertOk();
     }
@@ -110,7 +110,7 @@ class ArtisanCommandTest extends TestCase
     public function test_console_command_that_fails_from_unexpected_output()
     {
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Output "Your name is Taylor Otwell and you prefer PHP." was printed.');
+        $this->expectExceptionMessageIs('Output "Your name is Taylor Otwell and you prefer PHP." was printed.');
 
         $this->artisan('survey')
             ->expectsQuestion('What is your name?', 'Taylor Otwell')
@@ -122,7 +122,7 @@ class ArtisanCommandTest extends TestCase
     public function test_console_command_that_fails_from_unexpected_output_substring()
     {
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Output "Taylor Otwell" was printed.');
+        $this->expectExceptionMessageIs('Output "Taylor Otwell" was printed.');
 
         $this->artisan('contains')
             ->doesntExpectOutputToContain('Taylor Otwell')
@@ -132,7 +132,7 @@ class ArtisanCommandTest extends TestCase
     public function test_console_command_that_fails_from_zero_as_unexpected_output()
     {
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Output "0" was printed.');
+        $this->expectExceptionMessageIs('Output "0" was printed.');
 
         $this->artisan('zero')
             ->doesntExpectOutput('0')
@@ -142,7 +142,7 @@ class ArtisanCommandTest extends TestCase
     public function test_console_command_that_fails_from_zero_as_unexpected_output_substring()
     {
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Output "0" was printed.');
+        $this->expectExceptionMessageIs('Output "0" was printed.');
 
         $this->artisan('zero')
             ->doesntExpectOutputToContain('0')
@@ -152,7 +152,7 @@ class ArtisanCommandTest extends TestCase
     public function test_console_command_that_fails_from_missing_output()
     {
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Output "Your name is Taylor Otwell and you prefer PHP." was not printed.');
+        $this->expectExceptionMessageIs('Output "Your name is Taylor Otwell and you prefer PHP." was not printed.');
 
         $this->ignoringMockOnceExceptions(function () {
             $this->artisan('survey')
@@ -166,7 +166,7 @@ class ArtisanCommandTest extends TestCase
     public function test_console_command_that_fails_from_exit_code_mismatch()
     {
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Expected status code 1 but received 0.');
+        $this->expectExceptionMessageIs('Expected status code 1 but received 0.');
 
         $this->artisan('survey')
             ->expectsQuestion('What is your name?', 'Taylor Otwell')
@@ -300,7 +300,7 @@ class ArtisanCommandTest extends TestCase
     public function test_console_command_that_fails_if_the_output_does_not_contain()
     {
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Output does not contain "Otwell Taylor".');
+        $this->expectExceptionMessageIs('Output does not contain "Otwell Taylor".');
 
         $this->ignoringMockOnceExceptions(function () {
             $this->artisan('contains')

--- a/tests/JsonSchema/DeserializerTest.php
+++ b/tests/JsonSchema/DeserializerTest.php
@@ -325,7 +325,7 @@ class DeserializerTest extends TestCase
     public function test_it_throws_for_an_unresolvable_ref(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Unable to resolve JSON Schema $ref [#/$defs/Missing].');
+        $this->expectExceptionMessageIs('Unable to resolve JSON Schema $ref [#/$defs/Missing].');
 
         JsonSchema::fromArray([
             '$ref' => '#/$defs/Missing',
@@ -336,7 +336,7 @@ class DeserializerTest extends TestCase
     public function test_it_throws_for_a_remote_ref(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Unable to resolve non-local JSON Schema $ref [https://example.com/user.json].');
+        $this->expectExceptionMessageIs('Unable to resolve non-local JSON Schema $ref [https://example.com/user.json].');
 
         JsonSchema::fromArray([
             '$ref' => 'https://example.com/user.json',
@@ -421,7 +421,7 @@ class DeserializerTest extends TestCase
     public function test_it_throws_when_the_type_cannot_be_determined(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Unable to determine the JSON Schema type for the given schema.');
+        $this->expectExceptionMessageIs('Unable to determine the JSON Schema type for the given schema.');
 
         JsonSchema::fromArray([
             'title' => 'Mystery',
@@ -431,7 +431,7 @@ class DeserializerTest extends TestCase
     public function test_it_detects_a_circular_ref_instead_of_recursing(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Circular JSON Schema $ref [#/$defs/node] detected.');
+        $this->expectExceptionMessageIs('Circular JSON Schema $ref [#/$defs/node] detected.');
 
         JsonSchema::fromArray([
             'type' => 'object',
@@ -618,7 +618,7 @@ class DeserializerTest extends TestCase
     public function test_it_throws_for_an_unsupported_union_member(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Unsupported JSON Schema type [wat] in a multi-type union.');
+        $this->expectExceptionMessageIs('Unsupported JSON Schema type [wat] in a multi-type union.');
 
         JsonSchema::fromArray([
             'type' => ['string', 'wat'],
@@ -628,7 +628,7 @@ class DeserializerTest extends TestCase
     public function test_it_throws_for_a_non_string_union_member(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Unsupported JSON Schema type [123] in a multi-type union.');
+        $this->expectExceptionMessageIs('Unsupported JSON Schema type [123] in a multi-type union.');
 
         JsonSchema::fromArray([
             'type' => ['string', 123],
@@ -638,7 +638,7 @@ class DeserializerTest extends TestCase
     public function test_it_throws_when_a_union_carries_type_specific_keywords(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Type-specific keywords [items] are not supported on a multi-type JSON Schema union.');
+        $this->expectExceptionMessageIs('Type-specific keywords [items] are not supported on a multi-type JSON Schema union.');
 
         JsonSchema::fromArray([
             'type' => ['array', 'string'],
@@ -649,7 +649,7 @@ class DeserializerTest extends TestCase
     public function test_it_throws_for_a_boolean_property_schema(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Unable to represent the schema for property [meta]; boolean schemas are not supported.');
+        $this->expectExceptionMessageIs('Unable to represent the schema for property [meta]; boolean schemas are not supported.');
 
         JsonSchema::fromArray([
             'type' => 'object',
@@ -662,7 +662,7 @@ class DeserializerTest extends TestCase
     public function test_it_throws_for_a_non_numeric_numeric_constraint(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The JSON Schema [minimum] constraint must be a number.');
+        $this->expectExceptionMessageIs('The JSON Schema [minimum] constraint must be a number.');
 
         JsonSchema::fromArray([
             'type' => 'number',
@@ -673,7 +673,7 @@ class DeserializerTest extends TestCase
     public function test_it_throws_for_a_non_integer_integer_constraint(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The JSON Schema integer constraint [1.9] must be an integer.');
+        $this->expectExceptionMessageIs('The JSON Schema integer constraint [1.9] must be an integer.');
 
         JsonSchema::fromArray([
             'type' => 'integer',
@@ -684,7 +684,7 @@ class DeserializerTest extends TestCase
     public function test_it_throws_for_tuple_items(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Tuple and boolean JSON Schema "items" are not supported.');
+        $this->expectExceptionMessageIs('Tuple and boolean JSON Schema "items" are not supported.');
 
         JsonSchema::fromArray([
             'type' => 'array',
@@ -698,7 +698,7 @@ class DeserializerTest extends TestCase
     public function test_it_throws_when_a_union_branch_conflicts_with_sibling_keys(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Conflicting [type] between a "anyOf" branch and its sibling keys.');
+        $this->expectExceptionMessageIs('Conflicting [type] between a "anyOf" branch and its sibling keys.');
 
         JsonSchema::fromArray([
             'type' => 'integer',
@@ -712,7 +712,7 @@ class DeserializerTest extends TestCase
     public function test_it_throws_for_an_unsupported_one_of_union(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Only a nullable "oneOf" (a single schema plus a "null" branch) is supported.');
+        $this->expectExceptionMessageIs('Only a nullable "oneOf" (a single schema plus a "null" branch) is supported.');
 
         JsonSchema::fromArray([
             'oneOf' => [
@@ -725,7 +725,7 @@ class DeserializerTest extends TestCase
     public function test_it_throws_for_a_null_default(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('A null JSON Schema [default] is not supported.');
+        $this->expectExceptionMessageIs('A null JSON Schema [default] is not supported.');
 
         JsonSchema::fromArray([
             'type' => 'string',
@@ -737,7 +737,7 @@ class DeserializerTest extends TestCase
     {
         // "#" resolves to the root, so a self-reference is detected as circular...
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Circular JSON Schema $ref [#] detected.');
+        $this->expectExceptionMessageIs('Circular JSON Schema $ref [#] detected.');
 
         JsonSchema::fromArray(['$ref' => '#']);
     }

--- a/tests/JsonSchema/SerializerTest.php
+++ b/tests/JsonSchema/SerializerTest.php
@@ -11,7 +11,7 @@ class SerializerTest extends TestCase
     public function test_it_does_not_know_how_to_serialize_unknown_types(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unsupported [Illuminate\\JsonSchema\\Types\\Type@anonymous');
+        $this->expectExceptionMessageIs('Unsupported [Illuminate\\JsonSchema\\Types\\Type@anonymous');
 
         $type = new class extends Type {
             // anonymous type for triggering serializer failure

--- a/tests/JsonSchema/TypeTest.php
+++ b/tests/JsonSchema/TypeTest.php
@@ -139,7 +139,7 @@ class TypeTest extends TestCase
     public function test_throws_with_invalid_enum_string(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The provided class must be a BackedEnum.');
+        $this->expectExceptionMessageIs('The provided class must be a BackedEnum.');
         $this->expectExceptionCode(0);
 
         JsonSchema::string()->enum('NonExistentEnumClass');
@@ -148,7 +148,7 @@ class TypeTest extends TestCase
     public function test_throws_with_not_an_enum_class(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The provided class must be a BackedEnum.');
+        $this->expectExceptionMessageIs('The provided class must be a BackedEnum.');
         $this->expectExceptionCode(0);
 
         JsonSchema::string()->enum(stdClass::class);
@@ -157,7 +157,7 @@ class TypeTest extends TestCase
     public function test_throws_with_unit_enum_class(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The provided class must be a BackedEnum.');
+        $this->expectExceptionMessageIs('The provided class must be a BackedEnum.');
         $this->expectExceptionCode(0);
 
         JsonSchema::string()->enum(UnitEnum::class);

--- a/tests/JsonSchema/UnionTypeTest.php
+++ b/tests/JsonSchema/UnionTypeTest.php
@@ -71,7 +71,7 @@ class UnionTypeTest extends TestCase
     public function test_it_rejects_an_unsupported_member_name(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Unsupported JSON Schema type [wat] in a multi-type union.');
+        $this->expectExceptionMessageIs('Unsupported JSON Schema type [wat] in a multi-type union.');
 
         JsonSchema::union(['string', 'wat']);
     }
@@ -79,7 +79,7 @@ class UnionTypeTest extends TestCase
     public function test_it_rejects_a_non_string_member(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Unsupported JSON Schema type [123] in a multi-type union.');
+        $this->expectExceptionMessageIs('Unsupported JSON Schema type [123] in a multi-type union.');
 
         JsonSchema::union(['string', 123]);
     }

--- a/tests/Log/ContextTest.php
+++ b/tests/Log/ContextTest.php
@@ -192,7 +192,7 @@ class ContextTest extends TestCase
         Context::add('breadcrumbs', 'foo');
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unable to push value onto context stack for key [breadcrumbs].');
+        $this->expectExceptionMessageIs('Unable to push value onto context stack for key [breadcrumbs].');
         Context::push('breadcrumbs', 'bar');
     }
 
@@ -201,7 +201,7 @@ class ContextTest extends TestCase
         Context::add('breadcrumbs', ['foo' => 'bar']);
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unable to push value onto context stack for key [breadcrumbs].');
+        $this->expectExceptionMessageIs('Unable to push value onto context stack for key [breadcrumbs].');
         Context::push('breadcrumbs', 'bar');
     }
 
@@ -220,7 +220,7 @@ class ContextTest extends TestCase
         Context::pop('breadcrumbs');
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unable to pop value from context stack for key [breadcrumbs].');
+        $this->expectExceptionMessageIs('Unable to pop value from context stack for key [breadcrumbs].');
 
         Context::pop('breadcrumbs');
     }
@@ -230,7 +230,7 @@ class ContextTest extends TestCase
         Context::add('breadcrumbs', ['foo' => 'bar']);
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unable to pop value from context stack for key [breadcrumbs].');
+        $this->expectExceptionMessageIs('Unable to pop value from context stack for key [breadcrumbs].');
         Context::pop('breadcrumbs');
     }
 
@@ -249,7 +249,7 @@ class ContextTest extends TestCase
         Context::popHidden('breadcrumbs');
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unable to pop value from hidden context stack for key [breadcrumbs].');
+        $this->expectExceptionMessageIs('Unable to pop value from hidden context stack for key [breadcrumbs].');
 
         Context::popHidden('breadcrumbs');
     }
@@ -259,7 +259,7 @@ class ContextTest extends TestCase
         Context::addHidden('breadcrumbs', ['foo' => 'bar']);
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unable to pop value from hidden context stack for key [breadcrumbs].');
+        $this->expectExceptionMessageIs('Unable to pop value from hidden context stack for key [breadcrumbs].');
         Context::popHidden('breadcrumbs');
     }
 
@@ -496,7 +496,7 @@ class ContextTest extends TestCase
         Context::addHidden('foo', 'bar');
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unable to push value onto hidden context stack for key [foo].');
+        $this->expectExceptionMessageIs('Unable to push value onto hidden context stack for key [foo].');
         Context::pushHidden('foo', 2);
     }
 

--- a/tests/Log/LogLoggerTest.php
+++ b/tests/Log/LogLoggerTest.php
@@ -87,7 +87,7 @@ class LogLoggerTest extends TestCase
     public function testListenShortcutFailsWithNoDispatcher()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Events dispatcher has not been set.');
+        $this->expectExceptionMessageIs('Events dispatcher has not been set.');
 
         $writer = new Logger(m::mock(Monolog::class));
         $writer->listen(function () {

--- a/tests/Mail/AttachmentTest.php
+++ b/tests/Mail/AttachmentTest.php
@@ -25,7 +25,7 @@ class AttachmentTest extends TestCase
     public function testFromUrlThrowsForFtpScheme(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Attachment URLs must use the http or https scheme.');
+        $this->expectExceptionMessageIs('Attachment URLs must use the http or https scheme.');
 
         Attachment::fromUrl('ftp://example.com/file.pdf');
     }
@@ -33,7 +33,7 @@ class AttachmentTest extends TestCase
     public function testFromUrlThrowsForFileScheme(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Attachment URLs must use the http or https scheme.');
+        $this->expectExceptionMessageIs('Attachment URLs must use the http or https scheme.');
 
         Attachment::fromUrl('file:///var/www/file.pdf');
     }
@@ -41,7 +41,7 @@ class AttachmentTest extends TestCase
     public function testFromUrlThrowsForMailtoScheme(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Attachment URLs must use the http or https scheme.');
+        $this->expectExceptionMessageIs('Attachment URLs must use the http or https scheme.');
 
         Attachment::fromUrl('mailto:user@example.com');
     }
@@ -49,7 +49,7 @@ class AttachmentTest extends TestCase
     public function testFromUrlThrowsForInvalidUrl(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Attachment URLs must use the http or https scheme.');
+        $this->expectExceptionMessageIs('Attachment URLs must use the http or https scheme.');
 
         Attachment::fromUrl('not-a-url');
     }
@@ -57,7 +57,7 @@ class AttachmentTest extends TestCase
     public function testFromUrlThrowsForEmptyString(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Attachment URLs must use the http or https scheme.');
+        $this->expectExceptionMessageIs('Attachment URLs must use the http or https scheme.');
 
         Attachment::fromUrl('');
     }

--- a/tests/Mail/MailCloudflareTransportTest.php
+++ b/tests/Mail/MailCloudflareTransportTest.php
@@ -223,7 +223,7 @@ class MailCloudflareTransportTest extends TestCase
         $message->to('me@example.com');
 
         $this->expectException(TransportException::class);
-        $this->expectExceptionMessage('invalid_request_schema');
+        $this->expectExceptionMessageIs('invalid_request_schema');
 
         $transport->send($message);
     }

--- a/tests/Mail/MailMailerTest.php
+++ b/tests/Mail/MailMailerTest.php
@@ -212,7 +212,7 @@ class MailMailerTest extends TestCase
         $mailer = new Mailer('array', $view, new ArrayTransport);
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Email addresses may not contain line break characters.');
+        $this->expectExceptionMessageIs('Email addresses may not contain line break characters.');
 
         $mailer->send('foo', ['data'], function (Message $message) {
             $message->to("\"foo\r\nBcc: victim@example.com\"@example.com")->from('hello@laravel.com');

--- a/tests/Mail/MailManagerTest.php
+++ b/tests/Mail/MailManagerTest.php
@@ -25,7 +25,7 @@ class MailManagerTest extends TestCase
         ]);
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage("Unsupported mail transport [{$transport}]");
+        $this->expectExceptionMessageIs("Unsupported mail transport [{$transport}]");
         $this->app['mail.manager']->mailer('custom_smtp');
     }
 

--- a/tests/Pagination/CursorResourceTest.php
+++ b/tests/Pagination/CursorResourceTest.php
@@ -23,7 +23,7 @@ class CursorResourceTest extends TestCase
     public function testItThrowsExceptionWhenResourceCannotBeFound()
     {
         $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('Failed to find resource class for model [Illuminate\Tests\Pagination\Fixtures\Models\CursorResourceTestModel].');
+        $this->expectExceptionMessageIs('Failed to find resource class for model [Illuminate\Tests\Pagination\Fixtures\Models\CursorResourceTestModel].');
 
         $paginator = new CursorResourceTestPaginator([
             new CursorResourceTestModel(),

--- a/tests/Pagination/PaginatorResourceTest.php
+++ b/tests/Pagination/PaginatorResourceTest.php
@@ -23,7 +23,7 @@ class PaginatorResourceTest extends TestCase
     public function testItThrowsExceptionWhenResourceCannotBeFound()
     {
         $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('Failed to find resource class for model [Illuminate\Tests\Pagination\Fixtures\Models\PaginatorResourceTestModel].');
+        $this->expectExceptionMessageIs('Failed to find resource class for model [Illuminate\Tests\Pagination\Fixtures\Models\PaginatorResourceTestModel].');
 
         $paginator = new PaginatorResourceTestPaginator([
             new PaginatorResourceTestModel(),

--- a/tests/Pipeline/PipelineTest.php
+++ b/tests/Pipeline/PipelineTest.php
@@ -245,7 +245,7 @@ class PipelineTest extends TestCase
     public function testPipelineThrowsExceptionOnResolveWithoutContainer()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('A container instance has not been passed to the Pipeline.');
+        $this->expectExceptionMessageIs('A container instance has not been passed to the Pipeline.');
 
         (new Pipeline)->send('data')
             ->through(PipelineTestPipeOne::class)
@@ -257,7 +257,7 @@ class PipelineTest extends TestCase
     public function testPipelineThrowsExceptionWhenUsingTransactionsWithoutContainer()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('A container instance has not been passed to the Pipeline.');
+        $this->expectExceptionMessageIs('A container instance has not been passed to the Pipeline.');
 
         (new Pipeline)->send('data')
             ->through(PipelineTestPipeOne::class)
@@ -396,7 +396,7 @@ class PipelineTest extends TestCase
         $std = new stdClass();
 
         $this->expectException(Exception::class);
-        $this->expectExceptionMessage('My Exception: 1');
+        $this->expectExceptionMessageIs('My Exception: 1');
 
         try {
             (new Pipeline(new Container))

--- a/tests/Process/ProcessTest.php
+++ b/tests/Process/ProcessTest.php
@@ -403,9 +403,9 @@ class ProcessTest extends TestCase
     public function testStrayProcessesCanBePreventedWithStringCommand()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Attempted process [');
-        $this->expectExceptionMessage('cat composer.json');
-        $this->expectExceptionMessage('] without a matching fake.');
+        $this->expectExceptionMessageIs('Attempted process [');
+        $this->expectExceptionMessageIs('cat composer.json');
+        $this->expectExceptionMessageIs('] without a matching fake.');
 
         $factory = new Factory;
 
@@ -421,9 +421,9 @@ class ProcessTest extends TestCase
     public function testStrayProcessesCanBePreventedWithArrayCommand()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Attempted process [');
-        $this->expectExceptionMessage('cat composer.json');
-        $this->expectExceptionMessage('] without a matching fake.');
+        $this->expectExceptionMessageIs('Attempted process [');
+        $this->expectExceptionMessageIs('cat composer.json');
+        $this->expectExceptionMessageIs('] without a matching fake.');
 
         $factory = new Factory;
 
@@ -451,7 +451,7 @@ class ProcessTest extends TestCase
     public function testProcessFakeThrowShorthand()
     {
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('fake exception message');
+        $this->expectExceptionMessageIs('fake exception message');
 
         $factory = new Factory;
 
@@ -510,7 +510,7 @@ class ProcessTest extends TestCase
     public function testFakeProcessesCanThrowWithoutOutput()
     {
         $this->expectException(ProcessFailedException::class);
-        $this->expectExceptionMessage(<<<'EOT'
+        $this->expectExceptionMessageIs(<<<'EOT'
             The command "exit 1;" failed.
 
             Exit Code: 1
@@ -528,7 +528,7 @@ class ProcessTest extends TestCase
     public function testRealProcessesCanThrowWithoutOutput()
     {
         $this->expectException(ProcessFailedException::class);
-        $this->expectExceptionMessage(<<<'EOT'
+        $this->expectExceptionMessageIs(<<<'EOT'
             The command "exit 1;" failed.
 
             Exit Code: 1
@@ -544,7 +544,7 @@ class ProcessTest extends TestCase
     public function testFakeProcessesCanThrowWithErrorOutput()
     {
         $this->expectException(ProcessFailedException::class);
-        $this->expectExceptionMessage(<<<'EOT'
+        $this->expectExceptionMessageIs(<<<'EOT'
             The command "echo "Hello World" >&2; exit 1;" failed.
 
             Exit Code: 1
@@ -566,7 +566,7 @@ class ProcessTest extends TestCase
     public function testRealProcessesCanThrowWithErrorOutput()
     {
         $this->expectException(ProcessFailedException::class);
-        $this->expectExceptionMessage(<<<'EOT'
+        $this->expectExceptionMessageIs(<<<'EOT'
             The command "echo "Hello World" >&2; exit 1;" failed.
 
             Exit Code: 1
@@ -586,7 +586,7 @@ class ProcessTest extends TestCase
     public function testFakeProcessesCanThrowWithOutput()
     {
         $this->expectException(ProcessFailedException::class);
-        $this->expectExceptionMessage(<<<'EOT'
+        $this->expectExceptionMessageIs(<<<'EOT'
             The command "echo "Hello World" >&1; exit 1;" failed.
 
             Exit Code: 1
@@ -608,7 +608,7 @@ class ProcessTest extends TestCase
     public function testRealProcessesCanThrowWithOutput()
     {
         $this->expectException(ProcessFailedException::class);
-        $this->expectExceptionMessage(<<<'EOT'
+        $this->expectExceptionMessageIs(<<<'EOT'
             The command "echo "Hello World" >&1; exit 1;" failed.
 
             Exit Code: 1
@@ -629,7 +629,7 @@ class ProcessTest extends TestCase
     public function testRealProcessesCanTimeout()
     {
         $this->expectException(ProcessTimedOutException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionMessageIs(
             'The process "sleep 2; exit 1;" exceeded the timeout of 1 seconds.'
         );
 
@@ -643,7 +643,7 @@ class ProcessTest extends TestCase
     public function testATimeoutCanBeSetWithACarbonInterval()
     {
         $this->expectException(ProcessTimedOutException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionMessageIs(
             'The process "sleep 2; exit 1;" exceeded the timeout of 1 seconds.'
         );
 

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -1218,7 +1218,7 @@ class QueueSqsQueueTest extends TestCase
         $this->sqs->shouldReceive('sendMessageBatch')->once()->andThrow(new RuntimeException('SQS is down'));
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('SQS is down');
+        $this->expectExceptionMessageIs('SQS is down');
 
         $queue->bulk(range(1, 15), 'data', $this->fifoQueueName);
     }
@@ -1400,7 +1400,7 @@ class QueueSqsQueueTest extends TestCase
         $this->sqs->shouldReceive('sendMessageBatch')->once()->andThrow(new RuntimeException('SQS is down'));
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('SQS is down');
+        $this->expectExceptionMessageIs('SQS is down');
 
         $queue->bulk(['a'], 'data', $this->queueName);
     }

--- a/tests/Redis/Connections/PhpRedisClusterConnectionTest.php
+++ b/tests/Redis/Connections/PhpRedisClusterConnectionTest.php
@@ -52,7 +52,7 @@ class PhpRedisClusterConnectionTest extends TestCase
         $client->shouldReceive('_masters')->once()->andReturn([]);
         $client->shouldReceive('scan');
 
-        $this->expectExceptionMessage('Unable to determine default node. No master nodes found in the cluster.');
+        $this->expectExceptionMessageIs('Unable to determine default node. No master nodes found in the cluster.');
 
         $connection = new PhpRedisClusterConnection($client);
         $connection->scan(0);

--- a/tests/Redis/PhpRedisConnectorTest.php
+++ b/tests/Redis/PhpRedisConnectorTest.php
@@ -220,7 +220,7 @@ class PhpRedisConnectorTest extends TestCase
         $connector = new TestablePhpRedisConnector;
 
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Algorithm [bogus] is not a valid PhpRedis backoff algorithm.');
+        $this->expectExceptionMessageIs('Algorithm [bogus] is not a valid PhpRedis backoff algorithm.');
 
         $connector->testParseBackoffAlgorithm('bogus');
     }
@@ -250,7 +250,7 @@ class PhpRedisConnectorTest extends TestCase
         $connector = new TestablePhpRedisConnector;
 
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('The scheme configured in the Redis host option must match the scheme option.');
+        $this->expectExceptionMessageIs('The scheme configured in the Redis host option must match the scheme option.');
 
         $connector->testFormatHost([
             'host' => 'tcp://127.0.0.1',
@@ -273,7 +273,7 @@ class PhpRedisConnectorTest extends TestCase
         $connector = new TestablePhpRedisConnector;
 
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Redis host must be a non-empty string.');
+        $this->expectExceptionMessageIs('Redis host must be a non-empty string.');
 
         $connector->testFormatHost([
             'scheme' => 'tls',
@@ -285,7 +285,7 @@ class PhpRedisConnectorTest extends TestCase
         $connector = new TestablePhpRedisConnector;
 
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Redis host must be a non-empty string.');
+        $this->expectExceptionMessageIs('Redis host must be a non-empty string.');
 
         $connector->testFormatHost([
             'host' => null,

--- a/tests/Redis/PredisConnectorTest.php
+++ b/tests/Redis/PredisConnectorTest.php
@@ -72,7 +72,7 @@ class PredisConnectorTest extends TestCase
         $connector = new TestablePredisConnector;
 
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('The scheme configured in the Redis host option must match the scheme option.');
+        $this->expectExceptionMessageIs('The scheme configured in the Redis host option must match the scheme option.');
 
         $connector->testFormatHost([
             'host' => 'tcp://127.0.0.1',
@@ -229,7 +229,7 @@ class PredisConnectorTest extends TestCase
         $connector = new TestablePredisConnector;
 
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Strategy [bogus] is not a valid Predis backoff strategy.');
+        $this->expectExceptionMessageIs('Strategy [bogus] is not a valid Predis backoff strategy.');
 
         $connector->testFormatRetry([
             'retry' => [

--- a/tests/Redis/RedisEventsTest.php
+++ b/tests/Redis/RedisEventsTest.php
@@ -32,7 +32,7 @@ class RedisEventsTest extends TestCase
         $connection->setEventDispatcher($events);
 
         $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Test exception');
+        $this->expectExceptionMessageIs('Test exception');
 
         $connection->command('get', ['key']);
     }

--- a/tests/Routing/ImplicitRouteBindingTest.php
+++ b/tests/Routing/ImplicitRouteBindingTest.php
@@ -100,7 +100,7 @@ class ImplicitRouteBindingTest extends TestCase
         $container = Container::getInstance();
 
         $this->expectException(BackedEnumCaseNotFoundException::class);
-        $this->expectExceptionMessage(sprintf(
+        $this->expectExceptionMessageIs(sprintf(
             'Case [%s] not found on Backed Enum [%s].',
             'cars',
             CategoryBackedEnum::class,

--- a/tests/Routing/RouteCollectionTest.php
+++ b/tests/Routing/RouteCollectionTest.php
@@ -303,7 +303,7 @@ class RouteCollectionTest extends TestCase
     public function testRouteCollectionDontMatchNonMatchingDoubleSlashes()
     {
         $this->expectException(NotFoundHttpException::class);
-        $this->expectExceptionMessage('The route foo could not be found.');
+        $this->expectExceptionMessageIs('The route foo could not be found.');
 
         $this->routeCollection->add(new Route('GET', 'foo', [
             'uses' => 'FooController@index',
@@ -321,7 +321,7 @@ class RouteCollectionTest extends TestCase
     public function testRouteCollectionRequestMethodNotAllowed()
     {
         $this->expectException(MethodNotAllowedHttpException::class);
-        $this->expectExceptionMessage('The POST method is not supported for route users. Supported methods: GET, HEAD.');
+        $this->expectExceptionMessageIs('The POST method is not supported for route users. Supported methods: GET, HEAD.');
 
         $this->routeCollection->add(
             new Route('GET', 'users', ['uses' => 'UsersController@index', 'as' => 'users'])

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -520,7 +520,7 @@ class RouteRegistrarTest extends TestCase
     public function testRegisteringNonApprovedAttributesThrows()
     {
         $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage('Method Illuminate\Routing\RouteRegistrar::unsupportedMethod does not exist.');
+        $this->expectExceptionMessageIs('Method Illuminate\Routing\RouteRegistrar::unsupportedMethod does not exist.');
 
         $this->router->domain('foo')->unsupportedMethod('bar')->group(function ($router) {
             //

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -317,7 +317,7 @@ class RoutingRouteTest extends TestCase
     public function testFluentRouting()
     {
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('Route for [foo/bar] has no action.');
+        $this->expectExceptionMessageIs('Route for [foo/bar] has no action.');
 
         $router = $this->getRouter();
         $router->get('foo/bar')->uses(function () {
@@ -389,7 +389,7 @@ class RoutingRouteTest extends TestCase
     public function testMiddlewareGroupsCannotReferenceItself()
     {
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('[web] middleware group is referencing itself.');
+        $this->expectExceptionMessageIs('[web] middleware group is referencing itself.');
 
         $router = $this->getRouter();
         $router->get('foo/bar', ['middleware' => 'web', function () {
@@ -1068,7 +1068,7 @@ class RoutingRouteTest extends TestCase
     public function testModelBindingWithNullReturn()
     {
         $this->expectException(ModelNotFoundException::class);
-        $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Routing\RouteModelBindingNullStub].');
+        $this->expectExceptionMessageIs('No query results for model [Illuminate\Tests\Routing\RouteModelBindingNullStub].');
 
         $router = $this->getRouter();
         $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => function ($name) {
@@ -1433,7 +1433,7 @@ class RoutingRouteTest extends TestCase
     public function testInvalidActionException()
     {
         $this->expectException(UnexpectedValueException::class);
-        $this->expectExceptionMessage('Invalid route action: [Illuminate\Tests\Routing\RouteTestControllerStub].');
+        $this->expectExceptionMessageIs('Invalid route action: [Illuminate\Tests\Routing\RouteTestControllerStub].');
 
         $router = $this->getRouter();
         $router->get('/', ['uses' => RouteTestControllerStub::class]);
@@ -2163,7 +2163,7 @@ class RoutingRouteTest extends TestCase
     public function testRouteRedirectExceptionWhenMissingExpectedParameters()
     {
         $this->expectException(UrlGenerationException::class);
-        $this->expectExceptionMessage('Missing required parameter for [Route: laravel_route_redirect_destination] [URI: users/{user}] [Missing parameter: user].');
+        $this->expectExceptionMessageIs('Missing required parameter for [Route: laravel_route_redirect_destination] [URI: users/{user}] [Missing parameter: user].');
 
         $container = new Container;
         $router = new Router(new Dispatcher, $container);

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -618,7 +618,7 @@ class RoutingUrlGeneratorTest extends TestCase
     public function testUrlGenerationThrowsExceptionForMissingParametersWithMeaningfulMessage($parameters, $expectedMeaningfulExceptionMessage)
     {
         $this->expectException(UrlGenerationException::class);
-        $this->expectExceptionMessage($expectedMeaningfulExceptionMessage);
+        $this->expectExceptionMessageIs($expectedMeaningfulExceptionMessage);
 
         $url = new UrlGenerator(
             $routes = new RouteCollection,
@@ -764,7 +764,7 @@ class RoutingUrlGeneratorTest extends TestCase
     public function testRouteNotDefinedException()
     {
         $this->expectException(RouteNotFoundException::class);
-        $this->expectExceptionMessage('Route [not_exists_route] not defined.');
+        $this->expectExceptionMessageIs('Route [not_exists_route] not defined.');
 
         $url = new UrlGenerator(
             new RouteCollection,
@@ -898,7 +898,7 @@ class RoutingUrlGeneratorTest extends TestCase
         $routes->add($route);
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('reserved');
+        $this->expectExceptionMessageIs('reserved');
 
         Request::create($url->signedRoute('foo', ['signature' => 'bar']));
     }
@@ -919,7 +919,7 @@ class RoutingUrlGeneratorTest extends TestCase
         $routes->add($route);
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('reserved');
+        $this->expectExceptionMessageIs('reserved');
 
         Request::create($url->signedRoute('foo', ['expires' => 253402300799]));
     }

--- a/tests/Support/ForwardsCallsTest.php
+++ b/tests/Support/ForwardsCallsTest.php
@@ -26,7 +26,7 @@ class ForwardsCallsTest extends TestCase
     public function testMissingForwardedCallThrowsCorrectError()
     {
         $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage('Call to undefined method Illuminate\Tests\Support\ForwardsCallsOne::missingMethod()');
+        $this->expectExceptionMessageIs('Call to undefined method Illuminate\Tests\Support\ForwardsCallsOne::missingMethod()');
 
         (new ForwardsCallsOne)->missingMethod('foo', 'bar');
     }
@@ -34,7 +34,7 @@ class ForwardsCallsTest extends TestCase
     public function testMissingAlphanumericForwardedCallThrowsCorrectError()
     {
         $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage('Call to undefined method Illuminate\Tests\Support\ForwardsCallsOne::this1_shouldWork_too()');
+        $this->expectExceptionMessageIs('Call to undefined method Illuminate\Tests\Support\ForwardsCallsOne::this1_shouldWork_too()');
 
         (new ForwardsCallsOne)->this1_shouldWork_too('foo', 'bar');
     }
@@ -42,7 +42,7 @@ class ForwardsCallsTest extends TestCase
     public function testNonForwardedErrorIsNotTamperedWith()
     {
         $this->expectException(Error::class);
-        $this->expectExceptionMessage('Call to undefined method Illuminate\Tests\Support\ForwardsCallsBase::missingMethod()');
+        $this->expectExceptionMessageIs('Call to undefined method Illuminate\Tests\Support\ForwardsCallsBase::missingMethod()');
 
         (new ForwardsCallsOne)->baseError('foo', 'bar');
     }
@@ -50,7 +50,7 @@ class ForwardsCallsTest extends TestCase
     public function testThrowBadMethodCallException()
     {
         $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage('Call to undefined method Illuminate\Tests\Support\ForwardsCallsOne::test()');
+        $this->expectExceptionMessageIs('Call to undefined method Illuminate\Tests\Support\ForwardsCallsOne::test()');
 
         (new ForwardsCallsOne)->throwTestException('test');
     }

--- a/tests/Support/LotteryTest.php
+++ b/tests/Support/LotteryTest.php
@@ -140,14 +140,14 @@ class LotteryTest extends TestCase
         $this->assertSame('winner', $result);
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Missing key in sequence.');
+        $this->expectExceptionMessageIs('Missing key in sequence.');
         Lottery::odds(1, 10000)->winner(fn () => 'winner')->loser(fn () => 'loser')->choose();
     }
 
     public function testItThrowsForFloatsOverOne()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Float must not be greater than 1.');
+        $this->expectExceptionMessageIs('Float must not be greater than 1.');
 
         new Lottery(1.1);
     }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -91,7 +91,7 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['Chris', 'Nuno', 'Taylor'], $array);
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Array value for key [foo.bar] must be an array, boolean found.');
+        $this->expectExceptionMessageIs('Array value for key [foo.bar] must be an array, boolean found.');
 
         $array = ['foo' => ['bar' => false]];
         Arr::push($array, 'foo.bar', 'baz');
@@ -671,7 +671,7 @@ class SupportArrTest extends TestCase
 
         // Test that an exception is raised if the value is not a string
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('#^Array value for key \[integer\] must be a string, (.*) found.#');
+        $this->expectExceptionMessageIsMatches('#^Array value for key \[integer\] must be a string, (.*) found.#');
         Arr::string($test_array, 'integer');
     }
 
@@ -691,7 +691,7 @@ class SupportArrTest extends TestCase
 
         // Test that an exception is raised if the value is not an integer
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('#^Array value for key \[string\] must be an integer, (.*) found.#');
+        $this->expectExceptionMessageIsMatches('#^Array value for key \[string\] must be an integer, (.*) found.#');
         Arr::integer($test_array, 'string');
     }
 
@@ -711,7 +711,7 @@ class SupportArrTest extends TestCase
 
         // Test that an exception is raised if the value is not a float
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('#^Array value for key \[string\] must be a float, (.*) found.#');
+        $this->expectExceptionMessageIsMatches('#^Array value for key \[string\] must be a float, (.*) found.#');
         Arr::float($test_array, 'string');
     }
 
@@ -731,7 +731,7 @@ class SupportArrTest extends TestCase
 
         // Test that an exception is raised if the value is not a boolean
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('#^Array value for key \[string\] must be a boolean, (.*) found.#');
+        $this->expectExceptionMessageIsMatches('#^Array value for key \[string\] must be a boolean, (.*) found.#');
         Arr::boolean($test_array, 'string');
     }
 
@@ -751,7 +751,7 @@ class SupportArrTest extends TestCase
 
         // Test that an exception is raised if the value is not an array
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('#^Array value for key \[string\] must be an array, (.*) found.#');
+        $this->expectExceptionMessageIsMatches('#^Array value for key \[string\] must be an array, (.*) found.#');
         Arr::array($test_array, 'string');
     }
 
@@ -1756,7 +1756,7 @@ class SupportArrTest extends TestCase
         $this->assertSame(['bar'], Arr::from($items));
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Items cannot be represented by a scalar value.');
+        $this->expectExceptionMessageIs('Items cannot be represented by a scalar value.');
         Arr::from(123);
     }
 

--- a/tests/Support/SupportBinaryCodecTest.php
+++ b/tests/Support/SupportBinaryCodecTest.php
@@ -66,7 +66,7 @@ class SupportBinaryCodecTest extends TestCase
     public function testEncodeThrowsOnInvalidFormat()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Format [invalid] is invalid.');
+        $this->expectExceptionMessageIs('Format [invalid] is invalid.');
 
         BinaryCodec::encode('value', 'invalid');
     }
@@ -74,7 +74,7 @@ class SupportBinaryCodecTest extends TestCase
     public function testDecodeThrowsOnInvalidFormat()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Format [invalid] is invalid.');
+        $this->expectExceptionMessageIs('Format [invalid] is invalid.');
 
         BinaryCodec::decode('value', 'invalid');
     }

--- a/tests/Support/SupportCarbonTest.php
+++ b/tests/Support/SupportCarbonTest.php
@@ -55,7 +55,7 @@ class SupportCarbonTest extends TestCase
     public function testCarbonRaisesExceptionWhenStaticMacroIsNotFound()
     {
         $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage('nonExistingStaticMacro does not exist.');
+        $this->expectExceptionMessageIs('nonExistingStaticMacro does not exist.');
 
         Carbon::nonExistingStaticMacro();
     }
@@ -63,7 +63,7 @@ class SupportCarbonTest extends TestCase
     public function testCarbonRaisesExceptionWhenMacroIsNotFound()
     {
         $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage('nonExistingMacro does not exist.');
+        $this->expectExceptionMessageIs('nonExistingMacro does not exist.');
 
         Carbon::now()->nonExistingMacro();
     }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3440,7 +3440,7 @@ class SupportCollectionTest extends TestCase
     public function testNthThrowsExceptionForInvalidStep($collection)
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Step value must be at least 1.');
+        $this->expectExceptionMessageIs('Step value must be at least 1.');
 
         (new $collection([1, 2, 3]))->nth(0)->all();
     }
@@ -3449,7 +3449,7 @@ class SupportCollectionTest extends TestCase
     public function testNthThrowsExceptionForNegativeStep($collection)
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Step value must be at least 1.');
+        $this->expectExceptionMessageIs('Step value must be at least 1.');
 
         (new $collection([1, 2, 3]))->nth(-1)->all();
     }
@@ -3458,7 +3458,7 @@ class SupportCollectionTest extends TestCase
     public function testSplitThrowsExceptionForInvalidNumberOfGroups($collection)
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Number of groups must be at least 1.');
+        $this->expectExceptionMessageIs('Number of groups must be at least 1.');
 
         (new $collection([1, 2, 3]))->split(0);
     }
@@ -3467,7 +3467,7 @@ class SupportCollectionTest extends TestCase
     public function testSplitThrowsExceptionForNegativeNumberOfGroups($collection)
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Number of groups must be at least 1.');
+        $this->expectExceptionMessageIs('Number of groups must be at least 1.');
 
         (new $collection([1, 2, 3]))->split(-1);
     }
@@ -3476,7 +3476,7 @@ class SupportCollectionTest extends TestCase
     public function testSplitInThrowsExceptionForInvalidNumberOfGroups($collection)
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Number of groups must be at least 1.');
+        $this->expectExceptionMessageIs('Number of groups must be at least 1.');
 
         (new $collection([1, 2, 3]))->splitIn(0);
     }
@@ -3485,7 +3485,7 @@ class SupportCollectionTest extends TestCase
     public function testSplitInThrowsExceptionForNegativeNumberOfGroups($collection)
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Number of groups must be at least 1.');
+        $this->expectExceptionMessageIs('Number of groups must be at least 1.');
 
         (new $collection([1, 2, 3]))->splitIn(-1);
     }
@@ -5831,7 +5831,7 @@ class SupportCollectionTest extends TestCase
     {
         $data = new $collection;
         $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Property [foo] does not exist on this collection instance.');
+        $this->expectExceptionMessageIs('Property [foo] does not exist on this collection instance.');
         $data->foo;
     }
 
@@ -6036,7 +6036,7 @@ class SupportCollectionTest extends TestCase
 
         $data = $collection::make([1, 2, 3, 'foo']);
         $this->expectException(UnexpectedValueException::class);
-        $this->expectExceptionMessage("Collection should only include [int] items, but 'string' found at position 3.");
+        $this->expectExceptionMessageIs("Collection should only include [int] items, but 'string' found at position 3.");
         $data->ensure('int');
     }
 
@@ -6048,7 +6048,7 @@ class SupportCollectionTest extends TestCase
 
         $data = $collection::make([new stdClass, new stdClass, new stdClass, $collection]);
         $this->expectException(UnexpectedValueException::class);
-        $this->expectExceptionMessage(sprintf('Collection should only include [%s] items, but \'%s\' found at position %d.', class_basename(new stdClass()), gettype($collection), 3));
+        $this->expectExceptionMessageIs(sprintf('Collection should only include [%s] items, but \'%s\' found at position %d.', class_basename(new stdClass()), gettype($collection), 3));
         $data->ensure(stdClass::class);
     }
 
@@ -6061,7 +6061,7 @@ class SupportCollectionTest extends TestCase
         $wrongType = new $collection;
         $data = $collection::make([new \Error, new \Error, $wrongType]);
         $this->expectException(UnexpectedValueException::class);
-        $this->expectExceptionMessage(sprintf("Collection should only include [%s] items, but '%s' found at position %d.", \Throwable::class, get_class($wrongType), 2));
+        $this->expectExceptionMessageIs(sprintf("Collection should only include [%s] items, but '%s' found at position %d.", \Throwable::class, get_class($wrongType), 2));
         $data->ensure(\Throwable::class);
     }
 
@@ -6074,7 +6074,7 @@ class SupportCollectionTest extends TestCase
         $wrongType = new $collection;
         $data = $collection::make([new \Error, new \Error, $wrongType]);
         $this->expectException(UnexpectedValueException::class);
-        $this->expectExceptionMessage(sprintf('Collection should only include [%s] items, but \'%s\' found at position %d.', implode(', ', [\Throwable::class, 'int']), get_class($wrongType), 2));
+        $this->expectExceptionMessageIs(sprintf('Collection should only include [%s] items, but \'%s\' found at position %d.', implode(', ', [\Throwable::class, 'int']), get_class($wrongType), 2));
         $data->ensure([\Throwable::class, 'int']);
     }
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -851,7 +851,7 @@ class SupportHelpersTest extends TestCase
     public function testThrowExceptionWithMessage()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('test');
+        $this->expectExceptionMessageIs('test');
 
         throw_if(true, 'test');
     }
@@ -859,7 +859,7 @@ class SupportHelpersTest extends TestCase
     public function testThrowExceptionAsStringWithMessage()
     {
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('test');
+        $this->expectExceptionMessageIs('test');
 
         throw_if(true, LogicException::class, 'test');
     }
@@ -867,7 +867,7 @@ class SupportHelpersTest extends TestCase
     public function testThrowClosureException()
     {
         $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('test');
+        $this->expectExceptionMessageIs('test');
 
         throw_if(true, fn () => new \Exception('test'));
     }
@@ -875,7 +875,7 @@ class SupportHelpersTest extends TestCase
     public function testThrowClosureWithParamsException()
     {
         $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('test');
+        $this->expectExceptionMessageIs('test');
 
         throw_if(true, fn (string $message) => new \Exception($message), 'test');
     }
@@ -883,7 +883,7 @@ class SupportHelpersTest extends TestCase
     public function testThrowClosureStringWithParamsException()
     {
         $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('test');
+        $this->expectExceptionMessageIs('test');
 
         throw_if(true, fn () => \Exception::class, 'test');
     }
@@ -905,7 +905,7 @@ class SupportHelpersTest extends TestCase
     public function testThrowUnlessExceptionWithMessage()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('test');
+        $this->expectExceptionMessageIs('test');
 
         throw_unless(false, 'test');
     }
@@ -913,7 +913,7 @@ class SupportHelpersTest extends TestCase
     public function testThrowUnlessExceptionAsStringWithMessage()
     {
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('test');
+        $this->expectExceptionMessageIs('test');
 
         throw_unless(false, LogicException::class, 'test');
     }
@@ -926,7 +926,7 @@ class SupportHelpersTest extends TestCase
     public function testThrowWithString()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Test Message');
+        $this->expectExceptionMessageIs('Test Message');
 
         throw_if(true, RuntimeException::class, 'Test Message');
     }
@@ -1651,7 +1651,7 @@ class SupportHelpersTest extends TestCase
         $this->assertFalse(SupportLazyClass::$constructorCalled);
 
         $this->expectException(Error::class);
-        $this->expectExceptionMessage('Typed property Illuminate\Tests\Support\SupportLazyClass::$first must not be accessed before initialization');
+        $this->expectExceptionMessageIs('Typed property Illuminate\Tests\Support\SupportLazyClass::$first must not be accessed before initialization');
 
         $instance->first;
     }
@@ -1727,7 +1727,7 @@ class SupportHelpersTest extends TestCase
 
         $this->assertFalse(SupportLazyClass::$constructorCalled);
         $this->expectException(Error::class);
-        $this->expectExceptionMessage('Cannot use positional argument after named argument during unpacking');
+        $this->expectExceptionMessageIs('Cannot use positional argument after named argument during unpacking');
 
         $instance->first;
     }
@@ -1762,7 +1762,7 @@ class SupportHelpersTest extends TestCase
 
         $this->assertFalse(SupportLazyClass::$constructorCalled);
         $this->expectException(Error::class);
-        $this->expectExceptionMessage('Typed property Illuminate\Tests\Support\SupportLazyClass::$first must not be accessed before initialization');
+        $this->expectExceptionMessageIs('Typed property Illuminate\Tests\Support\SupportLazyClass::$first must not be accessed before initialization');
 
         $instance->first;
     }
@@ -1826,7 +1826,7 @@ class SupportHelpersTest extends TestCase
         $this->assertFalse(SupportLazyClass::$constructorCalled);
 
         $this->expectException(Error::class);
-        $this->expectExceptionMessage('Typed property Illuminate\Tests\Support\SupportLazyClass::$first must not be accessed before initialization');
+        $this->expectExceptionMessageIs('Typed property Illuminate\Tests\Support\SupportLazyClass::$first must not be accessed before initialization');
 
         $instance->first;
     }
@@ -1835,7 +1835,7 @@ class SupportHelpersTest extends TestCase
     public function testClosureOnlyLazyThrowsWhenNotClassSpecifiedInClosure(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('The first parameter of the given Closure is missing a type hint.');
+        $this->expectExceptionMessageIs('The first parameter of the given Closure is missing a type hint.');
 
         lazy(function ($instance) {
             //
@@ -1913,7 +1913,7 @@ class SupportHelpersTest extends TestCase
 
         $this->assertFalse(SupportLazyClass::$constructorCalled);
         $this->expectException(Error::class);
-        $this->expectExceptionMessage('Cannot use positional argument after named argument during unpacking');
+        $this->expectExceptionMessageIs('Cannot use positional argument after named argument during unpacking');
 
         $instance->first;
     }
@@ -1948,7 +1948,7 @@ class SupportHelpersTest extends TestCase
 
         $this->assertFalse(SupportLazyClass::$constructorCalled);
         $this->expectException(Error::class);
-        $this->expectExceptionMessage('Typed property Illuminate\Tests\Support\SupportLazyClass::$first must not be accessed before initialization');
+        $this->expectExceptionMessageIs('Typed property Illuminate\Tests\Support\SupportLazyClass::$first must not be accessed before initialization');
 
         $instance->first;
     }
@@ -2039,7 +2039,7 @@ class SupportHelpersTest extends TestCase
         $this->assertFalse(SupportLazyClass::$constructorCalled);
 
         $this->expectException(Error::class);
-        $this->expectExceptionMessage('Lazy proxy factory must return an instance of a class compatible with Illuminate\Tests\Support\SupportLazyClass, null returned');
+        $this->expectExceptionMessageIs('Lazy proxy factory must return an instance of a class compatible with Illuminate\Tests\Support\SupportLazyClass, null returned');
 
         $instance->first;
     }
@@ -2057,7 +2057,7 @@ class SupportHelpersTest extends TestCase
 
         $this->assertFalse(SupportLazyClass::$constructorCalled);
         $this->expectException(Error::class);
-        $this->expectExceptionMessage('Lazy proxy factory must return a non-lazy object');
+        $this->expectExceptionMessageIs('Lazy proxy factory must return a non-lazy object');
 
         $instance->first;
     }
@@ -2106,7 +2106,7 @@ class SupportHelpersTest extends TestCase
         $this->assertFalse(SupportLazyClass::$constructorCalled);
 
         $this->expectException(Error::class);
-        $this->expectExceptionMessage('Lazy proxy factory must return an instance of a class compatible with Illuminate\Tests\Support\SupportLazyClass, null returned');
+        $this->expectExceptionMessageIs('Lazy proxy factory must return an instance of a class compatible with Illuminate\Tests\Support\SupportLazyClass, null returned');
 
         $instance->first;
     }
@@ -2115,7 +2115,7 @@ class SupportHelpersTest extends TestCase
     public function testClosureOnlyProxyThrowsWhenNotClassSpecifiedInClosure(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('The first parameter of the given Closure is missing a type hint.');
+        $this->expectExceptionMessageIs('The first parameter of the given Closure is missing a type hint.');
 
         proxy(function ($proxy) {
             //
@@ -2135,7 +2135,7 @@ class SupportHelpersTest extends TestCase
 
         $this->assertFalse(SupportLazyClass::$constructorCalled);
         $this->expectException(Error::class);
-        $this->expectExceptionMessage('Lazy proxy factory must return a non-lazy object');
+        $this->expectExceptionMessageIs('Lazy proxy factory must return a non-lazy object');
 
         $instance->first;
     }

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -928,7 +928,7 @@ class SupportStrTest extends TestCase
         Str::random();
 
         try {
-            $this->expectExceptionMessage('Out of random strings.');
+            $this->expectExceptionMessageIs('Out of random strings.');
             Str::random();
             $this->fail();
         } finally {
@@ -1807,7 +1807,7 @@ class SupportStrTest extends TestCase
         Str::uuid();
 
         try {
-            $this->expectExceptionMessage('Out of Uuids.');
+            $this->expectExceptionMessageIs('Out of Uuids.');
             Str::uuid();
             $this->fail();
         } finally {
@@ -1912,7 +1912,7 @@ class SupportStrTest extends TestCase
         Str::ulid();
 
         try {
-            $this->expectExceptionMessage('Out of Ulids');
+            $this->expectExceptionMessageIs('Out of Ulids');
             Str::ulid();
             $this->fail();
         } finally {

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -143,7 +143,7 @@ class SupportTestingMailFakeTest extends TestCase
         $this->fake->to('taylor@laravel.com')->send($this->mailable);
 
         $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessageMatches('/The unexpected \['.preg_quote(MailableStub::class, '/').'\] mailable was sent./m');
+        $this->expectExceptionMessageIsMatches('/The unexpected \['.preg_quote(MailableStub::class, '/').'\] mailable was sent./m');
 
         $this->fake->assertNotSent($callback);
     }
@@ -155,7 +155,7 @@ class SupportTestingMailFakeTest extends TestCase
         $this->fake->to('taylor@laravel.com')->send($this->mailable);
 
         $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('The unexpected ['.MailableStub::class.'] mailable was sent to address [taylor@laravel.com].');
+        $this->expectExceptionMessageIs('The unexpected ['.MailableStub::class.'] mailable was sent to address [taylor@laravel.com].');
 
         $this->fake->assertNotSent(MailableStub::class, 'taylor@laravel.com');
     }
@@ -167,7 +167,7 @@ class SupportTestingMailFakeTest extends TestCase
         $this->fake->to('dries@laravel.com')->send($this->mailable);
 
         $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('The unexpected ['.MailableStub::class.'] mailable was sent to address [dries@laravel.com].');
+        $this->expectExceptionMessageIs('The unexpected ['.MailableStub::class.'] mailable was sent to address [dries@laravel.com].');
 
         $this->fake->assertNotSent(MailableStub::class, ['taylor@laravel.com', 'dries@laravel.com']);
     }
@@ -281,7 +281,7 @@ class SupportTestingMailFakeTest extends TestCase
         $this->fake->to('taylor@laravel.com')->queue($this->mailable);
 
         $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('The unexpected ['.MailableStub::class.'] mailable was queued to address [taylor@laravel.com].');
+        $this->expectExceptionMessageIs('The unexpected ['.MailableStub::class.'] mailable was queued to address [taylor@laravel.com].');
 
         $this->fake->assertNotQueued(MailableStub::class, 'taylor@laravel.com');
     }
@@ -293,7 +293,7 @@ class SupportTestingMailFakeTest extends TestCase
         $this->fake->to('dries@laravel.com')->queue($this->mailable);
 
         $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('The unexpected ['.MailableStub::class.'] mailable was queued to address [dries@laravel.com].');
+        $this->expectExceptionMessageIs('The unexpected ['.MailableStub::class.'] mailable was queued to address [dries@laravel.com].');
 
         $this->fake->assertNotQueued(MailableStub::class, ['taylor@laravel.com', 'dries@laravel.com']);
     }

--- a/tests/Support/SupportTimeboxTest.php
+++ b/tests/Support/SupportTimeboxTest.php
@@ -58,7 +58,7 @@ class SupportTimeboxTest extends TestCase
         $mock->shouldReceive('usleep')->once();
 
         try {
-            $this->expectExceptionMessage('Exception within Timebox callback.');
+            $this->expectExceptionMessageIs('Exception within Timebox callback.');
 
             $mock->call(function () {
                 throw new Exception('Exception within Timebox callback.');
@@ -73,7 +73,7 @@ class SupportTimeboxTest extends TestCase
         $mock = m::spy(Timebox::class)->shouldAllowMockingProtectedMethods()->makePartial();
 
         try {
-            $this->expectExceptionMessage('Exception within Timebox callback.');
+            $this->expectExceptionMessageIs('Exception within Timebox callback.');
 
             $mock->call(function ($timebox) {
                 $timebox->returnEarly();

--- a/tests/Testing/AssertTest.php
+++ b/tests/Testing/AssertTest.php
@@ -66,7 +66,7 @@ class AssertTest extends TestCase
     public function testArraySubsetMayFailIfArrayIsNotArray(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionMessageIs(
             'Argument #1 of Illuminate\Testing\Assert::assertArraySubset() must be an array or ArrayAccess'
         );
 
@@ -80,7 +80,7 @@ class AssertTest extends TestCase
     public function testArraySubsetMayFailIfSubsetIsNotArray(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionMessageIs(
             'Argument #2 of Illuminate\Testing\Assert::assertArraySubset() must be an array or ArrayAccess'
         );
 

--- a/tests/Testing/Concerns/InteractsWithDeprecationHandlingTest.php
+++ b/tests/Testing/Concerns/InteractsWithDeprecationHandlingTest.php
@@ -41,7 +41,7 @@ class InteractsWithDeprecationHandlingTest extends TestCase
         $this->withoutDeprecationHandling();
 
         $this->expectException(ErrorException::class);
-        $this->expectExceptionMessage('Something is deprecated');
+        $this->expectExceptionMessageIs('Something is deprecated');
 
         trigger_error('Something is deprecated', E_USER_DEPRECATED);
     }

--- a/tests/Testing/Fluent/AssertTest.php
+++ b/tests/Testing/Fluent/AssertTest.php
@@ -28,7 +28,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [prop] does not exist.');
+        $this->expectExceptionMessageIs('Property [prop] does not exist.');
 
         $assert->has('prop');
     }
@@ -53,7 +53,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [example.another] does not exist.');
+        $this->expectExceptionMessageIs('Property [example.another] does not exist.');
 
         $assert->has('example.another');
     }
@@ -80,7 +80,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [bar] does not have the expected size.');
+        $this->expectExceptionMessageIs('Property [bar] does not have the expected size.');
 
         $assert->has('bar', 1);
     }
@@ -95,7 +95,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [baz] does not exist.');
+        $this->expectExceptionMessageIs('Property [baz] does not exist.');
 
         $assert->has('baz', 1);
     }
@@ -131,7 +131,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Root level does not have the expected size.');
+        $this->expectExceptionMessageIs('Root level does not have the expected size.');
 
         $assert->has(2);
     }
@@ -146,7 +146,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [bar] does not have the expected size.');
+        $this->expectExceptionMessageIs('Property [bar] does not have the expected size.');
 
         $assert->has('bar', function ($bar) {
             $bar->has(3);
@@ -190,7 +190,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [data.1.id] contains a value that should be missing: [id, 2]');
+        $this->expectExceptionMessageIs('Property [data.1.id] contains a value that should be missing: [id, 2]');
 
         $assert->has('data', function ($bar) {
             $bar->has(2)
@@ -235,7 +235,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [data.1.id] was marked as invalid using a closure.');
+        $this->expectExceptionMessageIs('Property [data.1.id] was marked as invalid using a closure.');
 
         $assert->has('data', function ($bar) {
             $bar->has(2)
@@ -263,7 +263,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Root level does not have the expected size.');
+        $this->expectExceptionMessageIs('Root level does not have the expected size.');
 
         $assert->count(2);
     }
@@ -278,7 +278,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [bar] does not have the expected size.');
+        $this->expectExceptionMessageIs('Property [bar] does not have the expected size.');
 
         $assert->has('bar', function ($bar) {
             $bar->count(3);
@@ -305,7 +305,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Root level size is not less than or equal to [2].');
+        $this->expectExceptionMessageIs('Root level size is not less than or equal to [2].');
 
         $assert->countBetween(1, 2);
     }
@@ -319,7 +319,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Root level size is not greater than or equal to [4].');
+        $this->expectExceptionMessageIs('Root level size is not greater than or equal to [4].');
 
         $assert->countBetween(4, 3);
     }
@@ -335,7 +335,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [bar] size is not less than or equal to [2].');
+        $this->expectExceptionMessageIs('Property [bar] size is not less than or equal to [2].');
 
         $assert->has('bar', function (AssertableJson $bar) {
             $bar->countBetween(1, 2);
@@ -363,7 +363,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [foo.bar] was found while it was expected to be missing.');
+        $this->expectExceptionMessageIs('Property [foo.bar] was found while it was expected to be missing.');
 
         $assert->missing('foo.bar');
     }
@@ -387,7 +387,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [baz] was found while it was expected to be missing.');
+        $this->expectExceptionMessageIs('Property [baz] was found while it was expected to be missing.');
 
         $assert->missingAll([
             'bar',
@@ -404,7 +404,7 @@ class AssertTest extends TestCase
         $assert->missingAll('foo', 'bar');
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [baz] was found while it was expected to be missing.');
+        $this->expectExceptionMessageIs('Property [baz] was found while it was expected to be missing.');
 
         $assert->missingAll('bar', 'baz');
     }
@@ -425,7 +425,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [bar] does not match the expected value.');
+        $this->expectExceptionMessageIs('Property [bar] does not match the expected value.');
 
         $assert->where('bar', 'invalid');
     }
@@ -437,7 +437,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [baz] does not exist.');
+        $this->expectExceptionMessageIs('Property [baz] does not exist.');
 
         $assert->where('baz', 'invalid');
     }
@@ -449,7 +449,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [bar] does not match the expected value.');
+        $this->expectExceptionMessageIs('Property [bar] does not match the expected value.');
 
         $assert->where('bar', true);
     }
@@ -472,7 +472,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [bar] was marked as invalid using a closure.');
+        $this->expectExceptionMessageIs('Property [bar] was marked as invalid using a closure.');
 
         $assert->where('bar', function ($value) {
             return $value === 'invalid';
@@ -575,7 +575,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [bar] does not match the expected value.');
+        $this->expectExceptionMessageIs('Property [bar] does not match the expected value.');
 
         $assert->where('bar', BackedEnum::test_empty);
     }
@@ -596,7 +596,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [bar] should be null.');
+        $this->expectExceptionMessageIs('Property [bar] should be null.');
 
         $assert->whereNull('bar');
     }
@@ -608,7 +608,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [baz] does not exist.');
+        $this->expectExceptionMessageIs('Property [baz] does not exist.');
 
         $assert->whereNull('baz');
     }
@@ -629,7 +629,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [bar] should not be null.');
+        $this->expectExceptionMessageIs('Property [bar] should not be null.');
 
         $assert->whereNotNull('bar');
     }
@@ -641,7 +641,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [baz] does not exist.');
+        $this->expectExceptionMessageIs('Property [baz] does not exist.');
 
         $assert->whereNotNull('baz');
     }
@@ -651,7 +651,7 @@ class AssertTest extends TestCase
         $assert = AssertableJson::fromArray([]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [foo] does not contain [1].');
+        $this->expectExceptionMessageIs('Property [foo] does not contain [1].');
 
         $assert->whereContains('foo', ['1']);
     }
@@ -663,7 +663,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [foo] does not contain [invalid].');
+        $this->expectExceptionMessageIs('Property [foo] does not contain [invalid].');
 
         $assert->whereContains('foo', ['bar', 'baz', 'invalid']);
     }
@@ -678,7 +678,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [id] does not contain [5].');
+        $this->expectExceptionMessageIs('Property [id] does not contain [5].');
 
         $assert->whereContains('id', [1, 2, 3, 4, 5]);
     }
@@ -690,7 +690,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [foo] does not contain [1].');
+        $this->expectExceptionMessageIs('Property [foo] does not contain [1].');
 
         $assert->whereContains('foo', ['1']);
     }
@@ -702,7 +702,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [foo] does not contain a value that passes the truth test within the given closure.');
+        $this->expectExceptionMessageIs('Property [foo] does not contain a value that passes the truth test within the given closure.');
 
         $assert->whereContains('foo', [function ($actual) {
             return $actual === 5;
@@ -716,7 +716,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [foo] does not contain a value that passes the truth test within the given closure.');
+        $this->expectExceptionMessageIs('Property [foo] does not contain a value that passes the truth test within the given closure.');
 
         $assert->whereContains('foo', [1, function ($actual) {
             return $actual === 5;
@@ -730,7 +730,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [foo] does not contain [5].');
+        $this->expectExceptionMessageIs('Property [foo] does not contain [5].');
 
         $assert->whereContains('foo', [5, function ($actual) {
             return $actual === 1;
@@ -862,7 +862,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [bar] does not contain [test].');
+        $this->expectExceptionMessageIs('Property [bar] does not contain [test].');
 
         $assert->whereContains('bar', BackedEnum::test);
     }
@@ -887,7 +887,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [example.nested] does not match the expected value.');
+        $this->expectExceptionMessageIs('Property [example.nested] does not match the expected value.');
 
         $assert->where('example.nested', 'another-value');
     }
@@ -912,7 +912,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [example.nested] does not match the expected value.');
+        $this->expectExceptionMessageIs('Property [example.nested] does not match the expected value.');
 
         $assert->where('example.nested', BackedEnum::test);
     }
@@ -933,7 +933,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [bar] contains a value that should be missing: [bar, value]');
+        $this->expectExceptionMessageIs('Property [bar] contains a value that should be missing: [bar, value]');
 
         $assert->whereNot('bar', 'value');
     }
@@ -945,7 +945,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [baz] does not exist.');
+        $this->expectExceptionMessageIs('Property [baz] does not exist.');
 
         $assert->whereNot('baz', 'value');
     }
@@ -968,7 +968,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [bar] was marked as invalid using a closure.');
+        $this->expectExceptionMessageIs('Property [bar] was marked as invalid using a closure.');
 
         $assert->whereNot('bar', function ($value) {
             return $value === 'baz';
@@ -991,7 +991,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [bar] contains a value that should be missing: [bar, test]');
+        $this->expectExceptionMessageIs('Property [bar] contains a value that should be missing: [bar, test]');
 
         $assert->whereNot('bar', BackedEnum::test);
     }
@@ -1026,7 +1026,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [baz] does not exist.');
+        $this->expectExceptionMessageIs('Property [baz] does not exist.');
 
         $assert->has('baz', function (AssertableJson $item) {
             $item->where('baz', 'example');
@@ -1040,7 +1040,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [bar] is not scopeable.');
+        $this->expectExceptionMessageIs('Property [bar] is not scopeable.');
 
         $assert->has('bar', function (AssertableJson $item) {
             //
@@ -1093,7 +1093,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [bar] does not have the expected size.');
+        $this->expectExceptionMessageIs('Property [bar] does not have the expected size.');
 
         $assert->has('bar', 0, function (AssertableJson $item) {
             $item->where('key', 'first');
@@ -1110,7 +1110,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [bar] does not have the expected size.');
+        $this->expectExceptionMessageIs('Property [bar] does not have the expected size.');
 
         $assert->has('bar', 1, function (AssertableJson $item) {
             $item->where('key', 'first');
@@ -1124,7 +1124,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionMessageIs(
             'Cannot scope directly onto the first element of property [bar] because it is empty.'
         );
 
@@ -1140,7 +1140,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionMessageIs(
             'Cannot scope directly onto the first element of property [bar] because it is empty.'
         );
 
@@ -1186,7 +1186,7 @@ class AssertTest extends TestCase
         $assert = AssertableJson::fromArray([]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Cannot scope directly onto the first element of the root level because it is empty.');
+        $this->expectExceptionMessageIs('Cannot scope directly onto the first element of the root level because it is empty.');
 
         $assert->first(function (AssertableJson $item) {
             //
@@ -1200,7 +1200,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Cannot scope directly onto the first element of property [foo] because it is empty.');
+        $this->expectExceptionMessageIs('Cannot scope directly onto the first element of property [foo] because it is empty.');
 
         $assert->has('foo', function (AssertableJson $assert) {
             $assert->first(function (AssertableJson $item) {
@@ -1216,7 +1216,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [foo] is not scopeable.');
+        $this->expectExceptionMessageIs('Property [foo] is not scopeable.');
 
         $assert->first(function (AssertableJson $item) {
             //
@@ -1244,7 +1244,7 @@ class AssertTest extends TestCase
         $assert = AssertableJson::fromArray([]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Cannot scope directly onto each element of the root level because it is empty.');
+        $this->expectExceptionMessageIs('Cannot scope directly onto each element of the root level because it is empty.');
 
         $assert->each(function (AssertableJson $item) {
             //
@@ -1258,7 +1258,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Cannot scope directly onto each element of property [foo] because it is empty.');
+        $this->expectExceptionMessageIs('Cannot scope directly onto each element of property [foo] because it is empty.');
 
         $assert->has('foo', function (AssertableJson $assert) {
             $assert->each(function (AssertableJson $item) {
@@ -1274,7 +1274,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [foo] is not scopeable.');
+        $this->expectExceptionMessageIs('Property [foo] is not scopeable.');
 
         $assert->each(function (AssertableJson $item) {
             //
@@ -1291,7 +1291,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Unexpected properties were found in scope [bar].');
+        $this->expectExceptionMessageIs('Unexpected properties were found in scope [bar].');
 
         $assert->has('bar', function (AssertableJson $item) {
             $item->where('baz', 'example');
@@ -1325,7 +1325,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Unexpected properties were found in scope [bar.baz].');
+        $this->expectExceptionMessageIs('Unexpected properties were found in scope [bar.baz].');
 
         $assert->has('bar', function (AssertableJson $item) {
             $item
@@ -1354,7 +1354,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Unexpected properties were found on the root level.');
+        $this->expectExceptionMessageIs('Unexpected properties were found on the root level.');
 
         $assert
             ->has('foo')
@@ -1388,7 +1388,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [baz] was marked as invalid using a closure.');
+        $this->expectExceptionMessageIs('Property [baz] was marked as invalid using a closure.');
 
         $assert->whereAll([
             'foo' => 'bar',
@@ -1484,7 +1484,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [foo] is not of expected type [integer].');
+        $this->expectExceptionMessageIs('Property [foo] is not of expected type [integer].');
 
         $assert->whereType('foo', 'integer');
     }
@@ -1510,7 +1510,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [foo] is not of expected type [string|null].');
+        $this->expectExceptionMessageIs('Property [foo] is not of expected type [string|null].');
 
         $assert->whereType('foo', ['string', 'null']);
     }
@@ -1531,7 +1531,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [foo] is not of expected type [integer|null].');
+        $this->expectExceptionMessageIs('Property [foo] is not of expected type [integer|null].');
 
         $assert->whereType('foo', 'integer|null');
     }
@@ -1564,7 +1564,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [foo.baz] does not exist.');
+        $this->expectExceptionMessageIs('Property [foo.baz] does not exist.');
 
         $assert->hasAll([
             'foo.bar',
@@ -1586,7 +1586,7 @@ class AssertTest extends TestCase
         $assert->hasAll('foo.bar', 'foo.example', 'baz');
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [foo.baz] does not exist.');
+        $this->expectExceptionMessageIs('Property [foo.baz] does not exist.');
 
         $assert->hasAll('foo.bar', 'foo.baz', 'baz');
     }
@@ -1619,7 +1619,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [baz] does not exist.');
+        $this->expectExceptionMessageIs('Property [baz] does not exist.');
 
         $assert->hasAll([
             'bar' => 2,
@@ -1634,7 +1634,7 @@ class AssertTest extends TestCase
         });
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('My Custom Macro was called!');
+        $this->expectExceptionMessageIs('My Custom Macro was called!');
 
         $assert = AssertableJson::fromArray(['foo' => 'bar']);
         $assert->myCustomMacro();

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -594,7 +594,7 @@ class TestResponseTest extends TestCase
     public function testAssertSeeTextCanFail(): void
     {
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Failed asserting that \'foo<strong>bar</strong>\' contains "bazfoo".');
+        $this->expectExceptionMessageIs('Failed asserting that \'foo<strong>bar</strong>\' contains "bazfoo".');
 
         $response = $this->makeMockResponse([
             'render' => 'foo<strong>bar</strong>',
@@ -677,7 +677,7 @@ EOT
     public function testAssertSeeTextInOrderCanFail(): void
     {
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Failed asserting that \'foo<strong>bar</strong> baz <strong>foo</strong>\' contains "foobar" in specified order.');
+        $this->expectExceptionMessageIs('Failed asserting that \'foo<strong>bar</strong> baz <strong>foo</strong>\' contains "foobar" in specified order.');
 
         $response = $this->makeMockResponse([
             'render' => 'foo<strong>bar</strong> baz <strong>foo</strong>',
@@ -776,7 +776,7 @@ EOT
     public function testAssertDontSeeTextCanFail(): void
     {
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Failed asserting that \'foo<strong>bar</strong>baz<strong>qux</strong>\' does not contain "foobar".');
+        $this->expectExceptionMessageIs('Failed asserting that \'foo<strong>bar</strong>baz<strong>qux</strong>\' does not contain "foobar".');
 
         $response = $this->makeMockResponse([
             'render' => 'foo<strong>bar</strong>baz<strong>qux</strong>',
@@ -814,7 +814,7 @@ EOT
 
         $this->expectException(AssertionFailedError::class);
 
-        $this->expectExceptionMessage('Expected response status code');
+        $this->expectExceptionMessageIs('Expected response status code');
 
         $baseResponse = tap(new Response, function ($response) use ($statusCode) {
             $response->setStatusCode($statusCode);
@@ -830,7 +830,7 @@ EOT
 
         $this->expectException(AssertionFailedError::class);
 
-        $this->expectExceptionMessage('Expected response status code');
+        $this->expectExceptionMessageIs('Expected response status code');
 
         $baseResponse = tap(new Response, function ($response) use ($statusCode) {
             $response->setStatusCode($statusCode);
@@ -845,7 +845,7 @@ EOT
         $statusCode = 500;
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Expected response status code');
+        $this->expectExceptionMessageIs('Expected response status code');
 
         $baseResponse = tap(new Response, function ($response) use ($statusCode) {
             $response->setStatusCode($statusCode);
@@ -868,7 +868,7 @@ EOT
         );
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage("Expected response status code [405] but received 200.\nFailed asserting that 200 is identical to 405.");
+        $this->expectExceptionMessageIs("Expected response status code [405] but received 200.\nFailed asserting that 200 is identical to 405.");
 
         $response->assertMethodNotAllowed();
     }
@@ -886,7 +886,7 @@ EOT
         );
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage("Expected response status code [406] but received 200.\nFailed asserting that 200 is identical to 406.");
+        $this->expectExceptionMessageIs("Expected response status code [406] but received 200.\nFailed asserting that 200 is identical to 406.");
 
         $response->assertNotAcceptable();
         $this->fail();
@@ -898,7 +898,7 @@ EOT
 
         $this->expectException(AssertionFailedError::class);
 
-        $this->expectExceptionMessage('Expected response status code');
+        $this->expectExceptionMessageIs('Expected response status code');
 
         $baseResponse = tap(new Response, function ($response) use ($statusCode) {
             $response->setStatusCode($statusCode);
@@ -914,7 +914,7 @@ EOT
 
         $this->expectException(AssertionFailedError::class);
 
-        $this->expectExceptionMessage('Expected response status code');
+        $this->expectExceptionMessageIs('Expected response status code');
 
         $baseResponse = tap(new Response, function ($response) use ($statusCode) {
             $response->setStatusCode($statusCode);
@@ -937,7 +937,7 @@ EOT
         );
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage("Expected response status code [400] but received 200.\nFailed asserting that 200 is identical to 400.");
+        $this->expectExceptionMessageIs("Expected response status code [400] but received 200.\nFailed asserting that 200 is identical to 400.");
 
         $response->assertBadRequest();
         $this->fail();
@@ -956,7 +956,7 @@ EOT
         );
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage("Expected response status code [408] but received 200.\nFailed asserting that 200 is identical to 408.");
+        $this->expectExceptionMessageIs("Expected response status code [408] but received 200.\nFailed asserting that 200 is identical to 408.");
 
         $response->assertRequestTimeout();
         $this->fail();
@@ -975,7 +975,7 @@ EOT
         );
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage("Expected response status code [402] but received 200.\nFailed asserting that 200 is identical to 402.");
+        $this->expectExceptionMessageIs("Expected response status code [402] but received 200.\nFailed asserting that 200 is identical to 402.");
 
         $response->assertPaymentRequired();
         $this->fail();
@@ -994,7 +994,7 @@ EOT
         );
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage("Expected response status code [301] but received 200.\nFailed asserting that 200 is identical to 301.");
+        $this->expectExceptionMessageIs("Expected response status code [301] but received 200.\nFailed asserting that 200 is identical to 301.");
 
         $response->assertMovedPermanently();
         $this->fail();
@@ -1013,7 +1013,7 @@ EOT
         );
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage("Expected response status code [302] but received 200.\nFailed asserting that 200 is identical to 302.");
+        $this->expectExceptionMessageIs("Expected response status code [302] but received 200.\nFailed asserting that 200 is identical to 302.");
 
         $response->assertFound();
         $this->fail();
@@ -1032,7 +1032,7 @@ EOT
         );
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage("Expected response status code [304] but received 200.\nFailed asserting that 200 is identical to 304.");
+        $this->expectExceptionMessageIs("Expected response status code [304] but received 200.\nFailed asserting that 200 is identical to 304.");
 
         $response->assertNotModified();
         $this->fail();
@@ -1051,7 +1051,7 @@ EOT
         );
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage("Expected response status code [307] but received 200.\nFailed asserting that 200 is identical to 307.");
+        $this->expectExceptionMessageIs("Expected response status code [307] but received 200.\nFailed asserting that 200 is identical to 307.");
 
         $response->assertTemporaryRedirect();
         $this->fail();
@@ -1070,7 +1070,7 @@ EOT
         );
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage("Expected response status code [308] but received 200.\nFailed asserting that 200 is identical to 308.");
+        $this->expectExceptionMessageIs("Expected response status code [308] but received 200.\nFailed asserting that 200 is identical to 308.");
 
         $response->assertPermanentRedirect();
         $this->fail();
@@ -1089,7 +1089,7 @@ EOT
         );
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage("Expected response status code [409] but received 200.\nFailed asserting that 200 is identical to 409.");
+        $this->expectExceptionMessageIs("Expected response status code [409] but received 200.\nFailed asserting that 200 is identical to 409.");
 
         $response->assertConflict();
         $this->fail();
@@ -1108,7 +1108,7 @@ EOT
         );
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage("Expected response status code [410] but received 200.\nFailed asserting that 200 is identical to 410.");
+        $this->expectExceptionMessageIs("Expected response status code [410] but received 200.\nFailed asserting that 200 is identical to 410.");
 
         $response->assertGone();
     }
@@ -1126,7 +1126,7 @@ EOT
         );
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage("Expected response status code [429] but received 200.\nFailed asserting that 200 is identical to 429.");
+        $this->expectExceptionMessageIs("Expected response status code [429] but received 200.\nFailed asserting that 200 is identical to 429.");
 
         $response->assertTooManyRequests();
         $this->fail();
@@ -1145,7 +1145,7 @@ EOT
         );
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage("Expected response status code [202] but received 200.\nFailed asserting that 200 is identical to 202.");
+        $this->expectExceptionMessageIs("Expected response status code [202] but received 200.\nFailed asserting that 200 is identical to 202.");
 
         $response->assertAccepted();
         $this->fail();
@@ -1157,7 +1157,7 @@ EOT
 
         $this->expectException(AssertionFailedError::class);
 
-        $this->expectExceptionMessage('Expected response status code');
+        $this->expectExceptionMessageIs('Expected response status code');
 
         $baseResponse = tap(new Response, function ($response) use ($statusCode) {
             $response->setStatusCode($statusCode);
@@ -1180,7 +1180,7 @@ EOT
         );
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage("Expected response status code [424] but received 200.\nFailed asserting that 200 is identical to 424.");
+        $this->expectExceptionMessageIs("Expected response status code [424] but received 200.\nFailed asserting that 200 is identical to 424.");
 
         $response->assertFailedDependency();
         $this->fail();
@@ -1223,7 +1223,7 @@ EOT
         );
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage("Expected response status code [500] but received 200.\nFailed asserting that 200 is identical to 500.");
+        $this->expectExceptionMessageIs("Expected response status code [500] but received 200.\nFailed asserting that 200 is identical to 500.");
 
         $response->assertInternalServerError();
     }
@@ -1241,7 +1241,7 @@ EOT
         );
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage("Expected response status code [503] but received 200.\nFailed asserting that 200 is identical to 503.");
+        $this->expectExceptionMessageIs("Expected response status code [503] but received 200.\nFailed asserting that 200 is identical to 503.");
 
         $response->assertServiceUnavailable();
     }
@@ -1252,7 +1252,7 @@ EOT
 
         $this->expectException(AssertionFailedError::class);
 
-        $this->expectExceptionMessage('Expected response status code');
+        $this->expectExceptionMessageIs('Expected response status code');
 
         $baseResponse = tap(new Response, function ($response) use ($statusCode) {
             $response->setStatusCode($statusCode);
@@ -1269,7 +1269,7 @@ EOT
 
         $this->expectException(AssertionFailedError::class);
 
-        $this->expectExceptionMessage('Expected response status code');
+        $this->expectExceptionMessageIs('Expected response status code');
 
         $baseResponse = tap(new Response, function ($response) use ($statusCode) {
             $response->setStatusCode($statusCode);
@@ -1283,7 +1283,7 @@ EOT
     {
         $this->expectException(AssertionFailedError::class);
 
-        $this->expectExceptionMessage('Response content is not empty');
+        $this->expectExceptionMessageIs('Response content is not empty');
 
         $baseResponse = tap(new Response, function ($response) {
             $response->setStatusCode(204);
@@ -1301,7 +1301,7 @@ EOT
 
         $this->expectException(AssertionFailedError::class);
 
-        $this->expectExceptionMessage('Expected response status code');
+        $this->expectExceptionMessageIs('Expected response status code');
 
         $baseResponse = tap(new Response, function ($response) use ($statusCode) {
             $response->setStatusCode($statusCode);
@@ -1327,7 +1327,7 @@ EOT
     public function testAssertHeaderMissing(): void
     {
         $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('Unexpected header [Location] is present on response.');
+        $this->expectExceptionMessageIs('Unexpected header [Location] is present on response.');
 
         $baseResponse = tap(new Response, function ($response) {
             $response->header('Location', '/foo');
@@ -1341,7 +1341,7 @@ EOT
     public function testAssertPrecognitionSuccessfulWithMissingHeader(): void
     {
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Header [Precognition-Success] not present on response.');
+        $this->expectExceptionMessageIs('Header [Precognition-Success] not present on response.');
 
         $baseResponse = new Response('', 204);
 
@@ -1353,7 +1353,7 @@ EOT
     public function testAssertPrecognitionSuccessfulWithIncorrectValue(): void
     {
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('The Precognition-Success header was found, but the value is not `true`.');
+        $this->expectExceptionMessageIs('The Precognition-Success header was found, but the value is not `true`.');
 
         $baseResponse = tap(new Response('', 204), function ($response) {
             $response->header('Precognition-Success', '');
@@ -1378,7 +1378,7 @@ EOT
         $response = TestResponse::fromBaseResponse(new Response(null));
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Invalid JSON was returned from the route.');
+        $this->expectExceptionMessageIs('Invalid JSON was returned from the route.');
 
         $resource = new JsonSerializableSingleResourceStub;
 
@@ -1400,7 +1400,7 @@ EOT
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableMixedResourcesStub));
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Unexpected properties were found on the root level.');
+        $this->expectExceptionMessageIs('Unexpected properties were found on the root level.');
 
         $response->assertJson(function (AssertableJson $json) {
             $json->where('foo', 'bar');
@@ -1424,7 +1424,7 @@ EOT
         $response = TestResponse::fromBaseResponse(new Response([]));
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('None of properties [data, errors, meta] exist.');
+        $this->expectExceptionMessageIs('None of properties [data, errors, meta] exist.');
 
         $response->assertJson(function (AssertableJson $json) {
             $json->hasAny('data', 'errors', 'meta');
@@ -1472,7 +1472,7 @@ EOT
     public function testAssertExactJsonWithMixedWhenDataIsSimilar(): void
     {
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Failed asserting that two strings are equal.');
+        $this->expectExceptionMessageIs('Failed asserting that two strings are equal.');
 
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableMixedResourcesStub));
 
@@ -1521,7 +1521,7 @@ EOT
     public function testAssertJsonPathCanFail(): void
     {
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Failed asserting that 10 is identical to \'10\'.');
+        $this->expectExceptionMessageIs('Failed asserting that 10 is identical to \'10\'.');
 
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceWithIntegersStub));
 
@@ -1544,7 +1544,7 @@ EOT
         ]));
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Failed asserting that false is true.');
+        $this->expectExceptionMessageIs('Failed asserting that false is true.');
 
         $response->assertJsonPath('data.foo', fn ($value) => $value === null);
     }
@@ -1565,7 +1565,7 @@ EOT
         ]));
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Failed asserting that two strings are identical.');
+        $this->expectExceptionMessageIs('Failed asserting that two strings are identical.');
 
         $response->assertJsonPath('data.status', TestStatus::Booked);
     }
@@ -1588,7 +1588,7 @@ EOT
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceStub));
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Failed asserting that two arrays are equal.');
+        $this->expectExceptionMessageIs('Failed asserting that two arrays are equal.');
 
         $response->assertJsonPathCanonicalizing('*.foo', ['foo 0', 'foo 2', 'foo 3']);
     }
@@ -1614,7 +1614,7 @@ EOT
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceStub));
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Failed asserting that two arrays are equal.');
+        $this->expectExceptionMessageIs('Failed asserting that two arrays are equal.');
 
         $response->assertJsonPathsCanonicalizing([
             '*.foo' => ['foo 0', 'foo 2', 'foo 3'],
@@ -1643,7 +1643,7 @@ EOT
     public function testAssertJsonPathsCanFail(): void
     {
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Failed asserting that 10 is identical to 11.');
+        $this->expectExceptionMessageIs('Failed asserting that 10 is identical to 11.');
 
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceWithIntegersStub));
 
@@ -1702,7 +1702,7 @@ EOT
     public function testAssertJsonFragmentUnicodeCanFail(): void
     {
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessageMatches('/Привет|Мир/');
+        $this->expectExceptionMessageIsMatches('/Привет|Мир/');
 
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceWithUnicodeStub));
 
@@ -2501,7 +2501,7 @@ EOT
     public function testAssertJsonMissingValidationErrorsOnInvalidJson(): void
     {
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Invalid JSON was returned from the route.');
+        $this->expectExceptionMessageIs('Invalid JSON was returned from the route.');
 
         $invalidJsonResponse = TestResponse::fromBaseResponse(
             (new Response)->setContent('~invalid json')
@@ -2857,7 +2857,7 @@ EOT
         $response = TestResponse::fromBaseResponse($baseResponse);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Header [X-Custom-Header] was found, but [unrelated] does not contain [value].');
+        $this->expectExceptionMessageIs('Header [X-Custom-Header] was found, but [unrelated] does not contain [value].');
 
         $response->assertHeaderContains('X-Custom-Header', 'value');
     }
@@ -3209,7 +3209,7 @@ EOT
             ->withExceptions(collect([new Exception('Unexpected exception.')]));
 
         $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessageMatches('/Expected response status code \[200\] but received 500.*Exception: Unexpected exception/s');
+        $this->expectExceptionMessageIsMatches('/Expected response status code \[200\] but received 500.*Exception: Unexpected exception/s');
 
         $response->assertStatus(200);
     }
@@ -3226,7 +3226,7 @@ EOT
         );
 
         $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessageMatches('/Expected response status code \[200\] but received 302.*The first name field is required.*The last name field is required/s');
+        $this->expectExceptionMessageIsMatches('/Expected response status code \[200\] but received 302.*The first name field is required.*The last name field is required/s');
 
         $response->assertStatus(200);
     }
@@ -3241,7 +3241,7 @@ EOT
         ], 422));
 
         $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessageMatches('/Expected response status code \[200\] but received 422.*The first name field is required.*The last name field is required/s');
+        $this->expectExceptionMessageIsMatches('/Expected response status code \[200\] but received 422.*The first name field is required.*The last name field is required/s');
 
         $response->assertStatus(200);
     }
@@ -3253,7 +3253,7 @@ EOT
         );
 
         $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('Expected response status code [200] but received 422.');
+        $this->expectExceptionMessageIs('Expected response status code [200] but received 422.');
 
         $response->assertStatus(200);
     }
@@ -3265,7 +3265,7 @@ EOT
         );
 
         $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('Expected response status code [200] but received 422.');
+        $this->expectExceptionMessageIs('Expected response status code [200] but received 422.');
 
         $response->assertStatus(200);
     }

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -78,7 +78,7 @@ class TranslationTranslatorTest extends TestCase
         $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
         $t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn(['baz' => ['breeze']]);
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Translation value for key [foo::bar.baz] must be a string, array given.');
+        $this->expectExceptionMessageIs('Translation value for key [foo::bar.baz] must be a string, array given.');
 
         $t->string('foo::bar.baz', [], 'en');
     }
@@ -97,7 +97,7 @@ class TranslationTranslatorTest extends TestCase
         $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
         $t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn(['baz' => 'breeze']);
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Translation value for key [foo::bar.baz] must be an array, string given.');
+        $this->expectExceptionMessageIs('Translation value for key [foo::bar.baz] must be an array, string given.');
 
         $t->array('foo::bar.baz', [], 'en');
     }

--- a/tests/Validation/ValidationArrayKeysRuleTest.php
+++ b/tests/Validation/ValidationArrayKeysRuleTest.php
@@ -85,7 +85,7 @@ class ValidationArrayKeysRuleTest extends TestCase
         $v = new Validator($trans, ['foo' => ['key_1' => 'bar']], ['foo' => 'array_keys']);
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Validation rule array_keys requires at least 1 parameters.');
+        $this->expectExceptionMessageIs('Validation rule array_keys requires at least 1 parameters.');
 
         $v->passes();
     }

--- a/tests/Validation/ValidationFileRuleTest.php
+++ b/tests/Validation/ValidationFileRuleTest.php
@@ -390,7 +390,7 @@ class ValidationFileRuleTest extends TestCase
     public function testEncodingWithInvalidParameter()
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Validation rule encoding parameter [FOOBAR] is not a valid encoding.');
+        $this->expectExceptionMessageIs('Validation rule encoding parameter [FOOBAR] is not a valid encoding.');
 
         // Invalid encoding.
         $this->fails(

--- a/tests/Validation/ValidationPasswordRuleTest.php
+++ b/tests/Validation/ValidationPasswordRuleTest.php
@@ -291,7 +291,7 @@ class ValidationPasswordRuleTest extends TestCase
     public function testItCannotSetDefaultUsingGivenString()
     {
         $this->expectException('InvalidArgumentException');
-        $this->expectExceptionMessage('given callback should be callable');
+        $this->expectExceptionMessageIs('given callback should be callable');
 
         Password::defaults('required|password');
     }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1140,7 +1140,7 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, [], []);
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Exception [RuntimeException] is invalid. It must extend [Illuminate\Validation\ValidationException].');
+        $this->expectExceptionMessageIs('Exception [RuntimeException] is invalid. It must extend [Illuminate\Validation\ValidationException].');
 
         $v->setException(RuntimeException::class);
     }
@@ -7429,7 +7429,7 @@ class ValidationValidatorTest extends TestCase
     public function testExceptionThrownOnIncorrectParameterCount()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Validation rule required_if requires at least 2 parameters.');
+        $this->expectExceptionMessageIs('Validation rule required_if requires at least 2 parameters.');
 
         $trans = $this->getTranslator();
         $v = new Validator($trans, [], ['foo' => 'required_if:foo']);

--- a/tests/View/Blade/BladeCustomTest.php
+++ b/tests/View/Blade/BladeCustomTest.php
@@ -71,7 +71,7 @@ class BladeCustomTest extends AbstractBladeTestCase
     public function testInvalidCustomNames()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The directive name [custom-custom] is not valid.');
+        $this->expectExceptionMessageIs('The directive name [custom-custom] is not valid.');
         $this->compiler->directive('custom-custom', function () {
             //
         });
@@ -80,7 +80,7 @@ class BladeCustomTest extends AbstractBladeTestCase
     public function testInvalidCustomNames2()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The directive name [custom:custom] is not valid.');
+        $this->expectExceptionMessageIs('The directive name [custom:custom] is not valid.');
         $this->compiler->directive('custom:custom', function () {
             //
         });

--- a/tests/View/Blade/BladeEchoHandlerTest.php
+++ b/tests/View/Blade/BladeEchoHandlerTest.php
@@ -54,7 +54,7 @@ class BladeEchoHandlerTest extends AbstractBladeTestCase
     public function testHandlerLogicWorksCorrectly($blade)
     {
         $this->expectException(Exception::class);
-        $this->expectExceptionMessage('The fluent object has been successfully handled!');
+        $this->expectExceptionMessageIs('The fluent object has been successfully handled!');
 
         $this->compiler->stringable(Fluent::class, function ($object) {
             throw new Exception('The fluent object has been successfully handled!');

--- a/tests/View/Blade/BladeForeachStatementsTest.php
+++ b/tests/View/Blade/BladeForeachStatementsTest.php
@@ -99,7 +99,7 @@ tag info
     public function testForeachStatementsThrowHumanizedMessageWhenInvalidStatement($initialStatement)
     {
         $this->expectException(ViewCompilationException::class);
-        $this->expectExceptionMessage('Malformed @foreach statement.');
+        $this->expectExceptionMessageIs('Malformed @foreach statement.');
         $string = "$initialStatement
 test
 @endforeach";

--- a/tests/View/Blade/BladeForelseStatementsTest.php
+++ b/tests/View/Blade/BladeForelseStatementsTest.php
@@ -85,7 +85,7 @@ empty
     public function testForelseStatementsThrowHumanizedMessageWhenInvalidStatement($initialStatement)
     {
         $this->expectException(ViewCompilationException::class);
-        $this->expectExceptionMessage('Malformed @forelse statement.');
+        $this->expectExceptionMessageIs('Malformed @forelse statement.');
         $string = "$initialStatement
 breeze
 @empty

--- a/tests/View/ComponentTest.php
+++ b/tests/View/ComponentTest.php
@@ -137,7 +137,7 @@ class ComponentTest extends TestCase
     public function testResolveWithUnresolvableDependency()
     {
         $this->expectException(BindingResolutionException::class);
-        $this->expectExceptionMessage('Unresolvable dependency resolving');
+        $this->expectExceptionMessageIs('Unresolvable dependency resolving');
 
         TestInlineViewComponentWhereRenderDependsOnProps::resolve([]);
     }

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -21,7 +21,7 @@ class ViewBladeCompilerTest extends TestCase
     public function testCannotConstructWithBadCachePath()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Please provide a valid cache path.');
+        $this->expectExceptionMessageIs('Please provide a valid cache path.');
 
         new BladeCompiler($this->getFiles(), null);
     }

--- a/tests/View/ViewCompilerEngineTest.php
+++ b/tests/View/ViewCompilerEngineTest.php
@@ -46,7 +46,7 @@ class ViewCompilerEngineTest extends TestCase
         $engine->getCompiler()->shouldReceive('isExpired')->once()->andReturn(false);
 
         $this->expectException(ViewException::class);
-        $this->expectExceptionMessage('regular exception message');
+        $this->expectExceptionMessageIs('regular exception message');
 
         $engine->get(__DIR__.'/fixtures/foo.php');
     }
@@ -58,7 +58,7 @@ class ViewCompilerEngineTest extends TestCase
         $engine->getCompiler()->shouldReceive('isExpired')->once()->andReturn(false);
 
         $this->expectException(HttpException::class);
-        $this->expectExceptionMessage('http exception message');
+        $this->expectExceptionMessageIs('http exception message');
 
         $engine->get(__DIR__.'/fixtures/foo.php');
     }
@@ -215,7 +215,7 @@ class ViewCompilerEngineTest extends TestCase
         $engine->get($path);
 
         $this->expectException(ViewException::class);
-        $this->expectExceptionMessage("File does not exist at path {$path}.");
+        $this->expectExceptionMessageIs("File does not exist at path {$path}.");
         $engine->get($path);
     }
 
@@ -250,7 +250,7 @@ class ViewCompilerEngineTest extends TestCase
             ->andReturn($compiled);
 
         $this->expectException(ViewException::class);
-        $this->expectExceptionMessage('Just an regular error...');
+        $this->expectExceptionMessageIs('Just an regular error...');
         $engine->get($path);
     }
 
@@ -286,7 +286,7 @@ class ViewCompilerEngineTest extends TestCase
             ->andReturn($compiled);
 
         $this->expectException(ViewException::class);
-        $this->expectExceptionMessage("File does not exist at path {$path}.");
+        $this->expectExceptionMessageIs("File does not exist at path {$path}.");
         $engine->get($path);
     }
 

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -879,7 +879,7 @@ class ViewFactoryTest extends TestCase
     public function testExceptionsInSectionsAreThrown()
     {
         $this->expectException(ErrorException::class);
-        $this->expectExceptionMessage('section exception message');
+        $this->expectExceptionMessageIs('section exception message');
 
         $engine = new CompilerEngine(m::mock(CompilerInterface::class), new Filesystem);
         $engine->getCompiler()->shouldReceive('getCompiledPath')->andReturnUsing(function ($path) {
@@ -898,7 +898,7 @@ class ViewFactoryTest extends TestCase
     public function testExtraStopSectionCallThrowsException()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Cannot end a section without first starting one.');
+        $this->expectExceptionMessageIs('Cannot end a section without first starting one.');
 
         $factory = $this->getFactory();
         $factory->startSection('foo');
@@ -910,7 +910,7 @@ class ViewFactoryTest extends TestCase
     public function testExtraAppendSectionCallThrowsException()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Cannot end a section without first starting one.');
+        $this->expectExceptionMessageIs('Cannot end a section without first starting one.');
 
         $factory = $this->getFactory();
         $factory->startSection('foo');

--- a/tests/View/ViewFileViewFinderTest.php
+++ b/tests/View/ViewFileViewFinderTest.php
@@ -89,7 +89,7 @@ class ViewFileViewFinderTest extends TestCase
     public function testExceptionThrownOnInvalidViewName()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('No hint path defined for [name].');
+        $this->expectExceptionMessageIs('No hint path defined for [name].');
 
         $finder = $this->getFinder();
         $finder->find('name::');
@@ -98,7 +98,7 @@ class ViewFileViewFinderTest extends TestCase
     public function testExceptionThrownWhenNoHintPathIsRegistered()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('No hint path defined for [name].');
+        $this->expectExceptionMessageIs('No hint path defined for [name].');
 
         $finder = $this->getFinder();
         $finder->find('name::foo');

--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -170,7 +170,7 @@ class ViewTest extends TestCase
     public function testViewBadMethod()
     {
         $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage('Method Illuminate\View\View::badMethodCall does not exist.');
+        $this->expectExceptionMessageIs('Method Illuminate\View\View::badMethodCall does not exist.');
 
         $view = $this->getView();
         $view->badMethodCall();


### PR DESCRIPTION
## Description

PHPUnit 11.5.50 / 12.5.8 / 13.0.3 deprecate `expectExceptionMessage()` in favor of `expectExceptionMessageIs()` (exact match) or `expectExceptionMessageIsOrContains()` (old substring-match behavior). This composer.json already requires those minimum versions.

This PR mechanically replaces all `expectExceptionMessage()` calls with `expectExceptionMessageIs()` across the test suite (534 occurrences, 140 files). No other changes.