### PR TITLE
[13.x] Reject non-stream resources in HTTP fake response bodies

### DIFF
--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -175,7 +175,7 @@ class Factory
      *
      * @param  \Psr\Http\Message\StreamInterface|array|string|resource|null  $body
      * @param  int  $status
-     * @param  array<string, mixed>  $headers
+     * @param  array  $headers
      * @return \GuzzleHttp\Psr7\Response
      *
      * @throws \InvalidArgumentException
@@ -192,8 +192,8 @@ class Factory
             $headers['Content-Type'] = 'application/json';
         }
 
-        if (! is_string($body) && ! is_null($body) && ! is_resource($body) && ! $body instanceof StreamInterface) {
-            throw new InvalidArgumentException('HTTP fake response body must be a string, array, resource, Psr\Http\Message\StreamInterface, or null.');
+        if (! is_string($body) && ! is_null($body) && (! is_resource($body) || get_resource_type($body) !== 'stream') && ! $body instanceof StreamInterface) {
+            throw new InvalidArgumentException('HTTP fake response body must be a string, array, stream resource, Psr\Http\Message\StreamInterface, or null.');
         }
 
         return new Psr7Response($status, static::normalizeResponseHeaders($headers), $body);
@@ -266,7 +266,7 @@ class Factory
      *
      * @param  \Psr\Http\Message\StreamInterface|array|string|resource|null  $body
      * @param  int  $status
-     * @param  array<string, mixed>  $headers
+     * @param  array  $headers
      * @return \Illuminate\Http\Client\RequestException
      */
     public static function failedRequest($body = null, $status = 200, $headers = [])

--- a/src/Illuminate/Http/Client/ResponseSequence.php
+++ b/src/Illuminate/Http/Client/ResponseSequence.php
@@ -44,7 +44,7 @@ class ResponseSequence
     /**
      * Push a response to the sequence.
      *
-     * @param  string|array|null  $body
+     * @param  \Psr\Http\Message\StreamInterface|array|string|resource|null  $body
      * @param  int  $status
      * @param  array  $headers
      * @return $this

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -196,9 +196,17 @@ class HttpClientTest extends TestCase
     public function testFakeResponseRejectsUnsupportedBody()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('HTTP fake response body must be a string, array, resource, Psr\Http\Message\StreamInterface, or null.');
+        $this->expectExceptionMessage('HTTP fake response body must be a string, array, stream resource, Psr\Http\Message\StreamInterface, or null.');
 
         $this->factory::response(new stdClass);
+    }
+
+    public function testFakeResponseRejectsNonStreamResourceBody()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('HTTP fake response body must be a string, array, stream resource, Psr\Http\Message\StreamInterface, or null.');
+
+        $this->factory::response(stream_context_create());
     }
 
     public function testAcceptedRequest()


### PR DESCRIPTION
This PR tightens the HTTP fake response body validation to only accept stream resources, since other resource types cannot be converted to a PSR-7 stream and currently fail later with a more obscure error. It also corrects some related docblocks.