### PR TITLE
[13.x] Reject non-stream resources in HTTP request bodies

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -297,7 +297,7 @@ class PendingRequest
     /**
      * Attach a raw body to the request.
      *
-     * @param  \Psr\Http\Message\StreamInterface|string  $content
+     * @param  \Psr\Http\Message\StreamInterface|string|resource|null  $content
      * @param  string  $contentType
      * @return $this
      */
@@ -1617,8 +1617,8 @@ class PendingRequest
      */
     protected function ensureValidRequestBody($body): void
     {
-        if (! is_string($body) && ! is_null($body) && ! is_resource($body) && ! $body instanceof StreamInterface) {
-            throw new InvalidArgumentException('HTTP request body must be a string, resource, Psr\Http\Message\StreamInterface, or null.');
+        if (! is_string($body) && ! is_null($body) && (! is_resource($body) || get_resource_type($body) !== 'stream') && ! $body instanceof StreamInterface) {
+            throw new InvalidArgumentException('HTTP request body must be a string, stream resource, Psr\Http\Message\StreamInterface, or null.');
         }
     }
 

--- a/src/Illuminate/Support/Facades/Http.php
+++ b/src/Illuminate/Support/Facades/Http.php
@@ -34,7 +34,7 @@ use Illuminate\Http\Client\Factory;
  * @method static void flushMacros()
  * @method static mixed macroCall(string $method, array $parameters)
  * @method static \Illuminate\Http\Client\PendingRequest baseUrl(string $url)
- * @method static \Illuminate\Http\Client\PendingRequest withBody(\Psr\Http\Message\StreamInterface|string $content, string $contentType = 'application/json')
+ * @method static \Illuminate\Http\Client\PendingRequest withBody(\Psr\Http\Message\StreamInterface|string|resource|null $content, string $contentType = 'application/json')
  * @method static \Illuminate\Http\Client\PendingRequest asJson()
  * @method static \Illuminate\Http\Client\PendingRequest asForm()
  * @method static \Illuminate\Http\Client\PendingRequest attach(string|array $name, string|resource $contents = '', string|null $filename = null, array $headers = [])

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -593,6 +593,40 @@ class HttpClientTest extends TestCase
         $this->factory->withBody($body, 'text/plain')->send('post', 'http://foo.com/api');
     }
 
+    public function testSendStreamResourceRequestBody()
+    {
+        $string = 'Look at me, i am a stream resource!!';
+        $body = fopen('php://temp', 'w+');
+        fwrite($body, $string);
+        rewind($body);
+
+        $this->factory->fake(function (Request $request) use ($string) {
+            $this->assertSame($string, $request->body());
+
+            return ['my' => 'response'];
+        });
+
+        $this->factory->withBody($body, 'text/plain')->send('post', 'http://foo.com/api');
+    }
+
+    public function testRejectsNonStreamRequestBodyResource()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('HTTP request body must be a string, stream resource, Psr\Http\Message\StreamInterface, or null.');
+
+        $this->factory->withBody(stream_context_create());
+    }
+
+    public function testRejectsNonStreamRequestBodyResourceProvidedThroughOptions()
+    {
+        $this->factory->fake();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('HTTP request body must be a string, stream resource, Psr\Http\Message\StreamInterface, or null.');
+
+        $this->factory->withOptions(['body' => stream_context_create()])->post('http://foo.com/api');
+    }
+
     public function testUrlsCanBeStubbedByPath()
     {
         $this->factory->fake([


### PR DESCRIPTION
HTTP request body validation currently accepts any PHP resource, although Guzzle can only convert stream resources into PSR-7 streams. This rejects non-stream resources early with the existing `InvalidArgumentException` path, matching fake response body validation.

```php
Http::withBody(stream_context_create())->post("/endpoint");
// Before: accepted until Guzzle throws a TypeError
// After: InvalidArgumentException with a clear message
```