### PR TITLE
[13.x] Simplify most of the exceptions expectations

### DIFF
--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -663,9 +663,7 @@ class AuthAccessGateTest extends TestCase
 
     public function testAuthorizeThrowsUnauthorizedException()
     {
-        $this->expectException(AuthorizationException::class);
-        $this->expectExceptionMessage('You are not an admin.');
-        $this->expectExceptionCode(0);
+        $this->expectExceptionObject(new AuthorizationException('You are not an admin.', 0));
 
         $gate = $this->getBasicGate();
 
@@ -676,9 +674,7 @@ class AuthAccessGateTest extends TestCase
 
     public function testAuthorizeThrowsUnauthorizedExceptionWithCustomStatusCode()
     {
-        $this->expectException(AuthorizationException::class);
-        $this->expectExceptionMessage('Not allowed to view as it is not published.');
-        $this->expectExceptionCode('unpublished');
+        $this->expectExceptionObject(new AuthorizationException('Not allowed to view as it is not published.', 'unpublished'));
 
         $gate = $this->getBasicGate();
 
@@ -689,9 +685,7 @@ class AuthAccessGateTest extends TestCase
 
     public function testAuthorizeWithPolicyThatReturnsDeniedResponseObjectThrowsException()
     {
-        $this->expectException(AuthorizationException::class);
-        $this->expectExceptionMessage('Not allowed.');
-        $this->expectExceptionCode('some_code');
+        $this->expectExceptionObject(new AuthorizationException('Not allowed.', 'some_code'));
 
         $gate = $this->getBasicGate();
 
@@ -853,9 +847,7 @@ class AuthAccessGateTest extends TestCase
 
     public function testAllowIfThrowsExceptionWhenCallbackFalse()
     {
-        $this->expectException(AuthorizationException::class);
-        $this->expectExceptionMessage('foo');
-        $this->expectExceptionCode('bar');
+        $this->expectExceptionObject(new AuthorizationException('foo', 'bar'));
 
         $this->getBasicGate()->allowIf(function () {
             return false;
@@ -864,18 +856,14 @@ class AuthAccessGateTest extends TestCase
 
     public function testAllowIfThrowsExceptionWhenResponseDenied()
     {
-        $this->expectException(AuthorizationException::class);
-        $this->expectExceptionMessage('foo');
-        $this->expectExceptionCode('bar');
+        $this->expectExceptionObject(new AuthorizationException('foo', 'bar'));
 
         $this->getBasicGate()->allowIf(Response::deny('foo', 'bar'));
     }
 
     public function testAllowIfThrowsExceptionWhenCallbackResponseDenied()
     {
-        $this->expectException(AuthorizationException::class);
-        $this->expectExceptionMessage('quz');
-        $this->expectExceptionCode('qux');
+        $this->expectExceptionObject(new AuthorizationException('quz', 'qux'));
 
         $this->getBasicGate()->allowIf(function () {
             return Response::deny('quz', 'qux');
@@ -884,9 +872,7 @@ class AuthAccessGateTest extends TestCase
 
     public function testAllowIfThrowsExceptionIfUnauthenticated()
     {
-        $this->expectException(AuthorizationException::class);
-        $this->expectExceptionMessage('foo');
-        $this->expectExceptionCode('bar');
+        $this->expectExceptionObject(new AuthorizationException('foo', 'bar'));
 
         $gate = $this->getBasicGate()->forUser(null);
 
@@ -897,9 +883,7 @@ class AuthAccessGateTest extends TestCase
 
     public function testAllowIfThrowsExceptionIfAuthUserExpectedWhenGuest()
     {
-        $this->expectException(AuthorizationException::class);
-        $this->expectExceptionMessage('foo');
-        $this->expectExceptionCode('bar');
+        $this->expectExceptionObject(new AuthorizationException('foo', 'bar'));
 
         $gate = $this->getBasicGate()->forUser(null);
 
@@ -991,9 +975,7 @@ class AuthAccessGateTest extends TestCase
 
     public function testDenyIfThrowsExceptionWhenCallbackTrue()
     {
-        $this->expectException(AuthorizationException::class);
-        $this->expectExceptionMessage('foo');
-        $this->expectExceptionCode('bar');
+        $this->expectExceptionObject(new AuthorizationException('foo', 'bar'));
 
         $this->getBasicGate()->denyIf(function () {
             return true;
@@ -1002,18 +984,14 @@ class AuthAccessGateTest extends TestCase
 
     public function testDenyIfThrowsExceptionWhenResponseDenied()
     {
-        $this->expectException(AuthorizationException::class);
-        $this->expectExceptionMessage('foo');
-        $this->expectExceptionCode('bar');
+        $this->expectExceptionObject(new AuthorizationException('foo', 'bar'));
 
         $this->getBasicGate()->denyIf(Response::deny('foo', 'bar'));
     }
 
     public function testDenyIfThrowsExceptionWhenCallbackResponseDenied()
     {
-        $this->expectException(AuthorizationException::class);
-        $this->expectExceptionMessage('quz');
-        $this->expectExceptionCode('qux');
+        $this->expectExceptionObject(new AuthorizationException('quz', 'qux'));
 
         $this->getBasicGate()->denyIf(function () {
             return Response::deny('quz', 'qux');
@@ -1022,9 +1000,7 @@ class AuthAccessGateTest extends TestCase
 
     public function testDenyIfThrowsExceptionIfUnauthenticated()
     {
-        $this->expectException(AuthorizationException::class);
-        $this->expectExceptionMessage('foo');
-        $this->expectExceptionCode('bar');
+        $this->expectExceptionObject(new AuthorizationException('foo', 'bar'));
 
         $gate = $this->getBasicGate()->forUser(null);
 
@@ -1035,9 +1011,7 @@ class AuthAccessGateTest extends TestCase
 
     public function testDenyIfThrowsExceptionIfAuthUserExpectedWhenGuest()
     {
-        $this->expectException(AuthorizationException::class);
-        $this->expectExceptionMessage('foo');
-        $this->expectExceptionCode('bar');
+        $this->expectExceptionObject(new AuthorizationException('foo', 'bar'));
 
         $gate = $this->getBasicGate()->forUser(null);
 

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -296,8 +296,7 @@ class AuthGuardTest extends TestCase
 
     public function testAuthenticateThrowsWhenUserIsNull()
     {
-        $this->expectException(AuthenticationException::class);
-        $this->expectExceptionMessage('Unauthenticated.');
+        $this->expectExceptionObject(new AuthenticationException('Unauthenticated.'));
 
         $guard = $this->getGuard();
         $guard->getSession()->shouldReceive('get')->once()->andReturn(null);

--- a/tests/Auth/AuthPasswordBrokerTest.php
+++ b/tests/Auth/AuthPasswordBrokerTest.php
@@ -36,8 +36,7 @@ class AuthPasswordBrokerTest extends TestCase
 
     public function testGetUserThrowsExceptionIfUserDoesntImplementCanResetPassword()
     {
-        $this->expectException(UnexpectedValueException::class);
-        $this->expectExceptionMessage('User must implement CanResetPassword interface.');
+        $this->expectExceptionObject(new UnexpectedValueException('User must implement CanResetPassword interface.'));
 
         $broker = $this->getBroker($mocks = $this->getMocks());
         $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with(['foo'])->andReturn('bar');

--- a/tests/Auth/AuthenticateMiddlewareTest.php
+++ b/tests/Auth/AuthenticateMiddlewareTest.php
@@ -62,8 +62,7 @@ class AuthenticateMiddlewareTest extends TestCase
 
     public function testDefaultUnauthenticatedThrows()
     {
-        $this->expectException(AuthenticationException::class);
-        $this->expectExceptionMessage('Unauthenticated.');
+        $this->expectExceptionObject(new AuthenticationException('Unauthenticated.'));
 
         $this->registerAuthDriver('default', false);
 
@@ -107,8 +106,7 @@ class AuthenticateMiddlewareTest extends TestCase
 
     public function testMultipleDriversUnauthenticatedThrows()
     {
-        $this->expectException(AuthenticationException::class);
-        $this->expectExceptionMessage('Unauthenticated.');
+        $this->expectExceptionObject(new AuthenticationException('Unauthenticated.'));
 
         $this->registerAuthDriver('default', false);
 

--- a/tests/Auth/AuthorizeMiddlewareTest.php
+++ b/tests/Auth/AuthorizeMiddlewareTest.php
@@ -65,8 +65,7 @@ class AuthorizeMiddlewareTest extends TestCase
 
     public function testSimpleAbilityUnauthorized()
     {
-        $this->expectException(AuthorizationException::class);
-        $this->expectExceptionMessage('This action is unauthorized.');
+        $this->expectExceptionObject(new AuthorizationException('This action is unauthorized.'));
 
         $this->gate()->define('view-dashboard', function ($user, $additional = null) {
             $this->assertNull($additional);
@@ -227,8 +226,7 @@ class AuthorizeMiddlewareTest extends TestCase
 
     public function testModelTypeUnauthorized()
     {
-        $this->expectException(AuthorizationException::class);
-        $this->expectExceptionMessage('This action is unauthorized.');
+        $this->expectExceptionObject(new AuthorizationException('This action is unauthorized.'));
 
         $this->gate()->define('create', function ($user, $model) {
             $this->assertSame('App\User', $model);
@@ -268,8 +266,7 @@ class AuthorizeMiddlewareTest extends TestCase
 
     public function testModelUnauthorized()
     {
-        $this->expectException(AuthorizationException::class);
-        $this->expectExceptionMessage('This action is unauthorized.');
+        $this->expectExceptionObject(new AuthorizationException('This action is unauthorized.'));
 
         $post = new stdClass;
 

--- a/tests/Cache/CacheManagerTest.php
+++ b/tests/Cache/CacheManagerTest.php
@@ -311,8 +311,7 @@ class CacheManagerTest extends TestCase
 
     public function testThrowExceptionWhenUnknownDriverIsUsed()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Driver [unknown_taxi_driver] is not supported.');
+        $this->expectExceptionObject(new InvalidArgumentException('Driver [unknown_taxi_driver] is not supported.'));
 
         $userConfig = [
             'cache' => [
@@ -333,8 +332,7 @@ class CacheManagerTest extends TestCase
 
     public function testThrowExceptionWhenUnknownStoreIsUsed()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Cache store [alien_store] is not defined.');
+        $this->expectExceptionObject(new InvalidArgumentException('Cache store [alien_store] is not defined.'));
 
         $userConfig = [
             'cache' => [

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -698,8 +698,7 @@ class CacheRepositoryTest extends TestCase
 
     public function testItThrowsExceptionWhenGettingNonStringAsString()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Cache value for key [foo] must be a string, integer given.');
+        $this->expectExceptionObject(new InvalidArgumentException('Cache value for key [foo] must be a string, integer given.'));
 
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('get')->once()->with('foo')->andReturn(123);
@@ -729,8 +728,7 @@ class CacheRepositoryTest extends TestCase
 
     public function testItThrowsExceptionWhenGettingNonIntegerAsInteger()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Cache value for key [foo] must be an integer, string given.');
+        $this->expectExceptionObject(new InvalidArgumentException('Cache value for key [foo] must be an integer, string given.'));
 
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('get')->once()->with('foo')->andReturn('bar');
@@ -739,8 +737,7 @@ class CacheRepositoryTest extends TestCase
 
     public function testItThrowsExceptionWhenGettingFloatStringAsInteger()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Cache value for key [foo] must be an integer, string given.');
+        $this->expectExceptionObject(new InvalidArgumentException('Cache value for key [foo] must be an integer, string given.'));
 
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('get')->once()->with('foo')->andReturn('1.5');
@@ -770,8 +767,7 @@ class CacheRepositoryTest extends TestCase
 
     public function testItThrowsExceptionWhenGettingNonFloatAsFloat()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Cache value for key [foo] must be a float, string given.');
+        $this->expectExceptionObject(new InvalidArgumentException('Cache value for key [foo] must be a float, string given.'));
 
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('get')->once()->with('foo')->andReturn('bar');
@@ -794,8 +790,7 @@ class CacheRepositoryTest extends TestCase
 
     public function testItThrowsExceptionWhenGettingNonBooleanAsBoolean()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Cache value for key [foo] must be a boolean, string given.');
+        $this->expectExceptionObject(new InvalidArgumentException('Cache value for key [foo] must be a boolean, string given.'));
 
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('get')->once()->with('foo')->andReturn('bar');
@@ -818,8 +813,7 @@ class CacheRepositoryTest extends TestCase
 
     public function testItThrowsExceptionWhenGettingNonArrayAsArray()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Cache value for key [foo] must be an array, string given.');
+        $this->expectExceptionObject(new InvalidArgumentException('Cache value for key [foo] must be an array, string given.'));
 
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('get')->once()->with('foo')->andReturn('bar');

--- a/tests/Cache/ConcurrencyLimiterTest.php
+++ b/tests/Cache/ConcurrencyLimiterTest.php
@@ -240,8 +240,7 @@ class ConcurrencyLimiterTest extends TestCase
 
         $this->assertNotInstanceOf(LockProvider::class, $store);
 
-        $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage('This cache store does not support locks.');
+        $this->expectExceptionObject(new BadMethodCallException('This cache store does not support locks.'));
 
         $repository->funnel('test');
     }

--- a/tests/Console/ConsoleParserTest.php
+++ b/tests/Console/ConsoleParserTest.php
@@ -148,16 +148,14 @@ class ConsoleParserTest extends TestCase
 
     public function testNameIsSpacesException()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Unable to determine command name from signature.');
+        $this->expectExceptionObject(new InvalidArgumentException('Unable to determine command name from signature.'));
 
         Parser::parse(" \t\n\r\x0B\f");
     }
 
     public function testNameInEmptyException()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Unable to determine command name from signature.');
+        $this->expectExceptionObject(new InvalidArgumentException('Unable to determine command name from signature.'));
 
         Parser::parse('');
     }

--- a/tests/Container/ContainerCallTest.php
+++ b/tests/Container/ContainerCallTest.php
@@ -202,8 +202,7 @@ class ContainerCallTest extends TestCase
 
     public function testCallWithoutRequiredParamsThrowsException()
     {
-        $this->expectException(BindingResolutionException::class);
-        $this->expectExceptionMessage('Unable to resolve dependency [Parameter #0 [ <required> $foo ]] in class Illuminate\Tests\Container\ContainerTestCallStub');
+        $this->expectExceptionObject(new BindingResolutionException('Unable to resolve dependency [Parameter #0 [ <required> $foo ]] in class Illuminate\Tests\Container\ContainerTestCallStub'));
 
         $container = new Container;
         $container->call(ContainerTestCallStub::class.'@unresolvable');
@@ -211,8 +210,7 @@ class ContainerCallTest extends TestCase
 
     public function testCallWithUnnamedParametersThrowsException()
     {
-        $this->expectException(BindingResolutionException::class);
-        $this->expectExceptionMessage('Unable to resolve dependency [Parameter #0 [ <required> $foo ]] in class Illuminate\Tests\Container\ContainerTestCallStub');
+        $this->expectExceptionObject(new BindingResolutionException('Unable to resolve dependency [Parameter #0 [ <required> $foo ]] in class Illuminate\Tests\Container\ContainerTestCallStub'));
 
         $container = new Container;
         $container->call([new ContainerTestCallStub, 'unresolvable'], ['foo', 'bar']);
@@ -220,8 +218,7 @@ class ContainerCallTest extends TestCase
 
     public function testCallWithoutRequiredParamsOnClosureThrowsException()
     {
-        $this->expectException(BindingResolutionException::class);
-        $this->expectExceptionMessage('Unable to resolve dependency [Parameter #0 [ <required> $foo ]] in class Illuminate\Tests\Container\ContainerCallTest');
+        $this->expectExceptionObject(new BindingResolutionException('Unable to resolve dependency [Parameter #0 [ <required> $foo ]] in class Illuminate\Tests\Container\ContainerCallTest'));
 
         $container = new Container;
         $container->call(function ($foo, $bar = 'default') {

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -11,6 +11,7 @@ use Illuminate\Container\EntryNotFoundException;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Container\ContextualAttribute;
 use Illuminate\Contracts\Container\SelfBuilding;
+use LogicException;
 use PHPUnit\Framework\Attributes\RequiresPhp;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerExceptionInterface;
@@ -438,8 +439,7 @@ class ContainerTest extends TestCase
 
     public function testInternalClassWithDefaultParameters()
     {
-        $this->expectException(BindingResolutionException::class);
-        $this->expectExceptionMessage('Unresolvable dependency resolving [Parameter #0 [ <required> $first ]] in class Illuminate\Tests\Container\ContainerMixedPrimitiveStub');
+        $this->expectExceptionObject(new BindingResolutionException('Unresolvable dependency resolving [Parameter #0 [ <required> $first ]] in class Illuminate\Tests\Container\ContainerMixedPrimitiveStub'));
 
         $container = new Container;
         $container->make(ContainerMixedPrimitiveStub::class, []);
@@ -447,8 +447,7 @@ class ContainerTest extends TestCase
 
     public function testBindingResolutionExceptionMessage()
     {
-        $this->expectException(BindingResolutionException::class);
-        $this->expectExceptionMessage('Target [Illuminate\Tests\Container\IContainerContractStub] is not instantiable.');
+        $this->expectExceptionObject(new BindingResolutionException('Target [Illuminate\Tests\Container\IContainerContractStub] is not instantiable.'));
 
         $container = new Container;
         $container->make(IContainerContractStub::class, []);
@@ -456,8 +455,7 @@ class ContainerTest extends TestCase
 
     public function testBindingResolutionExceptionMessageIncludesBuildStack()
     {
-        $this->expectException(BindingResolutionException::class);
-        $this->expectExceptionMessage('Target [Illuminate\Tests\Container\IContainerContractStub] is not instantiable while building [Illuminate\Tests\Container\ContainerDependentStub].');
+        $this->expectExceptionObject(new BindingResolutionException('Target [Illuminate\Tests\Container\IContainerContractStub] is not instantiable while building [Illuminate\Tests\Container\ContainerDependentStub].'));
 
         $container = new Container;
         $container->make(ContainerDependentStub::class, []);
@@ -465,8 +463,7 @@ class ContainerTest extends TestCase
 
     public function testBindingResolutionExceptionMessageWhenClassDoesNotExist()
     {
-        $this->expectException(BindingResolutionException::class);
-        $this->expectExceptionMessage('Target class [Foo\Bar\Baz\DummyClass] does not exist.');
+        $this->expectExceptionObject(new BindingResolutionException('Target class [Foo\Bar\Baz\DummyClass] does not exist.'));
 
         $container = new Container;
         $container->build('Foo\Bar\Baz\DummyClass');
@@ -574,8 +571,7 @@ class ContainerTest extends TestCase
 
     public function testItThrowsExceptionWhenAbstractIsSameAsAlias()
     {
-        $this->expectException('LogicException');
-        $this->expectExceptionMessage('[name] is aliased to itself.');
+        $this->expectExceptionObject(new LogicException('[name] is aliased to itself.'));
 
         $container = new Container;
         $container->alias('name', 'name');

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -579,7 +579,7 @@ class ContainerTest extends TestCase
 
     public function testItThrowsExceptionOnCircularAliasReference(): void
     {
-        $this->expectExceptionObject(new \LogicException('Circular alias reference for [a].'));
+        $this->expectExceptionObject(new LogicException('Circular alias reference for [a].'));
 
         $container = new Container;
         $container->alias('a', 'b');
@@ -590,7 +590,7 @@ class ContainerTest extends TestCase
 
     public function testItThrowsExceptionOnIndirectCircularAliasReference(): void
     {
-        $this->expectExceptionObject(new \LogicException('Circular alias reference for [a].'));
+        $this->expectExceptionObject(new LogicException('Circular alias reference for [a].'));
 
         $container = new Container;
         $container->alias('a', 'b');

--- a/tests/Database/DatabaseConnectionFactoryTest.php
+++ b/tests/Database/DatabaseConnectionFactoryTest.php
@@ -341,8 +341,7 @@ class DatabaseConnectionFactoryTest extends TestCase
 
     public function testIfDriverIsntSetExceptionIsThrown()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('A driver must be specified.');
+        $this->expectExceptionObject(new InvalidArgumentException('A driver must be specified.'));
 
         $factory = new ConnectionFactory($container = m::mock(Container::class));
         $factory->createConnector(['foo']);
@@ -350,8 +349,7 @@ class DatabaseConnectionFactoryTest extends TestCase
 
     public function testExceptionIsThrownOnUnsupportedDriver()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Unsupported driver [foo]');
+        $this->expectExceptionObject(new InvalidArgumentException('Unsupported driver [foo]'));
 
         $factory = new ConnectionFactory($container = m::mock(Container::class));
         $container->shouldReceive('bound')->once()->andReturn(false);

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -511,8 +511,7 @@ class DatabaseConnectionTest extends TestCase
 
     public function testBeforeExecutingHooksCanBeRegistered()
     {
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage('The callback was fired');
+        $this->expectExceptionObject(new Exception('The callback was fired'));
 
         $connection = $this->getMockConnection();
         $connection->beforeExecuting(function () {
@@ -523,8 +522,7 @@ class DatabaseConnectionTest extends TestCase
 
     public function testBeforeStartingTransactionHooksCanBeRegistered()
     {
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage('The callback was fired');
+        $this->expectExceptionObject(new Exception('The callback was fired'));
 
         $connection = $this->getMockConnection();
         $connection->beforeStartingTransaction(function () {

--- a/tests/Database/DatabaseEloquentAsBinaryCastTest.php
+++ b/tests/Database/DatabaseEloquentAsBinaryCastTest.php
@@ -21,8 +21,7 @@ class DatabaseEloquentAsBinaryCastTest extends TestCase
 
     public function testCastThrowsWhenFormatMissing()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The binary codec format is required.');
+        $this->expectExceptionObject(new InvalidArgumentException('The binary codec format is required.'));
 
         $model = new AsBinaryTestModel;
         $model->setRawAttributes(['no_format' => 'value']);
@@ -31,8 +30,7 @@ class DatabaseEloquentAsBinaryCastTest extends TestCase
 
     public function testCastThrowsOnInvalidFormat()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Unsupported binary codec format [invalid]. Allowed formats are: uuid, ulid.');
+        $this->expectExceptionObject(new InvalidArgumentException('Unsupported binary codec format [invalid]. Allowed formats are: uuid, ulid.'));
 
         $model = new AsBinaryTestModel;
         $model->setRawAttributes(['invalid_format' => 'value']);

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -798,8 +798,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testMissingStaticMacrosThrowsProperException()
     {
-        $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage('Call to undefined method Illuminate\Database\Eloquent\Builder::missingMacro()');
+        $this->expectExceptionObject(new BadMethodCallException('Call to undefined method Illuminate\Database\Eloquent\Builder::missingMacro()'));
 
         Builder::missingMacro();
     }

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -255,8 +255,7 @@ class DatabaseEloquentCollectionTest extends TestCase
         $c->push($model2);
         $this->assertCount(2, $c->findOrFail([1, 2]));
 
-        $this->expectException(ModelNotFoundException::class);
-        $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Database\TestEloquentCollectionModel] 3');
+        $this->expectExceptionObject(new ModelNotFoundException('No query results for model [Illuminate\Tests\Database\TestEloquentCollectionModel] 3'));
 
         $c->findOrFail([1, 2, 3]);
     }
@@ -267,8 +266,7 @@ class DatabaseEloquentCollectionTest extends TestCase
 
         $c = new Collection([$model]);
 
-        $this->expectException(ModelNotFoundException::class);
-        $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Database\TestEloquentCollectionModel] 2');
+        $this->expectExceptionObject(new ModelNotFoundException('No query results for model [Illuminate\Tests\Database\TestEloquentCollectionModel] 2'));
 
         $c->findOrFail(2);
     }
@@ -277,8 +275,7 @@ class DatabaseEloquentCollectionTest extends TestCase
     {
         $c = new Collection();
 
-        $this->expectException(ModelNotFoundException::class);
-        $this->expectExceptionMessage('');
+        $this->expectExceptionObject(new ModelNotFoundException(''));
 
         $c->findOrFail(1);
     }
@@ -653,8 +650,7 @@ class DatabaseEloquentCollectionTest extends TestCase
 
     public function testQueueableCollectionImplementationThrowsExceptionOnMultipleModelTypes()
     {
-        $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('Queueing collections with multiple model types is not supported.');
+        $this->expectExceptionObject(new LogicException('Queueing collections with multiple model types is not supported.'));
 
         $c = new Collection([new TestEloquentCollectionModel, (object) ['id' => 'something']]);
         $c->getQueueableClass();

--- a/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
@@ -169,8 +169,7 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
 
     public function testFirstOrFailThrowsAnException()
     {
-        $this->expectException(ModelNotFoundException::class);
-        $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Database\HasManyThroughTestPost].');
+        $this->expectExceptionObject(new ModelNotFoundException('No query results for model [Illuminate\Tests\Database\HasManyThroughTestPost].'));
 
         HasManyThroughTestCountry::create(['id' => 1, 'name' => 'United States of America', 'shortname' => 'us'])
             ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us']);
@@ -180,8 +179,7 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
 
     public function testFindOrFailThrowsAnException()
     {
-        $this->expectException(ModelNotFoundException::class);
-        $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Database\HasManyThroughTestPost] 1');
+        $this->expectExceptionObject(new ModelNotFoundException('No query results for model [Illuminate\Tests\Database\HasManyThroughTestPost] 1'));
 
         HasManyThroughTestCountry::create(['id' => 1, 'name' => 'United States of America', 'shortname' => 'us'])
             ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us']);
@@ -191,8 +189,7 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
 
     public function testFindOrFailWithManyThrowsAnException()
     {
-        $this->expectException(ModelNotFoundException::class);
-        $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Database\HasManyThroughTestPost] 1, 2');
+        $this->expectExceptionObject(new ModelNotFoundException('No query results for model [Illuminate\Tests\Database\HasManyThroughTestPost] 1, 2'));
 
         HasManyThroughTestCountry::create(['id' => 1, 'name' => 'United States of America', 'shortname' => 'us'])
             ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us'])
@@ -203,8 +200,7 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
 
     public function testFindOrFailWithManyUsingCollectionThrowsAnException()
     {
-        $this->expectException(ModelNotFoundException::class);
-        $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Database\HasManyThroughTestPost] 1, 2');
+        $this->expectExceptionObject(new ModelNotFoundException('No query results for model [Illuminate\Tests\Database\HasManyThroughTestPost] 1, 2'));
 
         HasManyThroughTestCountry::create(['id' => 1, 'name' => 'United States of America', 'shortname' => 'us'])
             ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us'])

--- a/tests/Database/DatabaseEloquentHasOneOfManyTest.php
+++ b/tests/Database/DatabaseEloquentHasOneOfManyTest.php
@@ -152,8 +152,7 @@ class DatabaseEloquentHasOneOfManyTest extends TestCase
 
     public function testItFailsWhenUsingInvalidAggregate()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid aggregate [count] used within ofMany relation. Available aggregates: MIN, MAX');
+        $this->expectExceptionObject(new InvalidArgumentException('Invalid aggregate [count] used within ofMany relation. Available aggregates: MIN, MAX'));
         $user = HasOneOfManyTestUser::make();
         $user->latest_login_with_invalid_aggregate();
     }

--- a/tests/Database/DatabaseEloquentHasOneThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasOneThroughIntegrationTest.php
@@ -130,8 +130,7 @@ class DatabaseEloquentHasOneThroughIntegrationTest extends TestCase
 
     public function testFirstOrFailThrowsAnException()
     {
-        $this->expectException(ModelNotFoundException::class);
-        $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Database\HasOneThroughTestContract].');
+        $this->expectExceptionObject(new ModelNotFoundException('No query results for model [Illuminate\Tests\Database\HasOneThroughTestContract].'));
 
         HasOneThroughTestPosition::create(['id' => 1, 'name' => 'President', 'shortname' => 'ps'])
             ->user()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'position_short' => 'ps']);

--- a/tests/Database/DatabaseEloquentHasOneThroughOfManyTest.php
+++ b/tests/Database/DatabaseEloquentHasOneThroughOfManyTest.php
@@ -155,8 +155,7 @@ class DatabaseEloquentHasOneThroughOfManyTest extends TestCase
 
     public function testItFailsWhenUsingInvalidAggregate(): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid aggregate [count] used within ofMany relation. Available aggregates: MIN, MAX');
+        $this->expectExceptionObject(new InvalidArgumentException('Invalid aggregate [count] used within ofMany relation. Available aggregates: MIN, MAX'));
         $user = HasOneThroughOfManyTestUser::make();
         $user->latest_login_with_invalid_aggregate();
     }

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -1098,8 +1098,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
     public function testFindOrFailWithSingleIdThrowsModelNotFoundException()
     {
-        $this->expectException(ModelNotFoundException::class);
-        $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Database\EloquentTestUser] 1');
+        $this->expectExceptionObject(new ModelNotFoundException('No query results for model [Illuminate\Tests\Database\EloquentTestUser] 1'));
         $this->expectExceptionObject(
             (new ModelNotFoundException())->setModel(EloquentTestUser::class, [1]),
         );
@@ -1109,8 +1108,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
     public function testFindOrFailWithMultipleIdsThrowsModelNotFoundException()
     {
-        $this->expectException(ModelNotFoundException::class);
-        $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Database\EloquentTestUser] 2, 3');
+        $this->expectExceptionObject(new ModelNotFoundException('No query results for model [Illuminate\Tests\Database\EloquentTestUser] 2, 3'));
         $this->expectExceptionObject(
             (new ModelNotFoundException())->setModel(EloquentTestUser::class, [2, 3]),
         );
@@ -1121,8 +1119,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
     public function testFindOrFailWithMultipleIdsUsingCollectionThrowsModelNotFoundException()
     {
-        $this->expectException(ModelNotFoundException::class);
-        $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Database\EloquentTestUser] 2, 3');
+        $this->expectExceptionObject(new ModelNotFoundException('No query results for model [Illuminate\Tests\Database\EloquentTestUser] 2, 3'));
         $this->expectExceptionObject(
             (new ModelNotFoundException())->setModel(EloquentTestUser::class, [2, 3]),
         );

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1907,8 +1907,7 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testGlobalGuarded()
     {
-        $this->expectException(MassAssignmentException::class);
-        $this->expectExceptionMessage('name');
+        $this->expectExceptionObject(new MassAssignmentException('name'));
 
         $model = new EloquentModelStub;
         $model->guard(['*']);
@@ -2483,8 +2482,7 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testGetModelAttributeMethodThrowsExceptionIfNotRelation()
     {
-        $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('Illuminate\Tests\Database\EloquentModelStub::incorrectRelationStub must return a relationship instance.');
+        $this->expectExceptionObject(new LogicException('Illuminate\Tests\Database\EloquentModelStub::incorrectRelationStub must return a relationship instance.'));
 
         $model = new EloquentModelStub;
         $model->incorrectRelationStub;
@@ -3127,8 +3125,7 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testModelAttributeCastingFailsOnUnencodableData()
     {
-        $this->expectException(JsonEncodingException::class);
-        $this->expectExceptionMessage('Unable to encode attribute [objectAttribute] for model [Illuminate\Tests\Database\EloquentModelCastingStub] to JSON: Malformed UTF-8 characters, possibly incorrectly encoded.');
+        $this->expectExceptionObject(new JsonEncodingException('Unable to encode attribute [objectAttribute] for model [Illuminate\Tests\Database\EloquentModelCastingStub] to JSON: Malformed UTF-8 characters, possibly incorrectly encoded.'));
 
         $model = new EloquentModelCastingStub;
         $model->objectAttribute = ['foo' => "b\xF8r"];
@@ -3141,8 +3138,7 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testModelJsonCastingFailsOnUnencodableData()
     {
-        $this->expectException(JsonEncodingException::class);
-        $this->expectExceptionMessage('Unable to encode attribute [jsonAttribute] for model [Illuminate\Tests\Database\EloquentModelCastingStub] to JSON: Malformed UTF-8 characters, possibly incorrectly encoded.');
+        $this->expectExceptionObject(new JsonEncodingException('Unable to encode attribute [jsonAttribute] for model [Illuminate\Tests\Database\EloquentModelCastingStub] to JSON: Malformed UTF-8 characters, possibly incorrectly encoded.'));
 
         $model = new EloquentModelCastingStub;
         $model->jsonAttribute = ['foo' => "b\xF8r"];
@@ -3152,8 +3148,7 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testModelAttributeCastingFailsOnUnencodableDataWithUnicode()
     {
-        $this->expectException(JsonEncodingException::class);
-        $this->expectExceptionMessage('Unable to encode attribute [jsonAttributeWithUnicode] for model [Illuminate\Tests\Database\EloquentModelCastingStub] to JSON: Malformed UTF-8 characters, possibly incorrectly encoded.');
+        $this->expectExceptionObject(new JsonEncodingException('Unable to encode attribute [jsonAttributeWithUnicode] for model [Illuminate\Tests\Database\EloquentModelCastingStub] to JSON: Malformed UTF-8 characters, possibly incorrectly encoded.'));
 
         $model = new EloquentModelCastingStub;
         $model->jsonAttributeWithUnicode = ['foo' => "b\xF8r"];
@@ -3745,8 +3740,7 @@ class DatabaseEloquentModelTest extends TestCase
     {
         $model = new EloquentModelCastingStub;
 
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The cast object for the something attribute must implement Stringable.');
+        $this->expectExceptionObject(new InvalidArgumentException('The cast object for the something attribute must implement Stringable.'));
 
         $model->mergeCasts([
             'something' => (object) [],

--- a/tests/Database/DatabaseEloquentResourceCollectionTest.php
+++ b/tests/Database/DatabaseEloquentResourceCollectionTest.php
@@ -11,6 +11,7 @@ use Illuminate\Tests\Database\Fixtures\Models\EloquentResourceTestResourceModelW
 use Illuminate\Tests\Database\Fixtures\Resources\EloquentResourceCollectionTestResource;
 use Illuminate\Tests\Database\Fixtures\Resources\EloquentResourceTestJsonResource;
 use Illuminate\Tests\Database\Fixtures\Resources\EloquentResourceTestJsonResourceCollection;
+use LogicException;
 use PHPUnit\Framework\TestCase;
 
 class DatabaseEloquentResourceCollectionTest extends TestCase
@@ -28,8 +29,7 @@ class DatabaseEloquentResourceCollectionTest extends TestCase
 
     public function testItThrowsExceptionWhenResourceCannotBeFound()
     {
-        $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('Failed to find resource class for model [Illuminate\Tests\Database\Fixtures\Models\EloquentResourceCollectionTestModel].');
+        $this->expectExceptionObject(new LogicException('Failed to find resource class for model [Illuminate\Tests\Database\Fixtures\Models\EloquentResourceCollectionTestModel].'));
 
         $collection = new Collection([
             new EloquentResourceCollectionTestModel(),

--- a/tests/Database/DatabaseEloquentResourceModelTest.php
+++ b/tests/Database/DatabaseEloquentResourceModelTest.php
@@ -6,6 +6,7 @@ use Illuminate\Tests\Database\Fixtures\Models\EloquentResourceTestResourceModel;
 use Illuminate\Tests\Database\Fixtures\Models\EloquentResourceTestResourceModelWithGuessableResource;
 use Illuminate\Tests\Database\Fixtures\Models\EloquentResourceTestResourceModelWithUseResourceAttribute;
 use Illuminate\Tests\Database\Fixtures\Resources\EloquentResourceTestJsonResource;
+use LogicException;
 use PHPUnit\Framework\TestCase;
 
 class DatabaseEloquentResourceModelTest extends TestCase
@@ -21,8 +22,7 @@ class DatabaseEloquentResourceModelTest extends TestCase
 
     public function testItThrowsExceptionWhenResourceCannotBeFound()
     {
-        $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('Failed to find resource class for model [Illuminate\Tests\Database\Fixtures\Models\EloquentResourceTestResourceModel].');
+        $this->expectExceptionObject(new LogicException('Failed to find resource class for model [Illuminate\Tests\Database\Fixtures\Models\EloquentResourceTestResourceModel].'));
 
         $model = new EloquentResourceTestResourceModel();
         $model->toResource();

--- a/tests/Database/DatabaseMigrationCreatorTest.php
+++ b/tests/Database/DatabaseMigrationCreatorTest.php
@@ -83,8 +83,7 @@ class DatabaseMigrationCreatorTest extends TestCase
 
     public function testTableUpdateMigrationWontCreateDuplicateClass()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('A MigrationCreatorFakeMigration class already exists.');
+        $this->expectExceptionObject(new InvalidArgumentException('A MigrationCreatorFakeMigration class already exists.'));
 
         $creator = $this->getCreator();
 

--- a/tests/Database/DatabaseMySqlSchemaStateTest.php
+++ b/tests/Database/DatabaseMySqlSchemaStateTest.php
@@ -156,8 +156,7 @@ class DatabaseMySqlSchemaStateTest extends TestCase
 
         $schemaState->method('makeProcess')->willReturn($mockProcess);
 
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Dump execution exceeded maximum depth of 30.');
+        $this->expectExceptionObject(new Exception('Dump execution exceeded maximum depth of 30.'));
 
         // test executeDumpProcess
         $method = new ReflectionMethod(get_class($schemaState), 'executeDumpProcess');

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -3359,16 +3359,14 @@ class DatabaseQueryBuilderTest extends TestCase
 
     public function testIncrementManyArgumentValidation1()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Non-numeric value passed as increment amount for column: \'col\'.');
+        $this->expectExceptionObject(new InvalidArgumentException('Non-numeric value passed as increment amount for column: \'col\'.'));
         $builder = $this->getBuilder();
         $builder->from('users')->incrementEach(['col' => 'a']);
     }
 
     public function testIncrementManyArgumentValidation2()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Non-associative array passed to incrementEach method.');
+        $this->expectExceptionObject(new InvalidArgumentException('Non-associative array passed to incrementEach method.'));
         $builder = $this->getBuilder();
         $builder->from('users')->incrementEach([11 => 11]);
     }
@@ -4035,8 +4033,7 @@ class DatabaseQueryBuilderTest extends TestCase
 
         $builder->getProcessor()->shouldReceive('processSelect')->once()->with($builder, [])->andReturn([]);
 
-        $this->expectException(RecordNotFoundException::class);
-        $this->expectExceptionMessage('No record found for the given query.');
+        $this->expectExceptionObject(new RecordNotFoundException('No record found for the given query.'));
 
         $builder->from('users')->where('id', '=', 1)->firstOrFail();
     }
@@ -4339,8 +4336,7 @@ class DatabaseQueryBuilderTest extends TestCase
 
     public function testInsertOrIgnoreMethod()
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('does not support');
+        $this->expectExceptionObject(new RuntimeException('does not support'));
         $builder = $this->getBuilder();
         $builder->from('users')->insertOrIgnore(['email' => 'foo']);
     }
@@ -4371,16 +4367,14 @@ class DatabaseQueryBuilderTest extends TestCase
 
     public function testSqlServerInsertOrIgnoreMethod()
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('does not support');
+        $this->expectExceptionObject(new RuntimeException('does not support'));
         $builder = $this->getSqlServerBuilder();
         $builder->from('users')->insertOrIgnore(['email' => 'foo']);
     }
 
     public function testInsertOrIgnoreReturningMethod()
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('does not support');
+        $this->expectExceptionObject(new RuntimeException('does not support'));
         $builder = $this->getBuilder();
         $builder->from('users')->insertOrIgnoreReturning(['email' => 'foo']);
     }
@@ -4395,8 +4389,7 @@ class DatabaseQueryBuilderTest extends TestCase
 
     public function testMySqlInsertOrIgnoreReturningMethod()
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('does not support');
+        $this->expectExceptionObject(new RuntimeException('does not support'));
         $builder = $this->getMySqlBuilder();
         $builder->from('users')->insertOrIgnoreReturning(['email' => 'foo']);
     }
@@ -4513,32 +4506,28 @@ class DatabaseQueryBuilderTest extends TestCase
 
     public function testSqlServerInsertOrIgnoreReturningMethod()
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('does not support');
+        $this->expectExceptionObject(new RuntimeException('does not support'));
         $builder = $this->getSqlServerBuilder();
         $builder->from('users')->insertOrIgnoreReturning(['email' => 'foo']);
     }
 
     public function testInsertOrIgnoreReturningWithEmptyUniqueByArray()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The unique columns must not be empty.');
+        $this->expectExceptionObject(new InvalidArgumentException('The unique columns must not be empty.'));
         $builder = $this->getPostgresBuilder();
         $builder->from('users')->insertOrIgnoreReturning(['email' => 'foo'], ['*'], []);
     }
 
     public function testInsertOrIgnoreReturningWithEmptyUniqueByString()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The unique columns must not be empty.');
+        $this->expectExceptionObject(new InvalidArgumentException('The unique columns must not be empty.'));
         $builder = $this->getPostgresBuilder();
         $builder->from('users')->insertOrIgnoreReturning(['email' => 'foo'], ['*'], '');
     }
 
     public function testInsertOrIgnoreReturningWithEmptyReturning()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The returning columns must not be empty.');
+        $this->expectExceptionObject(new InvalidArgumentException('The returning columns must not be empty.'));
         $builder = $this->getPostgresBuilder();
         $builder->from('users')->insertOrIgnoreReturning(['email' => 'foo'], []);
     }
@@ -4558,16 +4547,14 @@ class DatabaseQueryBuilderTest extends TestCase
 
     public function testInsertOrIgnoreUsingMethod()
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('does not support');
+        $this->expectExceptionObject(new RuntimeException('does not support'));
         $builder = $this->getBuilder();
         $builder->from('users')->insertOrIgnoreUsing(['email' => 'foo'], 'bar');
     }
 
     public function testSqlServerInsertOrIgnoreUsingMethod()
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('does not support');
+        $this->expectExceptionObject(new RuntimeException('does not support'));
         $builder = $this->getSqlServerBuilder();
         $builder->from('users')->insertOrIgnoreUsing(['email' => 'foo'], 'bar');
     }
@@ -4817,16 +4804,14 @@ class DatabaseQueryBuilderTest extends TestCase
 
     public function testUpsertMethodWithEmptyUniqueByArray()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The unique columns must not be empty.');
+        $this->expectExceptionObject(new InvalidArgumentException('The unique columns must not be empty.'));
         $builder = $this->getPostgresBuilder();
         $builder->from('users')->upsert([['email' => 'foo', 'name' => 'bar']], []);
     }
 
     public function testUpsertMethodWithEmptyUniqueByString()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The unique columns must not be empty.');
+        $this->expectExceptionObject(new InvalidArgumentException('The unique columns must not be empty.'));
         $builder = $this->getPostgresBuilder();
         $builder->from('users')->upsert([['email' => 'foo', 'name' => 'bar']], '');
     }
@@ -5846,8 +5831,7 @@ SQL;
 
     public function testPrepareValueAndOperatorExpectException()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Illegal operator and value combination.');
+        $this->expectExceptionObject(new InvalidArgumentException('Illegal operator and value combination.'));
 
         $builder = $this->getBuilder();
         $builder->prepareValueAndOperator(null, 'like');
@@ -7223,8 +7207,7 @@ SQL;
 
     public function testWhereRowValuesArityMismatch()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The number of columns must match the number of values');
+        $this->expectExceptionObject(new InvalidArgumentException('The number of columns must match the number of values'));
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('orders')->whereRowValues(['last_update'], '<', [1, 2]);

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -133,8 +133,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     public function testDropSpatialIndex()
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('The database driver in use does not support spatial indexes.');
+        $this->expectExceptionObject(new RuntimeException('The database driver in use does not support spatial indexes.'));
 
         $blueprint = new Blueprint($this->getConnection(), 'geo');
         $blueprint->dropSpatialIndex(['coordinates']);
@@ -249,8 +248,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     public function testAddingSpatialIndex()
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('The database driver in use does not support spatial indexes.');
+        $this->expectExceptionObject(new RuntimeException('The database driver in use does not support spatial indexes.'));
 
         $blueprint = new Blueprint($this->getConnection(), 'geo');
         $blueprint->spatialIndex('coordinates');
@@ -259,8 +257,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     public function testAddingFluentSpatialIndex()
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('The database driver in use does not support spatial indexes.');
+        $this->expectExceptionObject(new RuntimeException('The database driver in use does not support spatial indexes.'));
 
         $blueprint = new Blueprint($this->getConnection(), 'geo');
         $blueprint->geometry('coordinates')->spatialIndex();

--- a/tests/Database/EloquentModelCustomCastingTest.php
+++ b/tests/Database/EloquentModelCustomCastingTest.php
@@ -127,8 +127,7 @@ class EloquentModelCustomCastingTest extends TestCase
             'string_field' => 'string_value',
         ]);
 
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The given value is not an Address instance.');
+        $this->expectExceptionObject(new InvalidArgumentException('The given value is not an Address instance.'));
         $model->address = 'single_string';
 
         // Ensure model values remain unchanged
@@ -146,8 +145,7 @@ class EloquentModelCustomCastingTest extends TestCase
             'string_field' => 'string_value',
         ]);
 
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The given value is not an Address instance.');
+        $this->expectExceptionObject(new InvalidArgumentException('The given value is not an Address instance.'));
         $model->address = null;
 
         // Ensure model values remain unchanged

--- a/tests/Database/PruneCommandTest.php
+++ b/tests/Database/PruneCommandTest.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Events\ModelPruningStarting;
 use Illuminate\Database\Events\ModelsPruned;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Foundation\Application;
+use InvalidArgumentException;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -39,8 +40,7 @@ class PruneCommandTest extends TestCase
 
     public function testPrunableModelAndExceptWithEachOther(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('The --model and --except options cannot be combined.');
+        $this->expectExceptionObject(new InvalidArgumentException('The --model and --except options cannot be combined.'));
 
         $this->artisan([
             '--model' => Pruning\Models\PrunableTestModelWithPrunableRecords::class,

--- a/tests/Encryption/EncrypterTest.php
+++ b/tests/Encryption/EncrypterTest.php
@@ -133,8 +133,7 @@ class EncrypterTest extends TestCase
         $encrypted = $e->encrypt('foo');
         $data = json_decode(base64_decode($encrypted));
 
-        $this->expectException(DecryptException::class);
-        $this->expectExceptionMessage('Could not decrypt the data.');
+        $this->expectExceptionObject(new DecryptException('Could not decrypt the data.'));
 
         $data->tag = substr($data->tag, 0, 4);
         $encrypted = base64_encode(json_encode($data));
@@ -147,8 +146,7 @@ class EncrypterTest extends TestCase
         $encrypted = $e->encrypt('foo');
         $data = json_decode(base64_decode($encrypted));
 
-        $this->expectException(DecryptException::class);
-        $this->expectExceptionMessage('Could not decrypt the data.');
+        $this->expectExceptionObject(new DecryptException('Could not decrypt the data.'));
 
         $data->tag[0] = $data->tag[0] === 'A' ? 'B' : 'A';
         $encrypted = base64_encode(json_encode($data));
@@ -167,40 +165,35 @@ class EncrypterTest extends TestCase
 
     public function testDoNoAllowLongerKey()
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unsupported cipher or incorrect key length. Supported ciphers are: aes-128-cbc, aes-256-cbc, aes-128-gcm, aes-256-gcm.');
+        $this->expectExceptionObject(new RuntimeException('Unsupported cipher or incorrect key length. Supported ciphers are: aes-128-cbc, aes-256-cbc, aes-128-gcm, aes-256-gcm.'));
 
         new Encrypter(str_repeat('z', 32));
     }
 
     public function testWithBadKeyLength()
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unsupported cipher or incorrect key length. Supported ciphers are: aes-128-cbc, aes-256-cbc, aes-128-gcm, aes-256-gcm.');
+        $this->expectExceptionObject(new RuntimeException('Unsupported cipher or incorrect key length. Supported ciphers are: aes-128-cbc, aes-256-cbc, aes-128-gcm, aes-256-gcm.'));
 
         new Encrypter(str_repeat('a', 5));
     }
 
     public function testWithBadKeyLengthAlternativeCipher()
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unsupported cipher or incorrect key length. Supported ciphers are: aes-128-cbc, aes-256-cbc, aes-128-gcm, aes-256-gcm.');
+        $this->expectExceptionObject(new RuntimeException('Unsupported cipher or incorrect key length. Supported ciphers are: aes-128-cbc, aes-256-cbc, aes-128-gcm, aes-256-gcm.'));
 
         new Encrypter(str_repeat('a', 16), 'AES-256-GCM');
     }
 
     public function testWithUnsupportedCipher()
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unsupported cipher or incorrect key length. Supported ciphers are: aes-128-cbc, aes-256-cbc, aes-128-gcm, aes-256-gcm.');
+        $this->expectExceptionObject(new RuntimeException('Unsupported cipher or incorrect key length. Supported ciphers are: aes-128-cbc, aes-256-cbc, aes-128-gcm, aes-256-gcm.'));
 
         new Encrypter(str_repeat('c', 16), 'AES-256-CFB8');
     }
 
     public function testExceptionThrownWhenPayloadIsInvalid()
     {
-        $this->expectException(DecryptException::class);
-        $this->expectExceptionMessage('The payload is invalid.');
+        $this->expectExceptionObject(new DecryptException('The payload is invalid.'));
 
         $e = new Encrypter(str_repeat('a', 16));
         $payload = $e->encrypt('foo');
@@ -210,8 +203,7 @@ class EncrypterTest extends TestCase
 
     public function testDecryptionExceptionIsThrownWhenUnexpectedTagIsAdded()
     {
-        $this->expectException(DecryptException::class);
-        $this->expectExceptionMessage('Unable to use tag because the cipher algorithm does not support AEAD.');
+        $this->expectExceptionObject(new DecryptException('Unable to use tag because the cipher algorithm does not support AEAD.'));
 
         $e = new Encrypter(str_repeat('a', 16));
         $payload = $e->encrypt('foo');
@@ -222,8 +214,7 @@ class EncrypterTest extends TestCase
 
     public function testExceptionThrownWithDifferentKey()
     {
-        $this->expectException(DecryptException::class);
-        $this->expectExceptionMessage('The MAC is invalid.');
+        $this->expectExceptionObject(new DecryptException('The MAC is invalid.'));
 
         $a = new Encrypter(str_repeat('a', 16));
         $b = new Encrypter(str_repeat('b', 16));
@@ -232,8 +223,7 @@ class EncrypterTest extends TestCase
 
     public function testExceptionThrownWhenIvIsTooLong()
     {
-        $this->expectException(DecryptException::class);
-        $this->expectExceptionMessage('The payload is invalid.');
+        $this->expectExceptionObject(new DecryptException('The payload is invalid.'));
 
         $e = new Encrypter(str_repeat('a', 16));
         $payload = $e->encrypt('foo');
@@ -259,10 +249,12 @@ class EncrypterTest extends TestCase
 
         return [
             [['iv' => ['value_in_array'], 'value' => '', 'mac' => '']],
-            [['iv' => new class() {
+            [['iv' => new class()
+            {
             }, 'value' => '', 'mac' => '']],
             [['iv' => $validIv, 'value' => ['value_in_array'], 'mac' => '']],
-            [['iv' => $validIv, 'value' => new class() {
+            [['iv' => $validIv, 'value' => new class()
+            {
             }, 'mac' => '']],
             [['iv' => $validIv, 'value' => '', 'mac' => ['value_in_array']]],
             [['iv' => $validIv, 'value' => '', 'mac' => null]],
@@ -274,8 +266,7 @@ class EncrypterTest extends TestCase
     #[DataProvider('provideTamperedData')]
     public function testTamperedPayloadWillGetRejected($payload)
     {
-        $this->expectException(DecryptException::class);
-        $this->expectExceptionMessage('The payload is invalid.');
+        $this->expectExceptionObject(new DecryptException('The payload is invalid.'));
 
         $enc = new Encrypter(str_repeat('x', 16));
         $enc->decrypt(base64_encode(json_encode($payload)));

--- a/tests/Encryption/EncrypterTest.php
+++ b/tests/Encryption/EncrypterTest.php
@@ -249,12 +249,10 @@ class EncrypterTest extends TestCase
 
         return [
             [['iv' => ['value_in_array'], 'value' => '', 'mac' => '']],
-            [['iv' => new class()
-            {
+            [['iv' => new class() {
             }, 'value' => '', 'mac' => '']],
             [['iv' => $validIv, 'value' => ['value_in_array'], 'mac' => '']],
-            [['iv' => $validIv, 'value' => new class()
-            {
+            [['iv' => $validIv, 'value' => new class() {
             }, 'mac' => '']],
             [['iv' => $validIv, 'value' => '', 'mac' => ['value_in_array']]],
             [['iv' => $validIv, 'value' => '', 'mac' => null]],

--- a/tests/Filesystem/FilesystemManagerTest.php
+++ b/tests/Filesystem/FilesystemManagerTest.php
@@ -16,8 +16,7 @@ class FilesystemManagerTest extends TestCase
 {
     public function testExceptionThrownOnUnsupportedDriver()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Disk [local] does not have a configured driver.');
+        $this->expectExceptionObject(new InvalidArgumentException('Disk [local] does not have a configured driver.'));
 
         $filesystem = new FilesystemManager(tap(new Application, function ($app) {
             $app['config'] = ['filesystems.disks.local' => null];

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -77,8 +77,7 @@ class FilesystemTest extends TestCase
 
     public function testLinesThrowsExceptionNonexisitingFile()
     {
-        $this->expectException(FileNotFoundException::class);
-        $this->expectExceptionMessage('File does not exist at path '.__DIR__.'/unknown-file.txt.');
+        $this->expectExceptionObject(new FileNotFoundException('File does not exist at path '.__DIR__.'/unknown-file.txt.'));
 
         (new Filesystem)->lines(__DIR__.'/unknown-file.txt');
     }
@@ -330,8 +329,7 @@ class FilesystemTest extends TestCase
 
     public function testGetThrowsExceptionNonexisitingFile()
     {
-        $this->expectException(FileNotFoundException::class);
-        $this->expectExceptionMessage('File does not exist at path '.self::$tempDir.'/unknown-file.txt.');
+        $this->expectExceptionObject(new FileNotFoundException('File does not exist at path '.self::$tempDir.'/unknown-file.txt.'));
 
         (new Filesystem)->get(self::$tempDir.'/unknown-file.txt');
     }
@@ -345,8 +343,7 @@ class FilesystemTest extends TestCase
 
     public function testGetRequireThrowsExceptionNonExistingFile()
     {
-        $this->expectException(FileNotFoundException::class);
-        $this->expectExceptionMessage('File does not exist at path '.self::$tempDir.'/unknown-file.txt.');
+        $this->expectExceptionObject(new FileNotFoundException('File does not exist at path '.self::$tempDir.'/unknown-file.txt.'));
 
         (new Filesystem)->getRequire(self::$tempDir.'/unknown-file.txt');
     }
@@ -588,8 +585,7 @@ class FilesystemTest extends TestCase
 
     public function testRequireOnceThrowsExceptionNonexisitingFile()
     {
-        $this->expectException(FileNotFoundException::class);
-        $this->expectExceptionMessage('File does not exist at path '.__DIR__.'/unknown-file.txt.');
+        $this->expectExceptionObject(new FileNotFoundException('File does not exist at path '.__DIR__.'/unknown-file.txt.'));
 
         (new Filesystem)->requireOnce(__DIR__.'/unknown-file.txt');
     }

--- a/tests/Foundation/Bootstrap/HandleExceptionsTest.php
+++ b/tests/Foundation/Bootstrap/HandleExceptionsTest.php
@@ -196,8 +196,7 @@ class HandleExceptionsTest extends TestCase
         $logger->shouldNotReceive('channel');
         $logger->shouldNotReceive('warning');
 
-        $this->expectException(ErrorException::class);
-        $this->expectExceptionMessage('Something went wrong');
+        $this->expectExceptionObject(new ErrorException('Something went wrong'));
 
         $this->handleExceptions()->handleError(
             E_ERROR,

--- a/tests/Foundation/Console/ServeCommandLogParserTest.php
+++ b/tests/Foundation/Console/ServeCommandLogParserTest.php
@@ -32,8 +32,7 @@ class ServeCommandLogParserTest extends TestCase
     {
         $line = '[Mon Nov 19 10:30:45 2024] Info';
 
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Failed to extract the request port. Ensure the log line contains a valid port: [Mon Nov 19 10:30:45 2024] Info');
+        $this->expectExceptionObject(new \InvalidArgumentException('Failed to extract the request port. Ensure the log line contains a valid port: [Mon Nov 19 10:30:45 2024] Info'));
 
         ServeCommand::getRequestPortFromLine($line);
     }
@@ -42,24 +41,21 @@ class ServeCommandLogParserTest extends TestCase
     {
         $line = '[Mon Nov 19 10:30:45 2024] :abcd Info';
 
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Failed to extract the request port. Ensure the log line contains a valid port: [Mon Nov 19 10:30:45 2024] :abcd Info');
+        $this->expectExceptionObject(new \InvalidArgumentException('Failed to extract the request port. Ensure the log line contains a valid port: [Mon Nov 19 10:30:45 2024] :abcd Info'));
 
         ServeCommand::getRequestPortFromLine($line);
     }
 
     public function testExtractRequestPortWithEmptyLogLine()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Failed to extract the request port. Ensure the log line contains a valid port: ');
+        $this->expectExceptionObject(new \InvalidArgumentException('Failed to extract the request port. Ensure the log line contains a valid port: '));
 
         ServeCommand::getRequestPortFromLine('');
     }
 
     public function testExtractRequestPortWithWhitespaceOnlyLine()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Failed to extract the request port. Ensure the log line contains a valid port: ');
+        $this->expectExceptionObject(new \InvalidArgumentException('Failed to extract the request port. Ensure the log line contains a valid port: '));
 
         ServeCommand::getRequestPortFromLine('   ');
     }
@@ -68,8 +64,7 @@ class ServeCommandLogParserTest extends TestCase
     {
         $line = 'Random log entry without port';
 
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Failed to extract the request port. Ensure the log line contains a valid port: Random log entry without port');
+        $this->expectExceptionObject(new \InvalidArgumentException('Failed to extract the request port. Ensure the log line contains a valid port: Random log entry without port'));
 
         ServeCommand::getRequestPortFromLine($line);
     }

--- a/tests/Foundation/Console/ServeCommandLogParserTest.php
+++ b/tests/Foundation/Console/ServeCommandLogParserTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Foundation\Console;
 
 use Illuminate\Foundation\Console\ServeCommand;
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
 class ServeCommandLogParserTest extends TestCase
@@ -32,7 +33,7 @@ class ServeCommandLogParserTest extends TestCase
     {
         $line = '[Mon Nov 19 10:30:45 2024] Info';
 
-        $this->expectExceptionObject(new \InvalidArgumentException('Failed to extract the request port. Ensure the log line contains a valid port: [Mon Nov 19 10:30:45 2024] Info'));
+        $this->expectExceptionObject(new InvalidArgumentException('Failed to extract the request port. Ensure the log line contains a valid port: [Mon Nov 19 10:30:45 2024] Info'));
 
         ServeCommand::getRequestPortFromLine($line);
     }
@@ -41,21 +42,21 @@ class ServeCommandLogParserTest extends TestCase
     {
         $line = '[Mon Nov 19 10:30:45 2024] :abcd Info';
 
-        $this->expectExceptionObject(new \InvalidArgumentException('Failed to extract the request port. Ensure the log line contains a valid port: [Mon Nov 19 10:30:45 2024] :abcd Info'));
+        $this->expectExceptionObject(new InvalidArgumentException('Failed to extract the request port. Ensure the log line contains a valid port: [Mon Nov 19 10:30:45 2024] :abcd Info'));
 
         ServeCommand::getRequestPortFromLine($line);
     }
 
     public function testExtractRequestPortWithEmptyLogLine()
     {
-        $this->expectExceptionObject(new \InvalidArgumentException('Failed to extract the request port. Ensure the log line contains a valid port: '));
+        $this->expectExceptionObject(new InvalidArgumentException('Failed to extract the request port. Ensure the log line contains a valid port: '));
 
         ServeCommand::getRequestPortFromLine('');
     }
 
     public function testExtractRequestPortWithWhitespaceOnlyLine()
     {
-        $this->expectExceptionObject(new \InvalidArgumentException('Failed to extract the request port. Ensure the log line contains a valid port: '));
+        $this->expectExceptionObject(new InvalidArgumentException('Failed to extract the request port. Ensure the log line contains a valid port: '));
 
         ServeCommand::getRequestPortFromLine('   ');
     }
@@ -64,7 +65,7 @@ class ServeCommandLogParserTest extends TestCase
     {
         $line = 'Random log entry without port';
 
-        $this->expectExceptionObject(new \InvalidArgumentException('Failed to extract the request port. Ensure the log line contains a valid port: Random log entry without port'));
+        $this->expectExceptionObject(new InvalidArgumentException('Failed to extract the request port. Ensure the log line contains a valid port: Random log entry without port'));
 
         ServeCommand::getRequestPortFromLine($line);
     }

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -582,8 +582,7 @@ class FoundationApplicationTest extends TestCase
 
     public function testAbortThrowsNotFoundHttpException()
     {
-        $this->expectException(NotFoundHttpException::class);
-        $this->expectExceptionMessage('Page was not found');
+        $this->expectExceptionObject(new NotFoundHttpException('Page was not found'));
 
         $app = new Application();
         $app->abort(404, 'Page was not found');

--- a/tests/Foundation/FoundationAuthorizesRequestsTraitTest.php
+++ b/tests/Foundation/FoundationAuthorizesRequestsTraitTest.php
@@ -55,8 +55,7 @@ class FoundationAuthorizesRequestsTraitTest extends TestCase
 
     public function testExceptionIsThrownIfGateCheckFails()
     {
-        $this->expectException(AuthorizationException::class);
-        $this->expectExceptionMessage('This action is unauthorized.');
+        $this->expectExceptionObject(new AuthorizationException('This action is unauthorized.'));
 
         $gate = $this->getBasicGate();
 

--- a/tests/Foundation/FoundationDocsCommandTest.php
+++ b/tests/Foundation/FoundationDocsCommandTest.php
@@ -174,8 +174,7 @@ class FoundationDocsCommandTest extends TestCase
     {
         putenv('ARTISAN_DOCS_ASK_STRATEGY='.__DIR__.'/fixtures/exception-throwing-strategy.php');
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('strategy failed');
+        $this->expectExceptionObject(new RuntimeException('strategy failed'));
 
         $this->artisan('docs');
     }

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -520,8 +520,7 @@ class FoundationExceptionsHandlerTest extends TestCase
         // When debug is true, it is OK to bubble the exception thrown while rendering
         // the error view as the debug handler should handle this gracefully.
 
-        $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('Rendering this view throws an exception');
+        $this->expectExceptionObject(new Exception('Rendering this view throws an exception'));
         $this->executeScenarioWhereErrorViewThrowsWhileRenderingAndDebugIs(true);
     }
 

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -113,16 +113,14 @@ class FoundationFormRequestTest extends TestCase
 
     public function testValidateMethodThrowsWhenAuthorizationFails()
     {
-        $this->expectException(AuthorizationException::class);
-        $this->expectExceptionMessage('This action is unauthorized.');
+        $this->expectExceptionObject(new AuthorizationException('This action is unauthorized.'));
 
         $this->createRequest([], FoundationTestFormRequestForbiddenStub::class)->validateResolved();
     }
 
     public function testValidateThrowsExceptionFromAuthorizationResponse()
     {
-        $this->expectException(AuthorizationException::class);
-        $this->expectExceptionMessage('foo');
+        $this->expectExceptionObject(new AuthorizationException('foo'));
 
         $this->createRequest([], FoundationTestFormRequestForbiddenWithResponseStub::class)->validateResolved();
     }

--- a/tests/Foundation/FoundationHelpersTest.php
+++ b/tests/Foundation/FoundationHelpersTest.php
@@ -104,8 +104,7 @@ class FoundationHelpersTest extends TestCase
 
     public function testMixMissingManifestThrowsException()
     {
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Mix manifest not found');
+        $this->expectExceptionObject(new Exception('Mix manifest not found'));
 
         mix('unversioned.css', 'missing');
     }

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -78,8 +78,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
 
     public function testSeeInDatabaseDoesNotFindResults()
     {
-        $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('The table is empty.');
+        $this->expectExceptionObject(new ExpectationFailedException('The table is empty.'));
 
         $builder = $this->mockCountBuilder(false);
 
@@ -209,8 +208,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
 
     public function testAssertTableEntriesCountWrong()
     {
-        $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('Failed asserting that table [products] matches expected entries count of 3. Entries found: 1.');
+        $this->expectExceptionObject(new ExpectationFailedException('Failed asserting that table [products] matches expected entries count of 3. Entries found: 1.'));
         $this->mockCountBuilder(true);
 
         $this->assertDatabaseCount($this->table, 3);
@@ -345,8 +343,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
 
     public function testAssertSoftDeletedInDatabaseDoesNotFindResults()
     {
-        $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('The table is empty.');
+        $this->expectExceptionObject(new ExpectationFailedException('The table is empty.'));
 
         $builder = $this->mockCountBuilder(false);
 
@@ -357,8 +354,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
 
     public function testAssertSoftDeletedInDatabaseDoesNotFindModelResults()
     {
-        $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('The table is empty.');
+        $this->expectExceptionObject(new ExpectationFailedException('The table is empty.'));
 
         $this->data = ['id' => 1];
 
@@ -371,8 +367,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
 
     public function testAssertSoftDeletedInDatabaseDoesNotFindModelWithCustomColumnResults()
     {
-        $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('The table is empty.');
+        $this->expectExceptionObject(new ExpectationFailedException('The table is empty.'));
 
         $model = new CustomProductStub(['id' => 1, 'name' => 'Laravel']);
         $this->data = ['id' => 1, 'name' => 'Tailwind'];
@@ -386,8 +381,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
 
     public function testAssertSoftDeletedInDatabaseDoesNotFindModePassedViaFcnWithCustomColumnResults()
     {
-        $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('The table is empty.');
+        $this->expectExceptionObject(new ExpectationFailedException('The table is empty.'));
 
         $model = new CustomProductStub(['id' => 1, 'name' => 'Laravel']);
         $this->data = ['id' => 1];
@@ -415,8 +409,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
 
     public function testAssertNotSoftDeletedOnlyFindsMatchingModels()
     {
-        $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('Failed asserting that any existing row');
+        $this->expectExceptionObject(new ExpectationFailedException('Failed asserting that any existing row'));
 
         $builder = $this->mockCountBuilder(false);
 
@@ -427,8 +420,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
 
     public function testAssertNotSoftDeletedInDatabaseDoesNotFindResults()
     {
-        $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('The table is empty.');
+        $this->expectExceptionObject(new ExpectationFailedException('The table is empty.'));
 
         $builder = $this->mockCountBuilder(false);
 
@@ -439,8 +431,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
 
     public function testAssertNotSoftDeletedInDatabaseDoesNotFindModelResults()
     {
-        $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('The table is empty.');
+        $this->expectExceptionObject(new ExpectationFailedException('The table is empty.'));
 
         $this->data = ['id' => 1];
 
@@ -453,8 +444,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
 
     public function testAssertNotSoftDeletedInDatabaseDoesNotFindModelWithCustomColumnResults()
     {
-        $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('The table is empty.');
+        $this->expectExceptionObject(new ExpectationFailedException('The table is empty.'));
 
         $model = new CustomProductStub(['id' => 1, 'name' => 'Laravel']);
         $this->data = ['id' => 1, 'name' => 'Tailwind'];
@@ -468,8 +458,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
 
     public function testAssertNotSoftDeletedInDatabaseDoesNotFindModelPassedViaFcnWithCustomColumnResults()
     {
-        $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('The table is empty.');
+        $this->expectExceptionObject(new ExpectationFailedException('The table is empty.'));
 
         $model = new CustomProductStub(['id' => 1, 'name' => 'Laravel']);
         $this->data = ['id' => 1];

--- a/tests/Foundation/FoundationViteTest.php
+++ b/tests/Foundation/FoundationViteTest.php
@@ -606,16 +606,14 @@ class FoundationViteTest extends TestCase
 
     public function testItThrowsWhenUnableToFindAssetManifestInBuildMode()
     {
-        $this->expectException(ViteException::class);
-        $this->expectExceptionMessage('Vite manifest not found at: '.public_path('build/manifest.json'));
+        $this->expectExceptionObject(new ViteException('Vite manifest not found at: '.public_path('build/manifest.json')));
 
         ViteFacade::asset('resources/js/app.js');
     }
 
     public function testItThrowsDeprecatedExecptionWhenUnableToFindAssetManifestInBuildMode()
     {
-        $this->expectException(ViteManifestNotFoundException::class);
-        $this->expectExceptionMessage('Vite manifest not found at: '.public_path('build/manifest.json'));
+        $this->expectExceptionObject(new ViteManifestNotFoundException('Vite manifest not found at: '.public_path('build/manifest.json')));
 
         ViteFacade::asset('resources/js/app.js');
     }
@@ -624,8 +622,7 @@ class FoundationViteTest extends TestCase
     {
         $this->makeViteManifest();
 
-        $this->expectException(ViteException::class);
-        $this->expectExceptionMessage('Unable to locate file in Vite manifest: resources/js/missing.js');
+        $this->expectExceptionObject(new ViteException('Unable to locate file in Vite manifest: resources/js/missing.js'));
 
         ViteFacade::asset('resources/js/missing.js');
     }
@@ -1299,8 +1296,7 @@ class FoundationViteTest extends TestCase
     {
         $this->makeViteManifest();
 
-        $this->expectException(ViteException::class);
-        $this->expectExceptionMessage('Unable to locate file from Vite manifest: '.public_path('build/assets/app.versioned.js'));
+        $this->expectExceptionObject(new ViteException('Unable to locate file from Vite manifest: '.public_path('build/assets/app.versioned.js')));
 
         ViteFacade::content('resources/js/app.js');
     }

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -3209,16 +3209,14 @@ class HttpClientTest extends TestCase
             );
         });
 
-        $this->expectException(ConnectionException::class);
-        $this->expectExceptionMessage('cURL error 60: SSL certificate problem: unable to get local issuer certificate');
+        $this->expectExceptionObject(new ConnectionException('cURL error 60: SSL certificate problem: unable to get local issuer certificate'));
 
         $this->factory->head('https://ssl-error.laravel.example');
     }
 
     public function testConnectExceptionIsConvertedToConnectionExceptionEvenWhenWithoutFactory()
     {
-        $this->expectException(ConnectionException::class);
-        $this->expectExceptionMessage('cURL error 60: SSL certificate problem');
+        $this->expectExceptionObject(new ConnectionException('cURL error 60: SSL certificate problem'));
 
         $pendingRequest = new PendingRequest();
 
@@ -3234,8 +3232,7 @@ class HttpClientTest extends TestCase
 
     public function testRequestExceptionWithoutResponseIsConvertedToConnectionExceptionEvenWhenWithoutFactory()
     {
-        $this->expectException(ConnectionException::class);
-        $this->expectExceptionMessage('cURL error 28: Operation timed out');
+        $this->expectExceptionObject(new ConnectionException('cURL error 28: Operation timed out'));
 
         $pendingRequest = new PendingRequest();
 
@@ -3251,8 +3248,7 @@ class HttpClientTest extends TestCase
 
     public function testRequestExceptionWithResponseIsConvertedToConnectionExceptionEvenWhenWithoutFactory()
     {
-        $this->expectException(ConnectionException::class);
-        $this->expectExceptionMessage('cURL error 28: Operation timed out');
+        $this->expectExceptionObject(new ConnectionException('cURL error 28: Operation timed out'));
 
         $pendingRequest = new PendingRequest();
 
@@ -3269,8 +3265,7 @@ class HttpClientTest extends TestCase
 
     public function testTooManyRedirectsExceptionIsConvertedToConnectionExceptionEvenWhenWithoutFactory()
     {
-        $this->expectException(ConnectionException::class);
-        $this->expectExceptionMessage('Maximum number of redirects (5) exceeded');
+        $this->expectExceptionObject(new ConnectionException('Maximum number of redirects (5) exceeded'));
 
         $pendingRequest = new PendingRequest();
 
@@ -3298,8 +3293,7 @@ class HttpClientTest extends TestCase
             );
         });
 
-        $this->expectException(ConnectionException::class);
-        $this->expectExceptionMessage('Maximum number of redirects (5) exceeded');
+        $this->expectExceptionObject(new ConnectionException('Maximum number of redirects (5) exceeded'));
 
         $this->factory->maxRedirects(5)->get('https://redirect.laravel.example');
     }

--- a/tests/Http/HttpRedirectResponseTest.php
+++ b/tests/Http/HttpRedirectResponseTest.php
@@ -211,8 +211,7 @@ class HttpRedirectResponseTest extends TestCase
 
     public function testMagicCallException()
     {
-        $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage('Call to undefined method Illuminate\Http\RedirectResponse::doesNotExist()');
+        $this->expectExceptionObject(new BadMethodCallException('Call to undefined method Illuminate\Http\RedirectResponse::doesNotExist()'));
 
         $response = new RedirectResponse('foo.bar');
         $response->doesNotExist('bar');

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -1729,8 +1729,7 @@ class HttpRequestTest extends TestCase
 
     public function testSessionMethod()
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Session store not set on request.');
+        $this->expectExceptionObject(new RuntimeException('Session store not set on request.'));
 
         $request = Request::create('/');
         $request->session();
@@ -1764,8 +1763,7 @@ class HttpRequestTest extends TestCase
 
     public function testGetSessionMethodWithoutLaravelSession()
     {
-        $this->expectException(SessionNotFoundException::class);
-        $this->expectExceptionMessage('There is currently no session available.');
+        $this->expectExceptionObject(new SessionNotFoundException('There is currently no session available.'));
 
         $request = Request::create('/');
 
@@ -1796,8 +1794,7 @@ class HttpRequestTest extends TestCase
 
     public function testFingerprintWithoutRoute()
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unable to generate fingerprint. Route unavailable.');
+        $this->expectExceptionObject(new RuntimeException('Unable to generate fingerprint. Route unavailable.'));
 
         $request = Request::create('/', 'GET', [], [], [], []);
         $request->fingerprint();

--- a/tests/Http/HttpResponseTest.php
+++ b/tests/Http/HttpResponseTest.php
@@ -255,8 +255,7 @@ class HttpResponseTest extends TestCase
 
     public function testMagicCallException()
     {
-        $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage('Call to undefined method Illuminate\Http\RedirectResponse::doesNotExist()');
+        $this->expectExceptionObject(new BadMethodCallException('Call to undefined method Illuminate\Http\RedirectResponse::doesNotExist()'));
 
         $response = new RedirectResponse('foo.bar');
         $response->doesNotExist('bar');

--- a/tests/Http/Resources/JsonApi/JsonApiResourceTest.php
+++ b/tests/Http/Resources/JsonApi/JsonApiResourceTest.php
@@ -24,16 +24,14 @@ class JsonApiResourceTest extends TestCase
 
     public function testUnableToSetWrapper()
     {
-        $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage('Using Illuminate\Http\Resources\JsonApi\JsonApiResource::wrap() method is not allowed.');
+        $this->expectExceptionObject(new BadMethodCallException('Using Illuminate\Http\Resources\JsonApi\JsonApiResource::wrap() method is not allowed.'));
 
         JsonApiResource::wrap('laravel');
     }
 
     public function testUnableToUnsetWrapper()
     {
-        $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage('Using Illuminate\Http\Resources\JsonApi\JsonApiResource::withoutWrapping() method is not allowed.');
+        $this->expectExceptionObject(new BadMethodCallException('Using Illuminate\Http\Resources\JsonApi\JsonApiResource::withoutWrapping() method is not allowed.'));
 
         JsonApiResource::withoutWrapping();
     }

--- a/tests/Integration/Auth/AuthenticationTest.php
+++ b/tests/Integration/Auth/AuthenticationTest.php
@@ -220,8 +220,7 @@ class AuthenticationTest extends TestCase
 
     public function testPasswordMustBeValidToLogOutOtherDevices()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('current password');
+        $this->expectExceptionObject(new InvalidArgumentException('current password'));
 
         $this->app['auth']->loginUsingId(1);
 

--- a/tests/Integration/Auth/ForgotPasswordWithoutDefaultRoutesTest.php
+++ b/tests/Integration/Auth/ForgotPasswordWithoutDefaultRoutesTest.php
@@ -12,6 +12,7 @@ use Illuminate\Tests\Integration\Auth\Fixtures\AuthenticationTestUser;
 use Orchestra\Testbench\Attributes\WithMigration;
 use Orchestra\Testbench\Factories\UserFactory;
 use Orchestra\Testbench\TestCase;
+use Symfony\Component\Routing\Exception\RouteNotFoundException;
 
 #[WithMigration]
 class ForgotPasswordWithoutDefaultRoutesTest extends TestCase
@@ -41,8 +42,7 @@ class ForgotPasswordWithoutDefaultRoutesTest extends TestCase
 
     public function testItCannotSendForgotPasswordEmail()
     {
-        $this->expectException('Symfony\Component\Routing\Exception\RouteNotFoundException');
-        $this->expectExceptionMessage('Route [password.reset] not defined.');
+        $this->expectExceptionObject(new RouteNotFoundException('Route [password.reset] not defined.'));
 
         Notification::fake();
 

--- a/tests/Integration/Broadcasting/BroadcastManagerTest.php
+++ b/tests/Integration/Broadcasting/BroadcastManagerTest.php
@@ -123,8 +123,7 @@ class BroadcastManagerTest extends TestCase
 
     public function testThrowExceptionWhenUnknownStoreIsUsed()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Broadcast connection [alien_connection] is not defined.');
+        $this->expectExceptionObject(new InvalidArgumentException('Broadcast connection [alien_connection] is not defined.'));
 
         $userConfig = [
             'broadcasting' => [

--- a/tests/Integration/Cache/PhpRedisBackoffTest.php
+++ b/tests/Integration/Cache/PhpRedisBackoffTest.php
@@ -93,8 +93,7 @@ class PhpRedisBackoffTest extends TestCase
 
     public function testItFailsWithAnInvalidPhpRedisAlgorithm()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Algorithm [foo] is not a valid PhpRedis backoff algorithm');
+        $this->expectExceptionObject(new InvalidArgumentException('Algorithm [foo] is not a valid PhpRedis backoff algorithm'));
 
         $host = Env::get('REDIS_HOST', '127.0.0.1');
         $port = Env::get('REDIS_PORT', 6379);

--- a/tests/Integration/Concurrency/ConcurrencyTest.php
+++ b/tests/Integration/Concurrency/ConcurrencyTest.php
@@ -119,8 +119,7 @@ PHP);
 
     public function testRunHandlerProcessErrorWithDefaultExceptionWithoutParam()
     {
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage('This is a different exception');
+        $this->expectExceptionObject(new Exception('This is a different exception'));
 
         Concurrency::run([
             fn () => throw new Exception(
@@ -131,8 +130,7 @@ PHP);
 
     public function testRunHandlerProcessErrorWithCustomExceptionWithoutParam()
     {
-        $this->expectException(ExceptionWithoutParam::class);
-        $this->expectExceptionMessage('Test');
+        $this->expectExceptionObject(new ExceptionWithoutParam('Test'));
         Concurrency::run([
             fn () => throw new ExceptionWithoutParam('Test'),
         ]);

--- a/tests/Integration/Console/CommandManualFailTest.php
+++ b/tests/Integration/Console/CommandManualFailTest.php
@@ -27,16 +27,14 @@ class CommandManualFailTest extends TestCase
 
     public function testCreatesAnExceptionFromString(): void
     {
-        $this->expectException(ManuallyFailedException::class);
-        $this->expectExceptionMessage('Whoops!');
+        $this->expectExceptionObject(new ManuallyFailedException('Whoops!'));
         $command = new Command;
         $command->fail('Whoops!');
     }
 
     public function testCreatesAnExceptionFromNull(): void
     {
-        $this->expectException(ManuallyFailedException::class);
-        $this->expectExceptionMessage('Command failed manually.');
+        $this->expectExceptionObject(new ManuallyFailedException('Command failed manually.'));
         $command = new Command;
         $command->fail();
     }

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -482,8 +482,7 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
 
     public function testFindOrFailMethod()
     {
-        $this->expectException(ModelNotFoundException::class);
-        $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Integration\Database\EloquentBelongsToManyTest\Tag] 10');
+        $this->expectExceptionObject(new ModelNotFoundException('No query results for model [Illuminate\Tests\Integration\Database\EloquentBelongsToManyTest\Tag] 10'));
 
         $post = Post::create(['title' => Str::random()]);
 
@@ -496,8 +495,7 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
 
     public function testFindOrFailMethodWithMany()
     {
-        $this->expectException(ModelNotFoundException::class);
-        $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Integration\Database\EloquentBelongsToManyTest\Tag] 10, 11');
+        $this->expectExceptionObject(new ModelNotFoundException('No query results for model [Illuminate\Tests\Integration\Database\EloquentBelongsToManyTest\Tag] 10, 11'));
 
         $post = Post::create(['title' => Str::random()]);
 
@@ -510,8 +508,7 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
 
     public function testFindOrFailMethodWithManyUsingCollection()
     {
-        $this->expectException(ModelNotFoundException::class);
-        $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Integration\Database\EloquentBelongsToManyTest\Tag] 10, 11');
+        $this->expectExceptionObject(new ModelNotFoundException('No query results for model [Illuminate\Tests\Integration\Database\EloquentBelongsToManyTest\Tag] 10, 11'));
 
         $post = Post::create(['title' => Str::random()]);
 

--- a/tests/Integration/Database/EloquentModelHashedCastingTest.php
+++ b/tests/Integration/Database/EloquentModelHashedCastingTest.php
@@ -74,8 +74,7 @@ class EloquentModelHashedCastingTest extends DatabaseTestCase
         Config::set('hashing.driver', 'bcrypt');
         Config::set('hashing.bcrypt.rounds', 10);
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage("Could not verify the hashed value's configuration.");
+        $this->expectExceptionObject(new RuntimeException("Could not verify the hashed value's configuration."));
 
         $subject = HashedCast::create([
             // "password"; 13 rounds; bcrypt;
@@ -105,8 +104,7 @@ class EloquentModelHashedCastingTest extends DatabaseTestCase
         Config::set('hashing.driver', 'bcrypt');
         Config::set('hashing.bcrypt.rounds', 13);
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage("Could not verify the hashed value's configuration.");
+        $this->expectExceptionObject(new RuntimeException("Could not verify the hashed value's configuration."));
 
         $subject = HashedCast::create([
             // "password"; argon2id;
@@ -180,8 +178,7 @@ class EloquentModelHashedCastingTest extends DatabaseTestCase
         Config::set('hashing.argon.threads', 2);
         Config::set('hashing.argon.time', 7);
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage("Could not verify the hashed value's configuration.");
+        $this->expectExceptionObject(new RuntimeException("Could not verify the hashed value's configuration."));
 
         $subject = HashedCast::create([
             // "password"; 2345 memory; 2 threads; 7 time; argon2i;
@@ -196,8 +193,7 @@ class EloquentModelHashedCastingTest extends DatabaseTestCase
         Config::set('hashing.argon.threads', 2);
         Config::set('hashing.argon.time', 7);
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage("Could not verify the hashed value's configuration.");
+        $this->expectExceptionObject(new RuntimeException("Could not verify the hashed value's configuration."));
 
         $subject = HashedCast::create([
             // "password"; 1234 memory; 2 threads; 8 time; argon2i;
@@ -212,8 +208,7 @@ class EloquentModelHashedCastingTest extends DatabaseTestCase
         Config::set('hashing.argon.threads', 2);
         Config::set('hashing.argon.time', 7);
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage("Could not verify the hashed value's configuration.");
+        $this->expectExceptionObject(new RuntimeException("Could not verify the hashed value's configuration."));
 
         $subject = HashedCast::create([
             // "password"; 1234 memory; 3 threads; 7 time; argon2i;
@@ -283,8 +278,7 @@ class EloquentModelHashedCastingTest extends DatabaseTestCase
         Config::set('hashing.driver', 'argon');
         Config::set('hashing.bcrypt.rounds', 13);
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage("Could not verify the hashed value's configuration.");
+        $this->expectExceptionObject(new RuntimeException("Could not verify the hashed value's configuration."));
 
         $subject = HashedCast::create([
             // "password"; bcrypt;
@@ -299,8 +293,7 @@ class EloquentModelHashedCastingTest extends DatabaseTestCase
         Config::set('hashing.argon.threads', 2);
         Config::set('hashing.argon.time', 7);
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage("Could not verify the hashed value's configuration.");
+        $this->expectExceptionObject(new RuntimeException("Could not verify the hashed value's configuration."));
 
         $subject = HashedCast::create([
             // "password"; 2345 memory; 2 threads; 7 time; argon2i;

--- a/tests/Integration/Database/EloquentStrictLoadingTest.php
+++ b/tests/Integration/Database/EloquentStrictLoadingTest.php
@@ -135,8 +135,7 @@ class EloquentStrictLoadingTest extends DatabaseTestCase
 
     public function testStrictModeWithOverriddenHandlerOnLazyLoading()
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Violated');
+        $this->expectExceptionObject(new RuntimeException('Violated'));
 
         EloquentStrictLoadingTestModel1WithCustomHandler::create();
         EloquentStrictLoadingTestModel1WithCustomHandler::create();

--- a/tests/Integration/Database/Sqlite/DatabaseSchemaBlueprintTest.php
+++ b/tests/Integration/Database/Sqlite/DatabaseSchemaBlueprintTest.php
@@ -496,8 +496,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
     public function testItEnsuresDroppingForeignKeyIsAvailable()
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('This database driver does not support dropping foreign keys by name.');
+        $this->expectExceptionObject(new RuntimeException('This database driver does not support dropping foreign keys by name.'));
 
         Schema::table('users', function (Blueprint $table) {
             $table->dropForeign('something');

--- a/tests/Integration/Filesystem/FilesystemServiceProviderTest.php
+++ b/tests/Integration/Filesystem/FilesystemServiceProviderTest.php
@@ -10,8 +10,7 @@ class FilesystemServiceProviderTest extends TestCase
 {
     public function test_it_throws_when_served_disks_have_conflicting_uris(): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The [other] disk conflicts with the [local] disk at [/storage]. Each served disk must have a unique URL.');
+        $this->expectExceptionObject(new InvalidArgumentException('The [other] disk conflicts with the [local] disk at [/storage]. Each served disk must have a unique URL.'));
 
         config(['filesystems.disks' => [
             'local' => [

--- a/tests/Integration/Foundation/Console/ConfigCacheCommandTest.php
+++ b/tests/Integration/Foundation/Console/ConfigCacheCommandTest.php
@@ -71,8 +71,7 @@ class ConfigCacheCommandTest extends TestCase
             PHP
         );
 
-        $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('Your configuration files could not be serialized because the value at "testconfig.closure" is non-serializable.');
+        $this->expectExceptionObject(new LogicException('Your configuration files could not be serialized because the value at "testconfig.closure" is non-serializable.'));
 
         $this->artisan('config:cache');
     }
@@ -95,8 +94,7 @@ class ConfigCacheCommandTest extends TestCase
             PHP
         );
 
-        $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('Your configuration files could not be serialized because the value at "testconfig.nested.deep.closure" is non-serializable.');
+        $this->expectExceptionObject(new LogicException('Your configuration files could not be serialized because the value at "testconfig.nested.deep.closure" is non-serializable.'));
 
         $this->artisan('config:cache');
     }

--- a/tests/Integration/Foundation/FoundationHelpersTest.php
+++ b/tests/Integration/Foundation/FoundationHelpersTest.php
@@ -81,8 +81,7 @@ class FoundationHelpersTest extends TestCase
     #[WithConfig('app.debug', true)]
     public function testMixThrowsExceptionWhenAssetIsMissingFromManifestWhenInDebugMode()
     {
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Unable to locate Mix file: /missing.js.');
+        $this->expectExceptionObject(new Exception('Unable to locate Mix file: /missing.js.'));
 
         $manifest = $this->makeManifest();
 

--- a/tests/Integration/Http/JsonResponseTest.php
+++ b/tests/Integration/Http/JsonResponseTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Integration\Http;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Route;
+use InvalidArgumentException;
 use JsonSerializable;
 use Orchestra\Testbench\TestCase;
 
@@ -12,8 +13,7 @@ class JsonResponseTest extends TestCase
 {
     public function testResponseWithInvalidJsonThrowsException()
     {
-        $this->expectException('InvalidArgumentException');
-        $this->expectExceptionMessage('Malformed UTF-8 characters, possibly incorrectly encoded');
+        $this->expectExceptionObject(new InvalidArgumentException('Malformed UTF-8 characters, possibly incorrectly encoded'));
 
         Route::get('/response', function () {
             return new JsonResponse(new class implements JsonSerializable

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -1448,8 +1448,7 @@ class ResourceTest extends TestCase
             new Post(['id' => 2, 'title' => 'Test title 2']),
         ]);
 
-        $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('must collect');
+        $this->expectExceptionObject(new LogicException('must collect'));
 
         new PostModelCollectionResource($posts);
     }
@@ -1572,8 +1571,7 @@ class ResourceTest extends TestCase
         $post = new ValidatePostSize;
         $post->handle($request, fn () => null);
 
-        $this->expectException(PostTooLargeException::class);
-        $this->expectExceptionMessage('The POST data is too large.');
+        $this->expectExceptionObject(new PostTooLargeException('The POST data is too large.'));
 
         $request = new Request(server: ['CONTENT_LENGTH' => '2147483640']);
         $post = new ValidatePostSize;

--- a/tests/Integration/Http/ResponseTest.php
+++ b/tests/Integration/Http/ResponseTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Integration\Http;
 
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Route;
+use InvalidArgumentException;
 use JsonSerializable;
 use Orchestra\Testbench\TestCase;
 
@@ -11,8 +12,7 @@ class ResponseTest extends TestCase
 {
     public function testResponseWithInvalidJsonThrowsException()
     {
-        $this->expectException('InvalidArgumentException');
-        $this->expectExceptionMessage('Malformed UTF-8 characters, possibly incorrectly encoded');
+        $this->expectExceptionObject(new InvalidArgumentException('Malformed UTF-8 characters, possibly incorrectly encoded'));
 
         Route::get('/response', function () {
             return (new Response())->setContent(new class implements JsonSerializable

--- a/tests/Integration/Http/ThrottleRequestsTest.php
+++ b/tests/Integration/Http/ThrottleRequestsTest.php
@@ -326,8 +326,7 @@ class ThrottleRequestsTest extends TestCase
 
     public function testItFailsIfNamedLimiterDoesNotExist()
     {
-        $this->expectException(MissingRateLimiterException::class);
-        $this->expectExceptionMessage('Rate limiter [test] is not defined.');
+        $this->expectExceptionObject(new MissingRateLimiterException('Rate limiter [test] is not defined.'));
 
         Route::get('/', fn () => 'ok')->middleware(ThrottleRequests::using('test'));
 
@@ -336,8 +335,7 @@ class ThrottleRequestsTest extends TestCase
 
     public function testItFailsIfNamedLimiterDoesNotExistAndAuthenticatedUserDoesNotHaveFallbackProperty()
     {
-        $this->expectException(MissingRateLimiterException::class);
-        $this->expectExceptionMessage('Rate limiter ['.User::class.'::rateLimiting] is not defined.');
+        $this->expectExceptionObject(new MissingRateLimiterException('Rate limiter ['.User::class.'::rateLimiting] is not defined.'));
 
         Route::get('/', fn () => 'ok')->middleware(['auth', ThrottleRequests::using('rateLimiting')]);
 

--- a/tests/Integration/Log/ContextIntegrationTest.php
+++ b/tests/Integration/Log/ContextIntegrationTest.php
@@ -97,8 +97,7 @@ class ContextIntegrationTest extends TestCase
             'hidden' => [],
         ];
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Value is incomplete class: {"__PHP_Incomplete_Class_Name":"App\\\\MyContextClass"}');
+        $this->expectExceptionObject(new RuntimeException('Value is incomplete class: {"__PHP_Incomplete_Class_Name":"App\\\\MyContextClass"}'));
 
         Context::hydrate($dehydrated);
     }
@@ -112,8 +111,7 @@ class ContextIntegrationTest extends TestCase
             'hidden' => [],
         ];
 
-        $this->expectException(ErrorException::class);
-        $this->expectExceptionMessage('unserialize(): Error at offset 0 of 8 bytes');
+        $this->expectExceptionObject(new ErrorException('unserialize(): Error at offset 0 of 8 bytes'));
 
         Context::hydrate($dehydrated);
     }

--- a/tests/Integration/Queue/DebouncedJobTest.php
+++ b/tests/Integration/Queue/DebouncedJobTest.php
@@ -119,8 +119,7 @@ class DebouncedJobTest extends QueueTestCase
 
     public function testDebouncedAndUniqueThrowsLogicException()
     {
-        $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('debounced job cannot also implement ShouldBeUnique');
+        $this->expectExceptionObject(new LogicException('debounced job cannot also implement ShouldBeUnique'));
 
         DebouncedAndUniqueTestJob::dispatch('entity-1');
     }

--- a/tests/Integration/Queue/JobEncryptionTest.php
+++ b/tests/Integration/Queue/JobEncryptionTest.php
@@ -50,8 +50,7 @@ class JobEncryptionTest extends DatabaseTestCase
     {
         Bus::dispatch(new JobEncryptionTestNonEncryptedJob);
 
-        $this->expectException(DecryptException::class);
-        $this->expectExceptionMessage('The payload is invalid');
+        $this->expectExceptionObject(new DecryptException('The payload is invalid'));
 
         $this->assertInstanceOf(JobEncryptionTestNonEncryptedJob::class,
             unserialize(json_decode(DB::table('jobs')->first()->payload)->data->command)

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -138,8 +138,7 @@ class ModelSerializationTest extends TestCase
 
     public function testItFailsIfModelsOnMultiConnections()
     {
-        $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('Queueing collections with multiple model connections is not supported.');
+        $this->expectExceptionObject(new LogicException('Queueing collections with multiple model connections is not supported.'));
 
         $user = ModelSerializationTestUser::on('custom')->create([
             'email' => 'mohamed@laravel.com',

--- a/tests/Integration/Routing/UrlSigningTest.php
+++ b/tests/Integration/Routing/UrlSigningTest.php
@@ -69,8 +69,7 @@ class UrlSigningTest extends TestCase
 
     public function testTemporarySignedUrlsWithExpiresParameter()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('reserved');
+        $this->expectExceptionObject(new InvalidArgumentException('reserved'));
 
         Route::get('/foo/{id}', function (Request $request, $id) {
             return $request->hasValidSignature() ? 'valid' : 'invalid';

--- a/tests/Integration/Support/ExceptionsFacadeTest.php
+++ b/tests/Integration/Support/ExceptionsFacadeTest.php
@@ -53,8 +53,7 @@ class ExceptionsFacadeTest extends TestCase
         Exceptions::report(new RuntimeException('test 1'));
         report(new RuntimeException('test 2'));
 
-        $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('The total number of exceptions reported was 2 instead of 1.');
+        $this->expectExceptionObject(new ExpectationFailedException('The total number of exceptions reported was 2 instead of 1.'));
 
         Exceptions::assertReportedCount(1);
     }
@@ -79,8 +78,7 @@ class ExceptionsFacadeTest extends TestCase
 
     public function testFakeAssertReportedAsStringMayFail()
     {
-        $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('The expected [InvalidArgumentException] exception was not reported.');
+        $this->expectExceptionObject(new ExpectationFailedException('The expected [InvalidArgumentException] exception was not reported.'));
 
         Exceptions::fake();
 
@@ -92,8 +90,7 @@ class ExceptionsFacadeTest extends TestCase
 
     public function testFakeAssertReportedAsClosureMayFail()
     {
-        $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('The expected [InvalidArgumentException] exception was not reported.');
+        $this->expectExceptionObject(new ExpectationFailedException('The expected [InvalidArgumentException] exception was not reported.'));
 
         Exceptions::fake();
 
@@ -105,8 +102,7 @@ class ExceptionsFacadeTest extends TestCase
 
     public function testFakeAssertReportedWithFakedExceptionsMayFail()
     {
-        $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('The expected [RuntimeException] exception was not reported.');
+        $this->expectExceptionObject(new ExpectationFailedException('The expected [RuntimeException] exception was not reported.'));
 
         Exceptions::fake(InvalidArgumentException::class);
 
@@ -147,8 +143,7 @@ class ExceptionsFacadeTest extends TestCase
 
     public function testFakeAssertNotReportedMayFail()
     {
-        $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('The expected [RuntimeException] exception was reported.');
+        $this->expectExceptionObject(new ExpectationFailedException('The expected [RuntimeException] exception was reported.'));
 
         Exceptions::fake();
 
@@ -159,8 +154,7 @@ class ExceptionsFacadeTest extends TestCase
 
     public function testFakeAssertNotReportedAsClosureMayFail()
     {
-        $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('The expected [RuntimeException] exception was reported.');
+        $this->expectExceptionObject(new ExpectationFailedException('The expected [RuntimeException] exception was reported.'));
 
         Exceptions::fake();
 
@@ -197,8 +191,7 @@ class ExceptionsFacadeTest extends TestCase
 
     public function testFakeAssertNothingReportedMayFail()
     {
-        $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('The following exceptions were reported: RuntimeException, RuntimeException, InvalidArgumentException.');
+        $this->expectExceptionObject(new ExpectationFailedException('The following exceptions were reported: RuntimeException, RuntimeException, InvalidArgumentException.'));
 
         Exceptions::fake();
 
@@ -251,8 +244,7 @@ class ExceptionsFacadeTest extends TestCase
     {
         Exceptions::fake()->throwOnReport();
 
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Test exception');
+        $this->expectExceptionObject(new Exception('Test exception'));
 
         report(new Exception('Test exception'));
     }
@@ -286,8 +278,7 @@ class ExceptionsFacadeTest extends TestCase
             report(new Exception('Test exception'));
         });
 
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Test exception');
+        $this->expectExceptionObject(new Exception('Test exception'));
 
         $this->get('/');
     }
@@ -302,8 +293,7 @@ class ExceptionsFacadeTest extends TestCase
             report(new Exception('Test exception'));
         });
 
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Test exception');
+        $this->expectExceptionObject(new Exception('Test exception'));
 
         $this->get('/');
     }
@@ -321,8 +311,7 @@ class ExceptionsFacadeTest extends TestCase
             rescue(fn () => throw new Exception('Test exception'));
         });
 
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Test exception');
+        $this->expectExceptionObject(new Exception('Test exception'));
 
         $this->get('/');
     }
@@ -340,8 +329,7 @@ class ExceptionsFacadeTest extends TestCase
             rescue(fn () => throw new Exception('Test exception'));
         });
 
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Test exception');
+        $this->expectExceptionObject(new Exception('Test exception'));
 
         $this->get('/');
     }
@@ -378,8 +366,7 @@ class ExceptionsFacadeTest extends TestCase
 
         Exceptions::fake()->throwOnReport();
 
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Test exception');
+        $this->expectExceptionObject(new Exception('Test exception'));
 
         report(new Exception('Test exception'));
     }
@@ -405,8 +392,7 @@ class ExceptionsFacadeTest extends TestCase
 
         Exceptions::fake([RuntimeException::class])->throwOnReport();
 
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('My exception message');
+        $this->expectExceptionObject(new InvalidArgumentException('My exception message'));
 
         report(new Exception('My exception message'));
     }
@@ -415,8 +401,7 @@ class ExceptionsFacadeTest extends TestCase
     {
         Exceptions::fake();
 
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Test exception');
+        $this->expectExceptionObject(new Exception('Test exception'));
 
         report(new Exception('Test exception'));
 
@@ -427,8 +412,7 @@ class ExceptionsFacadeTest extends TestCase
     {
         Exceptions::fake([InvalidArgumentException::class]);
 
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Test exception');
+        $this->expectExceptionObject(new InvalidArgumentException('Test exception'));
 
         report(new RuntimeException('Test exception'));
         report(new InvalidArgumentException('Test exception'));

--- a/tests/Integration/Testing/ArtisanCommandTest.php
+++ b/tests/Integration/Testing/ArtisanCommandTest.php
@@ -78,8 +78,7 @@ class ArtisanCommandTest extends TestCase
 
     public function test_console_command_that_fails()
     {
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Expected status code 0 but received 1.');
+        $this->expectExceptionObject(new AssertionFailedError('Expected status code 0 but received 1.'));
 
         $this->artisan('exit', ['code' => 1])->assertOk();
     }
@@ -109,8 +108,7 @@ class ArtisanCommandTest extends TestCase
 
     public function test_console_command_that_fails_from_unexpected_output()
     {
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Output "Your name is Taylor Otwell and you prefer PHP." was printed.');
+        $this->expectExceptionObject(new AssertionFailedError('Output "Your name is Taylor Otwell and you prefer PHP." was printed.'));
 
         $this->artisan('survey')
             ->expectsQuestion('What is your name?', 'Taylor Otwell')
@@ -121,8 +119,7 @@ class ArtisanCommandTest extends TestCase
 
     public function test_console_command_that_fails_from_unexpected_output_substring()
     {
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Output "Taylor Otwell" was printed.');
+        $this->expectExceptionObject(new AssertionFailedError('Output "Taylor Otwell" was printed.'));
 
         $this->artisan('contains')
             ->doesntExpectOutputToContain('Taylor Otwell')
@@ -151,8 +148,7 @@ class ArtisanCommandTest extends TestCase
 
     public function test_console_command_that_fails_from_missing_output()
     {
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Output "Your name is Taylor Otwell and you prefer PHP." was not printed.');
+        $this->expectExceptionObject(new AssertionFailedError('Output "Your name is Taylor Otwell and you prefer PHP." was not printed.'));
 
         $this->ignoringMockOnceExceptions(function () {
             $this->artisan('survey')
@@ -165,8 +161,7 @@ class ArtisanCommandTest extends TestCase
 
     public function test_console_command_that_fails_from_exit_code_mismatch()
     {
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Expected status code 1 but received 0.');
+        $this->expectExceptionObject(new AssertionFailedError('Expected status code 1 but received 0.'));
 
         $this->artisan('survey')
             ->expectsQuestion('What is your name?', 'Taylor Otwell')
@@ -299,8 +294,7 @@ class ArtisanCommandTest extends TestCase
 
     public function test_console_command_that_fails_if_the_output_does_not_contain()
     {
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Output does not contain "Otwell Taylor".');
+        $this->expectExceptionObject(new AssertionFailedError('Output does not contain "Otwell Taylor".'));
 
         $this->ignoringMockOnceExceptions(function () {
             $this->artisan('contains')

--- a/tests/JsonSchema/SerializerTest.php
+++ b/tests/JsonSchema/SerializerTest.php
@@ -10,10 +10,10 @@ class SerializerTest extends TestCase
 {
     public function test_it_does_not_know_how_to_serialize_unknown_types(): void
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unsupported [Illuminate\\JsonSchema\\Types\\Type@anonymous');
+        $this->expectExceptionObject(new RuntimeException('Unsupported [Illuminate\\JsonSchema\\Types\\Type@anonymous'));
 
-        $type = new class extends Type {
+        $type = new class extends Type
+        {
             // anonymous type for triggering serializer failure
         };
 

--- a/tests/JsonSchema/SerializerTest.php
+++ b/tests/JsonSchema/SerializerTest.php
@@ -12,8 +12,7 @@ class SerializerTest extends TestCase
     {
         $this->expectExceptionObject(new RuntimeException('Unsupported [Illuminate\\JsonSchema\\Types\\Type@anonymous'));
 
-        $type = new class extends Type
-        {
+        $type = new class extends Type {
             // anonymous type for triggering serializer failure
         };
 

--- a/tests/JsonSchema/TypeTest.php
+++ b/tests/JsonSchema/TypeTest.php
@@ -138,27 +138,21 @@ class TypeTest extends TestCase
 
     public function test_throws_with_invalid_enum_string(): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The provided class must be a BackedEnum.');
-        $this->expectExceptionCode(0);
+        $this->expectExceptionObject(new InvalidArgumentException('The provided class must be a BackedEnum.', 0));
 
         JsonSchema::string()->enum('NonExistentEnumClass');
     }
 
     public function test_throws_with_not_an_enum_class(): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The provided class must be a BackedEnum.');
-        $this->expectExceptionCode(0);
+        $this->expectExceptionObject(new InvalidArgumentException('The provided class must be a BackedEnum.', 0));
 
         JsonSchema::string()->enum(stdClass::class);
     }
 
     public function test_throws_with_unit_enum_class(): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The provided class must be a BackedEnum.');
-        $this->expectExceptionCode(0);
+        $this->expectExceptionObject(new InvalidArgumentException('The provided class must be a BackedEnum.', 0));
 
         JsonSchema::string()->enum(UnitEnum::class);
     }

--- a/tests/Log/ContextTest.php
+++ b/tests/Log/ContextTest.php
@@ -191,8 +191,7 @@ class ContextTest extends TestCase
     {
         Context::add('breadcrumbs', 'foo');
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unable to push value onto context stack for key [breadcrumbs].');
+        $this->expectExceptionObject(new RuntimeException('Unable to push value onto context stack for key [breadcrumbs].'));
         Context::push('breadcrumbs', 'bar');
     }
 
@@ -200,8 +199,7 @@ class ContextTest extends TestCase
     {
         Context::add('breadcrumbs', ['foo' => 'bar']);
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unable to push value onto context stack for key [breadcrumbs].');
+        $this->expectExceptionObject(new RuntimeException('Unable to push value onto context stack for key [breadcrumbs].'));
         Context::push('breadcrumbs', 'bar');
     }
 
@@ -219,8 +217,7 @@ class ContextTest extends TestCase
         Context::push('breadcrumbs', 'bar');
         Context::pop('breadcrumbs');
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unable to pop value from context stack for key [breadcrumbs].');
+        $this->expectExceptionObject(new RuntimeException('Unable to pop value from context stack for key [breadcrumbs].'));
 
         Context::pop('breadcrumbs');
     }
@@ -229,8 +226,7 @@ class ContextTest extends TestCase
     {
         Context::add('breadcrumbs', ['foo' => 'bar']);
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unable to pop value from context stack for key [breadcrumbs].');
+        $this->expectExceptionObject(new RuntimeException('Unable to pop value from context stack for key [breadcrumbs].'));
         Context::pop('breadcrumbs');
     }
 
@@ -248,8 +244,7 @@ class ContextTest extends TestCase
         Context::pushHidden('breadcrumbs', 'bar');
         Context::popHidden('breadcrumbs');
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unable to pop value from hidden context stack for key [breadcrumbs].');
+        $this->expectExceptionObject(new RuntimeException('Unable to pop value from hidden context stack for key [breadcrumbs].'));
 
         Context::popHidden('breadcrumbs');
     }
@@ -258,8 +253,7 @@ class ContextTest extends TestCase
     {
         Context::addHidden('breadcrumbs', ['foo' => 'bar']);
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unable to pop value from hidden context stack for key [breadcrumbs].');
+        $this->expectExceptionObject(new RuntimeException('Unable to pop value from hidden context stack for key [breadcrumbs].'));
         Context::popHidden('breadcrumbs');
     }
 
@@ -495,8 +489,7 @@ class ContextTest extends TestCase
 
         Context::addHidden('foo', 'bar');
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unable to push value onto hidden context stack for key [foo].');
+        $this->expectExceptionObject(new RuntimeException('Unable to push value onto hidden context stack for key [foo].'));
         Context::pushHidden('foo', 2);
     }
 

--- a/tests/Log/LogLoggerTest.php
+++ b/tests/Log/LogLoggerTest.php
@@ -86,8 +86,7 @@ class LogLoggerTest extends TestCase
 
     public function testListenShortcutFailsWithNoDispatcher()
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Events dispatcher has not been set.');
+        $this->expectExceptionObject(new RuntimeException('Events dispatcher has not been set.'));
 
         $writer = new Logger(m::mock(Monolog::class));
         $writer->listen(function () {

--- a/tests/Mail/MailManagerTest.php
+++ b/tests/Mail/MailManagerTest.php
@@ -24,8 +24,7 @@ class MailManagerTest extends TestCase
             'timeout' => null,
         ]);
 
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage("Unsupported mail transport [{$transport}]");
+        $this->expectExceptionObject(new InvalidArgumentException("Unsupported mail transport [{$transport}]"));
         $this->app['mail.manager']->mailer('custom_smtp');
     }
 

--- a/tests/Pagination/CursorResourceTest.php
+++ b/tests/Pagination/CursorResourceTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Pagination;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Pagination\CursorPaginator;
 use Illuminate\Tests\Pagination\Fixtures\Models\CursorResourceTestModel;
+use LogicException;
 use PHPUnit\Framework\TestCase;
 
 class CursorResourceTest extends TestCase
@@ -22,8 +23,7 @@ class CursorResourceTest extends TestCase
 
     public function testItThrowsExceptionWhenResourceCannotBeFound()
     {
-        $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('Failed to find resource class for model [Illuminate\Tests\Pagination\Fixtures\Models\CursorResourceTestModel].');
+        $this->expectExceptionObject(new LogicException('Failed to find resource class for model [Illuminate\Tests\Pagination\Fixtures\Models\CursorResourceTestModel].'));
 
         $paginator = new CursorResourceTestPaginator([
             new CursorResourceTestModel(),

--- a/tests/Pagination/PaginatorResourceTest.php
+++ b/tests/Pagination/PaginatorResourceTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Pagination;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Tests\Pagination\Fixtures\Models\PaginatorResourceTestModel;
+use LogicException;
 use PHPUnit\Framework\TestCase;
 
 class PaginatorResourceTest extends TestCase
@@ -22,8 +23,7 @@ class PaginatorResourceTest extends TestCase
 
     public function testItThrowsExceptionWhenResourceCannotBeFound()
     {
-        $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('Failed to find resource class for model [Illuminate\Tests\Pagination\Fixtures\Models\PaginatorResourceTestModel].');
+        $this->expectExceptionObject(new LogicException('Failed to find resource class for model [Illuminate\Tests\Pagination\Fixtures\Models\PaginatorResourceTestModel].'));
 
         $paginator = new PaginatorResourceTestPaginator([
             new PaginatorResourceTestModel(),

--- a/tests/Pipeline/PipelineTest.php
+++ b/tests/Pipeline/PipelineTest.php
@@ -244,8 +244,7 @@ class PipelineTest extends TestCase
 
     public function testPipelineThrowsExceptionOnResolveWithoutContainer()
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('A container instance has not been passed to the Pipeline.');
+        $this->expectExceptionObject(new RuntimeException('A container instance has not been passed to the Pipeline.'));
 
         (new Pipeline)->send('data')
             ->through(PipelineTestPipeOne::class)
@@ -256,8 +255,7 @@ class PipelineTest extends TestCase
 
     public function testPipelineThrowsExceptionWhenUsingTransactionsWithoutContainer()
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('A container instance has not been passed to the Pipeline.');
+        $this->expectExceptionObject(new RuntimeException('A container instance has not been passed to the Pipeline.'));
 
         (new Pipeline)->send('data')
             ->through(PipelineTestPipeOne::class)
@@ -395,8 +393,7 @@ class PipelineTest extends TestCase
     {
         $std = new stdClass();
 
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage('My Exception: 1');
+        $this->expectExceptionObject(new Exception('My Exception: 1'));
 
         try {
             (new Pipeline(new Container))

--- a/tests/Process/ProcessTest.php
+++ b/tests/Process/ProcessTest.php
@@ -402,8 +402,7 @@ class ProcessTest extends TestCase
 
     public function testStrayProcessesCanBePreventedWithStringCommand()
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Attempted process [');
+        $this->expectExceptionObject(new RuntimeException('Attempted process ['));
         $this->expectExceptionMessage('cat composer.json');
         $this->expectExceptionMessage('] without a matching fake.');
 
@@ -420,8 +419,7 @@ class ProcessTest extends TestCase
 
     public function testStrayProcessesCanBePreventedWithArrayCommand()
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Attempted process [');
+        $this->expectExceptionObject(new RuntimeException('Attempted process ['));
         $this->expectExceptionMessage('cat composer.json');
         $this->expectExceptionMessage('] without a matching fake.');
 
@@ -450,12 +448,11 @@ class ProcessTest extends TestCase
 
     public function testProcessFakeThrowShorthand()
     {
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('fake exception message');
+        $this->expectExceptionObject(new RuntimeException('fake exception message'));
 
         $factory = new Factory;
 
-        $factory->fake(['cat me' => new \RuntimeException('fake exception message')]);
+        $factory->fake(['cat me' => new RuntimeException('fake exception message')]);
 
         $factory->run('cat me');
     }

--- a/tests/Redis/PhpRedisConnectorTest.php
+++ b/tests/Redis/PhpRedisConnectorTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Redis;
 
 use Illuminate\Redis\Connectors\PhpRedisConnector;
+use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\TestCase;
 
@@ -219,8 +220,7 @@ class PhpRedisConnectorTest extends TestCase
     {
         $connector = new TestablePhpRedisConnector;
 
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Algorithm [bogus] is not a valid PhpRedis backoff algorithm.');
+        $this->expectExceptionObject(new InvalidArgumentException('Algorithm [bogus] is not a valid PhpRedis backoff algorithm.'));
 
         $connector->testParseBackoffAlgorithm('bogus');
     }

--- a/tests/Redis/RedisEventsTest.php
+++ b/tests/Redis/RedisEventsTest.php
@@ -31,8 +31,7 @@ class RedisEventsTest extends TestCase
         $connection = new PhpRedisConnection($client);
         $connection->setEventDispatcher($events);
 
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Test exception');
+        $this->expectExceptionObject(new Exception('Test exception'));
 
         $connection->command('get', ['key']);
     }

--- a/tests/Routing/RouteCollectionTest.php
+++ b/tests/Routing/RouteCollectionTest.php
@@ -302,8 +302,7 @@ class RouteCollectionTest extends TestCase
 
     public function testRouteCollectionDontMatchNonMatchingDoubleSlashes()
     {
-        $this->expectException(NotFoundHttpException::class);
-        $this->expectExceptionMessage('The route foo could not be found.');
+        $this->expectExceptionObject(new NotFoundHttpException('The route foo could not be found.'));
 
         $this->routeCollection->add(new Route('GET', 'foo', [
             'uses' => 'FooController@index',

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -656,7 +656,7 @@ class RouteRegistrarTest extends TestCase
 
     public function testRouteMetadataAttributeRequiresArray()
     {
-        $this->expectExceptionObject(new \InvalidArgumentException('Attribute [metadata] expects an array.'));
+        $this->expectExceptionObject(new InvalidArgumentException('Attribute [metadata] expects an array.'));
 
         (new RouteRegistrar($this->router))->attribute('metadata', 'invalid');
     }

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
 use Illuminate\Routing\RouteRegistrar;
+use InvalidArgumentException;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Stringable;
@@ -519,8 +520,7 @@ class RouteRegistrarTest extends TestCase
 
     public function testRegisteringNonApprovedAttributesThrows()
     {
-        $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage('Method Illuminate\Routing\RouteRegistrar::unsupportedMethod does not exist.');
+        $this->expectExceptionObject(new BadMethodCallException('Method Illuminate\Routing\RouteRegistrar::unsupportedMethod does not exist.'));
 
         $this->router->domain('foo')->unsupportedMethod('bar')->group(function ($router) {
             //
@@ -1466,7 +1466,7 @@ class RouteRegistrarTest extends TestCase
 
     public function testCannotSetRouteNameUsingIntegerBackedEnum()
     {
-        $this->expectExceptionObject(new \InvalidArgumentException('Attribute [name] expects a string backed enum.'));
+        $this->expectExceptionObject(new InvalidArgumentException('Attribute [name] expects a string backed enum.'));
 
         $this->router->name(IntegerEnum::One)->get('users', fn () => 'all-users');
     }
@@ -1480,7 +1480,7 @@ class RouteRegistrarTest extends TestCase
 
     public function testCannotSetRouteDomainUsingIntegerBackedEnum()
     {
-        $this->expectExceptionObject(new \InvalidArgumentException('Attribute [domain] expects a string backed enum.'));
+        $this->expectExceptionObject(new InvalidArgumentException('Attribute [domain] expects a string backed enum.'));
 
         $this->router->domain(IntegerEnum::One)->get('users', fn () => 'all-users');
     }

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -316,8 +316,7 @@ class RoutingRouteTest extends TestCase
 
     public function testFluentRouting()
     {
-        $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('Route for [foo/bar] has no action.');
+        $this->expectExceptionObject(new LogicException('Route for [foo/bar] has no action.'));
 
         $router = $this->getRouter();
         $router->get('foo/bar')->uses(function () {
@@ -1067,8 +1066,7 @@ class RoutingRouteTest extends TestCase
 
     public function testModelBindingWithNullReturn()
     {
-        $this->expectException(ModelNotFoundException::class);
-        $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Routing\RouteModelBindingNullStub].');
+        $this->expectExceptionObject(new ModelNotFoundException('No query results for model [Illuminate\Tests\Routing\RouteModelBindingNullStub].'));
 
         $router = $this->getRouter();
         $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => function ($name) {
@@ -1432,8 +1430,7 @@ class RoutingRouteTest extends TestCase
 
     public function testInvalidActionException()
     {
-        $this->expectException(UnexpectedValueException::class);
-        $this->expectExceptionMessage('Invalid route action: [Illuminate\Tests\Routing\RouteTestControllerStub].');
+        $this->expectExceptionObject(new UnexpectedValueException('Invalid route action: [Illuminate\Tests\Routing\RouteTestControllerStub].'));
 
         $router = $this->getRouter();
         $router->get('/', ['uses' => RouteTestControllerStub::class]);
@@ -2162,8 +2159,7 @@ class RoutingRouteTest extends TestCase
 
     public function testRouteRedirectExceptionWhenMissingExpectedParameters()
     {
-        $this->expectException(UrlGenerationException::class);
-        $this->expectExceptionMessage('Missing required parameter for [Route: laravel_route_redirect_destination] [URI: users/{user}] [Missing parameter: user].');
+        $this->expectExceptionObject(new UrlGenerationException('Missing required parameter for [Route: laravel_route_redirect_destination] [URI: users/{user}] [Missing parameter: user].'));
 
         $container = new Container;
         $router = new Router(new Dispatcher, $container);

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -617,8 +617,7 @@ class RoutingUrlGeneratorTest extends TestCase
     #[DataProvider('provideParametersAndExpectedMeaningfulExceptionMessages')]
     public function testUrlGenerationThrowsExceptionForMissingParametersWithMeaningfulMessage($parameters, $expectedMeaningfulExceptionMessage)
     {
-        $this->expectException(UrlGenerationException::class);
-        $this->expectExceptionMessage($expectedMeaningfulExceptionMessage);
+        $this->expectExceptionObject(new UrlGenerationException($expectedMeaningfulExceptionMessage));
 
         $url = new UrlGenerator(
             $routes = new RouteCollection,
@@ -763,8 +762,7 @@ class RoutingUrlGeneratorTest extends TestCase
 
     public function testRouteNotDefinedException()
     {
-        $this->expectException(RouteNotFoundException::class);
-        $this->expectExceptionMessage('Route [not_exists_route] not defined.');
+        $this->expectExceptionObject(new RouteNotFoundException('Route [not_exists_route] not defined.'));
 
         $url = new UrlGenerator(
             new RouteCollection,
@@ -897,8 +895,7 @@ class RoutingUrlGeneratorTest extends TestCase
         }]);
         $routes->add($route);
 
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('reserved');
+        $this->expectExceptionObject(new InvalidArgumentException('reserved'));
 
         Request::create($url->signedRoute('foo', ['signature' => 'bar']));
     }
@@ -918,8 +915,7 @@ class RoutingUrlGeneratorTest extends TestCase
         }]);
         $routes->add($route);
 
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('reserved');
+        $this->expectExceptionObject(new InvalidArgumentException('reserved'));
 
         Request::create($url->signedRoute('foo', ['expires' => 253402300799]));
     }

--- a/tests/Support/ForwardsCallsTest.php
+++ b/tests/Support/ForwardsCallsTest.php
@@ -25,16 +25,14 @@ class ForwardsCallsTest extends TestCase
 
     public function testMissingForwardedCallThrowsCorrectError()
     {
-        $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage('Call to undefined method Illuminate\Tests\Support\ForwardsCallsOne::missingMethod()');
+        $this->expectExceptionObject(new BadMethodCallException('Call to undefined method Illuminate\Tests\Support\ForwardsCallsOne::missingMethod()'));
 
         (new ForwardsCallsOne)->missingMethod('foo', 'bar');
     }
 
     public function testMissingAlphanumericForwardedCallThrowsCorrectError()
     {
-        $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage('Call to undefined method Illuminate\Tests\Support\ForwardsCallsOne::this1_shouldWork_too()');
+        $this->expectExceptionObject(new BadMethodCallException('Call to undefined method Illuminate\Tests\Support\ForwardsCallsOne::this1_shouldWork_too()'));
 
         (new ForwardsCallsOne)->this1_shouldWork_too('foo', 'bar');
     }
@@ -49,8 +47,7 @@ class ForwardsCallsTest extends TestCase
 
     public function testThrowBadMethodCallException()
     {
-        $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage('Call to undefined method Illuminate\Tests\Support\ForwardsCallsOne::test()');
+        $this->expectExceptionObject(new BadMethodCallException('Call to undefined method Illuminate\Tests\Support\ForwardsCallsOne::test()'));
 
         (new ForwardsCallsOne)->throwTestException('test');
     }

--- a/tests/Support/LotteryTest.php
+++ b/tests/Support/LotteryTest.php
@@ -139,15 +139,13 @@ class LotteryTest extends TestCase
         $result = Lottery::odds(1, 10000)->winner(fn () => 'winner')->loser(fn () => 'loser')->choose();
         $this->assertSame('winner', $result);
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Missing key in sequence.');
+        $this->expectExceptionObject(new RuntimeException('Missing key in sequence.'));
         Lottery::odds(1, 10000)->winner(fn () => 'winner')->loser(fn () => 'loser')->choose();
     }
 
     public function testItThrowsForFloatsOverOne()
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Float must not be greater than 1.');
+        $this->expectExceptionObject(new RuntimeException('Float must not be greater than 1.'));
 
         new Lottery(1.1);
     }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -90,8 +90,7 @@ class SupportArrTest extends TestCase
         Arr::push($array, null, 'Taylor');
         $this->assertEquals(['Chris', 'Nuno', 'Taylor'], $array);
 
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Array value for key [foo.bar] must be an array, boolean found.');
+        $this->expectExceptionObject(new InvalidArgumentException('Array value for key [foo.bar] must be an array, boolean found.'));
 
         $array = ['foo' => ['bar' => false]];
         Arr::push($array, 'foo.bar', 'baz');
@@ -1751,12 +1750,12 @@ class SupportArrTest extends TestCase
         $this->assertSame($subject, Arr::from($items));
 
         $items = new WeakMap;
-        $items[$temp = new class {
+        $items[$temp = new class
+        {
         }] = 'bar';
         $this->assertSame(['bar'], Arr::from($items));
 
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Items cannot be represented by a scalar value.');
+        $this->expectExceptionObject(new InvalidArgumentException('Items cannot be represented by a scalar value.'));
         Arr::from(123);
     }
 

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1750,8 +1750,7 @@ class SupportArrTest extends TestCase
         $this->assertSame($subject, Arr::from($items));
 
         $items = new WeakMap;
-        $items[$temp = new class
-        {
+        $items[$temp = new class {
         }] = 'bar';
         $this->assertSame(['bar'], Arr::from($items));
 

--- a/tests/Support/SupportBinaryCodecTest.php
+++ b/tests/Support/SupportBinaryCodecTest.php
@@ -65,16 +65,14 @@ class SupportBinaryCodecTest extends TestCase
 
     public function testEncodeThrowsOnInvalidFormat()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Format [invalid] is invalid.');
+        $this->expectExceptionObject(new InvalidArgumentException('Format [invalid] is invalid.'));
 
         BinaryCodec::encode('value', 'invalid');
     }
 
     public function testDecodeThrowsOnInvalidFormat()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Format [invalid] is invalid.');
+        $this->expectExceptionObject(new InvalidArgumentException('Format [invalid] is invalid.'));
 
         BinaryCodec::decode('value', 'invalid');
     }

--- a/tests/Support/SupportCarbonTest.php
+++ b/tests/Support/SupportCarbonTest.php
@@ -54,16 +54,14 @@ class SupportCarbonTest extends TestCase
 
     public function testCarbonRaisesExceptionWhenStaticMacroIsNotFound()
     {
-        $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage('nonExistingStaticMacro does not exist.');
+        $this->expectExceptionObject(new BadMethodCallException('nonExistingStaticMacro does not exist.'));
 
         Carbon::nonExistingStaticMacro();
     }
 
     public function testCarbonRaisesExceptionWhenMacroIsNotFound()
     {
-        $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage('nonExistingMacro does not exist.');
+        $this->expectExceptionObject(new BadMethodCallException('nonExistingMacro does not exist.'));
 
         Carbon::now()->nonExistingMacro();
     }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2599,12 +2599,10 @@ class SupportCollectionTest extends TestCase
     #[DataProvider('collectionClassProvider')]
     public function testImplodeModels($collection)
     {
-        $model = new class extends Model
-        {
+        $model = new class extends Model {
         };
         $model->setAttribute('email', 'foo');
-        $modelTwo = new class extends Model
-        {
+        $modelTwo = new class extends Model {
         };
         $modelTwo->setAttribute('email', 'bar');
         $data = new $collection([$model, $modelTwo]);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2599,10 +2599,12 @@ class SupportCollectionTest extends TestCase
     #[DataProvider('collectionClassProvider')]
     public function testImplodeModels($collection)
     {
-        $model = new class extends Model {
+        $model = new class extends Model
+        {
         };
         $model->setAttribute('email', 'foo');
-        $modelTwo = new class extends Model {
+        $modelTwo = new class extends Model
+        {
         };
         $modelTwo->setAttribute('email', 'bar');
         $data = new $collection([$model, $modelTwo]);
@@ -3439,8 +3441,7 @@ class SupportCollectionTest extends TestCase
     #[DataProvider('collectionClassProvider')]
     public function testNthThrowsExceptionForInvalidStep($collection)
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Step value must be at least 1.');
+        $this->expectExceptionObject(new InvalidArgumentException('Step value must be at least 1.'));
 
         (new $collection([1, 2, 3]))->nth(0)->all();
     }
@@ -3448,8 +3449,7 @@ class SupportCollectionTest extends TestCase
     #[DataProvider('collectionClassProvider')]
     public function testNthThrowsExceptionForNegativeStep($collection)
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Step value must be at least 1.');
+        $this->expectExceptionObject(new InvalidArgumentException('Step value must be at least 1.'));
 
         (new $collection([1, 2, 3]))->nth(-1)->all();
     }
@@ -3457,8 +3457,7 @@ class SupportCollectionTest extends TestCase
     #[DataProvider('collectionClassProvider')]
     public function testSplitThrowsExceptionForInvalidNumberOfGroups($collection)
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Number of groups must be at least 1.');
+        $this->expectExceptionObject(new InvalidArgumentException('Number of groups must be at least 1.'));
 
         (new $collection([1, 2, 3]))->split(0);
     }
@@ -3466,8 +3465,7 @@ class SupportCollectionTest extends TestCase
     #[DataProvider('collectionClassProvider')]
     public function testSplitThrowsExceptionForNegativeNumberOfGroups($collection)
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Number of groups must be at least 1.');
+        $this->expectExceptionObject(new InvalidArgumentException('Number of groups must be at least 1.'));
 
         (new $collection([1, 2, 3]))->split(-1);
     }
@@ -3475,8 +3473,7 @@ class SupportCollectionTest extends TestCase
     #[DataProvider('collectionClassProvider')]
     public function testSplitInThrowsExceptionForInvalidNumberOfGroups($collection)
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Number of groups must be at least 1.');
+        $this->expectExceptionObject(new InvalidArgumentException('Number of groups must be at least 1.'));
 
         (new $collection([1, 2, 3]))->splitIn(0);
     }
@@ -3484,8 +3481,7 @@ class SupportCollectionTest extends TestCase
     #[DataProvider('collectionClassProvider')]
     public function testSplitInThrowsExceptionForNegativeNumberOfGroups($collection)
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Number of groups must be at least 1.');
+        $this->expectExceptionObject(new InvalidArgumentException('Number of groups must be at least 1.'));
 
         (new $collection([1, 2, 3]))->splitIn(-1);
     }
@@ -5830,8 +5826,7 @@ class SupportCollectionTest extends TestCase
     public function testItThrowsExceptionWhenTryingToAccessNoProxyProperty($collection)
     {
         $data = new $collection;
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Property [foo] does not exist on this collection instance.');
+        $this->expectExceptionObject(new Exception('Property [foo] does not exist on this collection instance.'));
         $data->foo;
     }
 
@@ -6035,8 +6030,7 @@ class SupportCollectionTest extends TestCase
         $data->ensure('int');
 
         $data = $collection::make([1, 2, 3, 'foo']);
-        $this->expectException(UnexpectedValueException::class);
-        $this->expectExceptionMessage("Collection should only include [int] items, but 'string' found at position 3.");
+        $this->expectExceptionObject(new UnexpectedValueException("Collection should only include [int] items, but 'string' found at position 3."));
         $data->ensure('int');
     }
 
@@ -6047,8 +6041,7 @@ class SupportCollectionTest extends TestCase
         $data->ensure(stdClass::class);
 
         $data = $collection::make([new stdClass, new stdClass, new stdClass, $collection]);
-        $this->expectException(UnexpectedValueException::class);
-        $this->expectExceptionMessage(sprintf('Collection should only include [%s] items, but \'%s\' found at position %d.', class_basename(new stdClass()), gettype($collection), 3));
+        $this->expectExceptionObject(new UnexpectedValueException(sprintf('Collection should only include [%s] items, but \'%s\' found at position %d.', class_basename(new stdClass()), gettype($collection), 3)));
         $data->ensure(stdClass::class);
     }
 
@@ -6060,8 +6053,7 @@ class SupportCollectionTest extends TestCase
 
         $wrongType = new $collection;
         $data = $collection::make([new \Error, new \Error, $wrongType]);
-        $this->expectException(UnexpectedValueException::class);
-        $this->expectExceptionMessage(sprintf("Collection should only include [%s] items, but '%s' found at position %d.", \Throwable::class, get_class($wrongType), 2));
+        $this->expectExceptionObject(new UnexpectedValueException(sprintf("Collection should only include [%s] items, but '%s' found at position %d.", \Throwable::class, get_class($wrongType), 2)));
         $data->ensure(\Throwable::class);
     }
 
@@ -6073,8 +6065,7 @@ class SupportCollectionTest extends TestCase
 
         $wrongType = new $collection;
         $data = $collection::make([new \Error, new \Error, $wrongType]);
-        $this->expectException(UnexpectedValueException::class);
-        $this->expectExceptionMessage(sprintf('Collection should only include [%s] items, but \'%s\' found at position %d.', implode(', ', [\Throwable::class, 'int']), get_class($wrongType), 2));
+        $this->expectExceptionObject(new UnexpectedValueException(sprintf('Collection should only include [%s] items, but \'%s\' found at position %d.', implode(', ', [\Throwable::class, 'int']), get_class($wrongType), 2)));
         $data->ensure([\Throwable::class, 'int']);
     }
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -7,6 +7,7 @@ use ArrayIterator;
 use Carbon\CarbonInterval;
 use Countable;
 use Error;
+use Exception;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Filesystem\Filesystem;
@@ -850,42 +851,37 @@ class SupportHelpersTest extends TestCase
 
     public function testThrowExceptionWithMessage()
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('test');
+        $this->expectExceptionObject(new RuntimeException('test'));
 
         throw_if(true, 'test');
     }
 
     public function testThrowExceptionAsStringWithMessage()
     {
-        $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('test');
+        $this->expectExceptionObject(new LogicException('test'));
 
         throw_if(true, LogicException::class, 'test');
     }
 
     public function testThrowClosureException()
     {
-        $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('test');
+        $this->expectExceptionObject(new Exception('test'));
 
-        throw_if(true, fn () => new \Exception('test'));
+        throw_if(true, fn () => new Exception('test'));
     }
 
     public function testThrowClosureWithParamsException()
     {
-        $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('test');
+        $this->expectExceptionObject(new Exception('test'));
 
-        throw_if(true, fn (string $message) => new \Exception($message), 'test');
+        throw_if(true, fn (string $message) => new Exception($message), 'test');
     }
 
     public function testThrowClosureStringWithParamsException()
     {
-        $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('test');
+        $this->expectExceptionObject(new Exception('test'));
 
-        throw_if(true, fn () => \Exception::class, 'test');
+        throw_if(true, fn () => Exception::class, 'test');
     }
 
     public function testThrowUnless()
@@ -904,16 +900,14 @@ class SupportHelpersTest extends TestCase
 
     public function testThrowUnlessExceptionWithMessage()
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('test');
+        $this->expectExceptionObject(new RuntimeException('test'));
 
         throw_unless(false, 'test');
     }
 
     public function testThrowUnlessExceptionAsStringWithMessage()
     {
-        $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('test');
+        $this->expectExceptionObject(new LogicException('test'));
 
         throw_unless(false, LogicException::class, 'test');
     }
@@ -925,8 +919,7 @@ class SupportHelpersTest extends TestCase
 
     public function testThrowWithString()
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Test Message');
+        $this->expectExceptionObject(new RuntimeException('Test Message'));
 
         throw_if(true, RuntimeException::class, 'Test Message');
     }
@@ -1834,8 +1827,7 @@ class SupportHelpersTest extends TestCase
     #[RequiresPhp('>= 8.4.0')]
     public function testClosureOnlyLazyThrowsWhenNotClassSpecifiedInClosure(): void
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('The first parameter of the given Closure is missing a type hint.');
+        $this->expectExceptionObject(new RuntimeException('The first parameter of the given Closure is missing a type hint.'));
 
         lazy(function ($instance) {
             //
@@ -2114,8 +2106,7 @@ class SupportHelpersTest extends TestCase
     #[RequiresPhp('>= 8.4.0')]
     public function testClosureOnlyProxyThrowsWhenNotClassSpecifiedInClosure(): void
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('The first parameter of the given Closure is missing a type hint.');
+        $this->expectExceptionObject(new RuntimeException('The first parameter of the given Closure is missing a type hint.'));
 
         proxy(function ($proxy) {
             //

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -154,8 +154,7 @@ class SupportTestingMailFakeTest extends TestCase
 
         $this->fake->to('taylor@laravel.com')->send($this->mailable);
 
-        $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('The unexpected ['.MailableStub::class.'] mailable was sent to address [taylor@laravel.com].');
+        $this->expectExceptionObject(new ExpectationFailedException('The unexpected ['.MailableStub::class.'] mailable was sent to address [taylor@laravel.com].'));
 
         $this->fake->assertNotSent(MailableStub::class, 'taylor@laravel.com');
     }
@@ -166,8 +165,7 @@ class SupportTestingMailFakeTest extends TestCase
 
         $this->fake->to('dries@laravel.com')->send($this->mailable);
 
-        $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('The unexpected ['.MailableStub::class.'] mailable was sent to address [dries@laravel.com].');
+        $this->expectExceptionObject(new ExpectationFailedException('The unexpected ['.MailableStub::class.'] mailable was sent to address [dries@laravel.com].'));
 
         $this->fake->assertNotSent(MailableStub::class, ['taylor@laravel.com', 'dries@laravel.com']);
     }
@@ -280,8 +278,7 @@ class SupportTestingMailFakeTest extends TestCase
 
         $this->fake->to('taylor@laravel.com')->queue($this->mailable);
 
-        $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('The unexpected ['.MailableStub::class.'] mailable was queued to address [taylor@laravel.com].');
+        $this->expectExceptionObject(new ExpectationFailedException('The unexpected ['.MailableStub::class.'] mailable was queued to address [taylor@laravel.com].'));
 
         $this->fake->assertNotQueued(MailableStub::class, 'taylor@laravel.com');
     }
@@ -292,8 +289,7 @@ class SupportTestingMailFakeTest extends TestCase
 
         $this->fake->to('dries@laravel.com')->queue($this->mailable);
 
-        $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('The unexpected ['.MailableStub::class.'] mailable was queued to address [dries@laravel.com].');
+        $this->expectExceptionObject(new ExpectationFailedException('The unexpected ['.MailableStub::class.'] mailable was queued to address [dries@laravel.com].'));
 
         $this->fake->assertNotQueued(MailableStub::class, ['taylor@laravel.com', 'dries@laravel.com']);
     }

--- a/tests/Testing/Concerns/InteractsWithDeprecationHandlingTest.php
+++ b/tests/Testing/Concerns/InteractsWithDeprecationHandlingTest.php
@@ -40,8 +40,7 @@ class InteractsWithDeprecationHandlingTest extends TestCase
     {
         $this->withoutDeprecationHandling();
 
-        $this->expectException(ErrorException::class);
-        $this->expectExceptionMessage('Something is deprecated');
+        $this->expectExceptionObject(new ErrorException('Something is deprecated'));
 
         trigger_error('Something is deprecated', E_USER_DEPRECATED);
     }

--- a/tests/Testing/Fluent/AssertTest.php
+++ b/tests/Testing/Fluent/AssertTest.php
@@ -27,8 +27,7 @@ class AssertTest extends TestCase
             'bar' => 'value',
         ]);
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [prop] does not exist.');
+        $this->expectExceptionObject(new AssertionFailedError('Property [prop] does not exist.'));
 
         $assert->has('prop');
     }
@@ -52,8 +51,7 @@ class AssertTest extends TestCase
             ],
         ]);
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [example.another] does not exist.');
+        $this->expectExceptionObject(new AssertionFailedError('Property [example.another] does not exist.'));
 
         $assert->has('example.another');
     }
@@ -79,8 +77,7 @@ class AssertTest extends TestCase
             ],
         ]);
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [bar] does not have the expected size.');
+        $this->expectExceptionObject(new AssertionFailedError('Property [bar] does not have the expected size.'));
 
         $assert->has('bar', 1);
     }
@@ -94,8 +91,7 @@ class AssertTest extends TestCase
             ],
         ]);
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [baz] does not exist.');
+        $this->expectExceptionObject(new AssertionFailedError('Property [baz] does not exist.'));
 
         $assert->has('baz', 1);
     }
@@ -130,8 +126,7 @@ class AssertTest extends TestCase
             'baz',
         ]);
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Root level does not have the expected size.');
+        $this->expectExceptionObject(new AssertionFailedError('Root level does not have the expected size.'));
 
         $assert->has(2);
     }
@@ -145,8 +140,7 @@ class AssertTest extends TestCase
             ],
         ]);
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [bar] does not have the expected size.');
+        $this->expectExceptionObject(new AssertionFailedError('Property [bar] does not have the expected size.'));
 
         $assert->has('bar', function ($bar) {
             $bar->has(3);
@@ -189,8 +183,7 @@ class AssertTest extends TestCase
             ],
         ]);
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [data.1.id] contains a value that should be missing: [id, 2]');
+        $this->expectExceptionObject(new AssertionFailedError('Property [data.1.id] contains a value that should be missing: [id, 2]'));
 
         $assert->has('data', function ($bar) {
             $bar->has(2)
@@ -234,8 +227,7 @@ class AssertTest extends TestCase
             ],
         ]);
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [data.1.id] was marked as invalid using a closure.');
+        $this->expectExceptionObject(new AssertionFailedError('Property [data.1.id] was marked as invalid using a closure.'));
 
         $assert->has('data', function ($bar) {
             $bar->has(2)
@@ -262,8 +254,7 @@ class AssertTest extends TestCase
             'baz',
         ]);
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Root level does not have the expected size.');
+        $this->expectExceptionObject(new AssertionFailedError('Root level does not have the expected size.'));
 
         $assert->count(2);
     }
@@ -277,8 +268,7 @@ class AssertTest extends TestCase
             ],
         ]);
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [bar] does not have the expected size.');
+        $this->expectExceptionObject(new AssertionFailedError('Property [bar] does not have the expected size.'));
 
         $assert->has('bar', function ($bar) {
             $bar->count(3);
@@ -304,8 +294,7 @@ class AssertTest extends TestCase
             'baz',
         ]);
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Root level size is not less than or equal to [2].');
+        $this->expectExceptionObject(new AssertionFailedError('Root level size is not less than or equal to [2].'));
 
         $assert->countBetween(1, 2);
     }
@@ -318,8 +307,7 @@ class AssertTest extends TestCase
             'baz',
         ]);
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Root level size is not greater than or equal to [4].');
+        $this->expectExceptionObject(new AssertionFailedError('Root level size is not greater than or equal to [4].'));
 
         $assert->countBetween(4, 3);
     }
@@ -334,8 +322,7 @@ class AssertTest extends TestCase
             ],
         ]);
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [bar] size is not less than or equal to [2].');
+        $this->expectExceptionObject(new AssertionFailedError('Property [bar] size is not less than or equal to [2].'));
 
         $assert->has('bar', function (AssertableJson $bar) {
             $bar->countBetween(1, 2);
@@ -362,8 +349,7 @@ class AssertTest extends TestCase
             ],
         ]);
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [foo.bar] was found while it was expected to be missing.');
+        $this->expectExceptionObject(new AssertionFailedError('Property [foo.bar] was found while it was expected to be missing.'));
 
         $assert->missing('foo.bar');
     }
@@ -386,8 +372,7 @@ class AssertTest extends TestCase
             'baz' => 'foo',
         ]);
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [baz] was found while it was expected to be missing.');
+        $this->expectExceptionObject(new AssertionFailedError('Property [baz] was found while it was expected to be missing.'));
 
         $assert->missingAll([
             'bar',
@@ -403,8 +388,7 @@ class AssertTest extends TestCase
 
         $assert->missingAll('foo', 'bar');
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [baz] was found while it was expected to be missing.');
+        $this->expectExceptionObject(new AssertionFailedError('Property [baz] was found while it was expected to be missing.'));
 
         $assert->missingAll('bar', 'baz');
     }
@@ -424,8 +408,7 @@ class AssertTest extends TestCase
             'bar' => 'value',
         ]);
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [bar] does not match the expected value.');
+        $this->expectExceptionObject(new AssertionFailedError('Property [bar] does not match the expected value.'));
 
         $assert->where('bar', 'invalid');
     }
@@ -436,8 +419,7 @@ class AssertTest extends TestCase
             'bar' => 'value',
         ]);
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [baz] does not exist.');
+        $this->expectExceptionObject(new AssertionFailedError('Property [baz] does not exist.'));
 
         $assert->where('baz', 'invalid');
     }
@@ -448,8 +430,7 @@ class AssertTest extends TestCase
             'bar' => 1,
         ]);
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [bar] does not match the expected value.');
+        $this->expectExceptionObject(new AssertionFailedError('Property [bar] does not match the expected value.'));
 
         $assert->where('bar', true);
     }
@@ -471,8 +452,7 @@ class AssertTest extends TestCase
             'bar' => 'baz',
         ]);
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [bar] was marked as invalid using a closure.');
+        $this->expectExceptionObject(new AssertionFailedError('Property [bar] was marked as invalid using a closure.'));
 
         $assert->where('bar', function ($value) {
             return $value === 'invalid';
@@ -574,8 +554,7 @@ class AssertTest extends TestCase
             'bar' => BackedEnum::test->value,
         ]);
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [bar] does not match the expected value.');
+        $this->expectExceptionObject(new AssertionFailedError('Property [bar] does not match the expected value.'));
 
         $assert->where('bar', BackedEnum::test_empty);
     }
@@ -595,8 +574,7 @@ class AssertTest extends TestCase
             'bar' => 'value',
         ]);
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [bar] should be null.');
+        $this->expectExceptionObject(new AssertionFailedError('Property [bar] should be null.'));
 
         $assert->whereNull('bar');
     }
@@ -607,8 +585,7 @@ class AssertTest extends TestCase
             'bar' => 'value',
         ]);
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [baz] does not exist.');
+        $this->expectExceptionObject(new AssertionFailedError('Property [baz] does not exist.'));
 
         $assert->whereNull('baz');
     }
@@ -628,8 +605,7 @@ class AssertTest extends TestCase
             'bar' => null,
         ]);
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [bar] should not be null.');
+        $this->expectExceptionObject(new AssertionFailedError('Property [bar] should not be null.'));
 
         $assert->whereNotNull('bar');
     }
@@ -640,8 +616,7 @@ class AssertTest extends TestCase
             'bar' => 'value',
         ]);
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [baz] does not exist.');
+        $this->expectExceptionObject(new AssertionFailedError('Property [baz] does not exist.'));
 
         $assert->whereNotNull('baz');
     }
@@ -650,8 +625,7 @@ class AssertTest extends TestCase
     {
         $assert = AssertableJson::fromArray([]);
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [foo] does not contain [1].');
+        $this->expectExceptionObject(new AssertionFailedError('Property [foo] does not contain [1].'));
 
         $assert->whereContains('foo', ['1']);
     }
@@ -662,8 +636,7 @@ class AssertTest extends TestCase
             'foo' => ['bar', 'baz'],
         ]);
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [foo] does not contain [invalid].');
+        $this->expectExceptionObject(new AssertionFailedError('Property [foo] does not contain [invalid].'));
 
         $assert->whereContains('foo', ['bar', 'baz', 'invalid']);
     }
@@ -677,8 +650,7 @@ class AssertTest extends TestCase
             ['id' => 4],
         ]);
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [id] does not contain [5].');
+        $this->expectExceptionObject(new AssertionFailedError('Property [id] does not contain [5].'));
 
         $assert->whereContains('id', [1, 2, 3, 4, 5]);
     }
@@ -689,8 +661,7 @@ class AssertTest extends TestCase
             'foo' => [1, 2, 3, 4],
         ]);
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [foo] does not contain [1].');
+        $this->expectExceptionObject(new AssertionFailedError('Property [foo] does not contain [1].'));
 
         $assert->whereContains('foo', ['1']);
     }
@@ -701,8 +672,7 @@ class AssertTest extends TestCase
             'foo' => [1, 2, 3, 4],
         ]);
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [foo] does not contain a value that passes the truth test within the given closure.');
+        $this->expectExceptionObject(new AssertionFailedError('Property [foo] does not contain a value that passes the truth test within the given closure.'));
 
         $assert->whereContains('foo', [function ($actual) {
             return $actual === 5;
@@ -715,8 +685,7 @@ class AssertTest extends TestCase
             'foo' => [1, 2, 3, 4],
         ]);
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [foo] does not contain a value that passes the truth test within the given closure.');
+        $this->expectExceptionObject(new AssertionFailedError('Property [foo] does not contain a value that passes the truth test within the given closure.'));
 
         $assert->whereContains('foo', [1, function ($actual) {
             return $actual === 5;
@@ -729,8 +698,7 @@ class AssertTest extends TestCase
             'foo' => [1, 2, 3, 4],
         ]);
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [foo] does not contain [5].');
+        $this->expectExceptionObject(new AssertionFailedError('Property [foo] does not contain [5].'));
 
         $assert->whereContains('foo', [5, function ($actual) {
             return $actual === 1;
@@ -861,8 +829,7 @@ class AssertTest extends TestCase
             'bar' => [BackedEnum::test_empty->value],
         ]);
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [bar] does not contain [test].');
+        $this->expectExceptionObject(new AssertionFailedError('Property [bar] does not contain [test].'));
 
         $assert->whereContains('bar', BackedEnum::test);
     }
@@ -886,8 +853,7 @@ class AssertTest extends TestCase
             ],
         ]);
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [example.nested] does not match the expected value.');
+        $this->expectExceptionObject(new AssertionFailedError('Property [example.nested] does not match the expected value.'));
 
         $assert->where('example.nested', 'another-value');
     }
@@ -911,8 +877,7 @@ class AssertTest extends TestCase
             ],
         ]);
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [example.nested] does not match the expected value.');
+        $this->expectExceptionObject(new AssertionFailedError('Property [example.nested] does not match the expected value.'));
 
         $assert->where('example.nested', BackedEnum::test);
     }
@@ -932,8 +897,7 @@ class AssertTest extends TestCase
             'bar' => 'value',
         ]);
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [bar] contains a value that should be missing: [bar, value]');
+        $this->expectExceptionObject(new AssertionFailedError('Property [bar] contains a value that should be missing: [bar, value]'));
 
         $assert->whereNot('bar', 'value');
     }
@@ -944,8 +908,7 @@ class AssertTest extends TestCase
             'bar' => 'value',
         ]);
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [baz] does not exist.');
+        $this->expectExceptionObject(new AssertionFailedError('Property [baz] does not exist.'));
 
         $assert->whereNot('baz', 'value');
     }
@@ -967,8 +930,7 @@ class AssertTest extends TestCase
             'bar' => 'baz',
         ]);
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [bar] was marked as invalid using a closure.');
+        $this->expectExceptionObject(new AssertionFailedError('Property [bar] was marked as invalid using a closure.'));
 
         $assert->whereNot('bar', function ($value) {
             return $value === 'baz';
@@ -990,8 +952,7 @@ class AssertTest extends TestCase
             'bar' => BackedEnum::test->value,
         ]);
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [bar] contains a value that should be missing: [bar, test]');
+        $this->expectExceptionObject(new AssertionFailedError('Property [bar] contains a value that should be missing: [bar, test]'));
 
         $assert->whereNot('bar', BackedEnum::test);
     }
@@ -1025,8 +986,7 @@ class AssertTest extends TestCase
             ],
         ]);
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [baz] does not exist.');
+        $this->expectExceptionObject(new AssertionFailedError('Property [baz] does not exist.'));
 
         $assert->has('baz', function (AssertableJson $item) {
             $item->where('baz', 'example');
@@ -1039,8 +999,7 @@ class AssertTest extends TestCase
             'bar' => 'value',
         ]);
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [bar] is not scopeable.');
+        $this->expectExceptionObject(new AssertionFailedError('Property [bar] is not scopeable.'));
 
         $assert->has('bar', function (AssertableJson $item) {
             //
@@ -1092,8 +1051,7 @@ class AssertTest extends TestCase
             ],
         ]);
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [bar] does not have the expected size.');
+        $this->expectExceptionObject(new AssertionFailedError('Property [bar] does not have the expected size.'));
 
         $assert->has('bar', 0, function (AssertableJson $item) {
             $item->where('key', 'first');
@@ -1109,8 +1067,7 @@ class AssertTest extends TestCase
             ],
         ]);
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [bar] does not have the expected size.');
+        $this->expectExceptionObject(new AssertionFailedError('Property [bar] does not have the expected size.'));
 
         $assert->has('bar', 1, function (AssertableJson $item) {
             $item->where('key', 'first');
@@ -1185,8 +1142,7 @@ class AssertTest extends TestCase
     {
         $assert = AssertableJson::fromArray([]);
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Cannot scope directly onto the first element of the root level because it is empty.');
+        $this->expectExceptionObject(new AssertionFailedError('Cannot scope directly onto the first element of the root level because it is empty.'));
 
         $assert->first(function (AssertableJson $item) {
             //
@@ -1199,8 +1155,7 @@ class AssertTest extends TestCase
             'foo' => [],
         ]);
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Cannot scope directly onto the first element of property [foo] because it is empty.');
+        $this->expectExceptionObject(new AssertionFailedError('Cannot scope directly onto the first element of property [foo] because it is empty.'));
 
         $assert->has('foo', function (AssertableJson $assert) {
             $assert->first(function (AssertableJson $item) {
@@ -1215,8 +1170,7 @@ class AssertTest extends TestCase
             'foo' => 'bar',
         ]);
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [foo] is not scopeable.');
+        $this->expectExceptionObject(new AssertionFailedError('Property [foo] is not scopeable.'));
 
         $assert->first(function (AssertableJson $item) {
             //
@@ -1243,8 +1197,7 @@ class AssertTest extends TestCase
     {
         $assert = AssertableJson::fromArray([]);
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Cannot scope directly onto each element of the root level because it is empty.');
+        $this->expectExceptionObject(new AssertionFailedError('Cannot scope directly onto each element of the root level because it is empty.'));
 
         $assert->each(function (AssertableJson $item) {
             //
@@ -1257,8 +1210,7 @@ class AssertTest extends TestCase
             'foo' => [],
         ]);
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Cannot scope directly onto each element of property [foo] because it is empty.');
+        $this->expectExceptionObject(new AssertionFailedError('Cannot scope directly onto each element of property [foo] because it is empty.'));
 
         $assert->has('foo', function (AssertableJson $assert) {
             $assert->each(function (AssertableJson $item) {
@@ -1273,8 +1225,7 @@ class AssertTest extends TestCase
             'foo' => 'bar',
         ]);
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [foo] is not scopeable.');
+        $this->expectExceptionObject(new AssertionFailedError('Property [foo] is not scopeable.'));
 
         $assert->each(function (AssertableJson $item) {
             //
@@ -1290,8 +1241,7 @@ class AssertTest extends TestCase
             ],
         ]);
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Unexpected properties were found in scope [bar].');
+        $this->expectExceptionObject(new AssertionFailedError('Unexpected properties were found in scope [bar].'));
 
         $assert->has('bar', function (AssertableJson $item) {
             $item->where('baz', 'example');
@@ -1324,8 +1274,7 @@ class AssertTest extends TestCase
             ],
         ]);
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Unexpected properties were found in scope [bar.baz].');
+        $this->expectExceptionObject(new AssertionFailedError('Unexpected properties were found in scope [bar.baz].'));
 
         $assert->has('bar', function (AssertableJson $item) {
             $item
@@ -1353,8 +1302,7 @@ class AssertTest extends TestCase
             'bar' => 'baz',
         ]);
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Unexpected properties were found on the root level.');
+        $this->expectExceptionObject(new AssertionFailedError('Unexpected properties were found on the root level.'));
 
         $assert
             ->has('foo')
@@ -1387,8 +1335,7 @@ class AssertTest extends TestCase
             'baz' => 'example',
         ]);
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [baz] was marked as invalid using a closure.');
+        $this->expectExceptionObject(new AssertionFailedError('Property [baz] was marked as invalid using a closure.'));
 
         $assert->whereAll([
             'foo' => 'bar',
@@ -1483,8 +1430,7 @@ class AssertTest extends TestCase
             'foo' => 'bar',
         ]);
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [foo] is not of expected type [integer].');
+        $this->expectExceptionObject(new AssertionFailedError('Property [foo] is not of expected type [integer].'));
 
         $assert->whereType('foo', 'integer');
     }
@@ -1509,8 +1455,7 @@ class AssertTest extends TestCase
             'foo' => 123,
         ]);
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [foo] is not of expected type [string|null].');
+        $this->expectExceptionObject(new AssertionFailedError('Property [foo] is not of expected type [string|null].'));
 
         $assert->whereType('foo', ['string', 'null']);
     }
@@ -1530,8 +1475,7 @@ class AssertTest extends TestCase
             'foo' => 'bar',
         ]);
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [foo] is not of expected type [integer|null].');
+        $this->expectExceptionObject(new AssertionFailedError('Property [foo] is not of expected type [integer|null].'));
 
         $assert->whereType('foo', 'integer|null');
     }
@@ -1563,8 +1507,7 @@ class AssertTest extends TestCase
             'baz' => 'another',
         ]);
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [foo.baz] does not exist.');
+        $this->expectExceptionObject(new AssertionFailedError('Property [foo.baz] does not exist.'));
 
         $assert->hasAll([
             'foo.bar',
@@ -1585,8 +1528,7 @@ class AssertTest extends TestCase
 
         $assert->hasAll('foo.bar', 'foo.example', 'baz');
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [foo.baz] does not exist.');
+        $this->expectExceptionObject(new AssertionFailedError('Property [foo.baz] does not exist.'));
 
         $assert->hasAll('foo.bar', 'foo.baz', 'baz');
     }
@@ -1618,8 +1560,7 @@ class AssertTest extends TestCase
             ],
         ]);
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [baz] does not exist.');
+        $this->expectExceptionObject(new AssertionFailedError('Property [baz] does not exist.'));
 
         $assert->hasAll([
             'bar' => 2,
@@ -1633,8 +1574,7 @@ class AssertTest extends TestCase
             throw new RuntimeException('My Custom Macro was called!');
         });
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('My Custom Macro was called!');
+        $this->expectExceptionObject(new RuntimeException('My Custom Macro was called!'));
 
         $assert = AssertableJson::fromArray(['foo' => 'bar']);
         $assert->myCustomMacro();

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -593,8 +593,7 @@ class TestResponseTest extends TestCase
 
     public function testAssertSeeTextCanFail(): void
     {
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Failed asserting that \'foo<strong>bar</strong>\' contains "bazfoo".');
+        $this->expectExceptionObject(new AssertionFailedError('Failed asserting that \'foo<strong>bar</strong>\' contains "bazfoo".'));
 
         $response = $this->makeMockResponse([
             'render' => 'foo<strong>bar</strong>',
@@ -676,8 +675,7 @@ EOT
 
     public function testAssertSeeTextInOrderCanFail(): void
     {
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Failed asserting that \'foo<strong>bar</strong> baz <strong>foo</strong>\' contains "foobar" in specified order.');
+        $this->expectExceptionObject(new AssertionFailedError('Failed asserting that \'foo<strong>bar</strong> baz <strong>foo</strong>\' contains "foobar" in specified order.'));
 
         $response = $this->makeMockResponse([
             'render' => 'foo<strong>bar</strong> baz <strong>foo</strong>',
@@ -775,8 +773,7 @@ EOT
 
     public function testAssertDontSeeTextCanFail(): void
     {
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Failed asserting that \'foo<strong>bar</strong>baz<strong>qux</strong>\' does not contain "foobar".');
+        $this->expectExceptionObject(new AssertionFailedError('Failed asserting that \'foo<strong>bar</strong>baz<strong>qux</strong>\' does not contain "foobar".'));
 
         $response = $this->makeMockResponse([
             'render' => 'foo<strong>bar</strong>baz<strong>qux</strong>',
@@ -844,8 +841,7 @@ EOT
     {
         $statusCode = 500;
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Expected response status code');
+        $this->expectExceptionObject(new AssertionFailedError('Expected response status code'));
 
         $baseResponse = tap(new Response, function ($response) use ($statusCode) {
             $response->setStatusCode($statusCode);
@@ -867,8 +863,7 @@ EOT
             (new Response)->setStatusCode(Response::HTTP_OK)
         );
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage("Expected response status code [405] but received 200.\nFailed asserting that 200 is identical to 405.");
+        $this->expectExceptionObject(new AssertionFailedError("Expected response status code [405] but received 200.\nFailed asserting that 200 is identical to 405."));
 
         $response->assertMethodNotAllowed();
     }
@@ -885,8 +880,7 @@ EOT
             (new Response)->setStatusCode(Response::HTTP_OK)
         );
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage("Expected response status code [406] but received 200.\nFailed asserting that 200 is identical to 406.");
+        $this->expectExceptionObject(new AssertionFailedError("Expected response status code [406] but received 200.\nFailed asserting that 200 is identical to 406."));
 
         $response->assertNotAcceptable();
         $this->fail();
@@ -936,8 +930,7 @@ EOT
             (new Response)->setStatusCode(Response::HTTP_OK)
         );
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage("Expected response status code [400] but received 200.\nFailed asserting that 200 is identical to 400.");
+        $this->expectExceptionObject(new AssertionFailedError("Expected response status code [400] but received 200.\nFailed asserting that 200 is identical to 400."));
 
         $response->assertBadRequest();
         $this->fail();
@@ -955,8 +948,7 @@ EOT
             (new Response)->setStatusCode(Response::HTTP_OK)
         );
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage("Expected response status code [408] but received 200.\nFailed asserting that 200 is identical to 408.");
+        $this->expectExceptionObject(new AssertionFailedError("Expected response status code [408] but received 200.\nFailed asserting that 200 is identical to 408."));
 
         $response->assertRequestTimeout();
         $this->fail();
@@ -974,8 +966,7 @@ EOT
             (new Response)->setStatusCode(Response::HTTP_OK)
         );
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage("Expected response status code [402] but received 200.\nFailed asserting that 200 is identical to 402.");
+        $this->expectExceptionObject(new AssertionFailedError("Expected response status code [402] but received 200.\nFailed asserting that 200 is identical to 402."));
 
         $response->assertPaymentRequired();
         $this->fail();
@@ -993,8 +984,7 @@ EOT
             (new Response)->setStatusCode(Response::HTTP_OK)
         );
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage("Expected response status code [301] but received 200.\nFailed asserting that 200 is identical to 301.");
+        $this->expectExceptionObject(new AssertionFailedError("Expected response status code [301] but received 200.\nFailed asserting that 200 is identical to 301."));
 
         $response->assertMovedPermanently();
         $this->fail();
@@ -1012,8 +1002,7 @@ EOT
             (new Response)->setStatusCode(Response::HTTP_OK)
         );
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage("Expected response status code [302] but received 200.\nFailed asserting that 200 is identical to 302.");
+        $this->expectExceptionObject(new AssertionFailedError("Expected response status code [302] but received 200.\nFailed asserting that 200 is identical to 302."));
 
         $response->assertFound();
         $this->fail();
@@ -1031,8 +1020,7 @@ EOT
             (new Response)->setStatusCode(Response::HTTP_OK)
         );
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage("Expected response status code [304] but received 200.\nFailed asserting that 200 is identical to 304.");
+        $this->expectExceptionObject(new AssertionFailedError("Expected response status code [304] but received 200.\nFailed asserting that 200 is identical to 304."));
 
         $response->assertNotModified();
         $this->fail();
@@ -1050,8 +1038,7 @@ EOT
             (new Response)->setStatusCode(Response::HTTP_OK)
         );
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage("Expected response status code [307] but received 200.\nFailed asserting that 200 is identical to 307.");
+        $this->expectExceptionObject(new AssertionFailedError("Expected response status code [307] but received 200.\nFailed asserting that 200 is identical to 307."));
 
         $response->assertTemporaryRedirect();
         $this->fail();
@@ -1069,8 +1056,7 @@ EOT
             (new Response)->setStatusCode(Response::HTTP_OK)
         );
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage("Expected response status code [308] but received 200.\nFailed asserting that 200 is identical to 308.");
+        $this->expectExceptionObject(new AssertionFailedError("Expected response status code [308] but received 200.\nFailed asserting that 200 is identical to 308."));
 
         $response->assertPermanentRedirect();
         $this->fail();
@@ -1088,8 +1074,7 @@ EOT
             (new Response)->setStatusCode(Response::HTTP_OK)
         );
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage("Expected response status code [409] but received 200.\nFailed asserting that 200 is identical to 409.");
+        $this->expectExceptionObject(new AssertionFailedError("Expected response status code [409] but received 200.\nFailed asserting that 200 is identical to 409."));
 
         $response->assertConflict();
         $this->fail();
@@ -1107,8 +1092,7 @@ EOT
             (new Response)->setStatusCode(Response::HTTP_OK)
         );
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage("Expected response status code [410] but received 200.\nFailed asserting that 200 is identical to 410.");
+        $this->expectExceptionObject(new AssertionFailedError("Expected response status code [410] but received 200.\nFailed asserting that 200 is identical to 410."));
 
         $response->assertGone();
     }
@@ -1125,8 +1109,7 @@ EOT
             (new Response)->setStatusCode(Response::HTTP_OK)
         );
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage("Expected response status code [429] but received 200.\nFailed asserting that 200 is identical to 429.");
+        $this->expectExceptionObject(new AssertionFailedError("Expected response status code [429] but received 200.\nFailed asserting that 200 is identical to 429."));
 
         $response->assertTooManyRequests();
         $this->fail();
@@ -1144,8 +1127,7 @@ EOT
             (new Response)->setStatusCode(Response::HTTP_OK)
         );
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage("Expected response status code [202] but received 200.\nFailed asserting that 200 is identical to 202.");
+        $this->expectExceptionObject(new AssertionFailedError("Expected response status code [202] but received 200.\nFailed asserting that 200 is identical to 202."));
 
         $response->assertAccepted();
         $this->fail();
@@ -1179,8 +1161,7 @@ EOT
             (new Response)->setStatusCode(Response::HTTP_OK)
         );
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage("Expected response status code [424] but received 200.\nFailed asserting that 200 is identical to 424.");
+        $this->expectExceptionObject(new AssertionFailedError("Expected response status code [424] but received 200.\nFailed asserting that 200 is identical to 424."));
 
         $response->assertFailedDependency();
         $this->fail();
@@ -1222,8 +1203,7 @@ EOT
             (new Response)->setStatusCode(Response::HTTP_OK)
         );
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage("Expected response status code [500] but received 200.\nFailed asserting that 200 is identical to 500.");
+        $this->expectExceptionObject(new AssertionFailedError("Expected response status code [500] but received 200.\nFailed asserting that 200 is identical to 500."));
 
         $response->assertInternalServerError();
     }
@@ -1240,8 +1220,7 @@ EOT
             (new Response)->setStatusCode(Response::HTTP_OK)
         );
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage("Expected response status code [503] but received 200.\nFailed asserting that 200 is identical to 503.");
+        $this->expectExceptionObject(new AssertionFailedError("Expected response status code [503] but received 200.\nFailed asserting that 200 is identical to 503."));
 
         $response->assertServiceUnavailable();
     }
@@ -1326,8 +1305,7 @@ EOT
 
     public function testAssertHeaderMissing(): void
     {
-        $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('Unexpected header [Location] is present on response.');
+        $this->expectExceptionObject(new ExpectationFailedException('Unexpected header [Location] is present on response.'));
 
         $baseResponse = tap(new Response, function ($response) {
             $response->header('Location', '/foo');
@@ -1340,8 +1318,7 @@ EOT
 
     public function testAssertPrecognitionSuccessfulWithMissingHeader(): void
     {
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Header [Precognition-Success] not present on response.');
+        $this->expectExceptionObject(new AssertionFailedError('Header [Precognition-Success] not present on response.'));
 
         $baseResponse = new Response('', 204);
 
@@ -1352,8 +1329,7 @@ EOT
 
     public function testAssertPrecognitionSuccessfulWithIncorrectValue(): void
     {
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('The Precognition-Success header was found, but the value is not `true`.');
+        $this->expectExceptionObject(new AssertionFailedError('The Precognition-Success header was found, but the value is not `true`.'));
 
         $baseResponse = tap(new Response('', 204), function ($response) {
             $response->header('Precognition-Success', '');
@@ -1377,8 +1353,7 @@ EOT
     {
         $response = TestResponse::fromBaseResponse(new Response(null));
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Invalid JSON was returned from the route.');
+        $this->expectExceptionObject(new AssertionFailedError('Invalid JSON was returned from the route.'));
 
         $resource = new JsonSerializableSingleResourceStub;
 
@@ -1399,8 +1374,7 @@ EOT
     {
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableMixedResourcesStub));
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Unexpected properties were found on the root level.');
+        $this->expectExceptionObject(new AssertionFailedError('Unexpected properties were found on the root level.'));
 
         $response->assertJson(function (AssertableJson $json) {
             $json->where('foo', 'bar');
@@ -1423,8 +1397,7 @@ EOT
     {
         $response = TestResponse::fromBaseResponse(new Response([]));
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('None of properties [data, errors, meta] exist.');
+        $this->expectExceptionObject(new AssertionFailedError('None of properties [data, errors, meta] exist.'));
 
         $response->assertJson(function (AssertableJson $json) {
             $json->hasAny('data', 'errors', 'meta');
@@ -1471,8 +1444,7 @@ EOT
 
     public function testAssertExactJsonWithMixedWhenDataIsSimilar(): void
     {
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Failed asserting that two strings are equal.');
+        $this->expectExceptionObject(new AssertionFailedError('Failed asserting that two strings are equal.'));
 
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableMixedResourcesStub));
 
@@ -1520,8 +1492,7 @@ EOT
 
     public function testAssertJsonPathCanFail(): void
     {
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Failed asserting that 10 is identical to \'10\'.');
+        $this->expectExceptionObject(new AssertionFailedError('Failed asserting that 10 is identical to \'10\'.'));
 
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceWithIntegersStub));
 
@@ -1543,8 +1514,7 @@ EOT
             'data' => ['foo' => 'bar'],
         ]));
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Failed asserting that false is true.');
+        $this->expectExceptionObject(new AssertionFailedError('Failed asserting that false is true.'));
 
         $response->assertJsonPath('data.foo', fn ($value) => $value === null);
     }
@@ -1564,8 +1534,7 @@ EOT
             'data' => ['status' => 'failed'],
         ]));
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Failed asserting that two strings are identical.');
+        $this->expectExceptionObject(new AssertionFailedError('Failed asserting that two strings are identical.'));
 
         $response->assertJsonPath('data.status', TestStatus::Booked);
     }
@@ -1587,8 +1556,7 @@ EOT
     {
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceStub));
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Failed asserting that two arrays are equal.');
+        $this->expectExceptionObject(new AssertionFailedError('Failed asserting that two arrays are equal.'));
 
         $response->assertJsonPathCanonicalizing('*.foo', ['foo 0', 'foo 2', 'foo 3']);
     }
@@ -1642,8 +1610,7 @@ EOT
 
     public function testAssertJsonPathsCanFail(): void
     {
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Failed asserting that 10 is identical to 11.');
+        $this->expectExceptionObject(new AssertionFailedError('Failed asserting that 10 is identical to 11.'));
 
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceWithIntegersStub));
 
@@ -2500,8 +2467,7 @@ EOT
 
     public function testAssertJsonMissingValidationErrorsOnInvalidJson(): void
     {
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Invalid JSON was returned from the route.');
+        $this->expectExceptionObject(new AssertionFailedError('Invalid JSON was returned from the route.'));
 
         $invalidJsonResponse = TestResponse::fromBaseResponse(
             (new Response)->setContent('~invalid json')
@@ -2856,8 +2822,7 @@ EOT
 
         $response = TestResponse::fromBaseResponse($baseResponse);
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Header [X-Custom-Header] was found, but [unrelated] does not contain [value].');
+        $this->expectExceptionObject(new AssertionFailedError('Header [X-Custom-Header] was found, but [unrelated] does not contain [value].'));
 
         $response->assertHeaderContains('X-Custom-Header', 'value');
     }
@@ -3252,8 +3217,7 @@ EOT
             new Response(false, 422, ['Content-Type' => 'application/json'])
         );
 
-        $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('Expected response status code [200] but received 422.');
+        $this->expectExceptionObject(new ExpectationFailedException('Expected response status code [200] but received 422.'));
 
         $response->assertStatus(200);
     }
