### PR TITLE
Add integration coverage for migrate --seed after #60926

### DIFF
--- a/tests/Integration/Database/MigrateWithNonDefaultConnectionAndSeedTest.php
+++ b/tests/Integration/Database/MigrateWithNonDefaultConnectionAndSeedTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Orchestra\Testbench\Attributes\RequiresDatabase;
+use Orchestra\Testbench\TestCase;
+
+#[RequiresDatabase('mysql')]
+class MigrateWithNonDefaultConnectionAndSeedTest extends TestCase
+{
+    protected function defineEnvironment($app)
+    {
+        $app['config']->set('database.default', 'mysql');
+
+        $app['config']->set('database.connections.mysql', [
+            'driver' => 'mysql',
+            'host' => '127.0.0.1',
+            'port' => '3306',
+            'database' => 'forge',
+            'username' => 'root',
+            'password' => '',
+        ]);
+
+        $app['config']->set('database.connections.testing', [
+            'driver' => 'mysql',
+            'host' => '127.0.0.1',
+            'port' => '3306',
+            'database' => 'testing_db_name',
+            'username' => 'root',
+            'password' => '',
+        ]);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->dropAllTables('mysql');
+        $this->dropAllTables('testing');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->dropAllTables('mysql');
+        $this->dropAllTables('testing');
+
+        foreach (array_keys($this->app['db']->getConnections()) as $name) {
+            $this->app['db']->purge($name);
+        }
+
+        parent::tearDown();
+    }
+
+    protected function dropAllTables($connection)
+    {
+        $pdo = DB::connection($connection)->getPdo();
+
+        foreach (['people', 'migrations'] as $table) {
+            $pdo->exec("DROP TABLE IF EXISTS `{$table}`");
+        }
+    }
+
+    public function testMigratingOnANonDefaultConnectionCreatesTheMigrationsTableThere()
+    {
+        $this->artisan('migrate', [
+            '--database' => 'testing',
+            '--path' => realpath(__DIR__.'/stubs/migrate-connection'),
+            '--realpath' => true,
+            '--seed' => true,
+            '--seeder' => MigrateWithNonDefaultConnectionAndSeedTestSeeder::class,
+        ])->run();
+
+        $this->assertTrue(Schema::connection('testing')->hasTable('migrations'), 'migrations table missing on the [testing] connection.');
+        $this->assertDatabaseHas('migrations', [
+            'migration' => '2014_10_12_000000_create_people_table',
+        ], 'testing');
+
+        $this->assertTrue(Schema::connection('testing')->hasTable('people'), 'people table missing on the [testing] connection.');
+        $this->assertDatabaseHas('people', ['name' => 'seeded'], 'testing');
+
+        $this->assertFalse(Schema::connection('mysql')->hasTable('migrations'), 'migrations table was created on the default [mysql] connection instead of [testing].');
+    }
+}
+
+class MigrateWithNonDefaultConnectionAndSeedTestSeeder extends Seeder
+{
+    public function run()
+    {
+        DB::table('people')->insert(['name' => 'seeded']);
+    }
+}

--- a/tests/Integration/Database/MigrateWithStoredSchemaAndSeedTest.php
+++ b/tests/Integration/Database/MigrateWithStoredSchemaAndSeedTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Orchestra\Testbench\TestCase;
+
+class MigrateWithStoredSchemaAndSeedTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if ($this->app['config']->get('database.default') !== 'testing') {
+            $this->artisan('db:wipe', ['--drop-views' => true]);
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (array_keys($this->app['db']->getConnections()) as $name) {
+            $this->app['db']->purge($name);
+        }
+
+        parent::tearDown();
+    }
+
+    public function testMigratingWithStoredSchemaAndSeedCreatesTheMigrationsTable()
+    {
+        $this->artisan('migrate', [
+            '--path' => realpath(__DIR__.'/stubs/migrate-schema'),
+            '--realpath' => true,
+            '--schema-path' => __DIR__.'/stubs/migrate-schema/schema.sql',
+            '--seed' => true,
+            '--seeder' => MigrateWithStoredSchemaAndSeedTestSeeder::class,
+        ]);
+
+        $this->assertTrue(Schema::hasTable('migrations'));
+        $this->assertDatabaseHas('migrations', [
+            'migration' => '2014_10_12_000000_create_people_table',
+            'batch' => 1,
+        ]);
+
+        $this->assertTrue(Schema::hasTable('people'));
+        $this->assertDatabaseHas('people', ['name' => 'seeded']);
+    }
+}
+
+class MigrateWithStoredSchemaAndSeedTestSeeder extends Seeder
+{
+    public function run()
+    {
+        DB::table('people')->insert(['name' => 'seeded']);
+    }
+}

