### PR TITLE
[13.x] Prevent Redis over-throttling with multiple rate limits

### DIFF
--- a/src/Illuminate/Routing/Middleware/ThrottleRequestsWithRedis.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequestsWithRedis.php
@@ -59,7 +59,9 @@ class ThrottleRequestsWithRedis extends ThrottleRequests
             if ($this->tooManyAttempts($limit->key, $limit->maxAttempts, $limit->decaySeconds)) {
                 throw $this->buildException($request, $limit->key, $limit->maxAttempts, $limit->responseCallback);
             }
+        }
 
+        foreach ($limits as $limit) {
             if (! $limit->afterCallback) {
                 $this->hit($limit->key, $limit->maxAttempts, $limit->decaySeconds);
             }

--- a/tests/Integration/Http/ThrottleRequestsWithRedisTest.php
+++ b/tests/Integration/Http/ThrottleRequestsWithRedisTest.php
@@ -18,6 +18,24 @@ class ThrottleRequestsWithRedisTest extends TestCase
 {
     use InteractsWithRedis;
 
+    public function testRejectedRequestDoesNotIncrementEarlierLimits()
+    {
+        $this->ifRedisAvailable(function () {
+            RateLimiter::for('test', fn () => [
+                Limit::perDay(4)->by('day-key'),
+                Limit::perMinute(3)->by('minute-key'),
+            ]);
+            Route::get('/', fn () => 'ok')->middleware(ThrottleRequestsWithRedis::using('test'));
+
+            $this->get('/')->assertOk();
+            $this->get('/')->assertOk();
+            $this->get('/')->assertOk();
+            $this->get('/')->assertTooManyRequests();
+
+            $this->assertSame('3', $this->app['redis']->connection()->hget(md5('testday-key'), 'count'));
+        });
+    }
+
     public function testLockOpensImmediatelyAfterDecay()
     {
         $this->ifRedisAvailable(function () {


### PR DESCRIPTION
When a Redis-backed named rate limiter defines multiple limits, `ThrottleRequestsWithRedis` currently checks and increments each limit in the same loop.

If an earlier limit is available but a later limit rejects the request, the earlier limit has already been incremented. This causes rejected requests to consume unrelated rate-limit allowances and can prematurely throttle subsequent valid requests.

This PR checks all limits before incrementing any of them, consistent with the existing behavior of `ThrottleRequests`.

A regression test verifies that a request rejected by a later limit does not increment an earlier limit.