### PR TITLE
[13.x] Fix Str::numbers() type annotation

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -956,12 +956,12 @@ class Str
     /**
      * Remove all non-numeric characters from a string.
      *
-     * @param  string  $value
-     * @return string
+     * @param  string|string[]  $value
+     * @return ($value is string ? string : string[])
      */
     public static function numbers($value)
     {
-        return preg_replace('/[^0-9]/', '', $value);
+        return preg_replace('/\D/', '', $value);
     }
 
     /**


### PR DESCRIPTION
Str::numbers() already worked fine with an array of strings at runtime (preg_replace handles that natively), the docblock just didn't say so. Updated it to the same conditional-return style used a few methods above by Str::replace().