@@ -3264,8 +3228,7 @@ EOT
             new Response('b"x£½V*.I,)-V▓R╩¤V¬\x05\x00+ü\x059"', 422, ['Content-Type' => 'application/json', 'Content-Encoding' => 'gzip'])
         );
 
-        $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('Expected response status code [200] but received 422.');
+        $this->expectExceptionObject(new ExpectationFailedException('Expected response status code [200] but received 422.'));
 
         $response->assertStatus(200);
     }

--- a/tests/Validation/ValidationFileRuleTest.php
+++ b/tests/Validation/ValidationFileRuleTest.php
@@ -12,6 +12,7 @@ use Illuminate\Validation\Rule;
 use Illuminate\Validation\Rules\File;
 use Illuminate\Validation\ValidationServiceProvider;
 use Illuminate\Validation\Validator;
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
 class ValidationFileRuleTest extends TestCase
@@ -389,8 +390,7 @@ class ValidationFileRuleTest extends TestCase
 
     public function testEncodingWithInvalidParameter()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Validation rule encoding parameter [FOOBAR] is not a valid encoding.');
+        $this->expectExceptionObject(new InvalidArgumentException('Validation rule encoding parameter [FOOBAR] is not a valid encoding.'));
 
         // Invalid encoding.
         $this->fails(
@@ -478,7 +478,7 @@ class ValidationFileRuleTest extends TestCase
             UploadedFile::fake()->create('foo.png', 1000000000)
         );
 
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         File::image()->size('10xyz');
     }
 