--- a/tests/Integration/Database/stubs/migrate-connection/2014_10_12_000000_create_people_table.php
+++ b/tests/Integration/Database/stubs/migrate-connection/2014_10_12_000000_create_people_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreatePeopleTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('people', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::drop('people');
+    }
+}

--- a/tests/Integration/Database/stubs/migrate-schema/2014_10_12_000000_create_people_table.php
+++ b/tests/Integration/Database/stubs/migrate-schema/2014_10_12_000000_create_people_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreatePeopleTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('people', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::drop('people');
+    }
+}

--- a/tests/Integration/Database/stubs/migrate-schema/schema.sql
+++ b/tests/Integration/Database/stubs/migrate-schema/schema.sql
@@ -1,0 +1,3 @@
+CREATE TABLE "migrations" ("id" integer primary key autoincrement not null, "migration" varchar not null, "batch" integer not null);
+INSERT INTO "migrations" ("id", "migration", "batch") VALUES (1, '2014_10_12_000000_create_people_table', 1);
+CREATE TABLE "people" ("id" integer primary key autoincrement not null, "name" varchar not null);


### PR DESCRIPTION
There's a report on #60926 (https://github.com/laravel/framework/pull/60926#issuecomment-5194010548) that `migrate --seed` breaks on 13.24.0 when using the schema loader, and the reporter traced it back to `migrate:install` switching from `$name`/`getOptions()` to `$signature` in that PR.

I couldn't reproduce it, but wanted to add real coverage instead of just taking my word for it. This PR adds two integration tests that exercise `migrate:install` and `db:seed` the way `migrate --seed` actually calls them:

- `MigrateWithStoredSchemaAndSeedTest` runs the schema-loader path end to end: fresh DB, `migrate:install` gets created via `callSilent()`, then the schema dump gets reloaded (`Migrator::deleteRepository()` + `SchemaState::load()`), then `--seed` runs.
- `MigrateWithNonDefaultConnectionAndSeedTest` runs the same thing against a real MySQL server (via `docker-compose.yml`) with two separate connections, to check `--database=<non-default>` actually gets forwarded to both `migrate:install` and `db:seed` and nothing leaks onto the default connection.

Both pass on current 13.x. I also compared `InstallCommand`'s `InputDefinition` before/after #60926 directly and it's identical, so I don't think the `$signature` conversion is actually the cause here — but I could easily be missing something specific to the reporter's setup (driver, a package overriding a command name, etc.), so I'm opening this as a draft rather than closing the thread out. Figured the tests are worth having either way.

Worth noting: `tests/Console/CommandSignatureTest.php`, added in #60926 itself, asserts every command's name/aliases/arguments/options against a recorded fixture. If `migrate:install`'s name, options, or anything else in its signature had actually changed as part of that refactor, that test would already be failing — it isn't, which is further evidence the command's public shape didn't change.

Test plan:
- `php vendor/bin/phpunit tests/Integration/Database/MigrateWithStoredSchemaAndSeedTest.php` (sqlite)
- `php vendor/bin/phpunit tests/Integration/Database/MigrateWithNonDefaultConnectionAndSeedTest.php` (real MySQL via `docker-compose.yml`)
- `php vendor/bin/phpunit tests/Console/CommandSignatureTest.php tests/Database/DatabaseMigrationMigrateCommandTest.php`