### PR TITLE
[13.x] try/finally

### DIFF
--- a/src/Illuminate/Cache/Limiters/ConcurrencyLimiter.php
+++ b/src/Illuminate/Cache/Limiters/ConcurrencyLimiter.php
@@ -4,7 +4,6 @@ namespace Illuminate\Cache\Limiters;
 
 use Illuminate\Support\Sleep;
 use Illuminate\Support\Str;
-use Throwable;
 
 class ConcurrencyLimiter
 {
@@ -79,13 +78,9 @@ class ConcurrencyLimiter
 
         if (is_callable($callback)) {
             try {
-                return tap($callback(), function () use ($slot) {
-                    $this->release($slot);
-                });
-            } catch (Throwable $exception) {
+                return $callback();
+            } finally {
                 $this->release($slot);
-
-                throw $exception;
             }
         }
 

--- a/src/Illuminate/Redis/Limiters/ConcurrencyLimiter.php
+++ b/src/Illuminate/Redis/Limiters/ConcurrencyLimiter.php
@@ -6,7 +6,6 @@ use Illuminate\Contracts\Redis\LimiterTimeoutException;
 use Illuminate\Redis\Connections\Connection;
 use Illuminate\Support\Sleep;
 use Illuminate\Support\Str;
-use Throwable;
 
 class ConcurrencyLimiter
 {
@@ -88,13 +87,9 @@ class ConcurrencyLimiter
 
         if (is_callable($callback)) {
             try {
-                return tap($callback(), function () use ($slot, $id) {
-                    $this->release($slot, $id);
-                });
-            } catch (Throwable $exception) {
+                return $callback();
+            } finally {
                 $this->release($slot, $id);
-
-                throw $exception;
             }
         }
 


### PR DESCRIPTION
Both ConcurrencyLimiter classes (Cache and Redis) release the slot in two places: a `tap()` callback on success and again in a catch block before rethrowing. That's exactly what `finally` is for, and it's already the pattern used in Cache\Lock::get(). Swapped both over to match.