--- a/tests/Validation/ValidationPasswordRuleTest.php
+++ b/tests/Validation/ValidationPasswordRuleTest.php
@@ -13,6 +13,7 @@ use Illuminate\Translation\Translator;
 use Illuminate\Validation\Rules\Password;
 use Illuminate\Validation\ValidationServiceProvider;
 use Illuminate\Validation\Validator;
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
 class ValidationPasswordRuleTest extends TestCase
@@ -290,8 +291,7 @@ class ValidationPasswordRuleTest extends TestCase
 
     public function testItCannotSetDefaultUsingGivenString()
     {
-        $this->expectException('InvalidArgumentException');
-        $this->expectExceptionMessage('given callback should be callable');
+        $this->expectExceptionObject(new InvalidArgumentException('given callback should be callable'));
 
         Password::defaults('required|password');
     }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1122,7 +1122,8 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['name' => ''], ['name' => 'required']);
 
-        $exception = new class($v) extends ValidationException {
+        $exception = new class($v) extends ValidationException
+        {
         };
         $v->setException($exception);
 
@@ -1139,8 +1140,7 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, [], []);
 
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Exception [RuntimeException] is invalid. It must extend [Illuminate\Validation\ValidationException].');
+        $this->expectExceptionObject(new InvalidArgumentException('Exception [RuntimeException] is invalid. It must extend [Illuminate\Validation\ValidationException].'));
 
         $v->setException(RuntimeException::class);
     }
