### PR TITLE
[13.x] Normalize enum keys in typed cache getters

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -242,6 +242,8 @@ class Repository implements ArrayAccess, CacheContract
      */
     public function string($key, $default = null): string
     {
+        $key = enum_value($key);
+
         $value = $this->get($key, $default);
 
         if (! is_string($value)) {
@@ -263,6 +265,8 @@ class Repository implements ArrayAccess, CacheContract
      */
     public function integer($key, $default = null): int
     {
+        $key = enum_value($key);
+
         $value = $this->get($key, $default);
 
         if (is_int($value)) {
@@ -288,6 +292,8 @@ class Repository implements ArrayAccess, CacheContract
      */
     public function float($key, $default = null): float
     {
+        $key = enum_value($key);
+
         $value = $this->get($key, $default);
 
         if (is_float($value)) {
@@ -313,6 +319,8 @@ class Repository implements ArrayAccess, CacheContract
      */
     public function boolean($key, $default = null): bool
     {
+        $key = enum_value($key);
+
         $value = $this->get($key, $default);
 
         if (! is_bool($value)) {
@@ -335,6 +343,8 @@ class Repository implements ArrayAccess, CacheContract
      */
     public function array($key, $default = null): array
     {
+        $key = enum_value($key);
+
         $value = $this->get($key, $default);
 
         if (! is_array($value)) {

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -819,6 +819,27 @@ class CacheRepositoryTest extends TestCase
         $repo->getStore()->shouldReceive('get')->once()->with('foo')->andReturn('bar');
         $repo->array('foo');
     }
+
+    public static function typedGetterTypeMismatchProvider()
+    {
+        return [
+            ['string', 123, 'Cache value for key [foo] must be a string, integer given.'],
+            ['integer', 'bar', 'Cache value for key [foo] must be an integer, string given.'],
+            ['float', 'bar', 'Cache value for key [foo] must be a float, string given.'],
+            ['boolean', 'bar', 'Cache value for key [foo] must be a boolean, string given.'],
+            ['array', 'bar', 'Cache value for key [foo] must be an array, string given.'],
+        ];
+    }
+
+    #[DataProvider('typedGetterTypeMismatchProvider')]
+    public function testTypedGettersReportTypeMismatchesForEnumKeys($method, $value, $message)
+    {
+        $this->expectExceptionObject(new InvalidArgumentException($message));
+
+        $repo = $this->getRepository();
+        $repo->getStore()->shouldReceive('get')->once()->with('foo')->andReturn($value);
+        $repo->{$method}(TestCacheKey::FOO);
+    }
 }
 
 enum TestCacheKey: string


### PR DESCRIPTION
Typed cache getters accept enum keys, but type mismatch errors attempt to interpolate the enum object, causing an `Error` instead of the intended `InvalidArgumentException`. 
This normalizes enum keys before retrieval so each getter reports the existing type mismatch message.

  ```php
  Cache::put(CacheKey::User, 123);

  // Now throws InvalidArgumentException with the expected message.
  Cache::string(CacheKey::User);
  ```