@@ -7428,8 +7428,7 @@ class ValidationValidatorTest extends TestCase
 
     public function testExceptionThrownOnIncorrectParameterCount()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Validation rule required_if requires at least 2 parameters.');
+        $this->expectExceptionObject(new InvalidArgumentException('Validation rule required_if requires at least 2 parameters.'));
 
         $trans = $this->getTranslator();
         $v = new Validator($trans, [], ['foo' => 'required_if:foo']);

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1122,8 +1122,7 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['name' => ''], ['name' => 'required']);
 
-        $exception = new class($v) extends ValidationException
-        {
+        $exception = new class($v) extends ValidationException {
         };
         $v->setException($exception);
 

--- a/tests/View/Blade/BladeCustomTest.php
+++ b/tests/View/Blade/BladeCustomTest.php
@@ -70,8 +70,7 @@ class BladeCustomTest extends AbstractBladeTestCase
 
     public function testInvalidCustomNames()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The directive name [custom-custom] is not valid.');
+        $this->expectExceptionObject(new InvalidArgumentException('The directive name [custom-custom] is not valid.'));
         $this->compiler->directive('custom-custom', function () {
             //
         });
@@ -79,8 +78,7 @@ class BladeCustomTest extends AbstractBladeTestCase
 
     public function testInvalidCustomNames2()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The directive name [custom:custom] is not valid.');
+        $this->expectExceptionObject(new InvalidArgumentException('The directive name [custom:custom] is not valid.'));
         $this->compiler->directive('custom:custom', function () {
             //
         });

--- a/tests/View/Blade/BladeEchoHandlerTest.php
+++ b/tests/View/Blade/BladeEchoHandlerTest.php
@@ -53,8 +53,7 @@ class BladeEchoHandlerTest extends AbstractBladeTestCase
     #[DataProvider('handlerLogicDataProvider')]
     public function testHandlerLogicWorksCorrectly($blade)
     {
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage('The fluent object has been successfully handled!');
+        $this->expectExceptionObject(new Exception('The fluent object has been successfully handled!'));
 
         $this->compiler->stringable(Fluent::class, function ($object) {
             throw new Exception('The fluent object has been successfully handled!');

--- a/tests/View/Blade/BladeForeachStatementsTest.php
+++ b/tests/View/Blade/BladeForeachStatementsTest.php
@@ -98,8 +98,7 @@ tag info
     #[DataProvider('invalidForeachStatementsDataProvider')]
     public function testForeachStatementsThrowHumanizedMessageWhenInvalidStatement($initialStatement)
     {
-        $this->expectException(ViewCompilationException::class);
-        $this->expectExceptionMessage('Malformed @foreach statement.');
+        $this->expectExceptionObject(new ViewCompilationException('Malformed @foreach statement.'));
         $string = "$initialStatement
 test
 @endforeach";

--- a/tests/View/Blade/BladeForelseStatementsTest.php
+++ b/tests/View/Blade/BladeForelseStatementsTest.php
@@ -84,8 +84,7 @@ empty
     #[DataProvider('invalidForelseStatementsDataProvider')]
     public function testForelseStatementsThrowHumanizedMessageWhenInvalidStatement($initialStatement)
     {
-        $this->expectException(ViewCompilationException::class);
-        $this->expectExceptionMessage('Malformed @forelse statement.');
+        $this->expectExceptionObject(new ViewCompilationException('Malformed @forelse statement.'));
         $string = "$initialStatement
 breeze
 @empty

--- a/tests/View/ComponentTest.php
+++ b/tests/View/ComponentTest.php
@@ -136,8 +136,7 @@ class ComponentTest extends TestCase
 
     public function testResolveWithUnresolvableDependency()
     {
-        $this->expectException(BindingResolutionException::class);
-        $this->expectExceptionMessage('Unresolvable dependency resolving');
+        $this->expectExceptionObject(new BindingResolutionException('Unresolvable dependency resolving'));
 
         TestInlineViewComponentWhereRenderDependsOnProps::resolve([]);
     }

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -20,8 +20,7 @@ class ViewBladeCompilerTest extends TestCase
 
     public function testCannotConstructWithBadCachePath()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Please provide a valid cache path.');
+        $this->expectExceptionObject(new InvalidArgumentException('Please provide a valid cache path.'));
 
         new BladeCompiler($this->getFiles(), null);
     }

--- a/tests/View/ViewCompilerEngineTest.php
+++ b/tests/View/ViewCompilerEngineTest.php
@@ -45,8 +45,7 @@ class ViewCompilerEngineTest extends TestCase
         $engine->getCompiler()->shouldReceive('getCompiledPath')->with(__DIR__.'/fixtures/foo.php')->andReturn(__DIR__.'/fixtures/regular-exception.php');
         $engine->getCompiler()->shouldReceive('isExpired')->once()->andReturn(false);
 
-        $this->expectException(ViewException::class);
-        $this->expectExceptionMessage('regular exception message');
+        $this->expectExceptionObject(new ViewException('regular exception message'));
 
         $engine->get(__DIR__.'/fixtures/foo.php');
     }
@@ -214,8 +213,7 @@ class ViewCompilerEngineTest extends TestCase
 
         $engine->get($path);
 
-        $this->expectException(ViewException::class);
-        $this->expectExceptionMessage("File does not exist at path {$path}.");
+        $this->expectExceptionObject(new ViewException("File does not exist at path {$path}."));
         $engine->get($path);
     }
 
@@ -249,8 +247,7 @@ class ViewCompilerEngineTest extends TestCase
             ->with($path)
             ->andReturn($compiled);
 
-        $this->expectException(ViewException::class);
-        $this->expectExceptionMessage('Just an regular error...');
+        $this->expectExceptionObject(new ViewException('Just an regular error...'));
         $engine->get($path);
     }
 
@@ -285,8 +282,7 @@ class ViewCompilerEngineTest extends TestCase
             ->with($path)
             ->andReturn($compiled);
 
-        $this->expectException(ViewException::class);
-        $this->expectExceptionMessage("File does not exist at path {$path}.");
+        $this->expectExceptionObject(new ViewException("File does not exist at path {$path}."));
         $engine->get($path);
     }
 

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -878,8 +878,7 @@ class ViewFactoryTest extends TestCase
 
     public function testExceptionsInSectionsAreThrown()
     {
-        $this->expectException(ErrorException::class);
-        $this->expectExceptionMessage('section exception message');
+        $this->expectExceptionObject(new ErrorException('section exception message'));
 
         $engine = new CompilerEngine(m::mock(CompilerInterface::class), new Filesystem);
         $engine->getCompiler()->shouldReceive('getCompiledPath')->andReturnUsing(function ($path) {
@@ -897,8 +896,7 @@ class ViewFactoryTest extends TestCase
 
     public function testExtraStopSectionCallThrowsException()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Cannot end a section without first starting one.');
+        $this->expectExceptionObject(new InvalidArgumentException('Cannot end a section without first starting one.'));
 
         $factory = $this->getFactory();
         $factory->startSection('foo');
@@ -909,8 +907,7 @@ class ViewFactoryTest extends TestCase
 
     public function testExtraAppendSectionCallThrowsException()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Cannot end a section without first starting one.');
+        $this->expectExceptionObject(new InvalidArgumentException('Cannot end a section without first starting one.'));
 
         $factory = $this->getFactory();
         $factory->startSection('foo');

--- a/tests/View/ViewFileViewFinderTest.php
+++ b/tests/View/ViewFileViewFinderTest.php
@@ -88,8 +88,7 @@ class ViewFileViewFinderTest extends TestCase
 
     public function testExceptionThrownOnInvalidViewName()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('No hint path defined for [name].');
+        $this->expectExceptionObject(new InvalidArgumentException('No hint path defined for [name].'));
 
         $finder = $this->getFinder();
         $finder->find('name::');
@@ -97,8 +96,7 @@ class ViewFileViewFinderTest extends TestCase
 
     public function testExceptionThrownWhenNoHintPathIsRegistered()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('No hint path defined for [name].');
+        $this->expectExceptionObject(new InvalidArgumentException('No hint path defined for [name].'));
 
         $finder = $this->getFinder();
         $finder->find('name::foo');

--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -169,8 +169,7 @@ class ViewTest extends TestCase
 
     public function testViewBadMethod()
     {
-        $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage('Method Illuminate\View\View::badMethodCall does not exist.');
+        $this->expectExceptionObject(new BadMethodCallException('Method Illuminate\View\View::badMethodCall does not exist.'));
 
         $view = $this->getView();
         $view->badMethodCall();


### PR DESCRIPTION
Swaps `expectException()` + `expectExceptionMessage()` for the single `expectExceptionObject()` call, wherever the full exception message is known and asserted exactly. Less boilerplate, same coverage.

`Error` and its subclasses (`TypeError`, `ValueError`, `ArgumentCountError`, etc.) are left alone on purpose - didn't want to touch those here.

Also worth noting: PHPUnit 13.2 deprecates `expectExceptionMessage()` in favor of `expectExceptionMessageIs()` (strict match) or `expectExceptionMessageIsOrContains()` (same "contains" behavior as the old method), so these call sites would need updating eventually anyway.